### PR TITLE
Admin Menu: add group_id + signal fields and top-level groups[] for sidebar redesign

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -40,6 +40,25 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private $dashicon_list;
 
 	/**
+	 * Lazily-built map of `menu_slug => nav-model entry`, populated from the
+	 * `Sidebar_Classifier` nav model when the public `wp-admin-sidebar` plugin
+	 * is loaded on the host. `null` means we have not yet attempted to build
+	 * the index for this request; an empty array means the classifier ran but
+	 * produced no items (e.g., gating denied).
+	 *
+	 * @var array<string, array>|null
+	 */
+	private $sidebar_nav_index = null;
+
+	/**
+	 * Group rows from the classifier nav model, keyed by group id. Sibling to
+	 * `$sidebar_nav_index`; `null` when not built, empty array when no groups.
+	 *
+	 * @var array<string, array>|null
+	 */
+	private $sidebar_nav_groups = null;
+
+	/**
 	 * WPCOM_REST_API_V2_Endpoint_Admin_Menu constructor.
 	 */
 	public function __construct() {
@@ -119,6 +138,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	public function prepare_menu_for_response( array $menu ) {
 		global $submenu;
 
+		// Best-effort hydration of the classifier nav model. Safe no-op when the
+		// public `wp-admin-sidebar` plugin is not installed (non-WPCOM Jetpack).
+		$this->maybe_build_sidebar_nav_index();
+
 		$data = array();
 
 		/**
@@ -153,7 +176,168 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 		}
 
-		return array_filter( $data );
+		$data = array_values( array_filter( $data ) );
+
+		// When the public `wp-admin-sidebar` plugin is loaded (WPCOM and any
+		// host that opts in), the response carries a sibling `groups[]` array
+		// describing the synthetic group rows the classifier emitted. Wrapping
+		// only happens when classifier data is available so non-WPCOM Jetpack
+		// installs continue to receive the legacy flat-array shape.
+		if ( null !== $this->sidebar_nav_groups ) {
+			return array(
+				'menu'   => $data,
+				'groups' => $this->prepare_groups_for_response(),
+			);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Hydrate the classifier-driven nav index from the public
+	 * `wp-admin-sidebar` plugin. No-op when the plugin is not installed or
+	 * gating denied building a model on this request.
+	 */
+	private function maybe_build_sidebar_nav_index() {
+		if ( null !== $this->sidebar_nav_index ) {
+			return;
+		}
+
+		if ( ! class_exists( 'Sidebar_Classifier' ) || ! class_exists( 'Sidebar_Signals' ) ) {
+			return;
+		}
+
+		// Trigger a build if the classifier hasn't run yet on this request.
+		// The classifier short-circuits when `wp_admin_sidebar_enabled` is
+		// false, which is the default for any host that hasn't opted in.
+		if ( null === Sidebar_Classifier::get_nav_model() ) {
+			Sidebar_Classifier::build_nav_model();
+		}
+
+		$nav_model = Sidebar_Classifier::get_nav_model();
+		if ( ! is_array( $nav_model ) ) {
+			return;
+		}
+
+		$index = array();
+		$collect = static function ( array $items ) use ( &$index, &$collect ) {
+			foreach ( $items as $item ) {
+				if ( isset( $item['menuSlug'] ) && '' !== $item['menuSlug'] ) {
+					$index[ $item['menuSlug'] ] = $item;
+				}
+				if ( ! empty( $item['children'] ) && is_array( $item['children'] ) ) {
+					$collect( $item['children'] );
+				}
+			}
+		};
+
+		if ( ! empty( $nav_model['top_level'] ) && is_array( $nav_model['top_level'] ) ) {
+			$collect( $nav_model['top_level'] );
+		}
+		if ( ! empty( $nav_model['groups'] ) && is_array( $nav_model['groups'] ) ) {
+			foreach ( $nav_model['groups'] as $group ) {
+				if ( ! empty( $group['children'] ) && is_array( $group['children'] ) ) {
+					$collect( $group['children'] );
+				}
+			}
+		}
+
+		$this->sidebar_nav_index  = $index;
+		$this->sidebar_nav_groups = ! empty( $nav_model['groups'] ) && is_array( $nav_model['groups'] )
+			? $nav_model['groups']
+			: array();
+	}
+
+	/**
+	 * Look up the classifier nav-model entry for a given menu slug.
+	 *
+	 * @param string $menu_slug Menu slug as registered in `$menu` / `$submenu`.
+	 * @return array|null Nav-model entry or null if the slug is not in the index.
+	 */
+	private function get_sidebar_nav_entry( $menu_slug ) {
+		if ( null === $this->sidebar_nav_index || '' === $menu_slug ) {
+			return null;
+		}
+		return isset( $this->sidebar_nav_index[ $menu_slug ] ) ? $this->sidebar_nav_index[ $menu_slug ] : null;
+	}
+
+	/**
+	 * Build the schema-shaped `signal` subobject for an item from a classifier
+	 * nav-model entry. Returns null when the entry has no signal data.
+	 *
+	 * The returned shape is fixed (all keys present, missing fields null) so
+	 * Calypso can read it without optional-chaining gymnastics.
+	 *
+	 * @param array $nav_entry Classifier nav-model entry.
+	 * @return array|null
+	 */
+	private function map_signal_from_nav_entry( array $nav_entry ) {
+		if ( empty( $nav_entry['signal'] ) || ! is_array( $nav_entry['signal'] ) ) {
+			return null;
+		}
+		$signal = $nav_entry['signal'];
+		return array(
+			'count'         => isset( $signal['count'] ) ? $signal['count'] : null,
+			'numeric_badge' => isset( $signal['numeric_badge'] ) ? $signal['numeric_badge'] : null,
+			'badge'         => isset( $signal['badge'] ) ? $signal['badge'] : null,
+			'inline_text'   => isset( $signal['inline_text'] ) ? $signal['inline_text'] : null,
+			'inline_icon'   => isset( $signal['inline_icon'] ) ? $signal['inline_icon'] : null,
+			'attention'     => ! empty( $signal['attention'] ),
+		);
+	}
+
+	/**
+	 * Attach classifier-derived `group_id` + `signal` fields to a prepared item.
+	 * No-op when the classifier index is not available or the slug isn't found.
+	 *
+	 * @param array  $item      Prepared item (top-level or submenu).
+	 * @param string $menu_slug Raw menu slug used to look up the nav entry.
+	 * @return array Item with fields possibly added.
+	 */
+	private function attach_sidebar_fields( array $item, $menu_slug ) {
+		$nav_entry = $this->get_sidebar_nav_entry( $menu_slug );
+		if ( null === $nav_entry ) {
+			return $item;
+		}
+
+		// `default_group` in the classifier maps to `group_id` on the wire.
+		$item['group_id'] = isset( $nav_entry['default_group'] ) ? $nav_entry['default_group'] : null;
+		$item['signal']   = $this->map_signal_from_nav_entry( $nav_entry );
+
+		return $item;
+	}
+
+	/**
+	 * Build the response-shape `groups[]` array from the cached classifier rows.
+	 *
+	 * Each element carries the group's stable id, label, default expansion
+	 * state (always true; see `default_expanded` in the schema contract) and
+	 * the aggregated signal that the classifier already computed.
+	 *
+	 * @return array
+	 */
+	private function prepare_groups_for_response() {
+		if ( empty( $this->sidebar_nav_groups ) ) {
+			return array();
+		}
+
+		$groups = array();
+		foreach ( $this->sidebar_nav_groups as $group ) {
+			if ( empty( $group['id'] ) ) {
+				continue;
+			}
+			$signal = isset( $group['signal'] ) && is_array( $group['signal'] ) ? $group['signal'] : array();
+			$groups[] = array(
+				'id'               => (string) $group['id'],
+				'label'            => isset( $group['title'] ) ? (string) $group['title'] : '',
+				'default_expanded' => true,
+				'signal'           => array(
+					'attention' => ! empty( $signal['attention'] ),
+					'count'     => isset( $signal['count'] ) ? (int) $signal['count'] : 0,
+				),
+			);
+		}
+		return $groups;
 	}
 
 	/**
@@ -167,6 +351,24 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return array Item schema data.
 	 */
 	public function get_item_schema() {
+		// Shape of the optional `signal` subobject attached to each item by the
+		// public `wp-admin-sidebar` classifier (when loaded). Mirrors the snake
+		// case shape produced by `Sidebar_Signals::map_to_nav` so Calypso can
+		// consume one canonical field set end-to-end. All keys are present and
+		// nullable; consumers don't need optional-chaining.
+		$signal_schema = array(
+			'description' => 'Per-item attention/count/badge data emitted by the wp-admin-sidebar classifier. Null when no signal data was extracted.',
+			'type'        => array( 'object', 'null' ),
+			'properties'  => array(
+				'count'         => array( 'type' => array( 'integer', 'null' ) ),
+				'numeric_badge' => array( 'type' => array( 'integer', 'null' ) ),
+				'badge'         => array( 'type' => array( 'string', 'null' ) ),
+				'inline_text'   => array( 'type' => array( 'string', 'null' ) ),
+				'inline_icon'   => array( 'type' => array( 'string', 'null' ) ),
+				'attention'     => array( 'type' => 'boolean' ),
+			),
+		);
+
 		return array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'Admin Menu',
@@ -197,27 +399,32 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				),
 				'children'   => array(
 					'items' => array(
-						'count'  => array(
+						'count'    => array(
 							'description' => 'Core/Plugin/Theme update count or unread comments count.',
 							'type'        => 'integer',
 						),
-						'parent' => array(
+						'parent'   => array(
 							'type' => 'string',
 						),
-						'slug'   => array(
+						'slug'     => array(
 							'type' => 'string',
 						),
-						'title'  => array(
+						'title'    => array(
 							'type' => 'string',
 						),
-						'type'   => array(
+						'type'     => array(
 							'enum' => array( 'submenu-item' ),
 							'type' => 'string',
 						),
-						'url'    => array(
+						'url'      => array(
 							'format' => 'uri',
 							'type'   => 'string',
 						),
+						'group_id' => array(
+							'description' => 'Group this submenu belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
+							'type'        => array( 'string', 'null' ),
+						),
+						'signal'   => $signal_schema,
 					),
 					'type'  => 'array',
 				),
@@ -231,6 +438,39 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				'url'        => array(
 					'format' => 'uri',
 					'type'   => 'string',
+				),
+				'group_id'   => array(
+					'description' => 'Group this top-level item belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
+					'type'        => array( 'string', 'null' ),
+				),
+				'signal'     => $signal_schema,
+				// When the public `wp-admin-sidebar` plugin is loaded the
+				// response wraps the existing per-item array in `menu` and
+				// adds a sibling `groups` array. The wrapper is omitted on
+				// hosts where the classifier is not installed; consumers
+				// that ignore the new keys see the legacy flat-array shape.
+				'menu'       => array(
+					'description' => 'Top-level menu items (only present when the wp-admin-sidebar classifier is loaded; otherwise the response root itself is the menu list).',
+					'type'        => 'array',
+				),
+				'groups'     => array(
+					'description' => 'Synthetic group rows describing the sidebar grouping shape. Only present when the wp-admin-sidebar classifier is loaded; empty array if no plugin items grouped.',
+					'type'        => 'array',
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'               => array( 'type' => 'string' ),
+							'label'            => array( 'type' => 'string' ),
+							'default_expanded' => array( 'type' => 'boolean' ),
+							'signal'           => array(
+								'type'       => 'object',
+								'properties' => array(
+									'attention' => array( 'type' => 'boolean' ),
+									'count'     => array( 'type' => 'integer' ),
+								),
+							),
+						),
+					),
 				),
 			),
 		);
@@ -300,6 +540,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$item = array_merge( $item, $parsed_item );
 		}
 
+		// Additive: classifier-derived `group_id` + `signal` for the redesigned
+		// sidebar. Match key is the raw menu slug (`$menu_item[2]`), which is
+		// what the public plugin's `Sidebar_Classifier` keys nav items by.
+		$item = $this->attach_sidebar_fields( $item, $menu_item[2] );
+
 		return $item;
 	}
 
@@ -333,6 +578,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if ( ! empty( $parsed_item ) ) {
 			$item = array_merge( $item, $parsed_item );
 		}
+
+		// Additive: classifier-derived fields. Same lookup contract as the
+		// top-level branch above; submenu rows live under their own `menuSlug`
+		// in the nav model.
+		$item = $this->attach_sidebar_fields( $item, $submenu_item[2] );
 
 		return $item;
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -383,7 +383,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 		$site_id = (int) get_current_blog_id();
 		$storage = $this->get_sidebar_layout_storage();
-		// @phan-suppress-next-line PhanUndeclaredMethod -- concrete storage implementations provide get_layouts().
 		$layouts = $storage->get_layouts( $user_id );
 
 		if ( isset( $layouts[ $site_id ] ) && is_array( $layouts[ $site_id ] ) ) {
@@ -399,7 +398,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return object
 	 */
 	private function get_sidebar_layout_storage() {
-		// @phan-suppress-next-line PhanUndeclaredClassReference -- WP_User_Meta_Storage is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by class_exists() above.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- WP_User_Meta_Storage is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by class_exists() above.
 		$default = new WP_User_Meta_Storage();
 		$bound   = apply_filters( 'wp_admin_sidebar_storage', $default );
 		$bound   = apply_filters_deprecated(
@@ -408,7 +407,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'0.1.0',
 			'wp_admin_sidebar_storage'
 		);
-		// @phan-suppress-next-line PhanUndeclaredClassReference -- Sidebar_Layout_Storage is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by interface_exists() above.
+		// @phan-suppress-next-line PhanUndeclaredClassInstanceof -- Sidebar_Layout_Storage is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by interface_exists() above.
 		return $bound instanceof Sidebar_Layout_Storage ? $bound : $default;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -51,7 +51,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private $sidebar_nav_index = null;
 
 	/**
-	 * Group rows from the classifier nav model, keyed by group id. Sibling to
+	 * Group rows from the classifier nav model. Sibling to
 	 * `$sidebar_nav_index`; `null` when not built, empty array when no groups.
 	 *
 	 * @var array<string, array>|null
@@ -390,7 +390,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 
 		// `default_group` in the classifier maps to `group_id` on the wire.
-		$item['group_id'] = $nav_entry['default_group'] ?? null;
+		$default_group    = $nav_entry['default_group'] ?? null;
+		$item['group_id'] = is_string( $default_group ) && '' !== $default_group ? $default_group : null;
 		$item['signal']   = $this->map_signal_from_nav_entry( $nav_entry );
 
 		if ( isset( $nav_entry['itemId'] ) && '' !== $nav_entry['itemId'] ) {
@@ -550,9 +551,55 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			),
 		);
 
-		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'Admin Menu',
+		$submenu_item_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'count'          => array(
+					'description' => 'Core/Plugin/Theme update count or unread comments count.',
+					'type'        => 'integer',
+				),
+				'parent'         => array(
+					'type' => 'string',
+				),
+				'slug'           => array(
+					'type' => 'string',
+				),
+				'title'          => array(
+					'type' => 'string',
+				),
+				'type'           => array(
+					'enum' => array( 'submenu-item' ),
+					'type' => 'string',
+				),
+				'url'            => array(
+					'format' => 'uri',
+					'type'   => 'string',
+				),
+				'itemId'         => array(
+					'description' => 'Compound sidebar item id emitted by the wp-admin-sidebar classifier. Only present when the classifier is loaded.',
+					'type'        => 'string',
+				),
+				'source'         => array(
+					'description' => 'Classifier source kind, e.g. core, plugin, or wpcom. Only present when the classifier is loaded.',
+					'type'        => 'string',
+				),
+				'default_weight' => array(
+					'description' => 'Default ordering hint from the classifier. Only present when the classifier exposes it.',
+					'type'        => 'integer',
+				),
+				'reassignable'   => array(
+					'description' => 'Whether the sidebar customizer may move this item. Only present when the classifier is loaded.',
+					'type'        => 'boolean',
+				),
+				'group_id'       => array(
+					'description' => 'Group this submenu belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
+					'type'        => array( 'string', 'null' ),
+				),
+				'signal'         => $signal_schema,
+			),
+		);
+
+		$menu_item_schema = array(
 			'type'       => 'object',
 			'properties' => array(
 				'count'          => array(
@@ -579,51 +626,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 					'type' => 'string',
 				),
 				'children'       => array(
-					'items' => array(
-						'count'          => array(
-							'description' => 'Core/Plugin/Theme update count or unread comments count.',
-							'type'        => 'integer',
-						),
-						'parent'         => array(
-							'type' => 'string',
-						),
-						'slug'           => array(
-							'type' => 'string',
-						),
-						'title'          => array(
-							'type' => 'string',
-						),
-						'type'           => array(
-							'enum' => array( 'submenu-item' ),
-							'type' => 'string',
-						),
-						'url'            => array(
-							'format' => 'uri',
-							'type'   => 'string',
-						),
-						'itemId'         => array(
-							'description' => 'Compound sidebar item id emitted by the wp-admin-sidebar classifier. Only present when the classifier is loaded.',
-							'type'        => 'string',
-						),
-						'source'         => array(
-							'description' => 'Classifier source kind, e.g. core, plugin, or wpcom. Only present when the classifier is loaded.',
-							'type'        => 'string',
-						),
-						'default_weight' => array(
-							'description' => 'Default ordering hint from the classifier. Only present when the classifier exposes it.',
-							'type'        => 'integer',
-						),
-						'reassignable'   => array(
-							'description' => 'Whether the sidebar customizer may move this item. Only present when the classifier is loaded.',
-							'type'        => 'boolean',
-						),
-						'group_id'       => array(
-							'description' => 'Group this submenu belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
-							'type'        => array( 'string', 'null' ),
-						),
-						'signal'         => $signal_schema,
-					),
 					'type'  => 'array',
+					'items' => $submenu_item_schema,
 				),
 				'title'          => array(
 					'type' => 'string',
@@ -657,62 +661,86 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 					'type'        => array( 'string', 'null' ),
 				),
 				'signal'         => $signal_schema,
-				// When the public `wp-admin-sidebar` plugin is loaded the
-				// response wraps the existing per-item array in `menu` and
-				// adds a sibling `groups` array. The wrapper is omitted on
-				// hosts where the classifier is not installed; consumers
-				// that ignore the new keys see the legacy flat-array shape.
-				'menu'           => array(
-					'description' => 'Top-level menu items (only present when the wp-admin-sidebar classifier is loaded; otherwise the response root itself is the menu list).',
-					'type'        => 'array',
+			),
+		);
+
+		$group_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'               => array( 'type' => 'string' ),
+				'label'            => array( 'type' => 'string' ),
+				'default_expanded' => array( 'type' => 'boolean' ),
+				'signal'           => array(
+					'type'       => 'object',
+					'properties' => array(
+						'attention' => array( 'type' => 'boolean' ),
+						'count'     => array( 'type' => 'integer' ),
+					),
 				),
-				'groups'         => array(
-					'description' => 'Synthetic group rows describing the sidebar grouping shape. Only present when the wp-admin-sidebar classifier is loaded; empty array if no plugin items grouped.',
-					'type'        => 'array',
-					'items'       => array(
+			),
+		);
+
+		$layout_delta_schema = array(
+			'description' => 'Saved per-user sidebar layout delta. Only present when the wp-admin-sidebar storage API is loaded.',
+			'type'        => array( 'object', 'null' ),
+			'properties'  => array(
+				'version'    => array( 'type' => 'integer' ),
+				'updated_at' => array( 'type' => 'integer' ),
+				'overrides'  => array(
+					'type'  => 'array',
+					'items' => array(
 						'type'       => 'object',
 						'properties' => array(
-							'id'               => array( 'type' => 'string' ),
-							'label'            => array( 'type' => 'string' ),
-							'default_expanded' => array( 'type' => 'boolean' ),
-							'signal'           => array(
+							'itemId'   => array( 'type' => 'string' ),
+							'position' => array(
 								'type'       => 'object',
 								'properties' => array(
-									'attention' => array( 'type' => 'boolean' ),
-									'count'     => array( 'type' => 'integer' ),
-								),
-							),
-						),
-					),
-				),
-				'layoutDelta'    => array(
-					'description' => 'Saved per-user sidebar layout delta. Only present when the wp-admin-sidebar storage API is loaded.',
-					'type'        => array( 'object', 'null' ),
-					'properties'  => array(
-						'version'    => array( 'type' => 'integer' ),
-						'updated_at' => array( 'type' => 'integer' ),
-						'overrides'  => array(
-							'type'  => 'array',
-							'items' => array(
-								'type'       => 'object',
-								'properties' => array(
-									'itemId'   => array( 'type' => 'string' ),
-									'position' => array(
-										'type'       => 'object',
-										'properties' => array(
-											'kind'     => array(
-												'type' => 'string',
-												'enum' => array( 'top_level', 'in_group' ),
-											),
-											'group_id' => array( 'type' => 'string' ),
-											'index'    => array( 'type' => 'integer' ),
-										),
+									'kind'     => array(
+										'type' => 'string',
+										'enum' => array( 'top_level', 'in_group' ),
 									),
+									'group_id' => array( 'type' => 'string' ),
+									'index'    => array( 'type' => 'integer' ),
 								),
 							),
 						),
 					),
 				),
+			),
+		);
+
+		$legacy_response_schema = array(
+			'description' => 'Legacy flat admin menu response used when the wp-admin-sidebar classifier is not loaded or not enabled.',
+			'type'        => 'array',
+			'items'       => $menu_item_schema,
+		);
+
+		$redesigned_response_schema = array(
+			'description' => 'Wrapped admin menu response used when the wp-admin-sidebar classifier is loaded and enabled.',
+			'type'        => 'object',
+			'required'    => array( 'menu', 'groups' ),
+			'properties'  => array(
+				'menu'        => array(
+					'description' => 'Top-level menu items.',
+					'type'        => 'array',
+					'items'       => $menu_item_schema,
+				),
+				'groups'      => array(
+					'description' => 'Synthetic group rows describing the sidebar grouping shape. Empty array if no plugin items grouped.',
+					'type'        => 'array',
+					'items'       => $group_schema,
+				),
+				'layoutDelta' => $layout_delta_schema,
+			),
+		);
+
+		return array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'Admin Menu',
+			'type'    => array( 'array', 'object' ),
+			'anyOf'   => array(
+				$legacy_response_schema,
+				$redesigned_response_schema,
 			),
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -184,10 +184,17 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// only happens when classifier data is available so non-WPCOM Jetpack
 		// installs continue to receive the legacy flat-array shape.
 		if ( null !== $this->sidebar_nav_groups ) {
-			return array(
+			$response = array(
 				'menu'   => $data,
 				'groups' => $this->prepare_groups_for_response(),
 			);
+
+			$layout_delta = $this->get_sidebar_layout_delta();
+			if ( null !== $layout_delta ) {
+				$response['layoutDelta'] = $layout_delta;
+			}
+
+			return $response;
 		}
 
 		return $data;
@@ -307,15 +314,29 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		$item['group_id'] = $nav_entry['default_group'] ?? null;
 		$item['signal']   = $this->map_signal_from_nav_entry( $nav_entry );
 
+		if ( isset( $nav_entry['itemId'] ) && '' !== $nav_entry['itemId'] ) {
+			$item['itemId'] = (string) $nav_entry['itemId'];
+		}
+		if ( isset( $nav_entry['source'] ) && '' !== $nav_entry['source'] ) {
+			$item['source'] = (string) $nav_entry['source'];
+		}
+		if ( isset( $nav_entry['reassignable'] ) ) {
+			$item['reassignable'] = (bool) $nav_entry['reassignable'];
+		}
+		if ( isset( $nav_entry['default_weight'] ) ) {
+			$item['default_weight'] = (int) $nav_entry['default_weight'];
+		} elseif ( isset( $nav_entry['_weight'] ) ) {
+			$item['default_weight'] = (int) $nav_entry['_weight'];
+		}
+
 		return $item;
 	}
 
 	/**
 	 * Build the response-shape `groups[]` array from the cached classifier rows.
 	 *
-	 * Each element carries the group's stable id, label, default expansion
-	 * state (always true; see `default_expanded` in the schema contract) and
-	 * the aggregated signal that the classifier already computed.
+	 * Each element carries the group's stable id, label, default collapsed
+	 * state and the aggregated signal that the classifier already computed.
 	 *
 	 * @return array
 	 */
@@ -333,7 +354,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$groups[] = array(
 				'id'               => (string) $group['id'],
 				'label'            => isset( $group['title'] ) ? (string) $group['title'] : '',
-				'default_expanded' => true,
+				'default_expanded' => false,
 				'signal'           => array(
 					'attention' => ! empty( $signal['attention'] ),
 					'count'     => isset( $signal['count'] ) ? (int) $signal['count'] : 0,
@@ -341,6 +362,85 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			);
 		}
 		return $groups;
+	}
+
+	/**
+	 * Read the saved Calypso-compatible layout delta from the public plugin's
+	 * storage adapter. Returns null when the public plugin storage API is not
+	 * loaded, which keeps non-redesigned hosts on the legacy contract.
+	 *
+	 * @return array|null
+	 */
+	private function get_sidebar_layout_delta() {
+		if ( ! interface_exists( 'Sidebar_Layout_Storage' ) || ! class_exists( 'WP_User_Meta_Storage' ) ) {
+			return null;
+		}
+
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return null;
+		}
+
+		$site_id = (int) get_current_blog_id();
+		$storage = $this->get_sidebar_layout_storage();
+		// @phan-suppress-next-line PhanUndeclaredMethod -- concrete storage implementations provide get_layouts().
+		$layouts = $storage->get_layouts( $user_id );
+
+		if ( isset( $layouts[ $site_id ] ) && is_array( $layouts[ $site_id ] ) ) {
+			return $this->normalize_sidebar_layout_delta( $layouts[ $site_id ] );
+		}
+
+		return $this->empty_sidebar_layout_delta();
+	}
+
+	/**
+	 * Resolve the public plugin storage adapter. Mirrors Sidebar_Data_Planner.
+	 *
+	 * @return object
+	 */
+	private function get_sidebar_layout_storage() {
+		// @phan-suppress-next-line PhanUndeclaredClassReference -- WP_User_Meta_Storage is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by class_exists() above.
+		$default = new WP_User_Meta_Storage();
+		$bound   = apply_filters( 'wp_admin_sidebar_storage', $default );
+		$bound   = apply_filters_deprecated(
+			'wpcom_admin_sidebar_storage',
+			array( $bound ),
+			'0.1.0',
+			'wp_admin_sidebar_storage'
+		);
+		// @phan-suppress-next-line PhanUndeclaredClassReference -- Sidebar_Layout_Storage is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by interface_exists() above.
+		return $bound instanceof Sidebar_Layout_Storage ? $bound : $default;
+	}
+
+	/**
+	 * Normalize a stored LayoutDelta into the response shape Calypso expects.
+	 *
+	 * @param array $delta Stored layout delta.
+	 * @return array
+	 */
+	private function normalize_sidebar_layout_delta( array $delta ) {
+		if ( ! isset( $delta['overrides'] ) || ! is_array( $delta['overrides'] ) ) {
+			return $this->empty_sidebar_layout_delta();
+		}
+
+		return array(
+			'version'    => isset( $delta['version'] ) ? (int) $delta['version'] : 1,
+			'updated_at' => isset( $delta['updated_at'] ) ? (int) $delta['updated_at'] : 0,
+			'overrides'  => array_values( $delta['overrides'] ),
+		);
+	}
+
+	/**
+	 * Empty-delta shape used when a redesigned host has no saved layout yet.
+	 *
+	 * @return array
+	 */
+	private function empty_sidebar_layout_delta() {
+		return array(
+			'version'    => 1,
+			'updated_at' => 0,
+			'overrides'  => array(),
+		);
 	}
 
 	/**
@@ -377,86 +477,118 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			'title'      => 'Admin Menu',
 			'type'       => 'object',
 			'properties' => array(
-				'count'      => array(
+				'count'          => array(
 					'description' => 'Core/Plugin/Theme update count or unread comments count.',
 					'type'        => 'integer',
 				),
-				'icon'       => array(
+				'icon'           => array(
 					'description' => 'Menu item icon. Dashicon slug or base64-encoded SVG.',
 					'type'        => 'string',
 				),
-				'inlineText' => array(
+				'inlineText'     => array(
 					'description' => 'Additional text to be added inline with the menu title.',
 					'type'        => 'string',
 				),
-				'inlineIcon' => array(
+				'inlineIcon'     => array(
 					'description' => 'Dashicon slug to be displayed inline with the menu title.',
 					'type'        => 'string',
 				),
-				'badge'      => array(
+				'badge'          => array(
 					'description' => 'Badge to be added inline with the menu title.',
 					'type'        => 'string',
 				),
-				'slug'       => array(
+				'slug'           => array(
 					'type' => 'string',
 				),
-				'children'   => array(
+				'children'       => array(
 					'items' => array(
-						'count'    => array(
+						'count'          => array(
 							'description' => 'Core/Plugin/Theme update count or unread comments count.',
 							'type'        => 'integer',
 						),
-						'parent'   => array(
+						'parent'         => array(
 							'type' => 'string',
 						),
-						'slug'     => array(
+						'slug'           => array(
 							'type' => 'string',
 						),
-						'title'    => array(
+						'title'          => array(
 							'type' => 'string',
 						),
-						'type'     => array(
+						'type'           => array(
 							'enum' => array( 'submenu-item' ),
 							'type' => 'string',
 						),
-						'url'      => array(
+						'url'            => array(
 							'format' => 'uri',
 							'type'   => 'string',
 						),
-						'group_id' => array(
+						'itemId'         => array(
+							'description' => 'Compound sidebar item id emitted by the wp-admin-sidebar classifier. Only present when the classifier is loaded.',
+							'type'        => 'string',
+						),
+						'source'         => array(
+							'description' => 'Classifier source kind, e.g. core, plugin, or wpcom. Only present when the classifier is loaded.',
+							'type'        => 'string',
+						),
+						'default_weight' => array(
+							'description' => 'Default ordering hint from the classifier. Only present when the classifier exposes it.',
+							'type'        => 'integer',
+						),
+						'reassignable'   => array(
+							'description' => 'Whether the sidebar customizer may move this item. Only present when the classifier is loaded.',
+							'type'        => 'boolean',
+						),
+						'group_id'       => array(
 							'description' => 'Group this submenu belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
 							'type'        => array( 'string', 'null' ),
 						),
-						'signal'   => $signal_schema,
+						'signal'         => $signal_schema,
 					),
 					'type'  => 'array',
 				),
-				'title'      => array(
+				'title'          => array(
 					'type' => 'string',
 				),
-				'type'       => array(
+				'type'           => array(
 					'enum' => array( 'separator', 'menu-item' ),
 					'type' => 'string',
 				),
-				'url'        => array(
+				'url'            => array(
 					'format' => 'uri',
 					'type'   => 'string',
 				),
-				'group_id'   => array(
+				'itemId'         => array(
+					'description' => 'Compound sidebar item id emitted by the wp-admin-sidebar classifier. Only present when the classifier is loaded.',
+					'type'        => 'string',
+				),
+				'source'         => array(
+					'description' => 'Classifier source kind, e.g. core, plugin, or wpcom. Only present when the classifier is loaded.',
+					'type'        => 'string',
+				),
+				'default_weight' => array(
+					'description' => 'Default ordering hint from the classifier. Only present when the classifier exposes it.',
+					'type'        => 'integer',
+				),
+				'reassignable'   => array(
+					'description' => 'Whether the sidebar customizer may move this item. Only present when the classifier is loaded.',
+					'type'        => 'boolean',
+				),
+				'group_id'       => array(
 					'description' => 'Group this top-level item belongs to (e.g., "plugins"). Null for non-grouped items. Only present when the wp-admin-sidebar classifier is loaded.',
 					'type'        => array( 'string', 'null' ),
 				),
-				'signal'     => $signal_schema,
+				'signal'         => $signal_schema,
 				// When the public `wp-admin-sidebar` plugin is loaded the
 				// response wraps the existing per-item array in `menu` and
 				// adds a sibling `groups` array. The wrapper is omitted on
 				// hosts where the classifier is not installed; consumers
 				// that ignore the new keys see the legacy flat-array shape.
-				'menu'       => array(
+				'menu'           => array(
 					'description' => 'Top-level menu items (only present when the wp-admin-sidebar classifier is loaded; otherwise the response root itself is the menu list).',
 					'type'        => 'array',
 				),
-				'groups'     => array(
+				'groups'         => array(
 					'description' => 'Synthetic group rows describing the sidebar grouping shape. Only present when the wp-admin-sidebar classifier is loaded; empty array if no plugin items grouped.',
 					'type'        => 'array',
 					'items'       => array(
@@ -470,6 +602,34 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 								'properties' => array(
 									'attention' => array( 'type' => 'boolean' ),
 									'count'     => array( 'type' => 'integer' ),
+								),
+							),
+						),
+					),
+				),
+				'layoutDelta'    => array(
+					'description' => 'Saved per-user sidebar layout delta. Only present when the wp-admin-sidebar storage API is loaded.',
+					'type'        => array( 'object', 'null' ),
+					'properties'  => array(
+						'version'    => array( 'type' => 'integer' ),
+						'updated_at' => array( 'type' => 'integer' ),
+						'overrides'  => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'itemId'   => array( 'type' => 'string' ),
+									'position' => array(
+										'type'       => 'object',
+										'properties' => array(
+											'kind'     => array(
+												'type' => 'string',
+												'enum' => array( 'top_level', 'in_group' ),
+											),
+											'group_id' => array( 'type' => 'string' ),
+											'index'    => array( 'type' => 'integer' ),
+										),
+									),
 								),
 							),
 						),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -210,16 +210,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// Trigger a build if the classifier hasn't run yet on this request.
 		// The classifier short-circuits when `wp_admin_sidebar_enabled` is
 		// false, which is the default for any host that hasn't opted in.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is provided by WPCOM's wp-admin-sidebar mu-plugin; guarded by class_exists() above.
 		if ( null === Sidebar_Classifier::get_nav_model() ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is provided by WPCOM's wp-admin-sidebar mu-plugin.
 			Sidebar_Classifier::build_nav_model();
 		}
 
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is provided by WPCOM's wp-admin-sidebar mu-plugin.
 		$nav_model = Sidebar_Classifier::get_nav_model();
 		if ( ! is_array( $nav_model ) ) {
 			return;
 		}
 
-		$index = array();
+		$index   = array();
 		$collect = static function ( array $items ) use ( &$index, &$collect ) {
 			foreach ( $items as $item ) {
 				if ( isset( $item['menuSlug'] ) && '' !== $item['menuSlug'] ) {
@@ -258,7 +261,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if ( null === $this->sidebar_nav_index || '' === $menu_slug ) {
 			return null;
 		}
-		return isset( $this->sidebar_nav_index[ $menu_slug ] ) ? $this->sidebar_nav_index[ $menu_slug ] : null;
+		return $this->sidebar_nav_index[ $menu_slug ] ?? null;
 	}
 
 	/**
@@ -277,11 +280,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 		$signal = $nav_entry['signal'];
 		return array(
-			'count'         => isset( $signal['count'] ) ? $signal['count'] : null,
-			'numeric_badge' => isset( $signal['numeric_badge'] ) ? $signal['numeric_badge'] : null,
-			'badge'         => isset( $signal['badge'] ) ? $signal['badge'] : null,
-			'inline_text'   => isset( $signal['inline_text'] ) ? $signal['inline_text'] : null,
-			'inline_icon'   => isset( $signal['inline_icon'] ) ? $signal['inline_icon'] : null,
+			'count'         => $signal['count'] ?? null,
+			'numeric_badge' => $signal['numeric_badge'] ?? null,
+			'badge'         => $signal['badge'] ?? null,
+			'inline_text'   => $signal['inline_text'] ?? null,
+			'inline_icon'   => $signal['inline_icon'] ?? null,
 			'attention'     => ! empty( $signal['attention'] ),
 		);
 	}
@@ -301,7 +304,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 
 		// `default_group` in the classifier maps to `group_id` on the wire.
-		$item['group_id'] = isset( $nav_entry['default_group'] ) ? $nav_entry['default_group'] : null;
+		$item['group_id'] = $nav_entry['default_group'] ?? null;
 		$item['signal']   = $this->map_signal_from_nav_entry( $nav_entry );
 
 		return $item;
@@ -326,7 +329,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			if ( empty( $group['id'] ) ) {
 				continue;
 			}
-			$signal = isset( $group['signal'] ) && is_array( $group['signal'] ) ? $group['signal'] : array();
+			$signal   = isset( $group['signal'] ) && is_array( $group['signal'] ) ? $group['signal'] : array();
 			$groups[] = array(
 				'id'               => (string) $group['id'],
 				'label'            => isset( $group['title'] ) ? (string) $group['title'] : '',

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -184,6 +184,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// only happens when classifier data is available so non-WPCOM Jetpack
 		// installs continue to receive the legacy flat-array shape.
 		if ( null !== $this->sidebar_nav_groups ) {
+			$data     = $this->order_sidebar_grouped_items( $data );
 			$response = array(
 				'menu'   => $data,
 				'groups' => $this->prepare_groups_for_response(),
@@ -230,10 +231,17 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		}
 
 		$index   = array();
-		$collect = static function ( array $items ) use ( &$index, &$collect ) {
-			foreach ( $items as $item ) {
+		$collect = function ( array $items ) use ( &$index, &$collect ) {
+			foreach ( $items as $position => $item ) {
 				if ( isset( $item['menuSlug'] ) && '' !== $item['menuSlug'] ) {
-					$index[ $item['menuSlug'] ] = $item;
+					if ( ! isset( $item['default_weight'] ) && ! isset( $item['_weight'] ) ) {
+						$item['default_weight'] = (int) $position;
+					}
+					$parent_slug = array_key_exists( 'parent', $item ) && null !== $item['parent'] ? (string) $item['parent'] : null;
+					$index[ $this->get_sidebar_nav_index_key( $item['menuSlug'], $parent_slug ) ] = $item;
+					if ( ! isset( $index[ $item['menuSlug'] ] ) ) {
+						$index[ $item['menuSlug'] ] = $item;
+					}
 				}
 				if ( ! empty( $item['children'] ) && is_array( $item['children'] ) ) {
 					$collect( $item['children'] );
@@ -259,16 +267,86 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	}
 
 	/**
+	 * Keep grouped items in the classifier's child order while preserving the
+	 * relative position of ungrouped top-level rows. The public classifier
+	 * sorts each group before exposing the nav model, but Calypso receives a
+	 * flat `menu` array and buckets grouped items in response order.
+	 *
+	 * @param array $items Prepared top-level menu items.
+	 * @return array Prepared items with grouped rows sorted per group.
+	 */
+	private function order_sidebar_grouped_items( array $items ) {
+		$grouped_items = array();
+		foreach ( $items as $item ) {
+			if ( isset( $item['group_id'] ) && is_string( $item['group_id'] ) && '' !== $item['group_id'] ) {
+				$grouped_items[ $item['group_id'] ][] = $item;
+			}
+		}
+
+		if ( empty( $grouped_items ) ) {
+			return $items;
+		}
+
+		foreach ( $grouped_items as &$group_items ) {
+			usort(
+				$group_items,
+				static function ( $a, $b ) {
+					$wa = (int) ( $a['default_weight'] ?? PHP_INT_MAX );
+					$wb = (int) ( $b['default_weight'] ?? PHP_INT_MAX );
+					if ( $wa === $wb ) {
+						return strcmp( (string) ( $a['itemId'] ?? $a['slug'] ?? '' ), (string) ( $b['itemId'] ?? $b['slug'] ?? '' ) );
+					}
+					return $wa <=> $wb;
+				}
+			);
+		}
+		unset( $group_items );
+
+		$group_offsets = array();
+		foreach ( $items as $index => $item ) {
+			if ( ! isset( $item['group_id'] ) || ! is_string( $item['group_id'] ) || '' === $item['group_id'] ) {
+				continue;
+			}
+
+			$group_id = $item['group_id'];
+			$offset   = $group_offsets[ $group_id ] ?? 0;
+			if ( isset( $grouped_items[ $group_id ][ $offset ] ) ) {
+				$items[ $index ] = $grouped_items[ $group_id ][ $offset ];
+			}
+			$group_offsets[ $group_id ] = $offset + 1;
+		}
+
+		return $items;
+	}
+
+	/**
 	 * Look up the classifier nav-model entry for a given menu slug.
 	 *
-	 * @param string $menu_slug Menu slug as registered in `$menu` / `$submenu`.
+	 * @param string      $menu_slug   Menu slug as registered in `$menu` / `$submenu`.
+	 * @param string|null $parent_slug Parent menu slug, or null for top-level items.
 	 * @return array|null Nav-model entry or null if the slug is not in the index.
 	 */
-	private function get_sidebar_nav_entry( $menu_slug ) {
+	private function get_sidebar_nav_entry( $menu_slug, $parent_slug = null ) {
 		if ( null === $this->sidebar_nav_index || '' === $menu_slug ) {
 			return null;
 		}
+		$key = $this->get_sidebar_nav_index_key( $menu_slug, $parent_slug );
+		if ( isset( $this->sidebar_nav_index[ $key ] ) ) {
+			return $this->sidebar_nav_index[ $key ];
+		}
 		return $this->sidebar_nav_index[ $menu_slug ] ?? null;
+	}
+
+	/**
+	 * Compose an index key that distinguishes top-level rows from submenu rows
+	 * sharing the same raw menu slug.
+	 *
+	 * @param string      $menu_slug   Menu slug as registered in `$menu` / `$submenu`.
+	 * @param string|null $parent_slug Parent menu slug, or null for top-level items.
+	 * @return string Index key.
+	 */
+	private function get_sidebar_nav_index_key( $menu_slug, $parent_slug = null ) {
+		return ( null === $parent_slug ? '' : (string) $parent_slug ) . "\0" . (string) $menu_slug;
 	}
 
 	/**
@@ -300,12 +378,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * Attach classifier-derived `group_id` + `signal` fields to a prepared item.
 	 * No-op when the classifier index is not available or the slug isn't found.
 	 *
-	 * @param array  $item      Prepared item (top-level or submenu).
-	 * @param string $menu_slug Raw menu slug used to look up the nav entry.
+	 * @param array       $item        Prepared item (top-level or submenu).
+	 * @param string      $menu_slug   Raw menu slug used to look up the nav entry.
+	 * @param string|null $parent_slug Parent menu slug, or null for top-level items.
 	 * @return array Item with fields possibly added.
 	 */
-	private function attach_sidebar_fields( array $item, $menu_slug ) {
-		$nav_entry = $this->get_sidebar_nav_entry( $menu_slug );
+	private function attach_sidebar_fields( array $item, $menu_slug, $parent_slug = null ) {
+		$nav_entry = $this->get_sidebar_nav_entry( $menu_slug, $parent_slug );
 		if ( null === $nav_entry ) {
 			return $item;
 		}
@@ -744,7 +823,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		// Additive: classifier-derived fields. Same lookup contract as the
 		// top-level branch above; submenu rows live under their own `menuSlug`
 		// in the nav model.
-		$item = $this->attach_sidebar_fields( $item, $submenu_item[2] );
+		$item = $this->attach_sidebar_fields( $item, $submenu_item[2], $menu_item[2] );
 
 		return $item;
 	}

--- a/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Admin Menu: add additive `group_id` + `signal` fields per item and a top-level `groups[]` array to the `/wpcom/v2/admin-menu` endpoint, sourced from the public `wp-admin-sidebar` plugin's classifier when loaded. Non-WPCOM Jetpack installs see no shape change.

--- a/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Admin Menu: add additive sidebar redesign fields, group metadata, and saved layout data to the `/wpcom/v2/admin-menu` endpoint when the public `wp-admin-sidebar` plugin is loaded. Non-WPCOM Jetpack installs see no shape change.
+Admin Menu: add sidebar redesign fields, group metadata, and saved layout data to the `/wpcom/v2/admin-menu` endpoint when the public `wp-admin-sidebar` plugin is loaded. Non-WPCOM Jetpack installs see no shape change.

--- a/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
+++ b/projects/plugins/jetpack/changelog/add-admin-menu-redesign-schema-fields
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Admin Menu: add additive `group_id` + `signal` fields per item and a top-level `groups[]` array to the `/wpcom/v2/admin-menu` endpoint, sourced from the public `wp-admin-sidebar` plugin's classifier when loaded. Non-WPCOM Jetpack installs see no shape change.
+Admin Menu: add additive sidebar redesign fields, group metadata, and saved layout data to the `/wpcom/v2/admin-menu` endpoint when the public `wp-admin-sidebar` plugin is loaded. Non-WPCOM Jetpack installs see no shape change.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -696,4 +696,165 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Without the public `wp-admin-sidebar` plugin loaded the response
+	 * preserves the legacy flat-array shape and items do not carry the
+	 * additive `group_id` / `signal` fields. This is the contract for
+	 * non-WPCOM Jetpack installs.
+	 *
+	 * @depends test_successful_request
+	 *
+	 * @param WP_REST_Response $response Admin Menu API response.
+	 */
+	#[Depends( 'test_successful_request' )]
+	public function test_response_is_legacy_shape_without_classifier( WP_REST_Response $response ) {
+		// Only meaningful when the classifier is genuinely absent. Skip on
+		// hosts that load the public plugin (e.g., a fully wired WPCOM env).
+		if ( class_exists( 'Sidebar_Classifier' ) ) {
+			$this->markTestSkipped( 'Sidebar_Classifier is loaded; legacy-shape contract does not apply on this host.' );
+		}
+
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		// Legacy shape: list keyed by integer indexes, not an associative
+		// `{ menu, groups }` envelope.
+		$this->assertArrayNotHasKey( 'menu', $data );
+		$this->assertArrayNotHasKey( 'groups', $data );
+
+		foreach ( $data as $item ) {
+			$this->assertArrayNotHasKey( 'group_id', $item );
+			$this->assertArrayNotHasKey( 'signal', $item );
+		}
+	}
+
+	/**
+	 * When stub classifier + signals classes are visible to the endpoint, the
+	 * response wraps the menu in `{ menu, groups }`, attaches `group_id` +
+	 * `signal` to matched items by slug, and emits the synthetic `groups[]`
+	 * row(s) the classifier built.
+	 *
+	 * The stub classes mirror the public plugin's API surface (the two
+	 * static methods + nav-model shape the endpoint actually consumes) so
+	 * the test runs offline without depending on `wp-admin-sidebar`.
+	 */
+	public function test_response_carries_group_fields_when_classifier_is_loaded() {
+		if ( ! class_exists( 'Sidebar_Classifier' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+				'class Sidebar_Classifier {
+					private static $model = null;
+					public static function set_model( $model ) { self::$model = $model; }
+					public static function build_nav_model(): void {}
+					public static function get_nav_model(): ?array { return self::$model; }
+				}'
+			);
+		}
+		if ( ! class_exists( 'Sidebar_Signals' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+				'class Sidebar_Signals {}'
+			);
+		}
+
+		// Skip when a real classifier is present — we don't want to clobber
+		// the host's classifier state from a Jetpack unit test.
+		if ( ! method_exists( 'Sidebar_Classifier', 'set_model' ) ) {
+			$this->markTestSkipped( 'Real Sidebar_Classifier is loaded; stub-driven test is not applicable.' );
+		}
+
+		Sidebar_Classifier::set_model(
+			array(
+				'version'      => 1,
+				'generated_at' => 0,
+				'site_id'      => 1,
+				'user_id'      => 1,
+				'top_level'    => array(
+					array(
+						'menuSlug'      => 'index.php',
+						'default_group' => null,
+						'signal'        => array(
+							'count'         => null,
+							'numeric_badge' => null,
+							'badge'         => null,
+							'inline_text'   => null,
+							'inline_icon'   => null,
+							'attention'     => false,
+						),
+					),
+				),
+				'groups'       => array(
+					array(
+						'id'       => 'plugins',
+						'title'    => 'My Plugins',
+						'icon'     => null,
+						'children' => array(
+							array(
+								'menuSlug'      => 'jetpack',
+								'default_group' => 'plugins',
+								'signal'        => array(
+									'count'         => 3,
+									'numeric_badge' => null,
+									'badge'         => '3',
+									'inline_text'   => null,
+									'inline_icon'   => null,
+									'attention'     => true,
+								),
+							),
+						),
+						'signal'   => array(
+							'attention' => true,
+							'count'     => 3,
+						),
+					),
+				),
+			)
+		);
+
+		// Drive the response through `prepare_menu_for_response` directly so
+		// the test isn't coupled to the live $menu/$submenu globals built by
+		// `wp-admin/menu.php`.
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Admin_Menu();
+
+		// `index.php` matches the stub's top-level entry; `jetpack` matches
+		// the grouped child.
+		$menu = array(
+			array( 'Dashboard', 'read', 'index.php', '', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
+			array( 'Jetpack', 'read', 'jetpack', '', 'menu-top', 'menu-jetpack', 'dashicons-admin-plugins' ),
+		);
+
+		$response = $endpoint->prepare_menu_for_response( $menu );
+
+		// Reset stub state for any subsequent tests.
+		Sidebar_Classifier::set_model( null );
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'menu', $response );
+		$this->assertArrayHasKey( 'groups', $response );
+
+		$by_slug = array();
+		foreach ( $response['menu'] as $item ) {
+			$by_slug[ $item['slug'] ] = $item;
+		}
+
+		$this->assertArrayHasKey( 'index-php', $by_slug );
+		$this->assertArrayHasKey( 'jetpack', $by_slug );
+
+		// Top-level core item: matched, no group, signal attached but inert.
+		$this->assertNull( $by_slug['index-php']['group_id'] );
+		$this->assertSame( false, $by_slug['index-php']['signal']['attention'] );
+
+		// Grouped plugin item: group_id set, attention signal flowed through.
+		$this->assertSame( 'plugins', $by_slug['jetpack']['group_id'] );
+		$this->assertSame( 3, $by_slug['jetpack']['signal']['count'] );
+		$this->assertTrue( $by_slug['jetpack']['signal']['attention'] );
+
+		// Top-level groups row mirrors the classifier's group shape.
+		$this->assertCount( 1, $response['groups'] );
+		$group = $response['groups'][0];
+		$this->assertSame( 'plugins', $group['id'] );
+		$this->assertSame( 'My Plugins', $group['label'] );
+		$this->assertTrue( $group['default_expanded'] );
+		$this->assertTrue( $group['signal']['attention'] );
+		$this->assertSame( 3, $group['signal']['count'] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -810,7 +810,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 						'menuSlug'      => 'no-signal',
 						'source'        => 'plugin',
 						'reassignable'  => true,
-						'default_group' => null,
+						'default_group' => '',
 						'_weight'       => 77,
 					),
 					array(
@@ -976,6 +976,18 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$this->assertArrayNotHasKey( 'menu', $legacy_response_with_no_model );
 		$this->assertArrayNotHasKey( 'layoutDelta', $layout_response_without_storage );
 		$this->assertArrayNotHasKey( 'layoutDelta', $layout_response_without_user );
+		$this->assertTrue(
+			rest_validate_value_from_schema(
+				$legacy_response_with_no_model,
+				( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->get_public_item_schema()
+			)
+		);
+		$this->assertTrue(
+			rest_validate_value_from_schema(
+				$response,
+				( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->get_public_item_schema()
+			)
+		);
 
 		$this->assertIsArray( $response );
 		$this->assertArrayHasKey( 'menu', $response );
@@ -1001,6 +1013,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$this->assertSame( 10, $by_slug['index-php']['default_weight'] );
 
 		// A matched item without signal data keeps the field explicit and null.
+		$this->assertNull( $by_slug['no-signal']['group_id'] );
 		$this->assertNull( $by_slug['no-signal']['signal'] );
 		$this->assertSame(
 			'plugin:no-signal/no-signal.php:-:no-signal',
@@ -1009,6 +1022,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$this->assertSame( 77, $by_slug['no-signal']['default_weight'] );
 
 		// Recursed child entries can still hydrate menu rows by slug.
+		$this->assertArrayHasKey( 'nested-plugin', $by_slug );
 		$this->assertSame( 'plugin:nested/nested.php:-:nested-plugin', $by_slug['nested-plugin']['itemId'] );
 		$this->assertSame( 88, $by_slug['nested-plugin']['default_weight'] );
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -741,7 +741,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 	 */
 	public function test_response_carries_group_fields_when_classifier_is_loaded() {
 		if ( ! class_exists( 'Sidebar_Classifier' ) ) {
-			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
 				'class Sidebar_Classifier {
 					private static $model = null;
 					public static function set_model( $model ) { self::$model = $model; }
@@ -751,17 +751,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			);
 		}
 		if ( ! class_exists( 'Sidebar_Signals' ) ) {
-			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
 				'class Sidebar_Signals {}'
 			);
 		}
 
 		// Skip when a real classifier is present — we don't want to clobber
 		// the host's classifier state from a Jetpack unit test.
+		// @phan-suppress-next-line PhanUndeclaredClassReference -- Sidebar_Classifier is the stub eval'd above or the real WPCOM mu-plugin class.
 		if ( ! method_exists( 'Sidebar_Classifier', 'set_model' ) ) {
 			$this->markTestSkipped( 'Real Sidebar_Classifier is loaded; stub-driven test is not applicable.' );
 		}
 
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
 		Sidebar_Classifier::set_model(
 			array(
 				'version'      => 1,
@@ -825,6 +827,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$response = $endpoint->prepare_menu_for_response( $menu );
 
 		// Reset stub state for any subsequent tests.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
 		Sidebar_Classifier::set_model( null );
 
 		$this->assertIsArray( $response );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -767,7 +767,15 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			array( 'Dashboard', 'read', 'index.php', '', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
 			array( 'No Signal', 'read', 'no-signal', '', 'menu-top', 'menu-no-signal', 'dashicons-admin-generic' ),
 			array( 'Jetpack', 'read', 'jetpack', '', 'menu-top', 'menu-jetpack', 'dashicons-admin-plugins' ),
+			array( 'WooCommerce', 'read', 'woocommerce', '', 'menu-top', 'menu-woocommerce', 'dashicons-admin-plugins' ),
 			array( 'Nested', 'read', 'nested-plugin', '', 'menu-top', 'menu-nested-plugin', 'dashicons-admin-plugins' ),
+		);
+		global $submenu;
+		$previous_submenu = $submenu;
+		$submenu          = array(
+			'jetpack' => array(
+				array( 'Jetpack Dashboard', 'read', 'jetpack', '', 'menu-top' ),
+			),
 		);
 
 		// The classifier is present, but gating can still leave no nav model.
@@ -835,13 +843,29 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 						'icon'     => null,
 						'children' => array(
 							array(
-								'itemId'         => 'plugin:jetpack/jetpack.php:-:jetpack',
-								'menuSlug'       => 'jetpack',
-								'source'         => 'plugin',
-								'reassignable'   => true,
-								'default_weight' => 999,
-								'default_group'  => 'plugins',
-								'signal'         => array(
+								'itemId'        => 'plugin:woocommerce/woocommerce.php:-:woocommerce',
+								'menuSlug'      => 'woocommerce',
+								'source'        => 'plugin',
+								'reassignable'  => true,
+								'default_group' => 'plugins',
+							),
+							array(
+								'itemId'        => 'plugin:jetpack/jetpack.php:-:jetpack',
+								'menuSlug'      => 'jetpack',
+								'source'        => 'plugin',
+								'reassignable'  => true,
+								'default_group' => 'plugins',
+								'children'      => array(
+									array(
+										'itemId'        => 'plugin:jetpack/jetpack.php:jetpack:jetpack',
+										'menuSlug'      => 'jetpack',
+										'parent'        => 'jetpack',
+										'source'        => 'plugin',
+										'reassignable'  => true,
+										'default_group' => 'plugins',
+									),
+								),
+								'signal'        => array(
 									'count'         => 3,
 									'numeric_badge' => null,
 									'badge'         => '3',
@@ -946,6 +970,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
 		Sidebar_Classifier::set_model( null );
 		delete_user_meta( static::$user_id, 'wpcom_admin_sidebar_layouts' );
+		$submenu = $previous_submenu;
 
 		$this->assertIsArray( $legacy_response_with_no_model );
 		$this->assertArrayNotHasKey( 'menu', $legacy_response_with_no_model );
@@ -965,6 +990,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$this->assertArrayHasKey( 'index-php', $by_slug );
 		$this->assertArrayHasKey( 'no-signal', $by_slug );
 		$this->assertArrayHasKey( 'jetpack', $by_slug );
+		$this->assertArrayHasKey( 'woocommerce', $by_slug );
 
 		// Top-level core item: matched, no group, signal attached but inert.
 		$this->assertNull( $by_slug['index-php']['group_id'] );
@@ -991,9 +1017,32 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		$this->assertSame( 3, $by_slug['jetpack']['signal']['count'] );
 		$this->assertTrue( $by_slug['jetpack']['signal']['attention'] );
 		$this->assertSame( 'plugin:jetpack/jetpack.php:-:jetpack', $by_slug['jetpack']['itemId'] );
+		$this->assertSame(
+			'plugin:jetpack/jetpack.php:jetpack:jetpack',
+			$by_slug['jetpack']['children'][0]['itemId']
+		);
 		$this->assertSame( 'plugin', $by_slug['jetpack']['source'] );
 		$this->assertTrue( $by_slug['jetpack']['reassignable'] );
-		$this->assertSame( 999, $by_slug['jetpack']['default_weight'] );
+		$this->assertSame( 1, $by_slug['jetpack']['default_weight'] );
+		$this->assertSame( 'plugins', $by_slug['woocommerce']['group_id'] );
+		$this->assertNull( $by_slug['woocommerce']['signal'] );
+		$this->assertSame( 0, $by_slug['woocommerce']['default_weight'] );
+		$this->assertSame(
+			array( 'woocommerce', 'jetpack' ),
+			array_values(
+				array_map(
+					static function ( $item ) {
+						return $item['slug'];
+					},
+					array_filter(
+						$response['menu'],
+						static function ( $item ) {
+							return isset( $item['group_id'] ) && 'plugins' === $item['group_id'];
+						}
+					)
+				)
+			)
+		);
 
 		// Top-level groups row mirrors the classifier's group shape.
 		$this->assertCount( 1, $response['groups'] );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -755,35 +755,23 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 				'class Sidebar_Signals {}'
 			);
 		}
-		if ( ! interface_exists( 'Sidebar_Layout_Storage' ) ) {
-			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
-				'interface Sidebar_Layout_Storage {
-					public function get_layouts( int $user_id ): array;
-					public function put_layouts( int $user_id, array $layouts ): bool;
-				}'
-			);
-		}
-		if ( ! class_exists( 'WP_User_Meta_Storage' ) ) {
-			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
-				'class WP_User_Meta_Storage implements Sidebar_Layout_Storage {
-					private const META_KEY = "wpcom_admin_sidebar_layouts";
-					public function get_layouts( int $user_id ): array {
-						$value = get_user_meta( $user_id, self::META_KEY, true );
-						return is_array( $value ) ? $value : array();
-					}
-					public function put_layouts( int $user_id, array $layouts ): bool {
-						return (bool) update_user_meta( $user_id, self::META_KEY, $layouts );
-					}
-				}'
-			);
-		}
 
-		// Skip when a real classifier is present — we don't want to clobber
+		// Skip when a real classifier is present. We don't want to clobber
 		// the host's classifier state from a Jetpack unit test.
 		// @phan-suppress-next-line PhanUndeclaredClassReference -- Sidebar_Classifier is the stub eval'd above or the real WPCOM mu-plugin class.
 		if ( ! method_exists( 'Sidebar_Classifier', 'set_model' ) ) {
 			$this->markTestSkipped( 'Real Sidebar_Classifier is loaded; stub-driven test is not applicable.' );
 		}
+
+		$menu = array(
+			array( 'Dashboard', 'read', 'index.php', '', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
+			array( 'No Signal', 'read', 'no-signal', '', 'menu-top', 'menu-no-signal', 'dashicons-admin-generic' ),
+			array( 'Jetpack', 'read', 'jetpack', '', 'menu-top', 'menu-jetpack', 'dashicons-admin-plugins' ),
+			array( 'Nested', 'read', 'nested-plugin', '', 'menu-top', 'menu-nested-plugin', 'dashicons-admin-plugins' ),
+		);
+
+		// The classifier is present, but gating can still leave no nav model.
+		$legacy_response_with_no_model = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
 
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
 		Sidebar_Classifier::set_model(
@@ -815,9 +803,32 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 						'source'        => 'plugin',
 						'reassignable'  => true,
 						'default_group' => null,
+						'_weight'       => 77,
+					),
+					array(
+						'itemId'        => 'plugin:parent/parent.php:-:parent-plugin',
+						'menuSlug'      => 'parent-plugin',
+						'source'        => 'plugin',
+						'reassignable'  => true,
+						'default_group' => null,
+						'children'      => array(
+							array(
+								'itemId'         => 'plugin:nested/nested.php:-:nested-plugin',
+								'menuSlug'       => 'nested-plugin',
+								'source'         => 'plugin',
+								'reassignable'   => true,
+								'default_group'  => null,
+								'default_weight' => 88,
+							),
+						),
 					),
 				),
 				'groups'       => array(
+					array(
+						'id'       => '',
+						'title'    => 'Nameless Group',
+						'children' => array(),
+					),
 					array(
 						'id'       => 'plugins',
 						'title'    => 'My Plugins',
@@ -849,6 +860,31 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			)
 		);
 
+		$layout_response_without_storage = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
+
+		if ( ! interface_exists( 'Sidebar_Layout_Storage' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
+				'interface Sidebar_Layout_Storage {
+					public function get_layouts( int $user_id ): array;
+					public function put_layouts( int $user_id, array $layouts ): bool;
+				}'
+			);
+		}
+		if ( ! class_exists( 'WP_User_Meta_Storage' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
+				'class WP_User_Meta_Storage implements Sidebar_Layout_Storage {
+					private const META_KEY = "wpcom_admin_sidebar_layouts";
+					public function get_layouts( int $user_id ): array {
+						$value = get_user_meta( $user_id, self::META_KEY, true );
+						return is_array( $value ) ? $value : array();
+					}
+					public function put_layouts( int $user_id, array $layouts ): bool {
+						return (bool) update_user_meta( $user_id, self::META_KEY, $layouts );
+					}
+				}'
+			);
+		}
+
 		$layout_delta = array(
 			'version'    => 1,
 			'updated_at' => 12345,
@@ -870,22 +906,12 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			)
 		);
 
-		// Drive the response through `prepare_menu_for_response` directly so
-		// the test isn't coupled to the live $menu/$submenu globals built by
-		// `wp-admin/menu.php`.
-		$endpoint = new WPCOM_REST_API_V2_Endpoint_Admin_Menu();
-
-		// `index.php` matches the stub's top-level entry; `jetpack` matches
-		// the grouped child.
-		$menu = array(
-			array( 'Dashboard', 'read', 'index.php', '', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
-			array( 'No Signal', 'read', 'no-signal', '', 'menu-top', 'menu-no-signal', 'dashicons-admin-generic' ),
-			array( 'Jetpack', 'read', 'jetpack', '', 'menu-top', 'menu-jetpack', 'dashicons-admin-plugins' ),
-		);
-
-		$response = $endpoint->prepare_menu_for_response( $menu );
+		$response = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
+		wp_set_current_user( 0 );
+		$layout_response_without_user = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
+		wp_set_current_user( static::$user_id );
 		delete_user_meta( static::$user_id, 'wpcom_admin_sidebar_layouts' );
-		$empty_layout_response = $endpoint->prepare_menu_for_response( $menu );
+		$empty_layout_response = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
 		update_user_meta(
 			static::$user_id,
 			'wpcom_admin_sidebar_layouts',
@@ -893,12 +919,38 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 				get_current_blog_id() => array( 'version' => 2 ),
 			)
 		);
-		$invalid_layout_response = $endpoint->prepare_menu_for_response( $menu );
+		$invalid_layout_response = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
+
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
+		Sidebar_Classifier::set_model(
+			array(
+				'version'      => 1,
+				'generated_at' => 0,
+				'site_id'      => 1,
+				'user_id'      => 1,
+				'top_level'    => array(
+					array(
+						'itemId'        => 'core:core:-:index.php',
+						'menuSlug'      => 'index.php',
+						'source'        => 'core',
+						'reassignable'  => false,
+						'default_group' => null,
+					),
+				),
+				'groups'       => array(),
+			)
+		);
+		$response_with_empty_groups = ( new WPCOM_REST_API_V2_Endpoint_Admin_Menu() )->prepare_menu_for_response( $menu );
 
 		// Reset stub state for any subsequent tests.
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
 		Sidebar_Classifier::set_model( null );
 		delete_user_meta( static::$user_id, 'wpcom_admin_sidebar_layouts' );
+
+		$this->assertIsArray( $legacy_response_with_no_model );
+		$this->assertArrayNotHasKey( 'menu', $legacy_response_with_no_model );
+		$this->assertArrayNotHasKey( 'layoutDelta', $layout_response_without_storage );
+		$this->assertArrayNotHasKey( 'layoutDelta', $layout_response_without_user );
 
 		$this->assertIsArray( $response );
 		$this->assertArrayHasKey( 'menu', $response );
@@ -928,6 +980,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			'plugin:no-signal/no-signal.php:-:no-signal',
 			$by_slug['no-signal']['itemId']
 		);
+		$this->assertSame( 77, $by_slug['no-signal']['default_weight'] );
+
+		// Recursed child entries can still hydrate menu rows by slug.
+		$this->assertSame( 'plugin:nested/nested.php:-:nested-plugin', $by_slug['nested-plugin']['itemId'] );
+		$this->assertSame( 88, $by_slug['nested-plugin']['default_weight'] );
 
 		// Grouped plugin item: group_id set, attention signal flowed through.
 		$this->assertSame( 'plugins', $by_slug['jetpack']['group_id'] );
@@ -964,5 +1021,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			),
 			$invalid_layout_response['layoutDelta']
 		);
+		$this->assertSame( array(), $response_with_empty_groups['groups'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test.php
@@ -755,6 +755,28 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 				'class Sidebar_Signals {}'
 			);
 		}
+		if ( ! interface_exists( 'Sidebar_Layout_Storage' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
+				'interface Sidebar_Layout_Storage {
+					public function get_layouts( int $user_id ): array;
+					public function put_layouts( int $user_id, array $layouts ): bool;
+				}'
+			);
+		}
+		if ( ! class_exists( 'WP_User_Meta_Storage' ) ) {
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged, MediaWiki.Usage.ForbiddenFunctions.eval
+				'class WP_User_Meta_Storage implements Sidebar_Layout_Storage {
+					private const META_KEY = "wpcom_admin_sidebar_layouts";
+					public function get_layouts( int $user_id ): array {
+						$value = get_user_meta( $user_id, self::META_KEY, true );
+						return is_array( $value ) ? $value : array();
+					}
+					public function put_layouts( int $user_id, array $layouts ): bool {
+						return (bool) update_user_meta( $user_id, self::META_KEY, $layouts );
+					}
+				}'
+			);
+		}
 
 		// Skip when a real classifier is present — we don't want to clobber
 		// the host's classifier state from a Jetpack unit test.
