### PR TITLE
jetpack-mu-wpcom: Enable `gutenberg-classic-block-deprecation` experiment for all sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/enable-gutenberg-classic-block-deprecation-experiment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/enable-gutenberg-classic-block-deprecation-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable the `gutenberg-classic-block-deprecation` Gutenberg experiment for all sites. Sites with the `disable-classic-block-deprecation` blog sticker continue to use the Classic block.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -794,7 +794,7 @@ class Jetpack_Mu_Wpcom {
 	 * Skip sites that have the `disable-classic-block-deprecation` sticker enabled.
 	 *
 	 * @param mixed $experiments The current value of the gutenberg-experiments option.
-	 * @return array The filtered experiments.
+	 * @return mixed Original option value or the filtered experiments.
 	 */
 	public static function enable_gutenberg_classic_block_deprecation_experiment( $experiments ) {
 		if ( wpcom_has_blog_sticker( 'disable-classic-block-deprecation', get_wpcom_blog_id() ) ) {
@@ -808,6 +808,7 @@ class Jetpack_Mu_Wpcom {
 		$experiments['gutenberg-classic-block-deprecation'] = true;
 		return $experiments;
 	}
+
 	/**
 	 * Add Jetpack script data with host information on P2
 	 *

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -96,6 +96,13 @@ class Jetpack_Mu_Wpcom {
 			add_filter( 'wp_classic_block_supports_inserter', '__return_true' );
 		}
 
+		// Enable the `gutenberg-classic-block-deprecation` Gutenberg experiment for all sites, with an opt-out via the `disable-classic-block-deprecation` blog sticker.
+		// Both filters are needed: `default_option_` fires when the option doesn't exist in the DB, `option_` fires when it does.
+		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
+		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
+		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'maybe_disable_gutenberg_classic_block_deprecation_experiment' ), 1000 );
+		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'maybe_disable_gutenberg_classic_block_deprecation_experiment' ), 1000 );
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -782,6 +789,38 @@ class Jetpack_Mu_Wpcom {
 			$data['site']['wpcom']['blog_id'] = $blog_id;
 		}
 		return $data;
+	}
+
+	/**
+	 * Add `gutenberg-classic-block-deprecation` to the list of enabled Gutenberg experiments.
+	 *
+	 * @param mixed $experiments The current value of the gutenberg-experiments option.
+	 * @return array The filtered experiments.
+	 */
+	public static function enable_gutenberg_classic_block_deprecation_experiment( $experiments ) {
+		if ( ! is_array( $experiments ) ) {
+			$experiments = array();
+		}
+		$experiments['gutenberg-classic-block-deprecation'] = true;
+		return $experiments;
+	}
+
+	/**
+	 * Disable the `gutenberg-classic-block-deprecation` experiment on sites with the `disable-classic-block-deprecation` sticker.
+	 *
+	 * Runs at priority 1000 so it overrides the default-on filter.
+	 *
+	 * @param mixed $experiments The current value of the gutenberg-experiments option.
+	 * @return mixed The filtered experiments.
+	 */
+	public static function maybe_disable_gutenberg_classic_block_deprecation_experiment( $experiments ) {
+		if ( ! is_array( $experiments ) ) {
+			return $experiments;
+		}
+		if ( wpcom_has_blog_sticker( 'disable-classic-block-deprecation', get_wpcom_blog_id() ) ) {
+			unset( $experiments['gutenberg-classic-block-deprecation'] );
+		}
+		return $experiments;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -100,8 +100,6 @@ class Jetpack_Mu_Wpcom {
 		// Both filters are needed: `default_option_` fires when the option doesn't exist in the DB, `option_` fires when it does.
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
-		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'maybe_disable_gutenberg_classic_block_deprecation_experiment' ), 1000 );
-		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'maybe_disable_gutenberg_classic_block_deprecation_experiment' ), 1000 );
 
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
@@ -793,36 +791,23 @@ class Jetpack_Mu_Wpcom {
 
 	/**
 	 * Add `gutenberg-classic-block-deprecation` to the list of enabled Gutenberg experiments.
+	 * Skip sites that have the `disable-classic-block-deprecation` sticker enabled.
 	 *
 	 * @param mixed $experiments The current value of the gutenberg-experiments option.
 	 * @return array The filtered experiments.
 	 */
 	public static function enable_gutenberg_classic_block_deprecation_experiment( $experiments ) {
+		if ( wpcom_has_blog_sticker( 'disable-classic-block-deprecation', get_wpcom_blog_id() ) ) {
+			return $experiments;
+		}
+
 		if ( ! is_array( $experiments ) ) {
 			$experiments = array();
 		}
+
 		$experiments['gutenberg-classic-block-deprecation'] = true;
 		return $experiments;
 	}
-
-	/**
-	 * Disable the `gutenberg-classic-block-deprecation` experiment on sites with the `disable-classic-block-deprecation` sticker.
-	 *
-	 * Runs at priority 1000 so it overrides the default-on filter.
-	 *
-	 * @param mixed $experiments The current value of the gutenberg-experiments option.
-	 * @return mixed The filtered experiments.
-	 */
-	public static function maybe_disable_gutenberg_classic_block_deprecation_experiment( $experiments ) {
-		if ( ! is_array( $experiments ) ) {
-			return $experiments;
-		}
-		if ( wpcom_has_blog_sticker( 'disable-classic-block-deprecation', get_wpcom_blog_id() ) ) {
-			unset( $experiments['gutenberg-classic-block-deprecation'] );
-		}
-		return $experiments;
-	}
-
 	/**
 	 * Add Jetpack script data with host information on P2
 	 *


### PR DESCRIPTION
## Proposed changes

Adds filters in `jetpack-mu-wpcom` for enabling the `gutenberg-classic-block-deprecation` experiment across Simple and Atomic sites, with an opt-out controlled by the `disable-classic-block-deprecation` blog sticker.

This works by filtering the `gutenberg-experiments` option so the experiment is enabled by default unless the site has the opt-out sticker applied.

## Related product discussion/links

phcsdm-1cI#comment-2479

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

Test this on both a WPCOM Simple site and an Atomic site.

1. Make sure the site does **not** have the `disable-classic-block-deprecation` blog sticker.
2. Run `wp option get gutenberg-experiments --format=json`.
3. Confirm `gutenberg-classic-block-deprecation` is present and set to `true`.
4. Add the `disable-classic-block-deprecation` blog sticker to the test site.
5. Re-run `wp option get gutenberg-experiments --format=json`.
6. Confirm `gutenberg-classic-block-deprecation` is no longer present.
7. Optional: Open the post editor and confirm the experiment is enabled by default and disabled when the sticker is present.