### PR TITLE
Search 3.0: don't show "Matches content" when no query was typed (RSM-2817)

### DIFF
--- a/projects/packages/search/changelog/RSM-2817-match-hint-requires-query
+++ b/projects/packages/search/changelog/RSM-2817-match-hint-requires-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: stop showing the "Matches content" badge on result cards when the visitor has only applied filters (category, tag, price, etc.) without typing a search query.

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -639,7 +639,9 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken !== searchToken ) {
 					return;
 				}
-				state.results = ( data.results ?? [] ).map( r => normalizeResult( r, state.locale ) );
+				state.results = ( data.results ?? [] ).map( r =>
+					normalizeResult( r, state.locale, state.searchQuery )
+				);
 				state.totalResults = data.total ?? 0;
 				state.pageHandle = data.page_handle ?? null;
 				state.aggregations = data.aggregations ?? {};
@@ -705,7 +707,9 @@ const { state, actions } = store( NAMESPACE, {
 				}
 				state.results = [
 					...state.results,
-					...( data.results ?? [] ).map( r => normalizeResult( r, state.locale ) ),
+					...( data.results ?? [] ).map( r =>
+						normalizeResult( r, state.locale, state.searchQuery )
+					),
 				];
 				state.pageHandle = data.page_handle ?? null;
 			} catch {

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -374,11 +374,17 @@ export function deriveMatchHint( highlight, titlePieces ) {
  * Normalize a v1.3 Jetpack Search result into the flat shape expected by the
  * Interactivity API templates.
  *
- * @param {object} raw      - Raw result from the API.
- * @param {string} [locale] - BCP47 locale for date formatting.
+ * @param {object} raw           - Raw result from the API.
+ * @param {string} [locale]      - BCP47 locale for date formatting.
+ * @param {string} [searchQuery] - The query string the user actually typed. When
+ *                               empty (filter-only browse), the match-hint
+ *                               badge is suppressed — "Matches content" only
+ *                               makes sense in response to a typed query, and
+ *                               reads as misleading when every visible result
+ *                               was returned by a category/tag/price filter.
  * @return {object} Flat result.
  */
-export function normalizeResult( raw, locale = 'en-US' ) {
+export function normalizeResult( raw, locale = 'en-US', searchQuery = '' ) {
 	const fields = raw?.fields ?? {};
 	const highlight = raw?.highlight ?? {};
 	const permalink = toSafeUrl( fields[ 'permalink.url.raw' ] );
@@ -392,7 +398,8 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 	const plainTitle = stripTags( String( fields[ 'title.default' ] ?? fields.title ?? '' ) );
 	const titlePieces = tokenizeHighlight( highlight.title );
 	const contentPieces = tokenizeHighlight( highlight.content );
-	const matchHint = deriveMatchHint( highlight, titlePieces );
+	const hasQuery = typeof searchQuery === 'string' && searchQuery.trim() !== '';
+	const matchHint = hasQuery ? deriveMatchHint( highlight, titlePieces ) : '';
 	return {
 		id: String( raw?.result_id ?? fields.post_id ?? permalink ),
 		title: plainTitle,

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -463,6 +463,53 @@ describe( 'normalizeResult', () => {
 		} );
 	} );
 
+	describe( 'matchHint search-query gating', () => {
+		// "Matches content" / "Matches comments" are only meaningful in response
+		// to a typed query. When the user is browsing with filters only (no
+		// query), every visible result is trivially a "match" — the badge reads
+		// as misleading. The gate also covers whitespace-only queries, which
+		// the API treats as empty.
+		const RAW_WITH_CONTENT_HIGHLIGHT = {
+			fields: { post_id: 1, 'title.default': 'Hello' },
+			highlight: { content: [ 'body <mark>match</mark>' ] },
+		};
+
+		it( 'suppresses matchHint when no search query was provided', () => {
+			const r = normalizeResult( RAW_WITH_CONTENT_HIGHLIGHT );
+			expect( r.matchHint ).toBe( '' );
+			expect( r.matchHintIsComments ).toBe( false );
+		} );
+
+		it( 'suppresses matchHint when the search query is empty string', () => {
+			const r = normalizeResult( RAW_WITH_CONTENT_HIGHLIGHT, 'en-US', '' );
+			expect( r.matchHint ).toBe( '' );
+		} );
+
+		it( 'suppresses matchHint when the search query is whitespace only', () => {
+			const r = normalizeResult( RAW_WITH_CONTENT_HIGHLIGHT, 'en-US', '   \t  ' );
+			expect( r.matchHint ).toBe( '' );
+		} );
+
+		it( 'preserves matchHint when a real search query was typed', () => {
+			const r = normalizeResult( RAW_WITH_CONTENT_HIGHLIGHT, 'en-US', 'match' );
+			expect( r.matchHint ).toBe( 'content' );
+			expect( r.matchHintIsComments ).toBe( false );
+		} );
+
+		it( 'preserves comments matchHint when a real search query was typed', () => {
+			const r = normalizeResult(
+				{
+					fields: { post_id: 2, 'title.default': 'Hello' },
+					highlight: { comment: [ 'comment <mark>word</mark>' ] },
+				},
+				'en-US',
+				'word'
+			);
+			expect( r.matchHint ).toBe( 'comments' );
+			expect( r.matchHintIsComments ).toBe( true );
+		} );
+	} );
+
 	it( 'exposes a CSS-ready url() for the product image', () => {
 		const r = normalizeResult( {
 			fields: { 'image.url.raw': 'cdn.example.com/p.jpg' },
@@ -604,24 +651,32 @@ describe( 'normalizeResult', () => {
 	} );
 
 	it( 'exposes matchHint="content" when a non-title field is highlighted but the title is not', () => {
-		const r = normalizeResult( {
-			fields: { 'title.default': 'Hello' },
-			highlight: {
-				title: 'Hello',
-				content: [ 'some <mark>match</mark>' ],
+		const r = normalizeResult(
+			{
+				fields: { 'title.default': 'Hello' },
+				highlight: {
+					title: 'Hello',
+					content: [ 'some <mark>match</mark>' ],
+				},
 			},
-		} );
+			'en-US',
+			'match'
+		);
 		expect( r.matchHint ).toBe( 'content' );
 		expect( r.matchHintIsComments ).toBe( false );
 	} );
 
 	it( 'exposes matchHint="comments" when the comment field is highlighted but the title is not', () => {
-		const r = normalizeResult( {
-			fields: { 'title.default': 'Hello' },
-			highlight: {
-				comment: [ 'a <mark>match</mark> in comments' ],
+		const r = normalizeResult(
+			{
+				fields: { 'title.default': 'Hello' },
+				highlight: {
+					comment: [ 'a <mark>match</mark> in comments' ],
+				},
 			},
-		} );
+			'en-US',
+			'match'
+		);
 		expect( r.matchHint ).toBe( 'comments' );
 		expect( r.matchHintIsComments ).toBe( true );
 	} );


### PR DESCRIPTION
Fixes [RSM-2817](https://linear.app/a8c/issue/RSM-2817).

## Why

In the new Jetpack Search block UI, every product result card was labelled "Matches content" — even when the visitor hadn't typed anything and was just narrowing by category, tag, or price. That badge is supposed to mean "your query matched the body text, not the title", so showing it for a filter-only browse reads as misleading noise.

Now the badge only appears when there's an actual typed query to be informative about. Filter-only browsing renders clean product cards.

## Proposed changes

* `normalizeResult()` now takes the active `searchQuery` and gates the `matchHint` on it — empty / whitespace-only query forces `matchHint` to `''`, suppressing the badge.
* Both `actions.search` and `actions.loadMore` callsites in `store/index.js` thread `state.searchQuery` through.
* Unit tests cover empty / whitespace / typed-query cases, and the two existing `matchHint` cases now pass an explicit query (since "no query → no badge" is the new contract).

## Screenshots

Captured at `https://jp-raven.jurassic.tube/rsm-2817-fixture/?min_price=790&max_price=1000` (price filter active, no typed query) at 1440×900.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/8beef117-e83c-4fcc-96c4-d9bd3d2b758c) | ![after](https://github.com/user-attachments/assets/c2ebbb51-598e-46fc-866f-fcdc13c4e4c3) |

## Related product discussion/links

* Linear: [RSM-2817](https://linear.app/a8c/issue/RSM-2817)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a WooCommerce site, place the `jetpack-search/results-list` block with `layout: product` plus `jetpack-search/filter-wc-price` (and optionally `filter-checkbox` for category / tag) on a page.
2. Visit the page without a query but with a price range (e.g. `?min_price=790&max_price=1000`). Confirm result cards show no "Matches content" badge.
3. Repeat with a category or tag filter only — same expectation.
4. Type a query (e.g. `?q=bag`) that matches something other than the title. Confirm the "Matches content" / "Matches comments" badge does appear under the cards whose title was not the matching field.
5. Combine query + filter — the badge logic is unchanged when a query is present.
