### PR TITLE
CRM: Handle out-of-range object page requests in listview

### DIFF
--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -82,7 +82,6 @@ return [
     // PhanAbstractStaticMethodCallInStatic : 2 occurrences
     // PhanParamTooFew : 2 occurrences
     // PhanParamTooMany : 2 occurrences
-    // PhanPluginDuplicateExpressionAssignment : 2 occurrences
     // PhanRedefineFunction : 2 occurrences
     // PhanTypeInvalidLeftOperandOfAdd : 2 occurrences
     // PhanTypeInvalidUnaryOperandIncOrDec : 2 occurrences
@@ -97,6 +96,7 @@ return [
     // PhanNoopVariable : 1 occurrence
     // PhanPluginDuplicateArrayKey : 1 occurrence
     // PhanPluginDuplicateCatchStatementBody : 1 occurrence
+    // PhanPluginDuplicateExpressionAssignment : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
     // PhanRedefineFunctionInternal : 1 occurrence
     // PhanSuspiciousWeakTypeComparisonInLoop : 1 occurrence
@@ -151,7 +151,7 @@ return [
         'api/create_transaction.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullableInternal'],
         'api/customers.php' => ['PhanPluginSimplifyExpressionBool'],
         'api/status.php' => ['PhanTypePossiblyInvalidDimOffset'],
-        'includes/ZeroBSCRM.AJAX.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignment', 'PhanPluginNeverReturnFunction', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredConstant'],
+        'includes/ZeroBSCRM.AJAX.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginNeverReturnFunction', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredConstant'],
         'includes/ZeroBSCRM.API.php' => ['PhanCommentParamWithoutRealParam', 'PhanRedefineFunctionInternal', 'PhanRedundantCondition'],
         'includes/ZeroBSCRM.AdminPages.Checks.php' => ['PhanPluginUnreachableCode'],
         'includes/ZeroBSCRM.AdminPages.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument'],

--- a/projects/plugins/crm/changelog/fix-crm-handle_out_of_range_object_requests
+++ b/projects/plugins/crm/changelog/fix-crm-handle_out_of_range_object_requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Listview: Handle out-of-range page requests gracefully.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -2349,8 +2349,6 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					$sortField = 'ID';
 				}
 
