### PR TITLE
Admin Menu: add group_id + signal fields and top-level groups[] for sidebar redesign

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -40,6 +40,25 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private $dashicon_list;
 
 	/**
+	 * Lazily-built map of `menu_slug => nav-model entry`, populated from the
+	 * `Sidebar_Classifier` nav model when the public `wp-admin-sidebar` plugin
+	 * is loaded on the host. `null` means we have not yet attempted to build
+	 * the index for this request; an empty array means the classifier ran but
+	 * produced no items (e.g., gating denied).
+	 *
+	 * @var array<string, array>|null
+	 */
+	private $sidebar_nav_index = null;
+
+	/**
+	 * Group rows from the classifier nav model, keyed by group id. Sibling to
+	 * `$sidebar_nav_index`; `null` when not built, empty array when no groups.
+	 *
+	 * @var array<string, array>|null
+	 */
+	private $sidebar_nav_groups = null;
+
+	/**
 	 * WPCOM_REST_API_V2_Endpoint_Admin_Menu constructor.
 	 */
 	public function __construct() {
@@ -119,6 +138,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	public function prepare_menu_for_response( array $menu ) {
 		global $submenu;
 
+		// Best-effort hydration of the classifier nav model. Safe no-op when the
+		// public `wp-admin-sidebar` plugin is not installed (non-WPCOM Jetpack).
+		$this->maybe_build_sidebar_nav_index();
+
 		$data = array();
 
 		/**
@@ -153,7 +176,168 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 		}
 
-		return array_filter( $data );
+		$data = array_values( array_filter( $data ) );
+
+		// When the public `wp-admin-sidebar` plugin is loaded (WPCOM and any
+		// host that opts in), the response carries a sibling `groups[]` array
+		// describing the synthetic group rows the classifier emitted. Wrapping
+		// only happens when classifier data is available so non-WPCOM Jetpack
+		// installs continue to receive the legacy flat-array shape.
+		if ( null !== $this->sidebar_nav_groups ) {
+			return array(
+				'menu'   => $data,
+				'groups' => $this->prepare_groups_for_response(),
+			);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Hydrate the classifier-driven nav index from the public
+	 * `wp-admin-sidebar` plugin. No-op when the plugin is not installed or
+	 * gating denied building a model on this request.
+	 */
+	private function maybe_build_sidebar_nav_index() {
+		if ( null !== $this->sidebar_nav_index ) {
+			return;
+		}
+
+		if ( ! class_exists( 'Sidebar_Classifier' ) || ! class_exists( 'Sidebar_Signals' ) ) {
+			return;
+		}
+
+		// Trigger a build if the classifier hasn't run yet on this request.
+		// The classifier short-circuits when `wp_admin_sidebar_enabled` is
+		// false, which is the default for any host that hasn't opted in.
+		if ( null === Sidebar_Classifier::get_nav_model() ) {
+			Sidebar_Classifier::build_nav_model();
+		}
+
+		$nav_model = Sidebar_Classifier::get_nav_model();
+		if ( ! is_array( $nav_model ) ) {
+			return;
+		}
+
+		$index = array();
+		$collect = static function ( array $items ) use ( &$index, &$collect ) {
+			foreach ( $items as $item ) {
+				if ( isset( $item['menuSlug'] ) && '' !== $item['menuSlug'] ) {
+					$index[ $item['menuSlug'] ] = $item;
+				}
+				if ( ! empty( $item['children'] ) && is_array( $item['children'] ) ) {
+					$collect( $item['children'] );
+				}
+			}
+		};
+
+		if ( ! empty( $nav_model['top_level'] ) && is_array( $nav_model['top_level'] ) ) {
+			$collect( $nav_model['top_level'] );
+		}
+		if ( ! empty( $nav_model['groups'] ) && is_array( $nav_model['groups'] ) ) {
+			foreach ( $nav_model['groups'] as $group ) {
+				if ( ! empty( $group['children'] ) && is_array( $group['children'] ) ) {
+					$collect( $group['children'] );
+				}
+			}
+		}
+
+		$this->sidebar_nav_index  = $index;
+		$this->sidebar_nav_groups = ! empty( $nav_model['groups'] ) && is_array( $nav_model['groups'] )
+			? $nav_model['groups']
+			: array();
+	}
+
+	/**
+	 * Look up the classifier nav-model entry for a given menu slug.
+	 *
+	 * @param string $menu_slug Menu slug as registered in `$menu` / `$submenu`.
+	 * @return array|null Nav-model entry or null if the slug is not in the index.
+	 */
+	private function get_sidebar_nav_entry( $menu_slug ) {
+		if ( null === $this->sidebar_nav_index || '' === $menu_slug ) {
+			return null;
+		}
+		return isset( $this->sidebar_nav_index[ $menu_slug ] ) ? $this->sidebar_nav_index[ $menu_slug ] : null;
+	}
+
+	/**
+	 * Build the schema-shaped `signal` subobject for an item from a classifier
+	 * nav-model entry. Returns null when the entry has no signal data.
+	 *
+	 * The returned shape is fixed (all keys present, missing fields null) so
+	 * Calypso can read it without optional-chaining gymnastics.
+	 *
+	 * @param array $nav_entry Classifier nav-model entry.
+	 * @return array|null
+	 */
+	private function map_signal_from_nav_entry( array $nav_entry ) {
+		if ( empty( $nav_entry['signal'] ) || ! is_array( $nav_entry['signal'] ) ) {
+			return null;
+		}
+		$signal = $nav_entry['signal'];
+		return array(
+			'count'         => isset( $signal['count'] ) ? $signal['count'] : null,
+			'numeric_badge' => isset( $signal['numeric_badge'] ) ? $signal['numeric_badge'] : null,
+			'badge'         => isset( $signal['badge'] ) ? $signal['badge'] : null,
+			'inline_text'   => isset( $signal['inline_text'] ) ? $signal['inline_text'] : null,
+			'inline_icon'   => isset( $signal['inline_icon'] ) ? $signal['inline_icon'] : null,
+			'attention'     => ! empty( $signal['attention'] ),
+		);
+	}
+
+	/**
+	 * Attach classifier-derived `group_id` + `signal` fields to a prepared item.
+	 * No-op when the classifier index is not available or the slug isn't found.
+	 *
+	 * @param array  $item      Prepared item (top-level or submenu).
+	 * @param string $menu_slug Raw menu slug used to look up the nav entry.
+	 * @return array Item with fields possibly added.
+	 */
+	private function attach_sidebar_fields( array $item, $menu_slug ) {
+		$nav_entry = $this->get_sidebar_nav_entry( $menu_slug );
+		if ( null === $nav_entry ) {
+			return $item;
+		}
+
+		// `default_group` in the classifier maps to `group_id` on the wire.
+		$item['group_id'] = isset( $nav_entry['default_group'] ) ? $nav_entry['default_group'] : null;
+		$item['signal']   = $this->map_signal_from_nav_entry( $nav_entry );
+
+		return $item;
+	}
+
+	/**
+	 * Build the response-shape `groups[]` array from the cached classifier rows.
+	 *
+	 * Each element carries the group's stable id, label, default expansion
+	 * state (always true; see `default_expanded` in the schema contract) and
+	 * the aggregated signal that the classifier already computed.
+	 *
+	 * @return array
+	 */
+	private function prepare_groups_for_response() {
+		if ( empty( $this->sidebar_nav_groups ) ) {
+			return array();
+		}
+
+		$groups = array();
+		foreach ( $this->sidebar_nav_groups as $group ) {
+			if ( empty( $group['id'] ) ) {
+				continue;
+			}
+			$signal = isset( $group['signal'] ) && is_array( $group['signal'] ) ? $group['signal'] : array();
+			$groups[] = array(
+				'id'               => (string) $group['id'],
+				'label'            => isset( $group['title'] ) ? (string) $group['title'] : '',
+				'default_expanded' => true,
+				'signal'           => array(
+					'attention' => ! empty( $signal['attention'] ),
+					'count'     => isset( $signal['count'] ) ? (int) $signal['count'] : 0,
+				),
+			);
+		}
+		return $groups;
 	}
 
 	/**
@@ -167,6 +351,24 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
+		// Shape of the optional `signal` subobject attached to each item by the
+		// public `wp-admin-sidebar` classifier (when loaded). Mirrors the snake
+		// case shape produced by `Sidebar_Signals::map_to_nav` so Calypso can
+		// consume one canonical field set end-to-end. All keys are present and
+		// nullable; consumers don't need optional-chaining.
+		$signal_schema = array(
+			'description' => 'Per-item attention/count/badge data emitted by the wp-admin-sidebar classifier. Null when no signal data was extracted.',
+			'type'        => array( 'object', 'null' ),
+			'properties'  => array(
+				'count'         => array( 'type' => array( 'integer', 'null' ) ),
+				'numeric_badge' => array( 'type' => array( 'integer', 'null' ) ),
+				'badge'         => array( 'type' => array( 'string', 'null' ) ),
+				'inline_text'   => array( 'type' => array( 'string', 'null' ) ),
+				'inline_icon'   => array( 'type' => array( 'string', 'null' ) ),
+				'attention'     => array( 'type' => 'boolean' ),
+			),
+		);
+
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'Admin Menu',
@@ -197,27 +399,32 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				),
 				'children'   => array(
 					'items' => array(
-						'count'  => array(
+						'count'    => array(
 							'description' => 'Core/Plugin/Theme update count or unread comments count.',
 							'type'        => 'integer',
 						),
-						'parent' => array(
+						'parent'   => array(
 							'type' => 'string',
 						),
-						'slug'   => array(
+						'slug'     => array(
 							'type' => 'string',
 						),
-						'title'  => array(
+						'title'    => array(
 							'type' => 'string',
 						),
-						'type'   => array(
+						'type'     => array(
 							'enum' => array( 'submenu-item' ),
 							'type' => 'string',
 						),
-						'url'    => array(
+						'url'      => array(
 							'format' => 'uri',
 							'type'   => 'string',
 						),
+						'group_id' => array(
+							'description' => 'Group this submenu belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
+							'type'        => array( 'string', 'null' ),
+						),
+						'signal'   => $signal_schema,
 					),
 					'type'  => 'array',
 				),
@@ -231,6 +438,39 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				'url'        => array(
 					'format' => 'uri',
 					'type'   => 'string',
+				),
+				'group_id'   => array(
+					'description' => 'Group this top-level item belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
+					'type'        => array( 'string', 'null' ),
+				),
+				'signal'     => $signal_schema,
+				// When the public `wp-admin-sidebar` plugin is loaded the
+				// response wraps the existing per-item array in `menu` and
+				// adds a sibling `groups` array. The wrapper is omitted on
+				// hosts where the classifier is not installed; consumers
+				// that ignore the new keys see the legacy flat-array shape.
+				'menu'       => array(
+					'description' => 'Top-level menu items (only present when the wp-admin-sidebar classifier is loaded; otherwise the response root itself is the menu list).',
+					'type'        => 'array',
+				),
+				'groups'     => array(
+					'description' => 'Synthetic group rows describing the sidebar grouping shape. Only present when the wp-admin-sidebar classifier is loaded; empty array if no plugin items grouped.',
+					'type'        => 'array',
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'               => array( 'type' => 'string' ),
+							'label'            => array( 'type' => 'string' ),
+							'default_expanded' => array( 'type' => 'boolean' ),
+							'signal'           => array(
+								'type'       => 'object',
+								'properties' => array(
+									'attention' => array( 'type' => 'boolean' ),
+									'count'     => array( 'type' => 'integer' ),
+								),
+							),
+						),
+					),
 				),
 			),
 		);
@@ -300,6 +540,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$item = array_merge( $item, $parsed_item );
 		}
 
+		// Additive: classifier-derived `group_id` + `signal` for the redesigned
+		// sidebar. Match key is the raw menu slug (`$menu_item[2]`), which is
+		// what the public plugin's `Sidebar_Classifier` keys nav items by.
+		$item = $this->attach_sidebar_fields( $item, $menu_item[2] );
+
 		return $item;
 	}
 
@@ -333,6 +578,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if ( ! empty( $parsed_item ) ) {
 			$item = array_merge( $item, $parsed_item );
 		}
+
+		// Additive: classifier-derived fields. Same lookup contract as the
+		// top-level branch above; submenu rows live under their own `menuSlug`
+		// in the nav model.
+		$item = $this->attach_sidebar_fields( $item, $submenu_item[2] );
 
 		return $item;
 	}

--- a/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Admin Menu: add additive `group_id` + `signal` fields per item and a top-level `groups[]` array to the `/wpcom/v2/admin-menu` endpoint, sourced from the public `wp-admin-sidebar` plugin's classifier when loaded. Non-WPCOM Jetpack installs see no shape change.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -696,4 +696,165 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Without the public `wp-admin-sidebar` plugin loaded the response
+	 * preserves the legacy flat-array shape and items do not carry the
+	 * additive `group_id` / `signal` fields. This is the contract for
+	 * non-WPCOM Jetpack installs.
+	 *
+	 * @depends test_successful_request
+	 *
+	 * @param WP_REST_Response $response Admin Menu API response.
+	 */
+	#[Depends( 'test_successful_request' )]
+	public function test_response_is_legacy_shape_without_classifier( WP_REST_Response $response ) {
+		// Only meaningful when the classifier is genuinely absent. Skip on
+		// hosts that load the public plugin (e.g., a fully wired WPCOM env).
+		if ( class_exists( 'Sidebar_Classifier' ) ) {
+			$this->markTestSkipped( 'Sidebar_Classifier is loaded; legacy-shape contract does not apply on this host.' );
+		}
+
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		// Legacy shape: list keyed by integer indexes, not an associative
+		// `{ menu, groups }` envelope.
+		$this->assertArrayNotHasKey( 'menu', $data );
+		$this->assertArrayNotHasKey( 'groups', $data );
+
+		foreach ( $data as $item ) {
+			$this->assertArrayNotHasKey( 'group_id', $item );
+			$this->assertArrayNotHasKey( 'signal', $item );
+		}
+	}
+
+	/**
+	 * When stub classifier + signals classes are visible to the endpoint, the
+	 * response wraps the menu in `{ menu, groups }`, attaches `group_id` +
+	 * `signal` to matched items by slug, and emits the synthetic `groups[]`
+	 * row(s) the classifier built.
+	 *
+	 * The stub classes mirror the public plugin's API surface (the two
+	 * static methods + nav-model shape the endpoint actually consumes) so
+	 * the test runs offline without depending on `wp-admin-sidebar`.
+	 */
+	public function test_response_carries_group_fields_when_classifier_is_loaded() {
+		if ( ! class_exists( 'Sidebar_Classifier' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+				'class Sidebar_Classifier {
+					private static $model = null;
+					public static function set_model( $model ) { self::$model = $model; }
+					public static function build_nav_model(): void {}
+					public static function get_nav_model(): ?array { return self::$model; }
+				}'
+			);
+		}
+		if ( ! class_exists( 'Sidebar_Signals' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+				'class Sidebar_Signals {}'
+			);
+		}
+
+		// Skip when a real classifier is present — we don't want to clobber
+		// the host's classifier state from a Jetpack unit test.
+		if ( ! method_exists( 'Sidebar_Classifier', 'set_model' ) ) {
+			$this->markTestSkipped( 'Real Sidebar_Classifier is loaded; stub-driven test is not applicable.' );
+		}
+
+		Sidebar_Classifier::set_model(
+			array(
+				'version'      => 1,
+				'generated_at' => 0,
+				'site_id'      => 1,
+				'user_id'      => 1,
+				'top_level'    => array(
+					array(
+						'menuSlug'      => 'index.php',
+						'default_group' => null,
+						'signal'        => array(
+							'count'         => null,
+							'numeric_badge' => null,
+							'badge'         => null,
+							'inline_text'   => null,
+							'inline_icon'   => null,
+							'attention'     => false,
+						),
+					),
+				),
+				'groups'       => array(
+					array(
+						'id'       => 'plugins',
+						'title'    => 'My Plugins',
+						'icon'     => null,
+						'children' => array(
+							array(
+								'menuSlug'      => 'jetpack',
+								'default_group' => 'plugins',
+								'signal'        => array(
+									'count'         => 3,
+									'numeric_badge' => null,
+									'badge'         => '3',
+									'inline_text'   => null,
+									'inline_icon'   => null,
+									'attention'     => true,
+								),
+							),
+						),
+						'signal'   => array(
+							'attention' => true,
+							'count'     => 3,
+						),
+					),
+				),
+			)
+		);
+
+		// Drive the response through `prepare_menu_for_response` directly so
+		// the test isn't coupled to the live $menu/$submenu globals built by
+		// `wp-admin/menu.php`.
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Admin_Menu();
+
+		// `index.php` matches the stub's top-level entry; `jetpack` matches
+		// the grouped child.
+		$menu = array(
+			array( 'Dashboard', 'read', 'index.php', '', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
+			array( 'Jetpack', 'read', 'jetpack', '', 'menu-top', 'menu-jetpack', 'dashicons-admin-plugins' ),
+		);
+
+		$response = $endpoint->prepare_menu_for_response( $menu );
+
+		// Reset stub state for any subsequent tests.
+		Sidebar_Classifier::set_model( null );
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'menu', $response );
+		$this->assertArrayHasKey( 'groups', $response );
+
+		$by_slug = array();
+		foreach ( $response['menu'] as $item ) {
+			$by_slug[ $item['slug'] ] = $item;
+		}
+
+		$this->assertArrayHasKey( 'index-php', $by_slug );
+		$this->assertArrayHasKey( 'jetpack', $by_slug );
+
+		// Top-level core item: matched, no group, signal attached but inert.
+		$this->assertNull( $by_slug['index-php']['group_id'] );
+		$this->assertSame( false, $by_slug['index-php']['signal']['attention'] );
+
+		// Grouped plugin item: group_id set, attention signal flowed through.
+		$this->assertSame( 'plugins', $by_slug['jetpack']['group_id'] );
+		$this->assertSame( 3, $by_slug['jetpack']['signal']['count'] );
+		$this->assertTrue( $by_slug['jetpack']['signal']['attention'] );
+
+		// Top-level groups row mirrors the classifier's group shape.
+		$this->assertCount( 1, $response['groups'] );
+		$group = $response['groups'][0];
+		$this->assertSame( 'plugins', $group['id'] );
+		$this->assertSame( 'My Plugins', $group['label'] );
+		$this->assertTrue( $group['default_expanded'] );
+		$this->assertTrue( $group['signal']['attention'] );
+		$this->assertSame( 3, $group['signal']['count'] );
+	}
 }


