### PR TITLE
Search Blocks: retain checkbox filter options across searches (SEARCH-178)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-178-checkbox-retain-options
+++ b/projects/packages/search/changelog/SEARCH-178-checkbox-retain-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: checkbox filters retain previously-seen options across searches and keep selected values visible (and uncheckable) even when the current result set no longer surfaces them. Zero-result options sink to the bottom of the list unless they're checked.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -600,39 +600,39 @@ class Search_Blocks {
 
 		return array(
 			// Connection / routing config.
-			'siteId'           => $site_id,
-			'apiRoot'          => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
-			'nonce'            => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
-			'isPrivateSite'    => $is_private,
-			'isWpcom'          => $is_wpcom,
-			'homeUrl'          => function_exists( 'home_url' ) ? home_url() : '',
+			'siteId'                => $site_id,
+			'apiRoot'               => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
+			'nonce'                 => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
+			'isPrivateSite'         => $is_private,
+			'isWpcom'               => $is_wpcom,
+			'homeUrl'               => function_exists( 'home_url' ) ? home_url() : '',
 			// BCP47-ish locale (e.g. `en-US`) for Intl.DateTimeFormat on the
 			// client. Converts WP's `en_US` underscore form. Uses the blog
 			// locale (site setting) rather than the viewer's user-profile
 			// locale so formatting is consistent for logged-out visitors
 			// hitting a search page.
-			'locale'           => function_exists( 'get_locale' )
+			'locale'                => function_exists( 'get_locale' )
 				? str_replace( '_', '-', get_locale() )
 				: 'en-US',
 
 			// Search state, seeded from the URL so a deep link like
 			// /?s=boots&orderby=newest&category[]=news renders correctly on
 			// first paint.
-			'searchQuery'      => $search_query,
+			'searchQuery'           => $search_query,
 			// URL key the JS store uses to read/write the search query. `s`
 			// on the WP search route, `q` on non-search pages — see
 			// `get_search_param_name()`. Threaded through the seed so the JS
 			// store reads from the same key the seed pulled `searchQuery`
 			// from.
-			'searchParamName'  => static::get_search_param_name(),
-			'sortOrder'        => static::parse_url_sort(),
-			'activeFilters'    => $active_filters,
-			'priceRange'       => $price_range,
+			'searchParamName'       => static::get_search_param_name(),
+			'sortOrder'             => static::parse_url_sort(),
+			'activeFilters'         => $active_filters,
+			'priceRange'            => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
 			// taxonomy, label, showCount, maxItems } }.
-			'filterConfigs'    => array(),
+			'filterConfigs'         => array(),
 
 			// Note: `staticPostTypes` (contributed by `jetpack-search/filter-post-type`)
 			// is intentionally NOT seeded here. FSE block templates can render
@@ -646,19 +646,24 @@ class Search_Blocks {
 			// Results + aggregations are populated by the JS store on hydration —
 			// seed empty defaults so template bindings always have a shape to read.
 			// `aggregations` is a stdClass so JS sees `{}`, not `[]`.
-			'results'          => array(),
-			'aggregations'     => (object) array(),
-			'totalResults'     => 0,
-			'pageHandle'       => null,
+			'results'               => array(),
+			'aggregations'          => (object) array(),
+			// Per-filter union of values seen across the session's aggregation
+			// responses. The JS store appends to this on each successful fetch
+			// so checkbox-filter lists can keep options visible even after a
+			// narrower query drops them from ES results.
+			'retainedFilterOptions' => (object) array(),
+			'totalResults'          => 0,
+			'pageHandle'            => null,
 
 			// UI state. `isLoading` is seeded true when the URL carries a
 			// search query or filter selection so the empty-state region inside
 			// `jetpack-search/results-list` stays hidden between first paint and JS
 			// hydrating the initial fetch — otherwise a "No results found" flash
 			// appears on deep links.
-			'isLoading'        => $is_initial_loading,
-			'isLoadingMore'    => false,
-			'hasError'         => false,
+			'isLoading'             => $is_initial_loading,
+			'isLoadingMore'         => false,
+			'hasError'              => false,
 
 			// One-shot pre-hydration skeleton gate. The IA SSR pass evaluates
 			// `data-wp-bind--hidden` against literal seeded values (it can't
@@ -666,12 +671,12 @@ class Search_Blocks {
 			// boolean. JS flips it to true once `actions.search()` resolves
 			// and never resets it — subsequent re-searches keep live results
 			// on screen without re-flashing placeholders.
-			'skeletonHidden'   => false,
+			'skeletonHidden'        => false,
 
 			// Seeded so the SSR pass can resolve `data-wp-text` to a real
 			// string on first paint; `actions.search()` keeps it in lockstep
 			// with `isLoading` / `totalResults` via `computeResultsCountText`.
-			'resultsCountText' => $is_initial_loading ? $searching_text : '',
+			'resultsCountText'      => $is_initial_loading ? $searching_text : '',
 
 			// Translated view-bundle strings. The Interactivity API view bundle
 			// can't import @wordpress/i18n (only @wordpress/interactivity is
@@ -680,7 +685,7 @@ class Search_Blocks {
 			// are seeded so the client can pick based on the live totalResults
 			// without a round trip; languages with more than two plural forms
 			// degrade to "plural for all count > 1" as an accepted tradeoff.
-			'strings'          => static::build_initial_strings(),
+			'strings'               => static::build_initial_strings(),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -61,13 +61,25 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
  * visibility — without the retained / selection check a narrower query
  * could hide the section that holds the user's own selection.
  *
+ * Date filters bail out before the retention / selection clauses: they
+ * don't accumulate retained options (mergeRetainedFilterOptions skips
+ * them) and dateFilterItems doesn't render selected values that aren't
+ * in the current aggregation, so an empty bucket list means an empty
+ * <ul> and the wrapper should hide. Selections still surface via the
+ * active-filters pills.
+ *
  * @param {object} sharedState - Live store state.
  * @param {string} filterKey   - Filter key.
  * @return {boolean} True when the wrapper has something to show.
  */
 function filterHasContent( sharedState, filterKey ) {
+	if ( ( sharedState.aggregations?.[ filterKey ]?.buckets?.length ?? 0 ) > 0 ) {
+		return true;
+	}
+	if ( sharedState.filterConfigs?.[ filterKey ]?.filterType === 'date' ) {
+		return false;
+	}
 	return (
-		( sharedState.aggregations?.[ filterKey ]?.buckets?.length ?? 0 ) > 0 ||
 		( sharedState.retainedFilterOptions?.[ filterKey ]?.length ?? 0 ) > 0 ||
 		( sharedState.activeFilters?.[ filterKey ]?.length ?? 0 ) > 0
 	);
@@ -536,9 +548,12 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * `{ value, label, showCount, countLabel }` items for the current
-		 * filter block. Dispatches on `filterType`. Lives on the shared
-		 * namespace so per-block view bundles don't clobber siblings.
+		 * Item descriptors for the current filter block. Dispatches on
+		 * `filterType`. Lives on the shared namespace so per-block view
+		 * bundles don't clobber siblings. Each item carries `value`,
+		 * `label`, `count`, `countLabel`, `showCount`, and `checked`;
+		 * `checkboxFilterItems` also folds retained options and URL-seeded
+		 * selections into the list (see its JSDoc).
 		 *
 		 * @return {Array<object>} Item descriptors.
 		 */

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -56,6 +56,24 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
 }
 
 /**
+ * True when a filter key has anything to render: live aggregation buckets,
+ * session-retained options, or an active selection. Drives wrapper
+ * visibility — without the retained / selection check a narrower query
+ * could hide the section that holds the user's own selection.
+ *
+ * @param {object} sharedState - Live store state.
+ * @param {string} filterKey   - Filter key.
+ * @return {boolean} True when the wrapper has something to show.
+ */
+function filterHasContent( sharedState, filterKey ) {
+	return (
+		( sharedState.aggregations?.[ filterKey ]?.buckets?.length ?? 0 ) > 0 ||
+		( sharedState.retainedFilterOptions?.[ filterKey ]?.length ?? 0 ) > 0 ||
+		( sharedState.activeFilters?.[ filterKey ]?.length ?? 0 ) > 0
+	);
+}
+
+/**
  * Slug for a date_histogram bucket. Falls back to the numeric key when
  * `key_as_string` is missing.
  *
@@ -73,11 +91,23 @@ function dateBucketSlug( bucket ) {
 /**
  * filterItems for non-date filters. Handles both `slug/Name` keys (taxonomy,
  * author) and bare-slug keys (post_type) via `bucketLabel`/`bucketValue`.
- * Selected buckets stay in the list and surface their selection through
- * `checked`; the active-filters block renders the same selections as a
- * removable chip row above the filters. Resorts by visible label when
- * `bucketSortOrder === 'alpha'` since the ES `_key: asc` order is by slug,
- * not display label.
+ *
+ * Three sources are merged:
+ * 1. The current aggregation's buckets — authoritative for label and count.
+ * 2. `retainedFilterOptions[filterKey]` — values seen in earlier responses
+ * whose buckets dropped out of the latest result set; rendered with count
+ * `0` so the list stays stable across searches.
+ * 3. Selected values not yet seen in any aggregation (URL-seeded deep links
+ * that arrive before the first fetch resolves) — rendered as checked, count
+ * `0`, label falling back to the value itself when no `valueLabels` mapping
+ * exists.
+ *
+ * Sort order: unchecked, zero-count items sink to the bottom; the rest follow
+ * the configured `bucketSortOrder` (count desc or alpha by visible label).
+ * A checked option keeps its normal sort position even if its current count
+ * is `0`, so users always see what they've selected. The `count` sort uses
+ * the visible label as a tiebreaker so two buckets with the same count don't
+ * swap positions across re-renders — ES bucket order is unstable on ties.
  *
  * @param {object} sharedState - Live store state.
  * @param {string} filterKey   - Filter key.
@@ -85,28 +115,131 @@ function dateBucketSlug( bucket ) {
  * @return {Array<object>} Item descriptors.
  */
 function checkboxFilterItems( sharedState, filterKey, config ) {
-	const buckets = sharedState.aggregations?.[ filterKey ]?.buckets;
-	if ( ! Array.isArray( buckets ) ) {
-		return [];
-	}
+	const buckets = sharedState.aggregations?.[ filterKey ]?.buckets ?? [];
+	const retained = sharedState.retainedFilterOptions?.[ filterKey ] ?? [];
 	const selected = sharedState.activeFilters?.[ filterKey ] ?? [];
+	const selectedSet = new Set( selected );
 	const showCount = config.showCount !== false;
 	const valueLabels = config.valueLabels;
-	const items = buckets.map( bucket => {
-		const value = bucketValue( bucket.key );
-		return {
+
+	const seen = new Set();
+	const items = [];
+	const add = ( value, label, count ) => {
+		if ( seen.has( value ) ) {
+			return;
+		}
+		seen.add( value );
+		items.push( {
 			value,
-			label: bucketLabel( bucket.key, valueLabels ),
-			checked: selected.includes( value ),
+			label,
 			showCount,
-			countLabel: String( bucket.doc_count ?? 0 ),
-		};
-	} );
-	if ( config.bucketSortOrder === 'alpha' ) {
-		const locale = sharedState.locale || 'en-US';
-		items.sort( ( a, b ) => a.label.localeCompare( b.label, locale, { sensitivity: 'base' } ) );
+			countLabel: String( count ),
+			count,
+			checked: selectedSet.has( value ),
+		} );
+	};
+
+	for ( const bucket of buckets ) {
+		add( bucketValue( bucket.key ), bucketLabel( bucket.key, valueLabels ), bucket.doc_count ?? 0 );
 	}
-	return items;
+	for ( const option of retained ) {
+		add( option.value, option.label, 0 );
+	}
+	for ( const value of selected ) {
+		add( value, bucketLabel( value, valueLabels ), 0 );
+	}
+
+	return sortFilterItems( items, config, sharedState.locale );
+}
+
+/**
+ * Apply the configured bucket sort order with one global rule layered on top:
+ * unchecked options whose count is `0` sink to the bottom. Checked items keep
+ * their normal sort position even at count `0`.
+ *
+ * @param {Array<object>} items  - Items as built by `checkboxFilterItems`.
+ * @param {object}        config - filterConfigs entry (`bucketSortOrder`).
+ * @param {string}        locale - Locale tag for `localeCompare`.
+ * @return {Array<object>} The same array, sorted in place.
+ */
+function sortFilterItems( items, config, locale ) {
+	const lc = locale || 'en-US';
+	const byLabel = ( a, b ) => a.label.localeCompare( b.label, lc, { sensitivity: 'base' } );
+	const compareConfigured =
+		config.bucketSortOrder === 'alpha'
+			? byLabel
+			: ( a, b ) => ( a.count !== b.count ? b.count - a.count : byLabel( a, b ) );
+	const sinkRank = item => ( ! item.checked && item.count === 0 ? 1 : 0 );
+	return items.sort( ( a, b ) => sinkRank( a ) - sinkRank( b ) || compareConfigured( a, b ) );
+}
+
+/**
+ * Merge fresh aggregation buckets into `retainedFilterOptions` so the
+ * filter-checkbox list keeps options that have appeared at any point in
+ * the session, even after a narrower query drops them from ES results.
+ * Returns the original object when nothing is added so reactive subscribers
+ * don't re-run on no-op merges.
+ *
+ * Date filters are skipped — their bucket set is dense by interval and the
+ * `dateFilterItems` reader hides empty buckets for its own reasons.
+ *
+ * Tradeoffs intentionally left in: labels are set on first sight and never
+ * refreshed (a taxonomy term renamed mid-session keeps the original label
+ * until reload), and the map grows monotonically across the session — it's
+ * bounded only by tab lifetime, with no `sessionStorage` persistence today.
+ * `loadMore()` does not call this helper because it doesn't refresh
+ * aggregations either, so retention only advances when a fresh search runs.
+ *
+ * @param {object} prev          - Existing `retainedFilterOptions` map.
+ * @param {object} aggregations  - Latest API aggregations response.
+ * @param {object} filterConfigs - Registered filter configs (for valueLabels + filterType gate).
+ * @return {object} Possibly-new map; reference equality preserved when unchanged.
+ */
+export function mergeRetainedFilterOptions( prev, aggregations, filterConfigs ) {
+	let next = prev;
+	for ( const [ filterKey, agg ] of Object.entries( aggregations ?? {} ) ) {
+		const config = filterConfigs?.[ filterKey ];
+		if ( ! config || config.filterType === 'date' ) {
+			continue;
+		}
+		const buckets = agg?.buckets;
+		if ( ! Array.isArray( buckets ) || buckets.length === 0 ) {
+			continue;
+		}
+		const existing = next?.[ filterKey ] ?? [];
+		const merged = mergeNewBucketsIntoOptions( existing, buckets, config.valueLabels );
+		if ( merged !== existing ) {
+			next = { ...( next ?? {} ), [ filterKey ]: merged };
+		}
+	}
+	return next;
+}
+
+/**
+ * Append any not-yet-seen bucket values to `existing`. Returns the same
+ * array reference when nothing new lands so the caller can use reference
+ * equality to skip a parent-object clone.
+ *
+ * @param {Array<object>} existing    - Prior `[{value, label}]` list.
+ * @param {Array<object>} buckets     - Aggregation buckets for this filter.
+ * @param {object|null}   valueLabels - Optional slug→label map (post_type).
+ * @return {Array<object>} Original or appended-to list.
+ */
+function mergeNewBucketsIntoOptions( existing, buckets, valueLabels ) {
+	const seen = new Set( existing.map( option => option.value ) );
+	let merged = existing;
+	for ( const bucket of buckets ) {
+		const value = bucketValue( bucket.key );
+		if ( seen.has( value ) ) {
+			continue;
+		}
+		seen.add( value );
+		if ( merged === existing ) {
+			merged = [ ...existing ];
+		}
+		merged.push( { value, label: bucketLabel( bucket.key, valueLabels ) } );
+	}
+	return merged;
 }
 
 /**
@@ -403,7 +536,7 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * `{ value, label, checked, showCount, countLabel }` items for the current
+		 * `{ value, label, showCount, countLabel }` items for the current
 		 * filter block. Dispatches on `filterType`. Lives on the shared
 		 * namespace so per-block view bundles don't clobber siblings.
 		 *
@@ -464,6 +597,11 @@ const { state, actions } = store( NAMESPACE, {
 				state.totalResults = data.total ?? 0;
 				state.pageHandle = data.page_handle ?? null;
 				state.aggregations = data.aggregations ?? {};
+				state.retainedFilterOptions = mergeRetainedFilterOptions(
+					state.retainedFilterOptions,
+					state.aggregations,
+					state.filterConfigs
+				);
 				if ( syncUrl ) {
 					actions.syncToUrl();
 				}
@@ -840,20 +978,13 @@ const { state, actions } = store( NAMESPACE, {
 
 		/**
 		 * Reactively syncs `context.wrapperHidden` for each filter-checkbox
-		 * block. Pre-hydration / first-fetch the wrapper stays visible so the
-		 * skeleton list inside has somewhere to render; once the first fetch
-		 * resolves it falls back to the legacy "hide empty filter sections"
-		 * behaviour. Runs in each block's local context, so this single
-		 * callback handles all filter blocks on the page.
+		 * block. The wrapper stays visible while the pre-hydration skeleton
+		 * is up; afterwards it hides only when the filter has nothing to
+		 * show (no buckets, no retained options, no active selection).
 		 */
 		syncFilterWrapperVisibility() {
 			const ctx = getContext();
-			if ( ! state.skeletonHidden ) {
-				ctx.wrapperHidden = false;
-				return;
-			}
-			const buckets = state.aggregations?.[ ctx.filterKey ]?.buckets;
-			ctx.wrapperHidden = ! Array.isArray( buckets ) || buckets.length === 0;
+			ctx.wrapperHidden = state.skeletonHidden && ! filterHasContent( state, ctx.filterKey );
 		},
 	},
 } );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -371,6 +371,7 @@ describe( 'syncFilterWrapperVisibility callback', () => {
 		captured.state.activeFilters = {};
 		captured.state.aggregations = {};
 		captured.state.retainedFilterOptions = {};
+		captured.state.filterConfigs = {};
 		captured.state.skeletonHidden = true;
 		contextRef.current = { filterKey: 'category', wrapperHidden: true };
 	} );
@@ -412,6 +413,19 @@ describe( 'syncFilterWrapperVisibility callback', () => {
 		captured.state.aggregations = { category: { buckets: [] } };
 		captured.state.retainedFilterOptions = {};
 		captured.state.activeFilters = {};
+		run();
+		expect( contextRef.current.wrapperHidden ).toBe( true );
+	} );
+
+	it( 'hides the date-filter wrapper when buckets are empty even with an active selection', () => {
+		// dateFilterItems doesn't render selected values that aren't in the
+		// current aggregation, so an active date selection alone shouldn't
+		// keep an otherwise-empty wrapper visible — the active-filters pills
+		// are the affordance for removing the selection in that state.
+		contextRef.current = { filterKey: 'post_date', wrapperHidden: false };
+		captured.state.filterConfigs = { post_date: { filterType: 'date' } };
+		captured.state.aggregations = { post_date: { buckets: [] } };
+		captured.state.activeFilters = { post_date: [ '2023-01-01' ] };
 		run();
 		expect( contextRef.current.wrapperHidden ).toBe( true );
 	} );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -3,6 +3,7 @@
 const captured = {
 	state: {},
 	actions: {},
+	callbacks: {},
 };
 const contextRef = { current: { filterKey: '' } };
 
@@ -21,20 +22,23 @@ jest.mock(
 					}
 				}
 				Object.assign( captured.actions, config.actions || {} );
