### PR TITLE
Activity Log: add dynamic "Performed by" filter

### DIFF
--- a/projects/packages/activity-log/changelog/add-mcp-agent-filter-to-activity-log
+++ b/projects/packages/activity-log/changelog/add-mcp-agent-filter-to-activity-log
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Activity Log: add a "Performed by" filter that lists every actor with at least one event in the selected date range, including MCP agents. Filtering applies server-side so totals and pagination stay correct.
+Activity Log: add a "Performed by" filter for narrowing the log by actor, including MCP agents. Filtering is applied server-side so totals and pagination stay correct.

--- a/projects/packages/activity-log/changelog/add-mcp-agent-filter-to-activity-log
+++ b/projects/packages/activity-log/changelog/add-mcp-agent-filter-to-activity-log
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Activity Log: add a "Performed by" filter to isolate events recorded by MCP agents on the current page.
+Activity Log: add a "Performed by" filter that lists every actor with at least one event in the selected date range, including MCP agents. Filtering applies server-side so totals and pagination stay correct.

--- a/projects/packages/activity-log/changelog/add-mcp-agent-filter-to-activity-log
+++ b/projects/packages/activity-log/changelog/add-mcp-agent-filter-to-activity-log
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Activity Log: add a "Performed by" filter to isolate events recorded by MCP agents on the current page.

--- a/projects/packages/activity-log/src/class-rest-controller.php
+++ b/projects/packages/activity-log/src/class-rest-controller.php
@@ -114,6 +114,39 @@ class REST_Controller {
 				'description' => __( 'Full-text search string.', 'jetpack-activity-log' ),
 				'type'        => 'string',
 			),
+			'actor'       => array(
+				'description' => __( 'Only return events performed by these actor IDs.', 'jetpack-activity-log' ),
+				'type'        => 'array',
+				'items'       => array( 'type' => 'string' ),
+			),
+		);
+	}
+
+	/**
+	 * Query params accepted by the actors endpoint. Same date window as the
+	 * counts endpoint (no pagination, no sort, no filters) — we just want
+	 * the distinct set for the "Performed by" dropdown.
+	 *
+	 * @return array
+	 */
+	private static function actors_args() {
+		return array(
+			'number' => array(
+				'description' => __( 'Cap on the number of events considered when collecting actors.', 'jetpack-activity-log' ),
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'maximum'     => 1000,
+			),
+			'after'  => array(
+				'description' => __( 'ISO 8601 lower bound on event timestamp.', 'jetpack-activity-log' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+			),
+			'before' => array(
+				'description' => __( 'ISO 8601 upper bound on event timestamp.', 'jetpack-activity-log' ),
+				'type'        => 'string',
+				'format'      => 'date-time',
+			),
 		);
 	}
 
@@ -179,6 +212,17 @@ class REST_Controller {
 				'callback'            => array( __CLASS__, 'get_activity_log_group_counts' ),
 				'permission_callback' => array( __CLASS__, 'permissions_callback' ),
 				'args'                => self::group_counts_args(),
+			)
+		);
+
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/activity-log/actors',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_activity_log_actors' ),
+				'permission_callback' => array( __CLASS__, 'permissions_callback' ),
+				'args'                => self::actors_args(),
 			)
 		);
 	}
@@ -286,7 +330,7 @@ class REST_Controller {
 	 *   1. `number` is clamped to {@see self::FREE_TIER_ITEM_CAP}.
 	 *   2. `page` is forced to 1.
 	 *   3. All filter inputs (`after`, `before`, `group`, `not_group`,
-	 *      `text_search`) are dropped.
+	 *      `text_search`, `actor`) are dropped.
 	 *
 	 * Together these mean a client-side bypass (DevTools, direct
 	 * `wp.apiFetch`) is bounded to "the 20 most recent events overall" —
