### PR TITLE
WAF: register WP Abilities API reads

### DIFF
--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Action hooks for the Jetpack WAF package.
+ *
+ * Loaded via Composer's autoload.files so this fires in any plugin that
+ * autoloads the WAF package — currently both Jetpack and Jetpack Protect.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+// Register WP Abilities for the WAF on `plugins_loaded` so the gate filter
+// can be applied by callers (plugin bootstraps, mu-plugins, site filters)
+// before the Registrar checks it. Priority 20 keeps us after the bootstraps
+// that wire the filter.
+//
+// When WordPress hasn't booted yet (e.g. autoloader fires before the plugin
+// API is loaded), drop the callback into $wp_filter directly so
+// WP_Hook::build_preinitialized_hooks() picks it up once WP initializes.
+$jetpack_waf_register_abilities = static function () {
+	if ( ! apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
+		return;
+	}
+	\Automattic\Jetpack\Waf\Abilities\Waf_Abilities::init();
+};
+
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', $jetpack_waf_register_abilities, 20 );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Pre-initialization pattern; consumed by WP_Hook::build_preinitialized_hooks().
+	$wp_filter['plugins_loaded'][20][] = array(
+		'accepted_args' => 0,
+		'function'      => $jetpack_waf_register_abilities,
+	);
+}
+
+unset( $jetpack_waf_register_abilities );

