### PR TITLE
add: Tips variation of the Donations block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-donations-tips-variation
+++ b/projects/plugins/jetpack/changelog/add-donations-tips-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Donations Block: Add a "Tips" variation with coffee-themed defaults for creatives — sticky pop-up mode, "Buy me a coffee" trigger, $3/$5/$8 amounts, and a "Buy coffee" donate button.

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -190,6 +190,10 @@
 		},
 		"blockBorderRadius": {
 			"type": [ "string", "object" ]
+		},
+		"variationName": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.js
@@ -1,8 +1,10 @@
+import { registerBlockVariation } from '@wordpress/blocks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import save from './save';
+import tipsVariation from './tips-variation';
 
 import './editor.scss';
 
@@ -11,3 +13,5 @@ registerJetpackBlockFromMetadata( metadata, {
 	save,
 	deprecated: [ deprecatedV1 ],
 } );
+
+registerBlockVariation( 'jetpack/donations', tipsVariation );

--- a/projects/plugins/jetpack/extensions/blocks/donations/icons.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/icons.js
@@ -53,4 +53,4 @@ export const TRIGGER_ICONS = [
 	{ key: 'coffee', label: __( 'Cup', 'jetpack' ), icon: coffee },
 ];
 
-export { gift };
+export { coffee, gift };

--- a/projects/plugins/jetpack/extensions/blocks/donations/tips-variation.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tips-variation.js
@@ -1,0 +1,59 @@
+import { __ } from '@wordpress/i18n';
+import { coffee } from './icons';
+
+export const TIPS_VARIATION_NAME = 'tips';
+
+export const tipsVariationAttributes = {
+	variationName: TIPS_VARIATION_NAME,
+	displayMode: 'modal',
+	triggerSticky: false,
+	triggerButtonText: 'Buy me a coffee',
+	triggerIcon: 'coffee',
+	contentAlignment: 'center',
+	buttonAlignment: 'full',
+	tabsAppearance: 'buttons',
+	showCustomAmount: false,
+	chooseAmountText: '',
+	annualDonation: {
+		show: false,
+		planId: null,
+		amounts: [ 3, 5, 8 ],
+	},
+	oneTimeDonation: {
+		show: true,
+		planId: null,
+		amounts: [ 3, 5, 8 ],
+		defaultAmountIndex: 0,
+		heading: '',
+		buttonText: 'Buy coffee',
+		extraText: 'Thanks for your generosity!',
+	},
+	monthlyDonation: {
+		show: true,
+		planId: null,
+		amounts: [ 3, 5, 8 ],
+		defaultAmountIndex: 0,
+		heading: '',
+		buttonText: 'Buy coffee',
+		extraText: 'Thanks for your generosity!',
+	},
+};
+
+const tipsVariation = {
+	name: TIPS_VARIATION_NAME,
+	title: __( 'Tips', 'jetpack' ),
+	description: __( 'Get financial support from friends and followers.', 'jetpack' ),
+	icon: coffee,
+	isDefault: false,
+	attributes: tipsVariationAttributes,
+	scope: [ 'inserter' ],
+	isActive: attrs => attrs.variationName === TIPS_VARIATION_NAME,
+	keywords: [
+		__( 'tips', 'jetpack' ),
+		__( 'coffee', 'jetpack' ),
+		__( 'support', 'jetpack' ),
+		__( 'buy me a coffee', 'jetpack' ),
+	],
+};
+
+export default tipsVariation;

