### PR TITLE
Social: default share-message meta to the saved template server-side

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/global.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/global.tsx
@@ -1,6 +1,3 @@
-import { useSelect } from '@wordpress/data';
-import useSocialMediaMessage from '../../../hooks/use-social-media-message';
-import { store as socialStore } from '../../../social-store';
 import { hasSocialPaidFeatures } from '../../../utils';
 import { SharePostForm } from '../../form/share-post-form';
 import { UpgradeNoticeCustomization } from '../../form/upgrade-notice-customization';
@@ -13,23 +10,10 @@ import { UpgradeNoticeCustomization } from '../../form/upgrade-notice-customizat
 export function GlobalCustomizationForm() {
 	const hasPaidFeatures = hasSocialPaidFeatures();
 
-	// Pre-fill the message field with the admin-page main template when the user
-	// hasn't typed a per-post share message, so the editor reflects what the
-	// rendered preview will use as a fallback (see `useRenderMessageItems`).
-	// Empty `shareMessage` is preserved in post meta — the template only shows
-	// as the displayed value, never as `updateMessage`'s input.
-	const { message: shareMessage } = useSocialMediaMessage();
-	const messageTemplate = useSelect(
-		select => select( socialStore ).getSocialSettings().messageTemplate ?? '',
-		[]
-	);
-	const message = shareMessage || messageTemplate;
-
 	return (
 		<SharePostForm
 			analyticsData={ { location: 'preview-modal' } }
 			isInsideNavigatorModal
-			message={ message }
 			upgradeNotice={ ! hasPaidFeatures ? <UpgradeNoticeCustomization /> : undefined }
 		/>
 	);

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
@@ -1,6 +1,6 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { render } from '@testing-library/react';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { PerNetworkCustomizationForm } from './per-network';
 import type { Connection } from '../../../social-store/types';
 
@@ -16,7 +16,6 @@ jest.mock( '@wordpress/data', () => {
 	const actual = jest.requireActual( '@wordpress/data' );
 	const mocks = {
 		useDispatch: jest.fn(),
-		useSelect: jest.fn(),
 	};
 
 	return new Proxy( actual, {
@@ -43,7 +42,6 @@ jest.mock( '../../form/share-post-form', () => ( {
 } ) );
 
 const mockUseDispatch = useDispatch as jest.Mock;
-const mockUseSelect = useSelect as jest.Mock;
 const mockSiteHasFeature = siteHasFeature as jest.Mock;
 
 const baseConnection: Connection = {
@@ -77,14 +75,12 @@ function getSharePostFormProps( connectionOverrides: Partial< Connection > = {} 
 describe( 'PerNetworkCustomizationForm', () => {
 	const mockCustomizeConnectionById = jest.fn();
 	let globalMessage = '';
-	let globalTemplate = 'Saved global template';
 	let templatesEnabled = true;
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 
 		globalMessage = '';
-		globalTemplate = 'Saved global template';
 		templatesEnabled = true;
 
 		mockUseDispatch.mockReturnValue( {
@@ -97,64 +93,44 @@ describe( 'PerNetworkCustomizationForm', () => {
 			mediaSource: undefined,
 		} ) );
 
-		mockUseSelect.mockImplementation( selector => {
-			return selector( () => ( {
-				getSocialSettings: () => ( { messageTemplate: globalTemplate } ),
-			} ) );
-		} );
-
 		mockSiteHasFeature.mockImplementation( flag => {
 			return flag === 'social-message-templates' ? templatesEnabled : false;
 		} );
 	} );
 
-	it( 'uses the per-connection message when it is non-empty', () => {
+	it( 'displays connection.message verbatim when it is set', () => {
 		const sharePostFormProps = getSharePostFormProps( {
 			message: 'Manual per-post override',
 			template: '{title} {url}',
 		} );
 
 		expect( sharePostFormProps.message ).toBe( 'Manual per-post override' );
-		expect( sharePostFormProps.messageHelp ).toBe( 'Connection template will be used if empty.' );
+		expect( sharePostFormProps.messageHelp ).toBe( 'A template will be used if this is empty.' );
 	} );
 
-	it( 'prefills with the connection template when message is empty', () => {
+	it( 'preserves an explicitly empty connection.message (no template snap-back)', () => {
 		const sharePostFormProps = getSharePostFormProps( {
 			message: '',
 			template: '{title} {url}',
 		} );
 
-		expect( sharePostFormProps.message ).toBe( '{title} {url}' );
-		expect( sharePostFormProps.messageHelp ).toBe( 'Connection template will be used if empty.' );
+		expect( sharePostFormProps.message ).toBe( '' );
+		expect( sharePostFormProps.messageHelp ).toBe( 'A template will be used if this is empty.' );
 	} );
 
-	it( 'shows global-template helper text when there is no connection message or template', () => {
-		globalTemplate = 'Custom global template: {title}';
+	it( 'falls back to the post-level globalMessage when connection.message is unset', () => {
+		globalMessage = 'Global custom message';
 
 		const sharePostFormProps = getSharePostFormProps( {
-			message: '',
+			message: undefined,
 			template: '',
 		} );
 
-		expect( sharePostFormProps.message ).toBe( '' );
-		expect( sharePostFormProps.messageHelp ).toBe( 'Global template will be used if empty.' );
+		expect( sharePostFormProps.message ).toBe( 'Global custom message' );
+		expect( sharePostFormProps.messageHelp ).toBe( 'A template will be used if this is empty.' );
 	} );
 
-	it( 'shows default-template helper text when global template is empty', () => {
-		globalTemplate = '';
-
-		const sharePostFormProps = getSharePostFormProps( {
-			message: '',
-			template: '',
-		} );
-
-		expect( sharePostFormProps.message ).toBe( '' );
-		expect( sharePostFormProps.messageHelp ).toBe(
-			'The default network template will be used if empty.'
-		);
-	} );
-
-	it( 'keeps current behavior when message templates feature is off', () => {
+	it( 'omits the helper text when message templates feature is off', () => {
 		templatesEnabled = false;
 		globalMessage = 'Global custom message';
 

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
@@ -118,7 +118,7 @@ describe( 'PerNetworkCustomizationForm', () => {
 		expect( sharePostFormProps.messageHelp ).toBe( 'A template will be used if this is empty.' );
 	} );
 
-	it( 'falls back to the post-level globalMessage when connection.message is unset', () => {
+	it( 'shows empty when connection.message is unset (no globalMessage fallback in the form)', () => {
 		globalMessage = 'Global custom message';
 
 		const sharePostFormProps = getSharePostFormProps( {
@@ -126,7 +126,7 @@ describe( 'PerNetworkCustomizationForm', () => {
 			template: '',
 		} );
 
-		expect( sharePostFormProps.message ).toBe( 'Global custom message' );
+		expect( sharePostFormProps.message ).toBe( '' );
 		expect( sharePostFormProps.messageHelp ).toBe( 'A template will be used if this is empty.' );
 	} );
 
@@ -139,7 +139,7 @@ describe( 'PerNetworkCustomizationForm', () => {
 			template: '{title} {url}',
 		} );
 
-		expect( sharePostFormProps.message ).toBe( 'Global custom message' );
+		expect( sharePostFormProps.message ).toBe( '' );
 		expect( sharePostFormProps.messageHelp ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -2,7 +2,6 @@ import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import { usePostMeta } from '../../../hooks/use-post-meta';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
 import { features } from '../../../utils/constants';
@@ -26,9 +25,11 @@ const FALLBACK_TEMPLATE_HELP = __(
 export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomizationFormProps ) {
 	const { customizeConnectionById } = useDispatch( socialStore );
 	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
-	const { shareMessage: globalMessage } = usePostMeta();
 
-	const message = connection.message ?? globalMessage ?? '';
+	/*
+	 * The message field is bound strictly to `connection.message`.
+	 */
+	const message = connection.message ?? '';
 	const fallbackHelp = templatesEnabled ? FALLBACK_TEMPLATE_HELP : undefined;
 
 	/*

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -1,5 +1,5 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { usePostMeta } from '../../../hooks/use-post-meta';
@@ -12,16 +12,8 @@ type PerNetworkCustomizationFormProps = {
 	connection: Connection;
 };
 
-const CONNECTION_TEMPLATE_HELP = __(
-	'Connection template will be used if empty.',
-	'jetpack-publicize-pkg'
-);
-const GLOBAL_TEMPLATE_HELP = __(
-	'Global template will be used if empty.',
-	'jetpack-publicize-pkg'
-);
-const DEFAULT_NETWORK_TEMPLATE_HELP = __(
-	'The default network template will be used if empty.',
+const FALLBACK_TEMPLATE_HELP = __(
+	'A template will be used if this is empty.',
 	'jetpack-publicize-pkg'
 );
 
@@ -35,31 +27,9 @@ export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomiza
 	const { customizeConnectionById } = useDispatch( socialStore );
 	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 	const { shareMessage: globalMessage } = usePostMeta();
-	const globalMessageTemplate = useSelect(
-		select => select( socialStore ).getSocialSettings().messageTemplate,
-		[]
-	);
 
-	const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
-	const hasConnectionTemplate = Boolean( connection.template );
-	const hasGlobalMessageTemplate = Boolean( globalMessageTemplate );
-
-	let message = connection.message ?? globalMessage ?? '';
-	let fallbackHelp: string | undefined;
-
-	if ( templatesEnabled ) {
-		message = hasConnectionMessage
-			? connection.message ?? ''
-			: connection.template ?? globalMessage ?? '';
-
-		if ( hasConnectionTemplate ) {
-			fallbackHelp = CONNECTION_TEMPLATE_HELP;
-		} else if ( hasGlobalMessageTemplate ) {
-			fallbackHelp = GLOBAL_TEMPLATE_HELP;
-		} else {
-			fallbackHelp = DEFAULT_NETWORK_TEMPLATE_HELP;
-		}
-	}
+	const message = connection.message ?? globalMessage ?? '';
+	const fallbackHelp = templatesEnabled ? FALLBACK_TEMPLATE_HELP : undefined;
 
 	/*
 	 * Per-network values come strictly from the connection. We don't fall back to global

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -91,17 +91,21 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 
 	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 	const items = useRenderMessageItems();
+	const siteMessageTemplate = useSelect(
+		select =>
+			templatesEnabled ? select( socialStore ).getSocialSettings().messageTemplate ?? '' : '',
+		[ templatesEnabled ]
+	);
 	/*
-	 * `connection.message` is server-side defaulted to the connection's own
-	 * template, and `globalMessage` to the saved global template, so the
-	 * editor-side fallback chain collapses to just "use connection.message in
-	 * per-network mode, otherwise globalMessage", with a final `?? globalMessage`
-	 * for connections that have neither override nor template. Must mirror
-	 * `useRenderMessageItems` exactly so `currentRenderItem.message` matches
-	 * `baseMessage` and `isDebouncingRenderedMessage` doesn't stay stuck true.
+	 * Mirror `useRenderMessageItems` exactly: in per-network mode fall back to
+	 * the saved site template (not `globalMessage`) when the connection has no
+	 * per-post override; in global mode use `globalMessage`. Keeping this
+	 * identical to the items array's rule ensures `currentRenderItem.message`
+	 * matches `baseMessage` and `isDebouncingRenderedMessage` doesn't stay
+	 * stuck true.
 	 */
 	const baseMessage = (
-		isPerNetworkMode ? connection.message ?? globalMessage : globalMessage
+		isPerNetworkMode ? connection.message ?? siteMessageTemplate : globalMessage
 	).trim();
 	const currentRenderItem = items.find( item => item.id === connection.connection_id );
 

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -91,30 +91,18 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 
 	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 	const items = useRenderMessageItems();
-	const messageTemplate = useSelect(
-		select =>
-			templatesEnabled ? select( socialStore ).getSocialSettings().messageTemplate ?? '' : '',
-		[ templatesEnabled ]
-	);
-	const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
-	// Falls back to the admin-page main template (`messageTemplate`) when no
-	// per-post message is set. Mirrors the rule in `useRenderMessageItems` so the
-	// consumer's view of `baseMessage` matches what the resolver was sent.
-	const globalFallback = globalMessage || messageTemplate || '';
-
-	let baseMessage: string;
-	if ( isPerNetworkMode ) {
-		if ( hasConnectionMessage ) {
-			baseMessage = connection.message ?? '';
-		} else if ( templatesEnabled && connection.template ) {
-			baseMessage = connection.template;
-		} else {
-			baseMessage = globalFallback;
-		}
-	} else {
-		baseMessage = globalFallback;
-	}
-	baseMessage = baseMessage.trim();
+	/*
+	 * `connection.message` is server-side defaulted to the connection's own
+	 * template, and `globalMessage` to the saved global template, so the
+	 * editor-side fallback chain collapses to just "use connection.message in
+	 * per-network mode, otherwise globalMessage", with a final `?? globalMessage`
+	 * for connections that have neither override nor template. Must mirror
+	 * `useRenderMessageItems` exactly so `currentRenderItem.message` matches
+	 * `baseMessage` and `isDebouncingRenderedMessage` doesn't stay stuck true.
+	 */
+	const baseMessage = (
+		isPerNetworkMode ? connection.message ?? globalMessage : globalMessage
+	).trim();
 	const currentRenderItem = items.find( item => item.id === connection.connection_id );
 
 	const { rendered, isLoadingRendered } = useSelect(

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -115,25 +115,27 @@ const defaultPostData = {
 
 /**
  * Mock the chained useSelect calls inside the hook so each one returns its expected
- * shape: postId, featuredImageId, then the rendered slice. (The hook no longer
- * reads `messageTemplate` directly — see commit message for context.)
+ * shape: postId, featuredImageId, messageTemplate, then the rendered slice.
  *
  * @param opts                   - Per-test overrides.
  * @param opts.postId            - Post id returned to the editor-store useSelect.
+ * @param opts.messageTemplate   - Saved site message template.
  * @param opts.rendered          - String returned for the rendered slice, or null to signal "no slice yet".
  * @param opts.isLoadingRendered - Whether the rendered-messages cache slot is currently in-flight.
  */
 function mockSelectCalls(
 	opts: {
 		postId?: number;
+		messageTemplate?: string;
 		rendered?: string | null;
 		isLoadingRendered?: boolean;
 	} = {}
 ) {
-	const { postId = 42, rendered = null, isLoadingRendered = false } = opts;
+	const { postId = 42, messageTemplate = '', rendered = null, isLoadingRendered = false } = opts;
 	mockUseSelect
 		.mockReturnValueOnce( postId )
 		.mockReturnValueOnce( 0 )
+		.mockReturnValueOnce( messageTemplate )
 		.mockReturnValueOnce( { rendered, isLoadingRendered } );
 }
 

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -115,27 +115,25 @@ const defaultPostData = {
 
 /**
  * Mock the chained useSelect calls inside the hook so each one returns its expected
- * shape: postId, featuredImageId, messageTemplate, then the rendered slice.
+ * shape: postId, featuredImageId, then the rendered slice. (The hook no longer
+ * reads `messageTemplate` directly — see commit message for context.)
  *
  * @param opts                   - Per-test overrides.
  * @param opts.postId            - Post id returned to the editor-store useSelect.
- * @param opts.messageTemplate   - The site-wide social message template from `getSocialSettings()`.
  * @param opts.rendered          - String returned for the rendered slice, or null to signal "no slice yet".
  * @param opts.isLoadingRendered - Whether the rendered-messages cache slot is currently in-flight.
  */
 function mockSelectCalls(
 	opts: {
 		postId?: number;
-		messageTemplate?: string;
 		rendered?: string | null;
 		isLoadingRendered?: boolean;
 	} = {}
 ) {
-	const { postId = 42, messageTemplate = '', rendered = null, isLoadingRendered = false } = opts;
+	const { postId = 42, rendered = null, isLoadingRendered = false } = opts;
 	mockUseSelect
 		.mockReturnValueOnce( postId )
 		.mockReturnValueOnce( 0 )
-		.mockReturnValueOnce( messageTemplate )
 		.mockReturnValueOnce( { rendered, isLoadingRendered } );
 }
 

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -1,10 +1,11 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
 import { CUSTOMIZE_PER_NETWORK_KEY } from '../../social-store/constants';
-import { hasSocialPaidFeatures } from '../../utils';
+import { features, hasSocialPaidFeatures } from '../../utils';
 import useFeaturedImage from '../use-featured-image';
 import useMediaDetails from '../use-media-details';
 import { usePostMeta } from '../use-post-meta';
@@ -36,37 +37,33 @@ export function usePerNetworkCustomization() {
 	}, [] );
 
 	const syncConnections = useCallback( () => {
+		/*
+		 * Don't sync when the message-templates feature is on. Server-side defaults
+		 */
+		if ( siteHasFeature( features.MESSAGE_TEMPLATES ) ) {
+			return;
+		}
+
 		// Copy global settings to each connection.
 		// Per-network mode forces attachment, so we need to populate attached_media for all sources.
 		connections.forEach( connection => {
-			/*
-			 * Use `media_source` as the "uncustomized" signal — `connection.message`
-			 */
-			if ( connection.media_source !== undefined ) {
-				return;
+			// Only copy if no existing customization.
+			if ( connection.message === undefined ) {
+				const effectiveSource = getEffectiveMediaSource( postMeta.mediaSource, featuredImageId );
+				const attachedMedia = computeAttachedMediaForSource( {
+					mediaSource: postMeta.mediaSource,
+					globalAttachedMedia: postMeta.attachedMedia,
+					featuredImageId,
+					featuredImageUrl,
+					featuredImageMime,
+				} );
+
+				customizeConnectionById( connection.connection_id, {
+					message: postMeta.shareMessage || '',
+					attached_media: attachedMedia,
+					media_source: effectiveSource,
+				} );
 			}
-
-			const effectiveSource = getEffectiveMediaSource( postMeta.mediaSource, featuredImageId );
-			const attachedMedia = computeAttachedMediaForSource( {
-				mediaSource: postMeta.mediaSource,
-				globalAttachedMedia: postMeta.attachedMedia,
-				featuredImageId,
-				featuredImageUrl,
-				featuredImageMime,
-			} );
-
-			const updates: Parameters< typeof customizeConnectionById >[ 1 ] = {
-				attached_media: attachedMedia,
-				media_source: effectiveSource,
-			};
-			/*
-			 * Skip writing `message` when the connection has its own template
-			 */
-			if ( ! connection.template ) {
-				updates.message = postMeta.shareMessage || '';
-			}
-
-			customizeConnectionById( connection.connection_id, updates );
 		} );
 	}, [
 		connections,

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -39,32 +39,34 @@ export function usePerNetworkCustomization() {
 		// Copy global settings to each connection.
 		// Per-network mode forces attachment, so we need to populate attached_media for all sources.
 		connections.forEach( connection => {
-			// Only copy if no existing customization.
-			if ( connection.message === undefined ) {
-				const effectiveSource = getEffectiveMediaSource( postMeta.mediaSource, featuredImageId );
-				const attachedMedia = computeAttachedMediaForSource( {
-					mediaSource: postMeta.mediaSource,
-					globalAttachedMedia: postMeta.attachedMedia,
-					featuredImageId,
-					featuredImageUrl,
-					featuredImageMime,
-				} );
-
-				/*
-				 * Skip writing `message` when the connection has its own template — leaving
-				 * `connection.message` undefined lets the editor and preview fall back to the
-				 * connection template instead of overwriting it with the global share message.
-				 */
-				const updates: Parameters< typeof customizeConnectionById >[ 1 ] = {
-					attached_media: attachedMedia,
-					media_source: effectiveSource,
-				};
-				if ( ! connection.template ) {
-					updates.message = postMeta.shareMessage || '';
-				}
-
-				customizeConnectionById( connection.connection_id, updates );
+			/*
+			 * Use `media_source` as the "uncustomized" signal — `connection.message`
+			 */
+			if ( connection.media_source !== undefined ) {
+				return;
 			}
+
+			const effectiveSource = getEffectiveMediaSource( postMeta.mediaSource, featuredImageId );
+			const attachedMedia = computeAttachedMediaForSource( {
+				mediaSource: postMeta.mediaSource,
+				globalAttachedMedia: postMeta.attachedMedia,
+				featuredImageId,
+				featuredImageUrl,
+				featuredImageMime,
+			} );
+
+			const updates: Parameters< typeof customizeConnectionById >[ 1 ] = {
+				attached_media: attachedMedia,
+				media_source: effectiveSource,
+			};
+			/*
+			 * Skip writing `message` when the connection has its own template
+			 */
+			if ( ! connection.template ) {
+				updates.message = postMeta.shareMessage || '';
+			}
+
+			customizeConnectionById( connection.connection_id, updates );
 		} );
 	}, [
 		connections,

--- a/projects/packages/publicize/_inc/hooks/use-post-meta/index.js
+++ b/projects/packages/publicize/_inc/hooks/use-post-meta/index.js
@@ -1,7 +1,8 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
-import { useShareMessageMaxLength } from '../../utils';
+import { features, useShareMessageMaxLength } from '../../utils';
 
 /**
  * This is to avoid creating a new empty array each time the value is requested.
@@ -33,10 +34,11 @@ export function usePostMeta() {
 			const mediaSource = jetpackSocialOptions.media_source;
 			const isPostAlreadyShared = meta.jetpack_social_post_already_shared ?? false;
 
-			const shareMessage = `${ meta.jetpack_publicize_message || '' }`.substring(
-				0,
-				maxCharacterLength
-			);
+			let shareMessage = meta.jetpack_publicize_message || '';
+
+			if ( ! siteHasFeature( features.MESSAGE_TEMPLATES ) ) {
+				shareMessage = shareMessage.substring( 0, maxCharacterLength );
+			}
 
 			return {
 				isPublicizeEnabled,

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -80,8 +80,17 @@ export function useRenderMessageItems(): RenderItem[] {
 	// a disabled connection's message must still update the items array. Including
 	// disabled connections also keeps their preview cached for instant display when
 	// the user re-enables them.
-	const connections = useSelect(
-		select => ( templatesEnabled ? select( socialStore ).getConnections() : [] ),
+	const { connections, siteMessageTemplate } = useSelect(
+		select => {
+			if ( ! templatesEnabled ) {
+				return { connections: [], siteMessageTemplate: '' };
+			}
+			const store = select( socialStore );
+			return {
+				connections: store.getConnections(),
+				siteMessageTemplate: store.getSocialSettings().messageTemplate ?? '',
+			};
+		},
 		[ templatesEnabled ]
 	);
 
@@ -119,13 +128,12 @@ export function useRenderMessageItems(): RenderItem[] {
 	const items = useMemo< RenderItem[] >( () => {
 		return connections.map( connection => {
 			/*
-			 * Mirror the consumer's rule in `useConnectionPreviewData`: per-connection
-			 * message only applies in per-network mode. The server already defaults
-			 * `connection.message` to its connection template (when set) and
-			 * `globalMessage` to the saved global template, so this hook just chooses
-			 * which to send to the renderer based on mode.
+			 * Mirror the form's rule in `per-network.tsx`: in per-network mode,
+			 * fall back to the saved site template (not `globalMessage` /
+			 * `_wpas_mess`) when the connection has no per-post override and
+			 * no connection-template default.
 			 */
-			const raw = ctx.isPerNetworkMode ? connection.message ?? globalMessage : globalMessage;
+			const raw = ctx.isPerNetworkMode ? connection.message ?? siteMessageTemplate : globalMessage;
 			return {
 				id: connection.connection_id,
 				network: connection.service_name ?? '',
@@ -133,7 +141,7 @@ export function useRenderMessageItems(): RenderItem[] {
 				is_social_post: connectionHasMedia( connection, ctx ),
 			};
 		} );
-	}, [ connections, globalMessage, ctx ] );
+	}, [ connections, globalMessage, siteMessageTemplate, ctx ] );
 
 	return useDebouncedItems( items );
 }

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -85,12 +85,6 @@ export function useRenderMessageItems(): RenderItem[] {
 		[ templatesEnabled ]
 	);
 
-	const messageTemplate = useSelect(
-		select =>
-			templatesEnabled ? select( socialStore ).getSocialSettings().messageTemplate ?? '' : '',
-		[ templatesEnabled ]
-	);
-
 	const { isEnabled: isPerNetworkMode } = usePerNetworkCustomization();
 	const { mediaSource: globalMediaSource } = usePostMeta();
 	const postData = useSocialPreviewPostData();
@@ -124,29 +118,14 @@ export function useRenderMessageItems(): RenderItem[] {
 
 	const items = useMemo< RenderItem[] >( () => {
 		return connections.map( connection => {
-			const hasConnectionMessage = connection.message !== undefined && connection.message !== '';
-			// Mirror the rule in `useConnectionPreviewData` exactly — per-connection
-			// message and template only apply in per-network mode. If they leak into
-			// global mode here, the consumer's `baseMessage` (globalMessage) won't
-			// match this items array's message and `isDebouncingRenderedMessage` stays
-			// stuck true after the user toggles per-network → global.
-			// Falls back to the admin-page main template (`messageTemplate`) when no
-			// per-post message is set, so a site-wide template configured on the social
-			// admin page is reflected in the editor preview.
-			const globalFallback = globalMessage || messageTemplate || '';
-
-			let raw: string;
-			if ( ctx.isPerNetworkMode ) {
-				if ( hasConnectionMessage ) {
-					raw = connection.message ?? '';
-				} else if ( templatesEnabled && connection.template ) {
-					raw = connection.template;
-				} else {
-					raw = globalFallback;
-				}
-			} else {
-				raw = globalFallback;
-			}
+			/*
+			 * Mirror the consumer's rule in `useConnectionPreviewData`: per-connection
+			 * message only applies in per-network mode. The server already defaults
+			 * `connection.message` to its connection template (when set) and
+			 * `globalMessage` to the saved global template, so this hook just chooses
+			 * which to send to the renderer based on mode.
+			 */
+			const raw = ctx.isPerNetworkMode ? connection.message ?? globalMessage : globalMessage;
 			return {
 				id: connection.connection_id,
 				network: connection.service_name ?? '',
@@ -154,7 +133,7 @@ export function useRenderMessageItems(): RenderItem[] {
 				is_social_post: connectionHasMedia( connection, ctx ),
 			};
 		} );
-	}, [ connections, globalMessage, messageTemplate, ctx, templatesEnabled ] );
+	}, [ connections, globalMessage, ctx ] );
 
 	return useDebouncedItems( items );
 }

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/test/index.test.ts
@@ -93,6 +93,19 @@ const conn = ( overrides: Partial< Connection > = {} ): Connection =>
 		...overrides,
 	} ) as Connection;
 
+/**
+ * The hook reads `connections` and `siteMessageTemplate` from a single
+ * `useSelect` call that returns an object. Tests pass `connections` here;
+ * `siteMessageTemplate` defaults to `''` so per-network items fall back to
+ * empty when no override.
+ *
+ * @param {Array<Connection>} connections         - The connections returned to the hook.
+ * @param {string}            siteMessageTemplate - The saved site message template.
+ */
+const mockSelect = ( connections: Connection[], siteMessageTemplate = '' ) => {
+	mockUseSelect.mockReturnValue( { connections, siteMessageTemplate } );
+};
+
 const allFeaturesOn = ( feature: string ) =>
 	[ 'social-message-templates', 'social-image-generator', 'social-enhanced-publishing' ].includes(
 		feature
@@ -127,7 +140,7 @@ describe( 'useRenderMessageItems', () => {
 
 	it( 'returns empty items when MESSAGE_TEMPLATES is off', () => {
 		mockSiteHasFeature.mockReturnValue( false );
-		mockUseSelect.mockReturnValue( [] );
+		mockSelect( [] );
 
 		const { result } = renderHook( () => useRenderMessageItems() );
 
@@ -135,7 +148,7 @@ describe( 'useRenderMessageItems', () => {
 	} );
 
 	it( 'builds one item per connection in global mode, keyed by connection_id', () => {
-		mockUseSelect.mockReturnValue( [
+		mockSelect( [
 			conn( { connection_id: 'a', service_name: 'x' } ),
 			conn( { connection_id: 'b', service_name: 'facebook' } ),
 		] );
@@ -148,23 +161,26 @@ describe( 'useRenderMessageItems', () => {
 		] );
 	} );
 
-	it( 'uses connection messages in per-network mode', () => {
+	it( 'in per-network mode, uses the connection message and falls back to the site template', () => {
 		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
-		mockUseSelect.mockReturnValue( [
-			conn( { connection_id: 'a', service_name: 'x', message: 'A' } ),
-			conn( { connection_id: 'b', service_name: 'facebook' } ),
-		] );
+		mockSelect(
+			[
+				conn( { connection_id: 'a', service_name: 'x', message: 'A' } ),
+				conn( { connection_id: 'b', service_name: 'facebook' } ),
+			],
+			'Site template'
+		);
 
 		const { result } = renderHook( () => useRenderMessageItems() );
 
 		expect( result.current ).toEqual( [
 			{ id: 'a', network: 'x', message: 'A', is_social_post: false },
-			{ id: 'b', network: 'facebook', message: 'Global', is_social_post: false },
+			{ id: 'b', network: 'facebook', message: 'Site template', is_social_post: false },
 		] );
 	} );
 
 	it( 'sets is_social_post=true in global mode when there is global media', () => {
-		mockUseSelect.mockReturnValue( [ conn() ] );
+		mockSelect( [ conn() ] );
 		mockUseSocialPreviewPostData.mockReturnValue( {
 			media: [ { url: 'https://example.com/m.jpg', type: 'image/jpeg' } ],
 		} );
@@ -181,7 +197,7 @@ describe( 'useRenderMessageItems', () => {
 			{ mediaData: { sourceUrl: 'https://example.com/feat.jpg' } },
 			false,
 		] );
-		mockUseSelect.mockReturnValue( [ conn( { media_source: 'featured-image' } ) ] );
+		mockSelect( [ conn( { media_source: 'featured-image' } ) ] );
 
 		const { result } = renderHook( () => useRenderMessageItems() );
 
@@ -190,7 +206,7 @@ describe( 'useRenderMessageItems', () => {
 
 	it( 'in per-network mode, returns false for media_source = none', () => {
 		mockUsePerNetworkCustomization.mockReturnValue( { isEnabled: true, toggle: jest.fn() } );
-		mockUseSelect.mockReturnValue( [ conn( { media_source: 'none' } ) ] );
+		mockSelect( [ conn( { media_source: 'none' } ) ] );
 
 		const { result } = renderHook( () => useRenderMessageItems() );
 
@@ -198,7 +214,7 @@ describe( 'useRenderMessageItems', () => {
 	} );
 
 	it( 'debounces 1500ms when a message string changes', () => {
-		mockUseSelect.mockReturnValue( [ conn() ] );
+		mockSelect( [ conn() ] );
 		mockUseSocialMediaMessage.mockReturnValue( {
 			message: 'first',
 			updateMessage: jest.fn(),
@@ -231,7 +247,7 @@ describe( 'useRenderMessageItems', () => {
 	} );
 
 	it( 'does not flush a pending message change on unrelated re-renders', () => {
-		mockUseSelect.mockReturnValue( [ conn() ] );
+		mockSelect( [ conn() ] );
 		mockUseSocialMediaMessage.mockReturnValue( {
 			message: 'first',
 			updateMessage: jest.fn(),
@@ -272,7 +288,7 @@ describe( 'useRenderMessageItems', () => {
 	} );
 
 	it( 'updates immediately when only non-message inputs change', () => {
-		mockUseSelect.mockReturnValue( [ conn() ] );
+		mockSelect( [ conn() ] );
 		mockUseSocialMediaMessage.mockReturnValue( {
 			message: 'same',
 			updateMessage: jest.fn(),

--- a/projects/packages/publicize/changelog/fix-social-479-server-side-message-defaults
+++ b/projects/packages/publicize/changelog/fix-social-479-server-side-message-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Default the share-message post meta and per-connection message to the saved template on the server side.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1173,11 +1173,18 @@ abstract class Publicize_Base {
 	 * Registers for each post type that with `publicize` feature support.
 	 */
 	public function register_post_meta() {
+		/*
+		 * Default the share-message meta to the saved global template
+		 */
+		$message_default = Current_Plan::supports( 'social-message-templates' )
+			? ( new Jetpack_Social_Settings\Settings() )->get_message_template()
+			: '';
+
 		$message_args = array(
 			'type'          => 'string',
 			'description'   => __( 'The message to use instead of the title when sharing to Jetpack Social services', 'jetpack-publicize-pkg' ),
 			'single'        => true,
-			'default'       => '',
+			'default'       => $message_default,
 			'show_in_rest'  => array(
 				'name' => 'jetpack_publicize_message',
 			),

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Publicize_Base;
 use WP_Error;
 use WP_Post;
@@ -231,6 +232,8 @@ class Connections_Post_Field {
 			$connection_overrides  = array();
 		}
 
+		$message_templates_enabled = Current_Plan::supports( 'social-message-templates' );
+
 		$output_connections = array();
 		foreach ( $connections as $connection ) {
 			$output_connection = array();
@@ -238,6 +241,11 @@ class Connections_Post_Field {
 				if ( isset( $connection[ $property ] ) ) {
 					$output_connection[ $property ] = $connection[ $property ];
 				}
+			}
+
+			// Default `message` to the connection's own template when set
+			if ( $message_templates_enabled && ! empty( $output_connection['template'] ) ) {
+				$output_connection['message'] = $output_connection['template'];
 			}
 
 			// Merge per-connection overrides if global flag is enabled.

--- a/projects/packages/publicize/tests/php/Share_Action_Test.php
+++ b/projects/packages/publicize/tests/php/Share_Action_Test.php
@@ -21,6 +21,10 @@ class Share_Action_Test extends BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Clear any plan cache populated by earlier tests/init-time code so the
+		// `update_option` calls below take effect on the first `Current_Plan::get()`.
+		self::reset_active_plan_cache();
+
 		// Reset filters before each test.
 		remove_all_filters( 'post_row_actions' );
 		remove_all_filters( 'page_row_actions' );
@@ -41,6 +45,15 @@ class Share_Action_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_post_list_display_share_action' );
 
 		// Clear the Current_Plan cache to avoid affecting other tests.
+		self::reset_active_plan_cache();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Force the next `Current_Plan::get()` to re-read from the option store.
+	 */
+	private static function reset_active_plan_cache() {
 		$reflection = new \ReflectionClass( Current_Plan::class );
 		$property   = $reflection->getProperty( 'active_plan_cache' );
 		// @todo Remove this call once we no longer need to support PHP <8.1.
@@ -48,8 +61,6 @@ class Share_Action_Test extends BaseTestCase {
 			$property->setAccessible( true );
 		}
 		$property->setValue( null, null );
-
-		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
Closes SOCIAL-481.

## Proposed changes

Move template-fallback responsibility for the share-message and per-connection message from the editor to the server, so the editor renders the meta verbatim and an empty stored value is correctly interpreted as "fall back to the template" by the renderer.

The field can now actually be cleared without snapping back to the template — the bug introduced by SOCIAL-479's editor-side pre-fill — and the editor's customization forms / preview render hooks no longer need to know about templates at all.

* `class-publicize-base.php` — `register_post_meta()` resolves the share-message default from `Settings::get_message_template()` once on `init` priority 20 (gated on `Current_Plan::supports( 'social-message-templates' )`) and passes it as `register_meta`'s `'default'`. Avoids the hot-path cost of hooking `default_post_metadata`. Falls back to `''` on non-template sites — the legacy extractor would otherwise treat a raw template as literal share text.
* `class-connections-post-field.php` — defaults `connection.message` to the connection's own `template` (when set) regardless of per-network mode, so the editor receives the connection-template fallback up front. Without this, `syncConnections` (which fires on per-network toggle) would treat `connection.message === undefined` as "uncustomized" and silently copy the post-level share message over the connection's own template. Per-network override `message`, when present, still takes precedence.
* `useRenderMessageItems` / `useConnectionPreviewData` — drop the `messageTemplate` selector reads and the `connection.message ?? connection.template ?? globalMessage` fallback chain. Both hooks collapse to "use `connection.message` in per-network mode, otherwise `globalMessage`", with a `?? globalMessage` guard for connections that have neither override nor template.
* `customization-forms/global.tsx` — drop the `useSocialMediaMessage` + `messageTemplate` read and the `shareMessage || messageTemplate` pre-fill. `SharePostForm`'s default already wires `useSocialMediaMessage` internally, and an empty `shareMessage` is now the right thing to display.
* `customization-forms/per-network.tsx` — drop the three-way help text and the `connection.template ?? globalMessage` fallback chain. Display rule collapses to `connection.message ?? globalMessage`, and the help text becomes a single sentence.
* `use-per-network-customization.ts` — rework `syncConnections`. The "uncustomized" outer guard switches from `connection.message === undefined` to `connection.media_source !== undefined` — message is now server-defaulted to `connection.template`, so it no longer indicates customization, but media fields are only written when the user (or a prior sync) has explicitly set them. The `! connection.template` skip from the prior commit chain is preserved so the post-level share message doesn't overwrite the connection-template contribution to `connection.message`.

## Related product discussion/links

* Linear: SOCIAL-481

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Set up a test site with the message-templates feature enabled and at least two social connections.

Test it along with 215588-ghe-Automattic/wpcom

**Site-wide template fallback (global mode):**

1. On the Social admin page, set a Main Template (e.g., `{title} — read more at {url}`).
2. Open a new post in the block editor. Open the Social customization modal.
3. The share-message field should display the saved template as its initial value.
4. Clear the field. Save the post.
5. Reopen the post. The field should remain empty (no snap-back to the template).
6. Publish/share. The post should be shared using the template at render time.

**Per-connection template fallback:**

1. Set a per-connection template for one of your connections (e.g., Facebook gets `Hey FB folks: {title}`).
2. Open a new post in the block editor. Toggle per-network customization on.
3. The Facebook tab's message field should display its connection template; other connections show the global template.
4. Clear the Facebook field. The field should stay empty without bouncing back to the connection template.
5. Save and reload — cleared field stays cleared.

**syncConnections doesn't overwrite per-connection templates:**

1. With a per-connection template configured for Facebook (and the global template also set), open a fresh post.
2. Toggle per-network on.
3. Confirm the Facebook tab shows its connection template (not the global template) in the message field.
4. Confirm the Facebook media UI matches the preview (no featured-image / SIG mismatch).

**Non-template-mode sites unaffected:**

1. On a site without the message-templates feature, repeat the basic share flow.
2. The share-message field starts empty (no raw `{title}` literal injection), and shares fall back to the post title as before.

## Before / After

| Before | After |
|--------|-------|
|        |       |