### PR TITLE
crm: Re-enable Codeception tests

### DIFF
--- a/projects/plugins/crm/changelog/update-reenable-crm-tests
+++ b/projects/plugins/crm/changelog/update-reenable-crm-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Re-enable Codeception tests on PHP 8.4+; disable `opcache.jit` instead.
+
+

--- a/projects/plugins/crm/tests/action-skip-test-php.sh
+++ b/projects/plugins/crm/tests/action-skip-test-php.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
 
-# Skip tests on PHP 8.4.21 and 8.5.6 due to inconsistent Codeception timeouts on those versions.
-# @todo: remove this when PHP has higher patch versions: p1773618372849869-slack-C034JEXD1RD
-# @todo: Consider bumping timeout limit to see if that makes a difference
-if php -r 'exit(in_array(PHP_VERSION, ["8.4.21", "8.5.6"], true) ? 0 : 1);'; then
-	echo "Skipping Codeception tests on PHP $(php -r 'echo PHP_VERSION;')"
-	exit 3
-fi
+# No skipping needed right now.
+exit 0

--- a/projects/plugins/crm/tests/codeception/_support/Helper/JPCRM_Acceptance.php
+++ b/projects/plugins/crm/tests/codeception/_support/Helper/JPCRM_Acceptance.php
@@ -56,7 +56,8 @@ class JPCRM_Acceptance extends WPBrowser {
 		$wp_version = '-';
 		include_once "$wp_path/wp-includes/version.php"; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 
-		$serverCmd = "php -S $server_host -t $wp_path";
+		// PHP 8.4.19+ and 8.5.5+ inconsistently segfault here. Turning off opcache.jit seems to fix it. p1773618372849869-slack-C034JEXD1RD
+		$serverCmd = "php -dopcache.jit=off -S $server_host -t $wp_path";
 
 		$this->serverProcess = new RunProcess( $serverCmd, $this->server_output_path );
 		echo "\e[33mPHP version:\e[96m " . PHP_VERSION;


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It seems that turning off `opcache.jit` avoids the segfaulting we've been seeing in PHP 8.4.19+ and 8.5.5+. Let's do that for the test server and re-enable the tests.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1778275495981099/1773618372.849869-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CRM tests running again in PHP 8.4+? And not failing?