### PR TITLE
Podcast: simplify wp-build wiring per #48557 review

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3616,12 +3616,9 @@ importers:
 
   projects/packages/podcast:
     dependencies:
-      '@wordpress/admin-ui':
-        specifier: 1.12.0
-        version: 1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components':
-        specifier: 32.6.0
-        version: 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@automattic/jetpack-components':
+        specifier: workspace:*
+        version: link:../../js-packages/components
       '@wordpress/element':
         specifier: 6.44.0
         version: 6.44.0
@@ -3632,6 +3629,9 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@automattic/jetpack-base-styles':
+        specifier: workspace:*
+        version: link:../../js-packages/base-styles
       '@automattic/jetpack-wp-build-polyfills':
         specifier: workspace:*
         version: link:../wp-build-polyfills
@@ -3644,12 +3644,18 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@wordpress/base-styles':
+        specifier: 6.20.0
+        version: 6.20.0
       '@wordpress/browserslist-config':
         specifier: 6.44.0
         version: 6.44.0
       '@wordpress/build':
         specifier: 0.13.0
-        version: 0.13.0(@babel/core@7.29.0)(browserslist@4.28.2)
+        version: 0.13.0(@babel/core@7.29.0)(@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)
+      '@wordpress/theme':
+        specifier: 0.11.0
+        version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       browserslist:
         specifier: ^4.24.0
         version: 4.28.2
@@ -24140,6 +24146,30 @@ snapshots:
       sass-embedded: 1.97.3
     optionalDependencies:
       '@wordpress/route': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - browserslist
+      - supports-color
+
+  '@wordpress/build@0.13.0(@babel/core@7.29.0)(@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)':
+    dependencies:
+      '@emotion/babel-plugin': 11.13.5
+      autoprefixer: 10.4.27(postcss@8.5.10)
+      browserslist-to-esbuild: 2.1.1(browserslist@4.28.2)
+      change-case: 4.1.2
+      chokidar: 4.0.3
+      cssnano: 7.1.4(postcss@8.5.10)
+      esbuild: 0.27.4
+      esbuild-plugin-babel: 0.2.3(@babel/core@7.29.0)
+      esbuild-sass-plugin: 3.3.1(esbuild@0.27.4)(sass-embedded@1.97.3)
+      fast-glob: 3.3.3
+      moment-timezone: 0.5.48
+      postcss: 8.5.10
+      postcss-modules: 6.0.1(postcss@8.5.10)
+      rtlcss: 4.3.0
+      sass-embedded: 1.97.3
+    optionalDependencies:
       '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3616,6 +3616,9 @@ importers:
 
   projects/packages/podcast:
     dependencies:
+      '@wordpress/admin-ui':
+        specifier: 1.12.0
+        version: 1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/components':
         specifier: 32.6.0
         version: 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3632,6 +3632,9 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@automattic/jetpack-wp-build-polyfills':
+        specifier: workspace:*
+        version: link:../wp-build-polyfills
       '@babel/core':
         specifier: 7.29.0
         version: 7.29.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3629,9 +3629,6 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
-      '@automattic/jetpack-wp-build-polyfills':
-        specifier: workspace:*
-        version: link:../wp-build-polyfills
       '@babel/core':
         specifier: 7.29.0
         version: 7.29.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/arcangelini-podcast-make-it-better
+++ b/projects/packages/jetpack-mu-wpcom/changelog/arcangelini-podcast-make-it-better
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal: rename the new Podcast slug to 'podcast' in the Jetpack submenu reorder list; legacy 'podcasting' entry untouched.
+
+

