### PR TITLE
Search 3.0: consolidate block icons (RSM-2806)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4238,6 +4238,9 @@ importers:
       '@wordpress/element':
         specifier: 6.44.0
         version: 6.44.0
+      '@wordpress/hooks':
+        specifier: 4.44.0
+        version: 4.44.0
       '@wordpress/i18n':
         specifier: 6.17.0
         version: 6.17.0

--- a/projects/packages/search/changelog/RSM-2806-consolidate-search-block-icons
+++ b/projects/packages/search/changelog/RSM-2806-consolidate-search-block-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: consolidate icons across all Search blocks so they read as one branded family in the inserter, breadcrumb, and toolbar.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -56,6 +56,7 @@
 		"@wordpress/core-data": "7.44.0",
 		"@wordpress/data": "10.44.0",
 		"@wordpress/element": "6.44.0",
+		"@wordpress/hooks": "4.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/interactivity": "6.44.0",

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Active Filters",
 	"category": "jetpack-search",
-	"icon": "tag",
 	"description": "Pills showing the currently selected Jetpack Search filters.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Active Filters",
 	"category": "jetpack-search",
-	"description": "Pills showing the currently selected Jetpack Search filters.",
+	"description": "Pills showing the currently selected filters. Powered by Jetpack Search.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Clear Filters",
 	"category": "jetpack-search",
-	"icon": "trash",
 	"description": "A button that clears every active filter. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Checkbox Filter",
 	"category": "jetpack-search",
-	"description": "Checkbox filter for Jetpack Search. Use a variation (Category, Tag, Post Type, Author, Product Category, Product Tag, Product Brand, Custom Taxonomy) or configure manually.",
+	"description": "Checkbox filter. Use a variation (Category, Tag, Post Type, Author, Product Category, Product Tag, Product Brand, Custom Taxonomy) or configure manually. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Checkbox Filter",
 	"category": "jetpack-search",
-	"icon": "filter",
 	"description": "Checkbox filter for Jetpack Search. Use a variation (Category, Tag, Post Type, Author, Product Category, Product Tag, Product Brand, Custom Taxonomy) or configure manually.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Filter by Date",
 	"category": "jetpack-search",
-	"icon": "calendar-alt",
 	"description": "Date filter for Jetpack Search. Group results into yearly or monthly buckets so visitors can scope a search to a single time window.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Filter by Date",
 	"category": "jetpack-search",
-	"description": "Date filter for Jetpack Search. Group results into yearly or monthly buckets so visitors can scope a search to a single time window.",
+	"description": "Date filter. Group results into yearly or monthly buckets so visitors can scope a search to a single time window. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/filter-post-type/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-post-type/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Post Type Scope",
 	"category": "jetpack-search",
-	"description": "Author-configured filter that constrains Jetpack Search results to a fixed set of post types (or removes specific post types). Configured in the editor inspector; renders nothing on the front end.",
+	"description": "Author-configured filter that constrains results to a fixed set of post types (or removes specific post types). Configured in the editor inspector; renders nothing on the front end. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
 		"interactivity": true,

--- a/projects/packages/search/src/search-blocks/blocks/filter-post-type/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-post-type/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Post Type Scope",
 	"category": "jetpack-search",
-	"icon": "filter",
 	"description": "Author-configured filter that constrains Jetpack Search results to a fixed set of post types (or removes specific post types). Configured in the editor inspector; renders nothing on the front end.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Filter by Product Attribute",
 	"category": "jetpack-search",
-	"icon": "filter",
 	"description": "Let shoppers filter products by a WooCommerce attribute (color, size, …). Powered by Jetpack Search.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Filter by Price",
 	"category": "jetpack-search",
-	"icon": "money-alt",
 	"description": "Let shoppers filter products by price. Either two number inputs or a draggable range slider with paired inputs. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
@@ -32,7 +31,6 @@
 			"name": "filter",
 			"title": "Filter by Price",
 			"description": "Two number inputs, joined by an em-dash. Compact — best when a slider would take too much vertical space.",
-			"icon": "money-alt",
 			"isDefault": true,
 			"attributes": { "showSlider": false },
 			"scope": [ "inserter" ]
@@ -41,7 +39,6 @@
 			"name": "slider",
 			"title": "Filter by Price (Slider)",
 			"description": "Draggable range slider paired with min/max number inputs. Mirrors WooCommerce Blocks’ price slider.",
-			"icon": "money-alt",
 			"attributes": { "showSlider": true, "autoBounds": true },
 			"scope": [ "inserter" ]
 		}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Filter by Rating",
 	"category": "jetpack-search",
-	"icon": "star-filled",
 	"description": "Let shoppers filter products by star rating. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Filter by Stock Status",
 	"category": "jetpack-search",
-	"icon": "tag",
 	"description": "Let shoppers narrow product results to in-stock items. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Collapsible Filters",
 	"category": "jetpack-search",
-	"description": "Compact filter trigger that opens a popover containing filter checkboxes.",
+	"description": "Compact filter trigger that opens a popover containing filter checkboxes. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Collapsible Filters",
 	"category": "jetpack-search",
