### PR TITLE
wpcomsh: fix footer credit

### DIFF
--- a/projects/plugins/wpcomsh/changelog/wpcomsh-fix-footer-credit-theme-string-replacement
+++ b/projects/plugins/wpcomsh/changelog/wpcomsh-fix-footer-credit-theme-string-replacement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevents empty string replacement for the first instance of the word "theme" if a theme has an empty or invalid style.css where the theme name can't be detected. 

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
@@ -171,12 +171,14 @@ function wpcom_better_footer_links( $footer ) {
 		preg_quote( __( 'Design by', 'wpcomsh' ), '#' )
 	);
 
-	if ( preg_match( "#$designer_match#i", $footer ) ) {
-		$footer = preg_replace( "#$designer_match#i", '', $footer, 1 );
-	}
+	if ( ! empty( $theme->name ) ) {
+		if ( preg_match( "#$designer_match#i", $footer ) ) {
+			$footer = preg_replace( "#$designer_match#i", '', $footer, 1 );
+		}
 
-	if ( preg_match( "#$theme_match#i", $footer ) ) {
-		$footer = preg_replace( "#$theme_match#i", '', $footer, 1 );
+		if ( preg_match( "#$theme_match#i", $footer ) ) {
+			$footer = preg_replace( "#$theme_match#i", '', $footer, 1 );
+		}
 	}
 
 	if ( preg_match( "#$design_by#i", $footer ) ) {


### PR DESCRIPTION
Fixes [DOTTHEM-343](https://linear.app/a8c/issue/DOTTHEM-343/first-instance-of-theme-is-replaced-with-an-empty-string-in-footerphp)

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds a conditional check for an empty theme name to prevent improper replacement of the first instance of "theme" within a footer.php when the active theme does not follow coding standards and have a valid style.css. 

## Related product discussion/links
- https://linear.app/a8c/issue/DOTTHEM-343/first-instance-of-theme-is-replaced-with-an-empty-string-in-footerphp

## Testing instructions
1. Install and activate Jetpack Beta with this branch
2. Install and activate the following test theme manually via SFTP/SSH (wp-admin has guards to prevent installing a theme with invalid style.css) `wp theme activate testtheme` - [testtheme.zip](https://github.com/user-attachments/files/27402495/testtheme.zip)
3. Review the footer area on the frontend and see if the screenshot.png image displays or is broken.
4. Review the source code of the page in your browser and search for `wp-content/s/` to ensure an improper string replacement hasn't been made. 

## Does this pull request change what data or activity we track or use?
No