@@ -336,6 +380,22 @@ class REST_Controller {
 	 */
 	public static function get_activity_log_group_counts( WP_REST_Request $request ) {
 		return self::proxy_get( '/activity/count/group', $request, array_keys( self::group_counts_args() ) );
+	}
+
+	/**
+	 * Proxy the actors endpoint. Returns the distinct actors that have at
+	 * least one event in the requested date window — used to populate the
+	 * "Performed by" filter dropdown.
+	 *
+	 * Tier-clamping mirrors the group-counts endpoint: the list clamp at
+	 * {@see self::get_activity_log()} is the security boundary, so the
+	 * actors metadata is fine to serve unconditionally.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return mixed
+	 */
+	public static function get_activity_log_actors( WP_REST_Request $request ) {
+		return self::proxy_get( '/activity/actors', $request, array_keys( self::actors_args() ) );
 	}
 
 	/**

--- a/projects/packages/activity-log/src/js/components/ActivityLog/activity-transformer.ts
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/activity-transformer.ts
@@ -75,6 +75,7 @@ export const transformActivityLogEntry = ( entry: ActivityLogEntry ): Activity =
 		activityUnparsedTs: published ?? '',
 		activityTs: parseTimestamp( published ),
 		activityActor: {
+			actorId: actor?.id,
 			actorAvatarUrl: actor?.icon?.url,
 			actorName: actor?.name,
 			actorRole: actor?.role,

--- a/projects/packages/activity-log/src/js/components/ActivityLog/fields.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/fields.tsx
@@ -337,6 +337,20 @@ export function useActivityFields( {
 				elements: activityLogTypeElements,
 				isVisible: () => false,
 				filterBy: { operators: [ 'isAny' as Operator ] },
+			},
+			{
+				// Hidden field that powers the "Performed by" filter dropdown.
+				// `getValue` returns 'mcp' for MCP-driven events so the
+				// `isAny` filter matches when the user picks "MCP Agent".
+				// Rows performed by humans/CLI/Happiness return an empty
+				// string and are hidden whenever any element is selected.
+				id: 'actor_source',
+				type: 'text',
+				label: __( 'Performed by', 'jetpack-activity-log' ),
+				getValue: ( { item } ) => ( item.activityActor?.isMcpAgent ? 'mcp' : '' ),
+				elements: [ { value: 'mcp', label: __( 'MCP Agent', 'jetpack-activity-log' ) } ],
+				isVisible: () => false,
+				filterBy: { operators: [ 'isAny' as Operator ] },
 			}
 		);
 

--- a/projects/packages/activity-log/src/js/components/ActivityLog/fields.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/fields.tsx
@@ -9,7 +9,7 @@ import {
 	ActivityEventIcon,
 	ActivityEventTitle,
 } from './ActivityEvent';
-import type { Activity, ActivityLogGroupCountResponse } from './types';
+import type { Activity, ActivityLogGroupCountResponse, ActorSummary } from './types';
 import type { Field, Operator } from '@wordpress/dataviews';
 
 export type ActivityLogTypeOption = {
@@ -21,6 +21,7 @@ type UseActivityFieldsArgs = {
 	timezoneString?: string;
 	gmtOffset?: number;
 	activityLogTypes?: ActivityLogGroupCountResponse[ 'groups' ] | undefined;
+	actors?: ActorSummary[];
 };
 
 /**
@@ -159,18 +160,21 @@ const formatDateCell = ( {
  * Build the DataViews `fields` array for the Activity Log table: the
  * Date & time column (optionally paired with a UTC column when the site
  * isn't already on UTC), the Event cell, the User cell, and the hidden
- * `activity_type` field that powers the filter dropdown.
+ * `activity_type` / `actor` fields that power the filter dropdowns.
  *
  * @param args                  - Hook options.
  * @param args.timezoneString   - IANA timezone (e.g. "Europe/London").
  * @param args.gmtOffset        - Decimal hour offset from UTC.
  * @param args.activityLogTypes - Group map from /activity-log/count/group.
+ * @param args.actors           - Distinct actors from /activity-log/actors,
+ *                              used to populate the "Performed by" dropdown.
  * @return The fields array passed to `<DataViews fields=… />`.
  */
 export function useActivityFields( {
 	timezoneString,
 	gmtOffset,
 	activityLogTypes,
+	actors,
 }: UseActivityFieldsArgs ): Field< Activity >[] {
 	const isLargeScreen = useViewportMatch( 'huge', '>=' );
 	const dateTimeLabel = getDateTimeLabel( { timezoneString, gmtOffset, isLargeScreen } );
@@ -187,6 +191,20 @@ export function useActivityFields( {
 			} ) )
 			.sort( ( a, b ) => a.label.localeCompare( b.label ) );
 	}, [ activityLogTypes ] );
