### PR TITLE
Search 3.0: chips displayStyle for filter-date and filter-wc-attribute (RSM-2814)

### DIFF
--- a/projects/packages/search/changelog/RSM-2814-filter-blocks-chips-display-style
+++ b/projects/packages/search/changelog/RSM-2814-filter-blocks-chips-display-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search blocks: Extend the chips display style option to the Date and Product Attribute filter blocks.

--- a/projects/packages/search/src/search-blocks/blocks/display-style.js
+++ b/projects/packages/search/src/search-blocks/blocks/display-style.js
@@ -1,0 +1,25 @@
+/**
+ * Shared `displayStyle` helpers for the bucket-driven filter blocks
+ * (`filter-checkbox`, `filter-date`, `filter-wc-attribute`). JS-side
+ * mirror of `Search_Blocks::normalize_display_style()` (PHP) so editor
+ * previews and server-rendered output never disagree on what counts as
+ * a valid variant.
+ *
+ * `filter-wc-stock-status` and `filter-wc-rating` deliberately don't
+ * ship a chip variant today — single-option vs. star-row + suffix
+ * shapes don't translate cleanly into a pill toggle. The helper is
+ * ready for them to opt in later.
+ */
+
+/**
+ * Coerce a saved `displayStyle` value to the supported enum. Anything that
+ * isn't the literal string `'chips'` collapses to `'checkbox-list'`, so
+ * legacy saves (missing attribute, `null`, unknown future variants) keep
+ * rendering as the default rather than dropping out entirely.
+ *
+ * @param {unknown} value - Raw attribute value off `attributes.displayStyle`.
+ * @return {'checkbox-list' | 'chips'} Normalized variant.
+ */
+export function normalizeDisplayStyle( value ) {
+	return value === 'chips' ? 'chips' : 'checkbox-list';
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -168,12 +168,20 @@ class Filter_Checkbox {
 
 	/**
 	 * Normalize display style attribute so render wrappers always emit one of
-	 * the supported CSS variants.
+	 * the supported CSS variants. Thin pass-through to the shared
+	 * `Search_Blocks::normalize_display_style()` so the four sibling filter
+	 * blocks (`filter-date`, `filter-wc-attribute`, `filter-wc-rating`,
+	 * `filter-wc-stock-status`) and this one all share one implementation.
+	 *
+	 * Kept as a delegating wrapper rather than dropped so older
+	 * `Filter_Checkbox::normalize_display_style()` callers (and the existing
+	 * unit test that pins the contract) keep working — the API surface is
+	 * identical to before, just sourced from the shared helper.
 	 *
 	 * @param mixed $value Raw attribute value.
 	 * @return string Either 'checkbox-list' or 'chips'.
 	 */
 	public static function normalize_display_style( $value ): string {
-		return 'chips' === $value ? 'chips' : 'checkbox-list';
+		return Search_Blocks::normalize_display_style( $value );
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -31,6 +31,12 @@ import {
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { normalizeDisplayStyle } from '../display-style.js';
+
+// Re-export the shared helper under the same name this module has always
+// exposed so existing imports (notably the edit-side unit tests) keep
+// resolving without churn.
+export { normalizeDisplayStyle };
 
 const SAMPLE_FILTER_ITEMS = [
 	{ value: 'one', label: __( 'First option', 'jetpack-search-pkg' ), count: 24 },
@@ -234,17 +240,6 @@ export function variationDefaultLabel( attributes ) {
 		}
 	}
 	return '';
-}
-
-/**
- * Coerce saved displayStyle values to the supported enum so inspector UI and
- * editor preview always render from a valid CSS variant.
- *
- * @param {string} value - Raw display style attribute.
- * @return {string} Either `checkbox-list` or `chips`.
- */
-export function normalizeDisplayStyle( value ) {
-	return value === 'chips' ? 'chips' : 'checkbox-list';
 }
 
 /**

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/block.json
@@ -19,6 +19,11 @@
 			"enum": [ "year", "month" ]
 		},
 		"label": { "type": "string", "default": "" },
+		"displayStyle": {
+			"type": "string",
+			"default": "checkbox-list",
+			"enum": [ "checkbox-list", "chips" ]
+		},
 		"showCount": { "type": "boolean", "default": true },
 		"maxItems": { "type": "integer", "default": 10 },
 		"bucketSortOrder": {

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/edit.js
@@ -1,5 +1,11 @@
 /**
  * Editor preview for jetpack-search/filter-date.
+ *
+ * `displayStyle` swaps between the default checkbox-list rendering and a
+ * chip-pill variant for the date buckets, mirroring the same attribute on
+ * filter-checkbox / filter-wc-*. The runtime DOM stays identical across
+ * variants — only the wrapper data attribute changes — so the existing
+ * Interactivity bindings keep working.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
@@ -8,8 +14,15 @@ import {
 	RangeControl,
 	TextControl,
 	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { normalizeDisplayStyle } from '../display-style.js';
+
+export { normalizeDisplayStyle };
 
 const SAMPLE_BUCKETS_YEAR = [
 	{ value: '2024', label: '2024', count: 42 },
@@ -32,7 +45,8 @@ const SAMPLE_BUCKETS_MONTH = [
  * @return {object} Rendered element.
  */
 export default function FilterDateEdit( { attributes, setAttributes } ) {
-	const blockProps = useBlockProps();
+	const displayStyle = normalizeDisplayStyle( attributes?.displayStyle );
+	const blockProps = useBlockProps( { 'data-display-style': displayStyle } );
 	const rawLabel = attributes?.label || '';
 	const placeholderLabel = __( 'Date', 'jetpack-search-pkg' );
 	const previewLabel = rawLabel || placeholderLabel;
@@ -83,6 +97,20 @@ export default function FilterDateEdit( { attributes, setAttributes } ) {
 						checked={ showCount }
 						onChange={ value => setAttributes( { showCount: !! value } ) }
 					/>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Display style', 'jetpack-search-pkg' ) }
+						value={ displayStyle }
+						onChange={ value => setAttributes( { displayStyle: normalizeDisplayStyle( value ) } ) }
+					>
+						<ToggleGroupControlOption
+							value="checkbox-list"
+							label={ __( 'Checkbox list', 'jetpack-search-pkg' ) }
+						/>
+						<ToggleGroupControlOption value="chips" label={ __( 'Chips', 'jetpack-search-pkg' ) } />
+					</ToggleGroupControl>
 					<RangeControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/edit.js
@@ -22,8 +22,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { normalizeDisplayStyle } from '../display-style.js';
 
-export { normalizeDisplayStyle };
-
 const SAMPLE_BUCKETS_YEAR = [
 	{ value: '2024', label: '2024', count: 42 },
 	{ value: '2023', label: '2023', count: 31 },

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
@@ -30,11 +30,12 @@ wp_interactivity_state(
 	)
 );
 
-$view  = Search_Blocks::pre_hydration_filter_view( $filter_key );
-$label = $config['label'];
+$view          = Search_Blocks::pre_hydration_filter_view( $filter_key );
+$label         = $config['label'];
+$display_style = Search_Blocks::normalize_display_style( $attributes['displayStyle'] ?? null );
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'data-display-style' => $display_style ) ) ); ?>
 	data-wp-interactive="jetpack-search"
 	<?php Search_Blocks::emit_filter_wrapper_context( $filter_key, $view['show_wrapper'] ); ?>
 	data-wp-bind--hidden="context.wrapperHidden"

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
@@ -1,4 +1,5 @@
 @use "../skeleton" as skeleton;
+@use "../chip" as chip;
 
 .wp-block-jetpack-search-filter-date {
 
@@ -49,5 +50,10 @@
 		&[hidden] {
 			display: none;
 		}
+	}
+
+	&[data-display-style="chips"] {
+
+		@include chip.checkbox-filter-chips;
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
@@ -20,6 +20,11 @@
 	"attributes": {
 		"attributeTaxonomy": { "type": "string", "default": "" },
 		"label": { "type": "string", "default": "" },
+		"displayStyle": {
+			"type": "string",
+			"default": "checkbox-list",
+			"enum": [ "checkbox-list", "chips" ]
+		},
 		"showCount": { "type": "boolean", "default": true },
 		"maxItems": { "type": "integer", "default": 10 },
 		"bucketSortOrder": {

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -22,9 +22,16 @@ import {
 	SelectControl,
 	TextControl,
 	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { normalizeDisplayStyle } from '../display-style.js';
+
+export { normalizeDisplayStyle };
 
 const ATTRIBUTE_PREFIX = 'pa_';
 
@@ -113,7 +120,11 @@ function resolvePlaceholderInstructions( isLoading, hasAttributes ) {
  * @return {object} Rendered element.
  */
 export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
-	const blockProps = useBlockProps( { className: 'jetpack-search-filter-wc-attribute' } );
+	const displayStyle = normalizeDisplayStyle( attributes?.displayStyle );
+	const blockProps = useBlockProps( {
+		className: 'jetpack-search-filter-wc-attribute',
+		'data-display-style': displayStyle,
+	} );
 	const rawLabel = attributes?.label || '';
 	const showCount = attributes?.showCount !== false;
 	const maxItems = Math.max( 1, attributes?.maxItems ?? 10 );
@@ -197,6 +208,20 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 						checked={ showCount }
 						onChange={ value => setAttributes( { showCount: !! value } ) }
 					/>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Display style', 'jetpack-search-pkg' ) }
+						value={ displayStyle }
+						onChange={ value => setAttributes( { displayStyle: normalizeDisplayStyle( value ) } ) }
+					>
+						<ToggleGroupControlOption
+							value="checkbox-list"
+							label={ __( 'Checkbox list', 'jetpack-search-pkg' ) }
+						/>
+						<ToggleGroupControlOption value="chips" label={ __( 'Chips', 'jetpack-search-pkg' ) } />
+					</ToggleGroupControl>
 					<RangeControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -31,8 +31,6 @@ import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { normalizeDisplayStyle } from '../display-style.js';
 
-export { normalizeDisplayStyle };
-
 const ATTRIBUTE_PREFIX = 'pa_';
 
 const SAMPLE_FILTER_ITEMS = [

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
@@ -72,9 +72,20 @@ if ( $view['has_buckets'] ) {
 		}
 	}
 }
+
+$display_style = Search_Blocks::normalize_display_style( $attributes['displayStyle'] ?? null );
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-attribute' ) ) ); ?>
+	<?php
+	echo wp_kses_data(
+		get_block_wrapper_attributes(
+			array(
+				'class'              => 'jetpack-search-filter-wc-attribute',
+				'data-display-style' => $display_style,
+			)
+		)
+	);
+	?>
 	data-wp-interactive="jetpack-search"
 	<?php Search_Blocks::emit_filter_wrapper_context( $filter_key, $view['show_wrapper'] ); ?>
 	data-wp-bind--hidden="context.wrapperHidden"

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/style.scss
@@ -10,6 +10,7 @@
  * (filter-checkbox-scoped) original.
  */
 @use "../skeleton" as skeleton;
+@use "../chip" as chip;
 
 .wp-block-jetpack-search-filter-wc-attribute {
 
@@ -60,5 +61,10 @@
 		&[hidden] {
 			display: none;
 		}
+	}
+
+	&[data-display-style="chips"] {
+
+		@include chip.checkbox-filter-chips;
 	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1118,6 +1118,27 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Normalize the `displayStyle` attribute shared by the bucket-driven
+	 * filter blocks (`filter-checkbox`, `filter-date`, `filter-wc-attribute`)
+	 * so render wrappers always emit one of the two supported CSS variants.
+	 * Per-block classes delegate here so every adopting block applies the
+	 * same fallback rule.
+	 *
+	 * `filter-wc-stock-status` (single option) and `filter-wc-rating` (star
+	 * rows + "& up" suffix + count badge) deliberately don't ship a chip
+	 * variant — see the PR thread for the discussion — so they don't call
+	 * this helper today. Adding them later is a one-attribute change in
+	 * their respective `block.json` / `render.php` / `edit.js`; the helper
+	 * doesn't need updating.
+	 *
+	 * @param mixed $value Raw attribute value (string, null, or unexpected type).
+	 * @return string Either 'checkbox-list' or 'chips'.
+	 */
+	public static function normalize_display_style( $value ): string {
+		return 'chips' === $value ? 'chips' : 'checkbox-list';
+	}
+
+	/**
 	 * Seed translated view-bundle strings for the Interactivity API store.
 	 *
 	 * @return array<string, string>

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1060,6 +1060,24 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * The shared display-style normalizer powers the bucket-driven filter
+	 * blocks that opt into chips today (filter-checkbox, filter-date,
+	 * filter-wc-attribute). Per-block delegations are exercised in their
+	 * own tests; this case pins the source-of-truth contract so a `'chips'`
+	 * literal never gains a third synonym (`'chip'`, `'CHIPS'`, …) without
+	 * an explicit test update.
+	 */
+	public function test_normalize_display_style_pins_enum() {
+		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( null ) );
+		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( '' ) );
+		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( 'checkbox-list' ) );
+		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( 'bogus' ) );
+		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( 'CHIPS' ) );
+		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( 0 ) );
+		$this->assertSame( 'chips', Search_Blocks::normalize_display_style( 'chips' ) );
+	}
+
+	/**
 	 * Invoke a protected static on Search_Blocks from test code. Reflection
 	 * is the cheapest way to cover this logic without leaking visibility
 	 * just for testability.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-2814

## Why

Site authors who wanted chip-style filters on a Jetpack Search page could previously use them on the generic Category / Tag / Post Type filter (`filter-checkbox`) — but the Date filter and the WooCommerce Product Attribute filter were locked to the older checkbox-list rendering, which made mixed pages look inconsistent and meant Woo storefronts in particular couldn't ship the compact pill-toggle UX shoppers are used to for facets like Color / Size / Brand. This PR extends the same `displayStyle: 'checkbox-list' | 'chips'` switch from RSM-2810 to those two bucket-driven blocks so every front-end filter that visually fits the chip pattern can use it without re-inserting blocks or changing types.

## Proposed changes

* Add `displayStyle` attribute (default `checkbox-list`, enum `[checkbox-list, chips]`) to `filter-date` and `filter-wc-attribute` block.json files.
* Each block's `render.php` emits `data-display-style="<style>"` on the block wrapper via `get_block_wrapper_attributes()`. DOM stays identical so all existing `data-wp-bind` / `data-wp-on--change="actions.onFilterChange"` Interactivity hooks keep working — only CSS swaps presentation.
* Editor inspector picks up the same `__experimentalToggleGroupControl` segmented picker from RSM-2810 (with `isBlock`, `__next40pxDefaultSize`, `__nextHasNoMarginBottom`). `normalizeDisplayStyle()` is applied at the `onChange` boundary so the experimental API can't sneak a non-enum value past the contract.
* `style.scss` in each block adds `@use "../chip" as chip` and applies `@include chip.checkbox-filter-chips` under `[data-display-style="chips"]`, reusing the shared partial that landed with RSM-2810.
* Shared helpers introduced to keep the three adopting blocks (`filter-checkbox` + the two new ones) aligned:
  * `Search_Blocks::normalize_display_style()` — single source of truth on the PHP side; `Filter_Checkbox::normalize_display_style()` is now a thin pass-through so the existing PR-#48678 test contract still holds.
  * `src/search-blocks/blocks/display-style.js` — JS-side mirror; each block's `edit.js` imports + re-exports it so existing imports (notably the filter-checkbox test suite) keep resolving unchanged.

## Deliberately out of scope

* `jetpack-search/filter-wc-stock-status` — single-option list ("In stock"); rendering one row as a chip reads as a misuse of the pattern, not a benefit.
* `jetpack-search/filter-wc-rating` — each row is a star strip + an "& up" suffix + a count badge; collapsing that into a single pill drops the visual cues shoppers rely on. Worth a dedicated design pass before opting in.

Adding either block later is a one-attribute change in its `block.json` / `render.php` / `edit.js` — the shared helpers already model the contract, so opting in is small and reversible.

## Related product discussion/links

* Linear: [RSM-2814](https://linear.app/a8c/issue/RSM-2814)
* Predecessor PR: [#48678](https://github.com/Automattic/jetpack/pull/48678) (RSM-2810) — landed pattern for `filter-checkbox`
* Earlier sibling (now superseded): RSM-1949
* Epic: RSM-1929 (Done)

## Does this pull request change what data or activity we track or use?

No — `displayStyle` is purely a presentation toggle. Tracking and aggregation requests are unchanged, no new tracks events, no new persisted data shapes.

## Testing instructions

1. On a site with WooCommerce active and at least one `pa_*` product attribute registered (sample product data is fine), insert either `Filter by Date` or `Filter by Product Attribute` in the block editor.
2. In the block inspector, locate the new **Display style** segmented picker between `Show result counts` and the next setting.
3. Switch the picker to **Chips** — confirm the editor preview swaps to chip pills in place, mirroring what `filter-checkbox` does today.
4. Switch back to **Checkbox list** — confirm the original rendering returns.
5. Publish the page and view the front-end render: chip mode should show pill toggles, hover/focus rings, and filled state when a value is checked. Click round-trip should still update the URL filter param (`?filter_date[]=2024`, `?filter_pa_color[]=red`) the same way as in checkbox-list mode.

Tests:

* `pnpm test` in `projects/packages/search` — 554 / 554 JS tests pass (47 suites).
* `composer phpunit` in `projects/packages/search` — 361 / 361 PHP tests pass (818 assertions). Includes the new `Search_Blocks_Test::test_normalize_display_style_pins_enum` and the existing `Filter_Checkbox_Test::test_normalize_display_style` (delegation preserves the contract).

## Screenshots

Both opted-in blocks rendered side-by-side in the editor, contrasting the existing `checkbox-list` default with the new `chips` variant.

### Before (`displayStyle: "checkbox-list"`)

![filter blocks — checkbox-list mode](https://github.com/user-attachments/assets/d0690e6d-f869-4296-b6bc-acd1ffc15e0b)

### After (`displayStyle: "chips"`)

![filter blocks — chips mode](https://github.com/user-attachments/assets/bc31f2a2-52a8-44f7-8870-8606313ba927)
