### PR TITLE
CRM: Update System Status messaging if dir is not writable

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-update_messaging_if_dir_is_not_writable
+++ b/projects/plugins/crm/changelog/fix-crm-update_messaging_if_dir_is_not_writable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+System Status: Update messaging when assets dir is not correctly configured.

--- a/projects/plugins/crm/includes/ZeroBSCRM.SystemChecks.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.SystemChecks.php
@@ -601,20 +601,38 @@ function zeroBSCRM_checkSystemFeat_locale( $withInfo = false ) {
 
 function zeroBSCRM_checkSystemFeat_assetdir() {
 
-	$potentialDirObj = zeroBSCRM_privatisedDirCheck();
-	if ( is_array( $potentialDirObj ) && isset( $potentialDirObj['path'] ) ) {
-		$potentialDir = $potentialDirObj['path'];
-	} else {
-		$potentialDir = false;
+	$storage_dir_info = jpcrm_storage_dir_info();
+
+	if ( $storage_dir_info === false ) {
+		return array(
+			false,
+			__( 'Storage directory is disabled via the <strong>jpcrm_storage_dir_info</strong> filter. File uploads and other features that rely on private storage will not work.', 'zero-bs-crm' ),
+		);
 	}
 
-	$enabled    = false;
-	$enabledStr = 'Using Default WP Upload Library';
+	$path = $storage_dir_info['path'];
 
-	if ( ! empty( $potentialDir ) ) {
-		$enabled    = true;
-		$enabledStr = $potentialDir;
+	if ( ! is_dir( $path ) ) {
+		return array(
+			false,
+			sprintf(
+				/* translators: %s is the absolute filesystem path that could not be created. */
+				__( 'Storage directory does not exist and could not be created: <strong>%s</strong>. Check that the parent directory is writable by the web server.', 'zero-bs-crm' ),
+				esc_html( $path )
+			),
+		);
 	}
 
-	return array( $enabled, $enabledStr );
+	if ( ! wp_is_writable( $path ) ) {
+		return array(
+			false,
+			sprintf(
+				/* translators: %s is the absolute filesystem path that is not writable. */
+				__( 'Storage directory exists but is not writable: <strong>%s</strong>. Check the directory permissions and ownership.', 'zero-bs-crm' ),
+				esc_html( $path )
+			),
+		);
+	}
+
+	return array( true, esc_html( $path ) );
 }


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is a follow-up to #48663.

The System Status page shows this on a well-configured install:
<img width="994" height="134" alt="image" src="https://github.com/user-attachments/assets/9003fdf6-ef5f-42d7-bb23-d249055545f7" />

But has an inaccurate message if things were misconfigured:
<img width="1118" height="174" alt="image" src="https://github.com/user-attachments/assets/ab62a034-705e-432a-bb8e-0a1c8dcf0bf9" />

In reality, it fails if things are misconfigured. This PR updates the message to be more helpful.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Disabled via filter:
<img width="2400" height="156" alt="image" src="https://github.com/user-attachments/assets/5f686651-06e1-4071-a85e-73065c8bf2a0" />

Doesn't exist and couldn't be created:
<img width="2484" height="122" alt="image" src="https://github.com/user-attachments/assets/c6752d52-2bf1-4af0-ab4e-a3b6c4744902" />

Exists but is not writable:
<img width="2104" height="120" alt="image" src="https://github.com/user-attachments/assets/68710819-9653-4540-aa4d-9e18c141fd8f" />
