### PR TITLE
[RSM] Blog Talks Back: Fix Reader Chat toggle tracking

### DIFF
--- a/projects/packages/search/changelog/fix-reader-chat-toggle-tracking
+++ b/projects/packages/search/changelog/fix-reader-chat-toggle-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: Record Reader Chat toggle events immediately after settings save and move the Reader Chat setting after the Instant Search setting.

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -8,6 +8,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Fragment, useCallback } from 'react';
 import Card from 'components/card';
+import ReaderChatControl from 'components/reader-chat-control';
 import InstantSearchUpsellNudge from 'components/upsell-nudge';
 import { STORE_ID } from 'store';
 
@@ -38,11 +39,14 @@ const WIDGETS_EDITOR_URL = 'widgets.php';
  * @param {boolean}  props.isModuleEnabled                - true if Search module is enabled.
  * @param {boolean}  props.isInstantSearchEnabled         - true if Instant Search is enabled.
  * @param {boolean}  props.isInstantSearchPromotionActive - true if search promotion is active.
+ * @param {boolean}  props.isReaderChatAvailable          - true if the Reader Chat setting is available.
+ * @param {boolean}  props.isReaderChatEnabled            - true if Reader Chat is enabled.
  * @param {boolean}  props.supportsOnlyClassicSearch      - true if site has plan that supports only Classic Search.
  * @param {boolean}  props.supportsSearch                 - true if site has plan that supports either Classic or Instant Search.
  * @param {boolean}  props.supportsInstantSearch          - true if site has plan that supports Instant Search.
  * @param {boolean}  props.isTogglingModule               - true if toggling Search module.
  * @param {boolean}  props.isTogglingInstantSearch        - true if toggling Instant Search option.
