### PR TITLE
Search 3.0: add author to expanded results-list meta row (RSM-2999)

### DIFF
--- a/projects/packages/search/changelog/RSM-2999-author-expanded-layout
+++ b/projects/packages/search/changelog/RSM-2999-author-expanded-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search 3.0: show the post author in the expanded results-list layout's meta row, before the date.

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
@@ -39,6 +39,7 @@ const SAMPLE_RESULTS = [
 			'jetpack-search-pkg'
 		),
 		path: 'example.com/articles/first',
+		author: __( 'Sample Author', 'jetpack-search-pkg' ),
 		date: 'Apr 1, 2026',
 	},
 	{
@@ -48,6 +49,7 @@ const SAMPLE_RESULTS = [
 			'jetpack-search-pkg'
 		),
 		path: 'example.com/guides/another',
+		author: __( 'A. Writer, B. Editor', 'jetpack-search-pkg' ),
 		date: 'Mar 22, 2026',
 	},
 	{
@@ -196,8 +198,8 @@ function renderCompactPreview( results ) {
 }
 
 /**
- * Expanded preview — title, breadcrumb path, date, and a side image. The
- * default layout for blogs and content sites.
+ * Expanded preview — title, breadcrumb path, author + date meta, and a side
+ * image. The default layout for blogs and content sites.
  *
  * @param {Array} results - Sample rows.
  * @return {object} Rendered element.
@@ -214,7 +216,17 @@ function renderExpandedPreview( results ) {
 						) }
 						<div className="jetpack-search-results__path">{ result.path }</div>
 						<div className="jetpack-search-results__meta">
-							<span className="jetpack-search-results__date">{ result.date }</span>
+							{ result.author && (
+								<span className="jetpack-search-results__author">{ result.author }</span>
+							) }
+							{ result.author && result.date && (
+								<span className="jetpack-search-results__meta-separator" aria-hidden="true">
+									·
+								</span>
+							) }
+							{ result.date && (
+								<span className="jetpack-search-results__date">{ result.date }</span>
+							) }
 						</div>
 					</div>
 					<a className="jetpack-search-results__image-link" tabIndex={ -1 } aria-hidden="true">

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -27,7 +27,7 @@ namespace Automattic\Jetpack\Search;
  * sections differ.
  *
  * @param string $layout Layout key.
- * @return array{modifier:string, show_content:bool, show_date:bool, show_image:bool, show_path:bool, show_price:bool, show_rating:bool}
+ * @return array{modifier:string, show_author:bool, show_content:bool, show_date:bool, show_image:bool, show_path:bool, show_price:bool, show_rating:bool}
  */
 $resolve_layout = static function ( $layout ) {
 	$map = array(
@@ -36,6 +36,7 @@ $resolve_layout = static function ( $layout ) {
 			'show_image'   => false,
 			'show_path'    => false,
 			'show_content' => false,
+			'show_author'  => false,
 			'show_date'    => true,
 			'show_price'   => false,
 			'show_rating'  => false,
@@ -45,6 +46,7 @@ $resolve_layout = static function ( $layout ) {
 			'show_image'   => true,
 			'show_path'    => true,
 			'show_content' => true,
+			'show_author'  => true,
 			'show_date'    => true,
 			'show_price'   => false,
 			'show_rating'  => false,
@@ -54,6 +56,7 @@ $resolve_layout = static function ( $layout ) {
 			'show_image'   => true,
 			'show_path'    => false,
 			'show_content' => false,
+			'show_author'  => false,
 			'show_date'    => false,
 			'show_price'   => true,
 			'show_rating'  => true,
@@ -267,13 +270,29 @@ if ( '' === $error_message ) {
 							</mark>
 						</div>
 					<?php endif; ?>
-					<?php if ( $features['show_date'] ) : ?>
+					<?php if ( $features['show_author'] || $features['show_date'] ) : ?>
 						<div class="jetpack-search-results__meta">
-							<span
-								class="jetpack-search-results__date"
-								data-wp-bind--hidden="!context.result.dateLabel"
-								data-wp-text="context.result.dateLabel"
-							></span>
+							<?php if ( $features['show_author'] ) : ?>
+								<span
+									class="jetpack-search-results__author"
+									data-wp-bind--hidden="!context.result.authorLabel"
+									data-wp-text="context.result.authorLabel"
+								></span>
+							<?php endif; ?>
+							<?php if ( $features['show_author'] && $features['show_date'] ) : ?>
+								<span
+									class="jetpack-search-results__meta-separator"
+									aria-hidden="true"
+									data-wp-bind--hidden="!context.result.authorLabel || !context.result.dateLabel"
+								>&middot;</span>
+							<?php endif; ?>
+							<?php if ( $features['show_date'] ) : ?>
+								<span
+									class="jetpack-search-results__date"
+									data-wp-bind--hidden="!context.result.dateLabel"
+									data-wp-text="context.result.dateLabel"
+								></span>
+							<?php endif; ?>
 						</div>
 					<?php endif; ?>
 				</div>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/style.scss
@@ -113,11 +113,27 @@
 		}
 	}
 
-	.jetpack-search-results__date {
+	.jetpack-search-results__meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.5rem;
 		margin-top: 1rem;
 		color: inherit;
 		opacity: 0.6;
 		font-size: 0.9rem;
+	}
+
+	.jetpack-search-results__author,
+	.jetpack-search-results__date {
+		color: inherit;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	.jetpack-search-results__meta-separator {
 
 		&[hidden] {
 			display: none;
@@ -203,14 +219,13 @@
 	}
 
 	.jetpack-search-results__meta {
-		display: flex;
+		// Compact meta sits inline next to the title via `__copy`'s flex
+		// row — override the base 1rem top margin that lifts the meta row
+		// away from the snippet/path in the expanded layout.
+		margin-top: 0;
 		gap: 0.75rem;
 		font-size: 0.875em;
 		opacity: 0.75;
-	}
-
-	.jetpack-search-results__date {
-		margin-top: 0;
 	}
 }
 

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -17,6 +17,7 @@ import { encode } from 'qss';
  * a few hundred bytes per result.
  */
 export const SEARCH_FIELDS = [
+	'author',
 	'date',
 	'permalink.url.raw',
 	'post_type',

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -105,6 +105,33 @@ export function formatPath( permalink ) {
 }
 
 /**
+ * Format the v1.3 `author` field for display on a result card. The API hands
+ * back a single author as a string and co-authored posts as an array; in the
+ * array case, mirror instant-search's behavior — comma-join up to three
+ * entries, and for >3 keep the first three and append an ellipsis so the
+ * meta row doesn't run away on heavily co-authored posts.
+ *
+ * @param {*} value - `fields.author` from the v1.3 API response.
+ * @return {string} Display string, or '' when no author is present.
+ */
+export function formatAuthor( value ) {
+	if ( Array.isArray( value ) ) {
+		const names = value.map( v => String( v ?? '' ).trim() ).filter( Boolean );
+		if ( names.length === 0 ) {
+			return '';
+		}
+		if ( names.length > 3 ) {
+			return names.slice( 0, 3 ).join( ', ' ) + '...';
+		}
+		return names.join( ', ' );
+	}
+	if ( typeof value !== 'string' ) {
+		return '';
+	}
+	return value.trim();
+}
+
+/**
  * Decode the small set of HTML entities the v1.3 API can place in
  * text-rendered fields. WPCOM hands back WC-formatted prices and post titles
  * with numeric entities (e.g. `&#036;` for `$`) and a handful of named ones
@@ -414,6 +441,7 @@ export function normalizeResult( raw, locale = 'en-US', searchQuery = '' ) {
 		permalink,
 		path: formatPath( permalink ),
 		dateLabel: formatDate( fields.date, locale ),
+		authorLabel: formatAuthor( fields.author ),
 		imageUrl,
 		// Pre-built `url(...)` value so the product layout's CSS background
 		// image binds via `data-wp-style--background-image` without the

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -111,12 +111,17 @@ export function formatPath( permalink ) {
  * entries, and for >3 keep the first three and append an ellipsis so the
  * meta row doesn't run away on heavily co-authored posts.
  *
+ * Each name is run through `decodeEntities` because the API HTML-encodes
+ * punctuation in display names (`O&#8217;Brien`, `Jane &amp; John`). The meta
+ * row binds via `data-wp-text` (textContent, not innerHTML), so without
+ * decoding the raw entity would render literally on the card.
+ *
  * @param {*} value - `fields.author` from the v1.3 API response.
  * @return {string} Display string, or '' when no author is present.
  */
 export function formatAuthor( value ) {
 	if ( Array.isArray( value ) ) {
-		const names = value.map( v => String( v ?? '' ).trim() ).filter( Boolean );
+		const names = value.map( v => decodeEntities( String( v ?? '' ).trim() ) ).filter( Boolean );
 		if ( names.length === 0 ) {
 			return '';
 		}
@@ -128,7 +133,7 @@ export function formatAuthor( value ) {
 	if ( typeof value !== 'string' ) {
 		return '';
 	}
-	return value.trim();
+	return decodeEntities( value.trim() );
 }
 
 /**

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -11,9 +11,11 @@ import {
 } from '../../../src/search-blocks/store/api';
 
 describe( 'SEARCH_FIELDS', () => {
-	it( 'does not request author fields for result cards', () => {
-		expect( SEARCH_FIELDS ).not.toContain( 'author.name' );
-		expect( SEARCH_FIELDS ).not.toContain( 'author' );
+	it( 'requests the bare `author` field for the expanded result card', () => {
+		// The expanded results-list layout renders the post author in the meta
+		// row. Without `author` in the requested fields list, the v1.3 API
+		// would omit it entirely (default response is just date / post_id).
+		expect( SEARCH_FIELDS ).toContain( 'author' );
 	} );
 
 	it( 'requests WooCommerce price and rating fields for the product layout', () => {

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -341,6 +341,14 @@ describe( 'formatAuthor', () => {
 		expect( formatAuthor( [ 'Ada', '', '   ', 'Bob' ] ) ).toBe( 'Ada, Bob' );
 		expect( formatAuthor( [ '', '   ' ] ) ).toBe( '' );
 	} );
+
+	it( 'decodes HTML entities in author names', () => {
+		// The v1.3 API HTML-encodes punctuation in display names, and the meta
+		// row binds via `data-wp-text` (textContent). Without entity decoding,
+		// `O&#8217;Brien` would render as the literal string.
+		expect( formatAuthor( 'O&#8217;Brien' ) ).toBe( 'O’Brien' );
+		expect( formatAuthor( [ 'Jane &amp; John', 'Ada' ] ) ).toBe( 'Jane & John, Ada' );
+	} );
 } );
 
 describe( 'normalizeResult', () => {

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -696,16 +696,21 @@ describe( 'normalizeResult', () => {
 		} );
 	} );
 
-	it( 'does not expose author data from the API response', () => {
+	it( 'exposes the author as authorLabel rather than a raw author key', () => {
+		// The template binds to `authorLabel`; a stray `author` property on
+		// the normalized result would let downstream code render the raw API
+		// shape (potentially an array) instead of the formatted string.
 		const raw = {
 			result_id: '1',
 			fields: {
 				'permalink.url.raw': 'https://example.com/a',
 				'title.default': 'Post',
-				'author.name': 'Ada Lovelace',
+				author: 'Ada Lovelace',
 			},
 		};
-		expect( normalizeResult( raw ) ).not.toHaveProperty( 'author' );
+		const r = normalizeResult( raw );
+		expect( r ).not.toHaveProperty( 'author' );
+		expect( r.authorLabel ).toBe( 'Ada Lovelace' );
 	} );
 
 	it( 'exposes matchHint="content" when a non-title field is highlighted but the title is not', () => {

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -2,6 +2,7 @@ import {
 	countActiveFilters,
 	decodeEntities,
 	deriveMatchHint,
+	formatAuthor,
 	formatDate,
 	formatPath,
 	normalizeResult,
@@ -310,6 +311,38 @@ describe( 'deriveMatchHint', () => {
 	} );
 } );
 
+describe( 'formatAuthor', () => {
+	it( 'returns a single-author string trimmed', () => {
+		expect( formatAuthor( '  Sample Author  ' ) ).toBe( 'Sample Author' );
+	} );
+
+	it( 'joins two authors with a comma', () => {
+		expect( formatAuthor( [ 'Ada', 'Bob' ] ) ).toBe( 'Ada, Bob' );
+	} );
+
+	it( 'joins three authors with commas, no ellipsis', () => {
+		expect( formatAuthor( [ 'Ada', 'Bob', 'Cris' ] ) ).toBe( 'Ada, Bob, Cris' );
+	} );
+
+	it( 'truncates after the first three when the array has more than three entries', () => {
+		// Mirrors instant-search behavior so co-authored posts don't blow out
+		// the meta row. The ellipsis is three dots, not the U+2026 character.
+		expect( formatAuthor( [ 'Ada', 'Bob', 'Cris', 'Dee', 'Eve' ] ) ).toBe( 'Ada, Bob, Cris...' );
+	} );
+
+	it( 'returns empty string for missing or empty input', () => {
+		expect( formatAuthor( undefined ) ).toBe( '' );
+		expect( formatAuthor( null ) ).toBe( '' );
+		expect( formatAuthor( '' ) ).toBe( '' );
+		expect( formatAuthor( [] ) ).toBe( '' );
+	} );
+
+	it( 'drops empty entries from an array before joining or truncating', () => {
+		expect( formatAuthor( [ 'Ada', '', '   ', 'Bob' ] ) ).toBe( 'Ada, Bob' );
+		expect( formatAuthor( [ '', '   ' ] ) ).toBe( '' );
+	} );
+} );
+
 describe( 'normalizeResult', () => {
 	const RAW = {
 		result_id: 'r-42',
@@ -433,6 +466,22 @@ describe( 'normalizeResult', () => {
 		expect( r.dateLabel ).toMatch( /20 avr/ );
 	} );
 
+	it( 'exposes authorLabel for a single-author result', () => {
+		const r = normalizeResult( { fields: { author: 'Ada' } } );
+		expect( r.authorLabel ).toBe( 'Ada' );
+	} );
+
+	it( 'joins and truncates authorLabel for co-authored results', () => {
+		const r = normalizeResult( {
+			fields: { author: [ 'Ada', 'Bob', 'Cris', 'Dee' ] },
+		} );
+		expect( r.authorLabel ).toBe( 'Ada, Bob, Cris...' );
+	} );
+
+	it( 'authorLabel is empty when the field is absent', () => {
+		expect( normalizeResult( { fields: {} } ).authorLabel ).toBe( '' );
+	} );
+
 	it( 'returns a usable object for a fully empty raw result', () => {
 		const r = normalizeResult( {} );
 		expect( r ).toEqual( {
@@ -445,6 +494,7 @@ describe( 'normalizeResult', () => {
 			permalink: '',
 			path: '',
 			dateLabel: '',
+			authorLabel: '',
 			imageUrl: '',
 			imageBackgroundImage: '',
 			matchHint: '',


### PR DESCRIPTION
Fixes [RSM-2999](https://linear.app/a8c/issue/RSM-2999/search-30-add-author-field-to-expanded-layout-in-jetpack-searchresults)

## Why

Authors are a primary signal readers use to decide which result to click. Legacy Instant Search shows the post author in its expanded result card; Search 3.0's expanded `jetpack-search/results-list` block had dropped it. This PR brings that information back so site visitors and editors who migrate from Instant Search don't lose a familiar piece of context.

## Proposed changes

* Normalize `fields.author` from the v1.3 Search API into a single `authorLabel` on each result. Single-author posts pass through as-is; co-authored posts comma-join (Instant Search's behaviour), and >3 authors truncate to the first three + "..." so the meta row doesn't run away.
* Add a `show_author` per-layout flag, enabled for the `expanded` layout only (compact and product unchanged).
* Render the author in the same `.jetpack-search-results__meta` row that holds the date — author first, then a `·` separator span, then the date. The separator is bound to `data-wp-bind--hidden="!authorLabel || !dateLabel"` so posts with only an author or only a date don't get a stray bullet.
* Mirror the markup in the editor preview (`edit.js → renderExpandedPreview`) so Gutenberg authors see the field in the inserter, including the multi-author and no-author edge cases.
* Restyle `.jetpack-search-results__meta` as a flex row with a `0.5rem` gap and move the meta row's top margin off of the date span so the new author span doesn't get a stale top offset. Compact layout keeps its inline-with-title behaviour via a `margin-top: 0` override.

## Related product discussion/links

* [RSM-2999](https://linear.app/a8c/issue/RSM-2999/search-30-add-author-field-to-expanded-layout-in-jetpack-searchresults)

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Editor preview of the `jetpack-search/results-list` block in **Expanded** layout, captured locally via Playwright against the per-agent docker WordPress at 1440×900.

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/0ad6cc54-1024-4474-b4e8-23d9e418795b) | ![after](https://github.com/user-attachments/assets/b89a331b-ebf6-473d-adb1-0c1c1542676d) |

Notice the third sample row in the After image — it intentionally has no author, and the `·` separator is suppressed.

## Testing instructions

Acceptance criteria from RSM-2999, in checklist form:

- [ ] In a post/page containing a `jetpack-search/results-list` block in **Expanded** layout, a result with a single author shows that author in the meta row, *before* the date, separated by a `·`.
- [ ] A result with co-authors (2 or 3) shows their names comma-joined in the same meta row.
- [ ] A result with more than 3 co-authors shows the first three joined with commas and a trailing `"..."` (e.g. `Ada, Bob, Cris...`).
- [ ] A result with no author renders only the date — no stray `·` separator and no empty author span.
- [ ] **Compact** and **Product** layouts are unchanged (author is suppressed; meta row visual matches trunk).
- [ ] In the block editor, opening the Inserter preview for the Expanded layout shows the same author treatment via the sample data (Sample Author, A. Writer, B. Editor, and an author-less third row).
