### PR TITLE
HOG-551: Boost E2E: replace timeout-based assertions with deterministic waits and trim arbitrary explicit timeouts

### DIFF
--- a/projects/plugins/boost/changelog/hog-551
+++ b/projects/plugins/boost/changelog/hog-551
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E test refactor: replace timeout-based assertions with deterministic waits, no user-facing changes.
+
+

--- a/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
+++ b/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
@@ -142,22 +142,20 @@ export default class JetpackBoostPage {
 	 * the per-provider saves that generation fans out into.
 	 *
 	 * `page.waitForResponse()` only matches responses that arrive after it is called,
-	 * so create this promise *before* the action that triggers generation. For flows
-	 * that regenerate while the page already shows previously-generated CSS, pass
-	 * `requireRegeneration: true` so a stale `generated` poll is ignored and the wait
-	 * only resolves after a fresh `pending` -> terminal transition.
+	 * so create this promise *before* the action that triggers generation. For a
+	 * Regenerate flow where the page already shows previously-generated CSS, gate on
+	 * the `request-regenerate` action first (it flips the server state to `pending`,
+	 * see `Regenerate::start()`) so this wait cannot resolve on the stale `generated`
+	 * poll.
 	 *
-	 * The status literals (`pending`/`generated`/`error`) and the route are kept in
-	 * sync with `Critical_CSS_State` and the DataSync registry.
+	 * The status literals (`generated`/`error`) and the route are kept in sync with
+	 * `Critical_CSS_State` and the DataSync registry.
 	 *
-	 * @param {object}  [options]                           - Wait options.
-	 * @param {number}  [options.timeout=60000]             - Maximum time to wait in milliseconds.
-	 * @param {boolean} [options.requireRegeneration=false] - Require a fresh `pending` poll before accepting a terminal state.
+	 * @param {number} timeout - Maximum time to wait in milliseconds.
 	 * @return {Promise<void>} Resolves once generation reaches `generated`.
 	 */
-	async waitForCriticalCssGeneration( { timeout = 60000, requireRegeneration = false } = {} ) {
+	async waitForCriticalCssGeneration( timeout = 60000 ) {
 		let terminalStatus: string | undefined;
-		let seenPending = ! requireRegeneration;
 
 		await this.page.waitForResponse(
 			async response => {
@@ -176,14 +174,7 @@ export default class JetpackBoostPage {
 					 */
 					const body = ( await response.json() ) as { JSON?: { status?: string } };
 					const status = body?.JSON?.status;
-					if ( ! status ) {
-						return false;
-					}
-					if ( status === 'pending' ) {
-						seenPending = true;
-						return false;
-					}
-					if ( seenPending && ( status === 'generated' || status === 'error' ) ) {
+					if ( status === 'generated' || status === 'error' ) {
 						terminalStatus = status;
 						return true;
 					}

--- a/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
+++ b/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
@@ -128,20 +128,37 @@ export default class JetpackBoostPage {
 	}
 
 	/**
-	 * Waits for Critical CSS generation to complete by intercepting the DataSync
-	 * polling response for `critical_css_state`. Resolves once the status reaches a
-	 * terminal state — `generated` or `error` — which is the same signal the UI uses
-	 * to render the critical-css-meta element.
+	 * Waits for Critical CSS generation to reach a terminal state by intercepting the
+	 * DataSync poll for `critical_css_state` (exposed at the hyphenated REST route
+	 * `/jetpack-boost-ds/critical-css-state`). Resolves once the aggregate status
+	 * becomes `generated`, and throws if it becomes `error` — an `error` state renders
+	 * the show-stopper UI rather than the `critical-css-meta` element callers assert
+	 * on, so surfacing it as an explicit failure beats a downstream "element not
+	 * visible" timeout.
 	 *
 	 * The backend only flips the aggregate status away from `pending` once every
 	 * provider has finished (see `Critical_CSS_State::maybe_set_generated()`), so a
 	 * single matching response is a safe completion signal — there is no need to count
 	 * the per-provider saves that generation fans out into.
 	 *
-	 * @param {number} timeout - Maximum time to wait in milliseconds.
-	 * @return {Promise<void>} Resolves once generation reaches a terminal state.
+	 * `page.waitForResponse()` only matches responses that arrive after it is called,
+	 * so create this promise *before* the action that triggers generation. For flows
+	 * that regenerate while the page already shows previously-generated CSS, pass
+	 * `requireRegeneration: true` so a stale `generated` poll is ignored and the wait
+	 * only resolves after a fresh `pending` -> terminal transition.
+	 *
+	 * The status literals (`pending`/`generated`/`error`) and the route are kept in
+	 * sync with `Critical_CSS_State` and the DataSync registry.
+	 *
+	 * @param {object}  [options]                           - Wait options.
+	 * @param {number}  [options.timeout=60000]             - Maximum time to wait in milliseconds.
+	 * @param {boolean} [options.requireRegeneration=false] - Require a fresh `pending` poll before accepting a terminal state.
+	 * @return {Promise<void>} Resolves once generation reaches `generated`.
 	 */
-	async waitForCriticalCssGeneration( timeout = 60000 ) {
+	async waitForCriticalCssGeneration( { timeout = 60000, requireRegeneration = false } = {} ) {
+		let terminalStatus: string | undefined;
+		let seenPending = ! requireRegeneration;
+
 		await this.page.waitForResponse(
 			async response => {
 				if (
@@ -152,21 +169,40 @@ export default class JetpackBoostPage {
 					return false;
 				}
 				try {
-					const body = await response.json();
-					// DataSync wraps the value in a { status: 'success', JSON: <state> }
-					// envelope, so the real Critical CSS status lives at body.JSON.status,
-					// not the top-level body.status (which is always 'success').
-					const state = body?.JSON;
-					if ( ! state ) {
+					/*
+					 * DataSync wraps the value in a { status: 'success', JSON: <state> }
+					 * envelope, so the real Critical CSS status lives at body.JSON.status,
+					 * not the top-level body.status (which is always 'success').
+					 */
+					const body = ( await response.json() ) as { JSON?: { status?: string } };
+					const status = body?.JSON?.status;
+					if ( ! status ) {
 						return false;
 					}
-					return state.status === 'generated' || state.status === 'error';
-				} catch {
+					if ( status === 'pending' ) {
+						seenPending = true;
+						return false;
+					}
+					if ( seenPending && ( status === 'generated' || status === 'error' ) ) {
+						terminalStatus = status;
+						return true;
+					}
+					return false;
+				} catch ( error ) {
+					logger.error(
+						`waitForCriticalCssGeneration: failed to parse critical-css-state response: ${ error }`
+					);
 					return false;
 				}
 			},
 			{ timeout }
 		);
+
+		if ( terminalStatus === 'error' ) {
+			throw new Error(
+				'Critical CSS generation reached the terminal "error" state instead of "generated".'
+			);
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
+++ b/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
@@ -128,6 +128,48 @@ export default class JetpackBoostPage {
 	}
 
 	/**
+	 * Waits for Critical CSS generation to complete by intercepting the DataSync
+	 * polling response for `critical_css_state`. Resolves once the status reaches a
+	 * terminal state — `generated` or `error` — which is the same signal the UI uses
+	 * to render the critical-css-meta element.
+	 *
+	 * The backend only flips the aggregate status away from `pending` once every
+	 * provider has finished (see `Critical_CSS_State::maybe_set_generated()`), so a
+	 * single matching response is a safe completion signal — there is no need to count
+	 * the per-provider saves that generation fans out into.
+	 *
+	 * @param {number} timeout - Maximum time to wait in milliseconds.
+	 * @return {Promise<void>} Resolves once generation reaches a terminal state.
+	 */
+	async waitForCriticalCssGeneration( timeout = 60000 ) {
+		await this.page.waitForResponse(
+			async response => {
+				if (
+					! response.url().includes( '/jetpack-boost-ds/critical-css-state' ) ||
+					response.request().method() !== 'GET' ||
+					! response.ok()
+				) {
+					return false;
+				}
+				try {
+					const body = await response.json();
+					// DataSync wraps the value in a { status: 'success', JSON: <state> }
+					// envelope, so the real Critical CSS status lives at body.JSON.status,
+					// not the top-level body.status (which is always 'success').
+					const state = body?.JSON;
+					if ( ! state ) {
+						return false;
+					}
+					return state.status === 'generated' || state.status === 'error';
+				} catch {
+					return false;
+				}
+			},
+			{ timeout }
+		);
+	}
+
+	/**
 	 * Waits for the client to send the speed score refresh request.
 	 * Use when the test asserts that the client initiated a refresh — for example,
 	 * to verify that a debounce timer has fired. Decouples from backend latency and

--- a/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
+++ b/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
@@ -128,6 +128,35 @@ export default class JetpackBoostPage {
 	}
 
 	/**
+	 * Waits for Critical CSS generation to complete by intercepting the DataSync
+	 * polling response for `critical_css_state`. Resolves once the status
+	 * transitions away from "pending" / "not_generated", which is the same signal
+	 * the UI uses to render the critical-css-meta element.
+	 *
+	 * @param {number} timeout - Maximum time to wait in milliseconds.
+	 */
+	async waitForCriticalCssGeneration( timeout = 60000 ) {
+		await this.page.waitForResponse(
+			async response => {
+				if (
+					! response.url().includes( '/jetpack_boost_ds/critical-css-state' ) ||
+					response.request().method() !== 'GET' ||
+					! response.ok()
+				) {
+					return false;
+				}
+				try {
+					const body = await response.json();
+					return body?.status !== 'pending' && body?.status !== 'not_generated';
+				} catch {
+					return false;
+				}
+			},
+			{ timeout }
+		);
+	}
+
+	/**
 	 * Waits for the client to send the speed score refresh request.
 	 * Use when the test asserts that the client initiated a refresh — for example,
 	 * to verify that a debounce timer has fired. Decouples from backend latency and

--- a/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
@@ -40,6 +40,7 @@ test.describe( 'Common tests', () => {
 
 	test( 'Deactivating the plugin should clear Critical CSS and Dismissed Recommendation notice option', async ( {
 		boostUtils,
+		jetpackBoostPage,
 		admin,
 		page,
 	} ) => {
@@ -57,10 +58,11 @@ test.describe( 'Common tests', () => {
 				page.locator( '.jb-critical-css-progress' ),
 				'Critical CSS generation progress indicator should be visible'
 			).toBeVisible();
+			await jetpackBoostPage.waitForCriticalCssGeneration( 120000 );
 			await expect(
 				page.getByTestId( 'critical-css-meta' ),
 				'Critical CSS meta information should be visible'
-			).toBeVisible( { timeout: 240000 } );
+			).toBeVisible();
 		} );
 
 		await test.step( 'Deactivate Jetpack Boost plugin', async () => {

--- a/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
@@ -61,9 +61,7 @@ test.describe( 'Common tests', () => {
 			 * wait still resolves as soon as the terminal state arrives — the ceiling
 			 * only guards against flakiness on slow CI runners.
 			 */
-			const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( {
-				timeout: 240000,
-			} );
+			const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( 240000 );
 			await admin.visitAdminPage( 'admin.php', 'page=jetpack-boost' );
 			await expect(
 				page.locator( '.jb-critical-css-progress' ),

--- a/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
@@ -53,16 +53,23 @@ test.describe( 'Common tests', () => {
 		} );
 
 		await test.step( 'Navigate to Boost settings and verify Critical CSS generation', async () => {
+			/*
+			 * page.waitForResponse() only matches responses that arrive after it is
+			 * attached, so start listening before the navigation that kicks off
+			 * generation. This is a cold generation (fresh environment + module
+			 * activation), so use the 240s ceiling rather than the 60s default; the
+			 * wait still resolves as soon as the terminal state arrives — the ceiling
+			 * only guards against flakiness on slow CI runners.
+			 */
+			const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( {
+				timeout: 240000,
+			} );
 			await admin.visitAdminPage( 'admin.php', 'page=jetpack-boost' );
 			await expect(
 				page.locator( '.jb-critical-css-progress' ),
 				'Critical CSS generation progress indicator should be visible'
 			).toBeVisible();
-			// This step runs a cold generation (fresh environment + module activation),
-			// so keep the original 240s ceiling rather than the 60s default. The wait
-			// still resolves as soon as the terminal state arrives; the ceiling only
-			// guards against flakiness on slow CI runners.
-			await jetpackBoostPage.waitForCriticalCssGeneration( 240000 );
+			await criticalCssGenerated;
 			await expect(
 				page.getByTestId( 'critical-css-meta' ),
 				'Critical CSS meta information should be visible'

--- a/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/base/common.test.ts
@@ -58,7 +58,11 @@ test.describe( 'Common tests', () => {
 				page.locator( '.jb-critical-css-progress' ),
 				'Critical CSS generation progress indicator should be visible'
 			).toBeVisible();
-			await jetpackBoostPage.waitForCriticalCssGeneration( 120000 );
+			// This step runs a cold generation (fresh environment + module activation),
+			// so keep the original 240s ceiling rather than the 60s default. The wait
+			// still resolves as soon as the terminal state arrives; the ceiling only
+			// guards against flakiness on slow CI runners.
+			await jetpackBoostPage.waitForCriticalCssGeneration( 240000 );
 			await expect(
 				page.getByTestId( 'critical-css-meta' ),
 				'Critical CSS meta information should be visible'

--- a/projects/plugins/boost/tests/e2e/specs/concatenate/concatenate.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/concatenate/concatenate.test.ts
@@ -48,12 +48,12 @@ test.describe( 'Concatenate JS and CSS', () => {
 		await expect(
 			page.locator( '#e2e-script-one-js' ).first(),
 			'JS concatenation shouldn`t occur when the module is inactive'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 		// This style is enqueued via a helper plugin.
 		await expect(
 			page.locator( '#e2e-style-one-css' ).first(),
 			'CSS concatenation shouldn`t occur when the module is inactive'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 	} );
 
 	test( 'Meta information should be visible when the modules are active', async ( {
@@ -86,14 +86,14 @@ test.describe( 'Concatenate JS and CSS', () => {
 		await expect(
 			page.locator( '[data-handles*="e2e-script-one"][data-handles*="e2e-script-two"]' ).first(),
 			'JS Concatenation occurs when module is active'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 
 		// e2e-style-one and e2e-style-two are enqueued by a helper plugin. When concatenation is enabled,
 		// they should be concatenated into a single style.
 		await expect(
 			page.locator( '[data-handles*="e2e-style-one"][data-handles*="e2e-style-two"]' ).first(),
 			'CSS Concatenation occurs when module is active'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 	} );
 
 	test( 'Assets that are excluded by default shouldn`t be concatenated', async ( {
@@ -112,12 +112,12 @@ test.describe( 'Concatenate JS and CSS', () => {
 		await expect(
 			page.locator( '#jquery-core-js' ).first(),
 			'jQuery should not be concatenated'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 
 		// Admin bar stylesheet is enqueued by default when logged-in.
 		await expect(
 			page.locator( '#admin-bar-css' ).first(),
 			'Admin bar stylesheet should not be concatenated'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 	} );
 } );

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
@@ -142,11 +142,19 @@ test.describe.serial( 'Critical CSS module', () => {
 				response
 					.url()
 					.includes( '/jetpack-boost-ds/critical-css-state/action/request-regenerate' ) &&
-				response.request().method() === 'POST' &&
-				response.ok()
+				response.request().method() === 'POST'
 		);
 		await page.getByRole( 'button', { name: 'Regenerate' } ).click();
-		await regenerationRequested;
+		/*
+		 * Assert the action succeeded rather than matching only ok() responses, so a
+		 * failed request (e.g. nonce/permission) fails fast with its status instead of
+		 * timing out the generation wait below.
+		 */
+		const regenerationResponse = await regenerationRequested;
+		expect(
+			regenerationResponse.ok(),
+			`Regenerate request should succeed (got HTTP ${ regenerationResponse.status() })`
+		).toBeTruthy();
 
 		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( 240000 );
 		await expect(

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
@@ -128,15 +128,27 @@ test.describe.serial( 'Critical CSS module', () => {
 		await jetpackBoostPage.visit();
 
 		/*
-		 * The settings page already shows previously-generated CSS, so a poll could
-		 * report `generated` at any point before regeneration starts. Attach the wait
-		 * before clicking Regenerate and require a fresh `pending` -> `generated`
-		 * transition so it cannot resolve on that stale `generated` state.
+		 * The settings page already shows previously-generated CSS, so waiting for a
+		 * `generated` poll directly could resolve on that stale state. Clicking
+		 * Regenerate POSTs the `request-regenerate` action, which flips the server
+		 * state to `pending` (see `Regenerate::start()`). Wait for that POST first —
+		 * it is guaranteed to fire once and be observable — so that by the time the
+		 * generation wait is attached the server is already `pending` and the next
+		 * `generated` poll can only reflect the fresh regeneration. Use the 240s
+		 * ceiling since this runs the full generator, like the cold-generation case.
 		 */
-		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( {
-			requireRegeneration: true,
-		} );
+		const regenerationRequested = page.waitForResponse(
+			response =>
+				response
+					.url()
+					.includes( '/jetpack-boost-ds/critical-css-state/action/request-regenerate' ) &&
+				response.request().method() === 'POST' &&
+				response.ok()
+		);
 		await page.getByRole( 'button', { name: 'Regenerate' } ).click();
+		await regenerationRequested;
+
+		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( 240000 );
 		await expect(
 			page.locator( '.jb-critical-css-progress' ),
 			'Critical CSS generation progress indicator should be visible'

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
@@ -58,12 +58,13 @@ test.describe.serial( 'Critical CSS module', () => {
 		await boostUtils.executeWpCommand(
 			'plugin activate e2e-external-css-enqueue/e2e-external-css-enqueue.php'
 		);
+		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration();
 		await jetpackBoostPage.visit();
-
+		await criticalCssGenerated;
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 
 	test( 'Critical CSS meta information should show on the admin when the module is re-activated', async ( {
@@ -73,11 +74,13 @@ test.describe.serial( 'Critical CSS module', () => {
 	} ) => {
 		await boostUtils.deactivateBoostModule( 'critical_css' );
 		await boostUtils.activateBoostModule( 'critical_css' );
+		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration();
 		await jetpackBoostPage.visit();
+		await criticalCssGenerated;
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 
 	test( 'Critical CSS should be available on the frontend when the module is active', async ( {
@@ -90,6 +93,7 @@ test.describe.serial( 'Critical CSS module', () => {
 
 	test( 'Critical CSS Admin message should show when the theme is changed', async ( {
 		boostUtils,
+		jetpackBoostPage,
 		page,
 		admin,
 	} ) => {
@@ -105,12 +109,13 @@ test.describe.serial( 'Critical CSS module', () => {
 			'Action Required message should be visible'
 		).toBeVisible();
 
+		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration();
 		await page.getByRole( 'link', { name: 'Go to Jetpack Boost' } ).click();
-
+		await criticalCssGenerated;
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 
 	test( 'User can access the Critical advanced recommendations and go back to settings page', async ( {
@@ -122,12 +127,13 @@ test.describe.serial( 'Critical CSS module', () => {
 
 		await jetpackBoostPage.visit();
 
+		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration();
 		await page.getByRole( 'button', { name: 'Regenerate' } ).click();
-
+		await criticalCssGenerated;
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 
 		await page.getByText( 'Advanced Recommendations' ).click();
 		await expect(
@@ -139,6 +145,6 @@ test.describe.serial( 'Critical CSS module', () => {
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 } );

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
@@ -127,9 +127,16 @@ test.describe.serial( 'Critical CSS module', () => {
 
 		await jetpackBoostPage.visit();
 
-		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration();
 		await page.getByRole( 'button', { name: 'Regenerate' } ).click();
-		await criticalCssGenerated;
+		// The settings page already shows previously-generated CSS, so the first
+		// DataSync poll after load returns `generated`. Confirm regeneration has
+		// actually started (progress indicator) before listening for the terminal
+		// state, otherwise the wait could resolve on that stale `generated` response.
+		await expect(
+			page.locator( '.jb-critical-css-progress' ),
+			'Critical CSS generation progress indicator should be visible'
+		).toBeVisible();
+		await jetpackBoostPage.waitForCriticalCssGeneration();
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
@@ -127,16 +127,21 @@ test.describe.serial( 'Critical CSS module', () => {
 
 		await jetpackBoostPage.visit();
 
+		/*
+		 * The settings page already shows previously-generated CSS, so a poll could
+		 * report `generated` at any point before regeneration starts. Attach the wait
+		 * before clicking Regenerate and require a fresh `pending` -> `generated`
+		 * transition so it cannot resolve on that stale `generated` state.
+		 */
+		const criticalCssGenerated = jetpackBoostPage.waitForCriticalCssGeneration( {
+			requireRegeneration: true,
+		} );
 		await page.getByRole( 'button', { name: 'Regenerate' } ).click();
-		// The settings page already shows previously-generated CSS, so the first
-		// DataSync poll after load returns `generated`. Confirm regeneration has
-		// actually started (progress indicator) before listening for the terminal
-		// state, otherwise the wait could resolve on that stale `generated` response.
 		await expect(
 			page.locator( '.jb-critical-css-progress' ),
 			'Critical CSS generation progress indicator should be visible'
 		).toBeVisible();
-		await jetpackBoostPage.waitForCriticalCssGeneration();
+		await criticalCssGenerated;
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.ts
@@ -60,10 +60,11 @@ test.describe.serial( 'Critical CSS module', () => {
 		);
 		await jetpackBoostPage.visit();
 
+		await jetpackBoostPage.waitForCriticalCssGeneration();
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 
 	test( 'Critical CSS meta information should show on the admin when the module is re-activated', async ( {
@@ -74,10 +75,11 @@ test.describe.serial( 'Critical CSS module', () => {
 		await boostUtils.deactivateBoostModule( 'critical_css' );
 		await boostUtils.activateBoostModule( 'critical_css' );
 		await jetpackBoostPage.visit();
+		await jetpackBoostPage.waitForCriticalCssGeneration();
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 
 	test( 'Critical CSS should be available on the frontend when the module is active', async ( {
@@ -90,6 +92,7 @@ test.describe.serial( 'Critical CSS module', () => {
 
 	test( 'Critical CSS Admin message should show when the theme is changed', async ( {
 		boostUtils,
+		jetpackBoostPage,
 		page,
 		admin,
 	} ) => {
@@ -107,10 +110,11 @@ test.describe.serial( 'Critical CSS module', () => {
 
 		await page.getByRole( 'link', { name: 'Go to Jetpack Boost' } ).click();
 
+		await jetpackBoostPage.waitForCriticalCssGeneration();
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 
 	test( 'User can access the Critical advanced recommendations and go back to settings page', async ( {
@@ -124,10 +128,11 @@ test.describe.serial( 'Critical CSS module', () => {
 
 		await page.getByRole( 'button', { name: 'Regenerate' } ).click();
 
+		await jetpackBoostPage.waitForCriticalCssGeneration();
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 
 		await page.getByText( 'Advanced Recommendations' ).click();
 		await expect(
@@ -139,6 +144,6 @@ test.describe.serial( 'Critical CSS module', () => {
 		await expect(
 			page.getByTestId( 'critical-css-meta' ),
 			'Critical CSS meta information should be visible'
-		).toBeVisible( { timeout: 60000 } );
+		).toBeVisible();
 	} );
 } );

--- a/projects/plugins/boost/tests/e2e/specs/image-guide/image-guide.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/image-guide/image-guide.test.ts
@@ -38,7 +38,7 @@ test.describe( 'Image Guide', () => {
 		await expect(
 			page.locator( '#jetpack-boost-guide-js' ).first(),
 			'Image Guide script should be present'
-		).toBeAttached( { timeout: 20000 } );
+		).toBeAttached();
 
 		await expect(
 			page.locator( '#wp-toolbar #jetpack-boost-guide-bar' ),


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/HOG-551/boost-e2e-replace-timeout-based-assertions-with-deterministic-waits

## Proposed changes

Two cleanup areas around timeout usage in Boost E2E tests:

**Part 1 — Replace long `toBeVisible({ timeout: 60000+ })` with deterministic waits:**

- Added `waitForCriticalCssGeneration()` helper to `JetpackBoostPage` that uses `page.waitForResponse()` to intercept the DataSync polling response for `critical_css_state`. It resolves once the status transitions away from `pending`/`not_generated` — the same signal the UI uses to render the `critical-css-meta` element.
- Replaced 5 `toBeVisible({ timeout: 60000 })` calls in `critical-css.test.ts` and 1 `toBeVisible({ timeout: 240000 })` call in `common.test.ts` with `waitForCriticalCssGeneration()` followed by a bare `toBeVisible()`.
- This approach avoids the multi-call caveat (CSS generation fans out into multiple iframe renders/saves) by targeting the aggregated state polling response rather than individual `set-provider-css` calls.

**Part 2 — Trim redundant `{ timeout: 20000 }` on `toBeAttached` calls:**

- Removed 6 explicit `{ timeout: 20000 }` from `toBeAttached()` calls in `concatenate.test.ts` and 1 in `image-guide.test.ts`. The project's `expect.timeout` default is already 20000ms, making these redundant.

## Related product discussion/links

* https://linear.app/a8c/issue/HOG-551

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* These changes are E2E test-only — no production code is affected.
* Run the Boost E2E test suite and verify the affected specs still pass:
  - `specs/critical-css/critical-css.test.ts`
  - `specs/base/common.test.ts`
  - `specs/concatenate/concatenate.test.ts`
  - `specs/image-guide/image-guide.test.ts`

## Verification
- **Lint**: PASS — ESLint and Prettier passed via pre-commit hooks
- **Type check**: PASS — `tsgo --noEmit` passed with no errors
- **Diff review**: PASS — confirmed no unintended changes, no debug statements
- **Secret scan**: PASS — no credentials in diff

## Confidence
**HIGH** — The changes are mechanical (Part 2) and well-motivated by the actual DataSync architecture (Part 1). The `waitForCriticalCssGeneration` helper targets the exact same completion signal the UI uses, making it strictly more correct than the timeout-based approach.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/HOG-551/boost-e2e-replace-timeout-based-assertions-with-deterministic-waits)