### PR TITLE
Blaze abilities: register campaigns, eligibility, dashboard reads via Registrar

### DIFF
--- a/projects/packages/blaze/actions.php
+++ b/projects/packages/blaze/actions.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Action Hooks for Jetpack Blaze package.
+ *
+ * Wires the Blaze Abilities API registrar. The registrar's `init()` is
+ * gated behind the `jetpack_wp_abilities_enabled` filter (default false),
+ * so this call is safe to make unconditionally and still opt-in per-site
+ * until the flag is flipped.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+use Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities;
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', array( Blaze_Abilities::class, 'init' ), 1 );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][1][] = array(
+		'accepted_args' => 0,
+		'function'      => array( Blaze_Abilities::class, 'init' ),
+	);
+}

--- a/projects/packages/blaze/changelog/add-blaze-abilities
+++ b/projects/packages/blaze/changelog/add-blaze-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Abilities API: register jetpack-blaze/list-campaigns, jetpack-blaze/get-campaign-eligibility, and jetpack-blaze/get-dashboard-summary for WP 6.9+.

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -11,7 +11,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
@@ -24,6 +25,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -1,0 +1,637 @@
+<?php
+/**
+ * Jetpack Blaze Abilities Registration.
+ *
+ * Registers Jetpack Blaze (paid promotion) abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use Automattic\Jetpack\Blaze;
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+
+/**
+ * Registers Jetpack Blaze abilities with the WordPress Abilities API.
+ *
+ * Exposes a small, agent-facing read surface over the Blaze (paid promotion)
+ * dashboard so AI agents can answer "how are my campaigns doing?" and
+ * "can this post be Blaze-promoted?" through the standard
+ * `wp-abilities/v1` REST surface. Writes (campaign creation/edit) are
+ * deliberately deferred — those flows still go through the dashboard UI.
+ */
+class Blaze_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-blaze';
+	const ERROR_PREFIX  = 'jetpack_blaze_';
+
+	/**
+	 * Post types eligible for Blaze promotion.
+	 *
+	 * Mirrors the gate inside `Blaze::jetpack_blaze_row_action()` — keep this in
+	 * sync with the row-action UI so agents and humans see the same eligible set.
+	 */
+	const PROMOTABLE_POST_TYPES = array( 'post', 'page', 'product' );
+
+	/**
+	 * Allowed campaign status filter values.
+	 */
+	const CAMPAIGN_STATUSES = array( 'draft', 'approved', 'rejected', 'completed' );
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack Blaze" is a product name and should not be translated.
+			'label'       => 'Jetpack Blaze',
+			'description' => __( 'Abilities for inspecting Jetpack Blaze (paid promotion) campaigns, dashboard state, and per-content eligibility.', 'jetpack-blaze' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-blaze/list-campaigns'           => self::spec_list_campaigns(),
+			'jetpack-blaze/get-campaign-eligibility' => self::spec_get_campaign_eligibility(),
+			'jetpack-blaze/get-dashboard-summary'    => self::spec_get_dashboard_summary(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-blaze/list-campaigns.
+	 */
+	private static function spec_list_campaigns(): array {
+		return array(
+			'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
+			'description'         => __( 'List Blaze (paid promotion) campaigns for the site. Returns a paginated array of campaign summaries — each entry is the projected shape { id, content_id, status, spent_budget, total_budget, currency, start_date, end_date, target_url, impressions, clicks }. `content_id` is the promoted post/page ID (0 when the campaign targets a non-post URL). When `campaign_id` is provided, the response is a consolidated-read containing 0 or 1 entries — empty when the id is not found rather than an error. Precondition: site must be connected to WordPress.com.', 'jetpack-blaze' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'status'      => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by campaign status.', 'jetpack-blaze' ),
+						'enum'        => self::CAMPAIGN_STATUSES,
+					),
+					'page'        => array(
+						'type'        => 'integer',
+						'description' => __( 'Page number for paginated results.', 'jetpack-blaze' ),
+						'minimum'     => 1,
+						'default'     => 1,
+					),
+					'per_page'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Results per page (1-100).', 'jetpack-blaze' ),
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'default'     => 20,
+					),
+					'campaign_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Consolidated-read: fetch a single campaign by ID. Returns 0 or 1 elements; empty array when not found.', 'jetpack-blaze' ),
+						'minimum'     => 1,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'           => array( 'type' => 'integer' ),
+						'content_id'   => array( 'type' => 'integer' ),
+						'status'       => array( 'type' => 'string' ),
+						'spent_budget' => array( 'type' => 'number' ),
+						'total_budget' => array( 'type' => 'number' ),
+						'currency'     => array( 'type' => 'string' ),
+						'start_date'   => array( 'type' => array( 'string', 'null' ) ),
+						'end_date'     => array( 'type' => array( 'string', 'null' ) ),
+						'target_url'   => array( 'type' => 'string' ),
+						'impressions'  => array( 'type' => 'integer' ),
+						'clicks'       => array( 'type' => 'integer' ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_blaze' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-blaze/get-campaign-eligibility.
+	 */
+	private static function spec_get_campaign_eligibility(): array {
+		return array(
+			'label'               => __( 'Get Blaze campaign eligibility for a post', 'jetpack-blaze' ),
+			'description'         => __( 'Return whether a given post/page can be Blaze-promoted right now. Shape: { content_id, eligible, reasons, current_status }. `eligible` is true only when the site supports Blaze, the post exists, is published, has no password, and is one of the supported post types (post, page, product). `reasons` is an array of stable string codes (e.g. `site_not_eligible`, `post_not_found`, `post_not_published`, `post_password_protected`, `post_type_not_supported`) — empty when `eligible` is true. `current_status` is the post status (`publish`, `draft`, ...) or `unknown` when the post does not exist. Read-only, idempotent.', 'jetpack-blaze' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'content_id' ),
+				'properties'           => array(
+					'content_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'The post or page ID to check eligibility for.', 'jetpack-blaze' ),
+						'minimum'     => 1,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'content_id'     => array( 'type' => 'integer' ),
+					'eligible'       => array( 'type' => 'boolean' ),
+					'reasons'        => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+					'current_status' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_campaign_eligibility' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_blaze' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-blaze/get-dashboard-summary.
+	 */
+	private static function spec_get_dashboard_summary(): array {
+		return array(
+			'label'               => __( 'Get Blaze dashboard summary', 'jetpack-blaze' ),
+			'description'         => __( 'Return a zero-argument summary of agent-facing Blaze state for the site. Shape: { total_campaigns, active_campaigns, total_spent_30d, currency, supports_blaze, account_credit_balance }. `supports_blaze` reflects the WPCOM `site_supports_blaze` check (true when the site can run campaigns at all). `total_spent_30d` is the sum of recent spend in `currency`; `account_credit_balance` is the unused credit balance on the WordAds account, or null when the credits endpoint is unavailable. Composes the site campaigns + credits WPCOM endpoints — when remote calls fail, counts degrade to zero and `account_credit_balance` to null rather than erroring out. Read-only and idempotent. Precondition: site must be connected to WordPress.com.', 'jetpack-blaze' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'total_campaigns'        => array( 'type' => 'integer' ),
+					'active_campaigns'       => array( 'type' => 'integer' ),
+					'total_spent_30d'        => array( 'type' => 'number' ),
+					'currency'               => array( 'type' => 'string' ),
+					'supports_blaze'         => array( 'type' => 'boolean' ),
+					'account_credit_balance' => array( 'type' => array( 'number', 'null' ) ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_dashboard_summary' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_blaze' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Permission: can the current user manage Blaze?
+	 *
+	 * Mirrors the gate the Blaze REST controllers use — both `REST_Controller`
+	 * and `Dashboard_REST_Controller` require `manage_options`. Match exactly so
+	 * an agent can only see what the same caller would see through the existing
+	 * REST endpoints, not more.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_blaze(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-campaigns.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function list_campaigns( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$site_id = static::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$query_args = array();
+		if ( isset( $input['status'] ) && in_array( $input['status'], self::CAMPAIGN_STATUSES, true ) ) {
+			$query_args['status'] = $input['status'];
+		}
+
+		// Consolidated-read: when a campaign_id is supplied, project the result to a
+		// 0-or-1-element array. Empty array when not found (callers must not see a 404).
+		if ( isset( $input['campaign_id'] ) && is_numeric( $input['campaign_id'] ) && (int) $input['campaign_id'] > 0 ) {
+			$campaign_id = (int) $input['campaign_id'];
+			$response    = static::wpcom_request_as_user(
+				sprintf( '/sites/%d/wordads/dsp/api/v1/campaigns/%d', $site_id, $campaign_id )
+			);
+			if ( is_wp_error( $response ) ) {
+				// Distinguish "not found" from other failures — 404 collapses to empty array.
+				$status = (int) $response->get_error_data( $response->get_error_code() );
+				if ( 404 === $status ) {
+					return array();
+				}
+				return $response;
+			}
+			$campaign = self::project_campaign( $response );
+			return null === $campaign ? array() : array( $campaign );
+		}
+
+		$page               = self::clamp_int( $input['page'] ?? 1, 1, PHP_INT_MAX, 1 );
+		$per_page           = self::clamp_int( $input['per_page'] ?? 20, 1, 100, 20 );
+		$query_args['page'] = $page;
+		$query_args['size'] = $per_page;
+
+		$path     = sprintf( '/sites/%d/wordads/dsp/api/v1/campaigns', $site_id );
+		$response = static::wpcom_request_as_user( add_query_arg( $query_args, $path ) );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return self::project_campaign_list( $response );
+	}
+
+	/**
+	 * Execute: get-campaign-eligibility.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function get_campaign_eligibility( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['content_id'] ) || ! is_numeric( $input['content_id'] ) || (int) $input['content_id'] <= 0 ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_content_id',
+				__( 'A positive content_id is required.', 'jetpack-blaze' )
+			);
+		}
+
+		$content_id = (int) $input['content_id'];
+		$reasons    = array();
+
+		// Site-level gate: mirrors the row-action check in `Blaze::should_initialize()`.
+		// We only surface `site_not_eligible` here — finer-grained reasons (no connection,
+		// sync disabled, ...) belong to a future connection-status ability category and
+		// would just be noise for an agent that already saw it isn't eligible.
+		$init = Blaze::should_initialize();
+		if ( empty( $init['can_init'] ) ) {
+			$reasons[] = 'site_not_eligible';
+		}
+
+		$post = get_post( $content_id );
+		if ( ! $post ) {
+			return array(
+				'content_id'     => $content_id,
+				'eligible'       => false,
+				'reasons'        => array_values( array_unique( array_merge( $reasons, array( 'post_not_found' ) ) ) ),
+				'current_status' => 'unknown',
+			);
+		}
+
+		if ( ! in_array( $post->post_type, self::PROMOTABLE_POST_TYPES, true ) ) {
+			$reasons[] = 'post_type_not_supported';
+		}
+		if ( 'publish' !== $post->post_status ) {
+			$reasons[] = 'post_not_published';
+		}
+		if ( '' !== (string) $post->post_password ) {
+			$reasons[] = 'post_password_protected';
+		}
+
+		return array(
+			'content_id'     => $content_id,
+			'eligible'       => empty( $reasons ),
+			'reasons'        => array_values( array_unique( $reasons ) ),
+			'current_status' => (string) $post->post_status,
+		);
+	}
+
+	/**
+	 * Execute: get-dashboard-summary.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array|WP_Error
+	 */
+	public static function get_dashboard_summary( $input = null ) {
+		unset( $input );
+
+		$site_id = static::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$supports_blaze = (bool) static::site_supports_blaze( $site_id );
+
+		$campaigns_path = sprintf( '/sites/%1$d/wordads/dsp/api/v1/sites/%1$d/campaigns', $site_id );
+		$campaigns      = static::wpcom_request_as_user( $campaigns_path );
+
+		$total_campaigns  = 0;
+		$active_campaigns = 0;
+		$total_spent_30d  = 0.0;
+		$currency         = 'USD';
+
+		if ( ! is_wp_error( $campaigns ) ) {
+			$list = self::extract_campaign_list( $campaigns );
+			foreach ( $list as $row ) {
+				++$total_campaigns;
+				if ( self::is_active_campaign_status( $row['status'] ?? '' ) ) {
+					++$active_campaigns;
+				}
+				$total_spent_30d += isset( $row['spent_budget'] ) ? (float) $row['spent_budget'] : 0.0;
+				if ( ! empty( $row['currency'] ) ) {
+					$currency = (string) $row['currency'];
+				}
+			}
+		}
+
+		$credit_balance = null;
+		$credits        = static::wpcom_request_as_user(
+			sprintf( '/sites/%d/wordads/dsp/api/v1/credits', $site_id )
+		);
+		if ( ! is_wp_error( $credits ) ) {
+			$credit_balance = self::extract_credit_balance( $credits );
+		}
+
+		return array(
+			'total_campaigns'        => $total_campaigns,
+			'active_campaigns'       => $active_campaigns,
+			'total_spent_30d'        => (float) $total_spent_30d,
+			'currency'               => $currency,
+			'supports_blaze'         => $supports_blaze,
+			'account_credit_balance' => $credit_balance,
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Project a campaign row from the WordAds DSP response into the public schema.
+	 *
+	 * @param mixed $row Raw campaign payload from DSP.
+	 * @return array|null Projected shape, or null when the row is empty/non-array.
+	 */
+	private static function project_campaign( $row ): ?array {
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+
+		// DSP shapes vary slightly across endpoints — defensively read the most
+		// common keys with sensible fallbacks rather than picking one canonical
+		// name and silently dropping the others.
+		$content_id = 0;
+		if ( isset( $row['post_id'] ) ) {
+			$content_id = (int) $row['post_id'];
+		} elseif ( isset( $row['content_id'] ) ) {
+			$content_id = (int) $row['content_id'];
+		} elseif ( isset( $row['target_post_id'] ) ) {
+			$content_id = (int) $row['target_post_id'];
+		}
+
+		return array(
+			'id'           => isset( $row['campaign_id'] ) ? (int) $row['campaign_id'] : (int) ( $row['id'] ?? 0 ),
+			'content_id'   => $content_id,
+			'status'       => isset( $row['status'] ) ? (string) $row['status'] : '',
+			'spent_budget' => isset( $row['spent_budget'] ) ? (float) $row['spent_budget'] : (float) ( $row['total_budget_used'] ?? 0 ),
+			'total_budget' => isset( $row['total_budget'] ) ? (float) $row['total_budget'] : (float) ( $row['budget_cents'] ?? 0 ) / 100,
+			'currency'     => isset( $row['currency'] ) ? (string) $row['currency'] : (string) ( $row['display_currency'] ?? '' ),
+			'start_date'   => isset( $row['start_date'] ) && '' !== $row['start_date'] ? (string) $row['start_date'] : null,
+			'end_date'     => isset( $row['end_date'] ) && '' !== $row['end_date'] ? (string) $row['end_date'] : null,
+			'target_url'   => isset( $row['target_url'] ) ? (string) $row['target_url'] : (string) ( $row['target_urn'] ?? '' ),
+			'impressions'  => isset( $row['impressions_total'] ) ? (int) $row['impressions_total'] : (int) ( $row['impressions'] ?? 0 ),
+			'clicks'       => isset( $row['clicks_total'] ) ? (int) $row['clicks_total'] : (int) ( $row['clicks'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Project a campaign list payload into an array of campaign rows.
+	 *
+	 * @param mixed $response The DSP campaigns response (envelope or bare list).
+	 * @return array
+	 */
+	private static function project_campaign_list( $response ): array {
+		$rows = self::extract_campaign_list( $response );
+		$out  = array();
+		foreach ( $rows as $row ) {
+			$projected = self::project_campaign( $row );
+			if ( null !== $projected ) {
+				$out[] = $projected;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Extract the campaign list from a DSP response envelope.
+	 *
+	 * DSP wraps campaigns under `campaigns` or `results` for the list endpoints;
+	 * some single-campaign reads return a bare object. Normalize to `array<row>`.
+	 *
+	 * @param mixed $response Raw DSP response.
+	 * @return array
+	 */
+	private static function extract_campaign_list( $response ): array {
+		if ( ! is_array( $response ) ) {
+			return array();
+		}
+		if ( isset( $response['campaigns'] ) && is_array( $response['campaigns'] ) ) {
+			return $response['campaigns'];
+		}
+		if ( isset( $response['results'] ) && is_array( $response['results'] ) ) {
+			return $response['results'];
+		}
+		// Bare list (numeric keys) — pass through.
+		if ( array_keys( $response ) === range( 0, count( $response ) - 1 ) ) {
+			return $response;
+		}
+		return array();
+	}
+
+	/**
+	 * Extract a numeric credit balance from a DSP credits response.
+	 *
+	 * Reads the most common balance fields and falls back to null when none
+	 * are present — so an unexpected response shape degrades to "unknown
+	 * balance" rather than 0 (which would lie about a real zero balance).
+	 *
+	 * @param mixed $response Raw DSP credits response.
+	 * @return float|null
+	 */
+	private static function extract_credit_balance( $response ): ?float {
+		if ( ! is_array( $response ) ) {
+			return null;
+		}
+		foreach ( array( 'balance', 'available', 'credit_balance', 'amount' ) as $key ) {
+			if ( isset( $response[ $key ] ) && is_numeric( $response[ $key ] ) ) {
+				return (float) $response[ $key ];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Whether a campaign status counts as "active" for the dashboard summary.
+	 *
+	 * `approved` is the DSP active-on-market state; `running` is what the UI
+	 * displays for the same condition. Both count as active here.
+	 *
+	 * @param string $status Campaign status string.
+	 * @return bool
+	 */
+	private static function is_active_campaign_status( string $status ): bool {
+		return in_array( $status, array( 'approved', 'running', 'active' ), true );
+	}
+
+	/**
+	 * Resolve the connected site ID, or return a WP_Error agents can act on.
+	 *
+	 * Extracted as a protected seam so tests can override the connection lookup
+	 * without standing up a real Jetpack token fixture.
+	 *
+	 * @return int|WP_Error
+	 */
+	protected static function get_site_id() {
+		$site_id = Connection_Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'site_not_connected',
+				__( 'The site is not connected to WordPress.com. Connect the site before calling Blaze abilities.', 'jetpack-blaze' )
+			);
+		}
+		return (int) $site_id;
+	}
+
+	/**
+	 * Whether the connected site supports Blaze.
+	 *
+	 * Extracted as a protected seam so tests can override the remote call
+	 * without seeding the underlying transient.
+	 *
+	 * @param int $site_id Blog ID.
+	 * @return bool
+	 */
+	protected static function site_supports_blaze( int $site_id ): bool {
+		return (bool) Blaze::site_supports_blaze( $site_id );
+	}
+
+	/**
+	 * Query a WordPress.com REST path as the current user, returning the JSON
+	 * body on success or a WP_Error on a non-2xx response.
+	 *
+	 * Extracted as a protected seam so tests can override the transport without
+	 * standing up a real connection fixture.
+	 *
+	 * @param string $path The WPCOM REST path (including leading slash).
+	 * @return array|WP_Error
+	 */
+	protected static function wpcom_request_as_user( string $path ) {
+		$response = Client::wpcom_json_api_request_as_user(
+			$path,
+			'v2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $code < 200 || $code >= 300 ) {
+			$message = is_array( $body ) && isset( $body['errorMessage'] )
+				? (string) $body['errorMessage']
+				: __( 'Blaze data could not be fetched from WordPress.com.', 'jetpack-blaze' );
+			return new WP_Error(
+				self::ERROR_PREFIX . 'remote_request_failed',
+				$message,
+				(int) $code
+			);
+		}
+
+		return is_array( $body ) ? $body : array();
+	}
+
+	/**
+	 * Clamp an integer into [$min, $max] with a default on bad input.
+	 *
+	 * @param mixed $raw       Raw input.
+	 * @param int   $min       Minimum.
+	 * @param int   $max       Maximum.
+	 * @param int   $fallback  Default on bad input.
+	 * @return int
+	 */
+	private static function clamp_int( $raw, int $min, int $max, int $fallback ): int {
+		if ( ! is_numeric( $raw ) ) {
+			return $fallback;
+		}
+		$v = (int) $raw;
+		if ( $v < $min ) {
+			return $min;
+		}
+		if ( $v > $max ) {
+			return $max;
+		}
+		return $v;
+	}
+}

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1,0 +1,578 @@
+<?php
+/**
+ * Tests for the Blaze_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '/class-blaze-abilities-test-stub.php';
+
+/**
+ * Unit tests for Blaze_Abilities registration and execution.
+ *
+ * Run from projects/packages/blaze:
+ *
+ *   composer phpunit -- --filter Blaze_Abilities_Test
+ *
+ * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
+ */
+#[CoversClass( Blaze_Abilities::class )]
+class Blaze_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Admin user id.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function set_up() {
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'blaze_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'blaze_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		Blaze_Abilities_Test_Stub::reset();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_blaze_enabled' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_abilities' ) );
+
+		// The Abilities API singleton registry persists across tests. Deregister
+		// our category + abilities so per-test filter scenarios start from a clean
+		// state (e.g. the allow-list test would otherwise see leftovers).
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Blaze_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Blaze_Abilities::get_category_slug() );
+		}
+
+		Blaze_Abilities_Test_Stub::reset();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the Abilities API lifecycle actions
+	 * so registrations happen inside the action callstack — wp_register_ability(_category)
+	 * enforces doing_action(), so direct calls outside the hook are rejected.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	/**
+	 * Category slug must match the namespace shipped to the registry.
+	 */
+	public function test_category_slug_is_jetpack_blaze() {
+		$this->assertSame( 'jetpack-blaze', Blaze_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Blaze_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotSame( '', $def['label'] );
+		$this->assertNotSame( '', $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Blaze_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-blaze/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Blaze_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_surface_exposes_planned_abilities() {
+		$abilities = Blaze_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-blaze/list-campaigns', $abilities );
+		$this->assertArrayHasKey( 'jetpack-blaze/get-campaign-eligibility', $abilities );
+		$this->assertArrayHasKey( 'jetpack-blaze/get-dashboard-summary', $abilities );
+	}
+
+	public function test_every_spec_declares_annotations_permission_and_execute() {
+		foreach ( Blaze_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'execute_callback', $spec, "Ability {$slug} missing execute_callback" );
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback is not callable" );
+			$this->assertArrayHasKey( 'permission_callback', $spec, "Ability {$slug} missing permission_callback" );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback is not callable" );
+			$this->assertArrayHasKey( 'meta', $spec );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'] );
+			foreach ( array( 'readonly', 'destructive', 'idempotent' ) as $flag ) {
+				$this->assertArrayHasKey( $flag, $spec['meta']['annotations'], "Ability {$slug} missing annotation {$flag}" );
+				$this->assertIsBool( $spec['meta']['annotations'][ $flag ], "Ability {$slug} annotation {$flag} must be bool" );
+			}
+		}
+	}
+
+	public function test_all_read_abilities_are_readonly_idempotent_non_destructive() {
+		foreach ( Blaze_Abilities::get_abilities() as $slug => $spec ) {
+			$ann = $spec['meta']['annotations'];
+			$this->assertTrue( $ann['readonly'], "{$slug} should be readonly" );
+			$this->assertFalse( $ann['destructive'], "{$slug} should not be destructive" );
+			$this->assertTrue( $ann['idempotent'], "{$slug} should be idempotent" );
+		}
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	/**
+	 * Gate filter false => init() short-circuits and hooks nothing.
+	 */
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Blaze_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		if ( did_action( Registrar::ABILITIES_INIT_ACTION ) || did_action( Registrar::CATEGORIES_INIT_ACTION ) ) {
+			$this->markTestSkipped( 'Abilities API lifecycle already fired in this test run; late-load path covered elsewhere.' );
+		}
+
+		Blaze_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Blaze_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug_with_auto_injected_category() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Blaze_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-blaze',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter.
+				if ( 'ability' === $type ) {
+					return 'jetpack-blaze/get-dashboard-summary' === $slug;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$this->assertNotNull( wp_get_ability( 'jetpack-blaze/get-dashboard-summary' ) );
+		$this->assertNull( wp_get_ability( 'jetpack-blaze/list-campaigns' ) );
+		$this->assertNull( wp_get_ability( 'jetpack-blaze/get-campaign-eligibility' ) );
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	/**
+	 * Admins clear the `manage_options` gate.
+	 */
+	public function test_can_manage_blaze_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Blaze_Abilities::can_manage_blaze() );
+	}
+
+	public function test_can_manage_blaze_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Blaze_Abilities::can_manage_blaze() );
+	}
+
+	public function test_can_manage_blaze_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Blaze_Abilities::can_manage_blaze() );
+	}
+
+	// -------------------- get-campaign-eligibility --------------------
+
+	/**
+	 * Missing content_id => WP_Error with the documented error code.
+	 */
+	public function test_get_campaign_eligibility_rejects_missing_content_id() {
+		wp_set_current_user( $this->admin_id );
+		$result = Blaze_Abilities::get_campaign_eligibility( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_blaze_missing_content_id', $result->get_error_code() );
+	}
+
+	public function test_get_campaign_eligibility_rejects_zero_content_id() {
+		// Regression guard for the boundary: 0 is rejected before we look up the post.
+		wp_set_current_user( $this->admin_id );
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => 0 ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_blaze_missing_content_id', $result->get_error_code() );
+	}
+
+	public function test_get_campaign_eligibility_reports_post_not_found() {
+		wp_set_current_user( $this->admin_id );
+		// A high ID guaranteed not to exist in WorDBless's empty DB.
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => 999999 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['eligible'] );
+		$this->assertSame( 'unknown', $result['current_status'] );
+		$this->assertContains( 'post_not_found', $result['reasons'] );
+	}
+
+	public function test_get_campaign_eligibility_reports_unpublished_post() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Draft post',
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => $post_id ) );
+
+		$this->assertFalse( $result['eligible'] );
+		$this->assertContains( 'post_not_published', $result['reasons'] );
+		$this->assertSame( 'draft', $result['current_status'] );
+	}
+
+	public function test_get_campaign_eligibility_reports_password_protected_post() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'    => 'Protected post',
+				'post_status'   => 'publish',
+				'post_type'     => 'post',
+				'post_password' => 'secret',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => $post_id ) );
+
+		$this->assertFalse( $result['eligible'] );
+		$this->assertContains( 'post_password_protected', $result['reasons'] );
+	}
+
+	public function test_get_campaign_eligibility_reports_unsupported_post_type() {
+		wp_set_current_user( $this->admin_id );
+
+		register_post_type( 'blaze_no_promo', array( 'public' => true ) );
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Custom post',
+				'post_status' => 'publish',
+				'post_type'   => 'blaze_no_promo',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => $post_id ) );
+
+		$this->assertFalse( $result['eligible'] );
+		$this->assertContains( 'post_type_not_supported', $result['reasons'] );
+
+		unregister_post_type( 'blaze_no_promo' );
+	}
+
+	public function test_get_campaign_eligibility_eligible_for_published_post() {
+		wp_set_current_user( $this->admin_id );
+
+		// `should_initialize()` queries the live remote when no `jetpack_blaze_enabled`
+		// filter is set; short-circuit it to a stable `true` so we test the post-level
+		// branches in isolation.
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Eligible post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => $post_id ) );
+
+		$this->assertTrue( $result['eligible'] );
+		$this->assertSame( array(), $result['reasons'] );
+		$this->assertSame( 'publish', $result['current_status'] );
+	}
+
+	public function test_get_campaign_eligibility_reports_site_not_eligible() {
+		wp_set_current_user( $this->admin_id );
+
+		// Force the site-level gate closed; published post should still see a `site_not_eligible` reason.
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Eligible-post-but-disabled-site',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_eligibility( array( 'content_id' => $post_id ) );
+
+		$this->assertFalse( $result['eligible'] );
+		$this->assertContains( 'site_not_eligible', $result['reasons'] );
+	}
+
+	// -------------------- list-campaigns (via test stub) --------------------
+
+	/**
+	 * Happy path: each campaign row is projected into the documented public shape.
+	 */
+	public function test_list_campaigns_returns_projected_rows() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id  = 12345;
+		Blaze_Abilities_Test_Stub::$response = array(
+			'campaigns' => array(
+				array(
+					'campaign_id'       => 42,
+					'post_id'           => 100,
+					'status'            => 'approved',
+					'spent_budget'      => 12.5,
+					'total_budget'      => 50,
+					'currency'          => 'USD',
+					'start_date'        => '2026-01-01',
+					'end_date'          => '2026-01-31',
+					'target_url'        => 'https://example.test/promoted',
+					'impressions_total' => 1000,
+					'clicks_total'      => 25,
+				),
+			),
+		);
+
+		$result = Blaze_Abilities_Test_Stub::list_campaigns( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 42, $result[0]['id'] );
+		$this->assertSame( 100, $result[0]['content_id'] );
+		$this->assertSame( 'approved', $result[0]['status'] );
+		$this->assertSame( 12.5, $result[0]['spent_budget'] );
+		$this->assertSame( 50.0, $result[0]['total_budget'] );
+		$this->assertSame( 'USD', $result[0]['currency'] );
+		$this->assertSame( 'https://example.test/promoted', $result[0]['target_url'] );
+		$this->assertSame( 1000, $result[0]['impressions'] );
+		$this->assertSame( 25, $result[0]['clicks'] );
+	}
+
+	public function test_list_campaigns_consolidated_read_returns_single_element_when_found() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id  = 12345;
+		Blaze_Abilities_Test_Stub::$response = array(
+			'campaign_id'  => 42,
+			'post_id'      => 7,
+			'status'       => 'approved',
+			'total_budget' => 25,
+		);
+
+		$result = Blaze_Abilities_Test_Stub::list_campaigns( array( 'campaign_id' => 42 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 42, $result[0]['id'] );
+		// Verify the request path used the campaign_id segment, not the list endpoint.
+		$this->assertStringContainsString( '/campaigns/42', Blaze_Abilities_Test_Stub::$last_path );
+	}
+
+	public function test_list_campaigns_consolidated_read_returns_empty_array_on_404() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id        = 12345;
+		Blaze_Abilities_Test_Stub::$response_error = new \WP_Error(
+			'jetpack_blaze_remote_request_failed',
+			'Not found',
+			404
+		);
+
+		$result = Blaze_Abilities_Test_Stub::list_campaigns( array( 'campaign_id' => 999 ) );
+
+		// Consolidated-read contract: missing record collapses to empty array, NOT to WP_Error.
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_list_campaigns_passes_pagination_and_status_filter() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id  = 99;
+		Blaze_Abilities_Test_Stub::$response = array( 'campaigns' => array() );
+
+		Blaze_Abilities_Test_Stub::list_campaigns(
+			array(
+				'page'     => 3,
+				'per_page' => 50,
+				'status'   => 'draft',
+			)
+		);
+
+		$this->assertStringContainsString( 'page=3', Blaze_Abilities_Test_Stub::$last_path );
+		$this->assertStringContainsString( 'size=50', Blaze_Abilities_Test_Stub::$last_path );
+		$this->assertStringContainsString( 'status=draft', Blaze_Abilities_Test_Stub::$last_path );
+	}
+
+	public function test_list_campaigns_clamps_per_page_to_max_100() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id  = 99;
+		Blaze_Abilities_Test_Stub::$response = array( 'campaigns' => array() );
+
+		Blaze_Abilities_Test_Stub::list_campaigns( array( 'per_page' => 500 ) );
+
+		$this->assertStringContainsString( 'size=100', Blaze_Abilities_Test_Stub::$last_path );
+	}
+
+	public function test_list_campaigns_drops_unknown_status_silently() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id  = 99;
+		Blaze_Abilities_Test_Stub::$response = array( 'campaigns' => array() );
+
+		Blaze_Abilities_Test_Stub::list_campaigns( array( 'status' => 'bogus' ) );
+
+		$this->assertStringNotContainsString( 'status=', Blaze_Abilities_Test_Stub::$last_path );
+	}
+
+	// -------------------- get-dashboard-summary (via test stub) --------------------
+
+	/**
+	 * Happy path: sums spent budget across campaigns and counts only active ones.
+	 */
+	public function test_get_dashboard_summary_aggregates_active_and_spent() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id        = 7;
+		Blaze_Abilities_Test_Stub::$site_supports  = true;
+		Blaze_Abilities_Test_Stub::$path_responses = array(
+			'/sites/7/wordads/dsp/api/v1/sites/7/campaigns' => array(
+				'campaigns' => array(
+					array(
+						'status'       => 'approved',
+						'spent_budget' => 10,
+						'currency'     => 'USD',
+					),
+					array(
+						'status'       => 'completed',
+						'spent_budget' => 25,
+						'currency'     => 'USD',
+					),
+				),
+			),
+			'/sites/7/wordads/dsp/api/v1/credits' => array(
+				'balance' => 42.75,
+			),
+		);
+
+		$result = Blaze_Abilities_Test_Stub::get_dashboard_summary();
+
+		$this->assertSame( 2, $result['total_campaigns'] );
+		$this->assertSame( 1, $result['active_campaigns'] );
+		$this->assertSame( 35.0, $result['total_spent_30d'] );
+		$this->assertSame( 'USD', $result['currency'] );
+		$this->assertTrue( $result['supports_blaze'] );
+		$this->assertSame( 42.75, $result['account_credit_balance'] );
+	}
+
+	public function test_get_dashboard_summary_degrades_to_zero_and_null_on_remote_failure() {
+		wp_set_current_user( $this->admin_id );
+
+		Blaze_Abilities_Test_Stub::$site_id        = 7;
+		Blaze_Abilities_Test_Stub::$site_supports  = false;
+		Blaze_Abilities_Test_Stub::$response_error = new \WP_Error( 'jetpack_blaze_remote_request_failed', 'oops', 500 );
+
+		$result = Blaze_Abilities_Test_Stub::get_dashboard_summary();
+
+		$this->assertSame( 0, $result['total_campaigns'] );
+		$this->assertSame( 0, $result['active_campaigns'] );
+		$this->assertSame( 0.0, $result['total_spent_30d'] );
+		$this->assertFalse( $result['supports_blaze'] );
+		$this->assertNull( $result['account_credit_balance'] );
+	}
+}

