### PR TITLE
Search Blocks: register filter-checkbox variations via get_block_type_variations filter (SEARCH-176)

### DIFF
--- a/projects/packages/search/changelog/echo-fix-filter-checkbox-variations
+++ b/projects/packages/search/changelog/echo-fix-filter-checkbox-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Category, Tag, Post Type, Author, and Custom Taxonomy filter presets now appear in the block inserter.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -223,7 +223,9 @@ class Search_Blocks {
 	 * `register_block_variation()` because the latter is a JS-only API; no
 	 * matching PHP function exists in WordPress core. Filtering on the block
 	 * type's own variations getter is the supported PHP-side path and keeps
-	 * the editor-only JS bundle out of the ESM pipeline.
+	 * the editor-only JS bundle out of the ESM pipeline. On WP < 6.5 the
+	 * filter doesn't fire and no variations are registered — same end-state
+	 * as the prior code path, so this is not a version regression.
 	 *
 	 * Variation names and default `taxonomy` / `filterType` attributes
 	 * intentionally mirror the filter types exposed by the instant-search

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -301,7 +301,18 @@ class Search_Blocks {
 			),
 		);
 
-		return array_merge( (array) $variations, $additions );
+		// Merge by `name` so a variation already registered upstream (block.json
+		// or a higher-priority filter) wins over our preset of the same name —
+		// `array_merge` would otherwise append duplicates and the inserter
+		// would render two cards for the same variation.
+		$variations    = (array) $variations;
+		$existing_keys = array_flip( array_column( $variations, 'name' ) );
+		foreach ( $additions as $variation ) {
+			if ( ! isset( $existing_keys[ $variation['name'] ] ) ) {
+				$variations[] = $variation;
+			}
+		}
+		return $variations;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -212,24 +212,33 @@ class Search_Blocks {
 			}
 		}
 
-		static::register_variations();
+		add_filter( 'get_block_type_variations', array( static::class, 'inject_filter_checkbox_variations' ), 10, 2 );
 		static::register_patterns();
 	}
 
 	/**
-	 * Register named block variations for the filter-checkbox block.
+	 * Inject named block variations for the filter-checkbox block.
 	 *
-	 * PHP-side registration keeps the editor-only JS bundle out of the ESM
-	 * pipeline. Variation names and default `taxonomy` / `filterType`
-	 * attributes intentionally mirror the filter types exposed by the
-	 * instant-search overlay so the two surfaces describe the same filters.
+	 * Hooks `get_block_type_variations` (WP 6.5+) rather than calling
+	 * `register_block_variation()` because the latter is a JS-only API; no
+	 * matching PHP function exists in WordPress core. Filtering on the block
+	 * type's own variations getter is the supported PHP-side path and keeps
+	 * the editor-only JS bundle out of the ESM pipeline.
+	 *
+	 * Variation names and default `taxonomy` / `filterType` attributes
+	 * intentionally mirror the filter types exposed by the instant-search
+	 * overlay so the two surfaces describe the same filters.
+	 *
+	 * @param array          $variations Variations registered on the block type.
+	 * @param \WP_Block_Type $block_type Block type the filter is being applied to.
+	 * @return array
 	 */
