### PR TITLE
Search 3.0: hide the Off row of the feature-selector on WordPress.com (RSM-2400)

### DIFF
--- a/projects/packages/search/changelog/rsm-2400-feature-selector-hide-off-on-wpcom
+++ b/projects/packages/search/changelog/rsm-2400-feature-selector-hide-off-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search dashboard: hide the Off row of the new feature-selector on WordPress.com, matching the legacy module control's behaviour.

--- a/projects/packages/search/src/dashboard/components/feature-selector/index.jsx
+++ b/projects/packages/search/src/dashboard/components/feature-selector/index.jsx
@@ -2,7 +2,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack } from '@wordpress/ui';
 import { STORE_ID } from 'store';
-import { EXPERIENCE_ORDER } from './constants';
+import { EXPERIENCE, EXPERIENCE_ORDER } from './constants';
 import ExperienceOption from './experience-option';
 import './style.scss';
 
@@ -25,7 +25,15 @@ export default function FeatureSelector() {
 		select => select( STORE_ID ).supportsOnlyClassicSearch(),
 		[]
 	);
+	// On WordPress.com, search activation is managed from the .com side, so we
+	// hide the Off row here to mirror the legacy `<ModuleControl>`'s
+	// `! isWpcom` gate around the "Enable Jetpack Search" toggle.
+	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 	const { saveExperience } = useDispatch( STORE_ID );
+
+	const visibleExperiences = isWpcom
+		? EXPERIENCE_ORDER.filter( experience => experience !== EXPERIENCE.OFF )
+		: EXPERIENCE_ORDER;
 
 	const isExperienceDisabled = experience =>
 		supportsOnlyClassicSearch && ( experience === 'embedded' || experience === 'overlay' );
