### PR TITLE
CRM: Add link to docs when there are no objects

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-no_object_doc_links
+++ b/projects/plugins/crm/changelog/add-crm-no_object_doc_links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Listview: Add docs link when no objects are found.

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -391,7 +391,27 @@ class zeroBSCRM_list {
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error retrieving %s', 'zero-bs-crm' ), $this->plural ), sprintf( __( 'There has been a problem retrieving your %s. If this issue persists, please contact support.', 'zero-bs-crm' ), $this->plural ), 'disabled warning sign', 'zbsCantLoadData' );
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error updating columns %s', 'zero-bs-crm' ), $this->plural ), __( 'There has been a problem saving your column configuration. If this issue persists, please contact support.', 'zero-bs-crm' ), 'disabled warning sign', 'zbsCantSaveCols' );
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error updating columns %s', 'zero-bs-crm' ), $this->plural ), __( 'There has been a problem saving your filter button configuration. If this issue persists, please contact support.', 'zero-bs-crm' ), 'disabled warning sign', 'zbsCantSaveButtons' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					echo zeroBSCRM_UI2_messageHTML( 'info hidden', sprintf( __( 'No %s Found', 'zero-bs-crm' ), $this->plural ), sprintf( __( 'There are no %1$s here. Do you want to <a href="%2$s">create one</a>?', 'zero-bs-crm' ), $this->plural, jpcrm_esc_link( 'create', -1, $this->postType ) ), 'disabled warning sign', 'zbsNoResults' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					$no_results_msg = sprintf( __( 'There are no %1$s here. Do you want to <a href="%2$s">create one</a>?', 'zero-bs-crm' ), $this->plural, jpcrm_esc_link( 'create', -1, $this->postType ) );
+					$doc_links      = array(
+						'transaction' => array(
+							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-transaction/',
+							'text' => __( 'Learn more about <a href="%1$s" target="_blank">how to create a transaction</a>.', 'zero-bs-crm' ),
+						),
+						'invoice'     => array(
+							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-to-use-the-invoice-builder/',
+							'text' => __( 'Learn more about <a href="%1$s" target="_blank">how to create an invoice</a>.', 'zero-bs-crm' ),
+						),
+						'quote'       => array(
+							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-quote/',
+							'text' => __( 'Learn more about <a href="%1$s" target="_blank">how to create a quote</a>.', 'zero-bs-crm' ),
+						),
+					);
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					if ( isset( $doc_links[ $this->objType ] ) ) {
+						$link            = $doc_links[ $this->objType ];
+						$no_results_msg .= ' ' . sprintf( $link['text'], esc_url( $link['url'] ) );
+					}
+					echo zeroBSCRM_UI2_messageHTML( 'info hidden', sprintf( __( 'No %s Found', 'zero-bs-crm' ), $this->plural ), $no_results_msg, 'disabled warning sign', 'zbsNoResults' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 					// any additional messages?
 					if ( isset( $this->messages ) && is_array( $this->messages ) && count( $this->messages ) > 0 ) {

--- a/projects/plugins/crm/sass/emerald/_listview-table.scss
+++ b/projects/plugins/crm/sass/emerald/_listview-table.scss
@@ -19,6 +19,10 @@
 			color: var(--jp-grey-80);
 		}
 
+		#zbs-no-results-wrap a {
+			color: #2271b1;
+		}
+
 		th,
 		td {
 			text-align: left;
@@ -57,6 +61,10 @@
 
 				&:hover {
 					background-color: var(--jp-gray-0);
+				}
+
+				&:has(#zbs-no-results-wrap):hover {
+					background-color: transparent;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes JETCRM-13

## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is a second pass at #47473. It adds doc links when there are no objects. h/t @bobmatyas for the initial implementation.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Before:
<img width="3102" height="774" alt="image" src="https://github.com/user-attachments/assets/95a10a9c-cfa3-4d43-92b1-94b3d9931154" />

After:
<img width="3094" height="760" alt="image" src="https://github.com/user-attachments/assets/958c1d7e-79b7-4143-b793-64d78c0203d0" />
