### PR TITLE
Podcast: page chrome + empty tabs in dashboard route (3/4)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3579,6 +3579,19 @@ importers:
         version: 6.0.1(webpack@5.105.2)
 
   projects/packages/podcast:
+    dependencies:
+      '@wordpress/components':
+        specifier: 32.6.0
+        version: 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element':
+        specifier: 6.44.0
+        version: 6.44.0
+      '@wordpress/i18n':
+        specifier: 6.17.0
+        version: 6.17.0
+      '@wordpress/ui':
+        specifier: 0.11.0
+        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@automattic/jetpack-wp-build-polyfills':
         specifier: workspace:*
@@ -3598,12 +3611,6 @@ importers:
       '@wordpress/build':
         specifier: 0.13.0
         version: 0.13.0(@babel/core@7.29.0)(browserslist@4.28.2)
-      '@wordpress/element':
-        specifier: 6.44.0
-        version: 6.44.0
-      '@wordpress/i18n':
-        specifier: 6.17.0
-        version: 6.17.0
       browserslist:
         specifier: ^4.24.0
         version: 4.28.2
@@ -19432,6 +19439,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
+    optional: true
 
   '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -19444,6 +19452,21 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
+    optional: true
+
+  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@date-fns/tz': 1.4.1
+      '@types/react': 18.3.28
+      date-fns: 4.1.0
 
   '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -19468,6 +19491,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
+    optional: true
 
   '@base-ui/utils@0.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -19477,6 +19501,18 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       reselect: 5.1.1
       use-sync-external-store: 1.6.0(react@18.3.1)
+    optional: true
+
+  '@base-ui/utils@0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
 
   '@base-ui/utils@0.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24202,7 +24238,7 @@ snapshots:
       '@wordpress/base-styles': 6.20.0
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/date': 5.44.0
-      '@wordpress/deprecated': 4.44.0
+      '@wordpress/deprecated': 4.45.0
       '@wordpress/dom': 4.44.0
       '@wordpress/element': 6.44.0
       '@wordpress/escape-html': 3.44.0
@@ -24210,7 +24246,7 @@ snapshots:
       '@wordpress/html-entities': 4.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/icons': 12.2.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.44.0
+      '@wordpress/is-shallow-equal': 5.45.0
       '@wordpress/keycodes': 4.44.0
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
@@ -25916,7 +25952,7 @@ snapshots:
 
   '@wordpress/ui@0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/tz': 1.4.1
       '@wordpress/a11y': 4.44.0
       '@wordpress/compose': 7.44.0(react@18.3.1)
@@ -25938,7 +25974,7 @@ snapshots:
 
   '@wordpress/ui@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/tz': 1.4.1
       '@wordpress/a11y': 4.44.0
       '@wordpress/compose': 7.44.0(react@18.3.1)

--- a/projects/packages/podcast/changelog/add-admin-tabs-scaffold
+++ b/projects/packages/podcast/changelog/add-admin-tabs-scaffold
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace the wp-build placeholder with page chrome (title, tagline) plus tab navigation (Welcome, Settings, Episodes, Distribution). Each tab panel is still empty — PR 4 in the untangle train fills them in.

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -26,6 +26,12 @@
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
 	],
