### PR TITLE
Search Dashboard: unstick upsell page under layout mixin

### DIFF
--- a/projects/packages/search/changelog/fix-search-upsell-page-mixin-flex-shrink
+++ b/projects/packages/search/changelog/fix-search-upsell-page-mixin-flex-shrink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: fix the upsell page clipping its pricing rows at the footer line under the shared `jetpack-admin-page-layout` mixin. Wrap `<AdminSectionHero>` in a block-level `<div>` so the section's `overflow: hidden` (its margin-collapse guard) doesn't make it a flex item that shrinks below its content height — letting the mixin's middle `overflow: auto` engage and the rows scroll naturally. Mirrors the `.content { display: block }` precedent in `projects/packages/publicize/_inc/components/admin-page/styles.module.scss`.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -108,16 +108,29 @@ export default function UpsellPage( { isLoading = false } ) {
 						)
 					}
 				>
-					<AdminSectionHero>
-						{ isNewPricing ? (
-							<NewPricingComponent
-								sendToCartPaid={ sendToCartPaid }
-								sendToCartFree={ sendToCartFree }
-							/>
-						) : (
-							<OldPricingComponent sendToCart={ sendToCartPaid } />
-						) }
-					</AdminSectionHero>
+					{ /*
+					 * `<AdminSectionHero>` has `overflow: hidden` (BFC for margin
+					 * collapse), which under the shared admin-page-layout mixin's
+					 * flex chain resolves its `min-height: auto` to 0 and lets
+					 * flex shrink it past its content — clipping the pricing rows
+					 * at the footer line and starving the middle's `overflow:
+					 * auto` of any overflow to engage. The block-level wrapper
+					 * exits the flex chain so the inner content sizes to its
+					 * natural height. See `.jp-search-upsell-page-content` rule
+					 * + comment in styles.scss for full reasoning.
+					 */ }
+					<div className="jp-search-upsell-page-content">
+						<AdminSectionHero>
+							{ isNewPricing ? (
+								<NewPricingComponent
+									sendToCartPaid={ sendToCartPaid }
+									sendToCartFree={ sendToCartFree }
+								/>
+							) : (
+								<OldPricingComponent sendToCart={ sendToCartPaid } />
+							) }
+						</AdminSectionHero>
+					</div>
 				</AdminPage>
 			) }
 		</>

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/styles.scss
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/styles.scss
@@ -1,5 +1,22 @@
 @use "scss/variables";
 
+// Restore plain block layout between `<AdminPage>` and `<AdminSectionHero>`.
+// The shared `jetpack-admin-page-layout` mixin makes the wrapping `<Col>`
+// inside `<AdminPage>` a flex column so DataViews-style consumers can fill
+// the bounded slot. With `<AdminSectionHero>` (which has `overflow: hidden`
+// to break margin-collapse) sitting directly under that flex column, the
+// CSS spec resolves the section's implied `min-height: auto` to `0` —
+// flex shrinks it to the bounded height, its `overflow: hidden` clips the
+// taller pricing rows, and the middle's `overflow: auto` never sees any
+// overflow to scroll. Wrapping in a `display: block` div gives `<Col>` a
+// single flow item with the default `min-height: auto` (overflow visible),
+// so the inner content stacks at its natural height and overflow falls
+// back to the middle's scroll surface. Mirrors the `.content` class in
+// `projects/packages/publicize/_inc/components/admin-page/styles.module.scss`.
+.jp-search-upsell-page-content {
+	display: block;
+}
+
 // Container ships with width:100% + padding without border-box, so it
 // overflows its parent. Force border-box and let descendants shrink past
 // their intrinsic width.


### PR DESCRIPTION
## Proposed changes

* Wrap `<AdminSectionHero>` in a `display: block` div inside the Search upsell page so it isn't a direct flex child of `<AdminPage>`'s `<Col>` under the shared `jetpack-admin-page-layout` mixin.

### Why

`<AdminSectionHero>` sets `overflow: hidden` on itself to establish a BFC and break inner-section margin collapse. Per the CSS flex spec, a flex item whose main-axis overflow is anything but `visible` has its implied `min-height: auto` resolved to `0`. The mixin makes `<Col>` a flex column (so DataViews-style consumers can fill the bounded slot), so `<AdminSectionHero>` was being shrunk past its content height; its own `overflow: hidden` then clipped the taller pricing rows, and the middle's `overflow: auto` never saw any overflow to engage. Visually: the pricing rows cut at the footer line and the page wasn't scrollable.

The block-level wrapper exits the flex chain at the consumer level. The wrapper sizes to its content's natural height, the inner `<AdminSectionHero>` keeps its margin-collapse BFC, and the middle scroll surface engages naturally.

This mirrors the precedent established in [`projects/packages/publicize/_inc/components/admin-page/styles.module.scss`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/publicize/_inc/components/admin-page/styles.module.scss) (the `.content { display: block }` rule), which exists for the exact same reason in Publicize's mixin adoption. Comments in both the JSX and SCSS point at that precedent so future readers see the pattern.

## Related product discussion/links

* The bug is only observable on WPCOM (where the `isNewPricing202208` PricingTable variant renders). The local docker site serves the older `OldPricingComponent` (single `<PricingCard>`, short content), so the flex-shrink + clip path doesn't surface there.

## Does this pull request change what data or activity we track or use?

No. CSS/layout-only.

## Testing instructions

On a free-plan WPCOM site:

1. Visit `/wp-admin/admin.php?page=jetpack-search`. The upsell pricing page should render with the standard Jetpack chrome (header at top, JetpackFooter pinned at the viewport bottom).
2. **Before this PR:** the comparison table cuts off around "Powerful filtering" — the rows below ("Supports 38 languages", "Spelling correction", and the bottom CTA row for the free column) are clipped at the footer line and there's no scrollbar.
3. **After this PR:** the middle of the page should now scroll naturally. All comparison rows should be reachable, and both pricing columns' CTAs ("Get Search" / "Start for free") should be visible at the bottom of the scroll surface.

A console probe to confirm the mixin's scroll surface is engaging:

```js
const m = document.querySelector('.jp-admin-page__page > div[class*="SqdhU"]:not([class*="jetpack-footer"])');
console.log( getComputedStyle(m).overflow, m.scrollHeight, m.clientHeight );
// Before: "auto 608 608" (no overflow detected → no scroll)
// After:  "auto <bigger> 608" (overflow detected → scroll engages)
```

No regression expected on the local docker upsell page (it renders `OldPricingComponent`, which is short content that doesn't overflow either before or after).
