### PR TITLE
Protect: pass `from='protect'` in user-connection-needed modal

### DIFF
--- a/projects/plugins/protect/changelog/fix-pass-from-in-user-connection-modal
+++ b/projects/plugins/protect/changelog/fix-pass-from-in-user-connection-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: pass `from: 'protect'` when launching the user-connection flow from the user-connection-needed modal so the wpcom authorize page can attribute these connections to Protect rather than `[unknown]`.

--- a/projects/plugins/protect/src/js/components/user-connection-needed-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/user-connection-needed-modal/index.jsx
@@ -8,6 +8,7 @@ import styles from './styles.module.scss';
 const UserConnectionNeededModal = () => {
 	const { setModal } = useModal();
 	const { userIsConnecting, handleConnectUser } = useConnection( {
+		from: 'protect',
 		redirectUri: 'admin.php?page=jetpack-protect',
 	} );
 


### PR DESCRIPTION
## Summary

The `UserConnectionNeededModal` calls `useConnection({ redirectUri: ... })` without a `from` value. As a result, when a user clicks "Connect your user account" in the modal, the resulting wpcom authorize URL has no outer `from=` query param, and Calypso reports the connection in Tracks as `from='[unknown]'` instead of `from='protect'`.

This is a one-line fix: pass `from: 'protect'` (matching the convention already used in [pricing-table/index.jsx](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/protect/src/js/components/pricing-table/index.jsx#L27) and the rest of the Protect data hooks) so the connection is correctly attributed.

## Why

Investigation of the `[unknown]` Tracks cohort on `calypso_jpc_authorize_form_view` surfaced two `useConnection({...})` call sites in trunk that still omit `from` even after [#48318](https://github.com/Automattic/jetpack/pull/48318) fixed the server-side endpoints. This modal is one of them. The other is `packages/forms/.../google-drive.tsx`, addressed separately.

## Test plan

- [ ] Open Protect on a fresh site that needs a user connection
- [ ] Trigger the "User connection needed" modal (e.g. attempt to ignore a threat)
- [ ] Click "Connect your user account"
- [ ] Verify the Calypso authorize URL contains `&from=protect`
- [ ] Verify the resulting `calypso_jpc_authorize_form_view` Tracks event has `from: 'protect'`