### PR TITLE
Plugin Conflicts Guardian: include blog_id in logstash events

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-blog-id
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-blog-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: include `blog_id` in logstash events so multisite / Atomic / Simple rows carry site attribution, matching the verbum-comments and wpcom-blocks precedent.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
@@ -28,6 +28,7 @@ function pcg_log_event( $message, array $extra ) {
 
 		log2logstash(
 			array(
+				'blog_id' => get_current_blog_id(),
 				'feature' => 'plugin-conflicts-guardian',
 				'message' => (string) $message,
 				'extra'   => wp_json_encode( pcg_log_redact_paths( $extra ), JSON_UNESCAPED_SLASHES ),


### PR DESCRIPTION
## Proposed changes

Follow-up to #48565. `log2logstash()` doesn't auto-populate `blog_id` — callers pass it explicitly. Sibling `jetpack-mu-wpcom` features that log via `log2logstash` already do this (`verbum-comments/class-verbum-comments.php`, `wpcom-blocks/code/class-code-block.php`). Plugin Conflicts Guardian was logging without it, so on multisite (Atomic / Simple) every PCG row lands without site attribution and queries like "which site is tripping the guard?" can't be answered.

One-line change in `pcg-log.php`: add `'blog_id' => get_current_blog_id()` to the top-level payload alongside `feature` / `message` / `extra`. All four PCG events (`Activation blocked`, `Update blocked`, `Update rolled back`, `Probe transport error`) pick it up automatically since they all dispatch through `pcg_log_event()`.

## Related product discussion/links

* #48565 added the three block/rollback events.
* `verbum-comments` and `wpcom-blocks` precedent for the `blog_id` field.

## Does this pull request change what data or activity we track or use?

Yes — adds `blog_id` (integer) as a top-level field on the four existing PCG logstash events. No new events, no PII; just resolves the site that emitted the event.

## Testing instructions

1. Sync `jetpack-mu-wpcom` to a multisite / Atomic dev environment.
2. Trigger any PCG block path (e.g. activate a plugin that fatals on load, or install a zip with a parse error).
3. In the `plugin-conflicts-guardian` logstash bucket, confirm the resulting row carries a non-zero `blog_id` matching the site that emitted the event.
4. Pre-existing single-site flows are unchanged: `blog_id` will be `1` on a vanilla single-site install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)