### PR TITLE
Social: render connection template in per-network preview

### DIFF
--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -103,17 +103,28 @@ export function useConnectionPreviewData( connection: Connection ) {
 
 	return useMemo( () => {
 		const useRendered = templatesEnabled && typeof rendered === 'string';
-		const baseMessage = isPerNetworkMode
-			? ( connection.message ?? globalMessage ).trim()
-			: globalMessage.trim();
+		const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
+		let baseMessage: string;
+		if ( isPerNetworkMode ) {
+			if ( hasConnectionMessage ) {
+				baseMessage = connection.message ?? '';
+			} else if ( templatesEnabled && connection.template ) {
+				baseMessage = connection.template;
+			} else {
+				baseMessage = globalMessage;
+			}
+		} else {
+			baseMessage = globalMessage;
+		}
 
 		return {
 			...postData,
-			message: useRendered ? rendered : baseMessage,
+			message: useRendered ? rendered : baseMessage.trim(),
 			media,
 		};
 	}, [
 		connection.message,
+		connection.template,
 		globalMessage,
 		isPerNetworkMode,
 		media,

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -50,11 +50,20 @@ export function usePerNetworkCustomization() {
 					featuredImageMime,
 				} );
 
-				customizeConnectionById( connection.connection_id, {
-					message: postMeta.shareMessage || '',
+				/*
+				 * Skip writing `message` when the connection has its own template — leaving
+				 * `connection.message` undefined lets the editor and preview fall back to the
+				 * connection template instead of overwriting it with the global share message.
+				 */
+				const updates: Parameters< typeof customizeConnectionById >[ 1 ] = {
 					attached_media: attachedMedia,
 					media_source: effectiveSource,
-				} );
+				};
+				if ( ! connection.template ) {
+					updates.message = postMeta.shareMessage || '';
+				}
+
+				customizeConnectionById( connection.connection_id, updates );
 			}
 		} );
 	}, [

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -118,11 +118,14 @@ export function useRenderMessageItems(): RenderItem[] {
 
 	const items = useMemo< RenderItem[] >( () => {
 		return connections.map( connection => {
-			const message = ( connection.message ?? globalMessage ?? '' ).trim();
+			const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
+			const raw = hasConnectionMessage
+				? connection.message ?? ''
+				: connection.template ?? globalMessage ?? '';
 			return {
 				id: connection.connection_id,
 				network: connection.service_name ?? '',
-				message,
+				message: raw.trim(),
 				is_social_post: connectionHasMedia( connection, ctx ),
 			};
 		} );

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -119,9 +119,14 @@ export function useRenderMessageItems(): RenderItem[] {
 	const items = useMemo< RenderItem[] >( () => {
 		return connections.map( connection => {
 			const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
-			const raw = hasConnectionMessage
-				? connection.message ?? ''
-				: connection.template ?? globalMessage ?? '';
+			let raw: string;
+			if ( hasConnectionMessage ) {
+				raw = connection.message ?? '';
+			} else if ( ctx.isPerNetworkMode ) {
+				raw = connection.template ?? globalMessage ?? '';
+			} else {
+				raw = globalMessage ?? '';
+			}
 			return {
 				id: connection.connection_id,
 				network: connection.service_name ?? '',

--- a/projects/packages/publicize/changelog/social-453-per-network-template-render
+++ b/projects/packages/publicize/changelog/social-453-per-network-template-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: honor per-connection message templates in the per-network preview pipeline and stop overwriting them when toggling per-network mode.


### PR DESCRIPTION
Follow-up to #48568 (SOCIAL-453).

## Proposed changes

#48568 prefilled the per-network editor's message field with `connection.template` when no per-post override was set, but only in the form input. This PR aligns the rest of the pipeline with that behavior:

* `useRenderMessageItems`: in per-network mode, fall back to `connection.template` (then `globalMessage`) when `connection.message` is empty, so the items POSTed to `wpcom/v2/publicize/render-messages` match what the form displays. Global mode is unchanged (`connection.message ?? globalMessage`).
* `useConnectionPreviewData`: apply the same fallback to `baseMessage` so the non-rendered fallback (templates-disabled sites, or while the rendered batch is loading) also shows the connection template.
* `usePerNetworkCustomization.syncConnections`: when toggling per-network mode on, do not overwrite `connection.message` for connections that have their own `template` — leaving it `undefined` lets the editor and preview fall back to the connection template instead of clobbering it with the global share message.


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Prerequisites: site features include `social-enhanced-publishing` and `social-message-templates`, plus a Jetpack Social paid plan (so per-network customization is available).

1. **Connection template flows through to the per-network preview**
   * Set a connection template (e.g. `Hi from {network}: {post_title}`) for one connection in connection management.
   * Open the block editor for a post and open the customize-and-preview UI.
   * Enable per-network customization.
   * Open that connection's tab. The Message field should be prefilled with the connection template, and the preview pane should render that template (not the global share message).

2. **Toggling per-network mode preserves the connection template**
   * Set a non-empty global share message in the post's main share field.
   * Toggle per-network mode off, then on again.
   * For the connection that has its own template, the Message field should still be empty (so the connection-template prefill is shown), not the global share message.

3. **Switching back to global mode does not bleed the connection template**
   * After step 2, toggle per-network mode off (back to global mode).
   * The preview should render the global share message — not the connection template.

4. **No regression for connections without a template**
   * For a connection that does not have its own template, the per-network editor and preview should still fall back to the global share message (or default network template), as before.

5. **Automated checks**
   * `pnpm --filter @automattic/jetpack-publicize typecheck`
   * `pnpm --filter @automattic/jetpack-publicize test`

| Before | After |
| --- | --- |
|  |  |