### PR TITLE
Add Blaze campaign forecast estimates

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1038-forecast-estimates
+++ b/projects/packages/blaze/changelog/add-ads-1038-forecast-estimates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Add forecast estimates to prepared campaign proposals.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -314,7 +314,7 @@ class Blaze_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'intent', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
+					'required'    => array( 'status', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
 					'properties'  => array(
 						'status'          => array(
 							'type'        => 'string',
@@ -329,6 +329,10 @@ class Blaze_Abilities extends Registrar {
 							'type'        => 'string',
 							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
 							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
+						),
+						'forecast'        => array(
+							'type'        => 'object',
+							'description' => __( 'Forecast estimates for the recommended option. Available forecasts include views/impressions and clicks ranges; unavailable forecasts do not block the review URL.', 'jetpack-blaze' ),
 						),
 						'assumptions'     => array(
 							'type'        => 'array',

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -66,10 +66,12 @@ class Campaign_Preparer {
 		$recommendations = self::build_recommendations( $intent, $budget_context );
 		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
+		$forecast        = self::request_forecast( $prefill, $intent );
 
 		$proposal = array(
 			'status'          => 'pending_merchant_review',
 			'intent'          => $intent,
+			'forecast'        => $forecast,
 			'assumptions'     => $assumptions,
 			'recommendations' => $recommendations,
 			'prefill_url'     => $prefill_url,
@@ -202,6 +204,110 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Request a DSP forecast for the recommended prefilled campaign.
+	 *
+	 * @param array  $prefill Recommended campaign prefill payload.
+	 * @param string $intent  Inferred campaign intent.
+	 * @return array
+	 */
+	private static function request_forecast( array $prefill, string $intent ): array {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return self::unavailable_forecast( $site_id->get_error_code() );
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/forecast', (int) $site_id );
+		$request = new \WP_REST_Request( 'POST', $route );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( self::build_forecast_request_body( $prefill ), JSON_UNESCAPED_SLASHES ) );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			$error = $response->as_error();
+			return self::unavailable_forecast( $error->get_error_code() );
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) ) {
+			return self::unavailable_forecast( 'forecast_invalid_response' );
+		}
+
+		return self::normalize_forecast_response( $data, $intent );
+	}
+
+	/**
+	 * Build the request body expected by the DSP v1.1 forecast endpoint.
+	 *
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @return array
+	 */
+	private static function build_forecast_request_body( array $prefill ): array {
+		$duration_days = isset( $prefill['duration_days'] ) ? max( 1, (int) $prefill['duration_days'] ) : self::DEFAULT_DURATION_DAYS;
+		$start_date    = gmdate( 'Y-m-d' );
+		$end_date      = gmdate( 'Y-m-d', strtotime( '+' . ( $duration_days - 1 ) . ' days' ) );
+
+		return array(
+			'time_zone'       => self::get_site_timezone(),
+			'start_date'      => $start_date,
+			'end_date'        => $end_date,
+			'total_budget'    => isset( $prefill['budget']['amount'] ) ? (float) $prefill['budget']['amount'] : self::DEFAULT_BUDGET_TOTAL,
+			'is_evergreen'    => isset( $prefill['is_evergreen'] ) ? (bool) $prefill['is_evergreen'] : true,
+			'is_tsp_eligible' => false,
+			'targeting'       => array(
+				'locations'   => array(),
+				'languages'   => isset( $prefill['languages'] ) ? array_values( (array) $prefill['languages'] ) : array(),
+				'devices'     => isset( $prefill['devices'] ) ? array_values( (array) $prefill['devices'] ) : array(),
+				'page_topics' => isset( $prefill['page_topics'] ) ? array_values( (array) $prefill['page_topics'] ) : array(),
+			),
+		);
+	}
+
+	/**
+	 * Normalize the DSP forecast response into the prepare-campaign contract.
+	 *
+	 * @param array  $data   DSP forecast response.
+	 * @param string $intent Inferred campaign intent.
+	 * @return array
+	 */
+	private static function normalize_forecast_response( array $data, string $intent ): array {
+		$views  = array(
+			'min' => isset( $data['total_impressions_min'] ) ? (int) $data['total_impressions_min'] : 0,
+			'max' => isset( $data['total_impressions_max'] ) ? (int) $data['total_impressions_max'] : 0,
+		);
+		$clicks = array(
+			'min' => isset( $data['total_clicks_min'] ) ? (int) $data['total_clicks_min'] : 0,
+			'max' => isset( $data['total_clicks_max'] ) ? (int) $data['total_clicks_max'] : 0,
+		);
+
+		return array(
+			'status'           => 'available',
+			'primary_metric'   => self::INTENT_ECOMMERCE === $intent ? 'clicks' : 'views',
+			'secondary_metric' => self::INTENT_ECOMMERCE === $intent ? 'views' : 'clicks',
+			'views'            => $views,
+			'impressions'      => $views,
+			'clicks'           => $clicks,
+			'tsp_impressions'  => array(
+				'min' => isset( $data['total_tsp_impressions_min'] ) ? (int) $data['total_tsp_impressions_min'] : 0,
+				'max' => isset( $data['total_tsp_impressions_max'] ) ? (int) $data['total_tsp_impressions_max'] : 0,
+			),
+		);
+	}
+
+	/**
+	 * Build a non-blocking forecast failure response.
+	 *
+	 * @param string $reason Stable failure reason.
+	 * @return array
+	 */
+	private static function unavailable_forecast( string $reason ): array {
+		return array(
+			'status'  => 'unavailable',
+			'reason'  => $reason,
+			'message' => __( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', 'jetpack-blaze' ),
+		);
 	}
 
 	/**
@@ -501,5 +607,15 @@ class Campaign_Preparer {
 	 */
 	private static function get_site_currency(): string {
 		return 'USD';
+	}
+
+	/**
+	 * Site timezone for DSP forecast requests.
+	 *
+	 * @return string IANA timezone name.
+	 */
+	private static function get_site_timezone(): string {
+		$timezone = wp_timezone_string();
+		return '' !== $timezone ? $timezone : 'UTC';
 	}
 }

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -171,6 +171,16 @@ class Dashboard_REST_Controller {
 
 		register_rest_route(
 			static::$namespace,
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_dsp_forecast' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
 			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
@@ -1238,6 +1248,16 @@ class Dashboard_REST_Controller {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Redirect POST request to WordAds DSP Forecast endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array|WP_Error
+	 */
+	public function create_dsp_forecast( $req ) {
+		return $this->edit_dsp_generic( 'v1.1/forecast', $req, array( 'timeout' => 20 ) );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -11,6 +11,8 @@ use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
 
 /**
  * @covers \Automattic\Jetpack\Blaze\Campaign_Preparer
@@ -30,6 +32,9 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	 */
 	public function set_up() {
 		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
 	}
 
 	/**
@@ -37,6 +42,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	 */
 	public function tear_down() {
 		Jetpack_Options::delete_option( 'id' );
+		unset( $GLOBALS['wp_rest_server'] );
 	}
 
 	/**
@@ -62,6 +68,23 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		return array(
 			'post_id'    => (int) $post_id,
 			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * Register a test forecast route that captures the preparer's proxied DSP request.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_forecast_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
 		);
 	}
 
@@ -136,6 +159,147 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 150.0, $higher['budget']['amount'] );
 		$this->assertStringContainsString( 'more reach', strtolower( $higher['rationale'] ) );
 		$this->assertStringContainsString( 'product', implode( ' ', $result['assumptions'] ) );
+	}
+
+	/**
+	 * Forecast requests use the DSP v1.1 forecast body shape and ecommerce
+	 * responses emphasize clicks before visibility.
+	 */
+	public function test_prepare_adds_click_first_forecast_for_ecommerce_intent() {
+		$ctx           = $this->make_test_post( array( 'post_type' => 'product' ) );
+		$captured_body = null;
+		$this->register_forecast_route(
+			static function ( WP_REST_Request $request ) use ( &$captured_body ) {
+				$captured_body = json_decode( $request->get_body(), true );
+				return array(
+					'total_impressions_min'     => 1200,
+					'total_impressions_max'     => 2400,
+					'total_clicks_min'          => 30,
+					'total_clicks_max'          => 60,
+					'total_tsp_impressions_min' => 100,
+					'total_tsp_impressions_max' => 200,
+				);
+			}
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 80,
+				'duration_days' => 8,
+				'languages'     => array( 'en' ),
+				'devices'       => array( 'mobile' ),
+				'interests'     => array( 'IAB8_IAB18' ),
+			)
+		);
+
+			$this->assertIsArray( $result );
+			$this->assertIsArray( $captured_body );
+			$captured_body = is_array( $captured_body ) ? $captured_body : array();
+			$this->assertSame(
+				array(
+					'time_zone',
+					'start_date',
+					'end_date',
+					'total_budget',
+					'is_evergreen',
+					'is_tsp_eligible',
+					'targeting',
+				),
+				array_keys( $captured_body )
+			);
+		$this->assertSame( 80, $captured_body['total_budget'] );
+		$this->assertSame( gmdate( 'Y-m-d' ), $captured_body['start_date'] );
+		$this->assertSame( gmdate( 'Y-m-d', strtotime( '+7 days' ) ), $captured_body['end_date'] );
+		$this->assertSame(
+			array(
+				'locations'   => array(),
+				'languages'   => array( 'en' ),
+				'devices'     => array( 'mobile' ),
+				'page_topics' => array( 'IAB8_IAB18' ),
+			),
+			$captured_body['targeting']
+		);
+
+		$this->assertSame( 'available', $result['forecast']['status'] );
+		$this->assertSame( 'clicks', $result['forecast']['primary_metric'] );
+		$this->assertSame( 'views', $result['forecast']['secondary_metric'] );
+		$this->assertSame(
+			array(
+				'min' => 30,
+				'max' => 60,
+			),
+			$result['forecast']['clicks']
+		);
+		$this->assertSame(
+			array(
+				'min' => 1200,
+				'max' => 2400,
+			),
+			$result['forecast']['views']
+		);
+		$this->assertSame(
+			array(
+				'min' => 1200,
+				'max' => 2400,
+			),
+			$result['forecast']['impressions']
+		);
+	}
+
+	/**
+	 * Content forecasts put visibility first and clicks second.
+	 */
+	public function test_prepare_adds_view_first_forecast_for_content_intent() {
+		$ctx = $this->make_test_post( array( 'post_type' => 'post' ) );
+		$this->register_forecast_route(
+			static function () {
+				return array(
+					'total_impressions_min'     => 5000,
+					'total_impressions_max'     => 8000,
+					'total_clicks_min'          => 20,
+					'total_clicks_max'          => 35,
+					'total_tsp_impressions_min' => 0,
+					'total_tsp_impressions_max' => 0,
+				);
+			}
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'content', $result['intent'] );
+		$this->assertSame( 'available', $result['forecast']['status'] );
+		$this->assertSame( 'views', $result['forecast']['primary_metric'] );
+		$this->assertSame( 'clicks', $result['forecast']['secondary_metric'] );
+	}
+
+	/**
+	 * Forecast failure does not block the proposal or review URL.
+	 */
+	public function test_prepare_degrades_gracefully_when_forecast_fails() {
+		$ctx = $this->make_test_post();
+		$this->register_forecast_route(
+			static function () {
+				return new WP_Error( 'forecast_unavailable', 'Forecast failed.', array( 'status' => 500 ) );
+			}
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
+		$this->assertSame( 'forecast_unavailable', $result['forecast']['reason'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -406,6 +406,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$output_properties = $ability['output_schema']['properties'];
 		$this->assertArrayHasKey( 'intent', $output_properties );
+		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
 		$this->assertArrayHasKey( 'recommendations', $output_properties );
 		$this->assertArrayHasKey( 'budget_options', $output_properties );
@@ -521,6 +522,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 7, $prefill['duration_days'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
 		$this->assertSame( 'content', $result['intent'] );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
 		$this->assertCount( 3, $result['budget_options'] );
 	}
 


### PR DESCRIPTION
## Summary
- request DSP v1.1 forecast estimates for the recommended prepared campaign
- return structured clicks/views forecast ranges with intent-aware primary metric framing
- degrade gracefully when the forecast proxy is unavailable so the review URL still works
- expose forecast in the prepare-campaign output schema

## Tests
- composer phpunit -- tests/php/Campaign_Preparer_Test.php tests/php/abilities/Blaze_Abilities_Test.php

Note: I also tried the broader Dashboard_REST_Controller_Test.php locally after adding the forecast proxy route, but that file currently returns 500s across many pre-existing routes in this worktree/WorDBless setup. I did not include a new Dashboard route unit that could not be made green locally; the forecast request shape is covered through Campaign_Preparer_Test with a mocked REST route.