--- a/projects/plugins/jetpack/extensions/blocks/payments-intro/block-picker.js
+++ b/projects/plugins/jetpack/extensions/blocks/payments-intro/block-picker.js
@@ -20,10 +20,11 @@ export default function PaymentsIntroBlockPicker( { variations, onSelect, label 
 						role="presentation"
 					>
 						{
-							// Since `variations` is built from reading the variations block.json files directly,
-							// the block titles are not localized. We use getBlockType to get the localized title.
+							// `displayTitle` takes precedence for variation entries that have their own
+							// title (e.g. Tips). For standard block entries, fall back to the localized
+							// title from the block registry; raw block.json titles are not translated.
 							// See https://github.com/Automattic/jetpack/issues/37014
-							getBlockType?.( variation.name )?.title || variation.title
+							variation.displayTitle || getBlockType?.( variation.name )?.title || variation.title
 						}
 					</span>
 				</li>

--- a/projects/plugins/jetpack/extensions/blocks/payments-intro/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/payments-intro/edit.js
@@ -48,7 +48,7 @@ export default function JetpackPaymentsIntroEdit( { name, clientId } ) {
 		const blockName = variation.name;
 
 		maybeMakeBlockVisible( blockName );
-		replaceBlock( clientId, createBlock( blockName ) );
+		replaceBlock( clientId, createBlock( blockName, variation.attributes ?? {} ) );
 		selectBlock( clientId );
 	};
 

--- a/projects/plugins/jetpack/extensions/blocks/payments-intro/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/payments-intro/variations.js
@@ -4,16 +4,17 @@
 
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
 import donationMetadata from '../donations/block.json';
+import tipsVariation from '../donations/tips-variation';
 import paymentButtonsMetadata from '../payment-buttons/block.json';
 import premiumContentMetadata from '../premium-content/block.json';
 
-const variations = [
+const standardBlocks = [
 	[ donationMetadata.name, donationMetadata ],
 	[ paymentButtonsMetadata.name, paymentButtonsMetadata ],
 	[ premiumContentMetadata.name, premiumContentMetadata ],
 ];
 
-const variationDefinitions = variations.map( ( [ blockName, settings ] ) => {
+const standardDefs = standardBlocks.map( ( [ blockName, settings ] ) => {
 	const icon = settings.icon.src ?? settings.icon;
 
 	return {
@@ -27,4 +28,12 @@ const variationDefinitions = variations.map( ( [ blockName, settings ] ) => {
 	};
 } );
 
-export default variationDefinitions;
+const tipsDef = {
+	name: 'jetpack/donations',
+	displayTitle: tipsVariation.title,
+	description: tipsVariation.description,
+	icon: tipsVariation.icon,
+	attributes: tipsVariation.attributes,
+};
+
+export default [ ...standardDefs, tipsDef ];


### PR DESCRIPTION
## Proposed changes

Registers a block variation called **Tips** on top of `jetpack/donations`. It appears in the block inserter as its own entry and at the end of the Payments block picker. Selecting it inserts a Donations block pre-configured with defaults suited for creators who collect tips:

- Display mode: sticky pop-up modal
- Trigger: coffee cup icon, "Buy me a coffee" button text
- Content aligned center; donate button full-width
- Tabs appearance: Buttons
- One-time + monthly only (annual hidden); amounts $3 / $5 / $8, $3 default on both
- Custom amount hidden

### How it works

| File | What changed |
|---|---|
| `donations/block.json` | Added `variationName` attribute — written to block content so `isActive` can identify the variation unambiguously |
| `donations/tips-variation.js` | New file: exports the variation definition and its attribute defaults |
| `donations/editor.js` | Calls `registerBlockVariation` after the block registers |
| `donations/icons.js` | Exports `coffee` so the variation can use it as its icon |
| `payments-intro/variations.js` | Adds Tips as the last option in the Payments block picker |
| `payments-intro/block-picker.js` | Adds `displayTitle` precedence so Tips shows "Tips" not "Donations Form" |
| `payments-intro/edit.js` | Passes `variation.attributes` to `createBlock` so the picker inserts a pre-configured block |

## Related product discussion

Part of RSM project: "Little things matter: Improving the Donation block"
Linear: https://linear.app/a8c/project/rsm-donation-form-improvements-wip-061cec72952c/overview

Stacked on #48539 (pop-up display mode).

## Does this PR change what data or activity we track or use?

No.

## Testing instructions

**Block inserter:**
1. Open the editor and search for "Tips" in the block inserter.
2. A "Tips" entry should appear with a coffee cup icon.
3. Insert it — the block should appear as a sticky pop-up trigger button labelled "Buy me a coffee" with a coffee icon.
4. In the inspector: Display panel shows Pop-up mode + Sticky toggled on; Style panel should show Buttons appearance; amounts should be $3/$5/$8 with $3 selected by default on both one-time and monthly; annual tab and custom amount should be hidden.

**Payments block picker:**
1. Insert the Payments block from the block inserter.
2. The picker should show four options: Donations Form, Payment Buttons, Premium Content, **Tips** (in that order).
3. [screenshot] of the picker with Tips at the end
4. Click Tips — the block should insert pre-configured exactly as described above (not a vanilla Donations Form).

**Existing Donations Form blocks:**
5. Open an existing Donations Form block. Confirm it still works normally and does not show "Tips" in the toolbar.
6. Confirm the block inspector controls all still work.