### PR TITLE
Write editor: fix missing browser tab title

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rsm-2786-write-page-title
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rsm-2786-write-page-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: fix missing browser tab title caused by hidden submenu page not being found by get_admin_page_title().

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -67,6 +67,21 @@ add_action(
 	}
 );
 
+// Hidden submenu pages (empty parent slug) are not found by get_admin_page_title(),
+// so the browser tab shows only the site name. Fix via the admin_title filter.
+add_filter(
+	'admin_title',
+	function ( $admin_title, $title ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page routing.
+		if ( empty( $title ) && isset( $_GET['page'] ) && 'write' === $_GET['page'] ) {
+			return __( 'Write editor', 'jetpack-mu-wpcom' ) . ltrim( $admin_title );
+		}
+		return $admin_title;
+	},
+	10,
+	2
+);
+
 /**
  * Register the Write admin page.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -74,7 +74,7 @@ add_filter(
 	function ( $admin_title, $title ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page routing.
 		if ( empty( $title ) && isset( $_GET['page'] ) && 'write' === $_GET['page'] ) {
-			return __( 'Write editor', 'jetpack-mu-wpcom' ) . ltrim( $admin_title );
+			return __( 'Write editor', 'jetpack-mu-wpcom' ) . $admin_title;
 		}
 		return $admin_title;
 	},

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -527,4 +527,25 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'youtube.com/embed/dQw4w9WgXcQ', $output );
 		$this->assertStringContainsString( 'bw-video-figure', $output );
 	}
+
+	/**
+	 * Test that the admin_title filter sets the browser tab title on the Write page.
+	 */
+	public function test_admin_title_filter_sets_title_on_write_page() {
+		$_GET['page'] = 'write';
+		$result       = apply_filters( 'admin_title', ' &#8249; Test Site &#8212; WordPress', '' );
+		unset( $_GET['page'] );
+
+		$this->assertStringStartsWith( 'Write editor', $result );
+	}
+
+	/**
+	 * Test that the admin_title filter does not affect other admin pages.
+	 */
+	public function test_admin_title_filter_does_not_affect_other_pages() {
+		$original = 'Dashboard &#8249; Test Site &#8212; WordPress';
+		$result   = apply_filters( 'admin_title', $original, 'Dashboard' );
+
+		$this->assertSame( $original, $result );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -536,7 +536,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$result       = apply_filters( 'admin_title', ' &#8249; Test Site &#8212; WordPress', '' );
 		unset( $_GET['page'] );
 
-		$this->assertStringStartsWith( 'Write editor', $result );
+		$this->assertStringStartsWith( 'Write editor ', $result );
 	}
 
 	/**


### PR DESCRIPTION
Fixes RSM-2786

## Proposed changes

* `add_submenu_page()` with an empty parent slug stores the page in `$submenu['']`, which `get_admin_page_title()` never searches (it only looks in `$menu` when there is no parent). This left `$title` empty, so the browser tab showed only `‹ Site Name — WordPress`.
* Fix by hooking into `admin_title` to prepend "Write editor" when the page title is empty on the Write page.

Before | After
---- | ----
<img width="295" height="46" alt="Screenshot 2026-05-08 at 4 45 22 PM" src="https://github.com/user-attachments/assets/10b1b6ba-17e9-4413-ba0d-46dca466407b" /> | <img width="280" height="43" alt="Screenshot 2026-05-08 at 4 46 57 PM" src="https://github.com/user-attachments/assets/8502316a-2ce5-41e7-8617-a2a449929bee" />


## Related product discussion/links

* RSM-2786

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Enable the `wpcom-write-editor` blog sticker on a test site.
* Navigate to `wp-admin/admin.php?page=write`.
* **Before:** browser tab shows `‹ Site Name — WordPress` (empty page title).
* **After:** browser tab shows `Write editor ‹ Site Name — WordPress`.