### PR TITLE
Social: avoid row locking on template autosave

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
@@ -68,14 +68,7 @@ export function ConnectionTemplateEditor( props: ConnectionTemplateEditorProps )
 	const persist = useCallback(
 		( value: string ) => {
 			lastSentRef.current = value;
-			updateConnectionById(
-				connection.connection_id,
-				{ template: value },
-				{
-					trackUpdating: false,
-					showSuccessNotice: false,
-				}
-			);
+			updateConnectionById( connection.connection_id, { template: value }, { silent: true } );
 		},
 		[ connection.connection_id, updateConnectionById ]
 	);

--- a/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
@@ -68,7 +68,14 @@ export function ConnectionTemplateEditor( props: ConnectionTemplateEditorProps )
 	const persist = useCallback(
 		( value: string ) => {
 			lastSentRef.current = value;
-			updateConnectionById( connection.connection_id, { template: value } );
+			updateConnectionById(
+				connection.connection_id,
+				{ template: value },
+				{
+					trackUpdating: false,
+					showSuccessNotice: false,
+				}
+			);
 		},
 		[ connection.connection_id, updateConnectionById ]
 	);

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { setup } from '../../../../utils/test-factory';
 import { clearMockedScriptData, mockScriptData } from '../../../../utils/test-utils';
 import { ConnectionTemplateEditor } from '../../connection-template';
