### PR TITLE
Backup: add empty wp-build dashboard scaffold behind feature flag

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7313,6 +7313,19 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@base-ui/react@1.4.0':
+    resolution: {integrity: sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@base-ui/react@1.4.1':
     resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
     engines: {node: '>=14.0.0'}
@@ -7328,6 +7341,16 @@ packages:
       '@types/react':
         optional: true
       date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.7':
+    resolution: {integrity: sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@base-ui/utils@0.2.8':
@@ -18420,7 +18443,7 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/react-i18n': 4.43.0
       '@wordpress/url': 4.44.0
-      '@wordpress/warning': 3.45.0
+      '@wordpress/warning': 3.44.0
       canvas-confetti: 1.9.4
       clsx: 2.1.1
       colord: 2.9.3
@@ -18459,7 +18482,7 @@ snapshots:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/data': 10.44.0(react@18.3.1)
       '@wordpress/data-controls': 4.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.45.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/element': 6.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/primitives': 4.44.0(react@18.3.1)
@@ -19439,6 +19462,34 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.7(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/tz': 1.4.1
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      date-fns: 4.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+    optional: true
+
+  '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/tz': 1.4.1
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      date-fns: 4.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optional: true
+
   '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19465,6 +19516,28 @@ snapshots:
     optionalDependencies:
       '@date-fns/tz': 1.4.1
       date-fns: 4.1.0
+
+  '@base-ui/utils@0.2.7(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+    optional: true
+
+  '@base-ui/utils@0.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optional: true
 
   '@base-ui/utils@0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24092,28 +24165,6 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.13.0(@babel/core@7.29.0)(browserslist@4.28.2)':
-    dependencies:
-      '@emotion/babel-plugin': 11.13.5
-      autoprefixer: 10.4.27(postcss@8.5.10)
-      browserslist-to-esbuild: 2.1.1(browserslist@4.28.2)
-      change-case: 4.1.2
-      chokidar: 4.0.3
-      cssnano: 7.1.4(postcss@8.5.10)
-      esbuild: 0.27.4
-      esbuild-plugin-babel: 0.2.3(@babel/core@7.29.0)
-      esbuild-sass-plugin: 3.3.1(esbuild@0.27.4)(sass-embedded@1.97.3)
-      fast-glob: 3.3.3
-      moment-timezone: 0.5.48
-      postcss: 8.5.10
-      postcss-modules: 6.0.1(postcss@8.5.10)
-      rtlcss: 4.3.0
-      sass-embedded: 1.97.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - browserslist
-      - supports-color
-
   '@wordpress/commands@1.44.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 6.20.0
@@ -24240,13 +24291,13 @@ snapshots:
   '@wordpress/compose@7.44.0(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.45.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/dom': 4.44.0
       '@wordpress/element': 6.44.0
-      '@wordpress/is-shallow-equal': 5.45.0
+      '@wordpress/is-shallow-equal': 5.44.0
       '@wordpress/keycodes': 4.44.0
-      '@wordpress/priority-queue': 3.45.0
-      '@wordpress/undo-manager': 1.45.0
+      '@wordpress/priority-queue': 3.44.0
+      '@wordpress/undo-manager': 1.44.0
       change-case: 4.1.2
       mousetrap: 1.6.5
       react: 18.3.1
@@ -24373,10 +24424,10 @@ snapshots:
   '@wordpress/data@10.44.0(react@18.3.1)':
     dependencies:
       '@wordpress/compose': 7.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.45.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/element': 6.44.0
-      '@wordpress/is-shallow-equal': 5.45.0
-      '@wordpress/priority-queue': 3.45.0
+      '@wordpress/is-shallow-equal': 5.44.0
+      '@wordpress/priority-queue': 3.44.0
       '@wordpress/private-apis': 1.44.0
       '@wordpress/redux-routine': 5.44.0(redux@5.0.1)
       deepmerge: 4.3.1
@@ -24396,7 +24447,7 @@ snapshots:
       '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/data': 10.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.45.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/element': 6.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/icons': 12.2.0(react@18.3.1)
@@ -24404,12 +24455,12 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
       '@wordpress/ui': 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.45.0
+      '@wordpress/warning': 3.44.0
       clsx: 2.1.1
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
-      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
@@ -24447,7 +24498,7 @@ snapshots:
       '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/data': 10.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.45.0
+      '@wordpress/deprecated': 4.44.0
       '@wordpress/element': 6.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/icons': 12.2.0(react@18.3.1)
@@ -24455,12 +24506,12 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
       '@wordpress/ui': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.45.0
+      '@wordpress/warning': 3.44.0
       clsx: 2.1.1
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
-      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2073,6 +2073,9 @@ importers:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config
+      '@automattic/jetpack-wp-build-polyfills':
+        specifier: workspace:*
+        version: link:../wp-build-polyfills
       '@babel/core':
         specifier: 7.29.0
         version: 7.29.0
@@ -2100,6 +2103,12 @@ importers:
       '@wordpress/browserslist-config':
         specifier: 6.44.0
         version: 6.44.0
+      '@wordpress/build':
+        specifier: 0.13.0
+        version: 0.13.0(@babel/core@7.29.0)(browserslist@4.28.2)
+      browserslist:
+        specifier: ^4.24.0
+        version: 4.28.2
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -24056,6 +24065,28 @@ snapshots:
     optionalDependencies:
       '@wordpress/route': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - browserslist
+      - supports-color
+
+  '@wordpress/build@0.13.0(@babel/core@7.29.0)(browserslist@4.28.2)':
+    dependencies:
+      '@emotion/babel-plugin': 11.13.5
+      autoprefixer: 10.4.27(postcss@8.5.10)
+      browserslist-to-esbuild: 2.1.1(browserslist@4.28.2)
+      change-case: 4.1.2
+      chokidar: 4.0.3
+      cssnano: 7.1.4(postcss@8.5.10)
+      esbuild: 0.27.4
+      esbuild-plugin-babel: 0.2.3(@babel/core@7.29.0)
+      esbuild-sass-plugin: 3.3.1(esbuild@0.27.4)(sass-embedded@1.97.3)
+      fast-glob: 3.3.3
+      moment-timezone: 0.5.48
+      postcss: 8.5.10
+      postcss-modules: 6.0.1(postcss@8.5.10)
+      rtlcss: 4.3.0
+      sass-embedded: 1.97.3
     transitivePeerDependencies:
       - '@babel/core'
       - browserslist

--- a/projects/packages/backup/changelog/add-wp-build-modernization-dashboard
+++ b/projects/packages/backup/changelog/add-wp-build-modernization-dashboard
@@ -1,0 +1,3 @@
+Significance: patch
+Type: added
+Comment: Empty wp-build dashboard scaffold gated behind a feature flag; no user-visible change unless the flag is enabled.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -14,7 +14,8 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-build-polyfills": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -13,16 +13,19 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "pnpm run clean && pnpm run build-client",
+		"build": "pnpm run clean && pnpm run build-client && pnpm run build:wp-build && pnpm run build:boot-asset",
+		"build:boot-asset": "provide-boot-asset-file",
+		"build:wp-build": "wp-build",
 		"build-client": "webpack",
 		"build-concurrently": "pnpm run clean && concurrently 'pnpm:build-client' 'pnpm:build-php'",
-		"build-production-concurrently": "pnpm run clean && concurrently 'NODE_ENV=production BABEL_ENV=production pnpm run build-client' && pnpm run validate",
+		"build-production-concurrently": "pnpm run clean && concurrently 'NODE_ENV=production BABEL_ENV=production pnpm run build-client' && pnpm run build:wp-build && pnpm run build:boot-asset && pnpm run validate",
 		"clean": "rm -rf build/",
 		"test": "jest --config=tests/jest.config.js",
 		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es build/",
-		"watch": "pnpm run build && webpack watch"
+		"watch": "concurrently 'pnpm:build-client --watch' 'pnpm:watch:wp-build'",
+		"watch:wp-build": "wp-build --watch"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
@@ -51,6 +54,7 @@
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.0",
 		"@babel/preset-env": "7.29.2",
 		"@babel/runtime": "7.29.2",
@@ -60,6 +64,8 @@
 		"@types/react": "18.3.28",
 		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.44.0",
+		"@wordpress/build": "0.13.0",
+		"browserslist": "^4.24.0",
 		"concurrently": "9.2.1",
 		"jest": "30.3.0",
 		"sass-embedded": "1.97.3",
@@ -67,5 +73,14 @@
 		"storybook": "10.3.5",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
+	},
+	"wpPlugin": {
+		"name": "jetpack_backup",
+		"scriptGlobal": "jetpackBackup",
+		"packageNamespace": "jetpack-backup",
+		"handlePrefix": "jetpack-backup",
+		"pages": [
+			"jetpack-backup-dashboard"
+		]
 	}
 }

--- a/projects/packages/backup/routes/dashboard/package.json
+++ b/projects/packages/backup/routes/dashboard/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "_@jetpack-backup/dashboard-route",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@types/react": "18.3.28",
+		"@wordpress/element": "6.44.0",
+		"@wordpress/i18n": "6.17.0"
+	},
+	"route": {
+		"path": "/",
+		"page": "jetpack-backup-dashboard"
+	}
+}