--- a/projects/packages/waf/changelog/add-waf-abilities
+++ b/projects/packages/waf/changelog/add-waf-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register WAF reads (get-mode, get-rules-status)

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -9,6 +9,7 @@
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-ip": "@dev",
 		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev",
 		"wikimedia/aho-corasick": "^1.0"
 	},
 	"require-dev": {
@@ -21,6 +22,7 @@
 	},
 	"autoload": {
 		"files": [
+			"actions.php",
 			"cli.php"
 		],
 		"classmap": [

--- a/projects/packages/waf/src/abilities/class-waf-abilities.php
+++ b/projects/packages/waf/src/abilities/class-waf-abilities.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Jetpack WAF Abilities Registration.
+ *
+ * Registers Jetpack WAF (Web Application Firewall) abilities with the
+ * WordPress Abilities API so AI agents can read firewall mode and rule-set
+ * status through the standard `wp-abilities/v1` REST surface.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Waf\Abilities;
+
+use Automattic\Jetpack\IP\Utils as IP_Utils;
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
+use Automattic\Jetpack\Waf\Waf_Rules_Manager;
+use Automattic\Jetpack\Waf\Waf_Runner;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack WAF abilities with the WordPress Abilities API.
+ *
+ * Surface (read-only):
+ *
+ * - jetpack-waf/get-mode         — current firewall mode and rule-set status.
+ * - jetpack-waf/get-rules-status — rule-set health: timestamps and file state.
+ */
+class Waf_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-waf';
+
+	/**
+	 * Allowed values for the `mode` field returned by `get-mode`.
+	 *
+	 * `disabled` covers two states the WAF distinguishes internally — module
+	 * inactive, or mode option missing — because from an agent's perspective
+	 * "the firewall isn't filtering requests" is the same answer in both cases.
+	 */
+	const MODE_DISABLED = 'disabled';
+	const MODE_SILENT   = 'silent';
+	const MODE_NORMAL   = 'normal';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack WAF" is a product name and should not be translated.
+			'label'       => 'Jetpack WAF',
+			'description' => __( 'Abilities for reading Jetpack Web Application Firewall mode and rule-set status.', 'jetpack-waf' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-waf/get-mode'         => array(
+				'label'               => __( 'Get WAF mode and status', 'jetpack-waf' ),
+				'description'         => __( 'Return the firewall\'s current operating mode and high-level rule-set status as { mode, automatic_rules_active, automatic_rules_last_update, brute_force_protection_active, ip_allow_list_count, ip_block_list_count }. `mode` is "disabled" (module off or unconfigured), "silent" (logging without blocking), or "normal" (logging + blocking). `automatic_rules_last_update` is a unix timestamp or null when the rule set has never been fetched. Counts are the number of distinct IPs / ranges in each list. Read-only, idempotent, zero-arg. For the rule-set timestamps + filesystem health, call jetpack-waf/get-rules-status.', 'jetpack-waf' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'mode'                          => array(
+							'type' => 'string',
+							'enum' => array( self::MODE_DISABLED, self::MODE_SILENT, self::MODE_NORMAL ),
+						),
+						'automatic_rules_active'        => array( 'type' => 'boolean' ),
+						'automatic_rules_last_update'   => array( 'type' => array( 'integer', 'null' ) ),
+						'brute_force_protection_active' => array( 'type' => 'boolean' ),
+						'ip_allow_list_count'           => array( 'type' => 'integer' ),
+						'ip_block_list_count'           => array( 'type' => 'integer' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_mode' ),
+				'permission_callback' => array( __CLASS__, 'can_view_waf' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-waf/get-rules-status' => array(
+				'label'               => __( 'Get WAF rule-set status', 'jetpack-waf' ),
+				'description'         => __( 'Return rule-set health: { jetpack_waf_automatic_rules_last_updated_timestamp, jetpack_waf_last_updated_timestamp, standalone_mode, rules_file_present, rules_file_size }. Timestamps are unix integers or null when never recorded. `standalone_mode` is true when the WAF is running as a PHP prepend file (faster, before WordPress loads). `rules_file_present` and `rules_file_size` reflect the on-disk entrypoint rules file — `rules_file_size` is null when the file is absent or unreadable. Read-only, idempotent, zero-arg. For the active mode and per-list counts, call jetpack-waf/get-mode.', 'jetpack-waf' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'jetpack_waf_automatic_rules_last_updated_timestamp' => array( 'type' => array( 'integer', 'null' ) ),
+						'jetpack_waf_last_updated_timestamp' => array( 'type' => array( 'integer', 'null' ) ),
+						'standalone_mode'    => array( 'type' => 'boolean' ),
+						'rules_file_present' => array( 'type' => 'boolean' ),
+						'rules_file_size'    => array( 'type' => array( 'integer', 'null' ) ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_rules_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_waf' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check for the read abilities.
+	 *
+	 * Mirrors the gating on `REST_Controller::waf_permissions_callback()` —
+	 * the WAF admin UI is `manage_options`, and these reads expose the same
+	 * surface, so the cap is consistent across the REST and Abilities paths.
+	 */
+	public static function can_view_waf(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: jetpack-waf/get-mode.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_mode( $input = null ): array {
+		unset( $input );
+
+		return array(
+			'mode'                          => self::resolve_mode(),
+			'automatic_rules_active'        => Waf_Rules_Manager::automatic_rules_enabled(),
+			'automatic_rules_last_update'   => self::nullable_timestamp(
+				get_option( Waf_Rules_Manager::AUTOMATIC_RULES_LAST_UPDATED_OPTION_NAME )
+			),
+			'brute_force_protection_active' => (bool) Brute_Force_Protection::is_enabled(),
+			'ip_allow_list_count'           => self::count_ip_list( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ),
+			'ip_block_list_count'           => self::count_ip_list( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME ),
+		);
+	}
+
+	/**
+	 * Execute: jetpack-waf/get-rules-status.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_rules_status( $input = null ): array {
+		unset( $input );
+
+		$rules_file_present = false;
+		$rules_file_size    = null;
+
+		// Only probe the on-disk rules file when the WAF runtime can resolve
+		// its entrypoint. Resolving the path requires the JETPACK_WAF_ENTRYPOINT
+		// constant; when it's unset (module never activated), report "absent".
+		if ( defined( 'JETPACK_WAF_ENTRYPOINT' ) ) {
+			$path = Waf_Runner::get_waf_file_path( JETPACK_WAF_ENTRYPOINT );
+			if ( file_exists( $path ) ) {
+				$rules_file_present = true;
+				$size               = @filesize( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- filesize() warns on stat failures; treating those as "unknown" is the correct response shape.
+				$rules_file_size    = false === $size ? null : (int) $size;
+			}
+		}
+
+		return array(
+			'jetpack_waf_automatic_rules_last_updated_timestamp' => self::nullable_timestamp(
+				get_option( Waf_Rules_Manager::AUTOMATIC_RULES_LAST_UPDATED_OPTION_NAME )
+			),
+			'jetpack_waf_last_updated_timestamp' => self::nullable_timestamp(
+				get_option( Waf_Rules_Manager::RULE_LAST_UPDATED_OPTION_NAME )
+			),
+			'standalone_mode'                    => (bool) Waf_Runner::get_standalone_mode_status(),
+			'rules_file_present'                 => $rules_file_present,
+			'rules_file_size'                    => $rules_file_size,
+		);
+	}
+
+	/**
+	 * Resolve the WAF's effective `mode` for the agent-facing response.
+	 *
+	 * Returns `disabled` when the module is off or the mode option is unset
+	 * or set to a value the runner would reject — a single bucket for "not
+	 * filtering". Otherwise returns the literal mode option value.
+	 */
+	private static function resolve_mode(): string {
+		if ( ! Waf_Runner::is_enabled() ) {
+			return self::MODE_DISABLED;
+		}
+
+		$mode = get_option( Waf_Runner::MODE_OPTION_NAME );
+		if ( ! is_string( $mode ) || ! Waf_Runner::is_allowed_mode( $mode ) ) {
+			return self::MODE_DISABLED;
+		}
+
+		return $mode;
+	}
+
+	/**
+	 * Cast a stored timestamp option to integer or null.
+	 *
+	 * The WAF stores timestamps as strings or integers depending on entry
+	 * point; falsy values (false, '', 0) all mean "never updated" — collapse
+	 * them to null so the agent doesn't have to special-case them.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return int|null
+	 */
+	private static function nullable_timestamp( $value ) {
+		if ( empty( $value ) ) {
+			return null;
+		}
+		if ( ! is_numeric( $value ) ) {
+			return null;
+		}
+		$as_int = (int) $value;
+		return $as_int > 0 ? $as_int : null;
+	}
+
+	/**
+	 * Count the IP addresses / ranges stored in one of the WAF IP-list options.
+	 *
+	 * Uses the same parser the WAF runtime uses to enforce the list, so the
+	 * count agents see matches what the firewall actually applies.
+	 *
+	 * @param string $option_name Option key (allow or block list).
+	 * @return int
+	 */
+	private static function count_ip_list( string $option_name ): int {
+		$raw = get_option( $option_name );
+		if ( ! is_string( $raw ) || '' === $raw ) {
+			return 0;
+		}
+		$parsed = IP_Utils::get_ip_addresses_from_string( $raw );
+		return is_array( $parsed ) ? count( $parsed ) : 0;
+	}
+}

--- a/projects/packages/waf/tests/php/integration/abilities/WafAbilitiesTest.php
+++ b/projects/packages/waf/tests/php/integration/abilities/WafAbilitiesTest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Tests for the Waf_Abilities Registrar subclass.
+ *
+ * Exercises:
+ * - Gate filter (`jetpack_wp_abilities_enabled`) controlling registration.
+ * - Permission callbacks (anonymous / subscriber / admin).
+ * - Abstract getter contract and per-spec annotations.
+ * - Execute happy paths for `get-mode` and `get-rules-status`, including the
+ *   WAF-disabled edge case where the response must keep its documented shape
+ *   rather than returning a `WP_Error`.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Waf\Abilities\Waf_Abilities;
+use Automattic\Jetpack\Waf\Waf_Rules_Manager;
+use Automattic\Jetpack\Waf\Waf_Runner;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Integration tests for Waf_Abilities registration and execution.
+ *
+ * @covers \Automattic\Jetpack\Waf\Abilities\Waf_Abilities
+ */
+final class WafAbilitiesTest extends WorDBless\BaseTestCase {
+
+	/**
+	 * Admin user id created for permission checks.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id created for permission checks.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * Setup: create the two fixture users and open the abilities gate filter
+	 * for the common-case tests. The "gate closed" test removes the filter
+	 * explicitly.
+	 */
+	protected function set_up() {
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'waf_abilities_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'waf_abilities_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open. Tests that need it closed remove this filter.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Add waf to the available Jetpack modules so Waf_Runner::is_enabled() can resolve.
+		add_filter( 'jetpack_get_available_modules', array( $this, 'add_waf_to_available_modules' ), 10, 1 );
+		add_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_waf_to_available_modules' ), 10, 1 );
+
+		// Reset any hooks a prior test may have left on the Registrar lifecycle actions.
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Waf_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Waf_Abilities::class, 'register_abilities' ) );
+	}
+
+	/**
+	 * Teardown: undo every global filter / hook this test may have touched.
+	 */
+	protected function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_filter( 'jetpack_get_available_modules', array( $this, 'add_waf_to_available_modules' ), 10 );
+		remove_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_waf_to_available_modules' ), 10 );
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Waf_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Waf_Abilities::class, 'register_abilities' ) );
+
+		// Clean up option drift between tests.
+		delete_option( Waf_Runner::MODE_OPTION_NAME );
+		delete_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME );
+		delete_option( Waf_Rules_Manager::AUTOMATIC_RULES_LAST_UPDATED_OPTION_NAME );
+		delete_option( Waf_Rules_Manager::RULE_LAST_UPDATED_OPTION_NAME );
+		delete_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME );
+		delete_option( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Filter callback: declare "waf" as an available Jetpack module so that
+	 * Waf_Runner::is_enabled() can flip true when we activate it.
+	 *
+	 * @param array $modules Module slugs.
+	 * @return array
+	 */
+	public function add_waf_to_available_modules( $modules ) {
+		if ( ! in_array( 'waf', $modules, true ) ) {
+			$modules[] = 'waf';
+		}
+		return $modules;
+	}
+
+	/* -------------------- Abstract getters -------------------- */
+
+	public function test_category_slug_is_jetpack_waf() {
+		$this->assertSame( 'jetpack-waf', Waf_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Waf_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertSame( 'Jetpack WAF', $def['label'] );
+		$this->assertNotSame( '', $def['description'] );
+	}
+
+	public function test_abilities_map_is_namespaced_and_contains_expected_slugs() {
+		$abilities = Waf_Abilities::get_abilities();
+		$this->assertCount( 2, $abilities );
+		$this->assertArrayHasKey( 'jetpack-waf/get-mode', $abilities );
+		$this->assertArrayHasKey( 'jetpack-waf/get-rules-status', $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-waf/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Waf_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_every_spec_declares_required_keys() {
+		$required = array( 'label', 'description', 'input_schema', 'execute_callback', 'permission_callback', 'meta' );
+		foreach ( Waf_Abilities::get_abilities() as $slug => $spec ) {
+			foreach ( $required as $key ) {
+				$this->assertArrayHasKey( $key, $spec, "Ability {$slug} missing required key {$key}." );
+			}
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback must be callable." );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback must be callable." );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'] );
+			$this->assertArrayHasKey( 'show_in_rest', $spec['meta'] );
+			$this->assertFalse(
+				$spec['input_schema']['additionalProperties'],
+				"Ability {$slug} input_schema must set additionalProperties: false."
+			);
+		}
+	}
+
+	public function test_both_abilities_are_marked_readonly_idempotent_nondestructive() {
+		foreach ( Waf_Abilities::get_abilities() as $slug => $spec ) {
+			$annotations = $spec['meta']['annotations'];
+			$this->assertTrue( $annotations['readonly'], "Ability {$slug} must be readonly." );
+			$this->assertTrue( $annotations['idempotent'], "Ability {$slug} must be idempotent." );
+			$this->assertFalse( $annotations['destructive'], "Ability {$slug} must not be destructive." );
+		}
+	}
+
+	/* -------------------- Registrar wiring -------------------- */
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Waf_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Waf_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Waf_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Waf_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Waf_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Waf_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	/* -------------------- Permission callbacks -------------------- */
+
+	public function test_admin_can_view_waf() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Waf_Abilities::can_view_waf() );
+	}
+
+	public function test_subscriber_cannot_view_waf() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Waf_Abilities::can_view_waf() );
+	}
+
+	public function test_anonymous_user_cannot_view_waf() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Waf_Abilities::can_view_waf() );
+	}
+
+	/* -------------------- Execute: get-mode -------------------- */
+
+	public function test_get_mode_returns_documented_shape_when_module_active_and_normal() {
+		Waf_Runner::enable();
+		update_option( Waf_Runner::MODE_OPTION_NAME, 'normal' );
+		update_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME, '1' );
+		update_option( Waf_Rules_Manager::AUTOMATIC_RULES_LAST_UPDATED_OPTION_NAME, 1700000000 );
+		update_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, "1.1.1.1\n2.2.2.2" );
+		update_option( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME, '3.3.3.3' );
+
+		$result = Waf_Abilities::get_mode();
+
+		$this->assertSame( 'normal', $result['mode'] );
+		$this->assertTrue( $result['automatic_rules_active'] );
+		$this->assertSame( 1700000000, $result['automatic_rules_last_update'] );
+		$this->assertIsBool( $result['brute_force_protection_active'] );
+		$this->assertSame( 2, $result['ip_allow_list_count'] );
+		$this->assertSame( 1, $result['ip_block_list_count'] );
+	}
+
+	public function test_get_mode_returns_silent_when_mode_option_is_silent() {
+		Waf_Runner::enable();
+		update_option( Waf_Runner::MODE_OPTION_NAME, 'silent' );
+
+		$this->assertSame( 'silent', Waf_Abilities::get_mode()['mode'] );
+	}
+
+	public function test_get_mode_returns_disabled_when_module_inactive() {
+		// Module not activated; Waf_Runner::is_enabled() should return false.
+		$result = Waf_Abilities::get_mode();
+
+		// Documented shape must be preserved on the disabled branch.
+		$this->assertSame( 'disabled', $result['mode'] );
+		$this->assertFalse( $result['automatic_rules_active'] );
+		$this->assertNull( $result['automatic_rules_last_update'] );
+		$this->assertIsBool( $result['brute_force_protection_active'] );
+		$this->assertSame( 0, $result['ip_allow_list_count'] );
+		$this->assertSame( 0, $result['ip_block_list_count'] );
+	}
+
+	public function test_get_mode_returns_disabled_when_mode_option_is_unknown() {
+		Waf_Runner::enable();
+		update_option( Waf_Runner::MODE_OPTION_NAME, 'bogus-mode' );
+
+		$this->assertSame( 'disabled', Waf_Abilities::get_mode()['mode'] );
+	}
+
+	/* -------------------- Execute: get-rules-status -------------------- */
+
+	public function test_get_rules_status_returns_documented_shape_with_timestamps() {
+		update_option( Waf_Rules_Manager::AUTOMATIC_RULES_LAST_UPDATED_OPTION_NAME, 1700000000 );
+		update_option( Waf_Rules_Manager::RULE_LAST_UPDATED_OPTION_NAME, 1700000123 );
+
+		$result = Waf_Abilities::get_rules_status();
+
+		$this->assertArrayHasKey( 'jetpack_waf_automatic_rules_last_updated_timestamp', $result );
+		$this->assertArrayHasKey( 'jetpack_waf_last_updated_timestamp', $result );
+		$this->assertArrayHasKey( 'standalone_mode', $result );
+		$this->assertArrayHasKey( 'rules_file_present', $result );
+		$this->assertArrayHasKey( 'rules_file_size', $result );
+
+		$this->assertSame( 1700000000, $result['jetpack_waf_automatic_rules_last_updated_timestamp'] );
+		$this->assertSame( 1700000123, $result['jetpack_waf_last_updated_timestamp'] );
+		$this->assertIsBool( $result['standalone_mode'] );
+		$this->assertIsBool( $result['rules_file_present'] );
+	}
+
+	public function test_get_rules_status_collapses_missing_timestamps_to_null() {
+		// Neither timestamp option is set. The rules file may or may not exist
+		// on disk depending on whether a prior test in the suite ran Waf
+		// activation (which writes the entrypoint to JETPACK_WAF_DIR); we
+		// only assert on the timestamp branch here. File-presence behaviour
+		// is covered by the shape-completeness assertion in
+		// test_get_rules_status_returns_documented_shape_with_timestamps.
+		$result = Waf_Abilities::get_rules_status();
+
+		$this->assertNull( $result['jetpack_waf_automatic_rules_last_updated_timestamp'] );
+		$this->assertNull( $result['jetpack_waf_last_updated_timestamp'] );
+		$this->assertIsBool( $result['rules_file_present'] );
+		// rules_file_size is integer when the file is present, null when absent.
+		if ( $result['rules_file_present'] ) {
+			$this->assertIsInt( $result['rules_file_size'] );
+		} else {
+			$this->assertNull( $result['rules_file_size'] );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Registers two read-only abilities for the Jetpack WAF (Web Application Firewall) package via the `Automattic\Jetpack\WP_Abilities\Registrar` base class:

- `jetpack-waf/get-mode` — returns `{ mode, automatic_rules_active, automatic_rules_last_update, brute_force_protection_active, ip_allow_list_count, ip_block_list_count }`. `mode` is one of `disabled`, `silent`, or `normal`.
- `jetpack-waf/get-rules-status` — returns `{ jetpack_waf_automatic_rules_last_updated_timestamp, jetpack_waf_last_updated_timestamp, standalone_mode, rules_file_present, rules_file_size }`.

Both are read-only / idempotent / non-destructive, gated on `current_user_can( 'manage_options' )` to match the existing WAF REST controller cap.

## Cross-consumer wiring

WAF is consumed by both the Jetpack plugin and the Jetpack Protect plugin, so registration lives in a new `projects/packages/waf/actions.php` (added to `composer.json` `autoload.files`). It hooks `plugins_loaded` at priority 20 and checks the package-wide `jetpack_wp_abilities_enabled` gate filter (default `false`) before calling `Waf_Abilities::init()`. Net effect: when a host plugin opts in, the abilities fire on both Jetpack and Protect installs without duplicating bootstrap code.

References plan §4.2 (cross-consumer wiring via package `actions.php`) and §4.5 (read-only WAF surface; writes deferred to a follow-up).

## Test plan

- [x] `composer phpunit` from `projects/packages/waf/` — all 274 tests pass (48 integration including 17 new abilities tests, 226 unit).
- [ ] In a running WP with `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' )`, confirm `/wp-json/wp-abilities/v1/abilities` lists both `jetpack-waf/get-mode` and `jetpack-waf/get-rules-status`.
- [ ] On a Protect-only install (no Jetpack plugin), confirm the abilities still register (proves the cross-consumer wiring path).
- [ ] Manually exercise both abilities on a site with the WAF module disabled and with it enabled in each mode (`silent`, `normal`).
