### PR TITLE
Help Center: add wpcom_help_center_logged_out_force_load filter for non-support surfaces

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-05-11-09-41-18-537777
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-05-11-09-41-18-537777
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Help Center: add wpcom_help_center_logged_out_force_load filter so non-support surfaces can opt in to the logged-out bundle.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -642,9 +642,9 @@ class Help_Center {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param bool $force_load Whether to force-load the logged-out Help Center.
+		 * @param bool $should_load Whether to load the logged-out Help Center on this surface.
 		 */
-		$force_load_logged_out = ! is_admin()
+		$should_load_for_logged_out = ! is_admin()
 			&& ! is_user_logged_in()
 			&& ! $this->is_support_site
 			&& (bool) apply_filters( 'wpcom_help_center_logged_out_force_load', false );
@@ -654,12 +654,12 @@ class Help_Center {
 		// 2. On the front end of the site if the current user can edit posts
 		// 3. On the front end of the site and the theme is not P2
 		// 4. If it is the frontend we show the disconnected version of the help center.
-		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) && ! $this->is_support_site && ! $force_load_logged_out ) {
+		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) && ! $this->is_support_site && ! $should_load_for_logged_out ) {
 			return;
 		}
 
 		// Do not load Help Center for logged-out users if we are not on support sites.
-		if ( ! is_user_logged_in() && ! $this->is_support_site && ! $force_load_logged_out ) {
+		if ( ! is_user_logged_in() && ! $this->is_support_site && ! $should_load_for_logged_out ) {
 			return;
 		}
 
@@ -667,7 +667,7 @@ class Help_Center {
 
 		if ( $is_next_admin ) {
 			$variant = 'ciab-admin' . $suffix;
-		} elseif ( $force_load_logged_out ) {
+		} elseif ( $should_load_for_logged_out ) {
 			$variant = 'logged-out';
 		} elseif ( $this->is_support_site ) {
 			if ( ! is_user_logged_in() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -633,17 +633,33 @@ class Help_Center {
 		$can_edit_posts = current_user_can( 'edit_posts' ) && is_user_member_of_blog();
 		$is_p2          = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
 
+		/**
+		 * Allow surfaces outside the support/forum allow-list to opt in to the logged-out
+		 * Help Center bundle (the same `logged-out` variant served on /support and /forums).
+		 *
+		 * Only consulted for logged-out users on the frontend of non-support sites; it's a
+		 * no-op anywhere a logged-in flow would already load the Help Center.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $force_load Whether to force-load the logged-out Help Center.
+		 */
+		$force_load_logged_out = ! is_admin()
+			&& ! is_user_logged_in()
+			&& ! $this->is_support_site
+			&& (bool) apply_filters( 'wpcom_help_center_logged_out_force_load', false );
+
 		// We will show the help center icon in the admin bar when;
 		// 1. On wp-admin
 		// 2. On the front end of the site if the current user can edit posts
 		// 3. On the front end of the site and the theme is not P2
 		// 4. If it is the frontend we show the disconnected version of the help center.
-		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) && ! $this->is_support_site ) {
+		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) && ! $this->is_support_site && ! $force_load_logged_out ) {
 			return;
 		}
 
 		// Do not load Help Center for logged-out users if we are not on support sites.
-		if ( ! is_user_logged_in() && ! $this->is_support_site ) {
+		if ( ! is_user_logged_in() && ! $this->is_support_site && ! $force_load_logged_out ) {
 			return;
 		}
 
@@ -651,6 +667,8 @@ class Help_Center {
 
 		if ( $is_next_admin ) {
 			$variant = 'ciab-admin' . $suffix;
+		} elseif ( $force_load_logged_out ) {
+			$variant = 'logged-out';
 		} elseif ( $this->is_support_site ) {
 			if ( ! is_user_logged_in() ) {
 				$variant = 'logged-out';


### PR DESCRIPTION
Fixes #

## Proposed changes
* Adds a new `wpcom_help_center_logged_out_force_load` filter in `Help_Center::enqueue_wp_admin_scripts()` that lets non-support surfaces opt in to the existing `logged-out` Help Center bundle (the same one served on `/support` and `/forums` for logged-out users).
* When the filter returns `true` on a logged-out, non-admin, non-support-site request, the two early-return gates are skipped and the variant is set to `logged-out`.
* Filter evaluation is short-circuited so `apply_filters()` is only called on the request type where it can matter — logged-out frontend hits to non-support sites. Logged-in pages, wp-admin, and support sites skip it entirely.
* Default is `false`. With no subscriber, behavior on every existing surface is unchanged.

This is the foundation PR for shipping the logged-out Odie (AI pre-sales chat) experience to surfaces beyond `/support` and `/forums` — LOHP, marketing/landing pages, `/blog`, etc. The companion JS launcher (click → `helpCenter.loadHelpCenter()` glue) is a separate PR in `wp-calypso/packages/help-center/`. Each consuming surface is then a small PR that calls `add_filter( 'wpcom_help_center_logged_out_force_load', '__return_true' )` (scoped however that surface wants) and points the launcher at a button.

## How a surface opts in

```php
// Always on (e.g. the wpblog-2024 theme)
add_filter( 'wpcom_help_center_logged_out_force_load', '__return_true' );

// Conditional (e.g. only on landpack-rendered marketing pages)
add_filter( 'wpcom_help_center_logged_out_force_load', function ( $should_load ) {
    if ( landpack_is_rendering_page() ) {
        return true;
    }
    return $should_load;
} );

// Behind an experiment (e.g. LOHP rollout)
add_filter( 'wpcom_help_center_logged_out_force_load', function ( $should_load ) {
    if ( ! is_front_page() ) {
        return $should_load;
    }
    return 'treatment' === \ExPlat\assign_anon_user( 'wpcom_lohp_help_center_2026' );
} );
```

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No. This PR only adds a filter that gates whether an existing bundle is enqueued — no new tracking events, no new data collection, no new external requests.

## Testing instructions

**Sanity check — default behavior is unchanged:**

1. On a non-support, non-forum site, visit any frontend page while logged out. Confirm the Help Center bundle is NOT enqueued (no `widgets.wp.com/help-center/help-center-logged-out.min.js` in the network tab; no `window.helpCenter` global).
2. Visit `/support` or `/forums` while logged out. Confirm the Help Center bundle IS enqueued and the chat still works — same as before.
3. Log in to any site. Confirm the wp-admin Help Center icon still appears and behaves normally.

**New behavior — opt in via the filter:**

4. On a test non-support site, add to a mu-plugin or theme:
   ```php
   add_filter( 'wpcom_help_center_logged_out_force_load', '__return_true' );
   ```
5. Visit the frontend while logged out. Confirm:
   * `widgets.wp.com/help-center/help-center-logged-out.min.js` is enqueued.
   * `window.helpCenter.loadHelpCenter` is defined.
   * The `help-center-ready-to-load` event fires on `document`.
6. Log in to the same site. Confirm the filter does NOT change anything for logged-in users — they continue through the existing logged-in code path.
7. Remove the `add_filter` call. Confirm behavior reverts to step 1.