@@ -51,7 +59,7 @@ export default function FeatureSelector() {
 					aria-labelledby="jp-search-feature-selector-heading"
 				>
 					<Stack direction="column" gap="sm">
-						{ EXPERIENCE_ORDER.map( experience => (
+						{ visibleExperiences.map( experience => (
 							<ExperienceOption
 								key={ experience }
 								experience={ experience }

--- a/projects/packages/search/src/dashboard/components/feature-selector/index.jsx
+++ b/projects/packages/search/src/dashboard/components/feature-selector/index.jsx
@@ -18,17 +18,20 @@ import './style.scss';
  * @return {import('react').Element} - The selector.
  */
 export default function FeatureSelector() {
-	const isDirty = useSelect( select => select( STORE_ID ).isDirty(), [] );
-	const isUpdating = useSelect( select => select( STORE_ID ).isUpdatingJetpackSettings(), [] );
-	const pendingExperience = useSelect( select => select( STORE_ID ).getPendingExperience(), [] );
-	const supportsOnlyClassicSearch = useSelect(
-		select => select( STORE_ID ).supportsOnlyClassicSearch(),
+	// On WordPress.com Simple sites (where `IS_WPCOM` is defined), search
+	// activation is managed from the .com side, so we hide the Off row here to
+	// mirror the legacy `<ModuleControl>`'s `! isWpcom` gate around the
+	// "Enable Jetpack Search" toggle.
+	const { isDirty, isUpdating, pendingExperience, supportsOnlyClassicSearch, isWpcom } = useSelect(
+		select => ( {
+			isDirty: select( STORE_ID ).isDirty(),
+			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
+			pendingExperience: select( STORE_ID ).getPendingExperience(),
+			supportsOnlyClassicSearch: select( STORE_ID ).supportsOnlyClassicSearch(),
+			isWpcom: select( STORE_ID ).isWpcom(),
+		} ),
 		[]
 	);
-	// On WordPress.com, search activation is managed from the .com side, so we
-	// hide the Off row here to mirror the legacy `<ModuleControl>`'s
-	// `! isWpcom` gate around the "Enable Jetpack Search" toggle.
-	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 	const { saveExperience } = useDispatch( STORE_ID );
 
 	const visibleExperiences = isWpcom

--- a/projects/packages/search/tests/js/dashboard/feature-selector/index.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/feature-selector/index.test.jsx
@@ -113,6 +113,6 @@ describe( '<FeatureSelector>', () => {
 		expect( screen.getByRole( 'radio', { name: /embedded search/i } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'radio', { name: /overlay search/i } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'radio', { name: /theme search/i } ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'radio', { name: /^off$/i } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'radio', { name: /off/i } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/tests/js/dashboard/feature-selector/index.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/feature-selector/index.test.jsx
@@ -91,4 +91,28 @@ describe( '<FeatureSelector>', () => {
 		expect( screen.getByRole( 'radio', { name: /theme search/i } ) ).toBeEnabled();
 		expect( screen.getByRole( 'radio', { name: /off/i } ) ).toBeEnabled();
 	} );
+
+	test( 'hides the Off row on WordPress.com (parity with legacy ModuleControl)', () => {
+		const registry = createRegistry();
+		const store = createReduxStore( STORE_ID, {
+			...storeConfig,
+			initialState: {
+				...( storeConfig.initialState || {} ),
+				jetpackSettings: baseSettings,
+				siteData: { isWpcom: true },
+			},
+		} );
+		registry.register( store );
+		render(
+			<RegistryProvider value={ registry }>
+				<FeatureSelector />
+			</RegistryProvider>
+		);
+		const radios = screen.getAllByRole( 'radio' );
+		expect( radios ).toHaveLength( 3 );
+		expect( screen.getByRole( 'radio', { name: /embedded search/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: /overlay search/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: /theme search/i } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'radio', { name: /^off$/i } ) ).not.toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
Fixes [RSM-2400](https://linear.app/a8c/issue/RSM-2400/search-dashboard-feature-selector-hide-the-off-row-on-wordpresscom)

## Why

WordPress.com admins on the Search dashboard manage Search activation through the .com side, so the legacy `<ModuleControl>` deliberately hides its "Enable Jetpack Search" toggle on .com. The new feature-selector (shipped behind `jetpack_search_blocks_enabled` in #48500) was rendering all four rows regardless of platform, which would let a .com admin pick Off, hit Save, and trigger `Modules::deactivate( 'search' )` — the exact action the legacy UI hides. This PR brings the new selector to platform parity.

## Proposed changes

* `<FeatureSelector>` now reads the existing `isWpcom` selector (seeded from `Helper::is_wpcom()` in `class-initial-state.php`) and filters `EXPERIENCE_ORDER` to drop `EXPERIENCE.OFF` when true. The remaining rows (Embedded / Overlay / Theme search) render unchanged.
* New unit test `hides the Off row on WordPress.com (parity with legacy ModuleControl)` seeds `siteData: { isWpcom: true }` and asserts the Off radio is absent while the other three are present.
* Inline comment in the source documents the parity decision so a future reader doesn't accidentally re-introduce the row.

## Related product discussion/links

* RSM-2400
* Companion / parent: #48500 (RSM-2116, the feature-selector itself, already merged), #48540 (RSM-2291, back-end persistence)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The whole feature-selector is gated behind `jetpack_search_blocks_enabled`, so set that on a test site to see the new UI. The legacy `<ModuleControl>` continues to render alongside the new selector, so admins on .com retain the instant-search-vs-classic toggle that ModuleControl already shows unconditionally.

### Automated

```
cd projects/packages/search
pnpm jest tests/js/dashboard/feature-selector/
```

Expected: 17 tests pass across 2 suites.

### Manual

1. On a self-hosted Jetpack site, open **WP Admin → Jetpack → Search** with the filter `jetpack_search_blocks_enabled` returning `true`.
2. Confirm all four radio rows render (Embedded, Overlay, Theme search, Off) — baseline.
3. On a WordPress.com Simple site (or a site where `Helper::is_wpcom()` returns true), open the same dashboard.
4. Confirm only three rows render (Embedded, Overlay, Theme search). The Off row is not present.
5. Confirm the heading, Save button, and remaining-row interactions still work as before.
6. Below the new selector, the legacy `<ModuleControl>` continues to render its instant-search toggle on .com (its own module-active toggle remains hidden, same as before this PR).
