### PR TITLE
Search Blocks: add Powered by Jetpack block (SEARCH-164)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"23c1723d-b8a5-43bd-97a8-14f3986a3a66","pid":43886,"procStart":"Wed May  6 02:27:08 2026","acquiredAt":1778036606743}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"23c1723d-b8a5-43bd-97a8-14f3986a3a66","pid":43886,"procStart":"Wed May  6 02:27:08 2026","acquiredAt":1778036606743}

--- a/projects/packages/search/changelog/atlas-search-164-powered-by-block
+++ b/projects/packages/search/changelog/atlas-search-164-powered-by-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add a "Powered by Jetpack" block (`jetpack/powered-by`) to the results-panel default template, patterns, and search template. Free-plan sites always render the attribution; paid plans expose a "Hide on the front end" inspector toggle.

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/powered-by",
+	"version": "0.1.0",
+	"title": "Powered by Jetpack",
+	"category": "jetpack-search",
+	"icon": "wordpress",
+	"description": "Attribution link to jetpack.com. Free-plan sites always display this; paid sites can hide it from the front end.",
+	"keywords": [ "search", "jetpack", "powered by", "colophon" ],
+	"supports": {
+		"html": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"fontFamily": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"hide": { "type": "boolean", "default": false }
+	},
+	"render": "file:./render.php",
+	"style": "file:../../../../build/search-blocks/powered-by.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
@@ -6,7 +6,7 @@
 	"title": "Powered by Jetpack",
 	"category": "jetpack-search",
 	"icon": "wordpress",
-	"description": "Attribution link to jetpack.com. Free-plan sites always display this; paid sites can hide it from the front end.",
+	"description": "Attribution link to jetpack.com. Free-plan sites always display this; paid sites can remove the block to hide it.",
 	"keywords": [ "search", "jetpack", "powered by", "colophon" ],
 	"supports": {
 		"html": false,
@@ -26,9 +26,6 @@
 		}
 	},
 	"textdomain": "jetpack-search-pkg",
-	"attributes": {
-		"hide": { "type": "boolean", "default": false }
-	},
 	"render": "file:./render.php",
 	"style": "file:../../../../build/search-blocks/powered-by.css"
 }

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
@@ -59,6 +59,7 @@ export default function PoweredByEdit( { attributes, setAttributes } ) {
 					onClick={ e => e.preventDefault() }
 				>
 					<span className="jetpack-search-powered-by__logo" aria-hidden="true">
+						{ /* Brand mark — `fill` stays Jetpack Green regardless of the block's color supports. */ }
 						<svg width="12" height="12" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
 							<path
 								fill="#069E08"

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
@@ -1,84 +1,51 @@
 /**
  * Editor preview for jetpack/powered-by.
  *
- * Mirrors the front-end DOM render.php produces. The Inspector exposes a
- * "Hide on the front end" toggle on paid plans only; free-plan sites see an
- * informational note instead because the attribution is enforced
- * server-side regardless of the saved attribute (see render.php and the
- * results-panel auto-inject).
+ * Mirrors the front-end DOM render.php produces. The block has no
+ * custom attributes — paid-plan authors who want the colophon gone
+ * just delete the block from the panel; free-plan authors can't
+ * remove it (results-panel/render.php auto-injects it back, see that
+ * file for the gate).
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-
-const isFreePlan = () => !! window?.JetpackSearchBlocksConfig?.isFreePlan;
 
 /**
  * Edit component for the powered-by block.
  *
- * @param {object}   props               - Block props.
- * @param {object}   props.attributes    - Saved block attributes.
- * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function PoweredByEdit( { attributes, setAttributes } ) {
+export default function PoweredByEdit() {
 	const blockProps = useBlockProps( { className: 'jetpack-search-powered-by' } );
-	const freePlan = isFreePlan();
-	const hide = !! attributes?.hide;
 	return (
-		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
-					{ freePlan ? (
-						<p className="jetpack-search-powered-by__free-plan-note">
-							{ __(
-								'Free-plan sites always display this attribution. Upgrade to hide it.',
-								'jetpack-search-pkg'
-							) }
-						</p>
-					) : (
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Hide on the front end', 'jetpack-search-pkg' ) }
-							checked={ hide }
-							onChange={ value => setAttributes( { hide: value } ) }
-							help={ __(
-								'When enabled, this block stays visible in the editor but is removed from the public page.',
-								'jetpack-search-pkg'
-							) }
+		<div { ...blockProps }>
+			<a
+				className="jetpack-search-powered-by__link"
+				href="https://jetpack.com/upgrade/search/?utm_source=poweredby"
+				rel="external noopener noreferrer nofollow"
+				target="_blank"
+				onClick={ e => e.preventDefault() }
+			>
+				<span className="jetpack-search-powered-by__logo" aria-hidden="true">
+					{ /* Brand mark — `fill` stays Jetpack Green regardless of the block's color supports. */ }
+					<svg
+						viewBox="0 0 32 32"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+						focusable="false"
+					>
+						<path
+							fill="#069E08"
+							d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
 						/>