--- a/projects/packages/backup/routes/dashboard/route.tsx
+++ b/projects/packages/backup/routes/dashboard/route.tsx
@@ -1,0 +1,1 @@
+export const route = {};

--- a/projects/packages/backup/routes/dashboard/stage.tsx
+++ b/projects/packages/backup/routes/dashboard/stage.tsx
@@ -1,7 +1,6 @@
-import { __ } from '@wordpress/i18n';
-
 const Stage = () => {
-	return <h1>{ __( 'Backup', 'jetpack-backup-pkg' ) }</h1>;
+	// "Backup" is a product name, do not translate.
+	return <h1>Backup</h1>;
 };
 
 export { Stage as stage };

--- a/projects/packages/backup/routes/dashboard/stage.tsx
+++ b/projects/packages/backup/routes/dashboard/stage.tsx
@@ -1,0 +1,7 @@
+import { __ } from '@wordpress/i18n';
+
+const Stage = () => {
+	return <h1>{ __( 'Backup', 'jetpack-backup-pkg' ) }</h1>;
+};
+
+export { Stage as stage };

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -103,6 +103,14 @@ class Jetpack_Backup {
 	const JETPACK_BACKUP_DB_VERSION = '2';
 
 	/**
+	 * Filter name that gates the wp-build–based dashboard.
+	 *
+	 * When this filter returns true, "Jetpack > Backup" renders the new
+	 * wp-build dashboard instead of the legacy React app.
+	 */
+	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_backup';
+
+	/**
 	 * Constructor.
 	 */
 	public static function initialize() {
@@ -116,6 +124,11 @@ class Jetpack_Backup {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 
 		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 1 ); // Akismet uses 4, so we need to use 1 to ensure both menus are added when only they exist.
+
+		if ( self::is_modernized() && self::is_backup_admin_request() ) {
+			self::load_wp_build();
+			add_action( 'current_screen', array( __CLASS__, 'alias_screen_id_for_wp_build' ) );
+		}
 
 		// Init Jetpack packages.
 		add_action(
@@ -156,12 +169,16 @@ class Jetpack_Backup {
 	 * The page to be added to submenu
 	 */
 	public static function add_wp_admin_submenu() {
+		$callback = self::is_modernized() && function_exists( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page' )
+			? 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page'
+			: array( __CLASS__, 'plugin_settings_page' );
+
 		$page_suffix = Admin_Menu::add_menu(
 			'Jetpack Backup',
 			'Backup', // Product name, do not translate.
 			'manage_options',
-			'jetpack-backup',
-			array( __CLASS__, 'plugin_settings_page' ),
+			self::JETPACK_BACKUP_SLUG,
+			$callback,
 			7
 		);
 
@@ -204,6 +221,15 @@ class Jetpack_Backup {
 	 * Enqueue plugin admin scripts and styles.
 	 */
 	public static function enqueue_admin_scripts() {
+		// This callback is registered via `load-{$page_suffix}` in `add_wp_admin_submenu()`,
+		// so it only fires on the Backup admin page — no need to re-check the page here.
+		if ( self::is_modernized() ) {
+			// wp-build manages its own enqueue pipeline. The legacy script,
+			// initial state, and tracking are intentionally skipped for the
+			// wp-build dashboard.
+			return;
+		}
+
 		Assets::register_script(
 			'jetpack-backup',
 			'../build/index.js',
@@ -830,5 +856,79 @@ class Jetpack_Backup {
 	public static function plugin_deactivation() {
 		$manager = new Connection_Manager( 'jetpack-backup' );
 		$manager->remove_connection();
+	}
+
+	/**
+	 * Load the wp-build entry file and register its polyfills.
+	 *
+	 * Only called on `?page=jetpack-backup` admin requests when the
+	 * modernization filter is enabled. Keeps wp-build off every other request.
+	 *
+	 * @return void
+	 */
+	private static function load_wp_build() {
+		$build_index = dirname( __DIR__ ) . '/build/build.php';
+
+		if ( ! file_exists( $build_index ) ) {
+			return;
+		}
+
+		require_once $build_index;
+
+		\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::register(
+			'jetpack-backup',
+			array_merge(
+				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::SCRIPT_HANDLES,
+				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::MODULE_IDS
+			)
+		);
+	}
+
+	/**
+	 * Alias the current screen ID to satisfy wp-build's auto-generated enqueue check.
+	 *
+	 * Wp-build's `<page>-wp-admin` enqueue callback enqueues only when the screen ID
+	 * matches the wp-build page slug (`jetpack-backup-dashboard`). Our WP-admin
+	 * menu slug stays `jetpack-backup`, so we mutate the screen object in place
+	 * to make the check pass without changing the user-facing URL.
+	 *
+	 * Hooked only when modernization is on AND we're on the Backup admin page,
+	 * so this never affects any other request.
+	 *
+	 * @param \WP_Screen|null $screen The current screen object (passed by WP).
+	 * @return void
+	 */
+	public static function alias_screen_id_for_wp_build( $screen ) {
+		if ( ! is_object( $screen ) ) {
+			return;
+		}
+
+		$screen->id = 'jetpack-backup-dashboard';
+	}
+
+	/**
+	 * Returns true when the wp-build modernization filter is enabled.
+	 *
+	 * @return bool
+	 */
+	private static function is_modernized() {
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+	}
+
+	/**
+	 * Returns true when the current request targets the Backup admin page.
+	 *
+	 * Used to scope wp-build loading to the one page that needs it. The
+	 * `$_GET['page']` value is populated by wp-admin/admin.php before any of
+	 * our hooks fire, so this check is reliable from `initialize()` onwards.
+	 *
+	 * @return bool
+	 */
+	private static function is_backup_admin_request() {
+		if ( ! is_admin() || ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
+
+		return sanitize_text_field( wp_unslash( $_GET['page'] ) ) === self::JETPACK_BACKUP_SLUG; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 }

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -123,12 +123,8 @@ class Jetpack_Backup {
 
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 
+		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 1 );
 		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ), 1 ); // Akismet uses 4, so we need to use 1 to ensure both menus are added when only they exist.
-
-		if ( self::is_modernized() && self::is_backup_admin_request() ) {
-			self::load_wp_build();
-			add_action( 'current_screen', array( __CLASS__, 'alias_screen_id_for_wp_build' ) );
-		}
 
 		// Init Jetpack packages.
 		add_action(
@@ -856,6 +852,20 @@ class Jetpack_Backup {
 	public static function plugin_deactivation() {
 		$manager = new Connection_Manager( 'jetpack-backup' );
 		$manager->remove_connection();
+	}
+
+	/**
+	 * Load wp-build when modernization is enabled on the Backup admin page.
+	 *
+	 * @return void
+	 */
+	public static function maybe_load_wp_build() {
+		if ( ! self::is_modernized() || ! self::is_backup_admin_request() ) {
+			return;
+		}
+
+		self::load_wp_build();
+		add_action( 'current_screen', array( __CLASS__, 'alias_screen_id_for_wp_build' ) );
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/update-backup-modernization-scaffold
+++ b/projects/plugins/backup/changelog/update-backup-modernization-scaffold
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Empty wp-build dashboard scaffold gated behind a feature flag; no user-visible change unless the flag is enabled.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -280,7 +280,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "11fe789858155aece9036c7a7a42bcc2f83c8b38"
+                "reference": "6fc2646ba54a13f790b613c86dadabde5eaab43d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -293,6 +293,7 @@
                 "automattic/jetpack-my-jetpack": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
@@ -1822,6 +1823,64 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "50a49082c2623dd4e295860c6a3d9b6be5b66f4c"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available in WP < 7.0",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/jetpack/changelog/update-backup-modernization-scaffold
+++ b/projects/plugins/jetpack/changelog/update-backup-modernization-scaffold
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adding a new empty page under feature flag for Backup
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -477,7 +477,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "11fe789858155aece9036c7a7a42bcc2f83c8b38"
+                "reference": "6fc2646ba54a13f790b613c86dadabde5eaab43d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -490,6 +490,7 @@
                 "automattic/jetpack-my-jetpack": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {


### PR DESCRIPTION
Part of #48582 — first of seven PRs to modernize Jetpack's Backup admin page into a unified wp-admin product. This one stands up infrastructure only; the next six fill it in.

## Proposed changes

* Add a new wp-build–based admin dashboard scaffold for the Backup package, gated behind a new `rsm_jetpack_ui_modernization_backup` feature filter.
* When the filter is on, "Jetpack > Backup" renders the new wp-build dashboard (currently a `<h1>Backup</h1>` placeholder) inside the standard wp-admin chrome. When the filter is off (default), today's Backup admin page renders exactly as before — no behavior change unless an operator explicitly opts in.
* Wire the wp-build pipeline into `pnpm run build` / `pnpm run watch` alongside the existing webpack build, declare the wp-build "page" via a new top-level `wpPlugin` config block in `package.json`, and add the `provide-boot-asset-file` step required for wp-build's enqueue body to register scripts.
* Use a distinct internal wp-build page slug (`jetpack-backup-dashboard`) so wp-build's auto-generated `admin_init` standalone-render intercept doesn't hijack the menu callback. A small scoped `current_screen` action aliases `$screen->id` so wp-build's `<page>-wp-admin` enqueue callback fires on our existing `?page=jetpack-backup` URL — the user-facing URL is unchanged.
* Branch the menu render callback in `Jetpack_Backup::add_wp_admin_submenu()` between the legacy `plugin_settings_page` and the wp-build–generated render function, with a `function_exists` guard for graceful degradation if the build artifact is missing.
* Short-circuit `Jetpack_Backup::enqueue_admin_scripts()` when the flag is on — wp-build manages its own enqueue pipeline, so legacy script registration, `Connection_Initial_State`, Tracking, and inline initial-state injection are intentionally skipped for the empty starter (per spec; will be added back as the dashboard accumulates real surface area in PR 2).

## Related product discussion/links

* Umbrella: #48582
* PR 1 cadence model: #48494 (VideoPress wp-build scaffold), #48532 (Newsletter wp-build scaffold)
* Source of code (working reference, kept open until PR 7 lands): #48236

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Pull this branch, run `pnpm install` and `pnpm run build` from `projects/packages/backup/`. Then verify both flag states:

**Flag OFF (regression check)**

* Make sure no `add_filter( 'rsm_jetpack_ui_modernization_backup', ... )` exists in any mu-plugin / `wp-config.php` / theme.
* Visit `wp-admin/admin.php?page=jetpack-backup`.
* Confirm today's Backup admin page renders exactly as before — no console errors, legacy `build/index.js` script loads, `<div id="jetpack-backup-root">` mount point is present.

**Flag ON (new dashboard)**

* Add the following to a mu-plugin, `wp-config.php` or use the Code Snippet plugin:
  ```php
  add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
  ```
* Hard-refresh `wp-admin/admin.php?page=jetpack-backup`.
* Confirm the placeholder `<h1>Backup</h1>` renders inside the standard wp-admin chrome (sidebar visible). DevTools → Network should request wp-build's bundle (under `build/scripts/` or `build/pages/jetpack-backup-dashboard/`), and **not** the legacy `build/index.js`. No console errors.

**Toggle round-trip**

* Comment out the `add_filter` line and refresh — legacy Backup admin page should return immediately.
* Re-enable the filter and refresh — new dashboard should return. Both directions should be reversible without cache clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)