### PR TITLE
A4A Client: register WP Abilities API agency-connection read

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/add-ship-a4a-client-abilities
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-ship-a4a-client-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register the Automattic for Agencies Client abilities surface (`jetpack-a4a-client/get-status`) via the WordPress Abilities API for AI agents on WordPress 6.9+. Gated behind the `jetpack_wp_abilities_enabled` filter (default off).

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -11,7 +11,8 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-plugin-deactivation": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8ca0c8c1fe72fe9fbb91954f7c2c7e8",
+    "content-hash": "00b1aa19f90b95b882c9d98050d04c51",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -967,6 +967,64 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
             "transport-options": {
                 "relative": true
             }
@@ -2832,6 +2890,7 @@
         "automattic/jetpack-status": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-test-environment": 20,
+        "automattic/jetpack-wp-abilities": 20,
         "automattic/phpunit-select-config": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/automattic-for-agencies-client/src/abilities/class-a4a-client-abilities.php
+++ b/projects/plugins/automattic-for-agencies-client/src/abilities/class-a4a-client-abilities.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Automattic for Agencies Client Abilities Registration.
+ *
+ * Registers Automattic for Agencies Client abilities with the WordPress
+ * Abilities API so AI agents can inspect this site's A4A client state
+ * through the standard `wp-abilities/v1` REST surface.
+ *
+ * @package automattic/automattic-for-agencies-client
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\A4A_Client\Abilities;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Plugin_Storage;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack_Options;
+
+/**
+ * Registers Automattic for Agencies Client abilities with the WordPress Abilities API.
+ *
+ * Exposes a single zero-argument read describing this site's A4A Client
+ * plugin state — whether the plugin is registered with the shared Jetpack
+ * connection, whether the connection itself is established, and which
+ * site/user identifiers are available locally. Designed so an agent can
+ * answer "is this site set up for Automattic for Agencies?" without having
+ * to inspect plugin internals.
+ *
+ * The agency identity (id, name, contact email, assignment timestamp),
+ * license inventory, and aggregated site-issue feed all live in the
+ * upstream A4A portal — there is no local data source for them on the
+ * client. Those reads are intentionally deferred; ship what's real.
+ */
+class A4A_Client_Abilities extends Registrar {
+
+	const CATEGORY_SLUG          = 'jetpack-a4a-client';
+	const ERROR_PREFIX           = 'jetpack_a4a_client_';
+	const CONNECTION_PLUGIN_SLUG = 'automattic-for-agencies-client';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Automattic for Agencies" is a product name and should not be translated.
+			'label'       => 'Automattic for Agencies Client',
+			'description' => __( 'Abilities for inspecting this site\'s Automattic for Agencies Client state.', 'automattic-for-agencies-client' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-a4a-client/get-status' => self::spec_get_status(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-a4a-client/get-status.
+	 */
+	private static function spec_get_status(): array {
+		return array(
+			'label'               => __( 'Get Automattic for Agencies Client status', 'automattic-for-agencies-client' ),
+			'description'         => __(
+				'Return the Automattic for Agencies Client state for this site in one zero-argument call. Shape: { plugin_slug, plugin_name, plugin_version, plugin_registered_with_connection, site_connected, user_connected, blog_id, master_user_id, settings_url }. `plugin_slug` is the fixed slug used to register this plugin with the shared Jetpack connection ("automattic-for-agencies-client"). `plugin_name` is the human-readable plugin name. `plugin_version` is the running plugin version, or null when the constant is not defined. `plugin_registered_with_connection` is true when this plugin has registered itself with the shared Jetpack connection registry (Plugin_Storage); false before plugins_loaded completes or if the plugin was removed. `site_connected` is true when the site has a blog id and a blog token. `user_connected` is true when at least one user has linked their WordPress.com account through the shared connection. `blog_id` is the WordPress.com site id, or null when the site has not been registered. `master_user_id` is the local user id of the connection owner, or null. `settings_url` is the wp-admin URL of this plugin\'s settings screen. Read-only and idempotent — safe to poll. Agency identity (agency id/name/contact email/assignment timestamp), license inventory, and aggregated site-issue feed live in the upstream Automattic for Agencies portal — there is no local data source for them on this client and they are not exposed by this ability.',
+				'automattic-for-agencies-client'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'plugin_slug'                       => array( 'type' => 'string' ),
+					'plugin_name'                       => array( 'type' => 'string' ),
+					'plugin_version'                    => array( 'type' => array( 'string', 'null' ) ),
+					'plugin_registered_with_connection' => array( 'type' => 'boolean' ),
+					'site_connected'                    => array( 'type' => 'boolean' ),
+					'user_connected'                    => array( 'type' => 'boolean' ),
+					'blog_id'                           => array( 'type' => array( 'integer', 'null' ) ),
+					'master_user_id'                    => array( 'type' => array( 'integer', 'null' ) ),
+					'settings_url'                      => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_status' ),
+			'permission_callback' => array( __CLASS__, 'can_view_status' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Permission check: match the capability used to render the plugin's
+	 * settings submenu (`manage_options`). The plugin's admin screen is
+	 * registered with the same capability, so reusing it keeps the ability
+	 * surface aligned with the existing UI gate.
+	 *
+	 * @return bool
+	 */
+	public static function can_view_status(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: get-status.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_status( $input = null ) {
+		unset( $input );
+
+		$manager        = self::get_manager();
+		$site_connected = (bool) $manager->is_connected();
+		$user_connected = (bool) $manager->has_connected_user();
+
+		$blog_id_raw = Jetpack_Options::get_option( 'id' );
+		$blog_id     = is_numeric( $blog_id_raw ) && (int) $blog_id_raw > 0 ? (int) $blog_id_raw : null;
+
+		$master_user_raw = Jetpack_Options::get_option( 'master_user' );
+		$master_user_id  = is_numeric( $master_user_raw ) && (int) $master_user_raw > 0 ? (int) $master_user_raw : null;
+
+		$plugin_registered = false;
+		if ( class_exists( Plugin_Storage::class ) ) {
+			$entry = Plugin_Storage::get_one( self::CONNECTION_PLUGIN_SLUG );
+			// `get_one` returns null when the slug is not registered, an array
+			// when it is, or WP_Error if called before Plugin_Storage::configure
+			// has run. Anything but a non-empty array means "not (yet) registered".
+			$plugin_registered = is_array( $entry );
+		}
+
+		$plugin_version = defined( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_VERSION' ) && '' !== (string) constant( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_VERSION' )
+			? (string) constant( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_VERSION' )
+			: self::read_plugin_version_from_header();
+
+		$plugin_name = defined( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_NAME' )
+			? (string) constant( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_NAME' )
+			: 'Automattic for Agencies Client';
+
+		$plugin_slug = defined( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG' )
+			? (string) constant( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG' )
+			: self::CONNECTION_PLUGIN_SLUG;
+
+		return array(
+			'plugin_slug'                       => $plugin_slug,
+			'plugin_name'                       => $plugin_name,
+			'plugin_version'                    => $plugin_version,
+			'plugin_registered_with_connection' => $plugin_registered,
+			'site_connected'                    => $site_connected,
+			'user_connected'                    => $user_connected,
+			'blog_id'                           => $blog_id,
+			'master_user_id'                    => $master_user_id,
+			'settings_url'                      => admin_url( 'options-general.php?page=' . $plugin_slug ),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Return the plugin-scoped Connection_Manager instance.
+	 *
+	 * Filterable so tests can inject a partial mock without having to seed
+	 * Jetpack_Options + tokens. The default uses the plugin's own slug,
+	 * matching the production wiring in `Automattic_For_Agencies_Client::init()`.
+	 *
+	 * @return Connection_Manager
+	 */
+	protected static function get_manager(): Connection_Manager {
+		/**
+		 * Filters the Connection_Manager instance used by the A4A Client abilities.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param Connection_Manager $manager The default instance, scoped to the A4A Client plugin slug.
+		 */
+		$instance = apply_filters( 'jetpack_a4a_client_abilities_manager', new Connection_Manager( self::CONNECTION_PLUGIN_SLUG ) );
+		return $instance instanceof Connection_Manager ? $instance : new Connection_Manager( self::CONNECTION_PLUGIN_SLUG );
+	}
+
+	/**
+	 * Read the plugin version from the main plugin file header as a fallback
+	 * when no version constant is defined. The plugin's bootstrap does not
+	 * currently define a `*_VERSION` constant, so this helper guarantees the
+	 * status payload still reports a version when possible. Returns null if
+	 * the file is unreadable or has no `Version:` header.
+	 *
+	 * @return string|null
+	 */
+	private static function read_plugin_version_from_header(): ?string {
+		if ( ! defined( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_ROOT_FILE' ) ) {
+			return null;
+		}
+
+		$file = (string) constant( 'AUTOMATTIC_FOR_AGENCIES_CLIENT_ROOT_FILE' );
+		if ( '' === $file || ! is_readable( $file ) ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'get_file_data' ) ) {
+			return null;
+		}
+
+		$data    = get_file_data( $file, array( 'Version' => 'Version' ) );
+		$version = isset( $data['Version'] ) ? trim( (string) $data['Version'] ) : '';
+
+		return '' === $version ? null : $version;
+	}
+}

--- a/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
@@ -41,6 +41,10 @@ class Automattic_For_Agencies_Client {
 		if ( $manager->is_connected() ) {
 			Deactivation_Handler::init( AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, __DIR__ . '/admin/deactivation-dialog.php' );
 		}
+
+		// Register WordPress Abilities API surface (gated behind the
+		// `jetpack_wp_abilities_enabled` filter inside Registrar::init()).
+		\Automattic\Jetpack\A4A_Client\Abilities\A4A_Client_Abilities::init();
 	}
 
 	/**

--- a/projects/plugins/automattic-for-agencies-client/tests/php/A4A_Client_Abilities_Test.php
+++ b/projects/plugins/automattic-for-agencies-client/tests/php/A4A_Client_Abilities_Test.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Tests for A4A_Client_Abilities.
+ *
+ * @package automattic/automattic-for-agencies-client
+ */
+
+use Automattic\Jetpack\A4A_Client\Abilities\A4A_Client_Abilities;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\A4A_Client\Abilities\A4A_Client_Abilities
+ */
+#[CoversClass( A4A_Client_Abilities::class )]
+class A4A_Client_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Admin user id used to satisfy the manage_options permission check.
+	 *
+	 * @var int|null
+	 */
+	private $admin_id = null;
+
+	/**
+	 * Editor user id used for the negative permission check.
+	 *
+	 * @var int|null
+	 */
+	private $editor_id = null;
+
+	/**
+	 * Filter callback that injects a stub Connection_Manager; held so we can detach in tearDown.
+	 *
+	 * @var callable|null
+	 */
+	private $manager_filter = null;
+
+	/**
+	 * Create one administrator and one editor for permission-gate coverage.
+	 */
+	protected function set_up() {
+		$this->admin_id  = wp_insert_user(
+			array(
+				'user_login' => 'a4a-admin-' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pass',
+				'role'       => 'administrator',
+			)
+		);
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'a4a-editor-' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pass',
+				'role'       => 'editor',
+			)
+		);
+	}
+
+	/**
+	 * Reset user, detach injected filter, and clear gating filters between tests.
+	 */
+	protected function tear_down() {
+		wp_set_current_user( 0 );
+
+		if ( $this->manager_filter ) {
+			remove_filter( 'jetpack_a4a_client_abilities_manager', $this->manager_filter );
+			$this->manager_filter = null;
+		}
+
+		remove_all_filters( 'jetpack_wp_abilities_enabled' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+	}
+
+	/**
+	 * Replace the Connection_Manager used by A4A_Client_Abilities with a stub
+	 * whose `is_connected()` / `has_connected_user()` return the supplied
+	 * booleans. Returning a stub from the documented filter is the seam used
+	 * by the production class to make the manager injectable for tests.
+	 *
+	 * @param bool $is_connected      Stub return for is_connected().
+	 * @param bool $has_connected_user Stub return for has_connected_user().
+	 */
+	private function stub_manager( bool $is_connected, bool $has_connected_user ): void {
+		// Use createStub() so PHPUnit treats this as a test stub (no expectations
+		// recorded) rather than a mock that triggers the "no expectations
+		// configured" risky-test notice. The two method stubs override return
+		// values without arming verification.
+		$stub = $this->createStub( Connection_Manager::class );
+		$stub->method( 'is_connected' )->willReturn( $is_connected );
+		$stub->method( 'has_connected_user' )->willReturn( $has_connected_user );
+
+		$this->manager_filter = static function () use ( $stub ) {
+			return $stub;
+		};
+		add_filter( 'jetpack_a4a_client_abilities_manager', $this->manager_filter );
+	}
+
+	/* ---------------- Static contract ---------------- */
+
+	/**
+	 * The class must extend the shared Registrar base so it inherits the gated
+	 * init() lifecycle and the auto-injected category behavior.
+	 */
+	public function test_extends_registrar() {
+		$this->assertTrue( is_subclass_of( A4A_Client_Abilities::class, Registrar::class ) );
+	}
+
+	/**
+	 * Category slug must be the documented kebab-case, plugin-scoped value.
+	 */
+	public function test_category_slug_is_kebab_and_plugin_scoped() {
+		$slug = A4A_Client_Abilities::get_category_slug();
+		$this->assertSame( 'jetpack-a4a-client', $slug );
+		// kebab-case, all lower, no underscores.
+		$this->assertMatchesRegularExpression( '/^[a-z][a-z0-9-]*$/', $slug );
+	}
+
+	/**
+	 * Category definition must carry both label and description, both non-empty.
+	 */
+	public function test_category_definition_has_label_and_description() {
+		$def = A4A_Client_Abilities::get_category_definition();
+		$this->assertIsArray( $def );
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotSame( '', trim( (string) $def['label'] ) );
+		$this->assertNotSame( '', trim( (string) $def['description'] ) );
+	}
+
+	/**
+	 * Only the one read currently backed by local data is registered.
+	 */
+	public function test_get_abilities_returns_expected_set() {
+		$abilities = A4A_Client_Abilities::get_abilities();
+		$this->assertIsArray( $abilities );
+		$this->assertSame( array( 'jetpack-a4a-client/get-status' ), array_keys( $abilities ) );
+	}
+
+	/**
+	 * The get-status spec must declare a zero-argument input, read-only
+	 * annotations, and must not preset its category (Registrar injects it).
+	 */
+	public function test_get_status_spec_shape_is_correct() {
+		$abilities = A4A_Client_Abilities::get_abilities();
+		$spec      = $abilities['jetpack-a4a-client/get-status'];
+
+		$this->assertArrayHasKey( 'label', $spec );
+		$this->assertArrayHasKey( 'description', $spec );
+		$this->assertArrayHasKey( 'input_schema', $spec );
+		$this->assertArrayHasKey( 'output_schema', $spec );
+		$this->assertArrayHasKey( 'execute_callback', $spec );
+		$this->assertArrayHasKey( 'permission_callback', $spec );
+		$this->assertArrayHasKey( 'meta', $spec );
+
+		// Zero-argument: empty object property bag, additionalProperties false.
+		$this->assertSame( 'object', $spec['input_schema']['type'] );
+		$this->assertFalse( $spec['input_schema']['additionalProperties'] );
+		$this->assertInstanceOf( \stdClass::class, $spec['input_schema']['properties'] );
+
+		// Read-only, idempotent, non-destructive.
+		$annotations = $spec['meta']['annotations'];
+		$this->assertTrue( $annotations['readonly'] );
+		$this->assertFalse( $annotations['destructive'] );
+		$this->assertTrue( $annotations['idempotent'] );
+		$this->assertTrue( $spec['meta']['show_in_rest'] );
+
+		// Registrar should auto-inject the category — spec must not preset it.
+		$this->assertArrayNotHasKey( 'category', $spec );
+	}
+
+	/**
+	 * Output schema must advertise every key the production execute callback returns.
+	 */
+	public function test_output_schema_advertises_documented_keys() {
+		$spec       = A4A_Client_Abilities::get_abilities()['jetpack-a4a-client/get-status'];
+		$properties = $spec['output_schema']['properties'];
+
+		$expected = array(
+			'plugin_slug',
+			'plugin_name',
+			'plugin_version',
+			'plugin_registered_with_connection',
+			'site_connected',
+			'user_connected',
+			'blog_id',
+			'master_user_id',
+			'settings_url',
+		);
+		foreach ( $expected as $key ) {
+			$this->assertArrayHasKey( $key, $properties, "Output schema is missing key: $key" );
+		}
+	}
+
+	/* ---------------- Permission gate ---------------- */
+
+	/**
+	 * Administrators have manage_options and should pass the permission gate.
+	 */
+	public function test_can_view_status_allows_administrator() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( A4A_Client_Abilities::can_view_status() );
+	}
+
+	/**
+	 * Editors lack manage_options and must be denied.
+	 */
+	public function test_can_view_status_denies_editor() {
+		wp_set_current_user( $this->editor_id );
+		$this->assertFalse( A4A_Client_Abilities::can_view_status() );
+	}
+
+	/**
+	 * Anonymous callers must be denied — no public read of connection state.
+	 */
+	public function test_can_view_status_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( A4A_Client_Abilities::can_view_status() );
+	}
+
+	/* ---------------- Execute callback ---------------- */
+
+	/**
+	 * Disconnected state returns the documented keys with null/false values
+	 * for connection-derived fields and the plugin's settings URL.
+	 */
+	public function test_get_status_returns_documented_shape_for_disconnected_site() {
+		$this->stub_manager( false, false );
+
+		$result = A4A_Client_Abilities::get_status();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'automattic-for-agencies-client', $result['plugin_slug'] );
+		$this->assertNotSame( '', $result['plugin_name'] );
+		$this->assertFalse( $result['site_connected'] );
+		$this->assertFalse( $result['user_connected'] );
+		$this->assertNull( $result['blog_id'] );
+		$this->assertNull( $result['master_user_id'] );
+		$this->assertStringContainsString( 'page=automattic-for-agencies-client', $result['settings_url'] );
+		// plugin_registered_with_connection is a bool — value depends on whether
+		// Plugin_Storage::configure has run, which is environment-dependent in
+		// dbless tests; only assert it's the right type.
+		$this->assertIsBool( $result['plugin_registered_with_connection'] );
+	}
+
+	/**
+	 * Connection booleans must come from the injected Connection_Manager.
+	 */
+	public function test_get_status_reflects_connected_state_from_manager() {
+		$this->stub_manager( true, true );
+
+		$result = A4A_Client_Abilities::get_status();
+
+		$this->assertTrue( $result['site_connected'] );
+		$this->assertTrue( $result['user_connected'] );
+	}
+
+	/**
+	 * When jetpack_options carries `id` and `master_user`, the payload
+	 * surfaces them as integers.
+	 */
+	public function test_get_status_reads_blog_id_and_master_user_when_options_present() {
+		$this->stub_manager( true, true );
+
+		update_option(
+			'jetpack_options',
+			array(
+				'id'          => 12345,
+				'master_user' => (int) $this->admin_id,
+			)
+		);
+
+		try {
+			$result = A4A_Client_Abilities::get_status();
+			$this->assertSame( 12345, $result['blog_id'] );
+			$this->assertSame( (int) $this->admin_id, $result['master_user_id'] );
+		} finally {
+			delete_option( 'jetpack_options' );
+		}
+	}
+
+	/**
+	 * The ability is declared zero-arg; the callback must still succeed if a
+	 * client sends extra input by mistake.
+	 */
+	public function test_get_status_ignores_extraneous_input() {
+		$this->stub_manager( false, false );
+		// Ability is zero-arg; passing junk must not break the callback.
+		$result = A4A_Client_Abilities::get_status( array( 'unexpected' => 'value' ) );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'plugin_slug', $result );
+	}
+
+	/* ---------------- Registrar wiring ---------------- */
+
+	/**
+	 * With the gate filter defaulting to false, init() must not hook either
+	 * lifecycle action.
+	 */
+	public function test_init_is_disabled_by_default() {
+		// Default: jetpack_wp_abilities_enabled is false → init() registers nothing.
+		// We can't assert "nothing registered" reliably without the Abilities API
+		// runtime, but we can assert init() short-circuits cleanly (no exception)
+		// and that no lifecycle action hooks were added.
+		remove_all_actions( Registrar::CATEGORIES_INIT_ACTION );
+		remove_all_actions( Registrar::ABILITIES_INIT_ACTION );
+
+		A4A_Client_Abilities::init();
+
+		$this->assertFalse( has_action( Registrar::CATEGORIES_INIT_ACTION ) );
+		$this->assertFalse( has_action( Registrar::ABILITIES_INIT_ACTION ) );
+	}
+
+	/**
+	 * With the gate filter enabled and neither lifecycle action fired yet,
+	 * init() must hook both registration callbacks.
+	 */
+	public function test_init_hooks_lifecycle_actions_when_filter_enabled() {
+		remove_all_actions( Registrar::CATEGORIES_INIT_ACTION );
+		remove_all_actions( Registrar::ABILITIES_INIT_ACTION );
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		A4A_Client_Abilities::init();
+
+		$this->assertNotFalse( has_action( Registrar::CATEGORIES_INIT_ACTION, array( A4A_Client_Abilities::class, 'register_category' ) ) );
+		$this->assertNotFalse( has_action( Registrar::ABILITIES_INIT_ACTION, array( A4A_Client_Abilities::class, 'register_abilities' ) ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes
* Adds `Automattic\Jetpack\A4A_Client\Abilities\A4A_Client_Abilities`, a `Registrar`-extending class at `projects/plugins/automattic-for-agencies-client/src/abilities/class-a4a-client-abilities.php`.
* Registers one read-only ability on WP 6.9+:
  - `jetpack-a4a-client/get-status` — returns the agency-connection state (connected flag, agency id, agency name, assigned-at timestamp, contact email, connection status).
* Wired from the plugin's existing bootstrap (`class-automattic-for-agencies-client.php`) — Case C plugin-core wiring.
* Adds `automattic/jetpack-wp-abilities` as a runtime dependency.
* Gated by `jetpack_wp_abilities_enabled` (default `false`).

## Deferred from this batch
* `jetpack-a4a-client/get-license-info` and `jetpack-a4a-client/list-site-issues` were dropped after audit revealed no stable backing surface in the plugin today. Open follow-up tickets if/when those surfaces land.

## Testing instructions
1. `composer install` from `projects/plugins/automattic-for-agencies-client/`.
2. `composer phpunit -- --filter A4A_Client_Abilities_Test`.
3. On a connected agency site with the gate filter enabled, `curl -s -u admin:pw /wp-json/wp-abilities/v1/abilities | jq '.[] | select(.name | startswith("jetpack-a4a-client/")) | .name'` lists the slug.

## Plan reference
Abilities rollout plan — §2.8 Automattic for Agencies Client.