### PR TITLE
Social: default to the site-wide message template when no share message is set

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/global.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/global.tsx
@@ -1,3 +1,6 @@
+import { useSelect } from '@wordpress/data';
+import useSocialMediaMessage from '../../../hooks/use-social-media-message';
+import { store as socialStore } from '../../../social-store';
 import { hasSocialPaidFeatures } from '../../../utils';
 import { SharePostForm } from '../../form/share-post-form';
 import { UpgradeNoticeCustomization } from '../../form/upgrade-notice-customization';
@@ -10,10 +13,23 @@ import { UpgradeNoticeCustomization } from '../../form/upgrade-notice-customizat
 export function GlobalCustomizationForm() {
 	const hasPaidFeatures = hasSocialPaidFeatures();
 
+	// Pre-fill the message field with the admin-page main template when the user
+	// hasn't typed a per-post share message, so the editor reflects what the
+	// rendered preview will use as a fallback (see `useRenderMessageItems`).
+	// Empty `shareMessage` is preserved in post meta — the template only shows
+	// as the displayed value, never as `updateMessage`'s input.
+	const { message: shareMessage } = useSocialMediaMessage();
+	const messageTemplate = useSelect(
+		select => select( socialStore ).getSocialSettings().messageTemplate ?? '',
+		[]
+	);
+	const message = shareMessage || messageTemplate;
+
 	return (
 		<SharePostForm
 			analyticsData={ { location: 'preview-modal' } }
 			isInsideNavigatorModal
+			message={ message }
 			upgradeNotice={ ! hasPaidFeatures ? <UpgradeNoticeCustomization /> : undefined }
 		/>
 	);

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -91,7 +91,17 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 
 	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 	const items = useRenderMessageItems();
+	const messageTemplate = useSelect(
+		select =>
+			templatesEnabled ? select( socialStore ).getSocialSettings().messageTemplate ?? '' : '',
+		[ templatesEnabled ]
+	);
 	const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
+	// Falls back to the admin-page main template (`messageTemplate`) when no
+	// per-post message is set. Mirrors the rule in `useRenderMessageItems` so the
+	// consumer's view of `baseMessage` matches what the resolver was sent.
+	const globalFallback = globalMessage || messageTemplate || '';
+
 	let baseMessage: string;
 	if ( isPerNetworkMode ) {
 		if ( hasConnectionMessage ) {
@@ -99,10 +109,10 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		} else if ( templatesEnabled && connection.template ) {
 			baseMessage = connection.template;
 		} else {
-			baseMessage = globalMessage;
+			baseMessage = globalFallback;
 		}
 	} else {
-		baseMessage = globalMessage;
+		baseMessage = globalFallback;
 	}
 	baseMessage = baseMessage.trim();
 	const currentRenderItem = items.find( item => item.id === connection.connection_id );

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -115,24 +115,27 @@ const defaultPostData = {
 
 /**
  * Mock the chained useSelect calls inside the hook so each one returns its expected
- * shape: postId, featuredImageId, then the rendered slice.
+ * shape: postId, featuredImageId, messageTemplate, then the rendered slice.
  *
  * @param opts                   - Per-test overrides.
  * @param opts.postId            - Post id returned to the editor-store useSelect.
+ * @param opts.messageTemplate   - The site-wide social message template from `getSocialSettings()`.
  * @param opts.rendered          - String returned for the rendered slice, or null to signal "no slice yet".
  * @param opts.isLoadingRendered - Whether the rendered-messages cache slot is currently in-flight.
  */
 function mockSelectCalls(
 	opts: {
 		postId?: number;
+		messageTemplate?: string;
 		rendered?: string | null;
 		isLoadingRendered?: boolean;
 	} = {}
 ) {
-	const { postId = 42, rendered = null, isLoadingRendered = false } = opts;
+	const { postId = 42, messageTemplate = '', rendered = null, isLoadingRendered = false } = opts;
 	mockUseSelect
 		.mockReturnValueOnce( postId )
 		.mockReturnValueOnce( 0 )
+		.mockReturnValueOnce( messageTemplate )
 		.mockReturnValueOnce( { rendered, isLoadingRendered } );
 }
 

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -85,6 +85,12 @@ export function useRenderMessageItems(): RenderItem[] {
 		[ templatesEnabled ]
 	);
 
+	const messageTemplate = useSelect(
+		select =>
+			templatesEnabled ? select( socialStore ).getSocialSettings().messageTemplate ?? '' : '',
+		[ templatesEnabled ]
+	);
+
 	const { isEnabled: isPerNetworkMode } = usePerNetworkCustomization();
 	const { mediaSource: globalMediaSource } = usePostMeta();
 	const postData = useSocialPreviewPostData();
@@ -124,6 +130,11 @@ export function useRenderMessageItems(): RenderItem[] {
 			// global mode here, the consumer's `baseMessage` (globalMessage) won't
 			// match this items array's message and `isDebouncingRenderedMessage` stays
 			// stuck true after the user toggles per-network → global.
+			// Falls back to the admin-page main template (`messageTemplate`) when no
+			// per-post message is set, so a site-wide template configured on the social
+			// admin page is reflected in the editor preview.
+			const globalFallback = globalMessage || messageTemplate || '';
+
 			let raw: string;
 			if ( ctx.isPerNetworkMode ) {
 				if ( hasConnectionMessage ) {
@@ -131,10 +142,10 @@ export function useRenderMessageItems(): RenderItem[] {
 				} else if ( templatesEnabled && connection.template ) {
 					raw = connection.template;
 				} else {
-					raw = globalMessage ?? '';
+					raw = globalFallback;
 				}
 			} else {
-				raw = globalMessage ?? '';
+				raw = globalFallback;
 			}
 			return {
 				id: connection.connection_id,
@@ -143,7 +154,7 @@ export function useRenderMessageItems(): RenderItem[] {
 				is_social_post: connectionHasMedia( connection, ctx ),
 			};
 		} );
-	}, [ connections, globalMessage, ctx, templatesEnabled ] );
+	}, [ connections, globalMessage, messageTemplate, ctx, templatesEnabled ] );
 
 	return useDebouncedItems( items );
 }