-					) }
-				</PanelBody>
-			</InspectorControls>
-			<div { ...blockProps }>
-				<a
-					className="jetpack-search-powered-by__link"
-					href="https://jetpack.com/upgrade/search/?utm_source=poweredby"
-					rel="external noopener noreferrer nofollow"
-					target="_blank"
-					onClick={ e => e.preventDefault() }
-				>
-					<span className="jetpack-search-powered-by__logo" aria-hidden="true">
-						{ /* Brand mark — `fill` stays Jetpack Green regardless of the block's color supports. */ }
-						<svg
-							viewBox="0 0 32 32"
-							xmlns="http://www.w3.org/2000/svg"
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path
-								fill="#069E08"
-								d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
-							/>
-							<polygon fill="#FFFFFF" points="15,19 7,19 15,3 " />
-							<polygon fill="#FFFFFF" points="17,29 17,13 25,13 " />
-						</svg>
-					</span>
-					<span className="jetpack-search-powered-by__text">
-						{ __( 'Search powered by Jetpack', 'jetpack-search-pkg' ) }
-					</span>
-				</a>
-			</div>
-		</>
+						<polygon fill="#FFFFFF" points="15,19 7,19 15,3 " />
+						<polygon fill="#FFFFFF" points="17,29 17,13 25,13 " />
+					</svg>
+				</span>
+				<span className="jetpack-search-powered-by__text">
+					{ __( 'Search powered by Jetpack', 'jetpack-search-pkg' ) }
+				</span>
+			</a>
+		</div>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
@@ -60,7 +60,12 @@ export default function PoweredByEdit( { attributes, setAttributes } ) {
 				>
 					<span className="jetpack-search-powered-by__logo" aria-hidden="true">
 						{ /* Brand mark — `fill` stays Jetpack Green regardless of the block's color supports. */ }
-						<svg width="12" height="12" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+						<svg
+							viewBox="0 0 32 32"
+							xmlns="http://www.w3.org/2000/svg"
+							aria-hidden="true"
+							focusable="false"
+						>
 							<path
 								fill="#069E08"
 								d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/edit.js
@@ -1,0 +1,78 @@
+/**
+ * Editor preview for jetpack/powered-by.
+ *
+ * Mirrors the front-end DOM render.php produces. The Inspector exposes a
+ * "Hide on the front end" toggle on paid plans only; free-plan sites see an
+ * informational note instead because the attribution is enforced
+ * server-side regardless of the saved attribute (see render.php and the
+ * results-panel auto-inject).
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const isFreePlan = () => !! window?.JetpackSearchBlocksConfig?.isFreePlan;
+
+/**
+ * Edit component for the powered-by block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function PoweredByEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-powered-by' } );
+	const freePlan = isFreePlan();
+	const hide = !! attributes?.hide;
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					{ freePlan ? (
+						<p className="jetpack-search-powered-by__free-plan-note">
+							{ __(
+								'Free-plan sites always display this attribution. Upgrade to hide it.',
+								'jetpack-search-pkg'
+							) }
+						</p>
+					) : (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Hide on the front end', 'jetpack-search-pkg' ) }
+							checked={ hide }
+							onChange={ value => setAttributes( { hide: value } ) }
+							help={ __(
+								'When enabled, this block stays visible in the editor but is removed from the public page.',
+								'jetpack-search-pkg'
+							) }
+						/>
+					) }
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<a
+					className="jetpack-search-powered-by__link"
+					href="https://jetpack.com/upgrade/search/?utm_source=poweredby"
+					rel="external noopener noreferrer nofollow"
+					target="_blank"
+					onClick={ e => e.preventDefault() }
+				>
+					<span className="jetpack-search-powered-by__logo" aria-hidden="true">
+						<svg width="12" height="12" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+							<path
+								fill="#069E08"
+								d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+							/>
+							<polygon fill="#FFFFFF" points="15,19 7,19 15,3 " />
+							<polygon fill="#FFFFFF" points="17,29 17,13 25,13 " />
+						</svg>
+					</span>
+					<span className="jetpack-search-powered-by__text">
+						{ __( 'Search powered by Jetpack', 'jetpack-search-pkg' ) }
+					</span>
+				</a>
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
@@ -2,23 +2,16 @@
 /**
  * Powered by Jetpack block render.
  *
- * Free-plan sites always render this attribution — the `hide` attribute is
- * intentionally ignored. On paid plans, the saved `hide` attribute gates
- * rendering so authors can keep the block in the editor while suppressing
- * it on the public page.
+ * Renders the Jetpack attribution colophon. The block has no plan gate
+ * here — paid-plan authors who want the colophon gone delete the block
+ * from the panel. Free-plan attribution is enforced by results-panel's
+ * auto-inject (see `results-panel/render.php`), which renders this
+ * block server-side when it's missing from `$content`.
  *
  * @package automattic/jetpack-search
  */
 
 namespace Automattic\Jetpack\Search;
-
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-
-$is_free_plan = Search_Blocks::is_free_plan();
-$hide         = ! empty( $attributes['hide'] );
-if ( ! $is_free_plan && $hide ) {
-	return;
-}
 
 $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'jetpack-search-powered-by' ) );
 

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
@@ -22,9 +22,10 @@ if ( ! $is_free_plan && $hide ) {
 
 $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'jetpack-search-powered-by' ) );
 
