### PR TITLE
wpcom-admin-menu: dedupe submenu reorder to fix duplicate Podcasting

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-podcasting-duplicate-submenu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-podcasting-duplicate-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+wpcom-admin-menu: dedupe submenu reorder so a slug that's a substring of another doesn't register the same item twice (fixes Podcasting appearing twice under Jetpack).

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -276,11 +276,13 @@ function wpcom_reorder_submenu( $menu_slug, $desired_order ) {
 	$domain          = wp_parse_url( home_url(), PHP_URL_HOST );
 	$ordered_submenu = array();
 
-	// Re-add submenu items in the desired order.
+	// Re-add submenu items in the desired order. Dedupe because slugs in
+	// $desired_order can be substrings of one another (e.g. 'podcast' /
+	// 'podcasting'), which would otherwise match the same item twice.
 	foreach ( $desired_order as $submenu_slug ) {
 		foreach ( $submenu[ $menu_slug ] as $item ) {
 			$clean_url = str_replace( $domain, '', $item[2] );
-			if ( str_contains( $clean_url, $submenu_slug ) ) {
+			if ( str_contains( $clean_url, $submenu_slug ) && ! in_array( $item, $ordered_submenu, true ) ) {
 				$ordered_submenu[] = $item;
 			}
 		}


### PR DESCRIPTION
## Proposed changes
* `wpcom_reorder_submenu()` matches submenu items via `str_contains( $clean_url, $submenu_slug )`. The Jetpack `desired_order` list contains both `'podcast'` (new) and `'podcasting'` (legacy), and `'podcast'` is a substring of `'podcasting'` — so the legacy `…/settings/podcasting/<domain>` URL matches both slugs and the same item gets pushed into the reordered submenu twice.
* The function's second loop already dedupes via `! in_array( $item, $ordered_submenu, true )`; the first loop did not. This PR adds the same guard to the first loop, so any future substring-collision case is covered too.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. On a Simple or Atomic site with `wpcom_admin_interface=wp-admin`, ensure the `jetpack_podcast_untangle` filter is OFF (the default).
2. Visit wp-admin and open the Jetpack menu in the sidebar.
3. Before this PR: "Podcasting" appears twice under Jetpack.
4. After this PR: "Podcasting" appears once, linking to `https://wordpress.com/settings/podcasting/<domain>`.
5. Flip the `jetpack_podcast_untangle` filter on and reload — confirm the new "Podcast" item appears once (and the legacy "Podcasting" link does not).
