### PR TITLE
Sync: whitelist jetpack_social_message_template option

### DIFF
--- a/projects/packages/sync/changelog/add-jetpack-social-message-template-option
+++ b/projects/packages/sync/changelog/add-jetpack-social-message-template-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync: Whitelist the jetpack_social_message_template option so it propagates to WPCOM.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -88,6 +88,7 @@ class Defaults {
 		'jetpack_protect_key',
 		'jetpack_publicize_options',
 		'jetpack_relatedposts',
+		'jetpack_social_message_template',
 		'jetpack_social_notes_config',
 		'jetpack_social_settings',
 		'jetpack_social_utm_settings',

--- a/projects/plugins/jetpack/changelog/update-social-sync-template-options
+++ b/projects/plugins/jetpack/changelog/update-social-sync-template-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Whitelist the jetpack_social_message_template option so it propagates to WPCOM.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -238,6 +238,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'jetpack_excluded_extensions'                  => 'pineapple',
 			'jetpack-memberships-has-connected-account'    => true,
 			'jetpack_publicize_options'                    => array(),
+			'jetpack_social_message_template'              => array(),
 			'jetpack_social_notes_config'                  => array(),
 			'jetpack_social_utm_settings'                  => array(),
 			'jetpack_social_settings'                      => array( 'image' => true ),


### PR DESCRIPTION
Add the saved Social message-template option to the sync defaults whitelist so it propagates from Jetpack sites to WPcom. Without this, the parent commit's `register_meta` default for `_wpas_mess` resolves to the user's customized template on the Jetpack site (where the editor reads it) but to the hardcoded `Default_Templates` on WPcom (where the share is generated), so a customized site template is honored in the editor preview but ignored at share time.


WPCOM: 215935-ghe-Automattic/wpcom

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*