### PR TITLE
Docker CLI parallel flags: PR review follow-up (#48153)

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -98,6 +98,12 @@ const defaultOpts = yargs =>
 			describe:
 				'Auto-clone the database from jetpack_dev when spinning up a parallel instance with --name. Use --no-clone to opt out and get a fresh install instead.',
 		} )
+		.option( 'update-env', {
+			type: 'boolean',
+			default: false,
+			describe:
+				"When `up` flag values conflict with the worktree's tools/docker/.env, rewrite the conflicting keys in .env to match the flags. Without this, the flag wins for the current run and a warning is printed; .env is left untouched.",
+		} )
 		.option( 'ngrok', {
 			type: 'boolean',
 			describe: 'Flag to launch ngrok process',
@@ -161,6 +167,180 @@ export const buildEnv = argv => {
  */
 const setEnv = () => {
 	fs.closeSync( fs.openSync( `${ dockerFolder }/.env`, 'a' ) );
+};
+
+/**
+ * Keys the CLI manages in tools/docker/.env when spinning up a parallel instance.
+ * The CLI reads them as a base layer (flags still override) and may append the missing
+ * ones on `up --name <slug>`. Lines outside this set are never modified.
+ */
+export const PARALLEL_ENV_KEYS = [
+	'COMPOSE_PROJECT_NAME',
+	'PORT_WORDPRESS',
+	'PORT_PHPMY',
+	'PORT_INBOX',
+	'PORT_SMTP',
+	'PORT_SFTP',
+];
+
+const parallelEnvPath = () => `${ dockerFolder }/.env`;
+
+/**
+ * Read and parse the worktree's tools/docker/.env file.
+ *
+ * @param {string} [filePath] - Override path (mostly for tests).
+ * @return {object} Parsed key→value map. Empty object when the file is missing.
+ */
+export const readEnvFile = ( filePath = parallelEnvPath() ) => {
+	if ( ! fs.existsSync( filePath ) ) {
+		return {};
+	}
+	return envfile.parse( fs.readFileSync( filePath, 'utf8' ) );
+};
+
+/**
+ * Snapshot the parallel-instance argv values that came from CLI flags, so a later
+ * conflict check can distinguish flag-given values from .env-fill-in values.
+ *
+ * @param {object} argv - Yargs argv (post coerce, pre-augment).
+ * @return {object} Plain snapshot of parallel-relevant flag values.
+ */
+export const snapshotFlagArgv = argv => ( {
+	name: argv.name,
+	port: argv.port,
+	portPhpmy: argv.portPhpmy,
+	portInbox: argv.portInbox,
+	portSmtp: argv.portSmtp,
+	portSftp: argv.portSftp,
+} );
+
+/**
+ * Fill in argv defaults from the parsed .env file, but only for fields the user
+ * did not pass via flags. This lets a worktree configured by a previous
+ * `up --name foo --port 8080` "just work" with bare `jp docker up` afterwards.
+ *
+ * COMPOSE_PROJECT_NAME → argv.name only when it parses as `jetpack_<x>` and
+ * <x> is neither 'dev' nor 'e2e' — guards against the main checkout's .env
+ * silently redirecting the dev container.
+ *
+ * @param {object} argv    - Yargs argv (mutated in place).
+ * @param {object} fileEnv - Parsed .env contents (use readEnvFile()).
+ */
+export const augmentArgvFromEnvFile = ( argv, fileEnv ) => {
+	if ( ! argv.name && typeof fileEnv.COMPOSE_PROJECT_NAME === 'string' ) {
+		const match = fileEnv.COMPOSE_PROJECT_NAME.match( /^jetpack_(.+)$/ );
+		if ( match && match[ 1 ] !== 'dev' && match[ 1 ] !== 'e2e' ) {
+			argv.name = match[ 1 ];
+		}
+	}
+	if ( argv.port === undefined && fileEnv.PORT_WORDPRESS ) {
+		argv.port = Number( fileEnv.PORT_WORDPRESS );
+	}
+	if ( argv.portPhpmy === undefined && fileEnv.PORT_PHPMY ) {
+		argv.portPhpmy = Number( fileEnv.PORT_PHPMY );
+	}
+	if ( argv.portInbox === undefined && fileEnv.PORT_INBOX ) {
+		argv.portInbox = Number( fileEnv.PORT_INBOX );
+	}
+	if ( argv.portSmtp === undefined && fileEnv.PORT_SMTP ) {
+		argv.portSmtp = Number( fileEnv.PORT_SMTP );
+	}
+	if ( argv.portSftp === undefined && fileEnv.PORT_SFTP ) {
+		argv.portSftp = Number( fileEnv.PORT_SFTP );
+	}
+};
+
+/**
+ * Identify keys where the user passed a flag value that contradicts an existing
+ * .env entry. The flag wins for the current invocation; .env is left untouched
+ * unless --update-env was passed.
+ *
+ * @param {object} flagArgv - Snapshot of pre-augment flag values (from snapshotFlagArgv).
+ * @param {object} fileEnv  - Parsed .env contents.
+ * @return {Array<{key: string, fileValue: string, flagValue: string}>} Conflicting keys.
+ */
+export const detectEnvConflicts = ( flagArgv, fileEnv ) => {
+	const conflicts = [];
+	const check = ( key, flagValue ) => {
+		if ( flagValue === undefined || flagValue === null || flagValue === '' ) return;
+		const fileValue = fileEnv[ key ];
+		if ( fileValue === undefined ) return;
+		if ( String( fileValue ) !== String( flagValue ) ) {
+			conflicts.push( {
+				key,
+				fileValue: String( fileValue ),
+				flagValue: String( flagValue ),
+			} );
+		}
+	};
+	if ( flagArgv.name !== undefined ) {
+		check( 'COMPOSE_PROJECT_NAME', `jetpack_${ flagArgv.name }` );
+	}
+	check( 'PORT_WORDPRESS', flagArgv.port );
+	check( 'PORT_PHPMY', flagArgv.portPhpmy );
+	check( 'PORT_INBOX', flagArgv.portInbox );
+	check( 'PORT_SMTP', flagArgv.portSmtp );
+	check( 'PORT_SFTP', flagArgv.portSftp );
+	return conflicts;
+};
+
+/**
+ * Append the parallel-instance keys to .env when they are not already there.
+ * Strategy B: never modify lines that already exist; only append the keys we own
+ * that are missing. Idempotent — safe to run on every `up`.
+ *
+ * @param {object} envOpts    - Built env (from buildEnv) — provides the values to write.
+ * @param {string} [filePath] - Target .env path (mostly for tests).
+ * @return {string[]} Keys that were written. Empty when no-op.
+ */
+export const persistParallelEnv = ( envOpts, filePath = parallelEnvPath() ) => {
+	const existing = fs.existsSync( filePath )
+		? envfile.parse( fs.readFileSync( filePath, 'utf8' ) )
+		: {};
+	const toWrite = [];
+	for ( const key of PARALLEL_ENV_KEYS ) {
+		if ( envOpts[ key ] === undefined || envOpts[ key ] === '' ) continue;
+		if ( existing[ key ] !== undefined ) continue;
+		toWrite.push( key );
+	}
+	if ( toWrite.length === 0 ) return [];
+	const header =
+		"\n# Parallel-instance config (managed by `jp docker up --name`). Edit by hand at any\n# time; the CLI only appends keys that don't already exist.\n";
+	const block = toWrite.map( key => `${ key }=${ envOpts[ key ] }` ).join( '\n' ) + '\n';
+	fs.appendFileSync( filePath, header + block );
+	return toWrite;
+};
+
+/**
+ * Replace specific keys in .env in place, preserving every other line verbatim.
+ * Used by --update-env to reconcile flags with the persisted file.
+ *
+ * @param {string}                                  filePath  - Target .env path.
+ * @param {Array<{key: string, flagValue: string}>} conflicts - Conflicts from detectEnvConflicts.
+ * @return {string[]} Keys that were updated.
+ */
+export const applyUpdateEnv = ( filePath, conflicts ) => {
+	if ( conflicts.length === 0 ) return [];
+	const text = fs.existsSync( filePath ) ? fs.readFileSync( filePath, 'utf8' ) : '';
+	const lines = text.split( /\r?\n/ );
+	const updated = [];
+	for ( const { key, flagValue } of conflicts ) {
+		let replaced = false;
+		for ( let i = 0; i < lines.length; i++ ) {
+			const m = lines[ i ].match( /^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=/ );
+			if ( m && m[ 2 ] === key ) {
+				lines[ i ] = `${ m[ 1 ] }${ key }=${ flagValue }`;
+				replaced = true;
+				break;
+			}
+		}
+		if ( ! replaced ) {
+			lines.push( `${ key }=${ flagValue }` );
+		}
+		updated.push( key );
+	}
+	fs.writeFileSync( filePath, lines.join( '\n' ) );
+	return updated;
 };
 
 /**
@@ -626,6 +806,33 @@ async function retry( action, { times, delay = 5000 } ) {
 const defaultDockerCmdHandler = async argv => {
 	printPreCmdMsg( argv );
 
+	// Hybrid .env handling for `up`: read .env as a base layer (flags still win),
+	// surface conflicts as warnings (or rewrite when --update-env is set), and persist
+	// parallel-instance keys after a successful `up --name`. See tools/docker/README.md
+	// § "Parallel development environments" for the full precedence + semantics.
+	if ( argv._[ 1 ] === 'up' ) {
+		const flagSnapshot = snapshotFlagArgv( argv );
+		const fileEnv = readEnvFile();
+		augmentArgvFromEnvFile( argv, fileEnv );
+		const conflicts = detectEnvConflicts( flagSnapshot, fileEnv );
+		if ( conflicts.length ) {
+			if ( argv.updateEnv ) {
+				const updated = applyUpdateEnv( parallelEnvPath(), conflicts );
+				console.log(
+					chalk.cyan( `Updated tools/docker/.env keys to match flags: ${ updated.join( ', ' ) }.` )
+				);
+			} else {
+				for ( const c of conflicts ) {
+					console.warn(
+						chalk.yellow(
+							`⚠ ${ c.key }: flag value '${ c.flagValue }' differs from .env value '${ c.fileValue }'. Using flag for this run; pass --update-env to persist, or drop the flag to use .env.`
+						)
+					);
+				}
+			}
+		}
+	}
+
 	executor( argv, setEnv );
 	executor( argv, setConfig );
 
@@ -690,6 +897,23 @@ const defaultDockerCmdHandler = async argv => {
 			}
 		}
 	}
+
+	// Persist parallel-instance config to .env on `up --name`. Idempotent: only appends
+	// keys that aren't already in the file (Strategy B). Skipped for the primary
+	// `jetpack_dev` flow (no --name) so the main checkout's .env is never written to.
+	if ( argv._[ 1 ] === 'up' && argv.name ) {
+		const written = persistParallelEnv( envOpts );
+		if ( written.length ) {
+			console.log(
+				chalk.cyan(
+					`Persisted to tools/docker/.env: ${ written.join(
+						', '
+					) }. Subsequent \`jp docker up\` from this worktree will use these values.`
+				)
+			);
+		}
+	}
+
 	printPostCmdMsg( argv );
 };
 

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -164,14 +164,18 @@ const setEnv = () => {
 };
 
 /**
- * Decides which source instance to clone the DB from, if any.
+ * Decides which source instance to clone the DB from when bringing up a dev container, if any.
  *
  * Purely argv-driven; whether the chosen source is actually running is checked by the caller.
+ * Always returns null for non-dev container types — the e2e framework manages its own DB.
  *
  * @param {object} argv - Yargs
  * @return {{source: string, explicit: boolean} | null} Source compose project name and whether the user asked for it by name, or null to skip cloning.
  */
-export const resolveCloneSource = argv => {
+export const resolveDevCloneSource = argv => {
+	if ( argv.type !== 'dev' ) {
+		return null;
+	}
 	if ( argv.cloneFrom ) {
 		return { source: 'jetpack_' + argv.cloneFrom, explicit: true };
 	}
@@ -620,9 +624,10 @@ const defaultDockerCmdHandler = async argv => {
 	// Gate on the target actually being up rather than on `--detached`: in foreground
 	// mode `composeExecutor` blocks until the user exits compose, at which point the
 	// target is stopped and there's nothing to clone into. Skipping silently in that
-	// case is friendlier than hard-requiring `-d`.
-	if ( argv.type === 'dev' && argv._[ 1 ] === 'up' ) {
-		const cloneReq = resolveCloneSource( argv );
+	// case is friendlier than hard-requiring `-d`. The `type === 'dev'` gate lives
+	// inside resolveDevCloneSource so the function is correct on its own terms.
+	if ( argv._[ 1 ] === 'up' ) {
+		const cloneReq = resolveDevCloneSource( argv );
 		if ( cloneReq ) {
 			const target = getProjectName( argv );
 			if ( ! isProjectRunning( target ) ) {

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -1,4 +1,4 @@
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 import chalk from 'chalk';
 import * as envfile from 'envfile';
@@ -209,6 +209,56 @@ const isProjectRunning = project => {
 };
 
 /**
+ * Pipe `wp db export` from a source container into `wp db import` on a target container,
+ * surfacing failures from either side independently.
+ *
+ * Replaces an earlier `bash -c '… | …'` invocation that masked source-side failures: with
+ * default bash, the pipe's exit status is the importer's only, so a broken `wp db export`
+ * could go unnoticed while the importer happily consumed partial/empty bytes and exited 0.
+ * Going node-native gives each side its own exit code.
+ *
+ * @param {string} sourceContainer - Source WP container name (e.g. 'jetpack_dev-wordpress-1').
+ * @param {string} targetContainer - Target WP container name (e.g. 'jetpack_foo-wordpress-1').
+ * @param {string} wpPath          - WP install path inside both containers (e.g. '/var/www/html').
+ * @return {Promise<void>} Resolves only when both processes exit 0; rejects with attribution otherwise.
+ */
+export const pipeDbDump = async ( sourceContainer, targetContainer, wpPath ) => {
+	const source = spawn(
+		'docker',
+		[ 'exec', sourceContainer, 'wp', 'db', 'export', '-', `--path=${ wpPath }` ],
+		{ stdio: [ 'ignore', 'pipe', 'inherit' ] }
+	);
+	const target = spawn(
+		'docker',
+		[ 'exec', '-i', targetContainer, 'wp', 'db', 'import', '-', `--path=${ wpPath }` ],
+		{ stdio: [ 'pipe', 'inherit', 'inherit' ] }
+	);
+	source.stdout.pipe( target.stdin );
+
+	const exitOf = proc =>
+		new Promise( ( resolve, reject ) => {
+			proc.on( 'exit', code => resolve( code ) );
+			proc.on( 'error', err => reject( err ) );
+		} );
+
+	const [ sourceCode, targetCode ] = await Promise.all( [ exitOf( source ), exitOf( target ) ] );
+
+	if ( sourceCode !== 0 && targetCode !== 0 ) {
+		throw new Error(
+			`db dump pipeline failed: source 'wp db export' exit ${ sourceCode }; target 'wp db import' exit ${ targetCode }.`
+		);
+	}
+	if ( sourceCode !== 0 ) {
+		throw new Error(
+			`source 'wp db export' failed (exit ${ sourceCode }). Target import is unreliable; aborting clone.`
+		);
+	}
+	if ( targetCode !== 0 ) {
+		throw new Error( `target 'wp db import' failed (exit ${ targetCode }).` );
+	}
+};
+
+/**
  * Clone the database of a running source instance into a freshly-started target instance.
  *
  * Waits for the target's WordPress container to be ready, then skips if the target is already
@@ -292,19 +342,12 @@ const cloneDatabase = async ( argv, source, target, targetEnv ) => {
 	);
 
 	console.log( chalk.cyan( 'Dumping source DB and importing into target…' ) );
-	const pipe = spawnSync(
-		'bash',
-		[
-			'-c',
-			'docker exec "$1" wp db export - --path="$3" | docker exec -i "$2" wp db import - --path="$3"',
-			'--',
-			sourceWp,
-			targetWp,
-			wpPath,
-		],
-		{ stdio: 'inherit' }
-	);
-	checkProcessResult( pipe );
+	try {
+		await pipeDbDump( sourceWp, targetWp, wpPath );
+	} catch ( err ) {
+		console.error( chalk.red( err.message ) );
+		process.exit( 1 );
+	}
 
 	if ( sourceSiteUrl !== targetSiteUrl ) {
 		console.log( chalk.cyan( `Rewriting URLs: ${ sourceSiteUrl } → ${ targetSiteUrl }` ) );

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -13,7 +13,7 @@ jest.unstable_mockModule( 'fs', () => ( {
 	...fsStub,
 } ) );
 
-const { getProjectName, buildEnv, resolveCloneSource, normalizeProjectShortName } = await import(
+const { getProjectName, buildEnv, resolveDevCloneSource, normalizeProjectShortName } = await import(
 	'../../../commands/docker.js'
 );
 
@@ -84,30 +84,35 @@ describe( 'buildEnv', () => {
 	} );
 } );
 
-describe( 'resolveCloneSource', () => {
+describe( 'resolveDevCloneSource', () => {
 	test( 'returns null when --name is not set (primary dev instance path)', () => {
-		expect( resolveCloneSource( { type: 'dev', clone: true } ) ).toBeNull();
+		expect( resolveDevCloneSource( { type: 'dev', clone: true } ) ).toBeNull();
+	} );
+
+	test( 'returns null for type=e2e regardless of other flags', () => {
+		expect( resolveDevCloneSource( { type: 'e2e', name: 'foo', clone: true } ) ).toBeNull();
+		expect( resolveDevCloneSource( { type: 'e2e', name: 'foo', cloneFrom: 'dev' } ) ).toBeNull();
 	} );
 
 	test( 'auto-picks jetpack_dev when --name is set', () => {
-		expect( resolveCloneSource( { type: 'dev', name: 'feature', clone: true } ) ).toEqual( {
+		expect( resolveDevCloneSource( { type: 'dev', name: 'feature', clone: true } ) ).toEqual( {
 			source: 'jetpack_dev',
 			explicit: false,
 		} );
 	} );
 
 	test( '--no-clone (clone=false) short-circuits auto-clone', () => {
-		expect( resolveCloneSource( { type: 'dev', name: 'feature', clone: false } ) ).toBeNull();
+		expect( resolveDevCloneSource( { type: 'dev', name: 'feature', clone: false } ) ).toBeNull();
 	} );
 
 	test( '--clone-from wins over --no-clone', () => {
 		expect(
-			resolveCloneSource( { type: 'dev', name: 'feature', clone: false, cloneFrom: 'other' } )
+			resolveDevCloneSource( { type: 'dev', name: 'feature', clone: false, cloneFrom: 'other' } )
 		).toEqual( { source: 'jetpack_other', explicit: true } );
 	} );
 
 	test( '--clone-from works without --name (explicit wins over auto gating)', () => {
-		expect( resolveCloneSource( { type: 'dev', clone: true, cloneFrom: 'other' } ) ).toEqual( {
+		expect( resolveDevCloneSource( { type: 'dev', clone: true, cloneFrom: 'other' } ) ).toEqual( {
 			source: 'jetpack_other',
 			explicit: true,
 		} );
@@ -115,12 +120,12 @@ describe( 'resolveCloneSource', () => {
 
 	test( '--clone-from normalizes short name to full project name', () => {
 		expect(
-			resolveCloneSource( { type: 'dev', name: 'feature', clone: true, cloneFrom: 'scratch' } )
+			resolveDevCloneSource( { type: 'dev', name: 'feature', clone: true, cloneFrom: 'scratch' } )
 		).toEqual( { source: 'jetpack_scratch', explicit: true } );
 	} );
 
 	test( 'returns null when target would be the same as source (--name dev)', () => {
-		expect( resolveCloneSource( { type: 'dev', name: 'dev', clone: true } ) ).toBeNull();
+		expect( resolveDevCloneSource( { type: 'dev', name: 'dev', clone: true } ) ).toBeNull();
 	} );
 } );
 

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'events';
+import { Readable, Writable } from 'stream';
 import { jest } from '@jest/globals';
 
 const fsStub = {
@@ -13,9 +15,56 @@ jest.unstable_mockModule( 'fs', () => ( {
 	...fsStub,
 } ) );
 
-const { getProjectName, buildEnv, resolveDevCloneSource, normalizeProjectShortName } = await import(
-	'../../../commands/docker.js'
-);
+const cpStub = {
+	spawn: jest.fn(),
+	spawnSync: jest.fn( () => ( { status: 0, stdout: '', stderr: '' } ) ),
+};
+jest.unstable_mockModule( 'child_process', () => ( {
+	default: cpStub,
+	...cpStub,
+} ) );
+
+const { getProjectName, buildEnv, resolveDevCloneSource, normalizeProjectShortName, pipeDbDump } =
+	await import( '../../../commands/docker.js' );
+
+/**
+ * Build a minimum-viable mock child_process. Emits `exit` (and `close`) on the next tick
+ * with the configured exit code; `stdout` ends with the optional payload; `stdin` is a
+ * sink so `source.stdout.pipe(target.stdin)` doesn't backpressure the test.
+ *
+ * @param {object} opts                 - Mock-process options.
+ * @param {number} [opts.exitCode=0]    - Exit code to emit.
+ * @param {string} [opts.stdoutData=''] - Bytes to push on stdout before EOF.
+ * @param {Error}  [opts.error]         - If set, emit 'error' before exit.
+ * @return {EventEmitter} Mock process with .stdout / .stdin streams attached.
+ */
+const makeMockProc = ( { exitCode = 0, stdoutData = '', error = null } = {} ) => {
+	const proc = new EventEmitter();
+	proc.stdout = new Readable( { read() {} } );
+	proc.stdin = new Writable( {
+		write( _chunk, _enc, cb ) {
+			cb();
+		},
+	} );
+	setImmediate( () => {
+		if ( error ) {
+			proc.emit( 'error', error );
+		}
+		if ( stdoutData ) {
+			proc.stdout.push( stdoutData );
+		}
+		proc.stdout.push( null );
+		proc.emit( 'exit', exitCode );
+		proc.emit( 'close', exitCode );
+	} );
+	return proc;
+};
+
+beforeEach( () => {
+	cpStub.spawn.mockReset();
+	cpStub.spawnSync.mockReset();
+	cpStub.spawnSync.mockReturnValue( { status: 0, stdout: '', stderr: '' } );
+} );
 
 describe( 'getProjectName', () => {
 	test( 'defaults to jetpack_dev for dev type with no name', () => {
@@ -152,6 +201,56 @@ describe( 'normalizeProjectShortName', () => {
 		expect( () => normalizeProjectShortName( '-leading-dash' ) ).toThrow( /Invalid project name/ );
 		expect( () => normalizeProjectShortName( '_leading-underscore' ) ).toThrow(
 			/Invalid project name/
+		);
+	} );
+} );
+
+describe( 'pipeDbDump', () => {
+	test( 'resolves when both source and target exit 0', async () => {
+		cpStub.spawn
+			.mockReturnValueOnce( makeMockProc( { exitCode: 0, stdoutData: 'INSERT INTO ...' } ) )
+			.mockReturnValueOnce( makeMockProc( { exitCode: 0 } ) );
+		await expect( pipeDbDump( 'src-wp-1', 'tgt-wp-1', '/var/www/html' ) ).resolves.toBeUndefined();
+		expect( cpStub.spawn ).toHaveBeenCalledTimes( 2 );
+		const sourceCall = cpStub.spawn.mock.calls[ 0 ];
+		const targetCall = cpStub.spawn.mock.calls[ 1 ];
+		expect( sourceCall[ 0 ] ).toBe( 'docker' );
+		expect( sourceCall[ 1 ] ).toEqual(
+			expect.arrayContaining( [ 'exec', 'src-wp-1', 'wp', 'db', 'export' ] )
+		);
+		expect( targetCall[ 0 ] ).toBe( 'docker' );
+		expect( targetCall[ 1 ] ).toEqual(
+			expect.arrayContaining( [ 'exec', '-i', 'tgt-wp-1', 'wp', 'db', 'import' ] )
+		);
+	} );
+
+	test( 'rejects with source attribution when source export fails (target import "succeeds")', async () => {
+		// This is the silent-failure scenario the bash version masked: source exits 1 but
+		// the importer happily consumed whatever bytes it got and exits 0. The pipe used
+		// to report success because pipefail wasn't set.
+		cpStub.spawn
+			.mockReturnValueOnce( makeMockProc( { exitCode: 1, stdoutData: '' } ) )
+			.mockReturnValueOnce( makeMockProc( { exitCode: 0 } ) );
+		await expect( pipeDbDump( 'src-wp-1', 'tgt-wp-1', '/var/www/html' ) ).rejects.toThrow(
+			/source.*wp db export.*exit 1/i
+		);
+	} );
+
+	test( 'rejects with target attribution when target import fails', async () => {
+		cpStub.spawn
+			.mockReturnValueOnce( makeMockProc( { exitCode: 0, stdoutData: 'INSERT...' } ) )
+			.mockReturnValueOnce( makeMockProc( { exitCode: 2 } ) );
+		await expect( pipeDbDump( 'src-wp-1', 'tgt-wp-1', '/var/www/html' ) ).rejects.toThrow(
+			/target.*wp db import.*exit 2/i
+		);
+	} );
+
+	test( 'rejects mentioning both sides when both fail', async () => {
+		cpStub.spawn
+			.mockReturnValueOnce( makeMockProc( { exitCode: 1 } ) )
+			.mockReturnValueOnce( makeMockProc( { exitCode: 3 } ) );
+		await expect( pipeDbDump( 'src-wp-1', 'tgt-wp-1', '/var/www/html' ) ).rejects.toThrow(
+			/source.*exit 1.*target.*exit 3/is
 		);
 	} );
 } );

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -3,12 +3,13 @@ import { Readable, Writable } from 'stream';
 import { jest } from '@jest/globals';
 
 const fsStub = {
-	readFileSync: () => '',
-	writeFileSync: () => {},
-	existsSync: () => false,
-	mkdirSync: () => {},
-	closeSync: () => {},
-	openSync: () => 0,
+	readFileSync: jest.fn( () => '' ),
+	writeFileSync: jest.fn(),
+	appendFileSync: jest.fn(),
+	existsSync: jest.fn( () => false ),
+	mkdirSync: jest.fn(),
+	closeSync: jest.fn(),
+	openSync: jest.fn( () => 0 ),
 };
 jest.unstable_mockModule( 'fs', () => ( {
 	default: fsStub,
@@ -24,8 +25,20 @@ jest.unstable_mockModule( 'child_process', () => ( {
 	...cpStub,
 } ) );
 
-const { getProjectName, buildEnv, resolveDevCloneSource, normalizeProjectShortName, pipeDbDump } =
-	await import( '../../../commands/docker.js' );
+const {
+	getProjectName,
+	buildEnv,
+	resolveDevCloneSource,
+	normalizeProjectShortName,
+	pipeDbDump,
+	readEnvFile,
+	snapshotFlagArgv,
+	augmentArgvFromEnvFile,
+	detectEnvConflicts,
+	persistParallelEnv,
+	applyUpdateEnv,
+	PARALLEL_ENV_KEYS,
+} = await import( '../../../commands/docker.js' );
 
 /**
  * Build a minimum-viable mock child_process. Emits `exit` (and `close`) on the next tick
@@ -61,6 +74,12 @@ const makeMockProc = ( { exitCode = 0, stdoutData = '', error = null } = {} ) =>
 };
 
 beforeEach( () => {
+	fsStub.readFileSync.mockReset();
+	fsStub.writeFileSync.mockReset();
+	fsStub.appendFileSync.mockReset();
+	fsStub.existsSync.mockReset();
+	fsStub.readFileSync.mockReturnValue( '' );
+	fsStub.existsSync.mockReturnValue( false );
 	cpStub.spawn.mockReset();
 	cpStub.spawnSync.mockReset();
 	cpStub.spawnSync.mockReturnValue( { status: 0, stdout: '', stderr: '' } );
@@ -202,6 +221,328 @@ describe( 'normalizeProjectShortName', () => {
 		expect( () => normalizeProjectShortName( '_leading-underscore' ) ).toThrow(
 			/Invalid project name/
 		);
+	} );
+} );
+
+describe( 'PARALLEL_ENV_KEYS', () => {
+	test( 'covers the full parallel-instance key set', () => {
+		expect( PARALLEL_ENV_KEYS ).toEqual( [
+			'COMPOSE_PROJECT_NAME',
+			'PORT_WORDPRESS',
+			'PORT_PHPMY',
+			'PORT_INBOX',
+			'PORT_SMTP',
+			'PORT_SFTP',
+		] );
+	} );
+} );
+
+describe( 'readEnvFile', () => {
+	test( 'returns {} when the file does not exist', () => {
+		fsStub.existsSync.mockReturnValue( false );
+		expect( readEnvFile( '/tmp/missing.env' ) ).toEqual( {} );
+	} );
+
+	test( 'parses key=value pairs from the file', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue(
+			'COMPOSE_PROJECT_NAME=jetpack_foo\nPORT_WORDPRESS=8080\n'
+		);
+		expect( readEnvFile( '/tmp/.env' ) ).toEqual( {
+			COMPOSE_PROJECT_NAME: 'jetpack_foo',
+			PORT_WORDPRESS: '8080',
+		} );
+	} );
+
+	test( 'tolerates blank lines and comments', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue(
+			'# A comment\n\nWP_ADMIN_USER=cg\n# another\nPORT_INBOX=1180\n'
+		);
+		const parsed = readEnvFile( '/tmp/.env' );
+		expect( parsed.WP_ADMIN_USER ).toBe( 'cg' );
+		expect( parsed.PORT_INBOX ).toBe( '1180' );
+	} );
+} );
+
+describe( 'snapshotFlagArgv', () => {
+	test( 'extracts only parallel-instance flag fields', () => {
+		const argv = {
+			name: 'foo',
+			port: 8080,
+			portPhpmy: 8281,
+			portInbox: 1180,
+			portSmtp: 2525,
+			portSftp: 1122,
+			type: 'dev',
+			updateEnv: true,
+		};
+		expect( snapshotFlagArgv( argv ) ).toEqual( {
+			name: 'foo',
+			port: 8080,
+			portPhpmy: 8281,
+			portInbox: 1180,
+			portSmtp: 2525,
+			portSftp: 1122,
+		} );
+	} );
+
+	test( 'snapshot does not change when the source argv is mutated later', () => {
+		const argv = { name: undefined, port: undefined };
+		const snap = snapshotFlagArgv( argv );
+		argv.name = 'augmented';
+		argv.port = 8090;
+		expect( snap.name ).toBeUndefined();
+		expect( snap.port ).toBeUndefined();
+	} );
+} );
+
+describe( 'augmentArgvFromEnvFile', () => {
+	test( 'leaves argv alone when fileEnv is empty', () => {
+		const argv = { type: 'dev' };
+		augmentArgvFromEnvFile( argv, {} );
+		expect( argv ).toEqual( { type: 'dev' } );
+	} );
+
+	test( 'fills argv.port from PORT_WORDPRESS when --port not passed', () => {
+		const argv = { type: 'dev' };
+		augmentArgvFromEnvFile( argv, { PORT_WORDPRESS: '8080' } );
+		expect( argv.port ).toBe( 8080 );
+	} );
+
+	test( 'does NOT overwrite argv.port when --port was passed', () => {
+		const argv = { type: 'dev', port: 8090 };
+		augmentArgvFromEnvFile( argv, { PORT_WORDPRESS: '8080' } );
+		expect( argv.port ).toBe( 8090 );
+	} );
+
+	test( 'infers argv.name from COMPOSE_PROJECT_NAME=jetpack_foo', () => {
+		const argv = { type: 'dev' };
+		augmentArgvFromEnvFile( argv, { COMPOSE_PROJECT_NAME: 'jetpack_foo' } );
+		expect( argv.name ).toBe( 'foo' );
+	} );
+
+	test( 'does NOT infer argv.name from COMPOSE_PROJECT_NAME=jetpack_dev', () => {
+		const argv = { type: 'dev' };
+		augmentArgvFromEnvFile( argv, { COMPOSE_PROJECT_NAME: 'jetpack_dev' } );
+		expect( argv.name ).toBeUndefined();
+	} );
+
+	test( 'does NOT infer argv.name from COMPOSE_PROJECT_NAME=jetpack_e2e', () => {
+		const argv = { type: 'e2e' };
+		augmentArgvFromEnvFile( argv, { COMPOSE_PROJECT_NAME: 'jetpack_e2e' } );
+		expect( argv.name ).toBeUndefined();
+	} );
+
+	test( 'ignores malformed COMPOSE_PROJECT_NAME values', () => {
+		const argv = { type: 'dev' };
+		augmentArgvFromEnvFile( argv, { COMPOSE_PROJECT_NAME: 'something_else' } );
+		expect( argv.name ).toBeUndefined();
+	} );
+
+	test( 'fills all five auxiliary ports when corresponding flag is undefined', () => {
+		const argv = { type: 'dev' };
+		augmentArgvFromEnvFile( argv, {
+			PORT_PHPMY: '8281',
+			PORT_INBOX: '1180',
+			PORT_SMTP: '2525',
+			PORT_SFTP: '1122',
+		} );
+		expect( argv.portPhpmy ).toBe( 8281 );
+		expect( argv.portInbox ).toBe( 1180 );
+		expect( argv.portSmtp ).toBe( 2525 );
+		expect( argv.portSftp ).toBe( 1122 );
+	} );
+
+	test( 'flags-set fields take precedence per-key, .env fills in the rest', () => {
+		const argv = { type: 'dev', port: 9999 };
+		augmentArgvFromEnvFile( argv, { PORT_WORDPRESS: '8080', PORT_PHPMY: '8281' } );
+		expect( argv.port ).toBe( 9999 );
+		expect( argv.portPhpmy ).toBe( 8281 );
+	} );
+} );
+
+describe( 'detectEnvConflicts', () => {
+	test( 'returns [] when fileEnv is empty', () => {
+		expect( detectEnvConflicts( { name: 'foo', port: 8080 }, {} ) ).toEqual( [] );
+	} );
+
+	test( 'returns [] when flag and .env values agree', () => {
+		expect(
+			detectEnvConflicts(
+				{ name: 'foo', port: 8080 },
+				{ COMPOSE_PROJECT_NAME: 'jetpack_foo', PORT_WORDPRESS: '8080' }
+			)
+		).toEqual( [] );
+	} );
+
+	test( 'flags PORT_WORDPRESS conflict', () => {
+		expect( detectEnvConflicts( { port: 8090 }, { PORT_WORDPRESS: '8080' } ) ).toEqual( [
+			{ key: 'PORT_WORDPRESS', fileValue: '8080', flagValue: '8090' },
+		] );
+	} );
+
+	test( 'flags COMPOSE_PROJECT_NAME conflict', () => {
+		expect(
+			detectEnvConflicts( { name: 'bar' }, { COMPOSE_PROJECT_NAME: 'jetpack_foo' } )
+		).toEqual( [
+			{ key: 'COMPOSE_PROJECT_NAME', fileValue: 'jetpack_foo', flagValue: 'jetpack_bar' },
+		] );
+	} );
+
+	test( 'aggregates multiple conflicts', () => {
+		const conflicts = detectEnvConflicts(
+			{ name: 'bar', port: 8090, portInbox: 1280 },
+			{
+				COMPOSE_PROJECT_NAME: 'jetpack_foo',
+				PORT_WORDPRESS: '8080',
+				PORT_INBOX: '1280', // matches — should not appear
+			}
+		);
+		expect( conflicts ).toHaveLength( 2 );
+		expect( conflicts.map( c => c.key ) ).toEqual( [ 'COMPOSE_PROJECT_NAME', 'PORT_WORDPRESS' ] );
+	} );
+
+	test( 'does not flag a conflict when only .env has a value (no flag passed)', () => {
+		expect( detectEnvConflicts( {}, { PORT_WORDPRESS: '8080' } ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'persistParallelEnv', () => {
+	test( 'no-op when no parallel keys are present in envOpts', () => {
+		const written = persistParallelEnv( {}, '/tmp/.env' );
+		expect( written ).toEqual( [] );
+		expect( fsStub.appendFileSync ).not.toHaveBeenCalled();
+	} );
+
+	test( 'writes all six keys when .env is empty', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue( '' );
+		const envOpts = {
+			COMPOSE_PROJECT_NAME: 'jetpack_foo',
+			PORT_WORDPRESS: 8080,
+			PORT_PHPMY: 8281,
+			PORT_INBOX: 1180,
+			PORT_SMTP: 2525,
+			PORT_SFTP: 1122,
+		};
+		const written = persistParallelEnv( envOpts, '/tmp/.env' );
+		expect( written ).toEqual( PARALLEL_ENV_KEYS );
+		expect( fsStub.appendFileSync ).toHaveBeenCalledTimes( 1 );
+		const [ path, content ] = fsStub.appendFileSync.mock.calls[ 0 ];
+		expect( path ).toBe( '/tmp/.env' );
+		for ( const key of PARALLEL_ENV_KEYS ) {
+			expect( content ).toContain( `${ key }=${ envOpts[ key ] }` );
+		}
+	} );
+
+	test( 'skips keys already present in .env (Strategy B)', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue(
+			'WP_ADMIN_USER=cg\nPORT_WORDPRESS=8080\nCOMPOSE_PROJECT_NAME=jetpack_foo\n'
+		);
+		const envOpts = {
+			COMPOSE_PROJECT_NAME: 'jetpack_foo',
+			PORT_WORDPRESS: 8080,
+			PORT_PHPMY: 8281,
+			PORT_INBOX: 1180,
+		};
+		const written = persistParallelEnv( envOpts, '/tmp/.env' );
+		expect( written ).toEqual( [ 'PORT_PHPMY', 'PORT_INBOX' ] );
+		const [ , content ] = fsStub.appendFileSync.mock.calls[ 0 ];
+		expect( content ).toContain( 'PORT_PHPMY=8281' );
+		expect( content ).toContain( 'PORT_INBOX=1180' );
+		expect( content ).not.toContain( 'PORT_WORDPRESS=' );
+		expect( content ).not.toContain( 'COMPOSE_PROJECT_NAME=' );
+	} );
+
+	test( 'fully no-op when every parallel key is already in .env', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue(
+			[
+				'COMPOSE_PROJECT_NAME=jetpack_foo',
+				'PORT_WORDPRESS=8080',
+				'PORT_PHPMY=8281',
+				'PORT_INBOX=1180',
+				'PORT_SMTP=2525',
+				'PORT_SFTP=1122',
+			].join( '\n' )
+		);
+		const written = persistParallelEnv(
+			{
+				COMPOSE_PROJECT_NAME: 'jetpack_foo',
+				PORT_WORDPRESS: 8080,
+				PORT_PHPMY: 8281,
+				PORT_INBOX: 1180,
+				PORT_SMTP: 2525,
+				PORT_SFTP: 1122,
+			},
+			'/tmp/.env'
+		);
+		expect( written ).toEqual( [] );
+		expect( fsStub.appendFileSync ).not.toHaveBeenCalled();
+	} );
+
+	test( 'never modifies non-parallel keys', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue( 'WP_ADMIN_USER=cg\nWP_ADMIN_PASSWORD=secret\n' );
+		persistParallelEnv(
+			{ COMPOSE_PROJECT_NAME: 'jetpack_foo', PORT_WORDPRESS: 8080 },
+			'/tmp/.env'
+		);
+		expect( fsStub.writeFileSync ).not.toHaveBeenCalled();
+		const [ , content ] = fsStub.appendFileSync.mock.calls[ 0 ];
+		expect( content ).not.toContain( 'WP_ADMIN_USER' );
+		expect( content ).not.toContain( 'WP_ADMIN_PASSWORD' );
+	} );
+} );
+
+describe( 'applyUpdateEnv', () => {
+	test( 'no-op when conflicts is empty', () => {
+		const updated = applyUpdateEnv( '/tmp/.env', [] );
+		expect( updated ).toEqual( [] );
+		expect( fsStub.writeFileSync ).not.toHaveBeenCalled();
+	} );
+
+	test( 'replaces a single conflicting line, leaves rest verbatim', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue(
+			'WP_ADMIN_USER=cg\nPORT_WORDPRESS=8080\nWP_DOMAIN=localhost\n'
+		);
+		applyUpdateEnv( '/tmp/.env', [
+			{ key: 'PORT_WORDPRESS', fileValue: '8080', flagValue: '8090' },
+		] );
+		const [ , content ] = fsStub.writeFileSync.mock.calls[ 0 ];
+		expect( content ).toContain( 'WP_ADMIN_USER=cg' );
+		expect( content ).toContain( 'PORT_WORDPRESS=8090' );
+		expect( content ).not.toContain( 'PORT_WORDPRESS=8080' );
+		expect( content ).toContain( 'WP_DOMAIN=localhost' );
+	} );
+
+	test( 'replaces multiple conflicts in one pass', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue(
+			'COMPOSE_PROJECT_NAME=jetpack_foo\nPORT_WORDPRESS=8080\nPORT_PHPMY=8281\n'
+		);
+		const updated = applyUpdateEnv( '/tmp/.env', [
+			{ key: 'COMPOSE_PROJECT_NAME', fileValue: 'jetpack_foo', flagValue: 'jetpack_bar' },
+			{ key: 'PORT_PHPMY', fileValue: '8281', flagValue: '8381' },
+		] );
+		expect( updated ).toEqual( [ 'COMPOSE_PROJECT_NAME', 'PORT_PHPMY' ] );
+		const [ , content ] = fsStub.writeFileSync.mock.calls[ 0 ];
+		expect( content ).toContain( 'COMPOSE_PROJECT_NAME=jetpack_bar' );
+		expect( content ).toContain( 'PORT_PHPMY=8381' );
+		expect( content ).toContain( 'PORT_WORDPRESS=8080' );
+	} );
+
+	test( 'preserves indentation when present', () => {
+		fsStub.existsSync.mockReturnValue( true );
+		fsStub.readFileSync.mockReturnValue( '  PORT_WORDPRESS=8080\n' );
+		applyUpdateEnv( '/tmp/.env', [
+			{ key: 'PORT_WORDPRESS', fileValue: '8080', flagValue: '8090' },
+		] );
+		const [ , content ] = fsStub.writeFileSync.mock.calls[ 0 ];
+		expect( content ).toContain( '  PORT_WORDPRESS=8090' );
 	} );
 } );
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -179,6 +179,7 @@ This gives you `jetpack_feature-*` containers running in parallel with `jetpack_
 | `--port-sftp <n>` | all | `1022` | Host port for the SFTP container. |
 | `--clone-from <name>` | `dev` + `up` | — | Clone the DB from an existing running instance (e.g. `--clone-from feature`). The target site ends up with an installed WordPress populated from the source. |
 | `--no-clone` | `dev` + `up` | (auto-clone on) | Opt out of auto-cloning and get the default fresh-install flow instead. |
+| `--update-env` | `dev` + `up` | `false` | When a flag value conflicts with `tools/docker/.env`, rewrite the conflicting key in `.env` to match the flag. Without this, the flag wins for the current run only and a warning is printed; `.env` is left untouched. |
 
 #### Auto-clone behavior
 
@@ -203,6 +204,49 @@ jetpack docker up -d --name staging --port 8082 --clone-from feature
 jetpack docker up -d --name clean --port 8090 --no-clone
 jetpack docker install --name clean --port 8090
 ```
+
+#### How `.env` is used
+
+The CLI treats the worktree's `tools/docker/.env` as a per-instance config file, in addition to (not instead of) the CLI flags. This means a worktree configured once can be brought back up with bare `jetpack docker up` afterwards — the flag set above is only needed on the first invocation.
+
+**Read precedence on `up`** (last wins):
+
+`tools/docker/default.env` → worktree's `tools/docker/.env` → CLI flags → `process.env`
+
+**What the CLI writes:**
+
+* On `up --name <slug>`, after the instance is up, the CLI **appends** any of the following keys to `tools/docker/.env` that aren't already present: `COMPOSE_PROJECT_NAME`, `PORT_WORDPRESS`, `PORT_PHPMY`, `PORT_INBOX`, `PORT_SMTP`, `PORT_SFTP`. Existing lines are never modified or reordered.
+* The primary `jetpack_dev` flow (no `--name`) **never** writes to `.env`. Your main checkout's `.env` stays as you've set it.
+
+**Conflicts between flags and `.env`:**
+
+If you pass a flag (e.g. `--port 8090`) whose value differs from the corresponding `.env` entry (e.g. `PORT_WORDPRESS=8080`), the CLI:
+
+* uses the flag for the current run, and
+* prints a one-line warning naming the key, both values, and how to make it stick.
+
+`.env` is left untouched. To make the new value persistent, pass `--update-env` and the conflicting keys are rewritten in place — every other line preserved verbatim.
+
+```sh
+# First time — flags only, .env empty
+jetpack docker up -d --name feature --port 8080 --port-phpmy 8281 \
+  --port-inbox 1180 --port-smtp 2525 --port-sftp 1122
+# → CLI appends the 6 keys to tools/docker/.env
+
+# Subsequent runs — bare command works
+jetpack docker up -d
+# → reads .env, brings up jetpack_feature on port 8080
+
+# Override for one run; .env stays at 8080
+jetpack docker up -d --port 8090
+# → ⚠ warning, runs on 8090
+
+# Persist the override
+jetpack docker up -d --port 8090 --update-env
+# → tools/docker/.env's PORT_WORDPRESS is rewritten to 8090
+```
+
+`.env` is `git`-ignored, so per-worktree state stays local. Removing the worktree removes the file.
 
 #### Cleaning up a parallel instance
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -191,6 +191,7 @@ The auto-clone is only triggered when all of the following are true:
 * `jetpack_dev` has at least one running container.
 * `--no-clone` was not passed.
 * The target doesn't already have an installed WordPress (re-running `up` on an existing instance is a safe no-op).
+* The target instance is actually running by the time the clone step fires, which in practice means `-d` / `--detached` was passed. If you run `up` in the foreground (no `-d`), compose blocks until you exit it, the parallel target stops, and the auto-clone is silently skipped (there's nowhere to write into). For any persistent parallel instance — including the `/work-on` flow — always pass `-d`.
 
 The clone runs `wp db export | wp db import` between the source and target containers, then `wp search-replace` on the target to rewrite the siteurl to `http://localhost:<target-port>`. `guid` columns are skipped as WP-CLI recommends.
 

--- a/tools/docker/default.env
+++ b/tools/docker/default.env
@@ -9,6 +9,16 @@
 #
 # Note that there is no special handling of quotation marks.
 # This means that they are part of the value.
+#
+# Parallel-instance keys managed by the CLI:
+# When you run `jetpack docker up --name <slug>` from a worktree, the CLI may
+# APPEND any of the following keys to that worktree's tools/docker/.env so
+# subsequent bare `jetpack docker up` runs in the same worktree pick them up:
+#   COMPOSE_PROJECT_NAME, PORT_WORDPRESS, PORT_PHPMY,
+#   PORT_INBOX, PORT_SMTP, PORT_SFTP
+# It only appends keys that don't already exist; lines outside that set are
+# never modified. Pass --update-env on `up` to rewrite a conflicting key in
+# place. See tools/docker/README.md § "Parallel development environments".
 
 # WordPress
 WP_DOMAIN=localhost


### PR DESCRIPTION
Fixes # <!-- no ticket; PR review follow-up to #48153 -->

## Proposed changes

Stacked PR responding to the eight review comments on [#48153](https://github.com/Automattic/jetpack/pull/48153). Targets the original PR branch (`change/docker-cli-parallel-flags`) rather than `trunk` so it can be held, merged into the parent, or discarded as a unit. Each commit corresponds to one (or two related) review threads; the commit message quotes the reviewer verbatim and links back to the `#discussion_r…` URL so the rationale travels with the code.

### Commit-by-thread map

| Commit | Thread(s) | Reviewer comment | What changed |
|---|---|---|---|
| `579d27a3e4b` | [Thread 4](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119622848) — @anomiex | "It probably also doesn't make sense for `--type=e2e`. The E2E framework probably wants to populate the database instead." | Renamed `resolveCloneSource` → `resolveDevCloneSource`; moved the `type === 'dev'` gate from the caller into the function body so it's correct on its own terms. New unit test asserts `e2e` returns `null` regardless of other flags. |
| `403cb106b29` | [Thread 5](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119645966) — @anomiex | "Meh. This probably works, but usually we do the process plumbing inside node with its `.pipe()` method on streams." | Replaced `bash -c '… \| …'` with a node-native `pipeDbDump` helper using two `spawn()` calls + `source.stdout.pipe(target.stdin)`. Each side now has its own awaited exit code. Fixes a latent silent-failure bug: the bash invocation didn't set `pipefail`, so a broken `wp db export` could be masked by a `wp db import` that exited 0 on partial input — "Clone complete" with a half-cloned DB. 4 new unit tests cover all four exit-code combinations. |
| `ae3dee033b3` | [Thread 3](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119604619) — @anomiex (+ [Thread 6](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119671524) free) | "I wonder, instead of adding all these options, if it would make more sense to write the environment variables to `tools/docker/.env` in your new worktree directory." / "I note the message is still wrong if `tools/docker/.env` was used instead..." | Hybrid `.env` config: CLI reads `tools/docker/.env` as a base layer for parallel-instance keys, flags still override per invocation, and `up --name <slug>` appends resolved values to `.env` so subsequent bare `jp docker up` from the same worktree just works. New `--update-env` flag opt-in for rewriting conflicting keys in place; default behavior is a one-line warning. Strategy B append-only persistence: existing `.env` lines (comments, `WP_ADMIN_USER`, etc.) are never modified. Thread 6's post-up-URL bug auto-resolves because `argv.port` is now reliably populated whether passed as a flag or read from `.env`. ~30 new unit tests covering precedence, conflicts, append-only, in-place updates, and the `jetpack_dev`/`jetpack_e2e` inference guard. |
| `a33494bd67d` | [Thread 8](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119704838) — @anomiex | "Also, apparently, you passed `-d` / `--detached` to `jetpack docker up`." | README precondition list for auto-clone gains a bullet explicitly explaining that without `-d`, compose runs in the foreground, the parallel target stops when you exit, and the auto-clone is silently skipped. Wording is intentionally explicit (`-d` / `--detached` keywords, trigger → consequence → prescription) so an AI agent grepping the README picks it up cleanly. The behavioral half of this thread already landed in `6c4f1fa` on the parent branch (gate on `isProjectRunning(target)` instead of `argv.detached`). |

### Threads not addressed in this PR (already resolved)

| Thread | Status |
|---|---|
| [Thread 1](https://github.com/Automattic/jetpack/pull/48153#discussion_r3111581748) — port-band uniformity (@tbradsha) | Closed by author after assessment: any uniform strategy would either suffice or fall short, and `--port-*` flags already let users handpick every port. |
| [Thread 2](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119554012) — `lsof`-based port detection (@anomiex) | Fixed in `bb30b85` on the parent branch. |
| [Thread 7](https://github.com/Automattic/jetpack/pull/48153#discussion_r3119677576) — `argv.detached` gate on auto-clone (@anomiex) | Fixed in `6c4f1fa` on the parent branch. |

## Related product discussion/links

* Original PR: [#48153](https://github.com/Automattic/jetpack/pull/48153) (target branch of this PR)
* No external links — internal infra follow-up.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Quick — unit tests

From `tools/cli`:

```sh
pnpm test
```

Expected: 152 passed, 3 skipped (existing). New coverage spans `resolveDevCloneSource` e2e guard, `pipeDbDump` exit-code matrix, the `.env` precedence + Strategy B append-only behavior, conflict aggregation, and `applyUpdateEnv` line-replacement.

### Two-instance smoke test (the high-value path)

Confirms the hybrid `.env` flow end-to-end. Assumes `jetpack_dev` is up and installed.

1. **First-time bootstrap of a parallel instance**, with the full flag set:
   ```sh
   git worktree add --detach ../jetpack-envtest <this-branch>
   cd ../jetpack-envtest
   pnpm install --frozen-lockfile --prefer-offline
   jetpack docker up -d \
     --name envtest \
     --port 8080 \
     --port-phpmy 8281 \
     --port-inbox 1180 \
     --port-smtp 2525 \
     --port-sftp 1122
   ```
   Expected: parallel `jetpack_envtest-*` containers running. Output ends with `Persisted to tools/docker/.env: COMPOSE_PROJECT_NAME, PORT_WORDPRESS, PORT_PHPMY, PORT_INBOX, PORT_SMTP, PORT_SFTP. …`
2. **Verify `.env` was appended (not rewritten):**
   ```sh
   cat tools/docker/.env
   ```
   You should see your existing keys (`WP_ADMIN_USER`, etc.) untouched, followed by a comment block and the six parallel-instance keys.
3. **Bare `up` reads `.env`:**
   ```sh
   jetpack docker stop --name envtest
   jetpack docker up -d
   ```
   No flags this time. Expected: `jetpack_envtest-*` comes back up on the same ports. No warnings.
4. **Conflict warn (no `--update-env`):**
   ```sh
   jetpack docker up -d --port 8090
   ```
   Expected: yellow `⚠ PORT_WORDPRESS: flag value '8090' differs from .env value '8080'. Using flag for this run; pass --update-env to persist, or drop the flag to use .env.` `tools/docker/.env` unchanged on disk. Site comes up on `:8090` for this run.
5. **`--update-env` rewrites in place:**
   ```sh
   jetpack docker up -d --port 8090 --update-env
   ```
   Expected: cyan `Updated tools/docker/.env keys to match flags: PORT_WORDPRESS.` `cat tools/docker/.env` shows the line is now `PORT_WORDPRESS=8090`; every other line preserved verbatim.
6. **`pipeDbDump` failure attribution.** Hard to provoke deliberately without breaking your DB; the unit tests cover the four exit-code combinations. The behavior-of-record on success is unchanged: `Cloning database: jetpack_dev → jetpack_envtest` followed by `Dumping source DB and importing into target…` and `Clone complete. Target site ready at http://localhost:8090/`.
7. **Primary `jetpack_dev` is still untouched** — from your main checkout (NOT the worktree):
   ```sh
   cat tools/docker/.env  # whatever you'd configured before this PR
   jetpack docker up -d
   cat tools/docker/.env  # unchanged — primary flow never writes
   ```

### Teardown

```sh
jetpack docker stop --name envtest
jetpack docker clean --name envtest   # nuke the parallel DB
git worktree remove --force ../jetpack-envtest
```

### Regression notes

* The `--type=e2e` flow is unaffected: `resolveDevCloneSource` returns `null` for e2e regardless of other flags, so e2e never auto-clones (which it shouldn't — it manages its own DB).
* `bash` is no longer a dependency for the clone path; portable to any node-supported platform.
* `process.env` and `default.env` precedence rules unchanged.
