### PR TITLE
Backup: render the modernized dashboard inside a Page chassis

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2030,6 +2030,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.90.8
         version: 5.90.8(react@18.3.1)
+      '@wordpress/admin-ui':
+        specifier: 2.0.0
+        version: 2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/api-fetch':
         specifier: 7.44.0
         version: 7.44.0

--- a/projects/packages/backup/changelog/update-backup-modernization-page-shell
+++ b/projects/packages/backup/changelog/update-backup-modernization-page-shell
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Render the modernized dashboard inside Page from @wordpress/admin-ui and suppress core/plugin admin notices on the modernized page; no effect when the modernization filter is off.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -39,6 +39,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@tanstack/react-query": "5.90.8",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/data": "10.44.0",

--- a/projects/packages/backup/routes/dashboard/package.json
+++ b/projects/packages/backup/routes/dashboard/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@types/react": "18.3.28",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0"
 	},

--- a/projects/packages/backup/routes/dashboard/stage.tsx
+++ b/projects/packages/backup/routes/dashboard/stage.tsx
@@ -1,6 +1,18 @@
+import { Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+
 const Stage = () => {
-	// "Backup" is a product name, do not translate.
-	return <h1>Backup</h1>;
+	// "VaultPress Backup" is a product name, do not translate.
+	return (
+		<Page
+			title="VaultPress Backup"
+			subTitle={ __(
+				'Save changes and restore quickly with one-click recovery.',
+				'jetpack-backup-pkg'
+			) }
+			hasPadding={ false }
+		/>
+	);
 };
 
 export { Stage as stage };

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -188,6 +188,16 @@ class Jetpack_Backup {
 	 */
 	public static function admin_init() {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
+
+		if ( self::is_modernized() ) {
+			// The modernized Backup overview is a focused, full-screen product
+			// surface. Suppress JITMs and other core/plugin admin notices so they
+			// don't reflow on top of the dual-pane layout. Mirrors how Jetpack
+			// Forms handles its dashboard page
+			// (`plugins/forms/src/dashboard/class-dashboard.php`).
+			remove_all_actions( 'admin_notices' );
+			remove_all_actions( 'all_admin_notices' );
+		}
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/update-backup-modernization-page-shell
+++ b/projects/plugins/backup/changelog/update-backup-modernization-page-shell
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Render the modernized dashboard inside Page from @wordpress/admin-ui; no effect when the modernization filter is off.

--- a/projects/plugins/jetpack/changelog/update-backup-modernization-page-shell
+++ b/projects/plugins/jetpack/changelog/update-backup-modernization-page-shell
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Render the modernized Backup dashboard inside the wp-admin Page chassis under feature flag.


### PR DESCRIPTION
Refs #48582

## Proposed changes

PR 2 of eight in the Backup modernization umbrella. Replaces PR 1's [`<h1>Backup</h1>`](https://github.com/Automattic/jetpack/pull/48583) placeholder with `Page` from `@wordpress/admin-ui` (title "VaultPress Backup", subtitle, empty body) so the modernized surface picks up the standard wp-admin chrome. Suppresses `admin_notices` and `all_admin_notices` on the modernized page only, mirroring how Jetpack Forms keeps its dashboard from reflowing on top of JITMs and other plugin notices.

No data layer, no gates, no router yet — those land in PR 2.5 (`update/backup-modernization-data-layer`). The modernization filter (`rsm_jetpack_ui_modernization_backup`) still defaults to `false`, so today's Backup admin page renders unchanged for every site.

Mirrors the cadence of #48574 (Newsletter page-shell).

## Testing instructions

1. **Filter OFF — legacy Backup admin page is unchanged.** Visit **Jetpack → VaultPress Backup**. The page renders today's standalone UI exactly as it did before this PR. Any `admin_notices` / `all_admin_notices` registered by core or other plugins still render — this PR doesn't touch them.

2. **Filter ON — modernized chassis renders.** Add to a mu-plugin:
   ```php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
   Reload **Jetpack → VaultPress Backup**. The page now renders the wp-admin `Page` chassis: a header with the **VaultPress Backup** title and the *Save changes and restore quickly with one-click recovery.* subtitle, followed by an empty body. Any `admin_notices` registered above (e.g. via `add_action( 'admin_notices', fn() => print '<div class=\"notice notice-warning\"><p>Test</p></div>' );`) are suppressed.

3. **Toggle the filter back off.** Reload — legacy Backup returns immediately, no cache clears.

## Does this pull request change what data or activity we track or use?

No. No new endpoints, payloads, identifiers, Tracks events, or persistent options. The new `Page` shell renders an empty body — there is no data flow yet.

## Out of scope

* No data layer, no gates, no router, no REST bridges (PR 2.5).
* No Overview, file browser, Download, or Restore screens (PRs 3-6).

## References

* Umbrella: #48582
* Working reference (kept open until PR 7 lands): #48236
* Predecessor: #48583 (PR 1 — scaffold)
* Cadence template: #48574 (Newsletter page-shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)