### PR TITLE
Search 3.0: gate every WooCommerce-only feature in src/search-blocks/ (RSM-2805)

### DIFF
--- a/projects/packages/search/changelog/RSM-2805-gate-wc-only-features
+++ b/projects/packages/search/changelog/RSM-2805-gate-wc-only-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search 3.0: gate every WooCommerce-only feature in src/search-blocks/ behind a single canonical WC-active probe so non-WooCommerce sites stop seeing WC-only blocks, variations, layouts, and URL params they can't use.

--- a/projects/packages/search/changelog/RSM-2805-gate-wc-only-features
+++ b/projects/packages/search/changelog/RSM-2805-gate-wc-only-features
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Search 3.0: gate every WooCommerce-only feature in src/search-blocks/ behind a single canonical WC-active probe so non-WooCommerce sites stop seeing WC-only blocks, variations, layouts, and URL params they can't use.
+Search 3.0: hide WooCommerce-only blocks, filter variations, layouts, and price-range URL params on sites that don't have WooCommerce active.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -33,7 +33,7 @@ Price is the one exception, and only because its shape doesn't fit. `activeFilte
 
 WC-only features hang off three canonical gates — **don't add a fourth** by re-implementing the probe in a render path or block edit:
 
-- **PHP:** `Search_Blocks::is_woocommerce_active()` — single memoized `class_exists( 'WooCommerce', false )` probe. Must be called at or after `plugins_loaded`. Use from any registration / render / parse path that should disappear on non-Woo sites.
+- **PHP:** `Search_Blocks::is_woocommerce_active()` — single memoized `class_exists( 'WooCommerce', false )` probe. Must be called at or after `plugins_loaded`. Use from any registration / render / parse path that should disappear on non-Woo sites. The probed value passes through the `jetpack_search_blocks_is_woocommerce_active` filter once before being cached, so a site can force the gate either way (e.g. hide WC-only blocks on a non-shop content area of a Woo site, or render them in a non-Woo staging preview).
 - **Interactivity store seed:** `state.isWooCommerceActive` — read from JS store callbacks (e.g. URL-state parsing, sort-order validation) instead of probing for `window.WooCommerce` directly.
 - **Editor:** `window.JetpackSearchBlocksConfig.isWooCommerceActive` — localized in `Search_Blocks::enqueue_editor_assets()`. Read from block edit components to hide WC-only options from the inspector.
 

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -28,3 +28,29 @@ Filters round-trip through the URL in Jetpack Search's array shape: `?<filterKey
 Don't add a comma-joined / WC-style scalar shape (`?filter_stock_status=in,out`) for new product filters either. Stick to `?filter_stock_status[]=in&filter_stock_status[]=out` so deep links stay interchangeable with instant-search and the PHP parser doesn't need a per-filter URL-format opt-in.
 
 Price is the one exception, and only because its shape doesn't fit. `activeFilters` is typed `{ [filterKey]: string[] }` — discrete, OR-able selections that build a `terms` ES clause. `priceRange` is `{ min, max }`, builds a `range` clause, and writes scalar `min_price` / `max_price` URL params. It lives as a sibling on store state rather than getting shoehorned into `activeFilters` with a sentinel encoding.
+
+## WooCommerce gating
+
+WC-only features hang off three canonical gates — **don't add a fourth** by re-implementing the probe in a render path or block edit:
+
+- **PHP:** `Search_Blocks::is_woocommerce_active()` — single memoized `class_exists( 'WooCommerce', false )` probe. Must be called at or after `plugins_loaded`. Use from any registration / render / parse path that should disappear on non-Woo sites.
+- **Interactivity store seed:** `state.isWooCommerceActive` — read from JS store callbacks (e.g. URL-state parsing, sort-order validation) instead of probing for `window.WooCommerce` directly.
+- **Editor:** `window.JetpackSearchBlocksConfig.isWooCommerceActive` — localized in `Search_Blocks::enqueue_editor_assets()`. Read from block edit components to hide WC-only options from the inspector.
+
+Tests flip the gate via `Search_Blocks::set_is_woocommerce_active_for_testing( true|false|null )` (PHP) or `globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: true }` (JS). Add a WC-on / WC-off matrix test for every new gate.
+
+Single source of truth for which blocks count as WC-only:
+
+- **`Search_Blocks::woocommerce_only_block_names()`** — explicit list of full namespaced block names (e.g. `jetpack-search/filter-wc-rating`, `jetpack-search/filters-product`). Adding one entry there auto-applies the gate at every call site:
+  - `register_blocks()` skips the matching directory's `register_block_type()` on non-Woo sites.
+  - `filter_block_helpers()` drops the entry from the helper map so the filter-config walk stays symmetric with what's registered.
+  - The list is localized onto `window.JetpackSearchBlocksConfig.woocommerceOnlyBlocks` so the editor's `register-blocks.js` skips the matching `registerBlockType()` call too.
+- **`Search_Blocks::is_woocommerce_only_block( $block_name )`** — exact-match lookup against the list above. Accepts either a full namespaced block name or a bare directory basename (the registration loop walks dir basenames; the helpers map and editor bundle hold full names).
+
+Other WC-only surfaces have to opt into the gate explicitly because they aren't standalone blocks:
+
+- **WC-only patterns:** filename in `patterns/` starts with `wc-`. Caught in `register_patterns()`.
+- **WC-only block variations** (e.g. `product_cat`, `product_tag` on `filter-checkbox`): wrap their `$additions[] = …` push in an `if ( self::is_woocommerce_active() )` block in `inject_filter_checkbox_variations()`.
+- **WC-only render paths on shared blocks** (e.g. the `product` layout on `results-list`): collapse to a neutral default in `render.php` and prune the option from the editor inspector. Don't leave a reachable code path that reads WC-shaped fields on a non-Woo site.
+
+A saved post that contains a WC-only block on a site that later deactivates WooCommerce will render the missing-block placeholder for that block — that's expected (and matches WordPress's behavior for any deactivated-plugin block). Authors remove the placeholder and re-pick a non-WC alternative.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -58,6 +58,13 @@ export const VARIATION_PRODUCT_TAG = 'product_tag';
 export const VARIATION_PRODUCT_BRAND = 'product_brand';
 export const VARIATION_CUSTOM_TAXONOMY = 'custom_taxonomy';
 
