### PR TITLE
Social: per-connection message template editor (SOCIAL-451)

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/connection-info.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-info.tsx
@@ -10,6 +10,7 @@ import ConnectionIcon from '../connection-icon';
 import { XNotice } from '../services/x-notice';
 import { ConnectionName } from './connection-name';
 import { ConnectionStatus, ConnectionStatusProps } from './connection-status';
+import { ConnectionTemplateEditor } from './connection-template';
 import { Disconnect } from './disconnect';
 import { MarkAsShared } from './mark-as-shared';
 import styles from './style.module.scss';
@@ -74,6 +75,9 @@ export function ConnectionInfo( { connection, service, canMarkAsShared }: Connec
 							</IconTooltip>
 						</div>
 					) }
+					<div className={ styles[ 'connection-template-wrap' ] }>
+						<ConnectionTemplateEditor connection={ connection } />
+					</div>
 					{ canManageConnection ? (
 						<Disconnect connection={ connection } />
 					) : (

--- a/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
@@ -1,0 +1,102 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { useDebounce } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as socialStore } from '../../../social-store';
+import { Connection } from '../../../social-store/types';
+import { features } from '../../../utils/constants';
+import { MessageTemplateEditor } from '../../message-template-editor';
+import styles from './style.module.scss';
+
+type ConnectionTemplateEditorProps = {
+	connection: Connection;
+};
+
+const SAVE_DEBOUNCE_MS = 1000;
+
+const PLACEHOLDER_TEXT = __(
+	'Leave empty to use the default share message.',
+	'jetpack-publicize-pkg'
+);
+
+const HELP_TEXT = __(
+	'Posts shared to this account will use this template instead of the default.',
+	'jetpack-publicize-pkg'
+);
+
+/**
+ * Per-connection message template editor.
+ *
+ * Renders only when the site has the `social-message-templates` feature
+ * AND the `social-enhanced-publishing` paid plan, AND the user can manage
+ * the connection. Auto-saves through `updateConnectionById` after the user
+ * pauses typing.
+ *
+ * @param {ConnectionTemplateEditorProps} props - The component's props.
+ * @return The rendered editor, or `null` when gated out.
+ */
+export function ConnectionTemplateEditor( props: ConnectionTemplateEditorProps ) {
+	const { connection } = props;
+
+	const featureEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const planEnabled = siteHasFeature( features.ENHANCED_PUBLISHING );
+
+	const canManageConnection = useSelect(
+		select => select( socialStore ).canUserManageConnection( connection ),
+		[ connection ]
+	);
+
+	const savedTemplate = connection.template ?? '';
+
+	const [ draft, setDraft ] = useState( savedTemplate );
+
+	// Track the last value we sent so we can skip the useEffect re-sync when
+	// the saved value comes back equal to what our own save just persisted —
+	// otherwise a slow save can race with a still-typing user and clobber
+	// their edits.
+	const lastSentRef = useRef( savedTemplate );
+
+	useEffect( () => {
+		if ( savedTemplate !== lastSentRef.current ) {
+			setDraft( savedTemplate );
+		}
+	}, [ savedTemplate ] );
+
+	const { updateConnectionById } = useDispatch( socialStore );
+
+	const persist = useCallback(
+		( value: string ) => {
+			lastSentRef.current = value;
+			updateConnectionById( connection.connection_id, { template: value } );
+		},
+		[ connection.connection_id, updateConnectionById ]
+	);
+
+	const debouncedSave = useDebounce( persist, SAVE_DEBOUNCE_MS );
+
+	const handleChange = useCallback(
+		( value: string ) => {
+			setDraft( value );
+			debouncedSave( value );
+		},
+		[ debouncedSave ]
+	);
+
+	if ( ! featureEnabled || ! planEnabled || ! canManageConnection ) {
+		return null;
+	}
+
+	return (
+		<div className={ styles.editor }>
+			<MessageTemplateEditor
+				label={ __( 'Custom message for this connection', 'jetpack-publicize-pkg' ) }
+				placeholder={ PLACEHOLDER_TEXT }
+				helpText={ HELP_TEXT }
+				value={ draft }
+				onChange={ handleChange }
+				rows={ 3 }
+			/>
+		</div>
+	);
+}

--- a/projects/packages/publicize/_inc/components/connection-management/connection-template/style.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-template/style.module.scss
@@ -1,0 +1,3 @@
+.editor {
+	width: 100%;
+}

--- a/projects/packages/publicize/_inc/components/connection-management/style.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-management/style.module.scss
@@ -59,6 +59,14 @@
 	margin-bottom: 1rem;
 }
 
