### PR TITLE
Search Dashboard: harden plan-info renders against missing API data

### DIFF
--- a/projects/packages/search/changelog/fix-search-dashboard-harden-plan-info-renders
+++ b/projects/packages/search/changelog/fix-search-dashboard-harden-plan-info-renders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: guard `<PlanInfo>` and `<PlanUsageSection>` against missing wpcom plan fields so the dashboard React tree no longer throws "Cannot read properties of undefined" when `state.sitePlan.plan_usage` or `plan_current` is partially populated. Three landmines: `getLatestMonthRequests` selector's unguarded `[ 0 ]` after the `?.`; `displayPeriodFromAPIData` accessing `latestMonthRequests.start_date` without nullish guard; and the missing `?.` on `currentPlan.monthly_search_request_limit` in `usageInfoFromAPIData`. The dashboard now renders cleanly even when the wpcom plan response hasn't fully resolved.

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
@@ -8,6 +8,9 @@ const getPlanName = isFreePlan => {
 };
 
 const displayPeriodFromAPIData = apiData => {
+	if ( ! apiData?.latestMonthRequests?.start_date || ! apiData?.latestMonthRequests?.end_date ) {
+		return null;
+	}
 	const startDate = new Date( apiData.latestMonthRequests.start_date );
 	const endDate = new Date( apiData.latestMonthRequests.end_date );
 
@@ -26,6 +29,7 @@ const displayPeriodFromAPIData = apiData => {
 };
 
 const PlanSummary = ( { isFreePlan, planInfo } ) => {
+	const period = displayPeriodFromAPIData( planInfo );
 	return (
 		<h2>
 			{
@@ -33,7 +37,7 @@ const PlanSummary = ( { isFreePlan, planInfo } ) => {
 				__( 'Your usage', 'jetpack-search-pkg' )
 			}{ ' ' }
 			<span>
-				{ displayPeriodFromAPIData( planInfo ) } ({ getPlanName( isFreePlan ) })
+				{ period && `${ period } ` }({ getPlanName( isFreePlan ) })
 			</span>
 		</h2>
 	);

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -16,7 +16,7 @@ const usageInfoFromAPIData = apiData => {
 		recordCount: apiData?.currentUsage?.num_records || 0,
 		recordMax: apiData?.currentPlan?.record_limit || 0,
 		requestCount: apiData?.latestMonthRequests?.num_requests || 0,
-		requestMax: apiData?.currentPlan.monthly_search_request_limit || 0,
+		requestMax: apiData?.currentPlan?.monthly_search_request_limit || 0,
 	};
 };
 

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -11,7 +11,7 @@ const sitePlanSelectors = {
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
 	isFreePlan: state => state.sitePlan.effective_subscription?.product_slug === productSlugFree,
-	getLatestMonthRequests: state => state.sitePlan.plan_usage?.num_requests_3m[ 0 ],
+	getLatestMonthRequests: state => state.sitePlan.plan_usage?.num_requests_3m?.[ 0 ],
 	getCurrentPlan: state => state.sitePlan.plan_current,
 	getCurrentUsage: state => state.sitePlan.plan_usage,
 };


### PR DESCRIPTION
Fixes pre-existing `Cannot read properties of undefined` crashes in the Search dashboard when `state.sitePlan.plan_usage` / `plan_current` haven't fully populated yet.

## Proposed changes

* **Selector**: `projects/packages/search/src/dashboard/store/selectors/site-plan.js` — `getLatestMonthRequests` had `state.sitePlan.plan_usage?.num_requests_3m[ 0 ]`. The optional chain on `plan_usage` is undermined by the unguarded `[ 0 ]` — when `plan_usage` (or `num_requests_3m`) is undefined, accessing `undefined[ 0 ]` throws "Cannot read properties of undefined (reading '0')". Add the missing `?.` between `num_requests_3m` and `[ 0 ]`.
* **`<PlanSummary>`**: `displayPeriodFromAPIData` reads `apiData.latestMonthRequests.start_date` and `.end_date` unconditionally. Bail to `null` if either date is missing; the `<h2>` keeps rendering, just without the date span.
* **`<PlanUsageSection>`**: `usageInfoFromAPIData` had `apiData?.currentPlan.monthly_search_request_limit` — missing `?.` on `.currentPlan` (the three sibling lines had it). Same crash class. Add the `?.`.

## Why this matters

The Search dashboard renders `<PlanInfo>` → `<FirstRunSection>` → `<PlanSummary>` and `<PlanUsageSection>` whenever `isNewPricing && supportsInstantSearch`. These components reach into the redux `sitePlan` state without fully guarding against pieces being undefined while the resolver fetches the wpcom plan response. When any of the three landmines fires, React unmounts the entire dashboard subtree, the `<h1>` heading disappears, and the page renders blank — which is exactly what made the Search e2e dashboard test ("`Title should be visible`") flaky against the partner-provisioned 'free' plan that the e2e infra uses.

## Related product discussion/links

* Surfaced while working on #48550 — the Search e2e was flaking on this exact crash, intermittently catching the resolver mid-flight when `plan_usage` was partially populated. Splitting the hardening out so #48550 stays scoped to the notice migration.

## Does this pull request change what data or activity we track or use?

No. Defensive guards only.

## Testing instructions

1. On a connected Jetpack site, deactivate any paid Search subscription and visit `/wp-admin/admin.php?page=jetpack-search`.
2. **Before this PR**: with `?new_pricing_202208=1` (or wherever `isNewPricing && supportsInstantSearch` is true), if the wpcom plan endpoint hasn't fully resolved yet, the dashboard renders blank — main content area is empty, only WP-admin chrome shows. Console error: `Uncaught TypeError: Cannot read properties of undefined (reading '0')` traced to `<PlanInfo>`.
3. **After this PR**: the dashboard renders with `<PlanSummary>`'s `<h2>` showing just the plan name (e.g., "(Free plan)") when the date period isn't available, the donut meters show `0 / 0`, and no React-tree crash. The `<h1>` from `<MockedSearchContent>` is visible — Search e2e's `getByRole('heading', { name: 'Help your visitors find' })` finds it.

A console probe to confirm:

```js
console.log( document.querySelector('#jp-search-dashboard')?.children?.length );
// Before fix: 0 (React unmounted)
// After fix:  1 (React tree mounted)
```

No visual change for sites where the wpcom plan is fully populated — the guards just keep the existing render path.
