### PR TITLE
Boost: scaffold the wp-build dashboard chassis behind the modernization flag

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5024,6 +5024,9 @@ importers:
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../../js-packages/base-styles
+      '@automattic/jetpack-components':
+        specifier: workspace:*
+        version: link:../../js-packages/components
       '@automattic/jetpack-my-jetpack':
         specifier: workspace:*
         version: link:../../packages/my-jetpack
@@ -5039,18 +5042,36 @@ importers:
       '@react-spring/web':
         specifier: 9.7.5
         version: 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: 5.90.8
+        version: 5.90.8(react@18.3.1)
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@wordpress/admin-ui':
+        specifier: 1.12.0
+        version: 1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/base-styles':
+        specifier: 6.20.0
+        version: 6.20.0
       '@wordpress/components':
         specifier: 32.6.0
         version: 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: 6.44.0
         version: 6.44.0
+      '@wordpress/i18n':
+        specifier: 6.17.0
+        version: 6.17.0
       '@wordpress/icons':
         specifier: 12.2.0
         version: 12.2.0(react@18.3.1)
+      '@wordpress/route':
+        specifier: 0.10.0
+        version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/theme':
+        specifier: 0.11.0
+        version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
         specifier: 0.11.0
         version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5082,9 +5103,6 @@ importers:
       '@automattic/jetpack-boost-score-api':
         specifier: workspace:*
         version: link:../../js-packages/boost-score-api
-      '@automattic/jetpack-components':
-        specifier: workspace:*
-        version: link:../../js-packages/components
       '@automattic/jetpack-critical-css-gen':
         specifier: workspace:*
         version: link:../../js-packages/critical-css-gen
@@ -5094,6 +5112,9 @@ importers:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config
+      '@automattic/jetpack-wp-build-polyfills':
+        specifier: workspace:*
+        version: link:../../packages/wp-build-polyfills
       '@babel/core':
         specifier: 7.29.0
         version: 7.29.0
@@ -5121,9 +5142,12 @@ importers:
       '@wordpress/browserslist-config':
         specifier: 6.44.0
         version: 6.44.0
-      '@wordpress/i18n':
-        specifier: 6.17.0
-        version: 6.17.0
+      '@wordpress/build':
+        specifier: 0.13.0
+        version: 0.13.0(@babel/core@7.29.0)(@wordpress/route@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)
+      browserslist:
+        specifier: ^4.24.0
+        version: 4.28.2
       concurrently:
         specifier: 9.2.1
         version: 9.2.1

--- a/projects/plugins/boost/.gitattributes
+++ b/projects/plugins/boost/.gitattributes
@@ -5,6 +5,7 @@
 app/assets/dist/**                              production-include
 app/modules/image-guide/dist/**                 production-include
 app/modules/optimizations/image-cdn/dist/**     production-include
+/build/**                                       production-include
 jetpack_vendor/**                               production-include
 vendor/autoload.php                             production-include
 vendor/autoload_functions.php                   production-include
@@ -21,6 +22,8 @@ vendor/wikimedia/aho-corasick/**                production-include
 # Remember to end all directories with `/**` to properly tag every file.
 /app/assets/src/**                              production-exclude
 /app/assets/dist/**/*.js.map                    production-exclude
