### PR TITLE
Write editor: add dismissible beta disclaimer banner

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-05-08-20-02-30-534369
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-05-08-20-02-30-534369
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: add dismissible beta disclaimer banner warning that data loss is possible.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -263,6 +263,7 @@
 	left: 0;
 	right: 0;
 	z-index: 100001;
+	box-sizing: border-box;
 	height: 44px;
 	background: #fff8e6;
 	border-bottom: 1px solid #e8c84a;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -256,6 +256,68 @@
 	padding-top: 164px;
 }
 
+/* ===== Beta disclaimer banner ===== */
+.bw-disclaimer-banner {
+	position: fixed;
+	top: 56px;
+	left: 0;
+	right: 0;
+	z-index: 100001;
+	height: 44px;
+	background: #fff8e6;
+	border-bottom: 1px solid #e8c84a;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	animation: bw-fade-in 0.2s ease;
+}
+
+.bw-disclaimer-banner[hidden] {
+	display: none;
+}
+
+.bw-disclaimer-text {
+	font-size: 14px;
+	color: #1a1a1a;
+}
+
+.bw-disclaimer-dismiss {
+	border: none;
+	background: transparent;
+	color: #999;
+	font-size: 20px;
+	cursor: pointer;
+	padding: 4px 8px;
+	line-height: 1;
+}
+
+.bw-disclaimer-dismiss:hover {
+	color: #333;
+}
+
+/* Push toolbar and content down when disclaimer banner is visible */
+.bw-disclaimer-banner:not([hidden]) ~ .bw-toolbar {
+	top: 100px;
+}
+
+.bw-disclaimer-banner:not([hidden]) ~ .bw-main {
+	padding-top: 164px;
+}
+
+/* Both disclaimer and recovery visible — stack recovery below disclaimer */
+.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) {
+	top: 100px;
+}
+
+.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-toolbar {
+	top: 144px;
+}
+
+.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-main {
+	padding-top: 208px;
+}
+
 /* ===== Persistent formatting toolbar ===== */
 .bw-toolbar {
 	position: fixed;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -17,6 +17,7 @@ const i18n = window.wpcomWriteStrings || {};
 const AUTOSAVE_INTERVAL_MS = 30000; // 30 seconds.
 const AUTOSAVE_MESSAGE_DURATION_MS = 2000;
 const AUTOSAVE_STORAGE_KEY = 'wpcom-write-autosave-draft';
+const DISCLAIMER_STORAGE_KEY = 'wpcom-write-disclaimer-dismissed';
 
 // Autosave state — tracked outside the store to avoid triggering reactivity.
 let lastSavedSnapshot = { title: '', content: '' };
@@ -3134,6 +3135,11 @@ const { state } = store( 'wpcom-write', {
 			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
 			state.showRecoveryBanner = false;
 		},
+
+		dismissDisclaimer() {
+			localStorage.setItem( DISCLAIMER_STORAGE_KEY, '1' );
+			state.showDisclaimer = false;
+		},
 	},
 } );
 
@@ -3359,6 +3365,11 @@ const autosaveReady = setInterval( () => {
 	autosaveTimer = setInterval( () => {
 		actions.autosave();
 	}, AUTOSAVE_INTERVAL_MS );
+
+	// Show the beta disclaimer unless previously dismissed.
+	if ( ! localStorage.getItem( DISCLAIMER_STORAGE_KEY ) ) {
+		state.showDisclaimer = true;
+	}
 
 	// Check for a recoverable autosaved draft (only for new posts).
 	if ( ! state.editPostId ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -457,6 +457,12 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		</div>
 	</header>
 
+	<!-- Beta disclaimer banner -->
+	<div class="bw-disclaimer-banner" hidden data-wp-bind--hidden="!state.showDisclaimer">
+		<span class="bw-disclaimer-text"><?php echo esc_html__( 'Beta: This is an early-access feature. Data loss is possible.', 'jetpack-mu-wpcom' ); ?></span>
+		<button class="bw-disclaimer-dismiss" data-wp-on--click="actions.dismissDisclaimer" aria-label="<?php echo esc_attr__( 'Dismiss beta disclaimer', 'jetpack-mu-wpcom' ); ?>">&times;</button>
+	</div>
+
 	<!-- Recovery banner -->
 	<div class="bw-recovery-banner" hidden data-wp-bind--hidden="!state.showRecoveryBanner">
 		<span class="bw-recovery-text"><?php echo esc_html__( 'You have a recent draft — continue editing?', 'jetpack-mu-wpcom' ); ?></span>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -413,6 +413,30 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the template contains the beta disclaimer banner markup.
+	 */
+	public function test_template_contains_disclaimer_banner() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'class="bw-disclaimer-banner"', $output );
+		$this->assertStringContainsString( 'actions.dismissDisclaimer', $output );
+		$this->assertStringContainsString( 'Data loss is possible', $output );
+	}
+
+	/**
+	 * Test that the disclaimer banner is hidden by default (shown via JS after localStorage check).
+	 */
+	public function test_disclaimer_banner_hidden_by_default() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'bw-disclaimer-banner" hidden', $output );
+	}
+
+	/**
 	 * Test that autosave i18n strings are included in the rendered page state.
 	 */
 	public function test_autosave_i18n_strings_registered() {


### PR DESCRIPTION
Fixes RSM-2646

## Proposed changes
* Add a dismissible beta disclaimer banner to the Write editor (jetpack-mu-wpcom)
* Banner displays: "Beta: This is an early-access feature. Data loss is possible."
* Once dismissed, the banner never reappears (dismissal persisted to `localStorage`)
* Correctly stacks with the recovery banner if both are visible simultaneously

<img width="736" height="229" alt="Screenshot 2026-05-08 at 4 04 18 PM" src="https://github.com/user-attachments/assets/0ad5a76d-85a6-4792-99f8-12483fb23c08" />
<img width="778" height="386" alt="Screenshot 2026-05-08 at 4 02 25 PM" src="https://github.com/user-attachments/assets/41937a0a-7a07-4166-ab4f-b0b3278b8654" />

## Related product discussion/links
* RSM-2646

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to the Write editor (`admin.php?page=write`)
* The beta disclaimer banner should appear at the top of the editor
* Click `×` — the banner should disappear
* Refresh the page — the banner should remain hidden
* To reset: DevTools → Application → Local Storage → delete `wpcom-write-disclaimer-dismissed`, then refresh — the banner reappears

