### PR TITLE
Help Center: Add is_a11n flag

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-add-a11n-flag
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-add-a11n-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Is a11n field to the Help Center datawq

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -300,6 +300,7 @@ class Help_Center {
 							'display_name' => $display_name,
 							'avatar_URL'   => $avatar_url,
 							'email'        => $user_email,
+							'is_a11n'      => function_exists( '\is_automattician' ) && \is_automattician( $user_id ),
 						),
 						'site'             => $this->get_current_site(),
 						'locale'           => self::determine_iso_639_locale(),


### PR DESCRIPTION
This adds `is_a11n` to the user object shared with the Help Center.