### PR TITLE
Podcast: enqueue media library for cover image selector

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-fix-image-selector
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-fix-image-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: enqueue WP media library so the cover image selector loads.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -80,7 +80,8 @@ class Admin_Page {
 	 * Wire admin-init actions once we know the Podcast page is loading.
 	 */
 	public static function admin_init() {
-		// Intentionally empty for now.
+		// MediaUpload (cover-image-control) reads wp.media.view — only defined after this runs.
+		add_action( 'admin_enqueue_scripts', 'wp_enqueue_media' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This is to fix the broken image selector in Podcast.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Go to Jetpack ⇢ Podcast ⇢ Settings
2. Add a cover image for your feed
3. Image should get applied