### PR TITLE
Search Blocks: trigger initial search when `?s=` is present but empty

### DIFF
--- a/projects/packages/search/changelog/SEARCH-183-trigger-initial-search-on-empty-s-param
+++ b/projects/packages/search/changelog/SEARCH-183-trigger-initial-search-on-empty-s-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: trigger the initial search when the URL carries an explicit-but-empty `?s=` so a blank search submission shows the full result set instead of an empty results region.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -888,6 +888,12 @@ class Search_Blocks {
 			// /?s=boots&orderby=newest&category[]=news renders correctly on
 			// first paint.
 			'searchQuery'           => $search_query,
+			// Whether the search-query URL key was present in `$_GET`, even
+			// when its value is empty. The JS store's `initialize()` reads
+			// this so a `?s=` deep link still fires the initial search —
+			// `searchQuery` alone can't carry that signal because an empty
+			// param and a missing param both round-trip as `''`.
+			'hasSearchParam'        => static::has_search_param(),
 			// URL key the JS store uses to read/write the search query. `s`
 			// on the WP search route, `q` on non-search pages — see
 			// `get_search_param_name()`. Threaded through the seed so the JS
@@ -1031,8 +1037,12 @@ class Search_Blocks {
 		if ( null !== self::$is_initial_loading_cache ) {
 			return self::$is_initial_loading_cache;
 		}
-		$search_query = static::parse_url_search_query();
-		if ( '' !== $search_query ) {
+		// `has_search_param()` rather than `parse_url_search_query() !== ''` —
+		// an explicit `?s=` (empty value) still means the visitor landed on a
+		// search page and expects an initial unfiltered result set, the same
+		// as submitting a blank search form. The non-empty case is a subset
+		// of "param present" so this guard subsumes the old text-query check.
+		if ( static::has_search_param() ) {
 			self::$is_initial_loading_cache = true;
 			return true;
 		}
@@ -1203,6 +1213,27 @@ class Search_Blocks {
 			return '';
 		}
 		return trim( sanitize_text_field( wp_unslash( (string) $raw ) ) );
+	}
+
+	/**
+	 * Whether the active search-query URL key is present in `$_GET`, regardless
+	 * of value. Distinguishes `?s=` (visitor submitted a blank search and
+	 * expects an unfiltered result set) from a URL that omits `s` entirely
+	 * (homepage, archive, etc.) — `parse_url_search_query()` collapses both
+	 * to `''`. Mirrors the JS-side `hasSearchParam` field seeded into the
+	 * Interactivity store.
+	 *
+	 * Array-shaped `?s[]=foo` is treated as "not present" to stay in lockstep
+	 * with `parse_url_search_query()` (which returns `''` for non-scalar
+	 * input) — otherwise a malformed deep link would flip the page into the
+	 * loading state with no usable query to fire.
+	 *
+	 * @return bool
+	 */
+	public static function has_search_param(): bool {
+		$key = self::get_search_param_name();
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL presence check; the value is never read here.
+		return isset( $_GET[ $key ] ) && is_scalar( $_GET[ $key ] );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -458,17 +458,22 @@ const { state, actions } = store( NAMESPACE, {
 		 * Templates therefore must bind to a single getter, so derived
 		 * visibility flags live here.
 		 *
-		 * Gated on `searchQuery` (so the message doesn't flash on a bare
-		 * `/search/` page where the user hasn't typed) and on `!hasError`
-		 * (so "No results found" doesn't display when the fetch actually
-		 * failed — the error region inside `jetpack-search/results-list` owns
-		 * that message instead).
+		 * Gated on `searchQuery || hasSearchParam` (so the message doesn't
+		 * flash on a bare `/search/` page where the user hasn't typed, but
+		 * does surface when an explicit-but-empty `?s=` URL fired the
+		 * initial search and got nothing back — e.g. a site with no indexed
+		 * posts), and on `!hasError` (so "No results found" doesn't display
+		 * when the fetch actually failed — the error region inside
+		 * `jetpack-search/results-list` owns that message instead).
 		 *
 		 * @return {boolean} True when the no-results message should show.
 		 */
 		get showNoResults() {
 			return (
-				!! state.searchQuery && ! state.isLoading && ! state.hasError && state.results.length === 0
+				( !! state.searchQuery || !! state.hasSearchParam ) &&
+				! state.isLoading &&
+				! state.hasError &&
+				state.results.length === 0
 			);
 		},
 
@@ -907,12 +912,15 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*handlePopState() {
-			const { searchQuery, sortOrder, activeFilters, filterLogic, priceRange } = readStateFromUrl(
-				state.filterConfigs,
-				state.searchParamName,
-				state.isWooCommerceActive
-			);
+			const { searchQuery, hasSearchParam, sortOrder, activeFilters, filterLogic, priceRange } =
+				readStateFromUrl( state.filterConfigs, state.searchParamName, state.isWooCommerceActive );
 			state.searchQuery = searchQuery;
+			// Keep `hasSearchParam` in lockstep with the live URL so any future
+			// reader (e.g. `showNoResults`) sees the current state rather than
+			// the PHP-seeded value from first paint. `actions.search()` below
+			// fires unconditionally, so the popstate path doesn't depend on
+			// the flag — this write is for state-consistency only.
+			state.hasSearchParam = hasSearchParam;
 			state.sortOrder = sortOrder;
 			// urlParamsToState bypasses its own gate when filterConfigs is empty;
 			// re-gate here so popstate matches initialize() and stray URL keys

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1156,7 +1156,11 @@ const { state, actions } = store( NAMESPACE, {
 					state.filterLogic = gatedLogic;
 				}
 			}
-			if ( state.searchQuery || state.hasActiveFilters ) {
+			if ( state.searchQuery || state.hasActiveFilters || state.hasSearchParam ) {
+				// `hasSearchParam` catches `?s=` (empty value) — the param is
+				// present so the visitor expects a search to run, but
+				// `searchQuery` alone is `''` and indistinguishable from a
+				// URL that omits `s`. Seeded from PHP via build_initial_state().
 				// syncUrl=false: URL already carries this query; avoid a duplicate history entry.
 				actions.search( { syncUrl: false } );
 			} else if ( droppedAny ) {

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -172,7 +172,7 @@ export function stateToUrlParams( {
  *                                                `max_price` range params). Falsy on non-Woo
  *                                                sites ignores both rather than hydrating
  *                                                them into store state.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
  */
 export function urlParamsToState(
 	params,
@@ -271,6 +271,12 @@ export function urlParamsToState(
 
 	return {
 		searchQuery: params.get( searchParamName ) ?? '',
+		// `params.has()` distinguishes `?s=` (present, empty) from a URL with
+		// no `s` at all — `params.get() ?? ''` collapses both to `''`. The
+		// store's initialize() guard reads this so an explicit-but-empty
+		// search param still fires the initial fetch, matching what a user
+		// who submits a blank search form expects.
+		hasSearchParam: params.has( searchParamName ),
 		sortOrder: allowedSorts.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
 		activeFilters,
 		filterLogic,
@@ -302,7 +308,7 @@ export function pushStateToUrl( state ) {
  * @param {boolean} [isWooCommerceActive] - Gate for WC-only URL surface (product-format
  *                                        sort keys + `min_price` / `max_price` range params);
  *                                        forwarded to `urlParamsToState`.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
  */
 export function readStateFromUrl(
 	filterConfigs = {},

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -834,8 +834,10 @@ describe( 'handlePopState gating', () => {
 		const stub = require( '../../../src/search-blocks/store/url-state' );
 		jest.spyOn( stub, 'readStateFromUrl' ).mockReturnValue( {
 			searchQuery: 'hello',
+			hasSearchParam: true,
 			sortOrder: 'relevance',
 			activeFilters: { foo: [ 'bar' ] },
+			filterLogic: {},
 			priceRange: null,
 		} );
 		Object.assign( actions, originalActions );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -575,6 +575,26 @@ describe( 'store getters', () => {
 		expect( state.activeFilterCount ).toBe( 2 );
 	} );
 
+	it( 'surfaces showNoResults for an explicit-but-empty `?s=` deep link (SEARCH-183)', () => {
+		// Empty `?s=` URL — `searchQuery` is `''` but `hasSearchParam` is true,
+		// so the initial search fires (covered by other tests). If that search
+		// returns zero results (e.g. a site with no indexed posts), the
+		// no-results affordance must still surface; otherwise the page renders
+		// blank with no explanation. Pre-SEARCH-183 the getter gated only on
+		// `!! state.searchQuery` and silently swallowed this case.
+		state.results = [];
+		state.isLoading = false;
+		state.hasError = false;
+		state.searchQuery = '';
+		state.hasSearchParam = true;
+		expect( state.showNoResults ).toBe( true );
+
+		// Bare `/search/` page (no `s` in URL, no filters) — message stays
+		// hidden so it doesn't flash before the user types.
+		state.hasSearchParam = false;
+		expect( state.showNoResults ).toBe( false );
+	} );
+
 	it( 'hasActiveFilters counts the priceRange (including half-open) as a filter', () => {
 		state.activeFilters = {};
 		state.priceRange = null;
@@ -825,5 +845,29 @@ describe( 'handlePopState gating', () => {
 		await runGenerator( actions.handlePopState() );
 
 		expect( state.activeFilters ).toEqual( {} );
+	} );
+
+	it( 'syncs `state.hasSearchParam` to the popped URL (SEARCH-183)', async () => {
+		// `initialize()` is the only consumer today, but keeping
+		// state.hasSearchParam in lockstep with the live URL avoids a
+		// footgun for future readers (e.g. `showNoResults`, which now
+		// gates on it). Mirrors how `state.searchQuery` is rewritten on
+		// each popstate.
+		const stub = require( '../../../src/search-blocks/store/url-state' );
+		jest.spyOn( stub, 'readStateFromUrl' ).mockReturnValue( {
+			searchQuery: '',
+			hasSearchParam: true,
+			sortOrder: 'relevance',
+			activeFilters: {},
+			filterLogic: {},
+			priceRange: null,
+		} );
+		Object.assign( actions, originalActions );
+		jest.spyOn( actions, 'search' ).mockImplementation();
+		state.hasSearchParam = false;
+
+		await runGenerator( actions.handlePopState() );
+
+		expect( state.hasSearchParam ).toBe( true );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -773,6 +773,33 @@ describe( 'store callbacks', () => {
 			expect( fresh.state.skeletonHidden ).toBe( true );
 		} );
 	} );
+
+	it( 'runs the URL-seeded search for `?s=` (empty value) via hasSearchParam (SEARCH-183)', () => {
+		jest.isolateModules( () => {
+			const fresh = require( '../../../src/search-blocks/store' );
+			jest.spyOn( window, 'addEventListener' ).mockImplementation();
+			jest.spyOn( fresh.actions, 'handlePopState' ).mockImplementation();
+			const search = jest.spyOn( fresh.actions, 'search' ).mockImplementation();
+			// Visitor landed on `?s=` — searchQuery is `''` and no filters are
+			// selected. Without hasSearchParam the legacy guard `searchQuery ||
+			// hasActiveFilters` would skip the initial fetch and leave the
+			// results region empty until the visitor types.
+			fresh.state.searchQuery = '';
+			fresh.state.priceRange = null;
+			fresh.state.filterConfigs = {};
+			fresh.state.activeFilters = {};
+			fresh.state.hasSearchParam = true;
+
+			captured.callbacks.initialize();
+
+			expect( search ).toHaveBeenCalledTimes( 1 );
+			expect( search ).toHaveBeenCalledWith( { syncUrl: false } );
+
+			// Drop the flag so it doesn't leak into the `handlePopState` describe
+			// below — captured.state is a singleton across the mocked module.
+			fresh.state.hasSearchParam = false;
+		} );
+	} );
 } );
 
 describe( 'handlePopState gating', () => {

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -166,6 +166,27 @@ describe( 'urlParamsToState', () => {
 	it( 'reads search query from URL', () => {
 		const state = urlParamsToState( new URLSearchParams( 's=cats' ) );
 		expect( state.searchQuery ).toBe( 'cats' );
+		expect( state.hasSearchParam ).toBe( true );
+	} );
+
+	it( 'reports hasSearchParam=true for `?s=` (empty value) — distinguishes a blank search from a missing param (SEARCH-183)', () => {
+		const state = urlParamsToState( new URLSearchParams( 's=' ) );
+		expect( state.searchQuery ).toBe( '' );
+		expect( state.hasSearchParam ).toBe( true );
+	} );
+
+	it( 'reports hasSearchParam=false when the search key is absent', () => {
+		const state = urlParamsToState( new URLSearchParams( '' ) );
+		expect( state.searchQuery ).toBe( '' );
+		expect( state.hasSearchParam ).toBe( false );
+	} );
+
+	it( 'reads hasSearchParam against the threaded `searchParamName` (`q` off the search route)', () => {
+		const present = urlParamsToState( new URLSearchParams( 'q=' ), {}, 'q' );
+		expect( present.hasSearchParam ).toBe( true );
+		// Stray `s` on a non-search route doesn't satisfy the `q` gate.
+		const absent = urlParamsToState( new URLSearchParams( 's=stray' ), {}, 'q' );
+		expect( absent.hasSearchParam ).toBe( false );
 	} );
 
 	it( 'reads sort order from URL', () => {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -41,6 +41,7 @@ class Search_Blocks_Test extends TestCase {
 			'homeUrl',
 			'locale',
 			'searchQuery',
+			'hasSearchParam',
 			'searchParamName',
 			'sortOrder',
 			'results',
@@ -997,6 +998,117 @@ class Search_Blocks_Test extends TestCase {
 			);
 		} finally {
 			$_GET = $original_get;
+		}
+	}
+
+	/**
+	 * `?s=foo` is the established case: param present and non-empty. The
+	 * initial-loading gate must keep firing so `results-list/render.php`
+	 * paints the skeleton during the JS-side hydration round-trip.
+	 */
+	public function test_is_initial_loading_with_non_empty_search_query() {
+		$original_get        = $_GET;
+		$original_query      = $GLOBALS['wp_query'] ?? null;
+		$_GET                = array( 's' => 'boots' );
+		$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+		try {
+			$this->assertTrue( Search_Blocks::has_search_param() );
+			$this->assertTrue( Search_Blocks::is_initial_loading() );
+			$state = Search_Blocks::build_initial_state();
+			$this->assertTrue( $state['hasSearchParam'] );
+			$this->assertTrue( $state['isLoading'] );
+		} finally {
+			$_GET                = $original_get;
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * `?s=` (param present, value empty) is the SEARCH-183 case — visitor
+	 * submitted a blank search and expects an unfiltered result set. Both
+	 * the presence helper and the loading gate must flip true even though
+	 * `parse_url_search_query()` trims to `''`. The `wp_query` is primed
+	 * with a non-empty `s` so `is_search()` reports the search route and
+	 * `get_search_param_name()` picks the `s` key — the empty URL value
+	 * rides on `$_GET`.
+	 */
+	public function test_is_initial_loading_with_empty_search_query_string() {
+		$original_get        = $_GET;
+		$original_query      = $GLOBALS['wp_query'] ?? null;
+		$_GET                = array( 's' => '' );
+		$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'placeholder' ) );
+		try {
+			$this->assertSame( '', Search_Blocks::parse_url_search_query() );
+			$this->assertTrue( Search_Blocks::has_search_param() );
+			$this->assertTrue( Search_Blocks::is_initial_loading() );
+			$state = Search_Blocks::build_initial_state();
+			$this->assertTrue( $state['hasSearchParam'] );
+			$this->assertTrue( $state['isLoading'] );
+		} finally {
+			$_GET                = $original_get;
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * Off the search route the active key is `q`. `?q=` (empty value) must
+	 * still trigger initial loading so an inline-search page on a singular
+	 * post matches the search-route behavior — visitor submitted a blank
+	 * inline search, expects the unfiltered result set.
+	 */
+	public function test_is_initial_loading_with_empty_q_param_off_search_route() {
+		$original_get        = $_GET;
+		$original_query      = $GLOBALS['wp_query'] ?? null;
+		$_GET                = array( 'q' => '' );
+		$GLOBALS['wp_query'] = new \WP_Query();
+		try {
+			$this->assertTrue( Search_Blocks::has_search_param() );
+			$this->assertTrue( Search_Blocks::is_initial_loading() );
+		} finally {
+			$_GET                = $original_get;
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * A URL with no search param at all (homepage, archive, etc.) must not
+	 * flip into the loading state — there's no fetch to wait on, and a
+	 * seeded spinner would render placeholders that never resolve.
+	 */
+	public function test_is_initial_loading_with_no_search_param_present() {
+		$original_get        = $_GET;
+		$original_query      = $GLOBALS['wp_query'] ?? null;
+		$_GET                = array();
+		$GLOBALS['wp_query'] = new \WP_Query();
+		try {
+			$this->assertFalse( Search_Blocks::has_search_param() );
+			$this->assertFalse( Search_Blocks::is_initial_loading() );
+			$state = Search_Blocks::build_initial_state();
+			$this->assertFalse( $state['hasSearchParam'] );
+			$this->assertFalse( $state['isLoading'] );
+		} finally {
+			$_GET                = $original_get;
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * Array-shaped `?q[]=foo` is malformed input — `parse_url_search_query()`
+	 * bails to `''` via its `is_scalar()` guard, so `has_search_param()`
+	 * matches that contract and treats it as "not present" rather than
+	 * flipping the page into a loading state with no usable query.
+	 */
+	public function test_has_search_param_rejects_non_scalar_input() {
+		$original_get        = $_GET;
+		$original_query      = $GLOBALS['wp_query'] ?? null;
+		$_GET                = array( 'q' => array( 'foo' ) );
+		$GLOBALS['wp_query'] = new \WP_Query();
+		try {
+			$this->assertFalse( Search_Blocks::has_search_param() );
+			$this->assertFalse( Search_Blocks::is_initial_loading() );
+		} finally {
+			$_GET                = $original_get;
+			$GLOBALS['wp_query'] = $original_query;
 		}
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-183](https://linear.app/a8c/issue/SEARCH-183/search-blocks-trigger-initial-search-when-s-is-present-but-empty)

## Why
With the Embedded Search Experience enabled, visiting a page like `https://example.com/?s=` (the search-results route with a blank query) was leaving visitors staring at the search blocks template with no results, no count, and no spinner — until they typed something into the search input. That's the exact shape of a URL you get from submitting an empty search form, so the page should run the search and show the unfiltered result set instead of looking broken.

## Proposed changes
* Add `Search_Blocks::has_search_param()` that distinguishes "`s` (or `q`) present in `$_GET`" from "missing", since `parse_url_search_query()` trims both to `''`.
* Fold the new helper into `is_initial_loading()` so PHP seeds `isLoading=true` and the "Searching…" count text whenever the search param is present, even with an empty value.
* Seed `hasSearchParam` through `build_initial_state()` and surface it from `urlParamsToState()` on the JS side.
* OR `state.hasSearchParam` into the `initialize()` callback's URL-seeded-search guard so an explicit-but-empty `?s=` fires `actions.search()` on first mount.

## Screenshots
URL under test: `https://jp-echo.jurassic.tube/?s=` (Embedded Search Experience on).

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/8f78f185-93ec-4f3b-bdd6-49b1aa9b4e40) | ![after](https://github.com/user-attachments/assets/9a6b17f8-cce7-4b66-80e4-625d99a53959) |

## Related product discussion/links
* [SEARCH-183](https://linear.app/a8c/issue/SEARCH-183/search-blocks-trigger-initial-search-when-s-is-present-but-empty)

## Does this pull request change what data or activity we track or use?
No — same `actions.search()` call that already fires on every other deep link; only the trigger condition is widened.

## Testing instructions
1. On a site that consumes the `automattic/jetpack-search` package, set the Jetpack Search experience to `embedded` (`wp option update jetpack_search_experience embedded`) so the Search blocks template takes over the WP search route.
2. Visit `/?s=` (no value) and confirm:
   * The pre-hydration skeleton renders on first paint (PHP-seeded `isLoading=true`).
   * Within ~1 second the results-count flips to `Found <N> results` and result cards populate.
   * Network panel shows a `public-api.wordpress.com/.../search?query=&…` request firing on load.
3. Visit `/?s=boots` and confirm the existing happy-path is unchanged — initial fetch still fires, results render.
4. Visit `/` (no `s` at all) and confirm no initial fetch — the search blocks template doesn't take over that route, so there's nothing to verify visually beyond "no regression on the homepage".
5. Back/forward between the three URLs above — `handlePopState` already calls `actions.search()` unconditionally, so each navigation re-runs the search with the current URL state.
