### PR TITLE
Connection: include connection-using plugin slugs on every authorize URL

### DIFF
--- a/projects/packages/connection/changelog/add-plugins-to-all-auth-urls
+++ b/projects/packages/connection/changelog/add-plugins-to-all-auth-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: Include the comma-separated list of connection-using plugin slugs on every authorize URL, not only those built by the connectors card flow.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2092,6 +2092,45 @@ class Manager {
 		 */
 		$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
 
+		$body_args = array(
+			'response_type'         => 'code',
+			'client_id'             => \Jetpack_Options::get_option( 'id' ),
+			'redirect_uri'          => add_query_arg(
+				array(
+					'handler'  => 'jetpack-connection-webhooks',
+					'action'   => 'authorize',
+					'_wpnonce' => wp_create_nonce( "jetpack-authorize_{$role}_{$redirect}" ),
+					'redirect' => $redirect ? rawurlencode( $redirect ) : false,
+				),
+				esc_url( $processing_url )
+			),
+			'state'                 => $user->ID,
+			'scope'                 => $signed_role,
+			'user_email'            => $user->user_email,
+			'user_login'            => $user->user_login,
+			'is_active'             => $this->has_connected_owner(), // TODO Deprecate this.
+			'jp_version'            => (string) Constants::get_constant( 'JETPACK__VERSION' ),
+			'auth_type'             => $auth_type,
+			'secret'                => $secrets['secret_1'],
+			'blogname'              => get_option( 'blogname' ),
+			'site_url'              => Urls::site_url(),
+			'home_url'              => Urls::home_url(),
+			'site_icon'             => get_site_icon_url(),
+			'site_lang'             => get_locale(),
+			'site_created'          => $this->get_assumed_site_creation_date(),
+			'allow_site_connection' => ! $this->has_connected_owner(),
+			'calypso_env'           => ( new Host() )->get_calypso_env(),
+			'source'                => ( new Host() )->get_source_query(),
+		);
+
+		// Include the slugs of every plugin currently using the Jetpack connection so wpcom
+		// knows which integrations the site is authorizing on behalf of. `Plugin_Storage::get_all()`
+		// returns a `WP_Error` when called before `plugins_loaded`; in that case we silently skip.
+		$active_plugins = Plugin_Storage::get_all();
+		if ( is_array( $active_plugins ) && ! empty( $active_plugins ) ) {
+			$body_args['plugins'] = implode( ',', array_keys( $active_plugins ) );
+		}
+
 		/**
 		 * Filters the user connection request data for additional property addition.
 		 *
@@ -2100,39 +2139,7 @@ class Manager {
 		 *
 		 * @param array $request_data request data.
 		 */
-		$body = apply_filters(
-			'jetpack_connect_request_body',
-			array(
-				'response_type'         => 'code',
-				'client_id'             => \Jetpack_Options::get_option( 'id' ),
-				'redirect_uri'          => add_query_arg(
-					array(
-						'handler'  => 'jetpack-connection-webhooks',
-						'action'   => 'authorize',
-						'_wpnonce' => wp_create_nonce( "jetpack-authorize_{$role}_{$redirect}" ),
-						'redirect' => $redirect ? rawurlencode( $redirect ) : false,
-					),
-					esc_url( $processing_url )
-				),
-				'state'                 => $user->ID,
-				'scope'                 => $signed_role,
-				'user_email'            => $user->user_email,
-				'user_login'            => $user->user_login,
-				'is_active'             => $this->has_connected_owner(), // TODO Deprecate this.
-				'jp_version'            => (string) Constants::get_constant( 'JETPACK__VERSION' ),
-				'auth_type'             => $auth_type,
-				'secret'                => $secrets['secret_1'],
-				'blogname'              => get_option( 'blogname' ),
-				'site_url'              => Urls::site_url(),
-				'home_url'              => Urls::home_url(),
-				'site_icon'             => get_site_icon_url(),
-				'site_lang'             => get_locale(),
-				'site_created'          => $this->get_assumed_site_creation_date(),
-				'allow_site_connection' => ! $this->has_connected_owner(),
-				'calypso_env'           => ( new Host() )->get_calypso_env(),
-				'source'                => ( new Host() )->get_source_query(),
-			)
-		);
+		$body = apply_filters( 'jetpack_connect_request_body', $body_args );
 
 		$body = static::apply_activation_source_to_args( urlencode_deep( $body ) );
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -242,10 +242,6 @@ class REST_Connector {
 						'description' => __( 'Indicates from what plugin the request is coming from', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
-					'plugins'      => array(
-						'description' => __( 'Comma-separated list of plugin slugs currently using the Jetpack connection', 'jetpack-connection' ),
-						'type'        => 'string',
-					),
 				),
 			)
 		);
