### PR TITLE
CRM abilities: register contacts, deals, invoices reads via Registrar

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -402,6 +402,20 @@ if ( jpcrm_do_critical_prerun_checks() ) {
 		0
 	);
 
+	// Register Jetpack CRM abilities once the CRM core has booted.
+	// Runs at `init` priority 20 so that `$zbs->DAL` is available before
+	// any ability is invoked, and the Abilities API is ready to receive
+	// our category and ability registrations.
+	add_action(
+		'init',
+		function () {
+			if ( class_exists( \Automattic\Jetpack\CRM\Abilities\CRM_Abilities::class ) ) {
+				\Automattic\Jetpack\CRM\Abilities\CRM_Abilities::init();
+			}
+		},
+		20
+	);
+
 	add_action(
 		'plugins_loaded',
 		function () {

--- a/projects/plugins/crm/changelog/add-crm-abilities
+++ b/projects/plugins/crm/changelog/add-crm-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register read-only abilities for CRM contacts, deals, and invoices.

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -55,6 +55,7 @@
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev",
 		"automattic/woocommerce": "^3.1",
 		"dompdf/dompdf": "^3.1",
 		"thecodingmachine/safe": "^1.3"

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ec26d779e5614655d8c4563c32dc12f",
+    "content-hash": "089af8b508facdf91f8b9a12e839d4ec",
     "packages": [
         {
             "name": "automattic/jetpack-assets",
@@ -318,6 +318,64 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
             "transport-options": {
                 "relative": true
             }
@@ -5494,6 +5552,7 @@
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,
+        "automattic/jetpack-wp-abilities": 20,
         "automattic/phpunit-select-config": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/crm/phpunit.11.xml.dist
+++ b/projects/plugins/crm/phpunit.11.xml.dist
@@ -31,6 +31,9 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="abilities">
+			<directory suffix="Test.php">tests/php/abilities</directory>
+		</testsuite>
 	</testsuites>
 
 	<source>

--- a/projects/plugins/crm/phpunit.9.xml.dist
+++ b/projects/plugins/crm/phpunit.9.xml.dist
@@ -22,5 +22,8 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="abilities">
+			<directory suffix="Test.php">tests/php/abilities</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/projects/plugins/crm/src/abilities/class-crm-abilities.php
+++ b/projects/plugins/crm/src/abilities/class-crm-abilities.php
@@ -1,0 +1,802 @@
+<?php
+/**
+ * Jetpack CRM Abilities Registration.
+ *
+ * Registers read-only Jetpack CRM abilities (contacts, deals, invoices) with
+ * the WordPress Abilities API so AI agents can browse CRM data through the
+ * standard `wp-abilities/v1` REST surface.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\CRM\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack CRM abilities with the WordPress Abilities API.
+ *
+ * This first cut is read-only: contacts (filtered list + single id),
+ * deals (a.k.a. quotes), and invoices. Writes (create/update/delete,
+ * add-note) are intentionally deferred — they require a careful
+ * design pass on the CRM's DAL3 add/update entry points and aren't
+ * part of this PR.
+ */
+class CRM_Abilities extends Registrar {
+
+	/**
+	 * Capability gating read access to CRM admin data.
+	 *
+	 * The CRM grants `admin_zerobs_customers` to roles that can view the
+	 * contacts/customer screens (`administrator`, `zerobs_admin`,
+	 * `zerobs_customermgr`). Mirrors the cap used by the legacy admin
+	 * pages and the `jpcrm_can_user_manage_contacts()` helper.
+	 */
+	private const CAP_VIEW_CRM = 'admin_zerobs_customers';
+
+	/**
+	 * Hard ceiling on `per_page` for list-shaped reads. Mirrors the
+	 * 100-row default the underlying DAL uses but enforces it in the
+	 * ability layer too so agents can't ask for more.
+	 */
+	private const MAX_PER_PAGE = 100;
+
+	/**
+	 * Default `per_page` for list-shaped reads when none is supplied.
+	 */
+	private const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-crm';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack CRM" is a product name and should not be translated.
+			'label'       => 'Jetpack CRM',
+			'description' => __( 'Abilities for reading Jetpack CRM contacts, deals, and invoices.', 'zero-bs-crm' ),
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_abilities(): array {
+		$pagination_properties = array(
+			'page'     => array(
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'default'     => 1,
+				'description' => __( '1-indexed page of results.', 'zero-bs-crm' ),
+			),
+			'per_page' => array(
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'maximum'     => self::MAX_PER_PAGE,
+				'default'     => self::DEFAULT_PER_PAGE,
+				'description' => __( 'Number of results per page. Capped at 100.', 'zero-bs-crm' ),
+			),
+		);
+
+		$contact_summary_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'                => array( 'type' => 'integer' ),
+				'name'              => array( 'type' => 'string' ),
+				'email'             => array( 'type' => 'string' ),
+				'phone'             => array( 'type' => 'string' ),
+				'status'            => array( 'type' => 'string' ),
+				'owner'             => array( 'type' => 'integer' ),
+				'tags'              => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'created_at'        => array(
+					'type'        => array( 'integer', 'null' ),
+					'description' => __( 'Unix timestamp when the contact was created.', 'zero-bs-crm' ),
+				),
+				'last_contacted_at' => array(
+					'type'        => array( 'integer', 'null' ),
+					'description' => __( 'Unix timestamp of the contact\'s last logged interaction.', 'zero-bs-crm' ),
+				),
+			),
+		);
+
+		$contact_detail_schema = array(
+			'type'       => 'object',
+			'properties' => array_merge(
+				$contact_summary_schema['properties'],
+				array(
+					'notes'         => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+					'activity'      => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'object' ),
+					),
+					'custom_fields' => array( 'type' => 'object' ),
+				)
+			),
+		);
+
+		$deal_summary_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'                  => array( 'type' => 'integer' ),
+				'title'               => array( 'type' => 'string' ),
+				'value'               => array( 'type' => 'number' ),
+				'currency'            => array( 'type' => 'string' ),
+				'status'              => array( 'type' => 'string' ),
+				'contact_id'          => array( 'type' => array( 'integer', 'null' ) ),
+				'owner'               => array( 'type' => 'integer' ),
+				'created_at'          => array( 'type' => array( 'integer', 'null' ) ),
+				'expected_close_date' => array( 'type' => array( 'integer', 'null' ) ),
+			),
+		);
+
+		$invoice_summary_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'         => array( 'type' => 'integer' ),
+				'number'     => array( 'type' => 'string' ),
+				'contact_id' => array( 'type' => array( 'integer', 'null' ) ),
+				'total'      => array( 'type' => 'number' ),
+				'currency'   => array( 'type' => 'string' ),
+				'status'     => array( 'type' => 'string' ),
+				'due_date'   => array( 'type' => array( 'integer', 'null' ) ),
+				'issued_at'  => array( 'type' => array( 'integer', 'null' ) ),
+				'paid_at'    => array( 'type' => array( 'integer', 'null' ) ),
+			),
+		);
+
+		return array(
+			'jetpack-crm/list-contacts' => array(
+				'label'               => __( 'List CRM contacts', 'zero-bs-crm' ),
+				'description'         => __(
+					'Return Jetpack CRM contacts as an array of summaries. Combine search/status/contact_id filters to narrow the result. When contact_id is provided, returns at most one element — unknown ids yield an empty array. To fetch a contact with notes, activity, and custom fields, call jetpack-crm/get-contact.',
+					'zero-bs-crm'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array_merge(
+						array(
+							'search'     => array(
+								'type'        => 'string',
+								'description' => __( 'Case-insensitive substring match against name and email.', 'zero-bs-crm' ),
+								'minLength'   => 1,
+							),
+							'status'     => array(
+								'type'        => 'string',
+								'description' => __( 'Filter by CRM contact status (e.g. "Lead", "Customer").', 'zero-bs-crm' ),
+								'minLength'   => 1,
+							),
+							'contact_id' => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'description' => __( 'Return a single contact by id. Unknown ids yield an empty array.', 'zero-bs-crm' ),
+							),
+						),
+						$pagination_properties
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $contact_summary_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_contacts' ),
+				'permission_callback' => array( __CLASS__, 'can_view_crm' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-crm/get-contact'   => array(
+				'label'               => __( 'Get CRM contact', 'zero-bs-crm' ),
+				'description'         => __(
+					'Return a single Jetpack CRM contact as a 0- or 1-element array including notes, activity log, and custom fields. Unknown ids yield an empty array, not an error. For paginated browsing or summary fields only, call jetpack-crm/list-contacts.',
+					'zero-bs-crm'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'id' ),
+					'properties'           => array(
+						'id' => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Contact id. Unknown ids yield an empty array.', 'zero-bs-crm' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $contact_detail_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_contact' ),
+				'permission_callback' => array( __CLASS__, 'can_view_crm' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-crm/list-deals'    => array(
+				'label'               => __( 'List CRM deals', 'zero-bs-crm' ),
+				'description'         => __(
+					'Return Jetpack CRM deals (quotes) as an array of summaries. Combine status/owner filters to narrow the result. Currency reflects the site\'s base currency.',
+					'zero-bs-crm'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array_merge(
+						array(
+							'status' => array(
+								'type'        => 'string',
+								'description' => __( 'Filter by deal status (e.g. "Draft", "Sent", "Accepted").', 'zero-bs-crm' ),
+								'minLength'   => 1,
+							),
+							'owner'  => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'description' => __( 'Filter by owner WordPress user id.', 'zero-bs-crm' ),
+							),
+						),
+						$pagination_properties
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $deal_summary_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_deals' ),
+				'permission_callback' => array( __CLASS__, 'can_view_crm' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-crm/list-invoices' => array(
+				'label'               => __( 'List CRM invoices', 'zero-bs-crm' ),
+				'description'         => __(
+					'Return Jetpack CRM invoices as an array of summaries. Combine status filter to narrow by lifecycle state. Currency reflects the site\'s base currency.',
+					'zero-bs-crm'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array_merge(
+						array(
+							'status' => array(
+								'type'        => 'string',
+								'enum'        => array( 'paid', 'unpaid', 'overdue', 'draft' ),
+								'description' => __( 'Filter by invoice lifecycle status.', 'zero-bs-crm' ),
+							),
+						),
+						$pagination_properties
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $invoice_summary_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_invoices' ),
+				'permission_callback' => array( __CLASS__, 'can_view_crm' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check for all CRM read abilities.
+	 *
+	 * Gated on `admin_zerobs_customers`, which the CRM grants to
+	 * `administrator`, `zerobs_admin`, and `zerobs_customermgr` roles.
+	 */
+	public static function can_view_crm(): bool {
+		return current_user_can( self::CAP_VIEW_CRM );
+	}
+
+	// -------------------- Execute callbacks --------------------
+
+	/**
+	 * Execute: list contacts (or fetch one by id).
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_contacts( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$dal = self::get_dal();
+		if ( null === $dal ) {
+			return new \WP_Error(
+				'jetpack_crm_not_initialized',
+				__( 'Jetpack CRM has not finished loading. Retry on a later request.', 'zero-bs-crm' )
+			);
+		}
+
+		// Single-id short-circuit (consolidated-read contract).
+		if ( isset( $input['contact_id'] ) ) {
+			$id = (int) $input['contact_id'];
+			if ( $id <= 0 ) {
+				return array();
+			}
+			$row = $dal->contacts->getContact(
+				$id,
+				array(
+					'withTags'         => true,
+					'withCustomFields' => false,
+				)
+			);
+			if ( ! is_array( $row ) ) {
+				return array();
+			}
+			return array( self::shape_contact_summary( $row ) );
+		}
+
+		list( $page, $per_page ) = self::resolve_pagination( $input );
+
+		$args = array(
+			'page'             => max( 0, $page - 1 ),
+			'perPage'          => $per_page,
+			'withTags'         => true,
+			'withCustomFields' => false,
+		);
+		if ( isset( $input['search'] ) && is_string( $input['search'] ) && '' !== $input['search'] ) {
+			$args['searchPhrase'] = $input['search'];
+		}
+		if ( isset( $input['status'] ) && is_string( $input['status'] ) && '' !== $input['status'] ) {
+			$args['hasStatus'] = $input['status'];
+		}
+
+		$rows = $dal->contacts->getContacts( $args );
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$out[] = self::shape_contact_summary( $row );
+		}
+		return $out;
+	}
+
+	/**
+	 * Execute: fetch a single contact with notes, activity, and custom fields.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function get_contact( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['id'] ) ) {
+			return new \WP_Error(
+				'jetpack_crm_missing_id',
+				__( 'A contact id is required. Call jetpack-crm/list-contacts to enumerate available ids.', 'zero-bs-crm' )
+			);
+		}
+		$id = (int) $input['id'];
+		if ( $id <= 0 ) {
+			return new \WP_Error(
+				'jetpack_crm_invalid_id',
+				__( 'Contact id must be a positive integer.', 'zero-bs-crm' )
+			);
+		}
+
+		$dal = self::get_dal();
+		if ( null === $dal ) {
+			return new \WP_Error(
+				'jetpack_crm_not_initialized',
+				__( 'Jetpack CRM has not finished loading. Retry on a later request.', 'zero-bs-crm' )
+			);
+		}
+
+		$row = $dal->contacts->getContact(
+			$id,
+			array(
+				'withTags'         => true,
+				'withLogs'         => true,
+				'withCustomFields' => true,
+			)
+		);
+		if ( ! is_array( $row ) ) {
+			return array();
+		}
+
+		$summary  = self::shape_contact_summary( $row );
+		$activity = self::extract_activity( $row );
+		$notes    = self::extract_notes( $row );
+
+		$custom_fields = array();
+		if ( isset( $row['customfields'] ) && is_array( $row['customfields'] ) ) {
+			$custom_fields = $row['customfields'];
+		} elseif ( isset( $row['custom_fields'] ) && is_array( $row['custom_fields'] ) ) {
+			$custom_fields = $row['custom_fields'];
+		}
+
+		$summary['notes']         = $notes;
+		$summary['activity']      = $activity;
+		$summary['custom_fields'] = $custom_fields;
+
+		return array( $summary );
+	}
+
+	/**
+	 * Execute: list deals (quotes).
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_deals( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$dal = self::get_dal();
+		if ( null === $dal ) {
+			return new \WP_Error(
+				'jetpack_crm_not_initialized',
+				__( 'Jetpack CRM has not finished loading. Retry on a later request.', 'zero-bs-crm' )
+			);
+		}
+
+		list( $page, $per_page ) = self::resolve_pagination( $input );
+
+		$args = array(
+			'page'    => max( 0, $page - 1 ),
+			'perPage' => $per_page,
+		);
+		if ( isset( $input['status'] ) && is_string( $input['status'] ) && '' !== $input['status'] ) {
+			$args['hasStatus'] = $input['status'];
+		}
+		if ( isset( $input['owner'] ) ) {
+			$owner = (int) $input['owner'];
+			if ( $owner > 0 ) {
+				$args['ownedBy'] = $owner;
+			}
+		}
+
+		$rows = $dal->quotes->getQuotes( $args );
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$out[] = self::shape_deal_summary( $row );
+		}
+		return $out;
+	}
+
+	/**
+	 * Execute: list invoices.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_invoices( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$dal = self::get_dal();
+		if ( null === $dal ) {
+			return new \WP_Error(
+				'jetpack_crm_not_initialized',
+				__( 'Jetpack CRM has not finished loading. Retry on a later request.', 'zero-bs-crm' )
+			);
+		}
+
+		list( $page, $per_page ) = self::resolve_pagination( $input );
+
+		$args = array(
+			'page'    => max( 0, $page - 1 ),
+			'perPage' => $per_page,
+		);
+		if ( isset( $input['status'] ) && is_string( $input['status'] ) && '' !== $input['status'] ) {
+			$args['hasStatus'] = $input['status'];
+		}
+
+		$rows = $dal->invoices->getInvoices( $args );
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$out[] = self::shape_invoice_summary( $row );
+		}
+		return $out;
+	}
+
+	// -------------------- Shape helpers --------------------
+
+	/**
+	 * Build the summary shape returned by list-contacts / get-contact entries.
+	 *
+	 * Accepts a raw DAL row (associative array). Missing keys yield empty
+	 * defaults so the shape stays uniform across read paths.
+	 *
+	 * @param array $row Raw DAL contact row.
+	 * @return array
+	 */
+	private static function shape_contact_summary( array $row ): array {
+		$first = self::str_field( $row, 'fname' );
+		$last  = self::str_field( $row, 'lname' );
+		$name  = trim( $first . ' ' . $last );
+
+		$phone = self::str_field( $row, 'hometel' );
+		if ( '' === $phone ) {
+			$phone = self::str_field( $row, 'mobtel' );
+		}
+		if ( '' === $phone ) {
+			$phone = self::str_field( $row, 'worktel' );
+		}
+
+		$tags = array();
+		if ( isset( $row['tags'] ) && is_array( $row['tags'] ) ) {
+			foreach ( $row['tags'] as $tag ) {
+				if ( is_array( $tag ) && isset( $tag['name'] ) && is_string( $tag['name'] ) ) {
+					$tags[] = $tag['name'];
+				} elseif ( is_string( $tag ) ) {
+					$tags[] = $tag;
+				}
+			}
+		}
+
+		return array(
+			'id'                => isset( $row['id'] ) ? (int) $row['id'] : 0,
+			'name'              => '' !== $name ? $name : self::str_field( $row, 'email' ),
+			'email'             => self::str_field( $row, 'email' ),
+			'phone'             => $phone,
+			'status'            => self::str_field( $row, 'status' ),
+			'owner'             => isset( $row['owner'] ) ? (int) $row['owner'] : 0,
+			'tags'              => $tags,
+			'created_at'        => self::int_or_null( $row, 'created' ),
+			'last_contacted_at' => self::int_or_null( $row, 'lastcontacted' ),
+		);
+	}
+
+	/**
+	 * Build the deal summary shape.
+	 *
+	 * @param array $row Raw DAL quote row.
+	 * @return array
+	 */
+	private static function shape_deal_summary( array $row ): array {
+		// Currency: CRM stores it per-quote or falls back to the site base.
+		$currency = self::str_field( $row, 'currency' );
+		if ( '' === $currency && function_exists( 'zeroBSCRM_getCurrency' ) ) {
+			$currency = (string) zeroBSCRM_getCurrency();
+		}
+
+		return array(
+			'id'                  => isset( $row['id'] ) ? (int) $row['id'] : 0,
+			'title'               => self::str_field( $row, 'title' ),
+			'value'               => isset( $row['value'] ) ? (float) $row['value'] : 0.0,
+			'currency'            => $currency,
+			'status'              => self::str_field( $row, 'status' ),
+			'contact_id'          => isset( $row['contact_id'] ) ? (int) $row['contact_id'] : null,
+			'owner'               => isset( $row['owner'] ) ? (int) $row['owner'] : 0,
+			'created_at'          => self::int_or_null( $row, 'created' ),
+			'expected_close_date' => self::int_or_null( $row, 'expectedclosedate' ),
+		);
+	}
+
+	/**
+	 * Build the invoice summary shape.
+	 *
+	 * @param array $row Raw DAL invoice row.
+	 * @return array
+	 */
+	private static function shape_invoice_summary( array $row ): array {
+		$currency = self::str_field( $row, 'currency' );
+		if ( '' === $currency && function_exists( 'zeroBSCRM_getCurrency' ) ) {
+			$currency = (string) zeroBSCRM_getCurrency();
+		}
+
+		$total = 0.0;
+		if ( isset( $row['total'] ) ) {
+			$total = (float) $row['total'];
+		} elseif ( isset( $row['net'] ) ) {
+			$total = (float) $row['net'];
+		}
+
+		// CRM invoice number lives in `id_override` (the human-facing ref)
+		// with `id` as a fallback when no override is set.
+		$number = self::str_field( $row, 'id_override' );
+		if ( '' === $number && isset( $row['id'] ) ) {
+			$number = (string) (int) $row['id'];
+		}
+
+		return array(
+			'id'         => isset( $row['id'] ) ? (int) $row['id'] : 0,
+			'number'     => $number,
+			'contact_id' => isset( $row['contact_id'] ) ? (int) $row['contact_id'] : null,
+			'total'      => $total,
+			'currency'   => $currency,
+			'status'     => self::str_field( $row, 'status' ),
+			'due_date'   => self::int_or_null( $row, 'due_date' ),
+			'issued_at'  => self::int_or_null( $row, 'date' ),
+			'paid_at'    => self::int_or_null( $row, 'date_paid' ),
+		);
+	}
+
+	/**
+	 * Extract notes-shaped entries from a DAL contact detail row.
+	 *
+	 * @param array $row Raw DAL contact row (with logs).
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function extract_notes( array $row ): array {
+		$notes = array();
+		if ( ! isset( $row['logs'] ) || ! is_array( $row['logs'] ) ) {
+			return $notes;
+		}
+		foreach ( $row['logs'] as $log ) {
+			if ( ! is_array( $log ) ) {
+				continue;
+			}
+			$type = isset( $log['type'] ) ? (string) $log['type'] : '';
+			if ( 'Note' !== $type ) {
+				continue;
+			}
+			$notes[] = array(
+				'id'      => isset( $log['id'] ) ? (int) $log['id'] : 0,
+				'created' => isset( $log['created'] ) ? (int) $log['created'] : null,
+				'note'    => isset( $log['longdesc'] ) ? (string) $log['longdesc'] : (string) ( $log['shortdesc'] ?? '' ),
+			);
+		}
+		return $notes;
+	}
+
+	/**
+	 * Extract activity entries (non-note logs) from a DAL contact detail row.
+	 *
+	 * @param array $row Raw DAL contact row (with logs).
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function extract_activity( array $row ): array {
+		$activity = array();
+		if ( ! isset( $row['logs'] ) || ! is_array( $row['logs'] ) ) {
+			return $activity;
+		}
+		foreach ( $row['logs'] as $log ) {
+			if ( ! is_array( $log ) ) {
+				continue;
+			}
+			$type = isset( $log['type'] ) ? (string) $log['type'] : '';
+			if ( 'Note' === $type ) {
+				continue;
+			}
+			$activity[] = array(
+				'id'      => isset( $log['id'] ) ? (int) $log['id'] : 0,
+				'created' => isset( $log['created'] ) ? (int) $log['created'] : null,
+				'type'    => $type,
+				'summary' => isset( $log['shortdesc'] ) ? (string) $log['shortdesc'] : '',
+			);
+		}
+		return $activity;
+	}
+
+	// -------------------- Internal helpers --------------------
+
+	/**
+	 * Resolve `page` / `per_page` from input, applying defaults and clamping.
+	 *
+	 * @param array $input Validated input.
+	 * @return array{0:int,1:int} Tuple of [ page, per_page ].
+	 */
+	private static function resolve_pagination( array $input ): array {
+		$page = self::DEFAULT_PER_PAGE;
+		if ( isset( $input['page'] ) ) {
+			$page = (int) $input['page'];
+		}
+		if ( $page < 1 ) {
+			$page = 1;
+		}
+
+		$per_page = self::DEFAULT_PER_PAGE;
+		if ( isset( $input['per_page'] ) ) {
+			$per_page = (int) $input['per_page'];
+		}
+		if ( $per_page < 1 ) {
+			$per_page = self::DEFAULT_PER_PAGE;
+		}
+		if ( $per_page > self::MAX_PER_PAGE ) {
+			$per_page = self::MAX_PER_PAGE;
+		}
+
+		return array( $page, $per_page );
+	}
+
+	/**
+	 * Return the CRM data access layer, or null if it isn't initialized yet.
+	 *
+	 * @return \zbsDAL|null
+	 */
+	private static function get_dal() {
+		if ( ! isset( $GLOBALS['zbs'] ) || ! is_object( $GLOBALS['zbs'] ) ) {
+			return null;
+		}
+		if ( ! isset( $GLOBALS['zbs']->DAL ) || ! is_object( $GLOBALS['zbs']->DAL ) ) {
+			return null;
+		}
+		return $GLOBALS['zbs']->DAL;
+	}
+
+	/**
+	 * Read a string field from a DAL row, defaulting to ''.
+	 *
+	 * @param array  $row DAL row.
+	 * @param string $key Field name.
+	 * @return string
+	 */
+	private static function str_field( array $row, string $key ): string {
+		if ( ! isset( $row[ $key ] ) ) {
+			return '';
+		}
+		$value = $row[ $key ];
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+		return '';
+	}
+
+	/**
+	 * Read an integer timestamp from a DAL row, returning null when missing
+	 * or zero (the CRM uses 0 to mean "never").
+	 *
+	 * @param array  $row DAL row.
+	 * @param string $key Field name.
+	 * @return int|null
+	 */
+	private static function int_or_null( array $row, string $key ): ?int {
+		if ( ! isset( $row[ $key ] ) ) {
+			return null;
+		}
+		$value = (int) $row[ $key ];
+		return $value > 0 ? $value : null;
+	}
+}

--- a/projects/plugins/crm/tests/php/abilities/CRM_Abilities_Test.php
+++ b/projects/plugins/crm/tests/php/abilities/CRM_Abilities_Test.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * Tests for the Jetpack CRM Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use Automattic\Jetpack\CRM\Abilities\CRM_Abilities;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WP_Error;
+
+require_once __DIR__ . '/../class-jpcrm-base-integration-testcase.php';
+
+/**
+ * Integration tests for the Jetpack CRM abilities registrar.
+ *
+ * Exercises the Registrar wiring contract, the public abstract getters,
+ * the permission callback, and the happy paths for each read ability
+ * (with real DB-backed contacts, invoices, and quotes created via the
+ * existing CRM test factory helpers).
+ *
+ * @covers \Automattic\Jetpack\CRM\Abilities\CRM_Abilities
+ */
+#[CoversClass( CRM_Abilities::class )]
+class CRM_Abilities_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * Per-test setup.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		self::$admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'crm_ability_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'crm_ability_admin_' . wp_generate_password( 8, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'crm_ability_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'crm_ability_sub_' . wp_generate_password( 8, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	/**
+	 * Per-test teardown.
+	 */
+	public function tear_down(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-crm', CRM_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = CRM_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotEmpty( $def['label'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = CRM_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-crm/', $slug );
+		}
+	}
+
+	public function test_expected_ability_slugs_are_present() {
+		$abilities = CRM_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-crm/list-contacts', $abilities );
+		$this->assertArrayHasKey( 'jetpack-crm/get-contact', $abilities );
+		$this->assertArrayHasKey( 'jetpack-crm/list-deals', $abilities );
+		$this->assertArrayHasKey( 'jetpack-crm/list-invoices', $abilities );
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		foreach ( CRM_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_every_read_ability_is_marked_readonly() {
+		foreach ( CRM_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertTrue(
+				$spec['meta']['annotations']['readonly'],
+				"Ability {$slug} must declare readonly=true (all current abilities are read-only)."
+			);
+			$this->assertFalse(
+				$spec['meta']['annotations']['destructive'],
+				"Ability {$slug} must declare destructive=false (read-only)."
+			);
+			$this->assertTrue(
+				$spec['meta']['annotations']['idempotent'],
+				"Ability {$slug} must declare idempotent=true (read-only)."
+			);
+		}
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		CRM_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( CRM_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( CRM_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		CRM_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( CRM_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_init', array( CRM_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		CRM_Abilities::register_category();
+		CRM_Abilities::register_abilities();
+
+		foreach ( array_keys( CRM_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotNull(
+				wp_get_ability( $slug ),
+				"Ability {$slug} should be registered."
+			);
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		CRM_Abilities::register_category();
+		CRM_Abilities::register_abilities();
+
+		foreach ( array_keys( CRM_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNull( wp_get_ability( $slug ), "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	// -------------------- Permission callback --------------------
+
+	public function test_can_view_crm_allows_administrator() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( CRM_Abilities::can_view_crm() );
+	}
+
+	public function test_can_view_crm_denies_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( CRM_Abilities::can_view_crm() );
+	}
+
+	public function test_can_view_crm_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( CRM_Abilities::can_view_crm() );
+	}
+
+	// -------------------- Execute callbacks: contacts --------------------
+
+	public function test_list_contacts_returns_array_of_summaries() {
+		$contact_id = $this->add_contact(
+			array(
+				'fname' => 'Alice',
+				'lname' => 'Anderson',
+				'email' => 'alice@example.test',
+			)
+		);
+		$this->assertGreaterThan( 0, $contact_id );
+
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_contacts( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+
+		$found = null;
+		foreach ( $result as $row ) {
+			$this->assertIsArray( $row );
+			// Uniform shape — same keys regardless of which filter you used.
+			$this->assertArrayHasKey( 'id', $row );
+			$this->assertArrayHasKey( 'name', $row );
+			$this->assertArrayHasKey( 'email', $row );
+			$this->assertArrayHasKey( 'phone', $row );
+			$this->assertArrayHasKey( 'status', $row );
+			$this->assertArrayHasKey( 'owner', $row );
+			$this->assertArrayHasKey( 'tags', $row );
+			$this->assertArrayHasKey( 'created_at', $row );
+			$this->assertArrayHasKey( 'last_contacted_at', $row );
+
+			if ( (int) $row['id'] === (int) $contact_id ) {
+				$found = $row;
+			}
+		}
+
+		$this->assertNotNull( $found, 'The newly added contact should appear in list-contacts output.' );
+		$this->assertSame( 'Alice Anderson', $found['name'] );
+		$this->assertSame( 'alice@example.test', $found['email'] );
+	}
+
+	public function test_list_contacts_with_contact_id_returns_single_element_array() {
+		$contact_id = $this->add_contact(
+			array(
+				'fname' => 'Bob',
+				'lname' => 'Brown',
+				'email' => 'bob@example.test',
+			)
+		);
+
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_contacts( array( 'contact_id' => (int) $contact_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( (int) $contact_id, $result[0]['id'] );
+		$this->assertSame( 'bob@example.test', $result[0]['email'] );
+	}
+
+	public function test_list_contacts_with_unknown_contact_id_returns_empty_array() {
+		// Consolidated-read contract: unknown id is a no-match, not an error.
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_contacts( array( 'contact_id' => 9999999 ) );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_get_contact_returns_single_element_array_with_detail_keys() {
+		$contact_id = $this->add_contact(
+			array(
+				'fname' => 'Carol',
+				'lname' => 'Carter',
+				'email' => 'carol@example.test',
+			)
+		);
+
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::get_contact( array( 'id' => (int) $contact_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$row = $result[0];
+		$this->assertSame( (int) $contact_id, $row['id'] );
+		$this->assertArrayHasKey( 'notes', $row );
+		$this->assertArrayHasKey( 'activity', $row );
+		$this->assertArrayHasKey( 'custom_fields', $row );
+		$this->assertIsArray( $row['notes'] );
+		$this->assertIsArray( $row['activity'] );
+		$this->assertIsArray( $row['custom_fields'] );
+	}
+
+	public function test_get_contact_with_unknown_id_returns_empty_array() {
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::get_contact( array( 'id' => 9999999 ) );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_get_contact_missing_id_returns_wp_error() {
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::get_contact( array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_crm_missing_id', $result->get_error_code() );
+	}
+
+	public function test_get_contact_with_zero_id_returns_wp_error() {
+		// Zero is not a legal CRM id; the CRM uses positive integers (id >= 1).
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::get_contact( array( 'id' => 0 ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_crm_invalid_id', $result->get_error_code() );
+	}
+
+	// -------------------- Execute callbacks: deals --------------------
+
+	public function test_list_deals_returns_array_of_summaries() {
+		global $zbs;
+		$contact_id = $this->add_contact();
+		$this->assertGreaterThan( 0, $contact_id );
+
+		$quote_id = $zbs->DAL->quotes->addUpdateQuote(
+			array(
+				'data' => $this->generate_quote_data(
+					array(
+						'title'    => 'Q for Acme',
+						'value'    => '500.00',
+						'currency' => 'USD',
+						'status'   => 'Draft',
+						'contacts' => array( (int) $contact_id ),
+					)
+				),
+			)
+		);
+		$this->assertGreaterThan( 0, $quote_id );
+
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_deals( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+
+		$found = null;
+		foreach ( $result as $row ) {
+			$this->assertIsArray( $row );
+			$this->assertArrayHasKey( 'id', $row );
+			$this->assertArrayHasKey( 'title', $row );
+			$this->assertArrayHasKey( 'value', $row );
+			$this->assertArrayHasKey( 'currency', $row );
+			$this->assertArrayHasKey( 'status', $row );
+			$this->assertArrayHasKey( 'contact_id', $row );
+			$this->assertArrayHasKey( 'owner', $row );
+			$this->assertArrayHasKey( 'created_at', $row );
+			$this->assertArrayHasKey( 'expected_close_date', $row );
+
+			if ( (int) $row['id'] === (int) $quote_id ) {
+				$found = $row;
+			}
+		}
+
+		$this->assertNotNull( $found, 'Newly added deal should appear in list-deals output.' );
+		$this->assertSame( 'Q for Acme', $found['title'] );
+		$this->assertSame( 500.0, $found['value'] );
+	}
+
+	// -------------------- Execute callbacks: invoices --------------------
+
+	public function test_list_invoices_returns_array_of_summaries() {
+		$contact_id = $this->add_contact();
+		$this->assertGreaterThan( 0, $contact_id );
+
+		$invoice_id = $this->add_invoice(
+			array(
+				'contacts'    => array( (int) $contact_id ),
+				'id_override' => 'INV-CRM-ABIL-1',
+			)
+		);
+		$this->assertGreaterThan( 0, $invoice_id );
+
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_invoices( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+
+		$found = null;
+		foreach ( $result as $row ) {
+			$this->assertIsArray( $row );
+			$this->assertArrayHasKey( 'id', $row );
+			$this->assertArrayHasKey( 'number', $row );
+			$this->assertArrayHasKey( 'contact_id', $row );
+			$this->assertArrayHasKey( 'total', $row );
+			$this->assertArrayHasKey( 'currency', $row );
+			$this->assertArrayHasKey( 'status', $row );
+			$this->assertArrayHasKey( 'due_date', $row );
+			$this->assertArrayHasKey( 'issued_at', $row );
+			$this->assertArrayHasKey( 'paid_at', $row );
+
+			if ( (int) $row['id'] === (int) $invoice_id ) {
+				$found = $row;
+			}
+		}
+
+		$this->assertNotNull( $found, 'Newly added invoice should appear in list-invoices output.' );
+		$this->assertSame( 'INV-CRM-ABIL-1', $found['number'] );
+	}
+
+	// -------------------- Schema/pagination edge cases --------------------
+
+	public function test_list_contacts_per_page_is_clamped_to_maximum() {
+		// Even if input passes 1000, the callback clamps to 100; we can't easily
+		// inspect the DAL args without mocking, but we can assert the call still
+		// returns a normal array (no fatal, no WP_Error) and respects the limit.
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_contacts( array( 'per_page' => 1000 ) );
+		$this->assertIsArray( $result );
+		$this->assertLessThanOrEqual( 100, count( $result ) );
+	}
+
+	public function test_list_contacts_when_dal_is_unavailable_returns_wp_error() {
+		// Simulate the "ability called before CRM core booted" race.
+		global $zbs;
+		$saved_zbs = $zbs;
+		$zbs       = null;
+
+		wp_set_current_user( self::$admin_id );
+		$result = CRM_Abilities::list_contacts( array() );
+
+		// Restore before assertions so a failure can't leave subsequent tests broken.
+		$zbs = $saved_zbs;
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_crm_not_initialized', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary

First cut of WordPress Abilities API support for Jetpack CRM. Wires the CRM plugin into the shared `Registrar` base (`automattic/jetpack-wp-abilities`) and exposes four read-only abilities under the `jetpack-crm` category:

- `jetpack-crm/list-contacts` — paginated contact listing with `search`/`status`/`contact_id` filters (consolidated read: `contact_id` returns a 0- or 1-element array).
- `jetpack-crm/get-contact` — single contact with notes, activity log, and custom fields. Unknown ids return `[]` (consolidated-read contract).
- `jetpack-crm/list-deals` — paginated deal/quote listing with `status` / `owner` filters.
- `jetpack-crm/list-invoices` — paginated invoice listing with a `paid`|`unpaid`|`overdue`|`draft` enum filter.

Implements part of the Abilities Everywhere roadmap (plan §2.7) for the CRM surface.

## Implementation notes

- **Class:** `Automattic\Jetpack\CRM\Abilities\CRM_Abilities` in `projects/plugins/crm/src/abilities/class-crm-abilities.php`. Extends `Automattic\Jetpack\WP_Abilities\Registrar` — does not reimplement `init()`, lifecycle hooks, the `jetpack_wp_abilities_enabled` gate, or the per-ability `jetpack_wp_abilities_should_register` allow-list.
- **Permission gate:** `current_user_can( 'admin_zerobs_customers' )`. The CRM grants this cap to `administrator`, `zerobs_admin`, and `zerobs_customermgr`. It mirrors the gating used by the CRM admin pages and `jpcrm_can_user_manage_contacts()`.
- **Token thrift:** every shape helper (`shape_contact_summary`, `shape_deal_summary`, `shape_invoice_summary`) returns a flat, agent-friendly subset of the DAL row. No raw DAL row dumps, no full DB rows leaked.
- **Pagination:** every list-shaped read takes `page` / `per_page` with `default=20`, `maximum=100`, enforced again in the callback so an over-large input is clamped before reaching the DAL.
- **Consolidated-read contract:** `list-contacts` with `contact_id` returns at most one element; `get-contact` with an unknown id returns `[]`, not `WP_Error`. Errors are reserved for malformed input (missing/zero/non-int id) and CRM-not-booted races.
- **Wiring (Case C, plugin-core/always-on):** registered from `ZeroBSCRM.php` on `init` priority 20, after the priority-0 callback that initializes `$zbs->DAL`. The Abilities API itself fires `wp_abilities_api_*_init` after `init`, so the Registrar lifecycle is honoured.
- **No writes.** Create/update/delete/add-note are deferred — those require a careful design pass over CRM's `addUpdate*` entry points and are out of scope for this PR.

## Test coverage

`projects/plugins/crm/tests/php/abilities/CRM_Abilities_Test.php` covers:

- Registrar wiring (gate filter false → no hooks; true → both lifecycle hooks added; per-ability allow-list filter blocks registration).
- Abstract getters (slug, category definition, ability map shape, no manual `category` keys, all annotations marked `readonly=true`).
- Permission callback (administrator allowed; subscriber denied; anonymous denied).
- Execute callbacks for all four abilities — happy paths using the existing CRM factory helpers (`add_contact`, `add_invoice`, `addUpdateQuote`).
- Consolidated-read edge cases (unknown ids → `[]`).
- Schema edge cases (missing id, zero id → `WP_Error`).
- `per_page` clamping at 100.
- DAL-unavailable race → `jetpack_crm_not_initialized` `WP_Error`.

The test class extends the existing `JPCRM_Base_Integration_TestCase` and is wired into a new `abilities` testsuite in `phpunit.9.xml.dist` and `phpunit.11.xml.dist` (`phpunit.12.xml.dist` is a symlink to `.11`, so it inherits automatically).

**Local test execution:** the CRM phpunit suite requires a wordpress-develop checkout + MySQL (the existing CRM integration-test infrastructure). That environment is provided by `jetpack docker phpunit` and by CI; on my workstation it isn't bootstrapped, so I have not run the new tests locally. CI will run them. The class itself loads cleanly under `composer dump-autoload` (smoke-tested via `php -r`), and PHP lint + PHPCS pass.

## Test plan

- [ ] Wait for CI to run `abilities` testsuite under `composer phpunit` — every test case in `CRM_Abilities_Test` should pass.
- [ ] On a Jetpack-connected site with `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' )`, `wp_get_abilities()` lists the four new slugs.
- [ ] `GET /wp-json/wp-abilities/v1/abilities?category=jetpack-crm` returns four entries.
- [ ] Run each ability via `POST /wp-json/wp-abilities/v1/run` as an administrator; calling as a subscriber returns 403.

## Follow-ups (intentionally deferred)

- Write abilities: `create-contact`, `update-contact`, `delete-contact`, `add-contact-note`.
- Companies and transactions reads.
- Tighter coupling with `jpcrm_can_user_manage_contacts()` for per-object owner-aware checks once writes land.