### PR TITLE
Revert bad AI edits to root eslint.config.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,51 +1,7 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// WARNING: If you (or your AI) think you need to edit this file to fix some eslint issue in a project,
+// you're almost certainly wrong. Ask for help.
+
 import autoProjects from 'jetpack-js-tools/eslintrc/auto-projects.mjs';
 import { makeBaseConfig, defineConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
 
-const rootdir = fileURLToPath( new URL( '.', import.meta.url ) );
-
-/**
- * `projects/packages/scan` uses nested `routes/<name>/package.json` for wp-build.
- * Root ESLint skips per-project configs; merge those deps for import/no-extraneous-dependencies.
- *
- * @return {string[]} Absolute paths of route folders that contain a `package.json`.
- */
-function getJetpackScanRoutePackageDirs() {
-	const routesRoot = path.join( rootdir, 'projects/packages/scan/routes' );
-	if ( ! fs.existsSync( routesRoot ) ) {
-		return [];
-	}
-	return fs
-		.readdirSync( routesRoot, { withFileTypes: true } )
-		.filter( dirent => dirent.isDirectory() )
-		.map( dirent => path.join( routesRoot, dirent.name ) )
-		.filter( dir => fs.existsSync( path.join( dir, 'package.json' ) ) );
-}
-
-const jetpackScanRoutePackageDirs = getJetpackScanRoutePackageDirs();
-
-export default defineConfig(
-	makeBaseConfig( import.meta.url ),
-	autoProjects,
-	...( jetpackScanRoutePackageDirs.length > 0
-		? [
-				{
-					name: 'Jetpack Scan (wp-build routes): merge route package.json for import deps',
-					files: [ 'projects/packages/scan/routes/**/*.{js,jsx,ts,tsx,mjs,cjs}' ],
-					rules: {
-						'import/no-extraneous-dependencies': [
-							'error',
-							{
-								packageDir: [
-									path.join( rootdir, 'projects/packages/scan' ),
-									...jetpackScanRoutePackageDirs,
-								],
-							},
-						],
-					},
-				},
-		  ]
-		: [] )
-);
+export default defineConfig( makeBaseConfig( import.meta.url ), autoProjects );


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In 08f997b0 the AI claims it was running into issues with `import/no-extraneous-dependencies`, but checking out that commit or its parent doesn't reproduce.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI eslint job happy?
