### PR TITLE
Search 3.0: register product taxonomies as filter-checkbox variations (RSM-1929)

### DIFF
--- a/projects/packages/search/changelog/add-product-taxonomy-variations
+++ b/projects/packages/search/changelog/add-product-taxonomy-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: register WooCommerce product Category, Tag, and Brand as inserter-visible variations on the existing jetpack-search/filter-checkbox block (RSM-1929).

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
@@ -6,7 +6,7 @@
 	"title": "Checkbox Filter",
 	"category": "jetpack-search",
 	"icon": "filter",
-	"description": "Checkbox filter for Jetpack Search. Use a variation (Category, Tag, Post Type, Author, Custom Taxonomy) or configure manually.",
+	"description": "Checkbox filter for Jetpack Search. Use a variation (Category, Tag, Post Type, Author, Product Category, Product Tag, Product Brand, Custom Taxonomy) or configure manually.",
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -70,18 +70,16 @@ class Filter_Checkbox {
 			if ( 'post_tag' === $taxonomy ) {
 				return __( 'Tag', 'jetpack-search-pkg' );
 			}
-			if ( '' !== $taxonomy && in_array( $taxonomy, array( 'product_cat', 'product_tag', 'product_brand' ), true ) ) {
+			if ( in_array( $taxonomy, array( 'product_cat', 'product_tag', 'product_brand' ), true ) ) {
 				// WC localizes its taxonomy labels at runtime — prefer the
 				// registered singular_name so a French shop reads "Catégorie",
-				// "Étiquette", "Marque" rather than the English fallback. For
-				// fresh installs (or a phpunit run with no WC loaded),
-				// get_taxonomy() returns false; the per-slug fallback below
-				// keeps the heading meaningful in that case.
-				if ( function_exists( 'get_taxonomy' ) ) {
-					$tax = get_taxonomy( $taxonomy );
-					if ( $tax && ! empty( $tax->labels->singular_name ) ) {
-						return (string) $tax->labels->singular_name;
-					}
+				// "Étiquette", "Marque" rather than the English fallback. When
+				// the taxonomy isn't registered (no WooCommerce, or a phpunit
+				// run with no WC loaded), get_taxonomy() returns false; the
+				// per-slug fallback below keeps the heading meaningful.
+				$tax = get_taxonomy( $taxonomy );
+				if ( $tax && ! empty( $tax->labels->singular_name ) ) {
+					return (string) $tax->labels->singular_name;
 				}
 				if ( 'product_cat' === $taxonomy ) {
 					return __( 'Category', 'jetpack-search-pkg' );

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -70,6 +70,29 @@ class Filter_Checkbox {
 			if ( 'post_tag' === $taxonomy ) {
 				return __( 'Tag', 'jetpack-search-pkg' );
 			}
+			if ( '' !== $taxonomy && in_array( $taxonomy, array( 'product_cat', 'product_tag', 'product_brand' ), true ) ) {
+				// WC localizes its taxonomy labels at runtime — prefer the
+				// registered singular_name so a French shop reads "Catégorie",
+				// "Étiquette", "Marque" rather than the English fallback. For
+				// fresh installs (or a phpunit run with no WC loaded),
+				// get_taxonomy() returns false; the per-slug fallback below
+				// keeps the heading meaningful in that case.
+				if ( function_exists( 'get_taxonomy' ) ) {
+					$tax = get_taxonomy( $taxonomy );
+					if ( $tax && ! empty( $tax->labels->singular_name ) ) {
+						return (string) $tax->labels->singular_name;
+					}
+				}
+				if ( 'product_cat' === $taxonomy ) {
+					return __( 'Category', 'jetpack-search-pkg' );
+				}
+				if ( 'product_tag' === $taxonomy ) {
+					return __( 'Tag', 'jetpack-search-pkg' );
+				}
+				if ( 'product_brand' === $taxonomy ) {
+					return __( 'Brand', 'jetpack-search-pkg' );
+				}
+			}
 		}
 		return '';
 	}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -70,26 +70,21 @@ class Filter_Checkbox {
 			if ( 'post_tag' === $taxonomy ) {
 				return __( 'Tag', 'jetpack-search-pkg' );
 			}
-			if ( in_array( $taxonomy, array( 'product_cat', 'product_tag', 'product_brand' ), true ) ) {
-				// WC localizes its taxonomy labels at runtime — prefer the
-				// registered singular_name so a French shop reads "Catégorie",
-				// "Étiquette", "Marque" rather than the English fallback. When
-				// the taxonomy isn't registered (no WooCommerce, or a phpunit
-				// run with no WC loaded), get_taxonomy() returns false; the
-				// per-slug fallback below keeps the heading meaningful.
-				$tax = get_taxonomy( $taxonomy );
-				if ( $tax && ! empty( $tax->labels->singular_name ) ) {
-					return (string) $tax->labels->singular_name;
-				}
-				if ( 'product_cat' === $taxonomy ) {
-					return __( 'Category', 'jetpack-search-pkg' );
-				}
-				if ( 'product_tag' === $taxonomy ) {
-					return __( 'Tag', 'jetpack-search-pkg' );
-				}
-				if ( 'product_brand' === $taxonomy ) {
-					return __( 'Brand', 'jetpack-search-pkg' );
-				}
+			// Product taxonomies get distinct, prefixed defaults so an author
+			// using both "Filter by Category" (post taxonomy) and "Filter by
+			// Product Category" on the same page sees two clearly different
+			// headings. Skipping `get_taxonomy()->labels->singular_name`
+			// here is intentional — that lookup would collapse the product
+			// label back to the same "Category" / "Tag" / "Brand" string WC
+			// uses for its own admin and break the differentiation.
+			if ( 'product_cat' === $taxonomy ) {
+				return __( 'Product Category', 'jetpack-search-pkg' );
+			}
+			if ( 'product_tag' === $taxonomy ) {
+				return __( 'Product Tag', 'jetpack-search-pkg' );
+			}
+			if ( 'product_brand' === $taxonomy ) {
+				return __( 'Product Brand', 'jetpack-search-pkg' );
 			}
 		}
 		return '';

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -144,16 +144,14 @@ export function variationToAttributes( variation, previousTaxonomy ) {
  * fallback label for the inspector placeholder. Returns '' for custom
  * taxonomies (caller should then fall back to the generic "Filter").
  *
+ * Product taxonomies get distinct "Product X" defaults so an author using
+ * both "Filter by Category" and "Filter by Product Category" on the same
+ * page sees two clearly different headings.
+ *
  * Keep in sync with Filter_Checkbox::default_label() in
  * src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php — both
  * must recognize the same (filterType, taxonomy) pairs or the empty-label
  * preview heading will disagree with the server-rendered front end.
- *
- * Non-English WC sites: the editor preview shows the English fallback here
- * while the server-rendered heading prefers `get_taxonomy()->labels->singular_name`
- * (e.g. "Catégorie"). The browser has no path to the PHP-registered taxonomy
- * labels at editor time, so this divergence is intentional — authors who care
- * about the localized label can override via the inspector's Label field.
  *
  * @param {object} attributes - Block attributes.
  * @return {string} Variation default label, or '' when not a built-in variation.
@@ -168,14 +166,20 @@ export function variationDefaultLabel( attributes ) {
 	}
 	if ( filterType === 'taxonomy' ) {
 		const taxonomy = attributes?.taxonomy || '';
-		if ( taxonomy === 'category' || taxonomy === 'product_cat' ) {
+		if ( taxonomy === 'category' ) {
 			return __( 'Category', 'jetpack-search-pkg' );
 		}
-		if ( taxonomy === 'post_tag' || taxonomy === 'product_tag' ) {
+		if ( taxonomy === 'post_tag' ) {
 			return __( 'Tag', 'jetpack-search-pkg' );
 		}
+		if ( taxonomy === 'product_cat' ) {
+			return __( 'Product Category', 'jetpack-search-pkg' );
+		}
+		if ( taxonomy === 'product_tag' ) {
+			return __( 'Product Tag', 'jetpack-search-pkg' );
+		}
 		if ( taxonomy === 'product_brand' ) {
-			return __( 'Brand', 'jetpack-search-pkg' );
+			return __( 'Product Brand', 'jetpack-search-pkg' );
 		}
 	}
 	return '';

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -5,8 +5,9 @@
  * shape so designers can style the filter list in place. The inspector
  * exposes the user-tunable attributes (filter type, label, showCount,
  * maxItems, bucketSortOrder). The filter-type control lets authors swap
- * between the Category / Tag / Post Type / Author / Custom Taxonomy
- * variations without deleting and re-inserting the block.
+ * between the Category / Tag / Post Type / Author / Product Category /
+ * Product Tag / Product Brand / Custom Taxonomy variations without
+ * deleting and re-inserting the block.
  *
  * Custom Taxonomy is the one variation whose target isn't fixed by the
  * inserter choice: its variation seeds `taxonomy=''` so the inspector
@@ -34,24 +35,33 @@ const SAMPLE_FILTER_ITEMS = [
 ];
 
 // Built-in taxonomies that have their own filter-checkbox variations
-// (Category / Tag). Excluded from the custom-taxonomy picker so site builders
-// reach for the dedicated variation rather than re-creating it via the
-// generic Custom Taxonomy entry.
-const BUILT_IN_TAXONOMY_SLUGS = [ 'category', 'post_tag' ];
+// (Category / Tag plus the three WooCommerce product taxonomies). Excluded
+// from the custom-taxonomy picker so site builders reach for the dedicated
+// variation rather than re-creating it via the generic Custom Taxonomy entry.
+const BUILT_IN_TAXONOMY_SLUGS = [
+	'category',
+	'post_tag',
+	'product_cat',
+	'product_tag',
+	'product_brand',
+];
 
 // Variation identifiers mirror the variation `name`s registered in
-// Search_Blocks::register_variations() so the inspector picker and the
-// block-inserter picker describe the same set of filter schemas.
+// Search_Blocks::inject_filter_checkbox_variations() so the inspector picker
+// and the block-inserter picker describe the same set of filter schemas.
 export const VARIATION_CATEGORY = 'category';
 export const VARIATION_POST_TAG = 'post_tag';
 export const VARIATION_POST_TYPE = 'post_type';
 export const VARIATION_AUTHOR = 'author';
+export const VARIATION_PRODUCT_CAT = 'product_cat';
+export const VARIATION_PRODUCT_TAG = 'product_tag';
+export const VARIATION_PRODUCT_BRAND = 'product_brand';
 export const VARIATION_CUSTOM_TAXONOMY = 'custom_taxonomy';
 
 /**
  * Identify which built-in variation the current (filterType, taxonomy) pair
- * matches. Any taxonomy-family block that isn't `category` or `post_tag` is
- * treated as a custom taxonomy so the slug input reveals itself.
+ * matches. Any taxonomy-family block whose slug isn't a recognized built-in
+ * is treated as a custom taxonomy so the slug input reveals itself.
  *
  * @param {object} attributes - Block attributes.
  * @return {string} Variation identifier.
@@ -71,6 +81,15 @@ export function deriveVariation( attributes ) {
 	if ( taxonomy === 'post_tag' ) {
 		return VARIATION_POST_TAG;
 	}
+	if ( taxonomy === 'product_cat' ) {
+		return VARIATION_PRODUCT_CAT;
+	}
+	if ( taxonomy === 'product_tag' ) {
+		return VARIATION_PRODUCT_TAG;
+	}
+	if ( taxonomy === 'product_brand' ) {
+		return VARIATION_PRODUCT_BRAND;
+	}
 	return VARIATION_CUSTOM_TAXONOMY;
 }
 
@@ -84,10 +103,11 @@ export function deriveVariation( attributes ) {
  * whenever `filterType` isn't 'taxonomy', so the preserved value is purely
  * UI state and never reaches the aggregation request.
  *
- * Category and Tag overwrite `taxonomy` with their built-in slugs, which
- * means a Custom → Category → Custom round-trip *will* clear the slug.
- * On the return trip we deliberately drop 'category' and 'post_tag' so the
- * Taxonomy picker doesn't surface them as custom-typed slugs.
+ * Category, Tag, and the three product variations overwrite `taxonomy`
+ * with their built-in slugs, which means a Custom → Category → Custom
+ * round-trip *will* clear the slug. On the return trip we deliberately
+ * drop those built-in slugs so the Taxonomy picker doesn't surface them
+ * as custom-typed slugs.
  *
  * @param {string} variation        - Target variation identifier.
  * @param {string} previousTaxonomy - Current taxonomy attribute value.
@@ -99,14 +119,21 @@ export function variationToAttributes( variation, previousTaxonomy ) {
 			return { filterType: 'taxonomy', taxonomy: 'category' };
 		case VARIATION_POST_TAG:
 			return { filterType: 'taxonomy', taxonomy: 'post_tag' };
+		case VARIATION_PRODUCT_CAT:
+			return { filterType: 'taxonomy', taxonomy: 'product_cat' };
+		case VARIATION_PRODUCT_TAG:
+			return { filterType: 'taxonomy', taxonomy: 'product_tag' };
+		case VARIATION_PRODUCT_BRAND:
+			return { filterType: 'taxonomy', taxonomy: 'product_brand' };
 		case VARIATION_POST_TYPE:
 			return { filterType: 'post_type', taxonomy: previousTaxonomy || '' };
 		case VARIATION_AUTHOR:
 			return { filterType: 'author', taxonomy: previousTaxonomy || '' };
 		case VARIATION_CUSTOM_TAXONOMY:
 		default: {
-			const preserved =
-				previousTaxonomy === 'category' || previousTaxonomy === 'post_tag' ? '' : previousTaxonomy;
+			const preserved = BUILT_IN_TAXONOMY_SLUGS.includes( previousTaxonomy )
+				? ''
+				: previousTaxonomy;
 			return { filterType: 'taxonomy', taxonomy: preserved };
 		}
 	}
@@ -135,11 +162,14 @@ export function variationDefaultLabel( attributes ) {
 	}
 	if ( filterType === 'taxonomy' ) {
 		const taxonomy = attributes?.taxonomy || '';
-		if ( taxonomy === 'category' ) {
+		if ( taxonomy === 'category' || taxonomy === 'product_cat' ) {
 			return __( 'Category', 'jetpack-search-pkg' );
 		}
-		if ( taxonomy === 'post_tag' ) {
+		if ( taxonomy === 'post_tag' || taxonomy === 'product_tag' ) {
 			return __( 'Tag', 'jetpack-search-pkg' );
+		}
+		if ( taxonomy === 'product_brand' ) {
+			return __( 'Brand', 'jetpack-search-pkg' );
 		}
 	}
 	return '';
@@ -240,6 +270,18 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 							{ value: VARIATION_POST_TYPE, label: __( 'Post Type', 'jetpack-search-pkg' ) },
 							{ value: VARIATION_AUTHOR, label: __( 'Author', 'jetpack-search-pkg' ) },
 							{
+								value: VARIATION_PRODUCT_CAT,
+								label: __( 'Product Category', 'jetpack-search-pkg' ),
+							},
+							{
+								value: VARIATION_PRODUCT_TAG,
+								label: __( 'Product Tag', 'jetpack-search-pkg' ),
+							},
+							{
+								value: VARIATION_PRODUCT_BRAND,
+								label: __( 'Product Brand', 'jetpack-search-pkg' ),
+							},
+							{
 								value: VARIATION_CUSTOM_TAXONOMY,
 								label: __( 'Custom taxonomy', 'jetpack-search-pkg' ),
 							},
@@ -279,7 +321,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 											'jetpack-search-pkg'
 									  )
 									: __(
-											'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
+											'Pick which registered taxonomy this filter targets. Built-in Category, Tag, and the WooCommerce product taxonomies have their own dedicated filters in the inserter.',
 											'jetpack-search-pkg',
 											/* dummy arg to avoid bad minification */ 0
 									  )

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -149,6 +149,12 @@ export function variationToAttributes( variation, previousTaxonomy ) {
  * must recognize the same (filterType, taxonomy) pairs or the empty-label
  * preview heading will disagree with the server-rendered front end.
  *
+ * Non-English WC sites: the editor preview shows the English fallback here
+ * while the server-rendered heading prefers `get_taxonomy()->labels->singular_name`
+ * (e.g. "Catégorie"). The browser has no path to the PHP-registered taxonomy
+ * labels at editor time, so this divergence is intentional — authors who care
+ * about the localized label can override via the inspector's Label field.
+ *
  * @param {object} attributes - Block attributes.
  * @return {string} Variation default label, or '' when not a built-in variation.
  */

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -314,6 +314,42 @@ class Search_Blocks {
 				'isActive'    => array( 'filterType' ),
 			),
 			array(
+				'name'        => 'product_cat',
+				'title'       => __( 'Filter by Product Category', 'jetpack-search-pkg' ),
+				'description' => __( 'Show product category checkboxes with live result counts.', 'jetpack-search-pkg' ),
+				'icon'        => 'category',
+				'attributes'  => array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_cat',
+					'label'      => __( 'Category', 'jetpack-search-pkg' ),
+				),
+				'isActive'    => array( 'filterType', 'taxonomy' ),
+			),
+			array(
+				'name'        => 'product_tag',
+				'title'       => __( 'Filter by Product Tag', 'jetpack-search-pkg' ),
+				'description' => __( 'Show product tag checkboxes with live result counts.', 'jetpack-search-pkg' ),
+				'icon'        => 'category',
+				'attributes'  => array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_tag',
+					'label'      => __( 'Tag', 'jetpack-search-pkg' ),
+				),
+				'isActive'    => array( 'filterType', 'taxonomy' ),
+			),
+			array(
+				'name'        => 'product_brand',
+				'title'       => __( 'Filter by Product Brand', 'jetpack-search-pkg' ),
+				'description' => __( 'Show product brand checkboxes with live result counts. Requires a registered `product_brand` taxonomy.', 'jetpack-search-pkg' ),
+				'icon'        => 'category',
+				'attributes'  => array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_brand',
+					'label'      => __( 'Brand', 'jetpack-search-pkg' ),
+				),
+				'isActive'    => array( 'filterType', 'taxonomy' ),
+			),
+			array(
 				'name'        => 'custom_taxonomy',
 				'title'       => __( 'Filter by Custom Taxonomy', 'jetpack-search-pkg' ),
 				'description' => __( 'Show checkboxes for a custom taxonomy. Pick which taxonomy in the block settings after inserting.', 'jetpack-search-pkg' ),
@@ -324,11 +360,11 @@ class Search_Blocks {
 				),
 				// Match on filterType only (no taxonomy comparison) so the
 				// variation identity survives once the author picks a slug
-				// via the inspector. The Category and Tag variations both
-				// pin `taxonomy` in their isActive arrays, so WP's
-				// most-specific-match resolution still routes those slugs
-				// to their dedicated variations — Custom Taxonomy claims
-				// every other registered taxonomy.
+				// via the inspector. Category, Tag, and the three product
+				// taxonomies all pin `taxonomy` in their isActive arrays, so
+				// WP's most-specific-match resolution still routes those
+				// slugs to their dedicated variations — Custom Taxonomy
+				// claims every other registered taxonomy.
 				'isActive'    => array( 'filterType' ),
 			),
 		);

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -320,7 +320,7 @@ class Search_Blocks {
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => 'product_cat',
-					'label'      => __( 'Category', 'jetpack-search-pkg' ),
+					'label'      => __( 'Product Category', 'jetpack-search-pkg' ),
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
 			),
@@ -332,7 +332,7 @@ class Search_Blocks {
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => 'product_tag',
-					'label'      => __( 'Tag', 'jetpack-search-pkg' ),
+					'label'      => __( 'Product Tag', 'jetpack-search-pkg' ),
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
 			),
@@ -371,7 +371,7 @@ class Search_Blocks {
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => 'product_brand',
-					'label'      => __( 'Brand', 'jetpack-search-pkg' ),
+					'label'      => __( 'Product Brand', 'jetpack-search-pkg' ),
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
 			);

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -249,13 +249,12 @@ class Search_Blocks {
 	/**
 	 * Inject named block variations for the filter-checkbox block.
 	 *
-	 * Hooks `get_block_type_variations` (WP 6.5+) rather than calling
+	 * Hooks `get_block_type_variations` (added in WP 6.5) rather than calling
 	 * `register_block_variation()` because the latter is a JS-only API; no
 	 * matching PHP function exists in WordPress core. Filtering on the block
 	 * type's own variations getter is the supported PHP-side path and keeps
-	 * the editor-only JS bundle out of the ESM pipeline. On WP < 6.5 the
-	 * filter doesn't fire and no variations are registered — same end-state
-	 * as the prior code path, so this is not a version regression.
+	 * the editor-only JS bundle out of the ESM pipeline. Jetpack already
+	 * requires WP 6.8+, so the hook is always live in supported environments.
 	 *
 	 * Variation names and default `taxonomy` / `filterType` attributes
 	 * intentionally mirror the filter types exposed by the instant-search
@@ -329,23 +328,11 @@ class Search_Blocks {
 				'name'        => 'product_tag',
 				'title'       => __( 'Filter by Product Tag', 'jetpack-search-pkg' ),
 				'description' => __( 'Show product tag checkboxes with live result counts.', 'jetpack-search-pkg' ),
-				'icon'        => 'category',
+				'icon'        => 'tag',
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => 'product_tag',
 					'label'      => __( 'Tag', 'jetpack-search-pkg' ),
-				),
-				'isActive'    => array( 'filterType', 'taxonomy' ),
-			),
-			array(
-				'name'        => 'product_brand',
-				'title'       => __( 'Filter by Product Brand', 'jetpack-search-pkg' ),
-				'description' => __( 'Show product brand checkboxes with live result counts. Requires a registered `product_brand` taxonomy.', 'jetpack-search-pkg' ),
-				'icon'        => 'category',
-				'attributes'  => array(
-					'filterType' => 'taxonomy',
-					'taxonomy'   => 'product_brand',
-					'label'      => __( 'Brand', 'jetpack-search-pkg' ),
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
 			),
@@ -360,14 +347,35 @@ class Search_Blocks {
 				),
 				// Match on filterType only (no taxonomy comparison) so the
 				// variation identity survives once the author picks a slug
-				// via the inspector. Category, Tag, and the three product
-				// taxonomies all pin `taxonomy` in their isActive arrays, so
+				// via the inspector. Category, Tag, and the product taxonomy
+				// variations all pin `taxonomy` in their isActive arrays, so
 				// WP's most-specific-match resolution still routes those
 				// slugs to their dedicated variations — Custom Taxonomy
 				// claims every other registered taxonomy.
 				'isActive'    => array( 'filterType' ),
 			),
 		);
+
+		// `product_brand` isn't a core WooCommerce taxonomy — it's added by
+		// extensions (WC Brands, Perfect Brands, recent bundled WC versions).
+		// Registering the variation unconditionally would surface "Filter by
+		// Product Brand" in the inserter on sites without it, where the block
+		// renders no buckets and the failure is silent. Gate on the taxonomy's
+		// presence so authors only see the option when it can actually work.
+		if ( taxonomy_exists( 'product_brand' ) ) {
+			$additions[] = array(
+				'name'        => 'product_brand',
+				'title'       => __( 'Filter by Product Brand', 'jetpack-search-pkg' ),
+				'description' => __( 'Show product brand checkboxes with live result counts.', 'jetpack-search-pkg' ),
+				'icon'        => 'awards',
+				'attributes'  => array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_brand',
+					'label'      => __( 'Brand', 'jetpack-search-pkg' ),
+				),
+				'isActive'    => array( 'filterType', 'taxonomy' ),
+			);
+		}
 
 		// Merge by `name` so a variation already registered upstream (block.json
 		// or a higher-priority filter) wins over our preset of the same name —

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -336,24 +336,6 @@ class Search_Blocks {
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
 			),
-			array(
-				'name'        => 'custom_taxonomy',
-				'title'       => __( 'Filter by Custom Taxonomy', 'jetpack-search-pkg' ),
-				'description' => __( 'Show checkboxes for a custom taxonomy. Pick which taxonomy in the block settings after inserting.', 'jetpack-search-pkg' ),
-				'attributes'  => array(
-					'filterType' => 'taxonomy',
-					'taxonomy'   => '',
-					'label'      => '',
-				),
-				// Match on filterType only (no taxonomy comparison) so the
-				// variation identity survives once the author picks a slug
-				// via the inspector. Category, Tag, and the product taxonomy
-				// variations all pin `taxonomy` in their isActive arrays, so
-				// WP's most-specific-match resolution still routes those
-				// slugs to their dedicated variations — Custom Taxonomy
-				// claims every other registered taxonomy.
-				'isActive'    => array( 'filterType' ),
-			),
 		);
 
 		// `product_brand` isn't a core WooCommerce taxonomy — it's added by
@@ -362,6 +344,8 @@ class Search_Blocks {
 		// Product Brand" in the inserter on sites without it, where the block
 		// renders no buckets and the failure is silent. Gate on the taxonomy's
 		// presence so authors only see the option when it can actually work.
+		// Inserted before `custom_taxonomy` below so the three product
+		// variations stay grouped in the inserter when the gate fires.
 		if ( taxonomy_exists( 'product_brand' ) ) {
 			$additions[] = array(
 				'name'        => 'product_brand',
@@ -376,6 +360,25 @@ class Search_Blocks {
 				'isActive'    => array( 'filterType', 'taxonomy' ),
 			);
 		}
+
+		$additions[] = array(
+			'name'        => 'custom_taxonomy',
+			'title'       => __( 'Filter by Custom Taxonomy', 'jetpack-search-pkg' ),
+			'description' => __( 'Show checkboxes for a custom taxonomy. Pick which taxonomy in the block settings after inserting.', 'jetpack-search-pkg' ),
+			'attributes'  => array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => '',
+				'label'      => '',
+			),
+			// Match on filterType only (no taxonomy comparison) so the
+			// variation identity survives once the author picks a slug
+			// via the inspector. Category, Tag, and the product taxonomy
+			// variations all pin `taxonomy` in their isActive arrays, so
+			// WP's most-specific-match resolution still routes those
+			// slugs to their dedicated variations — Custom Taxonomy
+			// claims every other registered taxonomy.
+			'isActive'    => array( 'filterType' ),
+		);
 
 		// Merge by `name` so a variation already registered upstream (block.json
 		// or a higher-priority filter) wins over our preset of the same name —

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -175,15 +175,18 @@ describe( 'variationDefaultLabel', () => {
 		expect( variationDefaultLabel( { filterType: 'author' } ) ).toBe( 'Author' );
 	} );
 
-	it( 'returns the per-slug label for the three product variations', () => {
+	it( 'returns distinct "Product X" labels for the three product variations', () => {
+		// Product taxonomies must read differently from the post-taxonomy
+		// variations so an author with both Category and Product Category
+		// on the same page sees two distinct headings by default.
 		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'product_cat' } ) ).toBe(
-			'Category'
+			'Product Category'
 		);
 		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'product_tag' } ) ).toBe(
-			'Tag'
+			'Product Tag'
 		);
 		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'product_brand' } ) ).toBe(
-			'Brand'
+			'Product Brand'
 		);
 	} );
 

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -12,11 +12,14 @@ import {
 	VARIATION_POST_TAG,
 	VARIATION_POST_TYPE,
 	VARIATION_AUTHOR,
+	VARIATION_PRODUCT_CAT,
+	VARIATION_PRODUCT_TAG,
+	VARIATION_PRODUCT_BRAND,
 	VARIATION_CUSTOM_TAXONOMY,
 } from '../../../src/search-blocks/blocks/filter-checkbox/edit.js';
 
 describe( 'deriveVariation', () => {
-	it( 'maps the four built-in (filterType, taxonomy) pairs to their variation ids', () => {
+	it( 'maps the built-in (filterType, taxonomy) pairs to their variation ids', () => {
 		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'category' } ) ).toBe(
 			VARIATION_CATEGORY
 		);
@@ -27,11 +30,20 @@ describe( 'deriveVariation', () => {
 		expect( deriveVariation( { filterType: 'author' } ) ).toBe( VARIATION_AUTHOR );
 	} );
 
+	it( 'maps the WC product taxonomy slugs to their dedicated variations', () => {
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_cat' } ) ).toBe(
+			VARIATION_PRODUCT_CAT
+		);
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_tag' } ) ).toBe(
+			VARIATION_PRODUCT_TAG
+		);
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_brand' } ) ).toBe(
+			VARIATION_PRODUCT_BRAND
+		);
+	} );
+
 	it( 'treats any non-built-in taxonomy slug as Custom Taxonomy', () => {
 		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'genre' } ) ).toBe(
-			VARIATION_CUSTOM_TAXONOMY
-		);
-		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_cat' } ) ).toBe(
 			VARIATION_CUSTOM_TAXONOMY
 		);
 	} );
@@ -67,13 +79,28 @@ describe( 'variationToAttributes', () => {
 			filterType: 'post_type',
 			taxonomy: 'genre',
 		} );
-		expect( variationToAttributes( VARIATION_AUTHOR, 'product_cat' ) ).toEqual( {
+		expect( variationToAttributes( VARIATION_AUTHOR, 'genre' ) ).toEqual( {
 			filterType: 'author',
-			taxonomy: 'product_cat',
+			taxonomy: 'genre',
 		} );
 		expect( variationToAttributes( VARIATION_AUTHOR, '' ) ).toEqual( {
 			filterType: 'author',
 			taxonomy: '',
+		} );
+	} );
+
+	it( 'pins the slug for the three product variations', () => {
+		expect( variationToAttributes( VARIATION_PRODUCT_CAT, '' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'product_cat',
+		} );
+		expect( variationToAttributes( VARIATION_PRODUCT_TAG, 'genre' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'product_tag',
+		} );
+		expect( variationToAttributes( VARIATION_PRODUCT_BRAND, 'category' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'product_brand',
 		} );
 	} );
 
@@ -84,16 +111,14 @@ describe( 'variationToAttributes', () => {
 		} );
 	} );
 
-	it( 'drops built-in `category` / `post_tag` when switching to Custom Taxonomy', () => {
+	it( 'drops every built-in slug when switching to Custom Taxonomy', () => {
 		// Otherwise these would surface as user-typed slugs in the Taxonomy
 		// slug input, which would be wrong: they're built-in variations.
-		expect( variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'category' ) ).toEqual( {
-			filterType: 'taxonomy',
-			taxonomy: '',
-		} );
-		expect( variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'post_tag' ) ).toEqual( {
-			filterType: 'taxonomy',
-			taxonomy: '',
+		[ 'category', 'post_tag', 'product_cat', 'product_tag', 'product_brand' ].forEach( slug => {
+			expect( variationToAttributes( VARIATION_CUSTOM_TAXONOMY, slug ) ).toEqual( {
+				filterType: 'taxonomy',
+				taxonomy: '',
+			} );
 		} );
 	} );
 
@@ -114,10 +139,10 @@ describe( 'variationToAttributes', () => {
 	} );
 
 	it( 'preserves a custom slug across Custom → Post Type → Custom', () => {
-		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'product_cat' );
+		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'genre' );
 		const step2 = variationToAttributes( VARIATION_POST_TYPE, step1.taxonomy );
 		const step3 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, step2.taxonomy );
-		expect( step3.taxonomy ).toBe( 'product_cat' );
+		expect( step3.taxonomy ).toBe( 'genre' );
 	} );
 
 	it( 'intentionally clears the slug across Custom → Category → Custom', () => {
@@ -126,6 +151,13 @@ describe( 'variationToAttributes', () => {
 		// as a custom-typed slug. Documented behavior, not a regression.
 		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'genre' );
 		const step2 = variationToAttributes( VARIATION_CATEGORY, step1.taxonomy );
+		const step3 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, step2.taxonomy );
+		expect( step3.taxonomy ).toBe( '' );
+	} );
+
+	it( 'intentionally clears the slug across Custom → Product Category → Custom', () => {
+		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'genre' );
+		const step2 = variationToAttributes( VARIATION_PRODUCT_CAT, step1.taxonomy );
 		const step3 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, step2.taxonomy );
 		expect( step3.taxonomy ).toBe( '' );
 	} );
@@ -141,6 +173,18 @@ describe( 'variationDefaultLabel', () => {
 		);
 		expect( variationDefaultLabel( { filterType: 'post_type' } ) ).toBe( 'Post Type' );
 		expect( variationDefaultLabel( { filterType: 'author' } ) ).toBe( 'Author' );
+	} );
+
+	it( 'returns the per-slug label for the three product variations', () => {
+		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'product_cat' } ) ).toBe(
+			'Category'
+		);
+		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'product_tag' } ) ).toBe(
+			'Tag'
+		);
+		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'product_brand' } ) ).toBe(
+			'Brand'
+		);
 	} );
 
 	it( 'returns empty string for custom taxonomies so the caller falls back to the generic placeholder', () => {

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -109,11 +109,10 @@ class Filter_Checkbox_Test extends TestCase {
 		);
 		$this->assertSame( 'Post Type', Filter_Checkbox::default_label( array( 'filterType' => 'post_type' ) ) );
 		$this->assertSame( 'Author', Filter_Checkbox::default_label( array( 'filterType' => 'author' ) ) );
-		// Product taxonomies fall back to per-slug English labels when the WC
-		// taxonomies aren't loaded (phpunit, fresh install). Production WC
-		// sites override via the get_taxonomy()->labels->singular_name branch.
+		// Product taxonomies get distinct "Product X" defaults so they don't
+		// collide visually with the post-taxonomy variations on the same page.
 		$this->assertSame(
-			'Category',
+			'Product Category',
 			Filter_Checkbox::default_label(
 				array(
 					'filterType' => 'taxonomy',
@@ -122,7 +121,7 @@ class Filter_Checkbox_Test extends TestCase {
 			)
 		);
 		$this->assertSame(
-			'Tag',
+			'Product Tag',
 			Filter_Checkbox::default_label(
 				array(
 					'filterType' => 'taxonomy',
@@ -131,7 +130,7 @@ class Filter_Checkbox_Test extends TestCase {
 			)
 		);
 		$this->assertSame(
-			'Brand',
+			'Product Brand',
 			Filter_Checkbox::default_label(
 				array(
 					'filterType' => 'taxonomy',

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -109,6 +109,36 @@ class Filter_Checkbox_Test extends TestCase {
 		);
 		$this->assertSame( 'Post Type', Filter_Checkbox::default_label( array( 'filterType' => 'post_type' ) ) );
 		$this->assertSame( 'Author', Filter_Checkbox::default_label( array( 'filterType' => 'author' ) ) );
+		// Product taxonomies fall back to per-slug English labels when the WC
+		// taxonomies aren't loaded (phpunit, fresh install). Production WC
+		// sites override via the get_taxonomy()->labels->singular_name branch.
+		$this->assertSame(
+			'Category',
+			Filter_Checkbox::default_label(
+				array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_cat',
+				)
+			)
+		);
+		$this->assertSame(
+			'Tag',
+			Filter_Checkbox::default_label(
+				array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_tag',
+				)
+			)
+		);
+		$this->assertSame(
+			'Brand',
+			Filter_Checkbox::default_label(
+				array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'product_brand',
+				)
+			)
+		);
 		// Custom taxonomies get no fallback — the editor user is expected to
 		// provide a meaningful label.
 		$this->assertSame(

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -646,6 +646,65 @@ class Search_Blocks_Test extends TestCase {
 			$variations_by_name['custom_taxonomy']['attributes']
 		);
 		$this->assertSame( array( 'filterType' ), $variations_by_name['custom_taxonomy']['isActive'] );
+
+		// WC product taxonomies — product_cat / product_tag are unconditional
+		// (WooCommerce always registers them); product_brand is gated below
+		// in test_inject_filter_checkbox_variations_gates_product_brand_on_taxonomy_existence.
+		$this->assertSame(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'product_cat',
+				'label'      => 'Category',
+			),
+			$variations_by_name['product_cat']['attributes']
+		);
+		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_cat']['isActive'] );
+		$this->assertSame( 'category', $variations_by_name['product_cat']['icon'] );
+
+		$this->assertSame(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'product_tag',
+				'label'      => 'Tag',
+			),
+			$variations_by_name['product_tag']['attributes']
+		);
+		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_tag']['isActive'] );
+		$this->assertSame( 'tag', $variations_by_name['product_tag']['icon'] );
+
+		// product_brand is gated on `taxonomy_exists( 'product_brand' )`. In a
+		// bare phpunit run no taxonomies are registered, so it must NOT appear.
+		$this->assertArrayNotHasKey( 'product_brand', $variations_by_name );
+	}
+
+	/**
+	 * `product_brand` isn't a core WC taxonomy — it's added by extensions
+	 * (WC Brands, Perfect Brands, recent bundled WC versions). The variation
+	 * is registered only when the taxonomy is present so authors don't see
+	 * a silently-empty filter on sites without a brands extension.
+	 */
+	public function test_inject_filter_checkbox_variations_gates_product_brand_on_taxonomy_existence() {
+		register_taxonomy( 'product_brand', 'post' );
+
+		$variations         = Search_Blocks::inject_filter_checkbox_variations(
+			array(),
+			new \WP_Block_Type( 'jetpack-search/filter-checkbox' )
+		);
+		$variations_by_name = array_column( $variations, null, 'name' );
+
+		$this->assertArrayHasKey( 'product_brand', $variations_by_name );
+		$this->assertSame(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'product_brand',
+				'label'      => 'Brand',
+			),
+			$variations_by_name['product_brand']['attributes']
+		);
+		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_brand']['isActive'] );
+		$this->assertSame( 'awards', $variations_by_name['product_brand']['icon'] );
+
+		unregister_taxonomy( 'product_brand' );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -704,6 +704,17 @@ class Search_Blocks_Test extends TestCase {
 		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_brand']['isActive'] );
 		$this->assertSame( 'awards', $variations_by_name['product_brand']['icon'] );
 
+		// Inserter cards render in the order the variations are returned, so
+		// product_brand must precede custom_taxonomy to keep the three
+		// product variations grouped together rather than splitting around
+		// Custom Taxonomy.
+		$names           = array_column( $variations, 'name' );
+		$brand_position  = array_search( 'product_brand', $names, true );
+		$custom_position = array_search( 'custom_taxonomy', $names, true );
+		$this->assertNotFalse( $brand_position );
+		$this->assertNotFalse( $custom_position );
+		$this->assertLessThan( $custom_position, $brand_position );
+
 		unregister_taxonomy( 'product_brand' );
 	}
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -654,7 +654,7 @@ class Search_Blocks_Test extends TestCase {
 			array(
 				'filterType' => 'taxonomy',
 				'taxonomy'   => 'product_cat',
-				'label'      => 'Category',
+				'label'      => 'Product Category',
 			),
 			$variations_by_name['product_cat']['attributes']
 		);
@@ -665,7 +665,7 @@ class Search_Blocks_Test extends TestCase {
 			array(
 				'filterType' => 'taxonomy',
 				'taxonomy'   => 'product_tag',
-				'label'      => 'Tag',
+				'label'      => 'Product Tag',
 			),
 			$variations_by_name['product_tag']['attributes']
 		);
@@ -697,7 +697,7 @@ class Search_Blocks_Test extends TestCase {
 			array(
 				'filterType' => 'taxonomy',
 				'taxonomy'   => 'product_brand',
-				'label'      => 'Brand',
+				'label'      => 'Product Brand',
 			),
 			$variations_by_name['product_brand']['attributes']
 		);


### PR DESCRIPTION
Fixes #

## Proposed changes
* Drop the standalone `jetpack-search/filter-wc-taxonomy` block (proposed in #48451) in favor of three inserter-visible variations on the existing `jetpack-search/filter-checkbox` block — *Filter by Product Category*, *Filter by Product Tag*, *Filter by Product Brand*.
* Variations are registered via `inject_filter_checkbox_variations()` (PHP-side, hooked on `get_block_type_variations`) with distinct icons (`category` / `tag` / `awards`) and `isActive` matching on `(filterType, taxonomy)`, so a saved block round-trips to the right inserter card.
* `product_brand` is gated on `taxonomy_exists( 'product_brand' )` since it isn't a core WooCommerce taxonomy — registering it unconditionally surfaces a silently-empty filter on sites without a brands extension. `product_cat` and `product_tag` ship with WC core, so they're unconditional.
* Variation default labels are differentiated — `product_cat` → *Product Category*, `product_tag` → *Product Tag*, `product_brand` → *Product Brand*. Authors who use both *Filter by Category* and *Filter by Product Category* on the same page see two clearly different headings by default. `Filter_Checkbox::default_label()` and JS `variationDefaultLabel()` both return the new strings, so the inspector placeholder and server-rendered heading stay in sync.
* `edit.js` extends `deriveVariation` / `variationToAttributes` / `variationDefaultLabel` / `BUILT_IN_TAXONOMY_SLUGS` / the inspector picker so the three product variations behave like Category and Tag — pinned slug, dropped from the Custom Taxonomy slug picker, and labeled correctly in the preview.

The data plane is unchanged (`filterType: 'taxonomy'` with the same `taxonomy.<slug>.slug_slash_name` aggregation), so this collapses one block + one render.php + one edit.js + one stylesheet (and a fragile cross-block style dependency) without any front-end behavior change.

This supersedes #48451 — that PR has been closed.

## Screenshots

Captured against a local docker WP 6.x with WooCommerce active and the search blocks feature flag on.

### Block inserter (Filter by …)

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/8ab12bf8-aadf-4d62-9756-d1e737348f68) | ![after](https://github.com/user-attachments/assets/e4645707-a69a-493e-9bc8-73e04f79d509) |

The after view shows the three new product taxonomy variations (with distinct `category` / `tag` / `awards` icons) sitting alongside the existing Category / Tag / Post Type / Author / Custom Taxonomy entries.

### Front-end render

![front-end](https://github.com/user-attachments/assets/5b23fee6-ad6a-41b1-8165-20cf68312333)

A page with all three product filter blocks inserted, rendered on the live theme. Headings use the new distinct *Product Category* / *Product Tag* / *Product Brand* defaults; checkbox lists show realistic taxonomy buckets and counts (mock aggregations seeded server-side for this dev env, real Search backends supply them at runtime).

### Editor block settings

| Inspector (default state) | Inspector (Filter type dropdown) |
|---|---|
| ![inspector](https://github.com/user-attachments/assets/94c9a6df-9623-4567-936c-9186848cd64a) | ![inspector dropdown](https://github.com/user-attachments/assets/162f3678-83b4-4314-af14-f37b37906412) |

Inserting *Filter by Product Category* seeds the Label as *Product Category* (left). The *Filter type* dropdown (right) lists all eight variations the inspector picker can swap to without re-inserting the block.

## Related product discussion/links
* [RSM-1929] (Search 3.0 product filter epic)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Apply this PR to a Jetpack Search–enabled site with WooCommerce active and at least a few products tagged with categories, tags, and (optionally) brands.
2. Open the Site Editor / Post editor and search the inserter for `Filter by Product`. Three new entries should appear: *Filter by Product Category*, *Filter by Product Tag*, *Filter by Product Brand* — the third only if a `product_brand` taxonomy is registered (WC 9+, WC Brands, or Perfect Brands).
3. Insert each one onto a Jetpack Search results page (or pattern). Confirm the editor preview shows the new distinct labels (*Product Category* / *Product Tag* / *Product Brand*) — not just *Category* / *Tag* / *Brand*.
4. With the block selected, open the inspector. The *Filter type* dropdown should reflect the variation you inserted (e.g. `Product Category`). Switching it to `Custom taxonomy` should clear the slug; switching back to `Product Category` should re-pin `product_cat`.
5. On the front end, confirm each filter renders the WC taxonomy buckets with counts and that selecting checkboxes filters the result list.
6. Verify deep links: select a Product Category, copy the URL, paste it into a fresh tab. The selection should round-trip via `?product_cat[]=<slug>`.
7. Insert a `Custom Taxonomy` filter and confirm the slug picker no longer offers `product_cat` / `product_tag` / `product_brand` (they're routed to their dedicated variations).
8. On a non-WC site (or one without a `product_brand` taxonomy registered): confirm *Filter by Product Brand* does **not** appear in the inserter, while *Filter by Product Category* / *Filter by Product Tag* still do.