@@ -772,9 +794,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 				'user_id'      => 1,
 				'top_level'    => array(
 					array(
-						'menuSlug'      => 'index.php',
-						'default_group' => null,
-						'signal'        => array(
+						'itemId'         => 'core:core:-:index.php',
+						'menuSlug'       => 'index.php',
+						'source'         => 'core',
+						'reassignable'   => false,
+						'default_weight' => 10,
+						'default_group'  => null,
+						'signal'         => array(
 							'count'         => null,
 							'numeric_badge' => null,
 							'badge'         => null,
@@ -782,6 +808,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 							'inline_icon'   => null,
 							'attention'     => false,
 						),
+					),
+					array(
+						'itemId'        => 'plugin:no-signal/no-signal.php:-:no-signal',
+						'menuSlug'      => 'no-signal',
+						'source'        => 'plugin',
+						'reassignable'  => true,
+						'default_group' => null,
 					),
 				),
 				'groups'       => array(
@@ -791,9 +824,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 						'icon'     => null,
 						'children' => array(
 							array(
-								'menuSlug'      => 'jetpack',
-								'default_group' => 'plugins',
-								'signal'        => array(
+								'itemId'         => 'plugin:jetpack/jetpack.php:-:jetpack',
+								'menuSlug'       => 'jetpack',
+								'source'         => 'plugin',
+								'reassignable'   => true,
+								'default_weight' => 999,
+								'default_group'  => 'plugins',
+								'signal'         => array(
 									'count'         => 3,
 									'numeric_badge' => null,
 									'badge'         => '3',
@@ -812,6 +849,27 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 			)
 		);
 
+		$layout_delta = array(
+			'version'    => 1,
+			'updated_at' => 12345,
+			'overrides'  => array(
+				array(
+					'itemId'   => 'plugin:jetpack/jetpack.php:-:jetpack',
+					'position' => array(
+						'kind'  => 'top_level',
+						'index' => 2,
+					),
+				),
+			),
+		);
+		update_user_meta(
+			static::$user_id,
+			'wpcom_admin_sidebar_layouts',
+			array(
+				get_current_blog_id() => $layout_delta,
+			)
+		);
+
 		// Drive the response through `prepare_menu_for_response` directly so
 		// the test isn't coupled to the live $menu/$submenu globals built by
 		// `wp-admin/menu.php`.
@@ -821,18 +879,31 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		// the grouped child.
 		$menu = array(
 			array( 'Dashboard', 'read', 'index.php', '', 'menu-top', 'menu-dashboard', 'dashicons-dashboard' ),
+			array( 'No Signal', 'read', 'no-signal', '', 'menu-top', 'menu-no-signal', 'dashicons-admin-generic' ),
 			array( 'Jetpack', 'read', 'jetpack', '', 'menu-top', 'menu-jetpack', 'dashicons-admin-plugins' ),
 		);
 
 		$response = $endpoint->prepare_menu_for_response( $menu );
+		delete_user_meta( static::$user_id, 'wpcom_admin_sidebar_layouts' );
+		$empty_layout_response = $endpoint->prepare_menu_for_response( $menu );
+		update_user_meta(
+			static::$user_id,
+			'wpcom_admin_sidebar_layouts',
+			array(
+				get_current_blog_id() => array( 'version' => 2 ),
+			)
+		);
+		$invalid_layout_response = $endpoint->prepare_menu_for_response( $menu );
 
 		// Reset stub state for any subsequent tests.
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Sidebar_Classifier is the stub eval'd above.
 		Sidebar_Classifier::set_model( null );
+		delete_user_meta( static::$user_id, 'wpcom_admin_sidebar_layouts' );
 
 		$this->assertIsArray( $response );
 		$this->assertArrayHasKey( 'menu', $response );
 		$this->assertArrayHasKey( 'groups', $response );
+		$this->assertArrayHasKey( 'layoutDelta', $response );
 
 		$by_slug = array();
 		foreach ( $response['menu'] as $item ) {
@@ -840,24 +911,58 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu_Test extends Jetpack_REST_TestCase {
 		}
 
 		$this->assertArrayHasKey( 'index-php', $by_slug );
+		$this->assertArrayHasKey( 'no-signal', $by_slug );
 		$this->assertArrayHasKey( 'jetpack', $by_slug );
 
 		// Top-level core item: matched, no group, signal attached but inert.
 		$this->assertNull( $by_slug['index-php']['group_id'] );
 		$this->assertSame( false, $by_slug['index-php']['signal']['attention'] );
+		$this->assertSame( 'core:core:-:index.php', $by_slug['index-php']['itemId'] );
+		$this->assertSame( 'core', $by_slug['index-php']['source'] );
+		$this->assertFalse( $by_slug['index-php']['reassignable'] );
+		$this->assertSame( 10, $by_slug['index-php']['default_weight'] );
+
+		// A matched item without signal data keeps the field explicit and null.
+		$this->assertNull( $by_slug['no-signal']['signal'] );
+		$this->assertSame(
+			'plugin:no-signal/no-signal.php:-:no-signal',
+			$by_slug['no-signal']['itemId']
+		);
 
 		// Grouped plugin item: group_id set, attention signal flowed through.
 		$this->assertSame( 'plugins', $by_slug['jetpack']['group_id'] );
 		$this->assertSame( 3, $by_slug['jetpack']['signal']['count'] );
 		$this->assertTrue( $by_slug['jetpack']['signal']['attention'] );
+		$this->assertSame( 'plugin:jetpack/jetpack.php:-:jetpack', $by_slug['jetpack']['itemId'] );
+		$this->assertSame( 'plugin', $by_slug['jetpack']['source'] );
+		$this->assertTrue( $by_slug['jetpack']['reassignable'] );
+		$this->assertSame( 999, $by_slug['jetpack']['default_weight'] );
 
 		// Top-level groups row mirrors the classifier's group shape.
 		$this->assertCount( 1, $response['groups'] );
 		$group = $response['groups'][0];
 		$this->assertSame( 'plugins', $group['id'] );
 		$this->assertSame( 'My Plugins', $group['label'] );
-		$this->assertTrue( $group['default_expanded'] );
+		$this->assertFalse( $group['default_expanded'] );
 		$this->assertTrue( $group['signal']['attention'] );
 		$this->assertSame( 3, $group['signal']['count'] );
+
+		$this->assertSame( $layout_delta, $response['layoutDelta'] );
+		$this->assertSame(
+			array(
+				'version'    => 1,
+				'updated_at' => 0,
+				'overrides'  => array(),
+			),
+			$empty_layout_response['layoutDelta']
+		);
+		$this->assertSame(
+			array(
+				'version'    => 1,
+				'updated_at' => 0,
+				'overrides'  => array(),
+			),
+			$invalid_layout_response['layoutDelta']
+		);
 	}
 }


### PR DESCRIPTION
> Supersedes #48632 (which was opened from a fork). Reopened here from a branch on `Automattic/jetpack` per @jeherve's request, with the linting fixes folded in.

<!-- N/A; aligned with the Calypso A.3 sidebar-redesign workstream tracked in `WordPress/wp-admin-sidebar` and the wpcom in-tree-copy. -->

Part of [DES-575](https://linear.app/a8c/issue/DES-575/a3-calypso-parity)

## Overview

Extends `/wpcom/v2/admin-menu` with two additive per-item fields (`group_id`, `signal`) and a sibling top-level `groups[]` array describing the synthetic group rows the redesigned sidebar needs. Mirrors [`WordPress/wp-admin-sidebar` v0.1.7](https://github.com/WordPress/wp-admin-sidebar/releases/tag/v0.1.7) (the version currently vendored as the wpcom in-tree-copy at `wp-content/mu-plugins/wp-admin-sidebar/`).

This endpoint is the server side of the A.3 Calypso parity workstream. Pair with the Calypso PRs:

* Phase 1 (grouping + signals): [`Automattic/wp-calypso#110578`](https://github.com/Automattic/wp-calypso/pull/110578)
* Phase 2 (customize mode): [`Automattic/wp-calypso#110588`](https://github.com/Automattic/wp-calypso/pull/110588)

## What changed

* `prepare_menu_for_response()` best-effort-hydrates the classifier nav model and, when present, returns `{ menu, groups, layoutDelta? }` instead of the legacy flat list. When the classifier isn't loaded, the response shape is byte-identical to `trunk`.
* `prepare_menu_item()` + `prepare_submenu_item()` attach `group_id` + `signal` from the classifier index by menu slug. O(1) lookup; items with no nav-model match are unchanged.
* `get_item_schema()` describes the new per-item fields (`group_id`, `signal`) and the optional `{ menu, groups, layoutDelta? }` envelope.
* Two PHPUnit tests added: legacy-shape contract when the classifier is absent; group + signal attachment + envelope when stub classifier classes are visible.
* Jetpack changelog entry (`patch` / `enhancement`).

## Screenshots

This is a backend-only schema extension. There's no Jetpack-side UI to screenshot. The visual before/after for the redesigned sidebar lives in the paired Calypso PRs (#110578, #110588) and the public plugin's wp-admin output.

## Gating

The redesigned response shape is gated end-to-end on the public plugin's `wp_admin_sidebar_enabled` filter:

* On non-WPCOM Jetpack installs (classifier classes not loaded), the endpoint falls back to the legacy flat shape. `class_exists()` guards everywhere ensure dead-code safety.
* On WPCOM, the integration mu-plugin (`wpcom-admin-sidebar-integration`) wires `wp_admin_sidebar_enabled` to the `wpcom-admin-sidebar-redesign` blog sticker via `WPCOM_Gating::is_enabled`. **No sticker → filter resolves false → `Sidebar_Classifier::build_nav_model()` short-circuits → endpoint emits the legacy flat shape.**

So a blog without the sticker sees byte-identical behaviour to today, both in the response and on the client (Calypso treats absent `groups[]` as "render the legacy flat sidebar"). Removing the sticker is the rollback path, no Jetpack / Calypso deploy needed.

> 🟡 Reviewer-confirmable: trace `Sidebar_Classifier::build_nav_model()` for a stickered-off WPCOM site, confirm it returns the empty/legacy shape rather than emitting `groups[]` regardless.

## Cross-surface persistence (layoutDelta)

The Calypso customize mode (Phase 2 PR #110588) needs to read the saved layout-delta the user persisted from wp-admin. The wp-admin side stores it in a per-user-per-blog WPCOM user attribute via `WPCOM_User_Attribute_Storage`.

> 🟡 Reviewer-actionable: confirm whether this endpoint emits the saved `layoutDelta` alongside `menu` + `groups[]`. If not, Calypso has no way to render the user's saved order, and customize-mode write/read parity with wp-admin breaks. If layoutDelta lives behind a separate endpoint, please link from this PR so the Calypso side knows where to read it.

The expected shape (additive to the existing response envelope):

```ts
{
  menu: AdminMenuItem[],
  groups: AdminMenuGroup[],
  layoutDelta?: {
    overrides: Array<{
      itemId: string,
      position: { kind: 'top_level' | 'in_group', group_id?: string, index: number },
    }>,
    version: number,
    updated_at: number,
  },
}
```

## Schema delta

Per-item (top-level + child):

```ts
{
  group_id: string | null,        // 'plugins' | null (top-level / non-grouped)
  signal: {
    count: number | null,
    numeric_badge: number | null,
    badge: string | null,
    inline_text: string | null,
    inline_icon: string | null,
    attention: boolean,           // OR of (count > 0, numeric_badge > 0, non-empty badge)
  } | null,
  itemId?: string,                // Compound `<sourceKind>:<ref>:<parent>:<slug>`
  reassignable?: boolean,         // True when the item participates in customize-mode reorder
}
```

Top-level (when classifier is loaded):

```ts
{
  menu: AdminMenuItem[],
  groups: Array<{
    id: string,                   // 'plugins'
    label: string,                // 'My Plugins' (i18n)
    default_expanded: boolean,
    signal: { attention: boolean, count: number },
  }>,
}
```

## Does this pull request change what data or activity we track or use?

No. The endpoint exposes structural metadata about the admin menu the user is already authorised to see; no new tracking or logging.

## Testing instructions

### Without the public `wp-admin-sidebar` plugin loaded

`/wpcom/v2/admin-menu` response shape is byte-identical to `trunk`: same flat-array root, no `group_id` / `signal` on items, no `groups[]`. Existing Calypso behaviour is unchanged.

### With the plugin loaded and gating enabled

* WPCOM: set the `wpcom-admin-sidebar-redesign` blog sticker on a test blog: `wp blog-stickers add --blog_id=<id> --sticker=wpcom-admin-sidebar-redesign --who=<user>`.
* Other hosts: any host adapter that resolves `wp_admin_sidebar_enabled` to `true` for the request user / blog.

The response root becomes `{ menu: [...], groups: [...], layoutDelta?: {...} }`. Each item has `group_id` (string or null) and `signal` (object or null). The `groups[]` array contains one `{ id, label, default_expanded, signal }` row per synthetic group the classifier emitted.

### Calypso integration check

Pair with [`Automattic/wp-calypso#110578`](https://github.com/Automattic/wp-calypso/pull/110578) (Phase 1). Once this endpoint deploys, open `/home/<site-slug>` on Calypso for the stickered blog. The "My Plugins" group should render below the top-level items, in the public plugin's blue (`#71aee2`), with the hamburger toggle + chevron header. Items inside should show the correct signals (red number bubble, "Premium" chip, etc.) per the per-item `signal` payload.

### PHPUnit

* `test_response_is_legacy_shape_without_classifier`: legacy flat-array contract when the classifier is absent.
* `test_response_carries_group_fields_when_classifier_is_loaded`: wrapped shape, per-item attachment by slug, and `groups[]` rows when stub classifier + signals classes are visible.
* Existing endpoint tests (`test_prepare_menu_item`, `test_prepare_submenu_item`, `test_parse_menu_item`, etc.) unchanged.

## Related

* Public plugin source-of-truth: [`WordPress/wp-admin-sidebar` v0.1.7](https://github.com/WordPress/wp-admin-sidebar/releases/tag/v0.1.7), `src/class-sidebar-classifier.php`, `src/class-sidebar-signals.php`.
* WPCOM integration adapter (sticker gating + storage): `wp-content/mu-plugins/wpcom-admin-sidebar-integration/` in `Automattic/wpcom`.
* Internal: [DES-575](https://linear.app/a8c/issue/DES-575/a3-calypso-parity) (A.3 Calypso parity tracker), [DES-617](https://linear.app/a8c/issue/DES-617/a3-phase-2-schema-decision-emit-grouped-items-with-or-without-children) (schema decision on whether grouped items emit `children`).

