### PR TITLE
wpcomsh: bump at-pressable-podcasting to 2.0.8

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-podcast-untangle-gate
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-podcast-untangle-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcasting: stand down the legacy at-pressable-podcasting plugin when the new Jetpack podcast package owns the feature.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.1",
-		"automattic/at-pressable-podcasting": "^2.0.7",
+		"automattic/at-pressable-podcasting": "^2.0.8",
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92c91b9f92fa4ddc44de6deea3a1a051",
+    "content-hash": "f027d03433b3a70bb6f4b28317c7a19c",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
-            "version": "v2.0.7",
+            "version": "v2.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/automattic/at-pressable-podcasting.git",
-                "reference": "b3920eb6e94594aadb0c678f6c8328191091a9be"
+                "reference": "78780729dbf7b01e67e2a6472f8576ce8ba7f0fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/b3920eb6e94594aadb0c678f6c8328191091a9be",
-                "reference": "b3920eb6e94594aadb0c678f6c8328191091a9be",
+                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/78780729dbf7b01e67e2a6472f8576ce8ba7f0fc",
+                "reference": "78780729dbf7b01e67e2a6472f8576ce8ba7f0fc",
                 "shasum": ""
             },
             "type": "wordpress-plugin",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2026-04-24T20:01:37+00:00"
+            "time": "2026-05-12T12:18:56+00:00"
         },
         {
             "name": "automattic/block-delimiter",


### PR DESCRIPTION
Pulls in [at-pressable-podcasting v2.0.8](https://github.com/Automattic/at-pressable-podcasting/releases/tag/v2.0.8).

### Proposed changes

- Bumps `automattic/at-pressable-podcasting` from `^2.0.7` to `^2.0.8`.
- [#29](https://github.com/Automattic/at-pressable-podcasting/pull/29) — Gate the legacy plugin behind a `jetpack_podcast_untangle` filter so it stands down when the new `automattic/jetpack-podcast` package owns RSS customization, settings, Tracks, and the wp-admin UI. Default is `false`, so behavior is unchanged on sites that don't opt in.

## Does this pull request change what data or activity we track or use?

No

### Testing instructions

Upstream behavior was verified in the at-pressable-podcasting repo before release. To spot-check inside Jetpack/wpcomsh:

1. Build wpcomsh and load it on a sandbox with podcasting enabled.
2. Confirm default behavior is unchanged: the legacy plugin still owns the podcast settings UI, RSS customization, Tracks, and the widget.
3. Add a filter returning `true` for `jetpack_podcast_untangle`. Confirm `Automattic_Podcasting::__construct()` bails early — the legacy settings UI, REST settings, Tracks, feed customization, and the widget should all disappear, leaving the new `automattic/jetpack-podcast` package in charge.
