### PR TITLE
Modules: auto activate offline-compatible modules even if not connect-ready

### DIFF
--- a/projects/plugins/jetpack/changelog/enable-offline-default-modules
+++ b/projects/plugins/jetpack/changelog/enable-offline-default-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Modules: Auto-activate default modules that do not require a connection on unconnected sites, including Forms.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2754,9 +2754,7 @@ p {
 			Jetpack_Options::update_options( compact( 'version', 'old_version' ) );
 		}
 
-		if ( self::is_connection_ready() ) {
-			self::handle_default_module_activation( true );
-		}
+		self::handle_default_module_activation( true );
 
 		self::load_modules();
 
@@ -2773,7 +2771,8 @@ p {
 	 *                                           require a user connection activated.
 	 */
 	private static function handle_default_module_activation( $should_activate_user_modules ) {
-		$active_modules = Jetpack_Options::get_option( 'active_modules' );
+		$connection_ready = self::is_connection_ready();
+		$active_modules   = Jetpack_Options::get_option( 'active_modules' );
 		if ( $active_modules ) {
 			self::delete_active_modules();
 
@@ -2797,11 +2796,13 @@ p {
 				$active_modules,
 				false
 			);
-		} elseif ( $should_activate_user_modules && ( new Connection_Manager() )->get_connection_owner_id() ) { // Check for a user connection.
+		} elseif ( $connection_ready && $should_activate_user_modules && ( new Connection_Manager() )->get_connection_owner_id() ) { // Check for a user connection.
 			self::activate_default_modules( false, false, array(), false, null, null, null );
 			Jetpack_Options::update_option( 'active_modules_initialized', true );
-		} else {
+		} elseif ( $connection_ready ) {
 			self::activate_default_modules( false, false, array(), false, null, null, false );
+		} else {
+			self::activate_default_modules( false, false, array(), false, null, false, false );
 		}
 	}
 


### PR DESCRIPTION
Resolves JETPACK-1766
Related to JETPACK-1767

Help developers working with `localhost` (i.e. Jetpack's "offline mode") to test Jetpack before they are even ready to connect.


## Problem

- Jetpack Forms is the `contact-form` module: `projects/plugins/jetpack/modules/contact-form.php`.
- It is marked **`Auto Activate: Yes`** and **`Requires Connection: No`**, so it *should* be eligible for default activation even when a site never connects or is running at `localhost` for a developer.
- Previously, **default module activation only ran when `Jetpack::is_connection_ready()` was true**, because `Jetpack::plugin_initialize()` gated `handle_default_module_activation()` behind that check.
- Result: on sites that **install Jetpack but remain unconnected**, “default” modules (including Forms) were **not activated**, even if they don’t require a connection.

## The fix

- **Run `handle_default_module_activation()` unconditionally** from `Jetpack::plugin_initialize()`.
- When Jetpack is **not connection-ready**, restrict the activation pass to:
  - modules with **`Requires Connection: No`**, and
  - modules with **`Requires User Connection: No`**,
  - while still respecting **`Auto Activate: Yes`** via the existing default-module logic.

In code terms, the unconnected branch now calls:

- `activate_default_modules( ..., $requires_connection = false, $requires_user_connection = false )`

So **unconnected installs will auto-activate only “offline-safe” default modules**, including `contact-form` (Forms).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Ref p1778046076516749-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 