### PR TITLE
Componentry: migrate Status to @wordpress/ui Text in plugin consumers

### DIFF
--- a/projects/js-packages/components/changelog/change-migrate-status-wp-ui
+++ b/projects/js-packages/components/changelog/change-migrate-status-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Components: deprecate Status; inline @wordpress/ui Text in consumers.

--- a/projects/js-packages/components/components/status/index.tsx
+++ b/projects/js-packages/components/components/status/index.tsx
@@ -13,7 +13,7 @@ export interface StatusProps {
 /**
  * Status component.
  *
- * @deprecated Inline the equivalent JSX using `Text` from `@wordpress/ui` and a small color-coded indicator span. The wrapper renders a flex container at `body-extra-small` size with `font-weight: 600` and a `0.666em` round indicator coloured by status (`var(--jp-green-50)` for `active`, `--jp-red-50` for `error`, `--jp-gray-50` for `inactive`, `--jp-yellow-30` for `action`, `--jp-blue-40` for `initializing`).
+ * @deprecated Inline the equivalent JSX using `Text` from `@wordpress/ui` and a small color-coded indicator span. The wrapper renders a flex container at `body-sm` size with `font-weight: 600` and a `0.666em` round indicator coloured by status using WPDS design tokens (`var(--wpds-color-fg-content-success)` for `active`, `--wpds-color-fg-content-error` for `error`, `--wpds-color-fg-content-neutral-weak` for `inactive`, `--wpds-color-fg-content-warning` for `action`, `--wpds-color-fg-content-info` for `initializing`).
  *
  * @param {StatusProps} props           - The component properties.
  * @param {string}      props.className - Optional className forwarded to the outer element.

--- a/projects/js-packages/components/components/status/index.tsx
+++ b/projects/js-packages/components/components/status/index.tsx
@@ -10,6 +10,17 @@ export interface StatusProps {
 	className?: string;
 }
 
+/**
+ * Status component.
+ *
+ * @deprecated Inline the equivalent JSX using `Text` from `@wordpress/ui` and a small color-coded indicator span. The wrapper renders a flex container at `body-extra-small` size with `font-weight: 600` and a `0.666em` round indicator coloured by status (`var(--jp-green-50)` for `active`, `--jp-red-50` for `error`, `--jp-gray-50` for `inactive`, `--jp-yellow-30` for `action`, `--jp-blue-40` for `initializing`).
+ *
+ * @param {StatusProps} props           - The component properties.
+ * @param {string}      props.className - Optional className forwarded to the outer element.
+ * @param {string}      props.label     - Status label. Defaults to a status-derived string.
+ * @param {string}      props.status    - Status key: `active | error | inactive | action | initializing`.
+ * @return {JSX.Element} The `Status` component.
+ */
 const Status = ( { className, label, status = 'inactive' }: StatusProps ): JSX.Element => {
 	const defaultLabels: Record< string, string > = {
 		active: __( 'Active', 'jetpack-components' ),

--- a/projects/js-packages/components/components/status/index.tsx
+++ b/projects/js-packages/components/components/status/index.tsx
@@ -13,7 +13,7 @@ export interface StatusProps {
 /**
  * Status component.
  *
- * @deprecated Inline the equivalent JSX using `Text` from `@wordpress/ui` and a small color-coded indicator span. The wrapper renders a flex container at `body-sm` size with `font-weight: 600` and a `0.666em` round indicator coloured by status using WPDS design tokens (`var(--wpds-color-fg-content-success)` for `active`, `--wpds-color-fg-content-error` for `error`, `--wpds-color-fg-content-neutral-weak` for `inactive`, `--wpds-color-fg-content-warning` for `action`, `--wpds-color-fg-content-info` for `initializing`).
+ * @deprecated Inline the equivalent JSX using `Text` from `@wordpress/ui` and a small color-coded indicator span. The wrapper renders a flex container at `body-sm` size with `font-weight: 600` and a `0.666em` round indicator coloured by status using WPDS design tokens (`var(--wpds-color-fg-content-success-weak)` for `active`, `--wpds-color-fg-content-error-weak` for `error`, `--wpds-color-fg-content-neutral-weak` for `inactive`, `--wpds-color-fg-content-warning-weak` for `action`, `--wpds-color-fg-content-info-weak` for `initializing`). Include a fallback hex for surfaces that don't load `@wordpress/theme/design-tokens.css` (e.g. the legacy Jetpack settings dashboard).
  *
  * @param {StatusProps} props           - The component properties.
  * @param {string}      props.className - Optional className forwarded to the outer element.

--- a/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
@@ -1,5 +1,7 @@
-import { Status, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _n, _x } from '@wordpress/i18n';
+import { Text } from '@wordpress/ui';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -22,6 +24,30 @@ import { getRewindStatus } from 'state/rewind';
 import { getScanStatus } from 'state/scan';
 import { getSitePlan, siteHasFeature, isFetchingSiteData } from 'state/site';
 import { isFetchingPluginsData, isPluginActive, isPluginInstalled } from 'state/site/plugins';
+import styles from './style.module.scss';
+
+/**
+ * Render a small status indicator with a coloured dot and label.
+ *
+ * @param {object}          props        - Component props.
+ * @param {string}          props.status - Status key.
+ * @param {React.ReactNode} props.label  - Label content.
+ * @return {import('react').ReactElement} The status indicator.
+ */
+const StatusIndicator = ( { status, label } ) => (
+	<Text variant="body-sm" className={ clsx( styles.status, styles[ `is-${ status }` ] ) }>
+		<span className={ styles.indicator } />
+		<span>{ label }</span>
+	</Text>
+);
+
+const DEFAULT_LABELS = {
+	active: __( 'Active', 'jetpack' ),
+	error: __( 'Error', 'jetpack' ),
+	action: __( 'Action needed', 'jetpack' ),
+	inactive: __( 'Inactive', 'jetpack' ),
+	initializing: __( 'Setting up', 'jetpack' ),
+};
 
 /**
  * Track click on Pro status badge.
@@ -110,10 +136,15 @@ class ProStatus extends Component {
 				return;
 			case 'rewind_connected': {
 				const rewindMessage = this.getRewindMessage();
-				return <Status status={ rewindMessage.status } text={ rewindMessage.text } />;
+				return (
+					<StatusIndicator
+						status={ rewindMessage.status }
+						label={ DEFAULT_LABELS[ rewindMessage.status ] }
+					/>
+				);
 			}
 			case 'active':
-				return <Status status="active" />;
+				return <StatusIndicator status="active" label={ DEFAULT_LABELS.active } />;
 		}
 
 		const label = (
@@ -131,7 +162,7 @@ class ProStatus extends Component {
 			</>
 		);
 
-		return <Status status={ status } label={ label } />;
+		return <StatusIndicator status={ status } label={ label } />;
 	};
 
 	/**
@@ -209,7 +240,7 @@ class ProStatus extends Component {
 					} else if ( scanStatus && scanStatus.state !== 'unavailable' ) {
 						if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
 							return (
-								<Status
+								<StatusIndicator
 									status="error"
 									label={ _n( 'Threat', 'Threats', scanStatus.threats.length, 'jetpack' ) }
 								/>
@@ -219,7 +250,7 @@ class ProStatus extends Component {
 							return '';
 						}
 						if ( scanStatus.credentials.length === 0 ) {
-							return <Status status="action" />;
+							return <StatusIndicator status="action" label={ DEFAULT_LABELS.action } />;
 						}
 						return this.getProActions( 'secure', 'scan' );
 					}

--- a/projects/plugins/jetpack/_inc/client/pro-status/style.module.scss
+++ b/projects/plugins/jetpack/_inc/client/pro-status/style.module.scss
@@ -6,48 +6,48 @@
 	white-space: nowrap;
 
 	&.is-active {
-		color: var(--wpds-color-fg-content-success);
+		color: var(--wpds-color-fg-content-success-weak, #008030);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-success);
+			background-color: var(--wpds-color-fg-content-success-weak, #008030);
 		}
 	}
 
 	&.is-inactive {
-		color: var(--wpds-color-fg-content-neutral-weak);
+		color: var(--wpds-color-fg-content-neutral-weak, #707070);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-neutral-weak);
+			background-color: var(--wpds-color-fg-content-neutral-weak, #707070);
 		}
 	}
 
 	&.is-error {
-		color: var(--wpds-color-fg-content-error);
+		color: var(--wpds-color-fg-content-error-weak, #cc1818);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-error);
+			background-color: var(--wpds-color-fg-content-error-weak, #cc1818);
 		}
 	}
 
 	&.is-action {
-		color: var(--wpds-color-fg-content-warning);
+		color: var(--wpds-color-fg-content-warning-weak, #926300);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-warning);
+			background-color: var(--wpds-color-fg-content-warning-weak, #926300);
 		}
 	}
 
 	&.is-initializing {
-		color: var(--wpds-color-fg-content-info);
+		color: var(--wpds-color-fg-content-info-weak, #006bd7);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-info);
+			background-color: var(--wpds-color-fg-content-info-weak, #006bd7);
 		}
 	}
 }
 
 .indicator {
-	background-color: var(--wpds-color-fg-content-neutral-weak);
+	background-color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	border-radius: 50%;
 	flex-shrink: 0;
 	height: 0.666em;

--- a/projects/plugins/jetpack/_inc/client/pro-status/style.module.scss
+++ b/projects/plugins/jetpack/_inc/client/pro-status/style.module.scss
@@ -1,0 +1,56 @@
+.status {
+	align-items: center;
+	display: inline-flex;
+	font-weight: 600;
+	line-height: 1.666;
+	white-space: nowrap;
+
+	&.is-active {
+		color: var(--jp-green-50);
+
+		.indicator {
+			background-color: var(--jp-green-50);
+		}
+	}
+
+	&.is-inactive {
+		color: var(--jp-gray-50);
+
+		.indicator {
+			background-color: var(--jp-gray-50);
+		}
+	}
+
+	&.is-error {
+		color: var(--jp-red-50);
+
+		.indicator {
+			background-color: var(--jp-red-50);
+		}
+	}
+
+	&.is-action {
+		color: var(--jp-yellow-30);
+
+		.indicator {
+			background-color: var(--jp-yellow-30);
+		}
+	}
+
+	&.is-initializing {
+		color: var(--jp-blue-40);
+
+		.indicator {
+			background-color: var(--jp-blue-40);
+		}
+	}
+}
+
+.indicator {
+	background-color: var(--jp-gray-50);
+	border-radius: 50%;
+	flex-shrink: 0;
+	height: 0.666em;
+	margin-right: 4px;
+	width: 0.666em;
+}

--- a/projects/plugins/jetpack/_inc/client/pro-status/style.module.scss
+++ b/projects/plugins/jetpack/_inc/client/pro-status/style.module.scss
@@ -6,48 +6,48 @@
 	white-space: nowrap;
 
 	&.is-active {
-		color: var(--jp-green-50);
+		color: var(--wpds-color-fg-content-success);
 
 		.indicator {
-			background-color: var(--jp-green-50);
+			background-color: var(--wpds-color-fg-content-success);
 		}
 	}
 
 	&.is-inactive {
-		color: var(--jp-gray-50);
+		color: var(--wpds-color-fg-content-neutral-weak);
 
 		.indicator {
-			background-color: var(--jp-gray-50);
+			background-color: var(--wpds-color-fg-content-neutral-weak);
 		}
 	}
 
 	&.is-error {
-		color: var(--jp-red-50);
+		color: var(--wpds-color-fg-content-error);
 
 		.indicator {
-			background-color: var(--jp-red-50);
+			background-color: var(--wpds-color-fg-content-error);
 		}
 	}
 
 	&.is-action {
-		color: var(--jp-yellow-30);
+		color: var(--wpds-color-fg-content-warning);
 
 		.indicator {
-			background-color: var(--jp-yellow-30);
+			background-color: var(--wpds-color-fg-content-warning);
 		}
 	}
 
 	&.is-initializing {
-		color: var(--jp-blue-40);
+		color: var(--wpds-color-fg-content-info);
 
 		.indicator {
-			background-color: var(--jp-blue-40);
+			background-color: var(--wpds-color-fg-content-info);
 		}
 	}
 }
 
 .indicator {
-	background-color: var(--jp-gray-50);
+	background-color: var(--wpds-color-fg-content-neutral-weak);
 	border-radius: 50%;
 	flex-shrink: 0;
 	height: 0.666em;

--- a/projects/plugins/jetpack/_inc/client/security/style.scss
+++ b/projects/plugins/jetpack/_inc/client/security/style.scss
@@ -10,7 +10,7 @@
 
 	.waf__standalone__mode {
 		align-items: center;
-		color: var(--wpds-color-fg-content-success);
+		color: var(--wpds-color-fg-content-success-weak, #008030);
 		display: inline-flex;
 		font-weight: 600;
 		line-height: 1.666;
@@ -18,7 +18,7 @@
 		white-space: nowrap;
 
 		.waf__standalone__mode__indicator {
-			background-color: var(--wpds-color-fg-content-success);
+			background-color: var(--wpds-color-fg-content-success-weak, #008030);
 			border-radius: 50%;
 			flex-shrink: 0;
 			height: 0.666em;

--- a/projects/plugins/jetpack/_inc/client/security/style.scss
+++ b/projects/plugins/jetpack/_inc/client/security/style.scss
@@ -9,7 +9,22 @@
 	display: flex;
 
 	.waf__standalone__mode {
+		align-items: center;
+		color: var(--wpds-color-fg-content-success);
+		display: inline-flex;
+		font-weight: 600;
+		line-height: 1.666;
 		margin-left: auto;
+		white-space: nowrap;
+
+		.waf__standalone__mode__indicator {
+			background-color: var(--wpds-color-fg-content-success);
+			border-radius: 50%;
+			flex-shrink: 0;
+			height: 0.666em;
+			margin-right: 4px;
+			width: 0.666em;
+		}
 	}
 
 }

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -1,8 +1,8 @@
-import { getRedirectUrl, Status } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
+import { Link, Text } from '@wordpress/ui';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -206,11 +206,30 @@ export const Waf = class extends Component {
 			<div className="waf__header">
 				<span>{ _x( 'Firewall', 'Settings header', 'jetpack' ) }</span>
 				{ this.props.settings?.standaloneMode && (
-					<Status
+					<Text
+						variant="body-sm"
 						className="waf__standalone__mode"
-						status="active"
-						label={ __( 'Standalone mode', 'jetpack' ) }
-					/>
+						style={ {
+							alignItems: 'center',
+							color: 'var(--jp-green-50)',
+							display: 'inline-flex',
+							fontWeight: 600,
+							lineHeight: 1.666,
+							whiteSpace: 'nowrap',
+						} }
+					>
+						<span
+							style={ {
+								backgroundColor: 'var(--jp-green-50)',
+								borderRadius: '50%',
+								flexShrink: 0,
+								height: '0.666em',
+								marginRight: '4px',
+								width: '0.666em',
+							} }
+						/>
+						<span>{ __( 'Standalone mode', 'jetpack' ) }</span>
+					</Text>
 				) }
 			</div>
 		);

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -206,28 +206,8 @@ export const Waf = class extends Component {
 			<div className="waf__header">
 				<span>{ _x( 'Firewall', 'Settings header', 'jetpack' ) }</span>
 				{ this.props.settings?.standaloneMode && (
-					<Text
-						variant="body-sm"
-						className="waf__standalone__mode"
-						style={ {
-							alignItems: 'center',
-							color: 'var(--jp-green-50)',
-							display: 'inline-flex',
-							fontWeight: 600,
-							lineHeight: 1.666,
-							whiteSpace: 'nowrap',
-						} }
-					>
-						<span
-							style={ {
-								backgroundColor: 'var(--jp-green-50)',
-								borderRadius: '50%',
-								flexShrink: 0,
-								height: '0.666em',
-								marginRight: '4px',
-								width: '0.666em',
-							} }
-						/>
+					<Text variant="body-sm" className="waf__standalone__mode">
+						<span className="waf__standalone__mode__indicator" />
 						<span>{ __( 'Standalone mode', 'jetpack' ) }</span>
 					</Text>
 				) }

--- a/projects/plugins/jetpack/changelog/change-migrate-status-wp-ui
+++ b/projects/plugins/jetpack/changelog/change-migrate-status-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Jetpack: migrate Status indicator to @wordpress/ui Text.

--- a/projects/plugins/protect/changelog/change-migrate-status-wp-ui
+++ b/projects/plugins/protect/changelog/change-migrate-status-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: migrate Status indicator to @wordpress/ui Text.

--- a/projects/plugins/protect/src/js/components/admin-section-hero/index.tsx
+++ b/projects/plugins/protect/src/js/components/admin-section-hero/index.tsx
@@ -3,6 +3,8 @@ import {
 	H3,
 	getIconBySlug,
 } from '@automattic/jetpack-components';
+import { Text as UIText } from '@wordpress/ui';
+import clsx from 'clsx';
 import SeventyFiveLayout from '../seventy-five-layout';
 import AdminSectionHeroNotices from './admin-section-hero-notices';
 import styles from './styles.module.scss';
@@ -15,9 +17,15 @@ interface AdminSectionHeroProps {
 	spacing?: number;
 }
 
+interface StatusIndicatorProps {
+	status: 'active' | 'inactive';
+	label: ReactNode;
+}
+
 interface AdminSectionHeroComponent extends FC< AdminSectionHeroProps > {
 	Heading: FC< { children: ReactNode; showIcon?: boolean } >;
 	Subheading: FC< { children: ReactNode } >;
+	StatusIndicator: FC< StatusIndicatorProps >;
 }
 
 const AdminSectionHero: AdminSectionHeroComponent = ( {
@@ -62,6 +70,15 @@ AdminSectionHero.Heading = ( {
 
 AdminSectionHero.Subheading = ( { children }: { children: ReactNode } ) => {
 	return <div className={ styles.subheading }>{ children }</div>;
+};
+
+AdminSectionHero.StatusIndicator = ( { status, label }: StatusIndicatorProps ) => {
+	return (
+		<UIText variant="body-sm" className={ clsx( styles.status, styles[ `is-${ status }` ] ) }>
+			<span className={ styles.indicator } />
+			<span>{ label }</span>
+		</UIText>
+	);
 };
 
 export default AdminSectionHero;

--- a/projects/plugins/protect/src/js/components/admin-section-hero/stories/index.stories.jsx
+++ b/projects/plugins/protect/src/js/components/admin-section-hero/stories/index.stories.jsx
@@ -1,6 +1,9 @@
-import { Status, Text } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
+import { Text as UIText } from '@wordpress/ui';
 import AdminSectionHero from '..';
 import InProgressAnimation from '../../in-progress-animation';
+
+const activeColor = 'var(--jp-green-50)';
 
 export default {
 	title: 'Plugins/Protect/AdminSectionHero',
@@ -11,7 +14,29 @@ export const Default = args => <AdminSectionHero { ...args } />;
 Default.args = {
 	main: (
 		<>
-			<Status status={ 'active' } label={ 'Active' } />
+			<UIText
+				variant="body-sm"
+				style={ {
+					alignItems: 'center',
+					color: activeColor,
+					display: 'inline-flex',
+					fontWeight: 600,
+					lineHeight: 1.666,
+					whiteSpace: 'nowrap',
+				} }
+			>
+				<span
+					style={ {
+						backgroundColor: activeColor,
+						borderRadius: '50%',
+						flexShrink: 0,
+						height: '0.666em',
+						marginRight: '4px',
+						width: '0.666em',
+					} }
+				/>
+				<span>{ 'Active' }</span>
+			</UIText>
 			<AdminSectionHero.Heading showIcon>{ 'No threats found' }</AdminSectionHero.Heading>
 			<AdminSectionHero.Subheading>
 				<Text>{ 'Most recent results' }</Text>

--- a/projects/plugins/protect/src/js/components/admin-section-hero/stories/index.stories.jsx
+++ b/projects/plugins/protect/src/js/components/admin-section-hero/stories/index.stories.jsx
@@ -1,9 +1,6 @@
 import { Text } from '@automattic/jetpack-components';
-import { Text as UIText } from '@wordpress/ui';
 import AdminSectionHero from '..';
 import InProgressAnimation from '../../in-progress-animation';
-
-const activeColor = 'var(--jp-green-50)';
 
 export default {
 	title: 'Plugins/Protect/AdminSectionHero',
@@ -14,29 +11,7 @@ export const Default = args => <AdminSectionHero { ...args } />;
 Default.args = {
 	main: (
 		<>
-			<UIText
-				variant="body-sm"
-				style={ {
-					alignItems: 'center',
-					color: activeColor,
-					display: 'inline-flex',
-					fontWeight: 600,
-					lineHeight: 1.666,
-					whiteSpace: 'nowrap',
-				} }
-			>
-				<span
-					style={ {
-						backgroundColor: activeColor,
-						borderRadius: '50%',
-						flexShrink: 0,
-						height: '0.666em',
-						marginRight: '4px',
-						width: '0.666em',
-					} }
-				/>
-				<span>{ 'Active' }</span>
-			</UIText>
+			<AdminSectionHero.StatusIndicator status="active" label="Active" />
 			<AdminSectionHero.Heading showIcon>{ 'No threats found' }</AdminSectionHero.Heading>
 			<AdminSectionHero.Subheading>
 				<Text>{ 'Most recent results' }</Text>

--- a/projects/plugins/protect/src/js/components/admin-section-hero/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-section-hero/styles.module.scss
@@ -24,3 +24,36 @@
 .connection-error-col {
 	margin-top: calc(var(--spacing-base) * 3 + 1px); // 25px
 }
+
+.status {
+	align-items: center;
+	display: inline-flex;
+	font-weight: 600;
+	line-height: 1.666;
+	white-space: nowrap;
+
+	&.is-active {
+		color: var(--wpds-color-fg-content-success);
+
+		.indicator {
+			background-color: var(--wpds-color-fg-content-success);
+		}
+	}
+
+	&.is-inactive {
+		color: var(--wpds-color-fg-content-neutral-weak);
+
+		.indicator {
+			background-color: var(--wpds-color-fg-content-neutral-weak);
+		}
+	}
+}
+
+.indicator {
+	background-color: var(--wpds-color-fg-content-neutral-weak);
+	border-radius: 50%;
+	flex-shrink: 0;
+	height: 0.666em;
+	margin-right: 4px;
+	width: 0.666em;
+}

--- a/projects/plugins/protect/src/js/components/admin-section-hero/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-section-hero/styles.module.scss
@@ -33,24 +33,24 @@
 	white-space: nowrap;
 
 	&.is-active {
-		color: var(--wpds-color-fg-content-success);
+		color: var(--wpds-color-fg-content-success-weak, #008030);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-success);
+			background-color: var(--wpds-color-fg-content-success-weak, #008030);
 		}
 	}
 
 	&.is-inactive {
-		color: var(--wpds-color-fg-content-neutral-weak);
+		color: var(--wpds-color-fg-content-neutral-weak, #707070);
 
 		.indicator {
-			background-color: var(--wpds-color-fg-content-neutral-weak);
+			background-color: var(--wpds-color-fg-content-neutral-weak, #707070);
 		}
 	}
 }
 
 .indicator {
-	background-color: var(--wpds-color-fg-content-neutral-weak);
+	background-color: var(--wpds-color-fg-content-neutral-weak, #707070);
 	border-radius: 50%;
 	flex-shrink: 0;
 	height: 0.666em;

--- a/projects/plugins/protect/src/js/routes/firewall/firewall-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/firewall/firewall-admin-section-hero.tsx
@@ -1,6 +1,5 @@
 import { Text } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
-import { Text as UIText } from '@wordpress/ui';
 import { useMemo } from 'react';
 import AdminSectionHero from '../../components/admin-section-hero';
 import useWafData from '../../hooks/use-waf-data';
@@ -84,35 +83,13 @@ const FirewallAdminSectionHero = () => {
 		return <FirewallSubheading />;
 	}, [ status ] );
 
-	const statusColor = 'on' === status ? 'var(--jp-green-50)' : 'var(--jp-gray-50)';
+	const indicatorStatus = 'on' === status ? 'active' : 'inactive';
 
 	return (
 		<AdminSectionHero
 			main={
 				<>
-					<UIText
-						variant="body-sm"
-						style={ {
-							alignItems: 'center',
-							color: statusColor,
-							display: 'inline-flex',
-							fontWeight: 600,
-							lineHeight: 1.666,
-							whiteSpace: 'nowrap',
-						} }
-					>
-						<span
-							style={ {
-								backgroundColor: statusColor,
-								borderRadius: '50%',
-								flexShrink: 0,
-								height: '0.666em',
-								marginRight: '4px',
-								width: '0.666em',
-							} }
-						/>
-						<span>{ statusLabel }</span>
-					</UIText>
+					<AdminSectionHero.StatusIndicator status={ indicatorStatus } label={ statusLabel } />
 					<AdminSectionHero.Heading>{ heading }</AdminSectionHero.Heading>
 					<AdminSectionHero.Subheading>{ subheading }</AdminSectionHero.Subheading>
 				</>

--- a/projects/plugins/protect/src/js/routes/firewall/firewall-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/firewall/firewall-admin-section-hero.tsx
@@ -1,5 +1,6 @@
-import { Status, Text } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
+import { Text as UIText } from '@wordpress/ui';
 import { useMemo } from 'react';
 import AdminSectionHero from '../../components/admin-section-hero';
 import useWafData from '../../hooks/use-waf-data';
@@ -83,11 +84,35 @@ const FirewallAdminSectionHero = () => {
 		return <FirewallSubheading />;
 	}, [ status ] );
 
+	const statusColor = 'on' === status ? 'var(--jp-green-50)' : 'var(--jp-gray-50)';
+
 	return (
 		<AdminSectionHero
 			main={
 				<>
-					<Status status={ 'on' === status ? 'active' : 'inactive' } label={ statusLabel } />
+					<UIText
+						variant="body-sm"
+						style={ {
+							alignItems: 'center',
+							color: statusColor,
+							display: 'inline-flex',
+							fontWeight: 600,
+							lineHeight: 1.666,
+							whiteSpace: 'nowrap',
+						} }
+					>
+						<span
+							style={ {
+								backgroundColor: statusColor,
+								borderRadius: '50%',
+								flexShrink: 0,
+								height: '0.666em',
+								marginRight: '4px',
+								width: '0.666em',
+							} }
+						/>
+						<span>{ statusLabel }</span>
+					</UIText>
 					<AdminSectionHero.Heading>{ heading }</AdminSectionHero.Heading>
 					<AdminSectionHero.Subheading>{ subheading }</AdminSectionHero.Subheading>
 				</>

--- a/projects/plugins/protect/src/js/routes/scan/history/history-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/history/history-admin-section-hero.tsx
@@ -1,7 +1,6 @@
 import { Text } from '@automattic/jetpack-components';
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
-import { Text as UIText } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
 import AdminSectionHero from '../../../components/admin-section-hero';
@@ -50,29 +49,10 @@ const HistoryAdminSectionHero: FC = () => {
 		<AdminSectionHero
 			main={
 				<>
-					<UIText
-						variant="body-sm"
-						style={ {
-							alignItems: 'center',
-							color: 'var(--jp-green-50)',
-							display: 'inline-flex',
-							fontWeight: 600,
-							lineHeight: 1.666,
-							whiteSpace: 'nowrap',
-						} }
-					>
-						<span
-							style={ {
-								backgroundColor: 'var(--jp-green-50)',
-								borderRadius: '50%',
-								flexShrink: 0,
-								height: '0.666em',
-								marginRight: '4px',
-								width: '0.666em',
-							} }
-						/>
-						<span>{ __( 'Active', 'jetpack-protect' ) }</span>
-					</UIText>
+					<AdminSectionHero.StatusIndicator
+						status="active"
+						label={ __( 'Active', 'jetpack-protect' ) }
+					/>
 					<AdminSectionHero.Heading showIcon>
 						{ numAllThreats > 0
 							? sprintf(

--- a/projects/plugins/protect/src/js/routes/scan/history/history-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/history/history-admin-section-hero.tsx
@@ -1,6 +1,7 @@
-import { Status, Text } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
+import { Text as UIText } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
 import AdminSectionHero from '../../../components/admin-section-hero';
@@ -49,7 +50,29 @@ const HistoryAdminSectionHero: FC = () => {
 		<AdminSectionHero
 			main={
 				<>
-					<Status status="active" label={ __( 'Active', 'jetpack-protect' ) } />
+					<UIText
+						variant="body-sm"
+						style={ {
+							alignItems: 'center',
+							color: 'var(--jp-green-50)',
+							display: 'inline-flex',
+							fontWeight: 600,
+							lineHeight: 1.666,
+							whiteSpace: 'nowrap',
+						} }
+					>
+						<span
+							style={ {
+								backgroundColor: 'var(--jp-green-50)',
+								borderRadius: '50%',
+								flexShrink: 0,
+								height: '0.666em',
+								marginRight: '4px',
+								width: '0.666em',
+							} }
+						/>
+						<span>{ __( 'Active', 'jetpack-protect' ) }</span>
+					</UIText>
 					<AdminSectionHero.Heading showIcon>
 						{ numAllThreats > 0
 							? sprintf(

--- a/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
@@ -1,6 +1,7 @@
-import { Text, Status, useBreakpointMatch } from '@automattic/jetpack-components';
+import { Text, useBreakpointMatch } from '@automattic/jetpack-components';
 import { dateI18n } from '@wordpress/date';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
+import { Text as UIText } from '@wordpress/ui';
 import { useState } from 'react';
 import AdminSectionHero from '../../components/admin-section-hero';
 import ErrorAdminSectionHero from '../../components/error-admin-section-hero';
@@ -51,7 +52,29 @@ const ScanAdminSectionHero: FC = () => {
 		<AdminSectionHero
 			main={
 				<>
-					<Status status={ 'active' } label={ __( 'Active', 'jetpack-protect' ) } />
+					<UIText
+						variant="body-sm"
+						style={ {
+							alignItems: 'center',
+							color: 'var(--jp-green-50)',
+							display: 'inline-flex',
+							fontWeight: 600,
+							lineHeight: 1.666,
+							whiteSpace: 'nowrap',
+						} }
+					>
+						<span
+							style={ {
+								backgroundColor: 'var(--jp-green-50)',
+								borderRadius: '50%',
+								flexShrink: 0,
+								height: '0.666em',
+								marginRight: '4px',
+								width: '0.666em',
+							} }
+						/>
+						<span>{ __( 'Active', 'jetpack-protect' ) }</span>
+					</UIText>
 					<AdminSectionHero.Heading showIcon>
 						{ numThreats > 0
 							? sprintf(

--- a/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
@@ -1,7 +1,6 @@
 import { Text, useBreakpointMatch } from '@automattic/jetpack-components';
 import { dateI18n } from '@wordpress/date';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { Text as UIText } from '@wordpress/ui';
 import { useState } from 'react';
 import AdminSectionHero from '../../components/admin-section-hero';
 import ErrorAdminSectionHero from '../../components/error-admin-section-hero';
@@ -52,29 +51,10 @@ const ScanAdminSectionHero: FC = () => {
 		<AdminSectionHero
 			main={
 				<>
-					<UIText
-						variant="body-sm"
-						style={ {
-							alignItems: 'center',
-							color: 'var(--jp-green-50)',
-							display: 'inline-flex',
-							fontWeight: 600,
-							lineHeight: 1.666,
-							whiteSpace: 'nowrap',
-						} }
-					>
-						<span
-							style={ {
-								backgroundColor: 'var(--jp-green-50)',
-								borderRadius: '50%',
-								flexShrink: 0,
-								height: '0.666em',
-								marginRight: '4px',
-								width: '0.666em',
-							} }
-						/>
-						<span>{ __( 'Active', 'jetpack-protect' ) }</span>
-					</UIText>
+					<AdminSectionHero.StatusIndicator
+						status="active"
+						label={ __( 'Active', 'jetpack-protect' ) }
+					/>
 					<AdminSectionHero.Heading showIcon>
 						{ numThreats > 0
 							? sprintf(


### PR DESCRIPTION
Part of #48160.

## Proposed changes

Replace the internal Jetpack `Status` component (from `@automattic/jetpack-components`) with inline JSX using `Text` from `@wordpress/ui` plus a small colour-coded indicator span across all six in-repo consumer sites in `plugins/protect` and `plugins/jetpack`. Mark the `Status` source in `js-packages/components` as `@deprecated` (JSDoc-only, no API change) following the chip → badge precedent from #48162.

* **`plugins/protect`**: `AdminSectionHero` storybook, firewall admin-section-hero, scan admin-section-hero, scan history admin-section-hero — single Status sites. Now share an `AdminSectionHero.StatusIndicator` helper backed by `styles.module.scss` so the four call sites stay terse.
* **`plugins/jetpack`**: `_inc/client/security/waf.jsx` "Standalone mode" label. Styling lives under the existing `.waf__standalone__mode` class in `_inc/client/security/style.scss` (no inline `style` blocks).
* **`plugins/jetpack`**: `_inc/client/pro-status/index.jsx` renders four different status states (`active`, `error`, `action`, `initializing`); co-locate a `style.module.scss` mirroring the wrapper's status colour map (`is-active | is-inactive | is-error | is-action | is-initializing`) so the four call sites stay terse. Also drops the dead `text` prop on the legacy rewind status site (the original `Status` wrapper only ever read `label`, never `text`, so the prop was already being ignored — same strings reach the DOM via the now-explicit `DEFAULT_LABELS` map).
* **`js-packages/components`**: `Status` keeps the same implementation, styles, stories, and barrel export; only adds an `@deprecated` JSDoc block pointing at the inline replacement pattern so external npm consumers see the guidance without breaking on a patch upgrade.

### Colour tokens — design-system migration

This PR no longer uses `--jp-*` colour vars. Indicators now reference WPDS design tokens with a hex fallback for surfaces that don't enqueue `@wordpress/theme/design-tokens.css`:

| Status | Token | Fallback hex |
|---|---|---|
| `active` | `--wpds-color-fg-content-success-weak` | `#008030` |
| `error` | `--wpds-color-fg-content-error-weak` | `#cc1818` |
| `action` | `--wpds-color-fg-content-warning-weak` | `#926300` |
| `initializing` | `--wpds-color-fg-content-info-weak` | `#006bd7` |
| `inactive` | `--wpds-color-fg-content-neutral-weak` | `#707070` |

The `*-weak` family is the recognizable shade (matches the old `--jp-green-50` / `--jp-red-50` / `--jp-gray-50` palette); the base `--wpds-color-fg-content-*` tokens are near-black "ink" colours intended for text on tinted alert/badge backgrounds — wrong choice for a standalone dot + label, and they were what made the indicators look colourless on the previous push (commit `361bcad`). The fallback hex covers the legacy Jetpack settings dashboard, which does not load `@wordpress/theme/design-tokens.css`. See follow-up comment for the verification on the live dev site.

Acceptance:

- `grep -rn "from '@automattic/jetpack-components'" projects/plugins/protect/ projects/plugins/jetpack/ | grep '\\bStatus\\b'` returns zero matches.
- `pnpm jetpack build plugins/protect`, `pnpm jetpack build plugins/jetpack`, `pnpm jetpack build js-packages/components` all green.
- ESLint + Prettier + tsgo clean on all touched files; husky hooks ran on commit.
- Visual parity verified at Protect → Scan and Protect → Firewall heroes (see screenshots below).
- Indicator colour resolves to the recognizable shade on both the Protect React routes (`rgb(0, 128, 48)` from the token) and the legacy Jetpack settings dashboard (`rgb(0, 128, 48)` from the hex fallback).

## Related product discussion/links

* Tracking issue: #48160
* Precedent for `@deprecated` JSDoc on a jetpack-components export: #48162 (Chip → Badge)
* Precedent for `@wordpress/ui` `Text` adoption: #48150, #47894, #48414, #48489
* Precedent for WPDS design-token adoption: #47989 (Charts), #48414 (My Jetpack header), #48550 (Search Notice)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Install Jetpack Protect on a sandboxed site and visit **Jetpack → Protect**.
   * **Scan tab**: the green "● Active" indicator at the top of the hero should look identical to trunk — same green dot, same green label text, same spacing, same font weight.
   * **Firewall tab**: the "● Active" indicator above "Firewall is on" should also be unchanged. Toggle the firewall off in the firewall settings to confirm the indicator switches to the grey "● Inactive" state without layout shift.
   * **Scan → History** (if any history threats exist): the green "● Active" indicator should render identically.
2. With Jetpack (the plugin) active but Protect *not* active, visit **Jetpack → Settings → Security → Firewall**. If you have firewall standalone mode enabled (`waf['standalone_mode']` in WAF settings), the "● Standalone mode" green indicator should render in the section header, identical to trunk.
3. (Internal) Browse Storybook for `Plugins/Protect/AdminSectionHero` — the green "● Active" indicator at the top of the hero should still look the same.

## Screenshots

Visual parity check across the six Status consumer surfaces. Indicators paint identically — same recognizable green / red / amber / blue / grey, same dot size, same line-height. On modern Protect routes the colour resolves from the WPDS token; on the legacy Jetpack dashboard the `#008030` hex fallback paints (the token is absent there).

| Screen | Before (trunk) | After (this PR) |
|---|---|---|
| **Protect → Scan** hero | <img width="540" alt="Protect Scan, before" src="https://github.com/user-attachments/assets/caea7c91-f821-4b85-b593-bb261ca2674d" /> | <img width="540" alt="Protect Scan, after" src="https://github.com/user-attachments/assets/244f92e2-f179-4671-9f4c-5fd80d6ac3c7" /> |
| **Protect → Firewall** hero | <img width="540" alt="Protect Firewall, before" src="https://github.com/user-attachments/assets/a823fd6e-5b9f-4f01-866c-1fa684d83323" /> | <img width="540" alt="Protect Firewall, after" src="https://github.com/user-attachments/assets/863ebbc5-7723-4052-a6f7-d212546726e2" /> |
| **Protect → Scan → History** hero | <img width="540" alt="Protect Scan History, before" src="https://github.com/user-attachments/assets/8622c8cf-28bc-4f62-a66d-2a8bccd999e8" /> | <img width="540" alt="Protect Scan History, after" src="https://github.com/user-attachments/assets/c5c36332-ee54-46c6-b5cd-21193df9d1e5" /> |
| **Jetpack → Settings → Security** (WAF "Standalone mode") | <img width="540" alt="Jetpack Security WAF, before" src="https://github.com/user-attachments/assets/76c36f0b-f84a-48b5-955e-d96b96315f0f" /> | <img width="540" alt="Jetpack Security WAF, after (DOM-injected indicator on live page)" src="https://github.com/user-attachments/assets/a39ee11b-12c7-4417-b9d7-44d9c14e513e" /> |
| **Jetpack → Dashboard** (Pro Status panel) | <img width="540" alt="Jetpack Dashboard, before" src="https://github.com/user-attachments/assets/ce8288e9-7024-40a0-a391-60e5abcaefbe" /> | <img width="540" alt="Jetpack Dashboard, after (multi-status demo via DOM injection)" src="https://github.com/user-attachments/assets/9cc12c34-ec19-4ddb-b7a9-e9e8bf355f56" /> |

Notes on the legacy-dashboard captures:

* **WAF "Standalone mode"** — when Jetpack Protect is active on the same site the `waf.jsx` short-circuits to a redirect-banner branch and `<QueryWafSettings />` never mounts; the REST short-circuit returns `standalone_mode: true` but isn't fetched. The "after" image is the rendered DOM with the indicator HTML re-injected at `.waf__header` so the PR's CSS path (`.waf__standalone__mode` / `__indicator`) is exercised exactly as the production render emits it.
* **Pro Status panel** — the panel is gated by `! isOfflineMode`; the dev site is in Offline Mode (URL classed as local-dev). The "after" image is a multi-state DOM-injected demo at the Security section of the dashboard so all four status colour mappings can be eyeballed in one shot.

Verification that the hex fallback resolves correctly on the legacy dashboard (all five status colours rendered via the same CSS path, WPDS token absent on `:root` — the `var(--wpds-…, #hex)` fallback paints):

<img width="540" alt="Legacy dashboard hex fallback verification — all 5 status colours" src="https://github.com/user-attachments/assets/5c434247-8515-446f-b6bb-8e9e11ec9008" />
