### PR TITLE
CRM: Skip Codeception tests on PHP 8.4.21 and 8.5.6

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-skip_tests_on_php_8.4.21_and_8.5.6
+++ b/projects/plugins/crm/changelog/fix-crm-skip_tests_on_php_8.4.21_and_8.5.6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Disable tests on PHP 8.4.21 and 8.5.6.
+
+

--- a/projects/plugins/crm/tests/action-skip-test-php.sh
+++ b/projects/plugins/crm/tests/action-skip-test-php.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Skip tests on PHP 8.4.20 and 8.5.5 due to inconsistent Codeception timeouts on those versions.
+# Skip tests on PHP 8.4.21 and 8.5.6 due to inconsistent Codeception timeouts on those versions.
 # @todo: remove this when PHP has higher patch versions: p1773618372849869-slack-C034JEXD1RD
 # @todo: Consider bumping timeout limit to see if that makes a difference
-if php -r 'exit(in_array(PHP_VERSION, ["8.4.20", "8.5.5"], true) ? 0 : 1);'; then
+if php -r 'exit(in_array(PHP_VERSION, ["8.4.21", "8.5.6"], true) ? 0 : 1);'; then
 	echo "Skipping Codeception tests on PHP $(php -r 'echo PHP_VERSION;')"
 	exit 3
 fi


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Bump test skip to PHP 8.4.21 and 8.5.6 due to the same Codeception timeout issue.

Down the road we could try extending the timeouts instead.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1773618372849869-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*