### PR TITLE
Search 3.0: include clear-filters in filters-product allowed list + default template

### DIFF
--- a/projects/packages/search/changelog/add-RSM-2803-clear-filters-in-filters-product
+++ b/projects/packages/search/changelog/add-RSM-2803-clear-filters-in-filters-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: include `jetpack-search/clear-filters` in the `jetpack-search/filters-product` allowed list, and seed it in the default template so a fresh Product Filters insertion ships with a one-tap clear-all affordance. Tracked under [RSM-2803].

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
@@ -3,12 +3,12 @@
  *
  * Pure layout container with an InnerBlocks slot. The default template seeds
  * a useful starter set scoped to products (post-type scope locked to
- * `product` + stock-status + rating + price); authors can add, reorder, or
- * delete children freely. The allowedBlocks list restricts insertion to the
- * filter family in deliberate order — scope-setter, then the active-filters
- * pill region, then the curated WC filters, then generic extension points —
- * so unrelated blocks (paragraph, image, …) don't end up in the sidebar by
- * accident.
+ * `product` + a bulk clear-all + stock-status + rating + price); authors can
+ * add, reorder, or delete children freely. The allowedBlocks list restricts
+ * insertion to the filter family in deliberate order — scope-setter, then the
+ * active-filters pill region (with its companion clear-all), then the curated
+ * WC filters, then generic extension points — so unrelated blocks (paragraph,
+ * image, …) don't end up in the sidebar by accident.
  *
  * Children are *also* registered without an `ancestor` constraint in their
  * own block.json, so an author can drop e.g. `jetpack-search/filter-wc-stock-
@@ -19,6 +19,7 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const TEMPLATE = [
 	[ 'jetpack-search/filter-post-type', { mode: 'include', postTypes: [ 'product' ] } ],
+	[ 'jetpack-search/clear-filters' ],
 	[ 'jetpack-search/filter-wc-stock-status' ],
 	[ 'jetpack-search/filter-wc-rating' ],
 	[ 'jetpack-search/filter-wc-price' ],
@@ -29,8 +30,9 @@ const ALLOWED = [
 	// constrains; renders nothing on the front end.
 	'jetpack-search/filter-post-type',
 
-	// Visitor-facing summary of active selections.
+	// Visitor-facing summary of active selections + bulk-clear affordance.
 	'jetpack-search/active-filters',
+	'jetpack-search/clear-filters',
 
 	// WC-specific filters (the curated set this composition exists for).
 	'jetpack-search/filter-wc-stock-status',


### PR DESCRIPTION
Fixes [RSM-2803](https://linear.app/a8c/issue/RSM-2803/search-30-include-clear-filters-in-filters-product-allowed-list).

## Why

Authors who drop the **Product Filters** block onto a page get a curated WooCommerce sidebar (Post Type Scope / Stock Status / Rating / Price), but no way to wipe every selection in one tap. The standalone **Clear Filters** button exists, yet the parent block neither seeds it in its default template nor lists it as an allowed child — so authors can't restore that affordance even manually. This change ships the bulk-clear button by default and lets authors insert it freely inside the wrapper, matching the pattern already used by `filters-stack`.

## Proposed changes

* Add `jetpack-search/clear-filters` to the `ALLOWED` list of `jetpack-search/filters-product` so it can be inserted as a child.
* Append `[ 'jetpack-search/clear-filters' ]` to the default `TEMPLATE`, placed at the top of the visitor-facing section (immediately after the no-front-end `filter-post-type` scope-setter), so a fresh **Product Filters** insertion ships with a one-tap clear-all.

## Screenshots

Editor view of `wp:jetpack-search/filters-product` after a fresh insertion (1440×900):

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/ef27a69a-9440-4158-9cf3-5aa58ff0c29f) | ![after](https://github.com/user-attachments/assets/d915602a-34c3-45e1-8d65-a1072900fe3f) |

## Related product discussion/links

* [RSM-2803](https://linear.app/a8c/issue/RSM-2803/search-30-include-clear-filters-in-filters-product-allowed-list)
* Parent block introduced by #48454
* Standalone clear button introduced by #48452
* Active-filters product-aware chips (related sibling work): #48453
* Tracked under epic [RSM-1929](https://linear.app/a8c/issue/RSM-1929).

## Does this pull request change what data or activity we track or use?

No. Pure block-registration tweak — no data-plane changes, no new tracking, no new endpoints.

## Testing instructions

1. On a site with **Jetpack Search 3.0** active and the search experience set to `embedded`, open a post or page in the block editor.
2. Insert the **Product Filters** block (`jetpack-search/filters-product`).
3. Confirm the seeded children are, in order: **Post Type Scope** → **Clear Filters** → **Stock Status** → **Rating** → **Price**.
4. With the parent selected, open the block inserter inside the wrapper and confirm `Clear Filters` is now offered as an allowed child (it wasn't before).
5. Save the page, view it on the front end with WooCommerce installed, select a few filters, and confirm the **Clear Filters** button clears every active selection in one tap.
6. Existing pages that use **Product Filters** are unaffected — the change only seeds new insertions; existing inner-block markup is preserved.
