### PR TITLE
Podcast: Pocket Casts one-click submit via Relay API

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-add-pocket-cast
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-add-pocket-cast
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Pocket Casts: replace the 3-step submit modal with a one-click Relay API flow that reflects pending/submitted state on the button and surfaces rejection reasons inline.

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/index.tsx
@@ -1,4 +1,5 @@
-import type { PodcastApp } from './types';
+import PocketCastsSubmitModal from './submit-modal';
+import type { PodcastApp } from '../types';
 
 const PocketCastsLogo = () => (
 	<svg
@@ -26,4 +27,5 @@ export const pocketcasts: PodcastApp = {
 	submitUrl: 'https://pocketcasts.com/submit',
 	learnMoreUrl: 'https://support.pocketcasts.com/knowledge-base/submitting-podcasts/',
 	showHosts: [ 'pca.st', 'pocketcasts.com' ],
+	Modal: PocketCastsSubmitModal,
 };

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/style.scss
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/style.scss
@@ -1,0 +1,58 @@
+.podcast__pocketcasts-modal .components-modal__content {
+	max-width: 520px;
+}
+
+.podcast__pocketcasts-feed-url {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	padding: 8px 12px;
+	font-family: ui-monospace, SFMono-Regular, monospace;
+	font-size: 13px;
+	color: #1e1e1e;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+}
+
+.podcast__pocketcasts-errors {
+	margin: 8px 0 0;
+	padding-inline-start: 20px;
+}
+
+// State-driven submit button. Override the primary fill for pending/active so
+// the colour matches the verdict; idle keeps the default theme primary.
+.podcast__pocketcasts-button {
+
+	&--pending {
+
+		&,
+		&:hover:not(:disabled),
+		&:focus:not(:disabled),
+		&[disabled],
+		&[aria-disabled="true"] {
+			background: #dba617; // wp-admin warning
+			color: #1e1e1e;
+			box-shadow: none;
+		}
+	}
+
+	&--active {
+
+		&,
+		&:hover:not(:disabled),
+		&:focus:not(:disabled),
+		&[disabled],
+		&[aria-disabled="true"] {
+			background: #00a32a; // wp-admin success
+			color: #fff;
+			box-shadow: none;
+			opacity: 1;
+		}
+
+		svg {
+			fill: currentColor;
+		}
+	}
+}
+

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -74,11 +74,12 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 	const rejectedMessage = result?.state === 'rejected' ? result.message : null;
 
 	const handleSubmit = useCallback( () => {
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_pocketcasts_submit_clicked', {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_submit_clicked', {
+			directory: app.id,
 			prior_state: storedState || 'none',
 		} );
 		submit();
-	}, [ submit, storedState ] );
+	}, [ submit, storedState, app.id ] );
 
 	// Fire confetti once when this Pocket Casts submission is the user's first
 	// distribution activity. Ref guard so `result` staying set across renders

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -1,0 +1,176 @@
+// Pocket Casts ships its own submit endpoint
+// (`/wpcom/v2/sites/<blog_id>/podcast-distribution/pocket-casts/submit`), so this
+// app replaces the default 3-step modal with a single-click flow whose button
+// reflects the last-known state and the relay's verdict on submit.
+
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import {
+	Button,
+	ExternalLink,
+	Modal,
+	Notice,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import { usePodcastSettings } from '../../../hooks/use-podcast-settings';
+import './style.scss';
+import { extractRejectionReasons, usePocketCastsSubmit } from './use-submit';
+import type { PodcastShowState } from '../../../types';
+import type { PodcastAppModalProps } from '../types';
+
+const stateLabel = ( state: PodcastShowState ): string => {
+	switch ( state ) {
+		case 'active':
+			return __( 'Submitted', 'jetpack-podcast' );
+		case 'pending':
+			return __( 'Pending', 'jetpack-podcast' );
+		default:
+			return __( 'Submit to Pocket Casts', 'jetpack-podcast' );
+	}
+};
+
+// `rejected`/`unreachable` aren't a persisted button state — they trip a
+// notice instead and leave the button label whatever was last saved.
+const liveStateFromResult = ( state: string ): PodcastShowState | null => {
+	if ( state === 'active' || state === 'pending' ) {
+		return state;
+	}
+	return null;
+};
+
+const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalProps ) => {
+	const { data: settings } = usePodcastSettings();
+	const storedState = settings?.podcasting_show_states?.pocketcasts ?? '';
+
+	// True only if we know settings are loaded AND nothing else is saved yet —
+	// matches the parent's confetti rule (first successful directory action).
+	const isFirstEverActivity = useMemo( () => {
+		if ( ! settings ) {
+			return false;
+		}
+		const anyUrl = Object.values( settings.podcasting_show_urls ).some(
+			( url ): url is string => !! url
+		);
+		const anyState = Object.values( settings.podcasting_show_states ).some( s => !! s );
+		return ! anyUrl && ! anyState;
+	}, [ settings ] );
+
+	const { submit, isSubmitting, result, errorMessage } = usePocketCastsSubmit();
+	const celebratedRef = useRef( false );
+
+	// Live result wins over the persisted state until the modal is reopened.
+	const liveState = result ? liveStateFromResult( result.state ) : null;
+	const effectiveState: PodcastShowState = liveState ?? storedState;
+
+	const rejectionReasons = useMemo(
+		() => ( result?.state === 'rejected' ? extractRejectionReasons( result.pcc ) : [] ),
+		[ result ]
+	);
+	const rejectedMessage = result?.state === 'rejected' ? result.message : null;
+
+	const handleSubmit = useCallback( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_pocketcasts_submit_clicked', {
+			prior_state: storedState || 'none',
+		} );
+		submit();
+	}, [ submit, storedState ] );
+
+	// Fire confetti once when this Pocket Casts submission is the user's first
+	// distribution activity. Ref guard so `result` staying set across renders
+	// doesn't re-trigger the callback.
+	useEffect( () => {
+		if ( celebratedRef.current || ! isFirstEverActivity || ! result ) {
+			return;
+		}
+		if ( result.state === 'active' || result.state === 'pending' ) {
+			celebratedRef.current = true;
+			onFirstSave?.();
+		}
+	}, [ isFirstEverActivity, result, onFirstSave ] );
+
+	const titleText = sprintf(
+		/* translators: %s: podcast directory name. */
+		__( 'Submit to %s', 'jetpack-podcast' ),
+		app.name
+	);
+
+	const isDone = effectiveState === 'active';
+	const buttonClassName = `podcast__pocketcasts-button podcast__pocketcasts-button--${
+		effectiveState || 'idle'
+	}`;
+
+	return (
+		<Modal title={ titleText } onRequestClose={ onClose } className="podcast__pocketcasts-modal">
+			<VStack spacing={ 5 }>
+				<Text as="p" variant="muted">
+					{ feedUrl
+						? __(
+								'We’ll send your podcast feed to Pocket Casts. Most submissions go live within a few minutes.',
+								'jetpack-podcast'
+						  )
+						: __(
+								'Set your podcast category in the Settings tab to generate your RSS feed before submitting.',
+								'jetpack-podcast'
+						  ) }
+				</Text>
+
+				{ feedUrl && (
+					<Text as="p" className="podcast__pocketcasts-feed-url" title={ feedUrl }>
+						{ feedUrl }
+					</Text>
+				) }
+
+				{ result?.state === 'active' && result.share_link && (
+					<Text as="p" variant="muted">
+						<ExternalLink href={ result.share_link }>
+							{ __( 'View on Pocket Casts', 'jetpack-podcast' ) }
+						</ExternalLink>
+					</Text>
+				) }
+
+				{ result?.state === 'rejected' && (
+					<Notice status="error" isDismissible={ false }>
+						{ rejectedMessage ??
+							__( 'Pocket Casts could not accept this feed.', 'jetpack-podcast' ) }
+						{ rejectionReasons.length > 0 && (
+							<ul className="podcast__pocketcasts-errors">
+								{ rejectionReasons.map( reason => (
+									<li key={ reason }>{ reason }</li>
+								) ) }
+							</ul>
+						) }
+					</Notice>
+				) }
+
+				{ errorMessage && (
+					<Notice status="error" isDismissible={ false }>
+						{ errorMessage }
+					</Notice>
+				) }
+
+				<Button
+					variant="primary"
+					__next40pxDefaultSize
+					className={ buttonClassName }
+					icon={ isDone ? check : undefined }
+					iconPosition="left"
+					onClick={ handleSubmit }
+					isBusy={ isSubmitting }
+					disabled={ ! feedUrl || isSubmitting || isDone }
+					accessibleWhenDisabled
+				>
+					{ isSubmitting && ! effectiveState
+						? __( 'Submitting…', 'jetpack-podcast' )
+						: stateLabel( effectiveState ) }
+				</Button>
+			</VStack>
+		</Modal>
+	);
+};
+
+export default PocketCastsSubmitModal;

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/use-submit.ts
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/use-submit.ts
@@ -1,0 +1,115 @@
+import { getSiteData } from '@automattic/jetpack-script-data';
+import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+// Stable shape from
+// wpcom: wp-content/rest-api-plugins/endpoints/podcast-distribution.php.
+// `state` is the discriminator the UI switches on regardless of HTTP code.
+export interface PocketCastsSubmitResponse {
+	state: 'active' | 'pending' | 'rejected' | 'unreachable';
+	message: string;
+	feed_url: string;
+	share_link: string | null;
+	// Raw decoded Pocket Casts body (or null). We mine `feedback.errors` for
+	// rejection reasons; everything else stays opaque.
+	pcc: unknown;
+}
+
+export interface SubmitState {
+	isSubmitting: boolean;
+	result: PocketCastsSubmitResponse | null;
+	errorMessage: string | null;
+}
+
+/**
+ * Pull human-readable rejection reasons out of the raw Pocket Casts body.
+ * Their `feedback.errors` is an array of strings or `{ message }` objects in
+ * the wild; both forms are accepted, anything else is dropped.
+ *
+ * @param pcc - Raw decoded Pocket Casts body from the relay response.
+ * @return List of trimmed reason strings (empty if none found).
+ */
+export function extractRejectionReasons( pcc: unknown ): string[] {
+	if ( ! pcc || typeof pcc !== 'object' ) {
+		return [];
+	}
+	const feedback = ( pcc as Record< string, unknown > ).feedback;
+	if ( ! feedback || typeof feedback !== 'object' ) {
+		return [];
+	}
+	const errors = ( feedback as Record< string, unknown > ).errors;
+	if ( ! Array.isArray( errors ) ) {
+		return [];
+	}
+	const out: string[] = [];
+	for ( const entry of errors ) {
+		if ( typeof entry === 'string' && entry.trim() !== '' ) {
+			out.push( entry.trim() );
+		} else if ( entry && typeof entry === 'object' ) {
+			const msg = ( entry as Record< string, unknown > ).message;
+			if ( typeof msg === 'string' && msg.trim() !== '' ) {
+				out.push( msg.trim() );
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * State + dispatcher for the Pocket Casts feed submission.
+ *
+ * Calls the wpcom relay; the relay persists `podcasting_show_states.pocketcasts`
+ * on the server for pending/active/rejected, so we drop the core-data cache on
+ * those responses to keep the SPA in sync.
+ *
+ * @return `{ submit, isSubmitting, result, errorMessage }` — `result.state`
+ * is the discriminator the UI switches on.
+ */
+export function usePocketCastsSubmit(): SubmitState & { submit: () => void } {
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ result, setResult ] = useState< PocketCastsSubmitResponse | null >( null );
+	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+	const { invalidateResolution } = useDispatch( coreStore );
+
+	const submit = useCallback( () => {
+		const blogId = Number( getSiteData()?.wpcom?.blog_id ?? 0 );
+		if ( ! blogId ) {
+			setErrorMessage(
+				__( 'We couldn’t reach Pocket Casts right now. Please try again.', 'jetpack-podcast' )
+			);
+			return;
+		}
+		setIsSubmitting( true );
+		setErrorMessage( null );
+		apiFetch< PocketCastsSubmitResponse >( {
+			path: `/wpcom/v2/sites/${ blogId }/podcast-distribution/pocket-casts/submit`,
+			method: 'POST',
+		} )
+			.then( response => {
+				setResult( response );
+				if ( response.state === 'unreachable' ) {
+					setErrorMessage(
+						response.message ||
+							__( 'We couldn’t reach Pocket Casts right now. Please try again.', 'jetpack-podcast' )
+					);
+				} else {
+					// Endpoint persists `podcasting_show_states` for pending/active/rejected;
+					// drop the core-data cache so the next settings read picks it up.
+					invalidateResolution( 'getEntityRecord', [ 'root', 'site', undefined ] );
+				}
+			} )
+			.catch( () => {
+				setErrorMessage(
+					__( 'We couldn’t reach Pocket Casts right now. Please try again.', 'jetpack-podcast' )
+				);
+			} )
+			.finally( () => {
+				setIsSubmitting( false );
+			} );
+	}, [ invalidateResolution ] );
+
+	return { submit, isSubmitting, result, errorMessage };
+}

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -7,6 +7,8 @@ import { store as noticesStore } from '@wordpress/notices';
 import type {
 	PodcastSettings,
 	PodcastSettingsUpdate,
+	PodcastShowState,
+	PodcastShowStates,
 	PodcastShowUrls,
 	PodcatcherId,
 } from '../types';
@@ -25,6 +27,7 @@ const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_category_3',
 	'podcasting_email',
 	'podcasting_show_urls',
+	'podcasting_show_states',
 ];
 
 // Keep in sync with `SHOW_URL_HOSTS` in src/class-settings.php.
@@ -43,6 +46,21 @@ const normalizeShowUrls = ( raw: unknown ): PodcastShowUrls => {
 	for ( const id of PODCATCHER_IDS ) {
 		const value = source[ id ];
 		out[ id ] = typeof value === 'string' ? value : '';
+	}
+	return out;
+};
+
+const SHOW_STATES: readonly PodcastShowState[] = [ '', 'pending', 'active' ] as const;
+
+const normalizeShowStates = ( raw: unknown ): PodcastShowStates => {
+	const source = ( raw && typeof raw === 'object' ? raw : {} ) as Record< string, unknown >;
+	const out = {} as PodcastShowStates;
+	for ( const id of PODCATCHER_IDS ) {
+		const value = source[ id ];
+		out[ id ] =
+			typeof value === 'string' && ( SHOW_STATES as readonly string[] ).includes( value )
+				? ( value as PodcastShowState )
+				: '';
 	}
 	return out;
 };
@@ -70,6 +88,8 @@ const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings =>
 			out[ key ] = Boolean( value );
 		} else if ( key === 'podcasting_show_urls' ) {
 			out[ key ] = normalizeShowUrls( value );
+		} else if ( key === 'podcasting_show_states' ) {
+			out[ key ] = normalizeShowStates( value );
 		} else if (
 			key === 'podcasting_category_1' ||
 			key === 'podcasting_category_2' ||

--- a/projects/packages/podcast/src/dashboard/types.ts
+++ b/projects/packages/podcast/src/dashboard/types.ts
@@ -8,6 +8,11 @@ export type PodcatcherId =
 
 export type PodcastShowUrls = Record< PodcatcherId, string >;
 
+// Empty string means "no recorded state"; the relay clears the entry that way.
+export type PodcastShowState = '' | 'pending' | 'active';
+
+export type PodcastShowStates = Record< PodcatcherId, PodcastShowState >;
+
 export interface PodcastSettings {
 	podcasting_category_id: number;
 	podcasting_title: string;
@@ -22,12 +27,16 @@ export interface PodcastSettings {
 	podcasting_category_3: string;
 	podcasting_email: string;
 	podcasting_show_urls: PodcastShowUrls;
+	podcasting_show_states: PodcastShowStates;
 }
 
 // `podcasting_show_urls` is Partial because the server merges patches into the
 // stored map — callers can send `{ apple: 'url' }` without touching siblings.
-export type PodcastSettingsUpdate = Partial< Omit< PodcastSettings, 'podcasting_show_urls' > > & {
+export type PodcastSettingsUpdate = Partial<
+	Omit< PodcastSettings, 'podcasting_show_urls' | 'podcasting_show_states' >
+> & {
 	podcasting_show_urls?: Partial< PodcastShowUrls >;
+	podcasting_show_states?: Partial< PodcastShowStates >;
 };
 
 export interface Episode {


### PR DESCRIPTION
## Description

<img width="628" height="376" alt="Screenshot on 2026-05-17 at 11-46-15" src="https://github.com/user-attachments/assets/5d54c68c-bbab-4ab3-97d0-87c0e090d772" />

We are changing the Pocket Cast option to be a single click submission. Clicking "submit" will send a call to the relay which submits the RSS feed.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Go to Jetpack ⇢ Podcast ⇢ Distribution
2. Click on Pocket Cast and submit