### PR TITLE
Write: expand Write editor eligibility during gradual rollout

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-enable-for-a12s
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-enable-for-a12s
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: load the Write editor for additional users during gradual rollout.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -310,7 +310,9 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 
 		// Write: distraction-free front-end editor. Enabled for sites with the sticker or for a12s.
-		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) || ( function_exists( 'is_automattician' ) && is_automattician() ) ) {
+		$is_a12s = ( function_exists( 'is_automattician' ) && is_automattician() )
+			|| ( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) );
+		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) || $is_a12s ) {
 			require_once __DIR__ . '/features/write/write.php';
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -309,8 +309,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-widgets/wpcom-widgets.php';
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 
-		// Write: distraction-free front-end editor. Gated by blog sticker for gradual rollout.
-		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) ) {
+		// Write: distraction-free front-end editor. Enabled for sites with the sticker or for a12s.
+		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) || ( function_exists( 'is_automattician' ) && is_automattician() ) ) {
 			require_once __DIR__ . '/features/write/write.php';
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -311,7 +311,8 @@ class Jetpack_Mu_Wpcom {
 
 		// Write: distraction-free front-end editor. Enabled for sites with the sticker or for a12s.
 		$is_a12s = ( function_exists( 'is_automattician' ) && is_automattician() )
-			|| ( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) );
+			|| ( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) )
+			|| ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST );
 		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) || $is_a12s ) {
 			require_once __DIR__ . '/features/write/write.php';
 		}


### PR DESCRIPTION
Related to RSM-2870

## Proposed changes
* Expand Write editor loading to include additional users during gradual rollout, alongside sites with the `wpcom-write-editor` blog sticker.

## Related product discussion/links
* RSM-2870

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site without the `wpcom-write-editor` sticker, verify the Write editor is accessible at `/wp-admin/admin.php?page=write` for qualifying users.
* On a site without the sticker and a non-qualifying user, confirm the Write editor is not accessible.