+// `window.JetpackSearchBlocksConfig.isWooCommerceActive` is the canonical
+// editor-side gate, localized by `Search_Blocks::enqueue_editor_assets()`.
+// Read at call time (not module init) so tests can flip the gate per case
+// and the editor responds to a runtime change in the localized config.
+const isWooCommerceActive = () =>
+	typeof window !== 'undefined' && window.JetpackSearchBlocksConfig?.isWooCommerceActive === true;
+
 /**
  * Identify which built-in variation the current (filterType, taxonomy) pair
  * matches. Any taxonomy-family block whose slug isn't a recognized built-in
@@ -81,16 +88,56 @@ export function deriveVariation( attributes ) {
 	if ( taxonomy === 'post_tag' ) {
 		return VARIATION_POST_TAG;
 	}
-	if ( taxonomy === 'product_cat' ) {
+	// Product taxonomies map to their dedicated variations only when WC is
+	// active. On non-Woo sites the dedicated variations don't exist in the
+	// inspector picker, so a saved `product_cat` block surfaces as Custom
+	// Taxonomy with the slug preserved — author can still edit the block,
+	// and re-activating WC restores the dedicated variation on the next
+	// render. Mirrors the dormant-attribute pattern used by results-list.
+	if ( taxonomy === 'product_cat' && isWooCommerceActive() ) {
 		return VARIATION_PRODUCT_CAT;
 	}
-	if ( taxonomy === 'product_tag' ) {
+	if ( taxonomy === 'product_tag' && isWooCommerceActive() ) {
 		return VARIATION_PRODUCT_TAG;
 	}
-	if ( taxonomy === 'product_brand' ) {
+	if ( taxonomy === 'product_brand' && isWooCommerceActive() ) {
 		return VARIATION_PRODUCT_BRAND;
 	}
 	return VARIATION_CUSTOM_TAXONOMY;
+}
+
+/**
+ * Build the inspector "Filter type" picker options. Mirrors the variations
+ * registered server-side by `Search_Blocks::inject_filter_checkbox_variations()`
+ * — Product Category / Tag / Brand are dropped on non-Woo sites in lockstep
+ * with the inserter so the picker doesn't offer a variation that has no
+ * matching server-side schema.
+ *
+ * Declared as a function (not a module-level constant) so the `__()` calls
+ * run after the editor's i18n is loaded and so each render re-evaluates the
+ * WC gate. Mirrors the same pattern in `results-list/edit.js`.
+ *
+ * @return {Array} SelectControl options.
+ */
+export function variationOptions() {
+	const options = [
+		{ value: VARIATION_CATEGORY, label: __( 'Category', 'jetpack-search-pkg' ) },
+		{ value: VARIATION_POST_TAG, label: __( 'Tag', 'jetpack-search-pkg' ) },
+		{ value: VARIATION_POST_TYPE, label: __( 'Post Type', 'jetpack-search-pkg' ) },
+		{ value: VARIATION_AUTHOR, label: __( 'Author', 'jetpack-search-pkg' ) },
+	];
+	if ( isWooCommerceActive() ) {
+		options.push(
+			{ value: VARIATION_PRODUCT_CAT, label: __( 'Product Category', 'jetpack-search-pkg' ) },
+			{ value: VARIATION_PRODUCT_TAG, label: __( 'Product Tag', 'jetpack-search-pkg' ) },
+			{ value: VARIATION_PRODUCT_BRAND, label: __( 'Product Brand', 'jetpack-search-pkg' ) }
+		);
+	}
+	options.push( {
+		value: VARIATION_CUSTOM_TAXONOMY,
+		label: __( 'Custom taxonomy', 'jetpack-search-pkg' ),
+	} );
+	return options;
 }
 
 /**
@@ -274,28 +321,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 						__nextHasNoMarginBottom
 						label={ __( 'Filter type', 'jetpack-search-pkg' ) }
 						value={ currentVariation }
-						options={ [
-							{ value: VARIATION_CATEGORY, label: __( 'Category', 'jetpack-search-pkg' ) },
-							{ value: VARIATION_POST_TAG, label: __( 'Tag', 'jetpack-search-pkg' ) },
-							{ value: VARIATION_POST_TYPE, label: __( 'Post Type', 'jetpack-search-pkg' ) },
-							{ value: VARIATION_AUTHOR, label: __( 'Author', 'jetpack-search-pkg' ) },
-							{
-								value: VARIATION_PRODUCT_CAT,
-								label: __( 'Product Category', 'jetpack-search-pkg' ),
-							},
-							{
-								value: VARIATION_PRODUCT_TAG,
-								label: __( 'Product Tag', 'jetpack-search-pkg' ),
-							},
-							{
-								value: VARIATION_PRODUCT_BRAND,
-								label: __( 'Product Brand', 'jetpack-search-pkg' ),
-							},
-							{
-								value: VARIATION_CUSTOM_TAXONOMY,
-								label: __( 'Custom taxonomy', 'jetpack-search-pkg' ),
-							},
-						] }
+						options={ variationOptions() }
 						onChange={ onVariationChange }
 						help={ __(
 							'What this filter groups results by. Switch without deleting the block.',

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
@@ -18,7 +18,17 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, RadioControl, TextControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
-const LAYOUTS = [ 'compact', 'expanded', 'product' ];
+// `product` is WC-only. On non-Woo sites it's pruned from the picker and a
+// saved `product` value collapses to `expanded` — the renderer applies the
+// same fallback in `render.php`, so the editor preview stays in lockstep.
+// `window.JetpackSearchBlocksConfig.isWooCommerceActive` is the canonical
+// editor-side gate, localized by `Search_Blocks::enqueue_editor_assets()`.
+// Read at call time (not module init) so the editor responds to a runtime
+// change in the localized config, and so tests can flip the gate per case.
+const isWooCommerceActive = () =>
+	typeof window !== 'undefined' && window.JetpackSearchBlocksConfig?.isWooCommerceActive === true;
+const allowedLayouts = () =>
+	isWooCommerceActive() ? [ 'compact', 'expanded', 'product' ] : [ 'compact', 'expanded' ];
 const DEFAULT_LAYOUT = 'expanded';
 
 const SAMPLE_RESULTS = [
@@ -82,11 +92,19 @@ const SAMPLE_PRODUCTS = [
 // calls run after the block editor's i18n is loaded — otherwise the strings
 // would be cached in the source locale on module init. Mirrors the same
 // pattern in `results-sort/edit.js`.
-const LAYOUT_OPTIONS = () => [
-	{ label: __( 'Compact', 'jetpack-search-pkg' ), value: 'compact' },
-	{ label: __( 'Expanded', 'jetpack-search-pkg' ), value: 'expanded' },
-	{ label: __( 'Product (for WooCommerce stores)', 'jetpack-search-pkg' ), value: 'product' },
-];
+const LAYOUT_OPTIONS = () => {
+	const options = [
+		{ label: __( 'Compact', 'jetpack-search-pkg' ), value: 'compact' },
+		{ label: __( 'Expanded', 'jetpack-search-pkg' ), value: 'expanded' },
+	];
+	if ( isWooCommerceActive() ) {
+		options.push( {
+			label: __( 'Product (for WooCommerce stores)', 'jetpack-search-pkg' ),
+			value: 'product',
+		} );
+	}
+	return options;
+};
 
 /**
  * Editor preview for the results-list block.
@@ -103,7 +121,7 @@ export default function ResultsListEdit( { attributes, setAttributes } ) {
 	// class layout binding instead of falling through to the unknown-layout
 	// fallback. Mirrors `$resolve_layout` in render.php.
 	const normalized = stored === 'card' ? 'expanded' : stored;
-	const layout = LAYOUTS.includes( normalized ) ? normalized : DEFAULT_LAYOUT;
+	const layout = allowedLayouts().includes( normalized ) ? normalized : DEFAULT_LAYOUT;
 	const blockProps = useBlockProps( {
 		className: `jetpack-search-results--${ layout }`,
 	} );

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -72,6 +72,15 @@ $layout = $attrs['layout'] ?? 'expanded';
 if ( 'card' === $layout ) {
 	$layout = 'expanded';
 }
+// The product layout reads WC-shaped fields (price, sale price, rating)
+// off each result. On a non-Woo site those fields don't exist, so
+// rendering would emit empty price/rating regions. Collapse to the
+// neutral `expanded` layout so an author who saved `product` on a Woo
+// site that later deactivates WC still sees a sensible result page.
+// Mirrors the inspector-side gate in edit.js.
+if ( 'product' === $layout && ! Search_Blocks::is_woocommerce_active() ) {
+	$layout = 'expanded';
+}
 $features      = $resolve_layout( $layout );
 $wrapper_class = 'jetpack-search-results--' . $features['modifier'];
 $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class ) );

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -178,6 +178,15 @@ class Search_Blocks {
 	 * satisfied. New callers earlier in the request lifecycle should defer
 	 * the probe to a `plugins_loaded`-or-later hook.
 	 *
+	 * **Filter:** `jetpack_search_blocks_is_woocommerce_active` lets a site
+	 * force the gate either way — e.g. a WC site that wants to hide
+	 * WC-only Search blocks from a non-shop content area, or a non-Woo
+	 * site that wants to render WC-only blocks for a staging preview.
+	 * Filter fires once per request, before the result is memoized, so a
+	 * filter that probes the database or another expensive condition pays
+	 * its cost once and is then served from the cache for the remainder
+	 * of the request.
+	 *
 	 * @return bool
 	 */
 	public static function is_woocommerce_active(): bool {
@@ -185,7 +194,22 @@ class Search_Blocks {
 			// Pass `false` so a missing class doesn't fire the autoloader
 			// on non-Woo sites — the gate is hit on every request, and
 			// any upstream autoloader work is wasted when the answer is "no".
-			self::$is_woocommerce_active_cache = class_exists( 'WooCommerce', false );
+			$probed = class_exists( 'WooCommerce', false );
+
+			/**
+			 * Override whether Jetpack Search treats WooCommerce as active.
+			 *
+			 * Cast to bool before caching so a filter returning a truthy
+			 * non-bool (e.g. `1`) doesn't poison strictly-typed callers.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $is_active Result of the WooCommerce class probe.
+			 */
+			self::$is_woocommerce_active_cache = (bool) apply_filters(
+				'jetpack_search_blocks_is_woocommerce_active',
+				$probed
+			);
 		}
 		return self::$is_woocommerce_active_cache;
 	}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -213,6 +213,50 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Canonical list of WooCommerce-only block names. Single source of
