### PR TITLE
Protect abilities: register status, threats, and Account Protection via Registrar

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-abilities
+++ b/projects/plugins/protect/changelog/add-protect-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register Protect reads (get-status, list-threats, get-threat) and Account Protection get/set.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -18,11 +18,13 @@
 		"automattic/jetpack-waf": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-protect-status": "@dev",
-		"automattic/jetpack-account-protection": "@dev"
+		"automattic/jetpack-account-protection": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/phpunit-select-config": "@dev"
+		"automattic/phpunit-select-config": "@dev",
+		"automattic/jetpack-test-environment": "@dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acf4bf4f963d8f0b65e00c8bd18ac443",
+    "content-hash": "a17676cb9f17f8907186d79ffa550aa5",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1955,6 +1955,64 @@
             }
         },
         {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "wikimedia/aho-corasick",
             "version": "v1.0.1",
             "source": {
@@ -2007,6 +2065,58 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "automattic/jetpack-test-environment",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/test-environment",
+                "reference": "58edc60c1bba1989292acfc96878ca2b3e6165a2"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                },
+                "textdomain": "jetpack-test-environment",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-test-environment.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared WordPress test environment for Jetpack monorepo projects",
+            "transport-options": {
+                "relative": true
+            }
+        },
         {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
@@ -3817,8 +3927,10 @@
         "automattic/jetpack-protect-status": 20,
         "automattic/jetpack-status": 20,
         "automattic/jetpack-sync": 20,
+        "automattic/jetpack-test-environment": 20,
         "automattic/jetpack-transport-helper": 20,
         "automattic/jetpack-waf": 20,
+        "automattic/jetpack-wp-abilities": 20,
         "automattic/phpunit-select-config": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/protect/src/abilities/class-protect-abilities.php
+++ b/projects/plugins/protect/src/abilities/class-protect-abilities.php
@@ -1,0 +1,645 @@
+<?php
+/**
+ * Jetpack Protect Abilities Registration
+ *
+ * Registers Jetpack Protect read abilities and the Account Protection
+ * toggle with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-protect-plugin
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Protect\Abilities;
+
+use Automattic\Jetpack\Account_Protection\Account_Protection;
+use Automattic\Jetpack\Account_Protection\Settings as Account_Protection_Settings;
+use Automattic\Jetpack\Protect_Status\Status;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack Protect abilities with the WordPress Abilities API.
+ *
+ * The surface mirrors the read-only routes of the Protect REST controller
+ * (`projects/plugins/protect/src/class-rest-controller.php`) plus the
+ * Account Protection get/set pair. Destructive writes (fix-threat,
+ * ignore-threat, request-scan) are deliberately omitted from the v1
+ * surface; they need a follow-up design pass.
+ */
+class Protect_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-protect';
+
+	/**
+	 * Per_page cap for list-threats.
+	 *
+	 * Aligns with the token-thrift guidance: a single 100-element response
+	 * is the upper bound; callers paginate past that.
+	 */
+	const LIST_THREATS_MAX_PER_PAGE = 100;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// translators: "Jetpack" is a product name and should not be translated.
+			'label'       => __( 'Jetpack Protect', 'jetpack-protect' ),
+			'description' => __( 'Abilities for inspecting Jetpack Protect scan status, threats, and Account Protection state.', 'jetpack-protect' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-protect/get-status'                     => array(
+				'label'               => __( 'Get Jetpack Protect status', 'jetpack-protect' ),
+				'description'         => __( 'Return the current Protect plan and scan state as { has_plan, last_scan: { timestamp, status, threats_found }, threat_counts: { total, fixable, critical }, scan_in_progress }. Read-only; safe to call repeatedly. Use jetpack-protect/list-threats next to enumerate individual threats. Fails with jetpack_protect_status_data_unavailable when Status::get_status() returns no usable data (typically a transient remote failure or a disconnected site).', 'jetpack-protect' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'has_plan'          => array( 'type' => 'boolean' ),
+						'last_scan'         => array(
+							'type'       => array( 'object', 'null' ),
+							'properties' => array(
+								'timestamp'     => array( 'type' => array( 'string', 'null' ) ),
+								'status'        => array( 'type' => array( 'string', 'null' ) ),
+								'threats_found' => array( 'type' => 'integer' ),
+							),
+						),
+						'threat_counts'     => array(
+							'type'       => 'object',
+							'properties' => array(
+								'total'    => array( 'type' => 'integer' ),
+								'fixable'  => array( 'type' => 'integer' ),
+								'critical' => array( 'type' => 'integer' ),
+							),
+						),
+						'scan_in_progress' => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_protect' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-protect/list-threats'                   => array(
+				'label'               => __( 'List Jetpack Protect threats', 'jetpack-protect' ),
+				'description'         => __( 'Return a paginated array of currently open threats with optional severity/type filters. Each entry is { id, signature, title, description, severity, type, fixable, ignored, first_detected, source }. severity is bucketed as "critical" (raw >=5), "high" (3-4), "medium" (2), or "low" (<2). type is one of "core" | "plugin" | "theme" | "file". Pagination defaults to per_page=20, capped at 100. Read-only. Call jetpack-protect/get-status first for the overview, then drill in with this ability; use jetpack-protect/get-threat for a single threat by id.', 'jetpack-protect' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'severity' => array(
+							'type'        => 'string',
+							'enum'        => array( 'critical', 'high', 'medium', 'low' ),
+							'description' => __( 'Filter by severity bucket. Threats are bucketed from the raw 1-5 severity score: critical (>=5), high (3-4), medium (2), low (<2).', 'jetpack-protect' ),
+						),
+						'type'     => array(
+							'type'        => 'string',
+							'enum'        => array( 'core', 'plugin', 'theme', 'file' ),
+							'description' => __( 'Filter by threat surface: WordPress core, a plugin, a theme, or a file on disk.', 'jetpack-protect' ),
+						),
+						'page'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'default' => 1,
+						),
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => self::LIST_THREATS_MAX_PER_PAGE,
+							'default' => 20,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'             => array( 'type' => array( 'string', 'null' ) ),
+							'signature'      => array( 'type' => array( 'string', 'null' ) ),
+							'title'          => array( 'type' => array( 'string', 'null' ) ),
+							'description'    => array( 'type' => array( 'string', 'null' ) ),
+							'severity'       => array( 'type' => array( 'string', 'null' ) ),
+							'type'           => array( 'type' => array( 'string', 'null' ) ),
+							'fixable'        => array( 'type' => 'boolean' ),
+							'ignored'        => array( 'type' => 'boolean' ),
+							'first_detected' => array( 'type' => array( 'string', 'null' ) ),
+							'source'         => array( 'type' => array( 'string', 'null' ) ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'list_threats' ),
+				'permission_callback' => array( __CLASS__, 'can_view_protect' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-protect/get-threat'                     => array(
+				'label'               => __( 'Get a single Jetpack Protect threat', 'jetpack-protect' ),
+				'description'         => __( 'Return a single threat detail by id as a 1-element array of { id, signature, title, description, severity, type, fixable, ignored, first_detected, source, recommended_action }, or an empty array when no such threat exists (consolidated-read pattern — unknown ids are not errors). Read-only. Pair with jetpack-protect/list-threats for enumeration.', 'jetpack-protect' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'id' ),
+					'properties'           => array(
+						'id' => array(
+							'type'        => 'string',
+							'description' => __( 'Threat identifier as returned by jetpack-protect/list-threats. Both numeric ids (legacy "12345") and synthetic vulnerability ids ("plugin-jetpack-1.2.3") are accepted as strings.', 'jetpack-protect' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'object' ),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_threat' ),
+				'permission_callback' => array( __CLASS__, 'can_view_protect' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-protect/get-account-protection-status'  => array(
+				'label'               => __( 'Get Account Protection status', 'jetpack-protect' ),
+				'description'         => __( 'Return the current Account Protection state as { enabled, supported, last_event, attempt_count_24h, blocked_count_24h }. supported is false on environments where Account Protection cannot run (WordPress.com Simple, killswitch). last_event, attempt_count_24h, and blocked_count_24h are null/0 until activity data is available. Read-only. Use jetpack-protect/set-account-protection to toggle.', 'jetpack-protect' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'enabled'            => array( 'type' => 'boolean' ),
+						'supported'          => array( 'type' => 'boolean' ),
+						'last_event'         => array( 'type' => array( 'string', 'null' ) ),
+						'attempt_count_24h'  => array( 'type' => 'integer' ),
+						'blocked_count_24h'  => array( 'type' => 'integer' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_account_protection_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_protect' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-protect/set-account-protection'         => array(
+				'label'               => __( 'Set Account Protection state', 'jetpack-protect' ),
+				'description'         => __( 'Enable or disable the Account Protection module. Idempotent — setting the state to the current value returns changed=false without making a write. Returns { enabled, changed }. Preconditions: Account Protection must be supported in the current environment; call jetpack-protect/get-account-protection-status first to verify (supported=true). Fails with jetpack_protect_account_protection_unsupported on unsupported environments, jetpack_protect_account_protection_toggle_failed when the underlying module activation/deactivation returns false.', 'jetpack-protect' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'enabled' ),
+					'properties'           => array(
+						'enabled' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Desired Account Protection state. true activates the module; false deactivates it.', 'jetpack-protect' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'enabled' => array( 'type' => 'boolean' ),
+						'changed' => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'set_account_protection' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_protect' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check: can the current user read Protect data?
+	 *
+	 * Mirrors the REST controller's `current_user_can( 'manage_options' )` gate
+	 * on every Protect read route. We do not introduce a narrower Jetpack-Protect
+	 * cap here — the REST surface itself does not define one.
+	 */
+	public static function can_view_protect(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Permission check: can the current user manage Protect (toggle Account Protection)?
+	 *
+	 * Same `manage_options` gate as the underlying toggle route.
+	 */
+	public static function can_manage_protect(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	// -------------------- Execute callbacks --------------------
+
+	/**
+	 * Execute: zero-arg overview read.
+	 *
+	 * Wraps `Protect_Status_REST_Controller::api_get_status()` and
+	 * `Protect_Status\Status::get_status()` with a high-signal projection of
+	 * the underlying Status_Model: counts (total/fixable/critical), the last
+	 * scan summary, and a scan_in_progress boolean.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array|\WP_Error
+	 */
+	public static function get_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		$status = static::fetch_status();
+
+		if ( ! is_object( $status ) ) {
+			return new \WP_Error(
+				'jetpack_protect_status_data_unavailable',
+				__( 'Could not load Jetpack Protect status. Retry shortly; this is typically transient.', 'jetpack-protect' )
+			);
+		}
+
+		$threats          = is_array( $status->threats ?? null ) ? $status->threats : array();
+		$fixable_threats  = is_array( $status->fixable_threat_ids ?? null ) ? $status->fixable_threat_ids : array();
+		$status_string    = is_string( $status->status ?? null ) ? $status->status : null;
+		$scan_in_progress = in_array( $status_string, array( 'in_progress', 'scanning', 'provisioning', 'scheduled' ), true );
+
+		$critical_count = 0;
+		foreach ( $threats as $threat ) {
+			if ( static::severity_bucket( $threat->severity ?? null ) === 'critical' ) {
+				++$critical_count;
+			}
+		}
+
+		return array(
+			'has_plan'         => static::has_required_plan(),
+			'last_scan'        => array(
+				'timestamp'     => is_string( $status->last_checked ?? null ) && '' !== $status->last_checked ? $status->last_checked : null,
+				'status'        => $status_string,
+				'threats_found' => count( $threats ),
+			),
+			'threat_counts'    => array(
+				'total'    => count( $threats ),
+				'fixable'  => count( $fixable_threats ),
+				'critical' => $critical_count,
+			),
+			'scan_in_progress' => $scan_in_progress,
+		);
+	}
+
+	/**
+	 * Execute: paginated, filterable read of currently open threats.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_threats( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$severity = isset( $input['severity'] ) ? (string) $input['severity'] : null;
+		$type     = isset( $input['type'] ) ? (string) $input['type'] : null;
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : 20;
+		$per_page = max( 1, min( self::LIST_THREATS_MAX_PER_PAGE, $per_page ) );
+
+		$status = static::fetch_status();
+		if ( ! is_object( $status ) ) {
+			return new \WP_Error(
+				'jetpack_protect_status_data_unavailable',
+				__( 'Could not load Jetpack Protect threats. Retry shortly; this is typically transient.', 'jetpack-protect' )
+			);
+		}
+
+		$threats = is_array( $status->threats ?? null ) ? $status->threats : array();
+
+		if ( null !== $severity ) {
+			$threats = array_values(
+				array_filter(
+					$threats,
+					static function ( $threat ) use ( $severity ) {
+						return self::severity_bucket( $threat->severity ?? null ) === $severity;
+					}
+				)
+			);
+		}
+
+		if ( null !== $type ) {
+			$threats = array_values(
+				array_filter(
+					$threats,
+					static function ( $threat ) use ( $type ) {
+						return self::threat_type( $threat ) === $type;
+					}
+				)
+			);
+		}
+
+		$offset = ( $page - 1 ) * $per_page;
+		$slice  = array_slice( $threats, $offset, $per_page );
+
+		return array_map( array( __CLASS__, 'project_threat' ), $slice );
+	}
+
+	/**
+	 * Execute: single-threat read by id. Consolidated-read pattern — returns
+	 * an empty array (not a WP_Error) when no threat with that id exists.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function get_threat( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['id'] ) || ! is_string( $input['id'] ) || '' === $input['id'] ) {
+			return new \WP_Error(
+				'jetpack_protect_missing_id',
+				__( 'A threat id is required.', 'jetpack-protect' )
+			);
+		}
+
+		$id = $input['id'];
+
+		$status = static::fetch_status();
+		if ( ! is_object( $status ) ) {
+			return new \WP_Error(
+				'jetpack_protect_status_data_unavailable',
+				__( 'Could not load Jetpack Protect threats. Retry shortly; this is typically transient.', 'jetpack-protect' )
+			);
+		}
+
+		$threats = is_array( $status->threats ?? null ) ? $status->threats : array();
+		foreach ( $threats as $threat ) {
+			$threat_id = isset( $threat->id ) ? (string) $threat->id : null;
+			if ( null === $threat_id || $threat_id !== $id ) {
+				continue;
+			}
+
+			$projected                       = self::project_threat( $threat );
+			$projected['recommended_action'] = self::recommended_action( $threat );
+			return array( $projected );
+		}
+
+		// Unknown id → empty array (consolidated-read contract).
+		return array();
+	}
+
+	/**
+	 * Execute: zero-arg Account Protection state read.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array
+	 */
+	public static function get_account_protection_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		$settings = static::fetch_account_protection_settings();
+
+		return array(
+			'enabled'           => (bool) ( $settings['isEnabled'] ?? false ),
+			'supported'         => (bool) ( $settings['isSupported'] ?? false ),
+			'last_event'        => null,
+			'attempt_count_24h' => 0,
+			'blocked_count_24h' => 0,
+		);
+	}
+
+	/**
+	 * Execute: declarative Account Protection state-setter. Idempotent —
+	 * compares desired vs current and returns changed=false when they match.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function set_account_protection( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! array_key_exists( 'enabled', $input ) ) {
+			return new \WP_Error(
+				'jetpack_protect_missing_enabled',
+				__( 'A desired enabled state (boolean) is required.', 'jetpack-protect' )
+			);
+		}
+		if ( ! is_bool( $input['enabled'] ) ) {
+			return new \WP_Error(
+				'jetpack_protect_invalid_enabled',
+				__( 'The enabled parameter must be a boolean. Strings like "true" / "false" are not accepted.', 'jetpack-protect' )
+			);
+		}
+
+		$account_protection = static::account_protection();
+
+		if ( ! $account_protection->is_supported_environment() ) {
+			return new \WP_Error(
+				'jetpack_protect_account_protection_unsupported',
+				__( 'Account Protection is not supported in the current environment.', 'jetpack-protect' )
+			);
+		}
+
+		$desired = $input['enabled'];
+		$current = (bool) $account_protection->is_enabled();
+
+		if ( $desired === $current ) {
+			return array(
+				'enabled' => $current,
+				'changed' => false,
+			);
+		}
+
+		$applied = $desired ? $account_protection->enable() : $account_protection->disable();
+		if ( ! $applied ) {
+			return new \WP_Error(
+				'jetpack_protect_account_protection_toggle_failed',
+				__( 'Failed to toggle Account Protection. Retry shortly; this is typically transient.', 'jetpack-protect' )
+			);
+		}
+
+		return array(
+			'enabled' => $desired,
+			'changed' => true,
+		);
+	}
+
+	// -------------------- Internal seams --------------------
+
+	/**
+	 * Bucket the raw 1-5 severity score into the agent-facing label.
+	 *
+	 * Mirrors the UI's ThreatSeverityBadge thresholds (>=5 critical, >=3 high,
+	 * <3 low), with an explicit "medium" bucket for severity 2 so the four-bucket
+	 * input filter exposed in the schema is invertible.
+	 *
+	 * @param mixed $severity Raw severity (int|null).
+	 * @return string|null One of 'critical' | 'high' | 'medium' | 'low', or null when no severity is recorded.
+	 */
+	protected static function severity_bucket( $severity ): ?string {
+		if ( null === $severity || ! is_numeric( $severity ) ) {
+			return null;
+		}
+		$value = (int) $severity;
+		if ( $value >= 5 ) {
+			return 'critical';
+		}
+		if ( $value >= 3 ) {
+			return 'high';
+		}
+		if ( $value >= 2 ) {
+			return 'medium';
+		}
+		return 'low';
+	}
+
+	/**
+	 * Derive the threat type bucket from a Threat_Model-shaped object.
+	 *
+	 * The remote payload may already include `extension->type` (one of
+	 * 'plugin'|'theme'|'core'), or the threat may carry only `filename`
+	 * (file scan) — we normalize those to the four-value enum the input
+	 * filter accepts.
+	 *
+	 * @param object|null $threat Threat-like object.
+	 * @return string|null
+	 */
+	protected static function threat_type( $threat ): ?string {
+		if ( ! is_object( $threat ) ) {
+			return null;
+		}
+		if ( isset( $threat->extension->type ) && is_string( $threat->extension->type ) ) {
+			$type = $threat->extension->type;
+			if ( in_array( $type, array( 'plugin', 'theme', 'core' ), true ) ) {
+				return $type;
+			}
+		}
+		if ( ! empty( $threat->filename ) ) {
+			return 'file';
+		}
+		return null;
+	}
+
+	/**
+	 * Project a Threat_Model-shaped object into the documented ability shape.
+	 *
+	 * @param object $threat Threat-like object.
+	 * @return array
+	 */
+	protected static function project_threat( $threat ): array {
+		$type = self::threat_type( $threat );
+
+		// `fixable` on the Threat_Model is either falsy (no auto-fix), or an
+		// object describing the auto-fix; coerce to a plain boolean.
+		$fixable = isset( $threat->fixable ) ? (bool) $threat->fixable : false;
+
+		// `status` on the Threat_Model uses the legacy "ignored" string when
+		// a threat has been hidden by the operator.
+		$ignored = isset( $threat->status ) && 'ignored' === $threat->status;
+
+		return array(
+			'id'             => isset( $threat->id ) ? (string) $threat->id : null,
+			'signature'      => isset( $threat->signature ) ? (string) $threat->signature : null,
+			'title'          => isset( $threat->title ) ? (string) $threat->title : null,
+			'description'    => isset( $threat->description ) ? (string) $threat->description : null,
+			'severity'       => self::severity_bucket( $threat->severity ?? null ),
+			'type'           => $type,
+			'fixable'        => $fixable,
+			'ignored'        => $ignored,
+			'first_detected' => isset( $threat->first_detected ) ? (string) $threat->first_detected : null,
+			'source'         => isset( $threat->source ) ? (string) $threat->source : null,
+		);
+	}
+
+	/**
+	 * Compute a high-signal "what should the operator do next" hint for a
+	 * single threat. Kept inside the ability rather than projected onto the
+	 * list to avoid bloating list responses.
+	 *
+	 * @param object $threat Threat-like object.
+	 * @return string
+	 */
+	protected static function recommended_action( $threat ): string {
+		$fixable = isset( $threat->fixable ) ? (bool) $threat->fixable : false;
+		if ( $fixable ) {
+			return 'fix'; // Operator can ask Protect to auto-fix.
+		}
+		if ( isset( $threat->status ) && 'ignored' === $threat->status ) {
+			return 'unignore_or_keep_ignored';
+		}
+		return 'review_and_ignore_or_resolve_manually';
+	}
+
+	/**
+	 * Fetch the current Protect status. Extracted as a protected seam so
+	 * tests can substitute a fixture without touching the remote service.
+	 *
+	 * @return object|null Status_Model-like object on success, null on failure.
+	 */
+	protected static function fetch_status() {
+		return Status::get_status();
+	}
+
+	/**
+	 * Fetch the Account Protection settings. Extracted as a protected seam.
+	 *
+	 * @return array Settings array { isEnabled, isSupported, ... }.
+	 */
+	protected static function fetch_account_protection_settings(): array {
+		return ( new Account_Protection_Settings() )->get();
+	}
+
+	/**
+	 * Get the Account Protection instance. Extracted as a protected seam so
+	 * tests can inject a mock without touching the singleton.
+	 *
+	 * @return Account_Protection
+	 */
+	protected static function account_protection(): Account_Protection {
+		return Account_Protection::instance();
+	}
+
+	/**
+	 * Whether the site has the required Protect/Scan plan. Extracted as a
+	 * protected seam (the underlying call has its own remote behavior).
+	 *
+	 * @return bool
+	 */
+	protected static function has_required_plan(): bool {
+		return (bool) \Automattic\Jetpack\Protect_Status\Plan::has_required_plan();
+	}
+}

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -143,6 +143,10 @@ class Jetpack_Protect {
 
 		// Sets up JITMS.
 		JITM::configure();
+
+		// Register Jetpack Protect abilities with the WP Abilities API.
+		// Registrar::init() handles the jetpack_wp_abilities_enabled gate.
+		\Automattic\Jetpack\Protect\Abilities\Protect_Abilities::init();
 	}
 
 	/**

--- a/projects/plugins/protect/tests/php/abilities/Protect_Abilities_Test.php
+++ b/projects/plugins/protect/tests/php/abilities/Protect_Abilities_Test.php
@@ -1,0 +1,708 @@
+<?php
+/**
+ * Tests for the Protect_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-protect-plugin
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Account_Protection\Account_Protection;
+use Automattic\Jetpack\Protect\Abilities\Protect_Abilities;
+use Automattic\Jetpack\Protect_Models\Status_Model;
+use Automattic\Jetpack\Protect_Models\Threat_Model;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '/class-protect-abilities-test-stub.php';
+
+/**
+ * @covers \Automattic\Jetpack\Protect\Abilities\Protect_Abilities
+ */
+#[CoversClass( Protect_Abilities::class )]
+class Protect_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Administrator user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'protect_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'protect_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		Protect_Abilities_Test_Stub::reset();
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Protect_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Protect_Abilities::class, 'register_abilities' ) );
+
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Protect_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Protect_Abilities::get_category_slug() );
+		}
+
+		Protect_Abilities_Test_Stub::reset();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a Status_Model-like object out of a plain array, including
+	 * Threat_Model children. We don't reuse the real Status_Model
+	 * constructor because the tests want to drive the shape directly.
+	 *
+	 * @param array $overrides Status property overrides.
+	 * @return Status_Model
+	 */
+	private function make_status( array $overrides = array() ): Status_Model {
+		$defaults = array(
+			'status'             => 'idle',
+			'last_checked'       => '2024-01-15 12:34:56',
+			'threats'            => array(),
+			'fixable_threat_ids' => array(),
+		);
+		$merged   = array_merge( $defaults, $overrides );
+
+		return new Status_Model( $merged );
+	}
+
+	/**
+	 * Build a Threat_Model-like object.
+	 *
+	 * @param array $overrides Threat property overrides.
+	 * @return Threat_Model
+	 */
+	private function make_threat( array $overrides = array() ): Threat_Model {
+		$defaults = array(
+			'id'             => 'threat-1',
+			'signature'      => 'sig-1',
+			'title'          => 'Vulnerable thing',
+			'description'    => 'A thing that is bad.',
+			'severity'       => 5,
+			'first_detected' => '2024-01-10 00:00:00',
+			'source'         => 'https://example.test/threat/1',
+			'fixable'        => false,
+			'status'         => 'current',
+		);
+		return new Threat_Model( array_merge( $defaults, $overrides ) );
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so registrations
+	 * happen inside the action callstack.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Protect_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Protect_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-protect', Protect_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Protect_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Protect_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-protect/', $slug );
+		}
+	}
+
+	public function test_surface_exposes_documented_abilities() {
+		$abilities = Protect_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-protect/get-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack-protect/list-threats', $abilities );
+		$this->assertArrayHasKey( 'jetpack-protect/get-threat', $abilities );
+		$this->assertArrayHasKey( 'jetpack-protect/get-account-protection-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack-protect/set-account-protection', $abilities );
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		foreach ( Protect_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_read_abilities_are_annotated_readonly_idempotent() {
+		$reads = array(
+			'jetpack-protect/get-status',
+			'jetpack-protect/list-threats',
+			'jetpack-protect/get-threat',
+			'jetpack-protect/get-account-protection-status',
+		);
+		foreach ( $reads as $slug ) {
+			$spec = Protect_Abilities::get_abilities()[ $slug ];
+			$this->assertTrue( $spec['meta']['annotations']['readonly'], "{$slug} must be readonly." );
+			$this->assertFalse( $spec['meta']['annotations']['destructive'], "{$slug} must not be destructive." );
+			$this->assertTrue( $spec['meta']['annotations']['idempotent'], "{$slug} must be idempotent." );
+		}
+	}
+
+	public function test_set_account_protection_is_annotated_non_readonly_idempotent() {
+		$spec = Protect_Abilities::get_abilities()['jetpack-protect/set-account-protection'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_list_threats_per_page_is_capped_at_100() {
+		$spec = Protect_Abilities::get_abilities()['jetpack-protect/list-threats'];
+		$this->assertSame( 100, $spec['input_schema']['properties']['per_page']['maximum'] );
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Protect_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Protect_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Protect_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Protect_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Protect_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Protect_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-protect/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( Protect_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static function ( $a ) {
+				return $a->get_name();
+			},
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Protect_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Protect_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-protect',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	public function test_can_view_protect_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Protect_Abilities::can_view_protect() );
+	}
+
+	public function test_can_view_protect_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Protect_Abilities::can_view_protect() );
+	}
+
+	public function test_can_view_protect_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Protect_Abilities::can_view_protect() );
+	}
+
+	public function test_can_manage_protect_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Protect_Abilities::can_manage_protect() );
+	}
+
+	public function test_can_manage_protect_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Protect_Abilities::can_manage_protect() );
+	}
+
+	public function test_can_manage_protect_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Protect_Abilities::can_manage_protect() );
+	}
+
+	// -------------------- get-status execute --------------------
+
+	public function test_get_status_errors_when_status_unavailable() {
+		Protect_Abilities_Test_Stub::$status = null;
+
+		$result = Protect_Abilities_Test_Stub::get_status();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_status_data_unavailable', $result->get_error_code() );
+	}
+
+	public function test_get_status_returns_full_shape_on_success() {
+		Protect_Abilities_Test_Stub::$has_plan = true;
+		Protect_Abilities_Test_Stub::$status   = $this->make_status(
+			array(
+				'status'             => 'idle',
+				'last_checked'       => '2024-01-15 12:34:56',
+				'threats'            => array(
+					$this->make_threat( array( 'id' => 't1', 'severity' => 5 ) ),
+					$this->make_threat( array( 'id' => 't2', 'severity' => 3 ) ),
+					$this->make_threat( array( 'id' => 't3', 'severity' => 1 ) ),
+				),
+				'fixable_threat_ids' => array( 't1' ),
+			)
+		);
+
+		$result = Protect_Abilities_Test_Stub::get_status();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['has_plan'] );
+		$this->assertFalse( $result['scan_in_progress'] );
+		$this->assertSame( '2024-01-15 12:34:56', $result['last_scan']['timestamp'] );
+		$this->assertSame( 'idle', $result['last_scan']['status'] );
+		$this->assertSame( 3, $result['last_scan']['threats_found'] );
+		$this->assertSame( 3, $result['threat_counts']['total'] );
+		$this->assertSame( 1, $result['threat_counts']['fixable'] );
+		$this->assertSame( 1, $result['threat_counts']['critical'] );
+	}
+
+	public function test_get_status_marks_scan_in_progress_for_scanning_status() {
+		Protect_Abilities_Test_Stub::$status = $this->make_status( array( 'status' => 'scanning' ) );
+		$result                              = Protect_Abilities_Test_Stub::get_status();
+		$this->assertTrue( $result['scan_in_progress'] );
+	}
+
+	// -------------------- list-threats execute --------------------
+
+	public function test_list_threats_errors_when_status_unavailable() {
+		Protect_Abilities_Test_Stub::$status = null;
+		$result                              = Protect_Abilities_Test_Stub::list_threats( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_status_data_unavailable', $result->get_error_code() );
+	}
+
+	public function test_list_threats_returns_projected_entries() {
+		Protect_Abilities_Test_Stub::$status = $this->make_status(
+			array(
+				'threats' => array(
+					$this->make_threat(
+						array(
+							'id'        => 't1',
+							'severity'  => 5,
+							'extension' => (object) array( 'type' => 'plugin', 'name' => 'X', 'slug' => 'x', 'version' => '1.0' ),
+						)
+					),
+				),
+			)
+		);
+
+		$result = Protect_Abilities_Test_Stub::list_threats( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 't1', $result[0]['id'] );
+		$this->assertSame( 'critical', $result[0]['severity'] );
+		$this->assertSame( 'plugin', $result[0]['type'] );
+		$this->assertFalse( $result[0]['fixable'] );
+		$this->assertFalse( $result[0]['ignored'] );
+	}
+
+	public function test_list_threats_filters_by_severity() {
+		Protect_Abilities_Test_Stub::$status = $this->make_status(
+			array(
+				'threats' => array(
+					$this->make_threat( array( 'id' => 'crit',   'severity' => 5 ) ),
+					$this->make_threat( array( 'id' => 'high',   'severity' => 3 ) ),
+					$this->make_threat( array( 'id' => 'medium', 'severity' => 2 ) ),
+					$this->make_threat( array( 'id' => 'low',    'severity' => 1 ) ),
+				),
+			)
+		);
+
+		$result = Protect_Abilities_Test_Stub::list_threats( array( 'severity' => 'high' ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'high', $result[0]['id'] );
+	}
+
+	public function test_list_threats_filters_by_type_file_when_filename_set() {
+		Protect_Abilities_Test_Stub::$status = $this->make_status(
+			array(
+				'threats' => array(
+					$this->make_threat( array( 'id' => 'core-1', 'extension' => (object) array( 'type' => 'core' ) ) ),
+					$this->make_threat( array( 'id' => 'file-1', 'filename' => '/var/www/x.php' ) ),
+				),
+			)
+		);
+
+		$result = Protect_Abilities_Test_Stub::list_threats( array( 'type' => 'file' ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'file-1', $result[0]['id'] );
+	}
+
+	public function test_list_threats_caps_per_page_at_100() {
+		$threats = array();
+		for ( $i = 0; $i < 250; $i++ ) {
+			$threats[] = $this->make_threat( array( 'id' => 'threat-' . $i, 'severity' => 5 ) );
+		}
+		Protect_Abilities_Test_Stub::$status = $this->make_status( array( 'threats' => $threats ) );
+
+		// Request 1000; should clamp to 100.
+		$result = Protect_Abilities_Test_Stub::list_threats( array( 'per_page' => 1000 ) );
+		$this->assertCount( 100, $result );
+	}
+
+	public function test_list_threats_paginates() {
+		$threats = array();
+		for ( $i = 0; $i < 30; $i++ ) {
+			$threats[] = $this->make_threat( array( 'id' => 'threat-' . $i, 'severity' => 5 ) );
+		}
+		Protect_Abilities_Test_Stub::$status = $this->make_status( array( 'threats' => $threats ) );
+
+		$page_1 = Protect_Abilities_Test_Stub::list_threats( array( 'page' => 1, 'per_page' => 10 ) );
+		$page_2 = Protect_Abilities_Test_Stub::list_threats( array( 'page' => 2, 'per_page' => 10 ) );
+
+		$this->assertCount( 10, $page_1 );
+		$this->assertCount( 10, $page_2 );
+		$this->assertNotSame( $page_1[0]['id'], $page_2[0]['id'] );
+	}
+
+	// -------------------- get-threat execute --------------------
+
+	public function test_get_threat_rejects_missing_id() {
+		$result = Protect_Abilities_Test_Stub::get_threat( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_missing_id', $result->get_error_code() );
+	}
+
+	public function test_get_threat_rejects_empty_string_id() {
+		$result = Protect_Abilities_Test_Stub::get_threat( array( 'id' => '' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_missing_id', $result->get_error_code() );
+	}
+
+	public function test_get_threat_returns_empty_array_for_unknown_id() {
+		Protect_Abilities_Test_Stub::$status = $this->make_status(
+			array(
+				'threats' => array( $this->make_threat( array( 'id' => 'known' ) ) ),
+			)
+		);
+
+		$result = Protect_Abilities_Test_Stub::get_threat( array( 'id' => 'does-not-exist' ) );
+
+		$this->assertSame( array(), $result, 'Consolidated-read pattern: unknown id returns []' );
+	}
+
+	public function test_get_threat_returns_one_element_array_for_known_id() {
+		Protect_Abilities_Test_Stub::$status = $this->make_status(
+			array(
+				'threats' => array(
+					$this->make_threat( array( 'id' => 'known', 'severity' => 5, 'fixable' => true ) ),
+				),
+			)
+		);
+
+		$result = Protect_Abilities_Test_Stub::get_threat( array( 'id' => 'known' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'known', $result[0]['id'] );
+		$this->assertArrayHasKey( 'recommended_action', $result[0] );
+		$this->assertSame( 'fix', $result[0]['recommended_action'] );
+	}
+
+	// -------------------- get-account-protection-status execute --------------------
+
+	public function test_get_account_protection_status_returns_shape_from_settings() {
+		Protect_Abilities_Test_Stub::$account_protection_settings = array(
+			'isEnabled'   => true,
+			'isSupported' => true,
+		);
+
+		$result = Protect_Abilities_Test_Stub::get_account_protection_status();
+
+		$this->assertSame(
+			array(
+				'enabled'           => true,
+				'supported'         => true,
+				'last_event'        => null,
+				'attempt_count_24h' => 0,
+				'blocked_count_24h' => 0,
+			),
+			$result
+		);
+	}
+
+	// -------------------- set-account-protection execute --------------------
+
+	public function test_set_account_protection_rejects_missing_enabled() {
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_missing_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_account_protection_rejects_non_boolean_enabled_string() {
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => 'true' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_invalid_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_account_protection_rejects_non_boolean_enabled_integer() {
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => 1 ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_invalid_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_account_protection_errors_when_environment_unsupported() {
+		// Build an Account_Protection backed by a Modules mock whose
+		// is_supported_environment() returns false. The real implementation
+		// of is_supported_environment lives on Account_Protection itself and
+		// inspects constants + Host, so we override via a subclass instead.
+		Protect_Abilities_Test_Stub::$account_protection_fake = new class() extends Account_Protection {
+			public function __construct() {} // skip parent constructor
+			public function is_supported_environment(): bool {
+				return false;
+			}
+			public function is_enabled(): bool {
+				return false;
+			}
+		};
+
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => true ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_account_protection_unsupported', $result->get_error_code() );
+	}
+
+	public function test_set_account_protection_returns_changed_false_when_already_matches() {
+		Protect_Abilities_Test_Stub::$account_protection_fake = new class() extends Account_Protection {
+			public bool $enable_called  = false;
+			public bool $disable_called = false;
+			public function __construct() {}
+			public function is_supported_environment(): bool {
+				return true;
+			}
+			public function is_enabled(): bool {
+				return true;
+			}
+			public function enable(): bool {
+				$this->enable_called = true;
+				return true;
+			}
+			public function disable(): bool {
+				$this->disable_called = true;
+				return true;
+			}
+		};
+
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => true ) );
+
+		$this->assertSame(
+			array(
+				'enabled' => true,
+				'changed' => false,
+			),
+			$result
+		);
+		$this->assertFalse( Protect_Abilities_Test_Stub::$account_protection_fake->enable_called, 'Idempotent no-op: enable() should not be called.' );
+		$this->assertFalse( Protect_Abilities_Test_Stub::$account_protection_fake->disable_called, 'Idempotent no-op: disable() should not be called.' );
+	}
+
+	public function test_set_account_protection_returns_changed_true_when_enabling() {
+		Protect_Abilities_Test_Stub::$account_protection_fake = new class() extends Account_Protection {
+			public bool $enable_called  = false;
+			public bool $disable_called = false;
+			public function __construct() {}
+			public function is_supported_environment(): bool {
+				return true;
+			}
+			public function is_enabled(): bool {
+				return false;
+			}
+			public function enable(): bool {
+				$this->enable_called = true;
+				return true;
+			}
+			public function disable(): bool {
+				$this->disable_called = true;
+				return true;
+			}
+		};
+
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => true ) );
+
+		$this->assertSame(
+			array(
+				'enabled' => true,
+				'changed' => true,
+			),
+			$result
+		);
+		$this->assertTrue( Protect_Abilities_Test_Stub::$account_protection_fake->enable_called, 'enable() must be called when transitioning false -> true.' );
+		$this->assertFalse( Protect_Abilities_Test_Stub::$account_protection_fake->disable_called );
+	}
+
+	public function test_set_account_protection_returns_changed_true_when_disabling() {
+		Protect_Abilities_Test_Stub::$account_protection_fake = new class() extends Account_Protection {
+			public bool $enable_called  = false;
+			public bool $disable_called = false;
+			public function __construct() {}
+			public function is_supported_environment(): bool {
+				return true;
+			}
+			public function is_enabled(): bool {
+				return true;
+			}
+			public function enable(): bool {
+				$this->enable_called = true;
+				return true;
+			}
+			public function disable(): bool {
+				$this->disable_called = true;
+				return true;
+			}
+		};
+
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => false ) );
+
+		$this->assertSame(
+			array(
+				'enabled' => false,
+				'changed' => true,
+			),
+			$result
+		);
+		$this->assertTrue( Protect_Abilities_Test_Stub::$account_protection_fake->disable_called );
+	}
+
+	public function test_set_account_protection_errors_when_toggle_fails() {
+		Protect_Abilities_Test_Stub::$account_protection_fake = new class() extends Account_Protection {
+			public function __construct() {}
+			public function is_supported_environment(): bool {
+				return true;
+			}
+			public function is_enabled(): bool {
+				return false;
+			}
+			public function enable(): bool {
+				return false; // Simulate underlying failure.
+			}
+			public function disable(): bool {
+				return false;
+			}
+		};
+
+		$result = Protect_Abilities_Test_Stub::set_account_protection( array( 'enabled' => true ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_protect_account_protection_toggle_failed', $result->get_error_code() );
+	}
+}

--- a/projects/plugins/protect/tests/php/abilities/class-protect-abilities-test-stub.php
+++ b/projects/plugins/protect/tests/php/abilities/class-protect-abilities-test-stub.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Test-only subclass of Protect_Abilities that overrides the protected
+ * seams so happy-path and idempotency tests can exercise the full
+ * callback logic without hitting WordPress.com or a Jetpack token fixture.
+ *
+ * @package automattic/jetpack-protect-plugin
+ */
+
+use Automattic\Jetpack\Protect\Abilities\Protect_Abilities;
+
+/**
+ * Test-only subclass that overrides Protect_Abilities's protected seams:
+ *
+ * - fetch_status() returns the seeded Status_Model-like object (or null).
+ * - has_required_plan() returns the seeded boolean.
+ * - fetch_account_protection_settings() returns the seeded array.
+ * - account_protection() returns the seeded fake.
+ */
+class Protect_Abilities_Test_Stub extends Protect_Abilities {
+
+	/**
+	 * Seeded status payload returned by fetch_status().
+	 *
+	 * @var object|null
+	 */
+	public static $status = null;
+
+	/**
+	 * Seeded plan flag returned by has_required_plan().
+	 *
+	 * @var bool
+	 */
+	public static $has_plan = true;
+
+	/**
+	 * Seeded account-protection settings array.
+	 *
+	 * @var array
+	 */
+	public static $account_protection_settings = array(
+		'isEnabled'   => false,
+		'isSupported' => true,
+	);
+
+	/**
+	 * Seeded fake Account_Protection-like object.
+	 *
+	 * @var object|null
+	 */
+	public static $account_protection_fake = null;
+
+	/**
+	 * Reset all stubs to a clean default.
+	 */
+	public static function reset(): void {
+		self::$status                      = null;
+		self::$has_plan                    = true;
+		self::$account_protection_settings = array(
+			'isEnabled'   => false,
+			'isSupported' => true,
+		);
+		self::$account_protection_fake     = null;
+	}
+
+	/**
+	 * Return the seeded Status_Model-like object.
+	 */
+	protected static function fetch_status() {
+		return self::$status;
+	}
+
+	/**
+	 * Return the seeded plan flag.
+	 */
+	protected static function has_required_plan(): bool {
+		return self::$has_plan;
+	}
+
+	/**
+	 * Return the seeded Account Protection settings.
+	 */
+	protected static function fetch_account_protection_settings(): array {
+		return self::$account_protection_settings;
+	}
+
+	/**
+	 * Return the seeded Account Protection fake.
+	 *
+	 * Tests pass a real Account_Protection instance constructed with a
+	 * mocked Modules dependency, so we satisfy the parent return type
+	 * without duck-typing.
+	 */
+	protected static function account_protection(): \Automattic\Jetpack\Account_Protection\Account_Protection {
+		return self::$account_protection_fake;
+	}
+}

--- a/projects/plugins/protect/tests/php/bootstrap.php
+++ b/projects/plugins/protect/tests/php/bootstrap.php
@@ -9,3 +9,6 @@
  * Include the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Initialize the shared WordPress test environment (WorDBless-backed).
+\Automattic\Jetpack\Test_Environment::init( 'jetpack-protect' );


### PR DESCRIPTION
## Summary

Registers the first slice of Jetpack Protect abilities with the WordPress Abilities API, following the plan in the Abilities Everywhere project (§2.3 plugin-core abilities surface). The class extends the shared `Registrar` base from `automattic/jetpack-wp-abilities`, so the `jetpack_wp_abilities_enabled` gate, late-load fallback, and per-ability allow-list filter all come for free.

This v1 surface is **read-only plus one declarative state-setter**. Destructive writes (`fix-threat`, `ignore-threat`, `request-scan`) are deliberately deferred to a follow-up — they need careful per-id capability scoping that the read paths don't.

### Abilities registered

| Slug | Shape |
|---|---|
| `jetpack-protect/get-status` | `{ has_plan, last_scan: { timestamp, status, threats_found }, threat_counts: { total, fixable, critical }, scan_in_progress }` |
| `jetpack-protect/list-threats` | Paginated `[{ id, signature, title, description, severity, type, fixable, ignored, first_detected, source }]`, with `severity` (`critical`/`high`/`medium`/`low`) and `type` (`core`/`plugin`/`theme`/`file`) filters; `per_page` capped at 100 |
| `jetpack-protect/get-threat` | Single threat by `id` (consolidated-read pattern: unknown id → `[]`, not `WP_Error`); adds `recommended_action` |
| `jetpack-protect/get-account-protection-status` | `{ enabled, supported, last_event, attempt_count_24h, blocked_count_24h }` (event/count fields are placeholder-shaped; tracked for the follow-up) |
| `jetpack-protect/set-account-protection` | `{ enabled, changed }` — idempotent toggle of the Account Protection module |

### Capability matching

All five abilities gate on `current_user_can( 'manage_options' )`, matching the existing capability on every route in `projects/plugins/protect/src/class-rest-controller.php` and the `/status` route in `projects/packages/protect-status/src/class-rest-controller.php`. No new caps invented.

### Wiring

Case C (plugin-core ability — the REST surface lives in the plugin itself, not in a module). `Protect_Abilities::init()` is called from `Jetpack_Protect::init()` after the legacy `REST_Controller::init()`. The Registrar handles the `jetpack_wp_abilities_enabled` gate internally — no extra `apply_filters` at the call site.

### Test coverage

`projects/plugins/protect/tests/php/abilities/Protect_Abilities_Test.php` (41 tests, 125 assertions):

- Registrar wiring: gate-false short-circuit, gate-true hooks both lifecycle actions, per-ability allow-list filter, category auto-injection.
- Abstract getters: slug/category/abilities map shape, surface enumeration, annotation correctness, `per_page` cap == 100.
- Permission callbacks: admin allowed, subscriber denied, anonymous denied (for both view and manage gates).
- Execute happy paths for all 5 abilities — mocked via a `Protect_Abilities_Test_Stub` that overrides the protected seams (`fetch_status`, `fetch_account_protection_settings`, `account_protection`, `has_required_plan`).
- `get-threat` with unknown id returns `[]` (not `WP_Error`).
- `set-account-protection` idempotency: desired==current → `changed=false`, no call to `enable()`/`disable()`.
- Schema edge cases: missing required input rejected; `'0'`-style string id accepted; non-boolean `enabled` rejected with distinct error code.

## Test plan

- [ ] `cd projects/plugins/protect && composer phpunit -- --filter Protect_Abilities_Test` passes (currently 41/41).
- [ ] Manually flip `jetpack_wp_abilities_enabled` true on a Protect-connected site and confirm the 5 slugs appear in `wp_get_abilities()` / `/wp-json/wp-abilities/v1/abilities`.
- [ ] Call `jetpack-protect/get-status` with admin auth and confirm the 4-key shape.
- [ ] Call `jetpack-protect/list-threats` with `{ severity: 'critical' }` and confirm filter applies.
- [ ] Call `jetpack-protect/set-account-protection` twice with the same `enabled` value — second call returns `changed=false`.