### PR TITLE
Podcast: add tracks instrumentation

### DIFF
--- a/projects/packages/podcast/.phan/config.php
+++ b/projects/packages/podcast/.phan/config.php
@@ -10,4 +10,9 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs' => array( 'wpcom' ),
+	)
+);

--- a/projects/packages/podcast/changelog/add-podcast-tracks
+++ b/projects/packages/podcast/changelog/add-podcast-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tracks: record podcast publishing, media uploads, status changes, podcatcher show-URL submissions, and settings saves.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -73,9 +73,6 @@ class Podcast {
 		// stats-tracked enclosure URLs) for the configured podcast category.
 		Customize_Feed::init();
 
-		// Wire tracks instrumentation (publish, media upload, status change,
-		// show-URL submission, settings save). Names mirror wpcom so analytics
-		// queries cover Simple, Atomic, and Jetpack feeds without a rewrite.
 		Tracks::init();
 
 		// Wire the wp-admin entry point. Admin_Page::init() stages the wp-build

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -73,6 +73,11 @@ class Podcast {
 		// stats-tracked enclosure URLs) for the configured podcast category.
 		Customize_Feed::init();
 
+		// Wire tracks instrumentation (publish, media upload, status change,
+		// show-URL submission, settings save). Names mirror wpcom so analytics
+		// queries cover Simple, Atomic, and Jetpack feeds without a rewrite.
+		Tracks::init();
+
 		// Wire the wp-admin entry point. Admin_Page::init() stages the wp-build
 		// dashboard; menu registration itself runs from wpcom-admin-menu.php
 		// via Admin_Page::add_wp_admin_submenu() at admin_menu priority 999999.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -1,0 +1,717 @@
+<?php
+/**
+ * Tracks instrumentation for Jetpack Podcast.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Podcast;
+
+use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
+use Throwable;
+use WP_Post;
+use WP_Query;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_User;
+
+/**
+ * Records the lifecycle events that drive podcast funnel reporting:
+ * episode publishes, the per-site first-episode milestone, audio/video
+ * uploads, podcatcher show-URL submissions, podcasting on/off transitions,
+ * and `/wp/v2/settings` writes that touch any `podcasting_*` option.
+ *
+ * Mirrors the wpcom mu-plugin's `Automattic_Podcasting_Tracks`. Event names
+ * stay `wpcom_*` so analytics queries cover Simple, Atomic, and Jetpack feeds
+ * without a rewrite. Dispatch tries the wpcom-loadable `tracks_record_event`
+ * first and falls back to `\Automattic\Jetpack\Tracking::tracks_record_event`
+ * — neither is a hard dep, so the package degrades to silent no-op when
+ * neither is reachable.
+ */
+class Tracks {
+
+	/**
+	 * Whether `init()` has wired its hooks.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/**
+	 * Cached Jetpack Tracking instance, lazily created on first Atomic dispatch.
+	 *
+	 * @var \Automattic\Jetpack\Tracking|null
+	 */
+	private static $jetpack_tracking = null;
+
+	/**
+	 * Snapshot of `podcasting_*` option values captured at the start of a
+	 * `/wp/v2/settings` REST write, keyed by request object hash. Read back
+	 * after the write completes so the emitted event can include both new
+	 * and `previous_*` values per the wpcom shape.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private static $settings_snapshots = array();
+
+	/**
+	 * Wire the tracks hooks. Idempotent.
+	 */
+	public static function init(): void {
+		if ( self::$registered ) {
+			return;
+		}
+		self::$registered = true;
+
+		// `wp_after_insert_post` fires after post + terms + meta are saved. Required for
+		// Gutenberg/REST publishes where `transition_post_status` runs before terms are set.
+		add_action( 'wp_after_insert_post', array( __CLASS__, 'record_episode_published' ), 10, 4 );
+
+		add_action( 'add_attachment', array( __CLASS__, 'record_media_uploaded' ) );
+
+		// Catch every `podcasting_category_id` write — REST, WP-CLI, direct `update_option()`.
+		// `add_option` fires when no row exists yet; `update_option` covers subsequent writes.
+		add_action( 'add_option_podcasting_category_id', array( __CLASS__, 'record_category_added' ), 10, 2 );
+		add_action( 'update_option_podcasting_category_id', array( __CLASS__, 'record_category_updated' ), 10, 3 );
+
+		// Catch every `podcasting_show_urls` write. Both hooks point at the same method;
+		// it detects which fired by the first arg type (string on add, array on update).
+		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
+		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
+
+		// `/wp/v2/settings` PATCH — snapshot before, emit after, mirroring wpcom's
+		// `rest_api_update_site_settings`-driven `wpcom_podcasting_settings_saved`.
+		add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'snapshot_settings_before_write' ), 10, 3 );
+		add_filter( 'rest_request_after_callbacks', array( __CLASS__, 'record_settings_saved' ), 10, 3 );
+	}
+
+	/**
+	 * Reset internal state. Test-only — production never re-initializes.
+	 */
+	public static function reset_for_tests(): void {
+		self::$registered         = false;
+		self::$jetpack_tracking   = null;
+		self::$settings_snapshots = array();
+	}
+
+	/**
+	 * Emit `wpcom_podcast_episode_published` (and, on the very first episode
+	 * for the site, `wpcom_podcast_show_launched`) when a podcast-category
+	 * post enters `publish` for the first time.
+	 *
+	 * @param int          $post_id     Post ID.
+	 * @param WP_Post|null $post        Post object.
+	 * @param bool         $update      Whether this is an update.
+	 * @param WP_Post|null $post_before Previous post state (or null on insert).
+	 */
+	public static function record_episode_published( $post_id, $post, $update, $post_before ): void {
+		unset( $post_id, $update );
+
+		try {
+			if ( ! $post instanceof WP_Post ) {
+				return;
+			}
+
+			if ( 'publish' !== $post->post_status ) {
+				return;
+			}
+
+			if ( $post_before instanceof WP_Post && 'publish' === $post_before->post_status ) {
+				return;
+			}
+
+			if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+				return;
+			}
+
+			// `is_headstart_post` is a wpcom Simple helper that flags pre-populated
+			// demo content; on Atomic the function is absent and the guard short-circuits.
+			if ( function_exists( 'is_headstart_post' ) && is_headstart_post( $post ) ) {
+				return;
+			}
+
+			if ( in_array( $post->post_type, array( 'attachment', 'revision', 'nav_menu_item' ), true ) ) {
+				return;
+			}
+
+			$category_id = Customize_Feed::resolve_category_id();
+			if ( 0 === $category_id ) {
+				return;
+			}
+
+			if ( ! in_category( $category_id, $post ) ) {
+				return;
+			}
+
+			// Match the RSS feed's definition of an episode: must carry a site-hosted
+			// audio or video enclosure. Without this, a post merely categorized into
+			// the podcasting category would fire even when it has no media — top
+			// offenders pre-filter were posting 50+/day of non-podcast content.
+			if ( ! self::has_podcast_media( $post ) ) {
+				return;
+			}
+
+			$is_first = self::is_first_episode_for_site( $category_id, (int) $post->ID );
+			$identity = self::identity_for_post( $post );
+
+			self::record_event(
+				$identity,
+				'wpcom_podcast_episode_published',
+				array(
+					'blog_id'                   => (int) get_current_blog_id(),
+					'post_id'                   => (int) $post->ID,
+					'is_first_episode_for_site' => (bool) $is_first,
+				)
+			);
+
+			// `add_option()` is atomic — only one concurrent caller per site wins the INSERT,
+			// so `wpcom_podcast_show_launched` fires exactly once per site.
+			if ( $is_first && add_option( 'podcast_show_launched_tracked', time(), '', false ) ) {
+				self::record_event(
+					$identity,
+					'wpcom_podcast_show_launched',
+					array(
+						'blog_id' => (int) get_current_blog_id(),
+						'post_id' => (int) $post->ID,
+					)
+				);
+			}
+		} catch ( Throwable $e ) {
+			self::log_failure( 'episode-published-failed', $e );
+		}
+	}
+
+	/**
+	 * Emit `wpcom_podcast_media_uploaded` when an audio/video attachment is
+	 * uploaded on a podcasting-enabled site.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 */
+	public static function record_media_uploaded( $attachment_id ): void {
+		try {
+			if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+				return;
+			}
+
+			// Skip Headstart demo-content uploads — wpcom Simple-only helper.
+			$attachment = get_post( (int) $attachment_id );
+			if ( $attachment && function_exists( 'is_headstart_post' ) && is_headstart_post( $attachment ) ) {
+				return;
+			}
+
+			if ( 0 === Customize_Feed::resolve_category_id() ) {
+				return;
+			}
+
+			$mime_type = (string) get_post_mime_type( (int) $attachment_id );
+			if ( '' === $mime_type ) {
+				return;
+			}
+			if ( 0 !== strpos( $mime_type, 'audio/' ) && 0 !== strpos( $mime_type, 'video/' ) ) {
+				return;
+			}
+
+			self::record_event(
+				wp_get_current_user(),
+				'wpcom_podcast_media_uploaded',
+				array(
+					'blog_id'       => (int) get_current_blog_id(),
+					'attachment_id' => (int) $attachment_id,
+					'mime_type'     => $mime_type,
+				)
+			);
+		} catch ( Throwable $e ) {
+			self::log_failure( 'media-uploaded-failed', $e );
+		}
+	}
+
+	/**
+	 * `add_option_podcasting_category_id` callback — first-ever write of the
+	 * option. Treats the previous value as 0 (option absent == disabled).
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Newly stored value.
+	 */
+	public static function record_category_added( $option, $value ): void {
+		unset( $option );
+
+		try {
+			self::maybe_record_status_change( 0, (int) $value );
+		} catch ( Throwable $e ) {
+			self::log_failure( 'category-added-failed', $e );
+		}
+	}
+
+	/**
+	 * `update_option_podcasting_category_id` callback — every change to an
+	 * existing row. WP short-circuits identical writes upstream, so
+	 * `$old_value !== $value` is guaranteed here.
+	 *
+	 * @param mixed  $old_value Previous stored value.
+	 * @param mixed  $value     Newly stored value.
+	 * @param string $option    Option name.
+	 */
+	public static function record_category_updated( $old_value, $value, $option ): void {
+		unset( $option );
+
+		try {
+			self::maybe_record_status_change( (int) $old_value, (int) $value );
+		} catch ( Throwable $e ) {
+			self::log_failure( 'category-updated-failed', $e );
+		}
+	}
+
+	/**
+	 * Emit `wpcom_podcasting_show_url_saved` for the first podcatcher key
+	 * that transitions from absent/empty to a non-empty string. Each save
+	 * patches one URL by design, so we emit at most one event per write.
+	 *
+	 * Bound to both `add_option_podcasting_show_urls` (signature: option,
+	 * value) and `update_option_podcasting_show_urls` (signature: old_value,
+	 * value, option). The first arg is either the option name (string, on
+	 * add) or the previous stored value (array, on update); `is_array()`
+	 * picks them apart.
+	 *
+	 * @param mixed $first_arg Option name or previous value.
+	 * @param mixed $new_value Newly stored value.
+	 */
+	public static function record_show_url_addition( $first_arg, $new_value ): void {
+		try {
+			$old_value = is_array( $first_arg ) ? $first_arg : array();
+
+			if ( ! is_array( $new_value ) ) {
+				return;
+			}
+
+			foreach ( $new_value as $app => $url ) {
+				if ( ! is_string( $url ) || '' === $url ) {
+					continue;
+				}
+
+				$previous = isset( $old_value[ $app ] ) && is_string( $old_value[ $app ] ) ? $old_value[ $app ] : '';
+				if ( '' !== $previous ) {
+					continue;
+				}
+
+				self::record_event(
+					wp_get_current_user(),
+					'wpcom_podcasting_show_url_saved',
+					array(
+						'blog_id' => (int) get_current_blog_id(),
+						'app'     => (string) $app,
+					)
+				);
+				return;
+			}
+		} catch ( Throwable $e ) {
+			self::log_failure( 'show-url-record-failed', $e );
+		}
+	}
+
+	/**
+	 * Capture a snapshot of all `podcasting_*` option values before a
+	 * `/wp/v2/settings` write completes — only when the request body
+	 * actually touches at least one of those options. Pass-through filter.
+	 *
+	 * @param mixed                 $response Response (passed through unchanged).
+	 * @param array                 $handler  Route handler.
+	 * @param WP_REST_Request|mixed $request  Request object.
+	 * @return mixed
+	 */
+	public static function snapshot_settings_before_write( $response, $handler, $request ) {
+		unset( $handler );
+
+		try {
+			if ( ! self::is_settings_write( $request ) ) {
+				return $response;
+			}
+
+			$params = $request->get_params();
+			if ( ! is_array( $params ) ) {
+				return $response;
+			}
+
+			$touched = array_intersect_key( $params, array_flip( Settings::OPTION_NAMES ) );
+			if ( empty( $touched ) ) {
+				return $response;
+			}
+
+			self::$settings_snapshots[ spl_object_hash( $request ) ] = self::read_settings_state();
+		} catch ( Throwable $e ) {
+			self::log_failure( 'settings-snapshot-failed', $e );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Emit `wpcom_podcasting_settings_saved` once per `/wp/v2/settings`
+	 * write that touched any podcasting option, with `previous_*` keys for
+	 * every podcasting field the GET response would normally expose.
+	 *
+	 * @param mixed                 $response Response (passed through unchanged).
+	 * @param array                 $handler  Route handler.
+	 * @param WP_REST_Request|mixed $request  Request object.
+	 * @return mixed
+	 */
+	public static function record_settings_saved( $response, $handler, $request ) {
+		unset( $handler );
+
+		try {
+			if ( ! $request instanceof WP_REST_Request ) {
+				return $response;
+			}
+
+			$key = spl_object_hash( $request );
+			if ( ! isset( self::$settings_snapshots[ $key ] ) ) {
+				return $response;
+			}
+
+			$previous = self::$settings_snapshots[ $key ];
+			unset( self::$settings_snapshots[ $key ] );
+
+			// Don't emit if the write errored — the response would carry an error
+			// status and the option values wouldn't have changed.
+			if ( $response instanceof WP_REST_Response && $response->is_error() ) {
+				return $response;
+			}
+
+			$current   = self::read_settings_state();
+			$event_props = $current;
+			foreach ( $previous as $field => $value ) {
+				$event_props[ 'previous_' . $field ] = $value;
+			}
+
+			self::record_event(
+				wp_get_current_user(),
+				'wpcom_podcasting_settings_saved',
+				$event_props
+			);
+		} catch ( Throwable $e ) {
+			self::log_failure( 'settings-saved-failed', $e );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Emit `wpcom_podcasting_status_changed` when the on/off state or
+	 * assigned category transitions.
+	 *
+	 * @param int $old_value Previous category ID (0 == disabled).
+	 * @param int $new_value New category ID (0 == disabled).
+	 */
+	private static function maybe_record_status_change( int $old_value, int $new_value ): void {
+		if ( $old_value === $new_value ) {
+			return;
+		}
+
+		if ( 0 === $old_value && 0 !== $new_value ) {
+			$status = 'enabled';
+		} elseif ( 0 !== $old_value && 0 === $new_value ) {
+			$status = 'disabled';
+		} else {
+			$status = 'changed';
+		}
+
+		// Resolve the plan slug from whichever plan API is loaded. WPCOM_Store_API
+		// on Simple, Jetpack's Current_Plan on Atomic; either may be absent in
+		// unusual contexts, in which case we record an empty slug rather than fatal.
+		$plan_slug = '';
+		if ( class_exists( '\WPCOM_Store_API' ) ) {
+			$current_plan = \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() );
+			if ( ! empty( $current_plan['product_slug'] ) ) {
+				$plan_slug = (string) $current_plan['product_slug'];
+			}
+		} elseif ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ) {
+			$current_plan = \Automattic\Jetpack\Current_Plan::get();
+			if ( ! empty( $current_plan['product_slug'] ) ) {
+				$plan_slug = (string) $current_plan['product_slug'];
+			}
+		}
+
+		self::record_event(
+			wp_get_current_user(),
+			'wpcom_podcasting_status_changed',
+			array(
+				'blog_id'              => (int) get_current_blog_id(),
+				'status'               => $status,
+				'surface'              => 'option_write',
+				'previous_category_id' => (int) $old_value,
+				'new_category_id'      => (int) $new_value,
+				'user_id'              => (int) get_current_user_id(),
+				'product_slug'         => $plan_slug,
+			)
+		);
+
+		// Preserve the legacy mc.a8c.com counter the previous REST-side helper
+		// bumped. Wrapped because `bump_stats_extras()` is wpcom Simple-only.
+		if ( function_exists( 'bump_stats_extras' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredFunction -- Provided by wpcom Simple at runtime; guarded by `function_exists` above.
+			bump_stats_extras( 'wpcom-podcasting-status', $status );
+		}
+	}
+
+	/**
+	 * True if the request looks like a write to the `/wp/v2/settings` route.
+	 *
+	 * @param mixed $request Request object.
+	 * @return bool
+	 */
+	private static function is_settings_write( $request ): bool {
+		if ( ! $request instanceof WP_REST_Request ) {
+			return false;
+		}
+		if ( '/wp/v2/settings' !== $request->get_route() ) {
+			return false;
+		}
+		return in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH' ), true );
+	}
+
+	/**
+	 * Read the full set of podcasting-related option values that the wpcom
+	 * settings GET previously exposed. Mirrors that response shape so the
+	 * emitted event keeps schema parity with the wpcom version.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function read_settings_state(): array {
+		return array(
+			'podcasting_category_id' => Customize_Feed::resolve_category_id(),
+			'podcasting_title'       => (string) get_option( 'podcasting_title', '' ),
+			'podcasting_talent_name' => (string) get_option( 'podcasting_talent_name', '' ),
+			'podcasting_summary'     => (string) get_option( 'podcasting_summary', '' ),
+			'podcasting_copyright'   => (string) get_option( 'podcasting_copyright', '' ),
+			'podcasting_explicit'    => Settings::sanitize_explicit( get_option( 'podcasting_explicit', false ) ) ? 'yes' : 'no',
+			'podcasting_image'       => (string) get_option( 'podcasting_image', '' ),
+			'podcasting_image_id'    => (int) get_option( 'podcasting_image_id', 0 ),
+			'podcasting_category_1'  => (string) get_option( 'podcasting_category_1', '' ),
+			'podcasting_category_2'  => (string) get_option( 'podcasting_category_2', '' ),
+			'podcasting_category_3'  => (string) get_option( 'podcasting_category_3', '' ),
+			'podcasting_email'       => (string) get_option( 'podcasting_email', '' ),
+			'podcasting_show_urls'   => (array) get_option( 'podcasting_show_urls', array() ),
+			'podcasting_show_states' => (array) get_option( 'podcasting_show_states', array() ),
+		);
+	}
+
+	/**
+	 * Identity to attribute the publish event to. Scheduled/cron publishes
+	 * have no logged-in user — fall back to the post author.
+	 *
+	 * @param WP_Post $post Post being published.
+	 * @return WP_User
+	 */
+	private static function identity_for_post( WP_Post $post ): WP_User {
+		if ( ! empty( $post->post_author ) ) {
+			$user = get_userdata( (int) $post->post_author );
+			if ( $user instanceof WP_User ) {
+				return $user;
+			}
+		}
+		return wp_get_current_user();
+	}
+
+	/**
+	 * True if the post embeds site-hosted audio. The host check filters out
+	 * posts that merely embed third-party players (SoundCloud, Spotify,
+	 * RSS-imported audio links) — those flooded analytics pre-filter on
+	 * wpcom. Classic-editor attachments are site-hosted by definition and
+	 * skip the host check via the `WP_Query` lookup below.
+	 *
+	 * @param WP_Post $post Post being checked.
+	 * @return bool
+	 */
+	private static function has_podcast_media( WP_Post $post ): bool {
+		$content      = (string) $post->post_content;
+		$baseurl      = (string) ( wp_upload_dir()['baseurl'] ?? '' );
+		$home_host    = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		$baseurl_host = (string) wp_parse_url( $baseurl, PHP_URL_HOST );
+		$hosts        = array_values( array_unique( array_filter( array( $home_host, $baseurl_host ) ) ) );
+
+		if (
+			has_block( 'core/audio', $post )
+			&& self::has_site_hosted_audio_block( parse_blocks( $content ), $baseurl, $hosts )
+		) {
+			return true;
+		}
+
+		$extensions = implode( '|', array_map( 'preg_quote', wp_get_audio_extensions() ) );
+		if ( '' !== $extensions && preg_match_all( '#https?://\S+?\.(' . $extensions . ')\b#i', $content, $matches ) ) {
+			foreach ( $matches[0] as $url ) {
+				if ( self::is_site_hosted_url( $url, $baseurl, $hosts ) ) {
+					return true;
+				}
+			}
+		}
+
+		$attached = new WP_Query(
+			array(
+				'post_parent'            => (int) $post->ID,
+				'post_type'              => 'attachment',
+				'post_mime_type'         => 'audio',
+				'posts_per_page'         => 1,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'suppress_filters'       => true,
+			)
+		);
+		return ! empty( $attached->posts );
+	}
+
+	/**
+	 * Walk parsed blocks recursively looking for a `core/audio` block whose
+	 * `src` attribute points at site-hosted media.
+	 *
+	 * @param array  $blocks  Parsed blocks.
+	 * @param string $baseurl Site uploads baseurl.
+	 * @param array  $hosts   Allowed hostnames.
+	 * @return bool
+	 */
+	private static function has_site_hosted_audio_block( array $blocks, string $baseurl, array $hosts ): bool {
+		foreach ( $blocks as $block ) {
+			if ( 'core/audio' === ( $block['blockName'] ?? '' ) ) {
+				$src = (string) ( $block['attrs']['src'] ?? '' );
+				if ( '' !== $src && self::is_site_hosted_url( $src, $baseurl, $hosts ) ) {
+					return true;
+				}
+			}
+			if (
+				! empty( $block['innerBlocks'] )
+				&& self::has_site_hosted_audio_block( $block['innerBlocks'], $baseurl, $hosts )
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Baseurl prefix is the precise check. The host fallbacks cover (a) the
+	 * site's primary URL host and (b) the uploads host itself — on wpcom
+	 * multisite, `*.files.wordpress.com` subdomains are 1:1 per site, so
+	 * older uploads outside the current month's baseurl path still match
+	 * safely.
+	 *
+	 * @param string $url     Candidate URL.
+	 * @param string $baseurl Site uploads baseurl.
+	 * @param array  $hosts   Allowed hostnames.
+	 * @return bool
+	 */
+	private static function is_site_hosted_url( string $url, string $baseurl, array $hosts ): bool {
+		if ( '' !== $baseurl && 0 === strpos( $url, $baseurl ) ) {
+			return true;
+		}
+		$url_host = (string) wp_parse_url( $url, PHP_URL_HOST );
+		if ( '' === $url_host ) {
+			return false;
+		}
+		foreach ( $hosts as $allowed_host ) {
+			if ( 0 === strcasecmp( $url_host, $allowed_host ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * True when no other published post exists in the podcast category.
+	 *
+	 * @param int $category_id     Configured podcast category ID.
+	 * @param int $current_post_id Post being published (excluded from the check).
+	 * @return bool
+	 */
+	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {
+		$existing = new WP_Query(
+			array(
+				'post_status'      => 'publish',
+				'post_type'        => 'post',
+				'cat'              => $category_id,
+				'post__not_in'     => array( $current_post_id ),
+				'posts_per_page'   => 1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => true,
+			)
+		);
+
+		return empty( $existing->posts );
+	}
+
+	/**
+	 * Dispatch a tracks event. Prefers wpcom's `tracks_record_event` (Simple)
+	 * and falls back to Jetpack's `Tracking::tracks_record_event` (Atomic).
+	 * Returns silently when neither is reachable, or when the dispatcher
+	 * itself throws.
+	 *
+	 * @param mixed  $user       Username, user ID, or `WP_User` object.
+	 * @param string $event_name Tracks event name.
+	 * @param array  $properties Event properties.
+	 * @return mixed Dispatcher return value, or null on failure / no-op.
+	 */
+	private static function record_event( $user, string $event_name, array $properties ) {
+		try {
+			if ( is_numeric( $user ) ) {
+				$user = get_userdata( (int) $user );
+			}
+
+			if ( ! $user instanceof WP_User ) {
+				$user = wp_get_current_user();
+			}
+
+			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredFunction -- Provided by wpcom Simple at runtime; guarded by `function_exists` above.
+				require_lib( 'tracks/client' );
+			}
+
+			if ( function_exists( 'tracks_record_event' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredFunction -- Provided by wpcom Simple at runtime; guarded by `function_exists` above.
+				return tracks_record_event( $user, $event_name, $properties );
+			}
+
+			if ( class_exists( '\Automattic\Jetpack\Tracking' ) ) {
+				if ( null === self::$jetpack_tracking ) {
+					self::$jetpack_tracking = new \Automattic\Jetpack\Tracking();
+				}
+				return self::$jetpack_tracking->tracks_record_event( $user, $event_name, $properties );
+			}
+		} catch ( Throwable $e ) {
+			self::log_failure( 'dispatcher-failed', $e, array( 'event_name' => $event_name ) );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Best-effort error logging via `log2logstash` when available. Keeps the
+	 * package free of a hard logging dep — Atomic environments without the
+	 * lib silently skip.
+	 *
+	 * @param string    $message    Short failure tag.
+	 * @param Throwable $error      Throwable that triggered the log call.
+	 * @param array     $properties Extra context.
+	 */
+	private static function log_failure( string $message, Throwable $error, array $properties = array() ): void {
+		if ( ! function_exists( 'log2logstash' ) ) {
+			return;
+		}
+
+		// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
+		log2logstash(
+			array(
+				'feature'    => 'jetpack-podcast-tracks',
+				'message'    => $message,
+				'severity'   => 'error',
+				'blog_id'    => (int) get_current_blog_id(),
+				'extra'      => array(
+					'error_message' => $error->getMessage(),
+					'error_file'    => $error->getFile() . ':' . $error->getLine(),
+					'properties'    => $properties,
+				),
+			)
+		);
+	}
+}

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -415,7 +415,6 @@ class Tracks {
 			$properties['blog_id'] = (int) get_current_blog_id();
 
 			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredFunction -- wpcom Simple-only; guarded above.
 				require_lib( 'tracks/client' );
 			}
 

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -18,78 +18,51 @@ use WP_REST_Response;
 use WP_User;
 
 /**
- * Records the lifecycle events that drive podcast funnel reporting:
- * episode publishes, the per-site first-episode milestone, audio/video
- * uploads, podcatcher show-URL submissions, podcasting on/off transitions,
- * and `/wp/v2/settings` writes that touch any `podcasting_*` option.
- *
- * Mirrors the wpcom mu-plugin's `Automattic_Podcasting_Tracks`. Event names
- * stay `wpcom_*` so analytics queries cover Simple, Atomic, and Jetpack feeds
- * without a rewrite. Dispatch tries the wpcom-loadable `tracks_record_event`
- * first and falls back to `\Automattic\Jetpack\Tracking::tracks_record_event`
- * — neither is a hard dep, so the package degrades to silent no-op when
- * neither is reachable.
+ * Records podcast lifecycle events. Event names stay `wpcom_*` so analytics
+ * queries cover Simple, Atomic, and self-hosted Jetpack feeds without a rewrite.
+ * Dispatch tries `tracks_record_event` (Simple) and falls back to
+ * `\Automattic\Jetpack\Tracking::tracks_record_event` (Atomic). Neither is a
+ * hard dep — silently no-ops when neither is reachable.
  */
 class Tracks {
 
-	/**
-	 * Whether `init()` has wired its hooks.
-	 *
-	 * @var bool
-	 */
 	private static $registered = false;
 
 	/**
-	 * Cached Jetpack Tracking instance, lazily created on first Atomic dispatch.
-	 *
 	 * @var \Automattic\Jetpack\Tracking|null
 	 */
 	private static $jetpack_tracking = null;
 
 	/**
-	 * Snapshot of `podcasting_*` option values captured at the start of a
-	 * `/wp/v2/settings` REST write, keyed by request object hash. Read back
-	 * after the write completes so the emitted event can include both new
-	 * and `previous_*` values per the wpcom shape.
+	 * Per-request snapshot taken before a `/wp/v2/settings` write so the
+	 * emitted event can include `previous_*` keys. Keyed by request hash.
 	 *
 	 * @var array<string, array<string, mixed>>
 	 */
 	private static $settings_snapshots = array();
 
-	/**
-	 * Wire the tracks hooks. Idempotent.
-	 */
 	public static function init(): void {
 		if ( self::$registered ) {
 			return;
 		}
 		self::$registered = true;
 
-		// `wp_after_insert_post` fires after post + terms + meta are saved. Required for
-		// Gutenberg/REST publishes where `transition_post_status` runs before terms are set.
+		// `wp_after_insert_post` runs after terms + meta are saved — required
+		// because Gutenberg/REST publishes set terms after `transition_post_status`.
 		add_action( 'wp_after_insert_post', array( __CLASS__, 'record_episode_published' ), 10, 4 );
 
 		add_action( 'add_attachment', array( __CLASS__, 'record_media_uploaded' ) );
 
-		// Catch every `podcasting_category_id` write — REST, WP-CLI, direct `update_option()`.
-		// `add_option` fires when no row exists yet; `update_option` covers subsequent writes.
 		add_action( 'add_option_podcasting_category_id', array( __CLASS__, 'record_category_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_category_id', array( __CLASS__, 'record_category_updated' ), 10, 3 );
 
-		// Catch every `podcasting_show_urls` write. Both hooks point at the same method;
-		// it detects which fired by the first arg type (string on add, array on update).
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
 
-		// `/wp/v2/settings` PATCH — snapshot before, emit after, mirroring wpcom's
-		// `rest_api_update_site_settings`-driven `wpcom_podcasting_settings_saved`.
 		add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'snapshot_settings_before_write' ), 10, 3 );
 		add_filter( 'rest_request_after_callbacks', array( __CLASS__, 'record_settings_saved' ), 10, 3 );
 	}
 
-	/**
-	 * Reset internal state. Test-only — production never re-initializes.
-	 */
 	public static function reset_for_tests(): void {
 		self::$registered         = false;
 		self::$jetpack_tracking   = null;
@@ -97,14 +70,10 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcast_episode_published` (and, on the very first episode
-	 * for the site, `wpcom_podcast_show_launched`) when a podcast-category
-	 * post enters `publish` for the first time.
-	 *
 	 * @param int          $post_id     Post ID.
 	 * @param WP_Post|null $post        Post object.
 	 * @param bool         $update      Whether this is an update.
-	 * @param WP_Post|null $post_before Previous post state (or null on insert).
+	 * @param WP_Post|null $post_before Previous post state.
 	 */
 	public static function record_episode_published( $post_id, $post, $update, $post_before ): void {
 		unset( $post_id, $update );
@@ -126,8 +95,6 @@ class Tracks {
 				return;
 			}
 
-			// `is_headstart_post` is a wpcom Simple helper that flags pre-populated
-			// demo content; on Atomic the function is absent and the guard short-circuits.
 			if ( function_exists( 'is_headstart_post' ) && is_headstart_post( $post ) ) {
 				return;
 			}
@@ -145,10 +112,8 @@ class Tracks {
 				return;
 			}
 
-			// Match the RSS feed's definition of an episode: must carry a site-hosted
-			// audio or video enclosure. Without this, a post merely categorized into
-			// the podcasting category would fire even when it has no media — top
-			// offenders pre-filter were posting 50+/day of non-podcast content.
+			// Match the RSS feed's definition of an episode — must carry
+			// site-hosted audio, not just sit in the podcast category.
 			if ( ! self::has_podcast_media( $post ) ) {
 				return;
 			}
@@ -166,8 +131,8 @@ class Tracks {
 				)
 			);
 
-			// `add_option()` is atomic — only one concurrent caller per site wins the INSERT,
-			// so `wpcom_podcast_show_launched` fires exactly once per site.
+			// Atomic INSERT — only one concurrent caller per site wins, so
+			// `show_launched` fires exactly once per site.
 			if ( $is_first && add_option( 'podcast_show_launched_tracked', time(), '', false ) ) {
 				self::record_event(
 					$identity,
@@ -184,9 +149,6 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcast_media_uploaded` when an audio/video attachment is
-	 * uploaded on a podcasting-enabled site.
-	 *
 	 * @param int $attachment_id Attachment post ID.
 	 */
 	public static function record_media_uploaded( $attachment_id ): void {
@@ -195,7 +157,6 @@ class Tracks {
 				return;
 			}
 
-			// Skip Headstart demo-content uploads — wpcom Simple-only helper.
 			$attachment = get_post( (int) $attachment_id );
 			if ( $attachment && function_exists( 'is_headstart_post' ) && is_headstart_post( $attachment ) ) {
 				return;
@@ -228,9 +189,6 @@ class Tracks {
 	}
 
 	/**
-	 * `add_option_podcasting_category_id` callback — first-ever write of the
-	 * option. Treats the previous value as 0 (option absent == disabled).
-	 *
 	 * @param string $option Option name.
 	 * @param mixed  $value  Newly stored value.
 	 */
@@ -245,10 +203,6 @@ class Tracks {
 	}
 
 	/**
-	 * `update_option_podcasting_category_id` callback — every change to an
-	 * existing row. WP short-circuits identical writes upstream, so
-	 * `$old_value !== $value` is guaranteed here.
-	 *
 	 * @param mixed  $old_value Previous stored value.
 	 * @param mixed  $value     Newly stored value.
 	 * @param string $option    Option name.
@@ -264,15 +218,10 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcasting_show_url_saved` for the first podcatcher key
-	 * that transitions from absent/empty to a non-empty string. Each save
-	 * patches one URL by design, so we emit at most one event per write.
-	 *
-	 * Bound to both `add_option_podcasting_show_urls` (signature: option,
-	 * value) and `update_option_podcasting_show_urls` (signature: old_value,
-	 * value, option). The first arg is either the option name (string, on
-	 * add) or the previous stored value (array, on update); `is_array()`
-	 * picks them apart.
+	 * Bound to both `add_option_*` (signature: option, value) and
+	 * `update_option_*` (signature: old_value, value, option). The first arg
+	 * is either the option name or the previous array; `is_array()` picks
+	 * them apart.
 	 *
 	 * @param mixed $first_arg Option name or previous value.
 	 * @param mixed $new_value Newly stored value.
@@ -311,11 +260,7 @@ class Tracks {
 	}
 
 	/**
-	 * Capture a snapshot of all `podcasting_*` option values before a
-	 * `/wp/v2/settings` write completes — only when the request body
-	 * actually touches at least one of those options. Pass-through filter.
-	 *
-	 * @param mixed                 $response Response (passed through unchanged).
+	 * @param mixed                 $response Pass-through.
 	 * @param array                 $handler  Route handler.
 	 * @param WP_REST_Request|mixed $request  Request object.
 	 * @return mixed
@@ -347,11 +292,7 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcasting_settings_saved` once per `/wp/v2/settings`
-	 * write that touched any podcasting option, with `previous_*` keys for
-	 * every podcasting field the GET response would normally expose.
-	 *
-	 * @param mixed                 $response Response (passed through unchanged).
+	 * @param mixed                 $response Pass-through.
 	 * @param array                 $handler  Route handler.
 	 * @param WP_REST_Request|mixed $request  Request object.
 	 * @return mixed
@@ -372,14 +313,11 @@ class Tracks {
 			$previous = self::$settings_snapshots[ $key ];
 			unset( self::$settings_snapshots[ $key ] );
 
-			// Don't emit if the write errored — the response would carry an error
-			// status and the option values wouldn't have changed.
 			if ( $response instanceof WP_REST_Response && $response->is_error() ) {
 				return $response;
 			}
 
-			$current   = self::read_settings_state();
-			$event_props = $current;
+			$event_props = self::read_settings_state();
 			foreach ( $previous as $field => $value ) {
 				$event_props[ 'previous_' . $field ] = $value;
 			}
@@ -397,9 +335,6 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcasting_status_changed` when the on/off state or
-	 * assigned category transitions.
-	 *
 	 * @param int $old_value Previous category ID (0 == disabled).
 	 * @param int $new_value New category ID (0 == disabled).
 	 */
@@ -416,9 +351,7 @@ class Tracks {
 			$status = 'changed';
 		}
 
-		// Resolve the plan slug from whichever plan API is loaded. WPCOM_Store_API
-		// on Simple, Jetpack's Current_Plan on Atomic; either may be absent in
-		// unusual contexts, in which case we record an empty slug rather than fatal.
+		// `WPCOM_Store_API` on Simple, `Current_Plan` on Atomic.
 		$plan_slug = '';
 		if ( class_exists( '\WPCOM_Store_API' ) ) {
 			$current_plan = \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() );
@@ -446,19 +379,14 @@ class Tracks {
 			)
 		);
 
-		// Preserve the legacy mc.a8c.com counter the previous REST-side helper
-		// bumped. Wrapped because `bump_stats_extras()` is wpcom Simple-only.
 		if ( function_exists( 'bump_stats_extras' ) ) {
-			// @phan-suppress-next-line PhanUndeclaredFunction -- Provided by wpcom Simple at runtime; guarded by `function_exists` above.
+			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 			bump_stats_extras( 'wpcom-podcasting-status', $status );
 		}
 	}
 
 	/**
-	 * True if the request looks like a write to the `/wp/v2/settings` route.
-	 *
 	 * @param mixed $request Request object.
-	 * @return bool
 	 */
 	private static function is_settings_write( $request ): bool {
 		if ( ! $request instanceof WP_REST_Request ) {
@@ -471,10 +399,6 @@ class Tracks {
 	}
 
 	/**
-	 * Read the full set of podcasting-related option values that the wpcom
-	 * settings GET previously exposed. Mirrors that response shape so the
-	 * emitted event keeps schema parity with the wpcom version.
-	 *
 	 * @return array<string, mixed>
 	 */
 	private static function read_settings_state(): array {
@@ -497,11 +421,7 @@ class Tracks {
 	}
 
 	/**
-	 * Identity to attribute the publish event to. Scheduled/cron publishes
-	 * have no logged-in user — fall back to the post author.
-	 *
-	 * @param WP_Post $post Post being published.
-	 * @return WP_User
+	 * Scheduled/cron publishes have no logged-in user — fall back to author.
 	 */
 	private static function identity_for_post( WP_Post $post ): WP_User {
 		if ( ! empty( $post->post_author ) ) {
@@ -514,14 +434,10 @@ class Tracks {
 	}
 
 	/**
-	 * True if the post embeds site-hosted audio. The host check filters out
-	 * posts that merely embed third-party players (SoundCloud, Spotify,
-	 * RSS-imported audio links) — those flooded analytics pre-filter on
-	 * wpcom. Classic-editor attachments are site-hosted by definition and
-	 * skip the host check via the `WP_Query` lookup below.
-	 *
-	 * @param WP_Post $post Post being checked.
-	 * @return bool
+	 * The host check filters out third-party players (SoundCloud, Spotify
+	 * embeds, RSS-imported audio links) — those produced a flood of false
+	 * positives historically. Classic-editor attachments skip the host
+	 * check via the `WP_Query` lookup at the bottom.
 	 */
 	private static function has_podcast_media( WP_Post $post ): bool {
 		$content      = (string) $post->post_content;
@@ -562,15 +478,6 @@ class Tracks {
 		return ! empty( $attached->posts );
 	}
 
-	/**
-	 * Walk parsed blocks recursively looking for a `core/audio` block whose
-	 * `src` attribute points at site-hosted media.
-	 *
-	 * @param array  $blocks  Parsed blocks.
-	 * @param string $baseurl Site uploads baseurl.
-	 * @param array  $hosts   Allowed hostnames.
-	 * @return bool
-	 */
 	private static function has_site_hosted_audio_block( array $blocks, string $baseurl, array $hosts ): bool {
 		foreach ( $blocks as $block ) {
 			if ( 'core/audio' === ( $block['blockName'] ?? '' ) ) {
@@ -590,16 +497,9 @@ class Tracks {
 	}
 
 	/**
-	 * Baseurl prefix is the precise check. The host fallbacks cover (a) the
-	 * site's primary URL host and (b) the uploads host itself — on wpcom
-	 * multisite, `*.files.wordpress.com` subdomains are 1:1 per site, so
-	 * older uploads outside the current month's baseurl path still match
-	 * safely.
-	 *
-	 * @param string $url     Candidate URL.
-	 * @param string $baseurl Site uploads baseurl.
-	 * @param array  $hosts   Allowed hostnames.
-	 * @return bool
+	 * Baseurl prefix is the precise check; the host fallbacks cover the
+	 * site's primary URL host and the uploads host itself, so older
+	 * uploads outside the current month's baseurl path still match.
 	 */
 	private static function is_site_hosted_url( string $url, string $baseurl, array $hosts ): bool {
 		if ( '' !== $baseurl && 0 === strpos( $url, $baseurl ) ) {
@@ -617,13 +517,6 @@ class Tracks {
 		return false;
 	}
 
-	/**
-	 * True when no other published post exists in the podcast category.
-	 *
-	 * @param int $category_id     Configured podcast category ID.
-	 * @param int $current_post_id Post being published (excluded from the check).
-	 * @return bool
-	 */
 	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {
 		$existing = new WP_Query(
 			array(
@@ -642,15 +535,10 @@ class Tracks {
 	}
 
 	/**
-	 * Dispatch a tracks event. Prefers wpcom's `tracks_record_event` (Simple)
-	 * and falls back to Jetpack's `Tracking::tracks_record_event` (Atomic).
-	 * Returns silently when neither is reachable, or when the dispatcher
-	 * itself throws.
-	 *
 	 * @param mixed  $user       Username, user ID, or `WP_User` object.
 	 * @param string $event_name Tracks event name.
 	 * @param array  $properties Event properties.
-	 * @return mixed Dispatcher return value, or null on failure / no-op.
+	 * @return mixed
 	 */
 	private static function record_event( $user, string $event_name, array $properties ) {
 		try {
@@ -663,12 +551,12 @@ class Tracks {
 			}
 
 			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredFunction -- Provided by wpcom Simple at runtime; guarded by `function_exists` above.
+				// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 				require_lib( 'tracks/client' );
 			}
 
 			if ( function_exists( 'tracks_record_event' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredFunction -- Provided by wpcom Simple at runtime; guarded by `function_exists` above.
+				// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 				return tracks_record_event( $user, $event_name, $properties );
 			}
 
@@ -686,12 +574,8 @@ class Tracks {
 	}
 
 	/**
-	 * Best-effort error logging via `log2logstash` when available. Keeps the
-	 * package free of a hard logging dep — Atomic environments without the
-	 * lib silently skip.
-	 *
 	 * @param string    $message    Short failure tag.
-	 * @param Throwable $error      Throwable that triggered the log call.
+	 * @param Throwable $error      Throwable that triggered the log.
 	 * @param array     $properties Extra context.
 	 */
 	private static function log_failure( string $message, Throwable $error, array $properties = array() ): void {
@@ -702,11 +586,11 @@ class Tracks {
 		// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 		log2logstash(
 			array(
-				'feature'    => 'jetpack-podcast-tracks',
-				'message'    => $message,
-				'severity'   => 'error',
-				'blog_id'    => (int) get_current_blog_id(),
-				'extra'      => array(
+				'feature'  => 'jetpack-podcast-tracks',
+				'message'  => $message,
+				'severity' => 'error',
+				'blog_id'  => (int) get_current_blog_id(),
+				'extra'    => array(
 					'error_message' => $error->getMessage(),
 					'error_file'    => $error->getFile() . ':' . $error->getLine(),
 					'properties'    => $properties,

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -39,8 +39,8 @@ class Tracks {
 		add_action( 'add_option_podcasting_category_id', array( __CLASS__, 'record_category_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_category_id', array( __CLASS__, 'record_category_updated' ), 10, 3 );
 
-		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
-		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
+		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
+		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
 
 		add_filter( 'rest_request_after_callbacks', array( __CLASS__, 'record_settings_saved' ), 10, 3 );
 	}
@@ -74,6 +74,7 @@ class Tracks {
 				return;
 			}
 
+			// @phan-suppress-next-line PhanUndeclaredFunction -- wpcom Simple-only; guarded above.
 			if ( function_exists( 'is_headstart_post' ) && is_headstart_post( $post ) ) {
 				return;
 			}
@@ -135,6 +136,7 @@ class Tracks {
 			}
 
 			$attachment = get_post( (int) $attachment_id );
+			// @phan-suppress-next-line PhanUndeclaredFunction -- wpcom Simple-only; guarded above.
 			if ( $attachment && function_exists( 'is_headstart_post' ) && is_headstart_post( $attachment ) ) {
 				return;
 			}
@@ -199,21 +201,40 @@ class Tracks {
 	}
 
 	/**
-	 * Emit `wpcom_podcasting_show_url_saved` for the first podcatcher key that
-	 * transitions from absent/empty to a non-empty string.
+	 * `add_option_podcasting_show_urls` callback. No prior row exists, so
+	 * every entry is a first-time entry.
 	 *
-	 * Bound to both `add_option_*` (signature: option, value) and
-	 * `update_option_*` (signature: old_value, value, option). The first arg
-	 * is either the option name or the previous array; `is_array()` picks
-	 * them apart.
+	 * @param string $option    Option name.
+	 * @param mixed  $new_value Newly stored value.
+	 */
+	public static function record_show_url_added( $option, $new_value ): void {
+		unset( $option );
+		self::maybe_record_show_url_addition( array(), $new_value );
+	}
+
+	/**
+	 * `update_option_podcasting_show_urls` callback. Compare the new value
+	 * against the prior array to find the first directory that transitioned
+	 * from absent/empty to a non-empty URL.
 	 *
-	 * @param mixed $first_arg Option name or previous value.
+	 * @param mixed  $old_value Previous stored value (expected: array).
+	 * @param mixed  $new_value Newly stored value.
+	 * @param string $option    Option name.
+	 */
+	public static function record_show_url_updated( $old_value, $new_value, $option ): void {
+		unset( $option );
+		self::maybe_record_show_url_addition( is_array( $old_value ) ? $old_value : array(), $new_value );
+	}
+
+	/**
+	 * Emit `wpcom_podcasting_show_url_saved` for the first podcatcher key
+	 * that transitions from absent/empty to a non-empty string.
+	 *
+	 * @param array $old_value Previous map of directory => url.
 	 * @param mixed $new_value Newly stored value.
 	 */
-	public static function record_show_url_addition( $first_arg, $new_value ): void {
+	private static function maybe_record_show_url_addition( array $old_value, $new_value ): void {
 		try {
-			$old_value = is_array( $first_arg ) ? $first_arg : array();
-
 			if ( ! is_array( $new_value ) ) {
 				return;
 			}
@@ -268,8 +289,13 @@ class Tracks {
 				return $response;
 			}
 
+			// Skip user-supplied free-text fields — keep PII out of tracks.
+			$pii   = array( 'podcasting_email', 'podcasting_talent_name' );
 			$state = array();
 			foreach ( Settings::OPTION_NAMES as $name ) {
+				if ( in_array( $name, $pii, true ) ) {
+					continue;
+				}
 				$state[ $name ] = get_option( $name, '' );
 			}
 			self::record_event( 'wpcom_podcasting_settings_saved', $state );
@@ -389,6 +415,7 @@ class Tracks {
 			$properties['blog_id'] = (int) get_current_blog_id();
 
 			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredFunction -- wpcom Simple-only; guarded above.
 				require_lib( 'tracks/client' );
 			}
 

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -352,18 +352,10 @@ class Tracks {
 		}
 
 		// `WPCOM_Store_API` on Simple, `Current_Plan` on Atomic.
-		$plan_slug = '';
-		if ( class_exists( '\WPCOM_Store_API' ) ) {
-			$current_plan = \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() );
-			if ( ! empty( $current_plan['product_slug'] ) ) {
-				$plan_slug = (string) $current_plan['product_slug'];
-			}
-		} elseif ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ) {
-			$current_plan = \Automattic\Jetpack\Current_Plan::get();
-			if ( ! empty( $current_plan['product_slug'] ) ) {
-				$plan_slug = (string) $current_plan['product_slug'];
-			}
-		}
+		$plan = class_exists( '\WPCOM_Store_API' )
+			? \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() )
+			: ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ? \Automattic\Jetpack\Current_Plan::get() : array() );
+		$plan_slug = (string) ( $plan['product_slug'] ?? '' );
 
 		self::record_event(
 			wp_get_current_user(),
@@ -402,22 +394,11 @@ class Tracks {
 	 * @return array<string, mixed>
 	 */
 	private static function read_settings_state(): array {
-		return array(
-			'podcasting_category_id' => Customize_Feed::resolve_category_id(),
-			'podcasting_title'       => (string) get_option( 'podcasting_title', '' ),
-			'podcasting_talent_name' => (string) get_option( 'podcasting_talent_name', '' ),
-			'podcasting_summary'     => (string) get_option( 'podcasting_summary', '' ),
-			'podcasting_copyright'   => (string) get_option( 'podcasting_copyright', '' ),
-			'podcasting_explicit'    => Settings::sanitize_explicit( get_option( 'podcasting_explicit', false ) ) ? 'yes' : 'no',
-			'podcasting_image'       => (string) get_option( 'podcasting_image', '' ),
-			'podcasting_image_id'    => (int) get_option( 'podcasting_image_id', 0 ),
-			'podcasting_category_1'  => (string) get_option( 'podcasting_category_1', '' ),
-			'podcasting_category_2'  => (string) get_option( 'podcasting_category_2', '' ),
-			'podcasting_category_3'  => (string) get_option( 'podcasting_category_3', '' ),
-			'podcasting_email'       => (string) get_option( 'podcasting_email', '' ),
-			'podcasting_show_urls'   => (array) get_option( 'podcasting_show_urls', array() ),
-			'podcasting_show_states' => (array) get_option( 'podcasting_show_states', array() ),
-		);
+		$state = array();
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$state[ $name ] = get_option( $name, '' );
+		}
+		return $state;
 	}
 
 	/**
@@ -434,87 +415,13 @@ class Tracks {
 	}
 
 	/**
-	 * The host check filters out third-party players (SoundCloud, Spotify
-	 * embeds, RSS-imported audio links) — those produced a flood of false
-	 * positives historically. Classic-editor attachments skip the host
-	 * check via the `WP_Query` lookup at the bottom.
+	 * Filters out posts that sit in the podcast category but aren't
+	 * actually episodes — block-editor `core/audio` and classic-editor
+	 * attached audio cover the supported authoring paths.
 	 */
 	private static function has_podcast_media( WP_Post $post ): bool {
-		$content      = (string) $post->post_content;
-		$baseurl      = (string) ( wp_upload_dir()['baseurl'] ?? '' );
-		$home_host    = (string) wp_parse_url( home_url(), PHP_URL_HOST );
-		$baseurl_host = (string) wp_parse_url( $baseurl, PHP_URL_HOST );
-		$hosts        = array_values( array_unique( array_filter( array( $home_host, $baseurl_host ) ) ) );
-
-		if (
-			has_block( 'core/audio', $post )
-			&& self::has_site_hosted_audio_block( parse_blocks( $content ), $baseurl, $hosts )
-		) {
-			return true;
-		}
-
-		$extensions = implode( '|', array_map( 'preg_quote', wp_get_audio_extensions() ) );
-		if ( '' !== $extensions && preg_match_all( '#https?://\S+?\.(' . $extensions . ')\b#i', $content, $matches ) ) {
-			foreach ( $matches[0] as $url ) {
-				if ( self::is_site_hosted_url( $url, $baseurl, $hosts ) ) {
-					return true;
-				}
-			}
-		}
-
-		$attached = new WP_Query(
-			array(
-				'post_parent'            => (int) $post->ID,
-				'post_type'              => 'attachment',
-				'post_mime_type'         => 'audio',
-				'posts_per_page'         => 1,
-				'fields'                 => 'ids',
-				'no_found_rows'          => true,
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'suppress_filters'       => true,
-			)
-		);
-		return ! empty( $attached->posts );
-	}
-
-	private static function has_site_hosted_audio_block( array $blocks, string $baseurl, array $hosts ): bool {
-		foreach ( $blocks as $block ) {
-			if ( 'core/audio' === ( $block['blockName'] ?? '' ) ) {
-				$src = (string) ( $block['attrs']['src'] ?? '' );
-				if ( '' !== $src && self::is_site_hosted_url( $src, $baseurl, $hosts ) ) {
-					return true;
-				}
-			}
-			if (
-				! empty( $block['innerBlocks'] )
-				&& self::has_site_hosted_audio_block( $block['innerBlocks'], $baseurl, $hosts )
-			) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Baseurl prefix is the precise check; the host fallbacks cover the
-	 * site's primary URL host and the uploads host itself, so older
-	 * uploads outside the current month's baseurl path still match.
-	 */
-	private static function is_site_hosted_url( string $url, string $baseurl, array $hosts ): bool {
-		if ( '' !== $baseurl && 0 === strpos( $url, $baseurl ) ) {
-			return true;
-		}
-		$url_host = (string) wp_parse_url( $url, PHP_URL_HOST );
-		if ( '' === $url_host ) {
-			return false;
-		}
-		foreach ( $hosts as $allowed_host ) {
-			if ( 0 === strcasecmp( $url_host, $allowed_host ) ) {
-				return true;
-			}
-		}
-		return false;
+		return has_block( 'core/audio', $post )
+			|| ! empty( get_attached_media( 'audio', $post->ID ) );
 	}
 
 	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -26,6 +26,9 @@ use WP_User;
  */
 class Tracks {
 
+	/**
+	 * Wire the recorder hooks.
+	 */
 	public static function init(): void {
 		// `wp_after_insert_post` runs after terms + meta are saved — required
 		// because Gutenberg/REST publishes set terms after `transition_post_status`.
@@ -43,6 +46,9 @@ class Tracks {
 	}
 
 	/**
+	 * Emit `wpcom_podcast_episode_published` (and `wpcom_podcast_show_launched`
+	 * once per site) when a podcast-category post enters `publish`.
+	 *
 	 * @param int          $post_id     Post ID.
 	 * @param WP_Post|null $post        Post object.
 	 * @param bool         $update      Whether this is an update.
@@ -111,12 +117,15 @@ class Tracks {
 					self::identity_for_post( $post )
 				);
 			}
-		} catch ( Throwable $e ) {
-			self::log_failure( 'episode-published-failed', $e );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort — never break a publish.
 		}
 	}
 
 	/**
+	 * Emit `wpcom_podcast_media_uploaded` for audio/video attachments on a
+	 * podcasting-enabled site.
+	 *
 	 * @param int $attachment_id Attachment post ID.
 	 */
 	public static function record_media_uploaded( $attachment_id ): void {
@@ -149,12 +158,15 @@ class Tracks {
 					'mime_type'     => $mime_type,
 				)
 			);
-		} catch ( Throwable $e ) {
-			self::log_failure( 'media-uploaded-failed', $e );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort.
 		}
 	}
 
 	/**
+	 * `add_option_podcasting_category_id` callback — first-ever write of the
+	 * option (previous value treated as 0).
+	 *
 	 * @param string $option Option name.
 	 * @param mixed  $value  Newly stored value.
 	 */
@@ -163,12 +175,15 @@ class Tracks {
 
 		try {
 			self::maybe_record_status_change( 0, (int) $value );
-		} catch ( Throwable $e ) {
-			self::log_failure( 'category-added-failed', $e );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort.
 		}
 	}
 
 	/**
+	 * `update_option_podcasting_category_id` callback — every change to an
+	 * existing row.
+	 *
 	 * @param mixed  $old_value Previous stored value.
 	 * @param mixed  $value     Newly stored value.
 	 * @param string $option    Option name.
@@ -178,12 +193,15 @@ class Tracks {
 
 		try {
 			self::maybe_record_status_change( (int) $old_value, (int) $value );
-		} catch ( Throwable $e ) {
-			self::log_failure( 'category-updated-failed', $e );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort.
 		}
 	}
 
 	/**
+	 * Emit `wpcom_podcasting_show_url_saved` for the first podcatcher key that
+	 * transitions from absent/empty to a non-empty string.
+	 *
 	 * Bound to both `add_option_*` (signature: option, value) and
 	 * `update_option_*` (signature: old_value, value, option). The first arg
 	 * is either the option name or the previous array; `is_array()` picks
@@ -216,12 +234,15 @@ class Tracks {
 				);
 				return;
 			}
-		} catch ( Throwable $e ) {
-			self::log_failure( 'show-url-record-failed', $e );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort.
 		}
 	}
 
 	/**
+	 * Emit `wpcom_podcasting_settings_saved` when a `/wp/v2/settings` write
+	 * touches any podcasting option. Pass-through filter on the response.
+	 *
 	 * @param mixed                 $response Pass-through.
 	 * @param array                 $handler  Route handler.
 	 * @param WP_REST_Request|mixed $request  Request object.
@@ -252,14 +273,17 @@ class Tracks {
 				$state[ $name ] = get_option( $name, '' );
 			}
 			self::record_event( 'wpcom_podcasting_settings_saved', $state );
-		} catch ( Throwable $e ) {
-			self::log_failure( 'settings-saved-failed', $e );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort.
 		}
 
 		return $response;
 	}
 
 	/**
+	 * Emit `wpcom_podcasting_status_changed` (enabled / disabled / changed)
+	 * when the `podcasting_category_id` option transitions.
+	 *
 	 * @param int $old_value Previous category ID (0 == disabled).
 	 * @param int $new_value New category ID (0 == disabled).
 	 */
@@ -301,7 +325,10 @@ class Tracks {
 	}
 
 	/**
-	 * Scheduled/cron publishes have no logged-in user — fall back to author.
+	 * Identity for the publish event. Scheduled/cron publishes have no
+	 * logged-in user — fall back to the post author.
+	 *
+	 * @param WP_Post $post Post being published.
 	 */
 	private static function identity_for_post( WP_Post $post ): WP_User {
 		if ( ! empty( $post->post_author ) ) {
@@ -314,15 +341,23 @@ class Tracks {
 	}
 
 	/**
-	 * Filters out posts that sit in the podcast category but aren't
-	 * actually episodes — block-editor `core/audio` and classic-editor
-	 * attached audio cover the supported authoring paths.
+	 * Filters out posts in the podcast category that aren't actually episodes.
+	 * `core/audio` block + classic-editor attached audio cover the supported
+	 * authoring paths.
+	 *
+	 * @param WP_Post $post Post being checked.
 	 */
 	private static function has_podcast_media( WP_Post $post ): bool {
 		return has_block( 'core/audio', $post )
 			|| ! empty( get_attached_media( 'audio', $post->ID ) );
 	}
 
+	/**
+	 * True when no other published post exists in the podcast category.
+	 *
+	 * @param int $category_id     Configured podcast category ID.
+	 * @param int $current_post_id Post being published (excluded from the check).
+	 */
 	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {
 		$existing = new WP_Query(
 			array(
@@ -341,8 +376,8 @@ class Tracks {
 	}
 
 	/**
-	 * Auto-injects `blog_id` and defaults `$user` to the current user — the
-	 * shape every event needs, kept out of the call sites.
+	 * Dispatch a tracks event. Auto-injects `blog_id` and defaults `$user`
+	 * to the current user.
 	 *
 	 * @param string       $event_name Tracks event name.
 	 * @param array        $properties Event properties.
@@ -367,36 +402,10 @@ class Tracks {
 			if ( class_exists( '\Automattic\Jetpack\Tracking' ) ) {
 				return ( new \Automattic\Jetpack\Tracking() )->tracks_record_event( $user, $event_name, $properties );
 			}
-		} catch ( Throwable $e ) {
-			self::log_failure( 'dispatcher-failed', $e, array( 'event_name' => $event_name ) );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort.
 		}
 
 		return null;
-	}
-
-	/**
-	 * @param string    $message    Short failure tag.
-	 * @param Throwable $error      Throwable that triggered the log.
-	 * @param array     $properties Extra context.
-	 */
-	private static function log_failure( string $message, Throwable $error, array $properties = array() ): void {
-		if ( ! function_exists( 'log2logstash' ) ) {
-			return;
-		}
-
-		// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
-		log2logstash(
-			array(
-				'feature'  => 'jetpack-podcast-tracks',
-				'message'  => $message,
-				'severity' => 'error',
-				'blog_id'  => (int) get_current_blog_id(),
-				'extra'    => array(
-					'error_message' => $error->getMessage(),
-					'error_file'    => $error->getFile() . ':' . $error->getLine(),
-					'properties'    => $properties,
-				),
-			)
-		);
 	}
 }

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -103,7 +103,7 @@ class Tracks {
 				'wpcom_podcast_episode_published',
 				array(
 					'post_id'                   => (int) $post->ID,
-					'is_first_episode_for_site' => (bool) $is_first,
+					'is_first_episode_for_site' => $is_first,
 				),
 				self::identity_for_post( $post )
 			);
@@ -304,6 +304,7 @@ class Tracks {
 		// pattern as `Masterbar\Dashboard_Switcher_Tracking::get_plan()`.
 		$plan = class_exists( '\WPCOM_Store_API' )
 			? \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() )
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- Provided by the connection package on Atomic; not a hard dep.
 			: ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ? \Automattic\Jetpack\Current_Plan::get() : array() );
 
 		self::record_event(
@@ -318,10 +319,8 @@ class Tracks {
 			)
 		);
 
-		if ( function_exists( 'bump_stats_extras' ) ) {
-			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
-			bump_stats_extras( 'wpcom-podcasting-status', $status );
-		}
+		/** This action is documented in projects/packages/forms/src/contact-form/class-util.php */
+		do_action( 'jetpack_bump_stats_extras', 'wpcom-podcasting-status', $status );
 	}
 
 	/**
@@ -390,16 +389,15 @@ class Tracks {
 			$properties['blog_id'] = (int) get_current_blog_id();
 
 			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 				require_lib( 'tracks/client' );
 			}
 
 			if ( function_exists( 'tracks_record_event' ) ) {
-				// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 				return tracks_record_event( $user, $event_name, $properties );
 			}
 
 			if ( class_exists( '\Automattic\Jetpack\Tracking' ) ) {
+				// @phan-suppress-next-line PhanUndeclaredClassMethod -- Provided by the connection package on Atomic; not a hard dep.
 				return ( new \Automattic\Jetpack\Tracking() )->tracks_record_event( $user, $event_name, $properties );
 			}
 		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -26,27 +26,7 @@ use WP_User;
  */
 class Tracks {
 
-	private static $registered = false;
-
-	/**
-	 * @var \Automattic\Jetpack\Tracking|null
-	 */
-	private static $jetpack_tracking = null;
-
-	/**
-	 * Per-request snapshot taken before a `/wp/v2/settings` write so the
-	 * emitted event can include `previous_*` keys. Keyed by request hash.
-	 *
-	 * @var array<string, array<string, mixed>>
-	 */
-	private static $settings_snapshots = array();
-
 	public static function init(): void {
-		if ( self::$registered ) {
-			return;
-		}
-		self::$registered = true;
-
 		// `wp_after_insert_post` runs after terms + meta are saved — required
 		// because Gutenberg/REST publishes set terms after `transition_post_status`.
 		add_action( 'wp_after_insert_post', array( __CLASS__, 'record_episode_published' ), 10, 4 );
@@ -59,14 +39,7 @@ class Tracks {
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_addition' ), 10, 2 );
 
-		add_filter( 'rest_request_before_callbacks', array( __CLASS__, 'snapshot_settings_before_write' ), 10, 3 );
 		add_filter( 'rest_request_after_callbacks', array( __CLASS__, 'record_settings_saved' ), 10, 3 );
-	}
-
-	public static function reset_for_tests(): void {
-		self::$registered         = false;
-		self::$jetpack_tracking   = null;
-		self::$settings_snapshots = array();
 	}
 
 	/**
@@ -113,34 +86,29 @@ class Tracks {
 			}
 
 			// Match the RSS feed's definition of an episode — must carry
-			// site-hosted audio, not just sit in the podcast category.
+			// audio, not just sit in the podcast category.
 			if ( ! self::has_podcast_media( $post ) ) {
 				return;
 			}
 
 			$is_first = self::is_first_episode_for_site( $category_id, (int) $post->ID );
-			$identity = self::identity_for_post( $post );
 
 			self::record_event(
-				$identity,
 				'wpcom_podcast_episode_published',
 				array(
-					'blog_id'                   => (int) get_current_blog_id(),
 					'post_id'                   => (int) $post->ID,
 					'is_first_episode_for_site' => (bool) $is_first,
-				)
+				),
+				self::identity_for_post( $post )
 			);
 
 			// Atomic INSERT — only one concurrent caller per site wins, so
 			// `show_launched` fires exactly once per site.
 			if ( $is_first && add_option( 'podcast_show_launched_tracked', time(), '', false ) ) {
 				self::record_event(
-					$identity,
 					'wpcom_podcast_show_launched',
-					array(
-						'blog_id' => (int) get_current_blog_id(),
-						'post_id' => (int) $post->ID,
-					)
+					array( 'post_id' => (int) $post->ID ),
+					self::identity_for_post( $post )
 				);
 			}
 		} catch ( Throwable $e ) {
@@ -175,10 +143,8 @@ class Tracks {
 			}
 
 			self::record_event(
-				wp_get_current_user(),
 				'wpcom_podcast_media_uploaded',
 				array(
-					'blog_id'       => (int) get_current_blog_id(),
 					'attachment_id' => (int) $attachment_id,
 					'mime_type'     => $mime_type,
 				)
@@ -245,12 +211,8 @@ class Tracks {
 				}
 
 				self::record_event(
-					wp_get_current_user(),
 					'wpcom_podcasting_show_url_saved',
-					array(
-						'blog_id' => (int) get_current_blog_id(),
-						'app'     => (string) $app,
-					)
+					array( 'app' => (string) $app )
 				);
 				return;
 			}
@@ -265,68 +227,31 @@ class Tracks {
 	 * @param WP_REST_Request|mixed $request  Request object.
 	 * @return mixed
 	 */
-	public static function snapshot_settings_before_write( $response, $handler, $request ) {
-		unset( $handler );
-
-		try {
-			if ( ! self::is_settings_write( $request ) ) {
-				return $response;
-			}
-
-			$params = $request->get_params();
-			if ( ! is_array( $params ) ) {
-				return $response;
-			}
-
-			$touched = array_intersect_key( $params, array_flip( Settings::OPTION_NAMES ) );
-			if ( empty( $touched ) ) {
-				return $response;
-			}
-
-			self::$settings_snapshots[ spl_object_hash( $request ) ] = self::read_settings_state();
-		} catch ( Throwable $e ) {
-			self::log_failure( 'settings-snapshot-failed', $e );
-		}
-
-		return $response;
-	}
-
-	/**
-	 * @param mixed                 $response Pass-through.
-	 * @param array                 $handler  Route handler.
-	 * @param WP_REST_Request|mixed $request  Request object.
-	 * @return mixed
-	 */
 	public static function record_settings_saved( $response, $handler, $request ) {
 		unset( $handler );
 
 		try {
-			if ( ! $request instanceof WP_REST_Request ) {
+			if ( ! $request instanceof WP_REST_Request || '/wp/v2/settings' !== $request->get_route() ) {
+				return $response;
+			}
+			if ( ! in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH' ), true ) ) {
 				return $response;
 			}
 
-			$key = spl_object_hash( $request );
-			if ( ! isset( self::$settings_snapshots[ $key ] ) ) {
+			$params = (array) $request->get_params();
+			if ( empty( array_intersect_key( $params, array_flip( Settings::OPTION_NAMES ) ) ) ) {
 				return $response;
 			}
-
-			$previous = self::$settings_snapshots[ $key ];
-			unset( self::$settings_snapshots[ $key ] );
 
 			if ( $response instanceof WP_REST_Response && $response->is_error() ) {
 				return $response;
 			}
 
-			$event_props = self::read_settings_state();
-			foreach ( $previous as $field => $value ) {
-				$event_props[ 'previous_' . $field ] = $value;
+			$state = array();
+			foreach ( Settings::OPTION_NAMES as $name ) {
+				$state[ $name ] = get_option( $name, '' );
 			}
-
-			self::record_event(
-				wp_get_current_user(),
-				'wpcom_podcasting_settings_saved',
-				$event_props
-			);
+			self::record_event( 'wpcom_podcasting_settings_saved', $state );
 		} catch ( Throwable $e ) {
 			self::log_failure( 'settings-saved-failed', $e );
 		}
@@ -351,23 +276,21 @@ class Tracks {
 			$status = 'changed';
 		}
 
-		// `WPCOM_Store_API` on Simple, `Current_Plan` on Atomic.
+		// `WPCOM_Store_API` on Simple, `Current_Plan` on Atomic — same dual
+		// pattern as `Masterbar\Dashboard_Switcher_Tracking::get_plan()`.
 		$plan = class_exists( '\WPCOM_Store_API' )
 			? \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() )
 			: ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ? \Automattic\Jetpack\Current_Plan::get() : array() );
-		$plan_slug = (string) ( $plan['product_slug'] ?? '' );
 
 		self::record_event(
-			wp_get_current_user(),
 			'wpcom_podcasting_status_changed',
 			array(
-				'blog_id'              => (int) get_current_blog_id(),
 				'status'               => $status,
 				'surface'              => 'option_write',
-				'previous_category_id' => (int) $old_value,
-				'new_category_id'      => (int) $new_value,
+				'previous_category_id' => $old_value,
+				'new_category_id'      => $new_value,
 				'user_id'              => (int) get_current_user_id(),
-				'product_slug'         => $plan_slug,
+				'product_slug'         => (string) ( $plan['product_slug'] ?? '' ),
 			)
 		);
 
@@ -375,30 +298,6 @@ class Tracks {
 			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
 			bump_stats_extras( 'wpcom-podcasting-status', $status );
 		}
-	}
-
-	/**
-	 * @param mixed $request Request object.
-	 */
-	private static function is_settings_write( $request ): bool {
-		if ( ! $request instanceof WP_REST_Request ) {
-			return false;
-		}
-		if ( '/wp/v2/settings' !== $request->get_route() ) {
-			return false;
-		}
-		return in_array( $request->get_method(), array( 'POST', 'PUT', 'PATCH' ), true );
-	}
-
-	/**
-	 * @return array<string, mixed>
-	 */
-	private static function read_settings_state(): array {
-		$state = array();
-		foreach ( Settings::OPTION_NAMES as $name ) {
-			$state[ $name ] = get_option( $name, '' );
-		}
-		return $state;
 	}
 
 	/**
@@ -442,20 +341,18 @@ class Tracks {
 	}
 
 	/**
-	 * @param mixed  $user       Username, user ID, or `WP_User` object.
-	 * @param string $event_name Tracks event name.
-	 * @param array  $properties Event properties.
+	 * Auto-injects `blog_id` and defaults `$user` to the current user — the
+	 * shape every event needs, kept out of the call sites.
+	 *
+	 * @param string       $event_name Tracks event name.
+	 * @param array        $properties Event properties.
+	 * @param WP_User|null $user       Identity override; defaults to current user.
 	 * @return mixed
 	 */
-	private static function record_event( $user, string $event_name, array $properties ) {
+	private static function record_event( string $event_name, array $properties, ?WP_User $user = null ) {
 		try {
-			if ( is_numeric( $user ) ) {
-				$user = get_userdata( (int) $user );
-			}
-
-			if ( ! $user instanceof WP_User ) {
-				$user = wp_get_current_user();
-			}
+			$user                  = $user ?? wp_get_current_user();
+			$properties['blog_id'] = (int) get_current_blog_id();
 
 			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
 				// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by `function_exists` above.
@@ -468,10 +365,7 @@ class Tracks {
 			}
 
 			if ( class_exists( '\Automattic\Jetpack\Tracking' ) ) {
-				if ( null === self::$jetpack_tracking ) {
-					self::$jetpack_tracking = new \Automattic\Jetpack\Tracking();
-				}
-				return self::$jetpack_tracking->tracks_record_event( $user, $event_name, $properties );
+				return ( new \Automattic\Jetpack\Tracking() )->tracks_record_event( $user, $event_name, $properties );
 			}
 		} catch ( Throwable $e ) {
 			self::log_failure( 'dispatcher-failed', $e, array( 'event_name' => $event_name ) );

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -44,7 +44,6 @@ class Tracks_Test extends BaseTestCase {
 		wp_cache_flush();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
-		Tracks::reset_for_tests();
 		unset( $GLOBALS['jetpack_podcast_test_captured_events'] );
 		parent::tearDown();
 	}
@@ -329,29 +328,22 @@ class Tracks_Test extends BaseTestCase {
 	}
 
 	public function test_settings_saved_emits_after_settings_rest_write() {
-		update_option( 'podcasting_title', 'Old Title' );
+		update_option( 'podcasting_title', 'New Title' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
 		$request->set_param( 'podcasting_title', 'New Title' );
 
-		Tracks::snapshot_settings_before_write( null, array(), $request );
-
-		update_option( 'podcasting_title', 'New Title' );
-
-		$response = new WP_REST_Response( array(), 200 );
-		Tracks::record_settings_saved( $response, array(), $request );
+		Tracks::record_settings_saved( new WP_REST_Response( array(), 200 ), array(), $request );
 
 		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'New Title', $events[0]['properties']['podcasting_title'] );
-		$this->assertSame( 'Old Title', $events[0]['properties']['previous_podcasting_title'] );
 	}
 
 	public function test_settings_saved_skips_unrelated_routes() {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$request->set_param( 'podcasting_title', 'should be ignored' );
 
-		Tracks::snapshot_settings_before_write( null, array(), $request );
 		Tracks::record_settings_saved( new WP_REST_Response(), array(), $request );
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
@@ -361,7 +353,6 @@ class Tracks_Test extends BaseTestCase {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
 		$request->set_param( 'title', 'New Site Title' );
 
-		Tracks::snapshot_settings_before_write( null, array(), $request );
 		Tracks::record_settings_saved( new WP_REST_Response(), array(), $request );
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
@@ -371,10 +362,11 @@ class Tracks_Test extends BaseTestCase {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
 		$request->set_param( 'podcasting_title', 'New Title' );
 
-		Tracks::snapshot_settings_before_write( null, array(), $request );
-
-		$error_response = new WP_REST_Response( array( 'code' => 'rest_forbidden' ), 403 );
-		Tracks::record_settings_saved( $error_response, array(), $request );
+		Tracks::record_settings_saved(
+			new WP_REST_Response( array( 'code' => 'rest_forbidden' ), 403 ),
+			array(),
+			$request
+		);
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
 	}

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -15,13 +15,9 @@ use WP_REST_Response;
 use WP_Term;
 
 /**
- * `Tracks::record_event()` is exercised end-to-end against the
- * `tracks_record_event` shim defined in bootstrap.php; the shim captures
- * dispatched events into `$GLOBALS['jetpack_podcast_test_captured_events']`.
- *
- * Tracks::init() is intentionally NOT called — these tests invoke the
- * recorder methods directly so creating a fixture post via wp_insert_post()
- * doesn't double-fire `wp_after_insert_post` and pollute the buffer.
+ * Recorder methods are invoked directly so creating a fixture post via
+ * `wp_insert_post()` doesn't double-fire `wp_after_insert_post`. Captured
+ * events are read out of the bootstrap shim's global buffer.
  *
  * @covers \Automattic\Jetpack\Podcast\Tracks
  */
@@ -31,8 +27,7 @@ class Tracks_Test extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		// WorDBless skips `create_initial_taxonomies` — `is_first_episode_for_site`
-		// would assert against an unregistered `category` taxonomy without this.
+		// WorDBless skips `create_initial_taxonomies`.
 		if ( ! taxonomy_exists( 'category' ) ) {
 			register_taxonomy( 'category', 'post', array( 'hierarchical' => true ) );
 		}
@@ -54,12 +49,6 @@ class Tracks_Test extends BaseTestCase {
 		parent::tearDown();
 	}
 
-	/**
-	 * Helper: pull events of a given name out of the captured buffer.
-	 *
-	 * @param string $event_name Tracks event name to filter by.
-	 * @return array<int, array<string, mixed>>
-	 */
 	private function events_named( string $event_name ): array {
 		return array_values(
 			array_filter(
@@ -70,10 +59,9 @@ class Tracks_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Stand up a fake `category` term that `get_term()` can return. WorDBless
-	 * lacks term-taxonomy plumbing, so seed the `terms` object cache with a
-	 * fully-formed `WP_Term` directly — `get_term()` short-circuits to that
-	 * before falling through to its DB query.
+	 * WorDBless lacks term-taxonomy plumbing, so seed the `terms` object cache
+	 * with a fully-formed `WP_Term` directly — `get_term()` short-circuits
+	 * to that before falling through to its DB query.
 	 */
 	private function configure_podcast_category( int $id = 42 ): int {
 		$term = new WP_Term(
@@ -91,15 +79,9 @@ class Tracks_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Build a publish-ready episode post. WorDBless skips the term-relationships
-	 * table, so `wp_set_post_categories` is a no-op and `in_category` would never
-	 * find the term — pre-populate the `category_relationships` object cache
-	 * directly. Default content includes a site-hosted `.mp3` URL so the post
-	 * passes `has_podcast_media()`.
-	 *
-	 * @param int    $category_id Category to attach.
-	 * @param string $status      Post status (`publish`, `draft`, etc.).
-	 * @param string $content     Optional content override.
+	 * `wp_set_post_categories` is a no-op under WorDBless (no term-relationships
+	 * table), so prime the `category_relationships` cache directly. Default
+	 * content includes a site-hosted `.mp3` URL so `has_podcast_media()` accepts.
 	 */
 	private function insert_post_in_category(
 		int $category_id,
@@ -146,9 +128,6 @@ class Tracks_Test extends BaseTestCase {
 		$first = $this->insert_post_in_category( $cat_id );
 		Tracks::record_episode_published( $first->ID, $first, false, null );
 
-		// Second episode in the same category — the per-site `add_option` lock
-		// on `podcast_show_launched_tracked` is what guarantees `show_launched`
-		// fires exactly once even when the first-episode query is unreliable.
 		$second = $this->insert_post_in_category( $cat_id );
 		Tracks::record_episode_published( $second->ID, $second, false, null );
 
@@ -158,7 +137,6 @@ class Tracks_Test extends BaseTestCase {
 
 	public function test_show_launched_skipped_when_lock_already_set() {
 		$cat_id = $this->configure_podcast_category();
-		// Simulate a prior site that has already had its first episode tracked.
 		add_option( 'podcast_show_launched_tracked', time(), '', false );
 
 		$post = $this->insert_post_in_category( $cat_id );
@@ -172,7 +150,6 @@ class Tracks_Test extends BaseTestCase {
 		$cat_id = $this->configure_podcast_category();
 		$post   = $this->insert_post_in_category( $cat_id );
 
-		// Editing an already-published post — the `$post_before` guard suppresses re-emission.
 		$before              = clone $post;
 		$before->post_status = 'publish';
 		Tracks::record_episode_published( $post->ID, $post, true, $before );
@@ -223,10 +200,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
 	}
 
-	/**
-	 * Filters out the noise wpcom saw pre-`has_podcast_media`: posts merely
-	 * tagged into the podcast category but carrying no audio.
-	 */
 	public function test_episode_published_skips_post_without_podcast_media() {
 		$cat_id = $this->configure_podcast_category();
 		$post   = $this->insert_post_in_category( $cat_id, 'publish', 'No audio in this post.' );
@@ -236,10 +209,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
 	}
 
-	/**
-	 * Third-party-hosted audio (SoundCloud, Spotify embeds, RSS-imported
-	 * external links) doesn't count as an episode.
-	 */
 	public function test_episode_published_skips_third_party_hosted_audio() {
 		$cat_id  = $this->configure_podcast_category();
 		$content = 'External player: https://example-other-host.com/episode.mp3';
@@ -381,8 +350,6 @@ class Tracks_Test extends BaseTestCase {
 	}
 
 	public function test_show_url_saved_emits_only_once_for_first_new_directory() {
-		// Two new keys at once — wpcom emits exactly one event for the first one
-		// it sees, since saves are designed to patch one key at a time.
 		Tracks::record_show_url_addition(
 			array(),
 			array(
@@ -395,8 +362,6 @@ class Tracks_Test extends BaseTestCase {
 	}
 
 	public function test_show_url_addition_handles_add_option_signature() {
-		// `add_option_*` passes ($option_name, $value) — the option name is a
-		// string, which `is_array()` correctly rejects as the previous value.
 		Tracks::record_show_url_addition(
 			'podcasting_show_urls',
 			array( 'spotify' => 'https://open.spotify.com/show/789' )
@@ -420,7 +385,6 @@ class Tracks_Test extends BaseTestCase {
 
 		Tracks::snapshot_settings_before_write( null, array(), $request );
 
-		// Simulate the actual write the REST endpoint would perform.
 		update_option( 'podcasting_title', 'New Title' );
 
 		$response = new WP_REST_Response( array(), 200 );

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -40,6 +40,9 @@ class Tracks_Test extends BaseTestCase {
 		delete_option( 'podcasting_archive' );
 		delete_option( 'podcasting_show_urls' );
 		delete_option( 'podcasting_show_states' );
+		delete_option( 'podcasting_title' );
+		delete_option( 'podcasting_email' );
+		delete_option( 'podcasting_talent_name' );
 		delete_option( 'podcast_show_launched_tracked' );
 		wp_cache_flush();
 		WorDBless_Posts::init()->clear_all_posts();
@@ -258,9 +261,9 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertSame( 'changed', $events[0]['properties']['status'] );
 	}
 
-	public function test_show_url_saved_emits_on_first_entry_per_directory() {
-		Tracks::record_show_url_addition(
-			array(),
+	public function test_show_url_added_emits_on_first_entry_per_directory() {
+		Tracks::record_show_url_added(
+			'podcasting_show_urls',
 			array( 'apple' => 'https://podcasts.apple.com/show/123' )
 		);
 
@@ -269,18 +272,19 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertSame( 'apple', $events[0]['properties']['app'] );
 	}
 
-	public function test_show_url_saved_skips_when_directory_already_had_url() {
-		Tracks::record_show_url_addition(
+	public function test_show_url_updated_skips_when_directory_already_had_url() {
+		Tracks::record_show_url_updated(
 			array( 'apple' => 'https://podcasts.apple.com/show/old' ),
-			array( 'apple' => 'https://podcasts.apple.com/show/new' )
+			array( 'apple' => 'https://podcasts.apple.com/show/new' ),
+			'podcasting_show_urls'
 		);
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
 	}
 
-	public function test_show_url_saved_emits_only_once_for_first_new_directory() {
-		Tracks::record_show_url_addition(
-			array(),
+	public function test_show_url_added_emits_only_once_for_first_new_directory() {
+		Tracks::record_show_url_added(
+			'podcasting_show_urls',
 			array(
 				'apple'   => 'https://podcasts.apple.com/show/123',
 				'spotify' => 'https://open.spotify.com/show/456',
@@ -290,19 +294,10 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
 	}
 
-	public function test_show_url_addition_handles_add_option_signature() {
-		Tracks::record_show_url_addition(
-			'podcasting_show_urls',
-			array( 'spotify' => 'https://open.spotify.com/show/789' )
-		);
-
-		$events = $this->events_named( 'wpcom_podcasting_show_url_saved' );
-		$this->assertCount( 1, $events );
-		$this->assertSame( 'spotify', $events[0]['properties']['app'] );
-	}
-
 	public function test_settings_saved_emits_after_settings_rest_write() {
 		update_option( 'podcasting_title', 'New Title' );
+		update_option( 'podcasting_email', 'host@example.com' );
+		update_option( 'podcasting_talent_name', 'Jane Host' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
 		$request->set_param( 'podcasting_title', 'New Title' );
@@ -312,6 +307,9 @@ class Tracks_Test extends BaseTestCase {
 		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'New Title', $events[0]['properties']['podcasting_title'] );
+		// PII is redacted from the payload.
+		$this->assertArrayNotHasKey( 'podcasting_email', $events[0]['properties'] );
+		$this->assertArrayNotHasKey( 'podcasting_talent_name', $events[0]['properties'] );
 	}
 
 	public function test_settings_saved_skips_settings_writes_without_podcasting_fields() {

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -1,0 +1,468 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\Tracks;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Term;
+
+/**
+ * `Tracks::record_event()` is exercised end-to-end against the
+ * `tracks_record_event` shim defined in bootstrap.php; the shim captures
+ * dispatched events into `$GLOBALS['jetpack_podcast_test_captured_events']`.
+ *
+ * Tracks::init() is intentionally NOT called — these tests invoke the
+ * recorder methods directly so creating a fixture post via wp_insert_post()
+ * doesn't double-fire `wp_after_insert_post` and pollute the buffer.
+ *
+ * @covers \Automattic\Jetpack\Podcast\Tracks
+ */
+#[CoversClass( Tracks::class )]
+class Tracks_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// WorDBless skips `create_initial_taxonomies` — `is_first_episode_for_site`
+		// would assert against an unregistered `category` taxonomy without this.
+		if ( ! taxonomy_exists( 'category' ) ) {
+			register_taxonomy( 'category', 'post', array( 'hierarchical' => true ) );
+		}
+
+		$GLOBALS['jetpack_podcast_test_captured_events'] = array();
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'podcasting_category_id' );
+		delete_option( 'podcasting_archive' );
+		delete_option( 'podcasting_show_urls' );
+		delete_option( 'podcasting_show_states' );
+		delete_option( 'podcast_show_launched_tracked' );
+		wp_cache_flush();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+		Tracks::reset_for_tests();
+		unset( $GLOBALS['jetpack_podcast_test_captured_events'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper: pull events of a given name out of the captured buffer.
+	 *
+	 * @param string $event_name Tracks event name to filter by.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function events_named( string $event_name ): array {
+		return array_values(
+			array_filter(
+				$GLOBALS['jetpack_podcast_test_captured_events'],
+				static fn ( array $event ) => $event['event_name'] === $event_name
+			)
+		);
+	}
+
+	/**
+	 * Stand up a fake `category` term that `get_term()` can return. WorDBless
+	 * lacks term-taxonomy plumbing, so seed the `terms` object cache with a
+	 * fully-formed `WP_Term` directly — `get_term()` short-circuits to that
+	 * before falling through to its DB query.
+	 */
+	private function configure_podcast_category( int $id = 42 ): int {
+		$term = new WP_Term(
+			(object) array(
+				'term_id'          => $id,
+				'name'             => 'Podcast',
+				'slug'             => 'podcast',
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => $id,
+			)
+		);
+		wp_cache_set( $id, $term, 'terms' );
+		update_option( 'podcasting_category_id', $id );
+		return $id;
+	}
+
+	/**
+	 * Build a publish-ready episode post. WorDBless skips the term-relationships
+	 * table, so `wp_set_post_categories` is a no-op and `in_category` would never
+	 * find the term — pre-populate the `category_relationships` object cache
+	 * directly. Default content includes a site-hosted `.mp3` URL so the post
+	 * passes `has_podcast_media()`.
+	 *
+	 * @param int    $category_id Category to attach.
+	 * @param string $status      Post status (`publish`, `draft`, etc.).
+	 * @param string $content     Optional content override.
+	 */
+	private function insert_post_in_category(
+		int $category_id,
+		string $status = 'publish',
+		string $content = ''
+	): \WP_Post {
+		if ( '' === $content ) {
+			$content = sprintf(
+				'Listen here: %s/wp-content/uploads/2026/05/episode-%s.mp3',
+				rtrim( home_url(), '/' ),
+				wp_generate_uuid4()
+			);
+		}
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Episode ' . wp_generate_uuid4(),
+				'post_content' => $content,
+				'post_status'  => $status,
+				'post_type'    => 'post',
+			)
+		);
+		wp_cache_set( (int) $post_id, array( $category_id ), 'category_relationships' );
+		return get_post( (int) $post_id );
+	}
+
+	// region: episode_published / show_launched
+	// -------------------------------------------------------------------
+
+	public function test_episode_published_emits_for_first_published_post_in_category() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category( $cat_id );
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( $post->ID, $events[0]['properties']['post_id'] );
+		$this->assertTrue( $events[0]['properties']['is_first_episode_for_site'] );
+	}
+
+	public function test_episode_published_fires_show_launched_only_once_per_site() {
+		$cat_id = $this->configure_podcast_category();
+
+		$first = $this->insert_post_in_category( $cat_id );
+		Tracks::record_episode_published( $first->ID, $first, false, null );
+
+		// Second episode in the same category — the per-site `add_option` lock
+		// on `podcast_show_launched_tracked` is what guarantees `show_launched`
+		// fires exactly once even when the first-episode query is unreliable.
+		$second = $this->insert_post_in_category( $cat_id );
+		Tracks::record_episode_published( $second->ID, $second, false, null );
+
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_show_launched' ) );
+		$this->assertCount( 2, $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_show_launched_skipped_when_lock_already_set() {
+		$cat_id = $this->configure_podcast_category();
+		// Simulate a prior site that has already had its first episode tracked.
+		add_option( 'podcast_show_launched_tracked', time(), '', false );
+
+		$post = $this->insert_post_in_category( $cat_id );
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_episode_published' ) );
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_show_launched' ) );
+	}
+
+	public function test_episode_published_skips_when_post_was_already_published() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category( $cat_id );
+
+		// Editing an already-published post — the `$post_before` guard suppresses re-emission.
+		$before              = clone $post;
+		$before->post_status = 'publish';
+		Tracks::record_episode_published( $post->ID, $post, true, $before );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_skips_when_post_not_in_podcast_category() {
+		$this->configure_podcast_category();
+		$other_term = new WP_Term(
+			(object) array(
+				'term_id'          => 99,
+				'name'             => 'Other',
+				'slug'             => 'other',
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => 99,
+			)
+		);
+		wp_cache_set( 99, $other_term, 'terms' );
+
+		$post = $this->insert_post_in_category( 99 );
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_skips_when_no_category_configured() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Untagged',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+		$post = get_post( (int) $post_id );
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_skips_drafts() {
+		$cat_id = $this->configure_podcast_category();
+		$draft  = $this->insert_post_in_category( $cat_id, 'draft' );
+
+		Tracks::record_episode_published( $draft->ID, $draft, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	/**
+	 * Filters out the noise wpcom saw pre-`has_podcast_media`: posts merely
+	 * tagged into the podcast category but carrying no audio.
+	 */
+	public function test_episode_published_skips_post_without_podcast_media() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category( $cat_id, 'publish', 'No audio in this post.' );
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	/**
+	 * Third-party-hosted audio (SoundCloud, Spotify embeds, RSS-imported
+	 * external links) doesn't count as an episode.
+	 */
+	public function test_episode_published_skips_third_party_hosted_audio() {
+		$cat_id  = $this->configure_podcast_category();
+		$content = 'External player: https://example-other-host.com/episode.mp3';
+		$post    = $this->insert_post_in_category( $cat_id, 'publish', $content );
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	// endregion
+
+	// region: media_uploaded
+	// -------------------------------------------------------------------
+
+	public function test_media_uploaded_emits_for_audio_when_podcasting_enabled() {
+		$this->configure_podcast_category();
+
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'audio/mpeg',
+				'post_title'     => 'episode.mp3',
+			)
+		);
+
+		Tracks::record_media_uploaded( (int) $attachment_id );
+
+		$events = $this->events_named( 'wpcom_podcast_media_uploaded' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'audio/mpeg', $events[0]['properties']['mime_type'] );
+		$this->assertSame( (int) $attachment_id, $events[0]['properties']['attachment_id'] );
+	}
+
+	public function test_media_uploaded_emits_for_video() {
+		$this->configure_podcast_category();
+
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'video/mp4',
+				'post_title'     => 'episode.mp4',
+			)
+		);
+
+		Tracks::record_media_uploaded( (int) $attachment_id );
+
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_media_uploaded' ) );
+	}
+
+	public function test_media_uploaded_skips_non_audio_video() {
+		$this->configure_podcast_category();
+
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'cover.jpg',
+			)
+		);
+
+		Tracks::record_media_uploaded( (int) $attachment_id );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_media_uploaded' ) );
+	}
+
+	public function test_media_uploaded_skips_when_podcasting_disabled() {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'audio/mpeg',
+				'post_title'     => 'orphan.mp3',
+			)
+		);
+
+		Tracks::record_media_uploaded( (int) $attachment_id );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_media_uploaded' ) );
+	}
+
+	// endregion
+
+	// region: status_changed
+	// -------------------------------------------------------------------
+
+	public function test_status_changed_emits_enabled_when_category_first_set() {
+		Tracks::record_category_added( 'podcasting_category_id', 42 );
+
+		$events = $this->events_named( 'wpcom_podcasting_status_changed' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'enabled', $events[0]['properties']['status'] );
+		$this->assertSame( 0, $events[0]['properties']['previous_category_id'] );
+		$this->assertSame( 42, $events[0]['properties']['new_category_id'] );
+	}
+
+	public function test_status_changed_emits_disabled_when_category_cleared() {
+		Tracks::record_category_updated( 42, 0, 'podcasting_category_id' );
+
+		$events = $this->events_named( 'wpcom_podcasting_status_changed' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'disabled', $events[0]['properties']['status'] );
+	}
+
+	public function test_status_changed_emits_changed_when_category_swapped() {
+		Tracks::record_category_updated( 42, 99, 'podcasting_category_id' );
+
+		$events = $this->events_named( 'wpcom_podcasting_status_changed' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'changed', $events[0]['properties']['status'] );
+	}
+
+	// endregion
+
+	// region: show_url_saved
+	// -------------------------------------------------------------------
+
+	public function test_show_url_saved_emits_on_first_entry_per_directory() {
+		Tracks::record_show_url_addition(
+			array(),
+			array( 'apple' => 'https://podcasts.apple.com/show/123' )
+		);
+
+		$events = $this->events_named( 'wpcom_podcasting_show_url_saved' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'apple', $events[0]['properties']['app'] );
+	}
+
+	public function test_show_url_saved_skips_when_directory_already_had_url() {
+		Tracks::record_show_url_addition(
+			array( 'apple' => 'https://podcasts.apple.com/show/old' ),
+			array( 'apple' => 'https://podcasts.apple.com/show/new' )
+		);
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
+	}
+
+	public function test_show_url_saved_emits_only_once_for_first_new_directory() {
+		// Two new keys at once — wpcom emits exactly one event for the first one
+		// it sees, since saves are designed to patch one key at a time.
+		Tracks::record_show_url_addition(
+			array(),
+			array(
+				'apple'   => 'https://podcasts.apple.com/show/123',
+				'spotify' => 'https://open.spotify.com/show/456',
+			)
+		);
+
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
+	}
+
+	public function test_show_url_addition_handles_add_option_signature() {
+		// `add_option_*` passes ($option_name, $value) — the option name is a
+		// string, which `is_array()` correctly rejects as the previous value.
+		Tracks::record_show_url_addition(
+			'podcasting_show_urls',
+			array( 'spotify' => 'https://open.spotify.com/show/789' )
+		);
+
+		$events = $this->events_named( 'wpcom_podcasting_show_url_saved' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'spotify', $events[0]['properties']['app'] );
+	}
+
+	// endregion
+
+	// region: settings_saved
+	// -------------------------------------------------------------------
+
+	public function test_settings_saved_emits_after_settings_rest_write() {
+		update_option( 'podcasting_title', 'Old Title' );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( 'podcasting_title', 'New Title' );
+
+		Tracks::snapshot_settings_before_write( null, array(), $request );
+
+		// Simulate the actual write the REST endpoint would perform.
+		update_option( 'podcasting_title', 'New Title' );
+
+		$response = new WP_REST_Response( array(), 200 );
+		Tracks::record_settings_saved( $response, array(), $request );
+
+		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'New Title', $events[0]['properties']['podcasting_title'] );
+		$this->assertSame( 'Old Title', $events[0]['properties']['previous_podcasting_title'] );
+	}
+
+	public function test_settings_saved_skips_unrelated_routes() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
+		$request->set_param( 'podcasting_title', 'should be ignored' );
+
+		Tracks::snapshot_settings_before_write( null, array(), $request );
+		Tracks::record_settings_saved( new WP_REST_Response(), array(), $request );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
+	}
+
+	public function test_settings_saved_skips_settings_writes_without_podcasting_fields() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( 'title', 'New Site Title' );
+
+		Tracks::snapshot_settings_before_write( null, array(), $request );
+		Tracks::record_settings_saved( new WP_REST_Response(), array(), $request );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
+	}
+
+	public function test_settings_saved_suppressed_when_response_is_an_error() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( 'podcasting_title', 'New Title' );
+
+		Tracks::snapshot_settings_before_write( null, array(), $request );
+
+		$error_response = new WP_REST_Response( array( 'code' => 'rest_forbidden' ), 403 );
+		Tracks::record_settings_saved( $error_response, array(), $request );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
+	}
+
+	// endregion
+}

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -52,7 +52,9 @@ class Tracks_Test extends BaseTestCase {
 		return array_values(
 			array_filter(
 				$GLOBALS['jetpack_podcast_test_captured_events'],
-				static fn ( array $event ) => $event['event_name'] === $event_name
+				static function ( array $event ) use ( $event_name ) {
+					return $event['event_name'] === $event_name;
+				}
 			)
 		);
 	}

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -124,17 +124,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 2, $this->events_named( 'wpcom_podcast_episode_published' ) );
 	}
 
-	public function test_show_launched_skipped_when_lock_already_set() {
-		$cat_id = $this->configure_podcast_category();
-		add_option( 'podcast_show_launched_tracked', time(), '', false );
-
-		$post = $this->insert_post_in_category( $cat_id );
-		Tracks::record_episode_published( $post->ID, $post, false, null );
-
-		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_episode_published' ) );
-		$this->assertEmpty( $this->events_named( 'wpcom_podcast_show_launched' ) );
-	}
-
 	public function test_episode_published_skips_when_post_was_already_published() {
 		$cat_id = $this->configure_podcast_category();
 		$post   = $this->insert_post_in_category( $cat_id );
@@ -173,7 +162,7 @@ class Tracks_Test extends BaseTestCase {
 				'post_type'   => 'post',
 			)
 		);
-		$post = get_post( (int) $post_id );
+		$post    = get_post( (int) $post_id );
 
 		Tracks::record_episode_published( $post->ID, $post, false, null );
 
@@ -207,23 +196,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'audio/mpeg', $events[0]['properties']['mime_type'] );
 		$this->assertSame( (int) $attachment_id, $events[0]['properties']['attachment_id'] );
-	}
-
-	public function test_media_uploaded_emits_for_video() {
-		$this->configure_podcast_category();
-
-		$attachment_id = wp_insert_post(
-			array(
-				'post_type'      => 'attachment',
-				'post_status'    => 'inherit',
-				'post_mime_type' => 'video/mp4',
-				'post_title'     => 'episode.mp4',
-			)
-		);
-
-		Tracks::record_media_uploaded( (int) $attachment_id );
-
-		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_media_uploaded' ) );
 	}
 
 	public function test_media_uploaded_skips_non_audio_video() {
@@ -338,15 +310,6 @@ class Tracks_Test extends BaseTestCase {
 		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'New Title', $events[0]['properties']['podcasting_title'] );
-	}
-
-	public function test_settings_saved_skips_unrelated_routes() {
-		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
-		$request->set_param( 'podcasting_title', 'should be ignored' );
-
-		Tracks::record_settings_saved( new WP_REST_Response(), array(), $request );
-
-		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
 	}
 
 	public function test_settings_saved_skips_settings_writes_without_podcasting_fields() {

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -86,15 +86,8 @@ class Tracks_Test extends BaseTestCase {
 	private function insert_post_in_category(
 		int $category_id,
 		string $status = 'publish',
-		string $content = ''
+		string $content = '<!-- wp:audio --><figure class="wp-block-audio"><audio controls src="https://example.org/episode.mp3"></audio></figure><!-- /wp:audio -->'
 	): \WP_Post {
-		if ( '' === $content ) {
-			$content = sprintf(
-				'Listen here: %s/wp-content/uploads/2026/05/episode-%s.mp3',
-				rtrim( home_url(), '/' ),
-				wp_generate_uuid4()
-			);
-		}
 		$post_id = wp_insert_post(
 			array(
 				'post_title'   => 'Episode ' . wp_generate_uuid4(),
@@ -106,9 +99,6 @@ class Tracks_Test extends BaseTestCase {
 		wp_cache_set( (int) $post_id, array( $category_id ), 'category_relationships' );
 		return get_post( (int) $post_id );
 	}
-
-	// region: episode_published / show_launched
-	// -------------------------------------------------------------------
 
 	public function test_episode_published_emits_for_first_published_post_in_category() {
 		$cat_id = $this->configure_podcast_category();
@@ -191,15 +181,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
 	}
 
-	public function test_episode_published_skips_drafts() {
-		$cat_id = $this->configure_podcast_category();
-		$draft  = $this->insert_post_in_category( $cat_id, 'draft' );
-
-		Tracks::record_episode_published( $draft->ID, $draft, false, null );
-
-		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
-	}
-
 	public function test_episode_published_skips_post_without_podcast_media() {
 		$cat_id = $this->configure_podcast_category();
 		$post   = $this->insert_post_in_category( $cat_id, 'publish', 'No audio in this post.' );
@@ -208,21 +189,6 @@ class Tracks_Test extends BaseTestCase {
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
 	}
-
-	public function test_episode_published_skips_third_party_hosted_audio() {
-		$cat_id  = $this->configure_podcast_category();
-		$content = 'External player: https://example-other-host.com/episode.mp3';
-		$post    = $this->insert_post_in_category( $cat_id, 'publish', $content );
-
-		Tracks::record_episode_published( $post->ID, $post, false, null );
-
-		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
-	}
-
-	// endregion
-
-	// region: media_uploaded
-	// -------------------------------------------------------------------
 
 	public function test_media_uploaded_emits_for_audio_when_podcasting_enabled() {
 		$this->configure_podcast_category();
@@ -293,11 +259,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_media_uploaded' ) );
 	}
 
-	// endregion
-
-	// region: status_changed
-	// -------------------------------------------------------------------
-
 	public function test_status_changed_emits_enabled_when_category_first_set() {
 		Tracks::record_category_added( 'podcasting_category_id', 42 );
 
@@ -323,11 +284,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'changed', $events[0]['properties']['status'] );
 	}
-
-	// endregion
-
-	// region: show_url_saved
-	// -------------------------------------------------------------------
 
 	public function test_show_url_saved_emits_on_first_entry_per_directory() {
 		Tracks::record_show_url_addition(
@@ -371,11 +327,6 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'spotify', $events[0]['properties']['app'] );
 	}
-
-	// endregion
-
-	// region: settings_saved
-	// -------------------------------------------------------------------
 
 	public function test_settings_saved_emits_after_settings_rest_write() {
 		update_option( 'podcasting_title', 'Old Title' );
@@ -427,6 +378,4 @@ class Tracks_Test extends BaseTestCase {
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_settings_saved' ) );
 	}
-
-	// endregion
 }

--- a/projects/packages/podcast/tests/php/bootstrap.php
+++ b/projects/packages/podcast/tests/php/bootstrap.php
@@ -10,3 +10,20 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 define( 'WP_DEBUG', true );
 
 \Automattic\Jetpack\Test_Environment::init();
+
+/**
+ * Tracks dispatcher shim. The package's `Tracks::record_event()` looks up
+ * `\tracks_record_event` by name; defining it here makes events land in a
+ * test-readable buffer instead of attempting a real HTTP dispatch. Cleared
+ * per-test via `$GLOBALS['jetpack_podcast_test_captured_events']`.
+ */
+if ( ! function_exists( 'tracks_record_event' ) ) {
+	function tracks_record_event( $user, $event_name, $properties = array() ) {
+		$GLOBALS['jetpack_podcast_test_captured_events'][] = array(
+			'user'       => $user,
+			'event_name' => $event_name,
+			'properties' => $properties,
+		);
+		return true;
+	}
+}

--- a/projects/packages/podcast/tests/php/bootstrap.php
+++ b/projects/packages/podcast/tests/php/bootstrap.php
@@ -2,6 +2,11 @@
 /**
  * Bootstrap.
  *
+ * Shadows the wpcom Simple `tracks_record_event` from wpcom-stubs at test
+ * runtime so dispatched events land in a per-test buffer.
+ *
+ * @phan-file-suppress PhanRedefineFunction
+ *
  * @package automattic/jetpack-podcast
  */
 
@@ -11,7 +16,6 @@ define( 'WP_DEBUG', true );
 
 \Automattic\Jetpack\Test_Environment::init();
 
-// Capture tracks events into a per-test buffer instead of dispatching them.
 if ( ! function_exists( 'tracks_record_event' ) ) {
 	function tracks_record_event( $user, $event_name, $properties = array() ) {
 		$GLOBALS['jetpack_podcast_test_captured_events'][] = array(

--- a/projects/packages/podcast/tests/php/bootstrap.php
+++ b/projects/packages/podcast/tests/php/bootstrap.php
@@ -11,12 +11,7 @@ define( 'WP_DEBUG', true );
 
 \Automattic\Jetpack\Test_Environment::init();
 
-/**
- * Tracks dispatcher shim. The package's `Tracks::record_event()` looks up
- * `\tracks_record_event` by name; defining it here makes events land in a
- * test-readable buffer instead of attempting a real HTTP dispatch. Cleared
- * per-test via `$GLOBALS['jetpack_podcast_test_captured_events']`.
- */
+// Capture tracks events into a per-test buffer instead of dispatching them.
 if ( ! function_exists( 'tracks_record_event' ) ) {
 	function tracks_record_event( $user, $event_name, $properties = array() ) {
 		$GLOBALS['jetpack_podcast_test_captured_events'][] = array(

--- a/projects/plugins/jetpack/changelog/add-podcast-tracks
+++ b/projects/plugins/jetpack/changelog/add-podcast-tracks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Podcast: wire tracks instrumentation (gated; no behavior change while jetpack_podcast_untangle filter is off).


### PR DESCRIPTION
Fixes #

## Proposed changes

* Adds `Automattic\Jetpack\Podcast\Tracks` to the podcast package — gated behind the same `jetpack_podcast_untangle` filter as the rest of the package, so this is a no-op until that flips.
* Records the six events the wpcom mu-plugin's `Automattic_Podcasting_Tracks` already emits, with identical names so analytics queries cover Simple, Atomic, and self-hosted Jetpack feeds without a rewrite:
  * `wpcom_podcast_episode_published` — first publish of a podcast-category post that carries audio.
  * `wpcom_podcast_show_launched` — fires once per site, atomically gated on `add_option( 'podcast_show_launched_tracked' )`.
  * `wpcom_podcast_media_uploaded` — audio/video attachments on podcasting-enabled sites.
  * `wpcom_podcasting_show_url_saved` — first-time entry of a directory URL (Apple, Spotify, etc.).
  * `wpcom_podcasting_status_changed` — enabled / disabled / changed transitions on `podcasting_category_id`.
  * `wpcom_podcasting_settings_saved` — `/wp/v2/settings` PATCH that touches any `podcasting_*` option. Payload contains the post-write state minus PII (`podcasting_email`, `podcasting_talent_name` are redacted).
* Dispatch tries `tracks_record_event` (wpcom Simple lib) first and falls back to `\Automattic\Jetpack\Tracking::tracks_record_event()` on Atomic — neither is a hard dep, so the package degrades to a silent no-op when neither is reachable.
* Includes the same noise-filtering guards the wpcom version uses: `WP_IMPORTING`, `is_headstart_post`, post-type allowlist, and a `has_podcast_media()` check that requires either a `core/audio` block or attached audio media. Without that filter, posts merely categorized into the podcast category would fire as episodes.
* Bumps the legacy mc counter via `do_action( 'jetpack_bump_stats_extras', … )` (same pattern as forms / google-analytics / classic-theme-helper).

## Related product discussion/links


## Does this pull request change what data or activity we track or use?

Yes — adds the six tracks events listed above. Event names match the wpcom mu-plugin's `Automattic_Podcasting_Tracks` exactly. Payload shapes match for the publish/upload/status/show-URL events; the `wpcom_podcasting_settings_saved` event ships only the post-write state and intentionally redacts `podcasting_email` and `podcasting_talent_name`. Will need the "[Status] Needs Privacy Updates" label.

## Testing instructions

* Run the package phpunit suite: `cd projects/packages/podcast && composer phpunit` — should be 56 green (142 assertions). Tests cover each event's gating rules and payload shape using a `tracks_record_event` shim defined in `bootstrap.php`.
* Manual: with the `jetpack_podcast_untangle` filter forced to `true`:
  * Set a podcast category and configure show URLs via the SPA (or `/wp/v2/settings` directly) — confirm `wpcom_podcasting_status_changed`, `wpcom_podcasting_show_url_saved`, and `wpcom_podcasting_settings_saved` fire.
  * Upload an audio attachment — confirm `wpcom_podcast_media_uploaded`.
  * Publish a post in the podcast category with an audio block or attached audio — confirm `wpcom_podcast_episode_published` and (first time only) `wpcom_podcast_show_launched`.
  * Publish a post in the podcast category with NO audio — confirm nothing fires.
