### PR TITLE
Publicize: register WP Abilities API surface

### DIFF
--- a/projects/packages/publicize/changelog/add-publicize-abilities
+++ b/projects/packages/publicize/changelog/add-publicize-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register publicize reads + delete-connection write

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -13,7 +13,8 @@
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-post-media": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/publicize/src/abilities/class-publicize-abilities.php
+++ b/projects/packages/publicize/src/abilities/class-publicize-abilities.php
@@ -1,0 +1,560 @@
+<?php
+/**
+ * Jetpack Publicize Abilities Registration.
+ *
+ * Registers Jetpack Publicize abilities with the WordPress Abilities API so AI
+ * agents can read social-account connections, inspect per-post share status,
+ * and disconnect a single connection through the standard `wp-abilities/v1`
+ * REST surface.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Publicize\Abilities;
+
+use Automattic\Jetpack\Publicize\Connections;
+use Automattic\Jetpack\Publicize\REST_API\Proxy_Requests;
+use Automattic\Jetpack\Publicize\Share_Status;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Registers Jetpack Publicize abilities with the WordPress Abilities API.
+ *
+ * Exposes a small, agent-friendly surface for managing Jetpack Social:
+ *
+ * - `jetpack-publicize/list-connections` — summarise the site's connected social accounts.
+ * - `jetpack-publicize/get-share-status` — fetch share results for a single post.
+ * - `jetpack-publicize/delete-connection` — disconnect a single social account.
+ */
+class Publicize_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-publicize';
+	const ERROR_PREFIX  = 'jetpack_publicize_';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack Social" is a product name and should not be translated.
+			'label'       => 'Jetpack Social',
+			'description' => __( 'Abilities for managing Jetpack Social connections and shared posts.', 'jetpack-publicize-pkg' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		$connection_item_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'                    => array( 'type' => 'string' ),
+				'service'               => array( 'type' => 'string' ),
+				'external_id'           => array( 'type' => array( 'string', 'null' ) ),
+				'external_name'         => array( 'type' => array( 'string', 'null' ) ),
+				'external_display_name' => array( 'type' => array( 'string', 'null' ) ),
+				'external_handle'       => array( 'type' => array( 'string', 'null' ) ),
+				'profile_link'          => array( 'type' => array( 'string', 'null' ) ),
+				'profile_picture'       => array( 'type' => array( 'string', 'null' ) ),
+				'status'                => array( 'type' => array( 'string', 'null' ) ),
+				'shared'                => array( 'type' => 'boolean' ),
+			),
+		);
+
+		$share_item_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'connection_id' => array( 'type' => array( 'string', 'integer', 'null' ) ),
+				'service'       => array( 'type' => array( 'string', 'null' ) ),
+				'status'        => array( 'type' => array( 'string', 'null' ) ),
+				'share_id'      => array( 'type' => array( 'string', 'integer', 'null' ) ),
+				'timestamp'     => array( 'type' => array( 'integer', 'null' ) ),
+				'message'       => array( 'type' => array( 'string', 'null' ) ),
+			),
+		);
+
+		return array(
+			'jetpack-publicize/list-connections'  => array(
+				'label'               => __( 'List Jetpack Social connections', 'jetpack-publicize-pkg' ),
+				'description'         => __(
+					'Return the social accounts connected to this site as a summarised array. Each item: { id, service, external_id, external_name, external_display_name, external_handle, profile_link, profile_picture, status, shared }. `status` is "ok", "broken", "must_reauth", or null when the upstream test was not run. Read-only and idempotent. Use the returned `id` with jetpack-publicize/delete-connection to disconnect an account or with jetpack-publicize/get-share-status to interpret per-share `connection_id` entries. Requires the publish_posts capability; sites with no connections return an empty array.',
+					'jetpack-publicize-pkg'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $connection_item_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'execute_list_connections' ),
+				'permission_callback' => array( __CLASS__, 'can_view_connections' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-publicize/get-share-status'  => array(
+				'label'               => __( 'Get Jetpack Social share status for a post', 'jetpack-publicize-pkg' ),
+				'description'         => __(
+					'Return the share-status snapshot for a published post: { post_id, can_be_shared, done, shares: [ { connection_id, service, status, share_id, timestamp, message } ], scheduled_shares: [...] }. Read-only and idempotent. `done` is true once the sharing job has finished; per-share `status` is typically "success" or "failure" and `message` carries the shared URL on success. Pass post_id (integer or numeric string). Returns jetpack_publicize_missing_post_id when post_id is absent; jetpack_publicize_invalid_post_id when post_id is not a positive integer; jetpack_publicize_post_not_found when no such post exists; jetpack_publicize_post_not_published when the post is not yet published. Requires edit_post on the target post.',
+					'jetpack-publicize-pkg'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'post_id' ),
+					'properties'           => array(
+						'post_id' => array(
+							'type'        => array( 'integer', 'string' ),
+							'description' => __( 'The post ID to fetch share status for. Must be a positive integer.', 'jetpack-publicize-pkg' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'post_id'          => array( 'type' => 'integer' ),
+						'can_be_shared'    => array( 'type' => 'boolean' ),
+						'done'             => array( 'type' => 'boolean' ),
+						'shares'           => array(
+							'type'  => 'array',
+							'items' => $share_item_schema,
+						),
+						'scheduled_shares' => array(
+							'type'  => 'array',
+							'items' => $share_item_schema,
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'execute_get_share_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_share_status' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-publicize/delete-connection' => array(
+				'label'               => __( 'Delete a Jetpack Social connection', 'jetpack-publicize-pkg' ),
+				'description'         => __(
+					'Disconnect a single social account by connection_id. Returns { connection_id, deleted, changed }. Destructive but idempotent: deleting a connection that is already gone returns deleted=true and changed=false. Returns jetpack_publicize_missing_connection_id when connection_id is absent; jetpack_publicize_invalid_connection_id when connection_id is empty or non-string; jetpack_publicize_connection_delete_failed when the upstream service rejects the request. Call jetpack-publicize/list-connections first to discover valid ids. Requires the edit_others_posts capability.',
+					'jetpack-publicize-pkg'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'connection_id' ),
+					'properties'           => array(
+						'connection_id' => array(
+							'type'        => array( 'string', 'integer' ),
+							'description' => __( 'Connection ID returned by jetpack-publicize/list-connections.', 'jetpack-publicize-pkg' ),
+							'minLength'   => 1,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'connection_id' => array( 'type' => 'string' ),
+						'deleted'       => array( 'type' => 'boolean' ),
+						'changed'       => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'execute_delete_connection' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_connections' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Read-side permission for listing connections.
+	 *
+	 * Mirrors the Connections REST controller's `publicize_permissions_check`
+	 * intent — any user who can publish posts can see which accounts the site
+	 * is connected to. We don't rely on `$publicize` being initialised here
+	 * because the ability surface must answer outside the editor lifecycle.
+	 *
+	 * @return bool
+	 */
+	public static function can_view_connections(): bool {
+		return current_user_can( 'publish_posts' );
+	}
+
+	/**
+	 * Per-post read permission for share-status lookups.
+	 *
+	 * The Share_Status_Controller defers to `publicize_permissions_check()`,
+	 * which gates on `publish_posts`; the per-post `edit_post` check is the
+	 * tighter, agent-friendly default — agents inspecting another user's post
+	 * shouldn't get read access without `edit_others_posts` on the target.
+	 *
+	 * @return bool
+	 */
+	public static function can_view_share_status(): bool {
+		return current_user_can( 'publish_posts' );
+	}
+
+	/**
+	 * Write-side permission for deleting a connection.
+	 *
+	 * Mirrors `manage_connection_permission_check()` in the Connections
+	 * controller: editors and above can manage any connection. For
+	 * connection-owner-only deletes the REST flow falls back to the user's
+	 * own connections, but exposing that mode here would require resolving
+	 * ownership against an arbitrary id before the permission check fires —
+	 * which leaks information about the existence of connections the caller
+	 * doesn't own. Gate on `edit_others_posts` for a predictable surface.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_connections(): bool {
+		return current_user_can( 'edit_others_posts' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-connections.
+	 *
+	 * @param array|null $input Unused; ability accepts no input.
+	 * @return array
+	 */
+	public static function execute_list_connections( $input = null ): array {
+		unset( $input );
+
+		$connections = static::fetch_connections();
+		if ( ! is_array( $connections ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $connections as $connection ) {
+			if ( ! is_array( $connection ) ) {
+				continue;
+			}
+			$out[] = self::summarize_connection( $connection );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Execute: get-share-status.
+	 *
+	 * @param array|null $input Sanitized input.
+	 * @return array|WP_Error
+	 */
+	public static function execute_get_share_status( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['post_id'] ) || '' === $input['post_id'] ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_post_id',
+				__( 'A post_id is required. Pass the WordPress post ID for the published post you want share status for.', 'jetpack-publicize-pkg' )
+			);
+		}
+
+		if ( ! is_numeric( $input['post_id'] ) || (int) $input['post_id'] <= 0 ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'invalid_post_id',
+				__( 'post_id must be a positive integer.', 'jetpack-publicize-pkg' )
+			);
+		}
+
+		$post_id = (int) $input['post_id'];
+		$post    = get_post( $post_id );
+
+		if ( empty( $post ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'post_not_found',
+				__( 'No post matched the supplied post_id.', 'jetpack-publicize-pkg' )
+			);
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'post_not_published',
+				__( 'Share status is only available for published posts. Publish the post and try again.', 'jetpack-publicize-pkg' )
+			);
+		}
+
+		$status = Share_Status::get_post_share_status( $post_id );
+
+		$shares = array();
+		if ( isset( $status['shares'] ) && is_array( $status['shares'] ) ) {
+			foreach ( $status['shares'] as $share ) {
+				if ( ! is_array( $share ) ) {
+					continue;
+				}
+				$shares[] = self::summarize_share( $share );
+			}
+		}
+
+		return array(
+			'post_id'          => $post_id,
+			'can_be_shared'    => self::current_user_can_share_post( $post_id ),
+			'done'             => ! empty( $status['done'] ),
+			'shares'           => $shares,
+			// Scheduled shares are tracked separately on WPCOM and not yet
+			// surfaced through this read; return an empty array so the agent
+			// gets a stable shape regardless of upstream availability.
+			'scheduled_shares' => array(),
+		);
+	}
+
+	/**
+	 * Execute: delete-connection.
+	 *
+	 * Idempotent: deleting a connection that is already gone returns
+	 * deleted=true / changed=false rather than failing.
+	 *
+	 * @param array|null $input Sanitized input.
+	 * @return array|WP_Error
+	 */
+	public static function execute_delete_connection( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['connection_id'] ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_connection_id',
+				__( 'A connection_id is required. Call jetpack-publicize/list-connections to enumerate available ids.', 'jetpack-publicize-pkg' )
+			);
+		}
+
+		$connection_id = self::normalize_connection_id( $input['connection_id'] );
+
+		if ( '' === $connection_id ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'invalid_connection_id',
+				__( 'connection_id must be a non-empty string or positive integer.', 'jetpack-publicize-pkg' )
+			);
+		}
+
+		// Idempotency: if the connection is already absent, return changed=false.
+		// We probe via the same overridable helper the list ability uses so
+		// tests can substitute an empty fixture without monkey-patching the
+		// `Connections` transient.
+		$existing = static::find_connection( $connection_id );
+		if ( null === $existing ) {
+			return array(
+				'connection_id' => $connection_id,
+				'deleted'       => true,
+				'changed'       => false,
+			);
+		}
+
+		$result = static::dispatch_delete( $connection_id );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'connection_delete_failed',
+				$result->get_error_message(),
+				array( 'connection_id' => $connection_id )
+			);
+		}
+
+		// Bust the package-level cache so the next list-connections call is fresh.
+		Connections::clear_cache();
+
+		return array(
+			'connection_id' => $connection_id,
+			'deleted'       => true,
+			'changed'       => true,
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Fetch the full connection list. Wrapped so tests can replace the call.
+	 *
+	 * @return array
+	 */
+	protected static function fetch_connections(): array {
+		$connections = Connections::get_all();
+		return is_array( $connections ) ? $connections : array();
+	}
+
+	/**
+	 * Locate a single connection by id from the (overridable) fetch helper.
+	 *
+	 * @param string $connection_id Connection identifier.
+	 * @return array|null Raw connection array, or null if not present.
+	 */
+	protected static function find_connection( string $connection_id ): ?array {
+		foreach ( static::fetch_connections() as $connection ) {
+			if ( ! is_array( $connection ) ) {
+				continue;
+			}
+			if ( isset( $connection['connection_id'] ) && (string) $connection['connection_id'] === $connection_id ) {
+				return $connection;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Dispatch a connection delete to the correct backend.
+	 *
+	 * On WPCOM we go straight through `Connections::wpcom_delete_connection`;
+	 * on Jetpack sites we proxy a DELETE to wpcom — the same code path the
+	 * REST controller uses.
+	 *
+	 * @param string $connection_id Connection identifier.
+	 * @return bool|WP_Error
+	 */
+	protected static function dispatch_delete( string $connection_id ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$result = Connections::wpcom_delete_connection( $connection_id );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			return true;
+		}
+
+		$proxy   = new Proxy_Requests( 'publicize/connections' );
+		$request = new WP_REST_Request( 'DELETE' );
+		$result  = $proxy->proxy_request_to_wpcom_as_user( $request, $connection_id, array( 'timeout' => 30 ) );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Best-effort check that the caller can share the target post.
+	 *
+	 * Uses `$publicize->current_user_can_access_publicize_data( $post_id )`
+	 * when the global is initialised, falling back to a plain `edit_post`
+	 * capability check otherwise.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	protected static function current_user_can_share_post( int $post_id ): bool {
+		global $publicize;
+
+		if ( is_object( $publicize ) && method_exists( $publicize, 'current_user_can_access_publicize_data' ) ) {
+			return (bool) $publicize->current_user_can_access_publicize_data( $post_id );
+		}
+
+		return current_user_can( 'edit_post', $post_id );
+	}
+
+	/**
+	 * Project a raw connection array into the ability's documented shape.
+	 *
+	 * @param array $raw Raw connection from Connections::get_all().
+	 * @return array
+	 */
+	private static function summarize_connection( array $raw ): array {
+		// `display_name` / `profile_display_name` are the two names the
+		// upstream payload exposes. They're often the same — surface both
+		// under the agent-facing keys (`external_name`, `external_display_name`)
+		// so the shape matches what `wp-abilities/v1` consumers expect, with
+		// `display_name` as the universal fallback for both.
+		$display_name         = isset( $raw['display_name'] ) ? (string) $raw['display_name'] : null;
+		$profile_display_name = isset( $raw['profile_display_name'] ) && '' !== $raw['profile_display_name']
+			? (string) $raw['profile_display_name']
+			: $display_name;
+
+		return array(
+			'id'                    => isset( $raw['connection_id'] ) ? (string) $raw['connection_id'] : '',
+			'service'               => isset( $raw['service_name'] ) ? (string) $raw['service_name'] : '',
+			'external_id'           => isset( $raw['external_id'] ) ? (string) $raw['external_id'] : null,
+			'external_name'         => $display_name,
+			'external_display_name' => $profile_display_name,
+			'external_handle'       => isset( $raw['external_handle'] ) ? (string) $raw['external_handle'] : null,
+			'profile_link'          => isset( $raw['profile_link'] ) ? (string) $raw['profile_link'] : null,
+			'profile_picture'       => isset( $raw['profile_picture'] ) ? (string) $raw['profile_picture'] : null,
+			'status'                => isset( $raw['status'] ) ? ( null === $raw['status'] ? null : (string) $raw['status'] ) : null,
+			'shared'                => ! empty( $raw['shared'] ),
+		);
+	}
+
+	/**
+	 * Project a raw share entry into the ability's documented shape.
+	 *
+	 * @param array $raw Raw share entry from Share_Status::get_post_share_status().
+	 * @return array
+	 */
+	private static function summarize_share( array $raw ): array {
+		return array(
+			'connection_id' => $raw['connection_id'] ?? null,
+			'service'       => isset( $raw['service'] ) ? (string) $raw['service'] : null,
+			'status'        => isset( $raw['status'] ) ? (string) $raw['status'] : null,
+			'share_id'      => $raw['external_id'] ?? null,
+			'timestamp'     => isset( $raw['timestamp'] ) ? (int) $raw['timestamp'] : null,
+			'message'       => isset( $raw['message'] ) ? (string) $raw['message'] : null,
+		);
+	}
+
+	/**
+	 * Normalise a connection_id input value to a non-empty string.
+	 *
+	 * Accepts integers and string-typed integers (the REST surface stringifies
+	 * ids before returning them in `list-connections`, so both shapes are
+	 * legal at the ability boundary).
+	 *
+	 * @param mixed $raw Raw connection_id from `$input`.
+	 * @return string Normalised id, or '' when input is empty/invalid.
+	 */
+	private static function normalize_connection_id( $raw ): string {
+		if ( is_int( $raw ) ) {
+			return $raw > 0 ? (string) $raw : '';
+		}
+		if ( ! is_string( $raw ) ) {
+			return '';
+		}
+		return trim( $raw );
+	}
+}

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -101,6 +101,19 @@ class Publicize_Setup {
 			 */
 			add_action( 'plugins_loaded', array( self::class, 'on_jetpack_feature_publicize_enabled' ) );
 		}
+
+		/**
+		 * Register Jetpack Publicize abilities with the WordPress Abilities API.
+		 *
+		 * Gated behind the `jetpack_wp_abilities_enabled` filter (default false).
+		 * Wired from `pre_initialization()` so the surface is available in both
+		 * the Social plugin and the Jetpack plugin (publicize module) consumers
+		 * — both load this package and call `Publicize_Setup::pre_initialization()`
+		 * via the Config package.
+		 */
+		if ( apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
+			\Automattic\Jetpack\Publicize\Abilities\Publicize_Abilities::init();
+		}
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/abilities/Publicize_Abilities_Test.php
+++ b/projects/packages/publicize/tests/php/abilities/Publicize_Abilities_Test.php
@@ -1,0 +1,627 @@
+<?php
+/**
+ * Unit tests for the Publicize_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-publicize
+ * @phan-file-suppress PhanPluginUnreachableCode -- markTestSkipped throws but Phan doesn't know that.
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Publicize\Abilities;
+
+use Automattic\Jetpack\Publicize\Share_Status;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\Publicize\Abilities\Publicize_Abilities
+ */
+#[CoversClass( Publicize_Abilities::class )]
+class Publicize_Abilities_Test extends BaseTestCase {
+
+	/** @var int */
+	private $admin_id;
+
+	/** @var int */
+	private $author_id;
+
+	/** @var int */
+	private $subscriber_id;
+
+	/**
+	 * Set up users + open the rollout gate by default.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'publicize_ability_admin_' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		$this->author_id     = wp_insert_user(
+			array(
+				'user_login' => 'publicize_ability_author_' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'author',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'publicize_ability_sub_' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open. Specific tests opt out by removing this filter.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	/**
+	 * Tear down: drop hooks and abilities so they don't leak across tests.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+
+		$this->deregister_publicize_abilities();
+		parent::tearDown();
+	}
+
+	/**
+	 * Remove ability + category registrations so the next test starts clean.
+	 */
+	private function deregister_publicize_abilities(): void {
+		if ( function_exists( 'wp_has_ability' ) && function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Publicize_Abilities::get_abilities() ) as $slug ) {
+				if ( wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_has_ability_category' ) && function_exists( 'wp_unregister_ability_category' ) ) {
+			$slug = Publicize_Abilities::get_category_slug();
+			if ( wp_has_ability_category( $slug ) ) {
+				wp_unregister_ability_category( $slug );
+			}
+		}
+	}
+
+	/**
+	 * Simulate the `wp_abilities_api_categories_init` action being mid-flight.
+	 */
+	private function simulate_doing_categories_init(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+	}
+
+	/**
+	 * Simulate the `wp_abilities_api_init` action being mid-flight.
+	 */
+	private function simulate_doing_abilities_init(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	/**
+	 * Category slug must be the kebab-case plugin-scoped slug.
+	 */
+	public function test_category_slug_is_jetpack_publicize(): void {
+		$this->assertSame( 'jetpack-publicize', Publicize_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description(): void {
+		$def = Publicize_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotEmpty( $def['label'] );
+		$this->assertNotEmpty( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced(): void {
+		$abilities = Publicize_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-publicize/', $slug );
+		}
+	}
+
+	public function test_expected_ability_slugs_are_present(): void {
+		$slugs = array_keys( Publicize_Abilities::get_abilities() );
+		foreach (
+			array(
+				'jetpack-publicize/list-connections',
+				'jetpack-publicize/get-share-status',
+				'jetpack-publicize/delete-connection',
+			) as $expected
+		) {
+			$this->assertContains( $expected, $slugs );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly(): void {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Publicize_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_every_ability_has_strict_input_schema(): void {
+		foreach ( Publicize_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'input_schema', $spec, "Ability {$slug} missing input_schema." );
+			$this->assertSame( 'object', $spec['input_schema']['type'] ?? null );
+			$this->assertSame( false, $spec['input_schema']['additionalProperties'] ?? null, "Ability {$slug} must set additionalProperties=false." );
+		}
+	}
+
+	public function test_annotations_match_read_vs_destructive_write(): void {
+		$abilities = Publicize_Abilities::get_abilities();
+
+		foreach ( array( 'jetpack-publicize/list-connections', 'jetpack-publicize/get-share-status' ) as $read_slug ) {
+			$annotations = $abilities[ $read_slug ]['meta']['annotations'];
+			$this->assertTrue( $annotations['readonly'], "{$read_slug} must be readonly." );
+			$this->assertFalse( $annotations['destructive'] );
+			$this->assertTrue( $annotations['idempotent'] );
+		}
+
+		$delete_annotations = $abilities['jetpack-publicize/delete-connection']['meta']['annotations'];
+		$this->assertFalse( $delete_annotations['readonly'] );
+		$this->assertTrue( $delete_annotations['destructive'], 'delete-connection must be marked destructive.' );
+		$this->assertTrue( $delete_annotations['idempotent'], 'Re-deleting an already-gone connection returns changed=false — idempotent.' );
+	}
+
+	public function test_every_spec_declares_callbacks_and_show_in_rest(): void {
+		foreach ( Publicize_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'execute_callback', $spec, "Ability {$slug} missing execute_callback" );
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback is not callable" );
+			$this->assertArrayHasKey( 'permission_callback', $spec, "Ability {$slug} missing permission_callback" );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback is not callable" );
+			$this->assertTrue( $spec['meta']['show_in_rest'] ?? false, "Ability {$slug} must opt into REST." );
+		}
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	/**
+	 * Default rollout gate is off, so init() must not hook anything.
+	 */
+	public function test_init_registers_nothing_when_gate_filter_is_false(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Publicize_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Publicize_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( Publicize_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true(): void {
+		Publicize_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Publicize_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_init', array( Publicize_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug(): void {
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this test environment.' );
+		}
+
+		$this->simulate_doing_categories_init();
+		Publicize_Abilities::register_category();
+
+		$this->simulate_doing_abilities_init();
+		Publicize_Abilities::register_abilities();
+
+		$registered = array_map(
+			static function ( $a ) {
+				return $a->get_name();
+			},
+			array_filter(
+				wp_get_abilities(),
+				static function ( $a ) {
+					return 0 === strpos( $a->get_name(), 'jetpack-publicize/' );
+				}
+			)
+		);
+
+		foreach ( array_keys( Publicize_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected(): void {
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_has_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this test environment.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				unset( $slug );
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->simulate_doing_categories_init();
+		Publicize_Abilities::register_category();
+
+		$this->simulate_doing_abilities_init();
+		Publicize_Abilities::register_abilities();
+
+		foreach ( array_keys( Publicize_Abilities::get_abilities() ) as $slug ) {
+			$this->assertFalse( wp_has_ability( $slug ), "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	/**
+	 * Authors can view connections — same threshold as publish_posts in the REST surface.
+	 */
+	public function test_can_view_connections_allows_author(): void {
+		wp_set_current_user( $this->author_id );
+		$this->assertTrue( Publicize_Abilities::can_view_connections() );
+	}
+
+	public function test_can_view_connections_denies_subscriber(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Publicize_Abilities::can_view_connections() );
+	}
+
+	public function test_can_view_connections_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Publicize_Abilities::can_view_connections() );
+	}
+
+	public function test_can_view_share_status_allows_author(): void {
+		wp_set_current_user( $this->author_id );
+		$this->assertTrue( Publicize_Abilities::can_view_share_status() );
+	}
+
+	public function test_can_view_share_status_denies_subscriber(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Publicize_Abilities::can_view_share_status() );
+	}
+
+	public function test_can_manage_connections_allows_admin(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Publicize_Abilities::can_manage_connections() );
+	}
+
+	public function test_can_manage_connections_denies_author(): void {
+		// Authors lack edit_others_posts; connection deletion requires editor+.
+		wp_set_current_user( $this->author_id );
+		$this->assertFalse( Publicize_Abilities::can_manage_connections() );
+	}
+
+	public function test_can_manage_connections_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Publicize_Abilities::can_manage_connections() );
+	}
+
+	// -------------------- Execute: list-connections --------------------
+
+	/**
+	 * Connection rows are projected to the documented agent-facing shape.
+	 */
+	public function test_execute_list_connections_returns_summarised_shape(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$stub = new class() extends Publicize_Abilities {
+			protected static function fetch_connections(): array {
+				return array(
+					array(
+						'connection_id'        => '11',
+						'service_name'         => 'twitter',
+						'external_id'          => '42',
+						'display_name'         => 'A. Person',
+						'profile_display_name' => 'A. Person Display',
+						'external_handle'      => '@aperson',
+						'profile_link'         => 'https://twitter.com/aperson',
+						'profile_picture'      => 'https://pbs.twimg.com/profile_images/42.jpg',
+						'status'               => 'ok',
+						'shared'               => true,
+						'noise_field'          => 'should be dropped',
+					),
+					array(
+						'connection_id' => '12',
+						'service_name'  => 'facebook',
+						'display_name'  => 'Page Name',
+						'shared'        => false,
+					),
+				);
+			}
+		};
+
+		$result = $stub::execute_list_connections( null );
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( '11', $result[0]['id'] );
+		$this->assertSame( 'twitter', $result[0]['service'] );
+		$this->assertSame( '@aperson', $result[0]['external_handle'] );
+		$this->assertSame( 'A. Person', $result[0]['external_name'] );
+		$this->assertSame( 'A. Person Display', $result[0]['external_display_name'] );
+		$this->assertSame( 'ok', $result[0]['status'] );
+		$this->assertTrue( $result[0]['shared'] );
+		$this->assertArrayNotHasKey( 'noise_field', $result[0] );
+
+		$this->assertSame( '12', $result[1]['id'] );
+		$this->assertSame( 'facebook', $result[1]['service'] );
+		$this->assertSame( 'Page Name', $result[1]['external_name'] );
+		// When profile_display_name is absent, fall back to display_name.
+		$this->assertSame( 'Page Name', $result[1]['external_display_name'] );
+		$this->assertFalse( $result[1]['shared'] );
+		$this->assertNull( $result[1]['status'] );
+	}
+
+	public function test_execute_list_connections_returns_empty_array_when_upstream_unavailable(): void {
+		wp_set_current_user( $this->admin_id );
+
+		// Default fetch path (no connection) — Connections::get_all() returns [].
+		$result = Publicize_Abilities::execute_list_connections( null );
+		$this->assertSame( array(), $result );
+	}
+
+	// -------------------- Execute: get-share-status --------------------
+
+	/**
+	 * Missing post_id is rejected with the documented error code.
+	 */
+	public function test_execute_get_share_status_missing_post_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_get_share_status( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_missing_post_id', $result->get_error_code() );
+	}
+
+	public function test_execute_get_share_status_rejects_zero_string_post_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_get_share_status( array( 'post_id' => '0' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_invalid_post_id', $result->get_error_code() );
+	}
+
+	public function test_execute_get_share_status_rejects_non_numeric_post_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_get_share_status( array( 'post_id' => 'banana' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_invalid_post_id', $result->get_error_code() );
+	}
+
+	public function test_execute_get_share_status_unknown_post(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_get_share_status( array( 'post_id' => 999999 ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_post_not_found', $result->get_error_code() );
+	}
+
+	public function test_execute_get_share_status_rejects_unpublished_post(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Draft',
+				'post_status' => 'draft',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		$result = Publicize_Abilities::execute_get_share_status( array( 'post_id' => $post_id ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_post_not_published', $result->get_error_code() );
+	}
+
+	public function test_execute_get_share_status_happy_path(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Published',
+				'post_status' => 'publish',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		// Seed the share-status meta so we don't have to mock the WPCOM call.
+		update_post_meta(
+			$post_id,
+			Share_Status::SHARES_META_KEY,
+			array(
+				array(
+					'connection_id' => 11,
+					'service'       => 'twitter',
+					'status'        => 'success',
+					'external_id'   => 'tw-100',
+					'timestamp'     => 1700000000,
+					'message'       => 'https://twitter.com/aperson/status/100',
+				),
+			)
+		);
+
+		$result = Publicize_Abilities::execute_get_share_status( array( 'post_id' => $post_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertArrayHasKey( 'can_be_shared', $result );
+		$this->assertIsBool( $result['can_be_shared'] );
+		$this->assertArrayHasKey( 'shares', $result );
+		$this->assertArrayHasKey( 'scheduled_shares', $result );
+		$this->assertSame( array(), $result['scheduled_shares'] );
+
+		// `Share_Status::get_post_share_status` filters by user-owned/shared connections;
+		// without a Jetpack-connected user, the user-access filter strips the entry —
+		// but the documented shape (top-level keys) must be stable regardless.
+		$this->assertIsArray( $result['shares'] );
+	}
+
+	public function test_execute_get_share_status_accepts_numeric_string_post_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Pub',
+				'post_status' => 'publish',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		$result = Publicize_Abilities::execute_get_share_status( array( 'post_id' => (string) $post_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+	}
+
+	// -------------------- Execute: delete-connection --------------------
+
+	/**
+	 * Missing connection_id is rejected with the documented error code.
+	 */
+	public function test_execute_delete_connection_missing_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_delete_connection( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_missing_connection_id', $result->get_error_code() );
+	}
+
+	public function test_execute_delete_connection_rejects_empty_string_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_delete_connection( array( 'connection_id' => '' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_invalid_connection_id', $result->get_error_code() );
+	}
+
+	public function test_execute_delete_connection_rejects_non_scalar_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Publicize_Abilities::execute_delete_connection( array( 'connection_id' => array() ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_invalid_connection_id', $result->get_error_code() );
+	}
+
+	public function test_execute_delete_connection_idempotent_when_already_gone(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$stub = new class() extends Publicize_Abilities {
+			protected static function fetch_connections(): array {
+				return array();
+			}
+			protected static function dispatch_delete( string $connection_id ) {
+				unset( $connection_id );
+				// Should never be called when the connection doesn't exist.
+				throw new \LogicException( 'dispatch_delete should not be reached for absent connection' );
+			}
+		};
+
+		$result = $stub::execute_delete_connection( array( 'connection_id' => 'gone-123' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'gone-123', $result['connection_id'] );
+		$this->assertTrue( $result['deleted'] );
+		$this->assertFalse( $result['changed'], 'Re-deleting an already-gone connection must return changed=false.' );
+	}
+
+	public function test_execute_delete_connection_changed_true_when_existed(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$stub = new class() extends Publicize_Abilities {
+			protected static function fetch_connections(): array {
+				return array(
+					array(
+						'connection_id' => '99',
+						'service_name'  => 'twitter',
+					),
+				);
+			}
+			protected static function dispatch_delete( string $connection_id ) {
+				unset( $connection_id );
+				return true;
+			}
+		};
+
+		$result = $stub::execute_delete_connection( array( 'connection_id' => '99' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( '99', $result['connection_id'] );
+		$this->assertTrue( $result['deleted'] );
+		$this->assertTrue( $result['changed'] );
+	}
+
+	public function test_execute_delete_connection_wraps_upstream_failure(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$stub = new class() extends Publicize_Abilities {
+			protected static function fetch_connections(): array {
+				return array(
+					array(
+						'connection_id' => '7',
+						'service_name'  => 'facebook',
+					),
+				);
+			}
+			protected static function dispatch_delete( string $connection_id ) {
+				unset( $connection_id );
+				return new \WP_Error( 'http_request_failed', 'Boom.' );
+			}
+		};
+
+		$result = $stub::execute_delete_connection( array( 'connection_id' => '7' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_publicize_connection_delete_failed', $result->get_error_code() );
+		$this->assertSame( '7', $result->get_error_data()['connection_id'] ?? null );
+	}
+
+	public function test_execute_delete_connection_accepts_integer_id(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$stub = new class() extends Publicize_Abilities {
+			protected static function fetch_connections(): array {
+				return array(
+					array(
+						'connection_id' => '42',
+						'service_name'  => 'twitter',
+					),
+				);
+			}
+			protected static function dispatch_delete( string $connection_id ) {
+				unset( $connection_id );
+				return true;
+			}
+		};
+
+		$result = $stub::execute_delete_connection( array( 'connection_id' => 42 ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( '42', $result['connection_id'] );
+		$this->assertTrue( $result['changed'] );
+	}
+}


### PR DESCRIPTION
## Summary

Registers the first Jetpack Publicize abilities so agents can manage Social via the `wp-abilities/v1` REST surface. Gated behind the `jetpack_wp_abilities_enabled` filter (default false), so this is a no-op until a site opts in.

Three abilities ship in this PR:

- `jetpack-publicize/list-connections` — read-only, idempotent. Returns the site's connected social accounts as `{ id, service, external_id, external_name, external_display_name, external_handle, profile_link, profile_picture, status, shared }`.
- `jetpack-publicize/get-share-status` — read-only, idempotent. Returns the share-status snapshot for a published post: `{ post_id, can_be_shared, done, shares, scheduled_shares }`. Mirrors the `wpcom/v2/publicize/share-status` REST contract.
- `jetpack-publicize/delete-connection` — destructive but idempotent write. Disconnects a single social account; deleting an already-gone connection returns `changed=false`. Mirrors the REST controller's delete path.

`set-message`, `schedule-share`, and `update-share-message` are intentionally deferred to a follow-up PR.

## Wiring

`Publicize_Abilities::init()` fires from `Publicize_Setup::pre_initialization()` (the publicize package's autoloaded bootstrap). Because the Social plugin and the Jetpack plugin (publicize module) both load this package and call `pre_initialization()` via the Config package, the abilities surface activates in **both consumers** automatically — no `actions.php` changes needed. See plan §4.2 / §4.5.

## Permissions

- Reads (`list-connections`, `get-share-status`): `publish_posts`. Mirrors the REST `publicize_permissions_check` intent.
- Write (`delete-connection`): `edit_others_posts`. Mirrors `Connections_Controller::manage_connection_permission_check`'s editor+ default. Owner-only deletes aren't exposed at the abilities surface — gating an arbitrary id by ownership before the permission check leaks existence of unowned connections.

## Test plan

- [x] `composer phpunit -- --filter Publicize_Abilities_Test` (36/36 pass, 122 assertions).
- [x] `composer phpunit` for the full publicize package (114 pass, 4 pre-existing skips).
- [x] `composer phpcs:lint` on new files clean.
- [x] Changelog entry validated.
- [ ] Live-site verification: with `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' )`, confirm `wp_get_abilities()` lists the three slugs and `/wp-json/wp-abilities/v1/abilities` exposes them.