--- a/projects/packages/jetpack-mu-wpcom/changelog/arcangelini-podcast-make-it-better
+++ b/projects/packages/jetpack-mu-wpcom/changelog/arcangelini-podcast-make-it-better
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Internal: collapse the Podcast slug to a single 'podcast' entry in the Jetpack submenu reorder list.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/arcangelini-podcast-make-it-better
+++ b/projects/packages/jetpack-mu-wpcom/changelog/arcangelini-podcast-make-it-better
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal: collapse the Podcast slug to a single 'podcast' entry in the Jetpack submenu reorder list.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -466,7 +466,7 @@ function wpcom_add_jetpack_submenu() {
 			'search',
 			'subscribers',
 			'newsletter',
-			'jetpack-podcast',
+			'podcast',
 			'podcasting',
 			'traffic',
 			'jetpack#/settings',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -466,8 +466,7 @@ function wpcom_add_jetpack_submenu() {
 			'search',
 			'subscribers',
 			'newsletter',
-			'jetpack-podcast',
-			'podcasting',
+			'podcast',
 			'traffic',
 			'jetpack#/settings',
 		)

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -466,7 +466,8 @@ function wpcom_add_jetpack_submenu() {
 			'search',
 			'subscribers',
 			'newsletter',
-			'podcast',
+			'jetpack-podcast',
+			'podcasting',
 			'traffic',
 			'jetpack#/settings',
 		)

--- a/projects/packages/podcast/changelog/arcangelini-podcast-make-it-better
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-make-it-better
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Slim down wp-build wiring to the Backup pattern: drop bridge_wp_build_enqueue and fix_boot_import_map_ordering, alias $screen->id via current_screen instead.

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/ui": "0.11.0"
 	},
 	"devDependencies": {
+		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.0",
 		"@babel/runtime": "7.29.2",
 		"@types/react": "18.3.28",

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -27,19 +27,21 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@wordpress/admin-ui": "1.12.0",
-		"@wordpress/components": "32.6.0",
+		"@automattic/jetpack-components": "workspace:*",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/ui": "0.11.0"
 	},
 	"devDependencies": {
+		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.0",
 		"@babel/runtime": "7.29.2",
 		"@types/react": "18.3.28",
+		"@wordpress/base-styles": "6.20.0",
 		"@wordpress/browserslist-config": "6.44.0",
 		"@wordpress/build": "0.13.0",
+		"@wordpress/theme": "0.11.0",
 		"browserslist": "^4.24.0"
 	},
 	"optionalDependencies": {

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -33,7 +33,6 @@
 		"@wordpress/ui": "0.11.0"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.0",
 		"@babel/runtime": "7.29.2",
 		"@types/react": "18.3.28",

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -27,6 +27,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
+		"@wordpress/admin-ui": "1.12.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",

--- a/projects/packages/podcast/routes/dashboard/package.json
+++ b/projects/packages/podcast/routes/dashboard/package.json
@@ -3,9 +3,8 @@
 	"version": "1.0.0",
 	"private": true,
 	"dependencies": {
+		"@automattic/jetpack-components": "workspace:*",
 		"@types/react": "18.3.28",
-		"@wordpress/admin-ui": "1.12.0",
-		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/ui": "0.11.0"

--- a/projects/packages/podcast/routes/dashboard/package.json
+++ b/projects/packages/podcast/routes/dashboard/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@types/react": "18.3.28",
+		"@wordpress/admin-ui": "1.12.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",

--- a/projects/packages/podcast/routes/dashboard/route.scss
+++ b/projects/packages/podcast/routes/dashboard/route.scss
@@ -1,5 +1,6 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 
 body.jetpack_page_jetpack-podcast {
+
 	@include jetpack-admin-page-layout;
 }

--- a/projects/packages/podcast/routes/dashboard/route.scss
+++ b/projects/packages/podcast/routes/dashboard/route.scss
@@ -1,0 +1,5 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
+body.jetpack_page_jetpack-podcast {
+	@include jetpack-admin-page-layout;
+}

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -2,6 +2,7 @@ import AdminPage from '@automattic/jetpack-components/admin-page';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
+import './route.scss';
 
 const TAB_VALUES = [ 'settings', 'episodes', 'distribution', 'stats' ] as const;
 type TabName = ( typeof TAB_VALUES )[ number ];
@@ -28,12 +29,14 @@ const Stage = () => {
 					'jetpack-podcast'
 				) }
 				tabs={
-					<Tabs.List>
-						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
-						<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
-						<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
-						<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
-					</Tabs.List>
+					<div className="jp-admin-page-tabs">
+						<Tabs.List>
+							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
+							<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
+							<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
+							<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
+						</Tabs.List>
+					</div>
 				}
 			>
 				<Tabs.Panel value="settings">

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -38,9 +38,7 @@ const Stage = () => {
 				<Tabs.List>
 					<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
 					<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
-					<Tabs.Tab value="distribution">
-						{ __( 'Distribution', 'jetpack-podcast' ) }
-					</Tabs.Tab>
+					<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
 					<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
 				</Tabs.List>
 				<Tabs.Panel value="settings">

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -5,7 +5,7 @@
  * untangle train fills in the real tab contents.
  */
 
-import { Page } from '@wordpress/admin-ui';
+import AdminPage from '@automattic/jetpack-components/admin-page';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
@@ -27,20 +27,22 @@ const Stage = () => {
 
 	return (
 		<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
-			<Page
+			<AdminPage
 				/* "Podcast" is a product name, do not translate. */
 				title="Podcast"
 				subTitle={ __(
 					'Publish a podcast and reach your fans, anywhere they listen.',
 					'jetpack-podcast'
 				) }
+				tabs={
+					<Tabs.List>
+						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
+						<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
+						<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
+						<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
+					</Tabs.List>
+				}
 			>
-				<Tabs.List>
-					<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
-					<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
-					<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
-					<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
-				</Tabs.List>
 				<Tabs.Panel value="settings">
 					<p>{ __( 'Settings — placeholder.', 'jetpack-podcast' ) }</p>
 				</Tabs.Panel>
@@ -53,7 +55,7 @@ const Stage = () => {
 				<Tabs.Panel value="stats">
 					<p>{ __( 'Stats — placeholder.', 'jetpack-podcast' ) }</p>
 				</Tabs.Panel>
-			</Page>
+			</AdminPage>
 		</Tabs.Root>
 	);
 };

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -1,10 +1,3 @@
-/**
- * Podcast dashboard stage: page chrome + tab navigation.
- *
- * Placeholder scaffolding only — each tab panel renders a stub. PR 4 in the
- * untangle train fills in the real tab contents.
- */
-
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/projects/packages/podcast/routes/dashboard/stage.tsx
+++ b/projects/packages/podcast/routes/dashboard/stage.tsx
@@ -2,10 +2,10 @@
  * Podcast dashboard stage: page chrome + tab navigation.
  *
  * Placeholder scaffolding only — each tab panel renders a stub. PR 4 in the
- * untangle train wires the full AdminPage + jetpack-components integration
- * along with the real tab contents.
+ * untangle train fills in the real tab contents.
  */
 
+import { Page } from '@wordpress/admin-ui';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
@@ -26,17 +26,21 @@ const Stage = () => {
 	}, [] );
 
 	return (
-		<div className="wrap">
-			<h1>Podcast</h1>
-			<p>
-				{ __( 'Publish a podcast and reach your fans, anywhere they listen.', 'jetpack-podcast' ) }
-			</p>
-
-			<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
+		<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
+			<Page
+				/* "Podcast" is a product name, do not translate. */
+				title="Podcast"
+				subTitle={ __(
+					'Publish a podcast and reach your fans, anywhere they listen.',
+					'jetpack-podcast'
+				) }
+			>
 				<Tabs.List>
 					<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
 					<Tabs.Tab value="episodes">{ __( 'Episodes', 'jetpack-podcast' ) }</Tabs.Tab>
-					<Tabs.Tab value="distribution">{ __( 'Distribution', 'jetpack-podcast' ) }</Tabs.Tab>
+					<Tabs.Tab value="distribution">
+						{ __( 'Distribution', 'jetpack-podcast' ) }
+					</Tabs.Tab>
 					<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-podcast' ) }</Tabs.Tab>
 				</Tabs.List>
 				<Tabs.Panel value="settings">
@@ -51,8 +55,8 @@ const Stage = () => {
 				<Tabs.Panel value="stats">
 					<p>{ __( 'Stats — placeholder.', 'jetpack-podcast' ) }</p>
 				</Tabs.Panel>
-			</Tabs.Root>
-		</div>
+			</Page>
+		</Tabs.Root>
 	);
 };
 

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -14,47 +14,27 @@ use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
  * `jetpack_podcast_untangle` filter is enabled. Until that filter flips, every
  * entry point here is a no-op so the legacy podcasting experience keeps
  * running unchanged.
- *
- * Menu registration is owned by `wpcom-admin-menu.php` (in the
- * `jetpack-mu-wpcom` package), which calls `add_wp_admin_submenu()` at
- * `admin_menu` priority 999999 — late enough that the Jetpack parent menu
- * already exists. wpcom-admin-menu runs on both Simple and Atomic, so a single
- * registration path covers both. Standalone Jetpack is excluded by the host
- * gate in `Podcast::init()`.
- *
- * Mirrors `Automattic\Jetpack\Backup\V0005\Jetpack_Backup` — wp-build's
- * polyfills + auto-generated render/enqueue functions do the heavy lifting;
- * we just alias `$screen->id` so the auto-enqueue check passes for our slug.
  */
 class Admin_Page {
 
-	/**
-	 * URL-facing menu slug.
-	 *
-	 * @var string
-	 */
 	const ADMIN_PAGE_SLUG = 'jetpack-podcast';
 
 	/**
-	 * The wp-build page slug emitted by `@wordpress/build` (`wpPlugin.pages[0]`).
-	 * The auto-generated enqueue callback only fires when `$screen->id`
-	 * matches this value, so we alias the screen id via `current_screen`
-	 * on our admin page without changing the user-facing slug.
-	 *
-	 * @var string
+	 * Slug emitted by `@wordpress/build`. wp-build's auto-generated enqueue
+	 * callback only fires when `$screen->id` matches this value, so we alias
+	 * the screen id via `current_screen` without changing the user-facing URL.
 	 */
 	const WP_BUILD_SLUG = 'jetpack-podcast-dashboard';
 
 	/**
-	 * Whether the class has already wired its admin hooks.
+	 * Whether `init()` has already wired its hooks.
 	 *
 	 * @var bool
 	 */
 	private static $initialized = false;
 
 	/**
-	 * Wire the admin hooks. Called from `Podcast::init()` once the
-	 * `jetpack_podcast_untangle` filter and host gates have been satisfied.
+	 * Wire admin hooks. Idempotent.
 	 */
 	public static function init() {
 		if ( self::$initialized ) {
@@ -69,8 +49,7 @@ class Admin_Page {
 	 * Register the Podcast submenu under Jetpack on Simple and Atomic.
 	 *
 	 * Called from `wpcom-admin-menu.php` at priority 999999 once the Jetpack
-	 * parent menu exists. Bails when the untangle filter is off so the legacy
-	 * "Podcasting" Calypso link in `wpcom-admin-menu.php` keeps rendering.
+	 * parent menu exists.
 	 */
 	public static function add_wp_admin_submenu() {
 		if ( ! self::is_enabled() ) {
@@ -99,23 +78,15 @@ class Admin_Page {
 
 	/**
 	 * Wire admin-init actions once we know the Podcast page is loading.
-	 *
-	 * Subsequent PRs in the untangle train layer script-data + Tracks here.
-	 * The wp-build dashboard manages its own enqueue pipeline.
 	 */
 	public static function admin_init() {
 		// Intentionally empty for now.
 	}
 
 	/**
-	 * Load wp-build only on the Podcast admin page, then alias `$screen->id`
-	 * so wp-build's auto-generated enqueue callback fires for our slug.
-	 *
 	 * Hooked at admin_menu priority 1 so polyfills register before
 	 * `wp_default_scripts` fires and the wp-build render function is defined
 	 * before `add_wp_admin_submenu()` runs at priority 999999.
-	 *
-	 * Mirrors `Automattic\Jetpack\Backup\V0005\Jetpack_Backup::maybe_load_wp_build`.
 	 */
 	public static function maybe_load_wp_build() {
 		if ( ! self::is_enabled() || ! self::is_podcast_admin_request() ) {
@@ -127,8 +98,6 @@ class Admin_Page {
 	}
 
 	/**
-	 * Require the wp-build entry file and register its polyfills.
-	 *
 	 * The build artifact may be absent on a fresh checkout before
 	 * `pnpm build` has run; in that case `add_wp_admin_submenu()` falls back
 	 * to `render()` so the page still loads (just without the React app).
@@ -149,10 +118,7 @@ class Admin_Page {
 	}
 
 	/**
-	 * Alias `$screen->id` to wp-build's expected page slug so its
-	 * auto-generated `<page>-wp-admin` enqueue callback fires on our
-	 * `?page=jetpack-podcast` URL. Only hooked when we're already on the
-	 * Podcast admin page, so this never affects any other request.
+	 * Alias the current screen id to wp-build's expected slug.
 	 *
 	 * @param \WP_Screen|null $screen The current screen object (passed by WP).
 	 */
@@ -165,8 +131,7 @@ class Admin_Page {
 	}
 
 	/**
-	 * Default render callback. Used as a fallback when the wp-build artifact is
-	 * missing — for example, on a fresh checkout before `pnpm build` has run.
+	 * Fallback render used when the wp-build artifact is missing.
 	 */
 	public static function render() {
 		?>
@@ -177,9 +142,7 @@ class Admin_Page {
 	}
 
 	/**
-	 * Whether the Podcast untangle is enabled. Mirrors the gate in
-	 * `Podcast::init()` so callbacks invoked outside that flow (e.g.
-	 * `add_wp_admin_submenu()` from wpcom-admin-menu.php) still bail.
+	 * Whether the Podcast untangle is enabled.
 	 */
 	private static function is_enabled() {
 		/** This filter is documented in src/class-podcast.php. */
@@ -188,9 +151,6 @@ class Admin_Page {
 
 	/**
 	 * Whether the current request targets the Podcast admin page.
-	 *
-	 * `$_GET['page']` is populated by `wp-admin/admin.php` before any of our
-	 * hooks fire, so this check is reliable from `admin_menu` onwards.
 	 */
 	private static function is_podcast_admin_request() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -22,9 +22,9 @@ use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
  * registration path covers both. Standalone Jetpack is excluded by the host
  * gate in `Podcast::init()`.
  *
- * The wp-build chassis is loaded inline from `init()` and routed onto our
- * user-facing slug via `bridge_wp_build_enqueue()` — mirroring
- * `Automattic\Jetpack\Scan_Page\Jetpack_Scan`.
+ * Mirrors `Automattic\Jetpack\Backup\V0005\Jetpack_Backup` — wp-build's
+ * polyfills + auto-generated render/enqueue functions do the heavy lifting;
+ * we just alias `$screen->id` so the auto-enqueue check passes for our slug.
  */
 class Admin_Page {
 
@@ -36,13 +36,14 @@ class Admin_Page {
 	const ADMIN_PAGE_SLUG = 'jetpack-podcast';
 
 	/**
-	 * Internal slug emitted by `@wordpress/build` (`wpPlugin.pages[0]`
-	 * plus the `-wp-admin` suffix the build template appends). Used to
-	 * find the auto-generated render / enqueue functions.
+	 * wp-build page slug emitted by `@wordpress/build` (`wpPlugin.pages[0]`).
+	 * The auto-generated enqueue callback only fires when `$screen->id`
+	 * matches this value, so we alias the screen id via `current_screen`
+	 * on our admin page without changing the user-facing slug.
 	 *
 	 * @var string
 	 */
-	const WP_BUILD_SLUG = 'jetpack-podcast-dashboard-wp-admin';
+	const WP_BUILD_SLUG = 'jetpack-podcast-dashboard';
 
 	/**
 	 * Whether the class has already wired its admin hooks.
@@ -54,13 +55,6 @@ class Admin_Page {
 	/**
 	 * Wire the admin hooks. Called from `Podcast::init()` once the
 	 * `jetpack_podcast_untangle` filter and host gates have been satisfied.
-	 *
-	 * Menu registration itself is handled by `wpcom-admin-menu.php` calling
-	 * `add_wp_admin_submenu()` at `admin_menu` priority 999999. Here we set
-	 * up the wp-build chassis at plugins_loaded time so:
-	 *   - `WP_Build_Polyfills::register()` registers BEFORE `wp_default_scripts`
-	 *     fires (otherwise `@wordpress/boot` never lands in the import map).
-	 *   - The wp-build render function is defined before the menu callback runs.
 	 */
 	public static function init() {
 		if ( self::$initialized ) {
@@ -68,9 +62,7 @@ class Admin_Page {
 		}
 		self::$initialized = true;
 
-		self::load_wp_build();
-		self::bridge_wp_build_enqueue();
-		self::fix_boot_import_map_ordering();
+		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 1 );
 	}
 
 	/**
@@ -85,6 +77,11 @@ class Admin_Page {
 			return;
 		}
 
+		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
+		$callback        = function_exists( $wp_build_render )
+			? $wp_build_render
+			: array( __CLASS__, 'render' );
+
 		$page_suffix = add_submenu_page(
 			'jetpack',
 			/** "Podcast" is a product name, do not translate. */
@@ -92,7 +89,7 @@ class Admin_Page {
 			'Podcast',
 			'manage_options',
 			self::ADMIN_PAGE_SLUG,
-			self::get_render_callback()
+			$callback
 		);
 
 		if ( $page_suffix ) {
@@ -104,127 +101,67 @@ class Admin_Page {
 	 * Wire admin-init actions once we know the Podcast page is loading.
 	 *
 	 * Subsequent PRs in the untangle train layer script-data + Tracks here.
-	 * The wp-build dashboard manages its own enqueue pipeline (bridged via
-	 * `bridge_wp_build_enqueue()`).
+	 * The wp-build dashboard manages its own enqueue pipeline.
 	 */
 	public static function admin_init() {
 		// Intentionally empty for now.
 	}
 
 	/**
-	 * Bridge wp-build's auto-generated enqueue function — which checks for
-	 * `?page=jetpack-podcast-dashboard-wp-admin` — to our user-facing slug
-	 * `?page=jetpack-podcast`. Hooked at priority 9 so the wp-build copy
-	 * (registered at priority 10) sees the original `$_GET['page']` and skips
-	 * its own enqueue.
+	 * Load wp-build only on the Podcast admin page, then alias `$screen->id`
+	 * so wp-build's auto-generated enqueue callback fires for our slug.
 	 *
-	 * Mirrors `Automattic\Jetpack\Scan_Page\Jetpack_Scan::bridge_wp_build_enqueue`.
+	 * Hooked at admin_menu priority 1 so polyfills register before
+	 * `wp_default_scripts` fires and the wp-build render function is defined
+	 * before `add_wp_admin_submenu()` runs at priority 999999.
+	 *
+	 * Mirrors `Automattic\Jetpack\Backup\V0005\Jetpack_Backup::maybe_load_wp_build`.
 	 */
-	private static function bridge_wp_build_enqueue() {
-		add_action(
-			'admin_enqueue_scripts',
-			static function ( $hook_suffix ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				if ( ! isset( $_GET['page'] ) || self::ADMIN_PAGE_SLUG !== $_GET['page'] ) {
-					return;
-				}
-
-				$enqueue_fn = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_enqueue_scripts';
-				if ( ! function_exists( $enqueue_fn ) ) {
-					return;
-				}
-
-				// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$original     = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : null;
-				$_GET['page'] = self::WP_BUILD_SLUG;
-				// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- Function is generated by @wordpress/build into build/pages/jetpack-podcast-dashboard/page-wp-admin.php, which is outside Phan's analysis scope. The function_exists() guard above protects the call at runtime.
-				call_user_func( $enqueue_fn, $hook_suffix );
-				if ( null === $original ) {
-					unset( $_GET['page'] );
-				} else {
-					$_GET['page'] = $original;
-				}
-				// phpcs:enable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			},
-			9
-		);
-	}
-
-	/**
-	 * Fix import map ordering for the wp-build boot script.
-	 *
-	 * In wp-admin, `_wp_footer_scripts` (classic scripts) and
-	 * `print_import_map` both hook into `admin_print_footer_scripts` at
-	 * priority 10, but `_wp_footer_scripts` is registered first. This causes
-	 * the inline `import("@wordpress/boot")` to execute before the import
-	 * map exists.
-	 *
-	 * This fix moves the `import()` call from the classic inline script to a
-	 * `<script type="module">` printed at priority 20 (after the import map).
-	 *
-	 * Mirrors `Automattic\Jetpack\Scan_Page\Jetpack_Scan::fix_boot_import_map_ordering`.
-	 *
-	 * @todo Remove once @wordpress/build ships the loader.js fix upstream
-	 *       (WordPress/gutenberg#76870) and Jetpack updates the dependency.
-	 */
-	private static function fix_boot_import_map_ordering() {
-		$handle = self::WP_BUILD_SLUG . '-prerequisites';
-
-		add_action(
-			'admin_enqueue_scripts',
-			static function () use ( $handle ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				if ( ! isset( $_GET['page'] ) || self::ADMIN_PAGE_SLUG !== $_GET['page'] ) {
-					return;
-				}
-
-				$data = wp_scripts()->get_data( $handle, 'after' );
-				if ( empty( $data ) ) {
-					return;
-				}
-
-				$boot_script = null;
-				$remaining   = array();
-				foreach ( $data as $line ) {
-					if ( strpos( $line, '@wordpress/boot' ) !== false ) {
-						$boot_script = $line;
-					} else {
-						$remaining[] = $line;
-					}
-				}
-
-				if ( null === $boot_script ) {
-					return;
-				}
-
-				wp_scripts()->add_data( $handle, 'after', $remaining );
-
-				add_action(
-					'admin_print_footer_scripts',
-					static function () use ( $boot_script ) {
-						wp_print_inline_script_tag( $boot_script, array( 'type' => 'module' ) );
-					},
-					20
-				);
-			},
-			PHP_INT_MAX
-		);
-	}
-
-	/**
-	 * Resolve the menu render callback, preferring the wp-build–generated
-	 * function when the build artifact is in place.
-	 *
-	 * @return callable
-	 */
-	private static function get_render_callback() {
-		$wp_build_render = 'jetpack_podcast_jetpack_podcast_dashboard_wp_admin_render_page';
-
-		if ( function_exists( $wp_build_render ) ) {
-			return $wp_build_render;
+	public static function maybe_load_wp_build() {
+		if ( ! self::is_enabled() || ! self::is_podcast_admin_request() ) {
+			return;
 		}
 
-		return array( __CLASS__, 'render' );
+		self::load_wp_build();
+		add_action( 'current_screen', array( __CLASS__, 'alias_screen_id_for_wp_build' ) );
+	}
+
+	/**
+	 * Require the wp-build entry file and register its polyfills.
+	 *
+	 * The build artifact may be absent on a fresh checkout before
+	 * `pnpm build` has run; in that case `add_wp_admin_submenu()` falls back
+	 * to `render()` so the page still loads (just without the React app).
+	 */
+	private static function load_wp_build() {
+		$build_index = dirname( __DIR__ ) . '/build/build.php';
+
+		if ( ! file_exists( $build_index ) ) {
+			return;
+		}
+
+		require_once $build_index;
+
+		WP_Build_Polyfills::register(
+			'jetpack-podcast',
+			array_merge( WP_Build_Polyfills::SCRIPT_HANDLES, WP_Build_Polyfills::MODULE_IDS )
+		);
+	}
+
+	/**
+	 * Alias `$screen->id` to wp-build's expected page slug so its
+	 * auto-generated `<page>-wp-admin` enqueue callback fires on our
+	 * `?page=jetpack-podcast` URL. Only hooked when we're already on the
+	 * Podcast admin page, so this never affects any other request.
+	 *
+	 * @param \WP_Screen|null $screen The current screen object (passed by WP).
+	 */
+	public static function alias_screen_id_for_wp_build( $screen ) {
+		if ( ! is_object( $screen ) ) {
+			return;
+		}
+
+		$screen->id = self::WP_BUILD_SLUG;
 	}
 
 	/**
@@ -240,27 +177,6 @@ class Admin_Page {
 	}
 
 	/**
-	 * Register wp-build polyfills and require the wp-build entry file.
-	 *
-	 * Called from `init()` at plugins_loaded time so polyfill registration
-	 * happens before `wp_default_scripts` fires (otherwise `@wordpress/boot`
-	 * never lands in the import map). The build entry only defines functions —
-	 * the actual enqueue is gated by `bridge_wp_build_enqueue()` to our page.
-	 */
-	private static function load_wp_build() {
-		WP_Build_Polyfills::register(
-			'jetpack-podcast',
-			array_merge( WP_Build_Polyfills::SCRIPT_HANDLES, WP_Build_Polyfills::MODULE_IDS )
-		);
-
-		$build_index = dirname( __DIR__ ) . '/build/build.php';
-
-		if ( file_exists( $build_index ) ) {
-			require_once $build_index;
-		}
-	}
-
-	/**
 	 * Whether the Podcast untangle is enabled. Mirrors the gate in
 	 * `Podcast::init()` so callbacks invoked outside that flow (e.g.
 	 * `add_wp_admin_submenu()` from wpcom-admin-menu.php) still bail.
@@ -268,5 +184,21 @@ class Admin_Page {
 	private static function is_enabled() {
 		/** This filter is documented in src/class-podcast.php. */
 		return (bool) apply_filters( 'jetpack_podcast_untangle', false );
+	}
+
+	/**
+	 * Whether the current request targets the Podcast admin page.
+	 *
+	 * `$_GET['page']` is populated by `wp-admin/admin.php` before any of our
+	 * hooks fire, so this check is reliable from `admin_menu` onwards.
+	 */
+	private static function is_podcast_admin_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! is_admin() || ! isset( $_GET['page'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return self::ADMIN_PAGE_SLUG === sanitize_text_field( wp_unslash( $_GET['page'] ) );
 	}
 }

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -36,7 +36,7 @@ class Admin_Page {
 	const ADMIN_PAGE_SLUG = 'jetpack-podcast';
 
 	/**
-	 * wp-build page slug emitted by `@wordpress/build` (`wpPlugin.pages[0]`).
+	 * The wp-build page slug emitted by `@wordpress/build` (`wpPlugin.pages[0]`).
 	 * The auto-generated enqueue callback only fires when `$screen->id`
 	 * matches this value, so we alias the screen id via `current_screen`
 	 * on our admin page without changing the user-facing slug.


### PR DESCRIPTION
Follow-up to #48557 and #48559 addressing review feedback from @simison.

## Proposed changes

* Slim `Admin_Page` (`projects/packages/podcast/src/class-admin-page.php`) down to the same wp-build wiring shape as `Jetpack_Backup` (#48583): polyfills register + wp-build entry require + `current_screen` alias of `$screen->id` to `jetpack-podcast-dashboard`.
* Drop `bridge_wp_build_enqueue()` (the `$_GET[page]` swap) and `fix_boot_import_map_ordering()` (the boot-script reorder workaround). wp-build's auto-generated enqueue callback handles enqueue once `$screen->id` matches; the import-map fix isn't needed in this path.
* Collapse the Podcast slug in `wpcom_reorder_submenu()` from two entries (`jetpack-podcast`, `podcasting`) to a single `podcast`. `wpcom_reorder_submenu` does substring matching, and only one of the two URLs is ever registered at a time, so one entry covers both flag states.
* Render the dashboard `Stage` inside `Page` from `@wordpress/admin-ui` (matching the Newsletter pattern in #48581) — title/subtitle in the page header, tabs in the body. Replaces the bare `<h1>Podcast</h1> + <Tabs.Root>` layout.

## Related product discussion/links

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Pull this branch.
2. `pnpm jetpack build packages/podcast --deps`.
3. Add the filter to a mu-plugin / `wp-config.php`:
   ```php
   add_filter( 'jetpack_podcast_untangle', '__return_true' );
   ```
4. Visit `wp-admin/admin.php?page=jetpack-podcast`. The page should render inside the `@wordpress/admin-ui` Page chrome — "Podcast" title, the tagline as subtitle, and the four placeholder tabs (Settings / Episodes / Distribution / Stats) below. DevTools → Network should request from `build/pages/jetpack-podcast-dashboard/`. No console errors.
5. Without the build artifact (delete `projects/packages/podcast/build/` and reload), the page still renders the bare `<h1>Podcast</h1>` placeholder via the PHP fallback `Admin_Page::render()`.
6. Disable the filter and confirm the legacy "Jetpack > Podcasting" Calypso link is back exactly as before.
7. With the filter on, confirm the "Jetpack > Podcast" entry appears in the position previously held by "Jetpack > Podcasting" in the Jetpack submenu (between Newsletter and Traffic).
