### PR TITLE
Write editor: inline category selector + #hashtag tagging

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-2654-reconsider-categories-icon-placement-and-label
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-2654-reconsider-categories-icon-placement-and-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: replace floating categories FAB with inline 'Writing in X' selector above the title; support #hashtag extraction from standalone content lines for tagging on save

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -581,15 +581,9 @@
 	font-family: inherit;
 }
 
-.bw-meta-cat-prefix {
-	font-size: 13px;
-	color: #bbb;
-}
-
 .bw-meta-cat-label {
 	font-size: 13px;
-	color: #555;
-	font-weight: 500;
+	color: #888;
 }
 
 .bw-meta-cat-label:empty::before {
@@ -602,13 +596,9 @@
 	color: #999;
 }
 
-.bw-meta-cat-btn:hover .bw-meta-cat-prefix,
+.bw-meta-cat-btn:hover .bw-meta-cat-label,
 .bw-meta-cat-btn:hover .bw-meta-cat-caret {
-	color: #888;
-}
-
-.bw-meta-cat-btn:hover .bw-meta-cat-label {
-	color: #333;
+	color: #444;
 }
 
 .bw-meta-dropdown {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -564,41 +564,102 @@
 	color: #ccc;
 }
 
-/* Category pills */
-.bw-categories {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
+/* "Writing in X" category selector above the title */
+.bw-meta {
 	margin-bottom: 16px;
+	position: relative;
 }
 
-.bw-cat {
-	border: 1px solid #e0e0e0;
-	background: transparent;
+.bw-meta-cat-btn {
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-family: inherit;
+}
+
+.bw-meta-cat-prefix {
+	font-size: 13px;
+	color: #bbb;
+}
+
+.bw-meta-cat-label {
+	font-size: 13px;
+	color: #555;
+	font-weight: 500;
+}
+
+.bw-meta-cat-label:empty::before {
+	content: attr(data-placeholder);
+	color: #bbb;
+}
+
+.bw-meta-cat-caret {
+	font-size: 12px;
 	color: #999;
-	border-radius: 16px;
-	padding: 4px 14px;
+}
+
+.bw-meta-cat-btn:hover .bw-meta-cat-prefix,
+.bw-meta-cat-btn:hover .bw-meta-cat-caret {
+	color: #888;
+}
+
+.bw-meta-cat-btn:hover .bw-meta-cat-label {
+	color: #333;
+}
+
+.bw-meta-dropdown {
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	z-index: 100;
+	background: #fff;
+	border-radius: 8px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+	min-width: 160px;
+	max-height: 240px;
+	overflow-y: auto;
+	padding: 4px 0;
+	animation: bw-fade-in 0.1s ease;
+}
+
+.bw-meta-dropdown[hidden] {
+	display: none;
+}
+
+.bw-meta-dropdown-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	padding: 7px 14px;
 	font-size: 13px;
 	font-family: inherit;
+	color: #333;
 	cursor: pointer;
-	transition: all 0.15s ease;
 }
 
-.bw-cat:hover {
-	border-color: #bbb;
-	color: #666;
+.bw-meta-dropdown-item::before {
+	content: "";
+	display: inline-block;
+	width: 14px;
+	flex-shrink: 0;
 }
 
-.bw-cat-selected {
-	background: #1a1a1a;
-	border-color: #1a1a1a;
-	color: #fff;
+.bw-meta-dropdown-item--selected::before {
+	content: "✓";
+	color: #1a1a1a;
+	font-size: 12px;
 }
 
-.bw-cat-selected:hover {
-	background: #333;
-	border-color: #333;
-	color: #fff;
+.bw-meta-dropdown-item:hover {
+	background: #f5f5f5;
 }
 
 /* Leave confirmation modal — matches @wordpress/components ConfirmDialog */
@@ -792,75 +853,6 @@
 	flex-shrink: 0;
 }
 
-/* Floating category picker */
-.bw-cat-fab {
-	position: fixed;
-	bottom: 24px;
-	right: 24px;
-	z-index: 200;
-	width: 44px;
-	height: 44px;
-	border: none;
-	padding: 0;
-	border-radius: 50%;
-	background: #1e1e1e;
-	color: #fff;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	cursor: pointer;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-	transition: all 0.15s ease;
-}
-
-.bw-cat-fab:hover {
-	background: #333;
-	transform: scale(1.05);
-}
-
-.bw-cat-fab:focus-visible {
-	outline: 3px solid #2171b1;
-	outline-offset: 3px;
-}
-
-.bw-cat-fab-icon {
-	font-size: 20px;
-	width: 20px;
-	height: 20px;
-	line-height: 20px;
-}
-
-.bw-cat-popover {
-	position: fixed;
-	bottom: 80px;
-	right: 24px;
-	z-index: 201;
-	background: #fff;
-	border-radius: 12px;
-	padding: 16px;
-	min-width: 180px;
-	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
-	animation: bw-fade-in 0.12s ease;
-}
-
-.bw-cat-popover[hidden] {
-	display: none;
-}
-
-.bw-cat-popover-header {
-	font-size: 11px;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.08em;
-	color: #999;
-	margin-bottom: 10px;
-}
-
-.bw-cat-popover-list {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-}
 
 /* Separator between title and content */
 .bw-separator {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3243,16 +3243,22 @@ async function savePost( postStatus, isAutosave = false ) {
 	// Collect selected category IDs.
 	const selectedCats = state.categories.filter( c => c.selected ).map( c => c.id );
 
-	// Resolve extracted tag names to WP term IDs, creating new tags as needed.
+	// Resolve extracted tag names to WP term IDs only when #tag paragraphs are present.
+	// When present, merge with existing tag IDs so tags set outside the Write editor survive.
+	// Omitting `tags` entirely when no #tag lines exist preserves existing tags without fetching.
 	// WordPress returns a term_exists error (with the existing ID) for duplicates.
-	const allTagIds = await Promise.all(
-		tagNames.map( name =>
-			window.wp
-				.apiFetch( { path: '/wp/v2/tags', method: 'POST', data: { name } } )
-				.then( tag => tag.id )
-				.catch( err => err?.data?.term_id ?? null )
-		)
-	).then( ids => ids.filter( Boolean ) );
+	const tagData = {};
+	if ( tagNames.length ) {
+		const newTagIds = await Promise.all(
+			tagNames.map( name =>
+				window.wp
+					.apiFetch( { path: '/wp/v2/tags', method: 'POST', data: { name } } )
+					.then( tag => tag.id )
+					.catch( err => err?.data?.term_id ?? null )
+			)
+		).then( ids => ids.filter( Boolean ) );
+		tagData.tags = [ ...new Set( [ ...( state.existingTagIds || [] ), ...newTagIds ] ) ];
+	}
 
 	// If editing, PUT to the existing post. If new, POST to create.
 	const path = isEditing ? state.postsPath + '/' + state.editPostId : state.postsPath;
@@ -3266,7 +3272,7 @@ async function savePost( postStatus, isAutosave = false ) {
 				content: blockMarkup,
 				status: postStatus,
 				categories: selectedCats,
-				tags: allTagIds,
+				...tagData,
 				featured_media: state.featuredMediaId || 0,
 			},
 		} );
@@ -3274,6 +3280,11 @@ async function savePost( postStatus, isAutosave = false ) {
 		// Store the post ID so subsequent saves update the same post.
 		if ( ! isEditing ) {
 			state.editPostId = post.id;
+		}
+
+		// Keep existingTagIds in sync so the next save in this session merges correctly.
+		if ( tagData.tags ) {
+			state.existingTagIds = tagData.tags;
 		}
 
 		// Mark only the submitted content as saved — if the user typed

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -8,7 +8,7 @@
 /* eslint-disable @wordpress/no-global-get-selection -- Write serves a full page, not an iframe or shadow DOM. */
 
 // eslint-disable-next-line import/no-unresolved -- Provided by WordPress at runtime via wp_register_script_module.
-import { store, getElement, getContext } from '@wordpress/interactivity';
+import { store, getElement } from '@wordpress/interactivity';
 
 // Translated strings passed from PHP via wp_print_inline_script_tag.
 const i18n = window.wpcomWriteStrings || {};
@@ -1665,6 +1665,29 @@ function insertMediaBlock( mediaEl ) {
 	return p;
 }
 
+// --- Inline category meta helpers ---
+
+/**
+ * Recompute state.catLabel from the currently selected categories.
+ * Sets "in X, Y" when categories are selected, or empty string for none.
+ */
+function updateCatLabel() {
+	const selected = state.categories.filter( c => c.selected );
+	state.catLabel = selected.map( c => c.name ).join( ', ' );
+}
+
+/**
+ * Sync the visual selected state of each dropdown item with state.categories.
+ */
+function syncCatDropdownItems() {
+	document.querySelectorAll( '#bw-cat-dropdown .bw-meta-dropdown-item' ).forEach( item => {
+		const idx = parseInt( item.dataset.catIndex, 10 );
+		const selected = !! state.categories[ idx ]?.selected;
+		item.classList.toggle( 'bw-meta-dropdown-item--selected', selected );
+		item.setAttribute( 'aria-selected', selected ? 'true' : 'false' );
+	} );
+}
+
 const { state } = store( 'wpcom-write', {
 	state: {
 		formatBold: false,
@@ -2991,39 +3014,70 @@ const { state } = store( 'wpcom-write', {
 			}
 		},
 
-		toggleCatPicker( event ) {
-			event.stopPropagation();
-			state.showCatPicker = ! state.showCatPicker;
+		// --- Inline category meta ---
 
-			if ( state.showCatPicker ) {
-				const close = e => {
-					if ( e.target.closest( '.bw-cat-popover' ) || e.target.closest( '.bw-cat-fab' ) ) return;
-					state.showCatPicker = false;
-					document.removeEventListener( 'click', close );
-				};
-				// Delay so the current click doesn't immediately close it.
-				setTimeout( () => document.addEventListener( 'click', close ), 0 );
+		toggleCatDropdown( event ) {
+			event.stopPropagation();
+			state.showCatDropdown = ! state.showCatDropdown;
+			if ( state.showCatDropdown ) {
+				syncCatDropdownItems();
 			}
 		},
 
-		handleCatKeyDown( event ) {
-			if ( event.key === 'Escape' ) {
+		handleCatBtnKeyDown( event ) {
+			if ( event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
-				state.showCatPicker = false;
-				event.currentTarget.querySelector( '.bw-cat-fab' )?.focus();
+				if ( ! state.showCatDropdown ) {
+					state.showCatDropdown = true;
+					syncCatDropdownItems();
+				}
+				// Focus first item once the dropdown is visible.
+				requestAnimationFrame( () => {
+					const first = document.querySelector( '#bw-cat-dropdown .bw-meta-dropdown-item' );
+					if ( first ) first.focus();
+				} );
+			} else if ( event.key === 'Escape' ) {
+				state.showCatDropdown = false;
+			}
+		},
+
+		handleCatDropdownKeyDown( event ) {
+			const dropdown = event.currentTarget;
+			const focused = dropdown.ownerDocument.activeElement;
+			const items = [ ...dropdown.querySelectorAll( '.bw-meta-dropdown-item' ) ];
+
+			if ( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) {
+				event.preventDefault();
+				const idx = items.indexOf( focused );
+				const delta = event.key === 'ArrowDown' ? 1 : -1;
+				items[ ( idx + delta + items.length ) % items.length ]?.focus();
+			} else if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				focused.click();
+			} else if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				state.showCatDropdown = false;
+				document.querySelector( '.bw-meta-cat-btn' )?.focus();
 			}
 		},
 
 		handleCatFocusOut( event ) {
 			if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
-				state.showCatPicker = false;
+				state.showCatDropdown = false;
 			}
 		},
 
-		toggleCategory() {
-			const ctx = getContext();
-			ctx.catSelected = ! ctx.catSelected;
-			state.categories[ ctx.catIndex ].selected = ctx.catSelected;
+		handleCatDropdownClick( event ) {
+			const item = event.target.closest( '.bw-meta-dropdown-item' );
+			if ( ! item ) {
+				return;
+			}
+			const idx = parseInt( item.dataset.catIndex, 10 );
+			if ( ! isNaN( idx ) && state.categories[ idx ] ) {
+				state.categories[ idx ].selected = ! state.categories[ idx ].selected;
+				syncCatDropdownItems();
+				updateCatLabel();
+			}
 		},
 
 		async publish() {
@@ -3171,10 +3225,32 @@ async function savePost( postStatus, isAutosave = false ) {
 	// the submitted content, not whatever the DOM contains when the request resolves.
 	const submittedSnapshot = getContentSnapshot();
 
+	// Extract #tags from lines that contain only hashtag tokens (e.g. "#travel #food").
+	// Those paragraphs are metadata, not body text — strip them from the saved content.
+	const tagNames = [];
+	clone.querySelectorAll( ':scope > p' ).forEach( p => {
+		const text = p.textContent.trim();
+		if ( /^(#[\w-]+\s*)+$/.test( text ) ) {
+			text.match( /#([\w-]+)/g ).forEach( t => tagNames.push( t.slice( 1 ) ) );
+			p.remove();
+		}
+	} );
+
 	const blockMarkup = convertToBlocks( clone.innerHTML );
 
 	// Collect selected category IDs.
 	const selectedCats = state.categories.filter( c => c.selected ).map( c => c.id );
+
+	// Resolve extracted tag names to WP term IDs, creating new tags as needed.
+	// WordPress returns a term_exists error (with the existing ID) for duplicates.
+	const allTagIds = await Promise.all(
+		tagNames.map( name =>
+			window.wp
+				.apiFetch( { path: '/wp/v2/tags', method: 'POST', data: { name } } )
+				.then( tag => tag.id )
+				.catch( err => err?.data?.term_id ?? null )
+		)
+	).then( ids => ids.filter( Boolean ) );
 
 	// If editing, PUT to the existing post. If new, POST to create.
 	const path = isEditing ? state.postsPath + '/' + state.editPostId : state.postsPath;
@@ -3188,6 +3264,7 @@ async function savePost( postStatus, isAutosave = false ) {
 				content: blockMarkup,
 				status: postStatus,
 				categories: selectedCats,
+				tags: allTagIds,
 				featured_media: state.featuredMediaId || 0,
 			},
 		} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1669,11 +1669,13 @@ function insertMediaBlock( mediaEl ) {
 
 /**
  * Recompute state.catLabel from the currently selected categories.
- * Sets "in X, Y" when categories are selected, or empty string for none.
+ * Uses the translatable "Writing in %s" format string from i18n.
  */
 function updateCatLabel() {
 	const selected = state.categories.filter( c => c.selected );
-	state.catLabel = selected.map( c => c.name ).join( ', ' );
+	const names = selected.map( c => c.name ).join( ', ' );
+	const fmt = i18n.writingIn || 'Writing in %s';
+	state.catLabel = names ? fmt.replace( '%s', names ) : '';
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -292,9 +292,15 @@ function wpcom_write_render_admin_page() {
 		);
 	}
 
-	// Build categories list for the UI.
-	$all_cats        = get_categories( array( 'hide_empty' => false ) );
-	$selected_cats   = $edit_post_id ? wp_get_post_categories( $edit_post_id ) : array();
+	// Build categories list for the UI (only categories that have posts).
+	$all_cats      = get_categories( array( 'hide_empty' => true ) );
+	$selected_cats = $edit_post_id ? wp_get_post_categories( $edit_post_id ) : array();
+
+	// Fall back to the site's default category so the label is never empty.
+	if ( empty( $selected_cats ) ) {
+		$selected_cats = array( (int) get_option( 'default_category' ) );
+	}
+
 	$categories_data = array();
 	foreach ( $all_cats as $cat ) {
 		$categories_data[] = array(
@@ -303,6 +309,18 @@ function wpcom_write_render_admin_page() {
 			'selected' => in_array( $cat->term_id, $selected_cats, true ),
 		);
 	}
+
+	// Show the category row only when the site has 2+ used categories.
+	$show_cat_row = count( $categories_data ) >= 2;
+
+	// Compute the initial "Writing in …" label from any pre-selected categories.
+	$selected_cat_names = array_values(
+		array_map(
+			fn( $c ) => $c['name'],
+			array_filter( $categories_data, fn( $c ) => $c['selected'] )
+		)
+	);
+	$cat_label          = empty( $selected_cat_names ) ? '' : implode( ', ', $selected_cat_names );
 
 	// Seed Interactivity API state.
 	wp_interactivity_state(
@@ -330,7 +348,8 @@ function wpcom_write_render_admin_page() {
 			'featuredMediaId'     => $edit_featured_id,
 			'isUploading'         => false,
 			'categories'          => $categories_data,
-			'showCatPicker'       => false,
+			'catLabel'            => $cat_label,
+			'showCatDropdown'     => false,
 			'showHelp'            => false,
 			'showSlashMenu'       => false,
 			'slashActiveId'       => '',
@@ -351,7 +370,7 @@ function wpcom_write_render_admin_page() {
 	);
 
 	// Output the editor UI inside wp-admin's wrapper.
-	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status, $video_placeholders );
+	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status, $video_placeholders, $show_cat_row, $cat_label );
 }
 
 /**
@@ -366,8 +385,10 @@ function wpcom_write_render_admin_page() {
  * @param array  $categories_data     Array of category data for the picker.
  * @param string $post_status         The post status ('new', 'draft', 'publish', etc.).
  * @param array  $video_placeholders  Map of comment tokens to iframe HTML for video embeds.
+ * @param bool   $show_cat_row        Whether to show the category row (2+ used categories).
+ * @param string $cat_label           Initial "in X, Y" label text; empty string if none selected.
  */
-function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new', $video_placeholders = array() ) {
+function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new', $video_placeholders = array(), $show_cat_row = false, $cat_label = '' ) {
 	?>
 <div data-wp-interactive="wpcom-write" class="bw-app">
 
@@ -483,6 +504,50 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<!-- Writing area -->
 	<main class="bw-main" data-wp-on--click="actions.handleMainClick">
 		<div class="bw-editor">
+
+			<?php if ( $show_cat_row ) : ?>
+			<!-- Category selector — only shown when site has 2+ used categories -->
+			<div class="bw-meta" data-wp-on--focusout="actions.handleCatFocusOut">
+				<button
+					class="bw-meta-cat-btn"
+					aria-haspopup="listbox"
+					aria-expanded="false"
+					aria-controls="bw-cat-dropdown"
+					data-wp-bind--aria-expanded="state.showCatDropdown"
+					data-wp-on--click="actions.toggleCatDropdown"
+					data-wp-on--keydown="actions.handleCatBtnKeyDown"
+				>
+					<span class="bw-meta-cat-prefix"><?php echo esc_html__( 'Writing in', 'jetpack-mu-wpcom' ); ?></span>
+					<span
+						class="bw-meta-cat-label"
+						data-wp-text="state.catLabel"
+					><?php echo esc_html( $cat_label ); ?></span>
+					<span class="bw-meta-cat-caret" aria-hidden="true">&#9662;</span>
+				</button>
+				<div
+					class="bw-meta-dropdown"
+					id="bw-cat-dropdown"
+					role="listbox"
+					aria-multiselectable="true"
+					hidden
+					data-wp-bind--hidden="!state.showCatDropdown"
+					data-wp-on--keydown="actions.handleCatDropdownKeyDown"
+				>
+					<?php foreach ( $categories_data as $i => $cat ) : ?>
+					<button
+						class="bw-meta-dropdown-item<?php echo $cat['selected'] ? ' bw-meta-dropdown-item--selected' : ''; ?>"
+						role="option"
+						aria-selected="<?php echo $cat['selected'] ? 'true' : 'false'; ?>"
+						tabindex="-1"
+						data-cat-index="<?php echo (int) $i; ?>"
+						data-cat-name="<?php echo esc_attr( $cat['name'] ); ?>"
+						data-wp-on--click="actions.handleCatDropdownClick"
+					><?php echo esc_html( $cat['name'] ); ?></button>
+					<?php endforeach; ?>
+				</div>
+			</div><!-- /.bw-meta -->
+			<?php endif; ?>
+
 			<textarea
 				class="bw-title"
 				placeholder="<?php echo esc_attr__( 'Title', 'jetpack-mu-wpcom' ); ?>"
@@ -622,36 +687,6 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		</div>
 	</div>
 
-	<!-- Floating category picker -->
-	<div class="bw-cat-wrap" data-wp-on--keydown="actions.handleCatKeyDown" data-wp-on--focusout="actions.handleCatFocusOut">
-	<button class="bw-cat-fab" aria-label="<?php echo esc_attr__( 'Categories', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.toggleCatPicker">
-		<span class="bw-cat-fab-icon dashicons dashicons-tag" aria-hidden="true"></span>
-	</button>
-	<div class="bw-cat-popover" hidden data-wp-bind--hidden="!state.showCatPicker">
-		<div class="bw-cat-popover-header"><?php echo esc_html__( 'Categories', 'jetpack-mu-wpcom' ); ?></div>
-		<div class="bw-cat-popover-list">
-			<?php
-			foreach ( $categories_data as $i => $cat ) :
-				$cat_context = esc_attr(
-					wp_json_encode(
-						array(
-							'catIndex'    => $i,
-							'catSelected' => $cat['selected'],
-						),
-						JSON_HEX_TAG | JSON_HEX_AMP
-					)
-				);
-				?>
-			<button
-				class="bw-cat<?php echo $cat['selected'] ? ' bw-cat-selected' : ''; ?>"
-				data-wp-on--click="actions.toggleCategory"
-				data-wp-context='<?php echo $cat_context; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?>'
-				data-wp-class--bw-cat-selected="context.catSelected"
-			><?php echo esc_html( $cat['name'] ); ?></button>
-			<?php endforeach; ?>
-		</div>
-	</div>
-	</div><!-- /.bw-cat-wrap -->
 
 </div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -125,6 +125,8 @@ add_action(
 			'heading2'             => __( 'Heading 2', 'jetpack-mu-wpcom' ),
 			'heading3'             => __( 'Heading 3', 'jetpack-mu-wpcom' ),
 			'preview'              => __( 'Preview', 'jetpack-mu-wpcom' ),
+			// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
+			'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
 		);
 		wp_print_inline_script_tag(
 			'window.wpcomWriteStrings = ' . wp_json_encode( $write_strings, JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
@@ -293,14 +295,8 @@ function wpcom_write_render_admin_page() {
 	}
 
 	// Build categories list for the UI (only categories that have posts).
-	$all_cats      = get_categories( array( 'hide_empty' => true ) );
-	$selected_cats = $edit_post_id ? wp_get_post_categories( $edit_post_id ) : array();
-
-	// Fall back to the site's default category so the label is never empty.
-	if ( empty( $selected_cats ) ) {
-		$selected_cats = array( (int) get_option( 'default_category' ) );
-	}
-
+	$all_cats        = get_categories( array( 'hide_empty' => true ) );
+	$selected_cats   = $edit_post_id ? wp_get_post_categories( $edit_post_id ) : array();
 	$categories_data = array();
 	foreach ( $all_cats as $cat ) {
 		$categories_data[] = array(
@@ -308,6 +304,18 @@ function wpcom_write_render_admin_page() {
 			'name'     => $cat->name,
 			'selected' => in_array( $cat->term_id, $selected_cats, true ),
 		);
+	}
+
+	// For new posts, pre-select the default category if it's in the used-categories list,
+	// otherwise the first available used category, so the label is never empty.
+	if ( ! $edit_post_id && ! empty( $categories_data ) ) {
+		$has_selection = ! empty( array_filter( $categories_data, fn( $c ) => $c['selected'] ) );
+		if ( ! $has_selection ) {
+			$default_id                                 = (int) get_option( 'default_category' );
+			$default_idx                                = array_search( $default_id, array_column( $categories_data, 'id' ), true );
+			$select_idx                                 = false !== $default_idx ? $default_idx : 0;
+			$categories_data[ $select_idx ]['selected'] = true;
+		}
 	}
 
 	// Show the category row only when the site has 2+ used categories.
@@ -320,7 +328,11 @@ function wpcom_write_render_admin_page() {
 			array_filter( $categories_data, fn( $c ) => $c['selected'] )
 		)
 	);
-	$cat_label          = empty( $selected_cat_names ) ? '' : implode( ', ', $selected_cat_names );
+	// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
+	$writing_in_fmt = __( 'Writing in %s', 'jetpack-mu-wpcom' );
+	$cat_label      = empty( $selected_cat_names )
+		? ''
+		: sprintf( $writing_in_fmt, implode( ', ', $selected_cat_names ) );
 
 	// Seed Interactivity API state.
 	wp_interactivity_state(
@@ -386,7 +398,7 @@ function wpcom_write_render_admin_page() {
  * @param string $post_status         The post status ('new', 'draft', 'publish', etc.).
  * @param array  $video_placeholders  Map of comment tokens to iframe HTML for video embeds.
  * @param bool   $show_cat_row        Whether to show the category row (2+ used categories).
- * @param string $cat_label           Initial "in X, Y" label text; empty string if none selected.
+ * @param string $cat_label           Full "Writing in X, Y" label text; empty string if none selected.
  */
 function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new', $video_placeholders = array(), $show_cat_row = false, $cat_label = '' ) {
 	?>
@@ -518,9 +530,9 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 					data-wp-on--click="actions.toggleCatDropdown"
 					data-wp-on--keydown="actions.handleCatBtnKeyDown"
 				>
-					<span class="bw-meta-cat-prefix"><?php echo esc_html__( 'Writing in', 'jetpack-mu-wpcom' ); ?></span>
 					<span
 						class="bw-meta-cat-label"
+						data-placeholder="<?php echo esc_attr__( 'Select a category', 'jetpack-mu-wpcom' ); ?>"
 						data-wp-text="state.catLabel"
 					><?php echo esc_html( $cat_label ); ?></span>
 					<span class="bw-meta-cat-caret" aria-hidden="true">&#9662;</span>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -294,6 +294,9 @@ function wpcom_write_render_admin_page() {
 		);
 	}
 
+	// Fetch existing tag IDs so JS can merge them with any #hashtag-extracted tags on save.
+	$existing_tag_ids = $edit_post_id ? wp_get_post_tags( $edit_post_id, array( 'fields' => 'ids' ) ) : array();
+
 	// Build categories list for the UI (only categories that have posts).
 	$all_cats        = get_categories( array( 'hide_empty' => true ) );
 	$selected_cats   = $edit_post_id ? wp_get_post_categories( $edit_post_id ) : array();
@@ -361,6 +364,7 @@ function wpcom_write_render_admin_page() {
 			'isUploading'         => false,
 			'categories'          => $categories_data,
 			'catLabel'            => $cat_label,
+			'existingTagIds'      => $existing_tag_ids,
 			'showCatDropdown'     => false,
 			'showHelp'            => false,
 			'showSlashMenu'       => false,

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -405,6 +405,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<div class="bw-help-row"><kbd>Ctrl+K</kbd><span><?php echo esc_html__( 'Insert link', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Tab</kbd><span><?php echo esc_html__( 'Navigate slash menu options', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Shift+Tab</kbd><span><?php echo esc_html__( 'Focus formatting toolbar', 'jetpack-mu-wpcom' ); ?></span></div>
+			<div class="bw-help-row"><kbd>#tag</kbd><span><?php echo esc_html__( 'A line containing only #tags assigns them to the post on save', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
 		</div><!-- /.bw-help-wrap -->
 		<span class="bw-status" data-wp-text="state.message"></span>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -340,10 +340,10 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	public function test_category_row_shown_when_show_cat_row_true() {
 		wp_set_current_user( $this->admin_id );
 
-		$output = $this->render_template( '', '', 0, array(), 'new', array(), true, 'Uncategorized' );
+		$output = $this->render_template( '', '', 0, array(), 'new', array(), true, 'Writing in Uncategorized' );
 
 		$this->assertStringContainsString( 'bw-meta-cat-btn', $output );
-		$this->assertStringContainsString( 'Writing in', $output );
+		$this->assertStringContainsString( 'Writing in Uncategorized', $output );
 		$this->assertStringContainsString( 'bw-meta-cat-label', $output );
 	}
 
@@ -353,9 +353,9 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	public function test_cat_label_seeded_in_template() {
 		wp_set_current_user( $this->admin_id );
 
-		$output = $this->render_template( '', '', 0, array(), 'new', array(), true, 'Travel' );
+		$output = $this->render_template( '', '', 0, array(), 'new', array(), true, 'Writing in Travel' );
 
-		$this->assertStringContainsString( 'Travel', $output );
+		$this->assertStringContainsString( 'Writing in Travel', $output );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -95,18 +95,22 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 * Render the Write template with wp_head/wp_footer hooks removed to avoid
 	 * side effects from other features (e.g. missing build assets).
 	 *
-	 * @param string $title      Post title.
-	 * @param string $content    Post content.
-	 * @param int    $post_id    Post ID (0 for new).
-	 * @param array  $categories Categories data.
+	 * @param string $title             Post title.
+	 * @param string $content           Post content.
+	 * @param int    $post_id           Post ID (0 for new).
+	 * @param array  $categories        Categories data.
+	 * @param string $post_status       Post status.
+	 * @param array  $video_placeholders Video placeholder tokens.
+	 * @param bool   $show_cat_row      Whether to show the category row.
+	 * @param string $cat_label         Initial category label text.
 	 * @return string The rendered HTML.
 	 */
-	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array(), $post_status = 'new', $video_placeholders = array() ) {
+	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array(), $post_status = 'new', $video_placeholders = array(), $show_cat_row = false, $cat_label = '' ) {
 		remove_all_actions( 'wp_head' );
 		remove_all_actions( 'wp_footer' );
 
 		ob_start();
-		wpcom_write_template( $title, $content, $post_id, $categories, $post_status, $video_placeholders );
+		wpcom_write_template( $title, $content, $post_id, $categories, $post_status, $video_placeholders, $show_cat_row, $cat_label );
 		return ob_get_clean();
 	}
 
@@ -308,6 +312,62 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertArrayHasKey( 'formatAlignRight', $state );
 		$this->assertArrayHasKey( 'formatOList', $state );
 		$this->assertArrayHasKey( 'formatUList', $state );
+
+		// Category selector state.
+		$this->assertArrayHasKey( 'catLabel', $state );
+		$this->assertArrayHasKey( 'showCatDropdown', $state );
+		$this->assertFalse( $state['showCatDropdown'] );
+
+		// Old category picker key should not exist.
+		$this->assertArrayNotHasKey( 'showCatPicker', $state );
+	}
+
+	/**
+	 * Test that the category row is not rendered when show_cat_row is false.
+	 */
+	public function test_category_row_hidden_when_show_cat_row_false() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template( '', '', 0, array(), 'new', array(), false, '' );
+
+		$this->assertStringNotContainsString( 'bw-meta-cat-btn', $output );
+		$this->assertStringNotContainsString( 'Writing in', $output );
+	}
+
+	/**
+	 * Test that the category row is rendered when show_cat_row is true.
+	 */
+	public function test_category_row_shown_when_show_cat_row_true() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template( '', '', 0, array(), 'new', array(), true, 'Uncategorized' );
+
+		$this->assertStringContainsString( 'bw-meta-cat-btn', $output );
+		$this->assertStringContainsString( 'Writing in', $output );
+		$this->assertStringContainsString( 'bw-meta-cat-label', $output );
+	}
+
+	/**
+	 * Test that the category label is seeded into the template output.
+	 */
+	public function test_cat_label_seeded_in_template() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template( '', '', 0, array(), 'new', array(), true, 'Travel' );
+
+		$this->assertStringContainsString( 'Travel', $output );
+	}
+
+	/**
+	 * Test that the help modal contains the #tag tip.
+	 */
+	public function test_help_modal_contains_hashtag_tip() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( '#tag', $output );
+		$this->assertStringContainsString( 'assigns them to the post on save', $output );
 	}
 
 	/**


### PR DESCRIPTION
Fixes RSM-2654, RSM-1723

## Proposed changes

* Removes the floating category FAB button (bottom-right corner) that internal testers mistook for a settings panel or editor-switcher
* Adds a compact "Writing in [Category] ▾" button above the title, visible only on sites with 2+ used categories
* Pre-selects the site's default category so the label is never empty
* Dropdown supports multiple category selection with ✓ indicators and full keyboard navigation (↓/↑ to move, Enter/Space to toggle, Escape to close)
* Adds `#hashtag` tagging: paragraphs consisting entirely of `#tag` tokens are extracted on save, assigned as post tags, and stripped from the saved content — no dedicated tags UI needed

<img width="384" height="258" alt="Screenshot 2026-05-08 at 3 50 44 PM" src="https://github.com/user-attachments/assets/9aca39f5-152e-489c-82ba-621b553ffd63" />

## Related product discussion/links

* RSM-2654, RSM-1723

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a site with the Write editor enabled (`?page=write`).

**Category selector**
* Go to `wp-admin/admin.php?page=write` on a site with only one used category — confirm the "Writing in" row does not appear
* On a site with 2+ used categories: confirm "Writing in [default category] ▾" appears above the title field
* Click the button — dropdown opens showing all used categories with ✓ on selected ones
* Click a category to select/deselect it — label updates live
* Select multiple categories — label shows "Writing in X, Y"
* Press Escape — dropdown closes, focus returns to the button
* Tab to the button, press ↓ or Enter — dropdown opens, first item focused
* Press ↓/↑ to move between items, Enter/Space to toggle selection
* Save or publish — post has the correct categories assigned

**#hashtag tags**
* In the content area, type `#travel` on its own line (nothing else on that line), then save
* Confirm the saved post has the "travel" tag assigned and that line does not appear in the published post content
* Type `#travel #food` on one line — both tags should be extracted
* Type `some text #travel` on a line — should NOT be extracted (mixed content line)
* Type a `#tag` matching an already-existing tag on the site — existing term should be reused, no duplicate created

**Edit mode**
* Open an existing post with categories assigned — "Writing in [name]" label should show on load
* Confirm categories can be changed and re-saved correctly
