### PR TITLE
Search Blocks: sanitize text-rendered fields against API HTML and entities (RSM-2382)

### DIFF
--- a/projects/packages/search/changelog/nova-rsm-2382-sanitize-result-fields
+++ b/projects/packages/search/changelog/nova-rsm-2382-sanitize-result-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: render WC formatted prices and post titles as plain text by stripping HTML markup and decoding entities so result cards never expose the raw API HTML.

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -154,10 +154,20 @@ function safeFromCodePoint( n ) {
  * @return {string} Input with all tags removed and supported entities decoded.
  */
 export function stripTags( s ) {
+	if ( typeof s !== 'string' || s === '' ) {
+		return s;
+	}
 	let prev;
 	let out = s;
 	do {
 		prev = out;
+		// The strip regex on its own is "incomplete multi-character
+		// sanitization" — `<<script>script>` collapses to `<script>` after a
+		// single pass, which CodeQL flags. The loop runs the strip+decode
+		// pair until the output stabilizes, so the security guarantee holds
+		// across nested or entity-encoded tags. The `keeps stripping until
+		// the output is free of tag-like markup` test in result-utils.test.js
+		// pins this behavior.
 		out = decodeEntities( out ).replace( STRIP_TAGS_PATTERN, '' );
 	} while ( out !== prev );
 	return out;

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -14,6 +14,23 @@
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
 const ANY_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
 const STRIP_TAGS_PATTERN = /<[^>]*>/g;
+const NUMERIC_ENTITY_PATTERN = /&#(\d+);/g;
+const HEX_ENTITY_PATTERN = /&#x([0-9a-f]+);/gi;
+const NAMED_ENTITY_PATTERN = /&([a-z][a-z0-9]*);/gi;
+// Minimum entity coverage needed to render API-supplied prices/titles as plain
+// text — WPCOM hands back HTML-formatted prices like `<span>&#036;</span>11.05`
+// where `$` arrives as a numeric entity and `&nbsp;` is common between currency
+// and amount. Anything outside this map (e.g. `&copy;`) is left intact so it
+// stays visible as a question for whoever sees it, rather than silently
+// disappearing.
+const NAMED_ENTITY_MAP = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	nbsp: ' ',
+};
 
 /**
  * Ensure a URL is a browser-safe http(s)/protocol-relative reference. The
@@ -88,19 +105,60 @@ export function formatPath( permalink ) {
 }
 
 /**
- * Strip HTML tags from a string. Runs the regex repeatedly until the output
- * is stable so nested tag constructions (e.g. `<<script>script>`, which a
- * single pass would leave as `<script>`) can't smuggle a tag through.
+ * Decode the small set of HTML entities the v1.3 API can place in
+ * text-rendered fields. WPCOM hands back WC-formatted prices and post titles
+ * with numeric entities (e.g. `&#036;` for `$`) and a handful of named ones
+ * (`&amp;`, `&nbsp;`); everything else is left untouched.
  *
  * @param {string} s - Input string.
- * @return {string} Input with all `<...>` tags removed.
+ * @return {string} Input with the supported entities replaced.
+ */
+export function decodeEntities( s ) {
+	if ( typeof s !== 'string' || s === '' ) {
+		return s;
+	}
+	return s
+		.replace( NUMERIC_ENTITY_PATTERN, ( _, n ) => safeFromCodePoint( Number( n ) ) )
+		.replace( HEX_ENTITY_PATTERN, ( _, h ) => safeFromCodePoint( parseInt( h, 16 ) ) )
+		.replace( NAMED_ENTITY_PATTERN, ( m, name ) => {
+			const value = NAMED_ENTITY_MAP[ name.toLowerCase() ];
+			return value === undefined ? m : value;
+		} );
+}
+
+/**
+ * `String.fromCodePoint` throws on out-of-range integers; swallow the throw so
+ * a malformed numeric entity drops the bad bytes instead of crashing the whole
+ * sanitization pass.
+ *
+ * @param {number} n - Code point.
+ * @return {string} The character, or '' if the code point is invalid.
+ */
+function safeFromCodePoint( n ) {
+	try {
+		return String.fromCodePoint( n );
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Strip HTML tags from a string and decode any HTML entities the API may have
+ * encoded around them. Runs the strip+decode pair in a loop until the output
+ * is stable so nested tag constructions (e.g. `<<script>script>`, which a
+ * single strip pass would leave as `<script>`) and entity-encoded tags
+ * (`&lt;script&gt;`, which would survive a single strip pass) can't smuggle
+ * a tag through.
+ *
+ * @param {string} s - Input string.
+ * @return {string} Input with all tags removed and supported entities decoded.
  */
 export function stripTags( s ) {
 	let prev;
 	let out = s;
 	do {
 		prev = out;
-		out = out.replace( STRIP_TAGS_PATTERN, '' );
+		out = decodeEntities( out ).replace( STRIP_TAGS_PATTERN, '' );
 	} while ( out !== prev );
 	return out;
 }
@@ -189,11 +247,19 @@ function toNumber( value ) {
  * @return {object} Product fields.
  */
 function normalizeProductFields( fields ) {
-	const formattedPrice = String( firstScalar( fields[ 'wc.formatted_price' ] ) ?? '' );
-	const formattedRegularPrice = String(
-		firstScalar( fields[ 'wc.formatted_regular_price' ] ) ?? ''
+	// WPCOM returns WC prices as HTML fragments (e.g.
+	// `<span class="woocommerce-Price-amount"><span class="…-currencySymbol">&#036;</span>11.05</span>`)
+	// because the legacy instant-search overlay renders them via
+	// `dangerouslySetInnerHTML`. Search Blocks bind these via `data-wp-text`,
+	// so the markup has to be flattened to plain text up front or the result
+	// card prints the raw `<span>` tags and `&#036;` entity to the page.
+	const formattedPrice = stripTags( String( firstScalar( fields[ 'wc.formatted_price' ] ) ?? '' ) );
+	const formattedRegularPrice = stripTags(
+		String( firstScalar( fields[ 'wc.formatted_regular_price' ] ) ?? '' )
 	);
-	const formattedSalePrice = String( firstScalar( fields[ 'wc.formatted_sale_price' ] ) ?? '' );
+	const formattedSalePrice = stripTags(
+		String( firstScalar( fields[ 'wc.formatted_sale_price' ] ) ?? '' )
+	);
 	const hasSalePrice =
 		formattedSalePrice !== '' &&
 		formattedRegularPrice !== '' &&
@@ -309,7 +375,11 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 	const rawImage = fields[ 'image.url.raw' ];
 	const imageSrc = Array.isArray( rawImage ) ? rawImage[ 0 ] : rawImage;
 	const imageUrl = toSafeUrl( imageSrc );
-	const plainTitle = String( fields[ 'title.default' ] ?? fields.title ?? '' );
+	// The fallback title is rendered via `data-wp-text`, so any HTML or HTML
+	// entities the API returns (post titles can contain `&amp;`, `&#8217;`,
+	// etc.) need to be flattened the same way the highlight pieces are —
+	// otherwise the raw entity markup leaks onto the result card.
+	const plainTitle = stripTags( String( fields[ 'title.default' ] ?? fields.title ?? '' ) );
 	const titlePieces = tokenizeHighlight( highlight.title );
 	const contentPieces = tokenizeHighlight( highlight.content );
 	const matchHint = deriveMatchHint( highlight, titlePieces );

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -1,5 +1,6 @@
 import {
 	countActiveFilters,
+	decodeEntities,
 	deriveMatchHint,
 	formatDate,
 	formatPath,
@@ -112,6 +113,47 @@ describe( 'formatPath', () => {
 	} );
 } );
 
+describe( 'decodeEntities', () => {
+	it( 'decodes numeric entities', () => {
+		expect( decodeEntities( '&#036;' ) ).toBe( '$' );
+		expect( decodeEntities( '&#8217;' ) ).toBe( '’' );
+	} );
+
+	it( 'decodes hex entities (case-insensitive)', () => {
+		expect( decodeEntities( '&#x24;' ) ).toBe( '$' );
+		expect( decodeEntities( '&#X2019;' ) ).toBe( '’' );
+	} );
+
+	it( 'decodes the supported named entities', () => {
+		expect( decodeEntities( '&amp;' ) ).toBe( '&' );
+		expect( decodeEntities( '&lt;' ) ).toBe( '<' );
+		expect( decodeEntities( '&gt;' ) ).toBe( '>' );
+		expect( decodeEntities( '&quot;' ) ).toBe( '"' );
+		expect( decodeEntities( '&apos;' ) ).toBe( "'" );
+		expect( decodeEntities( '&nbsp;' ) ).toBe( ' ' );
+	} );
+
+	it( 'leaves unknown named entities untouched', () => {
+		// `&copy;` and friends aren't mapped — better to leave the raw entity
+		// than to silently drop it.
+		expect( decodeEntities( '&copy; 2026' ) ).toBe( '&copy; 2026' );
+	} );
+
+	it( 'drops invalid numeric code points instead of throwing', () => {
+		expect( decodeEntities( '&#9999999999;' ) ).toBe( '' );
+	} );
+
+	it( 'leaves plain text untouched', () => {
+		expect( decodeEntities( 'hello world' ) ).toBe( 'hello world' );
+	} );
+
+	it( 'returns non-string input unchanged', () => {
+		expect( decodeEntities( '' ) ).toBe( '' );
+		expect( decodeEntities( null ) ).toBeNull();
+		expect( decodeEntities( undefined ) ).toBeUndefined();
+	} );
+} );
+
 describe( 'stripTags', () => {
 	it( 'removes simple tags', () => {
 		expect( stripTags( '<p>hello</p>' ) ).toBe( 'hello' );
@@ -136,6 +178,24 @@ describe( 'stripTags', () => {
 
 	it( 'handles empty string', () => {
 		expect( stripTags( '' ) ).toBe( '' );
+	} );
+
+	it( 'flattens an HTML-formatted WC price into plain text', () => {
+		const wcPrice =
+			'<span class="woocommerce-Price-amount amount">' +
+			'<span class="woocommerce-Price-currencySymbol">&#036;</span>11.05</span>';
+		expect( stripTags( wcPrice ) ).toBe( '$11.05' );
+	} );
+
+	it( 'decodes entities while stripping tags', () => {
+		expect( stripTags( 'Joe&#039;s &amp; Co' ) ).toBe( "Joe's & Co" );
+	} );
+
+	it( 'strips entity-encoded tags via the decode → strip loop', () => {
+		// `&lt;script&gt;…&lt;/script&gt;` would survive a single tag-strip pass;
+		// the loop decodes the entities into real `<script>` tags first, then
+		// strips them on the next iteration.
+		expect( stripTags( '&lt;script&gt;alert(1)&lt;/script&gt;' ) ).toBe( 'alert(1)' );
 	} );
 } );
 
@@ -337,6 +397,15 @@ describe( 'normalizeResult', () => {
 		expect( normalizeResult( { fields: {} } ).title ).toBe( '' );
 	} );
 
+	it( 'flattens HTML/entities in the fallback title', () => {
+		// `data-wp-text` would otherwise render the raw markup. Post titles
+		// most commonly carry numeric entities for curly punctuation.
+		const r = normalizeResult( {
+			fields: { 'title.default': 'Joe&#8217;s &amp; <em>Co</em>' },
+		} );
+		expect( r.title ).toBe( 'Joe’s & Co' );
+	} );
+
 	it( 'takes the first image when image.url.raw is an array', () => {
 		const r = normalizeResult( {
 			fields: { 'image.url.raw': [ 'cdn.example.com/a.jpg', 'cdn.example.com/b.jpg' ] },
@@ -404,6 +473,30 @@ describe( 'normalizeResult', () => {
 			expect( r.formattedPrice ).toBe( '$24.00' );
 			expect( r.hasPrice ).toBe( true );
 			expect( r.hasSalePrice ).toBe( false );
+		} );
+
+		it( 'flattens HTML-formatted prices the WPCOM API returns for WC products', () => {
+			// WPCOM's `wc.formatted_price` field is the HTML fragment WC renders
+			// in the storefront — it leaks into the result card unless we strip
+			// the tags and decode `&#036;` / `&nbsp;` before binding via
+			// `data-wp-text`.
+			const r = normalizeResult( {
+				fields: {
+					'wc.formatted_price':
+						'<span class="woocommerce-Price-amount amount">' +
+						'<span class="woocommerce-Price-currencySymbol">&#036;</span>11.05</span>',
+					'wc.formatted_regular_price':
+						'<span class="woocommerce-Price-amount amount">' +
+						'<span class="woocommerce-Price-currencySymbol">&#036;</span>20.00</span>',
+					'wc.formatted_sale_price':
+						'<span class="woocommerce-Price-amount amount">' +
+						'<span class="woocommerce-Price-currencySymbol">&#036;</span>11.05</span>',
+				},
+			} );
+			expect( r.formattedPrice ).toBe( '$11.05' );
+			expect( r.formattedRegularPrice ).toBe( '$20.00' );
+			expect( r.formattedSalePrice ).toBe( '$11.05' );
+			expect( r.hasSalePrice ).toBe( true );
 		} );
 
 		it( 'flags hasSalePrice when sale and regular prices differ', () => {

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -180,6 +180,14 @@ describe( 'stripTags', () => {
 		expect( stripTags( '' ) ).toBe( '' );
 	} );
 
+	it( 'returns non-string input unchanged', () => {
+		// Call sites pre-convert via `String(...) ?? ''`, but defending the
+		// helper itself avoids a stray `.replace` throw if a future caller
+		// skips the conversion.
+		expect( stripTags( null ) ).toBeNull();
+		expect( stripTags( undefined ) ).toBeUndefined();
+	} );
+
 	it( 'flattens an HTML-formatted WC price into plain text', () => {
 		const wcPrice =
 			'<span class="woocommerce-Price-amount amount">' +

--- a/projects/plugins/jetpack/changelog/nova-rsm-2382-sanitize-result-fields
+++ b/projects/plugins/jetpack/changelog/nova-rsm-2382-sanitize-result-fields
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Search Blocks: render WC formatted prices and post titles as plain text so result cards never expose the raw API HTML.


### PR DESCRIPTION
Fixes [RSM-2382](https://linear.app/a8c/issue/RSM-2382/search-highlights-display-raw-html-content)

## Why
Searching a WooCommerce-enabled site with the new Search Blocks rendered the price right under the product title as raw text — `<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">&#036;</span>11.05</span>` — instead of `$11.05`. The same risk lurked in any other text-bound field that the API can return as HTML or with entities (post titles, the highlight snippet). After this PR every layout (compact / expanded / product) prints clean, plain text.

## Proposed changes
* Extend `stripTags` in `search-blocks/store/result-utils.js` to also decode the small set of HTML entities WPCOM emits (numeric, hex, and the common named entities) and run strip+decode in a loop until the output is stable, so entity-encoded tags can't survive a single pass (`&lt;script&gt;` → `<script>` → stripped).
* Apply `stripTags` to `formattedPrice` / `formattedRegularPrice` / `formattedSalePrice` in `normalizeProductFields` and to the fallback `plainTitle` in `normalizeResult` — every field handed to Interactivity `data-wp-text` from API content. Highlight pieces already routed through `stripTags`, so they pick up the new behavior automatically.
* Cover the new behavior with unit tests in `tests/js/search-blocks/result-utils.test.js`, including the WPCOM-shaped WC price fragment and an entity-encoded `<script>` payload.

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/4527c6d9-55de-44ad-9d4e-f5bf02f1d377)

### After
![after](https://github.com/user-attachments/assets/39b30d48-2b69-4ce9-a7bd-a7f605773ddd)

## Related product discussion/links
* [RSM-2382](https://linear.app/a8c/issue/RSM-2382/search-highlights-display-raw-html-content)
* Project: Jetpack Search blocks
* Builds on top of [#48516 (SEARCH-165)](https://github.com/Automattic/jetpack/pull/48516) which exposed the highlighted content snippet — that PR's `tokenizeHighlight` already routes through `stripTags`, so no per-layout follow-up is needed beyond hardening the helper.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Bring up a WooCommerce-enabled WordPress (the per-agent docker env at `https://jp-<agent>.jurassic.tube/` works — the bundled fixture has a `WordPress Pennant` product that triggers this exact case).
2. Place a Jetpack Search Results block on a search-results page (any layout — the bug surfaces most loudly on the **product** layout but is fixed for all of them).
3. Visit `/?s=wordpress` (or any query that returns a WooCommerce product result).
4. Confirm the price renders cleanly (`$11.05`) under the product title with no `<span class="…">` markup or `&#036;` entity visible. Repeat for a query whose result has a sale price; the strikethrough regular price + sale price should both render as clean text.
5. Search for a query whose hits include a post title with HTML entities (e.g. an apostrophe rendered as `&#8217;`) and confirm the title displays the actual character, not the raw entity.
6. Run `pnpm jetpack test js packages/search` — the new `decodeEntities`, `stripTags`, and `normalizeResult` cases should all pass.

