### PR TITLE
Social: use connection template in per-network editor

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
@@ -1,7 +1,6 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { render } from '@testing-library/react';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { DEFAULT_MESSAGE_TEMPLATE } from '../../../social-store/constants';
 import { PerNetworkCustomizationForm } from './per-network';
 import type { Connection } from '../../../social-store/types';
 
@@ -64,10 +63,6 @@ const baseConnection: Connection = {
 };
 
 /**
- *
- * @param connectionOverrides
- */
-/**
  * Render the form and return the props passed to SharePostForm.
  *
  * @param {Partial< Connection >} connectionOverrides - Partial connection values for the test case.
@@ -82,14 +77,14 @@ function getSharePostFormProps( connectionOverrides: Partial< Connection > = {} 
 describe( 'PerNetworkCustomizationForm', () => {
 	const mockCustomizeConnectionById = jest.fn();
 	let globalMessage = '';
-	let globalTemplate = DEFAULT_MESSAGE_TEMPLATE;
+	let globalTemplate = 'Saved global template';
 	let templatesEnabled = true;
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 
 		globalMessage = '';
-		globalTemplate = DEFAULT_MESSAGE_TEMPLATE;
+		globalTemplate = 'Saved global template';
 		templatesEnabled = true;
 
 		mockUseDispatch.mockReturnValue( {
@@ -145,7 +140,9 @@ describe( 'PerNetworkCustomizationForm', () => {
 		expect( sharePostFormProps.messageHelp ).toBe( 'Global template will be used if empty.' );
 	} );
 
-	it( 'shows default-template helper text when global template is still default', () => {
+	it( 'shows default-template helper text when global template is empty', () => {
+		globalTemplate = '';
+
 		const sharePostFormProps = getSharePostFormProps( {
 			message: '',
 			template: '',

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
@@ -1,0 +1,172 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { render } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { DEFAULT_MESSAGE_TEMPLATE } from '../../../social-store/constants';
+import { PerNetworkCustomizationForm } from './per-network';
+import type { Connection } from '../../../social-store/types';
+
+jest.mock( '@automattic/jetpack-script-data', () => {
+	const actual = jest.requireActual( '@automattic/jetpack-script-data' );
+	return {
+		...actual,
+		siteHasFeature: jest.fn(),
+	};
+} );
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	};
+
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+const mockUsePostMeta = jest.fn();
+jest.mock( '../../../hooks/use-post-meta', () => ( {
+	usePostMeta: () => mockUsePostMeta(),
+} ) );
+
+jest.mock( '../../../hooks/use-featured-image', () => jest.fn( () => null ) );
+jest.mock( '../../../hooks/use-media-details', () => jest.fn( () => [ null ] ) );
+
+const mockSharePostForm = jest.fn();
+jest.mock( '../../form/share-post-form', () => ( {
+	SharePostForm: ( props: unknown ) => {
+		mockSharePostForm( props );
+		return null;
+	},
+} ) );
+
+const mockUseDispatch = useDispatch as jest.Mock;
+const mockUseSelect = useSelect as jest.Mock;
+const mockSiteHasFeature = siteHasFeature as jest.Mock;
+
+const baseConnection: Connection = {
+	connection_id: 'connection-1',
+	display_name: 'Example Connection',
+	external_handle: '@example',
+	external_id: 'external-1',
+	profile_link: 'https://example.com/profile',
+	profile_picture: 'https://example.com/profile.jpg',
+	service_label: 'Facebook',
+	service_name: 'facebook',
+	shared: false,
+	status: 'ok',
+	wpcom_user_id: 123,
+	enabled: true,
+	attached_media: [ { id: 99, url: 'https://example.com/media.jpg', type: 'image/jpeg' } ],
+};
+
+/**
+ *
+ * @param connectionOverrides
+ */
+/**
+ * Render the form and return the props passed to SharePostForm.
+ *
+ * @param {Partial< Connection >} connectionOverrides - Partial connection values for the test case.
+ * @return {Record< string, unknown >} Props passed to SharePostForm.
+ */
+function getSharePostFormProps( connectionOverrides: Partial< Connection > = {} ) {
+	const connection = { ...baseConnection, ...connectionOverrides };
+	render( <PerNetworkCustomizationForm connection={ connection } /> );
+	return mockSharePostForm.mock.calls[ 0 ][ 0 ];
+}
+
+describe( 'PerNetworkCustomizationForm', () => {
+	const mockCustomizeConnectionById = jest.fn();
+	let globalMessage = '';
+	let globalTemplate = DEFAULT_MESSAGE_TEMPLATE;
+	let templatesEnabled = true;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		globalMessage = '';
+		globalTemplate = DEFAULT_MESSAGE_TEMPLATE;
+		templatesEnabled = true;
+
+		mockUseDispatch.mockReturnValue( {
+			customizeConnectionById: mockCustomizeConnectionById,
+		} );
+
+		mockUsePostMeta.mockImplementation( () => ( {
+			attachedMedia: [],
+			shareMessage: globalMessage,
+			mediaSource: undefined,
+		} ) );
+
+		mockUseSelect.mockImplementation( selector => {
+			return selector( () => ( {
+				getSocialSettings: () => ( { messageTemplate: globalTemplate } ),
+			} ) );
+		} );
+
+		mockSiteHasFeature.mockImplementation( flag => {
+			return flag === 'social-message-templates' ? templatesEnabled : false;
+		} );
+	} );
+
+	it( 'uses the per-connection message when it is non-empty', () => {
+		const sharePostFormProps = getSharePostFormProps( {
+			message: 'Manual per-post override',
+			template: '{title} {url}',
+		} );
+
+		expect( sharePostFormProps.message ).toBe( 'Manual per-post override' );
+		expect( sharePostFormProps.messageHelp ).toBe( 'Connection template will be used if empty.' );
+	} );
+
+	it( 'prefills with the connection template when message is empty', () => {
+		const sharePostFormProps = getSharePostFormProps( {
+			message: '',
+			template: '{title} {url}',
+		} );
+
+		expect( sharePostFormProps.message ).toBe( '{title} {url}' );
+		expect( sharePostFormProps.messageHelp ).toBe( 'Connection template will be used if empty.' );
+	} );
+
+	it( 'shows global-template helper text when there is no connection message or template', () => {
+		globalTemplate = 'Custom global template: {title}';
+
+		const sharePostFormProps = getSharePostFormProps( {
+			message: '',
+			template: '',
+		} );
+
+		expect( sharePostFormProps.message ).toBe( '' );
+		expect( sharePostFormProps.messageHelp ).toBe( 'Global template will be used if empty.' );
+	} );
+
+	it( 'shows default-template helper text when global template is still default', () => {
+		const sharePostFormProps = getSharePostFormProps( {
+			message: '',
+			template: '',
+		} );
+
+		expect( sharePostFormProps.message ).toBe( '' );
+		expect( sharePostFormProps.messageHelp ).toBe(
+			'The default network template will be used if empty.'
+		);
+	} );
+
+	it( 'keeps current behavior when message templates feature is off', () => {
+		templatesEnabled = false;
+		globalMessage = 'Global custom message';
+
+		const sharePostFormProps = getSharePostFormProps( {
+			message: undefined,
+			template: '{title} {url}',
+		} );
+
+		expect( sharePostFormProps.message ).toBe( 'Global custom message' );
+		expect( sharePostFormProps.messageHelp ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -16,6 +16,19 @@ type PerNetworkCustomizationFormProps = {
 	connection: Connection;
 };
 
+const CONNECTION_TEMPLATE_HELP = __(
+	'Connection template will be used if empty.',
+	'jetpack-publicize-pkg'
+);
+const GLOBAL_TEMPLATE_HELP = __(
+	'Global template will be used if empty.',
+	'jetpack-publicize-pkg'
+);
+const DEFAULT_NETWORK_TEMPLATE_HELP = __(
+	'The default network template will be used if empty.',
+	'jetpack-publicize-pkg'
+);
+
 /**
  * Per-Network Customization Form component.
  *
@@ -55,14 +68,11 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 			: connection.template ?? globalMessage ?? '';
 
 		if ( hasConnectionTemplate ) {
-			fallbackHelp = __( 'Connection template will be used if empty.', 'jetpack-publicize-pkg' );
+			fallbackHelp = CONNECTION_TEMPLATE_HELP;
 		} else if ( hasCustomGlobalTemplate ) {
-			fallbackHelp = __( 'Global template will be used if empty.', 'jetpack-publicize-pkg' );
+			fallbackHelp = GLOBAL_TEMPLATE_HELP;
 		} else {
-			fallbackHelp = __(
-				'The default network template will be used if empty.',
-				'jetpack-publicize-pkg'
-			);
+			fallbackHelp = DEFAULT_NETWORK_TEMPLATE_HELP;
 		}
 	}
 

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -7,7 +7,6 @@ import useMediaDetails from '../../../hooks/use-media-details';
 import { computeAttachedMediaForSource } from '../../../hooks/use-per-network-customization/utils';
 import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
-import { DEFAULT_MESSAGE_TEMPLATE } from '../../../social-store/constants';
 import { Connection } from '../../../social-store/types';
 import { features } from '../../../utils/constants';
 import { SharePostForm, SharePostFormProps } from '../../form/share-post-form';
@@ -56,8 +55,7 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 
 	const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
 	const hasConnectionTemplate = Boolean( connection.template );
-	const hasCustomGlobalTemplate =
-		Boolean( globalMessageTemplate ) && globalMessageTemplate !== DEFAULT_MESSAGE_TEMPLATE;
+	const hasGlobalMessageTemplate = Boolean( globalMessageTemplate );
 
 	let message = connection.message ?? globalMessage ?? '';
 	let fallbackHelp: string | undefined;
@@ -69,7 +67,7 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 
 		if ( hasConnectionTemplate ) {
 			fallbackHelp = CONNECTION_TEMPLATE_HELP;
-		} else if ( hasCustomGlobalTemplate ) {
+		} else if ( hasGlobalMessageTemplate ) {
 			fallbackHelp = GLOBAL_TEMPLATE_HELP;
 		} else {
 			fallbackHelp = DEFAULT_NETWORK_TEMPLATE_HELP;

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -1,11 +1,15 @@
-import { useDispatch } from '@wordpress/data';
+import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from 'react';
 import useFeaturedImage from '../../../hooks/use-featured-image';
 import useMediaDetails from '../../../hooks/use-media-details';
 import { computeAttachedMediaForSource } from '../../../hooks/use-per-network-customization/utils';
 import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
+import { DEFAULT_MESSAGE_TEMPLATE } from '../../../social-store/constants';
 import { Connection } from '../../../social-store/types';
+import { features } from '../../../utils/constants';
 import { SharePostForm, SharePostFormProps } from '../../form/share-post-form';
 
 type PerNetworkCustomizationFormProps = {
@@ -20,11 +24,16 @@ type PerNetworkCustomizationFormProps = {
  */
 export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomizationFormProps ) {
 	const { customizeConnectionById } = useDispatch( socialStore );
+	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 	const {
 		attachedMedia: globalAttachedMedia,
 		shareMessage: globalMessage,
 		mediaSource: globalMediaSource,
 	} = usePostMeta();
+	const globalMessageTemplate = useSelect(
+		select => select( socialStore ).getSocialSettings().messageTemplate,
+		[]
+	);
 
 	// Get featured image details for forced attachment
 	const featuredImageId = useFeaturedImage();
@@ -32,7 +41,30 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 	const featuredImageUrl = featuredImageDetails?.mediaData?.sourceUrl;
 	const featuredImageMime = featuredImageDetails?.metaData?.mime ?? 'image/jpeg';
 
-	const message = connection.message ?? globalMessage ?? '';
+	const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
+	const hasConnectionTemplate = Boolean( connection.template );
+	const hasCustomGlobalTemplate =
+		Boolean( globalMessageTemplate ) && globalMessageTemplate !== DEFAULT_MESSAGE_TEMPLATE;
+
+	let message = connection.message ?? globalMessage ?? '';
+	let fallbackHelp: string | undefined;
+
+	if ( templatesEnabled ) {
+		message = hasConnectionMessage
+			? connection.message ?? ''
+			: connection.template ?? globalMessage ?? '';
+
+		if ( hasConnectionTemplate ) {
+			fallbackHelp = __( 'Connection template will be used if empty.', 'jetpack-publicize-pkg' );
+		} else if ( hasCustomGlobalTemplate ) {
+			fallbackHelp = __( 'Global template will be used if empty.', 'jetpack-publicize-pkg' );
+		} else {
+			fallbackHelp = __(
+				'The default network template will be used if empty.',
+				'jetpack-publicize-pkg'
+			);
+		}
+	}
 
 	// Don't default to 'none' - let undefined trigger featured image fallback detection
 	const mediaSource = connection.media_source ?? globalMediaSource;
@@ -120,6 +152,7 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 			isInsideNavigatorModal
 			disabled={ ! connection.enabled }
 			message={ message }
+			messageHelp={ fallbackHelp }
 			onMessageChange={ handleMessageChange }
 			attachedMedia={ attachedMedia }
 			onMediaChange={ handleMediaChange }

--- a/projects/packages/publicize/_inc/components/form/share-post-form.tsx
+++ b/projects/packages/publicize/_inc/components/form/share-post-form.tsx
@@ -2,7 +2,7 @@ import { Disabled, useNavigator } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useCallback, type FC } from 'react';
+import { useCallback, type FC, type ReactNode } from 'react';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { store as socialStore } from '../../social-store';
 import { hasSocialPaidFeatures } from '../../utils';
@@ -36,6 +36,16 @@ export type SharePostFormProps = {
 	 * updating via the internal store.
 	 */
 	onMessageChange?: ( message: string ) => void;
+
+	/**
+	 * Optional placeholder for the message field.
+	 */
+	messagePlaceholder?: string;
+
+	/**
+	 * Optional help text for the message field.
+	 */
+	messageHelp?: ReactNode;
 
 	/**
 	 * Optional attached media array. In controlled mode (when `onMediaChange` is provided),
@@ -88,6 +98,8 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 	isInsideNavigatorModal,
 	message: messageProp,
 	onMessageChange,
+	messagePlaceholder,
+	messageHelp,
 	attachedMedia,
 	imageGeneratorSettings,
 	mediaSource,
@@ -134,6 +146,8 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 						maxLength={ maxLength }
 						onChange={ updateMessage }
 						message={ message }
+						placeholder={ messagePlaceholder }
+						help={ messageHelp }
 						analyticsData={ analyticsData }
 						disabled={ disabled }
 					/>

--- a/projects/packages/publicize/_inc/components/message-box-control/index.tsx
+++ b/projects/packages/publicize/_inc/components/message-box-control/index.tsx
@@ -7,6 +7,7 @@ import { useCallback, useRef } from 'react';
 import { features } from '../../utils/constants';
 import PlaceholdersHelp from '../placeholders-help';
 import styles from './styles.module.scss';
+import type { ReactNode } from 'react';
 
 export const getPlaceholderText = () =>
 	__(
@@ -33,6 +34,9 @@ export type MessageBoxControlProps = {
 
 	/** The placeholder text for the message box */
 	placeholder?: string;
+
+	/** Optional help text override */
+	help?: ReactNode;
 
 	/** The message to display */
 	message: string;
@@ -63,6 +67,7 @@ export type MessageBoxControlProps = {
 export default function MessageBoxControl( {
 	label = getDefaultLabel(),
 	placeholder,
+	help: helpProp,
 	message = '',
 	onChange,
 	disabled,
@@ -95,27 +100,29 @@ export default function MessageBoxControl( {
 	// Skip both the maxLength cap and the "characters remaining" counter, and instead
 	// wire the help slot to a placeholder-aware description that screen readers will
 	// announce via aria-describedby (which BaseControl sets on the textarea).
-	const help = templatesEnabled
-		? createInterpolateElement(
-				__(
-					'Supports placeholders like <title/> and <url/>. See the list below for all the options.',
-					'jetpack-publicize-pkg'
-				),
-				{
-					title: <code>{ '{title}' }</code>,
-					url: <code>{ '{url}' }</code>,
-				}
-		  )
-		: sprintf(
-				/* translators: %d: the number of characters remaining. */
-				_n(
-					'%d character remaining',
-					'%d characters remaining',
-					charactersRemaining,
-					'jetpack-publicize-pkg'
-				),
-				charactersRemaining
-		  );
+	const help =
+		helpProp ??
+		( templatesEnabled
+			? createInterpolateElement(
+					__(
+						'Supports placeholders like <title/> and <url/>. See the list below for all the options.',
+						'jetpack-publicize-pkg'
+					),
+					{
+						title: <code>{ '{title}' }</code>,
+						url: <code>{ '{url}' }</code>,
+					}
+			  )
+			: sprintf(
+					/* translators: %d: the number of characters remaining. */
+					_n(
+						'%d character remaining',
+						'%d characters remaining',
+						charactersRemaining,
+						'jetpack-publicize-pkg'
+					),
+					charactersRemaining
+			  ) );
 
 	return (
 		<div className={ styles[ 'message-box-control' ] }>

--- a/projects/packages/publicize/_inc/components/message-box-control/tests/index.test.js
+++ b/projects/packages/publicize/_inc/components/message-box-control/tests/index.test.js
@@ -151,6 +151,21 @@ describe( 'MessageBoxControl', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	it( 'uses explicit help text when provided', () => {
+		render(
+			<MessageBoxControl
+				message={ mockMessage }
+				onChange={ mockOnChange }
+				maxLength={ mockMaxLength }
+				help="Custom help text"
+			/>
+		);
+
+		expect( screen.getByText( 'Custom help text' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /characters remaining/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /character remaining/ ) ).not.toBeInTheDocument();
+	} );
+
 	describe( 'when templates feature is on', () => {
 		beforeEach( () => {
 			siteHasFeature.mockReturnValue( true );
@@ -226,6 +241,19 @@ describe( 'MessageBoxControl', () => {
 
 			expect( screen.queryByText( /characters remaining/ ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( /character remaining/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'uses explicit help text when provided', () => {
+			render(
+				<MessageBoxControl
+					message={ mockMessage }
+					onChange={ mockOnChange }
+					maxLength={ mockMaxLength }
+					help="Custom help text"
+				/>
+			);
+
+			expect( screen.getByText( 'Custom help text' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/projects/packages/publicize/_inc/social-store/constants.ts
+++ b/projects/packages/publicize/_inc/social-store/constants.ts
@@ -5,6 +5,7 @@ export const SOCIAL_NOTES_ENABLED_KEY = 'jetpack-social-note';
 export const SOCIAL_NOTES_CONFIG_KEY = 'jetpack_social_notes_config';
 export const SHOW_PRICING_PAGE_KEY = 'jetpack-social_show_pricing_page';
 export const MESSAGE_TEMPLATE_KEY = 'jetpack_social_message_template';
+export const DEFAULT_MESSAGE_TEMPLATE = '{title}\n\n{excerpt}\n\n{url}';
 
 export const CUSTOMIZE_PER_NETWORK_KEY = '_wpas_customize_per_network';
 

--- a/projects/packages/publicize/_inc/social-store/constants.ts
+++ b/projects/packages/publicize/_inc/social-store/constants.ts
@@ -5,7 +5,6 @@ export const SOCIAL_NOTES_ENABLED_KEY = 'jetpack-social-note';
 export const SOCIAL_NOTES_CONFIG_KEY = 'jetpack_social_notes_config';
 export const SHOW_PRICING_PAGE_KEY = 'jetpack-social_show_pricing_page';
 export const MESSAGE_TEMPLATE_KEY = 'jetpack_social_message_template';
-export const DEFAULT_MESSAGE_TEMPLATE = '{title}\n\n{excerpt}\n\n{url}';
 
 export const CUSTOMIZE_PER_NETWORK_KEY = '_wpas_customize_per_network';
 

--- a/projects/packages/publicize/changelog/social-453-per-network-template-visibility
+++ b/projects/packages/publicize/changelog/social-453-per-network-template-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Show per-connection template fallback help and prefill per-network editor messages from connection templates.


### PR DESCRIPTION
Fixes SOCIAL-453

## Proposed changes
* Use connection-level templates to prefill per-network message fields in the block editor when no per-post connection override is set.
* Add per-network fallback help text that clarifies what will be used when the field is empty:
  * Connection template
  * Global template
  * Default network template
* Gate the new per-network display behavior behind `social-message-templates`.
* Plumb optional `messageHelp`/`messagePlaceholder` support from `SharePostForm` to `MessageBoxControl`.
* Use the existing `messageTemplate` setting from social script data/store fallback instead of duplicating the PHP default template in JS.
* Add tests for per-network prefill/help behavior and for explicit `MessageBoxControl` help override.
* Add a Publicize changelog entry.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/SOCIAL-453/use-connection-template-in-the-editor

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Ensure site features include `social-enhanced-publishing` and `social-message-templates`.
* Open Gutenberg editor for a post and open the Social customize-and-preview UI.
* Enable per-network customization.

1. Connection-template prefill
* Set a connection template for one connection in connection management.
* Open that connection in per-network customization.
* Verify the Message field is prefilled with the connection template.
* Verify help text reads: `Connection template will be used if empty.`

<img width="692" height="590" alt="CleanShot 2026-05-06 at 15 46 57@2x" src="https://github.com/user-attachments/assets/4681aa38-1810-4153-9c71-4b2f1aff672b" />

2. Global-template fallback helper
* Use a connection with no connection template.
* Set a non-empty global message template in Social settings.
* Verify helper reads: `Global template will be used if empty.`

<img width="700" height="600" alt="CleanShot 2026-05-06 at 15 49 00@2x" src="https://github.com/user-attachments/assets/fe1b069a-3bdf-4f7d-ab79-e2e6aa488944" />

3. Default-network fallback helper
* Save an empty global message template in Social settings.
* Use a connection with no connection template.
* Verify helper reads: `The default network template will be used if empty.`

<img width="708" height="610" alt="CleanShot 2026-05-06 at 15 47 36@2x" src="https://github.com/user-attachments/assets/cf73adce-2766-48fc-928e-83256c9c044b" />

4. Override precedence
* Enter a non-empty per-network message override.
* Verify the entered value is shown instead of the connection template.

5. Feature-flag-off regression
* Disable `social-message-templates`.
* Verify current behavior is preserved (no new fallback helper text and no template-prefill behavior).

6. Automated checks run
* `pnpm --filter @automattic/jetpack-publicize test -- per-network.test.tsx message-box-control/tests/index.test.js`
* `pnpm --filter @automattic/jetpack-publicize typecheck`
* `pnpm --filter @automattic/jetpack-publicize run build-production-concurrently`