### PR TITLE
Plugin Conflicts Guardian: log blocked activations, blocked updates, and post-update rollbacks to logstash

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-blocked-activation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-blocked-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Plugin Conflicts Guardian: emit an `Activation blocked` logstash event when the activation guard refuses an activation, so we can measure how often the pre-flight check catches a real fatal in the wild.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-blocked-activation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-blocked-activation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Plugin Conflicts Guardian: emit an `Activation blocked` logstash event when the activation guard refuses an activation, so we can measure how often the pre-flight check catches a real fatal in the wild.
+Plugin Conflicts Guardian: emit logstash events when the guard refuses or recovers from a bad change — `Activation blocked` (refused activation), `Update blocked` (refused install/update with a parse error), and `Update rolled back` (post-update fatal triggered a rollback). All three share the `plugin-conflicts-guardian` feature bucket so the full PCG-block surface can be measured from one filter.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -144,30 +144,16 @@ function pcg_guard_evaluate_plugins( $plugins ) {
  * @return void
  */
 function pcg_guard_log_blocked_activation( array $checked, array $blocked, array $result ) {
-	if ( ! function_exists( 'log2logstash' ) ) {
-		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-		if ( ! is_readable( $log2logstash_path ) ) {
-			return;
-		}
-		require_once $log2logstash_path;
-	}
-
-	log2logstash(
+	pcg_log_event(
+		'Activation blocked',
 		array(
-			'feature' => 'plugin-conflicts-guardian',
-			'message' => 'Activation blocked',
-			'extra'   => wp_json_encode(
-				array(
-					'checked' => $checked,
-					'blocked' => array_keys( $blocked ),
-					'status'  => (string) ( $result['status'] ?? '' ),
-					// Basename only — absolute paths leak install layout.
-					'file'    => isset( $result['file'] ) ? basename( (string) $result['file'] ) : '',
-					'line'    => (int) ( $result['line'] ?? 0 ),
-					'reason'  => (string) ( $result['message'] ?? '' ),
-				),
-				JSON_UNESCAPED_SLASHES
-			),
+			'checked' => $checked,
+			'blocked' => array_keys( $blocked ),
+			'status'  => (string) ( $result['status'] ?? '' ),
+			// Basename only — absolute paths leak install layout.
+			'file'    => isset( $result['file'] ) ? basename( (string) $result['file'] ) : '',
+			'line'    => (int) ( $result['line'] ?? 0 ),
+			'reason'  => (string) ( $result['message'] ?? '' ),
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -114,21 +114,71 @@ function pcg_guard_evaluate_plugins( $plugins ) {
 
 	$blocked_plugin = pcg_guard_get_blocked_plugin( $result, $paths );
 	if ( '' !== $blocked_plugin ) {
-		return array(
+		$blocked = array(
 			$blocked_plugin => pcg_guard_format_block_reason( $result ),
 		);
+	} else {
+		// Verdict didn't pin a specific plugin (e.g. probe terminated without a
+		// JSON body, or the captured `file` was outside any candidate's tree).
+		// Surface a batch-level message so we don't blame an arbitrary plugin.
+		$reason = sprintf(
+			/* translators: 1: locale-formatted list of plugin basenames; 2: probe verdict reason. */
+			__( 'One of these plugins caused a fatal during the pre-flight check: %1$s. Reason: %2$s', 'jetpack-mu-wpcom' ),
+			wp_sprintf_l( '%l', array_keys( $paths ) ),
+			pcg_guard_format_block_reason( $result )
+		);
+		$blocked = array( '' => $reason );
 	}
 
-	// Verdict didn't pin a specific plugin (e.g. probe terminated without a
-	// JSON body, or the captured `file` was outside any candidate's tree).
-	// Surface a batch-level message so we don't blame an arbitrary plugin.
-	$reason = sprintf(
-		/* translators: 1: locale-formatted list of plugin basenames; 2: probe verdict reason. */
-		__( 'One of these plugins caused a fatal during the pre-flight check: %1$s. Reason: %2$s', 'jetpack-mu-wpcom' ),
-		wp_sprintf_l( '%l', array_keys( $paths ) ),
-		pcg_guard_format_block_reason( $result )
+	pcg_guard_log_blocked_activation( array_keys( $paths ), $blocked, $result );
+
+	return $blocked;
+}
+
+/**
+ * Emit a logstash event for an activation we just blocked, so we can
+ * measure how often the activation guard catches a real fatal in the
+ * wild. Mirrors the transport-error event in PCG_Load_Tester — same
+ * `feature` slug, same JSON-encoded `extra` shape — so consumers can
+ * filter both classes of events from one bucket. No-op outside
+ * WordPress.com (no `log2logstash` available) and best-effort: a
+ * logging failure must never escalate into a fatal of its own, since
+ * this runs on the activation request path.
+ *
+ * @param string[]             $checked Plugin basenames that went into the probe batch.
+ * @param array<string,string> $blocked Map of basename => human-readable reason being shown to the admin. The empty-string key is the batch-level fallback when a specific plugin couldn't be pinned.
+ * @param array                $result  Raw probe verdict from PCG_Load_Tester::test().
+ * @return void
+ */
+function pcg_guard_log_blocked_activation( array $checked, array $blocked, array $result ) {
+	if ( ! function_exists( 'log2logstash' ) ) {
+		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+		if ( ! is_readable( $log2logstash_path ) ) {
+			return;
+		}
+		require_once $log2logstash_path;
+	}
+
+	log2logstash(
+		array(
+			'feature' => 'plugin-conflicts-guardian',
+			'message' => 'Activation blocked',
+			'extra'   => wp_json_encode(
+				array(
+					'checked' => $checked,
+					'blocked' => array_keys( $blocked ),
+					'status'  => (string) ( $result['status'] ?? '' ),
+					// Send the basename only — absolute paths leak install layout.
+					'file'    => isset( $result['file'] ) ? basename( (string) $result['file'] ) : '',
+					'line'    => (int) ( $result['line'] ?? 0 ),
+					// Probe verdict message (the PHP error string), not the
+					// localized admin-notice copy we built from it.
+					'reason'  => (string) ( $result['message'] ?? '' ),
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+		)
 	);
-	return array( '' => $reason );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -136,18 +136,11 @@ function pcg_guard_evaluate_plugins( $plugins ) {
 }
 
 /**
- * Emit a logstash event for an activation we just blocked, so we can
- * measure how often the activation guard catches a real fatal in the
- * wild. Mirrors the transport-error event in PCG_Load_Tester — same
- * `feature` slug, same JSON-encoded `extra` shape — so consumers can
- * filter both classes of events from one bucket. No-op outside
- * WordPress.com (no `log2logstash` available) and best-effort: a
- * logging failure must never escalate into a fatal of its own, since
- * this runs on the activation request path.
+ * Log an activation block to logstash. Best-effort; no-op off WordPress.com.
  *
- * @param string[]             $checked Plugin basenames that went into the probe batch.
- * @param array<string,string> $blocked Map of basename => human-readable reason being shown to the admin. The empty-string key is the batch-level fallback when a specific plugin couldn't be pinned.
- * @param array                $result  Raw probe verdict from PCG_Load_Tester::test().
+ * @param string[]             $checked Probe batch as basenames.
+ * @param array<string,string> $blocked Map of basename => admin-notice reason. Empty-string key = batch-level fallback.
+ * @param array                $result  Probe verdict from PCG_Load_Tester::test().
  * @return void
  */
 function pcg_guard_log_blocked_activation( array $checked, array $blocked, array $result ) {
@@ -168,11 +161,9 @@ function pcg_guard_log_blocked_activation( array $checked, array $blocked, array
 					'checked' => $checked,
 					'blocked' => array_keys( $blocked ),
 					'status'  => (string) ( $result['status'] ?? '' ),
-					// Send the basename only — absolute paths leak install layout.
+					// Basename only — absolute paths leak install layout.
 					'file'    => isset( $result['file'] ) ? basename( (string) $result['file'] ) : '',
 					'line'    => (int) ( $result['line'] ?? 0 ),
-					// Probe verdict message (the PHP error string), not the
-					// localized admin-notice copy we built from it.
 					'reason'  => (string) ( $result['message'] ?? '' ),
 				),
 				JSON_UNESCAPED_SLASHES

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -133,27 +133,13 @@ class PCG_Load_Tester {
 	 * @return void
 	 */
 	protected function log_probe_error( $mode, array $plugin_mains, array $front_result, array $admin_result ) {
-		if ( ! function_exists( 'log2logstash' ) ) {
-			$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-			if ( ! is_readable( $log2logstash_path ) ) {
-				return;
-			}
-			require_once $log2logstash_path;
-		}
-
-		log2logstash(
+		pcg_log_event(
+			'Probe transport error',
 			array(
-				'feature' => 'plugin-conflicts-guardian',
-				'message' => 'Probe transport error',
-				'extra'   => wp_json_encode(
-					array(
-						'mode'    => $mode,
-						'plugins' => $this->relative_basenames( $plugin_mains ),
-						'front'   => $this->probe_error_reason( $front_result ),
-						'admin'   => $this->probe_error_reason( $admin_result ),
-					),
-					JSON_UNESCAPED_SLASHES
-				),
+				'mode'    => $mode,
+				'plugins' => $this->relative_basenames( $plugin_mains ),
+				'front'   => $this->probe_error_reason( $front_result ),
+				'admin'   => $this->probe_error_reason( $admin_result ),
 			)
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Shared logstash dispatch for the Plugin Conflicts Guardian feature.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Emit an event to the `plugin-conflicts-guardian` logstash bucket.
+ *
+ * Best-effort: a logging failure must never escalate into a fatal,
+ * since callers run on activation / install / update request paths.
+ * No-op outside WordPress.com (no `log2logstash` available).
+ *
+ * @param string $message Event message slug (e.g. "Activation blocked").
+ * @param array  $extra   Event-specific properties; JSON-encoded into the `extra` field.
+ * @return void
+ */
+function pcg_log_event( $message, array $extra ) {
+	if ( ! function_exists( 'log2logstash' ) ) {
+		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+		if ( ! is_readable( $log2logstash_path ) ) {
+			return;
+		}
+		require_once $log2logstash_path;
+	}
+
+	log2logstash(
+		array(
+			'feature' => 'plugin-conflicts-guardian',
+			'message' => (string) $message,
+			'extra'   => wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ),
+		)
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
@@ -17,19 +17,23 @@
  * @return void
  */
 function pcg_log_event( $message, array $extra ) {
-	if ( ! function_exists( 'log2logstash' ) ) {
-		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-		if ( ! is_readable( $log2logstash_path ) ) {
-			return;
+	try {
+		if ( ! function_exists( 'log2logstash' ) ) {
+			$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+			if ( ! is_readable( $log2logstash_path ) ) {
+				return;
+			}
+			require_once $log2logstash_path;
 		}
-		require_once $log2logstash_path;
-	}
 
-	log2logstash(
-		array(
-			'feature' => 'plugin-conflicts-guardian',
-			'message' => (string) $message,
-			'extra'   => wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ),
-		)
-	);
+		log2logstash(
+			array(
+				'feature' => 'plugin-conflicts-guardian',
+				'message' => (string) $message,
+				'extra'   => wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ),
+			)
+		);
+	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must not escalate on activation / install / update request paths.
+		unset( $e );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
@@ -30,10 +30,40 @@ function pcg_log_event( $message, array $extra ) {
 			array(
 				'feature' => 'plugin-conflicts-guardian',
 				'message' => (string) $message,
-				'extra'   => wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ),
+				'extra'   => wp_json_encode( pcg_log_redact_paths( $extra ), JSON_UNESCAPED_SLASHES ),
 			)
 		);
 	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must not escalate on activation / install / update request paths.
 		unset( $e );
 	}
+}
+
+/**
+ * Recursively replace `ABSPATH` and `WP_CONTENT_DIR` prefixes inside string
+ * values with `.../` so log lines don't leak the install layout. Keeps the
+ * relative tail (`plugins/foo/bar.php`), which is the useful part for triage.
+ *
+ * @param mixed $value Scalar or array.
+ * @return mixed
+ */
+function pcg_log_redact_paths( $value ) {
+	if ( is_array( $value ) ) {
+		return array_map( 'pcg_log_redact_paths', $value );
+	}
+	if ( ! is_string( $value ) || '' === $value ) {
+		return $value;
+	}
+	// WP_CONTENT_DIR first — it's a longer prefix that's typically *under*
+	// ABSPATH on standard installs, so swapping ABSPATH first would shadow it.
+	$replacements = array();
+	if ( defined( 'WP_CONTENT_DIR' ) && '' !== WP_CONTENT_DIR ) {
+		$replacements[ rtrim( WP_CONTENT_DIR, '/' ) . '/' ] = '.../';
+	}
+	if ( defined( 'ABSPATH' ) && '' !== ABSPATH ) {
+		$replacements[ rtrim( ABSPATH, '/' ) . '/' ] = '.../';
+	}
+	if ( empty( $replacements ) ) {
+		return $value;
+	}
+	return strtr( $value, $replacements );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php
@@ -10,6 +10,7 @@
 /**
  * Load dependencies.
  */
+require_once __DIR__ . '/pcg-log.php';
 require_once __DIR__ . '/class-pcg-load-tester.php';
 
 // Probe endpoint must answer front-end requests, so it's not gated on is_admin().

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -74,18 +74,11 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 }
 
 /**
- * Emit a logstash event for a plugin install/update we just refused, so we
- * can measure how often the parse-error gate catches a real broken package.
- * Mirrors the `Activation blocked` event in `activation-guard.php` — same
- * `feature` slug, same JSON-encoded `extra` shape — so consumers can filter
- * the full PCG-block surface from one bucket. No-op outside WordPress.com
- * (no `log2logstash` available) and best-effort: a logging failure must
- * never escalate into a fatal of its own, since this runs on the
- * install/update request path.
+ * Log a refused install/update to logstash. Best-effort; no-op off WordPress.com.
  *
- * @param string $action     Either `install` or `update`.
- * @param array  $hook_extra Hook payload from `upgrader_source_selection`; we read `plugin` / `theme` for slug attribution.
- * @param array  $scan       Scan result from `pcg_update_guard_scan_for_parse_errors()`.
+ * @param string $action     `install` or `update`.
+ * @param array  $hook_extra Hook payload from `upgrader_source_selection`.
+ * @param array  $scan       Result from `pcg_update_guard_scan_for_parse_errors()`.
  * @return void
  */
 function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan ) {
@@ -108,12 +101,10 @@ function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan )
 				array(
 					'action'      => (string) $action,
 					'slug'        => $slug,
-					// Send basenames only — absolute paths leak install layout.
+					// Basename only — absolute paths leak install layout.
 					'file'        => basename( (string) $first['file'] ),
 					'line'        => (int) $first['line'],
 					'reason'      => (string) $first['message'],
-					// Surface batch shape so we can tell a single broken file
-					// from a wholesale broken package.
 					'error_count' => count( $scan['errors'] ),
 				),
 				JSON_UNESCAPED_SLASHES

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -82,33 +82,18 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
  * @return void
  */
 function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan ) {
-	if ( ! function_exists( 'log2logstash' ) ) {
-		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-		if ( ! is_readable( $log2logstash_path ) ) {
-			return;
-		}
-		require_once $log2logstash_path;
-	}
-
 	$first = $scan['errors'][0];
-	$slug  = (string) ( $hook_extra['plugin'] ?? ( $hook_extra['theme'] ?? '' ) );
 
-	log2logstash(
+	pcg_log_event(
+		'Update blocked',
 		array(
-			'feature' => 'plugin-conflicts-guardian',
-			'message' => 'Update blocked',
-			'extra'   => wp_json_encode(
-				array(
-					'action'      => (string) $action,
-					'slug'        => $slug,
-					// Basename only — absolute paths leak install layout.
-					'file'        => basename( (string) $first['file'] ),
-					'line'        => (int) $first['line'],
-					'reason'      => (string) $first['message'],
-					'error_count' => count( $scan['errors'] ),
-				),
-				JSON_UNESCAPED_SLASHES
-			),
+			'action'      => (string) $action,
+			'slug'        => (string) ( $hook_extra['plugin'] ?? ( $hook_extra['theme'] ?? '' ) ),
+			// Basename only — absolute paths leak install layout.
+			'file'        => basename( (string) $first['file'] ),
+			'line'        => (int) $first['line'],
+			'reason'      => (string) $first['message'],
+			'error_count' => count( $scan['errors'] ),
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -57,7 +57,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 
 	$first = $scan['errors'][0];
 
-	pcg_update_guard_log_blocked( $action, $hook_extra, $scan );
+	pcg_update_guard_log_blocked( $action, $hook_extra, $scan, (string) $source );
 
 	return new WP_Error(
 		'pcg_update_parse_error',
@@ -79,16 +79,23 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
  * @param string $action     `install` or `update`.
  * @param array  $hook_extra Hook payload from `upgrader_source_selection`.
  * @param array  $scan       Result from `pcg_update_guard_scan_for_parse_errors()`.
+ * @param string $source     Extracted package directory (fallback slug source on installs,
+ *                           since `Plugin_Upgrader::install()` doesn't populate `hook_extra['plugin']`).
  * @return void
  */
-function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan ) {
+function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan, $source = '' ) {
 	$first = $scan['errors'][0];
+
+	$slug = (string) ( $hook_extra['plugin'] ?? ( $hook_extra['theme'] ?? '' ) );
+	if ( '' === $slug && '' !== $source ) {
+		$slug = basename( untrailingslashit( $source ) );
+	}
 
 	pcg_log_event(
 		'Update blocked',
 		array(
 			'action'      => (string) $action,
-			'slug'        => (string) ( $hook_extra['plugin'] ?? ( $hook_extra['theme'] ?? '' ) ),
+			'slug'        => $slug,
 			// Basename only — absolute paths leak install layout.
 			'file'        => basename( (string) $first['file'] ),
 			'line'        => (int) $first['line'],

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -56,6 +56,9 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	}
 
 	$first = $scan['errors'][0];
+
+	pcg_update_guard_log_blocked( $action, $hook_extra, $scan );
+
 	return new WP_Error(
 		'pcg_update_parse_error',
 		sprintf(
@@ -67,6 +70,55 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 			(string) $first['message']
 		),
 		array( 'errors' => $scan['errors'] )
+	);
+}
+
+/**
+ * Emit a logstash event for a plugin install/update we just refused, so we
+ * can measure how often the parse-error gate catches a real broken package.
+ * Mirrors the `Activation blocked` event in `activation-guard.php` — same
+ * `feature` slug, same JSON-encoded `extra` shape — so consumers can filter
+ * the full PCG-block surface from one bucket. No-op outside WordPress.com
+ * (no `log2logstash` available) and best-effort: a logging failure must
+ * never escalate into a fatal of its own, since this runs on the
+ * install/update request path.
+ *
+ * @param string $action     Either `install` or `update`.
+ * @param array  $hook_extra Hook payload from `upgrader_source_selection`; we read `plugin` / `theme` for slug attribution.
+ * @param array  $scan       Scan result from `pcg_update_guard_scan_for_parse_errors()`.
+ * @return void
+ */
+function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan ) {
+	if ( ! function_exists( 'log2logstash' ) ) {
+		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+		if ( ! is_readable( $log2logstash_path ) ) {
+			return;
+		}
+		require_once $log2logstash_path;
+	}
+
+	$first = $scan['errors'][0];
+	$slug  = (string) ( $hook_extra['plugin'] ?? ( $hook_extra['theme'] ?? '' ) );
+
+	log2logstash(
+		array(
+			'feature' => 'plugin-conflicts-guardian',
+			'message' => 'Update blocked',
+			'extra'   => wp_json_encode(
+				array(
+					'action'      => (string) $action,
+					'slug'        => $slug,
+					// Send basenames only — absolute paths leak install layout.
+					'file'        => basename( (string) $first['file'] ),
+					'line'        => (int) $first['line'],
+					'reason'      => (string) $first['message'],
+					// Surface batch shape so we can tell a single broken file
+					// from a wholesale broken package.
+					'error_count' => count( $scan['errors'] ),
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+		)
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
@@ -155,19 +155,11 @@ function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignor
 }
 
 /**
- * Emit a logstash event for a post-update rollback we just performed, so we
- * can measure how often the post-install probe catches a fatal that the
- * pre-install parse-error gate (`update-guard.php`) couldn't see — and
- * separately track rollback success vs `rollback_failed` /
- * `rollback_unavailable`. Mirrors the activation/install-block events —
- * same `feature` slug, same JSON-encoded `extra` shape. No-op outside
- * WordPress.com (no `log2logstash` available) and best-effort: a logging
- * failure must never escalate into a second fatal on a request path that
- * just rolled back from one.
+ * Log a post-update rollback to logstash. Best-effort; no-op off WordPress.com.
  *
- * @param array $candidate Per-plugin context built in `pcg_healthcheck_after_update()`: `plugin_file`, `plugin_name`, `new_version`, `snapshot`, `plugin_main`.
- * @param array $probe     Shared probe verdict from `PCG_Load_Tester::test()` for the whole batch.
- * @param array $rollback  Per-plugin rollback result from `PCG_Rollback::to_snapshot()`.
+ * @param array $candidate Per-plugin context built in `pcg_healthcheck_after_update()`.
+ * @param array $probe     Shared probe verdict from `PCG_Load_Tester::test()`.
+ * @param array $rollback  Result from `PCG_Rollback::to_snapshot()`.
  * @return void
  */
 function pcg_healthcheck_log_rollback( array $candidate, array $probe, array $rollback ) {
@@ -188,13 +180,11 @@ function pcg_healthcheck_log_rollback( array $candidate, array $probe, array $ro
 					'plugin'           => (string) $candidate['plugin_file'],
 					'new_version'      => (string) $candidate['new_version'],
 					'previous_version' => (string) ( $candidate['snapshot']['version'] ?? '' ),
-					// Probe verdict that triggered rollback.
 					'probe_status'     => (string) ( $probe['status'] ?? '' ),
+					// Basename only — absolute paths leak install layout.
 					'probe_file'       => isset( $probe['file'] ) ? basename( (string) $probe['file'] ) : '',
 					'probe_line'       => (int) ( $probe['line'] ?? 0 ),
 					'probe_reason'     => (string) ( $probe['message'] ?? '' ),
-					// Rollback outcome — distinguishes "we restored cleanly" from
-					// "we tried and failed; site still on the broken version."
 					'rollback_status'  => (string) ( $rollback['status'] ?? '' ),
 					'restored_to'      => (string) ( $rollback['restored_to'] ?? '' ),
 				),

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
@@ -140,6 +140,7 @@ function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignor
 	foreach ( $candidates as $candidate ) {
 		$rollback = PCG_Rollback::to_snapshot( $candidate['snapshot'] );
 		pcg_healthcheck_stash_notice( $candidate['plugin_file'], $result, $rollback, $candidate['plugin_name'], $candidate['new_version'] );
+		pcg_healthcheck_log_rollback( $candidate, $result, $rollback );
 
 		/**
 		 * Fires after a post-update probe fails and rollback has been attempted.
@@ -151,6 +152,56 @@ function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignor
 		 */
 		do_action( 'pcg_post_update_diagnosis', $candidate['plugin_file'], $result, $rollback, $candidate['snapshot'] );
 	}
+}
+
+/**
+ * Emit a logstash event for a post-update rollback we just performed, so we
+ * can measure how often the post-install probe catches a fatal that the
+ * pre-install parse-error gate (`update-guard.php`) couldn't see — and
+ * separately track rollback success vs `rollback_failed` /
+ * `rollback_unavailable`. Mirrors the activation/install-block events —
+ * same `feature` slug, same JSON-encoded `extra` shape. No-op outside
+ * WordPress.com (no `log2logstash` available) and best-effort: a logging
+ * failure must never escalate into a second fatal on a request path that
+ * just rolled back from one.
+ *
+ * @param array $candidate Per-plugin context built in `pcg_healthcheck_after_update()`: `plugin_file`, `plugin_name`, `new_version`, `snapshot`, `plugin_main`.
+ * @param array $probe     Shared probe verdict from `PCG_Load_Tester::test()` for the whole batch.
+ * @param array $rollback  Per-plugin rollback result from `PCG_Rollback::to_snapshot()`.
+ * @return void
+ */
+function pcg_healthcheck_log_rollback( array $candidate, array $probe, array $rollback ) {
+	if ( ! function_exists( 'log2logstash' ) ) {
+		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+		if ( ! is_readable( $log2logstash_path ) ) {
+			return;
+		}
+		require_once $log2logstash_path;
+	}
+
+	log2logstash(
+		array(
+			'feature' => 'plugin-conflicts-guardian',
+			'message' => 'Update rolled back',
+			'extra'   => wp_json_encode(
+				array(
+					'plugin'           => (string) $candidate['plugin_file'],
+					'new_version'      => (string) $candidate['new_version'],
+					'previous_version' => (string) ( $candidate['snapshot']['version'] ?? '' ),
+					// Probe verdict that triggered rollback.
+					'probe_status'     => (string) ( $probe['status'] ?? '' ),
+					'probe_file'       => isset( $probe['file'] ) ? basename( (string) $probe['file'] ) : '',
+					'probe_line'       => (int) ( $probe['line'] ?? 0 ),
+					'probe_reason'     => (string) ( $probe['message'] ?? '' ),
+					// Rollback outcome — distinguishes "we restored cleanly" from
+					// "we tried and failed; site still on the broken version."
+					'rollback_status'  => (string) ( $rollback['status'] ?? '' ),
+					'restored_to'      => (string) ( $rollback['restored_to'] ?? '' ),
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+		)
+	);
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
@@ -163,33 +163,19 @@ function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignor
  * @return void
  */
 function pcg_healthcheck_log_rollback( array $candidate, array $probe, array $rollback ) {
-	if ( ! function_exists( 'log2logstash' ) ) {
-		$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-		if ( ! is_readable( $log2logstash_path ) ) {
-			return;
-		}
-		require_once $log2logstash_path;
-	}
-
-	log2logstash(
+	pcg_log_event(
+		'Update rolled back',
 		array(
-			'feature' => 'plugin-conflicts-guardian',
-			'message' => 'Update rolled back',
-			'extra'   => wp_json_encode(
-				array(
-					'plugin'           => (string) $candidate['plugin_file'],
-					'new_version'      => (string) $candidate['new_version'],
-					'previous_version' => (string) ( $candidate['snapshot']['version'] ?? '' ),
-					'probe_status'     => (string) ( $probe['status'] ?? '' ),
-					// Basename only — absolute paths leak install layout.
-					'probe_file'       => isset( $probe['file'] ) ? basename( (string) $probe['file'] ) : '',
-					'probe_line'       => (int) ( $probe['line'] ?? 0 ),
-					'probe_reason'     => (string) ( $probe['message'] ?? '' ),
-					'rollback_status'  => (string) ( $rollback['status'] ?? '' ),
-					'restored_to'      => (string) ( $rollback['restored_to'] ?? '' ),
-				),
-				JSON_UNESCAPED_SLASHES
-			),
+			'plugin'           => (string) $candidate['plugin_file'],
+			'new_version'      => (string) $candidate['new_version'],
+			'previous_version' => (string) ( $candidate['snapshot']['version'] ?? '' ),
+			'probe_status'     => (string) ( $probe['status'] ?? '' ),
+			// Basename only — absolute paths leak install layout.
+			'probe_file'       => isset( $probe['file'] ) ? basename( (string) $probe['file'] ) : '',
+			'probe_line'       => (int) ( $probe['line'] ?? 0 ),
+			'probe_reason'     => (string) ( $probe['message'] ?? '' ),
+			'rollback_status'  => (string) ( $rollback['status'] ?? '' ),
+			'restored_to'      => (string) ( $rollback['restored_to'] ?? '' ),
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/pcg-log.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/class-pcg-load-tester.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/activation-guard.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/update-guard.php';


### PR DESCRIPTION
## Proposed changes

Follow-up from #48553 ([review comment](https://github.com/Automattic/jetpack/pull/48553#pullrequestreview-4235564693)): emit logstash events whenever Plugin Conflicts Guardian refuses a bad change or recovers from one, so we can measure how often the various PCG gates catch a real fatal in the wild.

Three new events, all under the existing `plugin-conflicts-guardian` feature bucket, all mirroring the JSON-encoded `extra` shape used by the existing `Probe transport error` event in `PCG_Load_Tester`:

* **`Activation blocked`** — `pcg_guard_evaluate_plugins()` (in `activation-guard.php`) calls a new `pcg_guard_log_blocked_activation()` helper right before returning a non-empty `$blocked` map. `extra`: `checked` (probe batch), `blocked` (basenames being blocked; empty-string entry indicates a batch-level fallback), `status` (`fatal` / `throwable`), `file` (basename only), `line`, `reason` (raw probe-verdict message).
* **`Update blocked`** — `pcg_update_guard_check()` (in `update-guard.php`) calls a new `pcg_update_guard_log_blocked()` helper just before returning the `WP_Error` that aborts the install/update. `extra`: `action` (`install` / `update`), `slug`, `file` (basename), `line`, `reason`, `error_count` (so a single broken file is distinguishable from a wholesale broken package).
* **`Update rolled back`** — `pcg_healthcheck_after_update()` (in `update-healthcheck.php`) calls a new `pcg_healthcheck_log_rollback()` helper inside the per-candidate rollback loop. `extra`: `plugin`, `new_version`, `previous_version`, the probe verdict that triggered rollback (`probe_status` / `probe_file` / `probe_line` / `probe_reason`), and the rollback outcome (`rollback_status` — distinguishes `reactivated` / `restored` / `rollback_failed` / `rollback_unavailable` — and `restored_to`).

All three are no-ops outside WordPress.com (no `log2logstash`) and best-effort: a logging failure must never escalate into a fatal, since these run on the activation / install / update request paths.

## Related product discussion/links

* PR #48553 review: "As a follow-up PR, can we add logstash for activations that we managed to block?"

## Does this pull request change what data or activity we track or use?

Yes — adds three new logstash event slugs (`Activation blocked`, `Update blocked`, `Update rolled back`) under the existing `plugin-conflicts-guardian` feature bucket. Properties shipped per event are listed above; no PII, no new outbound HTTP calls beyond the existing logstash transport.

## Testing instructions

1. Sync `jetpack-mu-wpcom` to a test site with `pcg_guard_activation` enabled (the new default after #48553) and `pcg_guard_updates` enabled.
2. **Activation block**: place a plugin known to fatal on load, click **Activate** in wp-admin → Plugins. Expected: existing admin notice **and** one new `Activation blocked` row in the `plugin-conflicts-guardian` logstash bucket.
3. **Update block**: upload-install a zip containing a PHP parse error. Expected: install refused with a parse-error notice **and** one `Update blocked` row carrying `action: install`, the offending file basename + line, and `error_count`.
4. **Rollback**: install a "good" plugin, then update it to a version that fatals only at runtime (passes parse-error gate). Expected: post-update probe fails, plugin gets rolled back, **and** one `Update rolled back` row with `rollback_status: reactivated` (or `restored` / `rollback_failed` depending on the snapshot path).
5. On a non-WordPress.com install (no `log2logstash`) → all three guards still work, no log emitted, no fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)