### PR TITLE
Plugin Conflicts Guardian: default pcg_guard_updates to true

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/pcg-guard-updates-default-true
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pcg-guard-updates-default-true
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Plugin Conflicts Guardian: pcg_guard_updates now defaults to true, enabling the post-update health check and rollback flow by default.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -5,7 +5,7 @@ Pre-flight plugin-activation check. When an admin clicks Activate (or finishes a
 Two independent filters:
 
 - `pcg_guard_activation` — enables the activation probe and the syntax-only install/update gate. Defaults `true`.
-- `pcg_guard_updates` — enables the post-update health check + rollback flow. Defaults `false`.
+- `pcg_guard_updates` — enables the post-update health check + rollback flow. Defaults `true`.
 
 ## Files
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
@@ -51,8 +51,7 @@ function pcg_maybe_handle_probe() {
 	// pull in the other as an unintended dependency.
 	$is_update_mode = PCG_Load_Tester::MODE_UPDATE === $mode;
 	$gate_filter    = $is_update_mode ? 'pcg_guard_updates' : 'pcg_guard_activation';
-	$gate_default   = ! $is_update_mode;
-	if ( ! apply_filters( $gate_filter, $gate_default ) ) {
+	if ( ! apply_filters( $gate_filter, true ) ) {
 		pcg_probe_bail_error( 'Plugin Conflicts Guardian is disabled.', 403 );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
@@ -26,7 +26,7 @@ add_action( 'admin_notices', 'pcg_healthcheck_render_notice' );
  * @return bool|WP_Error Passed through unchanged.
  */
 function pcg_healthcheck_capture_snapshot( $return, $hook_extra ) {
-	if ( ! apply_filters( 'pcg_guard_updates', false ) ) {
+	if ( ! apply_filters( 'pcg_guard_updates', true ) ) {
 		return $return;
 	}
 	if ( ! pcg_healthcheck_is_plugin_pre_install_update( $hook_extra ) ) {
@@ -66,7 +66,7 @@ function pcg_healthcheck_capture_snapshot( $return, $hook_extra ) {
  * @return void
  */
 function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $upgrader is the WP-Upgrader-supplied argument; we accept it for the action signature.
-	if ( ! apply_filters( 'pcg_guard_updates', false ) ) {
+	if ( ! apply_filters( 'pcg_guard_updates', true ) ) {
 		return;
 	}
 	if ( ! pcg_healthcheck_is_plugin_update( $hook_extra ) ) {


### PR DESCRIPTION
## Proposed changes

Follow-up to #48553 (which flipped `pcg_guard_activation` to default true). This flips the second gate, `pcg_guard_updates`, the same way:

* `update-healthcheck.php` — both `apply_filters( 'pcg_guard_updates', false )` callsites (snapshot capture on `upgrader_pre_install`, post-update healthcheck on `upgrader_process_complete`) now default `true`.
* `probe-endpoint.php` — drops the per-mode default split (`$gate_default = ! $is_update_mode`) introduced when only activation defaulted on. With both gates now default true the probe endpoint applies `true` uniformly: `apply_filters( $gate_filter, true )`.
* `README.md` — updates the `pcg_guard_updates` line to "Defaults `true`."

No behavior change for sites that have explicitly filtered `pcg_guard_updates` to `false`. For everyone else: post-update probes run, and a fatal-on-update triggers the snapshot-based rollback flow that PCG already had wired up but defaulted dark.

## Related product discussion/links

* Prior switch: #48553 (defaulted `pcg_guard_activation` to true).

## Does this pull request change what data or activity we track or use?

Indirectly — `pcg_guard_updates` controls whether the `Update rolled back` logstash event from #48565 fires in the wild. The event payload itself is unchanged.

## Testing instructions

1. Sync `jetpack-mu-wpcom` to a test site (no explicit `pcg_guard_updates` filter set).
2. Install a "good" plugin and activate it.
3. Update it to a version that fatals only at runtime (passes the parse-error gate).
4. Expected: post-update probe fails, plugin rolls back to its snapshot, admin notice points at the failed update, and one `Update rolled back` row lands in the `plugin-conflicts-guardian` logstash bucket.
5. Add `add_filter( 'pcg_guard_updates', '__return_false' );` and repeat — expected: snapshot is not captured, no probe runs, update completes (or fatals) without rollback.
6. Activation guard regression check: clicking Activate on a fataling plugin still blocks via the activation guard (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)