### PR TITLE
CRM: Remove Skype refs, add `sip:` prefix, and fix JS error

### DIFF
--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -435,21 +435,27 @@ if ( ! $confirmAct ) {
 
 
 				<tr>
-					<td class="wfieldname"><label for="wpzbscrm_clicktocalltype"><?php esc_html_e( 'Click 2 Call link type', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Use Skype or Standard Click to Call?', 'zero-bs-crm' ); ?></td>
+					<td class="wfieldname"><label for="wpzbscrm_clicktocalltype"><?php esc_html_e( 'Click 2 Call link type', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Choose the link protocol for Click to Call', 'zero-bs-crm' ); ?></td>
 					<td style="width:540px">
 						<select class="winput form-control" name="wpzbscrm_clicktocalltype" id="wpzbscrm_clicktocalltype">
 							<option value="1"
 							<?php
-							if ( isset( $settings['clicktocalltype'] ) && $settings['clicktocalltype'] == '1' ) {
+							if ( isset( $settings['clicktocalltype'] ) && $settings['clicktocalltype'] === 1 ) {
 								echo ' selected="selected"';}
 							?>
-							>Click to Call (tel:)</option>
+							>tel:</option>
 							<option value="2"
 							<?php
-							if ( isset( $settings['clicktocalltype'] ) && $settings['clicktocalltype'] == '2' ) {
+							if ( isset( $settings['clicktocalltype'] ) && $settings['clicktocalltype'] === 2 ) {
 								echo ' selected="selected"';}
 							?>
-							>Skype Call (callto:)</option>
+							>callto:</option>
+							<option value="3"
+							<?php
+							if ( isset( $settings['clicktocalltype'] ) && $settings['clicktocalltype'] === 3 ) {
+								echo ' selected="selected"';}
+							?>
+							>sip:</option>
 						</select>
 					</td>
 				</tr>

--- a/projects/plugins/crm/changelog/update-crm-remove_skype_refs
+++ b/projects/plugins/crm/changelog/update-crm-remove_skype_refs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Click 2 Call: Add `sip:` prefix.

--- a/projects/plugins/crm/changelog/update-crm-remove_skype_refs#1
+++ b/projects/plugins/crm/changelog/update-crm-remove_skype_refs#1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Click 2 Call: Catch JS error when creating links.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Config.Init.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Config.Init.php
@@ -82,7 +82,7 @@ $zeroBSCRM_Conf_Def = array(
 	'usercangiveownership'               => 0,
 	'taskownership'                      => 0,
 	'clicktocall'                        => 0,
-	'clicktocalltype'                    => 1, // 1 = tel: , 2 = callto:
+	'clicktocalltype'                    => 1, // 1 = tel: , 2 = callto: , 3 = sip:
 	'objnav'                             => -1,
 	'usesocial'                          => 1,
 	'useaka'                             => 1,

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -7318,11 +7318,14 @@ function zeroBSCRM_clickToCallPrefix() {
 
 	$click2CallType = zeroBSCRM_getSetting( 'clicktocalltype' );
 
-	if ( $click2CallType == 1 ) {
+	if ( $click2CallType === 1 ) {
 		return 'tel:';
 	}
-	if ( $click2CallType == 2 ) {
+	if ( $click2CallType === 2 ) {
 		return 'callto:';
+	}
+	if ( $click2CallType === 3 ) {
+		return 'sip:';
 	}
 }
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.editview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.editview.js
@@ -210,7 +210,7 @@ function zeroBSCRMJS_initLinkify( ele ) {
 	if ( v.length > 5 ) {
 		const possMatch = zeroBSCRMJS_retrieveURLS( v );
 
-		if ( typeof possMatch === 'object' && typeof possMatch[ 0 ] !== 'undefined' ) {
+		if ( possMatch !== null && typeof possMatch[ 0 ] !== 'undefined' ) {
 			// remove any prev
 			jQuery( '.zbs-linkify', jQuery( ele ).parent() ).remove();
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -1598,10 +1598,12 @@ function zeroBSCRMJS_telLinkFromNo( telno, internalHTML, extraClasses ) {
  * @param telno
  */
 function zeroBSCRMJS_telURLFromNo( telno ) {
-	if ( typeof window.zbsClick2CallType !== 'undefined' ) {
-		// eslint-disable-next-line eqeqeq
-		if ( window.zbsClick2CallType == 2 ) {
+	if ( window.zbsClick2CallType ) {
+		if ( window.zbsClick2CallType === 2 ) {
 			return 'callto:' + telno;
+		}
+		if ( window.zbsClick2CallType === 3 ) {
+			return 'sip:' + telno;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
1. This removes the Skype references from the setting, as Skype is no more, but leaves the `callto:` prefix, which can be used by other systems.
2. This adds a `sip:` prefix, which is another common prefix and was easy to add.
3. This fixes a JS error that occurred when trying to linkify non-URL inputs.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://github.com/Automattic/jetpack/pull/47154#pullrequestreview-3991873940

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. The Click 2 Call settings should save.
2. Changing the prefix should be reflected in phone number links.
3. There shouldn't be a JS error when an input (e.g. editing a contact) has more than 5 chars but is not a URL.