### PR TITLE
Write: Show post title in the header bar

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_header_bar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_header_bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Show post title (or 'Untitled') in the header bar so it never feels empty

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -142,11 +142,16 @@
 	font-size: 14px;
 	color: #999;
 	font-weight: 400;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	padding: 0 12px;
 }
 
 .bw-topbar-actions {
 	display: flex;
 	gap: 8px;
+	flex-shrink: 0;
 }
 
 .bw-btn {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1698,6 +1698,12 @@ const { state } = store( 'wpcom-write', {
 		formatQuote: false,
 		imageUrl: '',
 		headingLabel: i18n.normal || 'Normal',
+		get headerLabel() {
+			return state.title.trim() || i18n.untitled || 'Untitled';
+		},
+		get displayStatus() {
+			return state.message || state.headerLabel;
+		},
 	},
 
 	actions: {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -142,6 +142,7 @@ add_action(
 			'preview'              => __( 'Preview', 'jetpack-mu-wpcom' ),
 			// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
 			'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
+			'untitled'             => __( 'Untitled', 'jetpack-mu-wpcom' ),
 		);
 		wp_print_inline_script_tag(
 			'window.wpcomWriteStrings = ' . wp_json_encode( $write_strings, JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
@@ -439,7 +440,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<div class="bw-help-row"><kbd>#tag</kbd><span><?php echo esc_html__( 'A line containing only #tags assigns them to the post on save', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
 		</div><!-- /.bw-help-wrap -->
-		<span class="bw-status" data-wp-text="state.message"></span>
+		<span class="bw-status" data-wp-text="state.displayStatus"></span>
 		<div class="bw-topbar-actions">
 			<button
 				class="bw-btn bw-btn-draft"


### PR DESCRIPTION
Fixes RSM-2655

## Proposed changes

* Add a persistent title label to the Write editor header bar so it never feels empty. 
* The center area (`bw-status`) now shows the post title, or "Untitled" for new posts.
* Transient status messages ("Saving draft...", "Draft saved", etc.) still temporarily override the label, then it fades back.
* Long titles are truncated with ellipsis via CSS.
* "Untitled" is a translatable string.

Note that I chose to make the title persistent. It's not 'scroll-aware' and is displayed when the title input is displayed. I chose this approach because:
* I didn't like the empty space in the header while the title input is displayed, and I couldn't think of any thing else to display in the header.
* I wanted to keep the header consistent.

If you don't like the duplicated title, I'm open to finding a different solution.

## Related product discussion/links

* RSM-2655

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to `/wp-admin/admin.php?page=write` to open the Write editor for a new post
2. Observe the header bar center area — it should show **"Untitled"**
3. Type a title (e.g., "Why I Love Hiking in the Alps") — the header should reactively update to show the title
4. Click **Save draft** — the header should briefly show "Saving draft..." then "Draft saved", then revert to the post title
5. Clear the title field — the header should revert to "Untitled"
6. Type a very long title — it should truncate with "..." in the header bar without overflowing
7. Resize the browser to a narrow viewport (375px) — confirm the title truncates and doesn't overlap the Publish button
8. Navigate to an existing post (e.g., `/wp-admin/admin.php?page=write&post=123`) — confirm the header shows the existing post title on load

## Screenshots

Before title is entered:
<img width="1025" height="258" alt="Screenshot 2026-05-11 at 8 31 29 AM" src="https://github.com/user-attachments/assets/5cd186e8-6c23-43e6-8ca8-dc6783826086" />

After title is entered:
<img width="1031" height="234" alt="Screenshot 2026-05-11 at 8 31 21 AM" src="https://github.com/user-attachments/assets/3f49124c-e23b-451b-84f1-0345c9093862" />