+/_inc/**                                        production-exclude
+/routes/**                                      production-exclude
 /docs/**                                        production-exclude
 /vendor/automattic/jetpack-autoloader/**        production-exclude
 /vendor/automattic/jetpack-composer-plugin/**   production-exclude

--- a/projects/plugins/boost/.gitignore
+++ b/projects/plugins/boost/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /release
+/build
 /app/assets/dist
 /app/modules/image-guide/dist
 /app/modules/optimizations/image-cdn/dist

--- a/projects/plugins/boost/_inc/components/boost-page.scss
+++ b/projects/plugins/boost/_inc/components/boost-page.scss
@@ -1,0 +1,67 @@
+// Page-shell layout for the modernized Boost dashboard. Mirrors the
+// Newsletter shell: the body slot becomes the scroll container so the
+// `Page` header and the tab row stay pinned to the viewport while only
+// the active tab's content scrolls underneath. `@wordpress/admin-ui`
+// already paints `.admin-ui-page` and `.admin-ui-page__header` with the
+// neutral surface tokens, so this file only overrides what's specific to
+// the unified Boost layout.
+
+$jetpack-boost-inset: var(--wpds-dimension-padding-2xl, 24px);
+
+body.jetpack_page_jetpack-boost,
+body.toplevel_page_jetpack-boost {
+
+	// Anchor the page to the stage's height so the body slot below has a
+	// bounded box to fill — see the body-slot rule for the rest of the
+	// app-shell scroll model.
+	.admin-ui-page {
+		block-size: 100%;
+		min-block-size: 0;
+	}
+
+	// The body slot — `Tabs.Root` in tabbed mode — owns the scrolling so
+	// the sticky header and the `JetpackFooter` stay pinned while the
+	// active tab's content scrolls inside.
+	.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer) {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-block-size: 0;
+		overflow: auto;
+	}
+
+	// Page header keeps admin-ui's sticky behaviour but drops its bottom
+	// rule — the tab row owns the separator so the two never double-border.
+	// Locking the title row to the action-button height keeps the header
+	// the same size whether the active tab supplies actions or not, so the
+	// tab bar doesn't jump when switching between them.
+	.admin-ui-page__header {
+		border-bottom: 0;
+		padding-block-end: var(--wpds-dimension-padding-xs, 4px);
+
+		> *:first-child {
+			min-block-size: 36px;
+		}
+	}
+
+	// Tabs row: sticks at the top of the body wrapper so the bar stays in
+	// view while the panel content scrolls underneath. The wrapper carries
+	// the full-width separator + inline padding; the nested `Tabs.List`
+	// keeps its native `width: fit-content` so the animated active-tab
+	// indicator slides smoothly between tabs.
+	.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer) > .jetpack-boost-page__tabs-row {
+		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+		border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+		box-sizing: border-box;
+		flex: 0 0 auto;
+		padding-inline: $jetpack-boost-inset;
+		position: sticky;
+		top: 0;
+		width: 100%;
+		z-index: 9;
+	}
+
+	.jetpack-boost-page__content--padded {
+		padding: $jetpack-boost-inset;
+	}
+}

--- a/projects/plugins/boost/_inc/components/boost-page.tsx
+++ b/projects/plugins/boost/_inc/components/boost-page.tsx
@@ -1,0 +1,82 @@
+import JetpackFooter from '@automattic/jetpack-components/jetpack-footer';
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
+import { Page } from '@wordpress/admin-ui';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate } from '@wordpress/route';
+import { Stack, Tabs } from '@wordpress/ui';
+import './boost-page.scss';
+import type { ReactNode } from 'react';
+
+export type BoostTab = 'overview' | 'settings';
+
+type Props = {
+	activeTab: BoostTab;
+	actions?: ReactNode;
+	children: ReactNode;
+};
+
+const PRODUCT_NAME = 'Boost'; /** "Boost" is a product name, do not translate. */
+
+/**
+ * Shared chrome for the unified Boost page — owns the `Page` from
+ * `@wordpress/admin-ui` plus the Overview / Settings tab nav. Routes
+ * exchange tab via `?tab=` so the `Tabs.Root` mounts once and the
+ * active-tab indicator slides between tabs instead of remounting.
+ *
+ * @param props           - Component props.
+ * @param props.activeTab - Which tab the current route represents.
+ * @param props.actions   - Optional actions slot (top-right of the Page header).
+ * @param props.children  - `Tabs.Panel` children.
+ * @return The unified Boost page shell.
+ */
+export default function BoostPage( { activeTab, actions, children }: Props ): JSX.Element {
+	const navigate = useNavigate();
+
+	// Keep the route at `/` and toggle tabs via a `?tab=` search param so the
+	// `Tabs.Root` mounts once and the active-tab indicator can animate.
+	const onTabChange = useCallback(
+		( next: string | null ) => {
+			if ( next !== 'overview' && next !== 'settings' ) {
+				return;
+			}
+			navigate( {
+				search: {
+					tab: next === 'settings' ? 'settings' : undefined,
+				},
+			} as unknown as Parameters< typeof navigate >[ 0 ] );
+		},
+		[ navigate ]
+	);
+
+	const title = (
+		<Stack direction="row" align="center" gap="sm">
+			<JetpackLogo height={ 20 } showText={ false } />
+			{ /* "Boost" is a product name, do not translate. */ }
+			<span>{ PRODUCT_NAME }</span>
+		</Stack>
+	);
+
+	return (
+		<Page
+			title={ title }
+			ariaLabel={ PRODUCT_NAME }
+			subTitle={ __( 'Improve your site speed and performance.', 'jetpack-boost' ) }
+			actions={ actions }
+			hasPadding={ false }
+		>
+			<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
+				<div className="jetpack-boost-page__tabs-row">
+					<Tabs.List variant="minimal">
+						<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-boost' ) }</Tabs.Tab>
+						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-boost' ) }</Tabs.Tab>
+					</Tabs.List>
+				</div>
+				<div className="jetpack-boost-page__content jetpack-boost-page__content--padded">
+					{ children }
+				</div>
+			</Tabs.Root>
+			<JetpackFooter />
+		</Page>
+	);
+}

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -23,6 +23,14 @@ class Admin {
 	 */
 	const MENU_SLUG = 'jetpack-boost';
 
+	/**
+	 * Filter name that gates the wp-build–based dashboard.
+	 *
+	 * When this filter returns true, "Boost" renders the new wp-build
+	 * dashboard (Overview + Settings tabs) instead of the legacy React app.
+	 */
+	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_boost';
+
 	public function init( Modules_Setup $modules ) {
 		Environment_Change_Detector::init();
 
@@ -31,6 +39,11 @@ class Admin {
 
 		add_action( 'init', array( new Analytics(), 'init' ) );
 		add_filter( 'plugin_action_links_' . JETPACK_BOOST_PLUGIN_BASE, array( $this, 'plugin_page_settings_link' ) );
+
+		// wp-build must load before handle_admin_menu (priority 1) reads
+		// is_modernized() and looks up the auto-generated render function, so
+		// we register it at priority 0.
+		add_action( 'admin_menu', array( __CLASS__, 'maybe_load_wp_build' ), 0 );
 		add_action( 'admin_menu', array( $this, 'handle_admin_menu' ), 1 ); // Akismet uses 4, so we use 1 to ensure both menus are added when only they exist.
 	}
 
@@ -48,15 +61,36 @@ class Admin {
 			$menu_label .= sprintf( ' <span class="menu-counter count-%d"><span class="count">%d</span></span>', $total_problems, $total_problems );
 		}
 
+		$callback = self::is_modernized() && function_exists( 'jetpack_boost_jetpack_boost_dashboard_wp_admin_render_page' )
+			? 'jetpack_boost_jetpack_boost_dashboard_wp_admin_render_page'
+			: array( $this, 'render_settings' );
+
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Boost - Settings', 'jetpack-boost' ),
 			$menu_label,
 			'manage_options',
 			JETPACK_BOOST_SLUG,
-			array( $this, 'render_settings' ),
+			$callback,
 			2
 		);
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+	}
+
+	/**
+	 * Load wp-build for the Boost admin page when modernization is enabled.
+	 *
+	 * Hooked to `admin_menu` priority 0 so the wp-build render function and
+	 * enqueue hook are in place before `handle_admin_menu` runs at priority 1.
+	 *
+	 * @return void
+	 */
+	public static function maybe_load_wp_build() {
+		if ( ! self::is_modernized() || ! self::is_boost_admin_request() ) {
+			return;
+		}
+
+		self::load_wp_build();
+		add_action( 'current_screen', array( __CLASS__, 'alias_screen_id_for_wp_build' ) );
 	}
 
 	/**
@@ -76,6 +110,16 @@ class Admin {
 	 * @since    1.0.0
 	 */
 	public function enqueue_scripts() {
+		// This callback is registered via `load-{$page_suffix}` in
+		// `handle_admin_menu()`, so it only fires on the Boost admin page —
+		// no need to re-check the page here.
+		if ( self::is_modernized() ) {
+			// wp-build manages its own enqueue pipeline. The legacy Boost
+			// script, localized config, and My Jetpack dependency are
+			// intentionally skipped for the wp-build dashboard.
+			return;
+		}
+
 		/**
 		 * Filters the internal path to the distributed assets used by the plugin
 		 *
@@ -139,5 +183,83 @@ class Admin {
 		?>
 		<div id="jb-admin-settings"></div>
 		<?php
+	}
+
+	/**
+	 * Load the wp-build entry file and register its polyfills.
+	 *
+	 * Only called on `?page=jetpack-boost` admin requests when the
+	 * modernization filter is enabled. Keeps wp-build off every other request.
+	 *
+	 * @return void
+	 */
+	private static function load_wp_build() {
+		$build_index = plugin_dir_path( JETPACK_BOOST_PATH ) . 'build/build.php';
+
+		if ( ! file_exists( $build_index ) ) {
+			return;
+		}
+
+		require_once $build_index;
+
+		if ( ! class_exists( '\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills' ) ) {
+			return;
+		}
+
+		\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::register(
+			'jetpack-boost',
+			array_merge(
+				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::SCRIPT_HANDLES,
+				\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::MODULE_IDS
+			)
+		);
+	}
+
+	/**
+	 * Alias the current screen ID to satisfy wp-build's auto-generated enqueue check.
+	 *
+	 * Wp-build's `<page>-wp-admin` enqueue callback enqueues only when the
+	 * screen ID matches the wp-build page slug (`jetpack-boost-dashboard`).
+	 * Our wp-admin menu slug stays `jetpack-boost`, so we mutate the screen
+	 * object in place to make the check pass without changing the URL.
+	 *
+	 * Hooked only when modernization is on AND we're on the Boost admin
+	 * page, so this never affects any other request.
+	 *
+	 * @param \WP_Screen|null $screen The current screen object (passed by WP).
+	 * @return void
+	 */
+	public static function alias_screen_id_for_wp_build( $screen ) {
+		if ( ! is_object( $screen ) ) {
+			return;
+		}
+
+		$screen->id = 'jetpack-boost-dashboard';
+	}
+
+	/**
+	 * Returns true when the wp-build modernization filter is enabled.
+	 *
+	 * @return bool
+	 */
+	private static function is_modernized() {
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+	}
+
+	/**
+	 * Returns true when the current request targets the Boost admin page.
+	 *
+	 * Used to scope wp-build loading to the one page that needs it. The
+	 * `$_GET['page']` value is populated by wp-admin/admin.php before any
+	 * of our hooks fire, so this check is reliable from `init()` onwards.
+	 *
+	 * @return bool
+	 */
+	private static function is_boost_admin_request() {
+		if ( ! is_admin() || ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
+
+		return sanitize_text_field( wp_unslash( $_GET['page'] ) ) === self::MENU_SLUG; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 }

--- a/projects/plugins/boost/changelog/add-wp-build-modernization-scaffold
+++ b/projects/plugins/boost/changelog/add-wp-build-modernization-scaffold
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Empty wp-build dashboard scaffold (Overview + Settings tabs) gated behind a feature flag; no user-visible change unless the flag is enabled.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -30,6 +30,7 @@
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-wp-abilities": "@dev",
+		"automattic/jetpack-wp-build-polyfills": "@dev",
 		"automattic/jetpack-wp-js-data-sync": "@dev",
 		"matthiasmullie/minify": "^1.3"
 	},

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdc9310a7ef499e0c54bb2b98d2d64e5",
+    "content-hash": "1429295ac55edae5026334c8b73b1150",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1934,6 +1934,64 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "50a49082c2623dd4e295860c6a3d9b6be5b66f4c"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available in WP < 7.0",
             "transport-options": {
                 "relative": true
             }
@@ -4240,6 +4298,7 @@
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-test-environment": 20,
         "automattic/jetpack-wp-abilities": 20,
+        "automattic/jetpack-wp-build-polyfills": 20,
         "automattic/jetpack-wp-js-data-sync": 20,
         "automattic/phpunit-select-config": 20
     },

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -16,11 +16,14 @@
 		"test": "tests"
 	},
 	"scripts": {
-		"build": "pnpm run clean && pnpm run build-client",
+		"build": "pnpm run clean && pnpm run build-client && pnpm run build:wp-build && pnpm run build:boot-asset",
+		"build:boot-asset": "provide-boot-asset-file",
+		"build:strip-unminified-prod": "strip-unminified-prod",
+		"build:wp-build": "wp-build",
 		"build-client": "webpack",
-		"build-concurrently": "pnpm run clean && concurrently 'pnpm:build-client'",
-		"build-production-concurrently": "pnpm run clean && concurrently 'NODE_ENV=production BABEL_ENV=production pnpm run build-client' && pnpm run validate",
-		"clean": "rm -rf app/assets/dist/",
+		"build-concurrently": "pnpm run clean && concurrently 'pnpm:build-client' 'pnpm:build:wp-build' && pnpm run build:boot-asset",
+		"build-production-concurrently": "NODE_ENV=production BABEL_ENV=production pnpm run build-concurrently && pnpm run build:strip-unminified-prod && pnpm run validate",
+		"clean": "rm -rf app/assets/dist/ build/",
 		"test": "jest --config=tests/jest.config.cjs app",
 		"test-coverage": "pnpm run test --coverage",
 		"test-e2e:decrypt-config": "pnpm --prefix tests/e2e run config:decrypt",
@@ -28,23 +31,31 @@
 		"test-e2e:start": "pnpm --prefix tests/e2e run tunnel:up && pnpm --prefix tests/e2e run env:up",
 		"test-e2e:stop": "pnpm --prefix tests/e2e run tunnel:down && pnpm --prefix tests/e2e run env:down",
 		"typecheck": "echo \"pending implementation\"",
-		"validate": "pnpm exec validate-es app/assets/dist",
-		"watch": "pnpm run build && webpack watch"
+		"validate": "pnpm exec validate-es app/assets/dist && pnpm exec validate-es build/",
+		"watch": "pnpm run build && concurrently 'webpack watch' 'pnpm:watch:wp-build'",
+		"watch:wp-build": "wp-build --watch"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:*",
+		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-my-jetpack": "workspace:*",
 		"@automattic/jetpack-react-data-sync-client": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@react-spring/core": "9.7.5",
 		"@react-spring/web": "9.7.5",
+		"@tanstack/react-query": "5.90.8",
 		"@types/react": "18.3.28",
+		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/base-styles": "6.20.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
+		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
+		"@wordpress/route": "0.10.0",
+		"@wordpress/theme": "0.11.0",
 		"@wordpress/ui": "0.11.0",
 		"clsx": "2.1.1",
 		"copy-webpack-plugin": "14.0.0",
@@ -57,10 +68,10 @@
 	"devDependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-boost-score-api": "workspace:*",
-		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-critical-css-gen": "workspace:*",
 		"@automattic/jetpack-image-guide": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.0",
 		"@babel/preset-env": "7.29.2",
 		"@babel/preset-react": "7.28.5",
@@ -70,7 +81,8 @@
 		"@types/jquery": "3.5.33",
 		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.44.0",
-		"@wordpress/i18n": "6.17.0",
+		"@wordpress/build": "0.13.0",
+		"browserslist": "^4.24.0",
 		"concurrently": "9.2.1",
 		"jest": "30.3.0",
 		"livereload": "0.10.3",
@@ -86,5 +98,14 @@
 		"typescript": "5.9.3",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
+	},
+	"wpPlugin": {
+		"name": "jetpack_boost",
+		"scriptGlobal": "jetpackBoost",
+		"packageNamespace": "jetpack-boost",
+		"handlePrefix": "jetpack-boost",
+		"pages": [
+			"jetpack-boost-dashboard"
+		]
 	}
 }