@@ -20,6 +21,7 @@ describe( 'ConnectionTemplateEditor', () => {
 	afterEach( () => {
 		clearMockedScriptData();
 		jest.clearAllMocks();
+		jest.useRealTimers();
 	} );
 
 	test( 'renders the editor when both message-templates and enhanced-publishing are on', () => {
@@ -31,6 +33,30 @@ describe( 'ConnectionTemplateEditor', () => {
 		expect(
 			screen.getByRole( 'textbox', { name: /Custom message for this connection/i } )
 		).toBeInTheDocument();
+	} );
+
+	test( 'saves without marking the connection as updating', async () => {
+		jest.useFakeTimers();
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		setupFeatures( 'social-message-templates', 'social-enhanced-publishing' );
+		const { stubUpdateConnectionById } = setup();
+
+		render( <ConnectionTemplateEditor connection={ FB } /> );
+
+		await user.type( screen.getByRole( 'textbox' ), 'Custom template' );
+
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		expect( stubUpdateConnectionById ).toHaveBeenCalledWith(
+			'2',
+			{ template: 'Custom template' },
+			{
+				trackUpdating: false,
+				showSuccessNotice: false,
+			}
+		);
 	} );
 
 	test( 'renders nothing when the message-templates feature is off', () => {

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
@@ -52,10 +52,7 @@ describe( 'ConnectionTemplateEditor', () => {
 		expect( stubUpdateConnectionById ).toHaveBeenCalledWith(
 			'2',
 			{ template: 'Custom template' },
-			{
-				trackUpdating: false,
-				showSuccessNotice: false,
-			}
+			{ silent: true }
 		);
 	} );
 

--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -25,8 +25,11 @@ import {
 } from './constants';
 
 type UpdateConnectionOptions = {
-	trackUpdating?: boolean;
-	showSuccessNotice?: boolean;
+	/**
+	 * Skip transient UI side effects for background saves. This suppresses the
+	 * row-level updating state and generic success notice; errors are still shown.
+	 */
+	silent?: boolean;
 };
 
 /**
@@ -515,9 +518,10 @@ export function setReconnectingAccount( reconnectingAccount: Connection ) {
 /**
  * Updates a connection.
  *
- * @param connectionId - Connection ID to update.
- * @param data         - The data for API call.
- * @param options      - Options for update UI side-effects.
+ * @param connectionId   - Connection ID to update.
+ * @param data           - The data for API call.
+ * @param options        - Options for update UI side-effects.
+ * @param options.silent - Whether to skip row-level updating state and the generic success notice.
  * @return A thunk to update a connection.
  */
 export function updateConnectionById(
@@ -527,7 +531,7 @@ export function updateConnectionById(
 ) {
 	return async function ( { dispatch, select } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
-		const { trackUpdating = true, showSuccessNotice = true } = options;
+		const { silent = false } = options;
 
 		const prevConnection = select.getConnectionById( connectionId );
 
@@ -540,13 +544,13 @@ export function updateConnectionById(
 			// Optimistically update the connection.
 			dispatch( updateConnection( connectionId, data ) );
 
-			if ( trackUpdating ) {
+			if ( ! silent ) {
 				dispatch( updatingConnection( connectionId ) );
 			}
 
 			const connection = await apiFetch( { method: 'POST', path, data } );
 
-			if ( connection && showSuccessNotice ) {
+			if ( connection && ! silent ) {
 				createSuccessNotice( __( 'Account updated successfully.', 'jetpack-publicize-pkg' ), {
 					type: 'snackbar',
 					isDismissible: true,
@@ -564,7 +568,7 @@ export function updateConnectionById(
 
 			createErrorNotice( message, { type: 'snackbar', isDismissible: true } );
 		} finally {
-			if ( trackUpdating ) {
+			if ( ! silent ) {
 				dispatch( updatingConnection( connectionId, false ) );
 			}
 		}

--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -24,6 +24,11 @@ import {
 	CUSTOMIZE_CONNECTION,
 } from './constants';
 
+type UpdateConnectionOptions = {
+	trackUpdating?: boolean;
+	showSuccessNotice?: boolean;
+};
+
 /**
  * Set connections list
  * @param connections - list of connections
@@ -512,11 +517,17 @@ export function setReconnectingAccount( reconnectingAccount: Connection ) {
  *
  * @param connectionId - Connection ID to update.
  * @param data         - The data for API call.
+ * @param options      - Options for update UI side-effects.
  * @return A thunk to update a connection.
  */
-export function updateConnectionById( connectionId: string, data: Partial< Connection > ) {
+export function updateConnectionById(
+	connectionId: string,
+	data: Partial< Connection >,
+	options: UpdateConnectionOptions = {}
+) {
 	return async function ( { dispatch, select } ) {
 		const { createErrorNotice, createSuccessNotice } = coreDispatch( globalNoticesStore );
+		const { trackUpdating = true, showSuccessNotice = true } = options;
 
 		const prevConnection = select.getConnectionById( connectionId );
 
@@ -529,11 +540,13 @@ export function updateConnectionById( connectionId: string, data: Partial< Conne
 			// Optimistically update the connection.
 			dispatch( updateConnection( connectionId, data ) );
 
-			dispatch( updatingConnection( connectionId ) );
+			if ( trackUpdating ) {
+				dispatch( updatingConnection( connectionId ) );
+			}
 
 			const connection = await apiFetch( { method: 'POST', path, data } );
 
-			if ( connection ) {
+			if ( connection && showSuccessNotice ) {
 				createSuccessNotice( __( 'Account updated successfully.', 'jetpack-publicize-pkg' ), {
 					type: 'snackbar',
 					isDismissible: true,
@@ -551,7 +564,9 @@ export function updateConnectionById( connectionId: string, data: Partial< Conne
 
 			createErrorNotice( message, { type: 'snackbar', isDismissible: true } );
 		} finally {
-			dispatch( updatingConnection( connectionId, false ) );
+			if ( trackUpdating ) {
+				dispatch( updatingConnection( connectionId, false ) );
+			}
 		}
 	};
 }

--- a/projects/packages/publicize/_inc/social-store/actions/test/connection-data.js
+++ b/projects/packages/publicize/_inc/social-store/actions/test/connection-data.js
@@ -208,6 +208,65 @@ describe( 'Social store actions: connectionData', () => {
 		} );
 	} );
 
+	describe( 'updateConnectionById', () => {
+		const connectionId = connections[ 0 ].connection_id;
+
+		it( 'should track the connection as updating by default', async () => {
+			let resolveFetch;
+
+			apiFetch.setFetchHandler(
+				() =>
+					new Promise( resolve => {
+						resolveFetch = resolve;
+					} )
+			);
+
+			const registry = createRegistryWithStores();
+
+			const updatePromise = registry.dispatch( socialStore ).updateConnectionById( connectionId, {
+				shared: true,
+			} );
+
+			expect( registry.select( socialStore ).getUpdatingConnections() ).toEqual( [ connectionId ] );
+
+			resolveFetch();
+			await updatePromise;
+
+			expect( registry.select( socialStore ).getUpdatingConnections() ).toEqual( [] );
+		} );
+
+		it( 'should skip updating tracking when trackUpdating is false', async () => {
+			let resolveFetch;
+
+			apiFetch.setFetchHandler(
+				() =>
+					new Promise( resolve => {
+						resolveFetch = resolve;
+					} )
+			);
+
+			const registry = createRegistryWithStores();
+
+			const updatePromise = registry.dispatch( socialStore ).updateConnectionById(
+				connectionId,
+				{
+					template: 'Custom template',
+				},
+				{
+					trackUpdating: false,
+					showSuccessNotice: false,
+				}
+			);
+
+			expect( registry.select( socialStore ).getUpdatingConnections() ).toEqual( [] );
+
+			resolveFetch();
+			await updatePromise;
+
+			expect( registry.select( socialStore ).getUpdatingConnections() ).toEqual( [] );
+		} );
+	} );
+
 	describe( 'refreshConnectionTestResults', () => {
 		const refreshConnections = '/wpcom/v2/publicize/connection-test-results';
 		beforeAll( () => {

--- a/projects/packages/publicize/_inc/social-store/actions/test/connection-data.js
+++ b/projects/packages/publicize/_inc/social-store/actions/test/connection-data.js
@@ -235,7 +235,7 @@ describe( 'Social store actions: connectionData', () => {
 			expect( registry.select( socialStore ).getUpdatingConnections() ).toEqual( [] );
 		} );
 
-		it( 'should skip updating tracking when trackUpdating is false', async () => {
+		it( 'should skip updating tracking when silent is true', async () => {
 			let resolveFetch;
 
 			apiFetch.setFetchHandler(
@@ -253,8 +253,7 @@ describe( 'Social store actions: connectionData', () => {
 					template: 'Custom template',
 				},
 				{
-					trackUpdating: false,
-					showSuccessNotice: false,
+					silent: true,
 				}
 			);
 

--- a/projects/packages/publicize/changelog/social-474-template-editor-row-locking
+++ b/projects/packages/publicize/changelog/social-474-template-editor-row-locking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: avoid disabling connection rows while saving per-connection message templates.


### PR DESCRIPTION
Fixes SOCIAL-474

## Proposed changes
* Allow connection updates to opt out of the row-level `updatingConnections` state and generic success snackbar while keeping the existing default behavior for other callers.
* Save per-connection message templates with that non-locking, silent update path so the connection row stays interactive while the debounced template save is in flight.
* Add focused tests for the default connection update behavior and the per-connection template save options.

## Related product discussion/links
* SOCIAL-474
* p1778070097013599-slack-C0ATW4VK6JH

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Connect a site that has both `social-message-templates` and `social-enhanced-publishing` features active.
* Go to **Jetpack → Social** (`/wp-admin/admin.php?page=jetpack-social`).
* Expand an existing connection row.
* Type in **Custom message for this connection** and pause for the debounced save.
* Confirm the connection row stays interactive while the save request is in flight; for example, the row should not visually disable while the template is saving.
* Confirm the template still persists after reload.
* Open **Connect an account**, expand a service with existing connections, and repeat the template edit in the modal.

Verification run locally:
* `pnpm --dir projects/packages/publicize test -- _inc/components/connection-management/tests/specs/connection-template.test.jsx _inc/social-store/actions/test/connection-data.js --runInBand`
* `pnpm --dir projects/packages/publicize typecheck`