### PR TITLE
VideoPress: fix Add new video button being clipped on admin dashboard

### DIFF
--- a/projects/packages/videopress/changelog/fix-add-new-video-button-clipped
+++ b/projects/packages/videopress/changelog/fix-add-new-video-button-clipped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Add new video button disappearing on the admin dashboard after the first video is uploaded.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -95,73 +95,80 @@ const Admin = () => {
 			</div>
 
 			{ showPricingSection ? (
-				<AdminSectionHero>
-					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-						<Col sm={ 4 } md={ 8 } lg={ 12 }>
-							<PricingSection onRedirecting={ () => setShowPricingSection( true ) } />
-						</Col>
-					</Container>
-				</AdminSectionHero>
-			) : (
-				<>
+				<div className={ styles[ 'hero-shrink-guard' ] }>
 					<AdminSectionHero>
-						<Container horizontalSpacing={ 0 }>
-							<Col>
-								<div id="jp-admin-notices" className={ styles[ 'jetpack-videopress-jitm-card' ] } />
-							</Col>
-						</Container>
-
-						<Container horizontalSpacing={ 6 } horizontalGap={ 3 }>
-							{ hasConnectionError && (
-								<Col>
-									<ConnectionError />
-								</Col>
-							) }
-
-							{ ( ! hasConnectedOwner || ! isUserConnected ) && (
-								<Col sm={ 4 } md={ 8 } lg={ 12 }>
-									<NeedUserConnectionGlobalNotice />
-								</Col>
-							) }
-
-							<Col sm={ 4 } md={ 8 } lg={ 8 }>
-								<Text variant="headline-small" mb={ 3 }>
-									{ __( 'High quality, ad-free video', 'jetpack-videopress-pkg' ) }
-								</Text>
-
-								{ hasVideoPressPurchase && (
-									<ConnectVideoStorageMeter className={ styles[ 'storage-meter' ] } />
-								) }
-
-								{ hasVideos ? (
-									<FormFileUpload
-										onChange={ evt =>
-											handleFilesUpload( filterVideoFiles( evt.currentTarget.files ) )
-										}
-										accept={ fileInputExtensions }
-										multiple={ hasVideoPressPurchase }
-										render={ ( { openFileDialog } ) => (
-											<Button
-												fullWidth={ isSm }
-												onClick={ openFileDialog }
-												isLoading={ loading }
-												disabled={ ! canUpload }
-											>
-												{ __( 'Add new video', 'jetpack-videopress-pkg' ) }
-											</Button>
-										) }
-										__next40pxDefaultSize={ true }
-									/>
-								) : (
-									<Text variant="title-medium">
-										{ __( "Let's add your first video below!", 'jetpack-videopress-pkg' ) }
-									</Text>
-								) }
-
-								{ ! hasVideoPressPurchase && <UpgradeTrigger hasUsedVideo={ hasVideos } /> }
+						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+							<Col sm={ 4 } md={ 8 } lg={ 12 }>
+								<PricingSection onRedirecting={ () => setShowPricingSection( true ) } />
 							</Col>
 						</Container>
 					</AdminSectionHero>
+				</div>
+			) : (
+				<>
+					<div className={ styles[ 'hero-shrink-guard' ] }>
+						<AdminSectionHero>
+							<Container horizontalSpacing={ 0 }>
+								<Col>
+									<div
+										id="jp-admin-notices"
+										className={ styles[ 'jetpack-videopress-jitm-card' ] }
+									/>
+								</Col>
+							</Container>
+
+							<Container horizontalSpacing={ 6 } horizontalGap={ 3 }>
+								{ hasConnectionError && (
+									<Col>
+										<ConnectionError />
+									</Col>
+								) }
+
+								{ ( ! hasConnectedOwner || ! isUserConnected ) && (
+									<Col sm={ 4 } md={ 8 } lg={ 12 }>
+										<NeedUserConnectionGlobalNotice />
+									</Col>
+								) }
+
+								<Col sm={ 4 } md={ 8 } lg={ 8 }>
+									<Text variant="headline-small" mb={ 3 }>
+										{ __( 'High quality, ad-free video', 'jetpack-videopress-pkg' ) }
+									</Text>
+
+									{ hasVideoPressPurchase && (
+										<ConnectVideoStorageMeter className={ styles[ 'storage-meter' ] } />
+									) }
+
+									{ hasVideos ? (
+										<FormFileUpload
+											onChange={ evt =>
+												handleFilesUpload( filterVideoFiles( evt.currentTarget.files ) )
+											}
+											accept={ fileInputExtensions }
+											multiple={ hasVideoPressPurchase }
+											render={ ( { openFileDialog } ) => (
+												<Button
+													fullWidth={ isSm }
+													onClick={ openFileDialog }
+													isLoading={ loading }
+													disabled={ ! canUpload }
+												>
+													{ __( 'Add new video', 'jetpack-videopress-pkg' ) }
+												</Button>
+											) }
+											__next40pxDefaultSize={ true }
+										/>
+									) : (
+										<Text variant="title-medium">
+											{ __( "Let's add your first video below!", 'jetpack-videopress-pkg' ) }
+										</Text>
+									) }
+
+									{ ! hasVideoPressPurchase && <UpgradeTrigger hasUsedVideo={ hasVideos } /> }
+								</Col>
+							</Container>
+						</AdminSectionHero>
+					</div>
 					<AdminSection>
 						<Container horizontalSpacing={ 6 } horizontalGap={ 10 }>
 							{ hasVideos ? (

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -41,6 +41,17 @@
 	}
 }
 
+// VIDP-242: prevent <AdminSectionHero> from being shrunk to 0 by the
+// jetpack-admin-page-layout flex chain. The shared .section-hero has
+// overflow: hidden, which lets its min-height: auto resolve to 0 in a
+// flex column, so the hero absorbs all shrink pressure from the populated
+// library and clips the "Add new video" button. This wrapper keeps the
+// hero at content height. Safe to remove when the legacy dashboard is
+// retired at the Phase 9 cutover of issue #48506.
+.hero-shrink-guard {
+	flex-shrink: 0;
+}
+
 .first-video-wrapper {
 	display: flex;
 	flex-direction: column;

--- a/projects/plugins/jetpack/changelog/fix-add-new-video-button-clipped
+++ b/projects/plugins/jetpack/changelog/fix-add-new-video-button-clipped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: fix the Add new video button disappearing on the admin dashboard after the first video is uploaded.

--- a/projects/plugins/videopress/changelog/fix-add-new-video-button-clipped
+++ b/projects/plugins/videopress/changelog/fix-add-new-video-button-clipped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Add new video button disappearing on the admin dashboard after the first video is uploaded.


### PR DESCRIPTION
Fixes [VIDP-242](https://linear.app/a8c/issue/VIDP-242/videopress-add-new-video-button-disappears-after-first-uploaded-video)

## Context

Two recent user reports in Zendesk (11192950-zd-a8c, 11201391-zd-a8c). On the legacy VideoPress admin dashboard, the "Add new video" button disappears once videos exist in the library. Got p1778325739637059/1778323869.151139-slack-C02LT75D3 from the VideoPress team for a Bug Blitz fix.

## Root cause

At standard viewports, the hero collapses to 1px. The shared `.section-hero` has `overflow: hidden`, which in a flex column lets `min-height: auto` resolve to 0. All shrink pressure from siblings lands on the hero, which clamps to 0 and clips the button.

Recent regression from PR #48244 (base-styles v1.2.0). My Jetpack had a similar regression fixed in PR #48578.

## Fix

Wrap each `<AdminSectionHero>` in a local div with `flex-shrink: 0`. Shared component untouched, no blast radius on other admin pages using it (Backup, Search, Publicize, Protect, ~12 sites).

Legacy code will be replaced by modernization work in #48506 at Phase 9 cutover. This fix goes away with it.

**Note on the diff:** the TSX file shows 119 line changes due to JSX re-indentation when adding the wrappers. Toggle "Hide whitespace changes" in the GitHub diff view to see the actual fix: 2 wrappers + 1 Prettier-mandated multi-line reformat on `jp-admin-notices`.

## Testing

Tested live on JN sandbox with the fix deployed:
- Populated default viewport (1440x800) ✓
- Populated narrow viewport (1280x720) ✓
- Populated 80% zoom ✓
- Empty state unchanged ✓
- Build + lint + Stylelint clean

**Not tested:** other admin pages using `AdminSectionHero`, mobile viewports, many videos (5+).

**Test site:** https://ocelot-of-hydrozoans.jurassic.ninja/wp-admin/admin.php?page=jetpack-videopress

## Before / After

The bug in numbers: at default viewport (1440x800) on the populated dashboard, the hero collapses to **1px** height while its content needs **285px**. That's the entire "Add new video" button (and storage meter) clipped out of view.


**BEFORE (bug active):** baseline state. Hero collapsed to 1px, 284px of content clipped, including the upload button. Overlay shows the computed CSS values that cause it.

<img width="2880" height="1416" alt="devtools-04-computed-baseline" src="https://github.com/user-attachments/assets/65b81c9d-f748-4ee8-a06a-a2b722b3d010" />


**AFTER (fix applied via local override):** same page, `flex-shrink: 0` applied to wrapper. Hero renders at full 285px, button visible. Overlay shows `overflow: hidden` is preserved (we don't break the shared component's semantics).

<img width="2880" height="1416" alt="devtools-05-computed-fixed" src="https://github.com/user-attachments/assets/417248b7-3704-42a6-a7bf-a413eb68e9dc" />


**Live verification on JN with the deployed fix:** dashboard after the fix was actually shipped to the sandbox, populated state, default viewport.

<img width="1333" height="730" alt="phase-4-A-after-fix-overlay" src="https://github.com/user-attachments/assets/ef318d4f-6007-403b-a2af-3c5189ef885f" />

## Notes for reviewers

This PR was built using an AI-assisted workflow (Claude Code + Chrome DevTools MCP for investigation and testing). I drove the process, AI helped with the heavy lifting on code investigation and live verification. Happy to walk through the workflow if useful.