--- a/projects/plugins/boost/routes/dashboard/package.json
+++ b/projects/plugins/boost/routes/dashboard/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "_@jetpack-boost/dashboard-route",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@automattic/jetpack-components": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
+		"@types/react": "18.3.28",
+		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/element": "6.44.0",
+		"@wordpress/i18n": "6.17.0",
+		"@wordpress/route": "0.10.0",
+		"@wordpress/ui": "0.11.0"
+	},
+	"route": {
+		"path": "/",
+		"page": "jetpack-boost-dashboard"
+	}
+}

--- a/projects/plugins/boost/routes/dashboard/route.scss
+++ b/projects/plugins/boost/routes/dashboard/route.scss
@@ -1,0 +1,2 @@
+// Reserved for route-level overrides. Shared chrome lives in
+// `_inc/components/boost-page.scss`.

--- a/projects/plugins/boost/routes/dashboard/route.tsx
+++ b/projects/plugins/boost/routes/dashboard/route.tsx
@@ -1,0 +1,1 @@
+export const route = {};

--- a/projects/plugins/boost/routes/dashboard/stage.tsx
+++ b/projects/plugins/boost/routes/dashboard/stage.tsx
@@ -1,0 +1,45 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSearch } from '@wordpress/route';
+import { Tabs } from '@wordpress/ui';
+import BoostPage, { type BoostTab } from '../../_inc/components/boost-page';
+import './route.scss';
+
+type StageSearch = Record< string, unknown > & {
+	tab?: string;
+};
+
+// One client per page load; downstream route PRs will lift this to a shared
+// module so other routes/inspectors hit the same cache.
+const queryClient = new QueryClient();
+
+/**
+ * Single stage that owns the unified Boost page chrome — Page header, tab
+ * nav, and one `Tabs.Root` that persists across tab changes so the
+ * active-tab indicator slides between Overview and Settings instead of
+ * remounting on each route hop.
+ *
+ * Active tab is read from `?tab=`. Overview is the default; settings loads
+ * on `?tab=settings`. Both panels render placeholder content in PR 1 —
+ * later PRs fill them in.
+ *
+ * @return Stage content.
+ */
+const Stage = () => {
+	const search = useSearch( {
+		from: '/' as unknown as never,
+		strict: false,
+	} ) as StageSearch;
+
+	const activeTab: BoostTab = search.tab === 'settings' ? 'settings' : 'overview';
+
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<BoostPage activeTab={ activeTab }>
+				<Tabs.Panel value="overview" focusable={ false } />
+				<Tabs.Panel value="settings" focusable={ false } />
+			</BoostPage>
+		</QueryClientProvider>
+	);
+};
+
+export { Stage as stage };

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -4,6 +4,8 @@
 		"app/assets/src/js/**/*",
 		"app/modules/image-guide/src/**/*",
 		"app/modules/optimizations/image-cdn/src/**/*",