+				Object.assign( captured.callbacks, config.callbacks || {} );
 			}
 			return { state: captured.state, actions: captured.actions };
 		},
 		getContext: () => contextRef.current,
+		withSyncEvent: cb => cb,
 	} ),
 	{ virtual: true }
 );
 
-require( '../../../src/search-blocks/store' );
+const { mergeRetainedFilterOptions } = require( '../../../src/search-blocks/store' );
 
 describe( 'filter-checkbox view store — filterItems', () => {
 	beforeEach( () => {
 		captured.state.activeFilters = {};
 		captured.state.aggregations = {};
+		captured.state.retainedFilterOptions = {};
 		captured.state.filterConfigs = {};
 		captured.state.locale = 'en-US';
 		contextRef.current = { filterKey: '' };
@@ -58,8 +62,15 @@ describe( 'filter-checkbox view store — filterItems', () => {
 			},
 		};
 		expect( captured.state.filterItems ).toEqual( [
-			{ value: 'post', label: 'Post', checked: false, showCount: true, countLabel: '12' },
-			{ value: 'page', label: 'Page', checked: false, showCount: true, countLabel: '4' },
+			{
+				value: 'post',
+				label: 'Post',
+				showCount: true,
+				countLabel: '12',
+				count: 12,
+				checked: false,
+			},
+			{ value: 'page', label: 'Page', showCount: true, countLabel: '4', count: 4, checked: false },
 		] );
 	} );
 
@@ -127,10 +138,6 @@ describe( 'filter-checkbox view store — filterItems', () => {
 	} );
 
 	it( 'resorts by display label when bucketSortOrder is `alpha`', () => {
-		// `_key: asc` would sort by slug — `food-news`, `restaurant-reviews`,
-		// `zebra-archive` — placing "Restaurant Reviews" between "Apple Pie"
-		// and "Zebra Archive". Sorting by visible label puts them in true
-		// alphabetical order from the visitor's POV.
 		contextRef.current = { filterKey: 'category' };
 		captured.state.aggregations = {
 			category: {
@@ -152,11 +159,6 @@ describe( 'filter-checkbox view store — filterItems', () => {
 	} );
 
 	it( 'sorts post-type items by valueLabels-derived label, not by slug', () => {
-		// Slug order would be `attachment`, `page`, `post` → "Files", "Page",
-		// "Post". Label order is the trio sorted alphabetically by visible
-		// name: "Files", "Page", "Post" — same in this case, but the test
-		// fixture uses a slug whose first letter differs from its label so
-		// the sort is provably driven by the label.
 		contextRef.current = { filterKey: 'post_types' };
 		captured.state.aggregations = {
 			post_types: {
@@ -178,6 +180,105 @@ describe( 'filter-checkbox view store — filterItems', () => {
 			'Media file',
 			'Page',
 			'Post',
+		] );
+	} );
+
+	it( 'merges retained options no longer in current aggregation with count 0', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: { buckets: [ { key: 'news/News', doc_count: 7 } ] },
+		};
+		captured.state.retainedFilterOptions = {
+			category: [
+				{ value: 'news', label: 'News' },
+				{ value: 'reviews', label: 'Reviews' },
+			],
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
+		};
+		const items = captured.state.filterItems;
+		expect( items.map( i => i.value ) ).toEqual( [ 'news', 'reviews' ] );
+		expect( items.find( i => i.value === 'reviews' ).countLabel ).toBe( '0' );
+	} );
+
+	it( 'sinks unchecked zero-count options to the bottom regardless of count sort', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'reviews/Reviews', doc_count: 3 },
+					{ key: 'news/News', doc_count: 9 },
+				],
+			},
+		};
+		captured.state.retainedFilterOptions = {
+			category: [
+				{ value: 'news', label: 'News' },
+				{ value: 'reviews', label: 'Reviews' },
+				{ value: 'archive', label: 'Archive' }, // 0 count, retained, unchecked.
+			],
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
+		};
+		const items = captured.state.filterItems;
+		expect( items.map( i => i.value ) ).toEqual( [ 'news', 'reviews', 'archive' ] );
+	} );
+
+	it( 'keeps a checked option in normal sort even when its current count is 0', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.activeFilters = { category: [ 'archive' ] };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'news/News', doc_count: 9 },
+					{ key: 'reviews/Reviews', doc_count: 3 },
+				],
+			},
+		};
+		captured.state.retainedFilterOptions = {
+			category: [
+				{ value: 'news', label: 'News' },
+				{ value: 'reviews', label: 'Reviews' },
+				{ value: 'archive', label: 'Archive' },
+			],
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'alpha', valueLabels: {} },
+		};
+		// Alphabetical: Archive, News, Reviews. Archive is checked + count 0 but
+		// stays in its alphabetical position because the zero-count demotion
+		// only applies to UNchecked options.
+		expect( captured.state.filterItems.map( i => i.value ) ).toEqual( [
+			'archive',
+			'news',
+			'reviews',
+		] );
+	} );
+
+	it( 'renders selected values that are not in any aggregation yet (URL-seeded deep link)', () => {
+		contextRef.current = { filterKey: 'post_types' };
+		captured.state.activeFilters = { post_types: [ 'post' ] };
+		captured.state.aggregations = {};
+		captured.state.retainedFilterOptions = {};
+		captured.state.filterConfigs = {
+			post_types: {
+				showCount: true,
+				bucketSortOrder: 'count',
+				valueLabels: { post: 'Post' },
+			},
+		};
+		const items = captured.state.filterItems;
+		expect( items ).toEqual( [
+			{
+				value: 'post',
+				label: 'Post',
+				showCount: true,
+				countLabel: '0',
+				count: 0,
+				checked: true,
+			},
 		] );
 	} );
 
