### PR TITLE
Forms: submit button full width on mobile in horizontal layout

### DIFF
--- a/projects/packages/forms/changelog/forms-button-full-width-mobile
+++ b/projects/packages/forms/changelog/forms-button-full-width-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: submit button stretches to full width on mobile in horizontal layout

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -20,6 +20,14 @@
 				word-break: normal;
 			}
 		}
+
+		@media only screen and ( max-width: 480px ) {
+
+			.wp-block-button,
+			.wp-block-jetpack-button {
+				width: 100%;
+			}
+		}
 	}
 
 	&.is-vertical:not(.is-content-justification-stretch) {


### PR DESCRIPTION
Fixes #48075

**Problem:** The submit button in a horizontal Jetpack Form stayed at content width on mobile because `flex: 0 0 auto` was set on `.wp-block-button` inside `&.is-horizontal` with no responsive override.

**Fix:** Added `@media only screen and (max-width: 480px)` inside `&.is-horizontal` setting `width: 100%` on the button. Breakpoint matches the existing one in `grunion.scss`.

**Testing:** Verified on Jurassic Ninja. Desktop unchanged; mobile (395px) button fills full width. 
* Form example here: https://lovely-integrated.jurassic.ninja/2026/05/07/7/ 
* `flex: 1 0 auto` was tested locally as a one-character alternative to the existing `flex: 0 0 auto`. It fixed mobile correctly but also caused the button to grow at desktop widths — pushing it to fill the row beside the input. The media query approach is more targeted, applying width: 100% only below 480px.


**Review:** Self-reviewed with `/review` skill before marking ready.

## Testing instructions:
1. Add a Jetpack Form block to a post
2. Remove extra fields, keep one (e.g. Email) set to auto-width
3. Set orientation: Horizontal, vertical alignment: Bottom
4. View on a mobile device or resize to under 480px
5. Confirm the submit button stretches to full width
6. Confirm desktop (>480px) is unchanged — button sits beside the input

## Does this pull request change what data or activity we track or use?
No. This is a CSS-only change with no impact on data or privacy.

#jetpack-bug-blitz