-					// legacy from dal1
-					$page_number = $page_number;
 				if ( $page_number < 0 ) {
 					$page_number = 0;
 				}

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -2791,7 +2791,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-					$res['objectcount'] = zeroBS_getQuotesCountIncParams( true, $per_page, $page_number, true, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
+					$res['objectcount'] = (int) zeroBS_getQuotesCountIncParams( true, $per_page, $page_number, true, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
 					// If the page requested is out of range (e.g. after a bulk action emptied the
 					// last page), use the last valid page instead.
@@ -2929,7 +2929,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-					$res['objectcount'] = zeroBS_getInvoicesCountIncParams( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
+					$res['objectcount'] = (int) zeroBS_getInvoicesCountIncParams( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
 					// If the page requested is out of range (e.g. after a bulk action emptied the
 					// last page), use the last valid page instead.
@@ -3078,7 +3078,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-					$res['objectcount'] = zeroBS_getTransactionsCountIncParams( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $possibleTagIDs, $inArray, $sortField, $sortOrder, $withTags, $possibleQuickFilters );
+					$res['objectcount'] = (int) zeroBS_getTransactionsCountIncParams( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $possibleTagIDs, $inArray, $sortField, $sortOrder, $withTags, $possibleQuickFilters );
 
 					// If the page requested is out of range (e.g. after a bulk action emptied the
 					// last page), use the last valid page instead.
@@ -3203,7 +3203,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-					$res['objectcount'] = zeroBS_getFormsCountIncParams( false, $per_page, $page_number, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
+					$res['objectcount'] = (int) zeroBS_getFormsCountIncParams( false, $per_page, $page_number, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
 					// If the page requested is out of range (e.g. after a bulk action emptied the
 					// last page), use the last valid page instead.
@@ -3420,7 +3420,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-					$res['objectcount'] = zeroBS_getQuoteTemplatesCountIncParams( false, $per_page, $page_number, $possibleSearchTerm );
+					$res['objectcount'] = (int) zeroBS_getQuoteTemplatesCountIncParams( false, $per_page, $page_number, $possibleSearchTerm );
 
 					// If the page requested is out of range (e.g. after a bulk action emptied the
 					// last page), use the last valid page instead.
@@ -3626,7 +3626,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					$count_args['page']    = -1;
 					$count_args['perPage'] = -1;
 
-					$res['objectcount'] = $zbs->DAL->events->getEvents( $count_args );
+					$res['objectcount'] = (int) $zbs->DAL->events->getEvents( $count_args );
 
 					// If the page requested is out of range (e.g. after a bulk action emptied the
 					// last page), use the last valid page instead.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -2620,6 +2620,33 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 				// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+				// If using pagination, get total count
+				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
+
+					$count_args = array(
+						'searchPhrase' => $possibleSearchTerm,
+						'quickFilters' => $possibleQuickFilters,
+						'isTagged'     => $possibleTagIDs,
+						// just count
+						'count'        => true,
+						'ignoreowner'  => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_COMPANY ),
+					);
+
+					$res['objectcount'] = (int) $zbs->DAL->companies->getCompanies( $count_args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
+				}
+
+				$res['paged'] = $page_number;
+
 				// make ARGS
 				$args = array(
 					'searchPhrase'     => $possibleSearchTerm,
@@ -2641,22 +2668,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 				);
 
 				$companies = $zbs->DAL->companies->getCompanies( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-
-				// If using pagination, also return total count
-				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
-
-					// make count arguments
-					$args               = array(
-						'searchPhrase' => $possibleSearchTerm,
-						'quickFilters' => $possibleQuickFilters,
-						'isTagged'     => $possibleTagIDs,
-						// just count
-						'count'        => true,
-						'ignoreowner'  => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_COMPANY ),
-					);
-					$res['objectcount'] = (int) $zbs->DAL->companies->getCompanies( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				}
 
 					// } Tidy
 				if ( count( $companies ) > 0 ) {
@@ -2776,18 +2788,27 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-					// } Retrieve data
-					// $withFullDetails=false,$perPage=10,$page=0,$withCustomerDeets=false,$searchPhrase='',$inArray=array(),$sortByField='',$sortOrder='DESC',$quickFilters=array()
-					$quotes = zeroBS_getQuotes( true, $per_page, $page_number, true, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
-
-					// } If using pagination, also return total count
+					// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
 					$res['objectcount'] = zeroBS_getQuotesCountIncParams( true, $per_page, $page_number, true, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
 				}
 
-					// } Tidy
+				$res['paged'] = $page_number;
+
+				// Retrieve data
+				$quotes = zeroBS_getQuotes( true, $per_page, $page_number, true, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
+
+				// Tidy
 				if ( count( $quotes ) > 0 ) {
 					foreach ( $quotes as $quote ) {
 
@@ -2905,19 +2926,27 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-					// } Retrieve data
-					// MS: $invoices = zeroBS_getInvoicesv2(true,$per_page,$page_number,true,$possibleSearchTerm,$possibleTagIDs,$inArray,$possibleQuickFilters);
-					// WH: Moved back to original
-					$invoices = zeroBS_getInvoices( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
-
-					// } If using pagination, also return total count
+					// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
 					$res['objectcount'] = zeroBS_getInvoicesCountIncParams( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
 				}
 
-					// } Tidy
+				$res['paged'] = $page_number;
+
+				// Retrieve data
+				$invoices = zeroBS_getInvoices( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
+
+				// Tidy
 				if ( count( $invoices ) > 0 ) {
 					foreach ( $invoices as $invoice ) {
 
@@ -3046,17 +3075,27 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-					// Retrieve data
-					$transactions = zeroBS_getTransactions( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $possibleTagIDs, $inArray, $sortField, $sortOrder, $withTags, $possibleQuickFilters, $external_source_uid );
-
-					// If using pagination, also return total count
+				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
 					$res['objectcount'] = zeroBS_getTransactionsCountIncParams( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $possibleTagIDs, $inArray, $sortField, $sortOrder, $withTags, $possibleQuickFilters );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
 				}
 
-					// Tidy
+				$res['paged'] = $page_number;
+
+				// Retrieve data
+				$transactions = zeroBS_getTransactions( true, $per_page, $page_number, $withCustomer, $possibleSearchTerm, $possibleTagIDs, $inArray, $sortField, $sortOrder, $withTags, $possibleQuickFilters, $external_source_uid );
+
+				// Tidy
 				if ( count( $transactions ) > 0 ) {
 					foreach ( $transactions as $transaction ) {
 
@@ -3161,24 +3200,24 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-				// } Retrieve data
-				// ($withFullDetails=false,$perPage=10,$page=0,$withQuotes=false,$searchPhrase='',$withTransactions=false,$argsOverride=false,$companyID=false, $hasTagIDs='', $inArr = '')
-
-				// } Retrieve data
-				// old
-				// $withFullDetails=false,$perPage=10,$page=0,$withCustomerDeets=false, $possibleSearchTerm,$possibleTagIDs,$inArray,$possibleQuickFilters
-
-				// new
-				//
-
-				$forms = zeroBS_getForms( false, $per_page, $page_number, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
-
-				// } If using pagination, also return total count
+				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
 					$res['objectcount'] = zeroBS_getFormsCountIncParams( false, $per_page, $page_number, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
 				}
+
+				$res['paged'] = $page_number;
+
+				$forms = zeroBS_getForms( false, $per_page, $page_number, $possibleSearchTerm, $inArray, $sortField, $sortOrder, $possibleQuickFilters, $possibleTagIDs );
 
 				// } Tidy
 				if ( count( $forms ) > 0 ) {
@@ -3284,34 +3323,27 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-					// } Retrieve data
-					$segments = $zbs->DAL->segments->getSegments( $ownerID, $per_page, $page_number, false, $possibleSearchTerm, $inArray, $sortField, $sortOrder );
-
-					// } If using pagination, also return total count
+				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					$res['objectcount'] = (int) $zbs->DAL->segments->getSegmentsCountIncParams( $ownerID, $per_page, $page_number, false, $possibleSearchTerm, $inArray, $sortField, $sortOrder );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
 				}
 
-					// } No need to tidy from our straight-from-db stuff
-					// actually I do, to simplify ui
+				$res['paged'] = $page_number;
 
-					/*
-				MOVED THIS INTO DAL
-					#} Tidy
-					if (count($segments) > 0) foreach ($segments as $segment) {
-					$resArr = array();
-					$resArr['id'] = $segment->zbssegid;
-					$resArr['created'] = $segment->zbsseg_created;
-					$resArr['lastupdated'] = $segment->zbsseg_lastupdated;
-					$resArr['lastcompiled'] = $segment->zbsseg_lastcompiled;
-					$resArr['name'] = $segment->zbsseg_name;
-					$res['objects'][] = $resArr;
+				// } Retrieve data
+				$segments = $zbs->DAL->segments->getSegments( $ownerID, $per_page, $page_number, false, $possibleSearchTerm, $inArray, $sortField, $sortOrder );
 
-					} */
-
-					$res['objects'] = $segments;
+				$res['objects'] = $segments;
 
 				break;
 
@@ -3385,15 +3417,25 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-				// } Retrieve data
-				$quote_templates = zeroBS_getQuoteTemplates( false, $per_page, $page_number, $possibleSearchTerm );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-
-				// } If using pagination, also return total count
+				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
 					$res['objectcount'] = zeroBS_getQuoteTemplatesCountIncParams( false, $per_page, $page_number, $possibleSearchTerm );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
+						}
+					}
 				}
+
+				$res['paged'] = $page_number;
+
+				// Retrieve data
+				$quote_templates = zeroBS_getQuoteTemplates( false, $per_page, $page_number, $possibleSearchTerm );// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 				// } Tidy
 				if ( count( $quote_templates ) > 0 ) {
@@ -3576,19 +3618,30 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					}
 				}
 
-				$tasks = $zbs->DAL->events->getEvents( $args );
-
-				// } If using pagination, also return total count
+				// If using pagination, get total count
 				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-					// get count
-					$args['count']   = true;
-					$args['page']    = -1;
-					$args['perPage'] = -1;
+					$count_args            = $args;
+					$count_args['count']   = true;
+					$count_args['page']    = -1;
+					$count_args['perPage'] = -1;
 
-					$res['objectcount'] = $zbs->DAL->events->getEvents( $args );
+					$res['objectcount'] = $zbs->DAL->events->getEvents( $count_args );
 
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number  = $last_valid_page;
+							$args['page'] = $page_number;
+						}
+					}
 				}
+
+				$res['paged'] = $page_number;
+
+				$tasks = $zbs->DAL->events->getEvents( $args );
 
 				// } Tidy
 				if ( count( $tasks ) > 0 ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -2355,96 +2355,105 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 					$page_number = 0;
 				}
 
-					// make ARGS
-					$args = array(
+				// If using pagination, get total count
+				if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
 
-						'searchPhrase'     => $possibleSearchTerm,
-						'inCompany'        => $possibleCoID,
-						'inArr'            => $inArray,
-						'quickFilters'     => $possibleQuickFilters,
-						'isTagged'         => $possibleTagIDs,
-						'ownedBy'          => false,
+					$count_args = array(
 
-						'withCustomFields' => true,
-						'withQuotes'       => $withQuotes,
-						'withInvoices'     => false,
-						'withTransactions' => $withTransactions,
-						'withLogs'         => false,
-						'withLastLog'      => $latestLog,
-						'withTags'         => $withTags,
-						'withOwner'        => $withAssigned,
-						'withValues'       => $withValues,
+						'searchPhrase' => $possibleSearchTerm,
+						'inCompany'    => $possibleCoID,
+						'inArr'        => $inArray,
+						'quickFilters' => $possibleQuickFilters,
+						'isTagged'     => $possibleTagIDs,
 
-						'sortByField'      => $sortField,
-						'sortOrder'        => $sortOrder,
-						'page'             => $page_number,
-						'perPage'          => $per_page,
+						// just count
+						'count'        => true,
 
-						'ignoreowner'      => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
+						'ignoreowner'  => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
 
 					);
 
-					$customers = $zbs->DAL->contacts->getContacts( $args );
+					$res['objectcount'] = (int) $zbs->DAL->contacts->getContacts( $count_args );
 
-					$customers = jpcrm_inject_contacts( $customers, $args );
-
-					// } If using pagination, also return total count
-					if ( isset( $listViewParams['pagination'] ) && $listViewParams['pagination'] ) {
-
-						// make count arguments
-						$args = array(
-
-							'searchPhrase' => $possibleSearchTerm,
-							'inCompany'    => $possibleCoID,
-							'inArr'        => $inArray,
-							'quickFilters' => $possibleQuickFilters,
-							'isTagged'     => $possibleTagIDs,
-
-							// just count
-							'count'        => true,
-
-							'ignoreowner'  => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
-
-						);
-
-						$res['objectcount'] = (int) $zbs->DAL->contacts->getContacts( $args );
-
-					}
-
-					// with total
-					if ( $with_total_group_value ) {
-
-						// redo call for total valuesS
-						$args = array(
-
-							'searchPhrase'  => $possibleSearchTerm,
-							'inCompany'     => $possibleCoID,
-							'inArr'         => $inArray,
-							'quickFilters'  => $possibleQuickFilters,
-							'isTagged'      => $possibleTagIDs,
-							'ownedBy'       => false,
-							'ignoreowner'   => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
-
-							'onlyObjTotals' => true,
-
-						);
-
-						$res['totals'] = $zbs->DAL->contacts->getContacts( $args );
-
-					}
-
-					// } Tidy
-
-					// glob as used below. not pretty
-					global $companyNameCache;
-					$companyNameCache = array();
-
-					if ( count( $customers ) > 0 ) {
-						foreach ( $customers as $customer ) {
-							// DAL3 now processes these in the OBJ class (starting to centralise properly.)
-							$res['objects'][] = $zbs->DAL->contacts->listViewObj( $customer, $columnsRequired );
+					// If the page requested is out of range (e.g. after a bulk action emptied the
+					// last page), use the last valid page instead.
+					if ( $res['objectcount'] > 0 && $page_number > 1 ) {
+						$last_valid_page = max( 1, (int) ceil( $res['objectcount'] / $per_page ) );
+						if ( $page_number > $last_valid_page ) {
+							$page_number = $last_valid_page;
 						}
 					}
+				}
+
+				$res['paged'] = $page_number;
+
+				// make ARGS
+				$args = array(
+
+					'searchPhrase'     => $possibleSearchTerm,
+					'inCompany'        => $possibleCoID,
+					'inArr'            => $inArray,
+					'quickFilters'     => $possibleQuickFilters,
+					'isTagged'         => $possibleTagIDs,
+					'ownedBy'          => false,
+
+					'withCustomFields' => true,
+					'withQuotes'       => $withQuotes,
+					'withInvoices'     => false,
+					'withTransactions' => $withTransactions,
+					'withLogs'         => false,
+					'withLastLog'      => $latestLog,
+					'withTags'         => $withTags,
+					'withOwner'        => $withAssigned,
+					'withValues'       => $withValues,
+
+					'sortByField'      => $sortField,
+					'sortOrder'        => $sortOrder,
+					'page'             => $page_number,
+					'perPage'          => $per_page,
+
+					'ignoreowner'      => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
+
+				);
+
+				$customers = $zbs->DAL->contacts->getContacts( $args );
+
+				$customers = jpcrm_inject_contacts( $customers, $args );
+
+				// with total
+				if ( $with_total_group_value ) {
+
+					// redo call for total valuesS
+					$args = array(
+
+						'searchPhrase'  => $possibleSearchTerm,
+						'inCompany'     => $possibleCoID,
+						'inArr'         => $inArray,
+						'quickFilters'  => $possibleQuickFilters,
+						'isTagged'      => $possibleTagIDs,
+						'ownedBy'       => false,
+						'ignoreowner'   => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
+
+						'onlyObjTotals' => true,
+
+					);
+
+					$res['totals'] = $zbs->DAL->contacts->getContacts( $args );
+
+				}
+
+				// } Tidy
+
+				// glob as used below. not pretty
+				global $companyNameCache;
+				$companyNameCache = array();
+
+				if ( count( $customers ) > 0 ) {
+					foreach ( $customers as $customer ) {
+						// DAL3 now processes these in the OBJ class (starting to centralise properly.)
+						$res['objects'][] = $zbs->DAL->contacts->listViewObj( $customer, $columnsRequired );
+					}
+				}
 				break;
 
 			/*

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -322,6 +322,17 @@ function zeroBSCRMJS_retrieveListViewData( successcb, errcb ) {
 						window.zbsListViewCount = 0;
 					}
 
+					// Backend may change the page number (e.g. when a bulk
+					// action emptied the last page), so reflect that.
+					if ( response.paged > 0 && response.paged < window.zbsListViewParams.paged ) {
+						window.zbsListViewParams.paged = response.paged;
+						history.replaceState(
+							null,
+							null,
+							jpcrm_listview_generate_current_filter_url() + '&paged=' + response.paged
+						);
+					}
+
 					// store totals data
 					if ( typeof response.totals !== 'undefined' ) {
 						window.jpcrm_totals_table = response.totals;


### PR DESCRIPTION
Fixes #43155

## Proposed changes
<!--- Explain what functional changes your PR includes -->
If one requested a listview page that was beyond a valid range, it would show "no X found".

This PR changes the query to use the last available page. We already retrieve the item count and have the per-page, so this is easy enough to calculate.

Note that before it would do things in this order:
1. object retrieval
2. count retrieval

If we kept that order we would've needed a new object retrieval after we got the correct last page, but we can save that extra query by swapping the order like so:
1. count retrieval
2. object retrieval

That's why the change seems bigger than it really is.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Add some objects. Ensure you have more than a page-worth (you can change the per-page setting or use JPCRM-SDG).
2. Go to the last page.
3. Change the URL to point beyond the last page (e.g. if the last page is 2, change it to a 3).

In `trunk`, it'll say "No X found".

In this branch it'll query the correct last page (see the URL and pagination).