--- a/projects/packages/publicize/changelog/fix-social-479-default-to-message-template
+++ b/projects/packages/publicize/changelog/fix-social-479-default-to-message-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fall back to the site-wide social message template when no per-post share message is set, so the editor preview and customization field reflect the template configured on the Social admin page.

--- a/projects/plugins/jetpack/changelog/fix-social-479-default-to-message-template
+++ b/projects/plugins/jetpack/changelog/fix-social-479-default-to-message-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: fall back to the site-wide social message template when no per-post share message is set.

--- a/projects/plugins/social/changelog/fix-social-479-default-to-message-template
+++ b/projects/plugins/social/changelog/fix-social-479-default-to-message-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fall back to the site-wide social message template when no per-post share message is set.


### PR DESCRIPTION
Fixes SOCIAL-479

## Proposed changes

When a site admin configures a main social message template on the Social admin page but the post has no per-post share message, the editor previously ignored the template entirely:

- The "Message" field in the global customization form stayed empty.
- The platform-styled preview rendered against an empty `globalMessage`, so the template never appeared.

Adds the template as a fallback in three places so both sides of the preview pipeline agree:

- `useRenderMessageItems`: `items[i].message` falls back to `getSocialSettings().messageTemplate` when `globalMessage` is empty (so the `/render-messages` request renders against it).
- `useConnectionPreviewData`: `baseMessage` uses the same fallback. Mirrors the items rule exactly — if the two diverge, `isDebouncingRenderedMessage` stays stuck `true` and the preview hangs on the skeleton.
- `GlobalCustomizationForm`: pre-fills the `<MessageBoxControl>` value with the template when the user hasn't typed anything. `shareMessage` stays empty in post meta, so saving doesn't persist the template as if the user had typed it.

## Related product discussion/links

-

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Social admin page → "Message template" section. Set a main template, e.g. `Custom: {title} — {url}`. Save.
2. Open a post in the block editor. Open the Social preview/customization UI in **global mode**. Confirm:
   - The "Message" field is pre-filled with `Custom: {title} — {url}` (placeholder unchanged).
   - The platform-styled preview renders the template (resolved tokens) once `/render-messages` returns.
3. Type something in the message field. Confirm the preview switches to your typed text after the debounce.
4. Clear the message field. Confirm the field re-displays the template and the preview renders against it again.
5. Publish the post **without typing anything**. Open the post in the editor again — confirm the message field is empty (showing the template via the fallback, not because it was persisted).
6. Switch to **per-network mode**. Repeat 2–4 — the template should still flow through any connection that has neither a per-connection message nor a per-network template.