-	protected static function register_variations() {
-		if ( ! function_exists( 'register_block_variation' ) ) {
-			return;
+	public static function inject_filter_checkbox_variations( $variations, $block_type ) {
+		if ( ! isset( $block_type->name ) || 'jetpack-search/filter-checkbox' !== $block_type->name ) {
+			return $variations;
 		}
 
-		$variations = array(
+		$additions = array(
 			array(
 				'name'        => 'category',
 				'title'       => __( 'Filter by Category', 'jetpack-search-pkg' ),
@@ -292,10 +301,7 @@ class Search_Blocks {
 			),
 		);
 
-		foreach ( $variations as $variation ) {
-			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above; stub missing from wordpress-stubs.
-			register_block_variation( 'jetpack-search/filter-checkbox', $variation );
-		}
+		return array_merge( (array) $variations, $additions );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -436,6 +436,93 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * The filter-checkbox inserter cards come from
+	 * Search_Blocks::inject_filter_checkbox_variations(); if these names or
+	 * seeded attributes drift, the editor stops offering the expected filter
+	 * presets or inserts them with the wrong defaults.
+	 */
+	public function test_inject_filter_checkbox_variations_adds_expected_shapes() {
+		$variations = Search_Blocks::inject_filter_checkbox_variations(
+			array(
+				array(
+					'name'  => 'existing',
+					'title' => 'Existing variation',
+				),
+			),
+			new \WP_Block_Type( 'jetpack-search/filter-checkbox' )
+		);
+
+		$variations_by_name = array_column( $variations, null, 'name' );
+
+		$this->assertArrayHasKey( 'existing', $variations_by_name );
+		$this->assertSame(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'category',
+				'label'      => 'Category',
+			),
+			$variations_by_name['category']['attributes']
+		);
+		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['category']['isActive'] );
+
+		$this->assertSame(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'post_tag',
+				'label'      => 'Tag',
+			),
+			$variations_by_name['post_tag']['attributes']
+		);
+		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['post_tag']['isActive'] );
+
+		$this->assertSame(
+			array(
+				'filterType' => 'post_type',
+				'label'      => 'Post Type',
+			),
+			$variations_by_name['post_type']['attributes']
+		);
+		$this->assertSame( array( 'filterType' ), $variations_by_name['post_type']['isActive'] );
+
+		$this->assertSame(
+			array(
+				'filterType' => 'author',
+				'label'      => 'Author',
+			),
+			$variations_by_name['author']['attributes']
+		);
+		$this->assertSame( array( 'filterType' ), $variations_by_name['author']['isActive'] );
+
+		$this->assertSame(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => '',
+				'label'      => '',
+			),
+			$variations_by_name['custom_taxonomy']['attributes']
+		);
+		$this->assertSame( array( 'filterType' ), $variations_by_name['custom_taxonomy']['isActive'] );
+	}
+
+	/**
+	 * The injector must be scoped to jetpack-search/filter-checkbox so it
+	 * can't leak Search-specific presets onto unrelated blocks.
+	 */
+	public function test_inject_filter_checkbox_variations_ignores_other_block_types() {
+		$variations = array(
+			array(
+				'name'  => 'existing',
+				'title' => 'Existing variation',
+			),
+		);
+
+		$this->assertSame(
+			$variations,
+			Search_Blocks::inject_filter_checkbox_variations( $variations, new \WP_Block_Type( 'core/paragraph' ) )
+		);
+	}
+
+	/**
 	 * Invoke a protected static on Search_Blocks from test code. Reflection
 	 * is the cheapest way to cover this logic without leaking visibility
 	 * just for testability.

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -523,6 +523,44 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * If a variation with one of our preset names is already registered (via
+	 * block.json or a higher-priority filter), the existing entry must win —
+	 * otherwise `array_merge` would emit two inserter cards under the same
+	 * variation name and the editor would resolve `isActive` ambiguously.
+	 */
+	public function test_inject_filter_checkbox_variations_skips_name_collisions() {
+		$existing_category = array(
+			'name'       => 'category',
+			'title'      => 'Site-customized Category filter',
+			'attributes' => array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'category',
+				'label'      => 'Topics',
+			),
+		);
+		$variations        = Search_Blocks::inject_filter_checkbox_variations(
+			array( $existing_category ),
+			new \WP_Block_Type( 'jetpack-search/filter-checkbox' )
+		);
+
+		$category_entries = array();
+		foreach ( $variations as $v ) {
+			if ( 'category' === $v['name'] ) {
+				$category_entries[] = $v;
+			}
+		}
+		$this->assertCount( 1, $category_entries );
+
+		$by_name = array_column( $variations, null, 'name' );
+		$this->assertSame( 'Site-customized Category filter', $by_name['category']['title'] );
+		// Other presets are still added, only the colliding name is skipped.
+		$this->assertArrayHasKey( 'post_tag', $by_name );
+		$this->assertArrayHasKey( 'post_type', $by_name );
+		$this->assertArrayHasKey( 'author', $by_name );
+		$this->assertArrayHasKey( 'custom_taxonomy', $by_name );
+	}
+
+	/**
 	 * Invoke a protected static on Search_Blocks from test code. Reflection
 	 * is the cheapest way to cover this logic without leaking visibility
 	 * just for testability.


### PR DESCRIPTION
Fixes [SEARCH-176](https://linear.app/a8c/issue/SEARCH-176/search-blocks-filter-checkbox-variations-dont-reach-the-inserter)

## Proposed changes

* Replace the broken `register_block_variation()` PHP call in `Search_Blocks::register_variations()` with a `get_block_type_variations` filter (WP 6.5+) so the filter-checkbox block's variations actually reach the editor.

### Why

`register_block_variation()` is a JavaScript-only API — no matching PHP function exists in WordPress core. The `function_exists( 'register_block_variation' )` guard at the top of the previous `register_variations()` always returned `false`, so the method early-returned and **zero** variations were registered. The Category / Tag / Post Type / Author / Custom Taxonomy entries never appeared in the inserter, and `WP_Block_Type::get_variations()` for `jetpack-search/filter-checkbox` always returned `[]`.

The fix swaps the imperative registration loop for a `get_block_type_variations` filter callback (`inject_filter_checkbox_variations`) that scopes itself to `jetpack-search/filter-checkbox` and merges the variation array onto whatever variations are already registered. This is the supported PHP-side path for adding variations and keeps the editor-only JS bundle out of the ESM pipeline, which was the original design goal.

## Related product discussion/links

* Surfaced while reviewing the filter-checkbox block's separation of concerns.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Check out this branch in your local Jetpack monorepo and bring up a Search dev env with the Search Blocks feature enabled.
2. From inside the WP container, dump the registered variations:
   ```
   wp eval '\$bt = WP_Block_Type_Registry::get_instance()->get_registered( "jetpack-search/filter-checkbox" ); foreach ( \$bt->get_variations() as \$v ) { echo \$v["name"] . PHP_EOL; }'
   ```
   Expected: `category`, `post_tag`, `post_type`, `author`, `custom_taxonomy` (5 lines). On `trunk` the same command prints nothing.
3. Hit the block-types REST endpoint the editor's inserter consumes — `GET /wp-json/wp/v2/block-types/jetpack-search/filter-checkbox` (with editor auth) — and confirm the `variations` array contains those 5 entries with the correct `title` / `attributes` / `isActive` shape.
4. Open the post editor, open the inserter, and search for "Filter by". Expected: five distinct cards (Filter by Category, Filter by Tag, Filter by Post Type, Filter by Author, Filter by Custom Taxonomy). On `trunk` only the parent "Checkbox Filter" block shows up.
5. Insert each variation and confirm the inserted block carries the variation's seeded attributes (e.g. inserting "Filter by Category" produces a block with `filterType: "taxonomy"`, `taxonomy: "category"`, `label: "Category"`).
6. With a block already inserted, verify the inspector's "Filter type" SelectControl in-place swap still works and that `isActive` resolves to the most-specific match (e.g. switching from Custom Taxonomy → entering `category` slug routes to the Category variation rather than staying on Custom Taxonomy).

