### PR TITLE
Search Blocks: differentiate result path and content text styles (SEARCH-174)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-174-differentiate-path-content
+++ b/projects/packages/search/changelog/SEARCH-174-differentiate-path-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: differentiate result path and content text styles in the expanded layout so the breadcrumb and snippet are visually distinct.

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	.jetpack-search-skeleton--path {
-		height: 0.95rem;
+		height: 0.8125rem;
 		width: 40%;
 		margin-top: 0.5rem;
 	}
@@ -82,8 +82,9 @@
 	.jetpack-search-results__path {
 		margin-top: 0.25rem;
 		color: inherit;
-		opacity: 0.75;
-		font-size: 0.95rem;
+		opacity: 0.6;
+		font-size: 0.8125rem;
+		line-height: 1.4;
 
 		&[hidden] {
 			display: none;
@@ -92,10 +93,9 @@
 
 	.jetpack-search-results__content {
 		margin-top: 0.4rem;
-		font-size: 0.95rem;
-		line-height: 1.5;
+		font-size: 1rem;
+		line-height: 1.55;
 		color: inherit;
-		opacity: 0.85;
 
 		// Cap the snippet height so a very long excerpt doesn't push the
 		// metadata row far down. Three lines is enough to give the searcher


### PR DESCRIPTION
Fixes [SEARCH-174](https://linear.app/a8c/issue/SEARCH-174/search-blocks-differentiate-result-path-and-content-text-styles)

## Why

In the expanded result card, the snippet ("Matches content: …") and the breadcrumb path ("example.com/articles/first") rendered as the same band of muted text — same font size, almost the same opacity. Searchers had to slow down to figure out which line was the match excerpt and which was the source URL. After this change, the snippet reads as the dominant secondary line under the title, and the path drops back to a smaller, lighter breadcrumb — closer to the contrast Instant Search achieves with named color tokens.

## Proposed changes

* `.jetpack-search-results__path`: `font-size: 0.95rem` → `0.8125rem`, `opacity: 0.75` → `0.6`, added `line-height: 1.4`. Now reads as a secondary breadcrumb.
* `.jetpack-search-results__content`: `font-size: 0.95rem` → `1rem`, `line-height: 1.5` → `1.55`, removed `opacity: 0.85` (defaults to full). Now reads as primary body text.
* `.jetpack-search-skeleton--path`: `height: 0.95rem` → `0.8125rem` so the placeholder still matches the hydrated path height.
* Both rules continue to inherit `currentColor` so themed wrappers still drive the actual hue.
* No markup, class-name, or layout changes; the 3-line clamp on `__content` is preserved; compact and product layouts are untouched (neither shows `__path`/`__content`).

## Related product discussion/links

* Linear: [SEARCH-174](https://linear.app/a8c/issue/SEARCH-174/search-blocks-differentiate-result-path-and-content-text-styles)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the Jetpack Search plugin/module enabled, edit any post or page and insert the **Search Results** block.
2. In the block sidebar, set **Result format** to **Expanded** (the default).
3. Confirm in the editor preview that:
   * The snippet line ("Matches content: …") reads as standard body text.
   * The breadcrumb path ("example.com/articles/first") is visibly smaller and more muted than the snippet — it should look like metadata, not body copy.
   * The placeholder/skeleton path bar is consistent in height with the hydrated path line on first load.
4. Repeat against a real Search results page on the front end and verify the same hierarchy holds (the styles are shared between editor and front end).

### Before / After

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/de5b62ee-df02-42ff-9dd5-85a0c6afe238) | ![after](https://github.com/user-attachments/assets/4f23c91e-8007-43bb-b911-be4b0aeba4ac) |
