### PR TITLE
VideoPress: Modernization Phase 2 — Library tab (DataViews grid + table)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4457,6 +4457,9 @@ importers:
       '@wordpress/data':
         specifier: 10.44.0
         version: 10.44.0(react@18.3.1)
+      '@wordpress/dataviews':
+        specifier: 14.1.0
+        version: 14.1.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/date':
         specifier: 5.44.0
         version: 5.44.0
@@ -19568,6 +19571,21 @@ snapshots:
       '@types/react': 18.3.28
       date-fns: 4.1.0
 
+  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@date-fns/tz': 1.4.1
+      '@types/react': 18.3.28
+      date-fns: 4.1.0
+    optional: true
+
   '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19613,6 +19631,18 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
+
+  '@base-ui/utils@0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+    optional: true
 
   '@base-ui/utils@0.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24646,7 +24676,7 @@ snapshots:
       '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/data': 10.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.44.0
+      '@wordpress/deprecated': 4.45.0
       '@wordpress/element': 6.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/icons': 12.2.0(react@18.3.1)
@@ -24654,12 +24684,12 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
       '@wordpress/ui': 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.44.0
+      '@wordpress/warning': 3.45.0
       clsx: 2.1.1
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
-      '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
@@ -24697,7 +24727,7 @@ snapshots:
       '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.44.0(react@18.3.1)
       '@wordpress/data': 10.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.44.0
+      '@wordpress/deprecated': 4.45.0
       '@wordpress/element': 6.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/icons': 12.2.0(react@18.3.1)
@@ -24705,12 +24735,12 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
       '@wordpress/ui': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.44.0
