### PR TITLE
Scheduled Updates abilities: register schedule CRUD + run-now via Registrar

### DIFF
--- a/projects/packages/scheduled-updates/actions.php
+++ b/projects/packages/scheduled-updates/actions.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Action Hooks for the Jetpack Scheduled Updates package.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+// If WordPress's plugin API is available already, use it. If not, drop the
+// callback into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+//
+// Why the guarded pattern: composer's autoload.files runs BEFORE WP loads
+// `add_action`, so an unguarded `add_action()` call would fatal at autoload
+// time on environments where the package is loaded early (e.g. inside MU
+// plugins). See `projects/packages/publicize/actions.php` for the canonical
+// guard.
+if ( function_exists( 'add_action' ) ) {
+	$add_action = 'add_action';
+} else {
+	$add_action = function ( $name, $cb, $priority = 10, $accepted_args = 1 ) {
+		global $wp_filter;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_filter[ $name ][ $priority ][] = array(
+			'accepted_args' => $accepted_args,
+			'function'      => $cb,
+		);
+	};
+}
+
+// Register Scheduled Updates abilities with the WordPress Abilities API once
+// every consumer plugin (jetpack, jetpack-mu-wpcom, etc.) has had a chance to
+// load. The Registrar gates registration on the `jetpack_wp_abilities_enabled`
+// filter (default false), so this is a no-op until a site explicitly opts in
+// to abilities — we additionally pre-check the filter here so the class file
+// stays lazy-loaded when the gate is closed.
+$add_action(
+	'plugins_loaded',
+	static function () {
+		if ( ! apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
+			return;
+		}
+		if ( ! class_exists( \Automattic\Jetpack\Scheduled_Updates\Abilities\Scheduled_Updates_Abilities::class ) ) {
+			return;
+		}
+		\Automattic\Jetpack\Scheduled_Updates\Abilities\Scheduled_Updates_Abilities::init();
+	},
+	20
+);

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-abilities
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register Scheduled Updates schedule CRUD + run-now via the Registrar (list-schedules, create-schedule, update-schedule, delete-schedule, run-schedule-now).

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -9,7 +9,8 @@
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
@@ -22,6 +23,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/scheduled-updates/src/abilities/class-scheduled-updates-abilities.php
+++ b/projects/packages/scheduled-updates/src/abilities/class-scheduled-updates-abilities.php
@@ -1,0 +1,808 @@
+<?php
+/**
+ * Jetpack Scheduled Updates Abilities Registration.
+ *
+ * Registers Jetpack Scheduled Updates abilities with the WordPress Abilities
+ * API so AI agents can manage plugin update schedules through the standard
+ * `wp-abilities/v1` REST surface.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Scheduled_Updates\Abilities;
+
+use Automattic\Jetpack\Scheduled_Updates;
+use Automattic\Jetpack\Scheduled_Updates_Active;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+
+/**
+ * Registers Jetpack Scheduled Updates abilities with the WordPress Abilities API.
+ *
+ * Exposes the full schedule lifecycle — list, create, update, delete, run-now —
+ * so AI agents can manage plugin update schedules without reverse-engineering
+ * cron internals or chaining the WPCOM `update-schedules` REST endpoints.
+ *
+ * Tokens we deliberately spend the bytes on:
+ *  - Each schedule entry returns the compact `{ id, plugins, schedule,
+ *    last_run_status, last_run_timestamp, active }` shape, not the raw cron
+ *    event object — agents shouldn't need to know about `hook`, `args`, or
+ *    `interval` in seconds.
+ *  - Mutations return `changed` + (for updates) `changed_fields`, so idempotent
+ *    no-op replays don't waste a follow-up read to detect "did it actually
+ *    change anything?".
+ */
+class Scheduled_Updates_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-scheduled-updates';
+	const ERROR_PREFIX  = 'jetpack_scheduled_updates_';
+
+	/**
+	 * Allowed `schedule.interval` values, mirroring the REST controller's enum.
+	 */
+	const INTERVALS = array( 'daily', 'weekly' );
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Scheduled Updates',
+			'description' => __( 'Abilities for listing, creating, updating, deleting, and running Jetpack plugin update schedules.', 'jetpack-scheduled-updates' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-scheduled-updates/list-schedules'   => self::spec_list_schedules(),
+			'jetpack-scheduled-updates/create-schedule'  => self::spec_create_schedule(),
+			'jetpack-scheduled-updates/update-schedule'  => self::spec_update_schedule(),
+			'jetpack-scheduled-updates/delete-schedule'  => self::spec_delete_schedule(),
+			'jetpack-scheduled-updates/run-schedule-now' => self::spec_run_schedule_now(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-scheduled-updates/list-schedules.
+	 */
+	private static function spec_list_schedules(): array {
+		return array(
+			'label'               => __( 'List Jetpack scheduled-update jobs', 'jetpack-scheduled-updates' ),
+			'description'         => __(
+				'Return all configured plugin update schedules in one call. Each entry has the shape { id, plugins: [string], schedule: { interval, next_run, timestamp }, last_run_status, last_run_timestamp, active }. `id` is the deterministic md5 schedule id derived from the plugin list. `plugins` is the slug list (e.g. "akismet/akismet.php"). `schedule.interval` is one of "daily" or "weekly"; `schedule.timestamp` is the Unix timestamp of the next scheduled run; `schedule.next_run` is the same value formatted as a "YYYY-MM-DD HH:mm:ss" UTC string for human readability. `last_run_status` is one of WordPress\'s scheduled-update log states ("success", "failure", or null when the schedule has never run). `last_run_timestamp` is null when the schedule has never run. `active` is false when the schedule has been explicitly paused. Pass an optional `id` to filter to a single schedule — returns a 0- or 1-element array, never a WP_Error; unknown ids return an empty array.',
+				'jetpack-scheduled-updates'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'id' => array(
+						'type'        => 'string',
+						'description' => __( 'Optional schedule id to filter by. Unknown ids return an empty array.', 'jetpack-scheduled-updates' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'                 => array( 'type' => 'string' ),
+						'plugins'            => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'schedule'           => array( 'type' => 'object' ),
+						'last_run_status'    => array( 'type' => array( 'string', 'null' ) ),
+						'last_run_timestamp' => array( 'type' => array( 'integer', 'null' ) ),
+						'active'             => array( 'type' => 'boolean' ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'list_schedules' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_schedules' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-scheduled-updates/create-schedule.
+	 */
+	private static function spec_create_schedule(): array {
+		return array(
+			'label'               => __( 'Create a Jetpack scheduled-update job', 'jetpack-scheduled-updates' ),
+			'description'         => __(
+				'Schedule one or more plugins to be updated on a recurring cadence. Shape in: { plugins: [string], schedule: { interval: "daily" | "weekly", timestamp: int } }. `plugins` is the list of plugin slugs to update (e.g. "akismet/akismet.php"); each plugin must already be installed on the site. `schedule.timestamp` is the Unix timestamp of the first scheduled run; subsequent runs happen every interval thereafter. Returns { id, schedule } where `id` is the deterministic md5 schedule id (also the value to pass to update-schedule, delete-schedule, and run-schedule-now). Idempotent only at the id level — two creates with the same plugin list collide because they produce the same id. Two schedules at the same exact timestamp are also rejected by the underlying controller.',
+				'jetpack-scheduled-updates'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'plugins', 'schedule' ),
+				'properties'           => array(
+					'plugins'  => array(
+						'type'        => 'array',
+						'description' => __( 'List of plugin slugs to update on this schedule.', 'jetpack-scheduled-updates' ),
+						'items'       => array( 'type' => 'string' ),
+						'minItems'    => 1,
+						'maxItems'    => 10,
+					),
+					'schedule' => self::schedule_input_schema(),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'       => array( 'type' => 'string' ),
+					'schedule' => array( 'type' => 'object' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'create_schedule' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_schedules' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-scheduled-updates/update-schedule.
+	 */
+	private static function spec_update_schedule(): array {
+		return array(
+			'label'               => __( 'Update a Jetpack scheduled-update job', 'jetpack-scheduled-updates' ),
+			'description'         => __(
+				'Update an existing scheduled-update job by id. Shape in: { id, plugins?, schedule? } — at least one of `plugins` or `schedule` must be present. Returns { id, changed, changed_fields } where `id` is the (possibly new) deterministic schedule id (the id changes when `plugins` changes because the id is the md5 of the plugin list), `changed` is true when the underlying schedule was rewritten, and `changed_fields` is a subset of [ "plugins", "schedule" ] listing which inputs differed from the prior schedule. Idempotent — calling with the same values returns changed=false and an empty `changed_fields`. Fails with jetpack_scheduled_updates_not_found when no schedule matches `id`.',
+				'jetpack-scheduled-updates'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id'       => array(
+						'type'        => 'string',
+						'description' => __( 'Schedule id to update.', 'jetpack-scheduled-updates' ),
+					),
+					'plugins'  => array(
+						'type'        => 'array',
+						'description' => __( 'New plugin slug list for this schedule.', 'jetpack-scheduled-updates' ),
+						'items'       => array( 'type' => 'string' ),
+						'minItems'    => 1,
+						'maxItems'    => 10,
+					),
+					'schedule' => self::schedule_input_schema(),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'             => array( 'type' => 'string' ),
+					'changed'        => array( 'type' => 'boolean' ),
+					'changed_fields' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'update_schedule' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_schedules' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-scheduled-updates/delete-schedule.
+	 */
+	private static function spec_delete_schedule(): array {
+		return array(
+			'label'               => __( 'Delete a Jetpack scheduled-update job', 'jetpack-scheduled-updates' ),
+			'description'         => __(
+				'Delete a scheduled-update job by id. Shape in: { id }. Returns { id, deleted, changed } where `deleted` is true if no schedule with that id exists after the call (including the case where it was already gone before the call), and `changed` is true only when this call actually removed a schedule. Idempotent — deleting an already-deleted schedule returns deleted=true, changed=false.',
+				'jetpack-scheduled-updates'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array(
+						'type'        => 'string',
+						'description' => __( 'Schedule id to delete.', 'jetpack-scheduled-updates' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'      => array( 'type' => 'string' ),
+					'deleted' => array( 'type' => 'boolean' ),
+					'changed' => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'delete_schedule' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_schedules' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-scheduled-updates/run-schedule-now.
+	 */
+	private static function spec_run_schedule_now(): array {
+		return array(
+			'label'               => __( 'Run a Jetpack scheduled-update job immediately', 'jetpack-scheduled-updates' ),
+			'description'         => __(
+				'Force a scheduled-update job to run immediately, in addition to its normal cadence. Shape in: { id }. Returns { id, dispatched, job_id } where `dispatched` is true when the run was queued, and `job_id` is the cron one-off identifier (Unix timestamp of the queued run). NOT idempotent — re-running queues another run. Use sparingly: each call hits the WordPress.com Atomic update pipeline. Fails with jetpack_scheduled_updates_not_found when no schedule matches `id`, or jetpack_scheduled_updates_dispatch_failed when WP-Cron refuses the one-off (e.g. event collision).',
+				'jetpack-scheduled-updates'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array(
+						'type'        => 'string',
+						'description' => __( 'Schedule id to run.', 'jetpack-scheduled-updates' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'         => array( 'type' => 'string' ),
+					'dispatched' => array( 'type' => 'boolean' ),
+					'job_id'     => array( 'type' => array( 'integer', 'null' ) ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'run_schedule_now' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_schedules' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Shared input schema for the `schedule` object on create + update.
+	 *
+	 * Kept as a helper so the create/update specs agree on field shape and so
+	 * any tightening (e.g. minimum timestamp) lands in one place.
+	 */
+	private static function schedule_input_schema(): array {
+		return array(
+			'type'        => 'object',
+			'description' => __( 'Recurrence definition for the schedule.', 'jetpack-scheduled-updates' ),
+			'required'    => array( 'interval', 'timestamp' ),
+			'properties'  => array(
+				'interval'  => array(
+					'type'        => 'string',
+					'description' => __( 'How often the schedule recurs.', 'jetpack-scheduled-updates' ),
+					'enum'        => self::INTERVALS,
+				),
+				'timestamp' => array(
+					'type'        => 'integer',
+					'description' => __( 'Unix timestamp (UTC) of the first scheduled run.', 'jetpack-scheduled-updates' ),
+					'minimum'     => 1,
+				),
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Permission check for all scheduled-update abilities.
+	 *
+	 * Mirrors the underlying `WPCOM_REST_API_V2_Endpoint_Update_Schedules`
+	 * controller, which gates every method on `update_plugins`. We do not
+	 * split read vs. write because both surfaces touch the plugin-update
+	 * cron list, which leaks the site's plugin inventory — readers should
+	 * also need to be admin.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_schedules(): bool {
+		return current_user_can( 'update_plugins' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-schedules.
+	 *
+	 * @param array|null $input Optional input matching the ability's input_schema.
+	 * @return array
+	 */
+	public static function list_schedules( $input = null ): array {
+		$input  = is_array( $input ) ? $input : array();
+		$filter = isset( $input['id'] ) && is_string( $input['id'] ) && '' !== $input['id'] ? $input['id'] : null;
+
+		$events = self::get_scheduled_events();
+		$out    = array();
+		foreach ( $events as $schedule_id => $event ) {
+			if ( null !== $filter && $filter !== $schedule_id ) {
+				continue;
+			}
+			$out[] = self::project_event( (string) $schedule_id, $event );
+		}
+		return $out;
+	}
+
+	/**
+	 * Execute: create-schedule.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function create_schedule( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$plugins = self::sanitize_plugins( $input['plugins'] ?? null );
+		if ( is_wp_error( $plugins ) ) {
+			return $plugins;
+		}
+
+		$schedule = self::sanitize_schedule( $input['schedule'] ?? null );
+		if ( is_wp_error( $schedule ) ) {
+			return $schedule;
+		}
+
+		$request = self::make_rest_request(
+			'POST',
+			'/wpcom/v2/update-schedules',
+			array(
+				'plugins'  => $plugins,
+				'schedule' => $schedule,
+			)
+		);
+
+		$response = self::dispatch_request( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		// The endpoint returns the bare id string.
+		$id = is_string( $response ) ? $response : (string) $response;
+
+		return array(
+			'id'       => $id,
+			'schedule' => $schedule,
+		);
+	}
+
+	/**
+	 * Execute: update-schedule.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function update_schedule( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$id = isset( $input['id'] ) && is_string( $input['id'] ) ? $input['id'] : '';
+		if ( '' === $id ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_id',
+				__( 'An `id` is required.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		$events = self::get_scheduled_events();
+		if ( ! isset( $events[ $id ] ) ) {
+			return self::not_found_error( $id );
+		}
+
+		// At least one mutable field must be supplied.
+		$has_plugins  = array_key_exists( 'plugins', $input );
+		$has_schedule = array_key_exists( 'schedule', $input );
+		if ( ! $has_plugins && ! $has_schedule ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'no_changes',
+				__( 'Provide at least one of `plugins` or `schedule` to update.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		$existing      = $events[ $id ];
+		$existing_args = is_array( $existing->args ?? null ) ? array_values( $existing->args ) : array();
+		sort( $existing_args, SORT_NATURAL | SORT_FLAG_CASE );
+
+		$next_plugins = $existing_args;
+		if ( $has_plugins ) {
+			$sanitized = self::sanitize_plugins( $input['plugins'] );
+			if ( is_wp_error( $sanitized ) ) {
+				return $sanitized;
+			}
+			$next_plugins = $sanitized;
+		}
+
+		$existing_schedule = array(
+			'interval'  => (string) ( $existing->schedule ?? '' ),
+			'timestamp' => (int) ( $existing->timestamp ?? 0 ),
+		);
+
+		$next_schedule = $existing_schedule;
+		if ( $has_schedule ) {
+			$sanitized = self::sanitize_schedule( $input['schedule'] );
+			if ( is_wp_error( $sanitized ) ) {
+				return $sanitized;
+			}
+			$next_schedule = $sanitized;
+		}
+
+		// Detect no-op early so we don't churn cron + sync option for free.
+		$existing_sorted = $existing_args;
+		$next_sorted     = $next_plugins;
+		sort( $existing_sorted, SORT_NATURAL | SORT_FLAG_CASE );
+		sort( $next_sorted, SORT_NATURAL | SORT_FLAG_CASE );
+
+		$changed_fields = array();
+		if ( $existing_sorted !== $next_sorted ) {
+			$changed_fields[] = 'plugins';
+		}
+		if ( $existing_schedule !== $next_schedule ) {
+			$changed_fields[] = 'schedule';
+		}
+
+		if ( empty( $changed_fields ) ) {
+			return array(
+				'id'             => $id,
+				'changed'        => false,
+				'changed_fields' => array(),
+			);
+		}
+
+		$request = self::make_rest_request(
+			'PUT',
+			'/wpcom/v2/update-schedules/' . $id,
+			array(
+				'plugins'  => $next_plugins,
+				'schedule' => $next_schedule,
+			)
+		);
+		// The controller reads `schedule_id` off the request, not just the URL.
+		$request->set_param( 'schedule_id', $id );
+
+		$response = self::dispatch_request( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		// `update_item` returns the response from `create_item`, which is the new id.
+		$new_id = is_string( $response ) ? $response : (string) $response;
+
+		return array(
+			'id'             => $new_id,
+			'changed'        => true,
+			'changed_fields' => array_values( $changed_fields ),
+		);
+	}
+
+	/**
+	 * Execute: delete-schedule.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function delete_schedule( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$id = isset( $input['id'] ) && is_string( $input['id'] ) ? $input['id'] : '';
+		if ( '' === $id ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_id',
+				__( 'An `id` is required.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		$events = self::get_scheduled_events();
+		if ( ! isset( $events[ $id ] ) ) {
+			// Idempotent delete: already gone.
+			return array(
+				'id'      => $id,
+				'deleted' => true,
+				'changed' => false,
+			);
+		}
+
+		$request = self::make_rest_request( 'DELETE', '/wpcom/v2/update-schedules/' . $id );
+		$request->set_param( 'schedule_id', $id );
+
+		$response = self::dispatch_request( $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return array(
+			'id'      => $id,
+			'deleted' => true,
+			'changed' => true,
+		);
+	}
+
+	/**
+	 * Execute: run-schedule-now.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function run_schedule_now( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$id = isset( $input['id'] ) && is_string( $input['id'] ) ? $input['id'] : '';
+		if ( '' === $id ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_id',
+				__( 'An `id` is required.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		$events = self::get_scheduled_events();
+		if ( ! isset( $events[ $id ] ) ) {
+			return self::not_found_error( $id );
+		}
+
+		$event = $events[ $id ];
+		$args  = is_array( $event->args ?? null ) ? array_values( $event->args ) : array();
+
+		// Queue a single one-off run a few seconds in the future. The existing
+		// recurring schedule keeps running on its normal cadence — this is a
+		// force-run in addition to, not instead of, the next scheduled run.
+		$run_at = time() + 5;
+		$queued = wp_schedule_single_event( $run_at, Scheduled_Updates::PLUGIN_CRON_HOOK, $args, true );
+
+		if ( is_wp_error( $queued ) || false === $queued ) {
+			$message = is_wp_error( $queued )
+				? $queued->get_error_message()
+				: __( 'WP-Cron refused to queue the one-off run.', 'jetpack-scheduled-updates' );
+			return new WP_Error(
+				self::ERROR_PREFIX . 'dispatch_failed',
+				$message
+			);
+		}
+
+		return array(
+			'id'         => $id,
+			'dispatched' => true,
+			'job_id'     => $run_at,
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Return the current schedule events keyed by schedule id, defensively
+	 * coercing the WP-Cron return to an array.
+	 *
+	 * @return array<string, object>
+	 */
+	private static function get_scheduled_events(): array {
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		return is_array( $events ) ? $events : array();
+	}
+
+	/**
+	 * Project a raw cron event into the compact, agent-friendly shape.
+	 *
+	 * @param string $schedule_id The schedule id.
+	 * @param object $event       The raw cron event object.
+	 * @return array
+	 */
+	private static function project_event( string $schedule_id, $event ): array {
+		$timestamp = isset( $event->timestamp ) ? (int) $event->timestamp : 0;
+		$interval  = isset( $event->schedule ) ? (string) $event->schedule : '';
+		$plugins   = is_array( $event->args ?? null ) ? array_values( $event->args ) : array();
+
+		$status = Scheduled_Updates::get_scheduled_update_status( $schedule_id );
+		$status = is_array( $status ) ? $status : array();
+
+		return array(
+			'id'                 => $schedule_id,
+			'plugins'            => array_map( 'strval', $plugins ),
+			'schedule'           => array(
+				'interval'  => $interval,
+				'timestamp' => $timestamp,
+				'next_run'  => $timestamp > 0 ? gmdate( 'Y-m-d H:i:s', $timestamp ) : null,
+			),
+			'last_run_status'    => isset( $status['last_run_status'] ) && is_string( $status['last_run_status'] )
+				? $status['last_run_status']
+				: null,
+			'last_run_timestamp' => isset( $status['last_run_timestamp'] ) && is_numeric( $status['last_run_timestamp'] )
+				? (int) $status['last_run_timestamp']
+				: null,
+			'active'             => (bool) Scheduled_Updates_Active::get( $schedule_id ),
+		);
+	}
+
+	/**
+	 * Sanitize/validate a plugin slug list.
+	 *
+	 * Returns the sorted list on success, a WP_Error on bad input. We don't
+	 * verify installation here — the REST controller already enforces that
+	 * during dispatch and produces a more accurate error.
+	 *
+	 * @param mixed $raw Raw input value.
+	 * @return array<int, string>|WP_Error
+	 */
+	private static function sanitize_plugins( $raw ) {
+		if ( ! is_array( $raw ) || empty( $raw ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'invalid_plugins',
+				__( '`plugins` must be a non-empty array of plugin slugs.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		$out = array();
+		foreach ( $raw as $slug ) {
+			if ( ! is_string( $slug ) || '' === $slug ) {
+				return new WP_Error(
+					self::ERROR_PREFIX . 'invalid_plugins',
+					__( 'Each plugin slug must be a non-empty string.', 'jetpack-scheduled-updates' )
+				);
+			}
+			$out[] = $slug;
+		}
+
+		// Match the REST controller, which sorts the plugins list before storing.
+		sort( $out, SORT_NATURAL | SORT_FLAG_CASE );
+		return $out;
+	}
+
+	/**
+	 * Sanitize/validate a schedule object.
+	 *
+	 * @param mixed $raw Raw input value.
+	 * @return array{interval: string, timestamp: int}|WP_Error
+	 */
+	private static function sanitize_schedule( $raw ) {
+		if ( ! is_array( $raw ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'invalid_schedule',
+				__( '`schedule` must be an object with `interval` and `timestamp`.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		$interval = isset( $raw['interval'] ) && is_string( $raw['interval'] ) ? $raw['interval'] : '';
+		if ( ! in_array( $interval, self::INTERVALS, true ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'invalid_schedule',
+				sprintf(
+					/* translators: %s: comma-separated list of valid interval values. */
+					__( '`schedule.interval` must be one of: %s.', 'jetpack-scheduled-updates' ),
+					implode( ', ', self::INTERVALS )
+				)
+			);
+		}
+
+		if ( ! isset( $raw['timestamp'] ) || ! is_numeric( $raw['timestamp'] ) || (int) $raw['timestamp'] <= 0 ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'invalid_schedule',
+				__( '`schedule.timestamp` must be a positive Unix timestamp.', 'jetpack-scheduled-updates' )
+			);
+		}
+
+		return array(
+			'interval'  => $interval,
+			'timestamp' => (int) $raw['timestamp'],
+		);
+	}
+
+	/**
+	 * Build a `WP_REST_Request` pre-populated with the given JSON body.
+	 *
+	 * @param string $method HTTP method.
+	 * @param string $route  Route path.
+	 * @param array  $body   Optional body params.
+	 * @return \WP_REST_Request
+	 */
+	private static function make_rest_request( string $method, string $route, array $body = array() ): \WP_REST_Request {
+		$request = new \WP_REST_Request( $method, $route );
+		if ( ! empty( $body ) ) {
+			$request->set_body_params( $body );
+		}
+		return $request;
+	}
+
+	/**
+	 * Dispatch a request through the REST server and normalize the response
+	 * into the abilities layer's `array|WP_Error` convention.
+	 *
+	 * Going through `rest_do_request()` (rather than calling the controller
+	 * methods directly) reuses the full WPCOM update-schedules pipeline —
+	 * permission check, schema validation, plugin-installation validation,
+	 * sync option write — exactly as a public REST caller would. The
+	 * Abilities API does not understand `WP_REST_Response`, so callers
+	 * receive the unwrapped payload (or a WP_Error) directly.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return mixed|WP_Error
+	 */
+	private static function dispatch_request( \WP_REST_Request $request ) {
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Build a `not_found` WP_Error referencing the offending id.
+	 *
+	 * @param string $id Schedule id.
+	 * @return WP_Error
+	 */
+	private static function not_found_error( string $id ): WP_Error {
+		return new WP_Error(
+			self::ERROR_PREFIX . 'not_found',
+			sprintf(
+				/* translators: %s: the schedule id that could not be found. */
+				__( 'No scheduled-update job with id `%s` was found. Call jetpack-scheduled-updates/list-schedules first to discover valid ids.', 'jetpack-scheduled-updates' ),
+				$id
+			)
+		);
+	}
+}

--- a/projects/packages/scheduled-updates/tests/php/abilities/Scheduled_Updates_Abilities_Test.php
+++ b/projects/packages/scheduled-updates/tests/php/abilities/Scheduled_Updates_Abilities_Test.php
@@ -1,0 +1,648 @@
+<?php
+/**
+ * Tests for the Scheduled_Updates_Abilities Registrar subclass.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Scheduled_Updates\Abilities;
+
+use Automattic\Jetpack\Scheduled_Updates;
+use Automattic\Jetpack\Scheduled_Updates_Active;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Unit tests for Scheduled_Updates_Abilities registration and execution.
+ *
+ * Run from projects/packages/scheduled-updates:
+ *
+ *   composer phpunit -- --filter Scheduled_Updates_Abilities_Test
+ *
+ * @covers \Automattic\Jetpack\Scheduled_Updates\Abilities\Scheduled_Updates_Abilities
+ */
+#[CoversClass( Scheduled_Updates_Abilities::class )]
+class Scheduled_Updates_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Administrator user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Editor user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $editor_id;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function set_up() {
+		parent::set_up_wordbless();
+		WorDBless_Users::init()->clear_all_users();
+
+		// Reset cron state and ensure scheduled-updates REST endpoints are wired up.
+		delete_option( 'cron' );
+		update_option( 'cron', array( 'version' => 2 ), true );
+		Scheduled_Updates::init();
+
+		$this->admin_id  = wp_insert_user(
+			array(
+				'user_login' => 'su_abilities_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'su_abilities_editor_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( 0 );
+
+		// Most tests open the gate; the "default disabled" test closes it explicitly.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Reset registrar hooks a prior test may have left behind. We
+		// intentionally avoid touching the Abilities registry here.
+		remove_action( 'wp_abilities_api_categories_init', array( Scheduled_Updates_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Scheduled_Updates_Abilities::class, 'register_abilities' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_action( 'wp_abilities_api_categories_init', array( Scheduled_Updates_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Scheduled_Updates_Abilities::class, 'register_abilities' ) );
+
+		wp_set_current_user( 0 );
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$this->deregister_category_and_abilities();
+		}
+
+		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		delete_option( 'cron' );
+		delete_option( 'jetpack_scheduled_update_statuses' );
+		delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		delete_option( Scheduled_Updates_Active::OPTION_NAME );
+
+		WorDBless_Users::init()->clear_all_users();
+		WorDBless_Options::init()->clear_options();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Remove our category + abilities from the registry so tests don't leak.
+	 */
+	private function deregister_category_and_abilities(): void {
+		if ( function_exists( 'wp_has_ability' ) && function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Scheduled_Updates_Abilities::get_abilities() ) as $slug ) {
+				if ( wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_has_ability_category' ) && function_exists( 'wp_unregister_ability_category' ) ) {
+			if ( wp_has_ability_category( Scheduled_Updates_Abilities::CATEGORY_SLUG ) ) {
+				wp_unregister_ability_category( Scheduled_Updates_Abilities::CATEGORY_SLUG );
+			}
+		}
+	}
+
+	/**
+	 * Build a sanitized `{ interval, timestamp }` schedule.
+	 *
+	 * @param string $when     Strtotime expression.
+	 * @param string $interval Interval ("daily" or "weekly").
+	 * @return array
+	 */
+	private function make_schedule( string $when = 'next Monday 8:00', string $interval = 'weekly' ): array {
+		return array(
+			'timestamp' => (int) strtotime( $when ),
+			'interval'  => $interval,
+		);
+	}
+
+	/**
+	 * Seed a recurring schedule directly via WP-Cron so we don't have to
+	 * round-trip the REST endpoint for every fixture.
+	 *
+	 * @param array  $plugins  Plugin list.
+	 * @param int    $when     Unix timestamp of the next run.
+	 * @param string $interval Interval slug.
+	 * @return string Schedule id.
+	 */
+	private function seed_schedule( array $plugins, int $when, string $interval = 'daily' ): string {
+		sort( $plugins, SORT_NATURAL | SORT_FLAG_CASE );
+		wp_schedule_event( $when, $interval, Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
+		return Scheduled_Updates::generate_schedule_id( $plugins );
+	}
+
+	// --- Abstract getters --------------------------------------------------
+
+	/**
+	 * The category slug must be the namespaced "jetpack-scheduled-updates".
+	 */
+	public function test_category_slug_is_namespaced(): void {
+		$this->assertSame( 'jetpack-scheduled-updates', Scheduled_Updates_Abilities::get_category_slug() );
+	}
+
+	/**
+	 * The category definition exposes a label and description.
+	 */
+	public function test_category_definition_has_label_and_description(): void {
+		$def = Scheduled_Updates_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotSame( '', $def['label'] );
+		$this->assertNotSame( '', $def['description'] );
+	}
+
+	/**
+	 * The abilities map exposes exactly the five lifecycle slugs.
+	 */
+	public function test_abilities_map_lists_the_five_lifecycle_slugs(): void {
+		$abilities = Scheduled_Updates_Abilities::get_abilities();
+		$this->assertSame(
+			array(
+				'jetpack-scheduled-updates/list-schedules',
+				'jetpack-scheduled-updates/create-schedule',
+				'jetpack-scheduled-updates/update-schedule',
+				'jetpack-scheduled-updates/delete-schedule',
+				'jetpack-scheduled-updates/run-schedule-now',
+			),
+			array_keys( $abilities )
+		);
+	}
+
+	/**
+	 * Specs must not set their own `category` — Registrar auto-injects it.
+	 */
+	public function test_no_spec_sets_category_explicitly(): void {
+		foreach ( Scheduled_Updates_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	/**
+	 * Every spec must declare callable execute + permission and the standard
+	 * annotation triplet, in the shape the rest of Jetpack abilities use.
+	 */
+	public function test_every_spec_declares_callbacks_and_annotations(): void {
+		foreach ( Scheduled_Updates_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback not callable" );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback not callable" );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'] );
+			$this->assertArrayHasKey( 'readonly', $spec['meta']['annotations'] );
+			$this->assertArrayHasKey( 'destructive', $spec['meta']['annotations'] );
+			$this->assertArrayHasKey( 'idempotent', $spec['meta']['annotations'] );
+		}
+	}
+
+	/**
+	 * Mutation annotations encode the contract the docs describe:
+	 *  - list is readonly+idempotent
+	 *  - create is destructive + NOT idempotent
+	 *  - update is destructive + idempotent
+	 *  - delete is destructive + idempotent
+	 *  - run-now is destructive + NOT idempotent
+	 */
+	public function test_annotation_matrix_matches_contract(): void {
+		$abilities = Scheduled_Updates_Abilities::get_abilities();
+
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/list-schedules']['meta']['annotations']['readonly'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/list-schedules']['meta']['annotations']['idempotent'] );
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/list-schedules']['meta']['annotations']['destructive'] );
+
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/create-schedule']['meta']['annotations']['readonly'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/create-schedule']['meta']['annotations']['destructive'] );
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/create-schedule']['meta']['annotations']['idempotent'] );
+
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/update-schedule']['meta']['annotations']['readonly'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/update-schedule']['meta']['annotations']['destructive'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/update-schedule']['meta']['annotations']['idempotent'] );
+
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/delete-schedule']['meta']['annotations']['readonly'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/delete-schedule']['meta']['annotations']['destructive'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/delete-schedule']['meta']['annotations']['idempotent'] );
+
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/run-schedule-now']['meta']['annotations']['readonly'] );
+		$this->assertTrue( $abilities['jetpack-scheduled-updates/run-schedule-now']['meta']['annotations']['destructive'] );
+		$this->assertFalse( $abilities['jetpack-scheduled-updates/run-schedule-now']['meta']['annotations']['idempotent'] );
+	}
+
+	// --- Registrar wiring --------------------------------------------------
+
+	/**
+	 * When the `jetpack_wp_abilities_enabled` filter returns false, `init()`
+	 * must register nothing (no category, no abilities, no hooks).
+	 */
+	public function test_init_registers_nothing_when_gate_filter_is_false(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Scheduled_Updates_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Scheduled_Updates_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( Scheduled_Updates_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	/**
+	 * With the gate open, init() must hook both registrar lifecycle actions.
+	 */
+	public function test_init_hooks_both_lifecycle_actions_when_gate_filter_is_true(): void {
+		Scheduled_Updates_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Scheduled_Updates_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_init', array( Scheduled_Updates_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	// --- Permission callback ----------------------------------------------
+
+	/**
+	 * Anonymous callers are denied.
+	 */
+	public function test_can_manage_schedules_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Scheduled_Updates_Abilities::can_manage_schedules() );
+	}
+
+	/**
+	 * Editors lack `update_plugins` and are denied.
+	 */
+	public function test_can_manage_schedules_denies_editor_without_update_plugins(): void {
+		wp_set_current_user( $this->editor_id );
+		$this->assertFalse( Scheduled_Updates_Abilities::can_manage_schedules() );
+	}
+
+	/**
+	 * Administrators (who have `update_plugins`) are allowed.
+	 */
+	public function test_can_manage_schedules_allows_administrator(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Scheduled_Updates_Abilities::can_manage_schedules() );
+	}
+
+	// --- list-schedules ----------------------------------------------------
+
+	/**
+	 * With no schedules, list-schedules returns an empty array (not a WP_Error).
+	 */
+	public function test_list_schedules_returns_empty_array_when_no_schedules(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$out = Scheduled_Updates_Abilities::list_schedules();
+
+		$this->assertIsArray( $out );
+		$this->assertSame( array(), $out );
+	}
+
+	/**
+	 * List-schedules projects raw cron events into the compact ability shape.
+	 */
+	public function test_list_schedules_projects_into_compact_shape(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$when    = (int) strtotime( 'next Wednesday 10:00' );
+		$id      = $this->seed_schedule( $plugins, $when, 'daily' );
+
+		$out = Scheduled_Updates_Abilities::list_schedules();
+
+		$this->assertCount( 1, $out );
+		$entry = $out[0];
+		$this->assertSame( $id, $entry['id'] );
+		$this->assertSame( $plugins, $entry['plugins'] );
+		$this->assertSame( 'daily', $entry['schedule']['interval'] );
+		$this->assertSame( $when, $entry['schedule']['timestamp'] );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $when ), $entry['schedule']['next_run'] );
+		$this->assertNull( $entry['last_run_status'] );
+		$this->assertNull( $entry['last_run_timestamp'] );
+		$this->assertTrue( $entry['active'] );
+	}
+
+	/**
+	 * Passing `id` filters to a single schedule.
+	 */
+	public function test_list_schedules_filters_by_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$first_id  = $this->seed_schedule( array( 'gutenberg/gutenberg.php' ), (int) strtotime( 'next Tuesday 9:00' ), 'daily' );
+		$second_id = $this->seed_schedule( array( 'installed-plugin/installed-plugin.php' ), (int) strtotime( 'next Wednesday 9:00' ), 'weekly' );
+
+		$out = Scheduled_Updates_Abilities::list_schedules( array( 'id' => $second_id ) );
+
+		$this->assertCount( 1, $out );
+		$this->assertSame( $second_id, $out[0]['id'] );
+		$this->assertNotSame( $first_id, $out[0]['id'] );
+	}
+
+	/**
+	 * An unknown `id` returns an empty array, not a WP_Error.
+	 */
+	public function test_list_schedules_unknown_id_returns_empty_array(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_schedule( array( 'gutenberg/gutenberg.php' ), (int) strtotime( 'next Tuesday 9:00' ) );
+
+		$out = Scheduled_Updates_Abilities::list_schedules( array( 'id' => 'not-a-real-id' ) );
+
+		$this->assertSame( array(), $out );
+	}
+
+	/**
+	 * The `active` field reflects Scheduled_Updates_Active::update().
+	 */
+	public function test_list_schedules_reflects_paused_active_flag(): void {
+		wp_set_current_user( $this->admin_id );
+		$id = $this->seed_schedule( array( 'gutenberg/gutenberg.php' ), (int) strtotime( 'next Tuesday 9:00' ) );
+
+		Scheduled_Updates_Active::update( $id, false );
+
+		$out = Scheduled_Updates_Abilities::list_schedules( array( 'id' => $id ) );
+		$this->assertFalse( $out[0]['active'] );
+	}
+
+	// --- create-schedule ---------------------------------------------------
+
+	/**
+	 * Happy path — create produces a new schedule with the documented shape.
+	 */
+	public function test_create_schedule_returns_id_and_schedule(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$plugins  = array( 'gutenberg/gutenberg.php' );
+		$schedule = $this->make_schedule( 'next Tuesday 9:00', 'daily' );
+
+		$out = Scheduled_Updates_Abilities::create_schedule(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => $schedule,
+			)
+		);
+
+		$this->assertIsArray( $out );
+		$this->assertArrayHasKey( 'id', $out );
+		$this->assertArrayHasKey( 'schedule', $out );
+		$this->assertSame( Scheduled_Updates::generate_schedule_id( $plugins ), $out['id'] );
+		// Order-agnostic equality — the sanitizer normalizes key order.
+		$this->assertSame( $schedule['interval'], $out['schedule']['interval'] );
+		$this->assertSame( $schedule['timestamp'], $out['schedule']['timestamp'] );
+
+		// Schedule actually persisted in cron.
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertArrayHasKey( $out['id'], $events );
+	}
+
+	/**
+	 * Empty plugin list is rejected before we hit the REST controller.
+	 */
+	public function test_create_schedule_rejects_empty_plugin_list(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$out = Scheduled_Updates_Abilities::create_schedule(
+			array(
+				'plugins'  => array(),
+				'schedule' => $this->make_schedule(),
+			)
+		);
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_invalid_plugins', $out->get_error_code() );
+	}
+
+	/**
+	 * Unknown interval is rejected by the abilities layer.
+	 */
+	public function test_create_schedule_rejects_unknown_interval(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$out = Scheduled_Updates_Abilities::create_schedule(
+			array(
+				'plugins'  => array( 'gutenberg/gutenberg.php' ),
+				'schedule' => array(
+					'interval'  => 'hourly',
+					'timestamp' => (int) strtotime( 'next Tuesday 9:00' ),
+				),
+			)
+		);
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_invalid_schedule', $out->get_error_code() );
+	}
+
+	// --- update-schedule ---------------------------------------------------
+
+	/**
+	 * Update with the same plugins + same schedule returns changed=false and
+	 * skips the underlying delete+create.
+	 */
+	public function test_update_schedule_is_idempotent_when_no_changes(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$when    = (int) strtotime( 'next Tuesday 9:00' );
+		$id      = $this->seed_schedule( $plugins, $when, 'daily' );
+
+		$out = Scheduled_Updates_Abilities::update_schedule(
+			array(
+				'id'       => $id,
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'interval'  => 'daily',
+					'timestamp' => $when,
+				),
+			)
+		);
+
+		$this->assertIsArray( $out );
+		$this->assertSame( $id, $out['id'] );
+		$this->assertFalse( $out['changed'] );
+		$this->assertSame( array(), $out['changed_fields'] );
+
+		// Underlying cron event still keyed by the same id.
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertArrayHasKey( $id, $events );
+	}
+
+	/**
+	 * Changing the schedule reports changed_fields = [ "schedule" ] and the
+	 * underlying cron event is rewritten to the new timestamp.
+	 */
+	public function test_update_schedule_reports_schedule_change(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$plugins  = array( 'gutenberg/gutenberg.php' );
+		$original = (int) strtotime( 'next Tuesday 9:00' );
+		$id       = $this->seed_schedule( $plugins, $original, 'daily' );
+
+		$next_timestamp = (int) strtotime( 'next Friday 10:00' );
+
+		$out = Scheduled_Updates_Abilities::update_schedule(
+			array(
+				'id'       => $id,
+				'schedule' => array(
+					'interval'  => 'daily',
+					'timestamp' => $next_timestamp,
+				),
+			)
+		);
+
+		$this->assertIsArray( $out );
+		$this->assertTrue( $out['changed'] );
+		$this->assertSame( array( 'schedule' ), $out['changed_fields'] );
+
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertSame( $next_timestamp, $events[ $out['id'] ]->timestamp );
+	}
+
+	/**
+	 * Unknown id returns the documented not_found error.
+	 */
+	public function test_update_schedule_returns_not_found_for_unknown_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$out = Scheduled_Updates_Abilities::update_schedule(
+			array(
+				'id'       => 'not-a-real-id',
+				'schedule' => $this->make_schedule(),
+			)
+		);
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_not_found', $out->get_error_code() );
+	}
+
+	/**
+	 * Update with neither plugins nor schedule is rejected.
+	 */
+	public function test_update_schedule_requires_at_least_one_change(): void {
+		wp_set_current_user( $this->admin_id );
+		$id = $this->seed_schedule( array( 'gutenberg/gutenberg.php' ), (int) strtotime( 'next Tuesday 9:00' ) );
+
+		$out = Scheduled_Updates_Abilities::update_schedule( array( 'id' => $id ) );
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_no_changes', $out->get_error_code() );
+	}
+
+	// --- delete-schedule ---------------------------------------------------
+
+	/**
+	 * Happy path — delete reports the id, deleted=true, and changed=true.
+	 */
+	public function test_delete_schedule_removes_event(): void {
+		wp_set_current_user( $this->admin_id );
+		$id = $this->seed_schedule( array( 'gutenberg/gutenberg.php' ), (int) strtotime( 'next Tuesday 9:00' ) );
+
+		$out = Scheduled_Updates_Abilities::delete_schedule( array( 'id' => $id ) );
+
+		$this->assertIsArray( $out );
+		$this->assertSame( $id, $out['id'] );
+		$this->assertTrue( $out['deleted'] );
+		$this->assertTrue( $out['changed'] );
+
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertArrayNotHasKey( $id, $events );
+	}
+
+	/**
+	 * Deleting an already-deleted schedule is idempotent — deleted=true,
+	 * changed=false, no error.
+	 */
+	public function test_delete_schedule_is_idempotent_for_unknown_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$out = Scheduled_Updates_Abilities::delete_schedule( array( 'id' => 'not-a-real-id' ) );
+
+		$this->assertIsArray( $out );
+		$this->assertTrue( $out['deleted'] );
+		$this->assertFalse( $out['changed'] );
+	}
+
+	public function test_delete_schedule_requires_id(): void {
+		wp_set_current_user( $this->admin_id );
+		$out = Scheduled_Updates_Abilities::delete_schedule( array() );
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_missing_id', $out->get_error_code() );
+	}
+
+	// --- run-schedule-now --------------------------------------------------
+
+	/**
+	 * Happy path — queues a one-off run and reports the dispatch timestamp.
+	 */
+	public function test_run_schedule_now_queues_one_off_event(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$id      = $this->seed_schedule( $plugins, (int) strtotime( 'next Tuesday 9:00' ), 'daily' );
+
+		$out = Scheduled_Updates_Abilities::run_schedule_now( array( 'id' => $id ) );
+
+		$this->assertIsArray( $out );
+		$this->assertSame( $id, $out['id'] );
+		$this->assertTrue( $out['dispatched'] );
+		$this->assertIsInt( $out['job_id'] );
+		$this->assertGreaterThan( time() - 1, $out['job_id'] );
+
+		// A one-off cron event for the same hook + args is now queued at job_id.
+		$queued_event = wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, $out['job_id'] );
+		$this->assertNotFalse( $queued_event );
+	}
+
+	/**
+	 * Run-schedule-now refuses unknown ids with the documented not_found error.
+	 */
+	public function test_run_schedule_now_returns_not_found_for_unknown_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$out = Scheduled_Updates_Abilities::run_schedule_now( array( 'id' => 'not-a-real-id' ) );
+
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_not_found', $out->get_error_code() );
+	}
+
+	public function test_run_schedule_now_requires_id(): void {
+		wp_set_current_user( $this->admin_id );
+		$out = Scheduled_Updates_Abilities::run_schedule_now( array() );
+		$this->assertWPError( $out );
+		$this->assertSame( 'jetpack_scheduled_updates_missing_id', $out->get_error_code() );
+	}
+
+	/**
+	 * Assert that the value is a WP_Error.
+	 *
+	 * @param mixed $actual The value to check.
+	 */
+	private function assertWPError( $actual ): void {
+		$this->assertInstanceOf( \WP_Error::class, $actual );
+	}
+}


### PR DESCRIPTION
## Summary

Registers Jetpack Scheduled Updates abilities with the WordPress Abilities API so AI agents can manage plugin update schedules through the standard `wp-abilities/v1` REST surface. Implements RSM "Abilities Everywhere" plan §4.2 for the scheduled-updates package.

### Abilities

All slugs are namespaced under the new `jetpack-scheduled-updates` category. All five share the same permission gate (`current_user_can( 'update_plugins' )`), mirroring `WPCOM_REST_API_V2_Endpoint_Update_Schedules`.

| Slug | Annotations | Purpose |
| --- | --- | --- |
| `jetpack-scheduled-updates/list-schedules` | readonly, idempotent | List all scheduled-update jobs in the compact `{ id, plugins, schedule, last_run_status, last_run_timestamp, active }` shape. Supports an optional `id` filter; unknown ids return an empty array (never a `WP_Error`). |
| `jetpack-scheduled-updates/create-schedule` | destructive, NOT idempotent | Create a new schedule. Returns `{ id, schedule }`. Idempotent only at the id level (same plugin list collides). |
| `jetpack-scheduled-updates/update-schedule` | destructive, idempotent | Update plugins or schedule by id. Returns `{ id, changed, changed_fields }`; replaying with the same values returns `changed=false` with an empty `changed_fields`. |
| `jetpack-scheduled-updates/delete-schedule` | destructive, idempotent | Delete by id. Returns `{ id, deleted, changed }`; deleting an already-gone schedule returns `deleted=true, changed=false`. |
| `jetpack-scheduled-updates/run-schedule-now` | destructive, NOT idempotent | Force-run a schedule via `wp_schedule_single_event()` a few seconds out — the recurring cadence is unaffected. Re-running queues another run. |

### Cross-consumer wiring

The scheduled-updates package is consumed by `jetpack-mu-wpcom` and (indirectly) by the main Jetpack plugin. Wired via a new `projects/packages/scheduled-updates/actions.php` registered in composer's `autoload.files`. The file uses the canonical guarded pattern from `projects/packages/publicize/actions.php` so it stays safe when autoloaded before `add_action()` is available, and double-checks the `jetpack_wp_abilities_enabled` filter before touching the registrar class.

### Why this shape

The abilities go through `rest_do_request()` for create/update/delete so they reuse the full WPCOM `update-schedules` controller pipeline (schema validation, `is_plugin_installed` checks, sync option write, fired `jetpack_scheduled_update_{created,updated,deleted}` actions) exactly as a public REST caller would. `run-schedule-now` queues a one-off cron event directly because the REST surface has no equivalent.

## Test plan

- [x] `composer phpunit -- --filter Scheduled_Updates_Abilities_Test` (29 tests, 123 assertions, all passing)
- [x] Full package suite still green: `composer phpunit` (92 tests, 511 assertions, all passing)
- [x] PHPCS clean on the new files
- [ ] Manual smoke from the abilities REST surface once the `jetpack_wp_abilities_enabled` filter is opened on a test site