### PR TITLE
Search Blocks: add 'rebuild' mode to backfill() for full slot-taxonomy sweep (RSM-2108 follow-up)

### DIFF
--- a/projects/packages/search/changelog/RSM-2108-backfill-rebuild-mode
+++ b/projects/packages/search/changelog/RSM-2108-backfill-rebuild-mode
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search Blocks: add a `rebuild` mode to Custom_Taxonomy_Slot_Mapping::backfill() that wipes the slot taxonomy before re-mirroring so orphan slot rows from posts that lost their user-side terms get cleaned up. The default `mirror` mode keeps the existing per-post replacement behavior.
+Search Blocks: Add a `rebuild` mode to Custom_Taxonomy_Slot_Mapping::backfill() that wipes the slot taxonomy before re-mirroring so orphan slot rows from posts that lost their user-side terms get cleaned up. The default `mirror` mode keeps the existing per-post replacement behavior.

--- a/projects/packages/search/changelog/RSM-2108-backfill-rebuild-mode
+++ b/projects/packages/search/changelog/RSM-2108-backfill-rebuild-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add a `rebuild` mode to Custom_Taxonomy_Slot_Mapping::backfill() that wipes the slot taxonomy before re-mirroring so orphan slot rows from posts that lost their user-side terms get cleaned up. The default `mirror` mode keeps the existing per-post replacement behavior.

--- a/projects/packages/search/src/search-blocks/class-custom-taxonomy-slot-mapping.php
+++ b/projects/packages/search/src/search-blocks/class-custom-taxonomy-slot-mapping.php
@@ -361,6 +361,27 @@ class Custom_Taxonomy_Slot_Mapping {
 	}
 
 	/**
+	 * Backfill modes accepted by `backfill()`.
+	 *
+	 * - `mirror`: default. Per-post replacement only. For each post that
+	 *   currently has at least one user-side term, `wp_set_object_terms()`
+	 *   resets the slot's post-set for that post to match the current
+	 *   user-side names. **Posts that lost every user-side term during a
+	 *   gap when the auto-mirror was inactive are *not* visited** — their
+	 *   stale slot relationships orphan. Suitable for the common case:
+	 *   one-time initialization on a site that has data predating the
+	 *   mapping.
+	 * - `rebuild`: full sweep. Every term in the slot taxonomy is deleted
+	 *   first (which cascades to drop every slot term-relationship), then
+	 *   the per-post mirror runs over the current user-side state. The
+	 *   resulting slot is byte-for-byte a fresh projection of the user-side
+	 *   taxonomy with no orphans. Use when a site has had the mapping
+	 *   toggle on and off, changed slot, or otherwise believes the slot has
+	 *   drifted. Costly on large sites — runs N deletes for N slot terms.
+	 */
+	const BACKFILL_MODES = array( 'mirror', 'rebuild' );
+
+	/**
 	 * One-shot backfill: walk every post that carries a term in a mapped
 	 * user-facing taxonomy and mirror its current assignment onto the slot.
 	 * Use after first introducing a mapping on a site whose posts were
@@ -371,9 +392,25 @@ class Custom_Taxonomy_Slot_Mapping {
 	 * automatically; sites with millions of posts shouldn't pay this cost on
 	 * every request. Call from a one-off script or `wp eval`.
 	 *
-	 * @return int Number of (post, taxonomy) pairs mirrored.
+	 * The default `mirror` mode walks user-side terms only and won't clean
+	 * up orphan slot rows from posts that have lost all their user-side
+	 * terms. Pass `rebuild` to wipe the slot taxonomy first and re-project
+	 * from scratch — slower but guarantees no drift survives.
+	 *
+	 * @param string $mode One of `self::BACKFILL_MODES` — `mirror` (default) or `rebuild`.
+	 * @return int Number of (post, taxonomy) pairs mirrored. Slot wipes in
+	 *             `rebuild` mode are not counted; the return value is the
+	 *             count of fresh per-post writes either way.
 	 */