+// WP locales use underscores (en_US, de_DE, pt_BR), not hyphens — split on `_`.
 $locale_prefix = '';
 if ( function_exists( 'determine_locale' ) ) {
-	$parts         = explode( '-', determine_locale(), 2 );
+	$parts         = explode( '_', determine_locale(), 2 );
 	$locale_prefix = strtolower( (string) $parts[0] );
 }
 $url = ( '' !== $locale_prefix && 'en' !== $locale_prefix )
@@ -39,6 +40,7 @@ $url = ( '' !== $locale_prefix && 'en' !== $locale_prefix )
 		target="_blank"
 	>
 		<span class="jetpack-search-powered-by__logo" aria-hidden="true">
+			<?php // Brand mark — `fill` stays Jetpack Green regardless of the block's color supports. ?>
 			<svg width="12" height="12" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
 				<path fill="#069E08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z" />
 				<polygon fill="#FFFFFF" points="15,19 7,19 15,3 " />

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
@@ -41,7 +41,7 @@ $url = ( '' !== $locale_prefix && 'en' !== $locale_prefix )
 	>
 		<span class="jetpack-search-powered-by__logo" aria-hidden="true">
 			<?php // Brand mark — `fill` stays Jetpack Green regardless of the block's color supports. ?>
-			<svg width="12" height="12" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+			<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
 				<path fill="#069E08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z" />
 				<polygon fill="#FFFFFF" points="15,19 7,19 15,3 " />
 				<polygon fill="#FFFFFF" points="17,29 17,13 25,13 " />

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Powered by Jetpack block render.
+ *
+ * Free-plan sites always render this attribution — the `hide` attribute is
+ * intentionally ignored. On paid plans, the saved `hide` attribute gates
+ * rendering so authors can keep the block in the editor while suppressing
+ * it on the public page.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$is_free_plan = ( new Plan() )->is_free_plan();
+$hide         = ! empty( $attributes['hide'] );
+if ( ! $is_free_plan && $hide ) {
+	return;
+}
+
+$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'jetpack-search-powered-by' ) );
+
+$locale_prefix = '';
+if ( function_exists( 'determine_locale' ) ) {
+	$parts         = explode( '-', determine_locale(), 2 );
+	$locale_prefix = strtolower( (string) $parts[0] );
+}
+$url = ( '' !== $locale_prefix && 'en' !== $locale_prefix )
+	? sprintf( 'https://%s.jetpack.com/upgrade/search?utm_source=poweredby', $locale_prefix )
+	: 'https://jetpack.com/upgrade/search/?utm_source=poweredby';
+?>
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<a
+		class="jetpack-search-powered-by__link"
+		href="<?php echo esc_url( $url ); ?>"
+		rel="external noopener noreferrer nofollow"
+		target="_blank"
+	>
+		<span class="jetpack-search-powered-by__logo" aria-hidden="true">
+			<svg width="12" height="12" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+				<path fill="#069E08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z" />
+				<polygon fill="#FFFFFF" points="15,19 7,19 15,3 " />
+				<polygon fill="#FFFFFF" points="17,29 17,13 25,13 " />
+			</svg>
+		</span>
+		<span class="jetpack-search-powered-by__text">
+			<?php esc_html_e( 'Search powered by Jetpack', 'jetpack-search-pkg' ); ?>
+		</span>
+	</a>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/render.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-$is_free_plan = ( new Plan() )->is_free_plan();
+$is_free_plan = Search_Blocks::is_free_plan();
 $hide         = ! empty( $attributes['hide'] );
 if ( ! $is_free_plan && $hide ) {
 	return;

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/style.scss
@@ -7,24 +7,30 @@
 	align-items: center;
 	color: inherit;
 	display: inline-flex;
+	// Inherit the theme's "small" preset when defined (theme.json
+	// typography.fontSizes); fall back to ~0.7em of the surrounding
+	// flow size when the theme doesn't expose one.
+	font-size: var(--wp--preset--font-size--small, 0.7em);
+	gap: 0.5em;
+	line-height: 1;
 	text-decoration: none;
 }
 
 .jetpack-search-powered-by__logo {
 	display: inline-flex;
-	width: 16px;
-	height: 16px;
+	flex: 0 0 auto;
+	height: 1em;
+	width: 1em;
 
 	svg {
 		display: block;
+		height: 100%;
+		width: 100%;
 	}
 }
 
 .jetpack-search-powered-by__text {
-	font-size: 0.7em;
 	font-weight: 500;
-	padding-inline-start: 12px;
-	line-height: 16px;
 }
 
 .jetpack-search-powered-by__free-plan-note {

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/style.scss
@@ -1,0 +1,36 @@
+.wp-block-jetpack-powered-by {
+	margin-block: var(--wp--style--block-gap, 1.5em);
+	text-align: center;
+}
+
+.jetpack-search-powered-by__link {
+	align-items: center;
+	color: inherit;
+	display: inline-flex;
+	text-decoration: none;
+}
+
+.jetpack-search-powered-by__logo {
+	display: inline-flex;
+	width: 16px;
+	height: 16px;
+
+	svg {
+		display: block;
+	}
+}
+
+.jetpack-search-powered-by__text {
+	font-size: 0.7em;
+	font-weight: 500;
+	padding-inline-start: 12px;
+	line-height: 16px;
+}
+
+.jetpack-search-powered-by__free-plan-note {
+	color: var(--wp-components-color-foreground, currentColor);
+	font-size: 12px;
+	line-height: 1.4;
+	margin: 0;
+	opacity: 0.75;
+}

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/style.scss
@@ -33,10 +33,3 @@
 	font-weight: 500;
 }
 