+
+	const actorElements = useMemo< ActivityLogTypeOption[] >( () => {
+		if ( ! actors || actors.length === 0 ) {
+			return [];
+		}
+		return actors
+			.filter( actor => actor.id )
+			.map( actor => {
+				const name = actor.name || actor.id;
+				const label = typeof actor.count === 'number' ? `${ name } (${ actor.count })` : name;
+				return { value: actor.id, label };
+			} )
+			.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+	}, [ actors ] );
 
 	return useMemo( () => {
 		const fields: Field< Activity >[] = [
@@ -339,16 +357,17 @@ export function useActivityFields( {
 				filterBy: { operators: [ 'isAny' as Operator ] },
 			},
 			{
-				// Hidden field that powers the "Performed by" filter dropdown.
-				// `getValue` returns 'mcp' for MCP-driven events so the
-				// `isAny` filter matches when the user picks "MCP Agent".
-				// Rows performed by humans/CLI/Happiness return an empty
-				// string and are hidden whenever any element is selected.
-				id: 'actor_source',
+				// Hidden field that powers the "Performed by" filter
+				// dropdown. Elements are seeded from /activity-log/actors,
+				// so each entry matches a distinct actor across the date
+				// window. The actual filtering happens server-side via
+				// `actor[]` on the list endpoint — `getValue` is wired up
+				// only so the filter pill can render the selected label.
+				id: 'actor',
 				type: 'text',
 				label: __( 'Performed by', 'jetpack-activity-log' ),
-				getValue: ( { item } ) => ( item.activityActor?.isMcpAgent ? 'mcp' : '' ),
-				elements: [ { value: 'mcp', label: __( 'MCP Agent', 'jetpack-activity-log' ) } ],
+				getValue: ( { item } ) => item.activityActor?.actorId ?? '',
+				elements: actorElements,
 				isVisible: () => false,
 				filterBy: { operators: [ 'isAny' as Operator ] },
 			}
@@ -361,6 +380,7 @@ export function useActivityFields( {
 		dateTimeLabel,
 		activityLogTypeElements,
 		activityLogTypes,
+		actorElements,
 		localIsUTC,
 	] );
 }

--- a/projects/packages/activity-log/src/js/components/ActivityLog/filters.ts
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/filters.ts
@@ -15,8 +15,8 @@ export const extractActivityLogTypeValues = ( filters: Filter[] ): string[] => {
 	return [];
 };
 
-export const extractActorSourceValues = ( filters: Filter[] ): string[] => {
-	const filter = filters.find( item => item.field === 'actor_source' );
+export const extractActorIdValues = ( filters: Filter[] ): string[] => {
+	const filter = filters.find( item => item.field === 'actor' );
 	if ( ! filter ) {
 		return [];
 	}

--- a/projects/packages/activity-log/src/js/components/ActivityLog/filters.ts
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/filters.ts
@@ -14,3 +14,18 @@ export const extractActivityLogTypeValues = ( filters: Filter[] ): string[] => {
 	}
 	return [];
 };
+
+export const extractActorSourceValues = ( filters: Filter[] ): string[] => {
+	const filter = filters.find( item => item.field === 'actor_source' );
+	if ( ! filter ) {
+		return [];
+	}
+	const { value } = filter;
+	if ( Array.isArray( value ) ) {
+		return value.filter( ( item ): item is string => typeof item === 'string' && item.length > 0 );
+	}
+	if ( typeof value === 'string' && value.length > 0 ) {
+		return [ value ];
+	}
+	return [];
+};

--- a/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
@@ -12,7 +12,11 @@ import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import fastDeepEqual from 'fast-deep-equal/es6';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { activityLogQuery, activityLogGroupCountsQuery } from '../../hooks/use-activity-log';
+import {
+	activityLogQuery,
+	activityLogGroupCountsQuery,
+	activityLogActorsQuery,
+} from '../../hooks/use-activity-log';
 import { useAnalytics } from '../../hooks/use-analytics';
 import { usePersistentView } from '../../hooks/use-persistent-view';
 import { DateRangePicker } from '../DateRangePicker';
@@ -21,7 +25,7 @@ import { UpsellCallout } from './UpsellCallout';
 import { useActivityActions } from './actions';
 import { transformActivityLogEntry } from './activity-transformer';
 import { useActivityFields } from './fields';
-import { extractActivityLogTypeValues, extractActorSourceValues } from './filters';
+import { extractActivityLogTypeValues, extractActorIdValues } from './filters';
 import { DEFAULT_LAYOUTS, DEFAULT_VIEW } from './views';
 import type { Activity, ActivityLogParams } from './types';
 import type { Field, Filter, View } from '@wordpress/dataviews';
@@ -153,9 +157,9 @@ export default function ActivityLog() {
 		return extractActivityLogTypeValues( filters );
 	}, [ view.filters ] );
 
-	const actorSourceValues = useMemo( () => {
+	const actorIdValues = useMemo( () => {
 		const filters = ( view.filters as Filter[] | undefined ) ?? [];
-		return extractActorSourceValues( filters );
+		return extractActorIdValues( filters );
 	}, [ view.filters ] );
 
 	const searchTerm = view.search?.trim() ?? '';
@@ -189,6 +193,9 @@ export default function ActivityLog() {
 		if ( activityLogTypeValues.length ) {
 			params.group = activityLogTypeValues;
 		}
+		if ( actorIdValues.length ) {
+			params.actor = actorIdValues;
+		}
 		return params;
 	}, [
 		view.sort?.direction,
@@ -196,6 +203,7 @@ export default function ActivityLog() {
 		view.page,
 		searchTerm,
 		activityLogTypeValues,
+		actorIdValues,
 		afterIso,
 		beforeIso,
 	] );
@@ -224,7 +232,19 @@ export default function ActivityLog() {
 		} )
 	);
 
-	const isFetching = isFetchingData || isFetchingFilters;
+	// Actors query feeds the "Performed by" dropdown. Same date window as
+	// the list / counts queries so the available options match what's on
+	// screen, and intentionally independent of the current filter state so
+	// selections don't shrink the dropdown to themselves.
+	const { data: actorsData, isFetching: isFetchingActors } = useQuery(
+		activityLogActorsQuery( {
+			number: 1000,
+			after: afterIso,
+			before: beforeIso,
+		} )
+	);
+
+	const isFetching = isFetchingData || isFetchingFilters || isFetchingActors;
 
 	const paginationInfo = {
 		totalItems: activityLogData?.totalItems ?? 0,
@@ -239,6 +259,7 @@ export default function ActivityLog() {
 		gmtOffset,
 		timezoneString,
 		activityLogTypes: groupCountsData?.groups,
+		actors: actorsData?.actors,
 	} );
 
 	const actions = useActivityActions( { isLoading: isFetching, tracks } );
@@ -275,10 +296,11 @@ export default function ActivityLog() {
 			if ( filtersChanged ) {
 				const nextFilters = ( next.filters as Filter[] | undefined ) ?? [];
 				const activityTypes = extractActivityLogTypeValues( nextFilters );
-				const actorSources = extractActorSourceValues( nextFilters );
+				const actorIds = extractActorIdValues( nextFilters );
 				const eventProps: Record< string, boolean | number > = {
 					num_groups_selected: activityTypes.length,
-					mcp_agent_filter_selected: actorSources.includes( 'mcp' ),
+					num_actors_selected: actorIds.length,
+					actor_filter_includes_mcp: actorIds.some( id => id.startsWith( 'mcp:' ) ),
 				};
 				let totalActivitiesSelected = 0;
 				Object.entries( groupCountsData?.groups ?? {} ).forEach( ( [ groupKey, { count } ] ) => {
@@ -333,18 +355,7 @@ export default function ActivityLog() {
 
 	const getItemId = useCallback( ( item: Activity ) => item.activityId.toString(), [] );
 
-	// "Performed by" is filtered client-side on the current page. The list
-	// query stays server-paginated, so selecting "MCP Agent" only hides
-	// non-MCP rows in the rows already fetched — paginationInfo and the
-	// total counts are intentionally left untouched.
-	const logData = useMemo( () => {
-		const items = ( activityLogData?.activityLogs ?? [] ) as Activity[];
-		if ( actorSourceValues.length === 0 ) {
-			return items;
-		}
-		const wantsMcp = actorSourceValues.includes( 'mcp' );
-		return items.filter( item => wantsMcp && Boolean( item.activityActor?.isMcpAgent ) );
-	}, [ activityLogData?.activityLogs, actorSourceValues ] );
+	const logData = ( activityLogData?.activityLogs ?? [] ) as Activity[];
 
 	// Mounting the picker as an admin-ui `actions` slot places it in the
 	// AdminPage header alongside the title/subtitle — matches MSD's

--- a/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
@@ -236,6 +236,12 @@ export default function ActivityLog() {
 	// the list / counts queries so the available options match what's on
 	// screen, and intentionally independent of the current filter state so
 	// selections don't shrink the dropdown to themselves.
+	//
+	// `number: 1000` matches the upstream REST schema's max for events
+	// scanned. On very large windows where >1000 events exist, actors who
+	// only appear beyond the scan horizon won't surface in the dropdown
+	// — bumping that ceiling would need a coordinated change to the
+	// Jetpack proxy and the WPCOM endpoint.
 	const { data: actorsData, isFetching: isFetchingActors } = useQuery(
 		activityLogActorsQuery( {
 			number: 1000,

--- a/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
@@ -21,7 +21,7 @@ import { UpsellCallout } from './UpsellCallout';
 import { useActivityActions } from './actions';
 import { transformActivityLogEntry } from './activity-transformer';
 import { useActivityFields } from './fields';
-import { extractActivityLogTypeValues } from './filters';
+import { extractActivityLogTypeValues, extractActorSourceValues } from './filters';
 import { DEFAULT_LAYOUTS, DEFAULT_VIEW } from './views';
 import type { Activity, ActivityLogParams } from './types';
 import type { Field, Filter, View } from '@wordpress/dataviews';
@@ -153,6 +153,11 @@ export default function ActivityLog() {
 		return extractActivityLogTypeValues( filters );
 	}, [ view.filters ] );
 
+	const actorSourceValues = useMemo( () => {
+		const filters = ( view.filters as Filter[] | undefined ) ?? [];
+		return extractActorSourceValues( filters );
+	}, [ view.filters ] );
+
 	const searchTerm = view.search?.trim() ?? '';
 
 	// The picker hands us start-of-day / end-of-day Dates at local-midnight
@@ -268,11 +273,12 @@ export default function ActivityLog() {
 				} );
 			}
 			if ( filtersChanged ) {
-				const activityTypes = extractActivityLogTypeValues(
-					( next.filters as Filter[] | undefined ) ?? []
-				);
+				const nextFilters = ( next.filters as Filter[] | undefined ) ?? [];
+				const activityTypes = extractActivityLogTypeValues( nextFilters );
+				const actorSources = extractActorSourceValues( nextFilters );
 				const eventProps: Record< string, boolean | number > = {
 					num_groups_selected: activityTypes.length,
+					mcp_agent_filter_selected: actorSources.includes( 'mcp' ),
 				};
 				let totalActivitiesSelected = 0;
 				Object.entries( groupCountsData?.groups ?? {} ).forEach( ( [ groupKey, { count } ] ) => {
@@ -327,7 +333,18 @@ export default function ActivityLog() {
 
 	const getItemId = useCallback( ( item: Activity ) => item.activityId.toString(), [] );
 
-	const logData = ( activityLogData?.activityLogs ?? [] ) as Activity[];
+	// "Performed by" is filtered client-side on the current page. The list
+	// query stays server-paginated, so selecting "MCP Agent" only hides
+	// non-MCP rows in the rows already fetched — paginationInfo and the
+	// total counts are intentionally left untouched.
+	const logData = useMemo( () => {
+		const items = ( activityLogData?.activityLogs ?? [] ) as Activity[];
+		if ( actorSourceValues.length === 0 ) {
+			return items;
+		}
+		const wantsMcp = actorSourceValues.includes( 'mcp' );
+		return items.filter( item => wantsMcp && Boolean( item.activityActor?.isMcpAgent ) );
+	}, [ activityLogData?.activityLogs, actorSourceValues ] );
 
 	// Mounting the picker as an admin-ui `actions` slot places it in the
 	// AdminPage header alongside the title/subtitle — matches MSD's

--- a/projects/packages/activity-log/src/js/components/ActivityLog/types.ts
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/types.ts
@@ -6,6 +6,7 @@ export interface ActivityDescription {
 }
 
 export interface ActivityActorDetails {
+	actorId?: string;
 	actorAvatarUrl?: string;
 	actorName?: string;
 	actorRole?: string;
@@ -66,6 +67,7 @@ export interface ActivityNotificationRange {
 }
 
 export interface ActivityLogActor {
+	id?: string;
 	type?: 'Person' | 'Application' | 'Happiness Engineer';
 	name?: string;
 	role?: string;
@@ -122,6 +124,35 @@ export interface ActivityLogGroupCountResponse {
 	totalItems?: number;
 }
 
+/**
+ * Single entry in the /activity-log/actors response. `id` is the stable
+ * identifier the client sends back as a filter value; the rest are
+ * presentational. Mirrors the actor block on individual activity entries.
+ */
+export interface ActorSummary {
+	id: string;
+	type?: 'Person' | 'Application' | 'Happiness Engineer';
+	name?: string;
+	role?: string;
+	icon?: { url?: string };
+	is_cli?: boolean;
+	is_happiness?: boolean;
+	is_mcp_agent?: boolean;
+	mcp_client?: string;
+	count?: number;
+}
+
+export interface ActivityLogActorsResponse {
+	actors: ActorSummary[];
+	totalItems?: number;
+}
+
+export interface ActivityLogActorsParams {
+	number?: number;
+	after?: string;
+	before?: string;
+}
+
 export interface ActivityLogParams {
 	number?: number;
 	page?: number;
@@ -131,4 +162,5 @@ export interface ActivityLogParams {
 	group?: string[];
 	not_group?: string[];
 	text_search?: string;
+	actor?: string[];
 }

--- a/projects/packages/activity-log/src/js/hooks/use-activity-log.ts
+++ b/projects/packages/activity-log/src/js/hooks/use-activity-log.ts
@@ -10,6 +10,8 @@
 import { queryOptions } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import type {
+	ActivityLogActorsParams,
+	ActivityLogActorsResponse,
 	ActivityLogEntry,
 	ActivityLogGroupCountResponse,
 	ActivityLogParams,
@@ -40,7 +42,7 @@ interface RawActivityLogResponse {
  *               `key[]=value` pairs; undefined/null are dropped.
  * @return The combined path.
  */
-const buildPath = ( base: string, params: ActivityLogParams ): string => {
+const buildPath = ( base: string, params: ActivityLogParams | ActivityLogActorsParams ): string => {
 	const search = new URLSearchParams();
 	Object.entries( params ).forEach( ( [ key, value ] ) => {
 		if ( value === undefined || value === null ) {
@@ -95,6 +97,24 @@ export function activityLogGroupCountsQuery( params: ActivityLogParams ) {
 		queryFn: async (): Promise< ActivityLogGroupCountResponse > => {
 			return apiFetch< ActivityLogGroupCountResponse >( {
 				path: buildPath( '/jetpack/v4/activity-log/count/group', params ),
+			} );
+		},
+	} );
+}
+
+/**
+ * TanStack Query options for the actors endpoint powering the
+ * "Performed by" filter dropdown.
+ *
+ * @param params - Forwarded to the server as query params.
+ * @return `queryOptions` ready to pass to `useQuery`.
+ */
+export function activityLogActorsQuery( params: ActivityLogActorsParams ) {
+	return queryOptions( {
+		queryKey: [ 'jetpack-activity-log', 'actors', params ],
+		queryFn: async (): Promise< ActivityLogActorsResponse > => {
+			return apiFetch< ActivityLogActorsResponse >( {
+				path: buildPath( '/jetpack/v4/activity-log/actors', params ),
 			} );
 		},
 	} );


### PR DESCRIPTION
Fixes [AIINT-396](https://linear.app/a8c/issue/AIINT-396/jetpack-add-mcp-agent-filter-to-activity-log).

## Proposed changes

* New `GET /jetpack/v4/activity-log/actors` REST proxy that returns the distinct actors with at least one event in the date window. Powers the "Performed by" filter dropdown.
* Adds `actor[]` to the list endpoint args, with the existing free-tier filter strip covering it (no security regression).
* Adds `activityLogActorsQuery` (TanStack), `ActorSummary` / `ActivityLogActorsResponse` / `ActivityLogActorsParams` types, and threads the response through `useActivityFields`.
* The hidden filter field is now `actor` (was `actor_source`), with elements built dynamically from the actors response. `extractActorIdValues` mirrors the existing `extractActivityLogTypeValues` helper.
* Filtering is server-side via `params.actor`. The previous client-side `useMemo` over `logData` is gone, so `paginationInfo` and total counts stay correct.
* Tracks: `jetpack_activity_log_filter_changed` now records `num_actors_selected` and `actor_filter_includes_mcp` in place of the old `mcp_agent_filter_selected` boolean.

## Does this pull request change what data or activity we track or use?

Yes — the existing `jetpack_activity_log_filter_changed` Tracks event swaps `mcp_agent_filter_selected` (boolean) for two new props:

* `num_actors_selected: number`
* `actor_filter_includes_mcp: boolean`

`actor_filter_includes_mcp` is derived client-side from the selected actor IDs (any `mcp:*` prefix). No new event names; no new PII (actor IDs are opaque server identifiers).

## Demo

https://github.com/user-attachments/assets/75db80f5-fc15-4a7f-80f0-1454b6555a66

## Testing instructions

1. Spin up a site with Jetpack on the sandbox where AIINT-400 is deployed; ensure the Activity Log admin page renders (paid tier).
2. Make sure the activity stream contains events from a mix of actors over the selected date range — at least one human admin and one MCP-driven event.
3. Open the Activity Log page and click the filter toggle in the DataViews toolbar. Confirm a new **Performed by** dropdown appears alongside **Activity type** and lists the actors in the date window with their counts.
4. Select a single actor — only that actor's events should show, **across all pages** (`paginationInfo` and totals should reflect the filtered set, not just the current page).
5. Select multiple actors — the filter should OR together (matches the existing `group[]` semantics).
6. Open dev tools → Network. Toggling the filter fires `jetpack_activity_log_filter_changed` with `num_actors_selected` / `actor_filter_includes_mcp` props.
7. Free-tier path: log in as a free-tier user. Confirm the toolbar is still locked down (the existing inert overlay) and the actors endpoint returns its dropdown data harmlessly (no PII exposure beyond what's already on the count/group endpoint).
8. `pnpm typecheck` in `projects/packages/activity-log/` runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)