### PR TITLE
Fatal error: tag log events with request context

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-event-request-context
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-event-request-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fatal error: tag log events with request_kind/path/method and dedup per (signature, kind) so a site-wide fatal surfaces as one row per affected surface.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -149,10 +149,10 @@ function wpcomsh_fatal_log_deactivate( $plugin_basename ) {
  * @return array{kind:string,path:string,method:string}
  */
 function wpcomsh_fatal_request_context() {
-	$req_uri  = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' );
+	$req_uri  = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 	$raw_path = (string) wp_parse_url( $req_uri, PHP_URL_PATH );
 	$path     = rtrim( $raw_path, '/' );
-	$method   = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ) );
+	$method   = strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ) );
 
 	$kind = 'other';
 	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || str_ends_with( $path, '/wp-cron.php' ) ) {

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -134,10 +134,63 @@ function wpcomsh_fatal_log_deactivate( $plugin_basename ) {
 }
 
 /**
+ * Bucket the in-flight HTTP request into a coarse kind for telemetry,
+ * along with the path and method. Kind drives dedup; path and method
+ * ride on the row for drill-down.
+ *
+ * Buckets, in priority order: `cron`, `ajax`, `rest`, `wp-login`,
+ * `wp-admin`, `home`, `other`. Order matters because `admin-ajax.php`
+ * lives under `/wp-admin/`, so the more-specific buckets win first.
+ *
+ * Best-effort: option lookups (`admin_url()`, `home_url()`) are wrapped
+ * in try/catch so a misbehaving filter can't bubble out of the fatal
+ * handler.
+ *
+ * @return array{kind:string,path:string,method:string}
+ */
+function wpcomsh_fatal_request_context() {
+	$req_uri  = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' );
+	$raw_path = (string) wp_parse_url( $req_uri, PHP_URL_PATH );
+	$path     = rtrim( $raw_path, '/' );
+	$method   = strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ) );
+
+	$kind = 'other';
+	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || str_ends_with( $path, '/wp-cron.php' ) ) {
+		$kind = 'cron';
+	} elseif ( ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || str_ends_with( $path, '/admin-ajax.php' ) ) {
+		$kind = 'ajax';
+	} elseif ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || str_contains( $path, '/wp-json' ) ) {
+		$kind = 'rest';
+	} elseif ( str_ends_with( $path, '/wp-login.php' ) ) {
+		$kind = 'wp-login';
+	} else {
+		try {
+			$admin_path = rtrim( (string) wp_parse_url( admin_url(), PHP_URL_PATH ), '/' );
+			if ( '' !== $admin_path && str_starts_with( $path . '/', $admin_path . '/' ) ) {
+				$kind = 'wp-admin';
+			} else {
+				$home_path = rtrim( (string) wp_parse_url( home_url( '/' ), PHP_URL_PATH ), '/' );
+				if ( $home_path === $path ) {
+					$kind = 'home';
+				}
+			}
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: option lookup must not bubble during fatal handling.
+			// Fall through with $kind = 'other'.
+		}
+	}
+
+	return array(
+		'kind'   => $kind,
+		'path'   => '' === $path ? '/' : $path,
+		'method' => '' === $method ? 'UNKNOWN' : $method,
+	);
+}
+
+/**
  * Emit a fatal-error event keyed on a suspected extension. Builds the
- * signature, dedups per (message, signature) for 1 hour, and routes
- * through `wpcomsh_fatal_emit_logstash` so the recovery-login event can
- * share the same dispatch tail.
+ * signature, dedups per (message, signature, request_kind) for 1 hour,
+ * and routes through `wpcomsh_fatal_emit_logstash` so the recovery-login
+ * event can share the same dispatch tail.
  *
  * @param array|null $plugin  Extension metadata from wpcomsh_fatal_identify_plugin().
  * @param string     $message Event message slug (e.g. `wpcomsh_fatal_signature`, `wpcomsh_fatal_deactivate`).
@@ -169,14 +222,19 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 		return;
 	}
 
-	// Dedup per (message, signature) for 1 hour so a persistent fatal doesn't
-	// emit one log row + one outbound HTTP per visitor. $message is part of
-	// the key so a deactivate event isn't suppressed by a recent signature
-	// event for the same extension. The TTL stays short of core's 24h
-	// `recovery_mode_email_rate_limit` so a legitimate re-send — e.g. the
-	// admin exits recovery mode and the site fatals again — surfaces rather
-	// than getting silently swallowed.
-	$cache_key = 'wpcomsh_fatal_event:' . hash( 'sha256', $message . '|' . $signature );
+	$context = wpcomsh_fatal_request_context();
+
+	// Dedup per (message, signature, request_kind) for 1 hour so a persistent
+	// fatal doesn't emit one log row + one outbound HTTP per visitor. $message
+	// is part of the key so a deactivate event isn't suppressed by a recent
+	// signature event for the same extension. request_kind is part of the key
+	// so a fatal that hits both wp-admin and a front-end URL surfaces as two
+	// rows — that's the signal that distinguishes site-wide breakage from a
+	// single endpoint, which the in-request handler can't otherwise tell.
+	// The TTL stays short of core's 24h `recovery_mode_email_rate_limit` so a
+	// legitimate re-send — e.g. the admin exits recovery mode and the site
+	// fatals again — surfaces rather than getting silently swallowed.
+	$cache_key = 'wpcomsh_fatal_event:' . hash( 'sha256', $message . '|' . $signature . '|' . $context['kind'] );
 	try {
 		if ( ! wp_cache_add( $cache_key, 1, 'wpcomsh', HOUR_IN_SECONDS ) ) {
 			return;
@@ -185,7 +243,12 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 		// Fall through and log.
 	}
 
-	$properties = array( 'signature' => $signature );
+	$properties = array(
+		'signature'      => $signature,
+		'request_kind'   => $context['kind'],
+		'request_path'   => $context['path'],
+		'request_method' => $context['method'],
+	);
 
 	// Round-trip through the decoder so the logged parts always agree
 	// with the signature.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -149,10 +149,20 @@ function wpcomsh_fatal_log_deactivate( $plugin_basename ) {
  * @return array{kind:string,path:string,method:string}
  */
 function wpcomsh_fatal_request_context() {
-	$req_uri  = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
+	// REQUEST_URI is fed only to wp_parse_url for path extraction; the raw
+	// value is never echoed, rendered, or stored. sanitize_text_field would
+	// strip characters that are legitimate path content — wp_check_invalid_utf8
+	// can drop a raw-encoded UTF-8 slug to '', and the percent-encoded form
+	// would lose case in the unicode round-trip — so we skip text-field
+	// sanitization here and let wp_parse_url do the structural validation.
+	$req_uri  = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- path-only extraction; see comment.
 	$raw_path = (string) wp_parse_url( $req_uri, PHP_URL_PATH );
 	$path     = rtrim( $raw_path, '/' );
-	$method   = strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ) );
+
+	// Whitelist HTTP method to a closed set so request_method on the row is
+	// a small fixed-cardinality enum, not an arbitrary header value.
+	$method_raw = strtoupper( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- whitelisted below.
+	$method     = in_array( $method_raw, array( 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS' ), true ) ? $method_raw : 'UNKNOWN';
 
 	$kind = 'other';
 	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || str_ends_with( $path, '/wp-cron.php' ) ) {
@@ -182,7 +192,7 @@ function wpcomsh_fatal_request_context() {
 	return array(
 		'kind'   => $kind,
 		'path'   => '' === $path ? '/' : $path,
-		'method' => '' === $method ? 'UNKNOWN' : $method,
+		'method' => $method,
 	);
 }
 

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -149,27 +149,37 @@ function wpcomsh_fatal_log_deactivate( $plugin_basename ) {
  * @return array{kind:string,path:string,method:string}
  */
 function wpcomsh_fatal_request_context() {
+	static $cached = null;
+	if ( null !== $cached ) {
+		return $cached;
+	}
+
 	// REQUEST_URI is fed only to wp_parse_url for path extraction; the raw
 	// value is never echoed, rendered, or stored. sanitize_text_field would
-	// strip characters that are legitimate path content — wp_check_invalid_utf8
-	// can drop a raw-encoded UTF-8 slug to '', and the percent-encoded form
-	// would lose case in the unicode round-trip — so we skip text-field
-	// sanitization here and let wp_parse_url do the structural validation.
+	// drop legitimate path bytes via wp_check_invalid_utf8.
 	$req_uri  = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- path-only extraction; see comment.
 	$raw_path = (string) wp_parse_url( $req_uri, PHP_URL_PATH );
 	$path     = rtrim( $raw_path, '/' );
 
-	// Whitelist HTTP method to a closed set so request_method on the row is
-	// a small fixed-cardinality enum, not an arbitrary header value.
-	$method_raw = strtoupper( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- whitelisted below.
-	$method     = in_array( $method_raw, array( 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS' ), true ) ? $method_raw : 'UNKNOWN';
+	static $allowed_methods = array( 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS' );
+	$method_raw             = strtoupper( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- whitelisted below.
+	$method                 = in_array( $method_raw, $allowed_methods, true ) ? $method_raw : 'UNKNOWN';
 
+	// Bucket priority: cron / ajax / rest / wp-login win before wp-admin
+	// because admin-ajax.php lives under /wp-admin/. Constants (not the
+	// `wp_doing_cron` / `wp_doing_ajax` wrappers) are checked because the
+	// wrappers run filters — a callback registered by the fataling code, or
+	// by a plugin coincidentally loaded on this request, must not bubble out
+	// of the fatal handler and prevent the recovery screen from rendering.
+	// Path suffixes catch the early-fatal case where the constant hasn't
+	// been defined yet (e.g. a plugin-load fatal on /wp-cron.php before
+	// wp-cron.php sets DOING_CRON).
 	$kind = 'other';
 	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || str_ends_with( $path, '/wp-cron.php' ) ) {
 		$kind = 'cron';
 	} elseif ( ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || str_ends_with( $path, '/admin-ajax.php' ) ) {
 		$kind = 'ajax';
-	} elseif ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || str_contains( $path, '/wp-json' ) ) {
+	} elseif ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || str_contains( $path, '/wp-json/' ) || str_ends_with( $path, '/wp-json' ) ) {
 		$kind = 'rest';
 	} elseif ( str_ends_with( $path, '/wp-login.php' ) ) {
 		$kind = 'wp-login';
@@ -189,11 +199,12 @@ function wpcomsh_fatal_request_context() {
 		}
 	}
 
-	return array(
+	$cached = array(
 		'kind'   => $kind,
 		'path'   => '' === $path ? '/' : $path,
 		'method' => $method,
 	);
+	return $cached;
 }
 
 /**
@@ -234,16 +245,12 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 
 	$context = wpcomsh_fatal_request_context();
 
-	// Dedup per (message, signature, request_kind) for 1 hour so a persistent
-	// fatal doesn't emit one log row + one outbound HTTP per visitor. $message
-	// is part of the key so a deactivate event isn't suppressed by a recent
-	// signature event for the same extension. request_kind is part of the key
-	// so a fatal that hits both wp-admin and a front-end URL surfaces as two
-	// rows — that's the signal that distinguishes site-wide breakage from a
-	// single endpoint, which the in-request handler can't otherwise tell.
-	// The TTL stays short of core's 24h `recovery_mode_email_rate_limit` so a
-	// legitimate re-send — e.g. the admin exits recovery mode and the site
-	// fatals again — surfaces rather than getting silently swallowed.
+	// Dedup per (message, signature, request_kind) for 1 hour. $message keeps
+	// a deactivate event from being suppressed by a recent signature event for
+	// the same extension. request_kind splits site-wide breakage (multiple
+	// kinds per signature) from a single broken endpoint (one kind), which the
+	// in-request handler can't otherwise tell. TTL stays short of core's 24h
+	// `recovery_mode_email_rate_limit` so a legitimate re-send surfaces.
 	$cache_key = 'wpcomsh_fatal_event:' . hash( 'sha256', $message . '|' . $signature . '|' . $context['kind'] );
 	try {
 		if ( ! wp_cache_add( $cache_key, 1, 'wpcomsh', HOUR_IN_SECONDS ) ) {

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -34,17 +34,30 @@ function wpcomsh_customize_fatal_error_message( $message, $error = array() ) { /
 
 	// Identify only when used: admins need $plugin for the rendered
 	// notice; anonymous viewers don't render plugin info but still emit
-	// a signature event for telemetry. Volume is bounded downstream by
-	// wpcomsh_fatal_log_event's (message, signature, request_kind) dedup,
-	// so a coarser file-keyed gate here would only collapse kind variance
-	// (the very signal the row is meant to surface).
+	// a signature event for telemetry. The anonymous path gates on
+	// (error file, request_kind) before paying the plugin-header read so
+	// a fatal storm doesn't compound filesystem work on a sick site —
+	// kind is in the key so wp-admin / home / rest variance still reaches
+	// the downstream (message, signature, request_kind) dedup.
 	$plugin = null;
 
 	if ( $is_admin ) {
 		$plugin = wpcomsh_fatal_identify_plugin( $error );
 		wpcomsh_fatal_log_event( $plugin, 'wpcomsh_fatal_signature' );
 	} elseif ( ! empty( $error['file'] ) ) {
-		wpcomsh_fatal_log_event( wpcomsh_fatal_identify_plugin( $error ), 'wpcomsh_fatal_signature' );
+		$req_kind   = wpcomsh_fatal_request_context()['kind'];
+		$coarse_key = 'wpcomsh_fatal_file_kind:' . hash( 'sha256', (string) $error['file'] . '|' . $req_kind );
+		$do_log     = true;
+
+		try {
+			$do_log = wp_cache_add( $coarse_key, 1, 'wpcomsh', HOUR_IN_SECONDS );
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- fail open: a cache failure should not silence telemetry.
+			// Fail open.
+		}
+
+		if ( $do_log ) {
+			wpcomsh_fatal_log_event( wpcomsh_fatal_identify_plugin( $error ), 'wpcomsh_fatal_signature' );
+		}
 	}
 
 	$context = wpcomsh_fatal_build_render_context( $error, $plugin, $user_id, $is_admin );

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -33,27 +33,18 @@ function wpcomsh_customize_fatal_error_message( $message, $error = array() ) { /
 	$is_admin = $user_id && user_can( $user_id, 'manage_options' );
 
 	// Identify only when used: admins need $plugin for the rendered
-	// notice; the anonymous path identifies once per (file, 1-hour) for
-	// telemetry. Signature-level dedup downstream catches duplicates
-	// this gate misses.
+	// notice; anonymous viewers don't render plugin info but still emit
+	// a signature event for telemetry. Volume is bounded downstream by
+	// wpcomsh_fatal_log_event's (message, signature, request_kind) dedup,
+	// so a coarser file-keyed gate here would only collapse kind variance
+	// (the very signal the row is meant to surface).
 	$plugin = null;
 
 	if ( $is_admin ) {
 		$plugin = wpcomsh_fatal_identify_plugin( $error );
 		wpcomsh_fatal_log_event( $plugin, 'wpcomsh_fatal_signature' );
 	} elseif ( ! empty( $error['file'] ) ) {
-		$coarse_key = 'wpcomsh_fatal_file:' . hash( 'sha256', (string) $error['file'] );
-		$do_log     = true;
-
-		try {
-			$do_log = wp_cache_add( $coarse_key, 1, 'wpcomsh', HOUR_IN_SECONDS );
-		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- fail open: a cache failure should not silence telemetry.
-			// Fail open.
-		}
-
-		if ( $do_log ) {
-			wpcomsh_fatal_log_event( wpcomsh_fatal_identify_plugin( $error ), 'wpcomsh_fatal_signature' );
-		}
+		wpcomsh_fatal_log_event( wpcomsh_fatal_identify_plugin( $error ), 'wpcomsh_fatal_signature' );
 	}
 
 	$context = wpcomsh_fatal_build_render_context( $error, $plugin, $user_id, $is_admin );


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add `wpcomsh_fatal_request_context()` helper that buckets the in-flight request into a coarse kind (`cron`, `ajax`, `rest`, `wp-login`, `wp-admin`, `home`, `other`) plus path and method.
* Tag every `wpcomsh_fatal_log_event()` row with `request_kind` / `request_path` / `request_method`.
* Widen the 1-hour dedup key from `(message, signature)` to `(message, signature, request_kind)`. Bounded ceiling: ~7 rows per signature per message slug per hour.

## Why

Inside the `wp_php_error_message` filter the handler only sees the one request that fataled. That makes it structurally unable to tell "site-wide breakage" apart from "endpoint-specific bug" — a fatal that fires only on `/estate/$slug` produces the same in-request signal as one that breaks every page. By tagging each row with `request_kind`, the distinction moves to logstash:

* one kind per signature in a window → endpoint-specific (e.g. `kind=other` only).
* multiple kinds per signature in a window → site-wide (e.g. `wp-admin` + `home` + `rest`).

`request_path` rides on the row for drill-down; query strings are deliberately omitted to keep PII / cardinality bounded.

## Does this pull request change what data or activity we track or use?

Yes. Three new fields are added to existing `atomic_extension_conflict` logstash rows: `request_kind` (small fixed enum), `request_path` (URL path only — query string stripped), and `request_method`. No new event slugs, no new endpoints, no new pipelines — same dispatch tail through `wpcomsh_fatal_emit_logstash`. Path can in rare cases carry user-identifying segments (e.g. `/author/jane-doe/`); strictly less exposure than fpm's existing access/error logs.

## Testing instructions

* Trigger a fatal on a wp-admin page (e.g. via a deliberately broken plugin) and verify the resulting `wpcomsh_fatal_signature` row has `request_kind=wp-admin`.
* Trigger a fatal on the homepage; verify `request_kind=home`.
* Trigger a fatal on a `/wp-json/...` REST endpoint; verify `request_kind=rest`.
* Trigger fatals on two distinct paths under the same kind within an hour (same signature); verify only one row lands (dedup intact).
* Trigger fatals on two different kinds within an hour (same signature); verify two rows land.
* Verify `request_path` reflects the request path with no trailing slash and no query string, and `request_method` is the uppercased verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)