### PR TITLE
Podcast: add per-post podcast settings sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-podcast-post-settings
+++ b/projects/plugins/jetpack/changelog/add-podcast-post-settings
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: enhancement
 
 Podcast: add a Jetpack Podcast sidebar to the post editor for setting per-episode metadata (audio URL, duration, season/episode number, episode type, explicit, summary). Values are stored as post meta and injected into the RSS feed via the iTunes namespace.

--- a/projects/plugins/jetpack/changelog/add-podcast-post-settings
+++ b/projects/plugins/jetpack/changelog/add-podcast-post-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Podcast: add a Jetpack Podcast sidebar to the post editor for setting per-episode metadata (audio URL, duration, season/episode number, episode type, explicit, summary). Values are stored as post meta and injected into the RSS feed via the iTunes namespace.

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -77,7 +77,8 @@
 		"ai-correct-spelling",
 		"paypal-payment-buttons",
 		"image-studio",
-		"block-notes"
+		"block-notes",
+		"podcast-post-settings"
 	],
 	"beta": [
 		"google-docs-embed",

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/constants.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/constants.js
@@ -1,0 +1,25 @@
+import { __ } from '@wordpress/i18n';
+
+export const META_PODCAST_AUDIO_URL = '_jetpack_podcast_audio_url';
+export const META_PODCAST_AUDIO_MIME = '_jetpack_podcast_audio_mime';
+export const META_PODCAST_AUDIO_SIZE = '_jetpack_podcast_audio_size';
+export const META_PODCAST_DURATION = '_jetpack_podcast_duration';
+export const META_PODCAST_EPISODE_TITLE = '_jetpack_podcast_episode_title';
+export const META_PODCAST_EPISODE_SUMMARY = '_jetpack_podcast_episode_summary';
+export const META_PODCAST_EPISODE_NUMBER = '_jetpack_podcast_episode_number';
+export const META_PODCAST_SEASON_NUMBER = '_jetpack_podcast_season_number';
+export const META_PODCAST_EPISODE_TYPE = '_jetpack_podcast_episode_type';
+export const META_PODCAST_EXPLICIT = '_jetpack_podcast_explicit';
+export const META_PODCAST_BLOCK = '_jetpack_podcast_block';
+
+export const EPISODE_TYPE_OPTIONS = [
+	{ label: __( 'Full episode', 'jetpack' ), value: 'full' },
+	{ label: __( 'Trailer', 'jetpack' ), value: 'trailer' },
+	{ label: __( 'Bonus', 'jetpack' ), value: 'bonus' },
+];
+
+export const EXPLICIT_OPTIONS = [
+	{ label: __( 'Clean', 'jetpack' ), value: 'clean' },
+	{ label: __( 'Explicit', 'jetpack' ), value: 'yes' },
+	{ label: __( 'Not specified', 'jetpack' ), value: '' },
+];

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/editor.js
@@ -1,0 +1,4 @@
+import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
+import { name, settings } from '.';
+
+registerJetpackPlugin( name, settings );

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/icons.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/icons.js
@@ -1,0 +1,7 @@
+import { Path, SVG } from '@wordpress/primitives';
+
+export const MicrophoneIcon = () => (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+		<Path d="M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/index.js
@@ -1,0 +1,17 @@
+import { select } from '@wordpress/data';
+import { MicrophoneIcon } from './icons';
+import PodcastSettingsSidebar from './sidebar';
+
+export const name = 'podcast-post-settings';
+
+const isPostEditor = () => select( 'core/editor' )?.getCurrentPostType() === 'post';
+
+export const settings = {
+	render: function PodcastPostSettingsPlugin() {
+		if ( ! isPostEditor() ) {
+			return null;
+		}
+		return <PodcastSettingsSidebar />;
+	},
+	icon: isPostEditor() ? <MicrophoneIcon /> : undefined,
+};

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/podcast-post-settings.php
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/podcast-post-settings.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Podcast Post Settings.
+ *
+ * Adds a Jetpack Podcast sidebar to the post editor for setting per-post
+ * podcast/episode metadata, and pushes those values into the RSS feed using
+ * the iTunes namespace so the existing feed picks them up.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Post_Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+const FEATURE_NAME = 'podcast-post-settings';
+
+const META_AUDIO_URL       = '_jetpack_podcast_audio_url';
+const META_AUDIO_MIME      = '_jetpack_podcast_audio_mime';
+const META_AUDIO_SIZE      = '_jetpack_podcast_audio_size';
+const META_DURATION        = '_jetpack_podcast_duration';
+const META_EPISODE_TITLE   = '_jetpack_podcast_episode_title';
+const META_EPISODE_SUMMARY = '_jetpack_podcast_episode_summary';
+const META_EPISODE_NUMBER  = '_jetpack_podcast_episode_number';
+const META_SEASON_NUMBER   = '_jetpack_podcast_season_number';
+const META_EPISODE_TYPE    = '_jetpack_podcast_episode_type';
+const META_EXPLICIT        = '_jetpack_podcast_explicit';
+const META_BLOCK           = '_jetpack_podcast_block';
+
+/**
+ * Returns the post meta keys we register and sync.
+ *
+ * @return array<string, array{type: string, default?: mixed}>
+ */
+function get_meta_keys() {
+	return array(
+		META_AUDIO_URL       => array( 'type' => 'string' ),
+		META_AUDIO_MIME      => array( 'type' => 'string' ),
+		META_AUDIO_SIZE      => array(
+			'type'    => 'integer',
+			'default' => 0,
+		),
+		META_DURATION        => array( 'type' => 'string' ),
+		META_EPISODE_TITLE   => array( 'type' => 'string' ),
+		META_EPISODE_SUMMARY => array( 'type' => 'string' ),
+		META_EPISODE_NUMBER  => array(
+			'type'    => 'integer',
+			'default' => 0,
+		),
+		META_SEASON_NUMBER   => array(
+			'type'    => 'integer',
+			'default' => 0,
+		),
+		META_EPISODE_TYPE    => array( 'type' => 'string' ),
+		META_EXPLICIT        => array( 'type' => 'string' ),
+		META_BLOCK           => array(
+			'type'    => 'boolean',
+			'default' => false,
+		),
+	);
+}
+
+/**
+ * Register post meta fields with REST support so the editor sidebar can read/write them.
+ */
+function register_post_meta_fields() {
+	$auth_callback = function () {
+		return current_user_can( 'edit_posts' );
+	};
+
+	foreach ( get_meta_keys() as $meta_key => $args ) {
+		$config = array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => $args['type'],
+			'auth_callback' => $auth_callback,
+		);
+		if ( array_key_exists( 'default', $args ) ) {
+			$config['default'] = $args['default'];
+		}
+		register_post_meta( 'post', $meta_key, $config );
+	}
+}
+add_action( 'init', __NAMESPACE__ . '\register_post_meta_fields' );
+
+/**
+ * Sync the podcast post meta to WordPress.com so the WPCOM-side podcast feed
+ * generator can read the same values.
+ *
+ * @param array $allowed_meta Existing whitelist.
+ * @return array
+ */
+function sync_meta_whitelist( $allowed_meta ) {
+	return array_merge( (array) $allowed_meta, array_keys( get_meta_keys() ) );
+}
+add_filter( 'jetpack_sync_post_meta_whitelist', __NAMESPACE__ . '\sync_meta_whitelist' );
+
+/**
+ * Add the iTunes and Podcast namespace declarations to the RSS2 root tag so
+ * the per-item tags below validate.
+ */
+function rss2_namespaces() {
+	echo 'xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" ';
+	echo 'xmlns:podcast="https://podcastindex.org/namespace/1.0"';
+}
+add_action( 'rss2_ns', __NAMESPACE__ . '\rss2_namespaces' );
+
+/**
+ * Inject the configured iTunes tags into each post's RSS item, when the post
+ * has an audio URL. The site-wide podcast feed (configured via the
+ * `podcasting_archive` option / WPCOM podcasting feature) will surface these
+ * tags to subscribers.
+ */
+function rss2_item_tags() {
+	$post_id = get_the_ID();
+	if ( ! $post_id ) {
+		return;
+	}
+
+	$audio_url = get_post_meta( $post_id, META_AUDIO_URL, true );
+	if ( empty( $audio_url ) ) {
+		return;
+	}
+
+	$mime     = get_post_meta( $post_id, META_AUDIO_MIME, true );
+	$size     = (int) get_post_meta( $post_id, META_AUDIO_SIZE, true );
+	$duration = get_post_meta( $post_id, META_DURATION, true );
+	$title    = get_post_meta( $post_id, META_EPISODE_TITLE, true );
+	$summary  = get_post_meta( $post_id, META_EPISODE_SUMMARY, true );
+	$episode  = (int) get_post_meta( $post_id, META_EPISODE_NUMBER, true );
+	$season   = (int) get_post_meta( $post_id, META_SEASON_NUMBER, true );
+	$type     = get_post_meta( $post_id, META_EPISODE_TYPE, true );
+	$explicit = get_post_meta( $post_id, META_EXPLICIT, true );
+	$block    = (bool) get_post_meta( $post_id, META_BLOCK, true );
+
+	printf(
+		"\t\t<enclosure url=\"%s\" length=\"%s\" type=\"%s\" />\n",
+		esc_url( $audio_url ),
+		esc_attr( $size > 0 ? (string) $size : '0' ),
+		esc_attr( ! empty( $mime ) ? $mime : 'audio/mpeg' )
+	);
+
+	if ( ! empty( $title ) ) {
+		printf( "\t\t<itunes:title>%s</itunes:title>\n", esc_html( $title ) );
+	}
+	if ( ! empty( $summary ) ) {
+		printf( "\t\t<itunes:summary>%s</itunes:summary>\n", esc_html( $summary ) );
+	}
+	if ( ! empty( $duration ) ) {
+		printf( "\t\t<itunes:duration>%s</itunes:duration>\n", esc_html( $duration ) );
+	}
+	if ( $episode > 0 ) {
+		printf( "\t\t<itunes:episode>%d</itunes:episode>\n", (int) $episode );
+	}
+	if ( $season > 0 ) {
+		printf( "\t\t<itunes:season>%d</itunes:season>\n", (int) $season );
+	}
+	if ( ! empty( $type ) ) {
+		printf( "\t\t<itunes:episodeType>%s</itunes:episodeType>\n", esc_attr( $type ) );
+	}
+	if ( ! empty( $explicit ) ) {
+		printf( "\t\t<itunes:explicit>%s</itunes:explicit>\n", esc_attr( $explicit ) );
+	}
+	if ( $block ) {
+		echo "\t\t<itunes:block>Yes</itunes:block>\n";
+	}
+}
+add_action( 'rss2_item', __NAMESPACE__ . '\rss2_item_tags' );
+
+// Register the extension as available to the block editor.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge( (array) $extensions, array( FEATURE_NAME ) );
+	}
+);
+
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		\Jetpack_Gutenberg::set_extension_available( FEATURE_NAME );
+	}
+);

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/podcast-post-settings.php
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/podcast-post-settings.php
@@ -152,10 +152,10 @@ function rss2_item_tags() {
 		printf( "\t\t<itunes:duration>%s</itunes:duration>\n", esc_html( $duration ) );
 	}
 	if ( $episode > 0 ) {
-		printf( "\t\t<itunes:episode>%d</itunes:episode>\n", (int) $episode );
+		printf( "\t\t<itunes:episode>%s</itunes:episode>\n", esc_html( (string) $episode ) );
 	}
 	if ( $season > 0 ) {
-		printf( "\t\t<itunes:season>%d</itunes:season>\n", (int) $season );
+		printf( "\t\t<itunes:season>%s</itunes:season>\n", esc_html( (string) $season ) );
 	}
 	if ( ! empty( $type ) ) {
 		printf( "\t\t<itunes:episodeType>%s</itunes:episodeType>\n", esc_attr( $type ) );

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
@@ -63,7 +63,7 @@ const PodcastSettingsSidebar = () => {
 	return (
 		<PluginSidebar
 			name={ SIDEBAR_NAME }
-			title={ __( 'Jetpack Podcast', 'jetpack' ) }
+			title={ __( 'Podcast', 'jetpack' ) }
 			icon={ <MicrophoneIcon /> }
 			className="jetpack-podcast-settings-sidebar"
 		>

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
@@ -1,12 +1,17 @@
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import {
+	BaseControl,
+	Button,
 	PanelBody,
 	PanelRow,
 	SelectControl,
 	TextControl,
 	TextareaControl,
 	ToggleControl,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar, store as editorStore } from '@wordpress/editor';
@@ -52,6 +57,51 @@ const PodcastSettingsSidebar = () => {
 	const setAudioMime = useMetaSetter( meta, setMeta, META_PODCAST_AUDIO_MIME );
 	const setAudioSize = useIntMetaSetter( meta, setMeta, META_PODCAST_AUDIO_SIZE );
 	const setDuration = useMetaSetter( meta, setMeta, META_PODCAST_DURATION );
+
+	const onSelectAudio = useCallback(
+		media => {
+			if ( ! media?.url ) {
+				return;
+			}
+			setMeta( {
+				...meta,
+				[ META_PODCAST_AUDIO_URL ]: media.url,
+				[ META_PODCAST_AUDIO_MIME ]: media.mime || media.mime_type || '',
+				[ META_PODCAST_AUDIO_SIZE ]: media.filesizeInBytes
+					? parseInt( media.filesizeInBytes, 10 )
+					: 0,
+			} );
+		},
+		[ meta, setMeta ]
+	);
+
+	const onRemoveAudio = useCallback( () => {
+		setMeta( {
+			...meta,
+			[ META_PODCAST_AUDIO_URL ]: '',
+			[ META_PODCAST_AUDIO_MIME ]: '',
+			[ META_PODCAST_AUDIO_SIZE ]: 0,
+		} );
+	}, [ meta, setMeta ] );
+
+	const audioUrl = meta[ META_PODCAST_AUDIO_URL ] || '';
+	const audioFileId = useInstanceId( PodcastSettingsSidebar, 'jetpack-podcast-audio-file' );
+
+	const renderMediaButton = useCallback(
+		( { open } ) => (
+			<HStack wrap>
+				<Button variant="secondary" onClick={ open }>
+					{ audioUrl ? __( 'Replace audio', 'jetpack' ) : __( 'Select audio', 'jetpack' ) }
+				</Button>
+				{ audioUrl && (
+					<Button variant="tertiary" isDestructive onClick={ onRemoveAudio }>
+						{ __( 'Remove', 'jetpack' ) }
+					</Button>
+				) }
+			</HStack>
+		),
+		[ audioUrl, onRemoveAudio ]
+	);
 	const setEpisodeTitle = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_TITLE );
 	const setEpisodeSummary = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_SUMMARY );
 	const setSeasonNumber = useIntMetaSetter( meta, setMeta, META_PODCAST_SEASON_NUMBER );
@@ -69,11 +119,32 @@ const PodcastSettingsSidebar = () => {
 		>
 			<PanelBody title={ __( 'Audio', 'jetpack' ) } initialOpen={ true }>
 				<PanelRow>
+					<BaseControl
+						__nextHasNoMarginBottom
+						id={ audioFileId }
+						label={ __( 'Audio file', 'jetpack' ) }
+						help={
+							audioUrl
+								? audioUrl
+								: __( 'Upload, choose from the media library, or paste a URL below.', 'jetpack' )
+						}
+					>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ onSelectAudio }
+								allowedTypes={ [ 'audio' ] }
+								value={ audioUrl }
+								render={ renderMediaButton }
+							/>
+						</MediaUploadCheck>
+					</BaseControl>
+				</PanelRow>
+				<PanelRow>
 					<TextControl
 						label={ __( 'Audio file URL', 'jetpack' ) }
-						help={ __( 'Direct link to the episode audio file (MP3, M4A, etc.).', 'jetpack' ) }
+						help={ __( 'Or paste a direct link to an MP3 / M4A hosted elsewhere.', 'jetpack' ) }
 						type="url"
-						value={ meta[ META_PODCAST_AUDIO_URL ] || '' }
+						value={ audioUrl }
 						onChange={ setAudioUrl }
 						__nextHasNoMarginBottom
 					/>

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
@@ -1,0 +1,184 @@
+import {
+	PanelBody,
+	PanelRow,
+	SelectControl,
+	TextControl,
+	TextareaControl,
+	ToggleControl,
+	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { PluginSidebar, store as editorStore } from '@wordpress/editor';
+import { useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	EPISODE_TYPE_OPTIONS,
+	EXPLICIT_OPTIONS,
+	META_PODCAST_AUDIO_MIME,
+	META_PODCAST_AUDIO_SIZE,
+	META_PODCAST_AUDIO_URL,
+	META_PODCAST_BLOCK,
+	META_PODCAST_DURATION,
+	META_PODCAST_EPISODE_NUMBER,
+	META_PODCAST_EPISODE_SUMMARY,
+	META_PODCAST_EPISODE_TITLE,
+	META_PODCAST_EPISODE_TYPE,
+	META_PODCAST_EXPLICIT,
+	META_PODCAST_SEASON_NUMBER,
+} from './constants';
+import { MicrophoneIcon } from './icons';
+
+const SIDEBAR_NAME = 'jetpack-podcast-settings-sidebar';
+
+const useMetaSetter = ( meta, setMeta, key ) =>
+	useCallback( value => setMeta( { ...meta, [ key ]: value } ), [ meta, setMeta, key ] );
+
+const useIntMetaSetter = ( meta, setMeta, key ) =>
+	useCallback(
+		value => setMeta( { ...meta, [ key ]: value ? parseInt( value, 10 ) : 0 } ),
+		[ meta, setMeta, key ]
+	);
+
+const useBoolMetaSetter = ( meta, setMeta, key ) =>
+	useCallback( value => setMeta( { ...meta, [ key ]: !! value } ), [ meta, setMeta, key ] );
+
+const PodcastSettingsSidebar = () => {
+	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
+	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
+	const meta = useMemo( () => rawMeta || {}, [ rawMeta ] );
+
+	const setAudioUrl = useMetaSetter( meta, setMeta, META_PODCAST_AUDIO_URL );
+	const setAudioMime = useMetaSetter( meta, setMeta, META_PODCAST_AUDIO_MIME );
+	const setAudioSize = useIntMetaSetter( meta, setMeta, META_PODCAST_AUDIO_SIZE );
+	const setDuration = useMetaSetter( meta, setMeta, META_PODCAST_DURATION );
+	const setEpisodeTitle = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_TITLE );
+	const setEpisodeSummary = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_SUMMARY );
+	const setSeasonNumber = useIntMetaSetter( meta, setMeta, META_PODCAST_SEASON_NUMBER );
+	const setEpisodeNumber = useIntMetaSetter( meta, setMeta, META_PODCAST_EPISODE_NUMBER );
+	const setEpisodeType = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_TYPE );
+	const setExplicit = useMetaSetter( meta, setMeta, META_PODCAST_EXPLICIT );
+	const setBlock = useBoolMetaSetter( meta, setMeta, META_PODCAST_BLOCK );
+
+	return (
+		<PluginSidebar
+			name={ SIDEBAR_NAME }
+			title={ __( 'Jetpack Podcast', 'jetpack' ) }
+			icon={ <MicrophoneIcon /> }
+			className="jetpack-podcast-settings-sidebar"
+		>
+			<PanelBody title={ __( 'Audio', 'jetpack' ) } initialOpen={ true }>
+				<PanelRow>
+					<TextControl
+						label={ __( 'Audio file URL', 'jetpack' ) }
+						help={ __( 'Direct link to the episode audio file (MP3, M4A, etc.).', 'jetpack' ) }
+						type="url"
+						value={ meta[ META_PODCAST_AUDIO_URL ] || '' }
+						onChange={ setAudioUrl }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+				<PanelRow>
+					<TextControl
+						label={ __( 'MIME type', 'jetpack' ) }
+						placeholder="audio/mpeg"
+						value={ meta[ META_PODCAST_AUDIO_MIME ] || '' }
+						onChange={ setAudioMime }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+				<PanelRow>
+					<NumberControl
+						label={ __( 'File size (bytes)', 'jetpack' ) }
+						min={ 0 }
+						value={ meta[ META_PODCAST_AUDIO_SIZE ] || '' }
+						onChange={ setAudioSize }
+						__next40pxDefaultSize
+					/>
+				</PanelRow>
+				<PanelRow>
+					<TextControl
+						label={ __( 'Duration', 'jetpack' ) }
+						help={ __( 'HH:MM:SS or total seconds.', 'jetpack' ) }
+						value={ meta[ META_PODCAST_DURATION ] || '' }
+						onChange={ setDuration }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Episode details', 'jetpack' ) } initialOpen={ false }>
+				<PanelRow>
+					<TextControl
+						label={ __( 'Episode title override', 'jetpack' ) }
+						help={ __( 'Optional. Defaults to the post title.', 'jetpack' ) }
+						value={ meta[ META_PODCAST_EPISODE_TITLE ] || '' }
+						onChange={ setEpisodeTitle }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+				<PanelRow>
+					<TextareaControl
+						label={ __( 'Episode summary', 'jetpack' ) }
+						help={ __( 'Shown in podcast apps as the episode description.', 'jetpack' ) }
+						value={ meta[ META_PODCAST_EPISODE_SUMMARY ] || '' }
+						onChange={ setEpisodeSummary }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<NumberControl
+						label={ __( 'Season number', 'jetpack' ) }
+						min={ 0 }
+						value={ meta[ META_PODCAST_SEASON_NUMBER ] || '' }
+						onChange={ setSeasonNumber }
+						__next40pxDefaultSize
+					/>
+				</PanelRow>
+				<PanelRow>
+					<NumberControl
+						label={ __( 'Episode number', 'jetpack' ) }
+						min={ 0 }
+						value={ meta[ META_PODCAST_EPISODE_NUMBER ] || '' }
+						onChange={ setEpisodeNumber }
+						__next40pxDefaultSize
+					/>
+				</PanelRow>
+				<PanelRow>
+					<SelectControl
+						label={ __( 'Episode type', 'jetpack' ) }
+						options={ EPISODE_TYPE_OPTIONS }
+						value={ meta[ META_PODCAST_EPISODE_TYPE ] || 'full' }
+						onChange={ setEpisodeType }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+				<PanelRow>
+					<SelectControl
+						label={ __( 'Content rating', 'jetpack' ) }
+						options={ EXPLICIT_OPTIONS }
+						value={ meta[ META_PODCAST_EXPLICIT ] || '' }
+						onChange={ setExplicit }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Distribution', 'jetpack' ) } initialOpen={ false }>
+				<PanelRow>
+					<ToggleControl
+						label={ __( 'Hide from podcast feed', 'jetpack' ) }
+						help={ __(
+							'When enabled, this episode is excluded from the podcast feed (itunes:block).',
+							'jetpack'
+						) }
+						checked={ !! meta[ META_PODCAST_BLOCK ] }
+						onChange={ setBlock }
+						__nextHasNoMarginBottom
+					/>
+				</PanelRow>
+			</PanelBody>
+		</PluginSidebar>
+	);
+};
+
+export default PodcastSettingsSidebar;

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
@@ -1,4 +1,4 @@
-import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import { MediaPlaceholder, MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import {
 	BaseControl,
 	Button,
@@ -53,7 +53,6 @@ const PodcastSettingsSidebar = () => {
 	const [ rawMeta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const meta = useMemo( () => rawMeta || {}, [ rawMeta ] );
 
-	const setAudioUrl = useMetaSetter( meta, setMeta, META_PODCAST_AUDIO_URL );
 	const setAudioMime = useMetaSetter( meta, setMeta, META_PODCAST_AUDIO_MIME );
 	const setAudioSize = useIntMetaSetter( meta, setMeta, META_PODCAST_AUDIO_SIZE );
 	const setDuration = useMetaSetter( meta, setMeta, META_PODCAST_DURATION );
@@ -75,6 +74,16 @@ const PodcastSettingsSidebar = () => {
 		[ meta, setMeta ]
 	);
 
+	const onSelectAudioUrl = useCallback(
+		url => {
+			setMeta( {
+				...meta,
+				[ META_PODCAST_AUDIO_URL ]: url,
+			} );
+		},
+		[ meta, setMeta ]
+	);
+
 	const onRemoveAudio = useCallback( () => {
 		setMeta( {
 			...meta,
@@ -87,20 +96,13 @@ const PodcastSettingsSidebar = () => {
 	const audioUrl = meta[ META_PODCAST_AUDIO_URL ] || '';
 	const audioFileId = useInstanceId( PodcastSettingsSidebar, 'jetpack-podcast-audio-file' );
 
-	const renderMediaButton = useCallback(
+	const renderReplaceButton = useCallback(
 		( { open } ) => (
-			<HStack wrap>
-				<Button variant="secondary" onClick={ open }>
-					{ audioUrl ? __( 'Replace audio', 'jetpack' ) : __( 'Select audio', 'jetpack', 0 ) }
-				</Button>
-				{ audioUrl && (
-					<Button variant="tertiary" isDestructive onClick={ onRemoveAudio }>
-						{ __( 'Remove', 'jetpack' ) }
-					</Button>
-				) }
-			</HStack>
+			<Button variant="secondary" onClick={ open }>
+				{ __( 'Replace audio', 'jetpack' ) }
+			</Button>
 		),
-		[ audioUrl, onRemoveAudio ]
+		[]
 	);
 	const setEpisodeTitle = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_TITLE );
 	const setEpisodeSummary = useMetaSetter( meta, setMeta, META_PODCAST_EPISODE_SUMMARY );
@@ -119,35 +121,43 @@ const PodcastSettingsSidebar = () => {
 		>
 			<PanelBody title={ __( 'Audio', 'jetpack' ) } initialOpen={ true }>
 				<PanelRow>
-					<BaseControl
-						__nextHasNoMarginBottom
-						id={ audioFileId }
-						label={ __( 'Audio file', 'jetpack' ) }
-						help={
-							audioUrl
-								? audioUrl
-								: __( 'Upload, choose from the media library, or paste a URL below.', 'jetpack' )
-						}
-					>
-						<MediaUploadCheck>
-							<MediaUpload
-								onSelect={ onSelectAudio }
-								allowedTypes={ [ 'audio' ] }
-								value={ audioUrl }
-								render={ renderMediaButton }
-							/>
-						</MediaUploadCheck>
-					</BaseControl>
-				</PanelRow>
-				<PanelRow>
-					<TextControl
-						label={ __( 'Audio file URL', 'jetpack' ) }
-						help={ __( 'Or paste a direct link to an MP3 / M4A hosted elsewhere.', 'jetpack' ) }
-						type="url"
-						value={ audioUrl }
-						onChange={ setAudioUrl }
-						__nextHasNoMarginBottom
-					/>
+					{ audioUrl ? (
+						<BaseControl
+							__nextHasNoMarginBottom
+							id={ audioFileId }
+							label={ __( 'Audio file', 'jetpack' ) }
+							help={ audioUrl }
+						>
+							<HStack wrap>
+								<MediaUploadCheck>
+									<MediaUpload
+										onSelect={ onSelectAudio }
+										allowedTypes={ [ 'audio' ] }
+										value={ audioUrl }
+										render={ renderReplaceButton }
+									/>
+								</MediaUploadCheck>
+								<Button variant="tertiary" isDestructive onClick={ onRemoveAudio }>
+									{ __( 'Remove', 'jetpack' ) }
+								</Button>
+							</HStack>
+						</BaseControl>
+					) : (
+						<MediaPlaceholder
+							labels={ {
+								title: __( 'Audio file', 'jetpack' ),
+								instructions: __(
+									'Upload an audio file, choose one from the media library, or insert a URL.',
+									'jetpack'
+								),
+							} }
+							onSelect={ onSelectAudio }
+							onSelectURL={ onSelectAudioUrl }
+							accept="audio/*"
+							allowedTypes={ [ 'audio' ] }
+							value={ { src: audioUrl } }
+						/>
+					) }
 				</PanelRow>
 				<PanelRow>
 					<TextControl

--- a/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
+++ b/projects/plugins/jetpack/extensions/plugins/podcast-post-settings/sidebar.js
@@ -91,7 +91,7 @@ const PodcastSettingsSidebar = () => {
 		( { open } ) => (
 			<HStack wrap>
 				<Button variant="secondary" onClick={ open }>
-					{ audioUrl ? __( 'Replace audio', 'jetpack' ) : __( 'Select audio', 'jetpack' ) }
+					{ audioUrl ? __( 'Replace audio', 'jetpack' ) : __( 'Select audio', 'jetpack', 0 ) }
 				</Button>
 				{ audioUrl && (
 					<Button variant="tertiary" isDestructive onClick={ onRemoveAudio }>


### PR DESCRIPTION
## Proposed changes

* New `podcast-post-settings` editor extension that adds a Jetpack Podcast sidebar (microphone icon) to the post editor top bar.
* Sidebar fields: audio URL, MIME, file size, duration, episode title override, summary, season/episode number, episode type, content rating, and a hide-from-feed toggle.
* All values stored as post meta (REST-exposed, sync whitelisted).
* RSS feed picks them up via `rss2_ns` (iTunes/Podcast namespaces) and `rss2_item` (`<enclosure>` + `itunes:*` tags) when an audio URL is set.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Edit a Post in the block editor.
* Click the microphone icon in the top toolbar.
* Fill in an audio URL and any other episode fields, then save.
* Visit `/?feed=rss2` (or the configured podcast feed) and confirm the post's item contains `<enclosure>` and `itunes:*` tags matching what you entered.
* Confirm Pages do not show the microphone icon.
