### PR TITLE
Write: clear alt text input when re-opening the image inserter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-alt-text-persists
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-alt-text-persists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: clear alt text input when re-opening the image inserter modal.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -912,6 +912,21 @@ if ( typeof MutationObserver !== 'undefined' ) {
 }
 
 /**
+ * Reset the image modal's URL and alt text inputs to empty.
+ *
+ * Reactive state alone may not update the displayed value of inputs the user
+ * has interacted with, so we reset the .value property explicitly.
+ */
+function resetImageModalInputs() {
+	const modal = document.querySelector( '.bw-image-overlay .bw-image-modal' );
+	if ( ! modal ) return;
+	const urlInput = modal.querySelector( 'input[type="url"]' );
+	if ( urlInput ) urlInput.value = '';
+	const altInput = modal.querySelector( 'input[type="text"]' );
+	if ( altInput ) altInput.value = '';
+}
+
+/**
  * Reset the image upload zone to its default state.
  */
 function resetUploadZone() {
@@ -2444,16 +2459,7 @@ const { state } = store( 'wpcom-write', {
 			saveSelection();
 			state.imageUrl = '';
 			state.imageAlt = '';
-			// Explicitly reset the .value property so user-typed values are
-			// cleared — reactive state alone may not update the displayed value
-			// of inputs the user has interacted with.
-			const modal = document.querySelector( '.bw-image-modal' );
-			if ( modal ) {
-				const urlInput = modal.querySelector( 'input[type="url"]' );
-				if ( urlInput ) urlInput.value = '';
-				const altInput = modal.querySelector( 'input[type="text"]' );
-				if ( altInput ) altInput.value = '';
-			}
+			resetImageModalInputs();
 			state.setAsFeatured = false;
 			state.uploadedMediaId = 0;
 			resetUploadZone();
@@ -2592,13 +2598,7 @@ const { state } = store( 'wpcom-write', {
 			saveSelection();
 			state.imageUrl = '';
 			state.imageAlt = '';
-			const modal = document.querySelector( '.bw-image-modal' );
-			if ( modal ) {
-				const urlInput = modal.querySelector( 'input[type="url"]' );
-				if ( urlInput ) urlInput.value = '';
-				const altInput = modal.querySelector( 'input[type="text"]' );
-				if ( altInput ) altInput.value = '';
-			}
+			resetImageModalInputs();
 			resetUploadZone();
 			state.showImageModal = true;
 			focusModalInput();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2444,6 +2444,16 @@ const { state } = store( 'wpcom-write', {
 			saveSelection();
 			state.imageUrl = '';
 			state.imageAlt = '';
+			// Explicitly reset the .value property so user-typed values are
+			// cleared — reactive state alone may not update the displayed value
+			// of inputs the user has interacted with.
+			const modal = document.querySelector( '.bw-image-modal' );
+			if ( modal ) {
+				const urlInput = modal.querySelector( 'input[type="url"]' );
+				if ( urlInput ) urlInput.value = '';
+				const altInput = modal.querySelector( 'input[type="text"]' );
+				if ( altInput ) altInput.value = '';
+			}
 			state.setAsFeatured = false;
 			state.uploadedMediaId = 0;
 			resetUploadZone();
@@ -2580,8 +2590,17 @@ const { state } = store( 'wpcom-write', {
 			clearSlashText();
 			state.showSlashMenu = false;
 			saveSelection();
-			state.showImageModal = true;
 			state.imageUrl = '';
+			state.imageAlt = '';
+			const modal = document.querySelector( '.bw-image-modal' );
+			if ( modal ) {
+				const urlInput = modal.querySelector( 'input[type="url"]' );
+				if ( urlInput ) urlInput.value = '';
+				const altInput = modal.querySelector( 'input[type="text"]' );
+				if ( altInput ) altInput.value = '';
+			}
+			resetUploadZone();
+			state.showImageModal = true;
 			focusModalInput();
 		},
 


### PR DESCRIPTION
Fixes RSM-2170

## Proposed changes

* Clear `state.imageAlt` and reset the alt text input's `.value` property when the image inserter modal opens, so it never shows alt text from a previously inserted image.
* Fixed both the toolbar button path (`openImageModal`) and the slash command path (`insertImage`), which was missing the reset entirely.

## Related product discussion/links

* RSM-2170

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor (`/write` on WordPress.com or a local Jetpack site with the feature enabled)
* Click the image toolbar button, upload an image, type some alt text (e.g. "my cat"), and click **Insert image**
* Click the image toolbar button again to add a second image — the alt text field should be **empty**
* Repeat using the slash command: type `/image`, insert an image with alt text, then type `/image` again — the alt text field should again be **empty**

