### PR TITLE
pr-is-up-to-date: Fix detection of parent commits in shallow handling

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-parent-commit-finding
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-parent-commit-finding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix detection of parent commits in shallow handling.

--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -83,7 +83,7 @@ function git_clean_shallow {
 	rm .git/shallow
 	for REV in "${REVS[@]}"; do
 		# Read parents. If any are missing, put the rev back in .git/shallow. If not all are missing, queue the missing ones to be fetched.
-		mapfile -t PP < <(/usr/bin/git cat-file commit "$REV" 2>/dev/null | sed -n 's/^parent //p')
+		mapfile -t PP < <(/usr/bin/git cat-file commit "$REV" 2>/dev/null | sed -n 's/^parent //p; /^$/ q')
 		PPM=()
 		for P in "${PP[@]}"; do
 			if ! /usr/bin/git cat-file -e "$P" &>/dev/null; then


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
If a commit happened to use "parent " at the start of a line in its body, the check would try to interpret that as an additional parent commit. Usually that'd be malformed and result in an error; if it happened to match a valid commit object in the repository, that'd be fetched (to no real effect).

To avoid the errors, stop processing the commit when we reach the empty line separating the commit data from the message.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* To really test, I think you'd have to fork the repo and then create a commit matching the condition. To test just the changed command, you might run `git fetch origin 72532044a37d57ad4c25faa1cdbeb8b74852a84b` and then compare the result when running the old and new commands.