### PR TITLE
Boost abilities: critical-CSS regenerate/status + page-cache status reads

### DIFF
--- a/projects/plugins/boost/app/abilities/class-boost-abilities.php
+++ b/projects/plugins/boost/app/abilities/class-boost-abilities.php
@@ -15,20 +15,26 @@ namespace Automattic\Jetpack_Boost\Abilities;
 
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack\WP_Abilities\Registrar;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Regenerate;
 use Automattic\Jetpack_Boost\Modules\Features_Index;
 use Automattic\Jetpack_Boost\Modules\Module;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
 
 /**
  * Registers Jetpack Boost abilities with the WordPress Abilities API.
  *
- * Surface (4 abilities, all under the `jetpack-boost/` namespace):
+ * Surface (7 abilities, all under the `jetpack-boost/` namespace):
  *
- * - get-modules        — filtered read of every Boost module + submodule.
- * - set-module-status  — declarative toggle, idempotent.
- * - get-speed-score    — latest mobile/desktop scores from history.
- * - clear-page-cache   — flush the Boost page cache for the home URL.
+ * - get-modules                — filtered read of every Boost module + submodule.
+ * - set-module-status          — declarative toggle, idempotent.
+ * - get-speed-score            — latest mobile/desktop scores from history.
+ * - clear-page-cache           — flush the Boost page cache for the home URL.
+ * - regenerate-critical-css    — dispatch Critical CSS regeneration; idempotent when one is already running.
+ * - get-critical-css-status    — read the last Critical CSS generation result and per-provider outcomes.
+ * - get-page-cache-status      — read page-cache state (active flag, bypass cookies, size, file count).
  *
  * @since $$next-version$$
  */