@@ -203,5 +304,115 @@ describe( 'filter-checkbox view store — filterItems', () => {
 			{ value: '2024-01-01', checked: true },
 			{ value: '2025-01-01', checked: false },
 		] );
+	} );
+} );
+
+describe( 'mergeRetainedFilterOptions', () => {
+	it( 'adds new bucket values to the retained list', () => {
+		const next = mergeRetainedFilterOptions(
+			{},
+			{ category: { buckets: [ { key: 'news/News' }, { key: 'reviews/Reviews' } ] } },
+			{ category: { filterType: 'taxonomy', valueLabels: {} } }
+		);
+		expect( next ).toEqual( {
+			category: [
+				{ value: 'news', label: 'News' },
+				{ value: 'reviews', label: 'Reviews' },
+			],
+		} );
+	} );
+
+	it( 'preserves earlier values not present in the new aggregation', () => {
+		const prev = {
+			category: [
+				{ value: 'news', label: 'News' },
+				{ value: 'archive', label: 'Archive' },
+			],
+		};
+		const next = mergeRetainedFilterOptions(
+			prev,
+			{ category: { buckets: [ { key: 'news/News' }, { key: 'reviews/Reviews' } ] } },
+			{ category: { filterType: 'taxonomy', valueLabels: {} } }
+		);
+		expect( next.category.map( o => o.value ) ).toEqual( [ 'news', 'archive', 'reviews' ] );
+	} );
+
+	it( 'returns the same reference when no new values are added', () => {
+		const prev = { category: [ { value: 'news', label: 'News' } ] };
+		const next = mergeRetainedFilterOptions(
+			prev,
+			{ category: { buckets: [ { key: 'news/News' } ] } },
+			{ category: { filterType: 'taxonomy', valueLabels: {} } }
+		);
+		expect( next ).toBe( prev );
+	} );
+
+	it( 'skips date filters', () => {
+		const next = mergeRetainedFilterOptions(
+			{},
+			{ post_date: { buckets: [ { key: 1700000000, key_as_string: '2023' } ] } },
+			{ post_date: { filterType: 'date' } }
+		);
+		expect( next ).toEqual( {} );
+	} );
+
+	it( 'tolerates a missing `prev` map', () => {
+		const next = mergeRetainedFilterOptions(
+			undefined,
+			{ category: { buckets: [ { key: 'news/News' } ] } },
+			{ category: { filterType: 'taxonomy', valueLabels: {} } }
+		);
+		expect( next ).toEqual( { category: [ { value: 'news', label: 'News' } ] } );
+	} );
+} );
+
+describe( 'syncFilterWrapperVisibility callback', () => {
+	beforeEach( () => {
+		captured.state.activeFilters = {};
+		captured.state.aggregations = {};
+		captured.state.retainedFilterOptions = {};
+		captured.state.skeletonHidden = true;
+		contextRef.current = { filterKey: 'category', wrapperHidden: true };
+	} );
+
+	const run = () => captured.callbacks.syncFilterWrapperVisibility();
+
+	it( 'keeps the wrapper visible while the skeleton is still showing', () => {
+		captured.state.skeletonHidden = false;
+		captured.state.aggregations = {};
+		run();
+		expect( contextRef.current.wrapperHidden ).toBe( false );
+	} );
+
+	it( 'shows the wrapper when the latest aggregation has buckets', () => {
+		captured.state.aggregations = { category: { buckets: [ { key: 'news/News' } ] } };
+		run();
+		expect( contextRef.current.wrapperHidden ).toBe( false );
+	} );
+
+	it( 'shows the wrapper when retained options exist even with no current buckets', () => {
+		captured.state.aggregations = {};
+		captured.state.retainedFilterOptions = { category: [ { value: 'news', label: 'News' } ] };
+		run();
+		expect( contextRef.current.wrapperHidden ).toBe( false );
+	} );
+
+	it( 'shows the wrapper when a selection exists with no buckets and nothing retained', () => {
+		// URL-seeded deep link before the first fetch resolves: the user must
+		// be able to see (and uncheck) the selected value, so the wrapper
+		// can't hide out from under it.
+		captured.state.aggregations = {};
+		captured.state.retainedFilterOptions = {};
+		captured.state.activeFilters = { category: [ 'cat-a' ] };
+		run();
+		expect( contextRef.current.wrapperHidden ).toBe( false );
+	} );
+
+	it( 'hides the wrapper only when there is nothing to show — no buckets, no retained, no selection', () => {
+		captured.state.aggregations = { category: { buckets: [] } };
+		captured.state.retainedFilterOptions = {};
+		captured.state.activeFilters = {};
+		run();
+		expect( contextRef.current.wrapperHidden ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes [SEARCH-178](https://linear.app/a8c/issue/SEARCH-178/checkbox-filter-retain-options-across-searches-and-prioritize-by)

## Why

When a visitor narrows a search, checkbox filter lists currently rebuild from the latest aggregation response — options pop in and out, the list reorders, and a value the visitor has just selected can disappear from the checkboxes the moment the result set no longer contains it. A shared link with a stale selection (`?category=foo` for a `foo` that has zero matches today) lands in the same state. This change keeps the list stable across searches, leaves selected values visible and uncheckable in place, and pushes empty unchecked options to the bottom so what's actionable stays at the top.

## Proposed changes

* **Retain previously-seen options.** A new `retainedFilterOptions` map is updated on every successful search. Options that have appeared in any response stay in the list — their counts update, but they don't vanish when a narrower query drops them.
* **Show selected values in the list.** `checkboxFilterItems` no longer filters selected values out. Each item carries a `checked` flag and the input binds `data-wp-bind--checked`, so selections appear checked right in the filter block (still removable via the active-filters pills too — both paths now work).
* **Render URL-seeded deep links pre-fetch.** Selected values that haven't appeared in any aggregation yet still render — checked, count `0`, label falling back to the value when no `valueLabels` mapping exists — so a shared link is recoverable as soon as JS hydrates, even before the first fetch resolves.
* **Sort tweak.** Configured `bucketSortOrder` (`count` desc / `alpha`) is preserved with one rule layered on top: **unchecked** options with count `0` sink to the bottom. A checked option keeps its normal sort position even at count `0`, so the visitor always sees what they have selected.
* **Drop the now-redundant `allBucketsSelected` binding from the checkbox render.** The getter still serves filter-date.

Tests cover bucket-only render, retained-merge with zero counts, the zero-count demotion, the checked-but-zero exception, the URL-seeded fallback, and the merge helper itself (5 cases). Existing 16 filter-checkbox tests + 319 search-blocks tests + 294 PHP tests pass.

## Related product discussion/links

* [SEARCH-178](https://linear.app/a8c/issue/SEARCH-178/checkbox-filter-retain-options-across-searches-and-prioritize-by)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Real-screen before / after

Captured at `/?page_id=2137` (a demo page with two `jetpack-search/filter-checkbox` blocks) on a local docker WP. The store was driven directly so the same fixture data could be applied to both branches; the visitor flow being demonstrated is: select **Cat A**, then run a narrower query whose result set no longer contains Cat A or Cat C.

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/db7e8e57-9839-4da1-af0b-d0801535d27c) | ![after](https://github.com/user-attachments/assets/1527ad57-1d20-4c7c-92ac-d186cbca7ab7) |

In the **Before** column only the two buckets returned by the narrower query appear (`Cat B 5`, `arrangement 2`). The visitor's selection (`Cat A`) and the previously-seen `Cat C` are gone — `Cat A` can only be removed via the active-filters pills.

In the **After** column `Cat A` stays in the list, **checked**, with count `0`, in its sort-driven position; previously-seen `antiquarianism` and `Cat C` stay too but sink to the bottom because they are unchecked and their current count is `0`. The same retention rule applies in the post-types list (`Product` retained at the bottom with count `0`).

### Manual repro on a Search 3.0 page

1. Place two `jetpack-search/filter-checkbox` blocks on a page (one taxonomy = `category` with `bucketSortOrder: count`, one `filterType: post_type` with `bucketSortOrder: alpha`) plus `jetpack-search/search-input` and `jetpack-search/search-results`. Or copy the demo content from `https://jp-<agent>.jurassic.tube/?page_id=2137` if testing in a per-agent docker env.
2. Run a broad search that surfaces several buckets per filter.
3. Select one option in each filter, then type a narrower query.
4. **Verify** the selected options remain in the list, checked, with their counts updated (likely `0`). Other previously-seen options also remain, unchecked, and sink below any non-zero options.
5. **Verify** unchecking a selection from inside the filter block re-runs the search (pill in the active-filters block also updates).
6. **Verify** loading a URL like `/?s=anything&category[]=cat-a` where `cat-a` has zero matches still renders `cat-a` checked and uncheckable in the filter block.
7. **Verify** changing `bucketSortOrder` between `count` and `alpha` continues to apply within the non-sunk group.
