### PR TITLE
Search 3.0: filter-checkbox Any/All logic toggle (RSM-2815)

### DIFF
--- a/projects/packages/search/changelog/RSM-2815-filter-checkbox-any-all-logic
+++ b/projects/packages/search/changelog/RSM-2815-filter-checkbox-any-all-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: per-block "Logic" toggle on `jetpack-search/filter-checkbox` taxonomy filters — pick between Any (OR, default) and All (AND) combination of multi-value selections; URL round-trips as `?query_type_<filterKey>=and`.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
@@ -34,6 +34,11 @@
 			"type": "string",
 			"default": "count",
 			"enum": [ "count", "alpha" ]
+		},
+		"queryType": {
+			"type": "string",
+			"default": "or",
+			"enum": [ "or", "and" ]
 		}
 	},
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -115,6 +115,9 @@ class Filter_Checkbox {
 			'showCount'       => (bool) ( $attributes['showCount'] ?? true ),
 			'maxItems'        => max( 1, (int) ( $attributes['maxItems'] ?? 10 ) ),
 			'bucketSortOrder' => static::normalize_bucket_sort_order( $attributes['bucketSortOrder'] ?? null ),
+			// AND vs. OR combination across multi-value selections. Only
+			// honoured for taxonomy filters — see normalize_query_type().
+			'queryType'       => static::normalize_query_type( $attributes['queryType'] ?? null, $filter_type ),
 			// Pre-resolved value→label map used by the active-filters pill list
 			// and the checkbox list. Taxonomy and author aggregations use
 			// `slug_slash_name` keys, so the bucket already carries the label
@@ -164,6 +167,22 @@ class Filter_Checkbox {
 	 */
 	public static function normalize_bucket_sort_order( $value ): string {
 		return 'alpha' === $value ? 'alpha' : 'count';
+	}
+
+	/**
+	 * Normalize the queryType attribute. Returns 'and' only when the literal
+	 * string is 'and' AND the filter targets a taxonomy — post_type and
+	 * author are single-valued per document, so an AND combination with 2+
+	 * selections is guaranteed to return zero results. Gating here means
+	 * tampered saved data can never reach the ES query builder with a
+	 * value that would silently zero out the result set.
+	 *
+	 * @param mixed  $value       Raw attribute value.
+	 * @param string $filter_type Block `filterType` attribute.
+	 * @return string Either 'or' or 'and'.
+	 */
+	public static function normalize_query_type( $value, string $filter_type ): string {
+		return ( 'and' === $value && 'taxonomy' === $filter_type ) ? 'and' : 'or';
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -463,11 +463,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 							onChange={ value => setAttributes( { queryType: normalizeQueryType( value ) } ) }
 							help={
 								queryType === 'and'
-									? __(
-											'Show posts that match all selected options.',
-											'jetpack-search-pkg',
-											/* dummy arg to avoid bad minification */ 0
-									  )
+									? __( 'Show posts that match all selected options.', 'jetpack-search-pkg' )
 									: __(
 											'Show posts that match any of the selected options.',
 											'jetpack-search-pkg',

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -198,9 +198,15 @@ export function variationToAttributes( variation, previousTaxonomy ) {
 		case VARIATION_PRODUCT_BRAND:
 			return { filterType: 'taxonomy', taxonomy: 'product_brand' };
 		case VARIATION_POST_TYPE:
-			return { filterType: 'post_type', taxonomy: previousTaxonomy || '' };
+			// Reset queryType so a Category → Post Type → Category round-trip
+			// doesn't carry stale AND semantics from the prior taxonomy. The
+			// Logic toggle is hidden on non-taxonomy variations and ES queries
+			// double-guard via `filterType === 'taxonomy'`, but without this
+			// reset the toggle re-appears showing `All` on return and confuses
+			// the author about what the block will actually do.
+			return { filterType: 'post_type', taxonomy: previousTaxonomy || '', queryType: 'or' };
 		case VARIATION_AUTHOR:
-			return { filterType: 'author', taxonomy: previousTaxonomy || '' };
+			return { filterType: 'author', taxonomy: previousTaxonomy || '', queryType: 'or' };
 		case VARIATION_CUSTOM_TAXONOMY:
 		default: {
 			const preserved = BUILT_IN_TAXONOMY_SLUGS.includes( previousTaxonomy )
@@ -457,8 +463,16 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 							onChange={ value => setAttributes( { queryType: normalizeQueryType( value ) } ) }
 							help={
 								queryType === 'and'
-									? __( 'Show posts that match all selected options.', 'jetpack-search-pkg' )
-									: __( 'Show posts that match any of the selected options.', 'jetpack-search-pkg' )
+									? __(
+											'Show posts that match all selected options.',
+											'jetpack-search-pkg',
+											/* dummy arg to avoid bad minification */ 0
+									  )
+									: __(
+											'Show posts that match any of the selected options.',
+											'jetpack-search-pkg',
+											/* dummy arg to avoid bad minification */ 0
+									  )
 							}
 						>
 							<ToggleGroupControlOption value="or" label={ __( 'Any', 'jetpack-search-pkg' ) } />

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -38,6 +38,21 @@ import { normalizeDisplayStyle } from '../display-style.js';
 // resolving without churn.
 export { normalizeDisplayStyle };
 
+/**
+ * Coerce a saved `queryType` value to the supported enum. Anything that
+ * isn't the literal string `'and'` collapses to `'or'`, so legacy saves
+ * (missing attribute, `null`, garbage typed in) keep the OR default
+ * rather than dropping out entirely. Mirrors `Filter_Checkbox::normalize_query_type()`
+ * on the PHP side — both must agree or the editor preview and the
+ * server-rendered ES query would disagree on what "All" means.
+ *
+ * @param {unknown} value - Raw attribute value off `attributes.queryType`.
+ * @return {'or' | 'and'} Normalized variant.
+ */
+export function normalizeQueryType( value ) {
+	return value === 'and' ? 'and' : 'or';
+}
+
 const SAMPLE_FILTER_ITEMS = [
 	{ value: 'one', label: __( 'First option', 'jetpack-search-pkg' ), count: 24 },
 	{ value: 'two', label: __( 'Second option', 'jetpack-search-pkg' ), count: 12 },
@@ -300,6 +315,12 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// Unknown values fall back to `count` so the preview controls always
 	// reflect a valid enum option; render.php normalizes the same way.
 	const bucketSortOrder = attributes?.bucketSortOrder === 'alpha' ? 'alpha' : 'count';
+	const queryType = normalizeQueryType( attributes?.queryType );
+	// Logic toggle is only meaningful for taxonomy filters — each document
+	// has one post_type / author, so an "All" combination with 2+ selections
+	// always returns zero results. Hiding the control on those variations
+	// keeps authors from setting it by mistake.
+	const isTaxonomyFilter = attributes?.filterType === 'taxonomy';
 
 	// Swapping the filter type via the inspector shouldn't wipe an author's
 	// custom label, but when the stored label still matches the prior
@@ -426,6 +447,24 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 							setAttributes( { bucketSortOrder: value === 'alpha' ? 'alpha' : 'count' } )
 						}
 					/>
+					{ isTaxonomyFilter && (
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							isBlock
+							label={ __( 'Logic', 'jetpack-search-pkg' ) }
+							value={ queryType }
+							onChange={ value => setAttributes( { queryType: normalizeQueryType( value ) } ) }
+							help={
+								queryType === 'and'
+									? __( 'Show posts that match all selected options.', 'jetpack-search-pkg' )
+									: __( 'Show posts that match any of the selected options.', 'jetpack-search-pkg' )
+							}
+						>
+							<ToggleGroupControlOption value="or" label={ __( 'Any', 'jetpack-search-pkg' ) } />
+							<ToggleGroupControlOption value="and" label={ __( 'All', 'jetpack-search-pkg' ) } />
+						</ToggleGroupControl>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -859,6 +859,7 @@ class Search_Blocks {
 		$site_id            = class_exists( Helper::class ) ? Helper::get_wpcom_site_id() : 0;
 		$search_query       = static::parse_url_search_query();
 		$active_filters     = static::parse_url_filters();
+		$filter_logic       = static::parse_url_filter_logic( $active_filters );
 		$price_range        = static::parse_url_price_range();
 		$is_initial_loading = static::is_initial_loading();
 		$searching_text     = function_exists( '__' ) ? __( 'Searching…', 'jetpack-search-pkg' ) : 'Searching…';
@@ -898,6 +899,7 @@ class Search_Blocks {
 			'searchParamName'       => static::get_search_param_name(),
 			'sortOrder'             => static::parse_url_sort(),
 			'activeFilters'         => $active_filters,
+			'filterLogic'           => $filter_logic,
 			'priceRange'            => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
@@ -1336,6 +1338,46 @@ class Search_Blocks {
 			if ( $clean ) {
 				$out[ $filter_key ] = $clean;
 			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Parse the per-filter AND/OR override params (`?query_type_<key>=and`)
+	 * from the current request URL. Returns `{ [filterKey]: 'and' }` —
+	 * matches the JS-side parser in `store/url-state.js`. Only the literal
+	 * value `'and'` is honoured; anything else collapses to the default and
+	 * is omitted so it can never round-trip back through `pushStateToUrl`.
+	 *
+	 * Filter keys for which no active selection exists are dropped because
+	 * they'd otherwise hang around in state and re-emit on the next URL push.
+	 *
+	 * @param array<string, string[]> $active_filters Result of parse_url_filters().
+	 * @return array<string, string>
+	 */
+	protected static function parse_url_filter_logic( array $active_filters ): array {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only URL state; sanitized per-value below.
+		$raw = wp_unslash( $_GET );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $raw as $key => $value ) {
+			if ( ! is_string( $key ) || 0 !== strpos( $key, 'query_type_' ) ) {
+				continue;
+			}
+			if ( ! is_string( $value ) || 'and' !== $value ) {
+				continue;
+			}
+			$filter_key = sanitize_key( substr( $key, strlen( 'query_type_' ) ) );
+			if ( '' === $filter_key || in_array( $filter_key, self::RESERVED_QUERY_PARAMS, true ) ) {
+				continue;
+			}
+			if ( empty( $active_filters[ $filter_key ] ) ) {
+				continue;
+			}
+			$out[ $filter_key ] = 'and';
 		}
 		return $out;
 	}

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -327,10 +327,17 @@ function dateRangeFromSlug( value, interval ) {
 /**
  * Build the ES filter clause from active selections.
  *
- * OR within a single filter key (`bool.should`); AND across keys
+ * Default: OR within a single filter key (`bool.should`); AND across keys
  * (`bool.must`). Diverges from the legacy instant-search overlay which ANDs
  * multi-value selections — Search 3.0 follows the broaden-on-click UX of
  * modern faceted search.
+ *
+ * Taxonomy filters can opt into AND semantics via `config.queryType === 'and'`
+ * (set by the filter-checkbox "Logic" inspector toggle). In that case the
+ * per-value `term` clauses are pushed as separate top-level `must` entries
+ * rather than wrapped in `bool.should`, so the post must carry every selected
+ * term. Only honoured for the `taxonomy` filterType — see
+ * `Filter_Checkbox::normalize_query_type()`.
  *
  * @param {object} activeFilters - { [filterKey]: string[] } selections.
  * @param {object} filterConfigs - { [filterKey]: FilterConfig } map.
@@ -401,7 +408,16 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 		if ( clauses.length === 0 ) {
 			continue;
 		}
-		must.push( clauses.length === 1 ? clauses[ 0 ] : { bool: { should: clauses } } );
+		// AND semantics only apply to taxonomy filters — see header docblock.
+		// For a single value the wrapping is irrelevant, so the early single-clause
+		// short-circuit covers both branches.
+		if ( clauses.length === 1 ) {
+			must.push( clauses[ 0 ] );
+		} else if ( config?.queryType === 'and' && config?.filterType === 'taxonomy' ) {
+			must.push( ...clauses );
+		} else {
+			must.push( { bool: { should: clauses } } );
+		}
 	}
 	return must.length ? { bool: { must } } : undefined;
 }

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -56,20 +56,31 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
 }
 
 /**
- * Drop filterLogic entries whose filter key is missing from `activeFilters`
- * or has an empty selection set. Mirrors the cleanup `setFilter()` performs
- * locally; called from popstate where the URL parse is the source of truth.
+ * Drop filterLogic entries whose filter key is missing from `activeFilters`,
+ * has an empty selection set, or targets a non-taxonomy filter. Mirrors the
+ * cleanup `setFilter()` performs locally; called from popstate and at
+ * hydration where the URL parse is the source of truth and the
+ * taxonomy-only gate (server-side `Filter_Checkbox::normalize_query_type`)
+ * may not have run yet — because PHP `parse_url_filter_logic` runs before
+ * any block has registered its config, so it can't know which keys are
+ * taxonomy filters.
  *
- * @param {object} filterLogic   - { [filterKey]: 'or' | 'and' }.
- * @param {object} activeFilters - { [filterKey]: string[] }.
+ * @param {object} filterLogic     - { [filterKey]: 'or' | 'and' }.
+ * @param {object} activeFilters   - { [filterKey]: string[] }.
+ * @param {object} [filterConfigs] - { [filterKey]: FilterConfig } when available; passing
+ *                                 this enables the taxonomy gate.
  * @return {object} Gated logic map.
  */
-export function pickLogicForActive( filterLogic, activeFilters ) {
+export function pickLogicForActive( filterLogic, activeFilters, filterConfigs = null ) {
 	const out = {};
 	for ( const [ key, value ] of Object.entries( filterLogic ?? {} ) ) {
-		if ( ( activeFilters?.[ key ]?.length ?? 0 ) > 0 ) {
-			out[ key ] = value;
+		if ( ( activeFilters?.[ key ]?.length ?? 0 ) === 0 ) {
+			continue;
 		}
+		if ( filterConfigs && filterConfigs[ key ]?.filterType !== 'taxonomy' ) {
+			continue;
+		}
+		out[ key ] = value;
 	}
 	return out;
 }
@@ -879,6 +890,7 @@ const { state, actions } = store( NAMESPACE, {
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
 				filterLogic: state.filterLogic,
+				filterConfigs: state.filterConfigs,
 				priceRange: state.priceRange,
 				searchParamName: state.searchParamName,
 				isWooCommerceActive: state.isWooCommerceActive,
@@ -905,8 +917,9 @@ const { state, actions } = store( NAMESPACE, {
 			const { gated } = gateActiveFilters( activeFilters, state.filterConfigs );
 			state.activeFilters = gated;
 			// Gate filterLogic the same way: drop entries whose filter key
-			// either isn't registered or has no surviving selections.
-			state.filterLogic = pickLogicForActive( filterLogic, gated );
+			// either isn't registered, has no surviving selections, or
+			// targets a non-taxonomy filter.
+			state.filterLogic = pickLogicForActive( filterLogic, gated, state.filterConfigs );
 			state.priceRange = priceRange;
 			yield actions.search( { syncUrl: false } );
 		},
@@ -1123,10 +1136,18 @@ const { state, actions } = store( NAMESPACE, {
 				state.activeFilters = gated;
 			}
 			// Re-gate filterLogic against the (possibly trimmed) activeFilters
-			// so a `?query_type_<key>=and` whose `<key>` was dropped doesn't
-			// linger in state and re-emit on the next URL push.
+			// AND against the just-registered filterConfigs so a
+			// `?query_type_<key>=and` whose `<key>` was dropped or targets a
+			// non-taxonomy filter doesn't linger in state and re-emit on the
+			// next URL push. PHP `parse_url_filter_logic` can't apply the
+			// taxonomy gate itself because it runs before any block render.php
+			// has populated filterConfigs — this is where it lands.
 			if ( state.filterLogic && Object.keys( state.filterLogic ).length > 0 ) {
-				const gatedLogic = pickLogicForActive( state.filterLogic, state.activeFilters );
+				const gatedLogic = pickLogicForActive(
+					state.filterLogic,
+					state.activeFilters,
+					state.filterConfigs
+				);
 				if ( Object.keys( gatedLogic ).length !== Object.keys( state.filterLogic ).length ) {
 					state.filterLogic = gatedLogic;
 				}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -56,6 +56,55 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
 }
 
 /**
+ * Drop filterLogic entries whose filter key is missing from `activeFilters`
+ * or has an empty selection set. Mirrors the cleanup `setFilter()` performs
+ * locally; called from popstate where the URL parse is the source of truth.
+ *
+ * @param {object} filterLogic   - { [filterKey]: 'or' | 'and' }.
+ * @param {object} activeFilters - { [filterKey]: string[] }.
+ * @return {object} Gated logic map.
+ */
+export function pickLogicForActive( filterLogic, activeFilters ) {
+	const out = {};
+	for ( const [ key, value ] of Object.entries( filterLogic ?? {} ) ) {
+		if ( ( activeFilters?.[ key ]?.length ?? 0 ) > 0 ) {
+			out[ key ] = value;
+		}
+	}
+	return out;
+}
+
+/**
+ * Overlay per-filter AND/OR overrides onto each filterConfig's `queryType`.
+ * The override map (`filterLogic`) is its own state slice — kept separate so
+ * a deep-link `?query_type_category=and` survives even if the user toggles
+ * the block attribute in a future edit. Returns the original map untouched
+ * when no overrides apply, to avoid spurious referential changes that would
+ * defeat downstream identity checks.
+ *
+ * @param {object} filterConfigs - { [filterKey]: FilterConfig }.
+ * @param {object} filterLogic   - { [filterKey]: 'or' | 'and' } overrides.
+ * @return {object} Effective filterConfigs.
+ */
+export function overlayFilterLogic( filterConfigs, filterLogic ) {
+	if ( ! filterConfigs || ! filterLogic || Object.keys( filterLogic ).length === 0 ) {
+		return filterConfigs;
+	}
+	let dirty = false;
+	const overlaid = {};
+	for ( const [ key, config ] of Object.entries( filterConfigs ) ) {
+		const override = filterLogic[ key ];
+		if ( override && override !== config?.queryType ) {
+			overlaid[ key ] = { ...config, queryType: override };
+			dirty = true;
+		} else {
+			overlaid[ key ] = config;
+		}
+	}
+	return dirty ? overlaid : filterConfigs;
+}
+
+/**
  * True when a filter key has anything to render: live aggregation buckets,
  * session-retained options, or an active selection. Drives wrapper
  * visibility — without the retained / selection check a narrower query
@@ -353,7 +402,12 @@ function* fetchResults( pageHandle ) {
 		apiRoot: state.apiRoot,
 		homeUrl: state.homeUrl,
 		activeFilters: state.activeFilters,
-		filterConfigs: state.filterConfigs,
+		// Overlay per-filter `filterLogic` overrides onto each filterConfig's
+		// `queryType` before handing to the URL builder. The override lives
+		// separately in store state so it survives across navigations even
+		// when blocks re-register their configs; merging here keeps the
+		// downstream consumer (`buildFilterClause`) free of the override path.
+		filterConfigs: overlayFilterLogic( state.filterConfigs, state.filterLogic ),
 		priceRange: state.priceRange,
 		staticPostTypes: state.staticPostTypes,
 	} );
@@ -745,6 +799,14 @@ const { state, actions } = store( NAMESPACE, {
 				if ( next.length === 0 ) {
 					const { [ filterKey ]: _removed, ...rest } = state.activeFilters;
 					state.activeFilters = rest;
+					// Drop any logic override for the now-empty filter so the
+					// URL serializer doesn't leave `?query_type_<key>=and`
+					// orphaned in the address bar after the last selection
+					// is cleared.
+					if ( state.filterLogic && filterKey in state.filterLogic ) {
+						const { [ filterKey ]: _droppedLogic, ...restLogic } = state.filterLogic;
+						state.filterLogic = restLogic;
+					}
 				} else {
 					state.activeFilters = { ...state.activeFilters, [ filterKey ]: next };
 				}
@@ -764,6 +826,7 @@ const { state, actions } = store( NAMESPACE, {
 				return;
 			}
 			state.activeFilters = {};
+			state.filterLogic = {};
 			state.priceRange = null;
 			yield actions.search();
 		},
@@ -815,6 +878,7 @@ const { state, actions } = store( NAMESPACE, {
 				searchQuery: state.searchQuery,
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
+				filterLogic: state.filterLogic,
 				priceRange: state.priceRange,
 				searchParamName: state.searchParamName,
 				isWooCommerceActive: state.isWooCommerceActive,
@@ -827,7 +891,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*handlePopState() {
-			const { searchQuery, sortOrder, activeFilters, priceRange } = readStateFromUrl(
+			const { searchQuery, sortOrder, activeFilters, filterLogic, priceRange } = readStateFromUrl(
 				state.filterConfigs,
 				state.searchParamName,
 				state.isWooCommerceActive
@@ -838,7 +902,11 @@ const { state, actions } = store( NAMESPACE, {
 			// re-gate here so popstate matches initialize() and stray URL keys
 			// can't round-trip back into pushStateToUrl on a page with no
 			// registered filters.
-			state.activeFilters = gateActiveFilters( activeFilters, state.filterConfigs ).gated;
+			const { gated } = gateActiveFilters( activeFilters, state.filterConfigs );
+			state.activeFilters = gated;
+			// Gate filterLogic the same way: drop entries whose filter key
+			// either isn't registered or has no surviving selections.
+			state.filterLogic = pickLogicForActive( filterLogic, gated );
 			state.priceRange = priceRange;
 			yield actions.search( { syncUrl: false } );
 		},
@@ -1053,6 +1121,15 @@ const { state, actions } = store( NAMESPACE, {
 			const { gated, droppedAny } = gateActiveFilters( state.activeFilters, state.filterConfigs );
 			if ( droppedAny ) {
 				state.activeFilters = gated;
+			}
+			// Re-gate filterLogic against the (possibly trimmed) activeFilters
+			// so a `?query_type_<key>=and` whose `<key>` was dropped doesn't
+			// linger in state and re-emit on the next URL push.
+			if ( state.filterLogic && Object.keys( state.filterLogic ).length > 0 ) {
+				const gatedLogic = pickLogicForActive( state.filterLogic, state.activeFilters );
+				if ( Object.keys( gatedLogic ).length !== Object.keys( state.filterLogic ).length ) {
+					state.filterLogic = gatedLogic;
+				}
 			}
 			if ( state.searchQuery || state.hasActiveFilters ) {
 				// syncUrl=false: URL already carries this query; avoid a duplicate history entry.

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -66,7 +66,12 @@ function parsePriceBound( raw ) {
  * `?query_type_<filterKey>=and` param — mirrors WC's
  * `woocommerce/product-filter-attribute` URL surface. Only emitted when
  * the filter has selections AND the effective logic is `'and'`; `'or'` is
- * the default and never serialized so URLs stay short.
+ * the default and never serialized so URLs stay short. Effective logic is
+ * the union of `filterLogic[key]` (URL-derived) and `filterConfigs[key].queryType`
+ * (the block author's choice) — without the second source, a block configured
+ * with Logic = All would silently never get `query_type_*` into the address
+ * bar on visitor interaction, so cross-page shared links would lose the AND
+ * semantics.
  *
  * @param {object}      state                       - Store state slice.
  * @param {string}      state.searchQuery           - Current search query.
@@ -75,6 +80,10 @@ function parsePriceBound( raw ) {
  * @param {object}      [state.filterLogic]         - { [filterKey]: 'or' | 'and' } per-filter
  *                                                  AND/OR override. Entries without active
  *                                                  selections are dropped on write.
+ * @param {object}      [state.filterConfigs]       - { [filterKey]: FilterConfig } used to
+ *                                                  read the block-author-configured `queryType`
+ *                                                  so the URL also reflects block config when
+ *                                                  `filterLogic` has no override for that key.
  * @param {object|null} [state.priceRange]          - { min, max } price range; either bound may be null.
  * @param {string}      [state.searchParamName]     - URL key the search query is written under
  *                                                  (`s` on the WP search route, `q`
@@ -90,6 +99,7 @@ export function stateToUrlParams( {
 	sortOrder,
 	activeFilters = {},
 	filterLogic = {},
+	filterConfigs = {},
 	priceRange = null,
 	searchParamName = DEFAULT_SEARCH_PARAM,
 	isWooCommerceActive = false,
@@ -113,10 +123,14 @@ export function stateToUrlParams( {
 			continue;
 		}
 		values.forEach( value => params.append( `${ key }[]`, value ) );
-		// Only emit query_type when this filter has selections AND it's set to
-		// 'and'. Without selections the param is meaningless; for 'or' (the
-		// default) we skip the write to keep the URL short.
-		if ( filterLogic?.[ key ] === 'and' ) {
+		// Only emit query_type when this filter has selections AND the
+		// effective logic is 'and'. Effective = URL override (filterLogic)
+		// OR block-author config (filterConfigs[key].queryType). Without the
+		// second source a block saved with Logic = All would never get
+		// query_type_<key>=and into the URL on visitor interaction, so a
+		// shared deep link wouldn't carry the AND semantics.
+		const effective = filterLogic?.[ key ] || filterConfigs?.[ key ]?.queryType;
+		if ( effective === 'and' ) {
 			params.set( `${ QUERY_TYPE_PREFIX }${ key }`, 'and' );
 		}
 	}
@@ -182,6 +196,15 @@ export function urlParamsToState(
 				continue;
 			}
 			if ( hasFilterConfigGate && ! ( filterKey in filterConfigs ) ) {
+				continue;
+			}
+			// AND/OR combination is only meaningful for taxonomy filters —
+			// post_type / author each have one value per document, so
+			// `query_type_post_types=and` is semantically a no-op. Skipping
+			// it here keeps the param from sticking in filterLogic and
+			// re-emitting on every URL push thereafter. Mirrors the
+			// `filterType === 'taxonomy'` gate in `Filter_Checkbox::normalize_query_type()`.
+			if ( hasFilterConfigGate && filterConfigs[ filterKey ]?.filterType !== 'taxonomy' ) {
 				continue;
 			}
 			// 'or' is the default — silently drop it so the gate matches the

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -29,6 +29,12 @@ const DEFAULT_SEARCH_PARAM = 's';
 // both possible search-query keys so neither leaks into `activeFilters`.
 const RESERVED_PARAMS = new Set( [ 's', 'q', 'orderby', 'min_price', 'max_price' ] );
 
+// Per-filter URL prefix that controls AND/OR combination for a given filter
+// key (e.g. `?query_type_category=and`). Mirrors WooCommerce's
+// product-filter-attribute convention so Search 3.0 blocks on a Woo
+// storefront stay URL-interoperable with native WC filters.
+const QUERY_TYPE_PREFIX = 'query_type_';
+
 /**
  * Parse a `min_price` / `max_price` URL value into a finite number.
  * Returns null on missing, non-numeric, or negative input so a garbage
@@ -56,10 +62,19 @@ function parsePriceBound( raw ) {
  * so deep links are interchangeable between the two surfaces and the
  * PHP-side `parse_url_filters()` reads the same contract.
  *
+ * Per-filter AND/OR logic rides alongside as a scalar
+ * `?query_type_<filterKey>=and` param — mirrors WC's
+ * `woocommerce/product-filter-attribute` URL surface. Only emitted when
+ * the filter has selections AND the effective logic is `'and'`; `'or'` is
+ * the default and never serialized so URLs stay short.
+ *
  * @param {object}      state                       - Store state slice.
  * @param {string}      state.searchQuery           - Current search query.
  * @param {string}      state.sortOrder             - Current sort order.
  * @param {object}      [state.activeFilters]       - { [filterKey]: string[] } selected filters.
+ * @param {object}      [state.filterLogic]         - { [filterKey]: 'or' | 'and' } per-filter
+ *                                                  AND/OR override. Entries without active
+ *                                                  selections are dropped on write.
  * @param {object|null} [state.priceRange]          - { min, max } price range; either bound may be null.
  * @param {string}      [state.searchParamName]     - URL key the search query is written under
  *                                                  (`s` on the WP search route, `q`
@@ -74,6 +89,7 @@ export function stateToUrlParams( {
 	searchQuery,
 	sortOrder,
 	activeFilters = {},
+	filterLogic = {},
 	priceRange = null,
 	searchParamName = DEFAULT_SEARCH_PARAM,
 	isWooCommerceActive = false,
@@ -97,6 +113,12 @@ export function stateToUrlParams( {
 			continue;
 		}
 		values.forEach( value => params.append( `${ key }[]`, value ) );
+		// Only emit query_type when this filter has selections AND it's set to
+		// 'and'. Without selections the param is meaningless; for 'or' (the
+		// default) we skip the write to keep the URL short.
+		if ( filterLogic?.[ key ] === 'and' ) {
+			params.set( `${ QUERY_TYPE_PREFIX }${ key }`, 'and' );
+		}
 	}
 
 	// `min_price` / `max_price` are WC-only; the price filter block
@@ -136,7 +158,7 @@ export function stateToUrlParams( {
  *                                                `max_price` range params). Falsy on non-Woo
  *                                                sites ignores both rather than hydrating
  *                                                them into store state.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
  */
 export function urlParamsToState(
 	params,
@@ -147,8 +169,30 @@ export function urlParamsToState(
 	const rawOrderby = params.get( 'orderby' );
 	const allowedSorts = validSortOrders( isWooCommerceActive );
 	const activeFilters = {};
+	const filterLogic = {};
+	const hasFilterConfigGate = filterConfigs && Object.keys( filterConfigs ).length > 0;
 
 	for ( const [ rawKey, value ] of params.entries() ) {
+		// query_type_<filterKey>=or|and rides alongside the array-shaped
+		// filter params. Parse it before the `[]` gate below so the prefix
+		// branch can't be missed.
+		if ( rawKey.startsWith( QUERY_TYPE_PREFIX ) ) {
+			const filterKey = rawKey.slice( QUERY_TYPE_PREFIX.length );
+			if ( ! filterKey || RESERVED_PARAMS.has( filterKey ) ) {
+				continue;
+			}
+			if ( hasFilterConfigGate && ! ( filterKey in filterConfigs ) ) {
+				continue;
+			}
+			// 'or' is the default — silently drop it so the gate matches the
+			// serializer (which never emits 'or'). Anything that isn't the
+			// literal 'and' is treated as garbage and skipped, mirroring
+			// `Filter_Checkbox::normalize_query_type()`.
+			if ( value === 'and' ) {
+				filterLogic[ filterKey ] = 'and';
+			}
+			continue;
+		}
 		if ( ! rawKey.endsWith( '[]' ) ) {
 			continue;
 		}
@@ -156,11 +200,7 @@ export function urlParamsToState(
 		if ( RESERVED_PARAMS.has( filterKey ) ) {
 			continue;
 		}
-		if (
-			filterConfigs &&
-			Object.keys( filterConfigs ).length > 0 &&
-			! ( filterKey in filterConfigs )
-		) {
+		if ( hasFilterConfigGate && ! ( filterKey in filterConfigs ) ) {
 			continue;
 		}
 		const normalized = String( value ?? '' ).trim();
@@ -179,6 +219,15 @@ export function urlParamsToState(
 			continue;
 		}
 		activeFilters[ filterKey ].push( normalized );
+	}
+
+	// Drop filterLogic entries whose filter has no active selections.
+	// A stray `?query_type_category=and` without `?category[]=...` would
+	// otherwise leak back through the next serializer call.
+	for ( const key of Object.keys( filterLogic ) ) {
+		if ( ! activeFilters[ key ] || activeFilters[ key ].length === 0 ) {
+			delete filterLogic[ key ];
+		}
 	}
 
 	// Mirror `Search_Blocks::parse_url_price_range()`: drop `min_price` /
@@ -201,6 +250,7 @@ export function urlParamsToState(
 		searchQuery: params.get( searchParamName ) ?? '',
 		sortOrder: allowedSorts.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
 		activeFilters,
+		filterLogic,
 		priceRange,
 	};
 }
@@ -229,7 +279,7 @@ export function pushStateToUrl( state ) {
  * @param {boolean} [isWooCommerceActive] - Gate for WC-only URL surface (product-format
  *                                        sort keys + `min_price` / `max_price` range params);
  *                                        forwarded to `urlParamsToState`.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
  */
 export function readStateFromUrl(
 	filterConfigs = {},

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -444,6 +444,46 @@ describe( 'buildFilterClause', () => {
 		expect( buildFilterClause( {}, {} ) ).toBeUndefined();
 	} );
 
+	it( 'wraps multi-value taxonomy selections in flat `must` clauses when queryType is `and`', () => {
+		const clause = buildFilterClause(
+			{ category: [ 'news', 'sports' ] },
+			{ category: { filterType: 'taxonomy', taxonomy: 'category', queryType: 'and' } }
+		);
+		expect( clause ).toEqual( {
+			bool: {
+				must: [ { term: { 'category.slug': 'news' } }, { term: { 'category.slug': 'sports' } } ],
+			},
+		} );
+	} );
+
+	it( 'keeps single-value taxonomy selections as a bare `term` clause even under queryType `and`', () => {
+		const clause = buildFilterClause(
+			{ category: [ 'news' ] },
+			{ category: { filterType: 'taxonomy', taxonomy: 'category', queryType: 'and' } }
+		);
+		expect( clause ).toEqual( {
+			bool: { must: [ { term: { 'category.slug': 'news' } } ] },
+		} );
+	} );
+
+	it( 'ignores queryType `and` for non-taxonomy filters (defensive — post_type is single-valued per doc)', () => {
+		const clause = buildFilterClause(
+			{ post_types: [ 'post', 'page' ] },
+			{ post_types: { filterType: 'post_type', queryType: 'and' } }
+		);
+		expect( clause ).toEqual( {
+			bool: {
+				must: [
+					{
+						bool: {
+							should: [ { term: { post_type: 'post' } }, { term: { post_type: 'page' } } ],
+						},
+					},
+				],
+			},
+		} );
+	} );
+
 	it( 'emits a half-open `range` clause for a single year selection', () => {
 		const clause = buildFilterClause(
 			{ post_date: [ '2024' ] },
@@ -836,6 +876,47 @@ describe( 'product-shaped filter helpers', () => {
 			expect( decoded ).toContain( 'filter[bool][must][1][term][post_type]=post' );
 			expect( decoded ).toContain(
 				'filter[bool][must][2][bool][must_not][0][term][post_type]=product'
+			);
+		} );
+	} );
+
+	describe( 'buildSearchUrl: queryType `and`', () => {
+		const baseOpts = {
+			siteId: 1,
+			searchQuery: '',
+			sortOrder: 'relevance',
+			pageHandle: null,
+			isPrivateSite: false,
+			isWpcom: false,
+			apiRoot: '',
+		};
+
+		it( 'encodes flat `must` clauses for an AND-mode taxonomy filter', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				activeFilters: { category: [ 'news', 'sports' ] },
+				filterConfigs: {
+					category: { filterType: 'taxonomy', taxonomy: 'category', queryType: 'and' },
+				},
+			} );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
+			expect( decoded ).toContain( 'filter[bool][must][1][term][category.slug]=sports' );
+			expect( decoded ).not.toContain( 'filter[bool][must][0][bool][should]' );
+		} );
+
+		it( 'keeps the legacy `bool.should` wrapper for the default OR mode', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				activeFilters: { category: [ 'news', 'sports' ] },
+				filterConfigs: { category: { filterType: 'taxonomy', taxonomy: 'category' } },
+			} );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain(
+				'filter[bool][must][0][bool][should][0][term][category.slug]=news'
+			);
+			expect( decoded ).toContain(
+				'filter[bool][must][0][bool][should][1][term][category.slug]=sports'
 			);
 		} );
 	} );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -241,18 +241,32 @@ describe( 'variationToAttributes', () => {
 		// render.php ignores `taxonomy` when filterType isn't 'taxonomy', so
 		// keeping the slug here is purely UI state — but it lets the author
 		// flip Custom → Author → Custom without retyping `genre`.
+		// Author / Post Type also reset queryType to 'or' since AND is
+		// meaningless for single-valued filter types (see below test).
 		expect( variationToAttributes( VARIATION_POST_TYPE, 'genre' ) ).toEqual( {
 			filterType: 'post_type',
 			taxonomy: 'genre',
+			queryType: 'or',
 		} );
 		expect( variationToAttributes( VARIATION_AUTHOR, 'genre' ) ).toEqual( {
 			filterType: 'author',
 			taxonomy: 'genre',
+			queryType: 'or',
 		} );
 		expect( variationToAttributes( VARIATION_AUTHOR, '' ) ).toEqual( {
 			filterType: 'author',
 			taxonomy: '',
+			queryType: 'or',
 		} );
+	} );
+
+	it( 'resets queryType to `or` when switching to Author / Post Type so a stale AND from the prior taxonomy doesn’t persist', () => {
+		// Without this reset, setting Logic = All on Category, switching to
+		// Post Type (which hides the Logic toggle), then back to Category,
+		// would re-surface the toggle pre-set to All. The toggle visibility
+		// gate alone isn't enough — the saved attribute travels with the block.
+		expect( variationToAttributes( VARIATION_POST_TYPE, '' ).queryType ).toBe( 'or' );
+		expect( variationToAttributes( VARIATION_AUTHOR, '' ).queryType ).toBe( 'or' );
 	} );
 
 	it( 'pins the slug for the three product variations', () => {

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -9,6 +9,7 @@ import {
 	default as FilterCheckboxEdit,
 	deriveVariation,
 	normalizeDisplayStyle,
+	normalizeQueryType,
 	variationToAttributes,
 	variationDefaultLabel,
 	variationOptions,
@@ -370,6 +371,60 @@ describe( 'normalizeDisplayStyle', () => {
 
 	it( 'accepts chips', () => {
 		expect( normalizeDisplayStyle( 'chips' ) ).toBe( 'chips' );
+	} );
+} );
+
+describe( 'normalizeQueryType', () => {
+	it( 'defaults to `or` for missing or unknown values', () => {
+		expect( normalizeQueryType() ).toBe( 'or' );
+		expect( normalizeQueryType( null ) ).toBe( 'or' );
+		expect( normalizeQueryType( '' ) ).toBe( 'or' );
+		expect( normalizeQueryType( 'banana' ) ).toBe( 'or' );
+	} );
+
+	it( 'accepts the literal `and`', () => {
+		expect( normalizeQueryType( 'and' ) ).toBe( 'and' );
+	} );
+
+	it( 'accepts the literal `or` (idempotent)', () => {
+		expect( normalizeQueryType( 'or' ) ).toBe( 'or' );
+	} );
+} );
+
+describe( 'FilterCheckboxEdit Logic toggle', () => {
+	it( 'renders the Any/All toggle when filterType is taxonomy', () => {
+		render(
+			<FilterCheckboxEdit
+				attributes={ {
+					filterType: 'taxonomy',
+					taxonomy: 'category',
+				} }
+				setAttributes={ jest.fn() }
+			/>
+		);
+		// The ToggleGroupControl mock renders a fieldset with the label as
+		// aria-label and a <legend>. Look for the legend text since fieldsets
+		// don't expose a role.
+		expect( screen.getByText( 'Logic' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Any' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'All' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the Logic toggle for post_type filters', () => {
+		// post_type / author are single-valued per document, so "All" with
+		// 2+ selections is guaranteed empty. The inspector hides the option
+		// rather than serving an obvious footgun.
+		render(
+			<FilterCheckboxEdit attributes={ { filterType: 'post_type' } } setAttributes={ jest.fn() } />
+		);
+		expect( screen.queryByText( 'Logic' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Logic toggle for author filters', () => {
+		render(
+			<FilterCheckboxEdit attributes={ { filterType: 'author' } } setAttributes={ jest.fn() } />
+		);
+		expect( screen.queryByText( 'Logic' ) ).not.toBeInTheDocument();
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -291,6 +291,82 @@ describe( 'urlParamsToState', () => {
 	} );
 } );
 
+describe( 'filterLogic round-trip (RSM-2815)', () => {
+	const taxonomyConfig = { filterType: 'taxonomy', taxonomy: 'category' };
+
+	it( 'stateToUrlParams emits query_type_<key>=and when the filter has selections and logic is `and`', () => {
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			activeFilters: { category: [ 'news', 'sports' ] },
+			filterLogic: { category: 'and' },
+		} );
+		expect( params.get( 'query_type_category' ) ).toBe( 'and' );
+	} );
+
+	it( 'stateToUrlParams omits query_type_<key> when logic is the default `or`', () => {
+		// `or` is the default; serializing it would only bloat URLs and
+		// invite encoded-URL diff churn in tests of unrelated features.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			activeFilters: { category: [ 'news', 'sports' ] },
+			filterLogic: { category: 'or' },
+		} );
+		expect( params.has( 'query_type_category' ) ).toBe( false );
+	} );
+
+	it( 'stateToUrlParams omits query_type_<key> when the filter has no active selections', () => {
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			activeFilters: {},
+			filterLogic: { category: 'and' },
+		} );
+		expect( params.has( 'query_type_category' ) ).toBe( false );
+	} );
+
+	it( 'urlParamsToState parses ?category[]=…&query_type_category=and into both slices', () => {
+		const params = new URLSearchParams();
+		params.append( 'category[]', 'news' );
+		params.append( 'query_type_category', 'and' );
+		const state = urlParamsToState( params, { category: taxonomyConfig } );
+		expect( state.activeFilters ).toEqual( { category: [ 'news' ] } );
+		expect( state.filterLogic ).toEqual( { category: 'and' } );
+	} );
+
+	it( 'urlParamsToState drops query_type_<key> when <key> is not registered', () => {
+		const params = new URLSearchParams();
+		params.append( 'category[]', 'news' );
+		params.append( 'query_type_mystery', 'and' );
+		const state = urlParamsToState( params, { category: taxonomyConfig } );
+		expect( state.filterLogic ).toEqual( {} );
+	} );
+
+	it( 'urlParamsToState drops query_type_<key> with a non-`and` value (only `and` is honoured)', () => {
+		const params = new URLSearchParams();
+		params.append( 'category[]', 'news' );
+		params.append( 'query_type_category', 'banana' );
+		const state = urlParamsToState( params, { category: taxonomyConfig } );
+		expect( state.filterLogic ).toEqual( {} );
+	} );
+
+	it( 'urlParamsToState drops query_type_<key> when its filter has no surviving active selections', () => {
+		// Without this gate a `?query_type_category=and` without `?category[]=…`
+		// would leak through and re-emit on the next URL push.
+		const params = new URLSearchParams();
+		params.append( 'query_type_category', 'and' );
+		const state = urlParamsToState( params, { category: taxonomyConfig } );
+		expect( state.filterLogic ).toEqual( {} );
+	} );
+
+	it( 'urlParamsToState ignores query_type_<key> targeting a reserved param', () => {
+		const params = new URLSearchParams( 'query_type_orderby=and' );
+		const state = urlParamsToState( params );
+		expect( state.filterLogic ).toEqual( {} );
+	} );
+} );
+
 describe( 'urlParamsToState: priceRange', () => {
 	// All priceRange-parsing tests opt into `isWooCommerceActive=true` to
 	// exercise the parsing logic; the WC-off behaviour (price params are

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -304,6 +304,23 @@ describe( 'filterLogic round-trip (RSM-2815)', () => {
 		expect( params.get( 'query_type_category' ) ).toBe( 'and' );
 	} );
 
+	it( 'stateToUrlParams emits query_type_<key>=and when filterConfigs has queryType `and` (block-author config)', () => {
+		// filterLogic is only seeded from the URL; the block-author choice
+		// lives in filterConfigs. Without this source the URL would never
+		// emit query_type_* for a block configured with Logic = All, so a
+		// shared deep link couldn't carry the AND semantics across pages.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			activeFilters: { category: [ 'news', 'sports' ] },
+			filterLogic: {},
+			filterConfigs: {
+				category: { filterType: 'taxonomy', taxonomy: 'category', queryType: 'and' },
+			},
+		} );
+		expect( params.get( 'query_type_category' ) ).toBe( 'and' );
+	} );
+
 	it( 'stateToUrlParams omits query_type_<key> when logic is the default `or`', () => {
 		// `or` is the default; serializing it would only bloat URLs and
 		// invite encoded-URL diff churn in tests of unrelated features.
@@ -340,6 +357,19 @@ describe( 'filterLogic round-trip (RSM-2815)', () => {
 		params.append( 'category[]', 'news' );
 		params.append( 'query_type_mystery', 'and' );
 		const state = urlParamsToState( params, { category: taxonomyConfig } );
+		expect( state.filterLogic ).toEqual( {} );
+	} );
+
+	it( 'urlParamsToState drops query_type_<key> when <key> targets a non-taxonomy filter', () => {
+		// post_type / author have one value per document, so AND combination
+		// is semantically meaningless. Without this gate a stray
+		// `query_type_post_types=and` would linger in filterLogic and re-emit
+		// on every URL push.
+		const params = new URLSearchParams();
+		params.append( 'post_types[]', 'post' );
+		params.append( 'query_type_post_types', 'and' );
+		const state = urlParamsToState( params, { post_types: { filterType: 'post_type' } } );
+		expect( state.activeFilters ).toEqual( { post_types: [ 'post' ] } );
 		expect( state.filterLogic ).toEqual( {} );
 	} );
 

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -173,6 +173,9 @@ class Filter_Checkbox_Test extends TestCase {
 				'showCount'       => true,
 				'maxItems'        => 10,
 				'bucketSortOrder' => 'count',
+				// AND/OR combination of multi-value selections. Default OR
+				// matches Search 3.0's broaden-on-click UX.
+				'queryType'       => 'or',
 				// Taxonomy buckets carry their label inline (slug_slash_name), so
 				// no value→label seeding is needed.
 				'valueLabels'     => array(),
@@ -309,5 +312,65 @@ class Filter_Checkbox_Test extends TestCase {
 			'post_types'
 		);
 		$this->assertSame( 'count', $config['bucketSortOrder'] );
+	}
+
+	/**
+	 * The queryType attribute accepts only the literal 'and' AND only for taxonomy filters.
+	 * Tampered saved data with `queryType: 'and'` on a post_type or author
+	 * block would otherwise produce an ES query that always returns zero
+	 * results (each doc has one post_type / author).
+	 */
+	public function test_normalize_query_type() {
+		// Default: anything missing / garbage / explicit 'or' collapses to 'or'.
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( null, 'taxonomy' ) );
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( '', 'taxonomy' ) );
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( 'banana', 'taxonomy' ) );
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( 'or', 'taxonomy' ) );
+
+		// 'and' is honoured only for taxonomy filters.
+		$this->assertSame( 'and', Filter_Checkbox::normalize_query_type( 'and', 'taxonomy' ) );
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( 'and', 'post_type' ) );
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( 'and', 'author' ) );
+		$this->assertSame( 'or', Filter_Checkbox::normalize_query_type( 'and', '' ) );
+	}
+
+	/**
+	 * The queryType attribute round-trips through build_config so the JS-side ES query
+	 * builder can read it off the filterConfig entry without re-querying
+	 * the block attributes.
+	 */
+	public function test_build_config_round_trips_query_type_for_taxonomy() {
+		$config = Filter_Checkbox::build_config(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'category',
+				'queryType'  => 'and',
+			),
+			'category'
+		);
+		$this->assertSame( 'and', $config['queryType'] );
+	}
+
+	/**
+	 * Defensive gate: build_config must not echo `queryType: 'and'` back for
+	 * post_type / author saved data. Hiding the inspector control on those
+	 * variations is the primary defense, but tampered serialized markup or
+	 * legacy saves shouldn't be able to slip past it.
+	 */
+	public function test_build_config_drops_query_type_and_for_non_taxonomy_filters() {
+		foreach ( array( 'post_type', 'author' ) as $filter_type ) {
+			$config = Filter_Checkbox::build_config(
+				array(
+					'filterType' => $filter_type,
+					'queryType'  => 'and',
+				),
+				'post_type' === $filter_type ? 'post_types' : 'authors'
+			);
+			$this->assertSame(
+				'or',
+				$config['queryType'],
+				"queryType=and must collapse to 'or' for {$filter_type} filters."
+			);
+		}
 	}
 }


### PR DESCRIPTION
Fixes [RSM-2815](https://linear.app/a8c/issue/RSM-2815/search-30-filter-checkbox-anyall-logic-toggle)

## Why

Today a Search 3.0 `jetpack-search/filter-checkbox` block always combines a visitor's multi-value selections with OR — picking two categories returns posts in *either* category. That's the right default, but it makes the common "show posts that match **all** these tags" case impossible without dropping in a custom block.

This PR exposes a per-block **Logic** toggle in the inspector with two options:

- **Any** (default) — current behaviour: union the matches.
- **All** — narrow to posts that carry *every* selected term.

Mirrors WooCommerce's `woocommerce/product-filter-attribute` design (`queryType`, `Any`/`All` labels, `query_type_<slug>` URL param) so a Search 3.0 filter sat next to a native WC filter on a shop page agrees on conventions.

## Proposed changes

- New `queryType` block attribute (`'or' | 'and'`, default `'or'`), surfaced in the existing Settings panel as a `ToggleGroupControl` below "Sort order". The control is only visible when `filterType === 'taxonomy'` — post_type and author each have one value per document, so `All` with 2+ selections would always return zero results and authors shouldn't be able to step on that footgun.
- `Filter_Checkbox::normalize_query_type()` collapses `'and'` to `'or'` for non-taxonomy filters server-side too, so tampered saved data can't slip past the inspector gate.
- `store/api.js` → `buildFilterClause()` switches between the existing `{ bool: { should } }` wrapper (OR) and flat top-level `must` clauses (AND) based on the merged config.
- URL round-trip: `?category[]=a&category[]=b&query_type_category=and`. Read both server-side (PHP `parse_url_filter_logic`) for the SSR seed and client-side (`store/url-state.js`) for popstate. A new `filterLogic` state slice carries overrides across navigations; `setFilter` / `clearFilters` / popstate clean up orphan entries so `?query_type_*` can't outlive its selection.
- Tests: AND-mode `buildFilterClause` + `buildSearchUrl` encoding, full `filterLogic` URL round-trip, inspector visibility gate, PHP `normalize_query_type` taxonomy gate + `build_config` shape.

## Screenshots

Block editor inspector, with a Category filter-checkbox block selected:

| Before | After |
|---|---|
| ![before — no Logic toggle](https://github.com/user-attachments/assets/9dd790fd-9cd5-4a78-add2-7769c87c095b) | ![after — Logic Any/All toggle below Sort order](https://github.com/user-attachments/assets/366f84c6-9e37-4ad0-a5c6-8ca6d82967fd) |

## Related product discussion/links

* Linear: [RSM-2815](https://linear.app/a8c/issue/RSM-2815/search-30-filter-checkbox-anyall-logic-toggle)
* WooCommerce reference: `woocommerce/product-filter-attribute` (`queryType`, `query_type_<slug>` URL convention).

## Does this pull request change what data or activity we track or use?

No tracking changes. The new `query_type_<filterKey>` URL parameter rides on existing browser-history pushes that already encode `activeFilters` — same surface, same callers, no new telemetry.

## Testing instructions

1. `jp build packages/search && jp build plugins/search`
2. In a search page, insert `jetpack-search/filter-checkbox` (Category variation).
3. In the block inspector confirm the new **Logic** toggle group with **Any** / **All**, visible only on taxonomy variations (switch the picker to Post Type / Author — toggle disappears).
4. Set Logic = **All**, save, and load the front-end page.
5. Multi-select two categories with no overlapping posts → expect zero results. Confirm the URL contains `?category[]=a&category[]=b&query_type_category=and`.
6. Toggle to **Any** → expect the union; confirm `query_type_category=and` is dropped from the URL.
7. Clear all selections → confirm `query_type_category` is gone (no orphan).
8. Hard-refresh a deep link `?category[]=a&category[]=b&query_type_category=and` → both selections and AND semantics round-trip.
9. PHP unit tests: `composer phpunit -- --filter Filter_Checkbox_Test` (13 passing).
10. JS unit tests: `pnpm jest tests/js/search-blocks/api.test.js tests/js/search-blocks/url-state.test.js tests/js/search-blocks/filter-checkbox-edit.test.js` (157 passing).
