### PR TITLE
Search Blocks: keep selected filter buckets visible in the list [SEARCH-177]

### DIFF
--- a/projects/packages/search/changelog/SEARCH-177-show-checked-filters
+++ b/projects/packages/search/changelog/SEARCH-177-show-checked-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: filter-checkbox and filter-date now keep selected buckets visible in the list with their checkbox in the checked state, so visitors can untick them in the same place they ticked them. The active-filters chip row continues to show the same selections as removable pills.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
@@ -42,31 +42,7 @@ wp_interactivity_state(
 	)
 );
 
-$view = Search_Blocks::pre_hydration_filter_view( $filter_key );
-
-// `allBucketsSelected` first-paint mirror: read the same seeded buckets +
-// activeFilters the JS getter consults so the list and the fallback message
-// come out pre-hidden in the right state and don't flicker on hydration.
-// `aggregations` is seeded as `stdClass` when empty — cast before subscripting.
-$seeded_state          = wp_interactivity_state( 'jetpack-search' );
-$seeded_aggs           = (array) ( $seeded_state['aggregations'] ?? array() );
-$seeded_buckets        = (array) ( $seeded_aggs[ $filter_key ]['buckets'] ?? array() );
-$seeded_active_filters = (array) ( $seeded_state['activeFilters'] ?? array() );
-$seeded_selected       = (array) ( $seeded_active_filters[ $filter_key ] ?? array() );
-$all_selected_on_paint = false;
-if ( $view['has_buckets'] && ! empty( $seeded_selected ) ) {
-	$all_selected_on_paint = true;
-	foreach ( $seeded_buckets as $bucket ) {
-		$raw_key   = (string) ( $bucket['key'] ?? '' );
-		$slash_idx = strpos( $raw_key, '/' );
-		$value     = false === $slash_idx ? $raw_key : substr( $raw_key, 0, $slash_idx );
-		if ( ! in_array( $value, $seeded_selected, true ) ) {
-			$all_selected_on_paint = false;
-			break;
-		}
-	}
-}
-
+$view  = Search_Blocks::pre_hydration_filter_view( $filter_key );
 $label = $config['label'];
 ?>
 <div
@@ -85,11 +61,7 @@ $label = $config['label'];
 		require __DIR__ . '/../filter-skeleton-partial.php';
 	}
 	?>
-	<ul
-		class="jetpack-search-filter__list"
-		data-wp-bind--hidden="state.allBucketsSelected"
-		<?php echo $all_selected_on_paint ? 'hidden' : ''; ?>
-	>
+	<ul class="jetpack-search-filter__list">
 		<template
 			data-wp-each--item="state.filterItems"
 			data-wp-each-key="context.item.value"
@@ -101,6 +73,7 @@ $label = $config['label'];
 					<input
 						type="checkbox"
 						data-wp-bind--value="context.item.value"
+						data-wp-bind--checked="context.item.checked"
 						data-wp-on--change="actions.onFilterChange"
 					/>
 					<span
@@ -116,11 +89,4 @@ $label = $config['label'];
 			</li>
 		</template>
 	</ul>
-	<p
-		class="jetpack-search-filter__all-selected"
-		data-wp-bind--hidden="!state.allBucketsSelected"
-		<?php echo $all_selected_on_paint ? '' : 'hidden'; ?>
-	>
-		<?php esc_html_e( 'All filters applied', 'jetpack-search-pkg' ); ?>
-	</p>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
@@ -56,18 +56,4 @@
 			display: none;
 		}
 	}
-
-	.jetpack-search-filter__all-selected {
-		margin: 0;
-		font-size: 0.75rem;
-		// Inherit the theme's text color; opacity keeps the muted look
-		// across light and dark themes.
-		color: inherit;
-		opacity: 0.7;
-		font-style: italic;
-
-		&[hidden] {
-			display: none;
-		}
-	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
@@ -49,10 +49,7 @@ $label = $config['label'];
 		require __DIR__ . '/../filter-skeleton-partial.php';
 	}
 	?>