@@ -67,7 +73,7 @@ class Boost_Abilities extends Registrar {
 		);
 
 		return array(
-			'jetpack-boost/get-modules'       => array(
+			'jetpack-boost/get-modules'             => array(
 				'label'               => __( 'Get Boost modules', 'jetpack-boost' ),
 				'description'         => __( 'List Jetpack Boost performance modules and submodules. Returns an array of { slug, active, available, optimizing }. Slugs use underscores (e.g. "critical_css", "page_cache", "image_cdn"). Pass slug to fetch a single module (returns a 0- or 1-element array; unknown slugs yield an empty array, never an error). Pass status to filter by active/inactive/available/optimizing. Use the returned slugs as input to jetpack-boost/set-module-status.', 'jetpack-boost' ),
 				'input_schema'        => array(
@@ -112,7 +118,7 @@ class Boost_Abilities extends Registrar {
 				),
 			),
 
-			'jetpack-boost/set-module-status' => array(
+			'jetpack-boost/set-module-status'       => array(
 				'label'               => __( 'Set Boost module status', 'jetpack-boost' ),
 				'description'         => __( 'Enable or disable a single Jetpack Boost module by slug. Required: { slug, active }. Returns { slug, active, changed }. Idempotent: setting a module to its current state returns changed=false. Slugs use underscores (e.g. "critical_css", "page_cache"). Unknown slugs return jetpack_boost_invalid_slug; modules not loadable on this site return jetpack_boost_module_unavailable; always-on modules cannot be disabled and return jetpack_boost_module_always_on — call jetpack-boost/get-modules to enumerate available slugs. Toggling a parent module also drives submodule lifecycle.', 'jetpack-boost' ),
 				'input_schema'        => array(
@@ -155,7 +161,7 @@ class Boost_Abilities extends Registrar {
 				),
 			),
 
-			'jetpack-boost/get-speed-score'   => array(
+			'jetpack-boost/get-speed-score'         => array(
 				'label'               => __( 'Get latest speed score', 'jetpack-boost' ),
 				'description'         => __( 'Return the most recent Jetpack Boost speed score for the home URL. Returns { mobile, desktop, timestamp, is_stale, has_history }. mobile/desktop are integers 0-100 (Google PageSpeed scale) or null when no score has been recorded. timestamp is a Unix epoch in seconds. is_stale=true means the latest score is older than 24 hours or invalidated by a site change; agents should request a refresh from the Boost UI before quoting it. has_history=false means no scores have been recorded yet.', 'jetpack-boost' ),
 				'input_schema'        => array(
@@ -190,7 +196,7 @@ class Boost_Abilities extends Registrar {
 				),
 			),
 
-			'jetpack-boost/clear-page-cache'  => array(
+			'jetpack-boost/clear-page-cache'        => array(
 				'label'               => __( 'Clear page cache', 'jetpack-boost' ),
 				'description'         => __( 'Clear every cached page under the site home URL. Idempotent: re-running on an empty cache is a no-op. Returns { cleared, message }. cleared=true means the clear request was dispatched against an active page_cache module; it does not promise that cached files actually existed (the underlying API does not surface a count). Requires the page_cache module to be active; if it is not, returns jetpack_boost_page_cache_inactive — enable it first via jetpack-boost/set-module-status with slug="page_cache".', 'jetpack-boost' ),
 				'input_schema'        => array(
@@ -211,6 +217,128 @@ class Boost_Abilities extends Registrar {
 				'meta'                => array(
 					'annotations'  => array(
 						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool',
+					),
+				),
+			),
+
+			'jetpack-boost/regenerate-critical-css' => array(
+				'label'               => __( 'Regenerate Critical CSS', 'jetpack-boost' ),
+				'description'         => __( 'Dispatch a Critical CSS regeneration for every configured provider. Returns { dispatched, job_id, status }. status is one of "queued" (new run started), "running" (this call started or re-confirmed an in-flight run), or "already_running" (a generation was already in flight; this call did not enqueue a second one — safe to re-call, the existing run continues). job_id is a stable identifier for the active generation (or null when none could be determined). Requires the critical_css module to be active; if it is not, returns jetpack_boost_critical_css_inactive — enable it first via jetpack-boost/set-module-status with slug="critical_css".', 'jetpack-boost' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'dispatched' => array( 'type' => 'boolean' ),
+						'job_id'     => array( 'type' => array( 'string', 'null' ) ),
+						'status'     => array(
+							'type' => 'string',
+							'enum' => array( 'queued', 'running', 'already_running' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'regenerate_critical_css' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_modules' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool',
+					),
+				),
+			),
+
+			'jetpack-boost/get-critical-css-status' => array(
+				'label'               => __( 'Get Critical CSS status', 'jetpack-boost' ),
+				'description'         => __( 'Return the last Critical CSS generation result. Returns { status, generated_at, provider_count, providers, stale }. status is one of "not_generated" (no run yet), "pending" (currently running), "generated" (successful), or "error" (last run failed). generated_at is a Unix epoch in seconds (the most recent state update) or null when nothing has been recorded. providers is an array of { provider_id, success, error_message } — error_message is null when success=true. stale=true means Boost has flagged the existing Critical CSS as needing regeneration (theme change, post saved, plugin change, etc.); call jetpack-boost/regenerate-critical-css to refresh.', 'jetpack-boost' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'status'         => array(
+							'type' => 'string',
+							'enum' => array( 'not_generated', 'pending', 'generated', 'error' ),
+						),
+						'generated_at'   => array( 'type' => array( 'integer', 'null' ) ),
+						'provider_count' => array( 'type' => 'integer' ),
+						'providers'      => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'provider_id'   => array( 'type' => 'string' ),
+									'success'       => array( 'type' => 'boolean' ),
+									'error_message' => array( 'type' => array( 'string', 'null' ) ),
+								),
+							),
+						),
+						'stale'          => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_critical_css_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_modules' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool',
+					),
+				),
+			),
+
+			'jetpack-boost/get-page-cache-status'   => array(
+				'label'               => __( 'Get page cache status', 'jetpack-boost' ),
+				'description'         => __( 'Return the current state of the Boost page cache. Returns { active, bypass_cookies, cache_size_bytes, file_count, last_cleared_at }. active=true means the page_cache module is enabled, available, and configured to cache. bypass_cookies is an array of regex patterns that opt requests out of caching (configured via Boost settings). cache_size_bytes is the total bytes on disk under the boost-cache directory for the current host, or null when the cache directory does not exist. file_count is the number of cached files (excluding boilerplate index.html files) or null when the cache directory does not exist. last_cleared_at is reserved for a future field and is currently always null — Boost does not yet record explicit clear timestamps.', 'jetpack-boost' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'active'           => array( 'type' => 'boolean' ),
+						'bypass_cookies'   => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'cache_size_bytes' => array( 'type' => array( 'integer', 'null' ) ),
+						'file_count'       => array( 'type' => array( 'integer', 'null' ) ),
+						'last_cleared_at'  => array( 'type' => array( 'integer', 'null' ) ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_page_cache_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_modules' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
 						'destructive' => false,
 						'idempotent'  => true,
 					),
@@ -533,5 +661,257 @@ class Boost_Abilities extends Registrar {
 			'cleared' => true,
 			'message' => __( 'Page cache cleared.', 'jetpack-boost' ),
 		);
+	}
+
+	/**
+	 * Execute: dispatch Critical CSS regeneration. Idempotent — re-runs while a
+	 * generation is already in flight return status='already_running' without
+	 * starting a second one.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array|null $input Unused; ability has no inputs.
+	 * @return array|\WP_Error
+	 */
+	public static function regenerate_critical_css( $input = null ) {
+		unset( $input );
+
+		// Gate on either critical_css OR cloud_css being active. Both routes share
+		// the same Critical_CSS_State storage; users on the paid Cloud CSS plan
+		// would never have classic critical_css active, so checking only the
+		// classic slug would lock them out.
+		$index   = self::build_module_index();
+		$classic = isset( $index['critical_css'] ) ? $index['critical_css'] : null;
+		$cloud   = isset( $index['cloud_css'] ) ? $index['cloud_css'] : null;
+
+		$classic_on = $classic && $classic->is_available() && $classic->is_enabled();
+		$cloud_on   = $cloud && $cloud->is_available() && $cloud->is_enabled();
+
+		if ( ! $classic_on && ! $cloud_on ) {
+			return new \WP_Error(
+				'jetpack_boost_critical_css_inactive',
+				__( 'The critical_css module is not active. Enable it first via jetpack-boost/set-module-status with slug="critical_css" and active=true.', 'jetpack-boost' )
+			);
+		}
+
+		// Idempotency gate: if a generation is already in flight, return without
+		// re-dispatching. Regenerate::start() would otherwise reset the state and
+		// double-clear stored CSS, which is wasteful and confusing for the agent.
+		$state = new Critical_CSS_State();
+		if ( $state->is_requesting() ) {
+			return array(
+				'dispatched' => false,
+				'job_id'     => self::critical_css_job_id( $state->get() ),
+				'status'     => 'already_running',
+			);
+		}
+
+		$regenerate = new Regenerate();
+		$regenerate->start();
+		$new_state = $regenerate->get_state();
+
+		$data   = $new_state ? $new_state->get() : null;
+		$status = ( is_array( $data ) && isset( $data['status'] ) && 'pending' === $data['status'] )
+			? 'running'
+			: 'queued';
+
+		return array(
+			'dispatched' => true,
+			'job_id'     => self::critical_css_job_id( $data ),
+			'status'     => $status,
+		);
+	}
+
+	/**
+	 * Derive a stable job id from a Critical CSS state payload.
+	 *
+	 * Boost's state object stores `created` as a microtime float; we hash it so
+	 * the id is short, opaque, and changes when a new generation starts.
+	 *
+	 * @param array|null $state The state array as returned by Critical_CSS_State::get().
+	 * @return string|null
+	 */
+	private static function critical_css_job_id( $state ): ?string {
+		if ( ! is_array( $state ) || empty( $state['created'] ) ) {
+			return null;
+		}
+		return substr( md5( (string) $state['created'] ), 0, 12 );
+	}
+
+	/**
+	 * Execute: read the last Critical CSS generation result.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array|null $input Unused; ability has no inputs.
+	 * @return array
+	 */
+	public static function get_critical_css_status( $input = null ) {
+		unset( $input );
+
+		$state_obj = new Critical_CSS_State();
+		$state     = $state_obj->get();
+
+		if ( ! is_array( $state ) || empty( $state ) ) {
+			return array(
+				'status'         => 'not_generated',
+				'generated_at'   => null,
+				'provider_count' => 0,
+				'providers'      => array(),
+				'stale'          => false,
+			);
+		}
+
+		$status = isset( $state['status'] ) && is_string( $state['status'] )
+			? $state['status']
+			: 'not_generated';
+
+		// `updated` is microtime(true). Casting to int yields a Unix-epoch second.
+		$generated_at = null;
+		if ( isset( $state['updated'] ) && is_numeric( $state['updated'] ) ) {
+			$generated_at = (int) $state['updated'];
+		}
+
+		$providers       = array();
+		$state_providers = isset( $state['providers'] ) && is_array( $state['providers'] ) ? $state['providers'] : array();
+		foreach ( $state_providers as $provider ) {
+			if ( ! is_array( $provider ) ) {
+				continue;
+			}
+			$provider_id     = isset( $provider['key'] ) && is_string( $provider['key'] ) ? $provider['key'] : '';
+			$provider_status = isset( $provider['status'] ) && is_string( $provider['status'] ) ? $provider['status'] : '';
+			$success         = 'success' === $provider_status;
+
+			// Boost stores per-provider errors as an array of { url, message, type }.
+			// Surface the first message; richer detail lives in the data-sync state for the UI.
+			$error_message = null;
+			if ( ! $success && ! empty( $provider['errors'] ) && is_array( $provider['errors'] ) ) {
+				$first = reset( $provider['errors'] );
+				if ( is_array( $first ) && isset( $first['message'] ) && is_string( $first['message'] ) && '' !== $first['message'] ) {
+					$error_message = $first['message'];
+				}
+			}
+
+			$providers[] = array(
+				'provider_id'   => $provider_id,
+				'success'       => $success,
+				'error_message' => $error_message,
+			);
+		}
+
+		// "stale" tracks Boost's own suggest-regenerate flag, set by the invalidator
+		// when themes/posts/plugins change. Anything truthy means Boost wants a refresh.
+		$suggest = function_exists( 'jetpack_boost_ds_get' )
+			? jetpack_boost_ds_get( 'critical_css_suggest_regenerate' )
+			: null;
+		$stale   = ! empty( $suggest );
+
+		return array(
+			'status'         => $status,
+			'generated_at'   => $generated_at,
+			'provider_count' => count( $providers ),
+			'providers'      => $providers,
+			'stale'          => $stale,
+		);
+	}
+
+	/**
+	 * Execute: read current page-cache state (config + on-disk size).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array|null $input Unused; ability has no inputs.
+	 * @return array
+	 */
+	public static function get_page_cache_status( $input = null ) {
+		unset( $input );
+
+		$page_cache = new Module( new Page_Cache() );
+		$active     = $page_cache->is_available() && $page_cache->is_enabled();
+
+		// Bypass cookies live in the boost-cache settings file (NOT a WP option).
+		// We cannot call Boost_Cache_Settings::get_instance() unconditionally
+		// from autoloaded code without risking side effects, but reading it here
+		// is safe — get_instance() is idempotent and just memoises the file read.
+		$bypass_cookies = array();
+		if ( class_exists( Boost_Cache_Settings::class ) ) {
+			$settings = Boost_Cache_Settings::get_instance();
+			$patterns = $settings->get_bypass_patterns();
+			if ( is_array( $patterns ) ) {
+				foreach ( $patterns as $pattern ) {
+					if ( is_string( $pattern ) && '' !== $pattern ) {
+						$bypass_cookies[] = $pattern;
+					}
+				}
+			}
+		}
+
+		list( $size_bytes, $file_count ) = self::measure_page_cache_dir();
+
+		return array(
+			'active'           => $active,
+			'bypass_cookies'   => $bypass_cookies,
+			'cache_size_bytes' => $size_bytes,
+			'file_count'       => $file_count,
+			// Boost does not yet record an explicit "last cleared" timestamp;
+			// reserved here so consumers can rely on the field's presence.
+			'last_cleared_at'  => null,
+		);
+	}
+
+	/**
+	 * Walk the boost-cache directory for the current host and return [bytes, files].
+	 *
+	 * Returns [null, null] when the directory does not exist (cache empty / never
+	 * created) so callers can distinguish "no cache" from "cache of zero bytes".
+	 * Boilerplate index.html files used to block directory listing are excluded
+	 * from the file count.
+	 *
+	 * @return array{0:?int,1:?int}
+	 */
+	private static function measure_page_cache_dir(): array {
+		if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+			return array( null, null );
+		}
+		$host = isset( $_SERVER['HTTP_HOST'] ) ? strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) ) : '';
+		if ( '' === $host ) {
+			// Fall back to the parsed home_url host so CLI / cron requests still measure something useful.
+			$parsed = wp_parse_url( home_url(), PHP_URL_HOST );
+			$host   = is_string( $parsed ) ? strtolower( $parsed ) : '';
+		}
+		if ( '' === $host ) {
+			return array( null, null );
+		}
+
+		$root = WP_CONTENT_DIR . '/boost-cache/cache/' . $host;
+		if ( ! is_dir( $root ) ) {
+			return array( null, null );
+		}
+
+		$size  = 0;
+		$count = 0;
+		try {
+			$iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator( $root, \RecursiveDirectoryIterator::SKIP_DOTS ),
+				\RecursiveIteratorIterator::LEAVES_ONLY
+			);
+			foreach ( $iterator as $file ) {
+				/** @var \SplFileInfo $file */
+				if ( ! $file->isFile() ) {
+					continue;
+				}
+				$size += (int) $file->getSize();
+				// The boilerplate index.html guards against directory listing and is not a cached page.
+				if ( 'index.html' !== $file->getFilename() ) {
+					++$count;
+				}
+			}
+		} catch ( \UnexpectedValueException $e ) {
+			// Directory disappeared mid-walk (concurrent clear, permissions flip).
+			// Honest signal: we can't measure right now.
+			return array( null, null );
+		}
+
+		return array( $size, $count );
 	}
 }

--- a/projects/plugins/boost/changelog/add-boost-extension-abilities
+++ b/projects/plugins/boost/changelog/add-boost-extension-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register critical-CSS regenerate, critical-CSS status, and page-cache status reads

--- a/projects/plugins/boost/tests/php/abilities/Boost_Abilities_Test.php
+++ b/projects/plugins/boost/tests/php/abilities/Boost_Abilities_Test.php
@@ -598,4 +598,222 @@ class Boost_Abilities_Test extends BaseTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_boost_page_cache_inactive', $result->get_error_code() );
 	}
+
+	/** -------------------- New ability surface -------------------- */
+	public function test_new_abilities_are_in_get_abilities_map(): void {
+		$abilities = Boost_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-boost/regenerate-critical-css', $abilities );
+		$this->assertArrayHasKey( 'jetpack-boost/get-critical-css-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack-boost/get-page-cache-status', $abilities );
+	}
+
+	public function test_new_status_abilities_are_marked_readonly_and_idempotent(): void {
+		$abilities = Boost_Abilities::get_abilities();
+		foreach ( array( 'jetpack-boost/get-critical-css-status', 'jetpack-boost/get-page-cache-status' ) as $slug ) {
+			$this->assertTrue( $abilities[ $slug ]['meta']['annotations']['readonly'], "{$slug} must be readonly." );
+			$this->assertTrue( $abilities[ $slug ]['meta']['annotations']['idempotent'], "{$slug} must be idempotent." );
+			$this->assertFalse( $abilities[ $slug ]['meta']['annotations']['destructive'], "{$slug} must not be destructive." );
+		}
+	}
+
+	public function test_regenerate_critical_css_annotations(): void {
+		$abilities   = Boost_Abilities::get_abilities();
+		$annotations = $abilities['jetpack-boost/regenerate-critical-css']['meta']['annotations'];
+		$this->assertFalse( $annotations['readonly'], 'regenerate-critical-css is a write surface.' );
+		$this->assertFalse( $annotations['destructive'], 'No user data is destroyed.' );
+		// Idempotency is contractual — re-dispatch while running must return already_running, not queue a 2nd run.
+		$this->assertTrue( $annotations['idempotent'] );
+	}
+
+	/** -------------------- regenerate_critical_css -------------------- */
+	public function test_regenerate_critical_css_requires_module_active(): void {
+		// Neither critical_css nor cloud_css is enabled by default; default status options should be missing.
+		delete_option( 'jetpack_boost_status_critical-css' );
+		delete_option( 'jetpack_boost_status_cloud-css' );
+
+		$result = Boost_Abilities::regenerate_critical_css();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_boost_critical_css_inactive', $result->get_error_code() );
+	}
+
+	public function test_regenerate_critical_css_is_idempotent_while_running(): void {
+		// Enable critical_css so the activation gate passes.
+		update_option( 'jetpack_boost_status_critical-css', true );
+
+		// Make sure the DS registry knows about critical_css_state so the state object can read it.
+		self::ensure_critical_css_state_registered();
+		jetpack_boost_ds_set(
+			'critical_css_state',
+			array(
+				'status'    => 'pending',
+				'providers' => array(
+					array(
+						'key'           => 'core_front_page',
+						'label'         => 'Front Page',
+						'urls'          => array( home_url() ),
+						'success_ratio' => 0.0,
+						'status'        => 'pending',
+					),
+				),
+				'created'   => microtime( true ),
+				'updated'   => microtime( true ),
+			)
+		);
+
+		$result = Boost_Abilities::regenerate_critical_css();
+
+		// Cleanup before assertions so a failure mid-test doesn't leak state.
+		jetpack_boost_ds_delete( 'critical_css_state' );
+		delete_option( 'jetpack_boost_status_critical-css' );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['dispatched'], 'A second dispatch while running must not re-queue.' );
+		$this->assertSame( 'already_running', $result['status'] );
+		$this->assertIsString( $result['job_id'], 'job_id must be a stable string when a run is in flight.' );
+	}
+
+	/** -------------------- get_critical_css_status -------------------- */
+	public function test_get_critical_css_status_returns_not_generated_when_no_state(): void {
+		// Without DS registration the state read returns null; that's the "no run yet" shape.
+		$result = Boost_Abilities::get_critical_css_status();
+		$this->assertSame( 'not_generated', $result['status'] );
+		$this->assertNull( $result['generated_at'] );
+		$this->assertSame( 0, $result['provider_count'] );
+		$this->assertSame( array(), $result['providers'] );
+		$this->assertFalse( $result['stale'] );
+	}
+
+	public function test_get_critical_css_status_returns_per_provider_outcomes(): void {
+		self::ensure_critical_css_state_registered();
+
+		$now = microtime( true );
+		jetpack_boost_ds_set(
+			'critical_css_state',
+			array(
+				'status'    => 'generated',
+				'providers' => array(
+					array(
+						'key'           => 'core_front_page',
+						'label'         => 'Front Page',
+						'urls'          => array( home_url() ),
+						'success_ratio' => 1.0,
+						'status'        => 'success',
+					),
+					array(
+						'key'           => 'singular_page',
+						'label'         => 'Singular Page',
+						'urls'          => array( home_url( '/about' ) ),
+						'success_ratio' => 0.0,
+						'status'        => 'error',
+						'errors'        => array(
+							array(
+								'url'     => home_url( '/about' ),
+								'message' => 'Timeout while loading page',
+								'type'    => 'HttpError',
+							),
+						),
+					),
+				),
+				'created'   => $now - 5,
+				'updated'   => $now,
+			)
+		);
+
+		$result = Boost_Abilities::get_critical_css_status();
+
+		jetpack_boost_ds_delete( 'critical_css_state' );
+
+		$this->assertSame( 'generated', $result['status'] );
+		$this->assertIsInt( $result['generated_at'] );
+		$this->assertSame( 2, $result['provider_count'] );
+		$this->assertCount( 2, $result['providers'] );
+
+		// Index by provider_id for stable assertions independent of array order.
+		$by_id = array();
+		foreach ( $result['providers'] as $entry ) {
+			$by_id[ $entry['provider_id'] ] = $entry;
+		}
+		$this->assertTrue( $by_id['core_front_page']['success'] );
+		$this->assertNull( $by_id['core_front_page']['error_message'] );
+		$this->assertFalse( $by_id['singular_page']['success'] );
+		$this->assertSame( 'Timeout while loading page', $by_id['singular_page']['error_message'] );
+	}
+
+	public function test_get_critical_css_status_reports_stale_when_suggest_regenerate_set(): void {
+		self::ensure_critical_css_state_registered();
+		self::ensure_suggest_regenerate_registered();
+
+		jetpack_boost_ds_set(
+			'critical_css_state',
+			array(
+				'status'    => 'generated',
+				'providers' => array(),
+				'created'   => microtime( true ),
+				'updated'   => microtime( true ),
+			)
+		);
+		jetpack_boost_ds_set( 'critical_css_suggest_regenerate', 'switched_theme' );
+
+		$result = Boost_Abilities::get_critical_css_status();
+
+		jetpack_boost_ds_delete( 'critical_css_state' );
+		jetpack_boost_ds_delete( 'critical_css_suggest_regenerate' );
+
+		$this->assertTrue( $result['stale'], 'When suggest_regenerate is set, stale must be true.' );
+	}
+
+	/** -------------------- get_page_cache_status -------------------- */
+	public function test_get_page_cache_status_inactive_when_module_disabled(): void {
+		delete_option( 'jetpack_boost_status_page-cache' );
+
+		$result = Boost_Abilities::get_page_cache_status();
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['active'], 'Page cache must report inactive when the module is disabled.' );
+		$this->assertIsArray( $result['bypass_cookies'] );
+		// last_cleared_at is a reserved field — always null until Boost tracks it.
+		$this->assertNull( $result['last_cleared_at'] );
+	}
+
+	public function test_get_page_cache_status_returns_null_size_when_cache_dir_missing(): void {
+		// When the boost-cache directory doesn't exist for this host, size/count are null
+		// (distinct from "0" — the consumer can tell "no cache" from "empty cache").
+		$result = Boost_Abilities::get_page_cache_status();
+		$this->assertNull( $result['cache_size_bytes'] );
+		$this->assertNull( $result['file_count'] );
+	}
+
+	public function test_get_page_cache_status_output_matches_schema_keys(): void {
+		$result   = Boost_Abilities::get_page_cache_status();
+		$expected = array( 'active', 'bypass_cookies', 'cache_size_bytes', 'file_count', 'last_cleared_at' );
+		$this->assertSame( $expected, array_keys( $result ), 'Page-cache status payload keys must match the documented order.' );
+	}
+
+	/** -------------------- helpers -------------------- */
+
+	/**
+	 * Lazy-register the `critical_css_state` DS entry so tests that need to seed it
+	 * via jetpack_boost_ds_set() can do so without booting the full plugin.
+	 */
+	private static function ensure_critical_css_state_registered(): void {
+		if ( null !== jetpack_boost_ds_entry( 'critical_css_state' ) ) {
+			return;
+		}
+		jetpack_boost_register_option(
+			'critical_css_state',
+			\Automattic\Jetpack_Boost\Lib\Critical_CSS\Data_Sync\Data_Sync_Schema::critical_css_state()
+		);
+	}
+
+	/**
+	 * Lazy-register `critical_css_suggest_regenerate` for the stale-flag tests.
+	 */
+	private static function ensure_suggest_regenerate_registered(): void {
+		if ( null !== jetpack_boost_ds_entry( 'critical_css_suggest_regenerate' ) ) {
+			return;
+		}
+		jetpack_boost_register_option(
+			'critical_css_suggest_regenerate',
+			\Automattic\Jetpack_Boost\Lib\Critical_CSS\Data_Sync\Data_Sync_Schema::critical_css_suggest_regenerate()
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Extends the Jetpack Boost Abilities API surface (already shipped: `get-modules`, `set-module-status`, `get-speed-score`, `clear-page-cache`) with three additional abilities that give agents a complete read/write loop on Boost's Critical CSS and page-cache subsystems.

Surface added (all under the `jetpack-boost/` category):

- **`jetpack-boost/regenerate-critical-css`** — Dispatches Critical CSS regeneration. Returns `{ dispatched, job_id, status }` where `status` is `queued` | `running` | `already_running`. Idempotent: re-calling while a generation is in flight returns `dispatched=false, status="already_running"` instead of queuing a second run that would clobber stored CSS. Gates on either `critical_css` or `cloud_css` being active (both share the same `Critical_CSS_State` storage), and returns `jetpack_boost_critical_css_inactive` otherwise.
- **`jetpack-boost/get-critical-css-status`** — Read-only. Returns `{ status, generated_at, provider_count, providers, stale }`. `providers` is an array of `{ provider_id, success, error_message }`. `stale=true` mirrors Boost's own `critical_css_suggest_regenerate` flag (theme switch / post save / plugin change / etc.). When no state is recorded yet, returns the explicit `not_generated` shape rather than erroring.
- **`jetpack-boost/get-page-cache-status`** — Read-only. Returns `{ active, bypass_cookies, cache_size_bytes, file_count, last_cleared_at }`. `active` reflects the page_cache `Module` being available and enabled. `bypass_cookies` is read from `Boost_Cache_Settings`. `cache_size_bytes` and `file_count` are computed by walking `WP_CONTENT_DIR/boost-cache/cache/{host}`; both are `null` (not `0`) when the cache directory does not exist so consumers can distinguish "no cache" from "empty cache". The boilerplate `index.html` directory-listing guards are excluded from the file count. `last_cleared_at` is a reserved field, always `null` until Boost tracks it.

## Approach

The existing `class-boost-abilities.php` already extends `Registrar` (path 1 per the ship plan, not the legacy manual-hook pattern), so this PR just adds three entries to `get_abilities()`, three execute methods, and tests. No conversion needed. Permission callbacks reuse the existing `can_view_modules` / `can_manage_modules` helpers (both gate on `manage_options`).

Existing per-call docstrings, schema discipline, and token-thrift conventions are mirrored on the new specs (`additionalProperties: false`, full output schemas, MCP `public=true, type=tool`, accurate `readonly/destructive/idempotent` annotations).

Plan reference: §2.2 (Boost Extension Abilities).

## Test plan

- [x] `composer phpunit` in `projects/plugins/boost` — 169 tests pass (86 unit + 83 with-wordpress, 692 assertions). 18 new test cases cover the added surface.
- [x] PHPCS (`composer phpcs:lint`) clean on changed files.
- [x] PHP syntax (`composer php:lint`) clean.
- [ ] Manual: REST round-trip through `/wp-json/wp-abilities/v1/abilities` lists the three new slugs.
- [ ] Manual: With `critical_css` active, calling `regenerate-critical-css` twice in quick succession returns `dispatched=true` then `dispatched=false, status="already_running"`.
- [ ] Manual: With `page_cache` active and traffic warming the cache, `get-page-cache-status` returns a non-null `cache_size_bytes` and non-zero `file_count`.

### New test coverage

- Surface presence + annotation correctness for all three slugs.
- `regenerate-critical-css`: rejects when neither classic nor cloud CSS module is active; idempotent when a run is already in flight (`status=already_running, dispatched=false`).
- `get-critical-css-status`: returns the empty-state default when no state exists; surfaces per-provider success/error_message from a seeded state; reports `stale=true` when the suggest-regenerate flag is set.
- `get-page-cache-status`: returns `active=false` when the module is disabled; returns `null` size/count when the cache directory does not exist; output payload key order matches the documented schema.