### PR TITLE
External Media abilities: register provider list, search, import via Registrar

### DIFF
--- a/projects/packages/external-media/actions.php
+++ b/projects/packages/external-media/actions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Action Hooks for Jetpack External Media package.
+ *
+ * Registers the External Media abilities with the WordPress Abilities API.
+ * Registration is gated by `jetpack_wp_abilities_enabled` (default false)
+ * inside `Registrar::init()` — this file only schedules the call.
+ *
+ * @package automattic/jetpack-external-media
+ */
+
+use Automattic\Jetpack\External_Media\Abilities\External_Media_Abilities;
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', array( External_Media_Abilities::class, 'init' ), 1 );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][1][] = array(
+		'accepted_args' => 0,
+		'function'      => array( External_Media_Abilities::class, 'init' ),
+	);
+}

--- a/projects/packages/external-media/changelog/add-ship-external-media-abilities
+++ b/projects/packages/external-media/changelog/add-ship-external-media-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register list-providers, search-media, and import-media abilities for external media (Google Photos, Pexels, Openverse) on WP 6.9+.

--- a/projects/packages/external-media/composer.json
+++ b/projects/packages/external-media/composer.json
@@ -9,11 +9,13 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-external-connections": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/phpunit-select-config": "@dev"
+		"automattic/phpunit-select-config": "@dev",
+		"automattic/jetpack-test-environment": "@dev"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -21,6 +23,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/external-media/src/abilities/class-external-media-abilities.php
+++ b/projects/packages/external-media/src/abilities/class-external-media-abilities.php
@@ -1,0 +1,636 @@
+<?php
+/**
+ * Jetpack External Media Abilities Registration
+ *
+ * Registers Jetpack External Media abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-external-media
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9, but then we need a suppression for the WP 6.8 compat run. @todo Remove this line when we drop WP < 6.9.
+
+namespace Automattic\Jetpack\External_Media\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * Class External_Media_Abilities
+ *
+ * Registers Jetpack External Media abilities with the WordPress Abilities API.
+ * Search and import callbacks delegate to the underlying
+ * `wpcom/v2/external-media/*` REST controller (lives in the Jetpack plugin and
+ * proxies through WordPress.com) so they inherit endpoint validation,
+ * sanitization, and capability checks.
+ */
+class External_Media_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-external-media';
+
+	/**
+	 * The supported external media providers.
+	 *
+	 * Mirrors the regex enforced by the REST controller
+	 * (`google_photos|openverse|pexels`). Keep these in sync.
+	 *
+	 * @var array<string, array{name: string, requires_auth: bool}>
+	 */
+	const PROVIDERS = array(
+		'google_photos' => array(
+			'name'          => 'Google Photos',
+			'requires_auth' => true,
+		),
+		'pexels'        => array(
+			'name'          => 'Pexels',
+			'requires_auth' => false,
+		),
+		'openverse'     => array(
+			'name'          => 'Openverse',
+			'requires_auth' => false,
+		),
+	);
+
+	/**
+	 * Provider slugs accepted by `search-media` and `import-media`.
+	 *
+	 * Kept as a separate constant so the JSON schema `enum` can reference it
+	 * statically (constants in array context can't use array_keys()).
+	 */
+	const PROVIDER_SLUGS = array( 'google_photos', 'pexels', 'openverse' );
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack External Media" is a product name and should not be translated.
+			'label'       => 'Jetpack External Media',
+			'description' => __( 'Abilities for searching and importing media from external sources (Google Photos, Pexels, Openverse) into the WordPress media library.', 'jetpack-external-media' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-external-media/list-providers' => self::spec_list_providers(),
+			'jetpack-external-media/search-media'   => self::spec_search_media(),
+			'jetpack-external-media/import-media'   => self::spec_import_media(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-external-media/list-providers.
+	 */
+	private static function spec_list_providers(): array {
+		return array(
+			'label'               => __( 'List external media providers', 'jetpack-external-media' ),
+			'description'         => __( 'List configured external media providers (Google Photos, Pexels, Openverse). Returns an array of providers each shaped as `{slug, name, requires_auth, connected, supports_search, supports_import}`. Read-only and idempotent. Call before `search-media` to discover available `provider` slugs.', 'jetpack-external-media' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'list_providers' ),
+			'permission_callback' => array( __CLASS__, 'can_upload_files' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-external-media/search-media.
+	 */
+	private static function spec_search_media(): array {
+		return array(
+			'label'               => __( 'Search external media', 'jetpack-external-media' ),
+			'description'         => __( 'Search an external media provider (Google Photos, Pexels, Openverse) for items matching a query. Read-only — does not import anything. Returns up to `per_page` items each shaped as `{id, title, thumbnail, full_url, author, source_url, license, width, height}`. Pair with `import-media` to copy a returned item into the WordPress media library. Call `list-providers` first to discover valid `provider` slugs.', 'jetpack-external-media' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'provider', 'query' ),
+				'properties'           => array(
+					'provider' => array(
+						'type'        => 'string',
+						'description' => __( 'Provider slug. Use `list-providers` to enumerate.', 'jetpack-external-media' ),
+						'enum'        => self::PROVIDER_SLUGS,
+					),
+					'query'    => array(
+						'type'        => 'string',
+						'description' => __( 'Search query string.', 'jetpack-external-media' ),
+						'minLength'   => 1,
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'description' => __( 'Page number for paginated results.', 'jetpack-external-media' ),
+						'default'     => 1,
+						'minimum'     => 1,
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of items per page.', 'jetpack-external-media' ),
+						'default'     => 20,
+						'minimum'     => 1,
+						'maximum'     => 50,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'search_media' ),
+			'permission_callback' => array( __CLASS__, 'can_upload_files' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-external-media/import-media.
+	 */
+	private static function spec_import_media(): array {
+		return array(
+			'label'               => __( 'Import external media item', 'jetpack-external-media' ),
+			'description'         => __( 'Import a single external media item into the WordPress media library by provider and external `id`. Creates a new attachment each call — not idempotent. Returns `{attachment_id, attachment_url, source: {provider, source_id}}`. Use the `id` field returned by `search-media` as the `id` input. Requires `upload_files` capability.', 'jetpack-external-media' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'provider', 'id' ),
+				'properties'           => array(
+					'provider' => array(
+						'type'        => 'string',
+						'description' => __( 'Provider slug. Use `list-providers` to enumerate.', 'jetpack-external-media' ),
+						'enum'        => self::PROVIDER_SLUGS,
+					),
+					'id'       => array(
+						'type'        => 'string',
+						'description' => __( 'External item id as returned by `search-media`.', 'jetpack-external-media' ),
+						'minLength'   => 1,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => array( __CLASS__, 'import_media' ),
+			'permission_callback' => array( __CLASS__, 'can_upload_files' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Permission callback shared by every External Media ability.
+	 *
+	 * Matches the REST controller's coarse gate
+	 * (`current_user_can( 'upload_files' )`); the delegated controller
+	 * additionally enforces `create_posts` on the attachment post type for
+	 * the import path.
+	 *
+	 * @return bool
+	 */
+	public static function can_upload_files() {
+		return current_user_can( 'upload_files' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-providers.
+	 *
+	 * Returns the static provider catalog augmented with runtime
+	 * connection state (currently only `google_photos` reports a
+	 * connection check; others are public APIs and always `connected`).
+	 *
+	 * @param array|null $input Arguments from the ability input (unused).
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function list_providers( $input = null ) {
+		unset( $input ); // List has no inputs.
+
+		$out = array();
+		foreach ( self::PROVIDERS as $slug => $info ) {
+			$out[] = array(
+				'slug'            => $slug,
+				'name'            => $info['name'],
+				'requires_auth'   => $info['requires_auth'],
+				'connected'       => $info['requires_auth'] ? self::is_provider_connected( $slug ) : true,
+				'supports_search' => true,
+				'supports_import' => true,
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Execute: search-media.
+	 *
+	 * Delegates to `GET /wpcom/v2/external-media/list/<provider>` (registered
+	 * by the Jetpack plugin), reshaping the heterogenous per-provider payload
+	 * into a uniform `{id, title, thumbnail, full_url, author, source_url,
+	 * license, width, height}` shape.
+	 *
+	 * @param array|null $input Ability input.
+	 * @return array<int, array<string, mixed>>|WP_Error
+	 */
+	public static function search_media( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$provider = isset( $input['provider'] ) ? (string) $input['provider'] : '';
+		$query    = isset( $input['query'] ) ? (string) $input['query'] : '';
+
+		if ( ! isset( self::PROVIDERS[ $provider ] ) ) {
+			return new WP_Error(
+				'jetpack_external_media_invalid_provider',
+				__( 'Unknown provider. Call jetpack-external-media/list-providers to enumerate available providers.', 'jetpack-external-media' )
+			);
+		}
+
+		if ( '' === $query ) {
+			return new WP_Error(
+				'jetpack_external_media_missing_query',
+				__( 'Search query is required.', 'jetpack-external-media' )
+			);
+		}
+
+		// Normalize pagination defaults (schema defaults are not auto-injected).
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : 20;
+		$page     = isset( $input['page'] ) ? (int) $input['page'] : 1;
+		if ( $per_page < 1 ) {
+			$per_page = 20;
+		}
+		if ( $per_page > 50 ) {
+			$per_page = 50;
+		}
+		if ( $page < 1 ) {
+			$page = 1;
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/external-media/list/' . $provider );
+		$request->set_param( 'search', $query );
+		$request->set_param( 'number', $per_page );
+		// The REST controller does not implement page-numbered pagination — it
+		// uses `page_handle` cursors set by the upstream service. We forward
+		// `page` as a hint via `page_handle` when callers supply it >1 so
+		// upstream pagination still works in test environments that translate
+		// the param. For typical first-page queries this is a no-op.
+		if ( $page > 1 ) {
+			$request->set_param( 'page_handle', (string) $page );
+		}
+
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		return self::normalize_search_results( $provider, $data );
+	}
+
+	/**
+	 * Execute: import-media.
+	 *
+	 * Delegates to `POST /wpcom/v2/external-media/copy/<provider>`. The
+	 * controller accepts an array of items shaped like its `media_schema`;
+	 * we synthesize a minimal one-item payload from the search result the
+	 * caller already has.
+	 *
+	 * @param array|null $input Ability input.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function import_media( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$provider = isset( $input['provider'] ) ? (string) $input['provider'] : '';
+
+		if ( ! isset( self::PROVIDERS[ $provider ] ) ) {
+			return new WP_Error(
+				'jetpack_external_media_invalid_provider',
+				__( 'Unknown provider. Call jetpack-external-media/list-providers to enumerate available providers.', 'jetpack-external-media' )
+			);
+		}
+
+		// Empty-but-not-zero check: the literal string '0' is a valid id, so
+		// reject only missing keys / wrong types / empty strings — never use
+		// empty(), which would falsely flag '0'.
+		if ( ! isset( $input['id'] ) || ! is_string( $input['id'] ) || '' === $input['id'] ) {
+			return new WP_Error(
+				'jetpack_external_media_missing_id',
+				__( 'External media `id` is required.', 'jetpack-external-media' )
+			);
+		}
+		$id = (string) $input['id'];
+
+		// To copy by id we first need the item's URL; resolve it by searching
+		// the provider with the id as the query and selecting the matching
+		// result. Cheap, and avoids requiring callers to pass the full guid.
+		$resolved = self::resolve_media_item( $provider, $id );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/external-media/copy/' . $provider );
+		$request->set_body_params(
+			array(
+				'media' => array(
+					array(
+						'guid'    => array(
+							'url'   => $resolved['url'],
+							'name'  => $resolved['name'],
+							'title' => $resolved['title'],
+						),
+						'title'   => $resolved['title'],
+						'caption' => $resolved['caption'],
+					),
+				),
+			)
+		);
+
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		// The controller returns an array of per-item responses; we sent one
+		// item, so unwrap the first entry. A failed item surfaces as a
+		// WP_Error inside the array.
+		if ( ! is_array( $data ) || empty( $data ) ) {
+			return new WP_Error(
+				'jetpack_external_media_data_unavailable',
+				__( 'Import did not return an attachment. The external service may be unavailable.', 'jetpack-external-media' )
+			);
+		}
+
+		$first = reset( $data );
+		if ( is_wp_error( $first ) ) {
+			return $first;
+		}
+
+		if ( ! is_array( $first ) || ! isset( $first['id'], $first['url'] ) ) {
+			return new WP_Error(
+				'jetpack_external_media_data_unavailable',
+				__( 'Import returned an unexpected response shape.', 'jetpack-external-media' )
+			);
+		}
+
+		return array(
+			'attachment_id'  => (int) $first['id'],
+			'attachment_url' => (string) $first['url'],
+			'source'         => array(
+				'provider'  => $provider,
+				'source_id' => $id,
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Dispatch an internal REST request and unwrap the response.
+	 *
+	 * @param WP_REST_Request $request The REST request to dispatch.
+	 * @return array|WP_Error Response data array, or WP_Error on failure.
+	 */
+	private static function dispatch( WP_REST_Request $request ) {
+		if ( ! function_exists( 'rest_do_request' ) ) {
+			return new WP_Error(
+				'jetpack_external_media_not_initialized',
+				__( 'REST API is not available.', 'jetpack-external-media' )
+			);
+		}
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+		$data = $response->get_data();
+
+		// `rest_do_request` returns the response data unwrapped, but a missing
+		// route surfaces as a 404 with `rest_no_route`; tests that don't load
+		// the Jetpack plugin's REST controller will hit this branch.
+		if ( null === $data ) {
+			return new WP_Error(
+				'jetpack_external_media_data_unavailable',
+				__( 'No data returned from the external media endpoint. The Jetpack plugin must be loaded for this ability to work.', 'jetpack-external-media' )
+			);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Check whether the current user has an active connection to a provider.
+	 *
+	 * Currently only `google_photos` exposes a connection check via the
+	 * `wpcom/v2/external-media/connection/google_photos` endpoint; we
+	 * dispatch internally and treat any non-error response as connected.
+	 *
+	 * @param string $provider Provider slug.
+	 * @return bool
+	 */
+	private static function is_provider_connected( string $provider ): bool {
+		if ( 'google_photos' !== $provider ) {
+			return false;
+		}
+		if ( ! function_exists( 'rest_do_request' ) ) {
+			return false;
+		}
+
+		$request  = new WP_REST_Request( 'GET', '/wpcom/v2/external-media/connection/' . $provider );
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return false;
+		}
+		$data = $response->get_data();
+		// Treat any non-empty payload as "connected"; the wpcom payload
+		// includes `connect_URL`/`ID`/etc when a connection exists.
+		return is_array( $data ) || is_object( $data );
+	}
+
+	/**
+	 * Reshape a heterogenous provider list payload into the uniform shape
+	 * documented in the search-media spec.
+	 *
+	 * Pexels and Openverse use slightly different keys than Google Photos;
+	 * the wpcom upstream usually returns `media` arrays with `ID`, `URL`,
+	 * `thumbnails`, `title`, `caption`, `author`, `width`, `height` and
+	 * (for free-stock sources) a `license` / `link` field. Missing keys
+	 * degrade to empty strings rather than null so the shape is stable.
+	 *
+	 * @param string $provider Provider slug (preserved for forward-compat;
+	 *                         currently unused as the normalization is
+	 *                         identical across providers, but kept in the
+	 *                         signature so per-provider shape drift can be
+	 *                         handled here without touching callers).
+	 * @param mixed  $data     Raw response from the REST controller.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function normalize_search_results( string $provider, $data ): array {
+		unset( $provider );
+
+		// Endpoint sometimes returns `{ media: [...] }`, sometimes a plain array.
+		$items = array();
+		if ( is_array( $data ) ) {
+			if ( isset( $data['media'] ) && is_array( $data['media'] ) ) {
+				$items = $data['media'];
+			} else {
+				$items = $data;
+			}
+		}
+
+		$out = array();
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$thumbnail = '';
+			if ( isset( $item['thumbnails'] ) && is_array( $item['thumbnails'] ) ) {
+				// Pick the first thumbnail URL.
+				$thumbnail = (string) reset( $item['thumbnails'] );
+			} elseif ( isset( $item['thumbnail'] ) ) {
+				$thumbnail = (string) $item['thumbnail'];
+			}
+
+			$out[] = array(
+				'id'         => isset( $item['ID'] ) ? (string) $item['ID'] : ( isset( $item['id'] ) ? (string) $item['id'] : '' ),
+				'title'      => isset( $item['title'] ) ? (string) $item['title'] : '',
+				'thumbnail'  => $thumbnail,
+				'full_url'   => isset( $item['URL'] ) ? (string) $item['URL'] : ( isset( $item['url'] ) ? (string) $item['url'] : '' ),
+				'author'     => isset( $item['author'] ) ? (string) $item['author'] : '',
+				'source_url' => isset( $item['link'] ) ? (string) $item['link'] : ( isset( $item['source_url'] ) ? (string) $item['source_url'] : '' ),
+				'license'    => isset( $item['license'] ) ? (string) $item['license'] : '',
+				'width'      => isset( $item['width'] ) ? (int) $item['width'] : 0,
+				'height'     => isset( $item['height'] ) ? (int) $item['height'] : 0,
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Resolve a media item to the fields needed by the `/copy` endpoint.
+	 *
+	 * The `/copy` endpoint requires a `guid.url` to download; we don't ask
+	 * callers to pass the URL because (a) the ability surface is supposed
+	 * to wrap intent, not the REST internals, and (b) external ids are the
+	 * stable handle the search response advertises. We look the id up via a
+	 * `/list/<provider>` call using the id as the search term and pick the
+	 * matching item.
+	 *
+	 * Hookable for tests: filter `jetpack_external_media_resolve_item` to
+	 * inject a deterministic record without round-tripping through the
+	 * REST controller.
+	 *
+	 * @param string $provider Provider slug.
+	 * @param string $id       External id from `search-media`.
+	 * @return array{url: string, name: string, title: string, caption: string}|WP_Error
+	 */
+	private static function resolve_media_item( string $provider, string $id ) {
+		/**
+		 * Filters the resolved media item used by `import-media`.
+		 *
+		 * Return an array with `url`, `name`, `title`, `caption` to short-circuit
+		 * the lookup. Return a WP_Error to abort the import.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param array|null|WP_Error $resolved Pre-resolved item, null to fall through to the REST lookup.
+		 * @param string              $provider Provider slug.
+		 * @param string              $id       External media id.
+		 */
+		$resolved = apply_filters( 'jetpack_external_media_resolve_item', null, $provider, $id );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		if ( is_array( $resolved ) && isset( $resolved['url'] ) ) {
+			return array(
+				'url'     => (string) $resolved['url'],
+				'name'    => isset( $resolved['name'] ) ? (string) $resolved['name'] : (string) $id,
+				'title'   => isset( $resolved['title'] ) ? (string) $resolved['title'] : '',
+				'caption' => isset( $resolved['caption'] ) ? (string) $resolved['caption'] : '',
+			);
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/external-media/list/' . $provider );
+		$request->set_param( 'search', $id );
+
+		$data = self::dispatch( $request );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		$items = array();
+		if ( is_array( $data ) ) {
+			$items = isset( $data['media'] ) && is_array( $data['media'] ) ? $data['media'] : $data;
+		}
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$item_id = isset( $item['ID'] ) ? (string) $item['ID'] : ( isset( $item['id'] ) ? (string) $item['id'] : '' );
+			if ( $item_id !== $id ) {
+				continue;
+			}
+			$url = isset( $item['URL'] ) ? (string) $item['URL'] : ( isset( $item['url'] ) ? (string) $item['url'] : '' );
+			if ( '' === $url ) {
+				return new WP_Error(
+					'jetpack_external_media_data_unavailable',
+					__( 'External media item is missing a download URL.', 'jetpack-external-media' )
+				);
+			}
+			return array(
+				'url'     => $url,
+				'name'    => isset( $item['name'] ) ? (string) $item['name'] : (string) $id,
+				'title'   => isset( $item['title'] ) ? (string) $item['title'] : '',
+				'caption' => isset( $item['caption'] ) ? (string) $item['caption'] : '',
+			);
+		}
+
+		return new WP_Error(
+			'jetpack_external_media_not_found',
+			__( 'No external media item matched the provided id. Call jetpack-external-media/search-media to discover valid ids.', 'jetpack-external-media' )
+		);
+	}
+}

--- a/projects/packages/external-media/tests/php/abilities/External_Media_Abilities_Test.php
+++ b/projects/packages/external-media/tests/php/abilities/External_Media_Abilities_Test.php
@@ -1,0 +1,675 @@
+<?php
+/**
+ * Unit tests for Jetpack External Media Abilities.
+ *
+ * @package automattic/jetpack-external-media
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\External_Media\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+/**
+ * @coversDefaultClass \Automattic\Jetpack\External_Media\Abilities\External_Media_Abilities
+ */
+class External_Media_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Administrator user id (has upload_files).
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Subscriber user id (no upload_files).
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * Whether stub routes have been registered.
+	 *
+	 * @var bool
+	 */
+	private $rest_stub_registered = false;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		global $wp_rest_server;
+
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		self::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'external_media_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'external_media_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: open the rollout gate for most cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_external_media_resolve_item' );
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_abilities' ) );
+
+		// Reset registry between tests where possible.
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( External_Media_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( External_Media_Abilities::get_category_slug() );
+		}
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so
+	 * registrations happen inside the action callstack.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	/**
+	 * Register a fake `wpcom/v2/external-media/*` REST controller for the
+	 * test process so search and import dispatch land somewhere predictable
+	 * instead of returning rest_no_route. Stubbed per-test.
+	 *
+	 * @param callable|null $list_callback Optional override for `/list/<service>`.
+	 * @param callable|null $copy_callback Optional override for `/copy/<service>`.
+	 */
+	private function register_rest_stub( $list_callback = null, $copy_callback = null ): void {
+		if ( $this->rest_stub_registered ) {
+			return;
+		}
+		$this->rest_stub_registered = true;
+
+		register_rest_route(
+			'wpcom/v2',
+			'/external-media/list/(?P<service>google_photos|openverse|pexels)',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => $list_callback ?: array( $this, 'default_list_callback' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+		register_rest_route(
+			'wpcom/v2',
+			'/external-media/copy/(?P<service>google_photos|openverse|pexels)',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => $copy_callback ?: array( $this, 'default_copy_callback' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Default test stub for `/list/<service>` — returns two synthetic items.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return array
+	 */
+	public function default_list_callback( $request ) {
+		$search = $request->get_param( 'search' );
+		// If the caller asks for an exact id, return a single matching item so
+		// `resolve_media_item()` succeeds for import tests.
+		if ( 'item-42' === $search ) {
+			return array(
+				'media' => array(
+					array(
+						'ID'        => 'item-42',
+						'URL'       => 'https://example.test/photo-42.jpg',
+						'title'     => 'Photo 42',
+						'caption'   => 'A test photo',
+						'author'    => 'Tester',
+						'link'      => 'https://example.test/photos/42',
+						'license'   => 'CC0',
+						'width'     => 1200,
+						'height'    => 800,
+						'thumbnails' => array(
+							'medium' => 'https://example.test/photo-42-thumb.jpg',
+						),
+					),
+				),
+			);
+		}
+
+		return array(
+			'media' => array(
+				array(
+					'ID'         => 'item-1',
+					'URL'        => 'https://example.test/photo-1.jpg',
+					'title'      => 'Photo One',
+					'caption'    => '',
+					'author'     => 'Alice',
+					'link'       => 'https://example.test/photos/1',
+					'license'    => 'CC0',
+					'width'      => 800,
+					'height'     => 600,
+					'thumbnails' => array(
+						'medium' => 'https://example.test/photo-1-thumb.jpg',
+					),
+				),
+				array(
+					'ID'         => 'item-2',
+					'URL'        => 'https://example.test/photo-2.jpg',
+					'title'      => 'Photo Two',
+					'caption'    => '',
+					'author'     => 'Bob',
+					'link'       => 'https://example.test/photos/2',
+					'license'    => 'CC0',
+					'width'      => 1024,
+					'height'     => 768,
+					'thumbnails' => array(
+						'medium' => 'https://example.test/photo-2-thumb.jpg',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Default test stub for `/copy/<service>` — returns a fabricated attachment record.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return array
+	 */
+	public function default_copy_callback( $request ) {
+		$media = $request->get_param( 'media' );
+		$item  = is_array( $media ) ? reset( $media ) : array();
+		$title = isset( $item['title'] ) ? $item['title'] : '';
+
+		// Simulate the controller's response: array of per-item results, each
+		// with `id` and `url`.
+		return array(
+			array(
+				'id'      => 9001,
+				'url'     => 'https://example.test/wp-content/uploads/photo.jpg',
+				'caption' => '',
+				'alt'     => $title,
+				'type'    => 'image',
+			),
+		);
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-external-media', External_Media_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = External_Media_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = External_Media_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-external-media/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		foreach ( External_Media_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_surface_exposes_expected_abilities() {
+		$abilities = External_Media_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-external-media/list-providers', $abilities );
+		$this->assertArrayHasKey( 'jetpack-external-media/search-media', $abilities );
+		$this->assertArrayHasKey( 'jetpack-external-media/import-media', $abilities );
+	}
+
+	public function test_list_providers_is_annotated_readonly_idempotent() {
+		$spec = External_Media_Abilities::get_abilities()['jetpack-external-media/list-providers'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_search_media_is_annotated_readonly_idempotent() {
+		$spec = External_Media_Abilities::get_abilities()['jetpack-external-media/search-media'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_import_media_is_annotated_non_readonly_non_idempotent() {
+		$spec = External_Media_Abilities::get_abilities()['jetpack-external-media/import-media'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertFalse( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_every_spec_has_input_schema_with_additional_properties_false() {
+		foreach ( External_Media_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'input_schema', $spec, "Ability {$slug} should declare input_schema." );
+			$this->assertSame(
+				false,
+				$spec['input_schema']['additionalProperties'] ?? null,
+				"Ability {$slug} input_schema should set additionalProperties to false."
+			);
+		}
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		External_Media_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		External_Media_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( External_Media_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-external-media/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( External_Media_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static function ( $a ) {
+				return $a->get_name();
+			},
+			wp_get_abilities()
+		);
+		foreach ( array_keys( External_Media_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( External_Media_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-external-media',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	public function test_can_upload_files_allows_admin() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( External_Media_Abilities::can_upload_files() );
+	}
+
+	public function test_can_upload_files_denies_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( External_Media_Abilities::can_upload_files() );
+	}
+
+	public function test_can_upload_files_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( External_Media_Abilities::can_upload_files() );
+	}
+
+	// -------------------- Execute: list_providers --------------------
+
+	public function test_list_providers_returns_uniform_shape_for_each_provider() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::list_providers();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array( 'google_photos', 'pexels', 'openverse' ), array_column( $result, 'slug' ) );
+		foreach ( $result as $entry ) {
+			$this->assertArrayHasKey( 'slug', $entry );
+			$this->assertArrayHasKey( 'name', $entry );
+			$this->assertArrayHasKey( 'requires_auth', $entry );
+			$this->assertArrayHasKey( 'connected', $entry );
+			$this->assertArrayHasKey( 'supports_search', $entry );
+			$this->assertArrayHasKey( 'supports_import', $entry );
+			$this->assertIsBool( $entry['requires_auth'] );
+			$this->assertIsBool( $entry['connected'] );
+			$this->assertTrue( $entry['supports_search'] );
+			$this->assertTrue( $entry['supports_import'] );
+		}
+	}
+
+	public function test_list_providers_marks_public_providers_as_connected() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::list_providers();
+		$by_slug = array();
+		foreach ( $result as $entry ) {
+			$by_slug[ $entry['slug'] ] = $entry;
+		}
+
+		$this->assertFalse( $by_slug['pexels']['requires_auth'] );
+		$this->assertTrue( $by_slug['pexels']['connected'] );
+		$this->assertFalse( $by_slug['openverse']['requires_auth'] );
+		$this->assertTrue( $by_slug['openverse']['connected'] );
+		$this->assertTrue( $by_slug['google_photos']['requires_auth'] );
+	}
+
+	// -------------------- Execute: search_media --------------------
+
+	public function test_search_media_rejects_unknown_provider() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::search_media(
+			array(
+				'provider' => 'flickr',
+				'query'    => 'cats',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_invalid_provider', $result->get_error_code() );
+	}
+
+	public function test_search_media_rejects_missing_provider() {
+		wp_set_current_user( self::$admin_id );
+		$result = External_Media_Abilities::search_media( array( 'query' => 'cats' ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_invalid_provider', $result->get_error_code() );
+	}
+
+	public function test_search_media_rejects_empty_query() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::search_media(
+			array(
+				'provider' => 'pexels',
+				'query'    => '',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_missing_query', $result->get_error_code() );
+	}
+
+	public function test_search_media_returns_normalized_items_when_route_responds() {
+		wp_set_current_user( self::$admin_id );
+		$this->register_rest_stub();
+
+		$result = External_Media_Abilities::search_media(
+			array(
+				'provider' => 'pexels',
+				'query'    => 'cats',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+		$first = $result[0];
+		$this->assertSame( 'item-1', $first['id'] );
+		$this->assertSame( 'Photo One', $first['title'] );
+		$this->assertSame( 'https://example.test/photo-1.jpg', $first['full_url'] );
+		$this->assertSame( 'https://example.test/photo-1-thumb.jpg', $first['thumbnail'] );
+		$this->assertSame( 'Alice', $first['author'] );
+		$this->assertSame( 'CC0', $first['license'] );
+		$this->assertSame( 800, $first['width'] );
+		$this->assertSame( 600, $first['height'] );
+		// Every result must contain the full uniform shape, even when source
+		// keys are missing.
+		foreach ( array( 'id', 'title', 'thumbnail', 'full_url', 'author', 'source_url', 'license', 'width', 'height' ) as $key ) {
+			$this->assertArrayHasKey( $key, $first );
+		}
+	}
+
+	public function test_search_media_returns_error_when_route_unavailable() {
+		wp_set_current_user( self::$admin_id );
+		// No stub registered — `rest_do_request` will surface rest_no_route.
+
+		$result = External_Media_Abilities::search_media(
+			array(
+				'provider' => 'pexels',
+				'query'    => 'cats',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	// -------------------- Execute: import_media --------------------
+
+	public function test_import_media_rejects_unknown_provider() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::import_media(
+			array(
+				'provider' => 'flickr',
+				'id'       => 'item-42',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_invalid_provider', $result->get_error_code() );
+	}
+
+	public function test_import_media_rejects_missing_id() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::import_media( array( 'provider' => 'pexels' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_missing_id', $result->get_error_code() );
+	}
+
+	public function test_import_media_rejects_empty_id_string() {
+		wp_set_current_user( self::$admin_id );
+
+		$result = External_Media_Abilities::import_media(
+			array(
+				'provider' => 'pexels',
+				'id'       => '',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_missing_id', $result->get_error_code() );
+	}
+
+	public function test_import_media_accepts_literal_zero_id() {
+		// Regression guard: the literal string '0' is a valid id and must not
+		// be rejected by `empty()`-style checks. With a resolver filter we
+		// short-circuit the REST lookup so we don't depend on stub matching.
+		wp_set_current_user( self::$admin_id );
+		$this->register_rest_stub();
+
+		add_filter(
+			'jetpack_external_media_resolve_item',
+			static function ( $resolved, $provider, $id ) {
+				if ( '0' === $id ) {
+					return array(
+						'url'   => 'https://example.test/photo-zero.jpg',
+						'name'  => 'photo-zero.jpg',
+						'title' => 'Zero',
+					);
+				}
+				return $resolved;
+			},
+			10,
+			3
+		);
+
+		$result = External_Media_Abilities::import_media(
+			array(
+				'provider' => 'pexels',
+				'id'       => '0',
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertSame( 9001, $result['attachment_id'] );
+	}
+
+	public function test_import_media_returns_attachment_record_on_success() {
+		wp_set_current_user( self::$admin_id );
+		$this->register_rest_stub();
+
+		$result = External_Media_Abilities::import_media(
+			array(
+				'provider' => 'pexels',
+				'id'       => 'item-42',
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertSame( 9001, $result['attachment_id'] );
+		$this->assertSame( 'https://example.test/wp-content/uploads/photo.jpg', $result['attachment_url'] );
+		$this->assertSame(
+			array(
+				'provider'  => 'pexels',
+				'source_id' => 'item-42',
+			),
+			$result['source']
+		);
+	}
+
+	public function test_import_media_uses_resolver_filter_to_short_circuit_lookup() {
+		wp_set_current_user( self::$admin_id );
+		$this->register_rest_stub();
+
+		add_filter(
+			'jetpack_external_media_resolve_item',
+			static function () {
+				return array(
+					'url'     => 'https://example.test/direct.jpg',
+					'name'    => 'direct.jpg',
+					'title'   => 'Direct',
+					'caption' => 'Bypass',
+				);
+			}
+		);
+
+		$result = External_Media_Abilities::import_media(
+			array(
+				'provider' => 'pexels',
+				'id'       => 'whatever',
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 9001, $result['attachment_id'] );
+	}
+
+	public function test_import_media_returns_not_found_when_id_unknown() {
+		wp_set_current_user( self::$admin_id );
+		$this->register_rest_stub();
+
+		$result = External_Media_Abilities::import_media(
+			array(
+				'provider' => 'pexels',
+				'id'       => 'unknown-id',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_external_media_not_found', $result->get_error_code() );
+	}
+}

--- a/projects/packages/external-media/tests/php/bootstrap.php
+++ b/projects/packages/external-media/tests/php/bootstrap.php
@@ -2,10 +2,14 @@
 /**
  * Bootstrap.
  *
- * @package automattic/
+ * @package automattic/jetpack-external-media
  */
 
 /**
  * Include the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Initialize WordPress test environment so REST and post-type registration
+// helpers are available to abilities tests.
+\Automattic\Jetpack\Test_Environment::init();


### PR DESCRIPTION
## Summary

Register three abilities for the External Media package via the shared `Registrar` base from `automattic/jetpack-wp-abilities`:

- `jetpack-external-media/list-providers` — returns Google Photos, Pexels, Openverse with `{slug, name, requires_auth, connected, supports_search, supports_import}`. Read-only, idempotent.
- `jetpack-external-media/search-media` — searches a provider for items matching a query; returns up to 50 normalized records per page (`{id, title, thumbnail, full_url, author, source_url, license, width, height}`). Read-only, idempotent.
- `jetpack-external-media/import-media` — imports a single external item by `{provider, id}` into the WP media library and returns `{attachment_id, attachment_url, source: {provider, source_id}}`. Not idempotent (each call creates a new attachment).

References plan §4.2 of the Abilities Everywhere roadmap.

## Implementation notes

- Class `External_Media_Abilities` lives at `projects/packages/external-media/src/abilities/class-external-media-abilities.php` (package context, Case B from the ship-wp-ability skill).
- Wiring is done from `projects/packages/external-media/actions.php` (canonical guarded pattern from `publicize/actions.php`), pulled in via composer `autoload.files`.
- All three abilities gate on `current_user_can( 'upload_files' )` to match the upstream `WPCOM_REST_API_V2_Endpoint_External_Media::permission_callback()`.
- Search and import delegate to the existing `wpcom/v2/external-media/list/<service>` and `wpcom/v2/external-media/copy/<service>` REST endpoints via `rest_do_request()` so they inherit the controller's validation, sanitization, and the wpcom proxy round-trip.
- `import-media` resolves the external id to a download URL via the controller's `/list` endpoint; tests use the `jetpack_external_media_resolve_item` filter to short-circuit that lookup.

## Test plan

- [x] `cd projects/packages/external-media && composer phpunit -- --filter External_Media_Abilities_Test` — 31 tests pass (130 assertions).
- [x] Registrar wiring: `jetpack_wp_abilities_enabled=false` registers nothing; `=true` hooks both lifecycle actions; per-ability `jetpack_wp_abilities_should_register` filter is honored; category is auto-injected.
- [x] Permissions: admin allowed; subscriber denied; anonymous denied.
- [x] Execute paths: `list-providers` returns uniform shape; `search-media` rejects unknown provider, missing/empty query, and surfaces `WP_Error` when the REST route isn't loaded; `import-media` rejects unknown provider, missing id, empty-string id, and accepts the literal `'0'` id (regression guard against `empty()`-based validation).
- [x] `changelogger validate` passes for the new entry.

## Manual verification

- [ ] In a WP 6.9+ environment with `jetpack_wp_abilities_enabled` filtered to `true`, confirm `wp_get_abilities()` lists the three slugs and `/wp-json/wp-abilities/v1/abilities` exposes them.