### PR TITLE
Add intelligent Blaze campaign defaults

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1037-intelligent-defaults
+++ b/projects/packages/blaze/changelog/add-ads-1037-intelligent-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Add intent-aware defaults and budget options to prepared campaign proposals.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -314,23 +314,70 @@ class Blaze_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'prefill_url', 'prefill' ),
+					'required'    => array( 'status', 'intent', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
 					'properties'  => array(
-						'status'      => array(
+						'status'          => array(
 							'type'        => 'string',
 							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
 							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'message'     => array(
+						'message'         => array(
 							'type'        => 'string',
 							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'prefill_url' => array(
+						'intent'          => array(
+							'type'        => 'string',
+							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
+							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
+						),
+						'assumptions'     => array(
+							'type'        => 'array',
+							'description' => __( 'Plain-language assumptions used while preparing the recommended campaign.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'recommendations' => array(
+							'type'        => 'array',
+							'description' => __( 'Plain-language guidance for reviewing the prepared campaign.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'budget_options'  => array(
+							'type'        => 'array',
+							'description' => __( 'Lower, recommended, and higher budget options returned when budget or duration is omitted. The recommended option is encoded in prefill_url.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'       => 'object',
+								'properties' => array(
+									'key'           => array(
+										'type' => 'string',
+										'enum' => array( 'lower', 'recommended', 'higher' ),
+									),
+									'label'         => array(
+										'type' => 'string',
+									),
+									'budget'        => array(
+										'type' => 'object',
+									),
+									'daily_budget'  => array(
+										'type' => 'object',
+									),
+									'duration_days' => array(
+										'type' => 'integer',
+									),
+									'rationale'     => array(
+										'type' => 'string',
+									),
+								),
+							),
+						),
+						'prefill_url'     => array(
 							'type'        => 'string',
 							'format'      => 'uri',
 							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
 						),
-						'prefill'     => array(
+						'prefill'         => array(
 							'type'        => 'object',
 							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -14,6 +14,9 @@ class Campaign_Preparer {
 
 	private const DEFAULT_BUDGET_TOTAL  = 50.0;
 	private const DEFAULT_DURATION_DAYS = 7;
+	private const INTENT_ECOMMERCE      = 'ecommerce';
+	private const INTENT_CONTENT        = 'content';
+	private const INTENT_UNKNOWN        = 'unknown';
 	private const SUPPORTED_LANGUAGES   = array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' );
 	private const SUPPORTED_DEVICES     = array( 'mobile', 'desktop' );
 	private const SUPPORTED_PAGE_TOPICS = array(
@@ -57,24 +60,39 @@ class Campaign_Preparer {
 			);
 		}
 
-		$prefill     = self::build_prefill_payload( $args, $post );
-		$prefill_url = self::build_prefill_url( $post->ID, $prefill );
+		$intent          = self::infer_intent( $args, $post );
+		$budget_context  = self::resolve_budget_context( $args );
+		$assumptions     = self::build_assumptions( $args, $post, $intent, $budget_context );
+		$recommendations = self::build_recommendations( $intent, $budget_context );
+		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
+		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 
-		return array(
-			'status'      => 'pending_merchant_review',
-			'prefill_url' => $prefill_url,
-			'prefill'     => $prefill,
+		$proposal = array(
+			'status'          => 'pending_merchant_review',
+			'intent'          => $intent,
+			'assumptions'     => $assumptions,
+			'recommendations' => $recommendations,
+			'prefill_url'     => $prefill_url,
+			'prefill'         => $prefill,
 		);
+
+		if ( $budget_context['include_options'] ) {
+			$proposal['budget_options'] = $budget_context['options'];
+		}
+
+		return $proposal;
 	}
 
 	/**
 	 * Build the campaign prefill payload from caller input and the target post.
 	 *
-	 * @param array    $args Preparation input.
-	 * @param \WP_Post $post The target post.
+	 * @param array    $args           Preparation input.
+	 * @param \WP_Post $post           The target post.
+	 * @param string   $intent         Inferred campaign intent.
+	 * @param array    $budget_context Resolved budget defaults and options.
 	 * @return array
 	 */
-	private static function build_prefill_payload( array $args, $post ): array {
+	private static function build_prefill_payload( array $args, $post, string $intent, array $budget_context ): array {
 		$featured_image_id   = (int) get_post_thumbnail_id( $post->ID );
 		$featured_image_url  = $featured_image_id > 0 ? wp_get_attachment_image_url( $featured_image_id, 'full' ) : '';
 		$featured_image_mime = $featured_image_id > 0 ? get_post_mime_type( $featured_image_id ) : '';
@@ -100,12 +118,12 @@ class Campaign_Preparer {
 			'target_url'    => (string) get_permalink( $post ),
 			'budget'        => array(
 				'mode'     => 'total',
-				'amount'   => (float) ( $args['budget_total'] ?? self::DEFAULT_BUDGET_TOTAL ),
-				'currency' => self::get_site_currency(),
+				'amount'   => $budget_context['budget_total'],
+				'currency' => $budget_context['currency'],
 			),
-			'duration_days' => (int) ( $args['duration_days'] ?? self::DEFAULT_DURATION_DAYS ),
+			'duration_days' => $budget_context['duration_days'],
 			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
-			'objective'     => 'VIEWS',
+			'objective'     => self::objective_for_intent( $intent ),
 		);
 
 		if ( isset( $args['goal'] ) && '' !== (string) $args['goal'] ) {
@@ -184,6 +202,222 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Infer the campaign intent from natural language and target type.
+	 *
+	 * @param array    $args Preparation input.
+	 * @param \WP_Post $post The target post.
+	 * @return string
+	 */
+	private static function infer_intent( array $args, $post ): string {
+		$goal = isset( $args['goal'] ) ? strtolower( (string) $args['goal'] ) : '';
+
+		if ( '' !== $goal ) {
+			if ( preg_match( '/\b(sale|sales|sell|shop|purchase|order|conversion|conversions|revenue|roi|customer|customers)\b/', $goal ) ) {
+				return self::INTENT_ECOMMERCE;
+			}
+			if ( preg_match( '/\b(read|reader|readers|readership|article|blog|post|story|content|awareness|visibility|views|traffic)\b/', $goal ) ) {
+				return self::INTENT_CONTENT;
+			}
+		}
+
+		if ( 'product' === (string) $post->post_type ) {
+			return self::INTENT_ECOMMERCE;
+		}
+		if ( in_array( (string) $post->post_type, array( 'post', 'page' ), true ) ) {
+			return self::INTENT_CONTENT;
+		}
+
+		return self::INTENT_UNKNOWN;
+	}
+
+	/**
+	 * Resolve the recommended budget and optional comparison choices.
+	 *
+	 * @param array $args Preparation input.
+	 * @return array
+	 */
+	private static function resolve_budget_context( array $args ): array {
+		$currency              = self::get_site_currency();
+		$has_budget_override   = isset( $args['budget_total'] );
+		$has_duration_override = isset( $args['duration_days'] );
+		$budget_total          = $has_budget_override ? max( 1.0, (float) $args['budget_total'] ) : self::DEFAULT_BUDGET_TOTAL;
+		$duration_days         = $has_duration_override ? max( 1, (int) $args['duration_days'] ) : self::DEFAULT_DURATION_DAYS;
+		$include_options       = ! $has_budget_override || ! $has_duration_override;
+
+		return array(
+			'budget_total'          => $budget_total,
+			'currency'              => $currency,
+			'duration_days'         => $duration_days,
+			'has_budget_override'   => $has_budget_override,
+			'has_duration_override' => $has_duration_override,
+			'include_options'       => $include_options,
+			'options'               => $include_options ? self::build_budget_options( $budget_total, $duration_days, $currency ) : array(),
+		);
+	}
+
+	/**
+	 * Build lower/recommended/higher budget options around the recommended campaign.
+	 *
+	 * @param float  $recommended_total Recommended total budget.
+	 * @param int    $duration_days     Campaign duration in days.
+	 * @param string $currency          ISO 4217 currency code.
+	 * @return array
+	 */
+	private static function build_budget_options( float $recommended_total, int $duration_days, string $currency ): array {
+		$lower_total  = max( 10.0, round( $recommended_total * 0.5, 2 ) );
+		$higher_total = round( $recommended_total * 3, 2 );
+
+		return array(
+			self::build_budget_option(
+				'lower',
+				__( 'Lower', 'jetpack-blaze' ),
+				$lower_total,
+				$duration_days,
+				$currency,
+				__( 'Lower-risk test budget for learning before spending more.', 'jetpack-blaze' )
+			),
+			self::build_budget_option(
+				'recommended',
+				__( 'Recommended', 'jetpack-blaze' ),
+				$recommended_total,
+				$duration_days,
+				$currency,
+				__( 'Conservative starting point for a first prepared Blaze campaign.', 'jetpack-blaze' )
+			),
+			self::build_budget_option(
+				'higher',
+				__( 'Higher', 'jetpack-blaze' ),
+				$higher_total,
+				$duration_days,
+				$currency,
+				__( 'More budget can buy more reach; choose this only when broader delivery is worth the extra spend.', 'jetpack-blaze' )
+			),
+		);
+	}
+
+	/**
+	 * Build one budget option row.
+	 *
+	 * @param string $key           Stable option key.
+	 * @param string $label         Human-readable option label.
+	 * @param float  $budget_total  Total budget.
+	 * @param int    $duration_days Campaign duration in days.
+	 * @param string $currency      ISO 4217 currency code.
+	 * @param string $rationale     Why this option exists.
+	 * @return array
+	 */
+	private static function build_budget_option( string $key, string $label, float $budget_total, int $duration_days, string $currency, string $rationale ): array {
+		return array(
+			'key'           => $key,
+			'label'         => $label,
+			'budget'        => array(
+				'mode'     => 'total',
+				'amount'   => $budget_total,
+				'currency' => $currency,
+			),
+			'daily_budget'  => array(
+				'amount'   => round( $budget_total / $duration_days, 2 ),
+				'currency' => $currency,
+			),
+			'duration_days' => $duration_days,
+			'rationale'     => $rationale,
+		);
+	}
+
+	/**
+	 * Build human-readable assumptions for the prepared recommendation.
+	 *
+	 * @param array    $args           Preparation input.
+	 * @param \WP_Post $post           The target post.
+	 * @param string   $intent         Inferred campaign intent.
+	 * @param array    $budget_context Resolved budget defaults and options.
+	 * @return array
+	 */
+	private static function build_assumptions( array $args, $post, string $intent, array $budget_context ): array {
+		$post_type   = (string) $post->post_type;
+		$assumptions = array();
+
+		if ( self::INTENT_ECOMMERCE === $intent ) {
+			$assumptions[] = isset( $args['goal'] ) && '' !== (string) $args['goal']
+				? sprintf(
+					/* translators: %s: user-supplied natural language campaign goal. */
+					__( 'Goal "%s" suggests ecommerce intent, so the proposal uses traffic-oriented product defaults.', 'jetpack-blaze' ),
+					(string) $args['goal']
+				)
+				: __( 'Target is a product, so the proposal uses ecommerce-oriented defaults.', 'jetpack-blaze' );
+		} elseif ( self::INTENT_CONTENT === $intent ) {
+			$assumptions[] = isset( $args['goal'] ) && '' !== (string) $args['goal']
+				? sprintf(
+					/* translators: %s: user-supplied natural language campaign goal. */
+					__( 'Goal "%s" suggests content intent, so the proposal optimizes for visibility.', 'jetpack-blaze' ),
+					(string) $args['goal']
+				)
+				: sprintf(
+					/* translators: %s: WordPress post type. */
+					__( 'Target type "%s" is treated as content, so the proposal optimizes for visibility.', 'jetpack-blaze' ),
+					$post_type
+				);
+		} else {
+			$assumptions[] = sprintf(
+				/* translators: %s: WordPress post type. */
+				__( 'Target type "%s" has unknown intent, so the proposal uses conservative visibility defaults.', 'jetpack-blaze' ),
+				$post_type
+			);
+		}
+
+		if ( ! $budget_context['has_budget_override'] ) {
+			$assumptions[] = __( 'No budget was supplied, so the recommended option uses a conservative default total budget.', 'jetpack-blaze' );
+		}
+		if ( ! $budget_context['has_duration_override'] ) {
+			$assumptions[] = __( 'No duration was supplied, so the recommended option uses a seven-day campaign.', 'jetpack-blaze' );
+		}
+		if ( isset( $args['revision_instruction'] ) && '' !== (string) $args['revision_instruction'] ) {
+			$assumptions[] = sprintf(
+				/* translators: %s: user-supplied revision instruction. */
+				__( 'Revision requested: %s', 'jetpack-blaze' ),
+				(string) $args['revision_instruction']
+			);
+		}
+
+		return $assumptions;
+	}
+
+	/**
+	 * Build compact campaign recommendations for clients to surface.
+	 *
+	 * @param string $intent         Inferred campaign intent.
+	 * @param array  $budget_context Resolved budget defaults and options.
+	 * @return array
+	 */
+	private static function build_recommendations( string $intent, array $budget_context ): array {
+		$recommendations = array();
+
+		if ( self::INTENT_ECOMMERCE === $intent ) {
+			$recommendations[] = __( 'Use product-focused copy and send shoppers to the product page.', 'jetpack-blaze' );
+		} elseif ( self::INTENT_CONTENT === $intent ) {
+			$recommendations[] = __( 'Use visibility-focused copy and send readers to the post or page.', 'jetpack-blaze' );
+		} else {
+			$recommendations[] = __( 'Review the prepared copy and target before submitting because the target intent is uncertain.', 'jetpack-blaze' );
+		}
+
+		if ( $budget_context['include_options'] ) {
+			$recommendations[] = __( 'The recommended budget option is conservative; the higher option is framed as broader reach, not guaranteed performance.', 'jetpack-blaze' );
+		}
+
+		return $recommendations;
+	}
+
+	/**
+	 * Server-owned DSP objective for the inferred intent.
+	 *
+	 * @param string $intent Inferred campaign intent.
+	 * @return string
+	 */
+	private static function objective_for_intent( string $intent ): string {
+		return self::INTENT_ECOMMERCE === $intent ? 'CLICKS' : 'VIEWS';
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -93,6 +93,131 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'A short summary about the product.', $prefill['text_snippet'] );
 		$this->assertSame( 75.0, $prefill['budget']['amount'] );
 		$this->assertSame( 10, $prefill['duration_days'] );
+		$this->assertSame( 'content', $result['intent'] );
+		$this->assertArrayHasKey( 'assumptions', $result );
+		$this->assertArrayHasKey( 'recommendations', $result );
+		$this->assertArrayNotHasKey( 'budget_options', $result );
+	}
+
+	/**
+	 * Product targets get ecommerce-oriented defaults and conservative budget
+	 * options when budget or duration is omitted.
+	 */
+	public function test_prepare_infers_ecommerce_intent_and_budget_options_for_products() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'product',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'ecommerce', $result['intent'] );
+		$this->assertSame( 'CLICKS', $result['prefill']['objective'] );
+		$this->assertSame( 50.0, $result['prefill']['budget']['amount'] );
+		$this->assertSame( 7, $result['prefill']['duration_days'] );
+		$this->assertArrayHasKey( 'budget_options', $result );
+		$this->assertCount( 3, $result['budget_options'] );
+		$this->assertSame( array( 'lower', 'recommended', 'higher' ), wp_list_pluck( $result['budget_options'], 'key' ) );
+
+		$recommended = $result['budget_options'][1];
+		$this->assertSame( 'recommended', $recommended['key'] );
+		$this->assertSame( 50.0, $recommended['budget']['amount'] );
+		$this->assertSame( 7.14, $recommended['daily_budget']['amount'] );
+		$this->assertSame( 7, $recommended['duration_days'] );
+		$this->assertStringContainsString( 'conservative', strtolower( $recommended['rationale'] ) );
+
+		$higher = $result['budget_options'][2];
+		$this->assertSame( 150.0, $higher['budget']['amount'] );
+		$this->assertStringContainsString( 'more reach', strtolower( $higher['rationale'] ) );
+		$this->assertStringContainsString( 'product', implode( ' ', $result['assumptions'] ) );
+	}
+
+	/**
+	 * Content targets retain visibility-oriented defaults.
+	 */
+	public function test_prepare_infers_content_intent_for_posts_and_pages() {
+		$post = $this->make_test_post(
+			array(
+				'post_type' => 'post',
+			)
+		);
+		$page = $this->make_test_post(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$post_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $post['target_urn'],
+			)
+		);
+		$page_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $page['target_urn'],
+			)
+		);
+
+		$this->assertSame( 'content', $post_result['intent'] );
+		$this->assertSame( 'content', $page_result['intent'] );
+		$this->assertSame( 'VIEWS', $post_result['prefill']['objective'] );
+		$this->assertSame( 'VIEWS', $page_result['prefill']['objective'] );
+	}
+
+	/**
+	 * Unknown target types stay explicit so future intelligence can handle them
+	 * without pretending the preparer knows more than it does.
+	 */
+	public function test_prepare_infers_unknown_intent_for_custom_post_types() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'portfolio_item',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'unknown', $result['intent'] );
+		$this->assertSame( 'VIEWS', $result['prefill']['objective'] );
+		$this->assertStringContainsString( 'portfolio_item', implode( ' ', $result['assumptions'] ) );
+	}
+
+	/**
+	 * Natural-language goals can steer the inferred intent, and revision notes
+	 * remain visible as preparation assumptions.
+	 */
+	public function test_prepare_uses_goal_and_revision_instruction_in_assumptions() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'           => $ctx['target_urn'],
+				'goal'                 => 'Drive sales for a weekend offer.',
+				'revision_instruction' => 'Make the copy less salesy.',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'ecommerce', $result['intent'] );
+		$this->assertSame( 'CLICKS', $result['prefill']['objective'] );
+		$this->assertStringContainsString( 'goal', strtolower( implode( ' ', $result['assumptions'] ) ) );
+		$this->assertStringContainsString( 'Drive sales for a weekend offer.', implode( ' ', $result['assumptions'] ) );
+		$this->assertStringContainsString( 'Make the copy less salesy.', implode( ' ', $result['assumptions'] ) );
 	}
 
 	/**
@@ -138,7 +263,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( array( 'IAB8_IAB18', 'IAB9_IAB22' ), $prefill['page_topics'] );
 		$this->assertArrayNotHasKey( 'interests', $prefill );
 		$this->assertFalse( $prefill['is_evergreen'] );
-		$this->assertSame( 'VIEWS', $prefill['objective'] );
+		$this->assertSame( 'CLICKS', $prefill['objective'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -374,7 +374,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
 		$this->assertStringContainsString( 'Audience overrides must use stable codes or closed enums', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
-		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
+		$ability    = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ];
+		$schema     = $ability['input_schema'];
 		$properties = $schema['properties'];
 
 		$this->assertSame( array( 'target_urn' ), $schema['required'] );
@@ -402,6 +403,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Blaze public page topic IDs', $properties['interests']['description'] );
 		$this->assertContains( 'IAB8_IAB18', $properties['interests']['items']['enum'] );
 		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
+
+		$output_properties = $ability['output_schema']['properties'];
+		$this->assertArrayHasKey( 'intent', $output_properties );
+		$this->assertArrayHasKey( 'assumptions', $output_properties );
+		$this->assertArrayHasKey( 'recommendations', $output_properties );
+		$this->assertArrayHasKey( 'budget_options', $output_properties );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---
@@ -513,6 +520,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 50.0, $prefill['budget']['amount'] );
 		$this->assertSame( 7, $prefill['duration_days'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
+		$this->assertSame( 'content', $result['intent'] );
+		$this->assertCount( 3, $result['budget_options'] );
 	}
 
 	/**
@@ -545,8 +554,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'Drive sales for a spring promotion.', $prefill['goal'] );
 		$this->assertSame( 'Make it less salesy.', $prefill['revision_instruction'] );
 		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
-		$this->assertSame( 'VIEWS', $prefill['objective'], 'DSP objective is server-owned and not overridden by public input.' );
+		$this->assertSame( 'CLICKS', $prefill['objective'], 'DSP objective is server-owned and inferred from public intent.' );
 		$this->assertFalse( $prefill['is_evergreen'] );
+		$this->assertArrayNotHasKey( 'budget_options', $result );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- infer campaign intent from target type and natural-language goal
- return conservative lower/recommended/higher budget options when budget or duration is omitted
- expose intent, assumptions, recommendations, and budget options in the prepare-campaign output schema

## Tests
- composer phpunit -- tests/php/Campaign_Preparer_Test.php tests/php/abilities/Blaze_Abilities_Test.php