### PR TITLE
Write: redirect to fresh editor when bfcache restores published page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write_bfcache
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write_bfcache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: redirect to fresh editor when bfcache restores a published page, fixing grayed-out buttons on Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3382,6 +3382,16 @@ window.addEventListener( 'beforeunload', event => {
 	}
 } );
 
+// If the page is restored from bfcache after a publish, redirect to a
+// fresh editor.  On publish the isSaving flag is intentionally left true
+// (buttons stay disabled while the redirect fires), so a bfcache restore
+// would strand the user on a "done" page with grayed-out buttons.
+window.addEventListener( 'pageshow', event => {
+	if ( event.persisted && state.isPublished ) {
+		window.location.replace( state.writeUrl );
+	}
+} );
+
 // Clean up autosave timer on page unload.
 window.addEventListener( 'pagehide', () => {
 	if ( autosaveTimer ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3388,6 +3388,7 @@ window.addEventListener( 'beforeunload', event => {
 // would strand the user on a "done" page with grayed-out buttons.
 window.addEventListener( 'pageshow', event => {
 	if ( event.persisted && state.isPublished ) {
+		document.documentElement.style.visibility = 'hidden';
 		window.location.replace( state.writeUrl );
 	}
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3312,6 +3312,10 @@ async function savePost( postStatus, isAutosave = false ) {
 			// Clear any autosave draft reference on publish.
 			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
 			setTimeout( () => {
+				// Hide the page before navigating so the bfcache snapshot
+				// stores it hidden — prevents a flash of stale content if
+				// the user later presses Back.
+				document.documentElement.style.visibility = 'hidden';
 				window.location.href = post.link;
 			}, 800 );
 		} else {
@@ -3392,14 +3396,9 @@ window.addEventListener( 'pageshow', event => {
 	}
 } );
 
-// Clean up autosave timer on page unload.  When leaving after a publish,
-// also hide the page so bfcache stores it already hidden — prevents a
-// flash of stale content if the browser restores the snapshot.
+// Clean up autosave timer on page unload.
 window.addEventListener( 'pagehide', () => {
 	if ( autosaveTimer ) {
 		clearInterval( autosaveTimer );
-	}
-	if ( state.isPublished ) {
-		document.documentElement.style.visibility = 'hidden';
 	}
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3388,14 +3388,18 @@ window.addEventListener( 'beforeunload', event => {
 // would strand the user on a "done" page with grayed-out buttons.
 window.addEventListener( 'pageshow', event => {
 	if ( event.persisted && state.isPublished ) {
-		document.documentElement.style.visibility = 'hidden';
 		window.location.replace( state.writeUrl );
 	}
 } );
 
-// Clean up autosave timer on page unload.
+// Clean up autosave timer on page unload.  When leaving after a publish,
+// also hide the page so bfcache stores it already hidden — prevents a
+// flash of stale content if the browser restores the snapshot.
 window.addEventListener( 'pagehide', () => {
 	if ( autosaveTimer ) {
 		clearInterval( autosaveTimer );
+	}
+	if ( state.isPublished ) {
+		document.documentElement.style.visibility = 'hidden';
 	}
 } );


### PR DESCRIPTION
Fixes RSM-2709

## Proposed changes

* On Atomic sites, the browser's back-forward cache (bfcache) can restore the Write editor after publishing. Because the publish flow leaves `isSaving=true` while the redirect fires, a bfcache restore strands the user on a "done" page with grayed-out Save Draft and Publish buttons.
* Adds a `pageshow` event listener that detects bfcache restoration after a publish and redirects to a fresh Write editor using `location.replace()` to avoid creating a back-button trap.

## Related product discussion/links

* RSM-2709

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to an Atomic site with the Write editor enabled.
* Open the Write editor (`/wp-admin/admin.php?page=write`).
* Write some content, then click Publish.
* After being redirected to the published post, click the browser's Back button.
* Verify you land on a fresh Write editor (empty title and content, buttons enabled) — not a stale page with grayed-out buttons.
* Click Back again and verify you navigate past the Write editor (no redirect loop).
* On a non-Atomic (Simple) site, repeat the same steps and confirm the publish flow still works normally.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
