### PR TITLE
Search 3.0: gate the Jetpack Search template on the Embedded experience (RSM-2381)

### DIFF
--- a/projects/packages/search/changelog/rsm-2381-gate-search-template-on-embedded
+++ b/projects/packages/search/changelog/rsm-2381-gate-search-template-on-embedded
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search 3.0: only override the theme's search template when the saved experience is `embedded`. Sites on Overlay or Inline now resolve `/?s=…` through their theme's `search.html` again.
+Search 3.0: only override the theme's search template when the saved experience is `embedded`. Sites on Overlay or Inline now resolve `/?s=…` through their theme's `search.html` again. Block registration and Interactivity API state seeding stay on regardless of experience so Search blocks placed on other pages continue to work.

--- a/projects/packages/search/changelog/rsm-2381-gate-search-template-on-embedded
+++ b/projects/packages/search/changelog/rsm-2381-gate-search-template-on-embedded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: only override the theme's search template when the saved experience is `embedded`. Sites on Overlay or Inline now resolve `/?s=…` through their theme's `search.html` again.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -76,13 +76,39 @@ class Search_Blocks {
 	/**
 	 * Register block types and hook into WordPress.
 	 *
-	 * The caller (Initializer) is responsible for gating this behind the
-	 * `jetpack_search_blocks_enabled` feature flag.
+	 * Two gates apply:
+	 *
+	 * 1. The caller (Initializer) gates the whole method behind the
+	 *    `jetpack_search_blocks_enabled` feature flag — when off, the blocks
+	 *    don't exist at all.
+	 * 2. Within this method, the *template-takeover* surface (registering the
+	 *    Jetpack Search block template, prepending it to `search_template_hierarchy`,
+	 *    and seeding the Interactivity API state) is additionally gated on the
+	 *    saved experience being `'embedded'`. Block registration and editor
+	 *    assets always register so the blocks remain insertable in the editor
+	 *    regardless of which experience the site has saved.
+	 *
+	 * Why two gates: with four experiences (`embedded` / `overlay` / `inline` /
+	 * `off`), only Embedded should override the theme's `search.html`. A site
+	 * that saves Overlay or Inline still expects `/?s=…` to resolve through the
+	 * theme — the Jetpack template is the right answer only when the user has
+	 * explicitly opted into the block-built search page.
+	 *
+	 * `Module_Control::get_experience()` reads `get_option( 'jetpack_search_experience' )`
+	 * (object-cached) and falls back to deriving from the legacy booleans, so
+	 * this is cheap on every request. `update_experience()` writes the option
+	 * synchronously, so the next request after a save sees the new gate.
 	 */
 	public static function init() {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
-		add_action( 'init', array( static::class, 'register_search_template' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
+		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
+
+		if ( Module_Control::EXPERIENCE_EMBEDDED !== ( new Module_Control() )->get_experience() ) {
+			return;
+		}
+
+		add_action( 'init', array( static::class, 'register_search_template' ) );
 		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		// FSE block-template rendering runs *before* `wp_head()` (see
 		// `wp-includes/template-canvas.php`), so blocks would resolve
@@ -92,7 +118,6 @@ class Search_Blocks {
 		// deep-merge no-op and keeps classic-theme paths covered.
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
-		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -119,12 +119,10 @@ class Search_Blocks {
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 
-		if ( Module_Control::EXPERIENCE_EMBEDDED !== ( new Module_Control() )->get_experience() ) {
-			return;
+		if ( Module_Control::EXPERIENCE_EMBEDDED === ( new Module_Control() )->get_experience() ) {
+			add_action( 'init', array( static::class, 'register_search_template' ) );
+			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		}
-
-		add_action( 'init', array( static::class, 'register_search_template' ) );
-		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -81,18 +81,25 @@ class Search_Blocks {
 	 * 1. The caller (Initializer) gates the whole method behind the
 	 *    `jetpack_search_blocks_enabled` feature flag — when off, the blocks
 	 *    don't exist at all.
-	 * 2. Within this method, the *template-takeover* surface (registering the
-	 *    Jetpack Search block template, prepending it to `search_template_hierarchy`,
-	 *    and seeding the Interactivity API state) is additionally gated on the
-	 *    saved experience being `'embedded'`. Block registration and editor
-	 *    assets always register so the blocks remain insertable in the editor
-	 *    regardless of which experience the site has saved.
+	 * 2. Within this method, only the *template-takeover* surface (registering
+	 *    the Jetpack Search block template and prepending it to
+	 *    `search_template_hierarchy`) is additionally gated on the saved
+	 *    experience being `'embedded'`. Everything else — block registration,
+	 *    editor assets, and Interactivity API state seeding — runs whenever
+	 *    the feature flag is on, since admins can insert Search blocks
+	 *    anywhere blocks are configurable (post content, sidebar widgets,
+	 *    custom templates) regardless of which experience the dashboard has
+	 *    saved. Those blocks need the seeded base state (`apiRoot`, `nonce`,
+	 *    URL-derived `searchQuery` / `activeFilters`, `filterConfigs` slot,
+	 *    etc.) to hydrate; per-block `render.php` files only contribute their
+	 *    own config and rely on the global seed for the base.
 	 *
-	 * Why two gates: with four experiences (`embedded` / `overlay` / `inline` /
-	 * `off`), only Embedded should override the theme's `search.html`. A site
-	 * that saves Overlay or Inline still expects `/?s=…` to resolve through the
-	 * theme — the Jetpack template is the right answer only when the user has
-	 * explicitly opted into the block-built search page.
+	 * Why the template gate: with four experiences (`embedded` / `overlay` /
+	 * `inline` / `off`), only Embedded should override the theme's
+	 * `search.html`. A site that saves Overlay or Inline still expects
+	 * `/?s=…` to resolve through the theme — the Jetpack template is the
+	 * right answer only when the user has explicitly opted into the
+	 * block-built search page.
 	 *
 	 * `Module_Control::get_experience()` reads `get_option( 'jetpack_search_experience' )`
 	 * (object-cached) and falls back to deriving from the legacy booleans, so
@@ -103,13 +110,6 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
-
-		if ( Module_Control::EXPERIENCE_EMBEDDED !== ( new Module_Control() )->get_experience() ) {
-			return;
-		}
-
-		add_action( 'init', array( static::class, 'register_search_template' ) );
-		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		// FSE block-template rendering runs *before* `wp_head()` (see
 		// `wp-includes/template-canvas.php`), so blocks would resolve
 		// `data-wp-bind` / `data-wp-text` against an unseeded IA store if we
@@ -118,6 +118,13 @@ class Search_Blocks {
 		// deep-merge no-op and keeps classic-theme paths covered.
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
+
+		if ( Module_Control::EXPERIENCE_EMBEDDED !== ( new Module_Control() )->get_experience() ) {
+			return;
+		}
+
+		add_action( 'init', array( static::class, 'register_search_template' ) );
+		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -191,15 +191,17 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * `init()` must always register the block-level hooks (so blocks remain
-	 * insertable in the editor and the category appears in the inserter)
-	 * regardless of which experience the site has saved.
+	 * `init()` must always register the block-level hooks AND the IA state
+	 * seeding regardless of which experience the site has saved — admins can
+	 * insert Search blocks anywhere blocks are configurable, and those blocks
+	 * need the seeded base state to hydrate.
 	 */
-	public function test_init_always_registers_block_hooks() {
+	public function test_init_always_registers_block_and_seed_hooks() {
 		$this->reset_search_blocks_hooks();
 		$this->set_module_active( true );
 		// No experience opt-in saved — get_experience() falls back to 'inline'
 		// (or 'overlay' if instant_search_enabled is true). Either way, not embedded.
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 
 		Search_Blocks::init();
 
@@ -215,10 +217,19 @@ class Search_Blocks_Test extends TestCase {
 			has_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) ),
 			'enqueue_editor_assets must always hook into enqueue_block_editor_assets'
 		);
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
+			'seed_interactivity_state must always hook into template_redirect (blocks may be on any page)'
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
+			'seed_interactivity_state must always hook into wp_enqueue_scripts (blocks may be on any page)'
+		);
 	}
 
 	/**
-	 * Off the Embedded experience, the template-takeover hooks must NOT be
+	 * Off the Embedded experience, the template-takeover hooks
+	 * (`register_search_template` / `prepend_search_template`) must NOT be
 	 * registered — `/?s=…` should resolve to the theme's `search.html`, not
 	 * the Jetpack Search template.
 	 */
@@ -237,14 +248,6 @@ class Search_Blocks_Test extends TestCase {
 		$this->assertFalse(
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
 			'prepend_search_template must not hook into search_template_hierarchy when not embedded'
-		);
-		$this->assertFalse(
-			has_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
-			'seed_interactivity_state must not hook into template_redirect when not embedded'
-		);
-		$this->assertFalse(
-			has_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
-			'seed_interactivity_state must not hook into wp_enqueue_scripts when not embedded'
 		);
 	}
 
@@ -268,14 +271,6 @@ class Search_Blocks_Test extends TestCase {
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
 			'prepend_search_template must hook into search_template_hierarchy on embedded'
 		);
-		$this->assertNotFalse(
-			has_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
-			'seed_interactivity_state must hook into template_redirect on embedded'
-		);
-		$this->assertNotFalse(
-			has_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
-			'seed_interactivity_state must hook into wp_enqueue_scripts on embedded'
-		);
 
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
@@ -284,7 +279,8 @@ class Search_Blocks_Test extends TestCase {
 	 * If the module isn't active, the experience is `'off'` regardless of any
 	 * stale value in the experience option, so the template-takeover hooks
 	 * must not register. Guards against a leftover `'embedded'` value on a
-	 * site that's been deactivated.
+	 * site that's been deactivated. The block-level and seed hooks still
+	 * register so any post-content Search block continues to hydrate.
 	 */
 	public function test_init_does_not_register_template_hooks_when_module_inactive() {
 		$this->reset_search_blocks_hooks();
@@ -298,6 +294,13 @@ class Search_Blocks_Test extends TestCase {
 		);
 		$this->assertFalse(
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) )
+		);
+		// Block + seed hooks still register, since blocks may be on any page.
+		$this->assertNotFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_blocks' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) )
 		);
 
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -191,6 +191,147 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * `init()` must always register the block-level hooks (so blocks remain
+	 * insertable in the editor and the category appears in the inserter)
+	 * regardless of which experience the site has saved.
+	 */
+	public function test_init_always_registers_block_hooks() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		// No experience opt-in saved — get_experience() falls back to 'inline'
+		// (or 'overlay' if instant_search_enabled is true). Either way, not embedded.
+
+		Search_Blocks::init();
+
+		$this->assertNotFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_blocks' ) ),
+			'register_blocks must always hook into init'
+		);
+		$this->assertNotFalse(
+			has_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) ),
+			'register_block_category must always hook into block_categories_all'
+		);
+		$this->assertNotFalse(
+			has_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) ),
+			'enqueue_editor_assets must always hook into enqueue_block_editor_assets'
+		);
+	}
+
+	/**
+	 * Off the Embedded experience, the template-takeover hooks must NOT be
+	 * registered — `/?s=…` should resolve to the theme's `search.html`, not
+	 * the Jetpack Search template.
+	 */
+	public function test_init_does_not_register_template_hooks_when_not_embedded() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		// Inline = no opt-in saved. Overlay and Off are likewise non-embedded.
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+
+		Search_Blocks::init();
+
+		$this->assertFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
+			'register_search_template must not hook into init when experience is not embedded'
+		);
+		$this->assertFalse(
+			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
+			'prepend_search_template must not hook into search_template_hierarchy when not embedded'
+		);
+		$this->assertFalse(
+			has_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
+			'seed_interactivity_state must not hook into template_redirect when not embedded'
+		);
+		$this->assertFalse(
+			has_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
+			'seed_interactivity_state must not hook into wp_enqueue_scripts when not embedded'
+		);
+	}
+
+	/**
+	 * On the Embedded experience, the template-takeover hooks must be
+	 * registered so `/?s=…` resolves to the Jetpack Search template instead
+	 * of the theme's `search.html`.
+	 */
+	public function test_init_registers_template_hooks_when_embedded() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		Search_Blocks::init();
+
+		$this->assertNotFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
+			'register_search_template must hook into init on embedded'
+		);
+		$this->assertNotFalse(
+			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
+			'prepend_search_template must hook into search_template_hierarchy on embedded'
+		);
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
+			'seed_interactivity_state must hook into template_redirect on embedded'
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) ),
+			'seed_interactivity_state must hook into wp_enqueue_scripts on embedded'
+		);
+
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * If the module isn't active, the experience is `'off'` regardless of any
+	 * stale value in the experience option, so the template-takeover hooks
+	 * must not register. Guards against a leftover `'embedded'` value on a
+	 * site that's been deactivated.
+	 */
+	public function test_init_does_not_register_template_hooks_when_module_inactive() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( false );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		Search_Blocks::init();
+
+		$this->assertFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) )
+		);
+		$this->assertFalse(
+			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) )
+		);
+
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * Remove every hook this class registers, so each `init()` test starts
+	 * from a known-empty state.
+	 */
+	private function reset_search_blocks_hooks(): void {
+		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
+		remove_action( 'init', array( Search_Blocks::class, 'register_search_template' ) );
+		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
+		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) );
+		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
+		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
+		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
+	}
+
+	/**
+	 * Toggle whether the Search module reads as active by writing the
+	 * `jetpack_active_modules` option directly.
+	 *
+	 * @param bool $active True to add `'search'` to the option, false to remove it.
+	 */
+	private function set_module_active( bool $active ): void {
+		if ( $active ) {
+			update_option( 'jetpack_active_modules', array( 'search' ) );
+		} else {
+			update_option( 'jetpack_active_modules', array() );
+		}
+	}
+
+	/**
 	 * `register_search_template()` must push the template into
 	 * WP_Block_Templates_Registry (so it shows up in the Site Editor's
 	 * Templates list) and the stored content must reference the Jetpack


### PR DESCRIPTION
Fixes [RSM-2381](https://linear.app/a8c/issue/RSM-2381/search-30-gate-the-jetpack-search-template-on-the-embedded-experience)

## Why

Sites that use the new feature-selector to choose Overlay or Inline (Theme search) still expect `/?s=…` to resolve through their theme's `search.html`. Today, behind the `jetpack_search_blocks_enabled` filter, the Jetpack Search block template is registered and prepended to `search_template_hierarchy` unconditionally, so its slug always wins resolution and the theme's template is never consulted — regardless of which experience the admin actually saved. After this PR, the template-takeover only happens when the saved experience is `'embedded'`; everywhere else, the theme template renders again. Search blocks placed elsewhere (post content, sidebar widgets, custom templates) keep working on every experience, since block registration and Interactivity API state seeding stay on regardless.

## Proposed changes

* `Search_Blocks::init()` now splits its hooks into two groups:
  * **Always** when the feature flag is on:
    * `register_blocks` on `init`
    * `register_block_category` on `block_categories_all`
    * `enqueue_editor_assets` on `enqueue_block_editor_assets`
    * `seed_interactivity_state` on `template_redirect` *and* `wp_enqueue_scripts`
  * **Embedded-only:**
    * `register_search_template` on `init`
    * `prepend_search_template` on `search_template_hierarchy`
* The block-level and IA-seeding hooks stay on regardless of experience because admins can insert Search blocks anywhere blocks are configurable. Those blocks need the seeded base state — `apiRoot`, `nonce`, URL-derived `searchQuery` / `activeFilters` / `sortOrder`, the `filterConfigs: {}` slot, locale — to hydrate. Per-block `render.php` files only contribute their own config (e.g. a filter-checkbox block's filterConfig entry) and rely on the global seed for the base.
* The gate reads `Module_Control::get_experience()`, which consults `get_option( 'jetpack_search_experience' )` with a legacy-boolean fallback. The option is object-cached and `update_experience()` writes synchronously, so the next request after a save sees the new gate — no cache-bust needed.
* Tests for the four gate states:
  * `test_init_always_registers_block_and_seed_hooks` — block-level + IA-seeding hooks present regardless of experience.
  * `test_init_does_not_register_template_hooks_when_not_embedded` — template-takeover hooks absent off Embedded (option absent → falls back to inline).
  * `test_init_registers_template_hooks_when_embedded` — template-takeover hooks present when `EXPERIENCE_EMBEDDED` is saved.
  * `test_init_does_not_register_template_hooks_when_module_inactive` — even a stale `'embedded'` value is overridden by `is_active() === false`; block-level and seed hooks still register so any post-content block keeps working.

## Related product discussion/links

* RSM-2381
* #48540 (RSM-2291) — backend support for the `experience` field (merged to trunk)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Set up a test site with the feature flag on:

```
add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
```

### Automated

```
cd projects/packages/search
composer phpunit -- --filter Search_Blocks_Test
```

Expected: 23 tests pass (4 new gate-behaviour tests).

### Manual: template-takeover gate

1. Activate the Search module and save **Inline (Theme search)** via the new feature-selector.
2. Visit `/?s=anything` and confirm the page is rendered by the theme's `search.html` (or `index.html` fallback) — not the Jetpack Search template. The `<body>` class should be the theme's normal search-results class, no Jetpack Search blocks visible.
3. Save **Overlay** and repeat — same expectation: theme renders, no Jetpack template takeover. (Overlay search is provided by the existing instant-search modal, not the block template, so this is correct.)
4. Save **Embedded** and visit `/?s=anything` again. The page should now render the Jetpack Search template (results panel, filter blocks).
5. Site Editor → Templates: the "Jetpack Search Results" template should be listed when Embedded is active. Customize it (change the heading text). Switch to Inline → reload `/?s=…` (theme template renders, customizations dormant). Switch back to Embedded → the customized template re-resolves with the changes intact.
6. Save **Off** and confirm `/?s=…` falls back to the theme — same as Inline/Overlay.

### Manual: blocks-anywhere parity (regardless of experience)

These steps verify that Search blocks placed off the Jetpack template still hydrate on every experience. The IA state seed is what makes this work — without it, blocks dropped into a post / sidebar / custom template would be missing `apiRoot`, `nonce`, URL-derived state, and the `filterConfigs` slot.

7. Open the block inserter in any post or page (any experience). Confirm the "Jetpack Search" category and its blocks (search input, results panel, filter blocks, etc.) are still listed and insertable. They render correctly in the editor preview.
8. Insert a `jetpack/search-input` block plus a `jetpack/filter-checkbox` (or any filter block) into a post's content. Save and view the post on the front end.
9. With each non-Embedded experience saved (Inline, Overlay, Off), submit a query through the inline search input on that post. Confirm:
   * The block hydrates (no console errors, results panel updates).
   * URL-derived state works: open the post directly with `?q=test` (or `?s=test` if `is_search()`) and confirm the input is pre-populated and the filter UI reflects any active filters in the URL.
   * REST calls succeed (the block can reach `apiRoot` with the seeded `nonce`).
10. With Embedded saved, repeat step 9 — same expected behaviour. Confirms there's no regression for the experience the global seed has always covered.

### Network / cache sanity

11. Toggle `jetpack_search_blocks_enabled` off. Confirm `Search_Blocks::init()` is not called and none of its hooks register (theme `search.html` resolves at `/?s=…`, no Jetpack blocks in the inserter).
12. Switch the saved experience between Embedded and Inline a few times. The next request should reflect the new gate immediately — no manual cache flush.