### PR TITLE
Search 3.0: redesign filter-wc-rating as "X stars & up" threshold UX (RSM-2663)

### DIFF
--- a/projects/packages/search/changelog/atlas-rsm-2663-rating-filter-stars-and-up
+++ b/projects/packages/search/changelog/atlas-rsm-2663-rating-filter-stars-and-up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search 3.0: redesign `jetpack-search/filter-wc-rating` as the industry-standard "X stars & up" threshold filter — single-select rows where picking 4★ matches every product rated 4 stars or higher, click the active row to clear. Filter clauses collapse to a single `gte: N - 0.5` range per row (no upper bound) and the count badges project the histogram cumulatively, so `count(3)` ≥ `count(4)` ≥ `count(5)`. Tracked under [RSM-2663].

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/block.json
@@ -19,7 +19,12 @@
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {
 		"label": { "type": "string", "default": "" },
-		"showCount": { "type": "boolean", "default": true }
+		"showCount": { "type": "boolean", "default": true },
+		"enabledStars": {
+			"type": "array",
+			"default": [ 5, 4, 3, 2, 1 ],
+			"items": { "type": "number" }
+		}
 	},
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/filter-wc-rating.js",

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/class-filter-wc-rating.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/class-filter-wc-rating.php
@@ -30,16 +30,44 @@ class Filter_Wc_Rating {
 
 	/**
 	 * Stable star option list for rendering. Highest first matches the
-	 * conventional e-commerce "4 stars & up, 3 stars & up, …" ordering;
-	 * since the underlying ES range clauses are non-overlapping (star=4
-	 * means avg ∈ [3.5, 4.5), not "≥ 3.5"), the visible label may say
-	 * "& up" but the selection semantics are exact buckets — multi-select
-	 * to OR adjacent stars together.
+	 * conventional e-commerce "4 stars & up, 3 stars & up, …" ordering.
+	 * Each row applies a `≥ N - 0.5` threshold filter; the 5★ row is
+	 * the only one without an "& up" affordance since it has no higher
+	 * tier to roll up into.
 	 *
 	 * @return int[] Star values 5..1.
 	 */
 	public static function get_star_values(): array {
 		return array( 5, 4, 3, 2, 1 );
+	}
+
+	/**
+	 * Resolve the author-configured subset of star rows to render. Empty
+	 * / malformed `enabledStars` falls back to all five rows so a stale
+	 * attribute can't render the block as an empty `<ul>`. Sanitized to
+	 * the 1..5 range, deduplicated, and re-sorted high-to-low to match
+	 * the canonical render order.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return int[]
+	 */
+	public static function get_enabled_stars( array $attributes ): array {
+		$raw = $attributes['enabledStars'] ?? null;
+		if ( ! is_array( $raw ) || empty( $raw ) ) {
+			return static::get_star_values();
+		}
+		$clean = array();
+		foreach ( $raw as $value ) {
+			$int = (int) $value;
+			if ( $int >= 1 && $int <= 5 ) {
+				$clean[ $int ] = $int;
+			}
+		}
+		if ( empty( $clean ) ) {
+			return static::get_star_values();
+		}
+		krsort( $clean );
+		return array_values( $clean );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/edit.js
@@ -1,12 +1,19 @@
 /**
  * Editor preview for jetpack-search/filter-wc-rating.
  *
- * Mirrors the runtime DOM shape — labeled list with five star rows and
- * optional count badges — so designers can style the rating filter in
- * place. Inspector exposes the user-tunable attributes (label, showCount).
+ * Mirrors the runtime DOM shape — labeled list with up to five star rows
+ * and optional count badges — so designers can style the rating filter
+ * in place. Inspector exposes the user-tunable attributes (label,
+ * showCount, enabledStars).
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	CheckboxControl,
+	PanelBody,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 
 const STAR_VALUES = [ 5, 4, 3, 2, 1 ];
@@ -40,6 +47,31 @@ function renderStars( filled ) {
 }
 
 /**
+ * Normalize the `enabledStars` attribute. An unset / empty / malformed
+ * value falls back to all five rows so a stale block instance can't
+ * render an empty list. Mirrors PHP's `Filter_Wc_Rating::get_enabled_stars`.
+ *
+ * @param {unknown} raw - Raw attribute value.
+ * @return {number[]} Star ints, deduplicated, high-to-low.
+ */
+function normalizeEnabledStars( raw ) {
+	if ( ! Array.isArray( raw ) || raw.length === 0 ) {
+		return [ ...STAR_VALUES ];
+	}
+	const set = new Set();
+	for ( const v of raw ) {
+		const n = Number( v );
+		if ( Number.isFinite( n ) && n >= 1 && n <= 5 ) {
+			set.add( Math.trunc( n ) );
+		}
+	}
+	if ( set.size === 0 ) {
+		return [ ...STAR_VALUES ];
+	}
+	return [ ...set ].sort( ( a, b ) => b - a );
+}
+
+/**
  * Edit component for the filter-wc-rating block.
  *
  * @param {object}   props               - Block props.
@@ -52,6 +84,36 @@ export default function FilterWcRatingEdit( { attributes, setAttributes } ) {
 	const rawLabel = attributes?.label || '';
 	const previewLabel = rawLabel || DEFAULT_LABEL;
 	const showCount = attributes?.showCount !== false;
+	const enabledStars = normalizeEnabledStars( attributes?.enabledStars );
+	const enabledSet = new Set( enabledStars );
+
+	const toggleStar = ( star, on ) => {
+		const next = new Set( enabledSet );
+		if ( on ) {
+			next.add( star );
+		} else {
+			// Don't let the author save an empty list — the block would
+			// render nothing on the front end. Force at least one row to
+			// stay enabled by rejecting the un-toggle when this is the
+			// last selected row.
+			if ( next.size <= 1 ) {
+				return;
+			}
+			next.delete( star );
+		}
+		setAttributes( { enabledStars: [ ...next ].sort( ( a, b ) => b - a ) } );
+	};
+
+	const labelForStar = star =>
+		star === 5
+			? __( '5 stars', 'jetpack-search-pkg' )
+			: sprintf(
+					/* translators: %d is the rating threshold (1-4). */
+					_n( '%d star and up', '%d stars and up', star, 'jetpack-search-pkg' ),
+					star
+			  );
+
+	const previewStars = STAR_VALUES.filter( s => enabledSet.has( s ) );
 
 	return (
 		<>
@@ -75,17 +137,33 @@ export default function FilterWcRatingEdit( { attributes, setAttributes } ) {
 						checked={ showCount }
 						onChange={ value => setAttributes( { showCount: !! value } ) }
 					/>
+					<BaseControl
+						__nextHasNoMarginBottom
+						id="filter-wc-rating-enabled-stars"
+						label={ __( 'Visible rows', 'jetpack-search-pkg' ) }
+						help={ __(
+							'Hide rows you don’t want shoppers to pick. At least one row must stay visible.',
+							'jetpack-search-pkg'
+						) }
+					>
+						{ STAR_VALUES.map( star => (
+							<CheckboxControl
+								key={ star }
+								__nextHasNoMarginBottom
+								label={ labelForStar( star ) }
+								checked={ enabledSet.has( star ) }
+								onChange={ on => toggleStar( star, on ) }
+							/>
+						) ) }
+					</BaseControl>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
 				<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
 				<ul className="jetpack-search-filter__list">
-					{ STAR_VALUES.map( star => {
-						const aria = sprintf(
-							/* translators: %d is the rating threshold (1-5). The row applies a "rating ≥ N stars" filter. */
-							_n( '%d star and up', '%d stars and up', star, 'jetpack-search-pkg' ),
-							star
-						);
+					{ previewStars.map( star => {
+						const isTop = star === 5;
+						const aria = labelForStar( star );
 						return (
 							<li key={ star } className="jetpack-search-filter__item">
 								{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies; rule's nesting heuristic doesn't trace through sibling spans */ }
@@ -95,12 +173,18 @@ export default function FilterWcRatingEdit( { attributes, setAttributes } ) {
 										<span className="jetpack-search-filter-rating__stars" aria-hidden="true">
 											{ renderStars( star ) }
 										</span>
-										<span
-											className="jetpack-search-filter-rating__threshold-suffix"
-											aria-hidden="true"
-										>
-											{ _x( '& up', 'rating filter row, e.g. "★★★★ & up"', 'jetpack-search-pkg' ) }
-										</span>
+										{ ! isTop && (
+											<span
+												className="jetpack-search-filter-rating__threshold-suffix"
+												aria-hidden="true"
+											>
+												{ _x(
+													'& up',
+													'rating filter row, e.g. "★★★★ & up"',
+													'jetpack-search-pkg'
+												) }
+											</span>
+										) }
 									</span>
 									{ showCount && (
 										<span className="jetpack-search-filter__count">

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/edit.js
@@ -7,10 +7,13 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 
 const STAR_VALUES = [ 5, 4, 3, 2, 1 ];
-const SAMPLE_COUNTS = { 5: 18, 4: 12, 3: 5, 2: 1, 1: 0 };
+// Cumulative "& up" counts — each row's count is the threshold-superset
+// of the rows below it, matching the runtime projection so designers see
+// the right shape in the editor.
+const SAMPLE_COUNTS = { 5: 8, 4: 22, 3: 29, 2: 31, 1: 32 };
 const DEFAULT_LABEL = __( 'Rating', 'jetpack-search-pkg' );
 
 /**
@@ -28,7 +31,6 @@ function renderStars( filled ) {
 				className={
 					'jetpack-search-filter-rating__star ' + ( i <= filled ? 'is-filled' : 'is-empty' )
 				}
-				aria-hidden="true"
 			>
 				★
 			</span>
@@ -79,15 +81,26 @@ export default function FilterWcRatingEdit( { attributes, setAttributes } ) {
 				<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
 				<ul className="jetpack-search-filter__list">
 					{ STAR_VALUES.map( star => {
-						/* translators: %d: number of stars (1-5). */
-						const aria = sprintf( _n( '%d star', '%d stars', star, 'jetpack-search-pkg' ), star );
+						const aria = sprintf(
+							/* translators: %d is the rating threshold (1-5). The row applies a "rating ≥ N stars" filter. */
+							_n( '%d star and up', '%d stars and up', star, 'jetpack-search-pkg' ),
+							star
+						);
 						return (
 							<li key={ star } className="jetpack-search-filter__item">
 								{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies; rule's nesting heuristic doesn't trace through sibling spans */ }
 								<label>
 									<input type="checkbox" disabled />
 									<span className="jetpack-search-filter__label" aria-label={ aria }>
-										{ renderStars( star ) }
+										<span className="jetpack-search-filter-rating__stars" aria-hidden="true">
+											{ renderStars( star ) }
+										</span>
+										<span
+											className="jetpack-search-filter-rating__threshold-suffix"
+											aria-hidden="true"
+										>
+											{ _x( '& up', 'rating filter row, e.g. "★★★★ & up"', 'jetpack-search-pkg' ) }
+										</span>
 									</span>
 									{ showCount && (
 										<span className="jetpack-search-filter__count">

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
@@ -69,6 +69,8 @@ foreach ( $seeded_buckets as $bucket ) {
 
 $label      = (string) $config['label'];
 $show_count = (bool) $config['showCount'];
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$enabled_stars = Filter_Wc_Rating::get_enabled_stars( (array) $attributes );
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-rating' ) ) ); ?>
@@ -87,16 +89,24 @@ $show_count = (bool) $config['showCount'];
 	}
 	?>
 	<ul class="jetpack-search-filter__list">
-		<?php foreach ( Filter_Wc_Rating::get_star_values() as $star ) : ?>
+		<?php foreach ( $enabled_stars as $star ) : ?>
 			<?php
 			$value      = (string) $star;
 			$is_checked = in_array( $value, $seeded_selected, true );
 			$option_cnt = $counts_by_star[ $value ] ?? 0;
-			$aria_label = sprintf(
-				/* translators: %d is the rating threshold (1-5). The row applies a "rating ≥ N stars" filter. */
-				_n( '%d star and up', '%d stars and up', $star, 'jetpack-search-pkg' ),
-				$star
-			);
+			// The 5★ row matches `avg ≥ 4.5` — semantically "exactly
+			// 5 stars" since there's no higher rating — so the "& up"
+			// affordance is dropped on that row only.
+			$is_top = ( 5 === $star );
+			if ( $is_top ) {
+				$aria_label = __( '5 stars', 'jetpack-search-pkg' );
+			} else {
+				$aria_label = sprintf(
+					/* translators: %d is the rating threshold (1-4). The row applies a "rating ≥ N stars" filter. */
+					_n( '%d star and up', '%d stars and up', $star, 'jetpack-search-pkg' ),
+					$star
+				);
+			}
 			?>
 			<li
 				class="jetpack-search-filter__item"
@@ -123,9 +133,11 @@ $show_count = (bool) $config['showCount'];
 								>★</span>
 							<?php endfor; ?>
 						</span>
-						<span class="jetpack-search-filter-rating__threshold-suffix" aria-hidden="true">
-							<?php echo esc_html_x( '& up', 'rating filter row, e.g. "★★★★ & up"', 'jetpack-search-pkg' ); ?>
-						</span>
+						<?php if ( ! $is_top ) : ?>
+							<span class="jetpack-search-filter-rating__threshold-suffix" aria-hidden="true">
+								<?php echo esc_html_x( '& up', 'rating filter row, e.g. "★★★★ & up"', 'jetpack-search-pkg' ); ?>
+							</span>
+						<?php endif; ?>
 					</span>
 					<?php if ( $show_count ) : ?>
 						<span

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
@@ -43,18 +43,27 @@ $seeded_buckets  = (array) ( ( (array) ( $seeded_aggs[ Filter_Wc_Rating::FILTER_
 $seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
 $seeded_selected = (array) ( $seeded_active[ Filter_Wc_Rating::FILTER_KEY ] ?? array() );
 
-// Project histogram buckets keyed at .5 boundaries onto star values
-// 1..5. Bucket key 4.5 → star 5, 3.5 → star 4, etc. Anything below 0.5
-// (the "no rating" bucket the histogram emits at -0.5 thanks to
-// min_doc_count: 0) is dropped since there's no UI option for it.
-$counts_by_star = array();
+// Project histogram buckets onto cumulative "& up" counts: the count
+// for star N is the sum of doc_counts across every bucket whose key
+// is ≥ N - 0.5, i.e., every avg_rating that rounds to N or higher.
+// Guarantees the displayed counts are monotone (count(3) ≥ count(4) ≥
+// count(5)), matching shopper expectation for threshold rows.
+$counts_by_star = array_fill_keys( array( '1', '2', '3', '4', '5' ), 0 );
 foreach ( $seeded_buckets as $bucket ) {
 	$key   = (float) ( $bucket['key'] ?? -1 );
 	$count = (int) ( $bucket['doc_count'] ?? 0 );
-	// Map .5-boundary key → star integer. Equivalent to (int) round( $key + 0.5 ).
-	$star = (int) ( $key + 1.0 );
-	if ( $star >= 1 && $star <= 5 ) {
-		$counts_by_star[ (string) $star ] = $count;
+	if ( $key < 0.5 ) {
+		continue;
+	}
+	// `cap` is the highest star whose threshold this bucket clears.
+	// Bucket keys land on .5 boundaries, so `key + 0.5` is an integer;
+	// `(int) round(...)` shrugs off any FP slop without a config-time math lib.
+	$cap = (int) round( $key + 0.5 );
+	if ( $cap > 5 ) {
+		$cap = 5;
+	}
+	for ( $star = 1; $star <= $cap; $star++ ) {
+		$counts_by_star[ (string) $star ] += $count;
 	}
 }
 
@@ -83,8 +92,11 @@ $show_count = (bool) $config['showCount'];
 			$value      = (string) $star;
 			$is_checked = in_array( $value, $seeded_selected, true );
 			$option_cnt = $counts_by_star[ $value ] ?? 0;
-			/* translators: %d: number of stars (1-5). Used as the accessible name for the star-rating row. */
-			$aria_label = sprintf( _n( '%d star', '%d stars', $star, 'jetpack-search-pkg' ), $star );
+			$aria_label = sprintf(
+				/* translators: %d is the rating threshold (1-5). The row applies a "rating ≥ N stars" filter. */
+				_n( '%d star and up', '%d stars and up', $star, 'jetpack-search-pkg' ),
+				$star
+			);
 			?>
 			<li
 				class="jetpack-search-filter__item"
@@ -99,17 +111,21 @@ $show_count = (bool) $config['showCount'];
 						data-wp-on--change="actions.onRatingFilterChange"
 					/>
 					<span class="jetpack-search-filter__label" aria-label="<?php echo esc_attr( $aria_label ); ?>">
-						<?php
-						// Render the star-row as filled vs. empty stars so the
-						// row is recognizable without JS-side icon code; the
-						// aria-label above carries the accessible text.
-						for ( $i = 1; $i <= 5; $i++ ) :
-							?>
-							<span
-								class="jetpack-search-filter-rating__star <?php echo $i <= $star ? 'is-filled' : 'is-empty'; ?>"
-								aria-hidden="true"
-							>★</span>
-						<?php endfor; ?>
+						<span class="jetpack-search-filter-rating__stars" aria-hidden="true">
+							<?php
+							// Render the star-row as filled vs. empty stars so the
+							// row is recognizable without JS-side icon code; the
+							// aria-label above carries the accessible text.
+							for ( $i = 1; $i <= 5; $i++ ) :
+								?>
+								<span
+									class="jetpack-search-filter-rating__star <?php echo $i <= $star ? 'is-filled' : 'is-empty'; ?>"
+								>★</span>
+							<?php endfor; ?>
+						</span>
+						<span class="jetpack-search-filter-rating__threshold-suffix" aria-hidden="true">
+							<?php echo esc_html_x( '& up', 'rating filter row, e.g. "★★★★ & up"', 'jetpack-search-pkg' ); ?>
+						</span>
 					</span>
 					<?php if ( $show_count ) : ?>
 						<span

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
@@ -40,6 +40,20 @@
 
 	.jetpack-search-filter__label {
 		flex: 1;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.jetpack-search-filter-rating__stars {
+		display: inline-flex;
+		gap: 0.05em;
+		line-height: 1;
+	}
+
+	.jetpack-search-filter-rating__threshold-suffix {
+		font-size: 0.85rem;
+		opacity: 0.75;
 	}
 
 	.jetpack-search-filter__count {

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
@@ -5,30 +5,36 @@ import './style.scss';
 const NAMESPACE = 'jetpack-search';
 
 /**
- * Project a histogram bucket array onto a star → count map.
- *
- * Bucket keys land on half-integer boundaries (0.5, 1.5, 2.5, 3.5, 4.5)
- * thanks to the `interval: 1, offset: 0.5` aggregation. Each maps to one
- * star band per WC's `ROUND(avg_rating, 0)` rule: 4.5 → star 5, 3.5 →
- * star 4, etc. Buckets outside that range (the implicit -0.5 "no rating"
- * bucket from `min_doc_count: 0`) are ignored — there's no UI option
- * for them. Mirrors the same projection in render.php.
+ * Project a histogram bucket array onto a cumulative "& up" star → count
+ * map. Each star N's count is the sum of doc_counts for every bucket
+ * whose key is ≥ N - 0.5, i.e., every avg_rating that rounds to N or
+ * higher. Guarantees the rendered counts are monotone (count(3) ≥
+ * count(4) ≥ count(5)) — the property shoppers expect from threshold
+ * rows. Buckets below 0.5 (the implicit "no rating" bucket the histogram
+ * emits at -0.5 thanks to `min_doc_count: 0`) are ignored. Mirrors the
+ * same projection in render.php.
  *
  * @param {Array<{key: number, doc_count: number}>} buckets - Aggregation buckets.
  * @return {Object<string, number>} Star (as string key, "1".."5") → count.
  */
 function bucketsToStarCountMap( buckets ) {
+	const map = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
 	if ( ! Array.isArray( buckets ) ) {
-		return {};
+		return map;
 	}
-	const map = {};
 	for ( const bucket of buckets ) {
-		const key = Number( bucket?.key ?? -1 );
+		const key = Number( bucket?.key ?? NaN );
 		const count = Number( bucket?.doc_count ?? 0 );
-		// .5-boundary key → star integer. Equivalent to Math.round(key + 0.5).
-		const star = Math.trunc( key + 1.0 );
-		if ( star >= 1 && star <= 5 ) {
-			map[ String( star ) ] = count;
+		if ( ! Number.isFinite( key ) || key < 0.5 ) {
+			continue;
+		}
+		// Bucket keys land on .5 boundaries; `key + 0.5` is the highest
+		// star whose threshold this bucket clears. A doc in the 4.5
+		// bucket counts toward 5★+, 4★+, …, 1★+; a doc in the 0.5
+		// bucket only toward 1★+. `Math.round` shrugs off FP slop.
+		const cap = Math.min( 5, Math.round( key + 0.5 ) );
+		for ( let star = 1; star <= cap; star++ ) {
+			map[ star ] += count;
 		}
 	}
 	return map;
@@ -57,9 +63,7 @@ store( NAMESPACE, {
 		/**
 		 * `data-wp-text` per-row count badge. Reads the star value from
 		 * the row's `data-wp-context` (set by render.php on each `<li>`)
-		 * and looks up the projected histogram count for that star.
-		 * Falls back to "0" when the row has no matches — convention for
-		 * "always show all options" facet UIs.
+		 * and looks up the cumulative threshold count for that star.
 		 *
 		 * @return {string} Count as a string for the badge text node.
 		 */
@@ -77,17 +81,37 @@ store( NAMESPACE, {
 
 	actions: {
 		/**
-		 * Toggle the star value that owns the change event. The input's
-		 * `value` attribute carries the star (1–5) as a string; filterKey
-		 * comes from the wrapper context.
+		 * Single-select rating change handler. Picking a star *replaces*
+		 * the existing selection (rather than toggling into an array as
+		 * the shared `setFilter` does) — the threshold rows nest
+		 * (`4★+ ⊂ 3★+ ⊂ 2★+`), so a multi-select would only ever collapse
+		 * to the lowest-picked threshold. Re-clicking the active row
+		 * clears the selection — Amazon/Etsy convention, and the only
+		 * way to clear without leaving the block.
+		 *
+		 * Inlined here rather than going through `actions.setFilter` so
+		 * the shared toggle-into-array semantics other filter blocks rely
+		 * on stay untouched.
 		 *
 		 * @param {Event} event - Change event.
-		 * @yield {Promise} setFilter action.
+		 * @yield {Promise} search action.
 		 */
 		*onRatingFilterChange( event ) {
-			const { actions } = store( NAMESPACE );
+			const { state, actions } = store( NAMESPACE );
 			const { filterKey } = getContext();
-			yield actions.setFilter( filterKey, event.target.value );
+			if ( ! filterKey ) {
+				return;
+			}
+			const value = String( event.target.value );
+			const current = state.activeFilters?.[ filterKey ] ?? [];
+			const isOnlyActive = current.length === 1 && current[ 0 ] === value;
+			if ( isOnlyActive ) {
+				const { [ filterKey ]: _removed, ...rest } = state.activeFilters;
+				state.activeFilters = rest;
+			} else {
+				state.activeFilters = { ...state.activeFilters, [ filterKey ]: [ value ] };
+			}
+			yield actions.search();
 		},
 	},
 } );

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -149,30 +149,28 @@ export function resolveFilterFields( config ) {
 }
 
 /**
- * Star buckets for `wc_rating` filter clauses. Mirrors WC's
- * `ROUND(avg_rating, 0)` semantics: star=5 covers avg ∈ [4.5, ∞),
- * star=4 covers [3.5, 4.5), down to star=1 covering [0.5, 1.5).
+ * Threshold lower bounds for the `wc_rating` filter — `?rating_filter[]=N`
+ * matches `_wc_average_rating ≥ N - 0.5`, i.e. avg values that round to
+ * N stars or higher under WC's `ROUND(avg_rating, 0)` rule. Half-integer
+ * boundaries are deliberate: `4★ & up` includes products with avg ≥ 3.5
+ * (which round to 4 or 5), so the row is a true "and up" superset of the
+ * higher-star rows.
+ *
+ * Single-bound by design — there is no upper cap, mirroring the dominant
+ * shopper-facing rating filter on Amazon/Etsy/Wayfair/Walmart/eBay where
+ * picking "3★ & up" returns everything from 3 stars to perfect.
  *
  * Products with `_wc_average_rating` < 0.5 fall into a histogram
  * bucket at -0.5 with no corresponding star entry — they're returned
- * in unfiltered results but cannot be selected via the rating filter.
- * This matches WC's own `ROUND(avg_rating, 0)` filter UI which has
- * no "0-star" option either; when the front-end filter block lands
- * (DSGWOO-equivalent on the Search 3.0 side) it will surface only the
- * 1–5 entries here.
- *
- * Aggregation uses a histogram (range aggs aren't whitelisted on the
- * WPCOM v1.3 search API). `histogramKey` is the bucket key the
- * histogram emits for that star band when called with `interval: 1`
- * and `offset: 0.5` — useful for response-side bucket → star
- * projection.
+ * in unfiltered results but cannot be selected via the rating filter,
+ * matching WC's own filter UI which has no "0-star" option.
  */
 export const WC_RATING_RANGES = [
-	{ key: '1', from: 0.5, to: 1.5, histogramKey: 0.5 },
-	{ key: '2', from: 1.5, to: 2.5, histogramKey: 1.5 },
-	{ key: '3', from: 2.5, to: 3.5, histogramKey: 2.5 },
-	{ key: '4', from: 3.5, to: 4.5, histogramKey: 3.5 },
-	{ key: '5', from: 4.5, histogramKey: 4.5 },
+	{ key: '1', from: 0.5 },
+	{ key: '2', from: 1.5 },
+	{ key: '3', from: 2.5 },
+	{ key: '4', from: 3.5 },
+	{ key: '5', from: 4.5 },
 ];
 
 /**
@@ -299,20 +297,18 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 		}
 		const config = filterConfigs?.[ filterKey ];
 
-		// Rating: each selected star level maps to a range clause on
-		// the rating field resolved from the config; multiple selections OR.
+		// Rating: each selected star level maps to a `≥ N - 0.5` range
+		// clause. The block is single-select so `values` is normally one
+		// entry; tolerate multi-value URLs by OR-ing, which under threshold
+		// semantics collapses to the lowest selected threshold (a no-op
+		// vs. picking just that one) — harmless and keeps stale deep links
+		// functional.
 		if ( config?.filterType === 'wc_rating' ) {
 			const { filterField: ratingField } = resolveFilterFields( config );
 			const ranges = values
 				.map( value => WC_RATING_RANGES.find( r => r.key === String( value ) ) )
 				.filter( Boolean )
-				.map( r => {
-					const range = { gte: r.from };
-					if ( r.to !== undefined ) {
-						range.lt = r.to;
-					}
-					return { range: { [ ratingField ]: range } };
-				} );
+				.map( r => ( { range: { [ ratingField ]: { gte: r.from } } } ) );
 			if ( ranges.length === 0 ) {
 				continue;
 			}

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -570,22 +570,33 @@ describe( 'product-shaped filter helpers', () => {
 		} );
 	} );
 
-	describe( 'buildFilterClause: wc_rating range branch', () => {
-		it( 'emits a single range clause for one star selection', () => {
+	describe( 'buildFilterClause: wc_rating threshold branch', () => {
+		it( 'emits a single `gte` range clause for the picked star (no upper bound)', () => {
 			const clause = buildFilterClause(
-				{ rating_filter: [ '5' ] },
+				{ rating_filter: [ '4' ] },
 				{ rating_filter: { filterType: 'wc_rating' } }
 			);
 			expect( clause ).toEqual( {
 				bool: {
-					must: [ { range: { 'meta._wc_average_rating.double': { gte: 4.5 } } } ],
+					must: [ { range: { 'meta._wc_average_rating.double': { gte: 3.5 } } } ],
 				},
 			} );
 		} );
 
-		it( 'wraps multi-star selections in bool.should (OR within rating filter)', () => {
+		it( 'all star thresholds are single-bound (gte only) — no `lt` cap', () => {
+			for ( const r of WC_RATING_RANGES ) {
+				expect( r.to ).toBeUndefined();
+				expect( typeof r.from ).toBe( 'number' );
+			}
+		} );
+
+		it( 'tolerates a stale multi-value URL by OR-ing the thresholds', () => {
+			// Block UI is single-select, but a deep link from the prior
+			// exact-bucket era could still carry two values. OR-ing them
+			// collapses to the lowest threshold under "& up" semantics —
+			// harmless and avoids breaking old bookmarks.
 			const clause = buildFilterClause(
-				{ rating_filter: [ '4', '5' ] },
+				{ rating_filter: [ '3', '5' ] },
 				{ rating_filter: { filterType: 'wc_rating' } }
 			);
 			expect( clause ).toEqual( {
@@ -594,7 +605,7 @@ describe( 'product-shaped filter helpers', () => {
 						{
 							bool: {
 								should: [
-									{ range: { 'meta._wc_average_rating.double': { gte: 3.5, lt: 4.5 } } },
+									{ range: { 'meta._wc_average_rating.double': { gte: 2.5 } } },
 									{ range: { 'meta._wc_average_rating.double': { gte: 4.5 } } },
 								],
 							},
@@ -602,12 +613,6 @@ describe( 'product-shaped filter helpers', () => {
 					],
 				},
 			} );
-		} );
-
-		it( 'gives star=5 an open upper bound (no `lt`) so 5.0 ratings count', () => {
-			const five = WC_RATING_RANGES.find( r => r.key === '5' );
-			expect( five.to ).toBeUndefined();
-			expect( five.from ).toBe( 4.5 );
 		} );
 
 		it( 'drops unknown star values', () => {

--- a/projects/packages/search/tests/php/Filter_Wc_Rating_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Rating_Test.php
@@ -93,4 +93,51 @@ class Filter_Wc_Rating_Test extends TestCase {
 		);
 		$this->assertSame( 'Stars extra', $config['label'] );
 	}
+
+	/**
+	 * Missing / unset enabledStars defaults to all five rows.
+	 */
+	public function test_get_enabled_stars_defaults_to_all_when_unset() {
+		$this->assertSame( array( 5, 4, 3, 2, 1 ), Filter_Wc_Rating::get_enabled_stars( array() ) );
+	}
+
+	/**
+	 * Author-picked subset is preserved and sorted high-to-low.
+	 */
+	public function test_get_enabled_stars_preserves_subset_and_sorts() {
+		$this->assertSame(
+			array( 4, 2 ),
+			Filter_Wc_Rating::get_enabled_stars( array( 'enabledStars' => array( 2, 4 ) ) )
+		);
+	}
+
+	/**
+	 * Out-of-range and duplicate values are filtered out, never producing
+	 * a row outside 1..5 — protects render.php's projection map.
+	 */
+	public function test_get_enabled_stars_filters_invalid_and_duplicates() {
+		$this->assertSame(
+			array( 5, 3, 1 ),
+			Filter_Wc_Rating::get_enabled_stars(
+				array( 'enabledStars' => array( 0, 5, 6, 3, '1', 1, 'bogus', -2 ) )
+			)
+		);
+	}
+
+	/**
+	 * Empty list (after sanitization) falls back to all five — better than
+	 * rendering an empty `<ul>` from a stale attribute.
+	 */
+	public function test_get_enabled_stars_falls_back_when_all_invalid() {
+		$this->assertSame(
+			array( 5, 4, 3, 2, 1 ),
+			Filter_Wc_Rating::get_enabled_stars(
+				array( 'enabledStars' => array( 0, 6, 'no' ) )
+			)
+		);
+		$this->assertSame(
+			array( 5, 4, 3, 2, 1 ),
+			Filter_Wc_Rating::get_enabled_stars( array( 'enabledStars' => array() ) )
+		);
+	}
 }


### PR DESCRIPTION
Fixes [RSM-2663](https://linear.app/a8c/issue/RSM-2663/search-30-redesign-filter-wc-rating-as-x-stars-and-up-threshold-ux). Follow-up to #48448.

## Why

Shoppers don't think in exact rating buckets — they think "at least four stars." The rating filter that just landed asks them to pick a single star band (a product rated 3 stars only matches the "3 ★" row), which surfaces zero counts on every row except the one band that happens to have data and forces an awkward multi-select to express what every other shop spells "& up". This rewires the filter into the threshold pattern shoppers already recognize from Amazon, Etsy, Wayfair, Walmart, and eBay: pick a row and see every product that meets that bar or better. Block authors can also hide rows they don't want offered, so a store with no 1- or 2-star products doesn't have to show those rows.

## Proposed changes

* Each row applies a `≥ N - 0.5` threshold filter (avg rounds to N stars or higher under WC's `ROUND(avg, 0)` rule). `WC_RATING_RANGES` collapses to one `from` per row — no upper bound — so a single `range` clause replaces the per-bucket `bool.should`.
* Count badges project the histogram cumulatively: `count(N) = Σ doc_count` for `bucket.key ≥ N - 0.5`. Guarantees `count(3) ≥ count(4) ≥ count(5)`, which is what threshold rows are supposed to do.
* Single-select interaction: picking a row replaces the existing selection, re-clicking the active row clears it. The shared `actions.setFilter` toggle stays untouched — the single-select branch lives in the rating block's own `view.js` so other filter blocks keep their multi-select semantics.
* "& up" suffix is rendered next to each star strip *except* the 5★ row — it's redundant there since there's no higher tier — with a matching `_n( '%d star and up', '%d stars and up', … )` aria-label so screen readers convey the threshold semantics.
* New `enabledStars` block attribute exposes a per-row visibility checklist in the inspector. PHP and JS share the same sanitization (deduplicate, clamp to 1..5, fall back to all five rows on any malformed value), and the editor enforces a one-row minimum so an author can't save a block that renders nothing.
* Editor preview's `SAMPLE_COUNTS` updated to be cumulative-monotone so designers see the right shape.

## Screenshots

### Front-end rating filter

| Before (exact-bucket) | After ("& up" threshold, no suffix on 5★) |
|---|---|
| ![before](https://github.com/user-attachments/assets/ef632a10-a42d-4708-8f57-209b94e88341) | ![after](https://github.com/user-attachments/assets/40653476-7e40-4bf3-9224-67a99e58ba41) |

The atlas test store has one product rated 4★ and one rated 2★ out of 28 products. Before, only the 4★ and 2★ rows show "1"; after, the cumulative threshold rows correctly read 5★+: 0, 4★+: 1, 3★+: 1, 2★+: 2, 1★+: 2.

### Editor inspector — new "Visible rows" control

![inspector](https://github.com/user-attachments/assets/c1575a76-80aa-47b3-9770-04fb19742433)

## Related product discussion/links

* Epic: [RSM-1929](https://linear.app/a8c/issue/RSM-1929/epic-search-30-woocommerce-style-product-filter-blocks-jp-search)
* Issue: [RSM-2663](https://linear.app/a8c/issue/RSM-2663/search-30-redesign-filter-wc-rating-as-x-stars-and-up-threshold-ux)
* Parent PR: #48448

## Does this pull request change what data or activity we track or use?

No. The aggregation field (`meta._wc_average_rating.double`) and URL contract (`?rating_filter[]=N`) are unchanged. Only the JS-side projection, the ES filter clause shape, and the block's editor controls change.

## Testing instructions

1. Spin up a docker site with WooCommerce + Jetpack Search active and at least 2–3 products with varying `_wc_average_rating` (e.g. one rated 5, one rated 3, one unrated).
2. Place the `jetpack-search/filter-wc-rating` block on a search results page (or use the Embedded experience template the prior PR ships).
3. Visit the search page with a `?post_types[]=product` filter so only products are searched.
4. Verify each row's count is monotone from bottom to top — the 1★ & up row should equal the total count of rated products, and the 5★ & up row (no "& up" suffix on this one) should equal the count of products with avg ≥ 4.5.
5. Click a row (e.g. 4★ & up). Confirm:
    * URL gains `?rating_filter[]=4`.
    * Result list narrows to products with avg ≥ 3.5.
    * No other row becomes selected.
    * Re-clicking the same row clears it (URL drops `rating_filter[]`, results restore).
6. Pick a row, then click a different row. The first selection should be replaced (single-select, not multi-select).
7. Open the block in the editor and toggle the new "Visible rows" checkboxes. Hidden rows should disappear from both the editor preview and the front end. Confirm the editor refuses to un-toggle the last enabled row.
8. Sanity-check the edit-mode preview — sample counts are monotone-decreasing top-down, "& up" suffix renders on rows 1..4 only.
