### PR TITLE
Search 3.0: extract + unit-test the rating filter bucket projection (RSM-2663 follow-up)

### DIFF
--- a/projects/packages/search/changelog/atlas-rsm-2663-rating-buckets-tests
+++ b/projects/packages/search/changelog/atlas-rsm-2663-rating-buckets-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: extract the rating filter's cumulative bucket projection into its own module + add unit tests pinning the threshold semantics. Also tightens type symmetry (string keys throughout the count map) and mirrors the `!filterKey` defensive guard across the block's three context consumers. Internal-only; no behavior change.

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/bucket-projection.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/bucket-projection.js
@@ -1,0 +1,50 @@
+/**
+ * Bucket → cumulative "& up" projection for the rating filter.
+ *
+ * Lives in its own module so the runtime view (view.js) and the test
+ * suite share the same implementation — there's no parallel JS-side
+ * truth source for this projection. The PHP-side mirror is in
+ * render.php's foreach over `$seeded_buckets`.
+ *
+ * Returned shape uses string keys ("1".."5") because the consumer
+ * (`ratingOptionCount` getter in view.js) reads `starValue` from the
+ * `data-wp-context` attribute, which arrives as a string. Keeping
+ * the map keyed as strings throughout avoids relying on JS object
+ * keys' implicit number-to-string coercion.
+ */
+
+/**
+ * Project a histogram bucket array onto a cumulative "& up" star → count
+ * map. Each star N's count is the sum of doc_counts for every bucket
+ * whose key is ≥ N - 0.5 — i.e. every avg_rating that rounds to N or
+ * higher under WC's `ROUND(avg, 0)` rule. Guarantees the rendered
+ * counts are monotone (count(3) ≥ count(4) ≥ count(5)) — the property
+ * shoppers expect from threshold rows. Buckets below 0.5 (the implicit
+ * "no rating" bucket the histogram emits at -0.5 thanks to
+ * `min_doc_count: 0`) are ignored.
+ *
+ * @param {Array<{key: number, doc_count: number}>} buckets - Aggregation buckets.
+ * @return {Object<string, number>} Star (as string key, "1".."5") → count.
+ */
+export function bucketsToStarCountMap( buckets ) {
+	const map = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+	if ( ! Array.isArray( buckets ) ) {
+		return map;
+	}
+	for ( const bucket of buckets ) {
+		const key = Number( bucket?.key ?? NaN );
+		const count = Number( bucket?.doc_count ?? 0 );
+		if ( ! Number.isFinite( key ) || key < 0.5 ) {
+			continue;
+		}
+		// Bucket keys land on .5 boundaries; `key + 0.5` is the highest
+		// star whose threshold this bucket clears. A doc in the 4.5
+		// bucket counts toward 5★+, 4★+, …, 1★+; a doc in the 0.5
+		// bucket only toward 1★+. `Math.round` shrugs off FP slop.
+		const cap = Math.min( 5, Math.round( key + 0.5 ) );
+		for ( let star = 1; star <= cap; star++ ) {
+			map[ String( star ) ] += count;
+		}
+	}
+	return map;
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
@@ -1,44 +1,9 @@
 import { store, getContext } from '@wordpress/interactivity';
 import '../../store';
+import { bucketsToStarCountMap } from './bucket-projection';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';
-
-/**
- * Project a histogram bucket array onto a cumulative "& up" star → count
- * map. Each star N's count is the sum of doc_counts for every bucket
- * whose key is ≥ N - 0.5, i.e., every avg_rating that rounds to N or
- * higher. Guarantees the rendered counts are monotone (count(3) ≥
- * count(4) ≥ count(5)) — the property shoppers expect from threshold
- * rows. Buckets below 0.5 (the implicit "no rating" bucket the histogram
- * emits at -0.5 thanks to `min_doc_count: 0`) are ignored. Mirrors the
- * same projection in render.php.
- *
- * @param {Array<{key: number, doc_count: number}>} buckets - Aggregation buckets.
- * @return {Object<string, number>} Star (as string key, "1".."5") → count.
- */
-function bucketsToStarCountMap( buckets ) {
-	const map = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
-	if ( ! Array.isArray( buckets ) ) {
-		return map;
-	}
-	for ( const bucket of buckets ) {
-		const key = Number( bucket?.key ?? NaN );
-		const count = Number( bucket?.doc_count ?? 0 );
-		if ( ! Number.isFinite( key ) || key < 0.5 ) {
-			continue;
-		}
-		// Bucket keys land on .5 boundaries; `key + 0.5` is the highest
-		// star whose threshold this bucket clears. A doc in the 4.5
-		// bucket counts toward 5★+, 4★+, …, 1★+; a doc in the 0.5
-		// bucket only toward 1★+. `Math.round` shrugs off FP slop.
-		const cap = Math.min( 5, Math.round( key + 0.5 ) );
-		for ( let star = 1; star <= cap; star++ ) {
-			map[ star ] += count;
-		}
-	}
-	return map;
-}
 
 store( NAMESPACE, {
 	state: {
@@ -52,7 +17,7 @@ store( NAMESPACE, {
 		 */
 		get isRatingOptionSelected() {
 			const { filterKey, starValue } = getContext();
-			if ( ! starValue ) {
+			if ( ! starValue || ! filterKey ) {
 				return false;
 			}
 			const { state } = store( NAMESPACE );
@@ -69,7 +34,7 @@ store( NAMESPACE, {
 		 */
 		get ratingOptionCount() {
 			const { filterKey, starValue } = getContext();
-			if ( ! starValue ) {
+			if ( ! starValue || ! filterKey ) {
 				return '0';
 			}
 			const { state } = store( NAMESPACE );

--- a/projects/packages/search/tests/js/search-blocks/filter-wc-rating-bucket-projection.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-wc-rating-bucket-projection.test.js
@@ -1,0 +1,85 @@
+import { bucketsToStarCountMap } from '../../../src/search-blocks/blocks/filter-wc-rating/bucket-projection';
+
+describe( 'bucketsToStarCountMap (filter-wc-rating cumulative projection)', () => {
+	it( 'returns a baseline { "1": 0..."5": 0 } map for null / non-array input', () => {
+		expect( bucketsToStarCountMap( undefined ) ).toEqual( {
+			1: 0,
+			2: 0,
+			3: 0,
+			4: 0,
+			5: 0,
+		} );
+		expect( bucketsToStarCountMap( null ) ).toEqual( {
+			1: 0,
+			2: 0,
+			3: 0,
+			4: 0,
+			5: 0,
+		} );
+	} );
+
+	it( 'drops the implicit -0.5 "no rating" bucket and any other key < 0.5', () => {
+		expect(
+			bucketsToStarCountMap( [
+				{ key: -0.5, doc_count: 27 },
+				{ key: 0.0, doc_count: 5 },
+				{ key: 0.49, doc_count: 99 },
+			] )
+		).toEqual( { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } );
+	} );
+
+	it( 'projects a 4.5-key bucket onto every star row (1..5) — the all-up case', () => {
+		// avg ∈ [4.5, 5] rounds to 5★, so it should also count toward
+		// every "& up" row that has a lower threshold.
+		expect( bucketsToStarCountMap( [ { key: 4.5, doc_count: 7 } ] ) ).toEqual( {
+			1: 7,
+			2: 7,
+			3: 7,
+			4: 7,
+			5: 7,
+		} );
+	} );
+
+	it( 'projects a 0.5-key bucket onto only the 1★ row — the no-cumulation case', () => {
+		// avg ∈ [0.5, 1.5) rounds to 1★, so only the 1★ & up row should
+		// receive the count.
+		expect( bucketsToStarCountMap( [ { key: 0.5, doc_count: 3 } ] ) ).toEqual( {
+			1: 3,
+			2: 0,
+			3: 0,
+			4: 0,
+			5: 0,
+		} );
+	} );
+
+	it( 'sums multiple buckets cumulatively to produce monotone counts', () => {
+		// Mirrors the live atlas test store — one product rated 4★, one
+		// rated 2★, 26 unrated. Expected reading top-down: 0, 1, 1, 2, 2.
+		const map = bucketsToStarCountMap( [
+			{ key: -0.5, doc_count: 26 },
+			{ key: 0.5, doc_count: 0 },
+			{ key: 1.5, doc_count: 1 },
+			{ key: 2.5, doc_count: 0 },
+			{ key: 3.5, doc_count: 1 },
+		] );
+		expect( map ).toEqual( { 1: 2, 2: 2, 3: 1, 4: 1, 5: 0 } );
+		// Monotone-decreasing as the threshold rises:
+		expect( map[ 1 ] ).toBeGreaterThanOrEqual( map[ 2 ] );
+		expect( map[ 2 ] ).toBeGreaterThanOrEqual( map[ 3 ] );
+		expect( map[ 3 ] ).toBeGreaterThanOrEqual( map[ 4 ] );
+		expect( map[ 4 ] ).toBeGreaterThanOrEqual( map[ 5 ] );
+	} );
+
+	it( 'is keyed by string ("1".."5") so the data-wp-context star value reads correctly', () => {
+		const map = bucketsToStarCountMap( [ { key: 4.5, doc_count: 1 } ] );
+		// The view reads `counts[starValue]` where starValue is a string
+		// from data-wp-context. Both numeric and string lookups land the
+		// same value because JS object property access coerces the index
+		// to a string anyway, but we assert the explicit string keys to
+		// pin the contract.
+		expect( map[ '5' ] ).toBe( 1 );
+		expect( map[ '1' ] ).toBe( 1 );
+		// Property keys are explicitly strings.
+		expect( Object.keys( map ).sort() ).toEqual( [ '1', '2', '3', '4', '5' ] );
+	} );
+} );


### PR DESCRIPTION
Follow-up to #48628 (now merged) — addresses the [`claude[bot]` review there](https://github.com/Automattic/jetpack/pull/48628#issuecomment-4402848081).

## Why

The cumulative-from-top projection that powers the "X stars & up" count badges is the most algorithmically dense piece of the rating filter, but it shipped untested. A subtle off-by-one in the `key + 0.5 → cap` math would silently skew every count badge a row up or down without breaking any existing test. Pinning that behaviour with unit tests means a future refactor can't drift it without the suite catching it.

## Proposed changes

* Extract `bucketsToStarCountMap` from `view.js` into its own `bucket-projection.js` module so the runtime view and the test suite share a single source of truth (no more "test imports a side-effect store registration").
* Add six unit tests covering the corners that matter: `null` / non-array input, the implicit `-0.5` "no rating" bucket being dropped, a `4.5`-key bucket spanning every star row (the all-up case), a `0.5`-key bucket reaching only star 1 (the no-cumulation case), monotone summation across multiple buckets matching the live atlas store data, and the string-keyed shape of the returned map.
* Minor type-symmetry fix: initialise the count map with explicit string keys (`"1"`..`"5"`) and accumulate via `String(star)` so the consumer's `counts[starValue]` lookup (where `starValue` is a string from `data-wp-context`) doesn't rely on JS's silent number-to-string coercion.
* Mirror `onRatingFilterChange`'s defensive `!filterKey` guard in `isRatingOptionSelected` and `ratingOptionCount` so all three context consumers fail closed on a missing `filterKey` instead of two of them silently returning a no-op.

No behaviour change — purely a follow-up to lock down what merged in #48628.

## Related product discussion/links

* Parent PR (merged): #48628
* Issue: [RSM-2663](https://linear.app/a8c/issue/RSM-2663/search-30-redesign-filter-wc-rating-as-x-stars-and-up-threshold-ux)

## Does this pull request change what data or activity we track or use?

No. Pure refactor + tests.

## Testing instructions

1. `pnpm jest tests/js/search-blocks` should pass with 6 new tests in the `bucketsToStarCountMap` suite.
2. End-to-end: the rating filter should render and behave identically to what landed in #48628 — same star rows, same cumulative counts, same single-select interaction. The change is module-shaped only.
