### PR TITLE
My Jetpack: fix Overview tab scrolling under fixed wpbody-content

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -167,6 +167,21 @@ $jp-breakpoint-mobile: 782px;
 	// ── <AdminPage> root ──────────────────────────────────────────────
 	// Neutralize the legacy -20px shift and make AdminPage a flex child
 	// that fills its parent column.
+
+	// `overflow: visible` is enforced here because consumers that drop a
+	// className with `overflow-x: hidden` on the <AdminPage> root (e.g. to
+	// clip a stray horizontal overflow) would silently turn `.jp-admin-page`
+	// into a scroll container: any unspecified `overflow-y: visible` on the
+	// same element gets promoted to `overflow-y: auto` by the browser when
+	// the other axis is `hidden`/`scroll`/`clip`. With `.jp-admin-page` as
+	// a scroll container, wheel events past the inner middle's end propagate
+	// to it and the entire page (header + middle + footer) shifts up under
+	// the fixed `#wpbody-content`, exposing blank space below the footer.
+	// The intended scroll surface is the inner middle (defined further
+	// down); the inner middle clips horizontal overflow with `overflow:
+	// auto` already, and `#wpbody-content` is the ultimate `overflow:
+	// hidden` boundary, so consumer-side horizontal clipping isn't needed
+	// at this level.
 	.jp-admin-page {
 		margin-left: 0;
 		display: flex;
@@ -174,6 +189,7 @@ $jp-breakpoint-mobile: 782px;
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;
+		overflow: visible;
 	}
 
 	// ── admin-ui Page internals ───────────────────────────────────────

--- a/projects/js-packages/base-styles/changelog/admin-page-layout-defensive-overflow-visible
+++ b/projects/js-packages/base-styles/changelog/admin-page-layout-defensive-overflow-visible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+admin-page-layout mixin: explicitly set `overflow: visible` on `.jp-admin-page` so consumers that drop a className with `overflow-x: hidden` on the `<AdminPage>` root don't silently turn it into a scroll container (browsers promote unset `overflow-y: visible` to `auto` when the other axis is `hidden`/`scroll`/`clip`, which would shift the entire page under the fixed `#wpbody-content` once the inner middle reaches its scroll end).

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -1,7 +1,6 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 .my-jetpack-screen {
-	overflow-x: hidden;
 
 	:global(.jp-admin-page-header) {
 		padding-inline: 0.5rem;

--- a/projects/packages/my-jetpack/changelog/fix-admin-page-overflow-x-hidden
+++ b/projects/packages/my-jetpack/changelog/fix-admin-page-overflow-x-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: drop `overflow-x: hidden` on the `<AdminPage>` root. The rule was a vestigial guard against the old `100vw` breakouts (since restructured) and silently turned `.jp-admin-page` into a scroll container — when the inner middle reached its end, wheel events propagated up and shifted the entire page (header + middle + footer) under the fixed `#wpbody-content`, exposing blank space below the footer.


### PR DESCRIPTION
Fixes the scroll-past-the-end regression on the My Jetpack Overview tab introduced (visibly) by the recent layout-mixin adoption (#48503), and adds a defensive guard in the layout mixin so the same trap can't bite future consumers.

## Proposed changes

* **My Jetpack: drop `overflow-x: hidden` on the `<AdminPage>` root.** `.my-jetpack-screen { overflow-x: hidden }` was applied to the same div as `.jp-admin-page` (via `<AdminPage className={ … }>`). Browsers promote the unset `overflow-y: visible` to `auto` when the other axis is `hidden`/`scroll`/`clip`, so `.jp-admin-page` was silently turning into a scroll container. Once the inner middle reached its scroll end, wheel events propagated to `.jp-admin-page` and shifted the whole page (header + middle + footer) up under the fixed `#wpbody-content`, exposing blank space below the footer. The rule pre-dated the recent `100vw` breakout cleanup and was no longer load-bearing — the mixin's inner middle already handles horizontal overflow with `overflow: auto`, and `#wpbody-content` is the ultimate clip boundary.
* **`@automattic/jetpack-base-styles/admin-page-layout` mixin: add `overflow: visible` on `.jp-admin-page`.** Defensive, so any future consumer that drops a className with `overflow-x: hidden` on the AdminPage root won't reintroduce the same bug. Mixin specificity (`body.jetpack_page_<slug> .jp-admin-page`) beats consumer single-class selectors, so the override wins.

## Related product discussion/links

* Stacks behaviorally on #48503 (My Jetpack mixin adoption) and #48536 (`.jetpack-admin-full-screen` opt-out fix).
* Forward-compatible with #48410 (admin-ui 2.0): that PR renames `.admin-ui-page*` → `.jp-admin-page__page*` but does not touch `.jp-admin-page` itself, so the rule added here keeps applying after that update lands.

## Does this pull request change what data or activity we track or use?

No. CSS/layout-only change.

## Testing instructions

Repro the bug on `trunk`:

1. Visit `admin.php?page=my-jetpack#/overview`.
2. Scroll the inner middle (mouse wheel inside the page content) until it reaches its end (past the stat cards / product grid).
3. Continue scrolling down.
4. **Bug:** the entire page (Jetpack header + content + JetpackFooter) shifts up together, revealing a blank white area below the footer.

With this PR applied:

1. Same steps. Scroll past the inner middle's end.
2. **Expected:** scroll just stops. The Jetpack header stays pinned at the top, the JetpackFooter stays pinned at the viewport bottom. No blank space.

Smoke-test on the other migrated mixin pages — the layout should be unchanged. `.jp-admin-page` should be `overflow: visible` (not a scroll container) on each:

* My Jetpack (`?page=my-jetpack`) — Overview, Products, Help tabs
* Protect (`?page=jetpack-protect`)
* Social (`?page=jetpack-social`)
* VideoPress (`?page=jetpack-videopress`)
* Backup (`?page=jetpack-backup`)
* Newsletter (`?page=jetpack-newsletter`)
* Search (`?page=jetpack-search`)
* Boost (`?page=jetpack-boost`)
* Activity Log (`?page=jetpack-activity-log`)

A quick console probe at each: `getComputedStyle(document.querySelector('.jp-admin-page')).overflow` should report `visible`, and only the inner `.container--SqdhU.fluid--OZC_9` (or in PR #48410's structure, the `.jp-admin-page__page > :not(header):not(.jetpack-footer)` middle) should report `auto`.
