### PR TITLE
Image Studio: register _jetpack_feature_clip_id post meta

### DIFF
--- a/projects/plugins/jetpack/changelog/add-feature-clip-post-meta
+++ b/projects/plugins/jetpack/changelog/add-feature-clip-post-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Image Studio: register a `_jetpack_feature_clip_id` post meta that links a generated video clip to its post. Stored as the attachment ID, exposed over REST so the post editor can read/write it.

--- a/projects/plugins/jetpack/changelog/add-feature-clip-post-meta
+++ b/projects/plugins/jetpack/changelog/add-feature-clip-post-meta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Image Studio: register a `_jetpack_feature_clip_id` post meta that links a generated video clip to its post. Stored as the attachment ID, exposed over REST so the post editor can read/write it.
+Image Studio: Register a `_jetpack_feature_clip_id` post meta that links a generated video clip to its post. Stored as the attachment ID, exposed over REST so the post editor can read/write it.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -187,7 +187,9 @@ function register_plugin() {
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_plugin' );
 
 /**
- * Permission check for writing the feature clip meta on a given post.
+ * Permission check for reading or writing the feature clip meta on a given
+ * post. WordPress runs `auth_callback` for both REST GET and POST against the
+ * meta key, so this gate determines visibility as well as mutability.
  *
  * @param bool   $allowed   Whether the user is allowed (unused — recomputed here).
  * @param string $meta_key  Meta key being checked.
@@ -220,6 +222,7 @@ function register_feature_clip_post_meta() {
 			'type'              => 'integer',
 			'description'       => 'Attachment ID of the generated video clip designated as this post\'s feature clip.',
 			'single'            => true,
+			'default'           => 0,
 			'show_in_rest'      => true,
 			'sanitize_callback' => 'absint',
 			'auth_callback'     => __NAMESPACE__ . '\feature_clip_meta_auth_callback',

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/../../shared/cdn-locale.php';
 
 const FEATURE_NAME           = 'image-studio';
+const FEATURE_CLIP_META_KEY  = '_jetpack_feature_clip_id';
 const ASSET_BASE_PATH        = 'widgets.wp.com/agents-manager/';
 const ASSET_JS_URL           = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';
 const ASSET_CSS_URL          = 'https://' . ASSET_BASE_PATH . 'image-studio.css';
@@ -184,6 +185,48 @@ function register_plugin() {
 	\Jetpack_Gutenberg::set_extension_available( FEATURE_NAME );
 }
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_plugin' );
+
+/**
+ * Permission check for writing the feature clip meta on a given post.
+ *
+ * @param bool   $allowed   Whether the user is allowed (unused — recomputed here).
+ * @param string $meta_key  Meta key being checked.
+ * @param int    $object_id Post ID.
+ * @return bool
+ */
+function feature_clip_meta_auth_callback( $allowed, $meta_key, $object_id ) {
+	unset( $allowed, $meta_key );
+	return current_user_can( 'edit_post', (int) $object_id );
+}
+
+/**
+ * Register the post meta that links a generated video clip to a post.
+ *
+ * Stored as the attachment ID; the URL is resolved client-side via the
+ * Media Library so deletes/replacements stay consistent. Registered for
+ * `post` only — pages can be added later if there's a use case.
+ *
+ * @return void
+ */
+function register_feature_clip_post_meta() {
+	if ( ! is_image_studio_enabled() ) {
+		return;
+	}
+
+	register_post_meta(
+		'post',
+		FEATURE_CLIP_META_KEY,
+		array(
+			'type'              => 'integer',
+			'description'       => 'Attachment ID of the generated video clip designated as this post\'s feature clip.',
+			'single'            => true,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'absint',
+			'auth_callback'     => __NAMESPACE__ . '\feature_clip_meta_auth_callback',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_feature_clip_post_meta' );
 
 /**
  * Fetch and cache the remote asset manifest.

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -1779,7 +1779,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		// Re-run the registration explicitly so the test isn't sensitive to setup order.
 		ImageStudio\register_feature_clip_post_meta();
 
-		$registered = get_registered_meta_keys( 'post' );
+		$registered = get_registered_meta_keys( 'post', 'post' );
 		$this->assertArrayHasKey( ImageStudio\FEATURE_CLIP_META_KEY, $registered );
 
 		$schema = $registered[ ImageStudio\FEATURE_CLIP_META_KEY ];
@@ -1843,7 +1843,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 
 		ImageStudio\register_feature_clip_post_meta();
 
-		$registered = get_registered_meta_keys( 'post' );
+		$registered = get_registered_meta_keys( 'post', 'post' );
 		$this->assertArrayNotHasKey( ImageStudio\FEATURE_CLIP_META_KEY, $registered );
 
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -1786,8 +1786,23 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->assertSame( 'integer', $schema['type'] );
 		$this->assertTrue( $schema['single'] );
 		$this->assertTrue( $schema['show_in_rest'] );
+		$this->assertSame( 0, $schema['default'] );
 		$this->assertSame( 'absint', $schema['sanitize_callback'] );
 		$this->assertIsCallable( $schema['auth_callback'] );
+	}
+
+	/**
+	 * Test that the registered default surfaces as `0` from `get_post_meta()`
+	 * for posts without an explicit value, so REST clients always see a
+	 * deterministic integer instead of `null` or an empty string.
+	 */
+	public function test_feature_clip_meta_default_value_is_zero() {
+		ImageStudio\register_feature_clip_post_meta();
+
+		$post_id = self::factory()->post->create();
+		$value   = get_post_meta( $post_id, ImageStudio\FEATURE_CLIP_META_KEY, true );
+
+		$this->assertSame( 0, $value );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -1760,6 +1760,99 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// Feature clip post meta tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that the feature clip meta key constant is defined correctly.
+	 */
+	public function test_feature_clip_meta_key_constant() {
+		$this->assertEquals( '_jetpack_feature_clip_id', ImageStudio\FEATURE_CLIP_META_KEY );
+	}
+
+	/**
+	 * Test that the feature clip meta is registered for the 'post' object type
+	 * with the expected schema (integer, single, exposed in REST).
+	 */
+	public function test_feature_clip_post_meta_registered_when_enabled() {
+		// The plugin's `init` hook should have registered the meta during bootstrap.
+		// Re-run the registration explicitly so the test isn't sensitive to setup order.
+		ImageStudio\register_feature_clip_post_meta();
+
+		$registered = get_registered_meta_keys( 'post' );
+		$this->assertArrayHasKey( ImageStudio\FEATURE_CLIP_META_KEY, $registered );
+
+		$schema = $registered[ ImageStudio\FEATURE_CLIP_META_KEY ];
+		$this->assertSame( 'integer', $schema['type'] );
+		$this->assertTrue( $schema['single'] );
+		$this->assertTrue( $schema['show_in_rest'] );
+		$this->assertSame( 'absint', $schema['sanitize_callback'] );
+		$this->assertIsCallable( $schema['auth_callback'] );
+	}
+
+	/**
+	 * Test that the meta auth callback grants access when the user can edit the post.
+	 */
+	public function test_feature_clip_meta_auth_callback_grants_when_user_can_edit_post() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$post_id = self::factory()->post->create( array( 'post_author' => $user_id ) );
+
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue(
+			ImageStudio\feature_clip_meta_auth_callback( false, ImageStudio\FEATURE_CLIP_META_KEY, $post_id )
+		);
+	}
+
+	/**
+	 * Test that the meta auth callback denies access when the user cannot edit the post.
+	 */
+	public function test_feature_clip_meta_auth_callback_denies_when_user_cannot_edit_post() {
+		$post_id       = self::factory()->post->create();
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_set_current_user( $subscriber_id );
+
+		$this->assertFalse(
+			ImageStudio\feature_clip_meta_auth_callback( true, ImageStudio\FEATURE_CLIP_META_KEY, $post_id )
+		);
+	}
+
+	/**
+	 * Test that the meta auth callback denies access for an anonymous user.
+	 */
+	public function test_feature_clip_meta_auth_callback_denies_anonymous_user() {
+		$post_id = self::factory()->post->create();
+		wp_set_current_user( 0 );
+
+		$this->assertFalse(
+			ImageStudio\feature_clip_meta_auth_callback( true, ImageStudio\FEATURE_CLIP_META_KEY, $post_id )
+		);
+	}
+
+	/**
+	 * Test that the registration is gated on `is_image_studio_enabled()`. When
+	 * Image Studio is disabled, calling the registration helper directly is a no-op.
+	 */
+	public function test_feature_clip_post_meta_skipped_when_disabled() {
+		// Force the gate to false by disabling AI features and Big Sky.
+		add_filter( 'jetpack_ai_enabled', '__return_false' );
+
+		// Unregister any prior registration so we can detect a no-op.
+		unregister_post_meta( 'post', ImageStudio\FEATURE_CLIP_META_KEY );
+
+		ImageStudio\register_feature_clip_post_meta();
+
+		$registered = get_registered_meta_keys( 'post' );
+		$this->assertArrayNotHasKey( ImageStudio\FEATURE_CLIP_META_KEY, $registered );
+
+		remove_filter( 'jetpack_ai_enabled', '__return_false' );
+
+		// Restore for any later tests that depend on the meta being present.
+		ImageStudio\register_feature_clip_post_meta();
+	}
+
+	// -------------------------------------------------------------------------
 	// Hook priority tests
 	// -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Registers a new post meta — `_jetpack_feature_clip_id` — that links a generated video clip to its post. Stored as the attachment ID; the URL is resolved client-side via the Media Library so renames/deletes/replacements stay consistent without duplicating data.

- Registered for `post` only (pages can be added later if there's a use case).
- Gated behind the existing `is_image_studio_enabled()` check, so behaviour is unchanged on sites where Image Studio is off.
- `show_in_rest: true` exposes the field on `/wp-json/wp/v2/posts/{id}` so the post editor can read and write it via standard REST without a dedicated endpoint.
- Auth callback defers to `current_user_can( 'edit_post', $post_id )`.
- Sanitised through `absint`.

This is the server-side half. The post-editor sidebar that consumes this meta lands in a sibling Calypso PR.

## Testing instructions
1. Enable Image Studio on a test site (Premium+ on WordPress.com, or any Jetpack-connected site with AI features available).
2. Authenticate as a user who can edit posts and request a post:
   ```
   curl -s -u 'user:app-password' https://YOURSITE/wp-json/wp/v2/posts/123 | jq '.meta'
   ```
   Expect `"_jetpack_feature_clip_id": 0` for posts without a clip.
3. Write a value:
   ```
   curl -s -u 'user:app-password' -X POST -H 'content-type: application/json' \
     -d '{"meta":{"_jetpack_feature_clip_id":42}}' \
     https://YOURSITE/wp-json/wp/v2/posts/123 | jq '.meta._jetpack_feature_clip_id'
   ```
   Expect `42`. Re-read the post and confirm it persisted.
4. As a Subscriber (no `edit_post` on that post) repeat step 3 — REST should respond `403 rest_cannot_update`.
5. POST a non-integer (e.g. `"abc"`); expect it to round-trip as `0` (`absint`).
6. Disable Image Studio (`add_filter( 'jetpack_ai_enabled', '__return_false' )` on a non-WPCOM dev site) and confirm `_jetpack_feature_clip_id` no longer appears in the REST response.

## Does this pull request change what data or activity we track or use?
Yes — minimally. This PR introduces a new post meta, `_jetpack_feature_clip_id`, that stores a single integer (a Media Library attachment ID) per post. No tracking events, no PII, no third-party data flows. The meta is only writable by users with `edit_post` capability on the target post and only readable through the standard core REST `posts` endpoint as part of the existing `meta` payload.

## Test plan checklist
- [ ] On a site with Image Studio enabled (Atomic / WordPress.com / self-hosted with Jetpack), `GET /wp-json/wp/v2/posts/{id}` returns `meta._jetpack_feature_clip_id` (defaults to `0`).
- [ ] `POST /wp-json/wp/v2/posts/{id}` with `{ meta: { _jetpack_feature_clip_id: 123 } }` persists for editors of that post and rejects (403) for users without `edit_post`.
- [ ] On a site where Image Studio is disabled, the meta key is not exposed over REST.
- [ ] Non-integer payloads are coerced to `0` via `absint`.
- [ ] Anonymous (logged-out) requests cannot write the meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)