### PR TITLE
CRM: Fix errant object and tag retrieval params

### DIFF
--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -37,10 +37,10 @@ return [
     // PhanTypeArraySuspicious : 40+ occurrences
     // PhanUndeclaredMethod : 40+ occurrences
     // PhanDeprecatedFunction : 35+ occurrences
-    // PhanPluginSimplifyExpressionBool : 35+ occurrences
     // PhanTypeMismatchDimFetch : 35+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 30+ occurrences
     // PhanParamSignatureMismatch : 25+ occurrences
+    // PhanPluginSimplifyExpressionBool : 25+ occurrences
     // PhanTypeComparisonFromArray : 25+ occurrences
     // PhanTypeConversionFromArray : 25+ occurrences
     // PhanCommentParamWithoutRealParam : 20+ occurrences
@@ -145,11 +145,9 @@ return [
         'admin/support/main.page.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullable'],
         'admin/system/partials/title.block.php' => ['PhanUndeclaredGlobalVariable'],
         'admin/system/system-status.page.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypePossiblyInvalidDimOffset'],
-        'api/companies.php' => ['PhanPluginSimplifyExpressionBool'],
         'api/create_company.php' => ['PhanPossiblyUndeclaredGlobalVariable'],
         'api/create_customer.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanTypePossiblyInvalidDimOffset'],
         'api/create_transaction.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullableInternal'],
-        'api/customers.php' => ['PhanPluginSimplifyExpressionBool'],
         'api/status.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'includes/ZeroBSCRM.AJAX.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginNeverReturnFunction', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredConstant'],
         'includes/ZeroBSCRM.API.php' => ['PhanCommentParamWithoutRealParam', 'PhanRedefineFunctionInternal', 'PhanRedundantCondition'],

--- a/projects/plugins/crm/api/companies.php
+++ b/projects/plugins/crm/api/companies.php
@@ -30,17 +30,17 @@ $page_num = 0;
 if ( isset( $company_params['page'] ) ) {
 	$page_num = sanitize_text_field( $company_params['page'] );
 }
-$with_invoices = -1;
+$with_invoices = false;
 if ( isset( $company_params['invoices'] ) ) {
-	$with_invoices = sanitize_text_field( $company_params['invoices'] );
+	$with_invoices = filter_var( $company_params['invoices'], FILTER_VALIDATE_BOOLEAN );
 }
-$with_quotes = -1;
+$with_quotes = false;
 if ( isset( $company_params['quotes'] ) ) {
-	$with_quotes = sanitize_text_field( $company_params['quotes'] );
+	$with_quotes = filter_var( $company_params['quotes'], FILTER_VALIDATE_BOOLEAN );
 }
-$with_transactions = -1;
+$with_transactions = false;
 if ( isset( $company_params['transactions'] ) ) {
-	$with_transactions = sanitize_text_field( $company_params['transactions'] );
+	$with_transactions = filter_var( $company_params['transactions'], FILTER_VALIDATE_BOOLEAN );
 }
 $search_phrase = '';
 if ( isset( $company_params['search'] ) ) {
@@ -50,11 +50,6 @@ $owned_by = -1;
 if ( isset( $company_params['owned'] ) ) {
 	$owned_by = (int) $company_params['owned'];
 }
-
-// ... this forces them from string of "true" or "false" into a bool
-$with_invoices     = $with_invoices === 'true' ? true : false;
-$with_quotes       = $with_quotes === 'true' ? true : false;
-$with_transactions = $with_transactions === 'true' ? true : false;
 
 $args = array(
 	'perPage'          => $items_per_page,

--- a/projects/plugins/crm/api/customers.php
+++ b/projects/plugins/crm/api/customers.php
@@ -40,21 +40,21 @@ $page = 0;
 if ( isset( $customer_params['page'] ) ) {
 	$page = sanitize_text_field( $customer_params['page'] );
 }
-$withInvoices = -1;
+$withInvoices = false;
 if ( isset( $customer_params['invoices'] ) ) {
-	$withInvoices = sanitize_text_field( $customer_params['invoices'] );
+	$withInvoices = filter_var( $customer_params['invoices'], FILTER_VALIDATE_BOOLEAN );
 }
-$withQuotes = -1;
+$withQuotes = false;
 if ( isset( $customer_params['quotes'] ) ) {
-	$withQuotes = sanitize_text_field( $customer_params['quotes'] );
+	$withQuotes = filter_var( $customer_params['quotes'], FILTER_VALIDATE_BOOLEAN );
 }
 $searchPhrase = '';
 if ( isset( $customer_params['search'] ) ) {
 	$searchPhrase = sanitize_text_field( $customer_params['search'] );
 }
-$withTransactions = -1;
+$withTransactions = false;
 if ( isset( $customer_params['transactions'] ) ) {
-	$withTransactions = sanitize_text_field( $customer_params['transactions'] );
+	$withTransactions = filter_var( $customer_params['transactions'], FILTER_VALIDATE_BOOLEAN );
 }
 $isOwned = -1;
 if ( isset( $customer_params['owned'] ) ) {
@@ -68,15 +68,8 @@ if ( isset( $customer_params['company'] ) ) {
 
 $withTags = false;
 if ( isset( $customer_params['tags'] ) ) {
-	$withTags = (bool) $customer_params['tags'];
+	$withTags = filter_var( $customer_params['tags'], FILTER_VALIDATE_BOOLEAN );
 }
-
-// #FORMIKENOTES -
-// These should be Bools - see https://stackoverflow.com/questions/7336861/how-to-convert-string-to-boolean-php
-// ... this forces them from string of "true" or "false" into a bool
-$withInvoices     = $withInvoices === 'true' ? true : false;
-$withQuotes       = $withQuotes === 'true' ? true : false;
-$withTransactions = $withTransactions === 'true' ? true : false;
 
 $args = array(
 	// Search/Filtering (leave as false to ignore)

--- a/projects/plugins/crm/changelog/fix-crm-prevent_errant_object_and_tag_retrieval_params
+++ b/projects/plugins/crm/changelog/fix-crm-prevent_errant_object_and_tag_retrieval_params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+API: Fix object and tag retrieval.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
If `true`, `'1'`, or `1` was passed as a value, it'd cast to string (as `'1'`), sanitize, and then compare with `'true'`, evaluating to `false`.

This switches things to use `filter_var( $var, FILTER_VALIDATE_BOOLEAN )` instead.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