+	 * truth for the WC-only gate applied to block registration
+	 * (`register_blocks()`), the `filter_block_helpers()` map, and the
+	 * editor's `register-blocks.js` bundle (read after being localized
+	 * onto `window.JetpackSearchBlocksConfig.woocommerceOnlyBlocks` in
+	 * `enqueue_editor_assets()`).
+	 *
+	 * Add a new WC-only block by appending one entry — every gate picks
+	 * it up automatically. Names are full namespaced names (not bare
+	 * slugs) so the list reads identically to what `BLOCKS` contains in
+	 * `register-blocks.js` and what `filter_block_helpers()` keys against.
+	 *
+	 * @return string[]
+	 */
+	public static function woocommerce_only_block_names(): array {
+		return array(
+			'jetpack-search/filter-wc-attribute',
+			'jetpack-search/filter-wc-price',
+			'jetpack-search/filter-wc-rating',
+			'jetpack-search/filter-wc-stock-status',
+			'jetpack-search/filters-product',
+		);
+	}
+
+	/**
+	 * Whether a block name (or block-directory basename) belongs to a
+	 * WooCommerce-only block. Membership is decided by exact match against
+	 * `woocommerce_only_block_names()`; either form (full namespaced name
+	 * or bare directory basename) works because `register_blocks()` walks
+	 * directory basenames while the helpers map and editor bundle hold
+	 * full names.
+	 *
+	 * @param string $block_name Full block name (`jetpack-search/filter-wc-rating`)
+	 *                           or bare directory basename (`filter-wc-rating`).
+	 * @return bool
+	 */
+	public static function is_woocommerce_only_block( string $block_name ): bool {
+		$candidate = false === strpos( $block_name, '/' )
+			? 'jetpack-search/' . $block_name
+			: $block_name;
+		return in_array( $candidate, self::woocommerce_only_block_names(), true );
+	}
+
+	/**
 	 * URL param key the inline search experience uses for the current request.
 	 *
 	 * On WP's search route (`is_search()`) the canonical `s` key is used so
@@ -258,9 +302,15 @@ class Search_Blocks {
 			true
 		);
 
-		// Surface the WC-active flag to edit.js so the results-sort inspector
-		// can hide the product-format checkboxes on non-WooCommerce sites
-		// instead of offering options the renderer would silently drop.
+		// Surface the WC gate to the editor bundle. `isWooCommerceActive`
+		// drives per-component branches (e.g. the results-sort inspector
+		// hiding product-format checkboxes, the results-list inspector
+		// hiding the Product layout) and the `register-blocks.js`
+		// registration loop. `woocommerceOnlyBlocks` is the canonical
+		// list the registration loop intersects with — keeping it
+		// localized (rather than duplicated in JS) means
+		// `Search_Blocks::woocommerce_only_block_names()` is the single
+		// source of truth across the PHP and JS sides.
 		// `wp_add_inline_script` (rather than `wp_localize_script`) per
 		// core ticket #25280 — the latter HTML-encodes ampersands inside
 		// nested values.
@@ -268,7 +318,8 @@ class Search_Blocks {
 			'jetpack-search-blocks-register',
 			'window.JetpackSearchBlocksConfig = ' . wp_json_encode(
 				array(
-					'isWooCommerceActive' => self::is_woocommerce_active(),
+					'isWooCommerceActive'   => self::is_woocommerce_active(),
+					'woocommerceOnlyBlocks' => self::woocommerce_only_block_names(),
 				),
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',
@@ -315,10 +366,15 @@ class Search_Blocks {
 			return;
 		}
 
+		$is_wc = self::is_woocommerce_active();
 		foreach ( $block_dirs as $block_dir ) {
-			if ( file_exists( $block_dir . '/block.json' ) ) {
-				register_block_type( $block_dir );
+			if ( ! file_exists( $block_dir . '/block.json' ) ) {
+				continue;
 			}
+			if ( ! $is_wc && self::is_woocommerce_only_block( basename( $block_dir ) ) ) {
+				continue;
+			}
+			register_block_type( $block_dir );
 		}
 
 		add_filter( 'get_block_type_variations', array( static::class, 'inject_filter_checkbox_variations' ), 10, 2 );
@@ -391,7 +447,19 @@ class Search_Blocks {
 				),
 				'isActive'    => array( 'filterType' ),
 			),
-			array(
+		);
+
+		// WC-only product taxonomies. Gated on `is_woocommerce_active()` so
+		// they don't appear in the inserter on non-Woo sites where the
+		// taxonomies happen to exist via another plugin (or a previous WC
+		// install that left them registered). `product_brand` layers an
+		// extra `taxonomy_exists()` probe on top because it isn't a core WC
+		// taxonomy — extensions like WC Brands / Perfect Brands / recent
+		// bundled WC versions provide it. The three product variations stay
+		// grouped before `custom_taxonomy` below so the inserter renders
+		// them as a contiguous cluster.
+		if ( self::is_woocommerce_active() ) {
+			$additions[] = array(
 				'name'        => 'product_cat',
 				'title'       => __( 'Filter by Product Category', 'jetpack-search-pkg' ),
 				'description' => __( 'Show product category checkboxes with live result counts.', 'jetpack-search-pkg' ),
@@ -402,8 +470,8 @@ class Search_Blocks {
 					'label'      => __( 'Product Category', 'jetpack-search-pkg' ),
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
-			),
-			array(
+			);
+			$additions[] = array(
 				'name'        => 'product_tag',
 				'title'       => __( 'Filter by Product Tag', 'jetpack-search-pkg' ),
 				'description' => __( 'Show product tag checkboxes with live result counts.', 'jetpack-search-pkg' ),
@@ -414,30 +482,21 @@ class Search_Blocks {
 					'label'      => __( 'Product Tag', 'jetpack-search-pkg' ),
 				),
 				'isActive'    => array( 'filterType', 'taxonomy' ),
-			),
-		);
-
-		// `product_brand` isn't a core WooCommerce taxonomy — it's added by
-		// extensions (WC Brands, Perfect Brands, recent bundled WC versions).
-		// Registering the variation unconditionally would surface "Filter by
-		// Product Brand" in the inserter on sites without it, where the block
-		// renders no buckets and the failure is silent. Gate on the taxonomy's
-		// presence so authors only see the option when it can actually work.
-		// Inserted before `custom_taxonomy` below so the three product
-		// variations stay grouped in the inserter when the gate fires.
-		if ( taxonomy_exists( 'product_brand' ) ) {
-			$additions[] = array(
-				'name'        => 'product_brand',
-				'title'       => __( 'Filter by Product Brand', 'jetpack-search-pkg' ),
-				'description' => __( 'Show product brand checkboxes with live result counts.', 'jetpack-search-pkg' ),
-				'icon'        => 'awards',
-				'attributes'  => array(
-					'filterType' => 'taxonomy',
-					'taxonomy'   => 'product_brand',
-					'label'      => __( 'Product Brand', 'jetpack-search-pkg' ),
-				),
-				'isActive'    => array( 'filterType', 'taxonomy' ),
 			);
+			if ( taxonomy_exists( 'product_brand' ) ) {
+				$additions[] = array(
+					'name'        => 'product_brand',
+					'title'       => __( 'Filter by Product Brand', 'jetpack-search-pkg' ),
+					'description' => __( 'Show product brand checkboxes with live result counts.', 'jetpack-search-pkg' ),
+					'icon'        => 'awards',
+					'attributes'  => array(
+						'filterType' => 'taxonomy',
+						'taxonomy'   => 'product_brand',
+						'label'      => __( 'Product Brand', 'jetpack-search-pkg' ),
+					),
+					'isActive'    => array( 'filterType', 'taxonomy' ),
+				);
+			}
 		}
 
 		$additions[] = array(
@@ -475,6 +534,11 @@ class Search_Blocks {
 
 	/**
 	 * Register block patterns.
+	 *
+	 * Convention: a pattern file whose basename starts with `wc-` composes
+	 * WooCommerce-only blocks and is loaded only when WC is active. Mirrors
+	 * the `filter-wc-*` block-slug convention so a new WC-only pattern
+	 * auto-enrolls in the gate without an extra registration step.
 	 */
 	protected static function register_patterns() {
 		$patterns_dir = __DIR__ . '/patterns';
@@ -485,7 +549,11 @@ class Search_Blocks {
 		if ( ! $pattern_files ) {
 			return;
 		}
+		$is_wc = self::is_woocommerce_active();
 		foreach ( $pattern_files as $pattern_file ) {
+			if ( ! $is_wc && str_starts_with( basename( $pattern_file ), 'wc-' ) ) {
+				continue;
+			}
 			require_once $pattern_file;
 		}
 	}
@@ -704,13 +772,26 @@ class Search_Blocks {
 	 * @return array<string, class-string>
 	 */
 	protected static function filter_block_helpers(): array {
-		return array(
+		$helpers = array(
 			'jetpack-search/filter-checkbox'        => Filter_Checkbox::class,
 			'jetpack-search/filter-date'            => Filter_Date::class,
 			'jetpack-search/filter-wc-rating'       => Filter_Wc_Rating::class,
 			'jetpack-search/filter-wc-attribute'    => Filter_Wc_Attribute::class,
 			'jetpack-search/filter-wc-stock-status' => Search_Product_Filter_Status::class,
 		);
+		if ( self::is_woocommerce_active() ) {
+			return $helpers;
+		}
+		// On non-Woo sites the WC-only blocks aren't registered (see
+		// `register_blocks()`), so any saved instance in post content has no
+		// renderer. Drop them from the helper map too — that keeps the
+		// filter-config walk symmetrical with what the inserter offers.
+		foreach ( array_keys( $helpers ) as $name ) {
+			if ( self::is_woocommerce_only_block( $name ) ) {
+				unset( $helpers[ $name ] );
+			}
+		}
+		return $helpers;
 	}
 
 	/**
@@ -1111,11 +1192,18 @@ class Search_Blocks {
 	 * garbage URL can't drive the API into producing zero results.
 	 *
 	 * Returns null when neither bound is set, so callers can early-out
-	 * without checking individual fields.
+	 * without checking individual fields. Also returns null on non-Woo
+	 * sites — `min_price` / `max_price` are WC-only and the price filter
+	 * block (`filter-wc-price`) isn't registered there, so a stray
+	 * `?min_price=10` in the URL can't drive the API into building a
+	 * `range` clause for a field the index doesn't have.
 	 *
 	 * @return array{min: float|null, max: float|null}|null
 	 */
 	protected static function parse_url_price_range(): ?array {
+		if ( ! self::is_woocommerce_active() ) {
+			return null;
+		}
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- read-only URL state; coerced to float in parse_price_bound() which discards any non-numeric input.
 		$min = self::parse_price_bound( $_GET['min_price'] ?? null );
 		$max = self::parse_price_bound( $_GET['max_price'] ?? null );

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -551,7 +551,7 @@ class Search_Blocks {
 		}
 		$is_wc = self::is_woocommerce_active();
 		foreach ( $pattern_files as $pattern_file ) {
-			if ( ! $is_wc && str_starts_with( basename( $pattern_file ), 'wc-' ) ) {
+			if ( ! $is_wc && 0 === strpos( basename( $pattern_file ), 'wc-' ) ) {
 				continue;
 			}
 			require_once $pattern_file;

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -86,6 +86,28 @@ setCategories(
 	)
 );
 
+// On a non-Woo site PHP skips the server-side `register_block_type()`
+// call for every WC-only block (see `Search_Blocks::register_blocks()`),
+// so the editor must skip the matching client-side `registerBlockType()`
+// too — registering without a server-side counterpart would produce a
+// "Block JSON file not found" warning and a broken inserter card.
+//
+// The list of WC-only block names is localized from
+// `Search_Blocks::woocommerce_only_block_names()` onto
+// `window.JetpackSearchBlocksConfig.woocommerceOnlyBlocks` so PHP and JS
+// stay in lockstep — adding a new WC-only block on the PHP side
+// auto-applies here. Missing/malformed config defaults to "no blocks
+// gated out" — defensive against the bundle being loaded outside its
+// enqueue path (e.g. test harness), which can't happen in production.
+const config = ( typeof window !== 'undefined' && window.JetpackSearchBlocksConfig ) || {};
+const isWooCommerceActive = config.isWooCommerceActive === true;
+const wcOnlyBlocks = new Set(
+	Array.isArray( config.woocommerceOnlyBlocks ) ? config.woocommerceOnlyBlocks : []
+);
+
 BLOCKS.forEach( ( [ name, edit, blockSave ] ) => {
+	if ( ! isWooCommerceActive && wcOnlyBlocks.has( name ) ) {
+		return;
+	}
 	registerBlockType( name, { edit, save: blockSave ?? save } );
 } );

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -64,7 +64,10 @@ function parsePriceBound( raw ) {
  * @param {string}      [state.searchParamName]     - URL key the search query is written under
  *                                                  (`s` on the WP search route, `q`
  *                                                  on non-search pages). Defaults to `s`.
- * @param {boolean}     [state.isWooCommerceActive] - Gate for product-format sort keys.
+ * @param {boolean}     [state.isWooCommerceActive] - Gate for WC-only URL surface
+ *                                                  (product-format sort keys + `min_price` /
+ *                                                  `max_price` range params). Falsy on non-Woo
+ *                                                  sites drops both from the emitted URL.
  * @return {URLSearchParams} URL-ready params.
  */
 export function stateToUrlParams( {
@@ -128,7 +131,11 @@ export function stateToUrlParams( {
  * @param {object}          [filterConfigs]       - { [filterKey]: FilterConfig } map used to validate filter keys.
  * @param {string}          [searchParamName]     - URL key to read the search query from
  *                                                (`s` or `q`). Defaults to `s`.
- * @param {boolean}         [isWooCommerceActive] - Gate for product-format sort keys.
+ * @param {boolean}         [isWooCommerceActive] - Gate for WC-only URL surface
+ *                                                (product-format sort keys + `min_price` /
+ *                                                `max_price` range params). Falsy on non-Woo
+ *                                                sites ignores both rather than hydrating
+ *                                                them into store state.
  * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
  */
 export function urlParamsToState(
@@ -219,7 +226,9 @@ export function pushStateToUrl( state ) {
  * @param {object}  [filterConfigs]       - { [filterKey]: FilterConfig } map used to validate filter keys.
  * @param {string}  [searchParamName]     - URL key the search query lives under (`s` or
  *                                        `q`). Defaults to `s`.
- * @param {boolean} [isWooCommerceActive] - Gate for product-format sort keys.
+ * @param {boolean} [isWooCommerceActive] - Gate for WC-only URL surface (product-format
+ *                                        sort keys + `min_price` / `max_price` range params);
+ *                                        forwarded to `urlParamsToState`.
  * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
  */
 export function readStateFromUrl(

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -96,11 +96,18 @@ export function stateToUrlParams( {
 		values.forEach( value => params.append( `${ key }[]`, value ) );
 	}
 
-	if ( priceRange?.min != null ) {
-		params.set( 'min_price', String( priceRange.min ) );
-	}
-	if ( priceRange?.max != null ) {
-		params.set( 'max_price', String( priceRange.max ) );
+	// `min_price` / `max_price` are WC-only; the price filter block
+	// (`filter-wc-price`) isn't registered on non-Woo sites. Skip the
+	// write so a stray `priceRange` in store state can't leak into the
+	// URL and round-trip back into the next API request as a `range`
+	// clause for a field the index doesn't have.
+	if ( isWooCommerceActive ) {
+		if ( priceRange?.min != null ) {
+			params.set( 'min_price', String( priceRange.min ) );
+		}
+		if ( priceRange?.max != null ) {
+			params.set( 'max_price', String( priceRange.max ) );
+		}
 	}
 
 	return params;
@@ -167,8 +174,12 @@ export function urlParamsToState(
 		activeFilters[ filterKey ].push( normalized );
 	}
 
-	const minPrice = parsePriceBound( params.get( 'min_price' ) );
-	const maxPrice = parsePriceBound( params.get( 'max_price' ) );
+	// Mirror `Search_Blocks::parse_url_price_range()`: drop `min_price` /
+	// `max_price` entirely on non-Woo sites so a stray deep link can't
+	// hydrate `priceRange` into the store and re-emit the params on the
+	// next URL push.
+	const minPrice = isWooCommerceActive ? parsePriceBound( params.get( 'min_price' ) ) : null;
+	const maxPrice = isWooCommerceActive ? parsePriceBound( params.get( 'max_price' ) ) : null;
 	// Inverted bounds (min > max) build an ES range clause that always
 	// matches zero documents, so a URL like `?min_price=100&max_price=10`
 	// would render an empty page. Treat that as garbage and drop the range

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -8,6 +8,7 @@ import {
 	deriveVariation,
 	variationToAttributes,
 	variationDefaultLabel,
+	variationOptions,
 	VARIATION_CATEGORY,
 	VARIATION_POST_TAG,
 	VARIATION_POST_TYPE,
@@ -19,6 +20,10 @@ import {
 } from '../../../src/search-blocks/blocks/filter-checkbox/edit.js';
 
 describe( 'deriveVariation', () => {
+	afterEach( () => {
+		delete globalThis.JetpackSearchBlocksConfig;
+	} );
+
 	it( 'maps the built-in (filterType, taxonomy) pairs to their variation ids', () => {
 		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'category' } ) ).toBe(
 			VARIATION_CATEGORY
@@ -30,7 +35,8 @@ describe( 'deriveVariation', () => {
 		expect( deriveVariation( { filterType: 'author' } ) ).toBe( VARIATION_AUTHOR );
 	} );
 
-	it( 'maps the WC product taxonomy slugs to their dedicated variations', () => {
+	it( 'maps the WC product taxonomy slugs to their dedicated variations on Woo sites', () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: true };
 		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_cat' } ) ).toBe(
 			VARIATION_PRODUCT_CAT
 		);
@@ -40,6 +46,19 @@ describe( 'deriveVariation', () => {
 		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_brand' } ) ).toBe(
 			VARIATION_PRODUCT_BRAND
 		);
+	} );
+
+	it( 'collapses saved WC product slugs to Custom Taxonomy when WooCommerce is inactive', () => {
+		// Mirrors the dormant-attribute pattern in results-list: the saved
+		// attribute stays (re-activating WC restores the dedicated variation
+		// next render), but the inspector picker collapses to a value that
+		// still exists in `variationOptions()` so the SelectControl doesn't
+		// try to render an option that isn't there.
+		[ 'product_cat', 'product_tag', 'product_brand' ].forEach( taxonomy => {
+			expect( deriveVariation( { filterType: 'taxonomy', taxonomy } ) ).toBe(
+				VARIATION_CUSTOM_TAXONOMY
+			);
+		} );
 	} );
 
 	it( 'treats any non-built-in taxonomy slug as Custom Taxonomy', () => {
@@ -56,6 +75,44 @@ describe( 'deriveVariation', () => {
 		// recover, instead of misclassifying as a built-in variation.
 		expect( deriveVariation( {} ) ).toBe( VARIATION_CUSTOM_TAXONOMY );
 		expect( deriveVariation( { filterType: '', taxonomy: '' } ) ).toBe( VARIATION_CUSTOM_TAXONOMY );
+	} );
+} );
+
+describe( 'variationOptions', () => {
+	afterEach( () => {
+		delete globalThis.JetpackSearchBlocksConfig;
+	} );
+
+	it( 'lists all eight variations when WooCommerce is active', () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: true };
+		expect( variationOptions().map( o => o.value ) ).toEqual( [
+			VARIATION_CATEGORY,
+			VARIATION_POST_TAG,
+			VARIATION_POST_TYPE,
+			VARIATION_AUTHOR,
+			VARIATION_PRODUCT_CAT,
+			VARIATION_PRODUCT_TAG,
+			VARIATION_PRODUCT_BRAND,
+			VARIATION_CUSTOM_TAXONOMY,
+		] );
+	} );
+
+	it( 'drops the three product variations when WooCommerce is inactive', () => {
+		expect( variationOptions().map( o => o.value ) ).toEqual( [
+			VARIATION_CATEGORY,
+			VARIATION_POST_TAG,
+			VARIATION_POST_TYPE,
+			VARIATION_AUTHOR,
+			VARIATION_CUSTOM_TAXONOMY,
+		] );
+	} );
+
+	it( 'drops the three product variations when the gate is explicitly false', () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: false };
+		const values = variationOptions().map( o => o.value );
+		expect( values ).not.toContain( VARIATION_PRODUCT_CAT );
+		expect( values ).not.toContain( VARIATION_PRODUCT_TAG );
+		expect( values ).not.toContain( VARIATION_PRODUCT_BRAND );
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
@@ -59,6 +59,17 @@ jest.mock( '@wordpress/i18n', () => ( {
 } ) );
 
 describe( 'ResultsListEdit', () => {
+	// Default the editor's localized WC flag to true so the existing
+	// product-layout tests keep exercising the full picker. The non-Woo
+	// path (Product option absent, saved `product` collapses to `expanded`)
+	// is covered in its own `describe` block below.
+	beforeEach( () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: true };
+	} );
+	afterEach( () => {
+		delete globalThis.JetpackSearchBlocksConfig;
+	} );
+
 	it( 'does not show author names in the compact preview', () => {
 		render( <ResultsListEdit attributes={ { layout: 'compact' } } setAttributes={ jest.fn() } /> );
 
@@ -148,5 +159,39 @@ describe( 'ResultsListEdit', () => {
 		expect( screen.getByText( 'First sample result' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Try a broader query.' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Search is offline right now.' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'ResultsListEdit on non-WooCommerce sites (RSM-2805)', () => {
+	beforeEach( () => {
+		globalThis.JetpackSearchBlocksConfig = { isWooCommerceActive: false };
+	} );
+	afterEach( () => {
+		delete globalThis.JetpackSearchBlocksConfig;
+	} );
+
+	it( 'omits the Product layout option from the picker', () => {
+		render( <ResultsListEdit attributes={ { layout: 'expanded' } } setAttributes={ jest.fn() } /> );
+
+		// Compact and Expanded remain; Product is hidden so authors can't
+		// pick a layout that reads WC-shaped fields the index doesn't have.
+		expect( screen.getByRole( 'radio', { name: 'Compact' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: 'Expanded' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'radio', { name: 'Product (for WooCommerce stores)' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'collapses a saved product layout to expanded so the editor matches the renderer', () => {
+		// Authors who saved `product` on a Woo site that later deactivates
+		// WC should see the neutral expanded preview, not a broken product
+		// card. The PHP `render.php` applies the same fallback.
+		render( <ResultsListEdit attributes={ { layout: 'product' } } setAttributes={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'radio', { name: 'Expanded' } ) ).toBeChecked();
+		expect( screen.getByText( 'First sample result' ) ).toBeInTheDocument();
+		// Product-only sample data must not bleed into the canvas.
+		expect( screen.queryByText( 'Sample product' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( '$24.00' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -451,9 +451,12 @@ describe( 'store actions', () => {
 		// Regression: omitting priceRange from pushStateToUrl meant the
 		// first search after JS hydrated rewrote `?min_price=10` away,
 		// breaking shareable URLs and back-button behavior.
+		// `isWooCommerceActive` must be true — `min_price`/`max_price` are
+		// WC-only and `pushStateToUrl` drops them otherwise (RSM-2805).
 		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
 		state.searchQuery = 'shoes';
 		state.priceRange = { min: 10, max: 50 };
+		state.isWooCommerceActive = true;
 
 		actions.syncToUrl();
 
@@ -461,6 +464,24 @@ describe( 'store actions', () => {
 		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
 		expect( writtenUrl ).toContain( 'min_price=10' );
 		expect( writtenUrl ).toContain( 'max_price=50' );
+	} );
+
+	it( 'syncToUrl drops priceRange on non-Woo sites so a stray range cannot leak into the URL (RSM-2805)', () => {
+		// `filter-wc-price` isn't registered on non-Woo sites, but a stale
+		// `state.priceRange` (e.g. seeded from a deep link before the JS
+		// gate caught up, or set by an unrelated callback) must never round-
+		// trip into the URL — the next API request would otherwise carry a
+		// `range` clause for a field the index doesn't have.
+		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
+		state.searchQuery = 'shoes';
+		state.priceRange = { min: 10, max: 50 };
+		state.isWooCommerceActive = false;
+
+		actions.syncToUrl();
+
+		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
+		expect( writtenUrl ).not.toContain( 'min_price' );
+		expect( writtenUrl ).not.toContain( 'max_price' );
 	} );
 
 	it( 'closes open popovers on Escape only', () => {

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -86,11 +86,12 @@ describe( 'stateToUrlParams', () => {
 		expect( params.getAll( 'authors[]' ) ).toEqual( [ 'jane' ] );
 	} );
 
-	it( 'serializes priceRange bounds to min_price/max_price', () => {
+	it( 'serializes priceRange bounds to min_price/max_price on Woo sites', () => {
 		const params = stateToUrlParams( {
 			searchQuery: 'shoes',
 			sortOrder: 'relevance',
 			priceRange: { min: 10, max: 50 },
+			isWooCommerceActive: true,
 		} );
 		expect( params.get( 'min_price' ) ).toBe( '10' );
 		expect( params.get( 'max_price' ) ).toBe( '50' );
@@ -101,6 +102,7 @@ describe( 'stateToUrlParams', () => {
 			searchQuery: '',
 			sortOrder: 'relevance',
 			priceRange: { min: 10, max: null },
+			isWooCommerceActive: true,
 		} );
 		expect( params.get( 'min_price' ) ).toBe( '10' );
 		expect( params.has( 'max_price' ) ).toBe( false );
@@ -111,6 +113,23 @@ describe( 'stateToUrlParams', () => {
 			searchQuery: '',
 			sortOrder: 'relevance',
 			priceRange: null,
+			isWooCommerceActive: true,
+		} );
+		expect( params.has( 'min_price' ) ).toBe( false );
+		expect( params.has( 'max_price' ) ).toBe( false );
+	} );
+
+	it( 'omits min_price/max_price entirely on non-Woo sites (RSM-2805)', () => {
+		// `filter-wc-price` isn't registered on non-Woo sites, so a stray
+		// `priceRange` in store state must not leak into the URL — otherwise
+		// the next API request would carry a `range` clause for a field the
+		// index doesn't have. Mirrors the PHP-side gate in
+		// Search_Blocks::parse_url_price_range().
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			priceRange: { min: 10, max: 50 },
+			isWooCommerceActive: false,
 		} );
 		expect( params.has( 'min_price' ) ).toBe( false );
 		expect( params.has( 'max_price' ) ).toBe( false );
@@ -273,23 +292,29 @@ describe( 'urlParamsToState', () => {
 } );
 
 describe( 'urlParamsToState: priceRange', () => {
+	// All priceRange-parsing tests opt into `isWooCommerceActive=true` to
+	// exercise the parsing logic; the WC-off behaviour (price params are
+	// dropped entirely) is covered separately in the next describe block.
+	const wcOn = ( params, filterConfigs = {} ) =>
+		urlParamsToState( params, filterConfigs, 's', true );
+
 	it( 'returns null priceRange when neither bound is set', () => {
-		const state = urlParamsToState( new URLSearchParams() );
+		const state = wcOn( new URLSearchParams() );
 		expect( state.priceRange ).toBeNull();
 	} );
 
 	it( 'parses min and max into a numeric priceRange', () => {
-		const state = urlParamsToState( new URLSearchParams( '?min_price=10&max_price=50' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=10&max_price=50' ) );
 		expect( state.priceRange ).toEqual( { min: 10, max: 50 } );
 	} );
 
 	it( 'allows a half-open range when only one bound is set', () => {
-		const state = urlParamsToState( new URLSearchParams( '?min_price=10' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=10' ) );
 		expect( state.priceRange ).toEqual( { min: 10, max: null } );
 	} );
 
 	it( 'rejects garbage URL values so a bad URL cannot zero out results', () => {
-		const state = urlParamsToState( new URLSearchParams( '?min_price=abc&max_price=-5' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=abc&max_price=-5' ) );
 		expect( state.priceRange ).toBeNull();
 	} );
 
@@ -297,22 +322,22 @@ describe( 'urlParamsToState: priceRange', () => {
 		// `(float)"1.5.3"` is 1.5 in PHP but `Number("1.5.3")` is NaN in JS;
 		// without the explicit numeric gate on both sides the PHP initial
 		// render and the JS hydration would disagree on the parsed value.
-		const state = urlParamsToState( new URLSearchParams( '?min_price=1.5.3' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=1.5.3' ) );
 		expect( state.priceRange ).toBeNull();
 	} );
 
 	it( 'rejects inverted bounds (min > max) so an empty ES range clause is never sent', () => {
-		const state = urlParamsToState( new URLSearchParams( '?min_price=100&max_price=10' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=100&max_price=10' ) );
 		expect( state.priceRange ).toBeNull();
 	} );
 
 	it( 'accepts equal bounds (min === max) as a single-value range', () => {
-		const state = urlParamsToState( new URLSearchParams( '?min_price=42&max_price=42' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=42&max_price=42' ) );
 		expect( state.priceRange ).toEqual( { min: 42, max: 42 } );
 	} );
 
 	it( 'accepts min_price=0 (free products are a valid lower bound)', () => {
-		const state = urlParamsToState( new URLSearchParams( '?min_price=0' ) );
+		const state = wcOn( new URLSearchParams( '?min_price=0' ) );
 		expect( state.priceRange ).toEqual( { min: 0, max: null } );
 	} );
 
@@ -320,7 +345,29 @@ describe( 'urlParamsToState: priceRange', () => {
 		const params = new URLSearchParams();
 		params.append( 'min_price[]', '10' );
 		params.append( 'max_price[]', '50' );
-		const state = urlParamsToState( params );
+		const state = wcOn( params );
 		expect( state.activeFilters ).toEqual( {} );
+	} );
+} );
+
+describe( 'urlParamsToState: priceRange WooCommerce gate (RSM-2805)', () => {
+	it( 'drops min_price/max_price entirely on non-Woo sites', () => {
+		// A stray `?min_price=10&max_price=50` deep link must not seed the
+		// `priceRange` slice on a non-Woo site — `filter-wc-price` isn't
+		// registered there, so admitting the params would build a `range`
+		// clause against an index field that doesn't exist, *and* round-
+		// trip the params back into the URL on every URL push.
+		const state = urlParamsToState( new URLSearchParams( '?min_price=10&max_price=50' ) );
+		expect( state.priceRange ).toBeNull();
+	} );
+
+	it( 'still admits price params when isWooCommerceActive is true', () => {
+		const state = urlParamsToState(
+			new URLSearchParams( '?min_price=10&max_price=50' ),
+			{},
+			's',
+			true
+		);
+		expect( state.priceRange ).toEqual( { min: 10, max: 50 } );
 	} );
 } );

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -57,6 +57,25 @@ class Results_List_Render_Test extends TestCase {
 	}
 
 	/**
+	 * The product layout is WC-only and `render.php` collapses it to
+	 * `expanded` on non-Woo sites (RSM-2805). Most tests in this class
+	 * exercise the product layout; flip the WC gate on for every case so
+	 * the renderer emits product-shaped markup, then clear it in tearDown.
+	 * Non-Woo collapse is covered separately in
+	 * `test_product_layout_collapses_to_expanded_when_woocommerce_inactive`.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+	}
+
+	protected function tearDown(): void {
+		Search_Blocks::set_is_woocommerce_active_for_testing( null );
+		Search_Blocks::reset_initial_loading_cache();
+		parent::tearDown();
+	}
+
+	/**
 	 * Render the results-list block with the given attributes via `do_blocks`.
 	 *
 	 * @param array $attributes Block attributes.
@@ -99,6 +118,27 @@ class Results_List_Render_Test extends TestCase {
 		$markup = $this->render( array( 'layout' => 'compact' ) );
 		$this->assertStringNotContainsString( 'jetpack-search-results__path', $markup );
 		$this->assertStringNotContainsString( 'jetpack-search-results__image-link', $markup );
+	}
+
+	/**
+	 * On non-Woo sites the `product` layout collapses to `expanded` —
+	 * product-shaped fields (price, sale price, rating) don't exist on
+	 * non-product results, so leaving the WC-aware render path live
+	 * would emit empty price/rating regions. Authors who saved `product`
+	 * on a Woo site that later deactivates WC still see a sensible page.
+	 */
+	public function test_product_layout_collapses_to_expanded_when_woocommerce_inactive() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( false );
+
+		$markup = $this->render( array( 'layout' => 'product' ) );
+
+		$this->assertStringContainsString( 'jetpack-search-results--expanded', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results--product', $markup );
+		// The product-only rating + price + match-hint regions must not
+		// reach the rendered markup.
+		$this->assertStringNotContainsString( 'jetpack-search-results__rating', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results__price', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results__match-hint', $markup );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -204,9 +204,9 @@ class Search_Blocks_Test extends TestCase {
 		};
 		add_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
 		try {
-			Search_Blocks::is_woocommerce_active();
-			Search_Blocks::is_woocommerce_active();
-			Search_Blocks::is_woocommerce_active();
+			for ( $i = 0; $i < 3; $i++ ) {
+				Search_Blocks::is_woocommerce_active();
+			}
 			$this->assertSame( 1, $call_count, 'Filter ran once; subsequent calls served from cache.' );
 		} finally {
 			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -166,21 +166,50 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Symmetry: the filter must also be able to force the gate false on a
-	 * Woo install — useful for hiding WC-only Search blocks on a non-shop
-	 * content area without deactivating WooCommerce.
+	 * Symmetry: the filter must also be able to force the gate false. We
+	 * can't construct a "WC is loaded" PHPUnit env without polluting the
+	 * global namespace with a `WooCommerce` stub class, so instead the
+	 * test pins the *contract*: the filter receives the probed bool and
+	 * its return value is what the function returns. The cast-to-bool
+	 * test below covers the related "filter result wins over probe" path
+	 * for non-bool returns.
 	 */
-	public function test_is_woocommerce_active_filter_can_force_false() {
+	public function test_is_woocommerce_active_filter_receives_probe_and_return_wins() {
 		Search_Blocks::reset_is_woocommerce_active_cache();
-		// Pretend WC is loaded so the underlying probe would return true
-		// without the filter — proves the filter wins over the probe.
-		Search_Blocks::set_is_woocommerce_active_for_testing( true );
-		Search_Blocks::reset_is_woocommerce_active_cache(); // Force the filter path on the next call.
-		add_filter( 'jetpack_search_blocks_is_woocommerce_active', '__return_false' );
+		$received_value = null;
+		$callback       = function ( $value ) use ( &$received_value ) {
+			$received_value = $value;
+			return false;
+		};
+		add_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
 		try {
 			$this->assertFalse( Search_Blocks::is_woocommerce_active() );
+			$this->assertIsBool( $received_value, 'Filter received a bool from the probe.' );
 		} finally {
-			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', '__return_false' );
+			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
+		}
+	}
+
+	/**
+	 * Pins the docblock promise: the filter fires once per request and
+	 * the result is cached, so a callback that probes the database or
+	 * reads an option pays its cost once even on a hot path.
+	 */
+	public function test_is_woocommerce_active_filter_only_fires_once_per_request() {
+		Search_Blocks::reset_is_woocommerce_active_cache();
+		$call_count = 0;
+		$callback   = function ( $value ) use ( &$call_count ) {
+			++$call_count;
+			return $value;
+		};
+		add_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
+		try {
+			Search_Blocks::is_woocommerce_active();
+			Search_Blocks::is_woocommerce_active();
+			Search_Blocks::is_woocommerce_active();
+			$this->assertSame( 1, $call_count, 'Filter ran once; subsequent calls served from cache.' );
+		} finally {
+			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
 		}
 	}
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -626,6 +626,10 @@ class Search_Blocks_Test extends TestCase {
 	 * presets or inserts them with the wrong defaults.
 	 */
 	public function test_inject_filter_checkbox_variations_adds_expected_shapes() {
+		// Product variations are WC-gated; flip the probe so this matrix
+		// can assert their full shape. The non-Woo case is covered by
+		// `test_inject_filter_checkbox_variations_drops_product_when_woocommerce_inactive`.
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
 		$variations = Search_Blocks::inject_filter_checkbox_variations(
 			array(
 				array(
@@ -724,6 +728,7 @@ class Search_Blocks_Test extends TestCase {
 	 * a silently-empty filter on sites without a brands extension.
 	 */
 	public function test_inject_filter_checkbox_variations_gates_product_brand_on_taxonomy_existence() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
 		register_taxonomy( 'product_brand', 'post' );
 
 		$variations         = Search_Blocks::inject_filter_checkbox_variations(
@@ -756,6 +761,157 @@ class Search_Blocks_Test extends TestCase {
 		$this->assertLessThan( $custom_position, $brand_position );
 
 		unregister_taxonomy( 'product_brand' );
+	}
+
+	/**
+	 * On non-Woo sites the three product taxonomy variations (product_cat,
+	 * product_tag, product_brand) must NOT appear in the inserter — the
+	 * underlying taxonomies don't exist there, so the variations would
+	 * render silently-empty filters. The non-WC variations stay registered.
+	 */
+	public function test_inject_filter_checkbox_variations_drops_product_when_woocommerce_inactive() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( false );
+		register_taxonomy( 'product_brand', 'post' );
+		try {
+			$variations         = Search_Blocks::inject_filter_checkbox_variations(
+				array(),
+				new \WP_Block_Type( 'jetpack-search/filter-checkbox' )
+			);
+			$variations_by_name = array_column( $variations, null, 'name' );
+
+			$this->assertArrayNotHasKey( 'product_cat', $variations_by_name );
+			$this->assertArrayNotHasKey( 'product_tag', $variations_by_name );
+			$this->assertArrayNotHasKey( 'product_brand', $variations_by_name );
+			// Non-WC presets are unaffected.
+			$this->assertArrayHasKey( 'category', $variations_by_name );
+			$this->assertArrayHasKey( 'post_tag', $variations_by_name );
+			$this->assertArrayHasKey( 'post_type', $variations_by_name );
+			$this->assertArrayHasKey( 'author', $variations_by_name );
+			$this->assertArrayHasKey( 'custom_taxonomy', $variations_by_name );
+		} finally {
+			unregister_taxonomy( 'product_brand' );
+		}
+	}
+
+	/**
+	 * `is_woocommerce_only_block()` is the canonical predicate that drives
+	 * the three coupled gates — `register_blocks()` registration loop, the
+	 * `filter_block_helpers()` map, and the editor's `register-blocks.js`
+	 * bundle (after the localized list). Membership is decided by exact
+	 * match against `woocommerce_only_block_names()`, so adding a name to
+	 * that list auto-enrolls every gate without further plumbing.
+	 */
+	public function test_is_woocommerce_only_block_matches_canonical_list() {
+		// Every entry on the canonical list resolves to true under both
+		// the full namespaced form and the bare directory basename form
+		// (`register_blocks()` walks dir basenames; the helpers map and
+		// editor bundle hold full names).
+		foreach ( Search_Blocks::woocommerce_only_block_names() as $full_name ) {
+			$this->assertTrue(
+				Search_Blocks::is_woocommerce_only_block( $full_name ),
+				"Expected $full_name to be recognized as WC-only."
+			);
+			$bare = substr( $full_name, (int) strrpos( $full_name, '/' ) + 1 );
+			$this->assertTrue(
+				Search_Blocks::is_woocommerce_only_block( $bare ),
+				"Expected bare basename $bare to be recognized as WC-only."
+			);
+		}
+
+		// `filters-product` lives on the canonical list — it's the WC-specific
+		// filter container — and is caught despite not sharing the
+		// `filter-wc-` prefix the four filter blocks use.
+		$this->assertTrue( Search_Blocks::is_woocommerce_only_block( 'jetpack-search/filters-product' ) );
+		$this->assertTrue( Search_Blocks::is_woocommerce_only_block( 'filters-product' ) );
+
+		// Non-WC blocks must not be caught.
+		$this->assertFalse( Search_Blocks::is_woocommerce_only_block( 'jetpack-search/filter-checkbox' ) );
+		$this->assertFalse( Search_Blocks::is_woocommerce_only_block( 'jetpack-search/results-list' ) );
+		$this->assertFalse( Search_Blocks::is_woocommerce_only_block( 'jetpack-search/filters' ) );
+		$this->assertFalse( Search_Blocks::is_woocommerce_only_block( 'filter-date' ) );
+		// A made-up `filter-wc-foo` that isn't on the canonical list must
+		// not be caught — the gate is a list, not a name pattern.
+		$this->assertFalse( Search_Blocks::is_woocommerce_only_block( 'jetpack-search/filter-wc-bogus' ) );
+	}
+
+	/**
+	 * `filter_block_helpers()` underwrites both `walk_blocks_for_filter_configs()`
+	 * (which reads block trees in post content) and any future caller that
+	 * needs to know whether a block name is filter-shaped. On non-Woo sites
+	 * the WC-only blocks aren't registered, so they must drop out of the
+	 * helper map too — keeping the registry symmetric with what the inserter
+	 * offered.
+	 */
+	public function test_filter_block_helpers_drops_wc_helpers_when_woocommerce_inactive() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( false );
+		$helpers = $this->invoke_protected( 'filter_block_helpers' );
+
+		$this->assertArrayHasKey( 'jetpack-search/filter-checkbox', $helpers );
+		$this->assertArrayHasKey( 'jetpack-search/filter-date', $helpers );
+		$this->assertArrayNotHasKey( 'jetpack-search/filter-wc-rating', $helpers );
+		$this->assertArrayNotHasKey( 'jetpack-search/filter-wc-attribute', $helpers );
+		$this->assertArrayNotHasKey( 'jetpack-search/filter-wc-stock-status', $helpers );
+	}
+
+	/**
+	 * On Woo sites the helper map must include every WC-only block so
+	 * filter-config collection covers the full filter surface.
+	 */
+	public function test_filter_block_helpers_includes_wc_helpers_when_woocommerce_active() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		$helpers = $this->invoke_protected( 'filter_block_helpers' );
+
+		$this->assertArrayHasKey( 'jetpack-search/filter-wc-rating', $helpers );
+		$this->assertArrayHasKey( 'jetpack-search/filter-wc-attribute', $helpers );
+		$this->assertArrayHasKey( 'jetpack-search/filter-wc-stock-status', $helpers );
+	}
+
+	/**
+	 * `min_price` / `max_price` are WC-only; `filter-wc-price` isn't
+	 * registered on non-Woo sites. A stray deep link must not seed the
+	 * `priceRange` slice — otherwise the JS store would re-emit the params
+	 * on the next URL push and the API request would carry a `range` clause
+	 * for a field the index doesn't have.
+	 */
+	public function test_build_initial_state_drops_price_range_when_woocommerce_inactive() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( false );
+		$original_get = $_GET;
+		$_GET         = array(
+			'min_price' => '10',
+			'max_price' => '50',
+		);
+		try {
+			$state = Search_Blocks::build_initial_state();
+			$this->assertNull( $state['priceRange'] );
+		} finally {
+			$_GET = $original_get;
+		}
+	}
+
+	/**
+	 * The same deep link on a Woo site must round-trip into `priceRange`
+	 * so the API request fires with the matching `range` clause on first
+	 * paint — this is the same contract `filter-wc-price` writes to URL.
+	 */
+	public function test_build_initial_state_seeds_price_range_when_woocommerce_active() {
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		$original_get = $_GET;
+		$_GET         = array(
+			'min_price' => '10',
+			'max_price' => '50',
+		);
+		try {
+			$state = Search_Blocks::build_initial_state();
+			$this->assertSame(
+				array(
+					'min' => 10.0,
+					'max' => 50.0,
+				),
+				$state['priceRange']
+			);
+		} finally {
+			$_GET = $original_get;
+		}
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -883,6 +883,12 @@ class Search_Blocks_Test extends TestCase {
 		try {
 			$state = Search_Blocks::build_initial_state();
 			$this->assertNull( $state['priceRange'] );
+			// `isLoading` is derived from `is_initial_loading()`, which
+			// pivots on `parse_url_price_range()`. With the price gate
+			// dropped on non-Woo sites, a `?min_price=…` URL must not
+			// flip the page into the loading state — there's no fetch
+			// to wait on. End-to-end coverage for the WC-off branch.
+			$this->assertFalse( $state['isLoading'] );
 		} finally {
 			$_GET = $original_get;
 		}

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -149,6 +149,60 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * `jetpack_search_blocks_is_woocommerce_active` lets a site force the
+	 * gate true on a non-Woo install — useful for staging previews of
+	 * WC-only Search blocks. The filter result must be cached, so a
+	 * subsequent call returns the override even after the filter is
+	 * removed.
+	 */
+	public function test_is_woocommerce_active_filter_can_force_true() {
+		Search_Blocks::reset_is_woocommerce_active_cache();
+		add_filter( 'jetpack_search_blocks_is_woocommerce_active', '__return_true' );
+		try {
+			$this->assertTrue( Search_Blocks::is_woocommerce_active() );
+		} finally {
+			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', '__return_true' );
+		}
+	}
+
+	/**
+	 * Symmetry: the filter must also be able to force the gate false on a
+	 * Woo install — useful for hiding WC-only Search blocks on a non-shop
+	 * content area without deactivating WooCommerce.
+	 */
+	public function test_is_woocommerce_active_filter_can_force_false() {
+		Search_Blocks::reset_is_woocommerce_active_cache();
+		// Pretend WC is loaded so the underlying probe would return true
+		// without the filter — proves the filter wins over the probe.
+		Search_Blocks::set_is_woocommerce_active_for_testing( true );
+		Search_Blocks::reset_is_woocommerce_active_cache(); // Force the filter path on the next call.
+		add_filter( 'jetpack_search_blocks_is_woocommerce_active', '__return_false' );
+		try {
+			$this->assertFalse( Search_Blocks::is_woocommerce_active() );
+		} finally {
+			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', '__return_false' );
+		}
+	}
+
+	/**
+	 * A filter callback returning a truthy non-bool (`'1'`, `1`, etc.)
+	 * must not poison the strictly-typed `bool` cache. The function casts
+	 * before storing so callers using `===` against `true` still match.
+	 */
+	public function test_is_woocommerce_active_filter_casts_truthy_non_bool_to_true() {
+		Search_Blocks::reset_is_woocommerce_active_cache();
+		$callback = static function () {
+			return '1';
+		};
+		add_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
+		try {
+			$this->assertTrue( Search_Blocks::is_woocommerce_active() );
+		} finally {
+			remove_filter( 'jetpack_search_blocks_is_woocommerce_active', $callback );
+		}
+	}
+
+	/**
 	 * Seeded `activeFilters` is the raw URL params — gating moved to
 	 * store/index.js's `initialize()` callback, which can apply it once
 	 * every filter block's render.php has contributed its filterConfig (and


### PR DESCRIPTION
Fixes [RSM-2805](https://linear.app/a8c/issue/RSM-2805/search-blocks-gate-all-woocommerce-only-features-behind-search).

## Why

Authors building a Jetpack Search page on a non-WooCommerce site have been seeing inserter cards for filters they can't actually use — "Filter by Star Rating", "Filter by Stock Status", "Filter by Price", "Filter by Product Attribute", "Product Filters", plus "Filter by Product Category / Tag / Brand" variations of the generic checkbox filter, and a "Product (for WooCommerce stores)" layout option in the Results List inspector. Inserting any of those produced a silently-empty filter (no buckets, no useful UI). This PR makes those WC-only options disappear from the inserter on non-Woo sites — authors only see what they can use. WooCommerce sites are unchanged.

## Proposed changes

* `Search_Blocks::woocommerce_only_block_names()` is the canonical list of full namespaced WC-only block names — `filter-wc-attribute`, `filter-wc-price`, `filter-wc-rating`, `filter-wc-stock-status`, and `filters-product`. Adding a new WC-only block means appending one line; every gate picks it up.
* The list drives three coupled gates that previously had to be touched separately:
  - PHP: `register_blocks()` skips the matching `register_block_type()` on non-Woo sites.
  - PHP: `filter_block_helpers()` drops the entry from the helper map so the filter-config walk stays symmetric with what's registered.
  - JS: the list is localized onto `window.JetpackSearchBlocksConfig.woocommerceOnlyBlocks` so the editor's `register-blocks.js` skips the matching `registerBlockType()` call too.
* `inject_filter_checkbox_variations()` wraps the `product_cat`/`product_tag`/`product_brand` variations in a single `is_woocommerce_active()` gate (`product_brand` keeps its existing `taxonomy_exists()` layer because it's a WC extension addition, not a core WC taxonomy).
* `results-list/render.php` collapses the `product` layout to `expanded` on non-Woo sites; the inspector picker hides the option in lockstep so an author who saved `product` on a Woo site that later deactivates WC still sees a sensible preview.
* `parse_url_price_range()` (PHP) and `urlParamsToState()` / `stateToUrlParams()` (JS) drop `min_price`/`max_price` entirely on non-Woo sites — `filter-wc-price` isn't registered there, so admitting the params would build a `range` clause for a field the index doesn't have and round-trip the params back into the URL on every push.
* `register_patterns()` skips pattern files whose basename starts with `wc-` (no current patterns use this convention; reserved for future WC-only patterns).
* WC-on / WC-off matrix tests across `Search_Blocks_Test`, `Results_List_Render_Test`, `url-state.test.js`, `store.test.js`, and `results-list-edit.test.jsx`.
* `AGENTS.md` documents the canonical list + the three coupled gates so future WC-only features hang off the same plumbing.

## Related product discussion/links

* [RSM-2805 — Search blocks: gate all WooCommerce-only features behind Search_Blocks::is_woocommerce_active()](https://linear.app/a8c/issue/RSM-2805/search-blocks-gate-all-woocommerce-only-features-behind-search)
* Builds on [#48671](https://github.com/Automattic/jetpack/pull/48671) (RSM-1082), which introduced the `is_woocommerce_active()` helper, the IA store seed (`state.isWooCommerceActive`), the editor config (`window.JetpackSearchBlocksConfig.isWooCommerceActive`), and the test plumbing (`set_is_woocommerce_active_for_testing()` / `reset_is_woocommerce_active_cache()`).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**On a non-WooCommerce site:**

1. Open the block editor on any post or template that's not the Jetpack Search template. In the Inserter, search for "filter".
2. Confirm none of these inserter cards appear: **Filter by Star Rating**, **Filter by Price**, **Filter by Stock Status**, **Filter by Product Attribute**, **Product Filters**, **Filter by Product Category**, **Filter by Product Tag**, **Filter by Product Brand**.
3. Insert a **Filter by X** (Checkbox) block and check the variation picker — it should offer Category / Tag / Post Type / Author / Custom Taxonomy and nothing else.
4. Insert a **Search Results** block, drill into the **Results List**, open the inspector. The **Result format** picker should offer **Compact** and **Expanded** only — no "Product (for WooCommerce stores)".
5. Visit `/?s=test&min_price=10&max_price=50` directly. Confirm the API request the page fires does **not** include a `min_price` or `max_price` clause and the URL does not round-trip them on the next state push.

**On a WooCommerce site:**

6. Repeat steps 1–4. Every WC-only inserter card / variation / layout option should be present, exactly as on `trunk` today.
7. Insert a **Product Filters** block, save, and confirm the page renders the filter sidebar on the front end with the WC filter children inside.
8. Visit `/?s=shoes&min_price=10&max_price=50`. Confirm the page renders price-filtered results on first paint and that subsequent searches preserve the price params in the URL.

**Automated coverage:**

```bash
cd projects/packages/search
composer phpunit                               # 355 tests
pnpm jest tests/js/search-blocks/              # full search-blocks JS suite
```
