### PR TITLE
Forms: Make single Checkbox row fully clickable (FORMS-684)

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-checkbox-click-area
+++ b/projects/packages/forms/changelog/fix-forms-checkbox-click-area
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: make the single Checkbox row fully clickable.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1478,8 +1478,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$has_inner_block_option_styles = ! empty( $this->get_attribute( 'optionstyles' ) );
 
 		$field  = "<div class='contact-form__checkbox-wrap' style='" . ( $has_inner_block_option_styles ? esc_attr( $this->option_styles ) : '' ) . "' >";
-		$field .= "<input id='" . esc_attr( $id ) . "' type='checkbox' data-wp-on--change='actions.onFieldChange' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
 		$field .= "<label for='" . esc_attr( $id ) . "' class='" . esc_attr( $label_class ) . "' style='" . esc_attr( $this->label_styles ) . ( $has_inner_block_option_styles ? esc_attr( $this->option_styles ) : '' ) . "'>";
+		$field .= "<input id='" . esc_attr( $id ) . "' type='checkbox' data-wp-on--change='actions.onFieldChange' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
 		$field .= wp_kses_post( $label ) . ( $required && $required_indicator ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' );
 		$field .= "</label>\n";
 		$field .= "<div class='clear-form'></div>\n";


### PR DESCRIPTION
Fixes #41522
Linear: FORMS-684

On a Jetpack Form, clicking the empty space between a single Checkbox input and its label text did nothing. Only the input itself and the label text were clickable. This narrows the click target and is inconsistent with how the Radio and Multi-Choice fields already behave.

## Proposed changes

* In `projects/packages/forms/src/contact-form/class-contact-form-field.php`, swap the `<input>` and `<label>` open-tag lines inside `render_checkbox_field()` so the `<label>` wraps the `<input>` instead of being its sibling.
* No CSS changes. No editor-side changes. No attribute changes.

## Root cause

`render_checkbox_field()` emits the `<input>` and `<label>` as siblings inside a wrapper `<div>`:

```html
<div class="contact-form__checkbox-wrap">
  <input id="…" type="checkbox" … />
  <label for="…">…</label>
</div>
```

The wrapper is a `<div>`, not a `<label>`, so clicks in the gap between the input and the label text don't toggle the input. Browsers only forward clicks to a checkbox via the input itself or via a `<label>` that either wraps it or is associated with it through a labelable click target — the gap belongs to the `<div>` and isn't either.

## Fix

Move the `<label>` open tag above the `<input>` so the label wraps the input:

```html
<div class="contact-form__checkbox-wrap">
  <label for="…">
    <input id="…" type="checkbox" … />
    …
  </label>
</div>
```

This matches the convention already used by:

* the consent field (`render_consent_field`)
* the multi-checkbox `optionsdata` rendering path (refactored as a side effect of FORMS-131, PR #46263, merged Dec 2025)
* the radio `optionsdata` rendering path (refactored as a side effect of PR #46461)

The original GitHub issue #41522 reported this bug for single Checkbox, Radio, and Multi-Choice. Radio and Multi-Choice were fixed incidentally by the two PRs above; single Checkbox has its own dedicated render path that wasn't touched. This PR addresses only that remaining path.

## What is intentionally not changed

* **`for=` attribute on the label is kept.** It's now redundant for click association (the wrapping handles it) but keeping it costs nothing and avoids breaking any external tool that might key off it.
* **`id=` attribute on the input is kept.** It's reused by `get_error_div( $id, 'checkbox' )` so it has to stay.
* **The outer `<div class="contact-form__checkbox-wrap">` wrapper is kept.** It diverges from `render_consent_field()`'s pattern (which has no equivalent wrapper), but removing it would be a separate structural change with its own theme-compatibility risk (the class is public-facing CSS, possibly targeted by external theme stylesheets) and is out of scope for this PR.
* **Legacy radio path** (around line 1396, reachable only via the deprecated shortcode syntax) **is not touched.**
* **No CSS changes.** The existing `.contact-form__checkbox-wrap { display: inline-flex; align-items: baseline }` rule continues to apply at the wrapper level. Visual parity with the previous rendering was confirmed manually on Twenty Twenty-Five with no observed regressions.
* **No editor-side changes.** The editor preview is rendered by a different code path (the inner `jetpack/option` block) and the bug only ever manifested on the published frontend.

## Visual evidence

Before (no fix), recorded on a sandbox without the FORMS-684 patch:

<img width="298" height="62" alt="before-click-gap" src="https://github.com/user-attachments/assets/2e10cea2-c9cb-4761-b3fc-6e7218093049" />


After (with fix), recorded on `impossibly-literary.jurassic.ninja` with the build deployed:

<img width="296" height="62" alt="after-click-gap" src="https://github.com/user-attachments/assets/774957e9-0439-4fec-99bc-4f06b28b7967" />


## Testing instructions

1. Apply the patch to a Jurassic Ninja site (or any site with Jetpack 15.8 / trunk). Create a page with a Jetpack Form block containing a Checkbox field. Publish.
2. On the frontend, click in the empty space between the checkbox input and the label text. The checkbox should toggle.
3. Click on the input itself. Should still toggle.
4. Click on the label text. Should still toggle.
5. Mark the Checkbox required in the editor. Submit the form without checking it. The error message should still appear, and the required indicator span should still render inside the label.
6. Add a Radio field and a Multi-Choice (multi-checkbox) field to the same form to confirm those keep working as before.
7. Try at least two themes (e.g. Twenty Twenty-Five and Twenty Twenty-Four).

## Does this pull request change what data or activity we track or use?

No. No data, schema, or API changes.

## Notes

* No editor-side changes. The editor preview (`field-checkbox/edit.js` + the inner `jetpack/option` block) renders the checkbox via `<RichText>` and a non-interactive `<input>` in a different DOM shape; this PR only affects the published frontend.

