### PR TITLE
Write: fix publish status message for existing drafts

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_publish_button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_publish_button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: fix publish status message showing "Updating…" instead of "Publishing…" for existing drafts

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2835,7 +2835,7 @@ async function savePost( postStatus, isAutosave = false ) {
 	}
 
 	const isEditing = state.editPostId > 0;
-	const isUpdate = isEditing && postStatus === 'publish';
+	const isUpdate = isEditing && state.postStatus === 'publish';
 
 	state.isSaving = true;
 	if ( ! isAutosave ) {


### PR DESCRIPTION
Fixes RSM-2439

## Proposed changes

* Fix `isUpdate` flag in `savePost()` to check the **current** post status (`state.postStatus`) instead of the **target** status (`postStatus` parameter).
* This corrects the status message when publishing an existing draft — it now shows "Publishing…" / "Published!" instead of "Updating…" / "Updated!".

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Create a new post and save it as a draft (or use an existing draft post).
2. Open the draft in the Write editor: `wp-admin/admin.php?page=write&post={id}`
3. Click the **Publish** button.
4. **Before fix:** Status message flashes "Updating…" then "Updated!".
5. **After fix:** Status message flashes "Publishing…" then "Published!".
6. Also verify that updating an **already published** post still shows "Updating…" / "Updated!".

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