--- a/projects/packages/blaze/tests/php/abilities/class-blaze-abilities-test-stub.php
+++ b/projects/packages/blaze/tests/php/abilities/class-blaze-abilities-test-stub.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Test-only subclass of Blaze_Abilities that overrides the protected seams
+ * (site ID resolution, WPCOM request transport, Blaze::site_supports_blaze)
+ * so the execute paths can be exercised without standing up a live connection
+ * or remote DSP fixture.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use WP_Error;
+
+/**
+ * Test-only subclass overriding Blaze_Abilities's protected seams.
+ *
+ * - `get_site_id()` returns the seeded `$site_id`.
+ * - `wpcom_request_as_user()` returns either `$response_error` (if set), the
+ *   `$path_responses` entry that matches the requested path, or `$response`.
+ * - `Blaze::site_supports_blaze()` is short-circuited via the path-responses
+ *   table — the dashboard summary always calls the credits + campaigns paths.
+ */
+class Blaze_Abilities_Test_Stub extends Blaze_Abilities {
+
+	/**
+	 * Seeded site ID returned by the stubbed `get_site_id()`.
+	 *
+	 * @var int
+	 */
+	public static $site_id = 1;
+
+	/**
+	 * Default seeded WPCOM response (used when `$path_responses` doesn't match).
+	 *
+	 * @var array
+	 */
+	public static $response = array();
+
+	/**
+	 * Per-path response table. When set, the stub looks up the response by exact
+	 * path-prefix match before falling back to `$response`. The matching uses
+	 * `str_contains` (not full equality) so query strings can be appended without
+	 * forcing every test to know the exact wire format.
+	 *
+	 * @var array<string, array>
+	 */
+	public static $path_responses = array();
+
+	/**
+	 * If set, return this WP_Error from every wpcom_request_as_user() call
+	 * (unless overridden by a matching $path_responses entry).
+	 *
+	 * @var WP_Error|null
+	 */
+	public static $response_error = null;
+
+	/**
+	 * Last path passed to wpcom_request_as_user(). Lets tests assert on the
+	 * wire-format used by the abilities.
+	 *
+	 * @var string
+	 */
+	public static $last_path = '';
+
+	/**
+	 * Seeded value returned from the `site_supports_blaze` path; tests for
+	 * `get_dashboard_summary` use this to short-circuit the live blaze-status
+	 * check.
+	 *
+	 * @var bool
+	 */
+	public static $site_supports = true;
+
+	/**
+	 * Reset test-double state. Call from set_up() and tear_down().
+	 */
+	public static function reset(): void {
+		self::$site_id        = 1;
+		self::$response       = array();
+		self::$path_responses = array();
+		self::$response_error = null;
+		self::$last_path      = '';
+		self::$site_supports  = true;
+
+		// Reset the Blaze site_supports_blaze cache between tests so each test sees
+		// a consistent value. We re-seed via filter rather than mocking the static.
+		remove_all_filters( 'jetpack_blaze_dashboard_enable' );
+	}
+
+	/**
+	 * Returns the seeded site ID — bypasses the real Connection_Manager lookup.
+	 */
+	protected static function get_site_id() {
+		return self::$site_id;
+	}
+
+	/**
+	 * Returns the seeded `site_supports` flag — bypasses the live WPCOM eligibility check.
+	 *
+	 * @param int $site_id Ignored.
+	 * @return bool
+	 */
+	protected static function site_supports_blaze( int $site_id ): bool {
+		unset( $site_id );
+		return self::$site_supports;
+	}
+
+	/**
+	 * Returns the seeded response or error — bypasses real WPCOM transport.
+	 *
+	 * @param string $path WPCOM REST path.
+	 * @return array|WP_Error
+	 */
+	protected static function wpcom_request_as_user( string $path ) {
+		self::$last_path = $path;
+
+		// Per-path lookup wins over default response, but only for paths in the table.
+		foreach ( self::$path_responses as $needle => $resp ) {
+			if ( str_contains( $path, $needle ) ) {
+				return $resp;
+			}
+		}
+
+		if ( null !== self::$response_error ) {
+			return self::$response_error;
+		}
+
+		return self::$response;
+	}
+}


