### PR TITLE
Plugin Conflicts Guardian: default pcg_guard_activation to true

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/pcg-guard-activation-default-true
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pcg-guard-activation-default-true
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Plugin Conflicts Guardian: pcg_guard_activation now defaults to true, enabling the activation probe and install/update parse-error gate by default.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -2,10 +2,10 @@
 
 Pre-flight plugin-activation check. When an admin clicks Activate (or finishes an Upload Plugin install), this feature loads the plugin in an isolated HTTP request and refuses the activation if that probe captures a fatal — the site stays up instead of entering recovery mode.
 
-Ships dark. Three independent filters, all default `false`:
+Two independent filters:
 
-- `pcg_guard_activation` — enables the activation probe and the syntax-only install/update gate.
-- `pcg_guard_updates` — enables the post-update health check + rollback flow.
+- `pcg_guard_activation` — enables the activation probe and the syntax-only install/update gate. Defaults `true`.
+- `pcg_guard_updates` — enables the post-update health check + rollback flow. Defaults `false`.
 
 ## Files
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -15,7 +15,7 @@ add_action( 'admin_notices', 'pcg_guard_render_block_notice' );
  * plugin being activated and redirects with a notice on any failure.
  */
 function pcg_guard_maybe_block_activation() {
-	if ( ! apply_filters( 'pcg_guard_activation', false ) ) {
+	if ( ! apply_filters( 'pcg_guard_activation', true ) ) {
 		return;
 	}
 	if ( ! current_user_can( 'activate_plugins' ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
@@ -49,8 +49,10 @@ function pcg_maybe_handle_probe() {
 	// Gate per mode: activation probes need pcg_guard_activation, update
 	// probes need pcg_guard_updates. Otherwise enabling either flow would
 	// pull in the other as an unintended dependency.
-	$gate_filter = PCG_Load_Tester::MODE_UPDATE === $mode ? 'pcg_guard_updates' : 'pcg_guard_activation';
-	if ( ! apply_filters( $gate_filter, false ) ) {
+	$is_update_mode = PCG_Load_Tester::MODE_UPDATE === $mode;
+	$gate_filter    = $is_update_mode ? 'pcg_guard_updates' : 'pcg_guard_activation';
+	$gate_default   = ! $is_update_mode;
+	if ( ! apply_filters( $gate_filter, $gate_default ) ) {
 		pcg_probe_bail_error( 'Plugin Conflicts Guardian is disabled.', 403 );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -32,7 +32,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	if ( is_wp_error( $source ) ) {
 		return $source;
 	}
-	if ( ! apply_filters( 'pcg_guard_activation', false ) ) {
+	if ( ! apply_filters( 'pcg_guard_activation', true ) ) {
 		return $source;
 	}
 	$type   = $hook_extra['type'] ?? '';


### PR DESCRIPTION
Fixes #

## Proposed changes
* Flip the default of the `pcg_guard_activation` filter from `false` to `true`, so the Plugin Conflicts Guardian activation probe and the install/update parse-error gate are on by default.
* Split the gate default in `probe-endpoint.php` so activation-mode probes inherit the new `true` default while update-mode probes (gated by `pcg_guard_updates`) keep defaulting to `false`.
* Update the feature README to reflect the new defaults.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Sync `jetpack-mu-wpcom` to a test site (no extra filter wiring needed).
* In wp-admin → Plugins, activate a known-good plugin: activation succeeds normally (probe runs, returns clean).
* Activate a plugin known to fatal on load: activation is blocked with the Plugin Conflicts Guardian admin notice naming the plugin.
* Upload-install a zip containing a PHP parse error: install is refused with a parse-error notice.
* Add `add_filter( 'pcg_guard_activation', '__return_false' );` in an mu-plugin and confirm activations are no longer probed (back to core behavior).
* Confirm `pcg_guard_updates` flow remains off unless explicitly enabled — installing/updating a plugin does not trigger the post-update health-check + rollback path.