+      '@wordpress/warning': 3.45.0
       clsx: 2.1.1
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
-      '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7331,19 +7331,6 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.4.0':
-    resolution: {integrity: sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@date-fns/tz': ^1.2.0
-      '@types/react': ^17 || ^18 || ^19
-      date-fns: ^4.0.0
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@base-ui/react@1.4.1':
     resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
     engines: {node: '>=14.0.0'}
@@ -7359,16 +7346,6 @@ packages:
       '@types/react':
         optional: true
       date-fns:
-        optional: true
-
-  '@base-ui/utils@0.2.7':
-    resolution: {integrity: sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==}
-    peerDependencies:
-      '@types/react': ^17 || ^18 || ^19
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   '@base-ui/utils@0.2.8':
@@ -19529,34 +19506,6 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.7(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@date-fns/tz': 1.4.1
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.11
-      date-fns: 4.1.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.28
-    optional: true
-
-  '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@date-fns/tz': 1.4.1
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.11
-      date-fns: 4.1.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optional: true
-
   '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19570,21 +19519,6 @@ snapshots:
       '@date-fns/tz': 1.4.1
       '@types/react': 18.3.28
       date-fns: 4.1.0
-
-  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.11
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@date-fns/tz': 1.4.1
-      '@types/react': 18.3.28
-      date-fns: 4.1.0
-    optional: true
 
   '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -19599,28 +19533,6 @@ snapshots:
       '@date-fns/tz': 1.4.1
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.7(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.28
-    optional: true
-
-  '@base-ui/utils@0.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optional: true
-
   '@base-ui/utils@0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19631,18 +19543,6 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
-
-  '@base-ui/utils@0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.28
-    optional: true
 
   '@base-ui/utils@0.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/projects/js-packages/components/changelog/update-videopress-modernization-phase-2
+++ b/projects/js-packages/components/changelog/update-videopress-modernization-phase-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add global-notices sub-path export for use in wp-build dashboards.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -28,6 +28,11 @@
 			"types": "./build/components/admin-page/index.d.ts",
 			"default": "./build/components/admin-page/index.js"
 		},
+		"./global-notices": {
+			"jetpack:src": "./components/global-notices/index.ts",
+			"types": "./build/components/global-notices/index.d.ts",
+			"default": "./build/components/global-notices/index.js"
+		},
 		"./gravatar": {
 			"jetpack:src": "./components/gravatar/index.tsx",
 			"types": "./build/components/gravatar/index.d.ts",

--- a/projects/packages/videopress/changelog/update-videopress-modernization-phase-2
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-phase-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Library tab as a DataViews grid (with table alternate) and mocked uploads, all behind the existing modernization filter.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/compose": "7.44.0",
 		"@wordpress/core-data": "7.44.0",
 		"@wordpress/data": "10.44.0",
+		"@wordpress/dataviews": "14.1.0",
 		"@wordpress/date": "5.44.0",
 		"@wordpress/dom-ready": "4.44.0",
 		"@wordpress/editor": "14.44.0",

--- a/projects/packages/videopress/routes/library/package.json
+++ b/projects/packages/videopress/routes/library/package.json
@@ -5,6 +5,8 @@
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
 		"@types/react": "18.3.28",
+		"@wordpress/components": "32.6.0",
+		"@wordpress/dataviews": "14.1.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/route": "0.10.0",

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -170,7 +170,7 @@ const Stage = () => {
 			}
 		>
 			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
-				<div className="vp-library__viewport">
+				<div className={ `vp-library__viewport vp-library__viewport--${ view.type }` }>
 					<DataViews< MockLibraryItem >
 						data={ pagedData }
 						fields={ libraryFields }

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,6 +1,7 @@
+import { GlobalNotices, useGlobalNotices } from '@automattic/jetpack-components/global-notices';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
 import { buildLibraryActions } from '../../src/dashboard/components/Library/actions';
@@ -8,9 +9,15 @@ import { libraryFields } from '../../src/dashboard/components/Library/fields';
 import { UploadActionsProvider } from '../../src/dashboard/components/Library/upload-actions-context';
 import { useMockLibrary } from '../../src/dashboard/hooks/use-mock-library';
 import './style.scss';
-import type { MockLibraryItem } from '../../src/dashboard/types/library';
+import type { LibraryItemPrivacy, MockLibraryItem } from '../../src/dashboard/types/library';
 import type { View } from '@wordpress/dataviews';
 import type { ChangeEvent } from 'react';
+
+const PRIVACY_LABELS: Record< LibraryItemPrivacy, string > = {
+	public: __( 'Public', 'jetpack-videopress-pkg' ),
+	private: __( 'Private', 'jetpack-videopress-pkg' ),
+	'site-default': __( 'Site default', 'jetpack-videopress-pkg' ),
+};
 
 const GRID_VISIBLE_FIELDS = [ 'filename' ];
 const TABLE_VISIBLE_FIELDS = [ 'filename', 'duration', 'fileSize', 'uploadDate', 'privacy' ];
@@ -71,16 +78,36 @@ const Stage = () => {
 		// Phase 4 will route to the details screen.
 	}, [] );
 
+	const { createSuccessNotice } = useGlobalNotices();
+
 	const actions = useMemo(
 		() =>
 			buildLibraryActions( {
 				promoteLocal,
 				retryUpload,
-				deleteItems,
-				setPrivacy,
 				openVideoDetails,
+				deleteItems: ids => {
+					deleteItems( ids );
+					createSuccessNotice(
+						sprintf(
+							/* translators: %d: number of deleted videos. */
+							_n( '%d video deleted.', '%d videos deleted.', ids.length, 'jetpack-videopress-pkg' ),
+							ids.length
+						)
+					);
+				},
+				setPrivacy: ( id, privacy ) => {
+					setPrivacy( id, privacy );
+					createSuccessNotice(
+						sprintf(
+							/* translators: %s: new privacy label, e.g. "Public". */
+							__( 'Privacy updated to %s.', 'jetpack-videopress-pkg' ),
+							PRIVACY_LABELS[ privacy ]
+						)
+					);
+				},
 			} ),
-		[ promoteLocal, retryUpload, deleteItems, setPrivacy, openVideoDetails ]
+		[ promoteLocal, retryUpload, deleteItems, setPrivacy, openVideoDetails, createSuccessNotice ]
 	);
 
 	const filteredData = useMemo< MockLibraryItem[] >( () => {
@@ -186,6 +213,7 @@ const Stage = () => {
 					/>
 				</div>
 			</UploadActionsProvider>
+			<GlobalNotices />
 		</DashboardLayout>
 	);
 };

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,10 +1,174 @@
+import { Button } from '@wordpress/components';
+import { DataViews } from '@wordpress/dataviews';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
+import { buildLibraryActions } from '../../src/dashboard/components/Library/actions';
+import { libraryFields } from '../../src/dashboard/components/Library/fields';
+import { UploadActionsProvider } from '../../src/dashboard/components/Library/upload-actions-context';
+import { useMockLibrary } from '../../src/dashboard/hooks/use-mock-library';
+import './style.scss';
+import type { MockLibraryItem } from '../../src/dashboard/types/library';
+import type { View } from '@wordpress/dataviews';
+import type { ChangeEvent } from 'react';
+
+const DEFAULT_VIEW: View = {
+	type: 'grid',
+	page: 1,
+	perPage: 12,
+	titleField: 'title',
+	mediaField: 'thumbnail',
+	fields: [ 'filename' ],
+	layout: { previewSize: 220, density: 'comfortable' },
+	sort: { field: 'uploadDate', direction: 'desc' },
+	filters: [],
+	search: '',
+};
+
+const defaultLayouts = {
+	grid: { previewSize: 220, density: 'comfortable' as const },
+	table: { density: 'balanced' as const },
+};
 
 const Stage = () => {
+	const { items, isLoading, startUpload, promoteLocal, retryUpload, deleteItems, setPrivacy } =
+		useMockLibrary();
+
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ selection, setSelection ] = useState< string[] >( [] );
+
+	const filePickerRef = useRef< HTMLInputElement >( null );
+	const onClickHeaderUpload = useCallback( () => {
+		filePickerRef.current?.click();
+	}, [] );
+	const onFilePicked = useCallback(
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			const file = event.target.files?.[ 0 ];
+			if ( file ) {
+				startUpload( file );
+			}
+			event.target.value = '';
+		},
+		[ startUpload ]
+	);
+
+	const openVideoDetails = useCallback( () => {
+		// Phase 4 will route to the details screen.
+	}, [] );
+
+	const actions = useMemo(
+		() =>
+			buildLibraryActions( {
+				promoteLocal,
+				retryUpload,
+				deleteItems,
+				setPrivacy,
+				openVideoDetails,
+			} ),
+		[ promoteLocal, retryUpload, deleteItems, setPrivacy, openVideoDetails ]
+	);
+
+	const filteredData = useMemo< MockLibraryItem[] >( () => {
+		let result = items;
+
+		const search = view.search?.trim().toLowerCase();
+		if ( search ) {
+			result = result.filter(
+				item =>
+					item.title.toLowerCase().includes( search ) ||
+					item.filename.toLowerCase().includes( search )
+			);
+		}
+
+		for ( const filter of view.filters ?? [] ) {
+			const { field, value } = filter;
+			if ( value === undefined || value === null || value === 'all' ) {
+				continue;
+			}
+			result = result.filter( item => {
+				switch ( field ) {
+					case 'type':
+						return item.type === value;
+					case 'privacy':
+						return item.privacy === value;
+					default:
+						return true;
+				}
+			} );
+		}
+
+		if ( view.sort ) {
+			const { field, direction } = view.sort;
+			const dir = direction === 'asc' ? 1 : -1;
+			result = [ ...result ].sort( ( a, b ) => {
+				switch ( field ) {
+					case 'title':
+						return a.title.localeCompare( b.title ) * dir;
+					case 'uploadDate':
+						return ( a.uploadDate < b.uploadDate ? -1 : 1 ) * dir;
+					case 'duration':
+						return ( a.durationSeconds - b.durationSeconds ) * dir;
+					case 'fileSize':
+						return ( a.fileSizeBytes - b.fileSizeBytes ) * dir;
+					default:
+						return 0;
+				}
+			} );
+		}
+
+		return result;
+	}, [ items, view.search, view.filters, view.sort ] );
+
+	const perPage = view.perPage ?? 12;
+	const totalItems = filteredData.length;
+	const totalPages = Math.max( 1, Math.ceil( totalItems / perPage ) );
+	const page = Math.min( view.page ?? 1, totalPages );
+	const pagedData = useMemo(
+		() => filteredData.slice( ( page - 1 ) * perPage, page * perPage ),
+		[ filteredData, page, perPage ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( { totalItems, totalPages } ),
+		[ totalItems, totalPages ]
+	);
+
+	const getItemId = useCallback( ( item: MockLibraryItem ) => item.id, [] );
+
 	return (
-		<DashboardLayout activeTab="library">
-			<p>{ __( 'Library', 'jetpack-videopress-pkg' ) }</p>
+		<DashboardLayout
+			activeTab="library"
+			hideFooter
+			actions={
+				<>
+					<input
+						ref={ filePickerRef }
+						type="file"
+						accept="video/*"
+						style={ { display: 'none' } }
+						onChange={ onFilePicked }
+					/>
+					<Button variant="primary" onClick={ onClickHeaderUpload }>
+						{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
+					</Button>
+				</>
+			}
+		>
+			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
+				<DataViews< MockLibraryItem >
+					data={ pagedData }
+					fields={ libraryFields }
+					actions={ actions }
+					view={ view }
+					onChangeView={ setView }
+					selection={ selection }
+					onChangeSelection={ setSelection }
+					getItemId={ getItemId }
+					paginationInfo={ paginationInfo }
+					isLoading={ isLoading }
+					defaultLayouts={ defaultLayouts }
+				/>
+			</UploadActionsProvider>
 		</DashboardLayout>
 	);
 };

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
 import { buildLibraryActions } from '../../src/dashboard/components/Library/actions';
 import { libraryFields } from '../../src/dashboard/components/Library/fields';
@@ -12,13 +12,16 @@ import type { MockLibraryItem } from '../../src/dashboard/types/library';
 import type { View } from '@wordpress/dataviews';
 import type { ChangeEvent } from 'react';
 
+const GRID_VISIBLE_FIELDS = [ 'filename' ];
+const TABLE_VISIBLE_FIELDS = [ 'filename', 'duration', 'fileSize', 'uploadDate', 'privacy' ];
+
 const DEFAULT_VIEW: View = {
 	type: 'grid',
 	page: 1,
 	perPage: 12,
 	titleField: 'title',
 	mediaField: 'thumbnail',
-	fields: [ 'filename' ],
+	fields: GRID_VISIBLE_FIELDS,
 	layout: { previewSize: 220, density: 'comfortable' },
 	sort: { field: 'uploadDate', direction: 'desc' },
 	filters: [],
@@ -36,6 +39,18 @@ const Stage = () => {
 
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ selection, setSelection ] = useState< string[] >( [] );
+
+	const onChangeView = useCallback( ( next: View ) => {
+		setView( current => {
+			if ( next.type === current.type ) {
+				return next;
+			}
+			return {
+				...next,
+				fields: next.type === 'table' ? TABLE_VISIBLE_FIELDS : GRID_VISIBLE_FIELDS,
+			};
+		} );
+	}, [] );
 
 	const filePickerRef = useRef< HTMLInputElement >( null );
 	const onClickHeaderUpload = useCallback( () => {
@@ -148,26 +163,28 @@ const Stage = () => {
 						style={ { display: 'none' } }
 						onChange={ onFilePicked }
 					/>
-					<Button variant="primary" onClick={ onClickHeaderUpload }>
+					<Button size="compact" onClick={ onClickHeaderUpload }>
 						{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
 					</Button>
 				</>
 			}
 		>
 			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
-				<DataViews< MockLibraryItem >
-					data={ pagedData }
-					fields={ libraryFields }
-					actions={ actions }
-					view={ view }
-					onChangeView={ setView }
-					selection={ selection }
-					onChangeSelection={ setSelection }
-					getItemId={ getItemId }
-					paginationInfo={ paginationInfo }
-					isLoading={ isLoading }
-					defaultLayouts={ defaultLayouts }
-				/>
+				<div className="vp-library__viewport">
+					<DataViews< MockLibraryItem >
+						data={ pagedData }
+						fields={ libraryFields }
+						actions={ actions }
+						view={ view }
+						onChangeView={ onChangeView }
+						selection={ selection }
+						onChangeSelection={ setSelection }
+						getItemId={ getItemId }
+						paginationInfo={ paginationInfo }
+						isLoading={ isLoading }
+						defaultLayouts={ defaultLayouts }
+					/>
+				</div>
 			</UploadActionsProvider>
 		</DashboardLayout>
 	);

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -1,4 +1,30 @@
+@use "sass:meta";
+@include meta.load-css("@wordpress/dataviews/build-style/style.css");
+
 .vp-library {
+
+	&__viewport {
+		display: flex;
+		flex-direction: column;
+		min-height: calc(100vh - 220px);
+
+		// DataViews's wrapper has `height: 100%`, so flex-grow it inside the
+		// viewport to push the pagination footer to the bottom.
+		> .dataviews-wrapper {
+			flex: 1;
+			min-height: 0;
+		}
+	}
+
+	// Override wp-build's `.boot-layout-container .boot-layout img` reset
+	// (which forces `height: auto`, specificity 0,2,1) so our thumbnail img can
+	// fill its parent in both grid (large) and table (32x32) cells.
+	.boot-layout-container .boot-layout &__thumbnail-image {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
 
 	&__thumbnail {
 		position: relative;
@@ -6,6 +32,7 @@
 		height: 100%;
 		overflow: hidden;
 		background: #1e1e1e;
+		container-type: inline-size;
 
 		&-image {
 			width: 100%;
@@ -25,6 +52,10 @@
 			font-size: 11px;
 			font-variant-numeric: tabular-nums;
 			line-height: 1.4;
+
+			@container (max-width: 120px) {
+				display: none;
+			}
 		}
 	}
 
@@ -67,11 +98,12 @@
 		align-items: center;
 		justify-content: center;
 		gap: 8px;
-		background: rgba(0, 0, 0, 0.55);
-		color: #fff;
+		background: rgba(255, 255, 255, 0.92);
+		color: #1e1e1e;
 
 		&-percent {
 			font-size: 16px;
+			font-weight: 600;
 			font-variant-numeric: tabular-nums;
 		}
 
@@ -101,5 +133,55 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	// Table view: DataViews forces the thumbnail img to a fixed 32x32 inside
+	// `.dataviews-column-primary__media`. Suppress only the custom overlays —
+	// don't touch sizing, or the stock 32x32 thumbnail collapses. Status info
+	// moves into the title cell as a status pill (see `&__status-pill` below).
+	.dataviews-view-table & {
+
+		&__thumbnail-duration-badge,
+		&__placeholder,
+		&__hover-action,
+		&__progress,
+		&__failed {
+			display: none;
+		}
+	}
+
+	// Status pill (Local / Uploading 47% / Upload failed) renders in the title
+	// cell. Only show in the table view — in the grid view, the per-card overlays
+	// already convey the same information more visibly.
+	.dataviews-view-grid &__status-pill {
+		display: none;
+	}
+
+	&__status-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		margin-left: 8px;
+		padding: 1px 6px;
+		border-radius: 3px;
+		font-size: 11px;
+		font-weight: 500;
+		background: #f0f0f0;
+		color: #1e1e1e;
+
+		&--uploading {
+			background: rgba(56, 88, 233, 0.12);
+			color: #3858e9;
+		}
+
+		&--failed {
+			background: rgba(204, 24, 24, 0.12);
+			color: #cc1818;
+		}
+
+		&--local {
+			background: #f0f0f0;
+			color: #757575;
+		}
 	}
 }

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -9,18 +9,22 @@
 		flex: 1;
 		min-height: 0;
 
-		// DataViews's wrapper has `height: 100%`, so flex-grow it inside the
-		// viewport to push the pagination footer to the bottom.
-		> .dataviews-wrapper {
+		// Flex-grow the single DataViews child inside this viewport so its
+		// pagination footer lands at the bottom. Targets `> *` rather than
+		// `.dataviews-wrapper` to avoid coupling to DataViews' internal class
+		// names — this viewport only ever wraps one DataViews instance.
+		> * {
 			flex: 1;
 			min-height: 0;
 		}
 	}
 
-	// Override wp-build's `.boot-layout-container .boot-layout img` reset
-	// (which forces `height: auto`, specificity 0,2,1) so our thumbnail img can
-	// fill its parent in both grid (large) and table (32x32) cells.
-	.boot-layout-container .boot-layout &__thumbnail-image {
+	// Override wp-build's `.boot-layout-container .boot-layout img { height:
+	// auto }` reset (specificity 0,2,1) without referencing wp-build's class
+	// names. Our own class chain has specificity (0,3,0), which beats the
+	// reset and lets the img fill its parent in both grid (large) and table
+	// (32x32) cells.
+	&__viewport &__thumbnail &__thumbnail-image {
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
@@ -34,13 +38,6 @@
 		overflow: hidden;
 		background: #1e1e1e;
 		container-type: inline-size;
-
-		&-image {
-			width: 100%;
-			height: 100%;
-			object-fit: cover;
-			display: block;
-		}
 
 		&-duration-badge {
 			position: absolute;
@@ -141,8 +138,11 @@
 	// square intrinsic ratio collapses the wrapper to its content height (e.g.
 	// 32x18 for 16:9), leaving white space above/below. Lock the wrapper to the
 	// 32x32 slot. Suppress overlays; status info moves into the title cell as a
-	// pill (see `&__status-pill` below).
-	.dataviews-view-table & {
+	// pill (see `&__status-pill` below). Keyed off our own `&__viewport--table`
+	// modifier (set from `view.type` in stage.tsx) instead of DataViews'
+	// internal `.dataviews-view-table`, so we don't depend on
+	// @wordpress/dataviews' private class names.
+	&__viewport--table & {
 
 		&__thumbnail {
 			width: 32px;
@@ -161,7 +161,7 @@
 	// Status pill (Local / Uploading 47% / Upload failed) renders in the title
 	// cell. Only show in the table view — in the grid view, the per-card overlays
 	// already convey the same information more visibly.
-	.dataviews-view-grid &__status-pill {
+	&__viewport--grid &__status-pill {
 		display: none;
 	}
 

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -6,7 +6,8 @@
 	&__viewport {
 		display: flex;
 		flex-direction: column;
-		min-height: calc(100vh - 220px);
+		flex: 1;
+		min-height: 0;
 
 		// DataViews's wrapper has `height: 100%`, so flex-grow it inside the
 		// viewport to push the pagination footer to the bottom.
@@ -135,11 +136,18 @@
 		white-space: nowrap;
 	}
 
-	// Table view: DataViews forces the thumbnail img to a fixed 32x32 inside
-	// `.dataviews-column-primary__media`. Suppress only the custom overlays —
-	// don't touch sizing, or the stock 32x32 thumbnail collapses. Status info
-	// moves into the title cell as a status pill (see `&__status-pill` below).
+	// Table view: DataViews gives a 32x32 cell slot but doesn't force the img,
+	// and its cell wrapper uses `align-items: center` — so an img with a non-
+	// square intrinsic ratio collapses the wrapper to its content height (e.g.
+	// 32x18 for 16:9), leaving white space above/below. Lock the wrapper to the
+	// 32x32 slot. Suppress overlays; status info moves into the title cell as a
+	// pill (see `&__status-pill` below).
 	.dataviews-view-table & {
+
+		&__thumbnail {
+			width: 32px;
+			height: 32px;
+		}
 
 		&__thumbnail-duration-badge,
 		&__placeholder,

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -1,0 +1,105 @@
+.vp-library {
+
+	&__thumbnail {
+		position: relative;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: #1e1e1e;
+
+		&-image {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+
+		&-duration-badge {
+			position: absolute;
+			right: 8px;
+			bottom: 8px;
+			padding: 2px 6px;
+			border-radius: 2px;
+			background: rgba(0, 0, 0, 0.75);
+			color: #fff;
+			font-size: 11px;
+			font-variant-numeric: tabular-nums;
+			line-height: 1.4;
+		}
+	}
+
+	&__placeholder {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-direction: column;
+		gap: 8px;
+		background: #f0f0f0;
+		color: #1e1e1e;
+		font-size: 13px;
+	}
+
+	&__hover-action {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 120ms ease-out;
+		background: rgba(240, 240, 240, 0.92);
+
+		.vp-library__thumbnail:hover &,
+		.vp-library__thumbnail:focus-within & {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+
+	&__progress {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		background: rgba(0, 0, 0, 0.55);
+		color: #fff;
+
+		&-percent {
+			font-size: 16px;
+			font-variant-numeric: tabular-nums;
+		}
+
+		&-bar {
+			width: 70%;
+		}
+	}
+
+	&__failed {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		background: rgba(204, 24, 24, 0.85);
+		color: #fff;
+		font-size: 13px;
+	}
+
+	&__filename {
+		display: block;
+		font-size: 12px;
+		color: #757575;
+		line-height: 1.4;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -57,25 +57,19 @@
 		}
 	}
 
+	// Overlays — flex/centering live on the wp/ui Stack wrappers in JSX. The SCSS
+	// only owns position, background, and color so the visual treatment stays
+	// thumbnail-shaped (full overlay) while layout uses design-system primitives.
 	&__placeholder {
 		position: absolute;
 		inset: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		flex-direction: column;
-		gap: 8px;
 		background: #f0f0f0;
 		color: #1e1e1e;
-		font-size: 13px;
 	}
 
 	&__hover-action {
 		position: absolute;
 		inset: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 120ms ease-out;
@@ -91,16 +85,10 @@
 	&__progress {
 		position: absolute;
 		inset: 0;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 8px;
 		background: rgba(255, 255, 255, 0.92);
 		color: #1e1e1e;
 
 		&-percent {
-			font-size: 16px;
 			font-weight: 600;
 			font-variant-numeric: tabular-nums;
 		}
@@ -113,21 +101,13 @@
 	&__failed {
 		position: absolute;
 		inset: 0;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 6px;
 		background: rgba(204, 24, 24, 0.85);
 		color: #fff;
-		font-size: 13px;
 	}
 
 	&__filename {
 		display: block;
-		font-size: 12px;
 		color: #757575;
-		line-height: 1.4;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -158,38 +158,11 @@
 		}
 	}
 
-	// Status pill (Local / Uploading 47% / Upload failed) renders in the title
-	// cell. Only show in the table view — in the grid view, the per-card overlays
-	// already convey the same information more visibly.
-	&__viewport--grid &__status-pill {
+	// Status info (Local / Uploading 47% / Upload failed) renders as a Badge
+	// alongside the title. Hide it in grid view — the per-card overlays already
+	// convey the same information more visibly. Targets the second child of the
+	// title-cell Stack so the title stays visible.
+	&__viewport--grid &__title-cell > :not(:first-child) {
 		display: none;
-	}
-
-	&__status-pill {
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
-		margin-left: 8px;
-		padding: 1px 6px;
-		border-radius: 3px;
-		font-size: 11px;
-		font-weight: 500;
-		background: #f0f0f0;
-		color: #1e1e1e;
-
-		&--uploading {
-			background: rgba(56, 88, 233, 0.12);
-			color: #3858e9;
-		}
-
-		&--failed {
-			background: rgba(204, 24, 24, 0.12);
-			color: #cc1818;
-		}
-
-		&--local {
-			background: #f0f0f0;
-			color: #757575;
-		}
 	}
 }

--- a/projects/packages/videopress/routes/settings/stage.tsx
+++ b/projects/packages/videopress/routes/settings/stage.tsx
@@ -1,7 +1,7 @@
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Button, Card } from '@wordpress/ui';
-import { useCallback, useState } from 'react';
+import { Card } from '@wordpress/ui';
+import { useState } from 'react';
 import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
 import './style.scss';
 
@@ -9,19 +9,8 @@ const Stage = () => {
 	// Local-only state for Phase 1; wires to videopress/v1/settings in Phase 6.
 	const [ restrict, setRestrict ] = useState( false );
 
-	const onSave = useCallback( () => {
-		// No-op in Phase 1; wires to videopress/v1/settings in Phase 6.
-	}, [] );
-
 	return (
-		<DashboardLayout
-			activeTab="settings"
-			actions={
-				<Button size="compact" onClick={ onSave }>
-					{ __( 'Save', 'jetpack-videopress-pkg' ) }
-				</Button>
-			}
-		>
+		<DashboardLayout activeTab="settings">
 			<div className="jp-videopress-settings">
 				<Card.Root>
 					<Card.Header>

--- a/projects/packages/videopress/src/dashboard/components/DashboardLayout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/DashboardLayout/index.tsx
@@ -14,6 +14,7 @@ type Props = {
 	activeTab: DashboardTab;
 	children: ReactNode;
 	actions?: ReactNode;
+	hideFooter?: boolean;
 };
 
 const TAB_VALUES: DashboardTab[] = [ 'overview', 'library', 'settings' ];
@@ -25,14 +26,16 @@ const TAB_VALUES: DashboardTab[] = [ 'overview', 'library', 'settings' ];
  * Tab/Panel pairing validator stays happy. Tab navigation between
  * sibling routes happens via `@wordpress/route`'s useNavigate.
  *
- * @param props           - Component props.
- * @param props.activeTab - Currently active tab.
- * @param props.children  - Active tab's body content.
- * @param props.actions   - Optional content rendered in the page header's
- *                        top-right actions slot (e.g. a Save button).
+ * @param props            - Component props.
+ * @param props.activeTab  - Currently active tab.
+ * @param props.children   - Active tab's body content.
+ * @param props.actions    - Optional content rendered in the page header's
+ *                         top-right actions slot (e.g. a Save button).
+ * @param props.hideFooter - When true, suppresses the JetpackFooter rendered by
+ *                         AdminPage. Used by DataViews-centric tabs (e.g. Library).
  * @return The wrapped page element.
  */
-export default function DashboardLayout( { activeTab, children, actions }: Props ) {
+export default function DashboardLayout( { activeTab, children, actions, hideFooter }: Props ) {
 	const navigate = useNavigate();
 
 	const onValueChange = useCallback(
@@ -50,6 +53,7 @@ export default function DashboardLayout( { activeTab, children, actions }: Props
 			title={ 'VideoPress' /* product name; not translated */ }
 			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
 			actions={ actions }
+			showFooter={ ! hideFooter }
 		>
 			<Tabs.Root value={ activeTab } onValueChange={ onValueChange }>
 				<DashboardTabs />

--- a/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
@@ -10,10 +10,22 @@ body.jetpack_page_jetpack-videopress {
 
 	@include jetpack-admin-page-layout;
 
-	// TODO (Phase 2.5): pin the DataViews pagination footer to the bottom of the
-	// visible page area for the Library tab. Earlier attempts propagated flex
-	// height through Tabs.Root + Tabs.Panel, but the chain breaks above Tabs.Root
-	// because the AdminPage wrapper isn't itself a flex container. Revisit with
-	// DevTools open to identify the exact ancestor that needs `display: flex` /
-	// `min-height: 100%`.
+	// Propagate the admin page's flex column through @wordpress/ui's Tabs
+	// primitives, which default to display:block and break the chain. Lets
+	// DataViews-based tabs (Library) flex-grow into the available area and
+	// pin their pagination to the visible bottom. Targeted via stable ARIA
+	// roles, not Base UI's obfuscated CSS-in-JS classnames.
+	:has(> [role="tabpanel"]) { // Tabs.Root
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 0;
+		min-height: 0;
+	}
+
+	[role="tabpanel"] {
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 0;
+		min-height: 0;
+	}
 }

--- a/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
@@ -9,4 +9,11 @@
 body.jetpack_page_jetpack-videopress {
 
 	@include jetpack-admin-page-layout;
+
+	// TODO (Phase 2.5): pin the DataViews pagination footer to the bottom of the
+	// visible page area for the Library tab. Earlier attempts propagated flex
+	// height through Tabs.Root + Tabs.Panel, but the chain breaks above Tabs.Root
+	// because the AdminPage wrapper isn't itself a flex container. Revisit with
+	// DevTools open to identify the exact ancestor that needs `display: flex` /
+	// `min-height: 100%`.
 }

--- a/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
@@ -28,4 +28,22 @@ body.jetpack_page_jetpack-videopress {
 		flex: 1 1 0;
 		min-height: 0;
 	}
+
+	// Match the design-system default-variant Tabs (Storybook reference).
+	// We pair `<Tabs.List>` (no variant) with the canonical 16px per-tab inline
+	// padding — `admin-page-layout` would otherwise bump it to 24px to line the
+	// first tab up with the page-title edge. To keep that alignment, offset the
+	// tablist itself by the missing 8px so the first tab's text still starts at
+	// the page-header inline padding (8px tablist + 16px tab = 24px). The
+	// hairline lives on `.jp-admin-page-tabs` and still spans the full width.
+	.jp-admin-page-tabs {
+
+		[role="tablist"] {
+			padding-inline-start: 8px;
+		}
+
+		[role="tab"] {
+			padding-inline: var(--wpds-dimension-padding-lg);
+		}
+	}
 }

--- a/projects/packages/videopress/src/dashboard/components/DashboardTabs/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/DashboardTabs/index.tsx
@@ -23,7 +23,7 @@ export const TAB_PATHS: Record< DashboardTab, string > = {
 export default function DashboardTabs() {
 	return (
 		<div className="jp-admin-page-tabs">
-			<Tabs.List variant="minimal">
+			<Tabs.List>
 				<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
 				<Tabs.Tab value="library">{ __( 'Library', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
 				<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-videopress-pkg' ) }</Tabs.Tab>

--- a/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
@@ -1,0 +1,66 @@
+import { Button, ProgressBar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { formatDuration } from '../../utils/format';
+import { useUploadActions } from './upload-actions-context';
+import type { MockLibraryItem } from '../../types/library';
+
+type Props = { item: MockLibraryItem };
+
+/**
+ * Render the media-area for one DataViews grid card. Layers (priority order):
+ * 1. uploading → ProgressBar overlay
+ * 2. failed    → red overlay with Retry
+ * 3. local     → "Local video" placeholder + hover-revealed Upload button
+ * 4. videopress → thumbnail image + duration badge
+ *
+ * @param props      - Component props.
+ * @param props.item - The library item rendered by this card.
+ * @return The thumbnail element.
+ */
+export default function ThumbnailField( { item }: Props ) {
+	const { promoteLocal, retryUpload } = useUploadActions();
+	const { type, upload, thumbnailUrl, durationSeconds, id, title } = item;
+
+	return (
+		<div className="vp-library__thumbnail">
+			{ thumbnailUrl ? (
+				<img className="vp-library__thumbnail-image" src={ thumbnailUrl } alt={ title } />
+			) : null }
+
+			{ type === 'videopress' && upload.status === 'idle' ? (
+				<span className="vp-library__thumbnail-duration-badge">
+					{ formatDuration( durationSeconds ) }
+				</span>
+			) : null }
+
+			{ type === 'local' && upload.status === 'idle' ? (
+				<>
+					<div className="vp-library__placeholder">
+						<span>{ __( 'Local video', 'jetpack-videopress-pkg' ) }</span>
+					</div>
+					<div className="vp-library__hover-action">
+						<Button variant="secondary" size="compact" onClick={ () => promoteLocal( id ) }>
+							{ __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ) }
+						</Button>
+					</div>
+				</>
+			) : null }
+
+			{ upload.status === 'uploading' ? (
+				<div className="vp-library__progress">
+					<span className="vp-library__progress-percent">{ Math.round( upload.progress ) }%</span>
+					<ProgressBar className="vp-library__progress-bar" value={ upload.progress } />
+				</div>
+			) : null }
+
+			{ upload.status === 'failed' ? (
+				<div className="vp-library__failed">
+					<span>{ __( 'Upload failed', 'jetpack-videopress-pkg' ) }</span>
+					<Button variant="primary" size="compact" onClick={ () => retryUpload( id ) }>
+						{ __( 'Retry', 'jetpack-videopress-pkg' ) }
+					</Button>
+				</div>
+			) : null }
+		</div>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
@@ -1,6 +1,6 @@
 import { ProgressBar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { Button, Stack, Text } from '@wordpress/ui';
 import { formatDuration } from '../../utils/format';
 import { useUploadActions } from './upload-actions-context';
 import type { MockLibraryItem } from '../../types/library';
@@ -36,31 +36,53 @@ export default function ThumbnailField( { item }: Props ) {
 
 			{ type === 'local' && upload.status === 'idle' ? (
 				<>
-					<div className="vp-library__placeholder">
-						<span>{ __( 'Local video', 'jetpack-videopress-pkg' ) }</span>
-					</div>
-					<div className="vp-library__hover-action">
+					<Stack
+						direction="column"
+						align="center"
+						justify="center"
+						className="vp-library__placeholder"
+					>
+						<Text>{ __( 'Local video', 'jetpack-videopress-pkg' ) }</Text>
+					</Stack>
+					<Stack
+						direction="row"
+						align="center"
+						justify="center"
+						className="vp-library__hover-action"
+					>
 						<Button variant="outline" size="compact" onClick={ () => promoteLocal( id ) }>
 							{ __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ) }
 						</Button>
-					</div>
+					</Stack>
 				</>
 			) : null }
 
 			{ upload.status === 'uploading' ? (
-				<div className="vp-library__progress">
-					<span className="vp-library__progress-percent">{ Math.round( upload.progress ) }%</span>
+				<Stack
+					direction="column"
+					gap="sm"
+					align="center"
+					justify="center"
+					className="vp-library__progress"
+				>
+					<Text className="vp-library__progress-percent">{ Math.round( upload.progress ) }%</Text>
 					<ProgressBar className="vp-library__progress-bar" value={ upload.progress } />
-				</div>
+				</Stack>
 			) : null }
 
 			{ upload.status === 'failed' ? (
-				<div className="vp-library__failed">
-					<span>{ __( 'Upload failed', 'jetpack-videopress-pkg' ) }</span>
+				<Stack
+					direction="column"
+					gap="xs"
+					align="center"
+					justify="center"
+					className="vp-library__failed"
+				>
+					<Text>{ __( 'Upload failed', 'jetpack-videopress-pkg' ) }</Text>
 					<Button size="compact" onClick={ () => retryUpload( id ) }>
 						{ __( 'Retry', 'jetpack-videopress-pkg' ) }
 					</Button>
-				</div>
+				</Stack>
 			) : null }
 		</div>
 	);

--- a/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
@@ -1,5 +1,6 @@
-import { Button, ProgressBar } from '@wordpress/components';
+import { ProgressBar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { formatDuration } from '../../utils/format';
 import { useUploadActions } from './upload-actions-context';
 import type { MockLibraryItem } from '../../types/library';
@@ -39,7 +40,7 @@ export default function ThumbnailField( { item }: Props ) {
 						<span>{ __( 'Local video', 'jetpack-videopress-pkg' ) }</span>
 					</div>
 					<div className="vp-library__hover-action">
-						<Button variant="secondary" size="compact" onClick={ () => promoteLocal( id ) }>
+						<Button variant="outline" size="compact" onClick={ () => promoteLocal( id ) }>
 							{ __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ) }
 						</Button>
 					</div>
@@ -56,7 +57,7 @@ export default function ThumbnailField( { item }: Props ) {
 			{ upload.status === 'failed' ? (
 				<div className="vp-library__failed">
 					<span>{ __( 'Upload failed', 'jetpack-videopress-pkg' ) }</span>
-					<Button variant="primary" size="compact" onClick={ () => retryUpload( id ) }>
+					<Button size="compact" onClick={ () => retryUpload( id ) }>
 						{ __( 'Retry', 'jetpack-videopress-pkg' ) }
 					</Button>
 				</div>

--- a/projects/packages/videopress/src/dashboard/components/Library/actions.ts
+++ b/projects/packages/videopress/src/dashboard/components/Library/actions.ts
@@ -1,0 +1,115 @@
+import { __ } from '@wordpress/i18n';
+import type { LibraryItemPrivacy, MockLibraryItem } from '../../types/library';
+import type { Action } from '@wordpress/dataviews';
+
+type Api = {
+	promoteLocal: ( id: string ) => void;
+	retryUpload: ( id: string ) => void;
+	deleteItems: ( ids: string[] ) => void;
+	setPrivacy: ( id: string, privacy: LibraryItemPrivacy ) => void;
+	openVideoDetails: ( id: string ) => void;
+};
+
+const isVideoPressIdle = ( item: MockLibraryItem ) =>
+	item.type === 'videopress' && item.upload.status !== 'failed';
+
+/**
+ * Build the DataViews actions array for the Library tab. Eligibility predicates
+ * gate per-row availability based on `item.type` and `item.upload.status`. The
+ * Delete action sets `supportsBulk: true` and `isEligible` to filter local items
+ * out of mixed selections (DataViews silently skips ineligible items).
+ *
+ * @param api - Hook mutators forwarded into the action callbacks.
+ * @return The actions array for `<DataViews>`.
+ */
+export function buildLibraryActions( api: Api ): Action< MockLibraryItem >[] {
+	return [
+		{
+			id: 'edit-details',
+			label: __( 'Edit details', 'jetpack-videopress-pkg' ),
+			isPrimary: true,
+			supportsBulk: false,
+			isEligible: isVideoPressIdle,
+			callback: items => {
+				const [ item ] = items;
+				if ( item ) {
+					api.openVideoDetails( item.id );
+				}
+			},
+		},
+		{
+			id: 'set-privacy-public',
+			label: __( 'Make public', 'jetpack-videopress-pkg' ),
+			supportsBulk: false,
+			isEligible: item => item.type === 'videopress' && item.privacy !== 'public',
+			callback: items => {
+				const [ item ] = items;
+				if ( item ) {
+					api.setPrivacy( item.id, 'public' );
+				}
+			},
+		},
+		{
+			id: 'set-privacy-private',
+			label: __( 'Make private', 'jetpack-videopress-pkg' ),
+			supportsBulk: false,
+			isEligible: item => item.type === 'videopress' && item.privacy !== 'private',
+			callback: items => {
+				const [ item ] = items;
+				if ( item ) {
+					api.setPrivacy( item.id, 'private' );
+				}
+			},
+		},
+		{
+			id: 'set-privacy-site',
+			label: __( 'Use site default', 'jetpack-videopress-pkg' ),
+			supportsBulk: false,
+			isEligible: item => item.type === 'videopress' && item.privacy !== 'site-default',
+			callback: items => {
+				const [ item ] = items;
+				if ( item ) {
+					api.setPrivacy( item.id, 'site-default' );
+				}
+			},
+		},
+		{
+			id: 'delete',
+			label: __( 'Delete', 'jetpack-videopress-pkg' ),
+			supportsBulk: true,
+			isEligible: item => item.type === 'videopress',
+			callback: items => {
+				api.deleteItems( items.map( i => i.id ) );
+			},
+		},
+		{
+			id: 'upload-to-vp',
+			label: __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ),
+			isPrimary: true,
+			supportsBulk: false,
+			isEligible: item =>
+				item.type === 'local' &&
+				item.upload.status !== 'uploading' &&
+				item.upload.status !== 'failed',
+			callback: items => {
+				const [ item ] = items;
+				if ( item ) {
+					api.promoteLocal( item.id );
+				}
+			},
+		},
+		{
+			id: 'retry-upload',
+			label: __( 'Retry', 'jetpack-videopress-pkg' ),
+			isPrimary: true,
+			supportsBulk: false,
+			isEligible: item => item.upload.status === 'failed',
+			callback: items => {
+				const [ item ] = items;
+				if ( item ) {
+					api.retryUpload( item.id );
+				}
+			},
+		},
+	];
+}

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -93,7 +93,7 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 			{ value: 'videopress', label: 'VideoPress' },
 			{ value: 'local', label: __( 'Local', 'jetpack-videopress-pkg' ) },
 		],
-		filterBy: { operators: [ 'is' ] as Operator[], isPrimary: true },
+		filterBy: { operators: [ 'is' ] as Operator[] },
 		enableSorting: false,
 	},
 	{

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -78,11 +78,9 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		label: __( 'Type', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.type,
 		render: ( { item } ) =>
-			item.type === 'videopress'
-				? __( 'VideoPress', 'jetpack-videopress-pkg' )
-				: __( 'Local', 'jetpack-videopress-pkg' ),
+			item.type === 'videopress' ? 'VideoPress' : __( 'Local', 'jetpack-videopress-pkg' ),
 		elements: [
-			{ value: 'videopress', label: __( 'VideoPress', 'jetpack-videopress-pkg' ) },
+			{ value: 'videopress', label: 'VideoPress' },
 			{ value: 'local', label: __( 'Local', 'jetpack-videopress-pkg' ) },
 		],
 		filterBy: { operators: [ 'is' ] as Operator[], isPrimary: true },

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -1,6 +1,6 @@
 import { getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
-import { Badge, Stack } from '@wordpress/ui';
+import { Badge, Stack, Text } from '@wordpress/ui';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './ThumbnailField';
 import type { MockLibraryItem } from '../../types/library';
@@ -76,7 +76,11 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		id: 'filename',
 		label: __( 'Filename', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.filename,
-		render: ( { item } ) => <span className="vp-library__filename">{ item.filename }</span>,
+		render: ( { item } ) => (
+			<Text variant="body-sm" className="vp-library__filename">
+				{ item.filename }
+			</Text>
+		),
 		enableSorting: false,
 	},
 	{

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -1,11 +1,14 @@
 import { getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge, Stack } from '@wordpress/ui';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './ThumbnailField';
 import type { MockLibraryItem } from '../../types/library';
 import type { Field, Operator } from '@wordpress/dataviews';
 
 const dateSettings = getDateSettings();
+
+type BadgeIntent = React.ComponentProps< typeof Badge >[ 'intent' ];
 
 const privacyLabel = ( privacy: MockLibraryItem[ 'privacy' ] ): string => {
 	switch ( privacy ) {
@@ -20,10 +23,10 @@ const privacyLabel = ( privacy: MockLibraryItem[ 'privacy' ] ): string => {
 
 const TitleCell = ( { item }: { item: MockLibraryItem } ) => {
 	const { upload, type, title } = item;
-	let pill: { className: string; label: string } | null = null;
+	let pill: { intent: BadgeIntent; label: string } | null = null;
 	if ( upload.status === 'uploading' ) {
 		pill = {
-			className: 'vp-library__status-pill vp-library__status-pill--uploading',
+			intent: 'informational',
 			label: sprintf(
 				/* translators: %d: upload progress percentage */
 				__( 'Uploading %d%%', 'jetpack-videopress-pkg' ),
@@ -32,21 +35,24 @@ const TitleCell = ( { item }: { item: MockLibraryItem } ) => {
 		};
 	} else if ( upload.status === 'failed' ) {
 		pill = {
-			className: 'vp-library__status-pill vp-library__status-pill--failed',
+			intent: 'high',
 			label: __( 'Upload failed', 'jetpack-videopress-pkg' ),
 		};
 	} else if ( type === 'local' ) {
 		pill = {
-			className: 'vp-library__status-pill vp-library__status-pill--local',
+			intent: 'none',
 			label: __( 'Local', 'jetpack-videopress-pkg' ),
 		};
 	}
 
+	if ( ! pill ) {
+		return <>{ title }</>;
+	}
 	return (
-		<>
-			{ title }
-			{ pill ? <span className={ pill.className }>{ pill.label }</span> : null }
-		</>
+		<Stack direction="row" gap="sm" align="center" className="vp-library__title-cell">
+			<span>{ title }</span>
+			<Badge intent={ pill.intent }>{ pill.label }</Badge>
+		</Stack>
 	);
 };
 

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -1,5 +1,5 @@
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './ThumbnailField';
 import type { MockLibraryItem } from '../../types/library';
@@ -18,6 +18,38 @@ const privacyLabel = ( privacy: MockLibraryItem[ 'privacy' ] ): string => {
 	}
 };
 
+const TitleCell = ( { item }: { item: MockLibraryItem } ) => {
+	const { upload, type, title } = item;
+	let pill: { className: string; label: string } | null = null;
+	if ( upload.status === 'uploading' ) {
+		pill = {
+			className: 'vp-library__status-pill vp-library__status-pill--uploading',
+			label: sprintf(
+				/* translators: %d: upload progress percentage */
+				__( 'Uploading %d%%', 'jetpack-videopress-pkg' ),
+				Math.round( upload.progress )
+			),
+		};
+	} else if ( upload.status === 'failed' ) {
+		pill = {
+			className: 'vp-library__status-pill vp-library__status-pill--failed',
+			label: __( 'Upload failed', 'jetpack-videopress-pkg' ),
+		};
+	} else if ( type === 'local' ) {
+		pill = {
+			className: 'vp-library__status-pill vp-library__status-pill--local',
+			label: __( 'Local', 'jetpack-videopress-pkg' ),
+		};
+	}
+
+	return (
+		<>
+			{ title }
+			{ pill ? <span className={ pill.className }>{ pill.label }</span> : null }
+		</>
+	);
+};
+
 export const libraryFields: Field< MockLibraryItem >[] = [
 	{
 		id: 'thumbnail',
@@ -31,7 +63,7 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		id: 'title',
 		label: __( 'Title', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.title,
-		render: ( { item } ) => item.title,
+		render: TitleCell,
 		enableSorting: true,
 	},
 	{

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -1,0 +1,94 @@
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
+import { formatBytes, formatDuration } from '../../utils/format';
+import ThumbnailField from './ThumbnailField';
+import type { MockLibraryItem } from '../../types/library';
+import type { Field, Operator } from '@wordpress/dataviews';
+
+const dateSettings = getDateSettings();
+
+const privacyLabel = ( privacy: MockLibraryItem[ 'privacy' ] ): string => {
+	switch ( privacy ) {
+		case 'public':
+			return __( 'Public', 'jetpack-videopress-pkg' );
+		case 'private':
+			return __( 'Private', 'jetpack-videopress-pkg' );
+		case 'site-default':
+			return __( 'Site default', 'jetpack-videopress-pkg' );
+	}
+};
+
+export const libraryFields: Field< MockLibraryItem >[] = [
+	{
+		id: 'thumbnail',
+		label: __( 'Thumbnail', 'jetpack-videopress-pkg' ),
+		type: 'media',
+		render: ThumbnailField,
+		enableSorting: false,
+		enableHiding: false,
+	},
+	{
+		id: 'title',
+		label: __( 'Title', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.title,
+		render: ( { item } ) => item.title,
+		enableSorting: true,
+	},
+	{
+		id: 'filename',
+		label: __( 'Filename', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.filename,
+		render: ( { item } ) => <span className="vp-library__filename">{ item.filename }</span>,
+		enableSorting: false,
+	},
+	{
+		id: 'type',
+		label: __( 'Type', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.type,
+		render: ( { item } ) =>
+			item.type === 'videopress'
+				? __( 'VideoPress', 'jetpack-videopress-pkg' )
+				: __( 'Local', 'jetpack-videopress-pkg' ),
+		elements: [
+			{ value: 'videopress', label: __( 'VideoPress', 'jetpack-videopress-pkg' ) },
+			{ value: 'local', label: __( 'Local', 'jetpack-videopress-pkg' ) },
+		],
+		filterBy: { operators: [ 'is' ] as Operator[], isPrimary: true },
+		enableSorting: false,
+	},
+	{
+		id: 'uploadDate',
+		label: __( 'Uploaded', 'jetpack-videopress-pkg' ),
+		type: 'datetime',
+		getValue: ( { item } ) => item.uploadDate,
+		render: ( { item } ) => dateI18n( dateSettings.formats.date, item.uploadDate ),
+		enableSorting: true,
+	},
+	{
+		id: 'duration',
+		label: __( 'Duration', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.durationSeconds,
+		render: ( { item } ) => formatDuration( item.durationSeconds ),
+		enableSorting: true,
+	},
+	{
+		id: 'privacy',
+		label: __( 'Privacy', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.privacy,
+		render: ( { item } ) => privacyLabel( item.privacy ),
+		elements: [
+			{ value: 'public', label: __( 'Public', 'jetpack-videopress-pkg' ) },
+			{ value: 'private', label: __( 'Private', 'jetpack-videopress-pkg' ) },
+			{ value: 'site-default', label: __( 'Site default', 'jetpack-videopress-pkg' ) },
+		],
+		filterBy: { operators: [ 'is' ] as Operator[] },
+		enableSorting: false,
+	},
+	{
+		id: 'fileSize',
+		label: __( 'File size', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.fileSizeBytes,
+		render: ( { item } ) => formatBytes( item.fileSizeBytes ),
+		enableSorting: true,
+	},
+];

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -1,4 +1,4 @@
-import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './ThumbnailField';
@@ -91,7 +91,7 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		label: __( 'Uploaded', 'jetpack-videopress-pkg' ),
 		type: 'datetime',
 		getValue: ( { item } ) => item.uploadDate,
-		render: ( { item } ) => dateI18n( dateSettings.formats.date, item.uploadDate ),
+		format: { datetime: dateSettings.formats.date },
 		enableSorting: true,
 	},
 	{

--- a/projects/packages/videopress/src/dashboard/components/Library/upload-actions-context.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/upload-actions-context.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from '@wordpress/element';
+
+export type UploadActions = {
+	promoteLocal: ( id: string ) => void;
+	retryUpload: ( id: string ) => void;
+};
+
+const UploadActionsContext = createContext< UploadActions | null >( null );
+
+export const UploadActionsProvider = UploadActionsContext.Provider;
+
+/**
+ * Read the upload-actions callbacks supplied by the Library Stage. Used by
+ * `ThumbnailField` so the per-card hover button and Retry overlay can call
+ * the hook's mutators without prop-drilling through DataViews's grid layout.
+ *
+ * @return The upload-action callbacks.
+ */
+export function useUploadActions(): UploadActions {
+	const ctx = useContext( UploadActionsContext );
+	if ( ! ctx ) {
+		throw new Error( 'UploadActionsProvider missing in tree' );
+	}
+	return ctx;
+}

--- a/projects/packages/videopress/src/dashboard/fixtures/library.ts
+++ b/projects/packages/videopress/src/dashboard/fixtures/library.ts
@@ -1,0 +1,89 @@
+import type { LibraryItemPrivacy, LibraryItemType, MockLibraryItem } from '../types/library';
+
+const TITLES = [
+	'3D Animation Studio',
+	'Castle in the Sky',
+	'Forest Walk',
+	'Ocean Glide',
+	'Desert Bloom',
+	'Mountain Climb',
+	'Studio Setup',
+	'Coffee Brew',
+];
+const EXTENSIONS = [ 'mov', 'mp4', 'webm' ] as const;
+const PRIVACIES: LibraryItemPrivacy[] = [
+	'public',
+	'public',
+	'public',
+	'public',
+	'public',
+	'public',
+	'private',
+	'private',
+	'private',
+	'site-default',
+	'site-default',
+	'site-default',
+];
+
+/* Deterministic SVG data-URI thumbnails (no network needed). */
+const COLORS = [ '#3858E9', '#117AC9', '#80A35C', '#A36B0F', '#7A2C8C', '#B33A60' ];
+const colorThumbnail = ( hex: string ): string => {
+	const svg =
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 9">` +
+		`<rect width="16" height="9" fill="${ hex }"/></svg>`;
+	return `data:image/svg+xml;utf8,${ encodeURIComponent( svg ) }`;
+};
+
+const slugify = ( s: string ): string =>
+	s
+		.toLowerCase()
+		.replace( /[^a-z0-9]+/g, '-' )
+		.replace( /(^-|-$)/g, '' );
+
+/**
+ * Deterministic mock library generator. Same `count` always returns the same
+ * array (so React doesn't see new identities on re-render).
+ *
+ * Distribution:
+ * - ~80% videopress, ~20% local (every 5th item is local).
+ * - Privacy cycled through PRIVACIES.
+ * - Durations 8s..600s (cycled).
+ * - File sizes 5MB..500MB (cycled).
+ * - Upload dates spread across the last 90 days (1.8 days apart).
+ *
+ * @param count - Number of items to generate.
+ * @return Mock library items.
+ */
+export function generateMockLibrary( count = 50 ): MockLibraryItem[] {
+	const now = new Date( '2026-05-06T12:00:00Z' ).getTime();
+	const dayMs = 24 * 60 * 60 * 1000;
+
+	return Array.from( { length: count }, ( _, i ): MockLibraryItem => {
+		const type: LibraryItemType = i % 5 === 4 ? 'local' : 'videopress';
+		const baseTitle = TITLES[ i % TITLES.length ];
+		const title = `${ baseTitle } ${ i + 1 }`;
+		const ext = EXTENSIONS[ i % EXTENSIONS.length ];
+		const filename = `${ slugify( baseTitle ) }-v${ ( i % 9 ) + 1 }-${ String( i + 1 ).padStart(
+			2,
+			'0'
+		) }.${ ext }`;
+		const durationSeconds = 8 + ( ( i * 17 ) % 600 );
+		const fileSizeBytes = ( 5 + ( ( i * 11 ) % 495 ) ) * 1024 * 1024;
+		const uploadDate = new Date( now - i * 1.8 * dayMs ).toISOString();
+		const privacy = PRIVACIES[ i % PRIVACIES.length ];
+
+		return {
+			id: `mock-${ i + 1 }`,
+			type,
+			title,
+			filename,
+			thumbnailUrl: type === 'videopress' ? colorThumbnail( COLORS[ i % COLORS.length ] ) : null,
+			durationSeconds,
+			uploadDate,
+			privacy,
+			fileSizeBytes,
+			upload: { status: 'idle', progress: 0 },
+		};
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
@@ -94,11 +94,31 @@ export function useMockLibrary() {
 		};
 	}, [] );
 
-	const runUpload = useCallback( ( id: string, isPromote: boolean ) => {
+	const sessionCounterRef = useRef( 0 );
+	const forcedFailIdsRef = useRef< Set< string > >( new Set() );
+
+	const runUpload = useCallback( ( id: string, isPromote: boolean, isRetry = false ) => {
 		const tickIncrement = ( 100 * MOCK_UPLOAD_TICK_MS ) / MOCK_UPLOAD_DURATION_MS;
 		let progress = 0;
+		let willFail = false;
+		if ( ! isRetry ) {
+			sessionCounterRef.current += 1;
+			if ( sessionCounterRef.current % 5 === 0 ) {
+				willFail = true;
+				forcedFailIdsRef.current.add( id );
+			}
+		} else {
+			forcedFailIdsRef.current.delete( id );
+		}
+
 		const interval = setInterval( () => {
 			progress = Math.min( 100, progress + tickIncrement );
+			if ( willFail && progress >= 60 ) {
+				clearInterval( interval );
+				intervalsRef.current.delete( id );
+				dispatch( { type: 'patchUpload', id, status: 'failed', progress: 60 } );
+				return;
+			}
 			if ( progress >= 100 ) {
 				clearInterval( interval );
 				intervalsRef.current.delete( id );
@@ -157,16 +177,27 @@ export function useMockLibrary() {
 		dispatch( { type: 'patchPrivacy', id, privacy } );
 	}, [] );
 
+	const retryUpload = useCallback(
+		( id: string ) => {
+			const target = items.find( item => item.id === id );
+			const isPromote = target?.type === 'local' || forcedFailIdsRef.current.has( id );
+			dispatch( { type: 'patchUpload', id, status: 'uploading', progress: 0 } );
+			runUpload( id, isPromote, true );
+		},
+		[ items, runUpload ]
+	);
+
 	return useMemo(
 		() => ( {
 			items,
 			isLoading,
 			startUpload,
 			promoteLocal,
+			retryUpload,
 			deleteItems,
 			setPrivacy,
 		} ),
-		[ items, isLoading, startUpload, promoteLocal, deleteItems, setPrivacy ]
+		[ items, isLoading, startUpload, promoteLocal, retryUpload, deleteItems, setPrivacy ]
 	);
 }
 

--- a/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from '@wordpress/element';
+import { generateMockLibrary } from '../fixtures/library';
+import type { LibraryItemPrivacy, MockLibraryItem, UploadStatus } from '../types/library';
+
+const MOCK_INITIAL_LOAD_MS = 1_000;
+const MOCK_UPLOAD_DURATION_MS = 10_000;
+const MOCK_UPLOAD_TICK_MS = 120;
+
+type StartUploadInput = File | { name: string; sizeBytes: number };
+
+type Action =
+	| { type: 'set'; items: MockLibraryItem[] }
+	| { type: 'prepend'; item: MockLibraryItem }
+	| { type: 'remove'; ids: string[] }
+	| {
+			type: 'patchUpload';
+			id: string;
+			status: UploadStatus;
+			progress: number;
+			thumbnailUrl?: string | null;
+			flipToVideoPress?: boolean;
+	  }
+	| { type: 'patchPrivacy'; id: string; privacy: LibraryItemPrivacy };
+
+const PROMOTED_THUMBNAIL = ( () => {
+	const svg =
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 9">` +
+		`<rect width="16" height="9" fill="#3858E9"/></svg>`;
+	return `data:image/svg+xml;utf8,${ encodeURIComponent( svg ) }`;
+} )();
+
+/**
+ * Pure reducer over the library items array. Each action mutates the array
+ * immutably so React's identity tracking re-renders the affected card only.
+ *
+ * @param state  - Current items array.
+ * @param action - Mutation to apply.
+ * @return Next items array.
+ */
+function reducer( state: MockLibraryItem[], action: Action ): MockLibraryItem[] {
+	switch ( action.type ) {
+		case 'set':
+			return action.items;
+		case 'prepend':
+			return [ action.item, ...state ];
+		case 'remove': {
+			const drop = new Set( action.ids );
+			return state.filter( item => ! drop.has( item.id ) );
+		}
+		case 'patchUpload':
+			return state.map( item => {
+				if ( item.id !== action.id ) {
+					return item;
+				}
+				return {
+					...item,
+					type: action.flipToVideoPress ? 'videopress' : item.type,
+					thumbnailUrl: action.thumbnailUrl !== undefined ? action.thumbnailUrl : item.thumbnailUrl,
+					upload: { status: action.status, progress: action.progress },
+				};
+			} );
+		case 'patchPrivacy':
+			return state.map( item =>
+				item.id === action.id ? { ...item, privacy: action.privacy } : item
+			);
+		default:
+			return state;
+	}
+}
+
+/**
+ * Mock-data hook for the Library tab. Owns 50 generated fixture items, a
+ * one-second initial loading window, and a 10-second per-item upload
+ * simulation. Hook signature matches the TanStack Query hook Phase 6 will
+ * swap in.
+ *
+ * @return Library state and mutators.
+ */
+export function useMockLibrary() {
+	const [ items, dispatch ] = useReducer( reducer, undefined, () => generateMockLibrary( 50 ) );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const intervalsRef = useRef< Map< string, ReturnType< typeof setInterval > > >( new Map() );
+
+	useEffect( () => {
+		const handle = setTimeout( () => setIsLoading( false ), MOCK_INITIAL_LOAD_MS );
+		return () => clearTimeout( handle );
+	}, [] );
+
+	useEffect( () => {
+		const intervals = intervalsRef.current;
+		return () => {
+			intervals.forEach( clearInterval );
+			intervals.clear();
+		};
+	}, [] );
+
+	const runUpload = useCallback( ( id: string, isPromote: boolean ) => {
+		const tickIncrement = ( 100 * MOCK_UPLOAD_TICK_MS ) / MOCK_UPLOAD_DURATION_MS;
+		let progress = 0;
+		const interval = setInterval( () => {
+			progress = Math.min( 100, progress + tickIncrement );
+			if ( progress >= 100 ) {
+				clearInterval( interval );
+				intervalsRef.current.delete( id );
+				dispatch( {
+					type: 'patchUpload',
+					id,
+					status: 'idle',
+					progress: 0,
+					flipToVideoPress: isPromote,
+					thumbnailUrl: isPromote ? PROMOTED_THUMBNAIL : undefined,
+				} );
+				return;
+			}
+			dispatch( { type: 'patchUpload', id, status: 'uploading', progress } );
+		}, MOCK_UPLOAD_TICK_MS );
+
+		intervalsRef.current.set( id, interval );
+	}, [] );
+
+	const startUpload = useCallback(
+		( file: StartUploadInput ) => {
+			const sizeBytes = file instanceof File ? file.size : file.sizeBytes;
+			const name = file.name;
+			const id = `upload-${ Date.now() }-${ Math.random().toString( 36 ).slice( 2, 7 ) }`;
+			const item: MockLibraryItem = {
+				id,
+				type: 'local',
+				title: name.replace( /\.[^.]+$/, '' ) || 'Untitled',
+				filename: name,
+				thumbnailUrl: null,
+				durationSeconds: 0,
+				uploadDate: new Date().toISOString(),
+				privacy: 'site-default',
+				fileSizeBytes: sizeBytes,
+				upload: { status: 'uploading', progress: 0 },
+			};
+			dispatch( { type: 'prepend', item } );
+			runUpload( id, true );
+		},
+		[ runUpload ]
+	);
+
+	const promoteLocal = useCallback(
+		( id: string ) => {
+			dispatch( { type: 'patchUpload', id, status: 'uploading', progress: 0 } );
+			runUpload( id, true );
+		},
+		[ runUpload ]
+	);
+
+	const deleteItems = useCallback( ( ids: string[] ) => {
+		dispatch( { type: 'remove', ids } );
+	}, [] );
+
+	const setPrivacy = useCallback( ( id: string, privacy: LibraryItemPrivacy ) => {
+		dispatch( { type: 'patchPrivacy', id, privacy } );
+	}, [] );
+
+	return useMemo(
+		() => ( {
+			items,
+			isLoading,
+			startUpload,
+			promoteLocal,
+			deleteItems,
+			setPrivacy,
+		} ),
+		[ items, isLoading, startUpload, promoteLocal, deleteItems, setPrivacy ]
+	);
+}
+
+export type UseMockLibrary = ReturnType< typeof useMockLibrary >;

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -1,0 +1,21 @@
+export type LibraryItemType = 'videopress' | 'local';
+export type LibraryItemPrivacy = 'public' | 'private' | 'site-default';
+export type UploadStatus = 'idle' | 'uploading' | 'failed';
+
+export interface UploadState {
+	status: UploadStatus;
+	progress: number;
+}
+
+export interface MockLibraryItem {
+	id: string;
+	type: LibraryItemType;
+	title: string;
+	filename: string;
+	thumbnailUrl: string | null;
+	durationSeconds: number;
+	uploadDate: string;
+	privacy: LibraryItemPrivacy;
+	fileSizeBytes: number;
+	upload: UploadState;
+}

--- a/projects/packages/videopress/src/dashboard/utils/format.ts
+++ b/projects/packages/videopress/src/dashboard/utils/format.ts
@@ -1,0 +1,35 @@
+/**
+ * Format a duration in seconds as `mm:ss` or `hh:mm:ss`.
+ *
+ * @param seconds - Total seconds.
+ * @return Formatted duration.
+ */
+export function formatDuration( seconds: number ): string {
+	const safe = Math.max( 0, Math.floor( seconds ) );
+	const h = Math.floor( safe / 3600 );
+	const m = Math.floor( ( safe % 3600 ) / 60 );
+	const s = safe % 60;
+	const pad = ( n: number ) => String( n ).padStart( 2, '0' );
+	return h > 0 ? `${ h }:${ pad( m ) }:${ pad( s ) }` : `${ pad( m ) }:${ pad( s ) }`;
+}
+
+const BYTE_UNITS = [ 'B', 'KB', 'MB', 'GB', 'TB' ] as const;
+
+/**
+ * Format a byte count using binary units, one decimal place above KB.
+ *
+ * @param bytes - Total bytes.
+ * @return Formatted size.
+ */
+export function formatBytes( bytes: number ): string {
+	if ( bytes < 1024 ) {
+		return `${ bytes } B`;
+	}
+	let value = bytes;
+	let unitIndex = 0;
+	while ( value >= 1024 && unitIndex < BYTE_UNITS.length - 1 ) {
+		value /= 1024;
+		unitIndex += 1;
+	}
+	return `${ value.toFixed( 1 ) } ${ BYTE_UNITS[ unitIndex ] }`;
+}


### PR DESCRIPTION
Part of #48506

This PR is intended for visual changes only, for design review. All data is mocked.

---

This is **Phase 2** of the VideoPress dashboard modernization tracking issue (#48506) — the **Library tab**. UI-only with mocked data, all behind the existing `rsm_jetpack_ui_modernization_videopress` filter (Phase 0). Subsequent phases each open their own PR.

## Proposed changes

* **Library route is now a `@wordpress/dataviews` v14 grid (default) with a table alternate.** Layout switcher in the toolbar; grid is the primary mode for visual browsing, table is dense info.
* **One hook owns the mock data layer.** New `useMockLibrary()` (`src/dashboard/hooks/use-mock-library.ts`) returns 50 programmatically-generated fixtures (~80% VideoPress, ~20% Local) with a 1-second initial-loading window, a 10-second per-item upload simulation, and a deterministic every-5th-upload-fails-at-60% failure path with a `Retry` recovery action. The hook signature matches the TanStack Query hook Phase 6 will swap in — Phase 6 is a one-file change.
* **`ThumbnailField` (`src/dashboard/components/Library/ThumbnailField.tsx`)** layers four states on the DataViews grid card: idle VideoPress (thumbnail + duration badge), idle Local (gray "Local video" placeholder + hover-revealed `Upload to VideoPress` button), uploading (light overlay + percentage + `ProgressBar`), failed (red overlay + `Retry` button).
* **Table view shows status as a pill in the Title cell** (`Local` / `Uploading 47%` / `Upload failed`) instead of the larger card overlays — the table-cell thumbnail is too small to host the full chrome. Pills only render in the table view; in the grid the per-card overlays already convey the same info.
* **DataViews fields:** `thumbnail` (media), `title`, `filename`, `type` (primary filter, Local / VideoPress), `uploadDate` (default sort, desc), `duration`, `privacy` (secondary filter), `fileSize`. Default visible columns differ between layouts: grid shows `filename` below the title; switching to table reveals `filename`, `duration`, `fileSize`, `uploadDate`, `privacy`.
* **DataViews actions:** Per-row `Edit details` (primary, no-op until Phase 4 wires the details screen), three top-level `Make public` / `Make private` / `Use site default` actions (DataViews has no nested-submenu API in v14), `Delete`, `Upload to VideoPress` (Local only), `Retry` (failed only). Bulk: `Trash` only — `isEligible` filters out Local items, so mixed-selection bulk-Trash silently skips them while keeping them selectable (matches the Figma mock).
* **Page-header `Upload video` button** wires into `AdminPage`'s `actions` slot, opens a hidden `<input type="file" accept="video/*">`, and prepends an "uploading" card to the grid on file pick. Uses `@wordpress/ui` `Button size="compact"` to match Settings's Save button so there's no layout shift on tab change.
* **`DashboardLayout` gains a `hideFooter` prop.** Library opts in (per the design directive: pages with a central DataViews component don't show the JetpackFooter). Overview and Settings keep the footer.
* **Cross-package:** added `@wordpress/dataviews@14.1.0` as a direct dep of `@automattic/jetpack-videopress` (and the library route's `package.json`) so wp-build's externals plugin can resolve it. SCSS pulls in DataViews's stylesheet via `@include meta.load-css("@wordpress/dataviews/build-style/style.css")` — same pattern Forms uses (`projects/packages/forms/routes/shared.scss`).

## Related product discussion/links

* Tracking issue: #48506
* Phase 0 (feature flag + wp-build scaffold): #48494
* Phase 1 (shared chrome + Settings tab): #48510

## Does this pull request change what data or activity we track or use?

No. UI-only changes; all data is mocked client-side, no API calls, no analytics events, no tracked data added or changed.

## Testing instructions

1. Enable the modernization filter — drop into a mu-plugin or run `wp eval`:
   ```php
   add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );
   ```
2. Visit `wp-admin/admin.php?page=jetpack-videopress` → click the **Library** tab.
3. Confirm the grid:
   * 1-second loading state, then a 4-column grid of cards (12 per page across 5 pages).
   * Each VideoPress card has thumbnail + duration badge bottom-right + title + filename.
   * Local cards have a gray "Local video" placeholder; on hover, an **Upload to VideoPress** button is revealed.
   * Three-dot menu shows the right actions per type: VideoPress → `Edit details`, `Make public`/`Make private`/`Use site default`, `Delete`. Local → `Upload to VideoPress`. Failed → `Retry`.
4. **Per-card upload (Local → VideoPress):** hover a Local card → click `Upload to VideoPress` → ~10s `ProgressBar` climbs → card flips to a regular VideoPress card with a thumbnail.
5. **Failure path:** trigger uploads in sequence (mix of header `Upload video` and per-card promotions). Every 5th upload session deterministically stalls at ~60% with a red `Upload failed` overlay; click `Retry` → restarts and succeeds.
6. **Header upload:** click `Upload video` (top-right) → file picker → select any local video file → a new `Local`-typed card prepends to the grid in `uploading` state → progresses → resolves into a VideoPress card.
7. **Bulk Trash with mixed selection:** select 2 VideoPress cards + 1 Local card → click `Trash` in the bulk-action bar → only the VideoPress cards are removed; the Local card remains selected (DataViews's `isEligible` silently skips ineligible items).
8. **Filters:**
   * Primary `Type` chip is always visible — toggle to `Local` (only Local cards) or `VideoPress` (only VP cards).
   * Click the filter icon → secondary `Privacy` filter appears (`Public` / `Private` / `Site default`); intersects with the type filter.
9. **Search** filters titles and filenames in real time.
10. **Sort:** change sort field; grid re-orders.
11. **View switcher:** toggle to **table** view → 6 sortable columns (`Title`, `Filename`, `Duration`, `File size`, `Uploaded`, `Privacy`); status pills appear next to the title for `Local` / `Uploading XX%` / `Upload failed` rows. Switch back to grid.
12. **Pagination** prev / next / jump-to-page work; "12 of 50 Items · Page X of 5" displays.
13. **No JetpackFooter** is rendered on the Library tab. Switch to **Overview** and **Settings** — footer reappears on those tabs.
14. Open browser devtools and confirm no console errors or warnings.
15. Remove the `add_filter` and confirm the legacy VideoPress dashboard still loads at the same URL.

## Out of scope (parked for follow-up)

* **Pin DataViews pagination footer to the bottom of the visible page area.** Earlier attempts propagated flex height through `Tabs.Root` + `Tabs.Panel` but the chain breaks above `Tabs.Root` because `AdminPage`'s wrapper isn't itself a flex container. `TODO` note in `DashboardLayout/style.scss` flags it for Phase 2.5.
* **Table-view thumbnail white-band.** wp-build's `.boot-layout-container .boot-layout img { height: auto }` reset is winning specificity even with the matching `.boot-layout-container .boot-layout` prefix on our rule. Needs DevTools to pin down the exact override path.
* **Real persistence / backend wiring** — Phase 5 (REST surface) and Phase 6 (TanStack Query swap).
* **`class-initial-state.php` seeding** — Phase 5 (originally scoped into Phase 1, deferred since neither Phase 1 nor 2 has a client-side consumer).
* **phpunit + jest scaffolding** — tracked as a deferred follow-up in #48506.

<img width="2395" height="1238" alt="Screenshot from 2026-05-06 19-27-54" src="https://github.com/user-attachments/assets/38c36bdb-a034-4d27-8da5-019ba44de744" />

<img width="2395" height="1238" alt="Screenshot from 2026-05-06 19-28-06" src="https://github.com/user-attachments/assets/3b105962-156a-41a4-8f33-7f0e2fef8e1a" />
