### PR TITLE
Admin page mixin: move tabs padding from buttons to wrapper

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -301,15 +301,13 @@ $jp-breakpoint-mobile: 782px;
 		background: var(--wpds-color-bg-surface-neutral-strong);
 		border-bottom: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 
-		// Align tab buttons' inline padding with the page header's
-		// horizontal padding (admin-ui ships its page header at
-		// `padding-inline: var(--wpds-dimension-padding-2xl)`).
-		// `@wordpress/ui` Tabs default the buttons to `padding-inline:
-		// var(--wpds-dimension-padding-lg)`; bump them to 2xl so the
-		// first tab's start edge lines up under the page title.
-		[role="tab"] {
-			padding-inline: var(--wpds-dimension-padding-2xl, 24px);
-		}
+		// Align the first tab's start edge with the page header's title.
+		// admin-ui's page header sits at `padding-inline: 2xl` (24px); the
+		// `@wordpress/ui` tab buttons ship with their own `padding-inline:
+		// lg` (16px). Add the `sm` (8px) difference here on the wrapper so
+		// `lg + sm = 2xl` at the button's content edge — without touching
+		// the tab button's own padding.
+		padding-inline: var(--wpds-dimension-padding-sm, 8px);
 	}
 
 	// ── Mobile: admin bar grows to 46px; sidebar goes off-canvas ─────

--- a/projects/js-packages/base-styles/changelog/update-admin-page-tabs-wrapper-padding
+++ b/projects/js-packages/base-styles/changelog/update-admin-page-tabs-wrapper-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin page mixin: move the tabs-strip horizontal padding from the tab buttons onto the `.jp-admin-page-tabs` wrapper, so we no longer override the @wordpress/ui tab button's own padding.


### PR DESCRIPTION
Fixes #

## Proposed changes
* In the `jetpack-admin-page-layout` mixin, stop overriding the `@wordpress/ui` tab button's own `padding-inline`. Apply the missing horizontal padding on the `.jp-admin-page-tabs` wrapper instead.
* Net effect on the first tab's start edge is the same — `lg` (16px, from the tab button) + `sm` (8px, from the wrapper) = `2xl` (24px), matching the admin-ui page header — but we no longer reach into the third-party component's internals.

## Related product discussion/links
* Follow-up to the admin-page-layout tabs work — feedback was that we shouldn't mess with the tab buttons' padding directly.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The only consumer of `.jp-admin-page-tabs` today is the Protect plugin.

* Build Protect: `pnpm jetpack build plugins/protect`
* Open the Jetpack Protect admin page
* Confirm the tabs strip looks the same as before:
  * First tab's start edge aligns under the page title (24px from the page edge)
  * Tabs strip is sticky at the top of the scroll area
  * Hairline (border-bottom) still spans the full strip width
* Inspect a `[role="tab"]` button in DevTools and confirm there is no longer a Jetpack-side `padding-inline` rule overriding it — the only inline padding should be the one shipped by `@wordpress/ui` (`var(--wpds-dimension-padding-lg)`).
