### PR TITLE
Write: fix media modal closing on text-selection drag outside modal

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mouse_media_popovers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mouse_media_popovers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: Fix media modal closing when mouse drag moves outside the modal during text selection.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2713,6 +2713,19 @@ const { state } = store( 'wpcom-write', {
 			}
 		},
 
+		// Close whichever media modal is open, but only when the pointerdown
+		// lands directly on the overlay backdrop — not when it starts inside
+		// the modal (e.g. while selecting text in an input) and drags out.
+		handleOverlayPointerDown( event ) {
+			if ( event.button !== 0 || event.target !== event.currentTarget ) return;
+			const { actions: a } = store( 'wpcom-write' );
+			if ( state.showImageModal ) {
+				a.closeImageModal();
+			} else if ( state.showVideoModal ) {
+				a.closeVideoModal();
+			}
+		},
+
 		stopPropagation( event ) {
 			event.stopPropagation();
 		},

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -530,7 +530,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</main>
 
 	<!-- Image modal -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal" data-wp-on--keydown="actions.handleImageModalKeyDown" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--pointerdown="actions.handleOverlayPointerDown" data-wp-on--keydown="actions.handleImageModalKeyDown" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 		<div class="bw-image-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Add an image', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.stopPropagation" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 			<h3><?php echo esc_html__( 'Add an image', 'jetpack-mu-wpcom' ); ?></h3>
 			<label class="bw-upload-zone" id="bw-upload-zone" data-wp-on--dragover="actions.handleDragOver" data-wp-on--dragleave="actions.handleDragLeave" data-wp-on--drop="actions.handleDrop">
@@ -607,7 +607,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</div>
 
 	<!-- Video modal -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showVideoModal" data-wp-on--click="actions.closeVideoModal" data-wp-on--keydown="actions.handleVideoModalKeyDown">
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showVideoModal" data-wp-on--pointerdown="actions.handleOverlayPointerDown" data-wp-on--keydown="actions.handleVideoModalKeyDown">
 		<div class="bw-image-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Embed a video', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.stopPropagation">
 			<h3><?php echo esc_html__( 'Embed a video', 'jetpack-mu-wpcom' ); ?></h3>
 			<input


### PR DESCRIPTION
Fixes RSM-2048

## Proposed changes

* Replace the `click` handler on the image and video modal overlay backdrops with a `pointerdown` handler (`handleOverlayPointerDown`).
* The new handler checks `event.button !== 0` (primary button only) and `event.target !== event.currentTarget` (pointer must land directly on the backdrop) before closing the modal.
* This prevents the modal from closing when a user starts a drag inside the modal (e.g. selecting text in an input field) and the pointer moves outside onto the overlay.
* Using `pointerdown` instead of `mousedown` ensures uniform behavior across mouse, touch, and pen input devices.

## Related product discussion/links

* RSM-2048

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to a Write editor post (e.g. `/write` on a wp.com site with the Write feature enabled).
* Open the image modal (type `/` then select "Image", or use the toolbar).
* Click inside the URL input field and drag your mouse outside the modal onto the dark overlay backdrop while selecting text.
* **Expected:** The modal stays open; text selection works normally.
* **Before this fix:** The modal would close as soon as the mouse landed on the backdrop.
* Release the mouse button. The modal should still be open.
* Click directly on the dark overlay backdrop (not inside the modal).
* **Expected:** The modal closes.
* Right-click on the overlay backdrop.
* **Expected:** The modal does **not** close (context menu appears instead).
* Repeat the above steps for the video modal (type `/` then select "Video").
* Verify that pressing Escape still closes both modals.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
