### PR TITLE
Write: escape image alt attribute in block serialization

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-image-alt-escaping
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-image-alt-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Write: escape image alt text in block serialization to prevent markup integrity issues

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -344,9 +344,9 @@ function convertToBlocks( html ) {
 				? `<figcaption class="wp-element-caption">${ figcaption.innerHTML }</figcaption>`
 				: '';
 			blocks.push(
-				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ escapeAttr(
-					alt
-				) }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`
+				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ escapeAttr(
+					src
+				) }" alt="${ escapeAttr( alt ) }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`
 			);
 		} else if ( tag === 'blockquote' ) {
 			// inner may already contain <p> tags from contentEditable.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -227,6 +227,16 @@ function focusModalInput() {
 }
 
 /**
+ * Escape a string for safe interpolation into an HTML attribute value.
+ *
+ * @param {string} str - Raw string value.
+ * @return {string} HTML-attribute-safe string.
+ */
+function escapeAttr( str ) {
+	return str.replace( /&/g, '&amp;' ).replace( /"/g, '&quot;' );
+}
+
+/**
  * Normalize color markup from contentEditable before block serialization.
  *
  * The foreColor command creates <font color="..."> (legacy) or
@@ -334,7 +344,9 @@ function convertToBlocks( html ) {
 				? `<figcaption class="wp-element-caption">${ figcaption.innerHTML }</figcaption>`
 				: '';
 			blocks.push(
-				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ alt }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`
+				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ escapeAttr(
+					alt
+				) }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`
 			);
 		} else if ( tag === 'blockquote' ) {
 			// inner may already contain <p> tags from contentEditable.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2700,7 +2700,14 @@ const { state } = store( 'wpcom-write', {
 
 			const wrapper = document.createElement( 'figure' );
 			wrapper.className = 'bw-video-figure';
-			wrapper.innerHTML = `<div class="bw-video-wrap"><iframe src="${ embedUrl }" frameborder="0" allowfullscreen></iframe></div>`;
+			const videoWrap = document.createElement( 'div' );
+			videoWrap.className = 'bw-video-wrap';
+			const iframe = document.createElement( 'iframe' );
+			iframe.setAttribute( 'src', embedUrl );
+			iframe.setAttribute( 'frameborder', '0' );
+			iframe.setAttribute( 'allowfullscreen', '' );
+			videoWrap.appendChild( iframe );
+			wrapper.appendChild( videoWrap );
 
 			const p = insertMediaBlock( wrapper );
 			if ( p ) {


### PR DESCRIPTION
Fixes RSM-1946

## Proposed changes

* Add `escapeAttr()` helper to HTML-encode `&` and `"` characters
* Apply it to the image `alt` attribute in `convertToBlocks()` — user-typed alt text can contain `"`, breaking the serialized block markup
* Apply it to the image `src` attribute — the Write editor has a manual URL input field, so a URL with a literal `"` causes the same breakage
* Replace `innerHTML` string interpolation with `createElement`/`setAttribute` for video embed construction — eliminates a latent XSS vector in the live editor DOM if `embedUrl` ever contained a quote

## Related product discussion/links

* RSM-1946

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to a site with the Write editor enabled
* Insert an image and set the alt text to a value containing a double quote, e.g. `A "nice" photo`
* Save the post — verify the image block is valid in Gutenberg (no "unexpected or invalid content" warning)
* Repeat using the manual URL input field with a URL containing `"` — verify the block is still valid. Note that random `"` characters will break the image on Simple sites.
* Insert a YouTube or Vimeo video embed — verify it renders correctly in the editor and saves as a valid embed block