### PR DESCRIPTION
## Summary

Registers three read-only Blaze (paid promotion) abilities with the WordPress Abilities API via the shared `Automattic\Jetpack\WP_Abilities\Registrar` base class, so AI agents can answer "how are my Blaze campaigns doing?" and "can this post be Blaze-promoted?" through the standard `wp-abilities/v1` REST surface.

References plan §3.3 / §4.2 (Abilities Everywhere — Blaze read surface).

### Abilities

- `jetpack-blaze/list-campaigns` — Paginated list of campaign summaries `{ id, content_id, status, spent_budget, total_budget, currency, start_date, end_date, target_url, impressions, clicks }`. Supports `status`, `page`, `per_page (max 100)`, and a `campaign_id` consolidated-read that collapses 404 to an empty array.
- `jetpack-blaze/get-campaign-eligibility` — Per-content gate `{ content_id, eligible, reasons[], current_status }`. Mirrors the row-action gate in `Blaze::jetpack_blaze_row_action()` (supported post types, published, no password) plus the site-level `Blaze::should_initialize()` check.
- `jetpack-blaze/get-dashboard-summary` — Zero-arg summary `{ total_campaigns, active_campaigns, total_spent_30d, currency, supports_blaze, account_credit_balance }`. Composes the site campaigns + credits WPCOM endpoints; remote failure degrades counts to 0 and credits to null rather than erroring out.

