### PR TITLE
AI page: fix layout-mixin selector after slug rename

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -1,6 +1,6 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 
-body.jetpack_page_ai {
+body.jetpack_page_jetpack-ai {
 
 	@include jetpack-admin-page-layout;
 }

--- a/projects/plugins/jetpack/changelog/fix-ai-page-layout-selector
+++ b/projects/plugins/jetpack/changelog/fix-ai-page-layout-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI page: update the layout-mixin selector to match the renamed `jetpack-ai` body class so the page layout (sticky header, scrollable middle, pinned footer) applies again.


### PR DESCRIPTION
Fixes the layout regression on `wp-admin/admin.php?page=jetpack-ai` (sticky header / scrollable middle / pinned footer no longer applied).

## Proposed changes

* Update the `jetpack-admin-page-layout` mixin scope from `body.jetpack_page_ai` to `body.jetpack_page_jetpack-ai`.

<img width="1486" height="811" alt="image" src="https://github.com/user-attachments/assets/ef00c310-4c4f-44f2-beeb-49ee7e5679bb" />


### Timeline

* PR #48471 adopted the layout mixin on the AI page, scoping it to `body.jetpack_page_ai` (menu slug at the time was `ai`).
* PR #48483 renamed the menu slug from `ai` to `jetpack-ai` to avoid a conflict with WordPress core's AI plugin. PHP and JSX references were updated; the SCSS selector was missed.
* WordPress derives the body class as `<parent>_page_<menu_slug>`, so on trunk the body class is `jetpack_page_jetpack-ai`. The old selector matches nothing and the mixin doesn't apply.

## Related product discussion/links

* JETPACK-1391 (Jetpack Experience Unification — admin-page layout work)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `nvm use && jetpack build plugins/jetpack`
2. Visit `wp-admin/admin.php?page=jetpack-ai`.
3. Confirm:
   * Page header (`AI` / `Control how AI agents interact with your site.`) sticks at the top of the content area.
   * Middle scrolls internally if content overflows.
   * `JetpackFooter` (`Jetpack | Products | Help` / `AN AUTOMATTIC AIRLINE`) is pinned to the bottom of the viewport, not floating mid-page.
4. Inspect `body` — class includes `jetpack_page_jetpack-ai`.
5. Inspect `#wpbody-content` — `position: fixed`, `padding-left: 0` on `#wpcontent`, `display: flex`, `flex-direction: column`.
6. Inspect `.jp-admin-page` — `margin-left: 0`, `display: flex`, `flex: 1 1 auto`.
