### PR TITLE
ADS-1039: Render a readable prepare-campaign preview

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1039-human-readable-preview
+++ b/projects/packages/blaze/changelog/add-ads-1039-human-readable-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Show a readable prepare-campaign preview in agent responses.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -289,6 +289,7 @@ class Blaze_Abilities extends Registrar {
 								'type'      => 'string',
 								'minLength' => 2,
 								'maxLength' => 2,
+								'pattern'   => '^[A-Z]{2}$',
 							),
 						),
 						'devices'              => array(
@@ -314,41 +315,79 @@ class Blaze_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
+					'required'    => array( 'status', 'message', 'campaign_preview', 'forecast_summary', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
 					'properties'  => array(
-						'status'          => array(
+						'status'           => array(
 							'type'        => 'string',
 							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
 							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'message'         => array(
+						'message'          => array(
 							'type'        => 'string',
 							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'intent'          => array(
+						'campaign_preview' => array(
+							'type'        => 'object',
+							'description' => __( 'Structured campaign preview rows used by the MCP adapter to render the merchant-readable table.', 'jetpack-blaze' ),
+							'required'    => array( 'ad_heading', 'ad_copy', 'call_to_action', 'objective', 'budget', 'duration', 'schedule', 'audience', 'landing_page' ),
+							'properties'  => array(
+								'ad_heading'     => array(
+									'type' => 'string',
+								),
+								'ad_copy'        => array(
+									'type' => 'string',
+								),
+								'call_to_action' => array(
+									'type' => 'string',
+								),
+								'objective'      => array(
+									'type' => 'string',
+								),
+								'budget'         => array(
+									'type' => 'string',
+								),
+								'duration'       => array(
+									'type' => 'string',
+								),
+								'schedule'       => array(
+									'type' => 'string',
+								),
+								'audience'       => array(
+									'type' => 'string',
+								),
+								'landing_page'   => array(
+									'type' => 'string',
+								),
+							),
+						),
+						'forecast_summary' => array(
+							'type'        => 'string',
+							'description' => __( 'Human-readable forecast summary for the recommended option, or a fallback note when forecasts are unavailable.', 'jetpack-blaze' ),
+						),
+						'intent'           => array(
 							'type'        => 'string',
 							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
 							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
 						),
-						'forecast'        => array(
+						'forecast'         => array(
 							'type'        => 'object',
 							'description' => __( 'Forecast estimates for the recommended option. Available forecasts include views/impressions and clicks ranges; unavailable forecasts do not block the review URL.', 'jetpack-blaze' ),
 						),
-						'assumptions'     => array(
+						'assumptions'      => array(
 							'type'        => 'array',
 							'description' => __( 'Plain-language assumptions used while preparing the recommended campaign.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
-						'recommendations' => array(
+						'recommendations'  => array(
 							'type'        => 'array',
 							'description' => __( 'Plain-language guidance for reviewing the prepared campaign.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
-						'budget_options'  => array(
+						'budget_options'   => array(
 							'type'        => 'array',
 							'description' => __( 'Lower, recommended, and higher budget options returned when budget or duration is omitted. The recommended option is encoded in prefill_url.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -376,12 +415,12 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'prefill_url'     => array(
+						'prefill_url'      => array(
 							'type'        => 'string',
 							'format'      => 'uri',
 							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
 						),
-						'prefill'         => array(
+						'prefill'          => array(
 							'type'        => 'object',
 							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),
@@ -484,13 +523,302 @@ class Blaze_Abilities extends Registrar {
 		return array_merge(
 			$proposal,
 			array(
-				'message' => sprintf(
-					/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the prepared campaign proposal. */
-					__( 'Campaign proposal prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
-					$proposal['prefill_url']
-				),
+				'campaign_preview' => self::build_campaign_preview( $proposal ),
+				'forecast_summary' => self::build_forecast_summary( $proposal ),
+				'message'          => self::format_prepare_campaign_message( $proposal ),
 			)
 		);
+	}
+
+	/**
+	 * Build structured preview values for clients that do not want to parse the
+	 * raw widget prefill payload.
+	 *
+	 * @param array $proposal Structured campaign proposal.
+	 * @return array
+	 */
+	private static function build_campaign_preview( array $proposal ): array {
+		$prefill = isset( $proposal['prefill'] ) && is_array( $proposal['prefill'] ) ? $proposal['prefill'] : array();
+		$budget  = isset( $prefill['budget'] ) && is_array( $prefill['budget'] ) ? $prefill['budget'] : array();
+
+		$budget_amount   = isset( $budget['amount'] ) ? (float) $budget['amount'] : 0.0;
+		$budget_currency = isset( $budget['currency'] ) ? (string) $budget['currency'] : 'USD';
+		$duration_days   = isset( $prefill['duration_days'] ) ? max( 1, (int) $prefill['duration_days'] ) : 1;
+
+		return array(
+			'ad_heading'     => isset( $prefill['site_name'] ) ? (string) $prefill['site_name'] : '',
+			'ad_copy'        => isset( $prefill['text_snippet'] ) ? (string) $prefill['text_snippet'] : '',
+			'call_to_action' => isset( $prefill['cta_text'] ) ? (string) $prefill['cta_text'] : '',
+			'objective'      => self::format_objective( isset( $prefill['objective'] ) ? (string) $prefill['objective'] : '' ),
+			'budget'         => sprintf(
+				/* translators: 1: formatted currency amount, 2: formatted daily currency amount. */
+				__( '%1$s total (%2$s/day)', 'jetpack-blaze' ),
+				self::format_currency_amount( $budget_amount, $budget_currency ),
+				self::format_currency_amount( $budget_amount / $duration_days, $budget_currency )
+			),
+			'duration'       => self::format_days( $duration_days ),
+			'schedule'       => ! isset( $prefill['is_evergreen'] ) || (bool) $prefill['is_evergreen']
+				? __( 'Run until the merchant stops it', 'jetpack-blaze' )
+				: __( 'Run for the selected duration', 'jetpack-blaze' ),
+			'audience'       => self::format_audience_summary( $prefill ),
+			'landing_page'   => isset( $prefill['target_url'] ) ? (string) $prefill['target_url'] : '',
+		);
+	}
+
+	/**
+	 * Format the prepare-campaign response as adapter-owned Markdown for chat
+	 * clients.
+	 *
+	 * @param array $proposal Structured campaign proposal.
+	 * @return string
+	 */
+	private static function format_prepare_campaign_message( array $proposal ): string {
+		$preview          = self::build_campaign_preview( $proposal );
+		$forecast_summary = self::build_forecast_summary( $proposal );
+		$message          = __( 'Campaign proposal prepared for review in Blaze.', 'jetpack-blaze' ) . "\n\n";
+
+		$message .= '| ' . __( 'Campaign preview', 'jetpack-blaze' ) . ' | ' . __( 'Prepared value', 'jetpack-blaze' ) . " |\n";
+		$message .= "| --- | --- |\n";
+
+		$rows = array(
+			array(
+				'label' => __( 'Ad heading', 'jetpack-blaze' ),
+				'value' => $preview['ad_heading'],
+			),
+			array(
+				'label' => __( 'Ad copy', 'jetpack-blaze' ),
+				'value' => $preview['ad_copy'],
+			),
+			array(
+				'label' => __( 'Call to action', 'jetpack-blaze' ),
+				'value' => $preview['call_to_action'],
+			),
+			array(
+				'label' => __( 'Objective', 'jetpack-blaze' ),
+				'value' => $preview['objective'],
+			),
+			array(
+				'label' => __( 'Budget', 'jetpack-blaze' ),
+				'value' => $preview['budget'],
+			),
+			array(
+				'label' => __( 'Duration', 'jetpack-blaze' ),
+				'value' => $preview['duration'],
+			),
+			array(
+				'label' => __( 'Schedule', 'jetpack-blaze' ),
+				'value' => $preview['schedule'],
+			),
+			array(
+				'label' => __( 'Audience', 'jetpack-blaze' ),
+				'value' => $preview['audience'],
+			),
+			array(
+				'label' => __( 'Landing page', 'jetpack-blaze' ),
+				'value' => $preview['landing_page'],
+			),
+		);
+
+		foreach ( $rows as $row ) {
+			$message .= '| ' . self::format_markdown_table_cell( $row['label'] ) . ' | ' . self::format_markdown_table_cell( $row['value'] ) . " |\n";
+		}
+
+		$message .= "\n" . __( 'Forecast:', 'jetpack-blaze' ) . ' ' . $forecast_summary . "\n";
+
+		if ( ! empty( $proposal['budget_options'] ) && is_array( $proposal['budget_options'] ) ) {
+			$message .= "\n" . __( 'Budget options:', 'jetpack-blaze' ) . "\n";
+			$message .= '| ' . __( 'Option', 'jetpack-blaze' ) . ' | ' . __( 'Total budget', 'jetpack-blaze' ) . ' | ' . __( 'Daily budget', 'jetpack-blaze' ) . ' | ' . __( 'Duration', 'jetpack-blaze' ) . ' | ' . __( 'Recommendation', 'jetpack-blaze' ) . " |\n";
+			$message .= "| --- | --- | --- | --- | --- |\n";
+
+			foreach ( $proposal['budget_options'] as $option ) {
+				if ( ! is_array( $option ) ) {
+					continue;
+				}
+
+				$budget         = isset( $option['budget'] ) && is_array( $option['budget'] ) ? $option['budget'] : array();
+				$daily_budget   = isset( $option['daily_budget'] ) && is_array( $option['daily_budget'] ) ? $option['daily_budget'] : array();
+				$currency       = isset( $budget['currency'] ) ? (string) $budget['currency'] : 'USD';
+				$daily_currency = isset( $daily_budget['currency'] ) ? (string) $daily_budget['currency'] : $currency;
+
+				$message .= '| ' . self::format_markdown_table_cell( $option['label'] ?? '' );
+				$message .= ' | ' . self::format_markdown_table_cell( self::format_currency_amount( isset( $budget['amount'] ) ? (float) $budget['amount'] : 0.0, $currency ) );
+				$message .= ' | ' . self::format_markdown_table_cell( self::format_currency_amount( isset( $daily_budget['amount'] ) ? (float) $daily_budget['amount'] : 0.0, $daily_currency ) );
+				$message .= ' | ' . self::format_markdown_table_cell( self::format_days( isset( $option['duration_days'] ) ? (int) $option['duration_days'] : 1 ) );
+				$message .= ' | ' . self::format_markdown_table_cell( $option['rationale'] ?? '' ) . " |\n";
+			}
+		}
+
+		$message .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
+		$message .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
+		$message .= "\n" . __( 'Review URL:', 'jetpack-blaze' ) . ' ' . (string) ( $proposal['prefill_url'] ?? '' );
+
+		return $message;
+	}
+
+	/**
+	 * Build a compact human-readable forecast sentence.
+	 *
+	 * @param array $proposal Structured campaign proposal.
+	 * @return string
+	 */
+	private static function build_forecast_summary( array $proposal ): string {
+		$forecast = isset( $proposal['forecast'] ) && is_array( $proposal['forecast'] ) ? $proposal['forecast'] : array();
+		if ( 'available' !== ( $forecast['status'] ?? '' ) ) {
+			return isset( $forecast['message'] ) && '' !== (string) $forecast['message']
+				? (string) $forecast['message']
+				: __( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', 'jetpack-blaze' );
+		}
+
+		$primary_metric   = isset( $forecast['primary_metric'] ) ? (string) $forecast['primary_metric'] : 'views';
+		$secondary_metric = isset( $forecast['secondary_metric'] ) ? (string) $forecast['secondary_metric'] : 'clicks';
+
+		return sprintf(
+			/* translators: 1: primary metric range, 2: primary metric label, 3: secondary metric range, 4: secondary metric label. */
+			__( 'Estimated %1$s %2$s and %3$s %4$s for the recommended option.', 'jetpack-blaze' ),
+			self::format_metric_range( isset( $forecast[ $primary_metric ] ) && is_array( $forecast[ $primary_metric ] ) ? $forecast[ $primary_metric ] : array() ),
+			self::format_metric_label( $primary_metric ),
+			self::format_metric_range( isset( $forecast[ $secondary_metric ] ) && is_array( $forecast[ $secondary_metric ] ) ? $forecast[ $secondary_metric ] : array() ),
+			self::format_metric_label( $secondary_metric )
+		);
+	}
+
+	/**
+	 * Format an array of natural-language strings as a Markdown list.
+	 *
+	 * @param string $heading List heading.
+	 * @param mixed  $items   List items.
+	 * @return string
+	 */
+	private static function format_text_list( string $heading, $items ): string {
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return '';
+		}
+
+		$message = "\n\n" . $heading . "\n";
+		foreach ( $items as $item ) {
+			$message .= '- ' . str_replace( array( "\r\n", "\r", "\n" ), ' ', (string) $item ) . "\n";
+		}
+
+		return rtrim( $message, "\n" );
+	}
+
+	/**
+	 * Format a value for safe use inside a Markdown table cell.
+	 *
+	 * @param mixed $value Cell value.
+	 * @return string
+	 */
+	private static function format_markdown_table_cell( $value ): string {
+		$value = str_replace( array( "\r\n", "\r", "\n" ), ' ', (string) $value );
+		return str_replace( '|', '\\|', $value );
+	}
+
+	/**
+	 * Format a currency amount.
+	 *
+	 * @param float  $amount   Amount.
+	 * @param string $currency ISO 4217 currency code.
+	 * @return string
+	 */
+	private static function format_currency_amount( float $amount, string $currency ): string {
+		return sprintf( '%s %s', strtoupper( $currency ), number_format_i18n( $amount, 2 ) );
+	}
+
+	/**
+	 * Format campaign duration.
+	 *
+	 * @param int $days Duration in days.
+	 * @return string
+	 */
+	private static function format_days( int $days ): string {
+		$days = max( 1, $days );
+		return sprintf(
+			/* translators: %d: number of campaign days. */
+			_n( '%d day', '%d days', $days, 'jetpack-blaze' ),
+			$days
+		);
+	}
+
+	/**
+	 * Format the server-owned objective for display.
+	 *
+	 * @param string $objective DSP objective code.
+	 * @return string
+	 */
+	private static function format_objective( string $objective ): string {
+		if ( 'CLICKS' === strtoupper( $objective ) ) {
+			return __( 'Clicks', 'jetpack-blaze' );
+		}
+		if ( 'VIEWS' === strtoupper( $objective ) ) {
+			return __( 'Views', 'jetpack-blaze' );
+		}
+		return '' === $objective ? __( 'Not specified', 'jetpack-blaze' ) : $objective;
+	}
+
+	/**
+	 * Format a forecast metric range.
+	 *
+	 * @param array $range Metric range with min/max values.
+	 * @return string
+	 */
+	private static function format_metric_range( array $range ): string {
+		$min = isset( $range['min'] ) ? (int) $range['min'] : 0;
+		$max = isset( $range['max'] ) ? (int) $range['max'] : $min;
+
+		if ( $min === $max ) {
+			return number_format_i18n( $min );
+		}
+
+		return number_format_i18n( $min ) . '-' . number_format_i18n( $max );
+	}
+
+	/**
+	 * Format a forecast metric label.
+	 *
+	 * @param string $metric Metric code.
+	 * @return string
+	 */
+	private static function format_metric_label( string $metric ): string {
+		if ( 'clicks' === $metric ) {
+			return __( 'clicks', 'jetpack-blaze' );
+		}
+		return __( 'views', 'jetpack-blaze' );
+	}
+
+	/**
+	 * Summarize audience overrides without exposing implementation-shaped JSON.
+	 *
+	 * @param array $prefill Prefill payload.
+	 * @return string
+	 */
+	private static function format_audience_summary( array $prefill ): string {
+		$parts = array();
+
+		$parts[] = empty( $prefill['countries'] ) ? __( 'all locations', 'jetpack-blaze' ) : sprintf(
+			/* translators: %s: comma-separated country codes. */
+			__( 'countries: %s', 'jetpack-blaze' ),
+			implode( ', ', array_map( 'strval', (array) $prefill['countries'] ) )
+		);
+		$parts[] = empty( $prefill['languages'] ) ? __( 'all languages', 'jetpack-blaze' ) : sprintf(
+			/* translators: %s: comma-separated language codes. */
+			__( 'languages: %s', 'jetpack-blaze' ),
+			implode( ', ', array_map( 'strval', (array) $prefill['languages'] ) )
+		);
+		$parts[] = empty( $prefill['devices'] ) ? __( 'all devices', 'jetpack-blaze' ) : sprintf(
+			/* translators: %s: comma-separated device codes. */
+			__( 'devices: %s', 'jetpack-blaze' ),
+			implode( ', ', array_map( 'strval', (array) $prefill['devices'] ) )
+		);
+
+		if ( ! empty( $prefill['page_topics'] ) ) {
+			$parts[] = sprintf(
+				/* translators: %s: comma-separated page topic codes. */
+				__( 'topics: %s', 'jetpack-blaze' ),
+				implode( ', ', array_map( 'strval', (array) $prefill['page_topics'] ) )
+			);
+		}
+
+		return implode( '; ', $parts );
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -324,7 +324,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'message'          => array(
 							'type'        => 'string',
-							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
+							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat before the review link; it includes a campaign preview table and the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
 						'campaign_preview' => array(
 							'type'        => 'object',
@@ -520,14 +520,12 @@ class Blaze_Abilities extends Registrar {
 			return $proposal;
 		}
 
-		return array_merge(
-			$proposal,
-			array(
-				'campaign_preview' => self::build_campaign_preview( $proposal ),
-				'forecast_summary' => self::build_forecast_summary( $proposal ),
-				'message'          => self::format_prepare_campaign_message( $proposal ),
-			)
-		);
+		return array(
+			'status'           => $proposal['status'],
+			'message'          => self::format_prepare_campaign_message( $proposal ),
+			'campaign_preview' => self::build_campaign_preview( $proposal ),
+			'forecast_summary' => self::build_forecast_summary( $proposal ),
+		) + $proposal;
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -193,21 +193,21 @@ class Campaign_Preparer_Test extends BaseTestCase {
 			)
 		);
 
-			$this->assertIsArray( $result );
-			$this->assertIsArray( $captured_body );
-			$captured_body = is_array( $captured_body ) ? $captured_body : array();
-			$this->assertSame(
-				array(
-					'time_zone',
-					'start_date',
-					'end_date',
-					'total_budget',
-					'is_evergreen',
-					'is_tsp_eligible',
-					'targeting',
-				),
-				array_keys( $captured_body )
-			);
+		$this->assertIsArray( $result );
+		$this->assertIsArray( $captured_body );
+		$captured_body = is_array( $captured_body ) ? $captured_body : array();
+		$this->assertSame(
+			array(
+				'time_zone',
+				'start_date',
+				'end_date',
+				'total_budget',
+				'is_evergreen',
+				'is_tsp_eligible',
+				'targeting',
+			),
+			array_keys( $captured_body )
+		);
 		$this->assertSame( 80, $captured_body['total_budget'] );
 		$this->assertSame( gmdate( 'Y-m-d' ), $captured_body['start_date'] );
 		$this->assertSame( gmdate( 'Y-m-d', strtotime( '+7 days' ) ), $captured_body['end_date'] );

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -14,6 +14,7 @@ use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WP_Error;
+use WP_REST_Server;
 
 /**
  * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
@@ -51,6 +52,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			array( 'approved' => true ),
 			DAY_IN_SECONDS
 		);
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
 	}
 
 	/**
@@ -63,6 +67,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
 		remove_all_actions( 'wp_after_execute_ability' );
+		unset( $GLOBALS['wp_rest_server'] );
 	}
 
 	// --- list-campaigns read ability ---
@@ -397,6 +402,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
 		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
 		$this->assertSame( array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ), $properties['languages']['items']['enum'] );
+		$this->assertSame( '^[A-Z]{2}$', $properties['countries']['items']['pattern'] );
 		$this->assertSame( 1, $properties['devices']['maxItems'] );
 		$this->assertSame( array( 'mobile', 'desktop' ), $properties['devices']['items']['enum'] );
 		$this->assertStringContainsString( 'Tablet is not exposed', $properties['devices']['description'] );
@@ -405,6 +411,14 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
 
 		$output_properties = $ability['output_schema']['properties'];
+		$this->assertContains( 'message', $ability['output_schema']['required'] );
+		$this->assertContains( 'campaign_preview', $ability['output_schema']['required'] );
+		$this->assertContains( 'forecast_summary', $ability['output_schema']['required'] );
+		$this->assertArrayHasKey( 'message', $output_properties );
+		$this->assertArrayHasKey( 'campaign_preview', $output_properties );
+		$this->assertArrayHasKey( 'forecast_summary', $output_properties );
+		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
+		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
@@ -434,6 +448,23 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		return array(
 			'post_id'    => (int) $post_id,
 			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * Register a test forecast route for the preparer's proxied DSP request.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_forecast_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
 		);
 	}
 
@@ -490,6 +521,19 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertNotEmpty( $result['prefill_url'] );
 		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
 		$this->assertStringContainsString( $result['prefill_url'], $result['message'] );
+		$this->assertArrayNotHasKey( 'budget_options', $result );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
+		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
+		$this->assertSame( 'Test product page', $result['campaign_preview']['ad_heading'] );
+		$this->assertSame( 'USD 50.00 total (USD 3.57/day)', $result['campaign_preview']['budget'] );
+		$this->assertStringContainsString( '| Campaign preview | Prepared value |', $result['message'] );
+		$this->assertStringContainsString( '| Ad heading | Test product page |', $result['message'] );
+		$this->assertStringContainsString( '| Budget | USD 50.00 total (USD 3.57/day) |', $result['message'] );
+		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
+		$this->assertStringContainsString( 'Assumptions:', $result['message'] );
+		$this->assertStringContainsString( 'Recommendations:', $result['message'] );
+		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringNotContainsString( 'Budget options:', $result['message'] );
 
 		$prefill = $result['prefill'];
 		$this->assertSame( $ctx['target_urn'], $prefill['target_urn'] );
@@ -524,6 +568,73 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'content', $result['intent'] );
 		$this->assertSame( 'unavailable', $result['forecast']['status'] );
 		$this->assertCount( 3, $result['budget_options'] );
+		$this->assertStringContainsString( 'Budget options:', $result['message'] );
+		$this->assertStringContainsString( '| Lower | USD 25.00 | USD 3.57 | 7 days |', $result['message'] );
+		$this->assertStringContainsString( '| Recommended | USD 50.00 | USD 7.14 | 7 days |', $result['message'] );
+		$this->assertStringContainsString( '| Higher | USD 150.00 | USD 21.43 | 7 days |', $result['message'] );
+	}
+
+	/**
+	 * Available DSP forecasts are summarized in the chat-facing message while
+	 * the structured forecast remains available.
+	 */
+	public function test_prepare_campaign_message_includes_forecast_summary_when_available() {
+		$ctx = $this->make_test_post();
+		$this->register_forecast_route(
+			static function () {
+				return array(
+					'total_impressions_min'     => 1200,
+					'total_impressions_max'     => 2400,
+					'total_clicks_min'          => 30,
+					'total_clicks_max'          => 60,
+					'total_tsp_impressions_min' => 0,
+					'total_tsp_impressions_max' => 0,
+				);
+			}
+		);
+
+		$result = Blaze_Abilities::prepare_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'available', $result['forecast']['status'] );
+		$this->assertSame( 'views', $result['forecast']['primary_metric'] );
+		$this->assertSame( 'Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['forecast_summary'] );
+		$this->assertStringContainsString( 'Forecast: Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['message'] );
+		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+	}
+
+	/**
+	 * Forecast failures should produce a useful fallback instead of hiding the
+	 * review URL or structured proposal.
+	 */
+	public function test_prepare_campaign_message_includes_forecast_fallback() {
+		$ctx = $this->make_test_post();
+		$this->register_forecast_route(
+			static function () {
+				return new WP_Error( 'forecast_unavailable', 'Forecast failed.', array( 'status' => 500 ) );
+			}
+		);
+
+		$result = Blaze_Abilities::prepare_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
+		$this->assertSame( 'forecast_unavailable', $result['forecast']['reason'] );
+		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
+		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
+		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -517,6 +517,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		);
 
 		$this->assertIsArray( $result );
+		$this->assertSame( array( 'status', 'message' ), array_slice( array_keys( $result ), 0, 2 ) );
 		$this->assertSame( 'pending_merchant_review', $result['status'] );
 		$this->assertNotEmpty( $result['prefill_url'] );
 		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );


### PR DESCRIPTION
## Summary
- Adds a merchant-readable Markdown preview message for `blaze-ads/prepare-campaign`.
- Adds structured `campaign_preview` and `forecast_summary` fields for clients that can render richer UI.
- Covers forecast fallback, forecast summary, budget options, and output schema expectations in ability tests.

## Testing
- `composer test-php` from `projects/packages/blaze`
- `php -l projects/packages/blaze/src/abilities/class-blaze-abilities.php`
- `php -l projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php`
- `git diff --check origin/add/ads-1038-forecast-estimates...HEAD`

Stacked on #48601.

Refs ADS-1039