### PR TITLE
jetpack-mu-wpcom: add Jetpack_Mu_Wpcom::log2logstash() with Atomic fallback

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-atomic-fallback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-log-atomic-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a package-level `Jetpack_Mu_Wpcom::log2logstash( $feature, $message, $extra )` helper that dispatches to the in-process `log2logstash()` on WP.com Simple and falls back to the public-api `/rest/v1.1/logstash` endpoint (fire-and-forget) on Atomic. Plugin Conflicts Guardian now uses it, so its `Activation blocked` / `Update blocked` / `Update rolled back` events are observable on Atomic sites too.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -806,8 +806,7 @@ class Jetpack_Mu_Wpcom {
 	 * the public-api `/rest/v1.1/logstash` endpoint (fire-and-forget) on
 	 * Atomic, where `log2logstash()` isn't available.
 	 *
-	 * Best-effort: a logging failure must never escalate into a fatal,
-	 * since callers may run on activation / install / update request paths.
+	 * Best-effort: a logging failure must never escalate into a fatal for the caller.
 	 *
 	 * @param string $feature Logstash `feature` bucket (e.g. "plugin-conflicts-guardian").
 	 * @param string $message Event message slug.
@@ -850,7 +849,7 @@ class Jetpack_Mu_Wpcom {
 					'timeout'  => 1,
 				)
 			);
-		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must not escalate on activation / install / update request paths.
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must never escalate into a fatal for the caller.
 			unset( $e );
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -798,4 +798,60 @@ class Jetpack_Mu_Wpcom {
 		}
 		return $data;
 	}
