### PR TITLE
Track prepare-campaign server telemetry (ADS-1041)

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1041-prepare-campaign-telemetry
+++ b/projects/packages/blaze/changelog/add-ads-1041-prepare-campaign-telemetry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze: Track server-side telemetry for prepare-campaign ability requests.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -24,6 +24,7 @@ namespace Automattic\Jetpack\Blaze\Abilities;
 use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Blaze\Campaign_Preparer;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use WP_REST_Request;
 
@@ -863,16 +864,29 @@ class Blaze_Abilities extends Registrar {
 			return $args;
 		}
 
-		$args['execute_callback'] = static function ( $input = array() ) use ( $original_callback ) {
+		$args['execute_callback'] = static function ( $input = array() ) use ( $ability_name, $original_callback ) {
+			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+				self::record_prepare_campaign_event( 'called', is_array( $input ) ? $input : array() );
+			}
+
 			$tos_check = self::check_tos_and_payment();
 			if ( is_wp_error( $tos_check ) ) {
+				if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+					self::record_prepare_campaign_event( 'failed', is_array( $input ) ? $input : array(), $tos_check );
+				}
 				return $tos_check;
 			}
 
 			// Future write-path guardrails (per-session spend ceiling, Picard
 			// moderation gating) plug in here. Tracked separately as ADS-989.
 
-			return call_user_func( $original_callback, $input );
+			$result = call_user_func( $original_callback, $input );
+
+			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+				self::record_prepare_campaign_event( is_wp_error( $result ) ? 'failed' : 'succeeded', is_array( $input ) ? $input : array(), $result );
+			}
+
+			return $result;
 		};
 
 		return $args;
@@ -927,6 +941,99 @@ class Blaze_Abilities extends Registrar {
 				'fix_label' => __( 'Set up Blaze', 'jetpack-blaze' ),
 			)
 		);
+	}
+
+	/**
+	 * Record safe server-side telemetry for prepare-campaign.
+	 *
+	 * Never records caller prompts, ad copy, URLs, or the full prefill payload.
+	 * Keep properties deliberately low-cardinality so MCP and direct REST calls
+	 * are useful in aggregate without carrying merchant-sensitive data.
+	 *
+	 * @param string          $result  called|succeeded|failed.
+	 * @param array           $input   Ability input.
+	 * @param array|\WP_Error $outcome Optional callback result.
+	 * @return void
+	 */
+	private static function record_prepare_campaign_event( string $result, array $input, $outcome = null ): void {
+		$props = array(
+			'result'            => in_array( $result, array( 'called', 'succeeded', 'failed' ), true ) ? $result : 'unknown',
+			'target_type'       => self::get_prepare_campaign_target_type( $outcome ),
+			'inferred_intent'   => self::get_prepare_campaign_intent( $outcome ),
+			'budget_provided'   => array_key_exists( 'budget_total', $input ),
+			'duration_provided' => array_key_exists( 'duration_days', $input ),
+		);
+
+		if ( is_wp_error( $outcome ) ) {
+			$props['failure_category'] = self::get_prepare_campaign_failure_category( $outcome );
+		}
+
+		$event = array(
+			'name'  => 'blaze_prepare_campaign_' . $props['result'],
+			'props' => $props,
+		);
+
+		/**
+		 * Filters the prepare-campaign Tracks event before it is emitted.
+		 *
+		 * Returning false prevents emission. Primarily useful for tests and for
+		 * emergency suppression if the event contract ever needs to be disabled.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array|false     $event   Event name and safe props, or false to suppress.
+		 * @param string          $result  called|succeeded|failed.
+		 * @param array           $input   Ability input.
+		 * @param array|\WP_Error $outcome Optional callback result.
+		 */
+		$event = apply_filters( 'jetpack_blaze_prepare_campaign_tracks_event', $event, $result, $input, $outcome );
+		if ( false === $event || ! is_array( $event ) || empty( $event['name'] ) || ! isset( $event['props'] ) || ! is_array( $event['props'] ) ) {
+			return;
+		}
+
+		$tracking = new Tracking( 'jetpack' );
+		$tracking->record_user_event( (string) $event['name'], $event['props'] );
+	}
+
+	/**
+	 * Get the safe target type from a successful prepare outcome.
+	 *
+	 * @param mixed $outcome Callback result.
+	 * @return string
+	 */
+	private static function get_prepare_campaign_target_type( $outcome ): string {
+		$target_type = is_array( $outcome ) && isset( $outcome['prefill']['type'] ) ? (string) $outcome['prefill']['type'] : 'unknown';
+		return in_array( $target_type, array( 'post', 'page', 'product' ), true ) ? $target_type : 'unknown';
+	}
+
+	/**
+	 * Get the safe inferred intent from a successful prepare outcome.
+	 *
+	 * @param mixed $outcome Callback result.
+	 * @return string
+	 */
+	private static function get_prepare_campaign_intent( $outcome ): string {
+		$intent = is_array( $outcome ) && isset( $outcome['intent'] ) ? (string) $outcome['intent'] : 'unknown';
+		return in_array( $intent, array( 'ecommerce', 'content', 'unknown' ), true ) ? $intent : 'unknown';
+	}
+
+	/**
+	 * Map error codes to low-cardinality failure categories.
+	 *
+	 * @param \WP_Error $error Error returned by the prepare path.
+	 * @return string
+	 */
+	private static function get_prepare_campaign_failure_category( \WP_Error $error ): string {
+		switch ( $error->get_error_code() ) {
+			case 'blaze_invalid_target_urn':
+				return 'invalid_target';
+			case 'blaze_post_not_found':
+				return 'target_not_found';
+			case 'blaze_setup_required':
+				return 'setup_required';
+			default:
+				return 'prepare_failed';
+		}
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -66,6 +66,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_tracks_event' );
 		remove_all_actions( 'wp_after_execute_ability' );
 		unset( $GLOBALS['wp_rest_server'] );
 	}