-	"icon": "filter",
 	"description": "Compact filter trigger that opens a popover containing filter checkboxes.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Product Filters",
 	"category": "jetpack-search",
-	"icon": "filter",
 	"description": "A composable container for WooCommerce-style product filters (status, rating, price, attributes). Powered by Jetpack Search.",
 	"keywords": [ "woocommerce", "product", "filter", "sidebar" ],
 	"supports": {

--- a/projects/packages/search/src/search-blocks/blocks/filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Filters",
 	"category": "jetpack-search",
-	"icon": "filter",
 	"description": "Vertical stack of Jetpack Search filter blocks. Pre-populated with the most common filters; rearrange, remove, or add more from the inserter.",
 	"keywords": [ "search", "filter", "filters" ],
 	"supports": {

--- a/projects/packages/search/src/search-blocks/blocks/filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Filters",
 	"category": "jetpack-search",
-	"description": "Vertical stack of Jetpack Search filter blocks. Pre-populated with the most common filters; rearrange, remove, or add more from the inserter.",
+	"description": "Vertical stack of filter blocks. Pre-populated with the most common filters; rearrange, remove, or add more from the inserter. Powered by Jetpack Search.",
 	"keywords": [ "search", "filter", "filters" ],
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Powered by Jetpack",
 	"category": "jetpack-search",
-	"icon": "wordpress",
 	"description": "Attribution link to jetpack.com. Free-plan sites always display this; paid sites can remove the block to hide it.",
 	"keywords": [ "search", "jetpack", "powered by", "colophon" ],
 	"supports": {

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Powered by Jetpack",
 	"category": "jetpack-search",
-	"description": "Attribution link to jetpack.com. Free-plan sites always display this; paid sites can remove the block to hide it.",
+	"description": "Renders the \"Powered by Jetpack Search\" attribution link to jetpack.com. Free-plan sites always display this; paid sites can remove the block to hide it.",
 	"keywords": [ "search", "jetpack", "powered by", "colophon" ],
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/powered-by/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Powered by Jetpack",
 	"category": "jetpack-search",
-	"description": "Renders the \"Powered by Jetpack Search\" attribution link to jetpack.com. Free-plan sites always display this; paid sites can remove the block to hide it.",
+	"description": "Renders the \"Search powered by Jetpack\" attribution link to jetpack.com. Free-plan sites always display this; paid sites can remove the block to hide it.",
 	"keywords": [ "search", "jetpack", "powered by", "colophon" ],
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/results-count/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Results Count",
 	"category": "jetpack-search",
-	"description": "Displays the Jetpack Search results count.",
+	"description": "Displays the results count. Powered by Jetpack Search.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/results-count/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Results Count",
 	"category": "jetpack-search",
-	"icon": "info-outline",
 	"description": "Displays the Jetpack Search results count.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/results-list/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/block.json
@@ -5,7 +5,6 @@
 	"version": "0.2.0",
 	"title": "Results List",
 	"category": "jetpack-search",
-	"icon": "list-view",
 	"description": "Renders Jetpack Search results, plus the empty-state and error messages for the same region.",
 	"attributes": {
 		"layout": {

--- a/projects/packages/search/src/search-blocks/blocks/results-list/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/block.json
@@ -5,7 +5,7 @@
 	"version": "0.2.0",
 	"title": "Results List",
 	"category": "jetpack-search",
-	"description": "Renders Jetpack Search results, plus the empty-state and error messages for the same region.",
+	"description": "Renders search results, plus the empty-state and error messages for the same region. Powered by Jetpack Search.",
 	"attributes": {
 		"layout": {
 			"type": "string",

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Load More",
 	"category": "jetpack-search",
-	"description": "Loads the next page of Jetpack Search results.",
+	"description": "Loads the next page of results. Powered by Jetpack Search.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Load More",
 	"category": "jetpack-search",
-	"icon": "plus-alt2",
 	"description": "Loads the next page of Jetpack Search results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Sort By",
 	"category": "jetpack-search",
-	"icon": "sort",
 	"description": "Controls the order of Jetpack Search results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Sort By",
 	"category": "jetpack-search",
-	"description": "Controls the order of Jetpack Search results.",
+	"description": "Controls the order of search results. Powered by Jetpack Search.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Search Input",
 	"category": "jetpack-search",
-	"description": "Text input that drives Jetpack Search results.",
+	"description": "Text input for the search query. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Search Input",
 	"category": "jetpack-search",
-	"icon": "search",
 	"description": "Text input that drives Jetpack Search results.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/search-results/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Search Results",
 	"category": "jetpack-search",
-	"description": "Container for the Jetpack Search results region — bundles the results list, count, sort, load-more, and error/empty-state messaging. Pre-populated with a sensible default; rearrange, remove, or add more from the inserter.",
+	"description": "Container for the search results region — bundles the results list, count, sort, load-more, and error/empty-state messaging. Pre-populated with a sensible default; rearrange, remove, or add more from the inserter. Powered by Jetpack Search.",
 	"keywords": [ "search", "results", "feed" ],
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/search-results/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Search Results",
 	"category": "jetpack-search",
-	"icon": "list-view",
 	"description": "Container for the Jetpack Search results region — bundles the results list, count, sort, load-more, and error/empty-state messaging. Pre-populated with a sensible default; rearrange, remove, or add more from the inserter.",
 	"keywords": [ "search", "results", "feed" ],
 	"supports": {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -487,7 +487,6 @@ class Search_Blocks {
 				'name'        => 'product_cat',
 				'title'       => __( 'Filter by Product Category', 'jetpack-search-pkg' ),
 				'description' => __( 'Show product category checkboxes with live result counts.', 'jetpack-search-pkg' ),
-				'icon'        => 'category',
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => 'product_cat',
@@ -499,7 +498,6 @@ class Search_Blocks {
 				'name'        => 'product_tag',
 				'title'       => __( 'Filter by Product Tag', 'jetpack-search-pkg' ),
 				'description' => __( 'Show product tag checkboxes with live result counts.', 'jetpack-search-pkg' ),
-				'icon'        => 'tag',
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => 'product_tag',
@@ -512,7 +510,6 @@ class Search_Blocks {
 					'name'        => 'product_brand',
 					'title'       => __( 'Filter by Product Brand', 'jetpack-search-pkg' ),
 					'description' => __( 'Show product brand checkboxes with live result counts.', 'jetpack-search-pkg' ),
-					'icon'        => 'awards',
 					'attributes'  => array(
 						'filterType' => 'taxonomy',
 						'taxonomy'   => 'product_brand',

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -1,21 +1,18 @@
 /**
  * Single source of truth for Jetpack Search block icons.
  *
- * Each entry uses Gutenberg's documented `{ src, foreground, background }`
- * icon-object shape so the inserter, parent-block breadcrumb, and toolbar
- * render every Search block as a Jetpack-green pill. The shared tint is what
- * keeps the family visually distinct from Core / WooCommerce / other-plugin
- * blocks — distinct glyphs differentiate one Search block from another within
- * the family.
+ * Each block uses a distinct glyph from `@wordpress/icons`. The Jetpack
+ * brand mark lives on the inserter category header (see `setCategories`
+ * in `register-blocks.js`) — it carries the family identity for the whole
+ * Search group, so per-block icons can stay un-branded and the family
+ * still reads as one set.
  *
- * Glyphs come from `@wordpress/icons` (the modern replacement for dashicon
- * strings; Core has fully migrated and 12.2.0 is already a direct dep of this
- * package). Adding a new Search block: append one entry here, then reference
+ * Adding a new Search block: append one entry here, then reference
  * `BLOCK_ICONS[ name ]` from the editor's `registerBlockType()` call.
  *
- * `block.json` no longer carries an `icon` field for these blocks — the JS
- * registration's `icon` overrides the server-side metadata, and centralizing
- * here avoids drift between 19 sibling JSON files.
+ * `block.json` no longer carries an `icon` field for these blocks — the
+ * JS-side override is the single source of truth, so the 19 sibling JSON
+ * files can't drift from each other.
  */
 import {
 	archive,
@@ -39,42 +36,26 @@ import {
 	wordpress,
 } from '@wordpress/icons';
 
-/**
- * Jetpack brand green. Matches the default `logoColor` of `<JetpackLogo />`
- * (see `js-packages/components/components/jetpack-logo/index.tsx`) so the
- * inserter's "Search" category icon (rendered as the Jetpack logo) and each
- * block's per-icon pill share one brand swatch.
- */
-const BRAND_BACKGROUND = '#069e08';
-const BRAND_FOREGROUND = '#fff';
-
-const tinted = src => ( {
-	src,
-	background: BRAND_BACKGROUND,
-	foreground: BRAND_FOREGROUND,
-} );
-
 const BLOCK_ICONS = {
-	'jetpack-search/search-input': tinted( search ),
-	'jetpack-search/search-results': tinted( listView ),
-	'jetpack-search/results-list': tinted( grid ),
-	'jetpack-search/results-count': tinted( info ),
-	'jetpack-search/results-sort': tinted( chevronUpDown ),
-	'jetpack-search/results-load-more': tinted( plus ),
-	'jetpack-search/filter-checkbox': tinted( formatListBullets ),
-	'jetpack-search/filter-date': tinted( calendar ),
-	'jetpack-search/filter-post-type': tinted( customPostType ),
-	'jetpack-search/filter-wc-attribute': tinted( tag ),
-	'jetpack-search/filter-wc-price': tinted( currencyDollar ),
-	'jetpack-search/filter-wc-rating': tinted( starFilled ),
-	'jetpack-search/filter-wc-stock-status': tinted( box ),
-	'jetpack-search/filters': tinted( filter ),
-	'jetpack-search/filters-popover': tinted( funnel ),
-	'jetpack-search/filters-product': tinted( archive ),
-	'jetpack-search/active-filters': tinted( pin ),
-	'jetpack-search/clear-filters': tinted( reset ),
-	'jetpack-search/powered-by': tinted( wordpress ),
+	'jetpack-search/search-input': search,
+	'jetpack-search/search-results': listView,
+	'jetpack-search/results-list': grid,
+	'jetpack-search/results-count': info,
+	'jetpack-search/results-sort': chevronUpDown,
+	'jetpack-search/results-load-more': plus,
+	'jetpack-search/filter-checkbox': formatListBullets,
+	'jetpack-search/filter-date': calendar,
+	'jetpack-search/filter-post-type': customPostType,
+	'jetpack-search/filter-wc-attribute': tag,
+	'jetpack-search/filter-wc-price': currencyDollar,
+	'jetpack-search/filter-wc-rating': starFilled,
+	'jetpack-search/filter-wc-stock-status': box,
+	'jetpack-search/filters': filter,
+	'jetpack-search/filters-popover': funnel,
+	'jetpack-search/filters-product': archive,
+	'jetpack-search/active-filters': pin,
+	'jetpack-search/clear-filters': reset,
+	'jetpack-search/powered-by': wordpress,
 };
 
 export default BLOCK_ICONS;
-export { BRAND_BACKGROUND, BRAND_FOREGROUND };

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -1,14 +1,19 @@
 /**
  * Single source of truth for Jetpack Search block icons.
  *
- * Each block uses a distinct glyph from `@wordpress/icons`. The Jetpack
- * brand mark lives on the inserter category header (see `setCategories`
- * in `register-blocks.js`) — it carries the family identity for the whole
- * Search group, so per-block icons can stay un-branded and the family
- * still reads as one set.
+ * Each block uses a distinct glyph from `@wordpress/icons`, painted in the
+ * Jetpack brand green via the `foreground` field of Gutenberg's documented
+ * icon-object shape. The `background` field is intentionally omitted — the
+ * inserter / breadcrumb / toolbar all render the icon container without a
+ * filled pill, so the glyph reads as a coloured mark rather than a heavy
+ * badge. The Jetpack-logo brand mark on the inserter's "Search" category
+ * heading (see `setCategories` in `register-blocks.js`) carries the family
+ * identity for the whole group.
  *
- * Adding a new Search block: append one entry here, then reference
- * `BLOCK_ICONS[ name ]` from the editor's `registerBlockType()` call.
+ * Glyphs come from `@wordpress/icons` (Core's modern icon library, already
+ * a direct dep at 12.2.0). Adding a new Search block: append one entry
+ * here, then reference `BLOCK_ICONS[ name ]` from the editor's
+ * `registerBlockType()` call.
  *
  * `block.json` no longer carries an `icon` field for these blocks — the
  * JS-side override is the single source of truth, so the 19 sibling JSON
@@ -16,7 +21,6 @@
  */
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import {
-	archive,
 	box,
 	calendar,
 	chevronUpDown,
@@ -33,33 +37,41 @@ import {
 	reset,
 	search,
 	starFilled,
+	store,
 	tag,
 } from '@wordpress/icons';
 
+const BRAND_FOREGROUND = '#069e08';
+
+const greened = src => ( { src, foreground: BRAND_FOREGROUND } );
+
 const BLOCK_ICONS = {
-	'jetpack-search/search-input': search,
-	'jetpack-search/search-results': listView,
-	'jetpack-search/results-list': grid,
-	'jetpack-search/results-count': info,
-	'jetpack-search/results-sort': chevronUpDown,
-	'jetpack-search/results-load-more': plus,
-	'jetpack-search/filter-checkbox': formatListBullets,
-	'jetpack-search/filter-date': calendar,
-	'jetpack-search/filter-post-type': customPostType,
-	'jetpack-search/filter-wc-attribute': tag,
-	'jetpack-search/filter-wc-price': currencyDollar,
-	'jetpack-search/filter-wc-rating': starFilled,
-	'jetpack-search/filter-wc-stock-status': box,
-	'jetpack-search/filters': filter,
-	'jetpack-search/filters-popover': funnel,
-	'jetpack-search/filters-product': archive,
-	'jetpack-search/active-filters': pin,
-	'jetpack-search/clear-filters': reset,
-	// The "Powered by Jetpack Search" block specifically advertises Jetpack
-	// ownership in the post footer — the Jetpack logo is the right glyph here,
-	// even though every other Search block uses a neutral @wordpress/icons
-	// glyph. WordPress's `wordpress` (the W mark) would mis-read as Core.
+	'jetpack-search/search-input': greened( search ),
+	'jetpack-search/search-results': greened( listView ),
+	'jetpack-search/results-list': greened( grid ),
+	'jetpack-search/results-count': greened( info ),
+	'jetpack-search/results-sort': greened( chevronUpDown ),
+	'jetpack-search/results-load-more': greened( plus ),
+	'jetpack-search/filter-checkbox': greened( formatListBullets ),
+	'jetpack-search/filter-date': greened( calendar ),
+	'jetpack-search/filter-post-type': greened( customPostType ),
+	'jetpack-search/filter-wc-attribute': greened( tag ),
+	'jetpack-search/filter-wc-price': greened( currencyDollar ),
+	'jetpack-search/filter-wc-rating': greened( starFilled ),
+	'jetpack-search/filter-wc-stock-status': greened( box ),
+	'jetpack-search/filters': greened( filter ),
+	'jetpack-search/filters-popover': greened( funnel ),
+	'jetpack-search/filters-product': greened( store ),
+	'jetpack-search/active-filters': greened( pin ),
+	'jetpack-search/clear-filters': greened( reset ),
+	// The "Powered by Jetpack Search" block advertises Jetpack ownership in
+	// the post footer — the Jetpack logo is the right glyph here, even
+	// though every other Search block uses a neutral @wordpress/icons glyph.
+	// The logo SVG has hardcoded brand colours, so the `foreground` override
+	// is a no-op (and intentionally omitted) — included verbatim so the
+	// glyph keeps its native green / white treatment.
 	'jetpack-search/powered-by': <JetpackLogo showText={ false } height={ 24 } width={ 24 } />,
 };
 
 export default BLOCK_ICONS;
+export { BRAND_FOREGROUND };

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -14,6 +14,7 @@
  * JS-side override is the single source of truth, so the 19 sibling JSON
  * files can't drift from each other.
  */
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import {
 	archive,
 	box,
@@ -33,7 +34,6 @@ import {
 	search,
 	starFilled,
 	tag,
-	wordpress,
 } from '@wordpress/icons';
 
 const BLOCK_ICONS = {
@@ -55,7 +55,11 @@ const BLOCK_ICONS = {
 	'jetpack-search/filters-product': archive,
 	'jetpack-search/active-filters': pin,
 	'jetpack-search/clear-filters': reset,
-	'jetpack-search/powered-by': wordpress,
+	// The "Powered by Jetpack Search" block specifically advertises Jetpack
+	// ownership in the post footer — the Jetpack logo is the right glyph here,
+	// even though every other Search block uses a neutral @wordpress/icons
+	// glyph. WordPress's `wordpress` (the W mark) would mis-read as Core.
+	'jetpack-search/powered-by': <JetpackLogo showText={ false } height={ 24 } width={ 24 } />,
 };
 
 export default BLOCK_ICONS;

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -1,0 +1,80 @@
+/**
+ * Single source of truth for Jetpack Search block icons.
+ *
+ * Each entry uses Gutenberg's documented `{ src, foreground, background }`
+ * icon-object shape so the inserter, parent-block breadcrumb, and toolbar
+ * render every Search block as a Jetpack-green pill. The shared tint is what
+ * keeps the family visually distinct from Core / WooCommerce / other-plugin
+ * blocks — distinct glyphs differentiate one Search block from another within
+ * the family.
+ *
+ * Glyphs come from `@wordpress/icons` (the modern replacement for dashicon
+ * strings; Core has fully migrated and 12.2.0 is already a direct dep of this
+ * package). Adding a new Search block: append one entry here, then reference
+ * `BLOCK_ICONS[ name ]` from the editor's `registerBlockType()` call.
+ *
+ * `block.json` no longer carries an `icon` field for these blocks — the JS
+ * registration's `icon` overrides the server-side metadata, and centralizing
+ * here avoids drift between 19 sibling JSON files.
+ */
+import {
+	archive,
+	box,
+	calendar,
+	chevronUpDown,
+	currencyDollar,
+	customPostType,
+	filter,
+	formatListBullets,
+	funnel,
+	grid,
+	info,
+	listView,
+	pin,
+	plus,
+	reset,
+	search,
+	starFilled,
+	tag,
+	wordpress,
+} from '@wordpress/icons';
+
+/**
+ * Jetpack brand green. Matches the default `logoColor` of `<JetpackLogo />`
+ * (see `js-packages/components/components/jetpack-logo/index.tsx`) so the
+ * inserter's "Search" category icon (rendered as the Jetpack logo) and each
+ * block's per-icon pill share one brand swatch.
+ */
+const BRAND_BACKGROUND = '#069e08';
+const BRAND_FOREGROUND = '#fff';
+
+const tinted = src => ( {
+	src,
+	background: BRAND_BACKGROUND,
+	foreground: BRAND_FOREGROUND,
+} );
+
+const BLOCK_ICONS = {
+	'jetpack-search/search-input': tinted( search ),
+	'jetpack-search/search-results': tinted( listView ),
+	'jetpack-search/results-list': tinted( grid ),
+	'jetpack-search/results-count': tinted( info ),
+	'jetpack-search/results-sort': tinted( chevronUpDown ),
+	'jetpack-search/results-load-more': tinted( plus ),
+	'jetpack-search/filter-checkbox': tinted( formatListBullets ),
+	'jetpack-search/filter-date': tinted( calendar ),
+	'jetpack-search/filter-post-type': tinted( customPostType ),
+	'jetpack-search/filter-wc-attribute': tinted( tag ),
+	'jetpack-search/filter-wc-price': tinted( currencyDollar ),
+	'jetpack-search/filter-wc-rating': tinted( starFilled ),
+	'jetpack-search/filter-wc-stock-status': tinted( box ),
+	'jetpack-search/filters': tinted( filter ),
+	'jetpack-search/filters-popover': tinted( funnel ),
+	'jetpack-search/filters-product': tinted( archive ),
+	'jetpack-search/active-filters': tinted( pin ),
+	'jetpack-search/clear-filters': tinted( reset ),
+	'jetpack-search/powered-by': tinted( wordpress ),
+};
+
+export default BLOCK_ICONS;
+export { BRAND_BACKGROUND, BRAND_FOREGROUND };

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -23,6 +23,8 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import {
 	box,
 	calendar,
+	cart,
+	category,
 	chevronUpDown,
 	currencyDollar,
 	customPostType,
@@ -34,11 +36,17 @@ import {
 	listView,
 	pin,
 	plus,
+	postAuthor,
+	postList,
+	postTerms,
+	published,
 	reset,
 	search,
 	starFilled,
 	store,
+	swatch,
 	tag,
+	tool,
 } from '@wordpress/icons';
 
 const BRAND_FOREGROUND = '#069e08';
@@ -73,5 +81,34 @@ const BLOCK_ICONS = {
 	'jetpack-search/powered-by': <JetpackLogo showText={ false } height={ 24 } width={ 24 } />,
 };
 
+/**
+ * Per-variation icons for the `jetpack-search/filter-checkbox` block.
+ *
+ * The variations (Filter by Category / Tag / Post Type / Author / Product
+ * Category / Product Tag / Product Brand / Custom Taxonomy) are registered
+ * in PHP via `Search_Blocks::inject_filter_checkbox_variations()`, so they
+ * arrive at the editor preloaded onto the block type's metadata. Each one
+ * needs its own glyph in the inserter card — without it, every variation
+ * would inherit the parent block's `formatListBullets` icon and the
+ * resulting six-or-seven identical cards would all read the same to a
+ * merchant scanning the inserter.
+ *
+ * Applied via a `blocks.registerBlockType` filter in `register-blocks.js`
+ * (the only practical way to brand variation icons when the variations
+ * themselves are PHP-registered). Glyphs are picked from `@wordpress/icons`
+ * and intentionally avoid every name already used in `BLOCK_ICONS` so the
+ * full 19 + 8 set has no duplicates.
+ */
+const FILTER_CHECKBOX_VARIATION_ICONS = {
+	category: greened( category ),
+	post_tag: greened( postTerms ),
+	post_type: greened( postList ),
+	author: greened( postAuthor ),
+	product_cat: greened( cart ),
+	product_tag: greened( published ),
+	product_brand: greened( swatch ),
+	custom_taxonomy: greened( tool ),
+};
+
 export default BLOCK_ICONS;
-export { BRAND_FOREGROUND };
+export { BRAND_FOREGROUND, FILTER_CHECKBOX_VARIATION_ICONS };

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -37,6 +37,7 @@ import ResultsLoadMoreEdit from '../blocks/results-load-more/edit';
 import ResultsSortEdit from '../blocks/results-sort/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
 import SearchResultsEdit, { save as searchResultsSave } from '../blocks/search-results/edit';
+import BLOCK_ICONS from './icons';
 
 // Default save for blocks that own no editor-side state — render.php is the
 // source of truth on the front end, so save returns null. Container blocks
@@ -109,5 +110,8 @@ BLOCKS.forEach( ( [ name, edit, blockSave ] ) => {
 	if ( ! isWooCommerceActive && wcOnlyBlocks.has( name ) ) {
 		return;
 	}
-	registerBlockType( name, { edit, save: blockSave ?? save } );
+	// `icon` here overrides whatever server-side metadata block.json carries,
+	// so the centralized `{ src, foreground, background }` pill renders in
+	// the inserter, breadcrumb, and toolbar instead of the dashicon fallback.
+	registerBlockType( name, { edit, save: blockSave ?? save, icon: BLOCK_ICONS[ name ] } );
 } );

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -111,6 +111,19 @@ BLOCKS.forEach( ( [ name, edit, blockSave ] ) => {
 	if ( ! isWooCommerceActive && wcOnlyBlocks.has( name ) ) {
 		return;
 	}
+	// Dev-only safety net: since `block.json` no longer carries an `icon`
+	// field, a future contributor who appends to `BLOCKS` but forgets to
+	// add the matching entry in `editor/icons.js` would silently ship a
+	// generic gray-grid placeholder. Warning at registration time turns
+	// that into a noisy console message during local dev / CI builds; the
+	// guard is stripped in production bundles where `NODE_ENV` is set.
+	// eslint-disable-next-line no-undef -- webpack DefinePlugin substitutes process.env.NODE_ENV at build time.
+	if ( process.env.NODE_ENV !== 'production' && ! BLOCK_ICONS[ name ] ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`Jetpack Search: no icon registered for block "${ name }" — add an entry in editor/icons.js`
+		);
+	}
 	// `icon` here overrides whatever server-side metadata block.json carries
 	// — the centralized per-block glyph (`BLOCK_ICONS[ name ]`) renders in
 	// the inserter, breadcrumb, and toolbar instead of the dashicon fallback.

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -70,11 +70,12 @@ const BLOCKS = [
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /
 // Grow headings in the inserter: the Jetpack logo next to a single-word
-// label (the logo carries the branding, so the label drops the "Jetpack"
-// prefix). The category itself is registered server-side via the
-// `block_categories_all` filter (see Search_Blocks::register_block_category);
-// core strips SVG `icon` values at that PHP boundary, so the icon has to be
-// applied client-side with setCategories().
+// label (the logo carries the branding for the whole family, so per-block
+// icons can stay un-branded). The category itself is registered server-
+// side via the `block_categories_all` filter (see
+// Search_Blocks::register_block_category); core strips SVG `icon` values
+// at that PHP boundary, so the icon has to be applied client-side via
+// setCategories().
 setCategories(
 	getCategories().map( category =>
 		category.slug === 'jetpack-search'
@@ -110,8 +111,8 @@ BLOCKS.forEach( ( [ name, edit, blockSave ] ) => {
 	if ( ! isWooCommerceActive && wcOnlyBlocks.has( name ) ) {
 		return;
 	}
-	// `icon` here overrides whatever server-side metadata block.json carries,
-	// so the centralized `{ src, foreground, background }` pill renders in
+	// `icon` here overrides whatever server-side metadata block.json carries
+	// — the centralized per-block glyph (`BLOCK_ICONS[ name ]`) renders in
 	// the inserter, breadcrumb, and toolbar instead of the dashicon fallback.
 	registerBlockType( name, { edit, save: blockSave ?? save, icon: BLOCK_ICONS[ name ] } );
 } );

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -17,6 +17,7 @@
  */
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { getCategories, registerBlockType, setCategories } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import ActiveFiltersEdit from '../blocks/active-filters/edit';
 import ClearFiltersEdit from '../blocks/clear-filters/edit';
@@ -37,7 +38,7 @@ import ResultsLoadMoreEdit from '../blocks/results-load-more/edit';
 import ResultsSortEdit from '../blocks/results-sort/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
 import SearchResultsEdit, { save as searchResultsSave } from '../blocks/search-results/edit';
-import BLOCK_ICONS from './icons';
+import BLOCK_ICONS, { FILTER_CHECKBOX_VARIATION_ICONS } from './icons';
 
 // Default save for blocks that own no editor-side state — render.php is the
 // source of truth on the front end, so save returns null. Container blocks
@@ -105,6 +106,35 @@ const config = ( typeof window !== 'undefined' && window.JetpackSearchBlocksConf
 const isWooCommerceActive = config.isWooCommerceActive === true;
 const wcOnlyBlocks = new Set(
 	Array.isArray( config.woocommerceOnlyBlocks ) ? config.woocommerceOnlyBlocks : []
+);
+
+// `filter-checkbox`'s variations are PHP-registered (see
+// `Search_Blocks::inject_filter_checkbox_variations()`), so by the time
+// `registerBlockType` runs client-side, the editor's preloaded metadata
+// already carries them — but with no `icon` field. Hooking
+// `blocks.registerBlockType` is the documented place to mutate block
+// settings before they land in the registry; we walk the variations
+// array and stamp the matching branded glyph from
+// `FILTER_CHECKBOX_VARIATION_ICONS`. Variations without a mapped icon
+// (e.g. a forward-compat one added later) fall through and inherit the
+// parent block's `formatListBullets` glyph — the same fallback Gutenberg
+// applies when no variation icon is provided.
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack-search/filter-checkbox-variation-icons',
+	( settings, name ) => {
+		if ( name !== 'jetpack-search/filter-checkbox' || ! Array.isArray( settings.variations ) ) {
+			return settings;
+		}
+		return {
+			...settings,
+			variations: settings.variations.map( variation =>
+				FILTER_CHECKBOX_VARIATION_ICONS[ variation.name ]
+					? { ...variation, icon: FILTER_CHECKBOX_VARIATION_ICONS[ variation.name ] }
+					: variation
+			),
+		};
+	}
 );
 
 BLOCKS.forEach( ( [ name, edit, blockSave ] ) => {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -786,7 +786,6 @@ class Search_Blocks_Test extends TestCase {
 			$variations_by_name['product_cat']['attributes']
 		);
 		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_cat']['isActive'] );
-		$this->assertSame( 'category', $variations_by_name['product_cat']['icon'] );
 
 		$this->assertSame(
 			array(
@@ -797,7 +796,6 @@ class Search_Blocks_Test extends TestCase {
 			$variations_by_name['product_tag']['attributes']
 		);
 		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_tag']['isActive'] );
-		$this->assertSame( 'tag', $variations_by_name['product_tag']['icon'] );
 
 		// product_brand is gated on `taxonomy_exists( 'product_brand' )`. In a
 		// bare phpunit run no taxonomies are registered, so it must NOT appear.
@@ -830,7 +828,6 @@ class Search_Blocks_Test extends TestCase {
 			$variations_by_name['product_brand']['attributes']
 		);
 		$this->assertSame( array( 'filterType', 'taxonomy' ), $variations_by_name['product_brand']['isActive'] );
-		$this->assertSame( 'awards', $variations_by_name['product_brand']['icon'] );
 
 		// Inserter cards render in the order the variations are returned, so
 		// product_brand must precede custom_taxonomy to keep the three


### PR DESCRIPTION
Fixes [RSM-2806](https://linear.app/a8c/issue/RSM-2806/search-30-consolidate-block-icons-so-search-blocks-are-visually).

## Why

When a merchant opens the block inserter today, every Search 3.0 block borrows a generic Dashicon (`filter`, `sort`, `search`, `tag`, …). Five different blocks share the same `filter` glyph, the rest blend into Core and other plugins, and nothing tells the merchant at a glance which entries belong to the Search family. After this PR, each Search block carries its own distinct glyph from `@wordpress/icons`, sourced from one centralized module — and the inserter's "Search" category heading already shows the Jetpack logo, so the family identity reads cleanly from the section header without painting every card a saturated colour.

## Proposed changes

* Centralize Search-block icons in a new `src/search-blocks/editor/icons.js` — one entry per block, each mapping a block name to a glyph from `@wordpress/icons` (Core's modern icon library, already a direct dep at 12.2.0).
* Give each block a distinct glyph — the five blocks that previously all rendered the same `filter` dashicon now carry `filter`, `funnel`, `archive`, `formatListBullets`, and `customPostType` so they no longer collapse into each other inside the family.
* Wire the centralized map into `editor/register-blocks.js` so the JS-side `registerBlockType` override is the single source of truth for icons.
* `block.json` no longer carries an `icon` field for any of the 19 Search blocks.
* `filter-wc-price` block-variation icons and the PHP-registered `filter-checkbox` variations (Category / Tag / Post Type / Author / Product Category / Product Tag / Product Brand / Custom Taxonomy) drop their dashicon entries and inherit the parent block's glyph instead — so variations stay visually inside the Search family.

## Screenshots

### Block inserter — Search category

| Before | After |
|---|---|
| ![before — inserter](https://github.com/user-attachments/assets/05388583-ab18-4cc9-b3a3-5b0f92ef725d) | ![after — inserter](https://github.com/user-attachments/assets/06ab52c5-aa5d-4ca1-bc98-1664c6ee9ffc) |

Before, the Search category visually dissolves into Map / Podcast Player / Sharing Buttons above it — three of the four "Filter by …" cards share an identical funnel glyph. After, each Search block has its own glyph and the "SEARCH" section heading still carries the Jetpack-logo brand mark for the family.

### `filters-product` parent breadcrumb + toolbar

| Before | After |
|---|---|
| ![before — breadcrumb](https://github.com/user-attachments/assets/4b626877-7657-46ac-b019-72e8cf4aaf0d) | ![after — breadcrumb](https://github.com/user-attachments/assets/f6e8393b-6f67-487b-bd5d-2ce41882a469) |

The block toolbar at the top of the canvas, the right-rail inspector header, and the bottom breadcrumb (`Page › Product Filters › Filter by Rating`) all pick up the per-block glyph from the shared module — `archive` for the `filters-product` parent and `starFilled` for `filter-wc-rating`, instead of two indistinguishable funnels.

## Related product discussion/links

* [RSM-2806 on Linear](https://linear.app/a8c/issue/RSM-2806/search-30-consolidate-block-icons-so-search-blocks-are-visually)

## Does this pull request change what data or activity we track or use?

No. Editor-only metadata change — no client-collected events, no new request paths.

## Testing instructions

1. Pull this branch and run the full Jetpack Search build matrix (`pnpm jetpack build packages/my-jetpack && pnpm jetpack build plugins/jetpack && pnpm jetpack build packages/search && pnpm jetpack build plugins/search`).
2. Open a fresh page editor (Pages → Add New) in a docker / Jurassic-Ninja site with both Jetpack Search and WooCommerce active.
3. Click the `+` block inserter and scroll to the **Search** category — confirm the section heading shows the Jetpack logo + "Search", and that each block beneath it (Search Input, Results List, Checkbox Filter, the five `Filter by …` variations, Filter by Product Category / Tag / Brand, Filters / Collapsible Filters / Product Filters, Active Filters, Clear Filters, Results Count, Sort By, Load More, Powered by Jetpack Search) carries its own glyph, clearly distinct from its neighbours.
4. Insert a **Product Filters** block (`jetpack-search/filters-product`) and select one of its child filter blocks. Confirm:
   * The block toolbar at the top of the canvas shows distinct glyphs for the selected child and for the parent (`Product Filters`).
   * The breadcrumb at the bottom of the editor (`Page › Product Filters › Filter by …`) renders each block with its glyph.
   * The right-rail Block inspector header shows the block's glyph next to the block title.
5. Deactivate WooCommerce and reload. The five WC-only blocks (`filter-wc-*`, `filters-product`) should disappear from the inserter — and the remaining Search blocks should keep their consolidated glyphs.
6. (Optional) Open one of the Search blocks on the front end. The icon change is editor-only — there should be no visible difference on the front end.