+
+	/**
+	 * Emit an event to the wpcom logstash cluster.
+	 *
+	 * Uses the in-process `log2logstash()` on WP.com Simple, and falls back to
+	 * the public-api `/rest/v1.1/logstash` endpoint (fire-and-forget) on
+	 * Atomic, where `log2logstash()` isn't available.
+	 *
+	 * Best-effort: a logging failure must never escalate into a fatal,
+	 * since callers may run on activation / install / update request paths.
+	 *
+	 * @param string $feature Logstash `feature` bucket (e.g. "plugin-conflicts-guardian").
+	 * @param string $message Event message slug.
+	 * @param array  $extra   Event-specific properties; JSON-encoded into the `extra` field.
+	 * @return void
+	 */
+	public static function log2logstash( $feature, $message, array $extra = array() ) {
+		// Resolve the dispatch path once per request — on upgrade flows this
+		// can be called several times in a row (one per plugin) and the path
+		// doesn't change mid-request.
+		static $dispatch = null;
+		if ( null === $dispatch ) {
+			if ( ! function_exists( 'log2logstash' ) ) {
+				$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+				if ( is_readable( $log2logstash_path ) ) {
+					require_once $log2logstash_path;
+				}
+			}
+			$dispatch = function_exists( 'log2logstash' ) ? 'native' : 'http';
+		}
+
+		try {
+			$payload = array(
+				'blog_id' => get_current_blog_id(),
+				'feature' => (string) $feature,
+				'message' => (string) $message,
+				'extra'   => wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ),
+			);
+
+			if ( 'native' === $dispatch ) {
+				log2logstash( $payload );
+				return;
+			}
+
+			wp_remote_post(
+				'https://public-api.wordpress.com/rest/v1.1/logstash',
+				array(
+					'body'     => array( 'params' => wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ) ),
+					'blocking' => false,
+					'timeout'  => 1,
+				)
+			);
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must not escalate on activation / install / update request paths.
+			unset( $e );
+		}
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -819,18 +819,22 @@ class Jetpack_Mu_Wpcom {
 		// doesn't change mid-request.
 		static $dispatch = null;
 		if ( null === $dispatch ) {
-			if ( ! function_exists( 'log2logstash' ) ) {
-				$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-				if ( is_readable( $log2logstash_path ) ) {
-					require_once $log2logstash_path;
+			try {
+				if ( ! function_exists( 'log2logstash' ) ) {
+					$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+					if ( is_readable( $log2logstash_path ) ) {
+						require_once $log2logstash_path;
+					}
 				}
+			} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- require_once can still throw (parse error / top-level fatal in the included file); fall through to the HTTP dispatch.
+				unset( $e );
 			}
 			$dispatch = function_exists( 'log2logstash' ) ? 'native' : 'http';
 		}
 
 		try {
 			$payload = array(
-				'blog_id' => get_current_blog_id(),
+				'blog_id' => \get_wpcom_blog_id(),
 				'feature' => (string) $feature,
 				'message' => (string) $message,
 				'extra'   => wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -136,7 +136,7 @@ function pcg_guard_evaluate_plugins( $plugins ) {
 }
 
 /**
- * Log an activation block to logstash. Best-effort; no-op off WordPress.com.
+ * Log an activation block to logstash. Best-effort.
  *
  * @param string[]             $checked Probe batch as basenames.
  * @param array<string,string> $blocked Map of basename => admin-notice reason. Empty-string key = batch-level fallback.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -123,8 +123,7 @@ class PCG_Load_Tester {
 	 * Log a probe transport error to logstash whenever either probe came
 	 * back as `error` (timeout at PROBE_TIMEOUT, connection failure,
 	 * non-JSON body). Lets us measure timeout frequency vs. batch size
-	 * before deciding whether to scale `PROBE_TIMEOUT` with N. No-op
-	 * outside WordPress.com (no `log2logstash` available).
+	 * before deciding whether to scale `PROBE_TIMEOUT` with N.
 	 *
 	 * @param string   $mode         Probe mode constant.
 	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
@@ -8,35 +8,20 @@
 /**
  * Emit an event to the `plugin-conflicts-guardian` logstash bucket.
  *
- * Best-effort: a logging failure must never escalate into a fatal,
- * since callers run on activation / install / update request paths.
- * No-op outside WordPress.com (no `log2logstash` available).
+ * Thin wrapper around `Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash()`
+ * that pins the feature bucket and redacts ABSPATH/WP_CONTENT_DIR prefixes
+ * from any string values in `$extra` so log lines don't leak the install layout.
  *
  * @param string $message Event message slug (e.g. "Activation blocked").
  * @param array  $extra   Event-specific properties; JSON-encoded into the `extra` field.
  * @return void
  */
 function pcg_log_event( $message, array $extra ) {
-	try {
-		if ( ! function_exists( 'log2logstash' ) ) {
-			$log2logstash_path = WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-			if ( ! is_readable( $log2logstash_path ) ) {
-				return;
-			}
-			require_once $log2logstash_path;
-		}
-
-		log2logstash(
-			array(
-				'blog_id' => get_current_blog_id(),
-				'feature' => 'plugin-conflicts-guardian',
-				'message' => (string) $message,
-				'extra'   => wp_json_encode( pcg_log_redact_paths( $extra ), JSON_UNESCAPED_SLASHES ),
-			)
-		);
-	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must not escalate on activation / install / update request paths.
-		unset( $e );
-	}
+	\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
+		'plugin-conflicts-guardian',
+		$message,
+		pcg_log_redact_paths( $extra )
+	);
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -74,7 +74,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 }
 
 /**
- * Log a refused install/update to logstash. Best-effort; no-op off WordPress.com.
+ * Log a refused install/update to logstash. Best-effort.
  *
  * @param string $action     `install` or `update`.
  * @param array  $hook_extra Hook payload from `upgrader_source_selection`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
@@ -155,7 +155,7 @@ function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignor
 }
 
 /**
- * Log a post-update rollback to logstash. Best-effort; no-op off WordPress.com.
+ * Log a post-update rollback to logstash. Best-effort.
  *
  * @param array $candidate Per-plugin context built in `pcg_healthcheck_after_update()`.
  * @param array $probe     Shared probe verdict from `PCG_Load_Tester::test()`.


### PR DESCRIPTION
## Summary

- Add a package-level `Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash( $feature, $message, $extra )` helper that dispatches to the in-process `log2logstash()` on WP.com Simple and falls back to a fire-and-forget `wp_remote_post` to the public-api `/rest/v1.1/logstash` endpoint on Atomic, where the in-process function isn't loaded.
- Plugin Conflicts Guardian (`pcg_log_event`) now delegates to it, so its `Activation blocked` / `Update blocked` / `Update rolled back` events are observable on Atomic sites too — previously they were silently dropped.
- Dispatch decision is cached in a `static` so upgrade flows that block N plugins don't re-stat / re-check `function_exists` N times.

## Why

Existing logstash callers in `jetpack-mu-wpcom` (launchpad, verbum, code block, heif support, PCG) all hardcode `WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php'`, which only exists on WP.com Simple. On Atomic the `is_readable()` guard makes them silent no-ops. Verified empirically on an Atomic dev site: the file is not present, so no PCG events were reaching Logstash from Atomic blocks.

The HTTP fallback uses the same wire format as wpcomsh's `logstash_log_global_styles` in `feature-plugins/full-site-editing.php`: `body[params]` is the JSON-encoded `{blog_id, feature, message, extra}` envelope.

Migration of the other inline `log2logstash()` callers (`launchpad/launchpad.php`, `launchpad/launchpad-task-definitions.php`, `verbum-comments/class-verbum-comments.php`, `wpcom-blocks/code/class-code-block.php`, `media/heif-support.php`) is left for a follow-up to keep this diff narrowly scoped.

## Testing instructions:

1. Check out this branch on a WoA / Atomic site (the dev mu-plugin sync path works: `jetpack rsync jetpack-mu-wpcom <site>`).
2. Confirm the in-process function is not available on Atomic:
   ```
   wp eval 'var_dump( function_exists( "log2logstash" ) );'
   ```
   Expected: `bool(false)`.
3. Send a test event end-to-end:
   ```
   wp eval 'pcg_log_event( "test ping", array( "from" => "wp-cli", "ts" => time() ) ); echo "done\n";'
   ```
4. In Kibana / Logstash, search:
   ```
   feature:"plugin-conflicts-guardian" AND message:"test ping" AND blog_id:<site blog id>
   ```
   Expected: the event appears within a minute.
5. On a WP.com Simple site, repeat steps 3–4. Expected: same event appears via the in-process `log2logstash()` path.
6. In a single request that triggers multiple PCG blocks (e.g. activating a batch of N broken plugins), confirm the filesystem is only stat'd once for `log2logstash.php` — the static dispatch cache should short-circuit subsequent calls.
7. Run the package's unit tests:
   ```
   jetpack test php jetpack-mu-wpcom -- tests/php/features/plugin-conflicts-guardian
   ```
   Expected: green.

## Does this pull request change what data or activity we track or use?

Yes — on Atomic sites only. The Plugin Conflicts Guardian feature already emits `Activation blocked` / `Update blocked` / `Update rolled back` events to Logstash on WP.com Simple; this PR makes the same events flow from Atomic sites via the public-api `/rest/v1.1/logstash` endpoint. Payload fields are unchanged (`blog_id`, `feature`, `message`, and an `extra` envelope containing plugin basenames, status, redacted file path, line, and reason). No PII; `pcg_log_redact_paths()` continues to strip `ABSPATH` / `WP_CONTENT_DIR` prefixes from any string values in `extra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)