### PR TITLE
Charts: update README title to full library name

### DIFF
--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -1,4 +1,4 @@
-# Automattic Charts
+# Automattic Charts Library
 
 A comprehensive charting library for displaying interactive data visualizations within Automattic products. Built on top of modern libraries like `@visx/xychart` and designed for accessibility, responsiveness, and ease of use.
 

--- a/projects/js-packages/charts/changelog/test-charts-slack-pr-routine
+++ b/projects/js-packages/charts/changelog/test-charts-slack-pr-routine
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update README title to reflect full library name.


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Update the README heading for `@automattic/charts` from "Automattic Charts" to "Automattic Charts Library" so the title matches the package's full library name.

## Related product discussion/links
* N/A — minor docs polish.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open `projects/js-packages/charts/README.md` and confirm the top-level heading reads "Automattic Charts Library".
* No code paths are affected; no functional testing required.
