### PR TITLE
Wpcomsh fatal-error: log recovery email dispatches and recovery-mode logins

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-fatal-error-recovery-logging
+++ b/projects/plugins/wpcomsh/changelog/add-fatal-error-recovery-logging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fatal error: log recovery-mode email dispatches (sent, disabled, no recipient) and post-login recovery-mode entry to logstash.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-email.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-email.php
@@ -32,6 +32,21 @@ function wpcomsh_fatal_customize_recovery_email( $email, $url = '', $extension =
 	unset( $extension );
 
 	if ( empty( $email['to'] ) ) {
+		// Distinguish the two reasons `to` lands empty here so they're
+		// filterable downstream: `…_disabled` when the opt-out filter in
+		// functions.php (`wpcomsh_disable_fatal_error_emails`, priority 10)
+		// blanked it, vs `…_no_recipient` when core's
+		// `get_recovery_mode_email_address()` returned empty (no admin_email
+		// and no RECOVERY_MODE_EMAIL) — the latter is a real failure since
+		// the admin won't receive the recovery link.
+		$error_info = wpcomsh_fatal_get_last_error();
+		$plugin     = $error_info ? wpcomsh_fatal_identify_plugin( $error_info ) : null;
+		if ( is_array( $plugin ) ) {
+			$message = get_option( 'wpcomsh_disable_fatal_error_emails', false )
+				? 'wpcomsh_fatal_recovery_email_disabled'
+				: 'wpcomsh_fatal_recovery_email_no_recipient';
+			wpcomsh_fatal_log_event( $plugin, $message );
+		}
 		return $email;
 	}
 
@@ -43,6 +58,10 @@ function wpcomsh_fatal_customize_recovery_email( $email, $url = '', $extension =
 	$error_info  = wpcomsh_fatal_get_last_error();
 	$plugin      = $error_info ? wpcomsh_fatal_identify_plugin( $error_info ) : null;
 	$environment = wpcomsh_fatal_get_environment_lines();
+
+	if ( is_array( $plugin ) ) {
+		wpcomsh_fatal_log_event( $plugin, 'wpcomsh_fatal_recovery_email' );
+	}
 
 	$email['subject'] = wpcomsh_fatal_build_email_subject( $site_name, $plugin );
 	$email['message'] = wpcomsh_fatal_build_email_message( $site_url, (string) $url, $plugin, $error_info, $environment );

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -134,20 +134,10 @@ function wpcomsh_fatal_log_deactivate( $plugin_basename ) {
 }
 
 /**
- * Emit a fatal-error event via WPCOMSH_Log::unsafe_direct_log_logstash(),
- * alongside the decoded signature parts so consumers don't have to decode
- * the signature themselves.
- *
- * Callable from both the fatal-screen render path and the deactivator
- * endpoint at mu-plugin load time. The deactivator path runs before
- * constants.php, so we resolve the wpcomsh root via `dirname(__DIR__)`
- * rather than WPCOMSH__PLUGIN_DIR_PATH.
- *
- * Manual require with `class_exists( …, false )` skips the autoloader during
- * fatal handling, where its filesystem reads could compound a bad state.
- *
- * Best-effort: silently no-ops if either dependency is unreachable. A logging
- * failure must never escalate into a second fatal.
+ * Emit a fatal-error event keyed on a suspected extension. Builds the
+ * signature, dedups per (message, signature) for 1 hour, and routes
+ * through `wpcomsh_fatal_emit_logstash` so the recovery-login event can
+ * share the same dispatch tail.
  *
  * @param array|null $plugin  Extension metadata from wpcomsh_fatal_identify_plugin().
  * @param string     $message Event message slug (e.g. `wpcomsh_fatal_signature`, `wpcomsh_fatal_deactivate`).
@@ -158,10 +148,8 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 		return;
 	}
 
-	$wpcomsh_root = dirname( __DIR__ );
-
 	if ( ! function_exists( 'wpcom_build_fatal_error_signature' ) ) {
-		$helper = $wpcomsh_root . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/common/fatal-error-signature.php';
+		$helper = dirname( __DIR__ ) . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/common/fatal-error-signature.php';
 		if ( is_readable( $helper ) ) {
 			require_once $helper;
 		}
@@ -184,7 +172,10 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 	// Dedup per (message, signature) for 1 hour so a persistent fatal doesn't
 	// emit one log row + one outbound HTTP per visitor. $message is part of
 	// the key so a deactivate event isn't suppressed by a recent signature
-	// event for the same extension.
+	// event for the same extension. The TTL stays short of core's 24h
+	// `recovery_mode_email_rate_limit` so a legitimate re-send — e.g. the
+	// admin exits recovery mode and the site fatals again — surfaces rather
+	// than getting silently swallowed.
 	$cache_key = 'wpcomsh_fatal_event:' . hash( 'sha256', $message . '|' . $signature );
 	try {
 		if ( ! wp_cache_add( $cache_key, 1, 'wpcomsh', HOUR_IN_SECONDS ) ) {
@@ -194,43 +185,7 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 		// Fall through and log.
 	}
 
-	if ( ! class_exists( 'WPCOMSH_Log', false ) ) {
-		$log_file = $wpcomsh_root . '/class-wpcomsh-log.php';
-		if ( is_readable( $log_file ) ) {
-			require_once $log_file;
-		}
-	}
-	if ( ! class_exists( 'WPCOMSH_Log', false ) ) {
-		return;
-	}
-
 	$properties = array( 'signature' => $signature );
-
-	// `get_site_url()` runs the `site_url` / `option_siteurl` filters, so a
-	// misbehaving filter could throw — keep the lookup in its own guard so
-	// the rest of the signature still makes it to logstash.
-	try {
-		$properties['site_url'] = get_site_url();
-	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit site_url if a filter misbehaves.
-		// Fall through.
-	}
-
-	// Prefer the constant: it's set on Atomic and avoids the apply_filters()
-	// dispatch inside wpcomsh_get_atomic_site_id(). Fall back to the helper
-	// only when the constant isn't defined; guard the call because the helper
-	// runs the `wpcomsh_get_atomic_site_id` filter, and a misbehaving callback
-	// must not bubble out of this best-effort logger.
-	$atomic_site_id = defined( 'ATOMIC_SITE_ID' ) ? (int) ATOMIC_SITE_ID : 0;
-	if ( 0 === $atomic_site_id && function_exists( 'wpcomsh_get_atomic_site_id' ) ) {
-		try {
-			$atomic_site_id = (int) wpcomsh_get_atomic_site_id();
-		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit atomic_site_id if a filter misbehaves.
-			// Fall through.
-		}
-	}
-	if ( $atomic_site_id > 0 ) {
-		$properties['atomic_site_id'] = $atomic_site_id;
-	}
 
 	// Round-trip through the decoder so the logged parts always agree
 	// with the signature.
@@ -242,6 +197,69 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 			$properties['extension_version'] = $parts['version'];
 			$properties['wp_version']        = $parts['wp'];
 			$properties['php_version']       = $parts['php'];
+		}
+	}
+
+	wpcomsh_fatal_emit_logstash( $message, $properties );
+}
+
+/**
+ * Dispatch a fatal-flow event to the `atomic_extension_conflict` logstash
+ * bucket, after merging in the shared site identifiers (`site_url`,
+ * `atomic_site_id`) callers always want attached.
+ *
+ * Manual require with `class_exists( …, false )` skips the autoloader
+ * during fatal handling, where its filesystem reads could compound a bad
+ * state. Resolves the wpcomsh root via `dirname(__DIR__)` so the
+ * deactivator endpoint can call this at mu-plugin file-load time, before
+ * constants.php has run.
+ *
+ * Best-effort: silently no-ops when WPCOMSH_Log is unreachable, and never
+ * lets a dispatch failure bubble out — telemetry must not escalate a
+ * recovery flow into a second fatal.
+ *
+ * @param string                    $message    Event message slug.
+ * @param array<string,scalar|null> $properties Event-specific properties; site_url + atomic_site_id are added when missing.
+ * @return void
+ */
+function wpcomsh_fatal_emit_logstash( $message, $properties = array() ) {
+	if ( ! class_exists( 'WPCOMSH_Log', false ) ) {
+		$log_file = dirname( __DIR__ ) . '/class-wpcomsh-log.php';
+		if ( is_readable( $log_file ) ) {
+			require_once $log_file;
+		}
+	}
+	if ( ! class_exists( 'WPCOMSH_Log', false ) ) {
+		return;
+	}
+
+	// `get_site_url()` runs the `site_url` / `option_siteurl` filters, so a
+	// misbehaving filter could throw — keep the lookup in its own guard so
+	// the rest of the event still makes it to logstash.
+	if ( ! isset( $properties['site_url'] ) ) {
+		try {
+			$properties['site_url'] = get_site_url();
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit site_url if a filter misbehaves.
+			// Fall through.
+		}
+	}
+
+	// Prefer the constant: it's set on Atomic and avoids the apply_filters()
+	// dispatch inside wpcomsh_get_atomic_site_id(). Fall back to the helper
+	// only when the constant isn't defined; guard the call because the helper
+	// runs the `wpcomsh_get_atomic_site_id` filter, and a misbehaving callback
+	// must not bubble out.
+	if ( ! isset( $properties['atomic_site_id'] ) ) {
+		$atomic_site_id = defined( 'ATOMIC_SITE_ID' ) ? (int) ATOMIC_SITE_ID : 0;
+		if ( 0 === $atomic_site_id && function_exists( 'wpcomsh_get_atomic_site_id' ) ) {
+			try {
+				$atomic_site_id = (int) wpcomsh_get_atomic_site_id();
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit atomic_site_id if a filter misbehaves.
+				// Fall through.
+			}
+		}
+		if ( $atomic_site_id > 0 ) {
+			$properties['atomic_site_id'] = $atomic_site_id;
 		}
 	}
 

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-recovery-login.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-recovery-login.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Log when a user authenticates while a recovery-mode session is active.
+ *
+ * Hooks `wp_login` and checks `wp_is_recovery_mode()`: by the time the
+ * action runs, core's `WP_Recovery_Mode::handle_cookie()` has already
+ * validated the recovery cookie from wp-settings.php, so a true result
+ * means the just-authenticated user is now operating inside a recovery
+ * session — the support-relevant "user got past login in recovery mode"
+ * signal.
+ *
+ * Distinct from `wpcomsh_fatal_signature` / `wpcomsh_fatal_deactivate`,
+ * which are keyed on a suspected extension. This event has no fatal
+ * context (the recovery cookie was set on a previous request, possibly
+ * by core's email link rather than our screen), so it skips the
+ * signature-building wrapper and emits through `wpcomsh_fatal_emit_logstash`
+ * directly.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * `wp_login` callback. Emits a `wpcomsh_fatal_recovery_login` event the
+ * first time a user authenticates inside a given recovery-mode session,
+ * deduped per (session, user) so a re-login on the same recovery cookie
+ * doesn't double-log. Falls back to a per-user dedup when the session id
+ * is unavailable so unhealthy core state doesn't silently drop the event.
+ *
+ * @param string  $user_login Login name passed by `wp_login`. Unused.
+ * @param WP_User $user       Authenticated user.
+ * @return void
+ */
+function wpcomsh_fatal_log_recovery_login( $user_login, $user ) {
+	unset( $user_login );
+
+	if ( ! function_exists( 'wp_is_recovery_mode' ) || ! wp_is_recovery_mode() ) {
+		return;
+	}
+	if ( ! ( $user instanceof WP_User ) || ! $user->ID ) {
+		return;
+	}
+
+	$session_id = '';
+	if ( function_exists( 'wp_recovery_mode' ) ) {
+		try {
+			$session_id = (string) wp_recovery_mode()->get_session_id();
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; fall through to a per-user dedup.
+			// Fall through.
+		}
+	}
+
+	// Hash the session id (it's the validated cookie payload) before
+	// folding it into a dedup key, so the cache key never carries the
+	// raw secret. Keyed on (session, user) so two admins inside one
+	// shared recovery cookie still each emit once.
+	$dedup_seed = '' !== $session_id
+		? hash( 'sha256', $session_id . '|' . (int) $user->ID )
+		: 'user:' . (int) $user->ID;
+	$cache_key  = 'wpcomsh_fatal_event:recovery_login:' . $dedup_seed;
+	try {
+		if ( ! wp_cache_add( $cache_key, 1, 'wpcomsh', WEEK_IN_SECONDS ) ) {
+			return;
+		}
+	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- fail open: a cache outage MUST NOT silence telemetry.
+		// Fall through and log.
+	}
+
+	wpcomsh_fatal_emit_logstash(
+		'wpcomsh_fatal_recovery_login',
+		array( 'user_id' => (int) $user->ID )
+	);
+}
+add_action( 'wp_login', 'wpcomsh_fatal_log_recovery_login', 10, 2 );

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/load.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/load.php
@@ -13,6 +13,9 @@
  *                                 the admin notification copy.
  *   fatal-plugin-deactivator.php  Early-running endpoint that honors the
  *                                 signed deactivation URL the screen renders.
+ *   fatal-recovery-login.php      `wp_login` hook that logs when a user
+ *                                 authenticates inside a recovery-mode
+ *                                 session.
  *
  * @package wpcomsh
  */
@@ -22,3 +25,4 @@ require_once __DIR__ . '/fatal-error-helpers.php';
 require_once __DIR__ . '/fatal-error-screen.php';
 require_once __DIR__ . '/fatal-error-email.php';
 require_once __DIR__ . '/fatal-plugin-deactivator.php';
+require_once __DIR__ . '/fatal-recovery-login.php';


### PR DESCRIPTION
Fixes #

## Proposed changes
Add logstash logging for the recovery-mode flow alongside the existing fatal-error screen and deactivate events, so we can observe email dispatches and recovery-mode entry end-to-end. Four new event slugs:

* `wpcomsh_fatal_recovery_email` — core dispatched the admin recovery email (filter past the empty-`to` bail).
* `wpcomsh_fatal_recovery_email_disabled` — `to` was blanked by the `wpcomsh_disable_fatal_error_emails` opt-out (intentional, but useful to count).
* `wpcomsh_fatal_recovery_email_no_recipient` — `to` is empty for any other reason (no `admin_email`, no `RECOVERY_MODE_EMAIL`, or another mu-plugin blanked it); admin won't get the recovery link, which is a real failure to flag.
* `wpcomsh_fatal_recovery_login` — `wp_login` fired with `wp_is_recovery_mode()` true; the just-authenticated admin is operating inside a recovery session.

The three email events route through the existing `wpcomsh_fatal_log_event` and share its per-(message, signature) 1-hour dedup (intentionally short of core's 24h `recovery_mode_email_rate_limit` so a legitimate re-send — admin exits recovery, site fatals again — surfaces instead of being masked). The login event has its own per-(session, user) week-long dedup keyed on `wp_recovery_mode()->get_session_id()`, tied to the recovery cookie's lifetime so a re-login on the same cookie doesn't double-log.

Refactor: extracted `wpcomsh_fatal_emit_logstash()` from `wpcomsh_fatal_log_event` so the new login handler reuses the WPCOMSH_Log require + `site_url`/`atomic_site_id` assembly + dispatch try/catch instead of duplicating ~40 lines.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
Yes — adds four new logstash event slugs in the `atomic_extension_conflict` bucket (severity `critical`), all in the recovery-mode flow on Atomic. Properties carried: the existing fatal-error signature shape (suspected plugin slug/kind/version, WP/PHP versions, `site_url`, `atomic_site_id`) for the three email events; `user_id` + `site_url` + `atomic_site_id` for the login event. No PII beyond the WP user id (which the rest of `WPCOMSH_Log` already records).

## Testing instructions

1. On a non-multisite Atomic site (recovery mode is core-disabled on multisite), trigger a fatal — e.g. drop this throwaway mu-plugin under `wp-content/mu-plugins/`:
   ```php
   <?php add_action( 'init', function () { trigger_error( 'boom', E_USER_ERROR ); } );
   ```
2. Visit the site as anon and as admin in different sessions. The first time core dispatches the recovery-mode email (capped at once per 24h), confirm a `wpcomsh_fatal_recovery_email` row lands in logstash under `atomic_extension_conflict`.
3. Set the `wpcomsh_disable_fatal_error_emails` option to `true`, clear `recovery_mode_email_last_sent` to bypass core's rate limit, and reproduce the fatal — confirm a `wpcomsh_fatal_recovery_email_disabled` row.
4. With the option off, blank `admin_email` (`update_option('admin_email', '')`), clear the rate limit, reproduce — confirm a `wpcomsh_fatal_recovery_email_no_recipient` row.
5. Click the recovery link in the email (or the "Enter recovery mode" link on the fatal screen on a branch that has it), then log in. Confirm a `wpcomsh_fatal_recovery_login` row, and confirm a re-login on the same recovery cookie does not produce a second row within the week.