### PR DESCRIPTION
<!-- N/A; aligned with the Calypso A.3 sidebar-redesign workstream tracked in `WordPress/wp-admin-sidebar` and the wpcom in-tree-copy. -->

Part of [DES-575](https://linear.app/a8c/issue/DES-575/a3-calypso-parity)

## Overview

Extends `/wpcom/v2/admin-menu` with two additive per-item fields (`group_id`, `signal`) and a sibling top-level `groups[]` array describing the synthetic group rows the redesigned sidebar needs. Mirrors [`WordPress/wp-admin-sidebar` v0.1.7](https://github.com/WordPress/wp-admin-sidebar/releases/tag/v0.1.7) (the version currently vendored as the wpcom in-tree-copy at `wp-content/mu-plugins/wp-admin-sidebar/`).

This endpoint is the server side of the A.3 Calypso parity workstream — pair with the Calypso PRs:

* Phase 1 (grouping + signals): [`Automattic/wp-calypso#110578`](https://github.com/Automattic/wp-calypso/pull/110578)
* Phase 2 (customize mode): [`Automattic/wp-calypso#110588`](https://github.com/Automattic/wp-calypso/pull/110588)

## What changed

* `prepare_menu_for_response()` best-effort-hydrates the classifier nav model and, when present, returns `{ menu, groups }` instead of the legacy flat list. When the classifier isn't loaded, the response shape is byte-identical to `trunk`.
* `prepare_menu_item()` + `prepare_submenu_item()` attach `group_id` + `signal` from the classifier index by menu slug. O(1) lookup; items with no nav-model match are unchanged.
* `get_item_schema()` describes the new per-item fields (`group_id`, `signal`) and the optional `{ menu, groups }` envelope.
* Two PHPUnit tests added: legacy-shape contract when the classifier is absent; group + signal attachment + envelope when stub classifier classes are visible.
* Jetpack changelog entry (`patch` / `enhancement`).

## Gating

The redesigned response shape is gated end-to-end on the public plugin's `wp_admin_sidebar_enabled` filter:

* On non-WPCOM Jetpack installs (classifier classes not loaded), the endpoint falls back to the legacy flat shape — `class_exists()` guards everywhere ensure dead-code safety.
* On WPCOM, the integration mu-plugin (`wpcom-admin-sidebar-integration`) wires `wp_admin_sidebar_enabled` to the `wpcom-admin-sidebar-redesign` blog sticker via `WPCOM_Gating::is_enabled`. **No sticker → filter resolves false → `Sidebar_Classifier::build_nav_model()` short-circuits → endpoint emits the legacy flat shape.**

So a blog without the sticker sees byte-identical behaviour to today, both in the response and on the client (Calypso treats absent `groups[]` as "render the legacy flat sidebar"). Removing the sticker is the rollback path — no Jetpack / Calypso deploy needed.

> 🟡 Reviewer-confirmable: trace `Sidebar_Classifier::build_nav_model()` for a stickered-off WPCOM site, confirm it returns the empty/legacy shape rather than emitting `groups[]` regardless.

## Cross-surface persistence (layoutDelta)

The Calypso customize mode (Phase 2 PR #110588) needs to read the saved layout-delta the user persisted from wp-admin. The wp-admin side stores it in a per-user-per-blog WPCOM user attribute via `WPCOM_User_Attribute_Storage`.

> 🟡 Reviewer-actionable: confirm whether this endpoint emits the saved `layoutDelta` alongside `menu` + `groups[]`. If not, Calypso has no way to render the user's saved order, and customize-mode write/read parity with wp-admin breaks. If layoutDelta lives behind a separate endpoint, please link from this PR so the Calypso side knows where to read it.

The expected shape (additive to the existing response envelope):

```ts
{
  menu: AdminMenuItem[],
  groups?: AdminMenuGroup[],
  layoutDelta?: {
    overrides: Array<{
      itemId: string,
      position: { kind: 'top_level' | 'in_group', group_id?: string, index: number },
    }>,
    cleared: string[],
    version: number,
  },
}
```

## Schema delta

Per-item (top-level + child):

```ts
{
  group_id: string | null,        // 'plugins' | null (top-level / non-grouped)
  signal: {
    count: number | null,
    numeric_badge: number | null,
    badge: string | null,
    inline_text: string | null,
    inline_icon: string | null,
    attention: boolean,           // OR of (count > 0, numeric_badge > 0, non-empty badge)
  } | null,
  itemId?: string,                // Compound `<sourceKind>:<ref>:<parent>:<slug>`
  reassignable?: boolean,         // True when the item participates in customize-mode reorder
}
```

Top-level (when classifier is loaded):

```ts
{
  menu: AdminMenuItem[],
  groups: Array<{
    id: string,                   // 'plugins'
    label: string,                // 'My Plugins' (i18n)
    default_expanded: boolean,
    signal: { attention: boolean, count: number },
  }>,
}
```

## Does this pull request change what data or activity we track or use?

No. The endpoint exposes structural metadata about the admin menu the user is already authorised to see; no new tracking or logging.

## Testing instructions

### Without the public `wp-admin-sidebar` plugin loaded

`/wpcom/v2/admin-menu` response shape is byte-identical to `trunk` — same flat-array root, no `group_id` / `signal` on items, no `groups[]`. Existing Calypso behaviour is unchanged.

### With the plugin loaded and gating enabled

* WPCOM: set the `wpcom-admin-sidebar-redesign` blog sticker on a test blog: `wp blog-stickers add --blog_id=<id> --sticker=wpcom-admin-sidebar-redesign --who=<user>`.
* Other hosts: any host adapter that resolves `wp_admin_sidebar_enabled` to `true` for the request user / blog.

The response root becomes `{ menu: [...], groups: [...] }`. Each item has `group_id` (string or null) and `signal` (object or null). The `groups[]` array contains one `{ id, label, default_expanded, signal }` row per synthetic group the classifier emitted.

### Calypso integration check

Pair with [`Automattic/wp-calypso#110578`](https://github.com/Automattic/wp-calypso/pull/110578) (Phase 1) — once this endpoint deploys, open `/home/<site-slug>` on Calypso for the stickered blog. The "My Plugins" group should render below the top-level items, in the public plugin's blue (`#71aee2`), with the hamburger toggle + chevron header. Items inside should show the correct signals (red number bubble, "Premium" chip, etc.) per the per-item `signal` payload.

### PHPUnit

* `test_response_is_legacy_shape_without_classifier` — legacy flat-array contract when the classifier is absent.
* `test_response_carries_group_fields_when_classifier_is_loaded` — wrapped shape, per-item attachment by slug, and `groups[]` rows when stub classifier + signals classes are visible.
* Existing endpoint tests (`test_prepare_menu_item`, `test_prepare_submenu_item`, `test_parse_menu_item`, etc.) unchanged.

## Related

* Public plugin source-of-truth: [`WordPress/wp-admin-sidebar` v0.1.7](https://github.com/WordPress/wp-admin-sidebar/releases/tag/v0.1.7) — `src/class-sidebar-classifier.php`, `src/class-sidebar-signals.php`.
* WPCOM integration adapter (sticker gating + storage): `wp-content/mu-plugins/wpcom-admin-sidebar-integration/` in `Automattic/wpcom`.
* Internal: [DES-575](https://linear.app/a8c/issue/DES-575/a3-calypso-parity) (A.3 Calypso parity tracker), [DES-617](https://linear.app/a8c/issue/DES-617/a3-phase-2-schema-decision-emit-grouped-items-with-or-without-children) (schema decision on whether grouped items emit `children`).