+	"dependencies": {
+		"@wordpress/components": "32.6.0",
+		"@wordpress/element": "6.44.0",
+		"@wordpress/i18n": "6.17.0",
+		"@wordpress/ui": "0.11.0"
+	},
 	"devDependencies": {
 		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.0",
@@ -33,8 +39,6 @@
 		"@types/react": "18.3.28",
 		"@wordpress/browserslist-config": "6.44.0",
 		"@wordpress/build": "0.13.0",
-		"@wordpress/element": "6.44.0",
-		"@wordpress/i18n": "6.17.0",
 		"browserslist": "^4.24.0"
 	},
 	"optionalDependencies": {

--- a/projects/packages/podcast/routes/dashboard/package.json
+++ b/projects/packages/podcast/routes/dashboard/package.json
@@ -4,8 +4,10 @@
 	"private": true,
 	"dependencies": {
 		"@types/react": "18.3.28",
+		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
-		"@wordpress/i18n": "6.17.0"
+		"@wordpress/i18n": "6.17.0",
+		"@wordpress/ui": "0.11.0"
 	},
 	"route": {
 		"path": "/",

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -27,7 +27,6 @@ const Stage = () => {
 
 	return (
 		<div className="wrap">
-			{ /* "Podcast" is a product name, do not translate. */ }
 			<h1>Podcast</h1>
 			<p>
 				{ __( 'Publish a podcast and reach your fans, anywhere they listen.', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -10,14 +10,14 @@ import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
 
-const TAB_VALUES = [ 'welcome', 'settings', 'episodes', 'distribution' ] as const;
+const TAB_VALUES = [ 'settings', 'episodes', 'distribution', 'stats' ] as const;
 type TabName = ( typeof TAB_VALUES )[ number ];
 
 const isValidTab = ( value: string | null ): value is TabName =>
 	!! value && ( TAB_VALUES as readonly string[] ).includes( value );
 
 const Stage = () => {
-	const [ activeTab, setActiveTab ] = useState< TabName >( 'welcome' );
+	const [ activeTab, setActiveTab ] = useState< TabName >( 'settings' );
 
 	const handleTabChange = useCallback( ( value: string | null ) => {
 		if ( isValidTab( value ) ) {
@@ -30,22 +30,16 @@ const Stage = () => {
 			{ /* "Podcast" is a product name, do not translate. */ }
 			<h1>Podcast</h1>
 			<p>
-				{ __(
-					'Publish a podcast and reach your fans, anywhere they listen.',
-					'jetpack-podcast'
-				) }
+				{ __( 'Publish a podcast and reach your fans, anywhere they listen.', 'jetpack-podcast' ) }
 			</p>
 
 			<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
 				<Tabs.List>
-					<Tabs.Tab value="welcome">{ __( 'Welcome', 'jetpack-podcast' ) }</Tabs.Tab>
 					<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
 					<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
 					<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
+					<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
 				</Tabs.List>
-				<Tabs.Panel value="welcome">
-					<p>{ __( 'Welcome — placeholder.', 'jetpack-podcast' ) }</p>
-				</Tabs.Panel>
 				<Tabs.Panel value="settings">
 					<p>{ __( 'Settings — placeholder.', 'jetpack-podcast' ) }</p>
 				</Tabs.Panel>
@@ -54,6 +48,9 @@ const Stage = () => {
 				</Tabs.Panel>
 				<Tabs.Panel value="distribution">
 					<p>{ __( 'Distribution — placeholder.', 'jetpack-podcast' ) }</p>
+				</Tabs.Panel>
+				<Tabs.Panel value="stats">
+					<p>{ __( 'Stats — placeholder.', 'jetpack-podcast' ) }</p>
 				</Tabs.Panel>
 			</Tabs.Root>
 		</div>

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -1,6 +1,63 @@
+/**
+ * Podcast dashboard stage: page chrome + tab navigation.
+ *
+ * Placeholder scaffolding only — each tab panel renders a stub. PR 4 in the
+ * untangle train wires the full AdminPage + jetpack-components integration
+ * along with the real tab contents.
+ */
+
+import { useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Tabs } from '@wordpress/ui';
+
+const TAB_VALUES = [ 'welcome', 'settings', 'episodes', 'distribution' ] as const;
+type TabName = ( typeof TAB_VALUES )[ number ];
+
+const isValidTab = ( value: string | null ): value is TabName =>
+	!! value && ( TAB_VALUES as readonly string[] ).includes( value );
+
 const Stage = () => {
-	// "Podcast" is a product name, do not translate.
-	return <h1>Podcast</h1>;
+	const [ activeTab, setActiveTab ] = useState< TabName >( 'welcome' );
+
+	const handleTabChange = useCallback( ( value: string | null ) => {
+		if ( isValidTab( value ) ) {
+			setActiveTab( value );
+		}
+	}, [] );
+
+	return (
+		<div className="wrap">
+			{ /* "Podcast" is a product name, do not translate. */ }
+			<h1>Podcast</h1>
+			<p>
+				{ __(
+					'Publish a podcast and reach your fans, anywhere they listen.',
+					'jetpack-podcast'
+				) }
+			</p>
+
+			<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
+				<Tabs.List>
+					<Tabs.Tab value="welcome">{ __( 'Welcome', 'jetpack-podcast' ) }</Tabs.Tab>
+					<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
+					<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
+					<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
+				</Tabs.List>
+				<Tabs.Panel value="welcome">
+					<p>{ __( 'Welcome — placeholder.', 'jetpack-podcast' ) }</p>
+				</Tabs.Panel>
+				<Tabs.Panel value="settings">
+					<p>{ __( 'Settings — placeholder.', 'jetpack-podcast' ) }</p>
+				</Tabs.Panel>
+				<Tabs.Panel value="episodes">
+					<p>{ __( 'Episodes — placeholder.', 'jetpack-podcast' ) }</p>
+				</Tabs.Panel>
+				<Tabs.Panel value="distribution">
+					<p>{ __( 'Distribution — placeholder.', 'jetpack-podcast' ) }</p>
+				</Tabs.Panel>
+			</Tabs.Root>
+		</div>
+	);
 };
 
 export { Stage as stage };

--- a/projects/plugins/jetpack/changelog/add-podcast-admin-tabs-scaffold
+++ b/projects/plugins/jetpack/changelog/add-podcast-admin-tabs-scaffold
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Podcast: drop redundant late_initialization load — the package is loaded via jetpack-mu-wpcom on Simple/Atomic, and the host gate makes the Jetpack plugin call a no-op.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -32,7 +32,6 @@ use Automattic\Jetpack\Newsletter\Reader_Link;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Plugin\Deprecate;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
-use Automattic\Jetpack\Podcast\Podcast as Podcast_Init;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Scan_Page\Jetpack_Scan as Scan_Page_Init;
 use Automattic\Jetpack\Status;
@@ -874,7 +873,6 @@ class Jetpack {
 		My_Jetpack_Initializer::init();
 		Activity_Log_Init::initialize();
 		Scan_Page_Init::initialize();
-		Podcast_Init::init();
 
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-dashboard' );


### PR DESCRIPTION
*PR 3 of 4 in the Podcast untangle train*

<img width="1071" height="840" alt="Screenshot on 2026-05-06 at 11-41-13" src="https://github.com/user-attachments/assets/280e9d66-bec2-4be2-9c07-10af3058338b" />

## Proposed changes

Replaces the wp-build `<h1>Podcast</h1>` placeholder with page chrome (title, tagline) plus a four-tab navigation (Welcome, Settings, Episodes, Distribution) using `@wordpress/ui` `Tabs`. Each tab panel renders an empty placeholder. Still gated behind the `jetpack_podcast_untangle` filter (PR 1) — no behavior change for any user with the filter off.

The full `AdminPage` integration from `@automattic/jetpack-components\` (with footer, base-styles SCSS, etc.) lands together with the real tab contents in PR 4 — keeping that wiring out of the scaffold avoids dragging `number-formatters` / `base-styles` transitive deps through wp-build's bundler before they're needed.

Stacked on #48557. Upstream consolidation PR: #48499.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the filter `add_filter( 'jetpack_podcast_untangle', '__return_true' );`
2. Go to `/wp-admin` and make sure Podcast (not PodcastING) shows under Jetpack
3. Podcast should load a page with 4 tabs
4. Disable the filter and it should all go bye-bye