### PR TITLE
Build/mirror test: #48627 (newsletter mu-wpcom)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/try-newsletter-bootstrap-via-module
+++ b/projects/packages/jetpack-mu-wpcom/changelog/try-newsletter-bootstrap-via-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Newsletter: stop requiring the jetpack-newsletter package as a composer dependency. The Newsletter classes are now resolved through the Jetpack autoloader from the standalone Jetpack plugin (Atomic) or the wpcom platform's bundled Jetpack source (Simple), guarded with class_exists() at every call site. This removes the duplicate ship of the package's build artifacts from the mu-wpcom-plugin deploy.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -16,7 +16,6 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-google-analytics": "@dev",
 		"automattic/jetpack-masterbar": "@dev",
-		"automattic/jetpack-newsletter": "@dev",
 		"automattic/jetpack-podcast": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-rtc": "@dev",

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -389,7 +389,14 @@ class Jetpack_Mu_Wpcom {
 
 		// Initialize Newsletter Settings so hooks like the Reading page notice
 		// are registered on Simple sites (where load-jetpack.php doesn't run).
-		\Automattic\Jetpack\Newsletter\Settings::init();
+		// Guarded with class_exists since mu-wpcom no longer composer-requires
+		// the jetpack-newsletter package: the class is provided by the standalone
+		// Jetpack plugin on Atomic, or by the wpcom platform's bundled Jetpack
+		// source on Simple.
+		if ( class_exists( '\Automattic\Jetpack\Newsletter\Settings' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- class_exists guarded above; provided by sibling autoloader.
+			\Automattic\Jetpack\Newsletter\Settings::init();
+		}
 
 		// Initialize the Podcast package on Simple sites (where late_initialization
 		// in class.jetpack.php doesn't run). Gated by `jetpack_podcast_untangle`

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -472,18 +472,14 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Write a welcome message', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function () {
-				return \Automattic\Jetpack\Newsletter\Urls::get_newsletter_settings_url();
-			},
+			'get_calypso_path'     => 'wpcom_launchpad_get_newsletter_settings_url',
 		),
 		'enable_subscribers_modal'        => array(
 			'get_title'            => function () {
 				return __( 'Enable subscribers modal', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function () {
-				return \Automattic\Jetpack\Newsletter\Urls::get_newsletter_settings_url();
-			},
+			'get_calypso_path'     => 'wpcom_launchpad_get_newsletter_settings_url',
 		),
 		'add_10_email_subscribers'        => array(
 			'get_title'                 => function () {
@@ -635,9 +631,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_has_added_subscribe_block',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_subscribe_block_visible',
-			'get_calypso_path'     => function () {
-				return \Automattic\Jetpack\Newsletter\Urls::get_newsletter_settings_url();
-			},
+			'get_calypso_path'     => 'wpcom_launchpad_get_newsletter_settings_url',
 		),
 		'mobile_app_installed'            => array(
 			'get_title'            => function () {
@@ -1711,6 +1705,21 @@ function wpcom_launchpad_get_write_3_posts_repetition_count( $task ) {
 	$published_non_headstart_posts = wpcom_launchpad_get_published_non_headstart_posts_count();
 
 	return min( $task['target_repetitions'], $published_non_headstart_posts );
+}
+
+/**
+ * Resolve the Newsletter Settings page URL, falling back to the canonical wp-admin path
+ * if the Newsletter package isn't autoloaded (e.g. if the host plugin has been unloaded).
+ *
+ * @return string
+ */
+function wpcom_launchpad_get_newsletter_settings_url() {
+	if ( class_exists( '\Automattic\Jetpack\Newsletter\Urls' ) ) {
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- class_exists guarded above; provided by sibling autoloader.
+		return \Automattic\Jetpack\Newsletter\Urls::get_newsletter_settings_url();
+	}
+
+	return admin_url( 'admin.php?page=jetpack-newsletter' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -275,7 +275,15 @@ function wpcom_add_shopping_cart( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_shopping_cart', 11 );
 
 // Add the reader icon to the admin bar before the help center icon.
-add_action( 'wp_loaded', array( 'Automattic\Jetpack\Newsletter\Reader_Link', 'init' ) );
+add_action(
+	'wp_loaded',
+	function () {
+		if ( class_exists( '\Automattic\Jetpack\Newsletter\Reader_Link' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- class_exists guarded above; provided by sibling autoloader.
+			\Automattic\Jetpack\Newsletter\Reader_Link::init();
+		}
+	}
+);
 
 /**
  * Points the "Edit Profile" and "Howdy,..." to /me if the user is not member of the blog.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -425,8 +425,12 @@ function wpcom_add_jetpack_submenu() {
 		// Register the in-admin Newsletter settings page (with its own render callback
 		// and admin hooks). This must be done here (at priority 999999) because the
 		// Jetpack menu is created by this function and doesn't exist at earlier priorities.
-		$newsletter_settings = new Newsletter_Settings();
-		$newsletter_settings->add_wp_admin_submenu();
+		if ( class_exists( '\Automattic\Jetpack\Newsletter\Settings' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- class_exists guarded above; provided by sibling autoloader.
+			$newsletter_settings = new Newsletter_Settings();
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- class_exists guarded above; provided by sibling autoloader.
+			$newsletter_settings->add_wp_admin_submenu();
+		}
 
 		// Jetpack > Traffic
 		add_submenu_page(

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-newsletter-bootstrap-via-module
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-newsletter-bootstrap-via-module
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1227,7 +1227,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "5ac3b4268d352de7e901a9ce29ebab28ce26b950"
+                "reference": "9550ed17eaf560f57f7fe35b63b05f85e4051e06"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1239,7 +1239,6 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
-                "automattic/jetpack-newsletter": "@dev",
                 "automattic/jetpack-podcast": "@dev",
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-rtc": "@dev",
@@ -1305,85 +1304,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Enhances your site with features powered by WordPress.com",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-newsletter",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/newsletter",
-                "reference": "80b6d5ab8ec2964f09457217d43d5cfdf0321f9e"
-            },
-            "require": {
-                "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-plans": "@dev",
-                "automattic/jetpack-redirect": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "automattic/jetpack-wp-build-polyfills": "@dev",
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-newsletter",
-                "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
-                },
-                "textdomain": "jetpack-newsletter",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-settings.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-newsletter/compare/v${old}...v${new}"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "watch": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run watch"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-coverage": [
-                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "typecheck": [
-                    "pnpm run typecheck"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Newsletter functionality",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/wpcomsh/changelog/try-newsletter-bootstrap-via-module
+++ b/projects/plugins/wpcomsh/changelog/try-newsletter-bootstrap-via-module
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1434,7 +1434,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "5ac3b4268d352de7e901a9ce29ebab28ce26b950"
+                "reference": "9550ed17eaf560f57f7fe35b63b05f85e4051e06"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1446,7 +1446,6 @@
                 "automattic/jetpack-explat": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
-                "automattic/jetpack-newsletter": "@dev",
                 "automattic/jetpack-podcast": "@dev",
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-rtc": "@dev",
@@ -1512,85 +1511,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Enhances your site with features powered by WordPress.com",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-newsletter",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/newsletter",
-                "reference": "80b6d5ab8ec2964f09457217d43d5cfdf0321f9e"
-            },
-            "require": {
-                "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-plans": "@dev",
-                "automattic/jetpack-redirect": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "automattic/jetpack-wp-build-polyfills": "@dev",
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-newsletter",
-                "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
-                },
-                "textdomain": "jetpack-newsletter",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-settings.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-newsletter/compare/v${old}...v${new}"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "watch": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run watch"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-coverage": [
-                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "typecheck": [
-                    "pnpm run typecheck"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Newsletter functionality",
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
Build/mirror test for #48627 — that PR is currently in **Draft** state, so the "Push to mirror repos" job is skipped and the `try/newsletter-bootstrap-via-module` branch is missing on the `Automattic/jetpack-mu-wpcom-plugin` and `Automattic/wpcomsh` mirror repos. That makes it impossible to spin up a Jurassic Ninja site with `branches.jetpack-mu-wpcom-plugin=...&branches.wpcomsh=...` against the original PR's branch.

This PR is identical in content to #48627 (rebased on current trunk) and is **not draft**, so the mirror push runs and the matching branch lands on each mirror repo.

**Do not merge.** This is a build-only test branch — it will be closed once #48627 is marked ready for review (or merged) and the original branch's mirrors are populated.

## Testing

JN spawn URL once the mirror branches are live:

```
https://jurassic.ninja/create?jetpack-beta&branches.jetpack=cg/newsletter-mu-wpcom-build-test&branches.jetpack-mu-wpcom-plugin=cg/newsletter-mu-wpcom-build-test&branches.wpcomsh=cg/newsletter-mu-wpcom-build-test&wp-debug-log
```

## Does this pull request change what data or activity we track or use?

No.
