### PR TITLE
Podcast: visual polish on the Stats tab

### DIFF
--- a/projects/js-packages/charts/changelog/update-podcast-stats-visual-polish
+++ b/projects/js-packages/charts/changelog/update-podcast-stats-visual-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: expose tickValues on AxisOptions and nice on ScaleOptions so callers can force exact axis ticks.

--- a/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
@@ -89,6 +89,27 @@ describe( 'useChartMargin', () => {
 		expect( result.current.right ).toBe( 48 ); // 40 + 8
 	} );
 
+	it( 'uses explicit y tickValues when provided', () => {
+		const options = {
+			...optionsBase,
+			axis: {
+				...optionsBase.axis,
+				y: {
+					...optionsBase.axis.y,
+					tickValues: [ 0, 1000 ],
+				},
+			},
+		};
+		const height = 300;
+		const theme = baseTheme;
+		renderHook( () => useChartMargin( height, options, data, theme ) );
+		expect( mockGetLongestTickWidth ).toHaveBeenCalledWith(
+			[ 0, 1000 ],
+			options.axis.y.tickFormat,
+			theme.axisStyles.y.left.axisLabel
+		);
+	} );
+
 	it( 'sets top and bottom margin for top x axis', () => {
 		const options = {
 			...optionsBase,

--- a/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
+++ b/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
@@ -81,6 +81,10 @@ export const useChartMargin = (
 			);
 		}
 
+		if ( options.axis?.y?.tickValues?.length ) {
+			return options.axis.y.tickValues;
+		}
+
 		const minY = Math.min( ...allDataPoints.map( d => d.value ) );
 		const maxY = Math.max( ...allDataPoints.map( d => d.value ) );
 		const yScale = createScale( {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -322,6 +322,11 @@ export type CompleteChartTheme = Required< ChartTheme > & {
 export type AxisOptions = {
 	orientation?: OrientationType;
 	numTicks?: number;
+	/**
+	 * Explicit tick values for the axis. When set, takes precedence over `numTicks`
+	 * so callers can force a specific axis (e.g. integer-only steps on a sparse chart).
+	 */
+	tickValues?: number[];
 	axisClassName?: string;
 	axisLineClassName?: string;
 	labelClassName?: string;
@@ -352,6 +357,11 @@ export type AxisOptions = {
 export type ScaleOptions = {
 	type?: ScaleType;
 	zero?: boolean;
+	/**
+	 * Extends the scale's domain to nice round values. Pass `false` together with
+	 * an explicit `domain` to keep the tick values you set exactly.
+	 */
+	nice?: boolean;
 	domain?: [ number, number ];
 	range?: [ number, number ];
 	/**

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -326,7 +326,7 @@ export type AxisOptions = {
 	 * Explicit tick values for the axis. When set, takes precedence over `numTicks`
 	 * so callers can force a specific axis (e.g. integer-only steps on a sparse chart).
 	 */
-	tickValues?: number[];
+	tickValues?: ScaleInput< AxisScale >[];
 	axisClassName?: string;
 	axisLineClassName?: string;
 	labelClassName?: string;

--- a/projects/packages/podcast/changelog/update-podcast-stats-visual-polish
+++ b/projects/packages/podcast/changelog/update-podcast-stats-visual-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: visual polish on the Stats tab — keep horizontal padding at narrow widths, lighter card headers, and integer-only axis ticks on the Downloads chart.

--- a/projects/packages/podcast/src/dashboard/stats/components/section-card.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/section-card.tsx
@@ -7,7 +7,7 @@ type SectionCardProps = {
 	isLoading?: boolean;
 	isEmpty?: boolean;
 	emptyMessage?: string;
-	children: ReactNode;
+	children?: ReactNode;
 	className?: string;
 };
 
@@ -27,7 +27,7 @@ const renderBody = ( { isLoading, isEmpty, emptyMessage, children }: SectionCard
 	if ( isEmpty ) {
 		return <p className="podcast-stats__section-empty">{ emptyMessage }</p>;
 	}
-	return children;
+	return children ?? null;
 };
 
 const SectionCard = ( {

--- a/projects/packages/podcast/src/dashboard/stats/components/section-card.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/section-card.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 
 type SectionCardProps = {
 	title: string;
+	metric?: string;
 	isLoading?: boolean;
 	isEmpty?: boolean;
 	emptyMessage?: string;
@@ -31,6 +32,7 @@ const renderBody = ( { isLoading, isEmpty, emptyMessage, children }: SectionCard
 
 const SectionCard = ( {
 	title,
+	metric,
 	isLoading = false,
 	isEmpty = false,
 	emptyMessage,
@@ -42,6 +44,7 @@ const SectionCard = ( {
 		<Card className={ cardClass }>
 			<CardHeader>
 				<h3 className="podcast-stats__section-title">{ title }</h3>
+				{ metric && <p className="podcast-stats__section-metric">{ metric }</p> }
 			</CardHeader>
 			<CardBody>{ renderBody( { isLoading, isEmpty, emptyMessage, children } ) }</CardBody>
 		</Card>

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
@@ -103,6 +103,17 @@ const StatsByDayChart = ( {
 		return computeIntegerTicks( max );
 	}, [ chartData ] );
 
+	// BarChart's default numTicks: 4 leaves the x-axis sparse for 30/90-day
+	// ranges; pick ~15 evenly spaced dates so the cadence reads like wpcom Stats.
+	const xTickValues = useMemo( () => {
+		const target = 15;
+		if ( chartData.length <= target ) {
+			return chartData.map( datum => datum.dateString );
+		}
+		const step = Math.ceil( chartData.length / target );
+		return chartData.filter( ( _, idx ) => idx % step === 0 ).map( datum => datum.dateString );
+	}, [ chartData ] );
+
 	const rangeDays = getPeriodDayCount( period, range );
 	const rangeLabel =
 		period === 'all' && range
@@ -173,7 +184,7 @@ const StatsByDayChart = ( {
 					renderTooltip={ renderTooltip }
 					options={ {
 						axis: {
-							x: { tickFormat: formatAxisTick },
+							x: { tickFormat: formatAxisTick, tickValues: xTickValues },
 							y: { tickValues: yTickValues },
 						},
 						yScale: { type: 'linear', zero: true, nice: false, domain: yDomain },

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
@@ -104,15 +104,9 @@ const StatsByDayChart = ( {
 	}, [ chartData ] );
 
 	// BarChart's default numTicks: 4 leaves the x-axis sparse for 30/90-day
-	// ranges; pick ~15 evenly spaced dates so the cadence reads like wpcom Stats.
-	const xTickValues = useMemo( () => {
-		const target = 15;
-		if ( chartData.length <= target ) {
-			return chartData.map( datum => datum.dateString );
-		}
-		const step = Math.ceil( chartData.length / target );
-		return chartData.filter( ( _, idx ) => idx % step === 0 ).map( datum => datum.dateString );
-	}, [ chartData ] );
+	// ranges; bump toward 15 so the cadence reads like wpcom Stats. Cap at the
+	// number of bars to avoid duplicates on short ranges.
+	const xNumTicks = Math.min( chartData.length || 1, 15 );
 
 	const rangeDays = getPeriodDayCount( period, range );
 	const rangeLabel =
@@ -184,7 +178,7 @@ const StatsByDayChart = ( {
 					renderTooltip={ renderTooltip }
 					options={ {
 						axis: {
-							x: { tickFormat: formatAxisTick, tickValues: xTickValues },
+							x: { tickFormat: formatAxisTick, numTicks: xNumTicks },
 							y: { tickValues: yTickValues },
 						},
 						yScale: { type: 'linear', zero: true, nice: false, domain: yDomain },

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
@@ -46,15 +46,21 @@ const formatAxisTick = ( value: unknown ) => {
 const computeIntegerTicks = (
 	max: number
 ): { domain: [ number, number ]; tickValues: number[] } => {
-	const niceSteps: number[] = [];
-	for ( let n = 0; n < 9; n++ ) {
-		const magnitude = Math.pow( 10, n );
-		niceSteps.push( magnitude, 2 * magnitude, 5 * magnitude );
+	const normalizedMax = Number.isFinite( max ) ? Math.max( max, 0 ) : 0;
+	const target = Math.max( normalizedMax, 1 );
+	const roughStep = Math.max( target / 5, 1 );
+	const magnitude = Math.pow( 10, Math.floor( Math.log10( roughStep ) ) );
+	const normalizedStep = roughStep / magnitude;
+	let stepMultiplier = 10;
+	if ( normalizedStep <= 1 ) {
+		stepMultiplier = 1;
+	} else if ( normalizedStep <= 2 ) {
+		stepMultiplier = 2;
+	} else if ( normalizedStep <= 5 ) {
+		stepMultiplier = 5;
 	}
-	const target = Math.max( max, 1 );
-	const step =
-		niceSteps.find( s => Math.ceil( target / s ) <= 5 ) ?? niceSteps[ niceSteps.length - 1 ];
-	const domainMax = Math.max( Math.ceil( max / step ) * step, step * 5 );
+	const step = magnitude * stepMultiplier;
+	const domainMax = Math.max( Math.ceil( normalizedMax / step ) * step, step * 5 );
 	const tickValues: number[] = [];
 	for ( let tick = 0; tick <= domainMax; tick += step ) {
 		tickValues.push( tick );

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
@@ -38,6 +38,40 @@ const formatAxisTick = ( value: unknown ) => {
 	return Number.isNaN( date.getTime() ) ? String( value ) : AXIS_DATE_FORMATTER.format( date );
 };
 
+// Pick a step that yields integer ticks at roughly 5 stops, so the axis reads
+// like wpcom Stats (0, 5, 10) instead of visx's default fractional ticks
+// (0, 0.2, 0.4) when daily downloads are small.
+const computeIntegerTicks = (
+	max: number
+): { domain: [ number, number ]; tickValues: number[] } => {
+	let step: number;
+	if ( max <= 5 ) {
+		step = 1;
+	} else if ( max <= 10 ) {
+		step = 2;
+	} else if ( max <= 25 ) {
+		step = 5;
+	} else if ( max <= 50 ) {
+		step = 10;
+	} else if ( max <= 100 ) {
+		step = 20;
+	} else if ( max <= 250 ) {
+		step = 50;
+	} else if ( max <= 500 ) {
+		step = 100;
+	} else {
+		const magnitude = Math.pow( 10, Math.floor( Math.log10( max ) ) );
+		step = magnitude / 2;
+	}
+	const minDomainMax = step * 5;
+	const domainMax = Math.max( Math.ceil( max / step ) * step, minDomainMax );
+	const tickValues: number[] = [];
+	for ( let tick = 0; tick <= domainMax; tick += step ) {
+		tickValues.push( tick );
+	}
+	return { domain: [ 0, domainMax ], tickValues };
+};
+
 const StatsByDayChart = ( {
 	byDay = {},
 	range,
@@ -67,6 +101,11 @@ const StatsByDayChart = ( {
 		() => chartData.reduce( ( sum, datum ) => sum + datum.value, 0 ),
 		[ chartData ]
 	);
+
+	const { domain: yDomain, tickValues: yTickValues } = useMemo( () => {
+		const max = chartData.reduce( ( m, datum ) => Math.max( m, datum.value ), 0 );
+		return computeIntegerTicks( max );
+	}, [ chartData ] );
 
 	const rangeDays = getPeriodDayCount( period, range );
 	const rangeLabel =
@@ -139,8 +178,9 @@ const StatsByDayChart = ( {
 					options={ {
 						axis: {
 							x: { tickFormat: formatAxisTick },
+							y: { tickValues: yTickValues },
 						},
-						yScale: { type: 'linear', zero: true },
+						yScale: { type: 'linear', zero: true, nice: false, domain: yDomain },
 					} }
 				/>
 			</div>

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-by-day-chart.tsx
@@ -1,10 +1,11 @@
 import { BarChart, parseAsLocalDate } from '@automattic/charts';
 import { formatNumber } from '@automattic/number-formatters';
-import { Card, CardBody, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { formatPodcastDate } from '../lib/format';
 import { getPeriodDayCount } from '../range';
+import SectionCard from './section-card';
 import type { PodcastStatsPeriod, PodcastStatsRange } from '../types';
 import type { ReactNode } from 'react';
 
@@ -40,31 +41,20 @@ const formatAxisTick = ( value: unknown ) => {
 
 // Pick a step that yields integer ticks at roughly 5 stops, so the axis reads
 // like wpcom Stats (0, 5, 10) instead of visx's default fractional ticks
-// (0, 0.2, 0.4) when daily downloads are small.
+// (0, 0.2, 0.4) when daily downloads are small. Walks the 1-2-5 ladder across
+// magnitudes so the cadence stays consistent past 500 too.
 const computeIntegerTicks = (
 	max: number
 ): { domain: [ number, number ]; tickValues: number[] } => {
-	let step: number;
-	if ( max <= 5 ) {
-		step = 1;
-	} else if ( max <= 10 ) {
-		step = 2;
-	} else if ( max <= 25 ) {
-		step = 5;
-	} else if ( max <= 50 ) {
-		step = 10;
-	} else if ( max <= 100 ) {
-		step = 20;
-	} else if ( max <= 250 ) {
-		step = 50;
-	} else if ( max <= 500 ) {
-		step = 100;
-	} else {
-		const magnitude = Math.pow( 10, Math.floor( Math.log10( max ) ) );
-		step = magnitude / 2;
+	const niceSteps: number[] = [];
+	for ( let n = 0; n < 9; n++ ) {
+		const magnitude = Math.pow( 10, n );
+		niceSteps.push( magnitude, 2 * magnitude, 5 * magnitude );
 	}
-	const minDomainMax = step * 5;
-	const domainMax = Math.max( Math.ceil( max / step ) * step, minDomainMax );
+	const target = Math.max( max, 1 );
+	const step =
+		niceSteps.find( s => Math.ceil( target / s ) <= 5 ) ?? niceSteps[ niceSteps.length - 1 ];
+	const domainMax = Math.max( Math.ceil( max / step ) * step, step * 5 );
 	const tickValues: number[] = [];
 	for ( let tick = 0; tick <= domainMax; tick += step ) {
 		tickValues.push( tick );
@@ -187,17 +177,13 @@ const StatsByDayChart = ( {
 		);
 	}
 
+	// Render the SummaryTiles (passed via children) regardless of loading/empty
+	// so the user sees per-tile loading skeletons rather than a single page-wide spinner.
 	return (
-		<Card className="podcast-stats__section-card podcast-stats-chart">
-			<CardBody className="podcast-stats-chart__body">
-				<div className="podcast-stats-chart__header">
-					<h3 className="podcast-stats__section-title">{ downloadsLabel }</h3>
-					{ rangeLabel && <p className="podcast-stats__section-metric">{ rangeLabel }</p> }
-				</div>
-				{ chartContent }
-				{ children && <div className="podcast-stats-chart__summary">{ children }</div> }
-			</CardBody>
-		</Card>
+		<SectionCard className="podcast-stats-chart" title={ downloadsLabel } metric={ rangeLabel }>
+			{ chartContent }
+			{ children && <div className="podcast-stats-chart__summary">{ children }</div> }
+		</SectionCard>
 	);
 };
 

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -98,6 +98,14 @@ $bar-fill: #2271b1;
 				line-height: 1.3;
 			}
 		}
+
+		// Downloads chart card shares SectionCard but stays compact —
+		// no heavy CardHeader divider, tighter header padding.
+		&.podcast-stats-chart .components-card__header {
+			border-block-end: 0;
+			padding-block: 10px;
+			min-height: 0;
+		}
 	}
 
 	&__section-title {

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -14,7 +14,12 @@ $bar-fill: #2271b1;
 }
 
 .podcast-stats {
-	padding-top: 16px;
+	padding-block-start: 16px;
+	padding-inline: 16px;
+
+	@media (min-width: 783px) {
+		padding-inline: 24px;
+	}
 
 	&--stack {
 		display: flex;
@@ -97,8 +102,9 @@ $bar-fill: #2271b1;
 
 	&__section-title {
 		margin: 0;
-		font-size: 14px;
+		font-size: 15px;
 		font-weight: 600;
+		line-height: 1.3;
 		color: $text;
 	}
 

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -175,14 +175,6 @@ $bar-fill: #2271b1;
 
 .podcast-stats-chart {
 
-	&__body {
-		padding: 16px;
-	}
-
-	&__header {
-		margin-bottom: 8px;
-	}
-
 	// No min-height — fights the chart's ResizeObserver.
 	&__chart {
 		position: relative;


### PR DESCRIPTION
## Proposed changes

Visual polish on the Podcast dashboard Stats tab so it reads closer to the WordPress.com Stats look.

* Keep horizontal padding at narrow viewport widths so the Stats content never collapses against the edge.
* Lighter card headers (no heavy divider, tighter padding) and a slightly larger section title.
* Integer-only ticks on the Downloads chart. A new show with one or two downloads now shows `0, 1, 2` instead of visx's default `0, 0.2, 0.4`.
* Expose `tickValues` on `AxisOptions` and `nice` on `ScaleOptions` in `@automattic/charts` so consumers can force exact axis ticks. visx already supports both fields at runtime; this only widens the public type surface.

A follow-up PR will swap `PeriodControl` for `DateRangeCalendar` from `@wordpress/components` and update the query layer for arbitrary date ranges. Kept out of this PR because it crosses the visual-only line.

## Related product discussion/links

* podcast-tools Slack thread (2026-05-12) on Stats visual cleanup

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the podcast package: `cd projects/packages/podcast && pnpm run build`.
2. Activate Jetpack with the podcast package on a test site that has the podcast dashboard enabled.
3. Visit the Stats tab. Confirm:
   * Horizontal padding stays present at narrow widths (resize the window or use DevTools at <600px).
   * Card headers ("Top episodes", "By app", "Downloads") sit on a thinner header without the heavy gray divider.
   * Downloads chart y-axis shows integer ticks. With a low-volume show, ticks should read `0, 1, 2, 3, 4, 5`, not `0, 0.2, 0.4...`.
4. Drill into a single episode and confirm the same polish applies.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