@@ -265,10 +261,6 @@ class REST_Connector {
 					),
 					'from'         => array(
 						'description' => __( 'Tracking/segmentation identifier for this authorize URL request', 'jetpack-connection' ),
-						'type'        => 'string',
-					),
-					'plugins'      => array(
-						'description' => __( 'Comma-separated list of plugin slugs currently using the Jetpack connection', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
 				),
@@ -824,11 +816,6 @@ class REST_Connector {
 
 		$authorize_url = ( new Authorize_Redirect( $this->connection ) )->build_authorize_url( $redirect_uri, '' !== $from ? $from : false );
 
-		$plugins = $request->get_param( 'plugins' );
-		if ( ! empty( $plugins ) ) {
-			$authorize_url = add_query_arg( 'plugins', (string) $plugins, $authorize_url );
-		}
-
 		/**
 		 * Filters the response of jetpack/v4/connection/register endpoint
 		 *
@@ -862,11 +849,6 @@ class REST_Connector {
 		$redirect_uri  = $request->get_param( 'redirect_uri' ) ? admin_url( $request->get_param( 'redirect_uri' ) ) : null;
 		$from          = $request->get_param( 'from' );
 		$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri, ! empty( $from ) ? (string) $from : false );
-
-		$plugins = $request->get_param( 'plugins' );
-		if ( ! empty( $plugins ) ) {
-			$authorize_url = add_query_arg( 'plugins', (string) $plugins, $authorize_url );
-		}
 
 		return rest_ensure_response(
 			array(

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -42,10 +42,6 @@ const redirectUri = data.redirectUri || '';
 const currentUser = data.currentUser || null;
 const connectionOwner = data.connectionOwner || null;
 const connectedPlugins = data.connectedPlugins || [];
-const connectedPluginSlugs = connectedPlugins
-	.map( p => p.slug )
-	.filter( Boolean )
-	.join( ',' );
 const siteDetails = data.siteDetails || null;
 const isWoaSite = Boolean( data.isWoaSite );
 const isVipSite = Boolean( data.isVipSite );
@@ -73,9 +69,6 @@ async function startConnectionFlow( siteRegistered ) {
 			params.set( 'redirect_uri', redirectUri );
 		}
 		params.set( 'from', 'jetpack-connector' );
-		if ( connectedPluginSlugs ) {
-			params.set( 'plugins', connectedPluginSlugs );
-		}
 		const qs = params.toString();
 		const authRes = await window.fetch(
 			apiRoot + 'jetpack/v4/connection/authorize_url' + ( qs ? '?' + qs : '' ),
@@ -99,9 +92,6 @@ async function startConnectionFlow( siteRegistered ) {
 	const body = { from: 'jetpack-connector' };
 	if ( redirectUri ) {
 		body.redirect_uri = redirectUri;
-	}
-	if ( connectedPluginSlugs ) {
-		body.plugins = connectedPluginSlugs;
 	}
 
 	const response = await window.fetch( apiRoot + 'jetpack/v4/connection/register', {

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -1080,7 +1080,7 @@ class ManagerTest extends TestCase {
 	 * arg should be omitted entirely.
 	 *
 	 * The flow runs end-to-end: `Plugin::add()` -> `Plugin_Storage::upsert()` ->
-	 * `Plugin_Storage::configure()` -> `get_authorization_url()`.
+	 * `get_authorization_url()` -> `Plugin_Storage::get_all()`.
 	 */
 	public function test_get_authorization_url_includes_plugins_from_storage() {
 		$user_id = wp_insert_user(
@@ -1110,19 +1110,16 @@ class ManagerTest extends TestCase {
 		$manager->method( 'has_connected_owner' )->willReturn( true );
 		$manager->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
 
-		// No plugins seeded yet -> no `plugins` arg.
+		// No plugins seeded -> no `plugins` arg.
 		$this->reset_plugin_storage();
-		Plugin_Storage::configure();
 
 		$url = $manager->get_authorization_url();
 		$this->assertStringNotContainsString( 'plugins=', $url );
 
 		// Seed two plugins -> URL should carry them as a single-encoded
 		// comma-separated list.
-		$this->set_plugin_storage_configured( false );
 		( new Plugin( 'jetpack' ) )->add( 'Jetpack' );
 		( new Plugin( 'woocommerce' ) )->add( 'WooCommerce' );
-		Plugin_Storage::configure();
 
 		$url = $manager->get_authorization_url();
 		$this->assertStringContainsString( 'plugins=jetpack%2Cwoocommerce', $url );
@@ -1133,43 +1130,34 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * Reset the private static state of `Plugin_Storage` so a test can start
-	 * from a clean slate. Compatible with PHP <8.1 where `setStaticPropertyValue()`
-	 * cannot reach private static properties without `setAccessible(true)`.
+	 * Reset `Plugin_Storage` to a clean, "post-`plugins_loaded`" state for
+	 * tests: `configured = true`, no cached plugins. Setting `configured`
+	 * to `false` here would make `Plugin_Storage::get_all()` hand back a
+	 * `WP_Error` object, which on PHP 8.5 trips the deprecated
+	 * `ArrayIterator::__construct()` object-backing notice once that error
+	 * object is iterated by the WP HTTP Requests library downstream.
+	 *
+	 * Compatible with PHP <8.1 where `setStaticPropertyValue()` cannot reach
+	 * private static properties without `setAccessible(true)`.
 	 */
 	private function reset_plugin_storage() {
-		$this->set_plugin_storage_property( 'configured', false );
-		$this->set_plugin_storage_property( 'plugins', array() );
-	}
-
-	/**
-	 * Flip the `configured` flag without touching the cached `$plugins` array.
-	 * Lets the test seed plugins after a successful first `configure()` and
-	 * then call `configure()` again to pick them up.
-	 *
-	 * @param bool $value New value for the flag.
-	 */
-	private function set_plugin_storage_configured( $value ) {
-		$this->set_plugin_storage_property( 'configured', $value );
-	}
-
-	/**
-	 * Set a private static property on `Plugin_Storage` via reflection.
-	 *
-	 * @param string $name  Property name.
-	 * @param mixed  $value New value.
-	 */
-	private function set_plugin_storage_property( $name, $value ) {
 		$reflection = new \ReflectionClass( Plugin_Storage::class );
 		try {
-			$reflection->setStaticPropertyValue( $name, $value );
+			$reflection->setStaticPropertyValue( 'configured', true );
+			$reflection->setStaticPropertyValue( 'plugins', array() );
 		} catch ( \ReflectionException $e ) { // PHP <8.1: private statics need setAccessible.
-			$prop = $reflection->getProperty( $name );
-			// @todo Remove this call once we no longer need to support PHP <8.1.
-			if ( PHP_VERSION_ID < 80100 ) {
-				$prop->setAccessible( true );
+			$values = array(
+				'configured' => true,
+				'plugins'    => array(),
+			);
+			foreach ( $values as $name => $value ) {
+				$prop = $reflection->getProperty( $name );
+				// @todo Remove this call once we no longer need to support PHP <8.1.
+				if ( PHP_VERSION_ID < 80100 ) {
+					$prop->setAccessible( true );
+				}
+				$prop->setValue( null, $value );
 			}
-			$prop->setValue( null, $value );
 		}
 	}
 }

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -1072,4 +1072,66 @@ class ManagerTest extends TestCase {
 		// Clean up
 		wp_delete_user( $user_id );
 	}
+
+	/**
+	 * `Manager::get_authorization_url()` should append a comma-separated
+	 * `plugins` query arg listing every plugin currently using the Jetpack
+	 * connection (sourced from `Plugin_Storage`). With no plugins seeded the
+	 * arg should be omitted entirely.
+	 *
+	 * The flow runs end-to-end: `Plugin::add()` -> `Plugin_Storage::upsert()` ->
+	 * `Plugin_Storage::configure()` -> `get_authorization_url()`.
+	 */
+	public function test_get_authorization_url_includes_plugins_from_storage() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'authorize_url_test_user',
+				'user_pass'  => 'pass',
+				'user_email' => 'authorize-url@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Sign role / secrets need a blog token + site id; fake both.
+		Jetpack_Options::update_option( 'id', 1 );
+		Jetpack_Options::update_option( 'blog_token', 'fake.blogtoken' );
+
+		$tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
+			->onlyMethods( array( 'get_access_token', 'sign_role' ) )
+			->getMock();
+		$tokens->method( 'get_access_token' )->willReturn( (object) array( 'secret' => 'fake.secret' ) );
+		$tokens->method( 'sign_role' )->willReturn( 'administrator:signed' );
+
+		$manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->onlyMethods( array( 'get_tokens', 'has_connected_owner', 'get_assumed_site_creation_date' ) )
+			->getMock();
+		$manager->method( 'get_tokens' )->willReturn( $tokens );
+		$manager->method( 'has_connected_owner' )->willReturn( true );
+		$manager->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
+
+		// No plugins seeded yet -> no `plugins` arg.
+		$reflection = new \ReflectionClass( Plugin_Storage::class );
+		$reflection->setStaticPropertyValue( 'configured', false );
+		$reflection->setStaticPropertyValue( 'plugins', array() );
+		Plugin_Storage::configure();
+
+		$url = $manager->get_authorization_url();
+		$this->assertStringNotContainsString( 'plugins=', $url );
+
+		// Seed two plugins -> URL should carry them as a single-encoded
+		// comma-separated list.
+		$reflection->setStaticPropertyValue( 'configured', false );
+		( new Plugin( 'jetpack' ) )->add( 'Jetpack' );
+		( new Plugin( 'woocommerce' ) )->add( 'WooCommerce' );
+		Plugin_Storage::configure();
+
+		$url = $manager->get_authorization_url();
+		$this->assertStringContainsString( 'plugins=jetpack%2Cwoocommerce', $url );
+
+		// Cleanup.
+		$reflection->setStaticPropertyValue( 'configured', false );
+		$reflection->setStaticPropertyValue( 'plugins', array() );
+		wp_delete_user( $user_id );
+	}
 }

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -1111,9 +1111,7 @@ class ManagerTest extends TestCase {
 		$manager->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
 
 		// No plugins seeded yet -> no `plugins` arg.
-		$reflection = new \ReflectionClass( Plugin_Storage::class );
-		$reflection->setStaticPropertyValue( 'configured', false );
-		$reflection->setStaticPropertyValue( 'plugins', array() );
+		$this->reset_plugin_storage();
 		Plugin_Storage::configure();
 
 		$url = $manager->get_authorization_url();
@@ -1121,7 +1119,7 @@ class ManagerTest extends TestCase {
 
 		// Seed two plugins -> URL should carry them as a single-encoded
 		// comma-separated list.
-		$reflection->setStaticPropertyValue( 'configured', false );
+		$this->set_plugin_storage_configured( false );
 		( new Plugin( 'jetpack' ) )->add( 'Jetpack' );
 		( new Plugin( 'woocommerce' ) )->add( 'WooCommerce' );
 		Plugin_Storage::configure();
@@ -1130,8 +1128,48 @@ class ManagerTest extends TestCase {
 		$this->assertStringContainsString( 'plugins=jetpack%2Cwoocommerce', $url );
 
 		// Cleanup.
-		$reflection->setStaticPropertyValue( 'configured', false );
-		$reflection->setStaticPropertyValue( 'plugins', array() );
+		$this->reset_plugin_storage();
 		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Reset the private static state of `Plugin_Storage` so a test can start
+	 * from a clean slate. Compatible with PHP <8.1 where `setStaticPropertyValue()`
+	 * cannot reach private static properties without `setAccessible(true)`.
+	 */
+	private function reset_plugin_storage() {
+		$this->set_plugin_storage_property( 'configured', false );
+		$this->set_plugin_storage_property( 'plugins', array() );
+	}
+
+	/**
+	 * Flip the `configured` flag without touching the cached `$plugins` array.
+	 * Lets the test seed plugins after a successful first `configure()` and
+	 * then call `configure()` again to pick them up.
+	 *
+	 * @param bool $value New value for the flag.
+	 */
+	private function set_plugin_storage_configured( $value ) {
+		$this->set_plugin_storage_property( 'configured', $value );
+	}
+
+	/**
+	 * Set a private static property on `Plugin_Storage` via reflection.
+	 *
+	 * @param string $name  Property name.
+	 * @param mixed  $value New value.
+	 */
+	private function set_plugin_storage_property( $name, $value ) {
+		$reflection = new \ReflectionClass( Plugin_Storage::class );
+		try {
+			$reflection->setStaticPropertyValue( $name, $value );
+		} catch ( \ReflectionException $e ) { // PHP <8.1: private statics need setAccessible.
+			$prop = $reflection->getProperty( $name );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$prop->setAccessible( true );
+			}
+			$prop->setValue( null, $value );
+		}
 	}
 }

--- a/projects/packages/connection/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/connection/tests/php/REST_Endpoints_Test.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Status\Cache as StatusCache;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
 use WP_REST_Request;
@@ -196,6 +197,7 @@ class REST_Endpoints_Test extends TestCase {
 
 		Connection_Rest_Authentication::init()->reset_saved_auth_state();
 		$this->reset_connection_status();
+		$this->reset_plugin_storage();
 
 		// Clean up user meta and options
 		global $wpdb;
@@ -218,6 +220,29 @@ class REST_Endpoints_Test extends TestCase {
 			$manager = new \Automattic\Jetpack\Connection\Manager();
 		}
 		$manager->reset_connection_status();
+	}
+
+	/**
+	 * Reset the private static state of `Plugin_Storage` so tests that seed it
+	 * (or don't) start from a clean slate. The class refuses to return data
+	 * unless it has been `configure()`d, so we also flip the `configured` flag
+	 * back to false.
+	 */
+	public function reset_plugin_storage() {
+		$reflection = new ReflectionClass( Connection_Plugin_Storage::class );
+		try {
+			$reflection->setStaticPropertyValue( 'configured', false );
+			$reflection->setStaticPropertyValue( 'plugins', array() );
+			$reflection->setStaticPropertyValue( 'current_blog_id', null );
+		} catch ( \ReflectionException $e ) { // PHP 7 compat fallback.
+			foreach ( array( 'configured', 'plugins', 'current_blog_id' ) as $name ) {
+				$prop = $reflection->getProperty( $name );
+				if ( PHP_VERSION_ID < 80100 ) {
+					$prop->setAccessible( true );
+				}
+				$prop->setValue( null, 'plugins' === $name ? array() : ( 'configured' === $name ? false : null ) );
+			}
+		}
 	}
 
 	/**
@@ -479,10 +504,15 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Testing the `connection/register` endpoint forwards the `from` param into
-	 * the authorize URL builder, and appends `plugins` as a query arg on the
-	 * returned authorize URL.
+	 * the authorize URL builder, and that the returned authorize URL includes
+	 * the comma-separated list of connection-using plugin slugs that
+	 * `Plugin_Storage` knows about.
 	 */
-	public function test_connection_register_forwards_from_and_plugins() {
+	public function test_connection_register_forwards_from_and_includes_plugins_from_storage() {
+		( new Connection_Plugin( 'jetpack' ) )->add( 'Jetpack' );
+		( new Connection_Plugin( 'woocommerce' ) )->add( 'WooCommerce' );
+		Connection_Plugin_Storage::configure();
+
 		add_filter( 'pre_http_request', array( static::class, 'intercept_register_request' ), 10, 3 );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/register' );
@@ -492,7 +522,6 @@ class REST_Endpoints_Test extends TestCase {
 				array(
 					'registration_nonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 					'from'               => 'jetpack-connector',
-					'plugins'            => 'jetpack,woocommerce',
 				),
 				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
 			)
@@ -505,12 +534,14 @@ class REST_Endpoints_Test extends TestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertStringContainsString( 'from=jetpack-connector', $data['authorizeUrl'] );
-		$this->assertStringContainsString( 'plugins=jetpack,woocommerce', $data['authorizeUrl'] );
+		// The comma in the slug list is URL-encoded once by `urlencode_deep` inside `get_authorization_url`.
+		$this->assertStringContainsString( 'plugins=jetpack%2Cwoocommerce', $data['authorizeUrl'] );
 	}
 
 	/**
-	 * Testing the `connection/register` endpoint without the new `from` /
-	 * `plugins` params — older callers should keep working unchanged.
+	 * Testing the `connection/register` endpoint without `from` and with no
+	 * connection-using plugins seeded in `Plugin_Storage` — neither query arg
+	 * should appear on the resulting authorize URL.
 	 */
 	public function test_connection_register_without_from_or_plugins() {
 		add_filter( 'pre_http_request', array( static::class, 'intercept_register_request' ), 10, 3 );
@@ -536,28 +567,28 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Testing the `connection/authorize_url` endpoint forwards `from` to the
-	 * underlying authorization URL builder and appends `plugins` as a query arg.
+	 * underlying authorization URL builder and that the URL includes the
+	 * comma-separated list of plugins from `Plugin_Storage`.
 	 */
-	public function test_connection_authorize_url_with_from_and_plugins() {
+	public function test_connection_authorize_url_with_from_and_includes_plugins_from_storage() {
+		( new Connection_Plugin( 'jetpack' ) )->add( 'Jetpack' );
+		( new Connection_Plugin( 'woocommerce' ) )->add( 'WooCommerce' );
+		Connection_Plugin_Storage::configure();
+
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/connection/authorize_url' );
-		$request->set_query_params(
-			array(
-				'from'    => 'jetpack-connector',
-				'plugins' => 'jetpack,woocommerce',
-			)
-		);
+		$request->set_query_params( array( 'from' => 'jetpack-connector' ) );
 
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertStringContainsString( 'from=jetpack-connector', $data['authorizeUrl'] );
-		$this->assertStringContainsString( 'plugins=jetpack,woocommerce', $data['authorizeUrl'] );
+		$this->assertStringContainsString( 'plugins=jetpack%2Cwoocommerce', $data['authorizeUrl'] );
 	}
 
 	/**
-	 * Testing the `connection/authorize_url` endpoint without the new params —
-	 * older callers should not see `from` or `plugins` injected.
+	 * Testing the `connection/authorize_url` endpoint without `from` and with
+	 * no plugins seeded — neither query arg should be injected.
 	 */
 	public function test_connection_authorize_url_without_from_or_plugins() {
 		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/connection/authorize_url' );

--- a/projects/packages/connection/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/connection/tests/php/REST_Endpoints_Test.php
@@ -224,23 +224,28 @@ class REST_Endpoints_Test extends TestCase {
 
 	/**
 	 * Reset the private static state of `Plugin_Storage` so tests that seed it
-	 * (or don't) start from a clean slate. The class refuses to return data
-	 * unless it has been `configure()`d, so we also flip the `configured` flag
-	 * back to false.
+	 * (or don't) start from a clean slate. We deliberately keep `configured`
+	 * set to `true` here: in production it flips to `true` once on
+	 * `plugins_loaded` and stays that way, and leaving it `false` would make
+	 * `Plugin_Storage::get_all()` return a `WP_Error` object that downstream
+	 * code (e.g. `Manager::register()` on PHP 8.5) feeds into the WP HTTP
+	 * Requests library, where iterating an object backing for `ArrayIterator`
+	 * is now deprecated and trips `failOnDeprecation` in PHPUnit.
 	 */
 	public function reset_plugin_storage() {
 		$reflection = new ReflectionClass( Connection_Plugin_Storage::class );
 		try {
-			$reflection->setStaticPropertyValue( 'configured', false );
+			$reflection->setStaticPropertyValue( 'configured', true );
 			$reflection->setStaticPropertyValue( 'plugins', array() );
 			$reflection->setStaticPropertyValue( 'current_blog_id', null );
 		} catch ( \ReflectionException $e ) { // PHP 7 compat fallback.
 			foreach ( array( 'configured', 'plugins', 'current_blog_id' ) as $name ) {
 				$prop = $reflection->getProperty( $name );
+				// @todo Remove this call once we no longer need to support PHP <8.1.
 				if ( PHP_VERSION_ID < 80100 ) {
 					$prop->setAccessible( true );
 				}
-				$prop->setValue( null, 'plugins' === $name ? array() : ( 'configured' === $name ? false : null ) );
+				$prop->setValue( null, 'plugins' === $name ? array() : ( 'configured' === $name ? true : null ) );
 			}
 		}
 	}


### PR DESCRIPTION
Related CONNECT-186

## Proposed changes

* Centralize the `plugins` query arg on every Jetpack authorize URL by populating it once inside `Manager::get_authorization_url()` from `Plugin_Storage::get_all()`. Every existing caller (My Jetpack, SSO, Identity Crisis, the Connection Notice, the connectors card, Publicize, Post-by-Email) now picks the slug list up automatically — previously only the new connectors-card flow sent it.
* Drop the now-redundant `plugins` request param from the `/connection/register` and `/connection/authorize_url` REST endpoints plus the JS callers in `connectors-card.js` that used to send it. The single server-side source replaces both.
* Add a `ManagerTest` case for the new behavior end-to-end and update the affected `REST_Endpoints_Test` cases to seed `Plugin_Storage` directly. A `tearDown` reset hook keeps the class's private static state from leaking between tests.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No — the same `plugins` query arg is already sent today via the `/connection/register` and `/connection/authorize_url` REST endpoints (when called from the connectors card). This PR just makes the value emitted on **every** authorize URL flow rather than only that one. The data itself is unchanged: a comma-separated list of slugs from `Plugin_Storage::get_all()`, which already feeds the `jetpack_connection_active_plugins` option synced to WPCOM.

One subtle wire-format change worth flagging for reviewers: the comma between slugs now arrives at WPCOM URL-encoded once (`plugins=jetpack%2Cwoocommerce`) instead of literal (`plugins=jetpack,woocommerce`), because the value goes through `urlencode_deep()` inside `get_authorization_url()` before `add_query_arg`. WPCOM decodes query args normally so this is functionally equivalent.

## Testing instructions

* On a fresh site with the connection package, trigger any of these flows and confirm the resulting `wordpress.com/jetpack/connect/authorize?...` URL has a `plugins=...` query arg:
  * My Jetpack -> Connect button
  * Connectors card on the WP core Settings > Connectors page (WP 7.0+)
  * Connection Notice (admin notice when not connected)
  * Disconnect -> reconnect from any of the above

Made with [Cursor](https://cursor.com)