-	public static function backfill(): int {
+	public static function backfill( string $mode = 'mirror' ): int {
+		if ( ! in_array( $mode, self::BACKFILL_MODES, true ) ) {
+			/* translators: %s: invalid mode value passed to backfill(). */
+			$msg = sprintf( esc_html__( 'Unknown backfill mode "%s"; expected one of mirror | rebuild.', 'jetpack-search-pkg' ), esc_html( $mode ) );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $msg is sprintf() of esc_html__() with esc_html()-wrapped args.
+			_doing_it_wrong( __METHOD__, $msg, 'jetpack-search-pkg $$next-version$$' );
+			$mode = 'mirror';
+		}
+
 		$map = self::get_map();
 		if ( empty( $map ) ) {
 			return 0;
@@ -382,6 +419,29 @@ class Custom_Taxonomy_Slot_Mapping {
 		foreach ( $map as $user_slug => $slot ) {
 			if ( ! taxonomy_exists( $user_slug ) || ! taxonomy_exists( $slot ) ) {
 				continue;
+			}
+			// Rebuild mode: drop every term in the slot taxonomy *before*
+			// the user-side walk. `wp_delete_term()` cascades to remove
+			// each term's term_relationship rows, leaving the slot
+			// post-set empty so the mirror loop projects a fresh copy of
+			// the current user-side state with no orphans. The inner
+			// deletes fire `delete_term` on slot taxonomies; the mirror
+			// handler's `isset( $map[ $taxonomy ] )` gate (map keys are
+			// user-side slugs, never slot slugs) prevents recursion.
+			if ( 'rebuild' === $mode ) {
+				// @phan-suppress-next-line PhanAccessMethodInternal @phan-suppress-current-line UnusedSuppression -- Fixed in WP 6.9, but then we need a suppression for the WP 6.8 compat run. @todo Remove this suppression when we drop WP <6.9.
+				$existing_slot_terms = get_terms(
+					array(
+						'taxonomy'   => $slot,
+						'hide_empty' => false,
+						'fields'     => 'ids',
+					)
+				);
+				if ( ! is_wp_error( $existing_slot_terms ) ) {
+					foreach ( (array) $existing_slot_terms as $slot_term_id ) {
+						wp_delete_term( (int) $slot_term_id, $slot );
+					}
+				}
 			}
 			// @phan-suppress-next-line PhanAccessMethodInternal @phan-suppress-current-line UnusedSuppression -- Fixed in WP 6.9, but then we need a suppression for the WP 6.8 compat run. @todo Remove this suppression when we drop WP <6.9.
 			$terms = get_terms(

--- a/projects/packages/search/src/search-blocks/class-custom-taxonomy-slot-mapping.php
+++ b/projects/packages/search/src/search-blocks/class-custom-taxonomy-slot-mapping.php
@@ -45,6 +45,27 @@ namespace Automattic\Jetpack\Search;
 class Custom_Taxonomy_Slot_Mapping {
 
 	/**
+	 * Backfill modes accepted by `backfill()`.
+	 *
+	 * - `mirror`: default. Per-post replacement only. For each post that
+	 *   currently has at least one user-side term, `wp_set_object_terms()`
+	 *   resets the slot's post-set for that post to match the current
+	 *   user-side names. **Posts that lost every user-side term during a
+	 *   gap when the auto-mirror was inactive are *not* visited** — their
+	 *   stale slot relationships orphan. Suitable for the common case:
+	 *   one-time initialization on a site that has data predating the
+	 *   mapping.
+	 * - `rebuild`: full sweep. Every term in the slot taxonomy is deleted
+	 *   first (which cascades to drop every slot term-relationship), then
+	 *   the per-post mirror runs over the current user-side state. The
+	 *   resulting slot is byte-for-byte a fresh projection of the user-side
+	 *   taxonomy with no orphans. Use when a site has had the mapping
+	 *   toggle on and off, changed slot, or otherwise believes the slot has
+	 *   drifted. Costly on large sites — runs N deletes for N slot terms.
+	 */
+	const BACKFILL_MODES = array( 'mirror', 'rebuild' );
+
+	/**
 	 * Per-request memo backing `get_map()`. The map is validated once per
 	 * request — re-running the validation on every filter-block render and
 	 * on every API request would be wasted work, and the
@@ -359,27 +380,6 @@ class Custom_Taxonomy_Slot_Mapping {
 			wp_delete_term( (int) $slot_term->term_id, $slot );
 		}
 	}
-
-	/**
-	 * Backfill modes accepted by `backfill()`.
-	 *
-	 * - `mirror`: default. Per-post replacement only. For each post that
-	 *   currently has at least one user-side term, `wp_set_object_terms()`
-	 *   resets the slot's post-set for that post to match the current
-	 *   user-side names. **Posts that lost every user-side term during a
-	 *   gap when the auto-mirror was inactive are *not* visited** — their
-	 *   stale slot relationships orphan. Suitable for the common case:
-	 *   one-time initialization on a site that has data predating the
-	 *   mapping.
-	 * - `rebuild`: full sweep. Every term in the slot taxonomy is deleted
-	 *   first (which cascades to drop every slot term-relationship), then
-	 *   the per-post mirror runs over the current user-side state. The
-	 *   resulting slot is byte-for-byte a fresh projection of the user-side
-	 *   taxonomy with no orphans. Use when a site has had the mapping
-	 *   toggle on and off, changed slot, or otherwise believes the slot has
-	 *   drifted. Costly on large sites — runs N deletes for N slot terms.
-	 */
-	const BACKFILL_MODES = array( 'mirror', 'rebuild' );
 
 	/**
 	 * One-shot backfill: walk every post that carries a term in a mapped

--- a/projects/packages/search/tests/php/Custom_Taxonomy_Slot_Mapping_Test.php
+++ b/projects/packages/search/tests/php/Custom_Taxonomy_Slot_Mapping_Test.php
@@ -313,6 +313,100 @@ class Custom_Taxonomy_Slot_Mapping_Test extends TestCase {
 	}
 
 	/**
+	 * `backfill( 'rebuild' )` runs the slot-taxonomy enumeration query
+	 * before the per-post mirror — that's the wipe step. Observe the
+	 * `pre_get_terms` action: in rebuild mode it fires with the slot
+	 * taxonomy in `$query->query_vars['taxonomy']`; in mirror mode it
+	 * never does.
+	 *
+	 * The actual `wp_delete_term()` calls and the resulting empty-slot
+	 * state are verified in a live dev env — WorDBless's `get_terms()`
+	 * doesn't enumerate freshly-inserted terms, so we can't observe the
+	 * delete loop from this harness.
+	 */
+	public function test_backfill_rebuild_mode_runs_slot_enumeration() {
+		register_taxonomy( 'genre', 'post', array( 'public' => true ) );
+		$callback = static function ( $map ) {
+			$map['genre'] = 'jetpack-search-tag1';
+			return $map;
+		};
+		add_filter( 'jetpack_search_custom_taxonomy_map', $callback );
+		Custom_Taxonomy_Slot_Mapping::register_slot_taxonomies();
+
+		$slot_enumerations = array();
+		$listener          = static function ( $query ) use ( &$slot_enumerations ) {
+			$taxes = (array) ( $query->query_vars['taxonomy'] ?? array() );
+			foreach ( $taxes as $tax ) {
+				if ( 'jetpack-search-tag1' === $tax ) {
+					$slot_enumerations[] = $tax;
+				}
+			}
+		};
+		add_action( 'pre_get_terms', $listener, 5 );
+
+		try {
+			Custom_Taxonomy_Slot_Mapping::backfill( 'rebuild' );
+			$this->assertNotEmpty( $slot_enumerations, 'rebuild mode must enumerate the slot taxonomy before re-mirroring.' );
+		} finally {
+			remove_action( 'pre_get_terms', $listener, 5 );
+			remove_filter( 'jetpack_search_custom_taxonomy_map', $callback );
+			unregister_taxonomy( 'jetpack-search-tag1' );
+			unregister_taxonomy( 'genre' );
+		}
+	}
+
+	/**
+	 * The default `mirror` mode must NOT enumerate the slot taxonomy —
+	 * that's the cheap path that skips the wipe. If the enumeration ever
+	 * leaks into the default path it'd silently double the runtime cost.
+	 */
+	public function test_backfill_default_mode_skips_slot_enumeration() {
+		register_taxonomy( 'genre', 'post', array( 'public' => true ) );
+		$callback = static function ( $map ) {
+			$map['genre'] = 'jetpack-search-tag1';
+			return $map;
+		};
+		add_filter( 'jetpack_search_custom_taxonomy_map', $callback );
+		Custom_Taxonomy_Slot_Mapping::register_slot_taxonomies();
+
+		$slot_enumerations = array();
+		$listener          = static function ( $query ) use ( &$slot_enumerations ) {
+			$taxes = (array) ( $query->query_vars['taxonomy'] ?? array() );
+			foreach ( $taxes as $tax ) {
+				if ( 'jetpack-search-tag1' === $tax ) {
+					$slot_enumerations[] = $tax;
+				}
+			}
+		};
+		add_action( 'pre_get_terms', $listener, 5 );
+
+		try {
+			Custom_Taxonomy_Slot_Mapping::backfill();
+			Custom_Taxonomy_Slot_Mapping::backfill( 'mirror' );
+			$this->assertSame( array(), $slot_enumerations, 'mirror mode must never enumerate slot taxonomies.' );
+		} finally {
+			remove_action( 'pre_get_terms', $listener, 5 );
+			remove_filter( 'jetpack_search_custom_taxonomy_map', $callback );
+			unregister_taxonomy( 'jetpack-search-tag1' );
+			unregister_taxonomy( 'genre' );
+		}
+	}
+
+	/**
+	 * An unknown mode string falls back to `mirror` (with a
+	 * `_doing_it_wrong` notice) rather than crashing — defensive guard
+	 * against typos in one-off scripts.
+	 */
+	public function test_backfill_falls_back_to_mirror_on_unknown_mode() {
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		try {
+			$this->assertSame( 0, Custom_Taxonomy_Slot_Mapping::backfill( 'wipe-and-pray' ) );
+		} finally {
+			remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		}
+	}
+
+	/**
 	 * `get_map()` is the single source of truth. The feature is off by
 	 * default — the filter returns an empty array unless a site adds an
 	 * entry.


### PR DESCRIPTION
Follow-up to #48684.

## Why

`Custom_Taxonomy_Slot_Mapping::backfill()` (added in #48684) is the one-shot helper for sites turning on a slot mapping after their posts were already tagged with the user-side taxonomy. It walks every post that currently has at least one user-side term and replaces the slot's post-set with a fresh projection.

That's the right shape for the common path — one-time initialization on a site that has data predating the mapping — but it leaves a gap when the workflow looks more like:

1. Enable the map, let the auto-mirror run for a while (slot accumulates term-relationships).
2. Disable the filter (auto-mirror stops, slot rows freeze).
3. Remove user-side terms from some posts during the gap.
4. Re-enable the filter and re-run `backfill()` expecting a clean state.

In step 4 the default `mirror` mode doesn't visit posts whose user-side term set is now empty — those posts aren't returned by `get_objects_in_term( <user-side terms>, $user_slug )`. Their stale slot relationships orphan, and the next search-filter aggregation against that slot returns zero-doc buckets for terms nobody has anymore.

For sites that hit this workflow, opt-in `rebuild` mode does a full sweep: every term in the slot taxonomy is deleted first (which cascades to drop every slot term-relationship), then the normal mirror loop runs on top of the empty slot. Result is a byte-for-byte fresh projection with no orphans.

## Proposed changes

* New constant `Custom_Taxonomy_Slot_Mapping::BACKFILL_MODES = array( 'mirror', 'rebuild' )`.
* `backfill()` gains an optional `string $mode = 'mirror'` parameter.
* In `rebuild` mode, before the per-post mirror loop, enumerate every term in each in-use slot taxonomy and call `wp_delete_term()` on it. The slot deletions cascade through `term_relationships`. The mirror handler's `isset( $map[ $taxonomy ] )` gate (map keys are user-side slugs, slot slugs are never keys) prevents recursion when the cascade fires `delete_term` for `jetpack-search-tagN`.
* Unknown mode falls back to `mirror` with a `_doing_it_wrong()` notice.
* Default behavior unchanged — every existing caller of `backfill()` keeps the per-post replacement semantics.
* Tests pin:
  - `rebuild` mode runs the slot-taxonomy enumeration (observed via `pre_get_terms`).
  - Default `mirror` mode never enumerates the slot — cheap-path invariant.
  - Unknown mode falls back to mirror without throwing.
  - End-to-end persistence (actual `wp_delete_term()` calls + empty-slot state) is verified in a live dev env; WorDBless's `get_terms()` doesn't enumerate freshly-inserted terms.

## Related product discussion/links

* Parent PR: #48684
* Linear: [RSM-2108](https://linear.app/a8c/issue/RSM-2108/search-30-whitelist-supported-taxonomies-in-custom-taxonomy-filter)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The `rebuild` mode is observable in a live env when the slot has drifted relative to the user-side taxonomy. Drop the demo mu-plugin from #48684 (`tools/docker/mu-plugins/rsm-2108-demo.php`) and:

1. Add a `genre` term to a few posts. Auto-mirror creates matching `jetpack-search-tag1` terms.
2. Temporarily disable the mapping (remove the `jetpack_search_custom_taxonomy_map` filter line).
3. Remove the `genre` term from one of the posts via WP-CLI or the block editor. Auto-mirror is off, so the slot rows stay.
4. Re-enable the mapping.
5. Run `wp eval '\Automattic\Jetpack\Search\Custom_Taxonomy_Slot_Mapping::backfill();'` — observe that the orphan slot rows survive.
6. Run `wp eval '\Automattic\Jetpack\Search\Custom_Taxonomy_Slot_Mapping::backfill( "rebuild" );'` — observe the slot taxonomy now matches the user-side state exactly.

Unit tests:
```bash
cd projects/packages/search
composer phpunit -- --filter='Custom_Taxonomy_Slot_Mapping_Test'
```