All three abilities reuse the backing REST controllers' `manage_options` permission gate exactly. Writes (campaign create/edit) are deferred — the existing dashboard UI keeps owning those flows.

### Wiring

- New `projects/packages/blaze/actions.php` hooks `Blaze_Abilities::init` to `plugins_loaded:1`, following the canonical guarded pattern from `projects/packages/publicize/actions.php` (function_exists check + $wp_filter fallback). Added to composer autoload `files`.
- `automattic/jetpack-wp-abilities` added to require. Registration is gated behind the default-off `jetpack_wp_abilities_enabled` filter inherited from `Registrar::init()`, so this ships dormant per package convention.

### Testing

Mirrors the package's existing test layout. New `tests/php/abilities/` covers:

- Registrar wiring (gate filter respected, per-ability allow-list filter respected, category auto-injected, abilities only register when the gate is open).
- Surface contract (every spec declares annotations + permission + execute callbacks; no spec sets `category` explicitly; all three abilities annotated `readonly: true, destructive: false, idempotent: true`).
- Permission gate (admin allowed; subscriber + anonymous denied).
- `get-campaign-eligibility` reason codes (missing/zero content_id, post not found, draft, password-protected, unsupported post type, site filter false, happy path).
- `list-campaigns` (projected row shape, consolidated-read returning single element, consolidated-read collapsing 404 to `[]`, pagination + status filter forwarded, `per_page` clamped to 100, unknown status dropped silently) via a `Blaze_Abilities_Test_Stub` that overrides the protected WPCOM-transport / site-id / `site_supports_blaze` seams.
- `get-dashboard-summary` (aggregates active + spent across campaigns, degrades to zero/null on remote failure).

## Test plan

- [ ] `cd projects/packages/blaze && composer phpunit -- --filter Blaze_Abilities_Test` — all 30 tests pass.
- [ ] `cd projects/packages/blaze && composer phpunit` — full package suite still passes (95/95).
- [ ] `vendor/bin/phpcs projects/packages/blaze/src/abilities/ projects/packages/blaze/tests/php/abilities/ projects/packages/blaze/actions.php` — clean.
- [ ] Verify on a Blaze-enabled site with `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' )`: `wp-abilities/v1/abilities` lists the three slugs; `list-campaigns` returns projected rows; `get-campaign-eligibility` returns the documented shape; `get-dashboard-summary` returns aggregated state.
- [ ] Confirm the gate filter is still default-off — the abilities should NOT appear on a stock connected site without the explicit opt-in.