### PR TITLE
Blaze: expose safe audience targeting options (ADS-1044)

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1044-safe-audience-targeting
+++ b/projects/packages/blaze/changelog/add-ads-1044-safe-audience-targeting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Add safe audience targeting normalization for prepared campaign proposals.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -218,7 +218,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and limited audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Public audience overrides are limited to country and language codes. Device targeting and interest/topic targeting are not public MCP inputs in v1 because they depend on DSP-supported device IDs and IAB category mappings; use the goal/copy fields for intent and let Blaze defaults or the review UI handle those settings. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and DSP/IAB interest category IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn' ),
@@ -279,6 +279,7 @@ class Blaze_Abilities extends Registrar {
 								'type'      => 'string',
 								'minLength' => 2,
 								'maxLength' => 5,
+								'enum'      => array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ),
 							),
 						),
 						'countries'            => array(
@@ -288,6 +289,23 @@ class Blaze_Abilities extends Registrar {
 								'type'      => 'string',
 								'minLength' => 2,
 								'maxLength' => 2,
+							),
+						),
+						'devices'              => array(
+							'type'        => 'array',
+							'description' => __( 'Optional narrowed device targeting value. Supported values are "mobile" and "desktop"; omit to target all devices. Tablet is not exposed until Blaze widget prefill support is verified end-to-end.', 'jetpack-blaze' ),
+							'maxItems'    => 1,
+							'items'       => array(
+								'type' => 'string',
+								'enum' => array( 'mobile', 'desktop' ),
+							),
+						),
+						'interests'            => array(
+							'type'        => 'array',
+							'description' => __( 'Optional DSP page topic / IAB category IDs to target (e.g. ["IAB18", "IAB1_IAB2"]). Use only IDs discovered from the Blaze/DSP targeting options; do not send free-form interest names. Invalid or unsupported IDs are ignored.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'    => 'string',
+								'pattern' => '^IAB\\d+(?:_IAB\\d+)*$',
 							),
 						),
 					),

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -218,7 +218,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and DSP/IAB interest category IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn' ),
@@ -302,10 +302,10 @@ class Blaze_Abilities extends Registrar {
 						),
 						'interests'            => array(
 							'type'        => 'array',
-							'description' => __( 'Optional DSP page topic / IAB category IDs to target (e.g. ["IAB18", "IAB1_IAB2"]). Use only IDs discovered from the Blaze/DSP targeting options; do not send free-form interest names. Invalid or unsupported IDs are ignored.', 'jetpack-blaze' ),
+							'description' => __( 'Optional Blaze public page topic IDs to target. Supported IDs are the public DSP topic groups: IAB1, IAB8_IAB18, IAB19, IAB5_IAB15, IAB6_IAB7_IAB16, IAB3_IAB4_IAB13, IAB11_IAB12, IAB14_IAB23, IAB17, IAB2_IAB20, IAB10_IAB21_IAB13, and IAB9_IAB22. If a user asks for a bare included IAB category such as fashion (IAB18), use the matching public group ID, e.g. IAB8_IAB18. Do not send free-form interest names. Invalid or unsupported IDs are ignored.', 'jetpack-blaze' ),
 							'items'       => array(
-								'type'    => 'string',
-								'pattern' => '^IAB\\d+(?:_IAB\\d+)*$',
+								'type' => 'string',
+								'enum' => array( 'IAB1', 'IAB8_IAB18', 'IAB19', 'IAB5_IAB15', 'IAB6_IAB7_IAB16', 'IAB3_IAB4_IAB13', 'IAB11_IAB12', 'IAB14_IAB23', 'IAB17', 'IAB2_IAB20', 'IAB10_IAB21_IAB13', 'IAB9_IAB22' ),
 							),
 						),
 					),

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -14,6 +14,8 @@ class Campaign_Preparer {
 
 	private const DEFAULT_BUDGET_TOTAL  = 50.0;
 	private const DEFAULT_DURATION_DAYS = 7;
+	private const SUPPORTED_LANGUAGES   = array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' );
+	private const SUPPORTED_DEVICES     = array( 'mobile', 'desktop' );
 
 	/**
 	 * Prepare a Blaze campaign proposal from a target post and optional overrides.
@@ -118,7 +120,7 @@ class Campaign_Preparer {
 				array_filter(
 					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
 					static function ( $code ) {
-						return '' !== $code;
+						return in_array( $code, self::SUPPORTED_LANGUAGES, true );
 					}
 				)
 			);
@@ -137,6 +139,36 @@ class Campaign_Preparer {
 			);
 			if ( ! empty( $countries ) ) {
 				$payload['countries'] = $countries;
+			}
+		}
+		if ( isset( $args['devices'] ) && is_array( $args['devices'] ) ) {
+			$devices = array_values(
+				array_unique(
+					array_filter(
+						array_map( 'strtolower', array_map( 'strval', $args['devices'] ) ),
+						static function ( $device ) {
+							return in_array( $device, self::SUPPORTED_DEVICES, true );
+						}
+					)
+				)
+			);
+			if ( 1 === count( $devices ) ) {
+				$payload['devices'] = $devices;
+			}
+		}
+		if ( isset( $args['interests'] ) && is_array( $args['interests'] ) ) {
+			$page_topics = array_values(
+				array_unique(
+					array_filter(
+						array_map( 'strval', $args['interests'] ),
+						static function ( $topic ) {
+							return 1 === preg_match( '/^IAB\d+(?:_IAB\d+)*$/', $topic ) && 'IAB24' !== $topic;
+						}
+					)
+				)
+			);
+			if ( ! empty( $page_topics ) ) {
+				$payload['page_topics'] = $page_topics;
 			}
 		}
 

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -16,6 +16,20 @@ class Campaign_Preparer {
 	private const DEFAULT_DURATION_DAYS = 7;
 	private const SUPPORTED_LANGUAGES   = array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' );
 	private const SUPPORTED_DEVICES     = array( 'mobile', 'desktop' );
+	private const SUPPORTED_PAGE_TOPICS = array(
+		'IAB1',
+		'IAB8_IAB18',
+		'IAB19',
+		'IAB5_IAB15',
+		'IAB6_IAB7_IAB16',
+		'IAB3_IAB4_IAB13',
+		'IAB11_IAB12',
+		'IAB14_IAB23',
+		'IAB17',
+		'IAB2_IAB20',
+		'IAB10_IAB21_IAB13',
+		'IAB9_IAB22',
+	);
 
 	/**
 	 * Prepare a Blaze campaign proposal from a target post and optional overrides.
@@ -160,10 +174,7 @@ class Campaign_Preparer {
 			$page_topics = array_values(
 				array_unique(
 					array_filter(
-						array_map( 'strval', $args['interests'] ),
-						static function ( $topic ) {
-							return 1 === preg_match( '/^IAB\d+(?:_IAB\d+)*$/', $topic ) && 'IAB24' !== $topic;
-						}
+						array_map( array( self::class, 'normalize_page_topic' ), $args['interests'] )
 					)
 				)
 			);
@@ -173,6 +184,34 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Normalize an MCP-supplied interest code to a public Blaze page topic.
+	 *
+	 * Blaze's public targeting endpoint exposes a compact set of custom topic
+	 * IDs, some of which group several IAB categories. If an agent supplies a
+	 * bare IAB category that belongs to a public group, emit the supported group
+	 * ID so the widget can display and submit it correctly.
+	 *
+	 * @param mixed $topic Raw topic value.
+	 * @return string|null Supported public page topic ID, or null to drop it.
+	 */
+	private static function normalize_page_topic( $topic ): ?string {
+		$topic = strtoupper( (string) $topic );
+		if ( in_array( $topic, self::SUPPORTED_PAGE_TOPICS, true ) ) {
+			return $topic;
+		}
+		if ( 1 !== preg_match( '/^IAB\d+$/', $topic ) ) {
+			return null;
+		}
+		foreach ( self::SUPPORTED_PAGE_TOPICS as $supported_topic ) {
+			$parts = explode( '_', $supported_topic );
+			if ( in_array( $topic, $parts, true ) ) {
+				return $supported_topic;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -119,7 +119,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 				'languages'            => array( 'EN', '', 'es', 'xx' ),
 				'countries'            => array( 'gb', 'usa', 'FR' ),
 				'devices'              => array( 'mobile', 'tablet', 'spaceship' ),
-				'interests'            => array( 'IAB18', 'fashion', 'IAB1_IAB2', '0', 'IAB24' ),
+				'interests'            => array( 'IAB18', 'fashion', 'IAB1_IAB2', '0', 'IAB24', 'IAB9_IAB22' ),
 				'is_evergreen'         => false,
 			)
 		);
@@ -135,7 +135,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( array( 'en', 'es' ), $prefill['languages'] );
 		$this->assertSame( array( 'GB', 'FR' ), $prefill['countries'] );
 		$this->assertSame( array( 'mobile' ), $prefill['devices'] );
-		$this->assertSame( array( 'IAB18', 'IAB1_IAB2' ), $prefill['page_topics'] );
+		$this->assertSame( array( 'IAB8_IAB18', 'IAB9_IAB22' ), $prefill['page_topics'] );
 		$this->assertArrayNotHasKey( 'interests', $prefill );
 		$this->assertFalse( $prefill['is_evergreen'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -116,8 +116,10 @@ class Campaign_Preparer_Test extends BaseTestCase {
 				'revision_instruction' => 'Make it more direct.',
 				'main_image_url'       => 'https://example.com/custom.jpg',
 				'main_image_mime_type' => 'image/jpeg',
-				'languages'            => array( 'EN', '', 'es' ),
+				'languages'            => array( 'EN', '', 'es', 'xx' ),
 				'countries'            => array( 'gb', 'usa', 'FR' ),
+				'devices'              => array( 'mobile', 'tablet', 'spaceship' ),
+				'interests'            => array( 'IAB18', 'fashion', 'IAB1_IAB2', '0', 'IAB24' ),
 				'is_evergreen'         => false,
 			)
 		);
@@ -132,8 +134,29 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
 		$this->assertSame( array( 'en', 'es' ), $prefill['languages'] );
 		$this->assertSame( array( 'GB', 'FR' ), $prefill['countries'] );
+		$this->assertSame( array( 'mobile' ), $prefill['devices'] );
+		$this->assertSame( array( 'IAB18', 'IAB1_IAB2' ), $prefill['page_topics'] );
+		$this->assertArrayNotHasKey( 'interests', $prefill );
 		$this->assertFalse( $prefill['is_evergreen'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Asking for both supported narrowed device targets is equivalent to
+	 * targeting all devices, so the prefill payload omits the field.
+	 */
+	public function test_prepare_omits_device_prefill_when_all_supported_devices_are_requested() {
+		$ctx = $this->make_test_post();
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+				'devices'    => array( 'mobile', 'desktop' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'devices', $result['prefill'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -372,7 +372,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$abilities = Blaze_Abilities::get_abilities();
 
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
-		$this->assertStringContainsString( 'Device targeting and interest/topic targeting are not public MCP inputs in v1', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'Audience overrides must use stable codes or closed enums', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
 		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
 		$properties = $schema['properties'];
@@ -389,12 +389,17 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'main_image_url', $properties );
 		$this->assertArrayHasKey( 'languages', $properties );
 		$this->assertArrayHasKey( 'countries', $properties );
+		$this->assertArrayHasKey( 'devices', $properties );
+		$this->assertArrayHasKey( 'interests', $properties );
 		$this->assertArrayNotHasKey( 'objective', $properties );
-		$this->assertArrayNotHasKey( 'devices', $properties );
-		$this->assertArrayNotHasKey( 'interests', $properties );
 		$this->assertArrayNotHasKey( 'page_topics', $properties );
 		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
 		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
+		$this->assertSame( array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ), $properties['languages']['items']['enum'] );
+		$this->assertSame( 1, $properties['devices']['maxItems'] );
+		$this->assertSame( array( 'mobile', 'desktop' ), $properties['devices']['items']['enum'] );
+		$this->assertStringContainsString( 'Tablet is not exposed', $properties['devices']['description'] );
+		$this->assertStringContainsString( 'IAB category IDs', $properties['interests']['description'] );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -399,7 +399,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 1, $properties['devices']['maxItems'] );
 		$this->assertSame( array( 'mobile', 'desktop' ), $properties['devices']['items']['enum'] );
 		$this->assertStringContainsString( 'Tablet is not exposed', $properties['devices']['description'] );
-		$this->assertStringContainsString( 'IAB category IDs', $properties['interests']['description'] );
+		$this->assertStringContainsString( 'Blaze public page topic IDs', $properties['interests']['description'] );
+		$this->assertContains( 'IAB8_IAB18', $properties['interests']['items']['enum'] );
+		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---


### PR DESCRIPTION
## Summary

- expose safe audience targeting options in the `blaze-ads/prepare-campaign` schema
- validate supported language codes, narrowed device targeting, country codes, and DSP/IAB interest IDs before building `blaze_prefill`
- omit unsupported or ambiguous values instead of sending guesses into the widget

## Testing

- `composer phpunit -- tests/php/Campaign_Preparer_Test.php tests/php/abilities/Blaze_Abilities_Test.php`

## Notes

- Stacked on `add/ads-1036-campaign-preparer`.
- Tablet is intentionally not exposed yet because the current widget device picker path needs end-to-end verification before MCP can safely prefill it.
