### PR TITLE
Podcast: default untangle gate to enabled for A8C-proxied requests

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-proxy-default
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-proxy-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Default the untangle gate to enabled for A8C-proxied requests so Automatticians dogfood the new package on Simple and Atomic.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -145,8 +145,7 @@ class Admin_Page {
 	 * Whether the Podcast untangle is enabled.
 	 */
 	private static function is_enabled() {
-		/** This filter is documented in src/class-podcast.php. */
-		return (bool) apply_filters( 'jetpack_podcast_untangle', false );
+		return Podcast::is_enabled();
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -47,19 +47,7 @@ class Podcast {
 			return;
 		}
 
-		/**
-		 * Master switch for the Podcast untangle.
-		 *
-		 * While the legacy podcasting code is still the source of truth on
-		 * Simple and Atomic sites, this filter stays false. Subsequent PRs
-		 * layer the new wp-admin SPA, REST integration, and feed
-		 * customization on top of this gate.
-		 *
-		 * @since 0.1.0
-		 *
-		 * @param bool $enabled Whether to enable the new Podcast package.
-		 */
-		if ( ! apply_filters( 'jetpack_podcast_untangle', false ) ) {
+		if ( ! self::is_enabled() ) {
 			return;
 		}
 
@@ -81,5 +69,45 @@ class Podcast {
 		if ( is_admin() ) {
 			Admin_Page::init();
 		}
+	}
+
+	/**
+	 * Whether the Podcast untangle is enabled for the current request.
+	 *
+	 * Defaults to true for A8C-proxied requests so Automatticians dogfood
+	 * the new package; everyone else stays on the legacy stack until the
+	 * `jetpack_podcast_untangle` filter is flipped globally.
+	 */
+	public static function is_enabled() {
+		/**
+		 * Master switch for the Podcast untangle.
+		 *
+		 * While the legacy podcasting code is still the source of truth on
+		 * Simple and Atomic sites, this filter stays false for non-proxied
+		 * requests. Subsequent PRs layer the new wp-admin SPA, REST
+		 * integration, and feed customization on top of this gate.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool $enabled Whether to enable the new Podcast package.
+		 */
+		return (bool) apply_filters( 'jetpack_podcast_untangle', self::is_proxied_request() );
+	}
+
+	/**
+	 * Whether the current request is coming from the A8C proxy.
+	 */
+	private static function is_proxied_request() {
+		// Simple sites: use the wpcom helper when available.
+		if ( function_exists( 'wpcom_is_proxied_request' ) ) {
+			return wpcom_is_proxied_request();
+		}
+
+		// Atomic/WoA: fall back to the server variable or constant.
+		if ( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) ) {
+			return (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) );
+		}
+
+		return defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Test.php
@@ -35,41 +35,4 @@ class Podcast_Test extends BaseTestCase {
 	public function test_package_version_constant_is_defined() {
 		$this->assertNotEmpty( Podcast::PACKAGE_VERSION );
 	}
-
-	/**
-	 * Without a proxy signal and without a filter override, the gate stays
-	 * closed so the legacy podcasting stack keeps running.
-	 */
-	public function test_is_enabled_defaults_to_false_when_not_proxied() {
-		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
-		$this->assertFalse( Podcast::is_enabled() );
-	}
-
-	/**
-	 * A8C-proxied requests flip the default to true so Automatticians dogfood
-	 * the new package without needing a separate filter hook.
-	 */
-	public function test_is_enabled_defaults_to_true_for_proxied_requests() {
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		try {
-			$this->assertTrue( Podcast::is_enabled() );
-		} finally {
-			unset( $_SERVER['A8C_PROXIED_REQUEST'] );
-		}
-	}
-
-	/**
-	 * The `jetpack_podcast_untangle` filter still wins — a hook returning
-	 * false suppresses the package even on a proxied request.
-	 */
-	public function test_is_enabled_filter_overrides_proxy_default() {
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter( 'jetpack_podcast_untangle', '__return_false' );
-		try {
-			$this->assertFalse( Podcast::is_enabled() );
-		} finally {
-			remove_filter( 'jetpack_podcast_untangle', '__return_false' );
-			unset( $_SERVER['A8C_PROXIED_REQUEST'] );
-		}
-	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Test.php
@@ -35,4 +35,41 @@ class Podcast_Test extends BaseTestCase {
 	public function test_package_version_constant_is_defined() {
 		$this->assertNotEmpty( Podcast::PACKAGE_VERSION );
 	}
+
+	/**
+	 * Without a proxy signal and without a filter override, the gate stays
+	 * closed so the legacy podcasting stack keeps running.
+	 */
+	public function test_is_enabled_defaults_to_false_when_not_proxied() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+		$this->assertFalse( Podcast::is_enabled() );
+	}
+
+	/**
+	 * A8C-proxied requests flip the default to true so Automatticians dogfood
+	 * the new package without needing a separate filter hook.
+	 */
+	public function test_is_enabled_defaults_to_true_for_proxied_requests() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		try {
+			$this->assertTrue( Podcast::is_enabled() );
+		} finally {
+			unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+		}
+	}
+
+	/**
+	 * The `jetpack_podcast_untangle` filter still wins — a hook returning
+	 * false suppresses the package even on a proxied request.
+	 */
+	public function test_is_enabled_filter_overrides_proxy_default() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'jetpack_podcast_untangle', '__return_false' );
+		try {
+			$this->assertFalse( Podcast::is_enabled() );
+		} finally {
+			remove_filter( 'jetpack_podcast_untangle', '__return_false' );
+			unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes
* Default \`jetpack_podcast_untangle\` to \`true\` for A8C-proxied requests so Automatticians dogfood the new package on Simple and Atomic. Mirrors the WPCOM mu-plugin gate for non-Simple environments.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a Simple or Atomic site, hit it while A8C-proxied — the new Podcast package should activate (\`Jetpack > Podcast\` menu appears).
* Hit the same site un-proxied — legacy podcasting stays in charge.
* \`add_filter( 'jetpack_podcast_untangle', '__return_false' )\` still suppresses the package even when proxied.