### PR TITLE
VideoPress abilities: register list-videos, storage quota, upload token via Registrar

### DIFF
--- a/projects/packages/videopress/actions.php
+++ b/projects/packages/videopress/actions.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Action Hooks for the Jetpack VideoPress package.
+ *
+ * Registers VideoPress abilities with the WordPress Abilities API once the
+ * `jetpack_wp_abilities_enabled` filter opts in. The registration runs on
+ * `plugins_loaded` at priority 20 so the host plugin's bootstrap has already
+ * loaded its filters by the time the Registrar checks the gate.
+ *
+ * Loaded via composer.json `autoload.files`, so every consumer of the
+ * jetpack-videopress package (the Jetpack plugin, the standalone VideoPress
+ * plugin, mu-wpcom-plugin) wires the abilities through a single code path.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+$register_videopress_abilities = static function () {
+	if ( ! apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
+		return;
+	}
+	if ( ! class_exists( \Automattic\Jetpack\VideoPress\Abilities\VideoPress_Abilities::class ) ) {
+		return;
+	}
+	\Automattic\Jetpack\VideoPress\Abilities\VideoPress_Abilities::init();
+};
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', $register_videopress_abilities, 20 );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][20][] = array(
+		'accepted_args' => 0,
+		'function'      => $register_videopress_abilities,
+	);
+}