-	<ul
-		class="jetpack-search-filter__list"
-		data-wp-bind--hidden="state.allBucketsSelected"
-	>
+	<ul class="jetpack-search-filter__list">
 		<template
 			data-wp-each--item="state.filterItems"
 			data-wp-each-key="context.item.value"
@@ -64,6 +61,7 @@ $label = $config['label'];
 					<input
 						type="checkbox"
 						data-wp-bind--value="context.item.value"
+						data-wp-bind--checked="context.item.checked"
 						data-wp-on--change="actions.onFilterChange"
 					/>
 					<span
@@ -79,11 +77,4 @@ $label = $config['label'];
 			</li>
 		</template>
 	</ul>
-	<p
-		class="jetpack-search-filter__all-selected"
-		data-wp-bind--hidden="!state.allBucketsSelected"
-		hidden
-	>
-		<?php esc_html_e( 'All filters applied', 'jetpack-search-pkg' ); ?>
-	</p>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
@@ -50,16 +50,4 @@
 			display: none;
 		}
 	}
-
-	.jetpack-search-filter__all-selected {
-		margin: 0;
-		font-size: 0.75rem;
-		color: inherit;
-		opacity: 0.7;
-		font-style: italic;
-
-		&[hidden] {
-			display: none;
-		}
-	}
 }

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -73,9 +73,11 @@ function dateBucketSlug( bucket ) {
 /**
  * filterItems for non-date filters. Handles both `slug/Name` keys (taxonomy,
  * author) and bare-slug keys (post_type) via `bucketLabel`/`bucketValue`.
- * Drops selected buckets — those appear in the active-filters block.
- * Resorts by visible label when `bucketSortOrder === 'alpha'` since the
- * ES `_key: asc` order is by slug, not display label.
+ * Selected buckets stay in the list and surface their selection through
+ * `checked`; the active-filters block renders the same selections as a
+ * removable chip row above the filters. Resorts by visible label when
+ * `bucketSortOrder === 'alpha'` since the ES `_key: asc` order is by slug,
+ * not display label.
  *
  * @param {object} sharedState - Live store state.
  * @param {string} filterKey   - Filter key.
@@ -90,19 +92,16 @@ function checkboxFilterItems( sharedState, filterKey, config ) {
 	const selected = sharedState.activeFilters?.[ filterKey ] ?? [];
 	const showCount = config.showCount !== false;
 	const valueLabels = config.valueLabels;
-	const items = buckets.reduce( ( acc, bucket ) => {
+	const items = buckets.map( bucket => {
 		const value = bucketValue( bucket.key );
-		if ( selected.includes( value ) ) {
-			return acc;
-		}
-		acc.push( {
+		return {
 			value,
 			label: bucketLabel( bucket.key, valueLabels ),
+			checked: selected.includes( value ),
 			showCount,
 			countLabel: String( bucket.doc_count ?? 0 ),
-		} );
-		return acc;
-	}, [] );
+		};
+	} );
 	if ( config.bucketSortOrder === 'alpha' ) {
 		const locale = sharedState.locale || 'en-US';
 		items.sort( ( a, b ) => a.label.localeCompare( b.label, locale, { sensitivity: 'base' } ) );
@@ -111,8 +110,9 @@ function checkboxFilterItems( sharedState, filterKey, config ) {
 }
 
 /**
- * filterItems for a `date` filter. Drops empty + selected buckets, then
- * slices to `maxItems` (date_histogram has no ES `size`).
+ * filterItems for a `date` filter. Drops empty buckets, then slices to
+ * `maxItems` (date_histogram has no ES `size`). Selected buckets stay in
+ * the list and surface their state via `checked`.
  *
  * @param {object} sharedState - Live store state.
  * @param {string} filterKey   - Filter key.
@@ -138,12 +138,13 @@ function dateFilterItems( sharedState, filterKey, config ) {
 			continue;
 		}
 		const value = dateBucketSlug( bucket );
-		if ( ! value || selected.includes( value ) ) {
+		if ( ! value ) {
 			continue;
 		}
 		items.push( {
 			value,
 			label: formatDateBucketLabel( value, interval, locale ),
+			checked: selected.includes( value ),
 			showCount,
 			countLabel: String( bucket.doc_count ),
 		} );
@@ -402,34 +403,7 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * True when every bucket is in activeFilters — block then shows
-		 * the "All filters applied" message instead of an empty list.
-		 *
-		 * @return {boolean} True when nothing is left to offer.
-		 */
-		get allBucketsSelected() {
-			const { filterKey } = getContext();
-			const buckets = state.aggregations?.[ filterKey ]?.buckets;
-			if ( ! Array.isArray( buckets ) || buckets.length === 0 ) {
-				return false;
-			}
-			const selected = state.activeFilters?.[ filterKey ] ?? [];
-			if ( selected.length === 0 ) {
-				return false;
-			}
-			const config = state.filterConfigs?.[ filterKey ] ?? {};
-			if ( config.filterType === 'date' ) {
-				const populated = buckets.filter( bucket => ( bucket?.doc_count ?? 0 ) > 0 );
-				if ( populated.length === 0 ) {
-					return false;
-				}
-				return populated.every( bucket => selected.includes( dateBucketSlug( bucket ) ) );
-			}
-			return buckets.every( bucket => selected.includes( bucketValue( bucket.key ) ) );
-		},
-
-		/**
-		 * `{ value, label, showCount, countLabel }` items for the current
+		 * `{ value, label, checked, showCount, countLabel }` items for the current
 		 * filter block. Dispatches on `filterType`. Lives on the shared
 		 * namespace so per-block view bundles don't clobber siblings.
 		 *

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -58,8 +58,8 @@ describe( 'filter-checkbox view store — filterItems', () => {
 			},
 		};
 		expect( captured.state.filterItems ).toEqual( [
-			{ value: 'post', label: 'Post', showCount: true, countLabel: '12' },
-			{ value: 'page', label: 'Page', showCount: true, countLabel: '4' },
+			{ value: 'post', label: 'Post', checked: false, showCount: true, countLabel: '12' },
+			{ value: 'page', label: 'Page', checked: false, showCount: true, countLabel: '4' },
 		] );
 	} );
 
@@ -80,7 +80,10 @@ describe( 'filter-checkbox view store — filterItems', () => {
 		expect( labels ).toEqual( [ 'News', 'Reviews' ] );
 	} );
 
-	it( 'omits buckets already in activeFilters', () => {
+	it( 'keeps selected buckets in the list and marks them checked', () => {
+		// Selected buckets stay visible so the checkbox itself is the toggle
+		// affordance — the active-filters chip row is a complementary view,
+		// not the only place to remove a selection.
 		contextRef.current = { filterKey: 'category' };
 		captured.state.activeFilters = { category: [ 'news' ] };
 		captured.state.aggregations = {
@@ -94,7 +97,12 @@ describe( 'filter-checkbox view store — filterItems', () => {
 		captured.state.filterConfigs = {
 			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
 		};
-		expect( captured.state.filterItems.map( i => i.value ) ).toEqual( [ 'reviews' ] );
+		expect(
+			captured.state.filterItems.map( i => ( { value: i.value, checked: i.checked } ) )
+		).toEqual( [
+			{ value: 'news', checked: true },
+			{ value: 'reviews', checked: false },
+		] );
 	} );
 
 	it( 'preserves the API order when bucketSortOrder is `count`', () => {
@@ -171,17 +179,5 @@ describe( 'filter-checkbox view store — filterItems', () => {
 			'Page',
 			'Post',
 		] );
-	} );
-
-	it( 'allBucketsSelected is true once activeFilters covers every bucket value', () => {
-		contextRef.current = { filterKey: 'post_types' };
-		captured.state.activeFilters = { post_types: [ 'post', 'page' ] };
-		captured.state.aggregations = {
-			post_types: { buckets: [ { key: 'post' }, { key: 'page' } ] },
-		};
-		expect( captured.state.allBucketsSelected ).toBe( true );
-
-		captured.state.activeFilters = { post_types: [ 'post' ] };
-		expect( captured.state.allBucketsSelected ).toBe( false );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -180,4 +180,28 @@ describe( 'filter-checkbox view store — filterItems', () => {
 			'Post',
 		] );
 	} );
+
+	it( 'date variant: keeps selected date buckets in the list and marks them checked', () => {
+		// Mirrors the checkbox-variant `checked` assertion above for the
+		// `filterType: 'date'` branch of filterItems / dateFilterItems.
+		contextRef.current = { filterKey: 'post_date' };
+		captured.state.activeFilters = { post_date: [ '2024-01-01' ] };
+		captured.state.aggregations = {
+			post_date: {
+				buckets: [
+					{ key_as_string: '2024-01-01', key: 1704067200000, doc_count: 5 },
+					{ key_as_string: '2025-01-01', key: 1735689600000, doc_count: 3 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			post_date: { filterType: 'date', interval: 'year', maxItems: 10, showCount: true },
+		};
+		expect(
+			captured.state.filterItems.map( i => ( { value: i.value, checked: i.checked } ) )
+		).toEqual( [
+			{ value: '2024-01-01', checked: true },
+			{ value: '2025-01-01', checked: false },
+		] );
+	} );
 } );


### PR DESCRIPTION
Fixes [SEARCH-177](https://linear.app/a8c/issue/SEARCH-177/search-blocks-show-filter-buckets-even-when-theyre-already-checked)

## Why

Visitors filter searches by ticking checkboxes in the sidebar. Today, the moment a checkbox is ticked the bucket vanishes from the list and only shows up as a removable chip above — so to untick it, visitors have to leave the list, find it in the chip row, and click ✕. Worse, if they ticked the only category they had been considering, the whole CATEGORY group could disappear into an "All filters applied" state.

After this change, ticking a box keeps the option in place with the checkbox in its `:checked` state. Visitors untick from the same control they used to tick. The active-filters chip row still works, but it's now a *summary* — not the only escape hatch.

This is the dominant pattern in faceted-search UIs (Algolia InstantSearch, Amazon, eBay, Best Buy, Etsy) and the explicit recommendation in NN/g and Baymard's faceted-search guidance.

## Screenshots

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/ce9fcbdf-4d5d-4e41-a8d9-ad1288691d5b) | ![after](https://github.com/user-attachments/assets/1c8de3a2-6292-42dc-a765-37477b388002) |

Both shots show a search where Category=News and Post Type=Post are active. Trunk hides those buckets from the lists; this PR keeps them in place with checked checkboxes.

## Proposed changes

* `filterItems` descriptors gain a `checked` field; both `checkboxFilterItems` and `dateFilterItems` keep selected buckets in the list instead of skipping them.
* Filter-checkbox and filter-date templates bind the new field via `data-wp-bind--checked="context.item.checked"`.
* Drop the `allBucketsSelected` getter, the matching first-paint mirror block in filter-checkbox's `render.php`, and the "All filters applied" empty-state markup — the list never empties out anymore.
* Update the JS view test: the `omits buckets already in activeFilters` case becomes `keeps selected buckets in the list and marks them checked`.

## Related product discussion/links

* [SEARCH-177](https://linear.app/a8c/issue/SEARCH-177/search-blocks-show-filter-buckets-even-when-theyre-already-checked) — original issue with motivation and acceptance criteria.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Set up a Jetpack Search-enabled site that uses the new `jetpack-search/*` blocks (the "Blog Search Page" pattern is the easiest path).

> **Heads-up:** if your env was used for testing the standard Jetpack Search results template before the SEARCH-175 namespace rename (#48590), reset it first or the cached template still references the old block slugs and renders empty regions:
> ```
> wp post delete $(wp post list --post_type=wp_template --name=jetpack-search --field=ID) --force
> ```

* Visit the page with no active filters. Tick a category checkbox.
  * Expect: the checkbox stays in the list with its `:checked` state set; results filter accordingly; a chip appears above the filters showing the same selection.
* Untick the same checkbox by clicking it directly (not the chip).
  * Expect: checkbox unticks; results un-filter; the chip disappears.
* Tick the chip's ✕ button instead.
  * Expect: identical behaviour — checkbox unticks, results un-filter.
* Repeat for date filters (`jetpack-search/filter-date`) — same expectations.
* Tick every option in a category. The list does not collapse to an "All filters applied" message — every checkbox stays visible (and checked).

