### PR TITLE
CRM: Address jpcrm-storage dir warnings when not writable

### DIFF
--- a/projects/plugins/crm/changelog/fix-jetpack-crm-address_jpcrm_storage_dir_warnings
+++ b/projects/plugins/crm/changelog/fix-jetpack-crm-address_jpcrm_storage_dir_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Storage: Prevent PHP errors when storage dir is not writable.

--- a/projects/plugins/crm/changelog/fix-jetpack-crm-address_jpcrm_storage_dir_warnings#1
+++ b/projects/plugins/crm/changelog/fix-jetpack-crm-address_jpcrm_storage_dir_warnings#1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Storage: Add new `jpcrm_storage_dir_info` filter.

--- a/projects/plugins/crm/includes/ZeroBSCRM.FileUploads.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FileUploads.php
@@ -414,30 +414,40 @@ function jpcrm_get_hash_for_object( $object_id, $object_hash_string ) {
 	return $zbs->encryption->hash( $object_id . $zbs->encryption->get_encryption_key( $object_hash_string ) );
 }
 
-/*
+/**
  * Returns the 'dir info' for the storage folder.
- * dir info =
- * [
- *      'path' => 'path for the physical file',
- *      'url'  => 'public facing url'
- * ]
  *
+ * Defaults to `wp-content/jpcrm-storage`, but can be modified by the `jpcrm_storage_dir_info` filter.
+ *
+ * @return array|false {
+ *     Directory info, or false if filtered to an empty value.
+ *
+ *     @type string $path Absolute filesystem path for storing files.
+ *     @type string $url  Public-facing URL for the same location.
+ * }
  */
 function jpcrm_storage_dir_info() {
-	$uploads_dir      = WP_CONTENT_DIR;
-	$uploads_url      = content_url();
 	$private_dir_name = 'jpcrm-storage';
 
-	if ( ! empty( $uploads_dir ) && ! empty( $uploads_url ) ) {
-		$full_dir_path = $uploads_dir . '/' . $private_dir_name;
-		$full_url      = $uploads_url . '/' . $private_dir_name;
-		return array(
-			'path' => $full_dir_path,
-			'url'  => $full_url,
-		);
+	$dir_info = array(
+		'path' => trailingslashit( WP_CONTENT_DIR ) . $private_dir_name,
+		'url'  => trailingslashit( content_url() ) . $private_dir_name,
+	);
+
+	/**
+	 * Filters the CRM private storage directory location.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $dir_info
+	 */
+	$dir_info = apply_filters( 'jpcrm_storage_dir_info', $dir_info );
+
+	if ( empty( $dir_info['path'] ) || empty( $dir_info['url'] ) ) {
+		return false;
 	}
 
-	return false;
+	return $dir_info;
 }
 
 /**

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1433,7 +1433,6 @@ function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '',
 
 	$files = array(
 		array(
-			'base'    => $directory_path,
 			'file'    => 'index.html',
 			'content' => '<!--nope-->',
 		),
@@ -1441,7 +1440,6 @@ function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '',
 
 	if ( $include_htaccess ) {
 		$files[] = array(
-			'base'    => $directory_path,
 			'file'    => '.htaccess',
 			'content' => 'DirectoryIndex index.php index.html' . PHP_EOL . 'deny from all',
 		);
@@ -1450,25 +1448,20 @@ function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '',
 	}
 
 	foreach ( $files as $file ) {
+		$file_path = trailingslashit( $directory_path ) . $file['file'];
 
-		if ( ! file_exists( trailingslashit( $file['base'] ) ) ) {
-			wp_mkdir_p( $file['base'] );
+		if ( file_exists( $file_path ) ) {
+			continue;
 		}
 
-		if ( ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
+		$file_handle = @fopen( $file_path, 'wb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( $file_handle ) {
+			fwrite( $file_handle, $file['content'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+			fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		}
 
-			$file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'wb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-			if ( $file_handle ) {
-				fwrite( $file_handle, $file['content'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
-				fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-			}
-
-			if ( ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
-
-				// failed to create file
-				$safe = false;
-
-			}
+		if ( ! file_exists( $file_path ) ) {
+			$safe = false;
 		}
 	}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1429,6 +1429,11 @@ function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '',
 		chmod( $directory_path, 0755 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
 	}
 
+	// Bail if the directory exists but is not writable.
+	if ( ! wp_is_writable( $directory_path ) ) {
+		return false;
+	}
+
 	$safe = true;
 
 	$files = array(

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1457,10 +1457,10 @@ function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '',
 
 		if ( ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
 
-			$file_handle = fopen( trailingslashit( $file['base'] ) . $file['file'], 'wb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
+			$file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'wb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 			if ( $file_handle ) {
-				fwrite( $file_handle, $file['content'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
-				fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+				fwrite( $file_handle, $file['content'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+				fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			}
 
 			if ( ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1417,15 +1417,19 @@ function jpcrm_wordpress_version( $operator = '>', $version = '4.0' ) {
  */
 function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '', $include_htaccess = true ) {
 
-	$safe = true;
-
-	// Creates the directory if it doesn't exist
-	if ( ! is_dir( $directory_path ) ) {
-		// Attempt to create
-		mkdir( $directory_path, 0755, true );
-		// Force perms
-		chmod( $directory_path, 0755 );
+	if ( empty( $directory_path ) ) {
+		return false;
 	}
+
+	// Create the directory if it doesn't exist. Bail if creation fails.
+	if ( ! is_dir( $directory_path ) ) {
+		if ( ! wp_mkdir_p( $directory_path ) ) {
+			return false;
+		}
+		chmod( $directory_path, 0755 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+	}
+
+	$safe = true;
 
 	$files = array(
 		array(


### PR DESCRIPTION
Fixes #47440

## Proposed changes
<!--- Explain what functional changes your PR includes -->
This adjusts the CRM storage code to more gracefully handle non-writable folders:
* Adds a new `jpcrm_storage_dir_info` filter that can be used to specify a desired directory where things are stored.
* Silences several warnings when trying to protect a given folder.
* General code cleanup

Out of scope is a larger refactor; the goal is to avoid excessive PHP errors.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Try uploading files to a contact in the following scenarios:

1. non-writable wp-content folder (should get a user-facing error)
2. a filtered `jpcrm_storage_dir_info` var