### PR TITLE
Social: drop attachment toggle in per-network mode, promote Default media option

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -1,10 +1,7 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from 'react';
-import useFeaturedImage from '../../../hooks/use-featured-image';
-import useMediaDetails from '../../../hooks/use-media-details';
-import { computeAttachedMediaForSource } from '../../../hooks/use-per-network-customization/utils';
+import { useCallback } from 'react';
 import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
@@ -37,21 +34,11 @@ const DEFAULT_NETWORK_TEMPLATE_HELP = __(
 export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomizationFormProps ) {
 	const { customizeConnectionById } = useDispatch( socialStore );
 	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
-	const {
-		attachedMedia: globalAttachedMedia,
-		shareMessage: globalMessage,
-		mediaSource: globalMediaSource,
-	} = usePostMeta();
+	const { shareMessage: globalMessage } = usePostMeta();
 	const globalMessageTemplate = useSelect(
 		select => select( socialStore ).getSocialSettings().messageTemplate,
 		[]
 	);
-
-	// Get featured image details for forced attachment
-	const featuredImageId = useFeaturedImage();
-	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
-	const featuredImageUrl = featuredImageDetails?.mediaData?.sourceUrl;
-	const featuredImageMime = featuredImageDetails?.metaData?.mime ?? 'image/jpeg';
 
 	const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
 	const hasConnectionTemplate = Boolean( connection.template );
@@ -74,37 +61,15 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 		}
 	}
 
-	// Don't default to 'none' - let undefined trigger featured image fallback detection
-	const mediaSource = connection.media_source ?? globalMediaSource;
+	/*
+	 * Per-network values come strictly from the connection. We don't fall back to global
+	 * media here — uncustomized connections leave `media_source` undefined, which
+	 * MediaSectionV2 surfaces as the "Default" option (post-level OG drives the link
+	 * preview at publish time).
+	 */
+	const mediaSource = connection.media_source;
+	const attachedMedia = connection.attached_media ?? [];
 
-	// Compute attached media with forced attachment logic
-	// Per-network mode forces attachment, so we need to populate attached_media appropriately
-	const attachedMedia = useMemo( () => {
-		// If connection has explicit attached_media, use it
-		if ( connection.attached_media && connection.attached_media.length > 0 ) {
-			return connection.attached_media;
-		}
-
-		// Otherwise, compute based on effective media source (like syncConnections does)
-		return (
-			computeAttachedMediaForSource( {
-				mediaSource,
-				globalAttachedMedia,
-				featuredImageId,
-				featuredImageUrl,
-				featuredImageMime,
-			} ) ?? []
-		);
-	}, [
-		connection.attached_media,
-		mediaSource,
-		featuredImageId,
-		featuredImageUrl,
-		featuredImageMime,
-		globalAttachedMedia,
-	] );
-
-	// Handler for message changes
 	const handleMessageChange = useCallback(
 		( msg: string ) => {
 			customizeConnectionById( connection.connection_id, { message: msg } );
@@ -112,46 +77,14 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 		[ connection.connection_id, customizeConnectionById ]
 	);
 
-	// Handler for media changes
-	// Per-network mode forces attachment, so when media is cleared (Remove button),
-	// we reset to featured image (if available) or nothing
 	const handleMediaChange = useCallback< SharePostFormProps[ 'onMediaChange' ] >(
 		updates => {
-			let attachedMediaToStore = updates.attached_media;
-			let mediaSourceToStore = updates.media_source;
-
-			// When clearing media (Remove button), reset to featured image or nothing
-			// Don't use SIG as fallback - SIG is an explicit selection, not a default
-			const isClearing =
-				( ! updates.attached_media || updates.attached_media.length === 0 ) &&
-				updates.media_source === undefined;
-
-			if ( isClearing ) {
-				// Reset to featured image if available, otherwise no media
-				if ( featuredImageId && featuredImageUrl ) {
-					attachedMediaToStore = [
-						{ id: featuredImageId, url: featuredImageUrl, type: featuredImageMime },
-					];
-					mediaSourceToStore = 'featured-image';
-				} else {
-					// No featured image - explicitly set 'none' to prevent fallback to global
-					attachedMediaToStore = undefined;
-					mediaSourceToStore = 'none';
-				}
-			}
-
 			customizeConnectionById( connection.connection_id, {
-				attached_media: attachedMediaToStore,
-				media_source: mediaSourceToStore,
+				attached_media: updates.attached_media,
+				media_source: updates.media_source,
 			} );
 		},
-		[
-			connection.connection_id,
-			customizeConnectionById,
-			featuredImageId,
-			featuredImageUrl,
-			featuredImageMime,
-		]
+		[ connection.connection_id, customizeConnectionById ]
 	);
 
 	return (

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -165,7 +165,7 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 			attachedMedia={ attachedMedia }
 			onMediaChange={ handleMediaChange }
 			mediaSource={ mediaSource }
-			forceMediaAsAttachment
+			attachmentToggleMode="hidden"
 		/>
 	);
 }