@@ -251,6 +252,122 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->assertSame( array( 'campaign_id' => 'abc-123' ), $result, 'Original callback result should pass through unchanged.' );
 		$this->assertSame( array( 'budget_total' => 50 ), $received_input, 'Original callback should receive the original input.' );
+	}
+
+	/**
+	 * Prepare-campaign emits safe called + succeeded telemetry around
+	 * successful registered ability executions.
+	 */
+	public function test_wrapped_prepare_campaign_tracks_called_and_succeeded() {
+		$events = array();
+		add_filter(
+			'jetpack_blaze_prepare_campaign_tracks_event',
+			static function ( $event ) use ( &$events ) {
+				$events[] = $event;
+				return false;
+			},
+			10,
+			4
+		);
+
+		$callback = static function () {
+			return array(
+				'intent'  => 'ecommerce',
+				'prefill' => array(
+					'type'         => 'product',
+					'site_name'    => 'Secret merchant headline',
+					'text_snippet' => 'Secret merchant copy',
+					'target_url'   => 'https://example.com/private-product',
+				),
+			);
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'    => 'urn:wpcom:post:12345:42',
+				'budget_total'  => 50,
+				'duration_days' => 7,
+				'site_name'     => 'Secret caller headline',
+				'text_snippet'  => 'Secret caller copy',
+			)
+		);
+
+		$this->assertCount( 2, $events );
+		$called_event    = $events[0] ?? array();
+		$succeeded_event = $events[1] ?? array();
+
+		$this->assertSame( 'blaze_prepare_campaign_called', $called_event['name'] ?? null );
+		$this->assertSame(
+			array(
+				'result'            => 'called',
+				'target_type'       => 'unknown',
+				'inferred_intent'   => 'unknown',
+				'budget_provided'   => true,
+				'duration_provided' => true,
+			),
+			$called_event['props'] ?? array()
+		);
+		$succeeded_props = $succeeded_event['props'] ?? array();
+		$this->assertSame( 'blaze_prepare_campaign_succeeded', $succeeded_event['name'] ?? null );
+		$this->assertSame( 'succeeded', $succeeded_props['result'] ?? null );
+		$this->assertSame( 'product', $succeeded_props['target_type'] ?? null );
+		$this->assertSame( 'ecommerce', $succeeded_props['inferred_intent'] ?? null );
+		$this->assertStringNotContainsString( 'Secret', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
+		$this->assertStringNotContainsString( 'private-product', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * Failed prepare-campaign executions emit a low-cardinality failure
+	 * category without carrying raw input or error messages.
+	 */
+	public function test_wrapped_prepare_campaign_tracks_failed_with_safe_failure_category() {
+		$events = array();
+		add_filter(
+			'jetpack_blaze_prepare_campaign_tracks_event',
+			static function ( $event ) use ( &$events ) {
+				$events[] = $event;
+				return false;
+			},
+			10,
+			4
+		);
+
+		$callback = static function () {
+			return new WP_Error( 'blaze_invalid_target_urn', 'Secret malformed URN value' );
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'   => 'secret-bad-urn',
+				'budget_total' => 50,
+			)
+		);
+
+		$this->assertCount( 2, $events );
+		$called_event = $events[0] ?? array();
+		$failed_event = $events[1] ?? array();
+		$failed_props = $failed_event['props'] ?? array();
+
+		$this->assertSame( 'blaze_prepare_campaign_called', $called_event['name'] ?? null );
+		$this->assertSame( 'blaze_prepare_campaign_failed', $failed_event['name'] ?? null );
+		$this->assertSame( 'failed', $failed_props['result'] ?? null );
+		$this->assertSame( 'invalid_target', $failed_props['failure_category'] ?? null );
+		$this->assertSame( true, $failed_props['budget_provided'] ?? null );
+		$this->assertSame( false, $failed_props['duration_provided'] ?? null );
+		$this->assertStringNotContainsString( 'secret-bad-urn', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
+		$this->assertStringNotContainsString( 'Secret malformed', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Adds server-side Tracks telemetry around the Blaze prepare-campaign MCP flow so we can observe tool usage and generated prefill outcomes.

Stacked on #48604.

## Testing

- pnpm exec jetpack test php packages/blaze
- composer phpcs:lint projects/packages/blaze/src/abilities/class-blaze-abilities.php projects/packages/blaze/src/class-campaign-preparer.php projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
- tools/check-changelogger-use.php --debug origin/trunk HEAD
- tools/changelogger-validate-all.sh -vv