+ * @param {string}   props.readerChatGuidelinesUrl        - Guidelines admin URL, when available.
  * @return {import('react').Component} Search settings component.
  */
 export default function SearchModuleControl( {
@@ -54,11 +58,14 @@ export default function SearchModuleControl( {
 	isModuleEnabled,
 	isInstantSearchEnabled,
 	isInstantSearchPromotionActive,
+	isReaderChatAvailable,
+	isReaderChatEnabled,
 	supportsOnlyClassicSearch,
 	supportsSearch,
 	supportsInstantSearch,
 	isTogglingModule,
 	isTogglingInstantSearch,
+	readerChatGuidelinesUrl,
 } ) {
 	const { isUserConnected } = useConnection( {
 		redirectUri: 'admin.php?page=jetpack-search',
@@ -142,6 +149,14 @@ export default function SearchModuleControl( {
 						toggleInstantSearch={ toggleInstantSearch }
 						upgradeUrl={ upgradeUrl }
 						isDisabledFromOverLimit={ isDisabledFromOverLimit }
+					/>
+
+					<ReaderChatControl
+						isAvailable={ isReaderChatAvailable }
+						isEnabled={ isReaderChatEnabled }
+						isSaving={ isSavingEitherOption }
+						guidelinesUrl={ readerChatGuidelinesUrl }
+						updateOptions={ updateOptions }
 					/>
 				</div>
 			</Card>

--- a/projects/packages/search/src/dashboard/components/module-control/style.scss
+++ b/projects/packages/search/src/dashboard/components/module-control/style.scss
@@ -26,7 +26,8 @@
 
 .jp-form-search-settings-group__toggle {
 
-	&.is-instant-search {
+	&.is-instant-search,
+	&.is-reader-chat {
 		margin-top: 4em;
 	}
 

--- a/projects/packages/search/src/dashboard/components/module-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/test/index.test.jsx
@@ -1,0 +1,114 @@
+const mockReaderChatControl = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		tracks: {
+			recordEvent: jest.fn(),
+		},
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-components', () => ( {
+	getProductCheckoutUrl: jest.fn( () => 'https://example.com/checkout' ),
+} ) );
+
+jest.mock( '@automattic/jetpack-connection', () => ( {
+	useConnection: () => ( { isUserConnected: true } ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, disabled, href } ) => (
+		<a data-disabled={ disabled } href={ href }>
+			{ children }
+		</a>
+	),
+	ToggleControl: ( { checked, disabled, label } ) => {
+		const labelText = String( label );
+		const testId = labelText.includes( 'instant search' )
+			? 'instant-search-toggle'
+			: 'search-toggle';
+
+		return (
+			<div data-checked={ checked } data-disabled={ disabled } data-testid={ testId }>
+				{ labelText }
+			</div>
+		);
+	},
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: callback => callback( () => ( { isWpcom: () => false } ) ),
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	createInterpolateElement: text => text.replace( '<span>', '' ).replace( '</span>', '' ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+	sprintf: text => text,
+} ) );
+
+jest.mock( 'components/card', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div data-testid="search-settings-card">{ children }</div>,
+} ) );
+
+jest.mock( 'components/reader-chat-control', () => props => {
+	mockReaderChatControl( props );
+	return <div data-testid="reader-chat-control" />;
+} );
+
+jest.mock( 'components/upsell-nudge', () => () => <div data-testid="instant-search-upsell" /> );
+
+jest.mock( 'store', () => ( {
+	STORE_ID: 'jetpack-search-plugin',
+} ) );
+
+import { render, screen } from '@testing-library/react';
+import ModuleControl from '../index.jsx';
+
+const defaultProps = {
+	siteAdminUrl: 'https://example.com/wp-admin/',
+	updateOptions: jest.fn(),
+	domain: 'example.com',
+	isDisabledFromOverLimit: false,
+	isSavingEitherOption: false,
+	isModuleEnabled: true,
+	isInstantSearchEnabled: true,
+	isInstantSearchPromotionActive: false,
+	isReaderChatAvailable: true,
+	isReaderChatEnabled: true,
+	supportsOnlyClassicSearch: false,
+	supportsSearch: true,
+	supportsInstantSearch: true,
+	isTogglingModule: false,
+	isTogglingInstantSearch: false,
+	readerChatGuidelinesUrl:
+		'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
+};
+
+describe( 'ModuleControl', () => {
+	beforeEach( () => {
+		mockReaderChatControl.mockClear();
+	} );
+
+	test( 'renders the Reader Chat control after the Instant Search setting', () => {
+		render( <ModuleControl { ...defaultProps } /> );
+
+		expect( screen.getAllByTestId( /^(instant-search-toggle|reader-chat-control)$/ ) ).toEqual( [
+			screen.getByTestId( 'instant-search-toggle' ),
+			screen.getByTestId( 'reader-chat-control' ),
+		] );
+		expect( mockReaderChatControl ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isAvailable: true,
+				isEnabled: true,
+				isSaving: false,
+				guidelinesUrl: 'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
+				updateOptions: defaultProps.updateOptions,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -10,7 +10,6 @@ import NoticesList from 'components/global-notices';
 import Loading from 'components/loading';
 import MockedSearch from 'components/mocked-search';
 import ModuleControl from 'components/module-control';
-import ReaderChatControl from 'components/reader-chat-control';
 import RecordMeter from 'components/record-meter';
 import { STORE_ID } from 'store';
 import FirstRunSection from './sections/first-run-section';
@@ -158,13 +157,6 @@ export default function DashboardPage( { isLoading = false } ) {
 									supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 								/>
 							) }
-							<ReaderChatControl
-								isAvailable={ isReaderChatAvailable }
-								isEnabled={ isReaderChatEnabled }
-								isSaving={ isSavingEitherOption }
-								guidelinesUrl={ readerChatGuidelinesUrl }
-								updateOptions={ updateOptions }
-							/>
 						</div>
 						{ ! isPageLoading && (
 							<>
@@ -206,6 +198,8 @@ export default function DashboardPage( { isLoading = false } ) {
 											domain={ domain }
 											isDisabledFromOverLimit={ isOverLimit }
 											isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
+											isReaderChatAvailable={ isReaderChatAvailable }
+											isReaderChatEnabled={ isReaderChatEnabled }
 											supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 											supportsSearch={ supportsSearch }
 											supportsInstantSearch={ supportsInstantSearch }
@@ -214,6 +208,7 @@ export default function DashboardPage( { isLoading = false } ) {
 											isSavingEitherOption={ isSavingEitherOption }
 											isTogglingModule={ isTogglingModule }
 											isTogglingInstantSearch={ isTogglingInstantSearch }
+											readerChatGuidelinesUrl={ readerChatGuidelinesUrl }
 										/>
 									) }
 								</div>

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -1,4 +1,4 @@
-const mockReaderChatControl = jest.fn();
+const mockModuleControl = jest.fn();
 let mockSelectMethods;
 let mockDispatchMethods;
 
@@ -28,10 +28,9 @@ jest.mock( 'components/global-notices', () => () => <div data-testid="notices-li
 jest.mock( 'components/loading', () => () => <div data-testid="loading" /> );
 jest.mock( 'components/mocked-search', () => () => <div data-testid="mocked-search" /> );
 jest.mock( 'components/ai-answers-tab', () => () => <div data-testid="ai-answers-tab" /> );
-jest.mock( 'components/module-control', () => () => <div data-testid="module-control" /> );
-jest.mock( 'components/reader-chat-control', () => props => {
-	mockReaderChatControl( props );
-	return <div data-testid="reader-chat-control" />;
+jest.mock( 'components/module-control', () => props => {
+	mockModuleControl( props );
+	return <div data-testid="module-control" />;
 } );
 jest.mock( 'components/record-meter', () => () => <div data-testid="record-meter" /> );
 jest.mock( '../sections/first-run-section', () => () => <div data-testid="first-run-section" /> );
@@ -84,7 +83,7 @@ const createSelectMethods = () => ( {
 
 describe( 'DashboardPage', () => {
 	beforeEach( () => {
-		mockReaderChatControl.mockClear();
+		mockModuleControl.mockClear();
 		mockSelectMethods = createSelectMethods();
 		mockDispatchMethods = {
 			removeNotice: jest.fn(),
@@ -92,16 +91,16 @@ describe( 'DashboardPage', () => {
 		};
 	} );
 
-	test( 'passes the Reader Chat guidelines URL to the Reader Chat control', () => {
+	test( 'passes Reader Chat settings to the Search settings control', () => {
 		render( <DashboardPage /> );
 
-		expect( screen.getByTestId( 'reader-chat-control' ) ).toBeInTheDocument();
-		expect( mockReaderChatControl ).toHaveBeenCalledWith(
+		expect( screen.getByTestId( 'module-control' ) ).toBeInTheDocument();
+		expect( mockModuleControl ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				guidelinesUrl: 'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
-				isAvailable: true,
-				isEnabled: true,
-				isSaving: false,
+				isReaderChatAvailable: true,
+				isReaderChatEnabled: true,
+				readerChatGuidelinesUrl:
+					'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
 				updateOptions: mockDispatchMethods.updateJetpackSettings,
 			} )
 		);

--- a/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
@@ -1,7 +1,6 @@
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import Card from 'components/card';
 
 const READER_CHAT_DESCRIPTION = __(
 	'Let readers ask your blog questions and get answers from your content.',
@@ -11,9 +10,6 @@ const READER_CHAT_DESCRIPTION = __(
 /**
  * Reader Chat opt-in control. Reads and writes the reader_chat option
  * through the Search dashboard settings store.
- *
- * Styled to match the "Enable Jetpack Search" toggle pattern in
- * module-control/index.jsx so both cards align on the dashboard.
  *
  * @param {object}   props               - Component properties.
  * @param {boolean}  props.isAvailable   - Whether the reader_chat setting is available.
@@ -37,44 +33,38 @@ export default function ReaderChatControl( {
 		[ updateOptions ]
 	);
 
-	// Hide the entire card when the setting is not registered on this
+	// Hide the entire control when the setting is not registered on this
 	// site (non-proxied / non-dev contexts during rollout).
 	if ( ! isAvailable ) {
 		return null;
 	}
 
 	return (
-		<div className="jp-form-settings-group jp-form-search-settings-group">
-			<Card className="jp-form-has-child">
-				<div className="jp-form-search-settings-group-inside">
-					<div className="jp-form-search-settings-group__toggle jp-search-dashboard-wrap">
-						<div className="jp-search-dashboard-row">
-							<ToggleControl
-								checked={ Boolean( isEnabled ) }
-								disabled={ isSaving }
-								onChange={ toggle }
-								className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
-								label={ __( 'Enable Reader Chat', 'jetpack-search-pkg' ) }
-								__nextHasNoMarginBottom
-							/>
-						</div>
-						<div className="jp-search-dashboard-row">
-							<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
-								<p className="jp-form-search-settings-group__toggle-explanation">
-									{ READER_CHAT_DESCRIPTION }
-								</p>
-								{ isEnabled && guidelinesUrl && (
-									<p className="jp-form-search-settings-group__toggle-explanation">
-										<ExternalLink href={ guidelinesUrl }>
-											{ __( 'Set guidelines', 'jetpack-search-pkg' ) }
-										</ExternalLink>
-									</p>
-								) }
-							</div>
-						</div>
-					</div>
+		<div className="jp-form-search-settings-group__toggle is-reader-chat jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<ToggleControl
+					checked={ Boolean( isEnabled ) }
+					disabled={ isSaving }
+					onChange={ toggle }
+					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
+					label={ __( 'Enable Reader Chat', 'jetpack-search-pkg' ) }
+					__nextHasNoMarginBottom
+				/>
+			</div>
+			<div className="jp-search-dashboard-row">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+					<p className="jp-form-search-settings-group__toggle-explanation">
+						{ READER_CHAT_DESCRIPTION }
+					</p>
+					{ isEnabled && guidelinesUrl && (
+						<p className="jp-form-search-settings-group__toggle-explanation">
+							<ExternalLink href={ guidelinesUrl }>
+								{ __( 'Set guidelines', 'jetpack-search-pkg' ) }
+							</ExternalLink>
+						</p>
+					) }
 				</div>
-			</Card>
+			</div>
 		</div>
 	);
 }

--- a/projects/packages/search/src/dashboard/store/actions/jetpack-settings.js
+++ b/projects/packages/search/src/dashboard/store/actions/jetpack-settings.js
@@ -51,12 +51,10 @@ export function* updateJetpackSettings( settings = {} ) {
 		yield setUpdatingJetpackSettings();
 		previousSettings = getRollbackSettings( store.getSearchModuleStatus() );
 		yield setJetpackSettings( settings );
-		yield updateJetpackSettingsControl( settings );
-		const updatedSettings = yield fetchJetpackSettings();
-		yield setJetpackSettings( updatedSettings );
+		const savedSettings = yield updateJetpackSettingsControl( settings );
 		if ( shouldTrackReaderChat ) {
-			const updatedReaderChatEnabled = hasOwnSetting( updatedSettings, 'reader_chat' )
-				? Boolean( updatedSettings.reader_chat )
+			const updatedReaderChatEnabled = hasOwnSetting( savedSettings, 'reader_chat' )
+				? Boolean( savedSettings.reader_chat )
 				: Boolean( settings.reader_chat );
 
 			if ( updatedReaderChatEnabled !== previousReaderChatEnabled ) {
@@ -68,6 +66,8 @@ export function* updateJetpackSettings( settings = {} ) {
 				} );
 			}
 		}
+		const updatedSettings = yield fetchJetpackSettings();
+		yield setJetpackSettings( updatedSettings );
 		return successNotice( __( 'Updated settings.', 'jetpack-search-pkg' ) );
 	} catch {
 		yield setJetpackSettings( previousSettings ?? {} );

--- a/projects/packages/search/src/dashboard/store/actions/test/jetpack-settings.test.js
+++ b/projects/packages/search/src/dashboard/store/actions/test/jetpack-settings.test.js
@@ -16,18 +16,24 @@ import analytics from '@automattic/jetpack-analytics';
 import { select } from '@wordpress/data';
 import { updateJetpackSettings } from '../jetpack-settings';
 
-const selectors = {
-	getSearchModuleStatus: jest.fn( () => ( {
-		module_active: true,
-		instant_search_enabled: true,
-		experience: 'overlay',
-		reader_chat: false,
-	} ) ),
-	isReaderChatEnabled: jest.fn( () => false ),
-	isWpcom: jest.fn( () => true ),
+const defaultSearchModuleStatus = {
+	module_active: true,
+	instant_search_enabled: true,
+	experience: 'overlay',
+	reader_chat: false,
 };
 
-const advanceSuccessfulUpdate = ( action, updatedSettings = {} ) => {
+const selectors = {
+	getSearchModuleStatus: jest.fn(),
+	isReaderChatEnabled: jest.fn(),
+	isWpcom: jest.fn(),
+};
+
+const advanceSuccessfulUpdate = (
+	action,
+	updatedSettings = {},
+	savedSettings = updatedSettings
+) => {
 	// Create notice 'Updating'.
 	expect( action.next().value.type ).toBe( 'CREATE_NOTICE' );
 	// Set state updating flag.
@@ -37,7 +43,7 @@ const advanceSuccessfulUpdate = ( action, updatedSettings = {} ) => {
 	// Post new settings to API.
 	expect( action.next().value.type ).toBe( 'UPDATE_JETPACK_SETTINGS' );
 	// Fetch settings from API.
-	expect( action.next().value.type ).toBe( 'FETCH_JETPACK_SETTINGS' );
+	expect( action.next( savedSettings ).value.type ).toBe( 'FETCH_JETPACK_SETTINGS' );
 	// Set fetched setting from above step.
 	expect( action.next( updatedSettings ).value.type ).toBe( 'SET_JETPACK_SETTINGS' );
 };
@@ -45,6 +51,9 @@ const advanceSuccessfulUpdate = ( action, updatedSettings = {} ) => {
 describe( 'Jetpack Settings updateJetpackSettings action', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		selectors.getSearchModuleStatus.mockReturnValue( defaultSearchModuleStatus );
+		selectors.isReaderChatEnabled.mockReturnValue( false );
+		selectors.isWpcom.mockReturnValue( true );
 		select.mockReturnValue( selectors );
 	} );
 
@@ -66,13 +75,26 @@ describe( 'Jetpack Settings updateJetpackSettings action', () => {
 
 		advanceSuccessfulUpdate( action, { reader_chat: true } );
 
-		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
-
-		// Remove 'Updating' notice.
-		expect( action.next().value.type ).toBe( 'REMOVE_NOTICE' );
 		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_reader_chat_toggle', {
 			enabled: true,
 			previous_enabled: false,
+			is_wpcom: true,
+			surface: 'jetpack_search_dashboard',
+		} );
+
+		// Remove 'Updating' notice.
+		expect( action.next().value.type ).toBe( 'REMOVE_NOTICE' );
+	} );
+
+	test( 'records Reader Chat toggle tracking after disabling Reader Chat', () => {
+		selectors.isReaderChatEnabled.mockReturnValueOnce( true );
+		const action = updateJetpackSettings( { reader_chat: false } );
+
+		advanceSuccessfulUpdate( action, { reader_chat: false } );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_reader_chat_toggle', {
+			enabled: false,
+			previous_enabled: true,
 			is_wpcom: true,
 			surface: 'jetpack_search_dashboard',
 		} );
@@ -87,6 +109,33 @@ describe( 'Jetpack Settings updateJetpackSettings action', () => {
 		// Remove 'Updating' notice.
 		expect( action.next().value.type ).toBe( 'REMOVE_NOTICE' );
 		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+	} );
+
+	test( 'records Reader Chat tracking after the setting saves even when refetching settings fails', () => {
+		const action = updateJetpackSettings( { reader_chat: true } );
+
+		// Create notice 'Updating'.
+		expect( action.next().value.type ).toBe( 'CREATE_NOTICE' );
+		// Set state updating flag.
+		expect( action.next().value.type ).toBe( 'SET_JETPACK_SETTINGS' );
+		// Set state to the target state.
+		expect( action.next().value.type ).toBe( 'SET_JETPACK_SETTINGS' );
+		// Post new settings to API.
+		expect( action.next().value.type ).toBe( 'UPDATE_JETPACK_SETTINGS' );
+		// Fetch settings from API.
+		expect( action.next( { reader_chat: true } ).value.type ).toBe( 'FETCH_JETPACK_SETTINGS' );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_reader_chat_toggle', {
+			enabled: true,
+			previous_enabled: false,
+			is_wpcom: true,
+			surface: 'jetpack_search_dashboard',
+		} );
+
+		// Restore previous settings after the failed refetch.
+		expect( action.throw( new Error( 'Fetch failed' ) ).value ).toEqual( {
+			type: 'SET_JETPACK_SETTINGS',
+			options: defaultSearchModuleStatus,
+		} );
 	} );
 
 	test( 'does not record Reader Chat tracking when the setting update fails', () => {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Record the existing `jetpack_reader_chat_toggle` event immediately after the Search settings save request succeeds, using the saved settings response.
* Keep the follow-up settings refresh after tracking, so a stale or failed refetch no longer suppresses the event after a successful save.
* Move the Reader Chat setting into the Search settings card, directly after the Instant Search setting.
* Add coverage for enabling Reader Chat, disabling Reader Chat, unchanged values, refetch failure after save, and Reader Chat placement after the Instant Search setting.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
Yes. This changes when the existing `jetpack_reader_chat_toggle` event is recorded so successful Reader Chat setting changes are tracked more reliably. It does not add a new event or new event properties.

## Testing instructions
* Install this PR in your sandbox
* Go to Jetpack > Search
* Confirm Reader Chat appears after Enable instant search experience (recommended)
* Toggle Reader Chat On / Off
* Wait for a few minutes
* Check live track event `jetpack_reader_chat_toggle`