+		"_inc/**/*",
+		"routes/**/*",
 		"../../js-packages/image-guide/src/boost-ui/stores"
 	],
 	"exclude": [


### PR DESCRIPTION
Part of #48717 — first of four PRs to modernize Jetpack's Boost into a unified wp-admin product with Overview + Settings tabs. Scaffolds the wp-build dashboard chassis alongside the existing webpack pipeline and stands up the empty tab shell behind `rsm_jetpack_ui_modernization_boost`. Same approach the Newsletter umbrella took with #48532 + #48574 — combined here because Boost's IA is simpler.

## Proposed changes

* Add wp-build to `projects/plugins/boost/` next to the existing webpack build. `Page` from `@wordpress/admin-ui`, `@wordpress/route` for the router, persistent `Tabs.Root` from `@wordpress/ui`, React Query, and the `WP_Build_Polyfills` registration that the Newsletter / VideoPress chassis use.
* Introduce the `rsm_jetpack_ui_modernization_boost` filter and branch the menu render in `app/admin/class-admin.php`. With the filter off, the legacy `render_settings` callback stays in place. With it on, the menu callback swaps to the auto-generated `jetpack_boost_jetpack_boost_dashboard_wp_admin_render_page` function and the legacy enqueue short-circuits so both bundles never load together.
* Alias the current screen ID to `jetpack-boost-dashboard` on `current_screen` so wp-build's auto-generated enqueue check fires without changing the user-facing `?page=jetpack-boost` URL.
* Wire up the page chrome: Jetpack mark + "Boost" title in the `Page` header, off-white page surface (admin-ui's `--wpds-color-bg-surface-neutral`), sticky `Page` header with its default bottom rule removed, sticky tab row below carrying the full-width separator, scrollable body slot, sticky `JetpackFooter`. SCSS only overrides what's specific to the unified Boost layout — `@wordpress/admin-ui` already paints both surfaces with the WPDS neutral tokens.
* Tabs are route-driven via `?tab=` so the indicator slides between tabs instead of remounting. The inactive panel renders `null` so the other view's data fetching only fires once a visitor opens it.
* Both panels are placeholders. Performance scores + history chart land in PR 2; Settings cards in PR 3; the flip-and-retire in PR 4.

## Related product discussion/links

* Umbrella: #48717
* Cadence model: #48530 (Newsletter modernization umbrella) — specifically #48532 (PR 1: scaffold) + #48574 (PR 2: Page shell), folded together here.
* Wp-build scaffold precedent: #48494 (VideoPress)

## Does this pull request change what data or activity we track or use?

* **No new REST surface.** Nothing renders inside the tabs in this PR.
* **No new Tracks events.** Analytics init still happens once at the legacy page; the `jetpack_boost_tab_view` event lands in PR 4 with the telemetry pass.
* **No changes to privacy notices.**
* **No `add_script_data` payload changes.** No new identifiers, no PII.

## Testing instructions:

Pull this branch, run `pnpm install` (a new dev dep, `@automattic/jetpack-wp-build-polyfills`, lands in the lockfile) and `pnpm jetpack build plugins/boost --deps` to refresh both the legacy webpack bundle and the new wp-build output. Then verify three states.

**Flag OFF (regression check)**

* Make sure no `add_filter( 'rsm_jetpack_ui_modernization_boost', ... )` exists in any mu-plugin / `wp-config.php` / theme.
* Visit `wp-admin/admin.php?page=jetpack-boost`.
* Confirm today's Boost dashboard renders exactly as it does on trunk — Recommendations, Mobile/Desktop score widgets, Historical performance, Cornerstone Pages, all module toggles.

**Flag ON, default route (empty Overview)**

* Add the filter to a mu-plugin or Code Snippet:
  ```php
  add_filter( 'rsm_jetpack_ui_modernization_boost', '__return_true' );
  ```
* Hard-refresh `wp-admin/admin.php?page=jetpack-boost`.
* Page header shows the Jetpack mark + **Boost** title, the **Improve your site speed and performance.** subtitle, and the **Overview** (default) / **Settings** tab nav aligned with the title.
* Single full-width separator below the tab row. No separator between the header and the tab row.
* The Overview panel is empty — content lands in PR 2.

**Flag ON, Settings tab**

* Click **Settings**. URL gains `?tab=settings`, the active-tab indicator slides between tabs, the Overview panel is no longer rendered.
* The Settings panel is empty — content lands in PR 3.
* Click **Overview** to flip back. The URL strips `?tab=settings`, the indicator slides back.

**Toggle round-trip**

* Comment out the modernization filter and refresh — legacy Boost dashboard returns immediately, no cache clears needed.
* Re-enable and refresh — new chassis returns.

**Sticky chrome**

* On the new chassis, scroll the body slot — header + tab row + footer stay pinned while only the active panel scrolls. (Nothing to scroll in PR 1 yet — verify the model is in place by checking that the body slot is the scroll container.)

## Visual

Filter ON, default route — empty Overview tab:

![Overview tab](https://raw.githubusercontent.com/Automattic/jetpack/5f48f1ec2b/screenshot-boost-pr1-overview.png)

Filter ON, `?tab=settings` — empty Settings tab:

![Settings tab](https://raw.githubusercontent.com/Automattic/jetpack/5f48f1ec2b/screenshot-boost-pr1-settings.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