-.jetpack-search-powered-by__free-plan-note {
-	color: var(--wp-components-color-foreground, currentColor);
-	font-size: 12px;
-	line-height: 1.4;
-	margin: 0;
-	opacity: 0.75;
-}

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/view.js
@@ -1,0 +1,3 @@
+// The block has no front-end behavior; this entry exists only so the build
+// emits the bundled stylesheet alongside the other Search blocks.
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/edit.js
@@ -18,6 +18,7 @@ const TEMPLATE = [
 	],
 	[ 'jetpack/search-results' ],
 	[ 'jetpack/load-more' ],
+	[ 'jetpack/powered-by' ],
 ];
 
 const ALLOWED = [
@@ -26,6 +27,7 @@ const ALLOWED = [
 	'jetpack/sort-control',
 	'jetpack/search-results',
 	'jetpack/load-more',
+	'jetpack/powered-by',
 ];
 
 /**

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/render.php
@@ -8,16 +8,33 @@
  * chrome (block-wrapper attrs derived from color/spacing/border/typography
  * supports).
  *
+ * Free-plan attribution: the Jetpack colophon must appear on every
+ * free-plan results page. If an author has removed the
+ * `jetpack/powered-by` block from the panel (or never had one in their
+ * pattern), this renderer appends a canonical render of it on the way
+ * out so the attribution is structurally non-removable. Paid-plan sites
+ * are unaffected — authors can keep, hide, or delete the block freely.
+ *
  * @package automattic/jetpack-search
  */
 
 namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$panel_content = $content; // @phan-suppress-current-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
+
+if ( ( new Plan() )->is_free_plan() && false === strpos( $panel_content, 'wp-block-jetpack-powered-by' ) ) {
+	$panel_content .= render_block(
+		array(
+			'blockName' => 'jetpack/powered-by',
+			'attrs'     => array(),
+		)
+	);
+}
 ?>
 <div <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-results-panel' ) ) ); ?>>
 	<?php
-	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+	echo $panel_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer; auto-injected powered-by output is rendered through render_block() and escaped by its own renderer.
 	?>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/render.php
@@ -24,7 +24,7 @@ namespace Automattic\Jetpack\Search;
 
 $panel_content = $content; // @phan-suppress-current-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
 
-if ( ( new Plan() )->is_free_plan() && false === strpos( $panel_content, 'wp-block-jetpack-powered-by' ) ) {
+if ( Search_Blocks::is_free_plan() && false === strpos( $panel_content, 'wp-block-jetpack-powered-by' ) ) {
 	$panel_content .= render_block(
 		array(
 			'blockName' => 'jetpack/powered-by',

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -61,6 +61,19 @@ class Search_Blocks {
 	private static $is_initial_loading_cache = null;
 
 	/**
+	 * Per-request memo backing `is_free_plan()`. Block render callbacks
+	 * (`results-panel`, `powered-by`) call into the plan gate on every
+	 * inner render, including the auto-injected colophon path. WP's option
+	 * cache absorbs the redundancy in steady state, but on a cold cache
+	 * `Plan::get_plan_info()` falls back to a synchronous WPCOM HTTP call —
+	 * memoizing here fences that hazard to a single well-known site per
+	 * request.
+	 *
+	 * @var bool|null
+	 */
+	private static $is_free_plan_cache = null;
+
+	/**
 	 * Register block types and hook into WordPress.
 	 *
 	 * The caller (Initializer) is responsible for gating this behind the
@@ -80,6 +93,31 @@ class Search_Blocks {
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
+	}
+
+	/**
+	 * Per-request memoized read of `Plan::is_free_plan()`. Use from any
+	 * block render callback that needs the plan gate — avoids paying the
+	 * `get_option()` array-parse cost on every block, and ensures the
+	 * cold-cache WPCOM round-trip in `Plan::get_plan_info()` happens at
+	 * most once per request even when several blocks ask.
+	 *
+	 * @return bool
+	 */
+	public static function is_free_plan(): bool {
+		if ( null === self::$is_free_plan_cache ) {
+			self::$is_free_plan_cache = ( new Plan() )->is_free_plan();
+		}
+		return self::$is_free_plan_cache;
+	}
+
+	/**
+	 * Reset the `is_free_plan()` memo. Tests only — production callers
+	 * should never need this; the boolean state of the site's plan
+	 * doesn't change inside a single request.
+	 */
+	public static function reset_is_free_plan_cache() {
+		self::$is_free_plan_cache = null;
 	}
 
 	/**
@@ -135,7 +173,7 @@ class Search_Blocks {
 			'jetpack-search-blocks-register',
 			'window.JetpackSearchBlocksConfig = ' . wp_json_encode(
 				array(
-					'isFreePlan' => ( new Plan() )->is_free_plan(),
+					'isFreePlan' => self::is_free_plan(),
 				),
 				JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 			) . ';',

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -127,6 +127,20 @@ class Search_Blocks {
 			$asset['version'] ?? false,
 			true
 		);
+
+		// Surface the plan flag to editor blocks (powered-by uses it to gate
+		// its inspector toggle). The front-end render gate is enforced
+		// server-side in each block's render.php; this is editor-only.
+		wp_add_inline_script(
+			'jetpack-search-blocks-register',
+			'window.JetpackSearchBlocksConfig = ' . wp_json_encode(
+				array(
+					'isFreePlan' => ( new Plan() )->is_free_plan(),
+				),
+				JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+			) . ';',
+			'before'
+		);
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -165,20 +165,6 @@ class Search_Blocks {
 			$asset['version'] ?? false,
 			true
 		);
-
-		// Surface the plan flag to editor blocks (powered-by uses it to gate
-		// its inspector toggle). The front-end render gate is enforced
-		// server-side in each block's render.php; this is editor-only.
-		wp_add_inline_script(
-			'jetpack-search-blocks-register',
-			'window.JetpackSearchBlocksConfig = ' . wp_json_encode(
-				array(
-					'isFreePlan' => self::is_free_plan(),
-				),
-				JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
-			) . ';',
-			'before'
-		);
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -25,6 +25,7 @@ import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPopoverEdit, { save as filterPopoverSave } from '../blocks/filter-popover/edit';
 import LoadMoreEdit from '../blocks/load-more/edit';
 import PostTypeFilterEdit from '../blocks/post-type-filter/edit';
+import PoweredByEdit from '../blocks/powered-by/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
 import ResultsPanelEdit, { save as resultsPanelSave } from '../blocks/results-panel/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
@@ -51,6 +52,7 @@ const BLOCKS = [
 	[ 'jetpack/results-count', ResultsCountEdit ],
 	[ 'jetpack/load-more', LoadMoreEdit ],
 	[ 'jetpack/results-panel', ResultsPanelEdit, resultsPanelSave ],
+	[ 'jetpack/powered-by', PoweredByEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -38,6 +38,7 @@ register_block_pattern(
 
 <!-- wp:jetpack/search-results /-->
 <!-- wp:jetpack/load-more /-->
+<!-- wp:jetpack/powered-by /-->
 <!-- /wp:jetpack/results-panel -->
 </div>
 <!-- /wp:column -->

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -43,6 +43,7 @@ register_block_pattern(
 <!-- wp:jetpack/results-count /-->
 <!-- wp:jetpack/search-results {"layout":"compact"} /-->
 <!-- wp:jetpack/load-more /-->
+<!-- wp:jetpack/powered-by /-->
 <!-- /wp:jetpack/results-panel -->
 
 </div>

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -22,6 +22,7 @@
 
 <!-- wp:jetpack/search-results /-->
 <!-- wp:jetpack/load-more /-->
+<!-- wp:jetpack/powered-by /-->
 <!-- /wp:jetpack/results-panel -->
 </div>
 <!-- /wp:column -->

--- a/projects/packages/search/tests/js/search-blocks/results-panel-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-panel-edit.test.jsx
@@ -25,6 +25,7 @@ describe( 'ResultsPanelEdit', () => {
 			],
 			[ 'jetpack/search-results' ],
 			[ 'jetpack/load-more' ],
+			[ 'jetpack/powered-by' ],
 		] );
 		expect( props.allowedBlocks ).toEqual( [
 			'core/group',
@@ -32,6 +33,7 @@ describe( 'ResultsPanelEdit', () => {
 			'jetpack/sort-control',
 			'jetpack/search-results',
 			'jetpack/load-more',
+			'jetpack/powered-by',
 		] );
 	} );
 } );


### PR DESCRIPTION
Fixes [SEARCH-164](https://linear.app/a8c/issue/SEARCH-164/search-results-powered-by-jetpack-show-logo-affordance)

## Why

Jetpack Search has always shown a small "Search powered by Jetpack" attribution at the bottom of free-plan search results — it's the brand surface that turns Search 1.x / Customberg sites into a steady acquisition channel for the paid product. The new Search 3.0 results panel had no equivalent: free-plan sites running it were quietly losing that attribution. This restores the same affordance Customberg has had for years, in the block-theme idiom Search 3.0 uses everywhere else.

## Proposed changes
* Add a new `jetpack/powered-by` block (color / spacing / typography supports, same as the rest of the Search blocks). Renders the Jetpack-green colophon + "Search powered by Jetpack" link.
* Pre-populate it as the last child of `jetpack/results-panel`'s default template, both built-in patterns (`blog-search`, `compact-search`), and the Search FSE template (`templates/jetpack-search.html`). Authors get the attribution out of the box on a fresh insert.
* Make the colophon **structurally non-removable on free plans**: `results-panel/render.php` auto-injects the rendered output if the block isn't already in `$content`, gated on `Plan::is_free_plan()`. Editor-side block locks would be bypassable; the server-side gate isn't.
* **Paid plans:** authors who don't want the colophon delete the block from the panel. The auto-inject is free-plan-only, so a removed block stays gone for paid sites — no separate toggle needed.
* Memoize `Plan::is_free_plan()` per request via a `Search_Blocks::is_free_plan()` static cache. Both `results-panel/render.php` and `powered-by/render.php` go through it, so the cold-cache WPCOM round-trip in `Plan::get_plan_info()` can fire at most once per request even when several blocks ask for the gate.

## Screenshots

Free-plan search results page (`/?s=hello`), trunk vs. this branch, same theme and content:

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/430909a9-5cd4-4ab1-b983-2de785e8810a) | ![after](https://github.com/user-attachments/assets/6c8da710-337f-4f91-9236-4a85e82a9834) |

The "after" shows the new colophon (green Jetpack mark + "Search powered by Jetpack") rendered between the last result and the site footer. Logo size and text size both inherit `--wp--preset--font-size--small` (with a `0.7em` fallback), so the attribution scales with the active theme's typographic choices.

## Related product discussion/links
* [SEARCH-164](https://linear.app/a8c/issue/SEARCH-164/search-results-powered-by-jetpack-show-logo-affordance)
* Follow-up to [#48509](https://github.com/Automattic/jetpack/pull/48509) (the SEARCH-137 customization-parity PR — that PR explicitly called out the powered-by affordance as the remaining customberg gap).
* Customberg parallel: `projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx:185-194` (toggle), `class-customizer.php:325-346` (Customizer setting), `class-helper.php:915` (`showPoweredBy` resolution), `instant-search/components/search-results.jsx:323` (actual render gate). The new block reproduces that surface in block-theme form.

## Does this pull request change what data or activity we track or use?

No. The colophon link uses the same `https://jetpack.com/upgrade/search/?utm_source=poweredby` URL as the existing `JetpackColophon` component (with the same locale-prefix variant on non-English locales). No new tracking, no new data collection.

## Testing instructions

Repeat the verification on a free-plan site and a paid-plan site — the gating logic is the only place plan state matters and the two paths diverge entirely.

**Free-plan path (the one users will hit by default):**

1. Build the matrix: `jp build packages/my-jetpack && jp build plugins/jetpack && jp build packages/search && jp build plugins/search`.
2. On a Jetpack Search site running 3.0 blocks (`jetpack_search_blocks_enabled` filter true) on a free Search subscription, hit any `/?s=…` URL — the registered `jetpack-search` template renders.
3. Scroll to the bottom of the results panel. Confirm the green Jetpack mark + "Search powered by Jetpack" link is rendered between the load-more button and the site footer.
4. In the editor, open a page using the **Blog Search Page** or **Compact Search** pattern. Confirm the **Powered by Jetpack** block is the last child inside Results Panel.
5. Delete the block from the editor and save. Reload the front end — colophon is **still there** (auto-inject in `results-panel/render.php` puts it back).
6. The link target is `https://jetpack.com/upgrade/search/?utm_source=poweredby` (or `https://<lang>.jetpack.com/upgrade/search?utm_source=poweredby` on non-English locales).

**Paid-plan path:**

1. Force a paid plan locally (or test on a connected paid site). The `?free_plan=` URL override only forces free; for paid you need a real subscription or the `jetpack_search_plan_info` option mocked.
2. Same flow — on the front end the colophon renders by default.
3. Delete the block entirely from the panel and save. Reload — colophon is gone (no auto-inject on paid plans, by design).
4. Re-insert the block from the inserter — colophon is back.

**Smoke checks (both plans):**

* `jp test php packages/search` — existing block-render tests should still pass.
* The new block appears in the inserter under the **Search** block category alongside the other Search blocks.
* The block's wrapper-class supports (color / spacing / typography) work the same way they do on `results-count` / `load-more` / etc.
