### PR TITLE
Search 3.0: restore product-format sort keys on results-sort under a WooCommerce gate (RSM-1082)

### DIFF
--- a/projects/packages/search/changelog/RSM-1082-results-sort-woocommerce-keys
+++ b/projects/packages/search/changelog/RSM-1082-results-sort-woocommerce-keys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: restore the product-format sort keys (Rating, Price: low to high, Price: high to low) on the results-sort block when WooCommerce is active. Non-WooCommerce sites are unchanged.

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/block.json
@@ -13,14 +13,14 @@
 		"defaultSort": {
 			"type": "string",
 			"default": "relevance",
-			"enum": [ "relevance", "newest", "oldest" ]
+			"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]
 		},
 		"availableSortOptions": {
 			"type": "array",
 			"default": [ "relevance", "newest", "oldest" ],
 			"items": {
 				"type": "string",
-				"enum": [ "relevance", "newest", "oldest" ]
+				"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]
 			}
 		},
 		"label": { "type": "string", "default": "" },

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/class-results-sort.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/class-results-sort.php
@@ -12,39 +12,58 @@ namespace Automattic\Jetpack\Search;
  *
  * Centralizes the list of valid sort keys, their translated labels, and the
  * attribute-normalization logic so render.php and the block's own unit tests
- * share one source of truth. The block currently exposes only the base sort
- * keys (`relevance`, `newest`, `oldest`); product-format keys present in
- * instant-search's `VALID_SORT_KEYS` (src/instant-search/lib/constants.js)
- * are intentionally deferred to the WooCommerce integration tracked under
- * RSM-1082.
+ * share one source of truth. Base sort keys (`relevance`, `newest`, `oldest`)
+ * are always exposed; the product-format keys (`rating_desc`, `price_asc`,
+ * `price_desc`) join the set only when WooCommerce is active so deep links
+ * to a sort the API can't honour can't slip into the rendered control on
+ * non-Woo sites.
  */
 class Results_Sort {
 
-	/** Product-format keys (rating/price) land in RSM-1082. */
 	const BASE_SORT_KEYS = array( 'relevance', 'newest', 'oldest' );
 
 	/**
+	 * Product-format keys gated on WooCommerce. Order is meaningful — `rating`
+	 * leads because authors most often want it as the visible default sort
+	 * for product pages, with the two price directions grouped after it.
+	 */
+	const PRODUCT_SORT_KEYS = array( 'rating_desc', 'price_asc', 'price_desc' );
+
+	/**
 	 * All keys the block may render. Order is meaningful — `<option>` / radio
-	 * rows come out in this sequence.
+	 * rows come out in this sequence. Product-format keys append to the base
+	 * set when WooCommerce is active so non-Woo sites never expose a sort
+	 * the API would silently fall back to relevance on. Reads through to
+	 * `Search_Blocks::is_woocommerce_active()` so block-registration gates
+	 * for `filter-wc-*` and the sort-key gate share one memoized probe.
 	 *
 	 * @return string[]
 	 */
 	public static function get_all_option_keys(): array {
+		if ( Search_Blocks::is_woocommerce_active() ) {
+			return array_merge( self::BASE_SORT_KEYS, self::PRODUCT_SORT_KEYS );
+		}
 		return self::BASE_SORT_KEYS;
 	}
 
 	/**
 	 * Translated labels for each sort key. A separate accessor (rather than a
 	 * class constant) so the strings go through `__()` at call time — class
-	 * constants can't hold translation-function output.
+	 * constants can't hold translation-function output. Returns labels for
+	 * every key the block could render in any environment (base + product);
+	 * `resolve_available_options()` is the gate that decides which keys
+	 * actually surface, so the unused entries never reach the DOM.
 	 *
 	 * @return array<string, string>  Map of sort key → label.
 	 */
 	public static function get_option_labels(): array {
 		return array(
-			'relevance' => __( 'Relevance', 'jetpack-search-pkg' ),
-			'newest'    => __( 'Newest', 'jetpack-search-pkg' ),
-			'oldest'    => __( 'Oldest', 'jetpack-search-pkg' ),
+			'relevance'   => __( 'Relevance', 'jetpack-search-pkg' ),
+			'newest'      => __( 'Newest', 'jetpack-search-pkg' ),
+			'oldest'      => __( 'Oldest', 'jetpack-search-pkg' ),
+			'rating_desc' => __( 'Rating', 'jetpack-search-pkg' ),
+			'price_asc'   => __( 'Price: low to high', 'jetpack-search-pkg' ),
+			'price_desc'  => __( 'Price: high to low', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/edit.js
@@ -11,8 +11,35 @@ import { CheckboxControl, PanelBody, SelectControl, TextControl } from '@wordpre
 import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-// Mirror Results_Sort::BASE_SORT_KEYS. Product-format keys rejoin in RSM-1082.
-const ALL_SORT_KEYS = [ 'relevance', 'newest', 'oldest' ];
+// Mirror Results_Sort::BASE_SORT_KEYS / PRODUCT_SORT_KEYS. The product
+// keys only surface in the inspector when WooCommerce is active on this
+// site (see `isWooCommerceActive` below).
+const BASE_SORT_KEYS = [ 'relevance', 'newest', 'oldest' ];
+const PRODUCT_SORT_KEYS = [ 'rating_desc', 'price_asc', 'price_desc' ];
+
+/**
+ * Whether the product-format sort keys should appear in the inspector.
+ * Read at module-load from the editor-localized config (see
+ * `Search_Blocks::enqueue_editor_assets()`); defaults to `false` so an
+ * unconfigured environment (tests, headless editor previews) renders the
+ * non-Woo experience.
+ *
+ * @return {boolean} True when WooCommerce is active.
+ */
+function isWooCommerceActive() {
+	return Boolean( globalThis?.JetpackSearchBlocksConfig?.isWooCommerceActive );
+}
+
+/**
+ * Sort keys this block may render. Mirrors `Results_Sort::get_all_option_keys()`
+ * on the PHP side: base keys always, product keys only when WooCommerce is
+ * active.
+ *
+ * @return {string[]} Ordered sort keys available in this environment.
+ */
+function getAllSortKeys() {
+	return isWooCommerceActive() ? [ ...BASE_SORT_KEYS, ...PRODUCT_SORT_KEYS ] : BASE_SORT_KEYS;
+}
 
 /**
  * Translated human-readable labels for each sort key. Declared as a function
@@ -27,6 +54,9 @@ function getSortLabels() {
 		relevance: __( 'Relevance', 'jetpack-search-pkg' ),
 		newest: __( 'Newest', 'jetpack-search-pkg' ),
 		oldest: __( 'Oldest', 'jetpack-search-pkg' ),
+		rating_desc: __( 'Rating', 'jetpack-search-pkg' ),
+		price_asc: __( 'Price: low to high', 'jetpack-search-pkg' ),
+		price_desc: __( 'Price: high to low', 'jetpack-search-pkg' ),
 	};
 }
 
@@ -37,14 +67,15 @@ function getSortLabels() {
  * so a misconfigured block never shows a control with zero options.
  *
  * @param {string[]|undefined} stored - Saved `availableSortOptions` value.
+ * @param {string[]}           all    - Sort keys this environment exposes.
  * @return {string[]} Ordered sort keys to render.
  */
-function resolveAvailable( stored ) {
+function resolveAvailable( stored, all ) {
 	if ( ! Array.isArray( stored ) ) {
-		return ALL_SORT_KEYS;
+		return all;
 	}
-	const filtered = ALL_SORT_KEYS.filter( key => stored.includes( key ) );
-	return filtered.length === 0 ? ALL_SORT_KEYS : filtered;
+	const filtered = all.filter( key => stored.includes( key ) );
+	return filtered.length === 0 ? all : filtered;
 }
 
 /**
@@ -60,8 +91,9 @@ export default function ResultsSortEdit( { attributes, setAttributes } ) {
 	// editor renders more than one Results Sort on the same canvas.
 	const baseId = useId();
 
+	const allSortKeys = getAllSortKeys();
 	const labels = getSortLabels();
-	const defaultSort = ALL_SORT_KEYS.includes( attributes?.defaultSort )
+	const defaultSort = allSortKeys.includes( attributes?.defaultSort )
 		? attributes.defaultSort
 		: 'relevance';
 	let displayAs = 'select';
@@ -75,8 +107,8 @@ export default function ResultsSortEdit( { attributes, setAttributes } ) {
 	} );
 	const storedAvailable = Array.isArray( attributes?.availableSortOptions )
 		? attributes.availableSortOptions
-		: ALL_SORT_KEYS;
-	const available = resolveAvailable( storedAvailable );
+		: allSortKeys;
+	const available = resolveAvailable( storedAvailable, allSortKeys );
 	const labelText = ( attributes?.label || '' ).trim() || __( 'Sort by', 'jetpack-search-pkg' );
 
 	// If the saved default no longer appears in `availableSortOptions` (e.g.
@@ -86,7 +118,7 @@ export default function ResultsSortEdit( { attributes, setAttributes } ) {
 
 	const toggleAvailable = ( sortKey, checked ) => {
 		const next = checked
-			? ALL_SORT_KEYS.filter( key => key === sortKey || storedAvailable.includes( key ) )
+			? allSortKeys.filter( key => key === sortKey || storedAvailable.includes( key ) )
 			: storedAvailable.filter( key => key !== sortKey );
 		// Persisting `[]` would make the preview fall back to "all options"
 		// (matching `resolveAvailable()` and the PHP renderer) while every
@@ -94,7 +126,7 @@ export default function ResultsSortEdit( { attributes, setAttributes } ) {
 		// authors can't easily reason about. Snap the empty case back to the
 		// canonical full set so the saved attribute always matches what
 		// renders.
-		const normalizedNext = next.length === 0 ? ALL_SORT_KEYS : next;
+		const normalizedNext = next.length === 0 ? allSortKeys : next;
 		// If the author just unchecked the current `defaultSort` AND it's no
 		// longer in the saved set, move the attribute onto the first still-
 		// available key in the same setAttributes call. Without this,
@@ -157,7 +189,7 @@ export default function ResultsSortEdit( { attributes, setAttributes } ) {
 				/>
 			</PanelBody>
 			<PanelBody title={ __( 'Available options', 'jetpack-search-pkg' ) }>
-				{ ALL_SORT_KEYS.map( key => (
+				{ allSortKeys.map( key => (
 					<CheckboxControl
 						key={ key }
 						__nextHasNoMarginBottom

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/render.php
@@ -61,12 +61,6 @@ if ( function_exists( 'wp_interactivity_state' ) ) {
 
 $select_id = wp_unique_id( 'jetpack-search-results-sort-' );
 $menu_id   = wp_unique_id( 'jetpack-search-results-sort-menu-' );
-
-$checked_getters = array(
-	'relevance' => 'state.isSortByRelevance',
-	'newest'    => 'state.isSortByNewest',
-	'oldest'    => 'state.isSortByOldest',
-);
 ?>
 <?php if ( 'popover' === $display_as ) : ?>
 	<div
@@ -101,10 +95,7 @@ $checked_getters = array(
 			hidden
 		>
 			<?php foreach ( $options as $sort_key ) : ?>
-				<?php
-				$option_label    = $option_labels[ $sort_key ] ?? $sort_key;
-				$checked_binding = $checked_getters[ $sort_key ] ?? 'false';
-				?>
+				<?php $option_label = $option_labels[ $sort_key ] ?? $sort_key; ?>
 				<button
 					type="button"
 					role="menuitemradio"
@@ -112,7 +103,7 @@ $checked_getters = array(
 					value="<?php echo esc_attr( $sort_key ); ?>"
 					tabindex="-1"
 					data-wp-context='<?php echo esc_attr( wp_json_encode( array( 'sortKey' => $sort_key ), JSON_HEX_AMP | JSON_UNESCAPED_SLASHES ) ); ?>'
-					data-wp-bind--aria-checked="<?php echo esc_attr( $checked_binding ); ?>"
+					data-wp-bind--aria-checked="state.isSortOptionSelected"
 					data-wp-bind--tabindex="state.sortMenuItemTabIndex"
 					data-wp-on--click="actions.selectSortOrder"
 					data-wp-on--keydown="actions.onSortMenuKeydown"

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -173,7 +173,10 @@ class Search_Blocks {
 	 */
 	public static function is_woocommerce_active(): bool {
 		if ( null === self::$is_woocommerce_active_cache ) {
-			self::$is_woocommerce_active_cache = class_exists( 'WooCommerce' );
+			// Pass `false` so a missing class doesn't fire the autoloader
+			// on non-Woo sites — the gate is hit on every request, and
+			// any upstream autoloader work is wasted when the answer is "no".
+			self::$is_woocommerce_active_cache = class_exists( 'WooCommerce', false );
 		}
 		return self::$is_woocommerce_active_cache;
 	}
@@ -183,6 +186,8 @@ class Search_Blocks {
 	 * tests only. Pass `null` to clear the override and revive the real
 	 * `class_exists()` probe (also done by `reset_is_woocommerce_active_cache()`).
 	 *
+	 * @internal
+	 *
 	 * @param bool|null $value Forced answer or null to clear.
 	 */
 	public static function set_is_woocommerce_active_for_testing( ?bool $value ): void {
@@ -191,6 +196,8 @@ class Search_Blocks {
 
 	/**
 	 * Reset the `is_woocommerce_active()` memo. Tests only.
+	 *
+	 * @internal
 	 */
 	public static function reset_is_woocommerce_active_cache(): void {
 		self::$is_woocommerce_active_cache = null;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -74,6 +74,18 @@ class Search_Blocks {
 	private static $is_free_plan_cache = null;
 
 	/**
+	 * Per-request memo backing `is_woocommerce_active()`. Centralized here
+	 * (rather than inside any one WC-aware block helper) so every gate that
+	 * needs the answer — block-registration filters that hide WC-only blocks
+	 * on non-Woo sites, render callbacks that drop product-format sort keys,
+	 * the editor-side localized config, the Interactivity store seed —
+	 * shares the same `class_exists()` probe.
+	 *
+	 * @var bool|null
+	 */
+	private static $is_woocommerce_active_cache = null;
+
+	/**
 	 * Register block types and hook into WordPress.
 	 *
 	 * Two gates apply:
@@ -151,6 +163,40 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Whether WooCommerce is loaded on this site. Use from any gate that
+	 * needs to skip a WC-only feature (block registration of `filter-wc-*`
+	 * blocks, the product-format sort keys on `results-sort`, etc.). The
+	 * result is memoized per-request so adding a new caller doesn't
+	 * multiply autoloader probes.
+	 *
+	 * @return bool
+	 */
+	public static function is_woocommerce_active(): bool {
+		if ( null === self::$is_woocommerce_active_cache ) {
+			self::$is_woocommerce_active_cache = class_exists( 'WooCommerce' );
+		}
+		return self::$is_woocommerce_active_cache;
+	}
+
+	/**
+	 * Force the `is_woocommerce_active()` answer to a specific boolean —
+	 * tests only. Pass `null` to clear the override and revive the real
+	 * `class_exists()` probe (also done by `reset_is_woocommerce_active_cache()`).
+	 *
+	 * @param bool|null $value Forced answer or null to clear.
+	 */
+	public static function set_is_woocommerce_active_for_testing( ?bool $value ): void {
+		self::$is_woocommerce_active_cache = $value;
+	}
+
+	/**
+	 * Reset the `is_woocommerce_active()` memo. Tests only.
+	 */
+	public static function reset_is_woocommerce_active_cache(): void {
+		self::$is_woocommerce_active_cache = null;
+	}
+
+	/**
 	 * URL param key the inline search experience uses for the current request.
 	 *
 	 * On WP's search route (`is_search()`) the canonical `s` key is used so
@@ -194,6 +240,23 @@ class Search_Blocks {
 			$asset['dependencies'] ?? array(),
 			$asset['version'] ?? false,
 			true
+		);
+
+		// Surface the WC-active flag to edit.js so the results-sort inspector
+		// can hide the product-format checkboxes on non-WooCommerce sites
+		// instead of offering options the renderer would silently drop.
+		// `wp_add_inline_script` (rather than `wp_localize_script`) per
+		// core ticket #25280 — the latter HTML-encodes ampersands inside
+		// nested values.
+		wp_add_inline_script(
+			'jetpack-search-blocks-register',
+			'window.JetpackSearchBlocksConfig = ' . wp_json_encode(
+				array(
+					'isWooCommerceActive' => self::is_woocommerce_active(),
+				),
+				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+			) . ';',
+			'before'
 		);
 	}
 
@@ -686,6 +749,12 @@ class Search_Blocks {
 			'nonce'                 => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
 			'isPrivateSite'         => $is_private,
 			'isWpcom'               => $is_wpcom,
+			// Whether the product-format sort keys (rating, price asc/desc)
+			// are valid on this site, plus a JS-side gate any WC-only block
+			// can read. The store threads it into url-state so a
+			// `?orderby=price_asc` deep link round-trips on Woo sites and
+			// collapses to relevance everywhere else.
+			'isWooCommerceActive'   => self::is_woocommerce_active(),
 			'homeUrl'               => function_exists( 'home_url' ) ? home_url() : '',
 			// BCP47-ish locale (e.g. `en-US`) for Intl.DateTimeFormat on the
 			// client. Converts WP's `en_US` underscore form. Uses the blog
@@ -997,15 +1066,26 @@ class Search_Blocks {
 
 	/**
 	 * Parse the sort order from the URL, defaulting to 'relevance'. Valid
-	 * values mirror the UI keys in src/instant-search/lib/constants.js
-	 * SORT_OPTIONS so deep links work across both surfaces.
+	 * values come from `Results_Sort::get_all_option_keys()` so the seeded
+	 * sort matches what the results-sort block would render — including the
+	 * product-format keys when WooCommerce is active. On non-Woo sites a
+	 * `?orderby=price_asc` deep link collapses to `relevance`, mirroring the
+	 * JS-side gate in store/url-state.js.
 	 *
 	 * @return string
 	 */
 	protected static function parse_url_sort(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.
 		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : '';
-		return in_array( $orderby, array( 'newest', 'oldest' ), true ) ? $orderby : 'relevance';
+		$allowed = array_values(
+			array_filter(
+				Results_Sort::get_all_option_keys(),
+				static function ( $key ) {
+					return 'relevance' !== $key;
+				}
+			)
+		);
+		return in_array( $orderby, $allowed, true ) ? $orderby : 'relevance';
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -169,6 +169,15 @@ class Search_Blocks {
 	 * result is memoized per-request so adding a new caller doesn't
 	 * multiply autoloader probes.
 	 *
+	 * **Load-order contract:** must be called at or after `plugins_loaded`.
+	 * WooCommerce includes its main `WooCommerce` class only when its plugin
+	 * file runs (during `plugins_loaded`), so an earlier call would return
+	 * false on a WC site. Every existing caller fires from a hook later than
+	 * that — `enqueue_block_editor_assets`, `template_redirect`,
+	 * `wp_enqueue_scripts`, or block render — so the contract is naturally
+	 * satisfied. New callers earlier in the request lifecycle should defer
+	 * the probe to a `plugins_loaded`-or-later hook.
+	 *
 	 * @return bool
 	 */
 	public static function is_woocommerce_active(): bool {

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -36,12 +36,37 @@ export const HIGHLIGHT_FIELDS = [ 'title', 'content' ];
  * Maps Search 3.0 sort UI values to the v1.3 API `sort` parameter. Keep the
  * UI keys aligned with src/instant-search/lib/constants.js SORT_OPTIONS so
  * the two surfaces stay interoperable.
+ *
+ * Only contains the keys the API expects under a *different* name. The
+ * product-format keys (`rating_desc`, `price_asc`, `price_desc`) are passed
+ * through as-is by `mapSortToApiValue()` because the API accepts them
+ * verbatim — same contract as instant-search's `mapSortToApiValue` in
+ * src/instant-search/lib/api.js.
  */
 const SORT_QUERY_MAP = {
 	newest: 'date_desc',
 	oldest: 'date_asc',
 	relevance: 'score_default',
 };
+
+/**
+ * Sort keys the v1.3 API accepts unchanged. Mirrors the early-return pool in
+ * src/instant-search/lib/api.js → `mapSortToApiValue`.
+ */
+const SORT_PASSTHROUGH = new Set( [ 'rating_desc', 'price_asc', 'price_desc' ] );
+
+/**
+ * Translate a Search 3.0 store `sortOrder` to the API's `sort` value.
+ *
+ * @param {string} sortOrder - UI-side sort key.
+ * @return {string} API-side sort value.
+ */
+function mapSortToApiValue( sortOrder ) {
+	if ( SORT_PASSTHROUGH.has( sortOrder ) ) {
+		return sortOrder;
+	}
+	return SORT_QUERY_MAP[ sortOrder ] ?? 'score_default';
+}
 
 // Mirrors Filter_Date::ALLOWED_INTERVALS. Doubles as the gate in
 // buildAggregations — ES 400s on unknown intervals.
@@ -490,7 +515,9 @@ export function buildStaticPostTypeClauses( staticPostTypes ) {
  * @param {object}      opts                   - Options.
  * @param {number}      opts.siteId            - Site ID.
  * @param {string}      opts.searchQuery       - Search query string.
- * @param {string}      opts.sortOrder         - 'relevance' | 'newest' | 'oldest'.
+ * @param {string}      opts.sortOrder         - 'relevance' | 'newest' | 'oldest', plus
+ *                                             'rating_desc' | 'price_asc' | 'price_desc'
+ *                                             on WooCommerce sites.
  * @param {string|null} opts.pageHandle        - Cursor for pagination.
  * @param {boolean}     opts.isPrivateSite     - Whether the site is private.
  * @param {boolean}     opts.isWpcom           - Whether the site runs on WordPress.com.
@@ -532,7 +559,7 @@ export function buildSearchUrl( {
 	// would otherwise search for the wrong string.
 	const params = {
 		query: searchQuery || '',
-		sort: SORT_QUERY_MAP[ sortOrder ] ?? 'score_default',
+		sort: mapSortToApiValue( sortOrder ),
 		size: 10,
 		fields: SEARCH_FIELDS,
 		highlight_fields: HIGHLIGHT_FIELDS,

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -817,6 +817,7 @@ const { state, actions } = store( NAMESPACE, {
 				activeFilters: state.activeFilters,
 				priceRange: state.priceRange,
 				searchParamName: state.searchParamName,
+				isWooCommerceActive: state.isWooCommerceActive,
 			} );
 		},
 
@@ -828,7 +829,8 @@ const { state, actions } = store( NAMESPACE, {
 		*handlePopState() {
 			const { searchQuery, sortOrder, activeFilters, priceRange } = readStateFromUrl(
 				state.filterConfigs,
-				state.searchParamName
+				state.searchParamName,
+				state.isWooCommerceActive
 			);
 			state.searchQuery = searchQuery;
 			state.sortOrder = sortOrder;

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -1,6 +1,22 @@
-// Mirror `Results_Sort::get_all_option_keys()`. Product-format keys rejoin in RSM-1082.
-const VALID_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
+// Mirror `Results_Sort::BASE_SORT_KEYS` / `PRODUCT_SORT_KEYS`. Product
+// keys are gated on WooCommerce — only accepted when the caller threads
+// `isWooCommerceActive=true` through, so a `?orderby=price_asc` deep link
+// on a non-Woo site collapses to relevance instead of being forwarded to
+// an API surface that can't honour it.
+const BASE_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
+const PRODUCT_SORT_ORDERS = [ 'rating_desc', 'price_asc', 'price_desc' ];
 const DEFAULT_SORT_ORDER = 'relevance';
+
+/**
+ * Sort keys this environment will accept. Mirrors
+ * `Results_Sort::get_all_option_keys()` on the PHP side.
+ *
+ * @param {boolean} isWooCommerceActive - True when WooCommerce is loaded.
+ * @return {string[]} Ordered sort keys.
+ */
+function validSortOrders( isWooCommerceActive ) {
+	return isWooCommerceActive ? [ ...BASE_SORT_ORDERS, ...PRODUCT_SORT_ORDERS ] : BASE_SORT_ORDERS;
+}
 
 // Default search-query URL key. Used when no per-request name is threaded
 // through (tests, callers that don't care about the singular-page case).
@@ -40,14 +56,15 @@ function parsePriceBound( raw ) {
  * so deep links are interchangeable between the two surfaces and the
  * PHP-side `parse_url_filters()` reads the same contract.
  *
- * @param {object}      state                   - Store state slice.
- * @param {string}      state.searchQuery       - Current search query.
- * @param {string}      state.sortOrder         - Current sort order.
- * @param {object}      [state.activeFilters]   - { [filterKey]: string[] } selected filters.
- * @param {object|null} [state.priceRange]      - { min, max } price range; either bound may be null.
- * @param {string}      [state.searchParamName] - URL key the search query is written under
- *                                              (`s` on the WP search route, `q`
- *                                              on non-search pages). Defaults to `s`.
+ * @param {object}      state                       - Store state slice.
+ * @param {string}      state.searchQuery           - Current search query.
+ * @param {string}      state.sortOrder             - Current sort order.
+ * @param {object}      [state.activeFilters]       - { [filterKey]: string[] } selected filters.
+ * @param {object|null} [state.priceRange]          - { min, max } price range; either bound may be null.
+ * @param {string}      [state.searchParamName]     - URL key the search query is written under
+ *                                                  (`s` on the WP search route, `q`
+ *                                                  on non-search pages). Defaults to `s`.
+ * @param {boolean}     [state.isWooCommerceActive] - Gate for product-format sort keys.
  * @return {URLSearchParams} URL-ready params.
  */
 export function stateToUrlParams( {
@@ -56,6 +73,7 @@ export function stateToUrlParams( {
 	activeFilters = {},
 	priceRange = null,
 	searchParamName = DEFAULT_SEARCH_PARAM,
+	isWooCommerceActive = false,
 } ) {
 	const params = new URLSearchParams();
 
@@ -66,7 +84,8 @@ export function stateToUrlParams( {
 	// URL shape on `/about/?q=`.
 	params.set( searchParamName, searchQuery ?? '' );
 
-	if ( sortOrder && sortOrder !== DEFAULT_SORT_ORDER && VALID_SORT_ORDERS.includes( sortOrder ) ) {
+	const allowedSorts = validSortOrders( isWooCommerceActive );
+	if ( sortOrder && sortOrder !== DEFAULT_SORT_ORDER && allowedSorts.includes( sortOrder ) ) {
 		params.set( 'orderby', sortOrder );
 	}
 
@@ -98,18 +117,21 @@ export function stateToUrlParams( {
  * forwarded to ES with no matching config, so they'd silently drop but still
  * round-trip through the browser URL on every keystroke.
  *
- * @param {URLSearchParams} params            - URL search params.
- * @param {object}          [filterConfigs]   - { [filterKey]: FilterConfig } map used to validate filter keys.
- * @param {string}          [searchParamName] - URL key to read the search query from
- *                                            (`s` or `q`). Defaults to `s`.
+ * @param {URLSearchParams} params                - URL search params.
+ * @param {object}          [filterConfigs]       - { [filterKey]: FilterConfig } map used to validate filter keys.
+ * @param {string}          [searchParamName]     - URL key to read the search query from
+ *                                                (`s` or `q`). Defaults to `s`.
+ * @param {boolean}         [isWooCommerceActive] - Gate for product-format sort keys.
  * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
  */
 export function urlParamsToState(
 	params,
 	filterConfigs = {},
-	searchParamName = DEFAULT_SEARCH_PARAM
+	searchParamName = DEFAULT_SEARCH_PARAM,
+	isWooCommerceActive = false
 ) {
 	const rawOrderby = params.get( 'orderby' );
+	const allowedSorts = validSortOrders( isWooCommerceActive );
 	const activeFilters = {};
 
 	for ( const [ rawKey, value ] of params.entries() ) {
@@ -159,7 +181,7 @@ export function urlParamsToState(
 
 	return {
 		searchQuery: params.get( searchParamName ) ?? '',
-		sortOrder: VALID_SORT_ORDERS.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
+		sortOrder: allowedSorts.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
 		activeFilters,
 		priceRange,
 	};
@@ -183,15 +205,21 @@ export function pushStateToUrl( state ) {
 /**
  * Read initial state from the current URL.
  *
- * @param {object} [filterConfigs]   - { [filterKey]: FilterConfig } map used to validate filter keys.
- * @param {string} [searchParamName] - URL key the search query lives under (`s` or
- *                                   `q`). Defaults to `s`.
+ * @param {object}  [filterConfigs]       - { [filterKey]: FilterConfig } map used to validate filter keys.
+ * @param {string}  [searchParamName]     - URL key the search query lives under (`s` or
+ *                                        `q`). Defaults to `s`.
+ * @param {boolean} [isWooCommerceActive] - Gate for product-format sort keys.
  * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
  */
-export function readStateFromUrl( filterConfigs = {}, searchParamName = DEFAULT_SEARCH_PARAM ) {
+export function readStateFromUrl(
+	filterConfigs = {},
+	searchParamName = DEFAULT_SEARCH_PARAM,
+	isWooCommerceActive = false
+) {
 	return urlParamsToState(
 		new URLSearchParams( window.location.search ),
 		filterConfigs,
-		searchParamName
+		searchParamName,
+		isWooCommerceActive
 	);
 }

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -97,6 +97,27 @@ describe( 'buildSearchUrl', () => {
 		expect( url ).toContain( 'sort=date_asc' );
 	} );
 
+	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
+		'passes the product-format sort key %s through to the API verbatim (RSM-1082)',
+		key => {
+			// Mirrors instant-search/lib/api.js → mapSortToApiValue: the v1.3
+			// API accepts these three keys unchanged. Without the pass-through
+			// they'd hit the SORT_QUERY_MAP fallback and silently sort by
+			// relevance, leaving deep links broken on WC sites.
+			const url = buildSearchUrl( {
+				siteId: 12345,
+				searchQuery: 'shirt',
+				sortOrder: key,
+				pageHandle: null,
+				isPrivateSite: false,
+				isWpcom: false,
+				apiRoot: 'https://example.com/wp-json/',
+			} );
+			expect( url ).toContain( 'sort=' + key );
+			expect( url ).not.toContain( 'sort=score_default' );
+		}
+	);
+
 	it( 'single-encodes special characters in the search query', () => {
 		// `qss.encode` already runs encodeURIComponent, so the string we pass
 		// in must be raw. Double-encoding would turn `&` into `%2526` and

--- a/projects/packages/search/tests/js/search-blocks/results-sort-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-sort-edit.test.jsx
@@ -67,6 +67,13 @@ jest.mock( '@wordpress/i18n', () => ( {
 } ) );
 
 describe( 'ResultsSortEdit', () => {
+	afterEach( () => {
+		// `isWooCommerceActive()` reads window.JetpackSearchBlocksConfig at
+		// each render, so resetting between tests keeps a single case from
+		// pinning the gate for everything that follows.
+		delete globalThis.JetpackSearchBlocksConfig;
+	} );
+
 	it( 'renders the dropdown preview with the default label and swaps to radios when displayAs=radio', () => {
 		const { rerender } = render(
 			<ResultsSortEdit attributes={ {} } setAttributes={ jest.fn() } />
@@ -95,6 +102,41 @@ describe( 'ResultsSortEdit', () => {
 		render( <ResultsSortEdit attributes={ { display: 'popover' } } setAttributes={ jest.fn() } /> );
 		expect( screen.getByRole( 'button', { name: 'Sort results' } ) ).toBeDisabled();
 		expect( screen.queryByRole( 'combobox', { name: 'Sort by' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the product-format checkboxes when WooCommerce is inactive (RSM-1082)', () => {
+		render( <ResultsSortEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+		expect( screen.getByRole( 'checkbox', { name: 'Relevance' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'checkbox', { name: 'Rating' } ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'checkbox', { name: 'Price: low to high' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'checkbox', { name: 'Price: high to low' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'surfaces the product-format checkboxes when WooCommerce is active (RSM-1082)', () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: true };
+		render( <ResultsSortEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+		expect( screen.getByRole( 'checkbox', { name: 'Rating' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox', { name: 'Price: low to high' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox', { name: 'Price: high to low' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'lets an author check a product-format option when WooCommerce is active (RSM-1082)', () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: true };
+		const onSetAttributes = jest.fn();
+		render(
+			<ResultsSortEdit
+				attributes={ { availableSortOptions: [ 'relevance', 'newest', 'oldest' ] } }
+				setAttributes={ onSetAttributes }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Price: low to high' } ) );
+		expect( onSetAttributes ).toHaveBeenCalledWith( {
+			availableSortOptions: [ 'relevance', 'newest', 'oldest', 'price_asc' ],
+		} );
 	} );
 
 	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -36,13 +36,33 @@ describe( 'stateToUrlParams', () => {
 		expect( params.has( 'orderby' ) ).toBe( false );
 	} );
 
-	it( 'omits product-format sort orders until WooCommerce integration lands (RSM-1082)', () => {
+	it( 'omits product-format sort orders on non-WooCommerce sites (RSM-1082)', () => {
 		const params = stateToUrlParams( { searchQuery: '', sortOrder: 'price_asc' } );
 		expect( params.has( 'orderby' ) ).toBe( false );
 	} );
 
+	it( 'serializes product-format sort orders when isWooCommerceActive is true (RSM-1082)', () => {
+		for ( const key of [ 'rating_desc', 'price_asc', 'price_desc' ] ) {
+			const params = stateToUrlParams( {
+				searchQuery: '',
+				sortOrder: key,
+				isWooCommerceActive: true,
+			} );
+			expect( params.get( 'orderby' ) ).toBe( key );
+		}
+	} );
+
 	it( 'omits unknown sort orders', () => {
 		const params = stateToUrlParams( { searchQuery: '', sortOrder: 'bogus' } );
+		expect( params.has( 'orderby' ) ).toBe( false );
+	} );
+
+	it( 'still rejects unknown sort orders even when isWooCommerceActive is true', () => {
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'bogus',
+			isWooCommerceActive: true,
+		} );
 		expect( params.has( 'orderby' ) ).toBe( false );
 	} );
 
@@ -139,8 +159,20 @@ describe( 'urlParamsToState', () => {
 		expect( state.sortOrder ).toBe( 'relevance' );
 	} );
 
-	it( 'collapses product-format URL sort to relevance until WooCommerce integration lands (RSM-1082)', () => {
+	it( 'collapses product-format URL sort to relevance on non-WooCommerce sites (RSM-1082)', () => {
 		const state = urlParamsToState( new URLSearchParams( 'orderby=price_asc' ) );
+		expect( state.sortOrder ).toBe( 'relevance' );
+	} );
+
+	it( 'admits product-format URL sort when isWooCommerceActive is true (RSM-1082)', () => {
+		for ( const key of [ 'rating_desc', 'price_asc', 'price_desc' ] ) {
+			const state = urlParamsToState( new URLSearchParams( `orderby=${ key }` ), {}, 's', true );
+			expect( state.sortOrder ).toBe( key );
+		}
+	} );
+
+	it( 'still collapses unknown sort to relevance even when isWooCommerceActive is true', () => {
+		const state = urlParamsToState( new URLSearchParams( 'orderby=bogus' ), {}, 's', true );
 		expect( state.sortOrder ).toBe( 'relevance' );
 	} );
 

--- a/projects/packages/search/tests/php/Results_Sort_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_Sort_Render_Test.php
@@ -285,6 +285,36 @@ class Results_Sort_Render_Test extends TestCase {
 		}
 	}
 
+	/**
+	 * Every popover menu item — base or product — must bind `aria-checked`
+	 * to the shared `state.isSortOptionSelected` getter (which reads back
+	 * through `data-wp-context.sortKey`). Using a per-key getter map would
+	 * leave product keys falling through to a literal `"false"` binding,
+	 * which the Interactivity API resolves as `state.false` (undefined),
+	 * leaving screen reader users without a "currently selected" signal.
+	 */
+	public function test_display_as_popover_aria_checked_uses_shared_getter_for_all_keys() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		try {
+			$markup = $this->render(
+				array(
+					'displayAs'            => 'popover',
+					'availableSortOptions' => array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+				)
+			);
+			foreach ( array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+				$this->assertMatchesRegularExpression(
+					'/data-wp-context=\'[^\']*' . preg_quote( $key, '/' ) . '[^\']*\'\s+data-wp-bind--aria-checked="state\.isSortOptionSelected"/s',
+					$markup,
+					"Expected $key menu item to bind aria-checked to state.isSortOptionSelected."
+				);
+			}
+			$this->assertStringNotContainsString( 'data-wp-bind--aria-checked="false"', $markup );
+		} finally {
+			Search_Blocks::set_is_woocommerce_active_for_testing( null );
+		}
+	}
+
 	/** Label is user-controlled; must be HTML-escaped to block stored XSS. */
 	public function test_label_is_html_escaped() {
 		$markup = $this->render( array( 'label' => '<script>alert(1)</script>' ) );

--- a/projects/packages/search/tests/php/Results_Sort_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_Sort_Render_Test.php
@@ -69,14 +69,21 @@ class Results_Sort_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Reset `$_GET` between tests so URL parsing never leaks across cases.
-	 * Interactivity state carries across tests, but render.php always writes
-	 * `sortOrder` deterministically from attrs + URL, so each render
-	 * overwrites whatever the previous one left behind.
+	 * Reset `$_GET` and the WC-active memo between tests so URL parsing
+	 * and the gate state never leak across cases. Interactivity state
+	 * carries across tests, but render.php always writes `sortOrder`
+	 * deterministically from attrs + URL, so each render overwrites
+	 * whatever the previous one left behind.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 		$_GET = array();
+		Search_Blocks::reset_is_woocommerce_active_cache();
+	}
+
+	protected function tearDown(): void {
+		Search_Blocks::reset_is_woocommerce_active_cache();
+		parent::tearDown();
 	}
 
 	/**
@@ -92,13 +99,110 @@ class Results_Sort_Render_Test extends TestCase {
 		return do_blocks( '<!-- wp:jetpack-search/results-sort ' . $json . ' /-->' );
 	}
 
-	/** Default render: dropdown, "Sort by", all base options. Product keys deferred to RSM-1082. */
+	/** Default render on a non-Woo site: dropdown, "Sort by", base options only. */
 	public function test_default_attributes_render_select_with_base_options() {
 		$markup = $this->render();
 		$this->assertStringContainsString( '<select', $markup );
 		$this->assertStringContainsString( 'Sort by', $markup );
 		foreach ( array( 'relevance', 'newest', 'oldest' ) as $key ) {
 			$this->assertStringContainsString( 'value="' . $key . '"', $markup );
+		}
+		foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+			$this->assertStringNotContainsString( 'value="' . $key . '"', $markup );
+		}
+	}
+
+	/**
+	 * On a WooCommerce site, when an author opts the product-format keys
+	 * into `availableSortOptions`, the renderer must expose them with the
+	 * matching translated labels. Authors keep the base-three default until
+	 * they explicitly check the new options in the inspector — that's the
+	 * "non-Woo behavior is unchanged" half of the acceptance criteria.
+	 */
+	public function test_woocommerce_active_renders_product_keys_when_author_opts_in() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		try {
+			$markup = $this->render(
+				array(
+					'availableSortOptions' => array(
+						'relevance',
+						'newest',
+						'oldest',
+						'rating_desc',
+						'price_asc',
+						'price_desc',
+					),
+				)
+			);
+			foreach ( array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+				$this->assertStringContainsString( 'value="' . $key . '"', $markup );
+			}
+			$this->assertStringContainsString( 'Rating', $markup );
+			$this->assertStringContainsString( 'Price: low to high', $markup );
+			$this->assertStringContainsString( 'Price: high to low', $markup );
+		} finally {
+			Search_Blocks::set_is_woocommerce_active_for_testing( null );
+		}
+	}
+
+	/**
+	 * Even when WooCommerce is active, an unmodified block insertion — same
+	 * defaults the author would get on a non-Woo site — keeps the base
+	 * three options. This protects the "looks exactly as it does after
+	 * jetpack#48282" promise from the issue's acceptance criteria.
+	 */
+	public function test_woocommerce_active_keeps_base_options_when_author_did_not_opt_in() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		try {
+			$markup = $this->render();
+			foreach ( array( 'relevance', 'newest', 'oldest' ) as $key ) {
+				$this->assertStringContainsString( 'value="' . $key . '"', $markup );
+			}
+			foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+				$this->assertStringNotContainsString( 'value="' . $key . '"', $markup );
+			}
+		} finally {
+			Search_Blocks::set_is_woocommerce_active_for_testing( null );
+		}
+	}
+
+	/**
+	 * On a non-Woo site a `?orderby=price_asc` deep link must collapse to
+	 * the block's `defaultSort` (which itself falls back to `relevance`),
+	 * mirroring the JS-side gate in store/url-state.js.
+	 */
+	public function test_url_product_sort_collapses_when_woocommerce_inactive() {
+		$_GET = array( 'orderby' => 'price_asc' );
+		try {
+			$markup = $this->render();
+			$this->assertStringNotContainsString( 'value="price_asc"', $markup );
+			$this->assertMatchesRegularExpression(
+				'/<option[^>]*value="relevance"[^>]*selected/',
+				$markup
+			);
+		} finally {
+			$_GET = array();
+		}
+	}
+
+	/**
+	 * On a Woo site the URL `?orderby=price_asc` must win over `defaultSort`
+	 * and select the corresponding option so deep links round-trip end-to-end.
+	 */
+	public function test_url_product_sort_selected_when_woocommerce_active() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		$_GET = array( 'orderby' => 'price_asc' );
+		try {
+			$markup = $this->render(
+				array( 'availableSortOptions' => array( 'relevance', 'price_asc', 'price_desc' ) )
+			);
+			$this->assertMatchesRegularExpression(
+				'/<option[^>]*value="price_asc"[^>]*selected/',
+				$markup
+			);
+		} finally {
+			$_GET = array();
+			Search_Blocks::set_is_woocommerce_active_for_testing( null );
 		}
 	}
 

--- a/projects/packages/search/tests/php/Results_Sort_Test.php
+++ b/projects/packages/search/tests/php/Results_Sort_Test.php
@@ -17,6 +17,36 @@ use PHPUnit\Framework\TestCase;
 class Results_Sort_Test extends TestCase {
 
 	/**
+	 * Reset the central WC-active memo between tests so a case that flipped
+	 * the gate doesn't leak the answer into the next one.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Search_Blocks::reset_is_woocommerce_active_cache();
+	}
+
+	protected function tearDown(): void {
+		Search_Blocks::reset_is_woocommerce_active_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * Run a test body with the WC gate forced on, restoring the memo on
+	 * exit so a thrown assertion can't leak the override into the next
+	 * test case.
+	 *
+	 * @param callable $body Test body.
+	 */
+	private function withWooCommerceActive( callable $body ): void {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		try {
+			$body();
+		} finally {
+			Search_Blocks::set_is_woocommerce_active_for_testing( null );
+		}
+	}
+
+	/**
 	 * A missing `defaultSort` attribute must fall back to `relevance` — the
 	 * same default `parse_url_sort()` returns when the URL has no `orderby`.
 	 */
@@ -32,9 +62,34 @@ class Results_Sort_Test extends TestCase {
 		$this->assertSame( 'newest', Results_Sort::normalize_default_sort( array( 'defaultSort' => 'newest' ) ) );
 	}
 
-	/** Product-format keys are deferred to RSM-1082. */
-	public function test_normalize_default_sort_rejects_product_key_until_woocommerce_integration() {
+	/**
+	 * Product-format keys must collapse to `relevance` on non-WooCommerce
+	 * sites so a saved attribute can't render an option the API can't honour.
+	 * `Search_Blocks::is_woocommerce_active()` returns false in PHPUnit (no
+	 * WooCommerce class is loaded), so this is the unmocked default path.
+	 */
+	public function test_normalize_default_sort_rejects_product_key_when_woocommerce_inactive() {
 		$this->assertSame( 'relevance', Results_Sort::normalize_default_sort( array( 'defaultSort' => 'price_asc' ) ) );
+	}
+
+	/**
+	 * With WooCommerce active the product-format keys must pass through so
+	 * authors can save them as the visible default. Stubs the WC class for
+	 * the duration of the test so the gate flips on without booting a real
+	 * WooCommerce.
+	 */
+	public function test_normalize_default_sort_accepts_product_key_when_woocommerce_active() {
+		$this->withWooCommerceActive(
+			function () {
+				foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+					$this->assertSame(
+						$key,
+						Results_Sort::normalize_default_sort( array( 'defaultSort' => $key ) ),
+						"Expected $key to pass through when WooCommerce is active."
+					);
+				}
+			}
+		);
 	}
 
 	/**
@@ -47,12 +102,66 @@ class Results_Sort_Test extends TestCase {
 
 	/**
 	 * A missing `availableSortOptions` attribute must fall back to every
-	 * option so the control renders the full list by default.
+	 * option so the control renders the full list by default. On non-Woo
+	 * sites that's the base three keys.
 	 */
 	public function test_resolve_available_options_defaults_to_full_list() {
 		$this->assertSame(
 			array( 'relevance', 'newest', 'oldest' ),
 			Results_Sort::resolve_available_options( array() )
+		);
+	}
+
+	/**
+	 * `get_all_option_keys()` and the empty-attribute fallback must include
+	 * the product-format keys when WooCommerce is active so the inspector
+	 * default exposes them on Woo sites.
+	 */
+	public function test_get_all_option_keys_includes_product_keys_when_woocommerce_active() {
+		$this->withWooCommerceActive(
+			function () {
+				$this->assertSame(
+					array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+					Results_Sort::get_all_option_keys()
+				);
+				$this->assertSame(
+					array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+					Results_Sort::resolve_available_options( array() )
+				);
+			}
+		);
+	}
+
+	/**
+	 * On non-Woo sites the product-format keys must be silently dropped
+	 * from a saved `availableSortOptions` array — render.php would already
+	 * not expose them, but trusting the canonical key set from
+	 * `get_all_option_keys()` keeps the rendered DOM in lockstep with the
+	 * inspector even when an admin disables WC after authoring the block.
+	 */
+	public function test_resolve_available_options_drops_product_keys_when_woocommerce_inactive() {
+		$this->assertSame(
+			array( 'relevance', 'newest' ),
+			Results_Sort::resolve_available_options(
+				array( 'availableSortOptions' => array( 'relevance', 'newest', 'price_asc', 'rating_desc' ) )
+			)
+		);
+	}
+
+	/**
+	 * On Woo sites the product-format keys must filter through, in the
+	 * canonical order.
+	 */
+	public function test_resolve_available_options_keeps_product_keys_when_woocommerce_active() {
+		$this->withWooCommerceActive(
+			function () {
+				$this->assertSame(
+					array( 'relevance', 'newest', 'rating_desc', 'price_asc' ),
+					Results_Sort::resolve_available_options(
+						array( 'availableSortOptions' => array( 'newest', 'price_asc', 'relevance', 'rating_desc' ) )
+					)
+				);
+			}
 		);
 	}
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -23,6 +23,7 @@ class Search_Blocks_Test extends TestCase {
 	 */
 	protected function tearDown(): void {
 		Search_Blocks::reset_initial_loading_cache();
+		Search_Blocks::reset_is_woocommerce_active_cache();
 		parent::tearDown();
 	}
 
@@ -36,6 +37,7 @@ class Search_Blocks_Test extends TestCase {
 			'nonce',
 			'isPrivateSite',
 			'isWpcom',
+			'isWooCommerceActive',
 			'homeUrl',
 			'locale',
 			'searchQuery',
@@ -105,6 +107,44 @@ class Search_Blocks_Test extends TestCase {
 			$this->assertSame( 'relevance', $state['sortOrder'] );
 		} finally {
 			$_GET = $original_get;
+		}
+	}
+
+	/**
+	 * Product-format `?orderby` values seed `relevance` on non-Woo sites so
+	 * a deep link to a sort the API can't honour can't reach the
+	 * Elasticsearch query (RSM-1082).
+	 */
+	public function test_build_initial_state_rejects_product_sort_when_woocommerce_inactive() {
+		$original_get = $_GET;
+		$_GET         = array( 'orderby' => 'price_asc' );
+		try {
+			$state = Search_Blocks::build_initial_state();
+			$this->assertSame( 'relevance', $state['sortOrder'] );
+			$this->assertFalse( $state['isWooCommerceActive'] );
+		} finally {
+			$_GET = $original_get;
+		}
+	}
+
+	/**
+	 * On Woo sites the same product-format `?orderby` values must seed the
+	 * matching sort and surface `isWooCommerceActive=true` on the IA store
+	 * so the JS-side url-state gate accepts them too (RSM-1082).
+	 */
+	public function test_build_initial_state_accepts_product_sort_when_woocommerce_active() {
+		$original_get = $_GET;
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		try {
+			foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+				$_GET  = array( 'orderby' => $key );
+				$state = Search_Blocks::build_initial_state();
+				$this->assertSame( $key, $state['sortOrder'], "Expected $key to seed sortOrder when WC is active." );
+				$this->assertTrue( $state['isWooCommerceActive'] );
+			}
+		} finally {
+			$_GET = $original_get;
+			Search_Blocks::set_is_woocommerce_active_for_testing( null );
 		}
 	}
 


### PR DESCRIPTION
Fixes [RSM-1082](https://linear.app/a8c/issue/RSM-1082/woocommerce-integration-restore-product-format-sort-keys-on-sort).

## Why

Authors building a search results page on a WooCommerce site have only had `Relevance / Newest / Oldest` available on the **Sort By** block since [#48282](https://github.com/Automattic/jetpack/pull/48282) shipped — the three product-format sorts (`Rating`, `Price: low to high`, `Price: high to low`) were pulled out at that time so non-product sites wouldn't offer a sort the API silently falls back to relevance on. This PR brings them back, but only when WooCommerce is active, so the inspector now exposes the WC-specific options where they're meaningful and stays unchanged everywhere else.

## Proposed changes

- `Search_Blocks::is_woocommerce_active()` is the single memoized `class_exists( 'WooCommerce' )` probe. It's centralized here (with a test-only setter) so future WC-only block gating — `filter-wc-rating`, `filter-wc-price`, `filter-wc-stock-status`, `filter-wc-attribute` — can hang off the same helper without each block re-implementing the check.
- `Results_Sort::get_all_option_keys()` reads through that helper. Render.php, the inspector, and `parse_url_sort()` all stay in lockstep automatically.
- `block.json` admits the three product keys on both enums; `availableSortOptions` still defaults to the base three so non-Woo sites are visually unchanged.
- `Search_Blocks::parse_url_sort()` accepts the product keys when WC is active and collapses to `relevance` everywhere else.
- `class-search-blocks.php` localizes `JetpackSearchBlocksConfig.isWooCommerceActive` for the editor and seeds `state.isWooCommerceActive` into the IA store. The store threads it into `url-state.js` so a `?orderby=price_asc` deep link round-trips on a WooCommerce site and collapses to relevance on every other site.
- WC-on / WC-off matrix tests added across `Results_Sort_Test`, `Results_Sort_Render_Test`, `Search_Blocks_Test`, `url-state.test.js`, and `results-sort-edit.test.jsx`.

## Screenshots

Editor inspector for the **Sort By** block on a WooCommerce site, before/after this change. The three new product-format checkboxes appear in the **Available options** panel; the rest of the block UI is unchanged.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/a3896721-ba39-445f-a506-31d8a8836367) | ![after](https://github.com/user-attachments/assets/c40a600f-4c5b-4a0f-ac70-5f350020fc89) |

On a non-WooCommerce site the inspector is identical to the "Before" image — that's the intended unchanged surface.

## Related product discussion/links

* [RSM-1082 — WooCommerce integration: restore product-format sort keys on sort-control block](https://linear.app/a8c/issue/RSM-1082/woocommerce-integration-restore-product-format-sort-keys-on-sort)
* Follow-up to [#48282](https://github.com/Automattic/jetpack/pull/48282) (Search 3.0 sort-control default sort + presentation controls).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**On a WooCommerce site (e.g. `https://jp-sage.jurassic.tube/`):**

1. Insert the **Sort By** block (`jetpack-search/results-sort`) on a page or template, open the block sidebar, and expand the **Available options** panel.
2. Confirm the panel now lists six checkboxes: `Relevance`, `Newest`, `Oldest`, `Rating`, `Price: low to high`, `Price: high to low`. The first three remain checked by default; the three product options start unchecked.
3. Check `Rating` and `Price: low to high`, save the page, and visit it on the front end. Confirm the dropdown / radios / popover (depending on `displayAs`) now offers those two options and that selecting one updates the URL with `?orderby=rating_desc` (or `?orderby=price_asc`).
4. Open `…/?s=test&orderby=price_asc` directly. Confirm the dropdown lands on **Price: low to high** on first paint and that the API request that fires is sorted by that key.

**On a non-WooCommerce site:**

5. Repeat step 1. The **Available options** panel must show only the original `Relevance` / `Newest` / `Oldest` checkboxes — exactly as it does on `trunk` after [#48282](https://github.com/Automattic/jetpack/pull/48282).
6. Open `…/?s=test&orderby=price_asc`. The dropdown collapses to `Relevance` and the API request is sorted by relevance — no `price_asc` leaks into the ES query.

**Automated coverage:**

```bash
cd projects/packages/search
composer phpunit -- --filter "Results_Sort|Search_Blocks_Test"   # 61 tests
pnpm jest tests/js/search-blocks/url-state.test.js tests/js/search-blocks/results-sort-edit.test.jsx
```
