### PR TITLE
RTC: Re-enable RTC by default on WoW sites

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16781-temporarily-disable-rtc-on-atomic-sites
+++ b/projects/packages/rtc/changelog/dotcom-16781-temporarily-disable-rtc-on-atomic-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-RTC: Temporarily disable RTC on Atomic sites

--- a/projects/packages/rtc/changelog/dotcom-17053-re-enable-rtc-by-default-on-wow-sites
+++ b/projects/packages/rtc/changelog/dotcom-17053-re-enable-rtc-by-default-on-wow-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Re-enable RTC by default on WoW sites

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -243,12 +243,6 @@ class RTC {
 		if ( ! self::is_allowed() ) {
 			return '0';
 		}
-
-		// Temporarily disable RTC while an issue with CRDT documents is investigated/fixed.
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			return '0';
-		}
-
 		// RTC allowed and option is not stored yet
 		if ( $option === self::OPTION_NEW ) {
 			// If the old option is set, use that.


### PR DESCRIPTION
Fixes DOTCOM-17053

## Proposed changes

* Reverts the temporary `IS_ATOMIC` early-return added in #48199 to `Automattic\Jetpack\RTC\RTC::default_rtc_option()`, so RTC is enabled by default again on WoW (Atomic) sites.
* The CRDT-document bug that motivated #48199 was fixed upstream in [WordPress/gutenberg#77529](https://github.com/WordPress/gutenberg/pull/77529), shipped in **Gutenberg 23.0**, which has already been deployed to Atomic sites.
* Drops the unreleased `dotcom-16781-temporarily-disable-rtc-on-atomic-sites` changelog entry (the temp-disable hadn't been released at the package level yet — last `rtc` package release is `0.1.0`) and adds a new `changed` entry covering the re-enable.

## Related product discussion/links

* Original temp-disable: #48199 / DOTCOM-16781
* Upstream fix: https://github.com/WordPress/gutenberg/pull/77529

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Apply these changes to a WoW (Atomic) site that has never explicitly toggled the RTC setting (i.e. the `wp_collaboration_enabled` / `wp_enable_real_time_collaboration` option is not stored in the DB).
* Go to **Settings → Writing**.
* The "Enable real-time collaboration" toggle should now default to **enabled**.
* Confirm RTC works as expected in the editor with another user, and that the editor does not get stuck in a permanently dirty state (the bug fixed by [gutenberg#77529](https://github.com/WordPress/gutenberg/pull/77529)).