### PR TITLE
Write: Fix link insertion with no selection in Firefox

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write-ff-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write-ff-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix link insertion with no text selected in Firefox

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -233,6 +233,27 @@ function clearHighlight() {
 }
 
 /**
+ * Apply a link to the current selection. When the selection is collapsed
+ * (no text selected), insert the URL as visible text first so the link
+ * is created consistently across browsers — Firefox's createLink is a
+ * no-op on collapsed selections, while Chrome inserts the URL as text.
+ *
+ * @param {string} url - The URL to link to.
+ */
+function createLinkFromUrl( url ) {
+	const sel = window.getSelection();
+	if ( sel.isCollapsed ) {
+		// Insert the URL as text, then select it so createLink can wrap it.
+		document.execCommand( 'insertText', false, url );
+		const r = sel.getRangeAt( 0 );
+		r.setStart( r.startContainer, r.startOffset - url.length );
+		sel.removeAllRanges();
+		sel.addRange( r );
+	}
+	document.execCommand( 'createLink', false, url );
+}
+
+/**
  * Focus the first visible input inside a modal after it becomes visible.
  * Uses requestAnimationFrame so the element is no longer hidden.
  */
@@ -2632,7 +2653,7 @@ const { state } = store( 'wpcom-write', {
 				clearHighlight();
 				restoreSelection();
 				if ( state.linkUrl ) {
-					document.execCommand( 'createLink', false, state.linkUrl );
+					createLinkFromUrl( state.linkUrl );
 				}
 				state.showLinkInput = false;
 				if ( linkPopoverCloseHandler ) {
@@ -2660,7 +2681,7 @@ const { state } = store( 'wpcom-write', {
 			clearHighlight();
 			restoreSelection();
 			if ( state.linkUrl ) {
-				document.execCommand( 'createLink', false, state.linkUrl );
+				createLinkFromUrl( state.linkUrl );
 			}
 			state.showLinkInput = false;
 			if ( linkPopoverCloseHandler ) {


### PR DESCRIPTION
Fixes RSM-2927

## Proposed changes

* Fix link insertion in the Write editor when no text is selected in Firefox. Firefox's `execCommand('createLink')` is a no-op on collapsed selections, unlike Chrome which inserts the URL as link text. Added a `createLinkFromUrl()` helper that inserts the URL as text first, selects it, then wraps it with `createLink` — normalizing the behavior across browsers.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Write editor in **Firefox**
2. Place your cursor in a paragraph without selecting any text
3. Click the link button in the toolbar (or press Cmd/Ctrl+K)
4. Enter a URL (e.g. `https://example.com`) and press Enter
5. **Expected**: The URL appears as clickable link text, matching Chrome's behavior
6. **Previously**: Nothing happened in Firefox
7. Repeat the same test in **Chrome** to verify it still works as before
8. Also test with text selected — linking selected text should continue to work in both browsers

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