--- a/projects/packages/videopress/changelog/add-videopress-abilities
+++ b/projects/packages/videopress/changelog/add-videopress-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register list-videos, get-storage-quota, and get-upload-token abilities for Jetpack VideoPress (WP 6.9+, gated by the jetpack_wp_abilities_enabled filter).

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -11,6 +11,7 @@
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev",
 		"automattic/jetpack-wp-build-polyfills": "@dev"
 	},
 	"require-dev": {
@@ -25,6 +26,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/videopress/src/abilities/class-videopress-abilities.php
+++ b/projects/packages/videopress/src/abilities/class-videopress-abilities.php
@@ -1,0 +1,638 @@
+<?php
+/**
+ * Jetpack VideoPress Abilities Registration
+ *
+ * Registers Jetpack VideoPress abilities with the WordPress Abilities API.
+ * Ability callbacks delegate to the package's existing helper classes
+ * (`Data`, `Site`, `VideoPressToken`) so they inherit the same data sources
+ * the dashboard already uses.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9. The Registrar base class guards its function_exists() checks so the package is safe on older WP. @todo Remove this line when the minimum supported WordPress version is 6.9.
+
+namespace Automattic\Jetpack\VideoPress\Abilities;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\VideoPress\Data;
+use Automattic\Jetpack\VideoPress\Upload_Exception;
+use Automattic\Jetpack\VideoPress\VideoPressToken;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Class VideoPress_Abilities
+ *
+ * Registers Jetpack VideoPress abilities with the WordPress Abilities API.
+ * Reads-only first; write abilities (update / delete / upload-blob) are
+ * intentionally deferred to a follow-up PR so the dispatch design can land
+ * separately from the read surface.
+ */
+class VideoPress_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-videopress';
+
+	/**
+	 * VideoPress storage quota in bytes for the paid 1TB plan.
+	 *
+	 * Matches the constant the dashboard storage meter renders against —
+	 * see `client/admin/components/video-storage-meter/index.tsx` (`1000^4`).
+	 * Kept here in PHP so the ability returns the same number the UI shows.
+	 */
+	const QUOTA_BYTES_1TB = 1000000000000;
+
+	/**
+	 * Privacy enum values returned by the underlying jetpack_videopress meta.
+	 * Mirrors `VIDEOPRESS_PRIVACY::IS_PUBLIC` / `IS_PRIVATE` / `SITE_DEFAULT`.
+	 */
+	const PRIVACY_PUBLIC       = 0;
+	const PRIVACY_PRIVATE      = 1;
+	const PRIVACY_SITE_DEFAULT = 2;
+
+	/**
+	 * Maximum per_page value enforced by list-videos. The schema declares the
+	 * same maximum, but the callback re-clamps because schema defaults aren't
+	 * auto-injected.
+	 */
+	const MAX_PER_PAGE = 100;
+
+	/**
+	 * Default per_page when the caller omits it.
+	 */
+	const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * Input enum for the privacy filter on list-videos. Maps the human strings
+	 * the agent passes to the integer privacy_setting stored in attachment meta.
+	 */
+	const STATUS_TO_PRIVACY = array(
+		'public'       => self::PRIVACY_PUBLIC,
+		'private'      => self::PRIVACY_PRIVATE,
+		'site-private' => self::PRIVACY_SITE_DEFAULT,
+	);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack VideoPress" is a product name and should not be translated.
+			'label'       => 'Jetpack VideoPress',
+			'description' => __( 'Abilities for managing Jetpack VideoPress-hosted videos and storage.', 'jetpack-videopress-pkg' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-videopress/list-videos'        => self::spec_list_videos(),
+			'jetpack-videopress/get-storage-quota'  => self::spec_get_storage_quota(),
+			'jetpack-videopress/get-upload-token'   => self::spec_get_upload_token(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-videopress/list-videos.
+	 *
+	 * Consolidated-read shape. When `media_id` is supplied the ability returns
+	 * a 0- or 1-element array, so the caller doesn't have to pick between
+	 * `list-videos` and a `get-video` ability for the single-record case.
+	 */
+	private static function spec_list_videos(): array {
+		return array(
+			'label'               => __( 'List VideoPress-hosted videos', 'jetpack-videopress-pkg' ),
+			'description'         => __(
+				'List VideoPress-hosted videos on this site. Returns a paginated array of compact summaries, one per video, including media_id, guid, title, public URL, poster image, privacy and rating, duration (ms), dimensions, upload date, and current thumbnail/processing status. Supply `media_id` to fetch a single entry (returns a 0- or 1-element array — never WP_Error for a missing id). Combine with `search` (matches title), `status` (`public`, `private`, `site-private`), and `page` / `per_page` (max 100) to narrow results. Reads VideoPress attachments out of the WordPress media library; the agent typically calls this before `jetpack-videopress/get-storage-quota` for a dashboard overview.',
+				'jetpack-videopress-pkg'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(
+					'search'   => array(
+						'type'        => 'string',
+						'description' => __( 'Search videos by title.', 'jetpack-videopress-pkg' ),
+					),
+					'status'   => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by privacy: "public" (everyone), "private" (always private), "site-private" (follows the site default).', 'jetpack-videopress-pkg' ),
+						'enum'        => array( 'public', 'private', 'site-private' ),
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Page number for paginated results.', 'jetpack-videopress-pkg' ),
+						'default'     => 1,
+						'minimum'     => 1,
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of videos per page. Server caps at 100.', 'jetpack-videopress-pkg' ),
+						'default'     => self::DEFAULT_PER_PAGE,
+						'minimum'     => 1,
+						'maximum'     => self::MAX_PER_PAGE,
+					),
+					'media_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Return only the video with this attachment ID. Empty result when the id does not exist or is not a VideoPress video.', 'jetpack-videopress-pkg' ),
+						'minimum'     => 1,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'list_videos' ),
+			'permission_callback' => array( __CLASS__, 'can_upload_files' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-videopress/get-storage-quota.
+	 *
+	 * Zero-arg overview ability. The dashboard storage meter renders the same
+	 * data; surfacing it here lets the agent answer "how much space have I
+	 * used?" in one call without paginating list-videos.
+	 */
+	private static function spec_get_storage_quota(): array {
+		return array(
+			'label'               => __( 'Get VideoPress storage quota', 'jetpack-videopress-pkg' ),
+			'description'         => __(
+				'Return the current VideoPress storage state for this site. Output: { used_bytes (int), quota_bytes (int|null — null for unlimited plans), percent_used (float, 0-100, null for unlimited), plan_class (one of "free", "videopress-1tb", "videopress-unlimited"), can_upload (bool — whether the current user can upload to VideoPress) }. Idempotent: repeated calls return the same numbers within the underlying 15-second feature transient. Pair with `jetpack-videopress/list-videos` for a full dashboard snapshot.',
+				'jetpack-videopress-pkg'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'get_storage_quota' ),
+			'permission_callback' => array( __CLASS__, 'can_upload_files' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-videopress/get-upload-token.
+	 *
+	 * Mints a one-shot upload JWT and the resumable upload URL. Annotated
+	 * non-readonly because it allocates a fresh credential on every call, and
+	 * non-idempotent because each call returns a new token even when the inputs
+	 * are the same. Destructive remains false: minting a token doesn't change
+	 * any site-visible state.
+	 */
+	private static function spec_get_upload_token(): array {
+		return array(
+			'label'               => __( 'Get VideoPress upload token', 'jetpack-videopress-pkg' ),
+			'description'         => __(
+				'Mint a one-shot VideoPress upload credential the caller can use to PUT/POST a video file to WPCOM. Returns { upload_url (string), token (string), expires_at (int|null — Unix timestamp; null when the underlying service did not include an expiry), max_size_bytes (int|null — null when the service did not advertise a per-upload limit) }. Each call mints a fresh token, so do not cache the result; expect short-lived JWTs. Returns WP_Error when the site is not connected to WordPress.com (`videopress_not_connected`) or when the WPCOM token mint fails (`videopress_upload_token_unavailable`).',
+				'jetpack-videopress-pkg'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'get_upload_token' ),
+			'permission_callback' => array( __CLASS__, 'can_upload_files' ),
+			'meta'                => array(
+				'annotations'  => array(
+					// Token minting is a state-allocating call from the service
+					// side, not a pure read.
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Shared permission callback for the read+mint surface.
+	 *
+	 * Mirrors `Uploader_Rest_Endpoints::permissions_callback()` and
+	 * `WPCOM_REST_API_V2_Endpoint_VideoPress`'s upload-jwt route, which both
+	 * gate on `upload_files`. Storage and listing also gate on the same cap so
+	 * the surface answers a uniform question — "is this user the person who
+	 * would actually be uploading?" — rather than splitting cap checks per
+	 * ability.
+	 *
+	 * @return bool
+	 */
+	public static function can_upload_files(): bool {
+		return current_user_can( 'upload_files' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-videos.
+	 *
+	 * Delegates to GET /wp/v2/media filtered to `video/videopress`, then
+	 * reshapes each attachment into the compact summary documented by the
+	 * spec. When `media_id` is supplied we short-circuit to a single internal
+	 * request for that attachment so callers get a 0- or 1-element array
+	 * without an N-page scan.
+	 *
+	 * @param array $input Arguments from the ability input.
+	 * @return array
+	 */
+	public static function list_videos( $input = null ): array {
+		$input = is_array( $input ) ? $input : array();
+
+		// Single-id short circuit. Returns 0- or 1-element array per the
+		// consolidated-read contract.
+		if ( isset( $input['media_id'] ) && is_numeric( $input['media_id'] ) ) {
+			$media_id = (int) $input['media_id'];
+			if ( $media_id <= 0 ) {
+				return array();
+			}
+			$summary = self::fetch_single_video_summary( $media_id );
+			return null === $summary ? array() : array( $summary );
+		}
+
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : self::DEFAULT_PER_PAGE;
+		if ( $per_page < 1 ) {
+			$per_page = self::DEFAULT_PER_PAGE;
+		}
+		if ( $per_page > self::MAX_PER_PAGE ) {
+			$per_page = self::MAX_PER_PAGE;
+		}
+
+		$page = isset( $input['page'] ) ? (int) $input['page'] : 1;
+		if ( $page < 1 ) {
+			$page = 1;
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$request->set_param( 'mime_type', 'video/videopress' );
+		$request->set_param( 'per_page', $per_page );
+		$request->set_param( 'page', $page );
+
+		if ( isset( $input['search'] ) && '' !== $input['search'] ) {
+			$request->set_param( 'search', (string) $input['search'] );
+		}
+
+		if ( isset( $input['status'], self::STATUS_TO_PRIVACY[ $input['status'] ] ) ) {
+			// Reuses the videopress_privacy_setting filter exposed by
+			// WPCOM_REST_API_V2_Attachment_VideoPress_Data::filter_attachments_by_jetpack_videopress_fields().
+			$request->set_param( 'videopress_privacy_setting', (string) self::STATUS_TO_PRIVACY[ $input['status'] ] );
+		}
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return array();
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) ) {
+			return array();
+		}
+
+		$result = array();
+		foreach ( $data as $attachment ) {
+			$summary = self::summarize_attachment( (array) $attachment );
+			if ( null !== $summary ) {
+				$result[] = $summary;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Execute: get-storage-quota.
+	 *
+	 * Derives the same numbers the dashboard renders:
+	 *  - used_bytes from `Site::get_site_info()['options']['videopress_storage_used']`
+	 *    (already converted to bytes by `Data::get_storage_used()`).
+	 *  - quota_bytes / plan_class from the WPCOM features list.
+	 *
+	 * @param array $input Unused.
+	 * @return array
+	 */
+	public static function get_storage_quota( $input = null ): array {
+		unset( $input );
+
+		$used_bytes = (int) Data::get_storage_used();
+
+		$plan_class = self::detect_plan_class();
+		$quota_bytes = self::quota_for_plan( $plan_class );
+
+		$percent_used = null;
+		if ( null !== $quota_bytes && $quota_bytes > 0 ) {
+			$percent_used = round( ( $used_bytes / $quota_bytes ) * 100, 2 );
+			if ( $percent_used > 100 ) {
+				$percent_used = 100.0;
+			}
+		}
+
+		return array(
+			'used_bytes'   => $used_bytes,
+			'quota_bytes'  => $quota_bytes,
+			'percent_used' => $percent_used,
+			'plan_class'   => $plan_class,
+			'can_upload'   => Data::can_perform_action() && current_user_can( 'upload_files' ),
+		);
+	}
+
+	/**
+	 * Execute: get-upload-token.
+	 *
+	 * Wraps `VideoPressToken::videopress_upload_jwt()` and the same
+	 * resumable-upload URL the wpcom v2 `upload-jwt` controller surfaces. The
+	 * token is short-lived; the agent must consume it immediately rather than
+	 * caching it.
+	 *
+	 * @param array $input Unused.
+	 * @return array|WP_Error
+	 */
+	public static function get_upload_token( $input = null ) {
+		unset( $input );
+
+		if ( ! Data::has_connected_owner() ) {
+			return new WP_Error(
+				'videopress_not_connected',
+				__( 'Connect Jetpack to WordPress.com before requesting a VideoPress upload token. Run the Jetpack connection flow, then retry this ability.', 'jetpack-videopress-pkg' )
+			);
+		}
+
+		$blog_id = Data::get_blog_id();
+		if ( ! $blog_id ) {
+			return new WP_Error(
+				'videopress_not_connected',
+				__( 'The site is not registered with WordPress.com. Complete the Jetpack site-registration step, then retry this ability.', 'jetpack-videopress-pkg' )
+			);
+		}
+
+		try {
+			$token = VideoPressToken::videopress_upload_jwt();
+		} catch ( Upload_Exception $e ) {
+			return new WP_Error(
+				'videopress_upload_token_unavailable',
+				$e->getMessage()
+			);
+		}
+
+		$upload_url = function_exists( 'videopress_make_resumable_upload_path' )
+			? videopress_make_resumable_upload_path( $blog_id )
+			: '';
+
+		return array(
+			'upload_url'     => (string) $upload_url,
+			'token'          => (string) $token,
+			'expires_at'     => self::extract_jwt_expiry( $token ),
+			'max_size_bytes' => null,
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Fetch and project a single VideoPress attachment summary by id.
+	 *
+	 * Returns null when the id does not resolve to a VideoPress video so the
+	 * caller can produce a 0-element array for the unknown-id case.
+	 *
+	 * @param int $media_id Attachment id.
+	 * @return array|null
+	 */
+	private static function fetch_single_video_summary( int $media_id ): ?array {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media/' . $media_id );
+		$request->set_param( 'context', 'edit' );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return null;
+		}
+
+		$data = (array) $response->get_data();
+		if ( empty( $data['id'] ) ) {
+			return null;
+		}
+
+		// Reject non-VideoPress attachments — the caller asked for a VideoPress
+		// video and an "other media" object would be a confusing answer.
+		$mime = isset( $data['mime_type'] ) ? (string) $data['mime_type'] : '';
+		if ( 'video/videopress' !== $mime ) {
+			return null;
+		}
+
+		return self::summarize_attachment( $data );
+	}
+
+	/**
+	 * Project a /wp/v2/media attachment payload into the compact list-videos
+	 * shape documented by the spec.
+	 *
+	 * @param array $attachment Attachment payload from the REST media endpoint.
+	 * @return array|null Summary, or null if the payload is missing the
+	 *                    minimum fields needed to identify the video.
+	 */
+	private static function summarize_attachment( array $attachment ): ?array {
+		if ( empty( $attachment['id'] ) ) {
+			return null;
+		}
+
+		$videopress    = isset( $attachment['jetpack_videopress'] ) && is_array( $attachment['jetpack_videopress'] )
+			? $attachment['jetpack_videopress']
+			: array();
+		$media_details = isset( $attachment['media_details'] ) && is_array( $attachment['media_details'] )
+			? $attachment['media_details']
+			: array();
+		$vp_details    = isset( $media_details['videopress'] ) && is_array( $media_details['videopress'] )
+			? $media_details['videopress']
+			: array();
+
+		$privacy_setting = isset( $videopress['privacy_setting'] )
+			? (int) $videopress['privacy_setting']
+			: self::PRIVACY_SITE_DEFAULT;
+
+		$privacy_label = 'site-default';
+		if ( self::PRIVACY_PUBLIC === $privacy_setting ) {
+			$privacy_label = 'public';
+		} elseif ( self::PRIVACY_PRIVATE === $privacy_setting ) {
+			$privacy_label = 'private';
+		}
+
+		$duration_ms = null;
+		if ( isset( $vp_details['duration'] ) && is_numeric( $vp_details['duration'] ) ) {
+			$duration_ms = (int) $vp_details['duration'];
+		}
+
+		$width = null;
+		if ( isset( $media_details['width'] ) && is_numeric( $media_details['width'] ) ) {
+			$width = (int) $media_details['width'];
+		}
+
+		$height = null;
+		if ( isset( $media_details['height'] ) && is_numeric( $media_details['height'] ) ) {
+			$height = (int) $media_details['height'];
+		}
+
+		$title = '';
+		if ( isset( $videopress['title'] ) && is_string( $videopress['title'] ) ) {
+			$title = $videopress['title'];
+		} elseif ( isset( $attachment['title'] ) && is_array( $attachment['title'] ) ) {
+			$title = (string) ( $attachment['title']['rendered'] ?? $attachment['title']['raw'] ?? '' );
+		}
+
+		$poster = null;
+		if ( isset( $vp_details['poster'] ) && is_string( $vp_details['poster'] ) && '' !== $vp_details['poster'] ) {
+			$poster = $vp_details['poster'];
+		}
+
+		$thumbnail_status = $poster ? 'ready' : 'pending';
+		$processing_status = isset( $vp_details['finished'] ) && $vp_details['finished'] ? 'complete' : 'processing';
+
+		return array(
+			'media_id'          => (int) $attachment['id'],
+			'guid'              => isset( $attachment['jetpack_videopress_guid'] )
+				? (string) $attachment['jetpack_videopress_guid']
+				: '',
+			'title'             => $title,
+			'url'               => isset( $attachment['source_url'] ) ? (string) $attachment['source_url'] : '',
+			'poster'            => $poster,
+			'privacy'           => $privacy_label,
+			'rating'            => isset( $videopress['rating'] ) ? (string) $videopress['rating'] : '',
+			'duration_ms'       => $duration_ms,
+			'width'             => $width,
+			'height'            => $height,
+			'uploaded_at'       => isset( $attachment['date_gmt'] ) ? (string) $attachment['date_gmt'] : '',
+			'thumbnail_status'  => $thumbnail_status,
+			'processing_status' => $processing_status,
+		);
+	}
+
+	/**
+	 * Determine the active VideoPress plan class from the WPCOM features list.
+	 *
+	 * Returns one of `free`, `videopress-1tb`, `videopress-unlimited`. The
+	 * `unlimited` branch matches My Jetpack's feature catalog; the `1tb`
+	 * branch covers both Jetpack's `videopress-1tb-storage` and the simple
+	 * `videopress` feature WPCOM uses on its own platform.
+	 *
+	 * @return string
+	 */
+	private static function detect_plan_class(): string {
+		$features = Product::get_site_features_from_wpcom();
+		if ( ! is_array( $features ) ) {
+			return 'free';
+		}
+
+		$active = isset( $features['active'] ) && is_array( $features['active'] )
+			? $features['active']
+			: array();
+
+		if ( in_array( 'videopress-unlimited-storage', $active, true ) ) {
+			return 'videopress-unlimited';
+		}
+
+		$is_wpcom_platform = ( new Host() )->is_wpcom_platform();
+
+		if ( in_array( 'videopress-1tb-storage', $active, true )
+			|| ( $is_wpcom_platform && in_array( 'videopress', $active, true ) )
+		) {
+			return 'videopress-1tb';
+		}
+
+		return 'free';
+	}
+
+	/**
+	 * Translate a plan class into the byte quota the dashboard shows.
+	 *
+	 * @param string $plan_class One of the detect_plan_class() return values.
+	 * @return int|null Bytes, or null for unlimited.
+	 */
+	private static function quota_for_plan( string $plan_class ): ?int {
+		if ( 'videopress-unlimited' === $plan_class ) {
+			return null;
+		}
+		// Both the free tier and the 1TB plan render against the same 1TB
+		// cap in the dashboard. We surface the same number here so the
+		// agent's percent_used matches what the user sees.
+		return self::QUOTA_BYTES_1TB;
+	}
+
+	/**
+	 * Decode the `exp` claim from a JWT without verifying the signature.
+	 *
+	 * Returns null when the payload can't be parsed — callers treat a missing
+	 * expiry as "unknown" rather than guessing one.
+	 *
+	 * @param string $token JWT.
+	 * @return int|null Unix timestamp, or null when not available.
+	 */
+	private static function extract_jwt_expiry( string $token ): ?int {
+		$parts = explode( '.', $token );
+		if ( count( $parts ) < 2 ) {
+			return null;
+		}
+
+		$payload_b64 = strtr( $parts[1], '-_', '+/' );
+		$padding     = strlen( $payload_b64 ) % 4;
+		if ( $padding > 0 ) {
+			$payload_b64 .= str_repeat( '=', 4 - $padding );
+		}
+
+		$payload_json = base64_decode( $payload_b64, true );
+		if ( false === $payload_json ) {
+			return null;
+		}
+
+		$payload = json_decode( $payload_json, true );
+		if ( ! is_array( $payload ) || ! isset( $payload['exp'] ) || ! is_numeric( $payload['exp'] ) ) {
+			return null;
+		}
+
+		return (int) $payload['exp'];
+	}
+}

--- a/projects/packages/videopress/tests/php/abilities/VideoPress_Abilities_Test.php
+++ b/projects/packages/videopress/tests/php/abilities/VideoPress_Abilities_Test.php
@@ -1,0 +1,581 @@
+<?php
+/**
+ * Unit tests for Jetpack VideoPress Abilities.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9. The class guards function_exists() so the package is safe on older WP. @todo Remove this line when the minimum supported WordPress version is 6.9.
+
+namespace Automattic\Jetpack\VideoPress\Abilities;
+
+use Automattic\Jetpack\VideoPress\Data;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WorDBless\BaseTestCase;
+
+/**
+ * Unit tests for VideoPress_Abilities registration and execution.
+ *
+ * To run this test from the projects/packages/videopress directory:
+ *
+ *   composer phpunit -- --filter VideoPress_Abilities_Test
+ */
+class VideoPress_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Administrator user id (can upload_files).
+	 *
+	 * @var int
+	 */
+	private $admin_user_id;
+
+	/**
+	 * Subscriber user id (cannot upload_files).
+	 *
+	 * @var int
+	 */
+	private $subscriber_user_id;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		$this->admin_user_id = wp_insert_user(
+			array(
+				'user_login' => 'vp_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_user_id = wp_insert_user(
+			array(
+				'user_login' => 'vp_subscriber',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tearDown(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		wp_set_current_user( 0 );
+
+		// Reset the abilities registry between tests so back-to-back
+		// `register_*()` calls don't trigger "already registered" notices.
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( VideoPress_Abilities::get_abilities() ) as $slug ) {
+				if ( function_exists( 'wp_has_ability' ) && wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' )
+			&& function_exists( 'wp_has_ability_category' )
+			&& wp_has_ability_category( VideoPress_Abilities::CATEGORY_SLUG )
+		) {
+			wp_unregister_ability_category( VideoPress_Abilities::CATEGORY_SLUG );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Simulate `wp_abilities_api_categories_init` having fired so the
+	 * Registrar's `did_action()` branch takes the synchronous registration
+	 * path during tests.
+	 */
+	private function simulate_doing_categories_init_action(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = Registrar::CATEGORIES_INIT_ACTION;
+	}
+
+	/**
+	 * Simulate `wp_abilities_api_init` having fired.
+	 */
+	private function simulate_doing_abilities_init_action(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = Registrar::ABILITIES_INIT_ACTION;
+	}
+
+	/**
+	 * Skip the test if the WP 6.9+ Abilities API isn't available in the test
+	 * environment. The class still loads — only the live-registration tests
+	 * need the runtime.
+	 */
+	private function skip_when_abilities_api_missing(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this test environment.' );
+		}
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Registrar wiring
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Gate filter defaulting to false must short-circuit init() — nothing
+	 * hooks, nothing registers.
+	 */
+	public function test_init_registers_nothing_when_rollout_filter_is_disabled(): void {
+		$this->skip_when_abilities_api_missing();
+
+		// Capture every category and ability the test environment registers
+		// before our init() runs, so we can isolate "did init() add ours?"
+		// from the WP-core abilities/categories that already exist.
+		$baseline_abilities = function_exists( 'wp_get_abilities' )
+			? array_keys( wp_get_abilities() )
+			: array();
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		try {
+			VideoPress_Abilities::init();
+
+			// Trigger the lifecycle actions only if they haven't already been
+			// fired, to confirm init() did not hook anything into them.
+			if ( ! did_action( Registrar::ABILITIES_INIT_ACTION ) ) {
+				do_action( Registrar::ABILITIES_INIT_ACTION );
+			}
+
+			$after_abilities = function_exists( 'wp_get_abilities' )
+				? array_keys( wp_get_abilities() )
+				: array();
+			$added           = array_diff( $after_abilities, $baseline_abilities );
+
+			$this->assertEmpty(
+				array_filter(
+					$added,
+					static fn ( $slug ) => 0 === strpos( $slug, VideoPress_Abilities::CATEGORY_SLUG . '/' )
+				),
+				'VideoPress abilities must not register while the rollout filter is disabled.'
+			);
+			$this->assertFalse(
+				wp_has_ability_category( VideoPress_Abilities::CATEGORY_SLUG ),
+				'Category must not register while the rollout filter is disabled.'
+			);
+		} finally {
+			remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		}
+	}
+
+	/**
+	 * Filter enabled + Abilities API ready: the category and every ability
+	 * register and the category slug is auto-injected onto each spec.
+	 */
+	public function test_init_registers_category_and_abilities_when_enabled(): void {
+		$this->skip_when_abilities_api_missing();
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		try {
+			$this->simulate_doing_categories_init_action();
+			VideoPress_Abilities::register_category();
+
+			$this->simulate_doing_abilities_init_action();
+			VideoPress_Abilities::register_abilities();
+
+			$this->assertTrue(
+				wp_has_ability_category( VideoPress_Abilities::CATEGORY_SLUG ),
+				'VideoPress category should be registered.'
+			);
+
+			$expected = array(
+				'jetpack-videopress/list-videos',
+				'jetpack-videopress/get-storage-quota',
+				'jetpack-videopress/get-upload-token',
+			);
+			foreach ( $expected as $slug ) {
+				$ability = wp_get_ability( $slug );
+				$this->assertNotNull( $ability, "Ability $slug must register." );
+			}
+		} finally {
+			remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		}
+	}
+
+	/**
+	 * The per-ability `jetpack_wp_abilities_should_register` filter returning
+	 * false for a specific slug must skip only that ability — siblings still
+	 * register.
+	 */
+	public function test_per_ability_filter_can_disable_a_single_ability(): void {
+		$this->skip_when_abilities_api_missing();
+
+		$skip = static function ( $enabled, $type, $slug ) {
+			if ( 'ability' === $type && 'jetpack-videopress/get-upload-token' === $slug ) {
+				return false;
+			}
+			return $enabled;
+		};
+		add_filter( 'jetpack_wp_abilities_should_register', $skip, 10, 3 );
+
+		try {
+			$this->simulate_doing_categories_init_action();
+			VideoPress_Abilities::register_category();
+
+			$this->simulate_doing_abilities_init_action();
+			VideoPress_Abilities::register_abilities();
+
+			$this->assertNotNull(
+				wp_get_ability( 'jetpack-videopress/list-videos' ),
+				'list-videos must still register when only upload-token is skipped.'
+			);
+			$this->assertFalse(
+				wp_has_ability( 'jetpack-videopress/get-upload-token' ),
+				'get-upload-token must not register when the per-ability filter returns false.'
+			);
+		} finally {
+			remove_filter( 'jetpack_wp_abilities_should_register', $skip, 10 );
+		}
+	}
+
+	/**
+	 * Abilities omit `category` in their specs — the Registrar must inject
+	 * the subclass's slug so the dashboard groups them under jetpack-videopress.
+	 */
+	public function test_category_is_auto_injected_into_each_spec(): void {
+		$abilities = VideoPress_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( $abilities as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Spec for $slug must omit 'category' so Registrar injects the slug."
+			);
+		}
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Abstract getters
+	 * ---------------------------------------------------------------------
+	 */
+
+	public function test_get_category_slug_returns_jetpack_videopress(): void {
+		$this->assertSame( 'jetpack-videopress', VideoPress_Abilities::get_category_slug() );
+	}
+
+	public function test_get_category_definition_returns_label_and_description(): void {
+		$def = VideoPress_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertNotEmpty( $def['description'] );
+	}
+
+	public function test_get_abilities_returns_expected_slugs(): void {
+		$abilities = VideoPress_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-videopress/list-videos', $abilities );
+		$this->assertArrayHasKey( 'jetpack-videopress/get-storage-quota', $abilities );
+		$this->assertArrayHasKey( 'jetpack-videopress/get-upload-token', $abilities );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callback
+	 * ---------------------------------------------------------------------
+	 */
+
+	public function test_can_upload_files_allows_admin(): void {
+		wp_set_current_user( $this->admin_user_id );
+		$this->assertTrue( VideoPress_Abilities::can_upload_files() );
+	}
+
+	public function test_can_upload_files_denies_subscriber(): void {
+		wp_set_current_user( $this->subscriber_user_id );
+		$this->assertFalse( VideoPress_Abilities::can_upload_files() );
+	}
+
+	public function test_can_upload_files_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( VideoPress_Abilities::can_upload_files() );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute: list-videos
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Happy path: list-videos returns the documented compact shape for a
+	 * VideoPress attachment. Exercised via the `media_id` filter, which goes
+	 * through the same `summarize_attachment` projection the list query
+	 * uses; the consolidated-read contract guarantees the two code paths
+	 * return entries shaped identically.
+	 */
+	public function test_list_videos_returns_compact_shape_for_videopress_attachment(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$attachment_id = $this->make_videopress_attachment( 'My Test Video' );
+
+		$result = VideoPress_Abilities::list_videos( array( 'media_id' => $attachment_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$found = $result[0];
+
+		// Documented shape — every key must be present.
+		foreach (
+			array(
+				'media_id',
+				'guid',
+				'title',
+				'url',
+				'poster',
+				'privacy',
+				'rating',
+				'duration_ms',
+				'width',
+				'height',
+				'uploaded_at',
+				'thumbnail_status',
+				'processing_status',
+			) as $key
+		) {
+			$this->assertArrayHasKey( $key, $found, "Entry missing key '$key'." );
+		}
+
+		$this->assertSame( $attachment_id, $found['media_id'] );
+		$this->assertIsString( $found['title'] );
+		$this->assertContains(
+			$found['privacy'],
+			array( 'public', 'private', 'site-default' ),
+			'privacy must be one of the three documented labels.'
+		);
+	}
+
+	/**
+	 * `media_id` filter with an unknown id must return an empty array — not a
+	 * WP_Error — per the consolidated-read contract.
+	 */
+	public function test_list_videos_with_unknown_media_id_returns_empty_array(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$result = VideoPress_Abilities::list_videos( array( 'media_id' => 9999999 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * `media_id` filter with the literal string `'0'` is treated as an unknown
+	 * id (regression guard against `empty('0')` returning true).
+	 */
+	public function test_list_videos_with_string_zero_media_id_returns_empty_array(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		// Negative ids and 0 collapse to empty.
+		$this->assertSame( array(), VideoPress_Abilities::list_videos( array( 'media_id' => '0' ) ) );
+	}
+
+	/**
+	 * `media_id` filter for an existing VideoPress attachment returns a
+	 * 1-element array with the same shape as the list response.
+	 */
+	public function test_list_videos_with_known_media_id_returns_single_element_array(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$attachment_id = $this->make_videopress_attachment( 'Single video' );
+
+		$result = VideoPress_Abilities::list_videos( array( 'media_id' => $attachment_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( $attachment_id, $result[0]['media_id'] );
+	}
+
+	/**
+	 * `media_id` pointing at a non-VideoPress attachment (regular media)
+	 * returns an empty array — we don't want callers seeing "other media"
+	 * objects bleed into the VideoPress surface.
+	 */
+	public function test_list_videos_with_non_videopress_media_id_returns_empty_array(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_title'     => 'plain image',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/png',
+			)
+		);
+
+		$result = VideoPress_Abilities::list_videos( array( 'media_id' => $attachment_id ) );
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * `per_page` above the cap must be clamped — even if the schema's
+	 * maximum is bypassed by a non-validating caller.
+	 */
+	public function test_list_videos_clamps_per_page_at_100(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		// Capture the per_page that reaches /wp/v2/media so we can assert the
+		// clamp without inserting 1000 attachments.
+		$captured = null;
+		$capture  = static function ( $result, $server, $request ) use ( &$captured ) {
+			if ( '/wp/v2/media' === $request->get_route() ) {
+				$captured = $request->get_param( 'per_page' );
+			}
+			return $result;
+		};
+		add_filter( 'rest_pre_dispatch', $capture, 10, 3 );
+
+		try {
+			VideoPress_Abilities::list_videos( array( 'per_page' => 5000 ) );
+		} finally {
+			remove_filter( 'rest_pre_dispatch', $capture, 10 );
+		}
+
+		$this->assertSame( VideoPress_Abilities::MAX_PER_PAGE, $captured );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute: get-storage-quota
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Happy path: get-storage-quota returns the documented shape with sane
+	 * defaults when no plan/features are known.
+	 */
+	public function test_get_storage_quota_returns_documented_shape(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		$result = VideoPress_Abilities::get_storage_quota();
+
+		$this->assertIsArray( $result );
+		foreach ( array( 'used_bytes', 'quota_bytes', 'percent_used', 'plan_class', 'can_upload' ) as $key ) {
+			$this->assertArrayHasKey( $key, $result, "Quota missing key '$key'." );
+		}
+		$this->assertIsInt( $result['used_bytes'] );
+		$this->assertIsBool( $result['can_upload'] );
+		$this->assertIsString( $result['plan_class'] );
+		$this->assertContains(
+			$result['plan_class'],
+			array( 'free', 'videopress-1tb', 'videopress-unlimited' ),
+			'plan_class must be one of the documented enum values.'
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute: get-upload-token
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Without a connected owner the ability must return WP_Error with the
+	 * documented `videopress_not_connected` code so the agent knows what to
+	 * fix.
+	 */
+	public function test_get_upload_token_returns_wp_error_when_not_connected(): void {
+		wp_set_current_user( $this->admin_user_id );
+
+		// `Data::has_connected_owner()` returns false by default in WorDBless,
+		// since no Jetpack connection exists.
+		$result = VideoPress_Abilities::get_upload_token();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'videopress_not_connected', $result->get_error_code() );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Schema sanity
+	 * ---------------------------------------------------------------------
+	 */
+
+	public function test_list_videos_schema_clamps_per_page_at_100_in_schema(): void {
+		$abilities = VideoPress_Abilities::get_abilities();
+		$schema    = $abilities['jetpack-videopress/list-videos']['input_schema'];
+		$this->assertSame(
+			100,
+			$schema['properties']['per_page']['maximum'],
+			'list-videos input_schema must cap per_page at 100.'
+		);
+		$this->assertFalse( $schema['additionalProperties'] );
+	}
+
+	public function test_each_ability_declares_annotations(): void {
+		$abilities = VideoPress_Abilities::get_abilities();
+		foreach ( $abilities as $slug => $spec ) {
+			$this->assertArrayHasKey( 'meta', $spec, "$slug must declare meta." );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'], "$slug must declare meta.annotations." );
+			foreach ( array( 'readonly', 'destructive', 'idempotent' ) as $annotation ) {
+				$this->assertArrayHasKey(
+					$annotation,
+					$spec['meta']['annotations'],
+					"$slug missing annotations.$annotation."
+				);
+				$this->assertIsBool(
+					$spec['meta']['annotations'][ $annotation ],
+					"$slug annotation $annotation must be a bool."
+				);
+			}
+		}
+	}
+
+	public function test_upload_token_annotated_not_readonly_and_not_idempotent(): void {
+		$abilities  = VideoPress_Abilities::get_abilities();
+		$annotations = $abilities['jetpack-videopress/get-upload-token']['meta']['annotations'];
+		$this->assertFalse( $annotations['readonly'], 'Minting a token is not a pure read.' );
+		$this->assertFalse( $annotations['destructive'], 'Minting a token does not delete state.' );
+		$this->assertFalse( $annotations['idempotent'], 'Each call mints a fresh token.' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Fixtures
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Create a VideoPress attachment fixture with a `jetpack_videopress`
+	 * field shaped like the dashboard expects.
+	 *
+	 * @param string $title Post title.
+	 * @return int Attachment id.
+	 */
+	private function make_videopress_attachment( string $title ): int {
+		// The REST attachments controller filters orphan attachments by their
+		// (missing) parent's visibility; pin a published post as the parent so
+		// the test fixture survives the controller's parent_status filter.
+		$parent_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => $title . ' parent',
+				'post_status' => 'publish',
+			)
+		);
+
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_parent'    => $parent_id,
+				'post_title'     => $title,
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'video/videopress',
+			)
+		);
+		update_post_meta( $attachment_id, 'videopress_guid', 'abcd1234' );
+		update_post_meta( $attachment_id, 'videopress_privacy_setting', 0 );
+		update_post_meta( $attachment_id, 'videopress_rating', 'G' );
+
+		return (int) $attachment_id;
+	}
+}


### PR DESCRIPTION
## Summary

Registers three read-leaning WP Abilities for the VideoPress package — `jetpack-videopress/list-videos`, `jetpack-videopress/get-storage-quota`, and `jetpack-videopress/get-upload-token` — extending `Automattic\Jetpack\WP_Abilities\Registrar`. Wiring is plumbed via `projects/packages/videopress/actions.php` (a new autoload-files entry following the canonical guarded pattern from `projects/packages/publicize/actions.php`) so every consumer of the package — the Jetpack plugin, the standalone VideoPress plugin, mu-wpcom-plugin — opts in through a single call gated by `apply_filters( 'jetpack_wp_abilities_enabled', false )`.

Aligns the VideoPress package with §4.2 of the Abilities Everywhere rollout plan: list + overview + mint-credential is the smallest surface that lets an agent answer "what videos do I have, how much space is left, and how do I upload another one?" Updates and deletes are deferred to a follow-up PR — the write design needs to land on its own.

### Ability details

| Slug | Shape | Permission | Annotations |
|---|---|---|---|
| `jetpack-videopress/list-videos` | Paginated array of `{ media_id, guid, title, url, poster, privacy, rating, duration_ms, width, height, uploaded_at, thumbnail_status, processing_status }`. `media_id` filter returns a 0- or 1-element array (consolidated-read pattern). `per_page` clamped at 100. | `current_user_can( 'upload_files' )` | readonly, idempotent |
| `jetpack-videopress/get-storage-quota` | `{ used_bytes, quota_bytes, percent_used, plan_class, can_upload }`. Zero-arg overview. | `current_user_can( 'upload_files' )` | readonly, idempotent |
| `jetpack-videopress/get-upload-token` | `{ upload_url, token, expires_at, max_size_bytes }`. Mints a fresh JWT per call via `VideoPressToken::videopress_upload_jwt()`. Returns `videopress_not_connected` WP_Error when the site isn't connected. | `current_user_can( 'upload_files' )` | not readonly, not destructive, not idempotent |

The read callbacks delegate to the package's existing helpers (`Data::get_storage_used`, `Site::get_site_info`, the WPCOM features cache exposed by `Product::get_site_features_from_wpcom`) and to `/wp/v2/media` filtered to `video/videopress` so they inherit the same data the dashboard renders.

## Test plan

- [x] `cd projects/packages/videopress && composer phpunit -- --filter VideoPress_Abilities_Test` — 21 tests / 90 assertions green.
- [x] `cd projects/packages/videopress && composer phpunit` — full suite 133/133 green.
- [x] Changelog entry validates via `jetpack changelog validate packages/videopress`.
- [ ] On a connected site with the `jetpack_wp_abilities_enabled` filter returning true, verify `/wp-json/wp-abilities/v1/abilities` lists the three new slugs.
- [ ] Verify `jetpack-videopress/list-videos` against a site with VideoPress-hosted videos returns the documented compact shape (without raw `WP_Post` leakage).
- [ ] Verify `jetpack-videopress/get-upload-token` mints a fresh JWT and the returned `upload_url` accepts a small Tus upload.

### Test coverage included

- Registrar wiring: rollout-filter-off path registers nothing; rollout-filter-on registers the category + every ability; per-ability `jetpack_wp_abilities_should_register` filter can skip a single ability.
- Abstract getters return expected slug / definition / map.
- Category auto-injection: every spec omits `category` so the Registrar injects the slug.
- Permission callbacks: admin allowed, subscriber denied, anonymous denied.
- `list-videos` happy path returns the full documented shape.
- `list-videos` with unknown `media_id`, string `'0'`, and non-VideoPress media_id all return empty array (regression guards against `empty()` and against bleed-through of non-VP attachments).
- `list-videos` clamps `per_page` to 100 in both the schema and the callback.
- `get-storage-quota` returns the documented shape with `plan_class` in the enum set.
- `get-upload-token` returns the documented `videopress_not_connected` WP_Error when the connection isn't ready.
- Annotation schema: every ability declares `readonly`/`destructive`/`idempotent` as booleans; the upload-token annotations match its "mints fresh credential per call" semantics.

## Deferred

- `update-video`, `delete-video`, and a server-side upload-blob receiver are intentionally out of scope. The write surface needs an independent design pass (privacy state transitions, deletion semantics on attached posts) before it ships.