### PR TITLE
Update woocommerce-analytics to 0.16.4

### DIFF
--- a/projects/plugins/jetpack/changelog/update-woocommerce-analytics-0.16.4
+++ b/projects/plugins/jetpack/changelog/update-woocommerce-analytics-0.16.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3874,30 +3874,30 @@
         },
         {
             "name": "automattic/woocommerce-analytics",
-            "version": "v0.16.3",
+            "version": "0.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-analytics.git",
-                "reference": "95dae7b3b036e4e3d435c10d8cef39893cd286b8"
+                "reference": "3108d3cabe127d4a30d213d610968067fbeb5c3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/95dae7b3b036e4e3d435c10d8cef39893cd286b8",
-                "reference": "95dae7b3b036e4e3d435c10d8cef39893cd286b8",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/3108d3cabe127d4a30d213d610968067fbeb5c3f",
+                "reference": "3108d3cabe127d4a30d213d610968067fbeb5c3f",
                 "shasum": ""
             },
             "require": {
-                "automattic/block-delimiter": "^0.3.5",
-                "automattic/jetpack-assets": "^4.3.31",
-                "automattic/jetpack-connection": "^8.2.0",
-                "automattic/jetpack-constants": "^3.0.8",
-                "automattic/jetpack-device-detection": "^3.4.0",
+                "automattic/block-delimiter": "^0.3",
+                "automattic/jetpack-assets": "^4.3",
+                "automattic/jetpack-connection": "^8.1",
+                "automattic/jetpack-constants": "^3.0",
+                "automattic/jetpack-device-detection": "^3.4",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^6.0.14",
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "^1.0.4",
+                "automattic/jetpack-changelogger": "3.3.0",
+                "automattic/wordbless": "^0.5",
+                "woocommerce/woocommerce-sniffs": "1.0.0",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
@@ -3905,17 +3905,8 @@
             },
             "type": "jetpack-library",
             "extra": {
-                "autotagger": true,
-                "textdomain": "woocommerce-analytics",
-                "mirror-repo": "Automattic/woocommerce-analytics",
-                "branch-alias": {
-                    "dev-trunk": "0.16.x-dev"
-                },
                 "changelogger": {
-                    "link-template": "https://github.com/Automattic/woocommerce-analytics/compare/v${old}...v${new}"
-                },
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-woocommerce-analytics.php"
+                    "changelog": "CHANGELOG.md"
                 }
             },
             "autoload": {
@@ -3929,9 +3920,9 @@
             ],
             "description": "Enhanced analytics for WooCommerce users.",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.3"
+                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.4"
             },
-            "time": "2026-04-06T18:44:32+00:00"
+            "time": "2026-05-11T04:52:05+00:00"
         },
         {
             "name": "wikimedia/aho-corasick",


### PR DESCRIPTION
Fixes #

## Proposed changes
* Bump `automattic/woocommerce-analytics` from v0.16.3 to 0.16.4 in `projects/plugins/jetpack/composer.lock`. The `^0.16` constraint in `composer.json` already permits this, so no manifest change is required.
* Add a patch-level changelog entry (`update-woocommerce-analytics-0.16.4`).

0.16.4 syncs the standalone mirror with the latest `@automattic/woocommerce-analytics` package from the WooCommerce monorepo (where the package now lives — see [woocommerce/woocommerce#63996](https://github.com/woocommerce/woocommerce/pull/63996) for context on the migration set up in #47950).

## Related product discussion/links
* Upstream release: https://github.com/Automattic/woocommerce-analytics/releases/tag/0.16.4

## Does this pull request change what data or activity we track or use?
No. This is a dependency version bump; the analytics events emitted by the package are unchanged in this release.

## Testing instructions
* On a WooCommerce site with Jetpack connected, confirm the `WC_ANALYTICS` constant path still loads the package (`jetpack_vendor/automattic/woocommerce-analytics/`) and reports v0.16.4.
* Visit a WooCommerce shop / product / cart / checkout page as a logged-out shopper and verify the existing `wcanalytics-*` tracks events still fire (Network tab, request to `pixel.wp.com/t.gif`).
* Run `composer install` in `projects/plugins/jetpack/` and confirm no other lockfile drift.