--- a/projects/packages/publicize/_inc/components/form/share-post-form.tsx
+++ b/projects/packages/publicize/_inc/components/form/share-post-form.tsx
@@ -77,9 +77,12 @@ export type SharePostFormProps = {
 	disabled?: boolean;
 
 	/**
-	 * Whether to force media as attachment.
+	 * Controls the "Share as attachment" toggle inside the media section.
+	 * 'visible' (default): toggle is rendered and user-controlled.
+	 * 'hidden': toggle is not rendered; attachment mode is implied by the selected source.
+	 * Per-network customization passes 'hidden' so the dropdown alone decides media behavior.
 	 */
-	forceMediaAsAttachment?: boolean;
+	attachmentToggleMode?: 'visible' | 'hidden';
 
 	/**
 	 * Optional upgrade notice depending on where the form is rendered.
@@ -105,7 +108,7 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 	mediaSource,
 	onMediaChange,
 	disabled = false,
-	forceMediaAsAttachment,
+	attachmentToggleMode,
 	upgradeNotice,
 } ) => {
 	const {
@@ -163,12 +166,12 @@ export const SharePostForm: FC< SharePostFormProps > = ( {
 						<MediaSectionV2
 							analyticsData={ analyticsData }
 							onEditTemplate={ onEditTemplate }
+							attachmentToggleMode={ attachmentToggleMode }
 							{ ...( isMediaControlled && {
 								attachedMedia,
 								imageGeneratorSettings,
 								mediaSource,
 								onMediaChange,
-								forceAsAttachment: forceMediaAsAttachment,
 							} ) }
 						/>
 					) }

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -40,8 +40,9 @@ export default function MediaSectionV2( {
 	imageGeneratorSettings: imageGeneratorSettingsProp,
 	mediaSource: mediaSourceProp,
 	onMediaChange,
-	forceAsAttachment,
+	attachmentToggleMode = 'visible',
 }: MediaSectionV2Props ) {
+	const isAttachmentToggleHidden = attachmentToggleMode === 'hidden';
 	const { recordEvent } = useAnalytics();
 	const featuredImageId = useFeaturedImage();
 	const { isEnabled: sigEnabled } = useImageGeneratorConfig();
@@ -100,10 +101,13 @@ export default function MediaSectionV2( {
 		return detectMediaSource( attachedMedia, featuredImageId, sigEnabled );
 	}, [ mediaSource, attachedMedia, featuredImageId, sigEnabled ] );
 
-	// Attachment mode:
-	// - When attachedMedia has items, this reflects the backend behavior (attached_media is set).
-	// - When forceAsAttachment is true, attachment mode is forced on at the UI level, even if attachedMedia is empty.
-	const isShareAsAttachment = forceAsAttachment || attachedMedia?.length > 0;
+	/*
+	 * Attachment mode:
+	 * - When attachedMedia has items, this reflects the backend behavior (attached_media is set).
+	 * - When the attachment toggle is hidden (per-network mode), attachment mode is implicit:
+	 *   the dropdown alone decides — non-Default sources always attach.
+	 */
+	const isShareAsAttachment = isAttachmentToggleHidden || attachedMedia?.length > 0;
 
 	// Get media ID for preview
 	const mediaId = useMemo( () => {
@@ -294,23 +298,6 @@ export default function MediaSectionV2( {
 		return null;
 	}, [] );
 
-	// Handle remove - reset to automatic detection (allows featured image fallback)
-	const handleRemove = useCallback( () => {
-		// Reset to allow automatic detection and inheritance:
-		// - media_source: undefined allows fallback detection in global mode
-		// - attached_media: [] clears explicit attachment, triggering forced attachment logic in per-network mode
-		updateMediaOptions( {
-			media_source: undefined,
-			attached_media: [],
-			image_generator_settings: { ...imageGeneratorSettings, enabled: false },
-		} );
-
-		recordEvent( 'jetpack_social_media_removed', {
-			...analyticsData,
-			source: currentSource,
-		} );
-	}, [ updateMediaOptions, imageGeneratorSettings, recordEvent, analyticsData, currentSource ] );
-
 	// Determine the effective source - for featured image fallback (currentSource is null),
 	// treat it as 'featured-image' when there's preview data from featured image
 	const effectiveSource = useMemo( () => {
@@ -384,7 +371,10 @@ export default function MediaSectionV2( {
 						{ __( 'Media', 'jetpack-publicize-pkg' ) }
 					</BaseControl.VisualLabel>
 					<p className={ styles.description }>
-						{ getMediaSourceDescription( currentSource, { featuredImageId } ) }
+						{ getMediaSourceDescription( currentSource, {
+							featuredImageId,
+							sigEnabled,
+						} ) }
 					</p>
 
 					{ /* MediaUpload component - rendered once, open function stored in ref */ }
@@ -410,7 +400,7 @@ export default function MediaSectionV2( {
 									onAiImageClick={ handleAiImageClick }
 									disabled={ disabled }
 									featuredImageId={ featuredImageId }
-									onRemove={ handleRemove }
+									includeDefaultOption={ isAttachmentToggleHidden }
 								/>
 								{ currentSource === 'sig' && (
 									<div className={ styles.action }>
@@ -426,12 +416,14 @@ export default function MediaSectionV2( {
 									</div>
 								) }
 							</div>
-							<CustomMediaToggle
-								source={ effectiveSource }
-								checked={ isShareAsAttachment }
-								onChange={ handleAttachmentToggle }
-								disabled={ forceAsAttachment || disabled }
-							/>
+							{ ! isAttachmentToggleHidden && (
+								<CustomMediaToggle
+									source={ effectiveSource }
+									checked={ isShareAsAttachment }
+									onChange={ handleAttachmentToggle }
+									disabled={ disabled }
+								/>
+							) }
 						</>
 					) }
 
@@ -444,7 +436,7 @@ export default function MediaSectionV2( {
 							onAiImageClick={ handleAiImageClick }
 							disabled={ disabled }
 							featuredImageId={ featuredImageId }
-							onRemove={ handleRemove }
+							includeDefaultOption={ isAttachmentToggleHidden }
 						/>
 					) }
 					{ currentSource === 'media-library' && (

--- a/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/index.tsx
@@ -91,15 +91,24 @@ export default function MediaSectionV2( {
 	// State for AI image generation modal
 	const [ showAiImageModal, toggleShowAiImageModal ] = useReducer( state => ! state, false );
 
-	// Determine current media source
-	// Priority 1: Explicit user choice (if media_source is set)
-	// Priority 2: Detect from existing data (backward compatibility)
+	/*
+	 * Determine current media source.
+	 * Priority 1: Explicit user choice (if media_source is set).
+	 * Priority 2 (global mode only): detect from existing data (backward compatibility).
+	 * In per-network mode (toggle hidden), no explicit source means Default (null) — we
+	 * skip auto-detection so the dropdown doesn't show e.g. "Featured image" for a
+	 * connection whose attached_media is empty (which would mislead the user into
+	 * thinking the image is attached when it isn't).
+	 */
 	const currentSource = useMemo( () => {
 		if ( mediaSource !== undefined ) {
 			return mediaSource === 'none' ? null : ( mediaSource as MediaSourceType );
 		}
+		if ( isAttachmentToggleHidden ) {
+			return null;
+		}
 		return detectMediaSource( attachedMedia, featuredImageId, sigEnabled );
-	}, [ mediaSource, attachedMedia, featuredImageId, sigEnabled ] );
+	}, [ mediaSource, isAttachmentToggleHidden, attachedMedia, featuredImageId, sigEnabled ] );
 
 	/*
 	 * Attachment mode:
@@ -150,9 +159,18 @@ export default function MediaSectionV2( {
 		}
 
 		if ( ! mediaId || ! mediaDetails?.mediaData ) {
-			// Fallback to featured image when no explicit media and source is undefined/null
-			if ( ! currentSource && featuredImageData ) {
-				return featuredImageData;
+			/*
+			 * Default mode (no explicit source) — mirror the post-level OG resolution
+			 * priority so the preview matches what the destination network will actually
+			 * serve: SIG (if globally enabled) → featured image → nothing.
+			 */
+			if ( ! currentSource ) {
+				if ( sigEnabled ) {
+					return { id: 0, url: sigPreviewUrl || '', type: 'image' };
+				}
+				if ( featuredImageData ) {
+					return featuredImageData;
+				}
 			}
 			return null;
 		}
@@ -165,7 +183,10 @@ export default function MediaSectionV2( {
 			url: sourceUrl,
 			type: mime?.startsWith( 'video/' ) ? 'video' : 'image',
 		};
-	}, [ currentSource, mediaId, mediaDetails, sigPreviewUrl, featuredImageData ] );
+	}, [ currentSource, mediaId, mediaDetails, sigEnabled, sigPreviewUrl, featuredImageData ] );
+
+	// Preview will render the SIG image whenever SIG is the explicit source or the OG fallback in Default mode.
+	const isPreviewingSig = currentSource === 'sig' || ( ! currentSource && sigEnabled );
 
 	// Handle media source selection from dropdown
 	const handleSourceSelect = useCallback(
@@ -174,6 +195,25 @@ export default function MediaSectionV2( {
 				...analyticsData,
 				source,
 			} );
+
+			/*
+			 * Default (source === null) means "no per-connection override" — unset both fields
+			 * so the saved override entry doesn't carry a media_source. The REST layer drops
+			 * fields whose value is undefined (isset() check), and wpcom's Extractor treats a
+			 * missing media_source as 'none' anyway, so this cleans up the persisted shape
+			 * without changing runtime behavior.
+			 */
+			if ( source === null ) {
+				updateMediaOptions( {
+					media_source: undefined,
+					attached_media: undefined,
+					image_generator_settings: {
+						...imageGeneratorSettings,
+						enabled: false,
+					},
+				} );
+				return;
+			}
 
 			// Determine attached_media based on source and current attachment state
 			let attachedMediaUpdate: Array< { id: number; url: string; type: string } > = [];
@@ -192,7 +232,7 @@ export default function MediaSectionV2( {
 
 			// Single batch update with explicit media_source and all related fields
 			updateMediaOptions( {
-				media_source: source || 'none',
+				media_source: source,
 				attached_media: attachedMediaUpdate,
 				image_generator_settings: {
 					...imageGeneratorSettings,
@@ -388,10 +428,7 @@ export default function MediaSectionV2( {
 					{ /* Show preview + dropdown when there's media */ }
 					{ previewData && (
 						<>
-							<MediaPreview
-								media={ previewData }
-								isLoading={ currentSource === 'sig' && sigIsLoading }
-							/>
+							<MediaPreview media={ previewData } isLoading={ isPreviewingSig && sigIsLoading } />
 							<div className={ styles.actions }>
 								<MediaSourceMenu
 									currentSource={ currentSource }

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu-item.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu-item.tsx
@@ -2,8 +2,9 @@
  * MediaSourceMenuItem component
  */
 
-import { MenuItem } from '@wordpress/components';
+import { Icon, MenuItem } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
+import { check } from '@wordpress/icons';
 import { MediaSourceOption, MediaSourceType } from './types';
 
 /**
@@ -62,21 +63,28 @@ export default function MediaSourceMenuItem( {
 	disabled = false,
 }: MediaSourceMenuItemProps ) {
 	const handleClick = useCallback( () => {
+		/*
+		 * Media library / AI image always re-open their picker even when active —
+		 * re-clicking the active item means "let me swap to a different image".
+		 * For terminal sources (sig / featured-image / Default), re-clicking is a no-op.
+		 */
 		if ( option.id === 'media-library' ) {
 			onMediaLibraryClick?.();
 		} else if ( option.id === 'ai-image' ) {
 			onAiImageClick?.();
-		} else {
+		} else if ( ! isSelected ) {
 			onSelect( option.id );
 		}
 		onClose();
-	}, [ option.id, onSelect, onClose, onMediaLibraryClick, onAiImageClick ] );
+	}, [ isSelected, option.id, onSelect, onClose, onMediaLibraryClick, onAiImageClick ] );
 
 	return (
 		<MenuItem
-			key={ option.id }
+			role="menuitemradio"
 			icon={ option.icon }
+			iconPosition="left"
 			isSelected={ isSelected }
+			suffix={ isSelected ? <Icon icon={ check } /> : undefined }
 			onClick={ handleClick }
 			disabled={ disabled }
 		>

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu.tsx
@@ -3,45 +3,13 @@
  * Displays a dropdown menu with grouped media source options
  */
 
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button, Dropdown, MenuGroup } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import MediaSourceMenuItem from './media-source-menu-item';
 import styles from './styles.module.scss';
 import { MediaSourceMenuProps } from './types';
 import { getMediaSourceOptions } from './utils/media-source-options';
-
-/**
- * Menu item for clearing media selection.
- *
- * @param {object}   root0            - Component props.
- * @param {boolean}  root0.isSelected - Whether this option is currently active.
- * @param {Function} root0.onRemove   - Callback to clear media.
- * @param {Function} root0.onClose    - Callback to close the dropdown.
- * @return {JSX.Element} NoMediaMenuItem component.
- */
-function NoMediaMenuItem( {
-	isSelected,
-	onRemove,
-	onClose,
-}: {
-	isSelected: boolean;
-	onRemove?: () => void;
-	onClose: () => void;
-} ) {
-	const handleClick = useCallback( () => {
-		onRemove?.();
-		onClose();
-	}, [ onRemove, onClose ] );
-
-	return (
-		<MenuGroup>
-			<MenuItem isSelected={ isSelected } onClick={ handleClick }>
-				{ __( 'No media', 'jetpack-publicize-pkg' ) }
-			</MenuItem>
-		</MenuGroup>
-	);
-}
 
 /**
  * MediaSourceMenu component
@@ -56,19 +24,25 @@ export default function MediaSourceMenu( {
 	onAiImageClick,
 	disabled = false,
 	featuredImageId,
-	onRemove,
+	includeDefaultOption = false,
 	children,
 }: MediaSourceMenuProps ) {
 	// Get options from function to ensure translations are loaded
 	const options = useMemo( () => getMediaSourceOptions(), [] );
 
-	// Group options by category, hiding "Featured image" when no featured image exists
+	/*
+	 * Group options by category. Hide "Featured image" when no featured image exists.
+	 * Hide "Default" unless the caller opts in (per-network customization only).
+	 */
 	const linkPreviewOptions = useMemo(
 		() =>
-			options.filter(
-				opt => opt.group === 'link-preview' && ( opt.id !== 'featured-image' || featuredImageId )
-			),
-		[ options, featuredImageId ]
+			options.filter( opt => {
+				if ( opt.group !== 'link-preview' ) return false;
+				if ( opt.id === 'featured-image' && ! featuredImageId ) return false;
+				if ( opt.id === null && ! includeDefaultOption ) return false;
+				return true;
+			} ),
+		[ options, featuredImageId, includeDefaultOption ]
 	);
 	const attachmentOptions = useMemo(
 		() => options.filter( opt => opt.group === 'attachment' ),
@@ -108,7 +82,7 @@ export default function MediaSourceMenu( {
 				>
 					{ linkPreviewOptions.map( option => (
 						<MediaSourceMenuItem
-							key={ option.id }
+							key={ option.id ?? 'default' }
 							option={ option }
 							isSelected={ currentSource === option.id }
 							onSelect={ onSelect }
@@ -126,7 +100,7 @@ export default function MediaSourceMenu( {
 				>
 					{ attachmentOptions.map( option => (
 						<MediaSourceMenuItem
-							key={ option.id }
+							key={ option.id ?? 'default' }
 							option={ option }
 							isSelected={ currentSource === option.id }
 							onSelect={ onSelect }
@@ -136,24 +110,15 @@ export default function MediaSourceMenu( {
 						/>
 					) ) }
 				</MenuGroup>
-				{ ! featuredImageId && (
-					<NoMediaMenuItem
-						isSelected={ ! currentSource }
-						onRemove={ onRemove }
-						onClose={ onClose }
-					/>
-				) }
 			</>
 		),
 		[
 			linkPreviewOptions,
 			attachmentOptions,
 			currentSource,
-			featuredImageId,
 			onSelect,
 			onMediaLibraryClick,
 			onAiImageClick,
-			onRemove,
 		]
 	);
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/media-source-menu.tsx
@@ -31,22 +31,36 @@ export default function MediaSourceMenu( {
 	const options = useMemo( () => getMediaSourceOptions(), [] );
 
 	/*
-	 * Group options by category. Hide "Featured image" when no featured image exists.
-	 * Hide "Default" unless the caller opts in (per-network customization only).
+	 * Group options for display:
+	 * - Hide "Featured image" when no featured image exists.
+	 * - Hide "Default" unless the caller opts in (per-network customization only).
+	 * - In per-network mode, SIG and Featured image are always attached (no toggle to make
+	 *   them link-preview-only), so they're surfaced under "Attachment". Default is the only
+	 *   link-preview option.
 	 */
 	const linkPreviewOptions = useMemo(
 		() =>
 			options.filter( opt => {
-				if ( opt.group !== 'link-preview' ) return false;
 				if ( opt.id === 'featured-image' && ! featuredImageId ) return false;
-				if ( opt.id === null && ! includeDefaultOption ) return false;
-				return true;
+				if ( includeDefaultOption ) {
+					return opt.id === null;
+				}
+				if ( opt.id === null ) return false;
+				return opt.group === 'link-preview';
 			} ),
 		[ options, featuredImageId, includeDefaultOption ]
 	);
 	const attachmentOptions = useMemo(
-		() => options.filter( opt => opt.group === 'attachment' ),
-		[ options ]
+		() =>
+			options.filter( opt => {
+				if ( opt.id === null ) return false;
+				if ( opt.id === 'featured-image' && ! featuredImageId ) return false;
+				if ( includeDefaultOption ) {
+					return true;
+				}
+				return opt.group === 'attachment';
+			} ),
+		[ options, featuredImageId, includeDefaultOption ]
 	);
 
 	const renderToggle = useCallback(
@@ -87,7 +101,6 @@ export default function MediaSourceMenu( {
 							isSelected={ currentSource === option.id }
 							onSelect={ onSelect }
 							onClose={ onClose }
-							disabled={ currentSource === option.id }
 						/>
 					) ) }
 				</MenuGroup>

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -163,7 +163,7 @@ describe( 'MediaSectionV2', () => {
 			] );
 		} );
 
-		it( 'should show "no image" description when no media source is selected', () => {
+		it( 'should show no-image warning when no fallback image is available', () => {
 			render( <MediaSectionV2 /> );
 
 			expect( screen.getByText( "Your post won't show an image." ) ).toBeInTheDocument();
@@ -323,10 +323,8 @@ describe( 'MediaSectionV2', () => {
 		} );
 	} );
 
-	describe( 'Remove media via No media option', () => {
+	describe( 'Switch to Default option', () => {
 		beforeEach( () => {
-			// Set up state with no featured image so "No media" option appears
-			( useFeaturedImage as jest.Mock ).mockReturnValue( null );
 			( usePostMeta as jest.Mock ).mockReturnValue( {
 				attachedMedia: [],
 				imageGeneratorSettings: { enabled: true },
@@ -336,7 +334,6 @@ describe( 'MediaSectionV2', () => {
 		} );
 
 		afterEach( () => {
-			( useFeaturedImage as jest.Mock ).mockReturnValue( 123 );
 			( usePostMeta as jest.Mock ).mockReturnValue( {
 				attachedMedia: [],
 				imageGeneratorSettings: { enabled: false },
@@ -345,25 +342,31 @@ describe( 'MediaSectionV2', () => {
 			} );
 		} );
 
-		it( 'should clear media and record event when No media is selected', async () => {
+		it( 'should reset media to Default and disable SIG when Default is selected', async () => {
 			const user = userEvent.setup();
 
-			render( <MediaSectionV2 analyticsData={ { test: 'data' } } /> );
+			render(
+				<MediaSectionV2
+					analyticsData={ { test: 'data' } }
+					attachmentToggleMode="hidden"
+					onMediaChange={ mockUpdateJetpackSocialOptions }
+				/>
+			);
 
 			// Open dropdown
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
-			// Click No media
-			await user.click( screen.getByRole( 'menuitem', { name: 'No media' } ) );
+			// Click Default
+			await user.click( screen.getByRole( 'menuitem', { name: 'Default' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
-				media_source: undefined,
+				media_source: 'none',
 				attached_media: [],
 				image_generator_settings: { enabled: false },
 			} );
-			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_media_removed', {
+			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_media_source_changed', {
 				test: 'data',
-				source: 'sig',
+				source: null,
 			} );
 		} );
 	} );

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -342,13 +342,15 @@ describe( 'MediaSectionV2', () => {
 			} );
 		} );
 
-		it( 'should reset media to Default and disable SIG when Default is selected', async () => {
+		it( 'should unset media_source and attached_media when Default is selected', async () => {
 			const user = userEvent.setup();
 
 			render(
 				<MediaSectionV2
 					analyticsData={ { test: 'data' } }
 					attachmentToggleMode="hidden"
+					mediaSource="sig"
+					imageGeneratorSettings={ { enabled: true } }
 					onMediaChange={ mockUpdateJetpackSocialOptions }
 				/>
 			);
@@ -360,8 +362,8 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'menuitem', { name: 'Default' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
-				media_source: 'none',
-				attached_media: [],
+				media_source: undefined,
+				attached_media: undefined,
 				image_generator_settings: { enabled: false },
 			} );
 			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_media_source_changed', {

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/index.test.tsx
@@ -266,7 +266,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 			// Select SIG
-			await user.click( screen.getByRole( 'menuitem', { name: 'Social image template' } ) );
+			await user.click( screen.getByRole( 'menuitemradio', { name: 'Social image template' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: 'sig',
@@ -290,7 +290,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 			// Select Use featured image
-			await user.click( screen.getByRole( 'menuitem', { name: 'Featured image' } ) );
+			await user.click( screen.getByRole( 'menuitemradio', { name: 'Featured image' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: 'featured-image',
@@ -314,7 +314,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 			// Select SIG
-			await user.click( screen.getByRole( 'menuitem', { name: 'Social image template' } ) );
+			await user.click( screen.getByRole( 'menuitemradio', { name: 'Social image template' } ) );
 
 			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_social_media_source_changed', {
 				test: 'data',
@@ -359,7 +359,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 			// Click Default
-			await user.click( screen.getByRole( 'menuitem', { name: 'Default' } ) );
+			await user.click( screen.getByRole( 'menuitemradio', { name: 'Default' } ) );
 
 			expect( mockUpdateJetpackSocialOptions ).toHaveBeenCalledWith( {
 				media_source: undefined,
@@ -428,7 +428,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 			// Click Generate image option
-			await user.click( screen.getByRole( 'menuitem', { name: 'Generate image' } ) );
+			await user.click( screen.getByRole( 'menuitemradio', { name: 'Generate image' } ) );
 
 			// The GeneralPurposeImage modal should now be rendered
 			expect( screen.getByTestId( 'ai-image-modal' ) ).toBeInTheDocument();
@@ -445,7 +445,7 @@ describe( 'MediaSectionV2', () => {
 			await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
 			// Click Generate image option
-			await user.click( screen.getByRole( 'menuitem', { name: 'Generate image' } ) );
+			await user.click( screen.getByRole( 'menuitemradio', { name: 'Generate image' } ) );
 
 			expect( mockCustomHandler ).toHaveBeenCalled();
 		} );

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
@@ -20,15 +20,21 @@ jest.mock( '../../../utils', () => ( {
 } ) );
 
 describe( 'getMediaSourceDescription', () => {
-	it( 'should return Default description when sourceType is null and a featured image exists', () => {
+	it( 'should describe Default as featured image when sourceType is null and a featured image exists', () => {
 		expect( getMediaSourceDescription( null, { featuredImageId: 123 } ) ).toBe(
-			"You are using the post's link preview image."
+			'You are using the featured image for the link preview.'
 		);
 	} );
 
-	it( 'should return Default description when sourceType is null and SIG is enabled globally', () => {
+	it( 'should describe Default as social image template when sourceType is null and SIG is enabled', () => {
 		expect( getMediaSourceDescription( null, { sigEnabled: true } ) ).toBe(
-			"You are using the post's link preview image."
+			'You are using the social image template for the link preview.'
+		);
+	} );
+
+	it( 'should prefer SIG over featured image when both are available in Default mode', () => {
+		expect( getMediaSourceDescription( null, { sigEnabled: true, featuredImageId: 123 } ) ).toBe(
+			'You are using the social image template for the link preview.'
 		);
 	} );
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
@@ -112,10 +112,14 @@ describe( 'MediaSourceMenu', () => {
 		expect( screen.getByText( 'Attachment' ) ).toBeInTheDocument();
 
 		// Check that menu items are rendered
-		expect( screen.getByRole( 'menuitem', { name: 'Default' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'Featured image' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'Social image template' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'menuitem', { name: 'From Media Library' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitemradio', { name: 'Default' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitemradio', { name: 'Featured image' } ) ).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'menuitemradio', { name: 'Social image template' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'menuitemradio', { name: 'From Media Library' } )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should hide Default option by default (global mode)', async () => {
@@ -148,7 +152,7 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'Featured image' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'Featured image' } ) );
 
 		expect( mockOnSelect ).toHaveBeenCalledWith( 'featured-image' );
 	} );
@@ -165,7 +169,7 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'Social image template' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'Social image template' } ) );
 
 		expect( mockOnSelect ).toHaveBeenCalledWith( 'sig' );
 	} );
@@ -182,7 +186,7 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'From Media Library' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'From Media Library' } ) );
 
 		expect( mockOnMediaLibraryClick ).toHaveBeenCalledTimes( 1 );
 		expect( mockOnSelect ).not.toHaveBeenCalled();
@@ -221,7 +225,7 @@ describe( 'MediaSourceMenu', () => {
 		expect( screen.getByText( 'Link preview' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should disable the current source item', async () => {
+	it( 'should mark the current source as the radio-checked item and not re-fire onSelect', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -235,12 +239,11 @@ describe( 'MediaSourceMenu', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
 
-		// Verify the menu renders with the current source item disabled
-		const featuredImageItem = screen.getByRole( 'menuitem', { name: 'Featured image' } );
+		const featuredImageItem = screen.getByRole( 'menuitemradio', { name: 'Featured image' } );
 		expect( featuredImageItem ).toBeInTheDocument();
-		expect( featuredImageItem ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( featuredImageItem ).toBeChecked();
 
-		// Verify clicking the disabled item does not trigger onSelect
+		// Re-clicking the active option must not call onSelect (it's a no-op).
 		await user.click( featuredImageItem );
 		expect( mockOnSelect ).not.toHaveBeenCalled();
 	} );
@@ -274,7 +277,7 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		expect( screen.getByRole( 'menuitem', { name: 'Default' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitemradio', { name: 'Default' } ) ).toBeInTheDocument();
 
 		rerender(
 			<MediaSourceMenu
@@ -286,7 +289,7 @@ describe( 'MediaSourceMenu', () => {
 			/>
 		);
 
-		expect( screen.getByRole( 'menuitem', { name: 'Default' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitemradio', { name: 'Default' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'should call onSelect with null when Default is clicked', async () => {
@@ -302,7 +305,7 @@ describe( 'MediaSourceMenu', () => {
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'Default' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'Default' } ) );
 
 		expect( mockOnSelect ).toHaveBeenCalledWith( null );
 	} );

--- a/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
+++ b/projects/packages/publicize/_inc/components/media-section-v2/test/media-source-menu.test.tsx
@@ -20,13 +20,33 @@ jest.mock( '../../../utils', () => ( {
 } ) );
 
 describe( 'getMediaSourceDescription', () => {
-	it( 'should return default message when sourceType is null', () => {
-		expect( getMediaSourceDescription( null ) ).toBe( "Your post won't show an image." );
+	it( 'should return Default description when sourceType is null and a featured image exists', () => {
+		expect( getMediaSourceDescription( null, { featuredImageId: 123 } ) ).toBe(
+			"You are using the post's link preview image."
+		);
+	} );
+
+	it( 'should return Default description when sourceType is null and SIG is enabled globally', () => {
+		expect( getMediaSourceDescription( null, { sigEnabled: true } ) ).toBe(
+			"You are using the post's link preview image."
+		);
+	} );
+
+	it( 'should return no-image warning when sourceType is null and no fallback is available', () => {
+		expect(
+			getMediaSourceDescription( null, { featuredImageId: undefined, sigEnabled: false } )
+		).toBe( "Your post won't show an image." );
 	} );
 
 	it( 'should return featured image description', () => {
 		expect( getMediaSourceDescription( 'featured-image' ) ).toBe(
 			'You are using your post featured image.'
+		);
+	} );
+
+	it( 'should return no-image fallback when featured-image is selected without a featured image', () => {
+		expect( getMediaSourceDescription( 'featured-image', { featuredImageId: undefined } ) ).toBe(
+			"Your post won't show an image."
 		);
 	} );
 
@@ -42,7 +62,6 @@ describe( 'getMediaSourceDescription', () => {
 describe( 'MediaSourceMenu', () => {
 	const mockOnSelect = jest.fn();
 	const mockOnMediaLibraryClick = jest.fn();
-	const mockOnRemove = jest.fn();
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -82,6 +101,7 @@ describe( 'MediaSourceMenu', () => {
 				onSelect={ mockOnSelect }
 				onMediaLibraryClick={ mockOnMediaLibraryClick }
 				featuredImageId={ 123 }
+				includeDefaultOption
 			/>
 		);
 
@@ -92,9 +112,27 @@ describe( 'MediaSourceMenu', () => {
 		expect( screen.getByText( 'Attachment' ) ).toBeInTheDocument();
 
 		// Check that menu items are rendered
+		expect( screen.getByRole( 'menuitem', { name: 'Default' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'menuitem', { name: 'Featured image' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'menuitem', { name: 'Social image template' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'menuitem', { name: 'From Media Library' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'should hide Default option by default (global mode)', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<MediaSourceMenu
+				currentSource={ null }
+				onSelect={ mockOnSelect }
+				onMediaLibraryClick={ mockOnMediaLibraryClick }
+				featuredImageId={ 123 }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
+
+		expect( screen.queryByRole( 'menuitem', { name: 'Default' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should call onSelect when Featured image is clicked', async () => {
@@ -223,24 +261,35 @@ describe( 'MediaSourceMenu', () => {
 		expect( screen.queryByRole( 'menuitem', { name: 'Featured image' } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should show No media option when no featured image exists', async () => {
+	it( 'should show Default option regardless of featured image presence when opted in', async () => {
 		const user = userEvent.setup();
 
-		render(
+		const { rerender } = render(
 			<MediaSourceMenu
 				currentSource={ null }
 				onSelect={ mockOnSelect }
 				onMediaLibraryClick={ mockOnMediaLibraryClick }
-				onRemove={ mockOnRemove }
+				includeDefaultOption
 			/>
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
+		expect( screen.getByRole( 'menuitem', { name: 'Default' } ) ).toBeInTheDocument();
 
-		expect( screen.getByRole( 'menuitem', { name: 'No media' } ) ).toBeInTheDocument();
+		rerender(
+			<MediaSourceMenu
+				currentSource={ null }
+				onSelect={ mockOnSelect }
+				onMediaLibraryClick={ mockOnMediaLibraryClick }
+				featuredImageId={ 123 }
+				includeDefaultOption
+			/>
+		);
+
+		expect( screen.getByRole( 'menuitem', { name: 'Default' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'should call onRemove when No media is clicked', async () => {
+	it( 'should call onSelect with null when Default is clicked', async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -248,31 +297,13 @@ describe( 'MediaSourceMenu', () => {
 				currentSource="sig"
 				onSelect={ mockOnSelect }
 				onMediaLibraryClick={ mockOnMediaLibraryClick }
-				onRemove={ mockOnRemove }
+				includeDefaultOption
 			/>
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-		await user.click( screen.getByRole( 'menuitem', { name: 'No media' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Default' } ) );
 
-		expect( mockOnRemove ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'should not show No media option when featured image exists', async () => {
-		const user = userEvent.setup();
-
-		render(
-			<MediaSourceMenu
-				currentSource={ null }
-				onSelect={ mockOnSelect }
-				onMediaLibraryClick={ mockOnMediaLibraryClick }
-				onRemove={ mockOnRemove }
-				featuredImageId={ 123 }
-			/>
-		);
-
-		await user.click( screen.getByRole( 'button', { name: 'Select' } ) );
-
-		expect( screen.queryByRole( 'menuitem', { name: 'No media' } ) ).not.toBeInTheDocument();
+		expect( mockOnSelect ).toHaveBeenCalledWith( null );
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/media-section-v2/types.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/types.ts
@@ -95,9 +95,12 @@ export interface MediaSectionV2Props {
 	onMediaChange?: ( updates: Partial< JetpackSocialOptions > ) => void;
 
 	/**
-	 * Whether to force media as attachment.
+	 * Controls the "Share as attachment" toggle.
+	 * 'visible' (default): toggle is rendered and user-controlled.
+	 * 'hidden': toggle is not rendered; attachment mode is implied by the selected source.
+	 * Per-network customization passes 'hidden' so the dropdown alone decides media behavior.
 	 */
-	forceAsAttachment?: boolean;
+	attachmentToggleMode?: 'visible' | 'hidden';
 }
 
 /**
@@ -135,9 +138,11 @@ export interface MediaSourceMenuProps {
 	featuredImageId?: number;
 
 	/**
-	 * Callback when "No media" is selected (removes media)
+	 * Whether to surface the "Default" option in the dropdown. Only used by per-network
+	 * customization, where the attachment toggle is hidden and the dropdown alone decides
+	 * media behavior — Default is the link-preview-only choice.
 	 */
-	onRemove?: () => void;
+	includeDefaultOption?: boolean;
 
 	/**
 	 * Optional children render function that receives open function

--- a/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
@@ -3,7 +3,7 @@
  */
 
 import { __ } from '@wordpress/i18n';
-import { postFeaturedImage, mediaAndText, media as mediaIcon } from '@wordpress/icons';
+import { postFeaturedImage, mediaAndText, media as mediaIcon, link } from '@wordpress/icons';
 import { getSocialScriptData } from '../../../utils';
 import sparkle from '../icons/sparkle';
 import { MediaSourceOption, MediaSourceType } from '../types';
@@ -18,6 +18,13 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 	const { plugin_info } = getSocialScriptData();
 
 	return [
+		{
+			id: null,
+			label: __( 'Default', 'jetpack-publicize-pkg' ),
+			description: __( "You are using the post's link preview image.", 'jetpack-publicize-pkg' ),
+			icon: link,
+			group: 'link-preview',
+		},
 		{
 			id: 'sig',
 			label: __( 'Social image template', 'jetpack-publicize-pkg' ),
@@ -65,6 +72,7 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 
 interface MediaSourceContext {
 	featuredImageId?: number;
+	sigEnabled?: boolean;
 }
 
 /**
@@ -80,12 +88,17 @@ export function getMediaSourceDescription(
 ): string {
 	const noImageMessage = __( "Your post won't show an image.", 'jetpack-publicize-pkg' );
 
-	if ( ! sourceType ) {
+	// If featured image is selected but doesn't exist, show "no image" message
+	if ( sourceType === 'featured-image' && context && ! context.featuredImageId ) {
 		return noImageMessage;
 	}
 
-	// If featured image is selected but doesn't exist, show "no image" message
-	if ( sourceType === 'featured-image' && context && ! context.featuredImageId ) {
+	/*
+	 * Default mode (sourceType === null) relies on the post-level OG image. If neither SIG
+	 * is globally enabled nor a featured image exists, there is no link preview image to
+	 * inherit, so warn the user instead of promising one.
+	 */
+	if ( sourceType === null && context && ! context.sigEnabled && ! context.featuredImageId ) {
 		return noImageMessage;
 	}
 

--- a/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
+++ b/projects/packages/publicize/_inc/components/media-section-v2/utils/media-source-options.ts
@@ -21,7 +21,10 @@ export function getMediaSourceOptions(): MediaSourceOption[] {
 		{
 			id: null,
 			label: __( 'Default', 'jetpack-publicize-pkg' ),
-			description: __( "You are using the post's link preview image.", 'jetpack-publicize-pkg' ),
+			description: __(
+				"You are using the post's Open Graph image for the link preview.",
+				'jetpack-publicize-pkg'
+			),
 			icon: link,
 			group: 'link-preview',
 		},
@@ -94,11 +97,23 @@ export function getMediaSourceDescription(
 	}
 
 	/*
-	 * Default mode (sourceType === null) relies on the post-level OG image. If neither SIG
-	 * is globally enabled nor a featured image exists, there is no link preview image to
-	 * inherit, so warn the user instead of promising one.
+	 * Default mode (sourceType === null): describe what the link preview will actually
+	 * resolve to, mirroring the OG resolution priority — SIG (if globally enabled) →
+	 * featured image → no image.
 	 */
-	if ( sourceType === null && context && ! context.sigEnabled && ! context.featuredImageId ) {
+	if ( sourceType === null ) {
+		if ( context?.sigEnabled ) {
+			return __(
+				'You are using the social image template for the link preview.',
+				'jetpack-publicize-pkg'
+			);
+		}
+		if ( context?.featuredImageId ) {
+			return __(
+				'You are using the featured image for the link preview.',
+				'jetpack-publicize-pkg'
+			);
+		}
 		return noImageMessage;
 	}
 

--- a/projects/packages/publicize/changelog/update-social-per-network-default-media-option
+++ b/projects/packages/publicize/changelog/update-social-per-network-default-media-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Per-network customization: replace forced attachment toggle with a Default media option that lets the post-level link preview decide.


### PR DESCRIPTION
Fixes #

Completes SOCIAL-473.

## Proposed changes

* Drop the forced "Share as attachment" toggle in per-network customization. The toggle was non-interactable and had no functional effect — its state was always implicit.
* Promote `media_source: 'none'` to a first-class **Default** option in the media dropdown, surfaced only when the toggle is hidden (per-network mode). Picking Default produces no per-connection attachment; the destination network falls back to the post-level OG image.
* Replace the `forceMediaAsAttachment: boolean` prop on `SharePostForm` / `MediaSectionV2` with `attachmentToggleMode: 'visible' | 'hidden'`. Per-network passes `'hidden'`.
* In per-network mode:
  * The form reads strictly from the connection (no global media fallback). Uncustomized connections leave `media_source` undefined.
  * `MediaSectionV2` skips `detectMediaSource` when the toggle is hidden, so undefined / missing media maps to Default.
  * The preview thumbnail mirrors the OG resolver: SIG (if globally enabled) → featured image → nothing.
  * Picking Default unsets `media_source` and `attached_media` on the connection, clearing the per-connection override entirely (REST `update()` already drops fields whose value is `undefined`).
* No backend changes. wpcom's `Extractor::is_social_post()` already returns `false` for `media_source: 'none'` or missing, and `get_attached_media()` returns empty.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the paid Social features (`SOCIAL_ENHANCED_PUBLISHING`), open a post in the editor.
2. Add at least two social connections.
3. Set a featured image on the post and confirm the global media defaults to "Featured image".
4. Open the per-network customize modal for one connection.
5. The connection should land on **Default** in the media dropdown — not "Featured image".
   * The preview thumbnail should still show whatever the post's OG would serve (SIG image if global SIG is enabled, otherwise the featured image).
   * The "Share as attachment" toggle should NOT be rendered.
6. Pick **Featured image** in the dropdown — connection now stores `media_source: 'featured-image'` and the actual featured image is attached on publish.
7. Pick **Default** again — connection's `media_source` and `attached_media` are unset; on publish the share goes through as a regular link with the post-level OG preview.
8. Pick **Social image template** — connection stores `media_source: 'sig'` and the SIG image is attached on publish.
9. Pick **From Media Library** — connection stores `media_source: 'media-library'` with the chosen image, attached on publish.
10. With Instagram (a `requiresMedia` network) selected: pick Default and confirm a `NO_MEDIA_ERROR` validation surfaces (Instagram requires a real attachment).
11. In **global** mode (per-network not enabled), confirm the dropdown does NOT include the Default option — the existing SIG / Featured / Media Library / AI Image options behave exactly as before.
12. Confirm the post-level OG tag (`og:image`) is unchanged for any of these per-connection states.


https://github.com/user-attachments/assets/5b9cd747-8406-4943-98ad-e280d06bf202

