### PR TITLE
Jetpack: resolve WPDS design tokens in legacy dashboard CSS

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5614,6 +5614,9 @@ importers:
       '@wordpress/rich-text':
         specifier: 7.46.0
         version: 7.46.0(react@18.3.1)
+      '@wordpress/theme':
+        specifier: 0.13.0
+        version: 0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
         specifier: 0.13.0
         version: 0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5569,6 +5569,9 @@ importers:
       '@wordpress/rich-text':
         specifier: 7.44.0
         version: 7.44.0(react@18.3.1)
+      '@wordpress/theme':
+        specifier: 0.11.0
+        version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
         specifier: 0.11.0
         version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -16448,8 +16451,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.2.6:
-    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+  react-is@19.2.5:
+    resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
 
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -32780,7 +32783,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.6
+      react-is-19: react-is@19.2.5
 
   print-this@2.0.0:
     dependencies:
@@ -32981,7 +32984,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.2.6: {}
+  react-is@19.2.5: {}
 
   react-lifecycles-compat@3.0.4: {}
 

--- a/projects/plugins/jetpack/changelog/change-dashboard-load-design-tokens
+++ b/projects/plugins/jetpack/changelog/change-dashboard-load-design-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Jetpack: resolve WPDS design tokens in the legacy settings dashboard CSS so token-based colors (e.g. Hello Dolly) use the design-system value instead of a hardcoded hex fallback.

--- a/projects/plugins/jetpack/changelog/change-dashboard-load-design-tokens
+++ b/projects/plugins/jetpack/changelog/change-dashboard-load-design-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Jetpack: load WPDS design tokens on legacy settings dashboard via postcss-global-data.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -82,6 +82,7 @@
 		"@wordpress/plugins": "7.46.0",
 		"@wordpress/primitives": "4.46.0",
 		"@wordpress/rich-text": "7.46.0",
+		"@wordpress/theme": "0.13.0",
 		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.46.0",
 		"@wordpress/viewport": "6.46.0",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -82,6 +82,7 @@
 		"@wordpress/plugins": "7.44.0",
 		"@wordpress/primitives": "4.44.0",
 		"@wordpress/rich-text": "7.44.0",
+		"@wordpress/theme": "0.11.0",
 		"@wordpress/ui": "0.11.0",
 		"@wordpress/url": "4.44.0",
 		"@wordpress/viewport": "6.44.0",

--- a/projects/plugins/jetpack/tools/postcss.config.js
+++ b/projects/plugins/jetpack/tools/postcss.config.js
@@ -2,7 +2,17 @@ module.exports = () => ( {
 	plugins: [
 		require( '@csstools/postcss-global-data' )( {
 			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
+			files: [
+				require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ),
+				// Feed the WPDS design tokens to postcss-custom-properties so the legacy
+				// `_inc/` dashboard's `var(--wpds-*, #fallback)` usages inline to the actual
+				// token value (e.g. #707070) instead of the hand-written hex fallback. These
+				// tokens normally arrive transitively via `@wordpress/ui`'s CSS bundle, which
+				// this dashboard doesn't import. Modernized (admin-ui) pages get them at
+				// runtime instead; see the shared token stylesheet enqueued there.
+				// The `design-tokens.css` subpath is exposed via @wordpress/theme's exports map.
+				require.resolve( '@wordpress/theme/design-tokens.css' ),
+			],
 		} ),
 		require( 'postcss-custom-properties' )( {
 			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.

--- a/projects/plugins/jetpack/tools/postcss.config.js
+++ b/projects/plugins/jetpack/tools/postcss.config.js
@@ -2,7 +2,13 @@ module.exports = () => ( {
 	plugins: [
 		require( '@csstools/postcss-global-data' )( {
 			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
+			files: [
+				require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ),
+				// Loads --wpds-* design tokens so legacy dashboard consumers can use raw
+				// var(--wpds-*) — these tokens normally arrive transitively via @wordpress/ui's
+				// CSS bundle, which the legacy _inc/ dashboard doesn't import.
+				require.resolve( '@wordpress/theme/design-tokens.css' ),
+			],
 		} ),
 		require( 'postcss-custom-properties' )( {
 			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.


### PR DESCRIPTION
Part of #49285. Companion to #49345 (the runtime half).

## Proposed changes

This is the **build-time half** of WPDS-token loading, scoped to the **legacy `_inc/` dashboard** (Settings / Dashboard / Debugger).

* `projects/plugins/jetpack/tools/postcss.config.js`: add `@wordpress/theme/design-tokens.css` to the `@csstools/postcss-global-data` `files` list (alongside the existing calypso-color-schemes entry).
* `projects/plugins/jetpack/package.json`: add `@wordpress/theme@0.13.0` as a direct dependency so `require.resolve( '@wordpress/theme/design-tokens.css' )` (exposed via the package's `exports` map) resolves deterministically.

### Why build-time here (and runtime elsewhere)

The `_inc/` dashboard's postcss runs `postcss-custom-properties` with **`preserve: false`**, which inlines `var(--wpds-*, #fallback)` to its hex fallback at build time and strips the `var()`. So on the legacy dashboard, token-based colors (e.g. Hello Dolly) were baked to `#87a6bc` and a runtime `:root{--wpds-*}` stylesheet has nothing to bind to.

Feeding the tokens into `postcss-global-data` makes `postcss-custom-properties` inline them to the **actual token value** (`#707070`) instead of the fallback.

The obvious alternative — flipping `preserve: true` so vars survive to runtime — is **not viable here**: `@automattic/calypso-color-schemes` (732 generic vars like `--color-text`) is only build-time-inlined and **not loaded at runtime**, so preserving would leave every no-fallback calypso var undefined → broken. That's the exact "extremely generic vars" blocker called out in the existing postcss.config.js comment. The modernized **admin-ui** pages don't have this constraint (they preserve `var()` and load tokens at runtime), so they get the runtime stylesheet in #49345 instead.

No version skew: both this build-time source and #49345's runtime source come from `@wordpress/theme@0.13.0`.

## Verification

Rebuilt `_inc/build/admin.css`:

| | Before (trunk) | After |
| --- | --- | --- |
| `#87a6bc` (Dolly fallback) occurrences | present | **0** |
| `#707070` (token value) occurrences | 0 | **6** |

Standalone postcss check of the config also confirms `.dolly{ color: var(--wpds-color-fg-content-neutral-weak, #87a6bc) }` → `color:#707070`, while a generic `var(--color-text)` stays inlined (unchanged) — i.e. no calypso regression.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. `pnpm jetpack build plugins/jetpack` (the CSS/webpack step; an unrelated `composer build-development` step may fail locally).
2. `grep -c 87a6bc projects/plugins/jetpack/_inc/build/admin.css` → `0`; `grep -c 707070 …` → non-zero.
3. On a connected site, hard-refresh **Jetpack → Settings / Dashboard** and the **Debugger**: the Hello Dolly strip reads `#707070` (neutral gray) instead of the old bluish `#87a6bc`.
