### PR TITLE
Podcast: rebuild Stats tiles and bar list on @wordpress/components primitives

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-stats-components-refactor
+++ b/projects/packages/podcast/changelog/update-podcast-stats-components-refactor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast stats: rebuild summary tiles and bar list rows on @wordpress/components primitives.

--- a/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
@@ -34,6 +34,11 @@ const HorizontalBarList = ( { rows }: HorizontalBarListProps ) => {
 					row.labelText !== undefined ? `${ row.labelText }: ${ row.formattedValue }` : undefined;
 				const inner = (
 					<>
+						<span
+							className="podcast-stats-bar-list__bar"
+							style={ { width: `${ pct }%` } }
+							aria-hidden="true"
+						/>
 						<HStack
 							as="span"
 							className="podcast-stats-bar-list__content"
@@ -56,11 +61,6 @@ const HorizontalBarList = ( { rows }: HorizontalBarListProps ) => {
 								{ row.formattedValue }
 							</Text>
 						</HStack>
-						<span
-							className="podcast-stats-bar-list__bar"
-							style={ { width: `${ pct }%` } }
-							aria-hidden="true"
-						/>
 					</>
 				);
 				return (

--- a/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
@@ -1,3 +1,9 @@
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+} from '@wordpress/components';
 import type { ReactNode, MouseEventHandler } from 'react';
 
 // Not @automattic/charts BarListChart — that's SVG/visx with no per-row onClick (Top episodes needs drilldown).
@@ -28,11 +34,28 @@ const HorizontalBarList = ( { rows }: HorizontalBarListProps ) => {
 					row.labelText !== undefined ? `${ row.labelText }: ${ row.formattedValue }` : undefined;
 				const inner = (
 					<>
-						{ row.leftSideItem && (
-							<span className="podcast-stats-bar-list__leading">{ row.leftSideItem }</span>
-						) }
-						<span className="podcast-stats-bar-list__label">{ row.label }</span>
-						<span className="podcast-stats-bar-list__value">{ row.formattedValue }</span>
+						<HStack
+							as="span"
+							className="podcast-stats-bar-list__content"
+							spacing={ 2 }
+							justify="flex-start"
+							alignment="center"
+						>
+							{ row.leftSideItem && (
+								<span className="podcast-stats-bar-list__leading">{ row.leftSideItem }</span>
+							) }
+							<Text className="podcast-stats-bar-list__label" truncate>
+								{ row.label }
+							</Text>
+							<Text
+								className="podcast-stats-bar-list__value"
+								size={ 12 }
+								variant="muted"
+								numberOfLines={ 1 }
+							>
+								{ row.formattedValue }
+							</Text>
+						</HStack>
 						<span
 							className="podcast-stats-bar-list__bar"
 							style={ { width: `${ pct }%` } }

--- a/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
@@ -56,7 +56,7 @@ const HorizontalBarList = ( { rows }: HorizontalBarListProps ) => {
 								className="podcast-stats-bar-list__value"
 								size={ 12 }
 								variant="muted"
-								numberOfLines={ 1 }
+								truncate
 							>
 								{ row.formattedValue }
 							</Text>

--- a/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
@@ -1,5 +1,12 @@
 import { formatNumber } from '@automattic/number-formatters';
-import { Card, CardBody } from '@wordpress/components';
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { formatAppName, formatPct, formatPodcastDate, getCountryName } from '../lib/format';
 import type { PodcastStatsAppRow, PodcastStatsCountryRow, PodcastStatsTopDay } from '../types';
@@ -12,7 +19,6 @@ type SummaryTilesProps = {
 	byCountry?: PodcastStatsCountryRow[];
 	topDay?: PodcastStatsTopDay | null;
 	isLoading?: boolean;
-	layout?: 'standalone' | 'chart';
 };
 
 type Tile = {
@@ -21,21 +27,12 @@ type Tile = {
 	note?: string;
 };
 
-const TileContent = ( { heading, value, note }: Tile ) => (
-	<>
-		<div className="podcast-stats-summary__heading">{ heading }</div>
-		<div className="podcast-stats-summary__value">{ value }</div>
-		{ note && <div className="podcast-stats-summary__note">{ note }</div> }
-	</>
-);
-
 const SummaryTiles = ( {
 	totalPlays,
 	byApp = [],
 	byCountry = [],
 	topDay,
 	isLoading = false,
-	layout = 'standalone',
 }: SummaryTilesProps ) => {
 	const topApp = byApp[ 0 ];
 	const topCountry = byCountry[ 0 ];
@@ -73,28 +70,24 @@ const SummaryTiles = ( {
 		},
 	];
 
-	if ( layout === 'chart' ) {
-		return (
-			<ul className="podcast-stats-summary">
-				{ tiles.map( tile => (
-					<li key={ tile.heading } className="podcast-stats-summary__tile">
-						<TileContent { ...tile } />
-					</li>
-				) ) }
-			</ul>
-		);
-	}
-
 	return (
-		<section className="podcast-stats-summary podcast-stats-summary--standalone">
+		<div className="podcast-stats-summary">
 			{ tiles.map( tile => (
-				<Card key={ tile.heading } className="podcast-stats-summary__tile">
-					<CardBody>
-						<TileContent { ...tile } />
-					</CardBody>
-				</Card>
+				<VStack key={ tile.heading } className="podcast-stats-summary__tile" spacing={ 1 }>
+					<Heading level={ 3 } size={ 13 } lineHeight="20px" weight={ 500 }>
+						{ tile.heading }
+					</Heading>
+					<Text size={ 28 } lineHeight="36px" truncate>
+						{ tile.value }
+					</Text>
+					{ tile.note && (
+						<Text size={ 12 } variant="muted">
+							{ tile.note }
+						</Text>
+					) }
+				</VStack>
 			) ) }
-		</section>
+		</div>
 	);
 };
 

--- a/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
@@ -74,7 +74,7 @@ const SummaryTiles = ( {
 		<div className="podcast-stats-summary">
 			{ tiles.map( tile => (
 				<VStack key={ tile.heading } className="podcast-stats-summary__tile" spacing={ 1 }>
-					<Heading level={ 3 } size={ 13 } lineHeight="20px" weight={ 500 }>
+					<Heading level={ 4 } size={ 13 } lineHeight="20px" weight={ 500 }>
 						{ tile.heading }
 					</Heading>
 					<Text size={ 28 } lineHeight="36px" truncate>

--- a/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
@@ -73,7 +73,12 @@ const SummaryTiles = ( {
 	return (
 		<div className="podcast-stats-summary">
 			{ tiles.map( tile => (
-				<VStack key={ tile.heading } className="podcast-stats-summary__tile" spacing={ 1 }>
+				<VStack
+					key={ tile.heading }
+					className="podcast-stats-summary__tile"
+					spacing={ 1 }
+					alignment="topLeft"
+				>
 					<Heading level={ 4 } size={ 13 } lineHeight="20px" weight={ 500 }>
 						{ tile.heading }
 					</Heading>

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -3,7 +3,6 @@
 // Match other dashboard tabs; avoid --wp-admin-theme-color-darker-20.
 $text: #1e1e1e;
 $muted: #757575;
-$bar-bg: #f0f0f0;
 $bar-bg-hover: #e5e5e5;
 $bar-fill: #2271b1;
 
@@ -209,7 +208,6 @@ $bar-fill: #2271b1;
 		position: relative;
 		padding: 6px 8px;
 		border-radius: 4px;
-		background: $bar-bg;
 		width: 100%;
 		text-align: start;
 		border: 0;

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -233,6 +233,7 @@ $bar-fill: #2271b1;
 	// HStack wrapper — sits above the bar so the fill renders behind text.
 	&__content {
 		position: relative;
+		z-index: 1;
 	}
 
 	&__leading {
@@ -254,6 +255,7 @@ $bar-fill: #2271b1;
 		position: absolute;
 		inset-block: 0;
 		inset-inline-start: 0;
+		z-index: 0;
 		background: $bar-fill;
 		opacity: 0.08;
 		border-radius: 4px;

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -193,7 +193,6 @@ $bar-fill: #2271b1;
 	}
 }
 
-// Row layout flows through HStack; bar sits behind via absolute positioning.
 .podcast-stats-bar-list {
 	list-style: none;
 	margin: 0;

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -230,10 +230,8 @@ $bar-fill: #2271b1;
 		}
 	}
 
-	// HStack wrapper — sits above the bar so the fill renders behind text.
 	&__content {
 		position: relative;
-		z-index: 1;
 	}
 
 	&__leading {
@@ -255,7 +253,6 @@ $bar-fill: #2271b1;
 		position: absolute;
 		inset-block: 0;
 		inset-inline-start: 0;
-		z-index: 0;
 		background: $bar-fill;
 		opacity: 0.08;
 		border-radius: 4px;

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -7,14 +7,6 @@ $bar-bg: #f0f0f0;
 $bar-bg-hover: #e5e5e5;
 $bar-fill: #2271b1;
 
-%eyebrow {
-	font-size: 11px;
-	font-weight: 500;
-	color: $muted;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-}
-
 .podcast-stats {
 	padding-block-start: 16px;
 	padding-inline: 16px;
@@ -108,10 +100,9 @@ $bar-fill: #2271b1;
 	}
 }
 
+// Inline metric tiles. Display-only; typography is owned by Heading/Text,
+// so only layout lives here.
 .podcast-stats-summary {
-	list-style: none;
-	margin: 0;
-	padding: 0;
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 	gap: 0;
@@ -122,35 +113,6 @@ $bar-fill: #2271b1;
 
 		&:not(:first-child) {
 			border-inline-start: 1px solid #e0e0e0;
-		}
-	}
-
-	&__heading {
-
-		@extend %eyebrow;
-
-		margin-bottom: 6px;
-	}
-
-	&__value {
-		font-size: 24px;
-		font-weight: 500;
-		line-height: 1.2;
-		color: $text;
-	}
-
-	&__note {
-
-		@extend %eyebrow;
-
-		margin-top: 4px;
-	}
-
-	&--standalone {
-		gap: 12px;
-
-		.podcast-stats-summary__tile {
-			border-inline-start: 0;
 		}
 	}
 }
@@ -222,14 +184,16 @@ $bar-fill: #2271b1;
 	}
 
 	&__list-title {
-
-		@extend %eyebrow;
-
 		margin: 0 0 8px;
-		font-size: 12px;
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: $muted;
 	}
 }
 
+// Row layout flows through HStack; bar sits behind via absolute positioning.
 .podcast-stats-bar-list {
 	list-style: none;
 	margin: 0;
@@ -244,10 +208,6 @@ $bar-fill: #2271b1;
 
 	&__row {
 		position: relative;
-		display: grid;
-		grid-template-columns: auto 1fr auto;
-		align-items: center;
-		gap: 8px;
 		padding: 6px 8px;
 		border-radius: 4px;
 		background: $bar-bg;
@@ -271,24 +231,24 @@ $bar-fill: #2271b1;
 		}
 	}
 
+	// HStack wrapper — sits above the bar so the fill renders behind text.
+	&__content {
+		position: relative;
+	}
+
 	&__leading {
-		grid-column: 1;
+		display: inline-flex;
+		flex: 0 0 auto;
 	}
 
 	&__label {
-		grid-column: 2;
+		flex: 1;
 		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		color: $text;
 	}
 
 	&__value {
-		grid-column: 3;
+		flex: 0 0 auto;
 		font-variant-numeric: tabular-nums;
-		font-size: 12px;
-		color: $muted;
 	}
 
 	&__bar {

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -210,6 +210,9 @@ $bar-fill: #2271b1;
 		border-radius: 4px;
 		width: 100%;
 		text-align: start;
+		// Reset UA <button> grey on clickable rows (Top episodes); is-clickable
+		// hover/focus rules override.
+		background: transparent;
 		border: 0;
 		cursor: default;
 


### PR DESCRIPTION
This PR updates the top Stats cards.

- Summary tiles now use WordPress's stock Heading, Text, and VStack components instead of hand-rolled divs with custom SCSS.
- Bar list rows (Top apps, Top countries, Top episodes) now use HStack and Text instead of CSS grid plus custom typography rules.
- SCSS shrinks: ~25 lines deleted. Typography (font sizes, weights, colors, ellipsis) is owned by the components now — only layout (grid placement, the bar fill, hover/focus states) stays in SCSS.
- Removes the layout prop on SummaryTiles — both consumers used the inline variant, so the standalone Card/CardBody branch was dead code.

## Proposed changes
* Summary tiles render through `VStack` + `__experimentalHeading` + `__experimentalText` instead of raw divs with explicit font sizing in SCSS.
* Bar list rows lay out through `HStack` + `Text` rather than a CSS grid of spans. The `HStack` inside clickable rows renders `as=\"span\"` so the wrapping `<button>` stays valid phrasing content.
* SCSS drops ~25 lines and the `%eyebrow` placeholder goes away — typography now comes from the primitives.

Stacked on top of #48722 (date range picker). When that merges, this rebases onto trunk automatically.

## Related product discussion/links
* Follow-up to #48722

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Open the podcast Stats tab on a connected site.
2. Confirm the 4 summary tiles (Total downloads, Top app, Top country, Top day) render with the new `Heading` label + large value + small muted note, with hairline dividers between them.
3. Confirm Top episodes / By app / By location bar rows align under `HStack` with the tinted bar behind the row text.
4. Click a row in Top episodes — drilldown still navigates to the episode view.

Screenshots will be attached as a follow-up comment.