+.connection-template-wrap {
+	margin-bottom: 1.5rem;
+
+	&:empty {
+		margin-bottom: 0;
+	}
+}
+
 .connection-panel.connection-panel {
 	border: 0;
 	margin-left: 3rem;

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { setup } from '../../../../utils/test-factory';
+import { clearMockedScriptData, mockScriptData } from '../../../../utils/test-utils';
+import { ConnectionTemplateEditor } from '../../connection-template';
+
+const FB = {
+	service_name: 'facebook',
+	connection_id: '2',
+	display_name: 'Facebook',
+	template: '',
+};
+
+const setupFeatures = ( ...active ) => {
+	mockScriptData( {
+		site: { plan: { features: { active } } },
+	} );
+};
+
+describe( 'ConnectionTemplateEditor', () => {
+	afterEach( () => {
+		clearMockedScriptData();
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the editor when both message-templates and enhanced-publishing are on', () => {
+		setupFeatures( 'social-message-templates', 'social-enhanced-publishing' );
+		setup();
+
+		render( <ConnectionTemplateEditor connection={ FB } /> );
+
+		expect(
+			screen.getByRole( 'textbox', { name: /Custom message for this connection/i } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders nothing when the message-templates feature is off', () => {
+		setupFeatures( 'social-enhanced-publishing' );
+		setup();
+
+		const { container } = render( <ConnectionTemplateEditor connection={ FB } /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing when the enhanced-publishing plan is off', () => {
+		setupFeatures( 'social-message-templates' );
+		setup();
+
+		const { container } = render( <ConnectionTemplateEditor connection={ FB } /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing when the user cannot manage the connection', () => {
+		setupFeatures( 'social-message-templates', 'social-enhanced-publishing' );
+		setup( { canUserManageConnection: false } );
+
+		const { container } = render( <ConnectionTemplateEditor connection={ FB } /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/services/service-connection-info.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-connection-info.tsx
@@ -6,6 +6,7 @@ import { Connection } from '../../social-store/types';
 import ConnectionIcon from '../connection-icon';
 import { ConnectionName } from '../connection-management/connection-name';
 import { ConnectionStatus } from '../connection-management/connection-status';
+import { ConnectionTemplateEditor } from '../connection-management/connection-template';
 import { Disconnect } from '../connection-management/disconnect';
 import { MarkAsShared } from '../connection-management/mark-as-shared';
 import styles from './style.module.scss';
@@ -28,65 +29,68 @@ export const ServiceConnectionInfo = ( {
 	);
 
 	return (
-		<div className={ styles[ 'service-connection' ] }>
-			<div>
-				<ConnectionIcon
-					className={ styles[ 'profile-pic' ] }
-					profilePicture={ connection.profile_picture }
-					label={ connection.display_name }
-				/>
-			</div>
-			<div className={ styles[ 'connection-details' ] }>
-				<ConnectionName connection={ connection } />
-				{ ( conn => {
-					/**
-					 * Showing only the connection status makes sense only
-					 * if the user can disconnect the connection.
-					 * Otherwise, non-admin authors will see only the status without any further context.
-					 */
-					if (
-						( conn.status === 'broken' || conn.status === 'must_reauth' ) &&
-						canManageConnection
-					) {
-						return <ConnectionStatus connection={ conn } service={ service } />;
-					}
+		<div className={ styles[ 'service-connection-wrapper' ] }>
+			<div className={ styles[ 'service-connection' ] }>
+				<div>
+					<ConnectionIcon
+						className={ styles[ 'profile-pic' ] }
+						profilePicture={ connection.profile_picture }
+						label={ connection.display_name }
+					/>
+				</div>
+				<div className={ styles[ 'connection-details' ] }>
+					<ConnectionName connection={ connection } />
+					{ ( conn => {
+						/**
+						 * Showing only the connection status makes sense only
+						 * if the user can disconnect the connection.
+						 * Otherwise, non-admin authors will see only the status without any further context.
+						 */
+						if (
+							( conn.status === 'broken' || conn.status === 'must_reauth' ) &&
+							canManageConnection
+						) {
+							return <ConnectionStatus connection={ conn } service={ service } />;
+						}
 
-					if ( canMarkAsShared ) {
-						return (
-							<div className={ styles[ 'mark-shared-wrap' ] }>
-								<MarkAsShared connection={ conn } />
-								<IconTooltip placement="top" inline={ false } shift>
+						if ( canMarkAsShared ) {
+							return (
+								<div className={ styles[ 'mark-shared-wrap' ] }>
+									<MarkAsShared connection={ conn } />
+									<IconTooltip placement="top" inline={ false } shift>
+										{ __(
+											'If enabled, the connection will be available to all administrators, editors, and authors.',
+											'jetpack-publicize-pkg'
+										) }
+									</IconTooltip>
+								</div>
+							);
+						}
+
+						/**
+						 * Now if the user is not an admin, we tell them that the connection
+						 * was added by an admin and show the connection status if it's broken.
+						 */
+						return ! canManageConnection ? (
+							<>
+								<Text className={ styles.description }>
 									{ __(
-										'If enabled, the connection will be available to all administrators, editors, and authors.',
+										'This connection is added by a site administrator.',
 										'jetpack-publicize-pkg'
 									) }
-								</IconTooltip>
-							</div>
-						);
-					}
-
-					/**
-					 * Now if the user is not an admin, we tell them that the connection
-					 * was added by an admin and show the connection status if it's broken.
-					 */
-					return ! canManageConnection ? (
-						<>
-							<Text className={ styles.description }>
-								{ __(
-									'This connection is added by a site administrator.',
-									'jetpack-publicize-pkg'
-								) }
-							</Text>
-							{ conn.status === 'broken' ? (
-								<ConnectionStatus connection={ conn } service={ service } />
-							) : null }
-						</>
-					) : null;
-				} )( connection ) }
+								</Text>
+								{ conn.status === 'broken' ? (
+									<ConnectionStatus connection={ conn } service={ service } />
+								) : null }
+							</>
+						) : null;
+					} )( connection ) }
+				</div>
+				<div className={ styles[ 'connection-actions' ] }>
+					<Disconnect connection={ connection } variant="minimal" />
+				</div>
 			</div>
-			<div className={ styles[ 'connection-actions' ] }>
-				<Disconnect connection={ connection } variant="minimal" />
-			</div>
+			<ConnectionTemplateEditor connection={ connection } />
 		</div>
 	);
 };

--- a/projects/packages/publicize/_inc/components/services/style.module.scss
+++ b/projects/packages/publicize/_inc/components/services/style.module.scss
@@ -137,6 +137,12 @@
 	}
 }
 
+.service-connection-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
 .service-connection {
 	display: flex;
 	gap: 1rem;

--- a/projects/packages/publicize/_inc/components/services/tests/service-connection-info.test.js
+++ b/projects/packages/publicize/_inc/components/services/tests/service-connection-info.test.js
@@ -8,6 +8,9 @@ jest.mock( '../../connection-management/connection-name', () => ( {
 jest.mock( '../../connection-management/connection-status', () => ( {
 	ConnectionStatus: ( { connection } ) => <div>Status: { connection.status }</div>,
 } ) );
+jest.mock( '../../connection-management/connection-template', () => ( {
+	ConnectionTemplateEditor: () => null,
+} ) );
 jest.mock( '../../connection-management/disconnect', () => ( {
 	Disconnect: ( { connection } ) => <button>Disconnect { connection.display_name }</button>,
 } ) );

--- a/projects/packages/publicize/changelog/social-451-per-connection-template-editor
+++ b/projects/packages/publicize/changelog/social-451-per-connection-template-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: add a per-connection message template editor in the connections list and the connection-confirmation modal (SOCIAL-451).


### PR DESCRIPTION
Fixes SOCIAL-451

> [!NOTE]
> Stacked on top of #48560. Easier to review the deltas there: <https://github.com/Automattic/jetpack/compare/add/social-message-template-editors...add/social-451-per-connection-template-editor>

## Proposed changes

Surfaces the per-connection `template` field (server-side wiring landed in #48522) in two places on the Social admin page, both anchored under the row that exposes the **Disconnect** button so users find it where they already go to manage a connection:

* **Inline list** — inside each connection's collapsible panel on the Social admin page, below the "Mark the connection as shared" row and above Disconnect.
* **Manage Jetpack Social connections modal** — under each existing connection's row in the services list. Opens via "Connect an account" → expand a service → see the connection rows.

Both surfaces render the same new `ConnectionTemplateEditor`, which wraps the shared `MessageTemplateEditor` from #48560 and auto-saves through `updateConnectionById` after a 1s debounce. Both stay in sync for free since they read/write through the same `connection-data` store slice.

**Gating** (all three required):

* `social-message-templates` feature flag.
* `social-enhanced-publishing` paid plan.
* `canUserManageConnection` capability check.

If any one is missing, the editor is simply hidden — no read-only fallback in this iteration.

**Save behaviour** mirrors the polish that landed in the SOCIAL-450 PR after review:

* The textarea is *not* disabled while a save is in flight; the connections endpoint is "last write wins" so concurrent saves resolve fine without freezing the UI on each keystroke pause.
* A `lastSentRef` guards the `useEffect` re-sync so a slow save resolving while the user is still typing past the debounce window doesn't clobber their in-progress edits with the just-confirmed earlier value.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect a site that has both `social-message-templates` and `social-enhanced-publishing` features active.
* Go to **Jetpack → Social** (`/wp-admin/admin.php?page=jetpack-social`).
* **Inline test:**
  * Expand any connection's row by clicking the chevron on the right.
  * Confirm a "Custom message for this connection" textarea appears below "Mark the connection as shared" and above Disconnect.
  * Type a custom template; pause; a `POST /wp-json/wpcom/v2/publicize/connections/{id}` should fire with `{"template":"..."}` and return `201`.
  * Reload the page and re-expand — the saved value hydrates back into the textarea.
* **Modal test:**
  * Click "Connect an account".
  * Click the chevron next to a service that already has connections (e.g. Bluesky, Facebook).
  * Confirm the same editor renders below each existing connection's "Disconnect" row, with the same auto-save behaviour.
  * Edit the template in the modal; close the modal; expand the same connection in the inline list — value should be in sync without a reload.
* **Gate tests:**
  * Switch to a user without `edit_others_posts` (so `canUserManageConnection` is false for connections owned by others) — the editor should be hidden for those connections.
  * Drop the `social-enhanced-publishing` feature on the test site — the editor should disappear from both surfaces.
  * Drop `social-message-templates` — same.


<img width="998" height="384" alt="Screenshot 2026-05-06 at 2 50 47 PM" src="https://github.com/user-attachments/assets/01dd97ec-592e-4092-b9c7-36734ae3dd20" />
<br>
<img width="1029" height="546" alt="Screenshot 2026-05-06 at 2 50 37 PM" src="https://github.com/user-attachments/assets/81545b54-2ca7-4ead-8daa-33ae11de3227" />
