### PR TITLE
Licensing abilities: register list, error info, attach via Registrar

### DIFF
--- a/projects/packages/licensing/actions.php
+++ b/projects/packages/licensing/actions.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Action Hooks for Jetpack Licensing package.
+ *
+ * Registers the package's WordPress Abilities API surface as soon as the
+ * plugin API is available. The Registrar base class is itself gated on the
+ * `jetpack_wp_abilities_enabled` filter (default false), so this only takes
+ * effect on sites that have opted in to the staged Abilities rollout.
+ *
+ * @package automattic/jetpack-licensing
+ */
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action(
+		'plugins_loaded',
+		array( Automattic\Jetpack\Licensing\Abilities\Licensing_Abilities::class, 'init' ),
+		1
+	);
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][1][] = array(
+		'accepted_args' => 0,
+		'function'      => array( Automattic\Jetpack\Licensing\Abilities\Licensing_Abilities::class, 'init' ),
+	);
+}

--- a/projects/packages/licensing/changelog/add-licensing-abilities
+++ b/projects/packages/licensing/changelog/add-licensing-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register list-licenses, get-error-info, and attach-license abilities on WP 6.9+.

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -5,7 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
@@ -18,6 +19,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/licensing/src/abilities/class-licensing-abilities.php
+++ b/projects/packages/licensing/src/abilities/class-licensing-abilities.php
@@ -1,0 +1,622 @@
+<?php
+/**
+ * Jetpack Licensing Abilities Registration.
+ *
+ * Registers Jetpack Licensing abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-licensing
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Licensing\Abilities;
+
+use Automattic\Jetpack\Licensing;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+
+/**
+ * Registers Jetpack Licensing abilities with the WordPress Abilities API.
+ *
+ * Exposes a small, agent-shaped surface around the user-licensing endpoints
+ * the package already provides: list attached / unattached licenses,
+ * surface the last attach-error, and attach a new license key. The three
+ * abilities wrap `Licensing::get_user_licenses`, `Licensing::last_error`
+ * and `Licensing::attach_licenses` respectively so the standard
+ * `wp-abilities/v1` REST surface can drive end-to-end licensing flows.
+ */
+class Licensing_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-licensing';
+	const ERROR_PREFIX  = 'jetpack_licensing_';
+
+	/**
+	 * Pagination ceiling for list-licenses.
+	 */
+	const MAX_PER_PAGE = 100;
+
+	/**
+	 * Default page size for list-licenses.
+	 */
+	const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * Allowed status filter values for list-licenses.
+	 *
+	 * - `attached`  -> attached_at !== null && revoked_at === null
+	 * - `detached`  -> attached_at === null && revoked_at === null
+	 * - `expired`   -> revoked_at !== null OR expires_at in the past
+	 * - `active`    -> attached + not expired (the agent's "what's actually
+	 *                  protecting this site right now?" question)
+	 */
+	const STATUSES = array( 'active', 'expired', 'attached', 'detached' );
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack Licensing" is a product name and should not be translated.
+			'label'       => 'Jetpack Licensing',
+			'description' => __( 'Abilities for listing Jetpack licenses, inspecting attach errors, and attaching new license keys.', 'jetpack-licensing' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-licensing/list-licenses'  => self::spec_list_licenses(),
+			'jetpack-licensing/get-error-info' => self::spec_get_error_info(),
+			'jetpack-licensing/attach-license' => self::spec_attach_license(),
+		);
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-licensing/list-licenses.
+	 */
+	private static function spec_list_licenses(): array {
+		return array(
+			'label'               => __( 'List Jetpack licenses', 'jetpack-licensing' ),
+			'description'         => __(
+				'Return the licenses owned by the current Jetpack-connected user, optionally filtered by status or by `license_id`. Shape: array of { id, slug, product_name, attached_at, status, expires_at }. The per-entry `status` value is one of "active" (attached and not expired), "expired" (revoked or past expiry), or "detached" (never attached). As an input filter, `status` also accepts "attached", which returns every license whose `attached_at` is set — including expired ones — so callers do not have to issue separate calls for active and expired-but-attached. Pass `license_id` to look up a single license — the result is a 0- or 1-element array, not a different shape; an unknown id returns []. Pagination defaults to per_page=20, max 100; use `page` to walk additional results. Precondition: the site must have a connected user with Jetpack; otherwise returns jetpack_licensing_data_unavailable. Related: call jetpack-licensing/get-error-info if a recent attach attempt failed.',
+				'jetpack-licensing'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'status'     => array(
+						'type'        => 'string',
+						'description' => __( 'Optional status filter.', 'jetpack-licensing' ),
+						'enum'        => self::STATUSES,
+					),
+					'license_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Optional license id to look up. Result is a 0- or 1-element array.', 'jetpack-licensing' ),
+						'minimum'     => 1,
+					),
+					'page'       => array(
+						'type'        => 'integer',
+						'description' => __( '1-based page index.', 'jetpack-licensing' ),
+						'minimum'     => 1,
+						'default'     => 1,
+					),
+					'per_page'   => array(
+						'type'        => 'integer',
+						'description' => __( 'Results per page (1-100).', 'jetpack-licensing' ),
+						'minimum'     => 1,
+						'maximum'     => self::MAX_PER_PAGE,
+						'default'     => self::DEFAULT_PER_PAGE,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'           => array( 'type' => 'integer' ),
+						'slug'         => array( 'type' => 'string' ),
+						'product_name' => array( 'type' => 'string' ),
+						'attached_at'  => array( 'type' => array( 'string', 'null' ) ),
+						'status'       => array( 'type' => 'string' ),
+						'expires_at'   => array( 'type' => array( 'string', 'null' ) ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'list_licenses' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_licensing' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-licensing/get-error-info.
+	 */
+	private static function spec_get_error_info(): array {
+		return array(
+			'label'               => __( 'Get last Jetpack license attach error', 'jetpack-licensing' ),
+			'description'         => __(
+				'Return the latest license-attach error recorded by the Licensing package. Shape: { has_error, message, code, last_attempt_at }. `has_error` is false and the other fields are empty/null when no error is pending. `code` and `last_attempt_at` are best-effort and may be null even when `has_error` is true (the underlying option only stores a human-readable message). Useful immediately after calling jetpack-licensing/attach-license to disambiguate which key(s) failed and why. Reading the error does not clear it — it remains visible until the next attach attempt overwrites the option.',
+				'jetpack-licensing'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'has_error'       => array( 'type' => 'boolean' ),
+					'message'         => array( 'type' => 'string' ),
+					'code'            => array( 'type' => array( 'string', 'null' ) ),
+					'last_attempt_at' => array( 'type' => array( 'string', 'null' ) ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_error_info' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_licensing' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-licensing/attach-license.
+	 */
+	private static function spec_attach_license(): array {
+		return array(
+			'label'               => __( 'Attach a Jetpack license key', 'jetpack-licensing' ),
+			'description'         => __(
+				'Attach a single Jetpack license key to this site. Shape: { attached, license_id, products_activated, error }. `attached` is true on success — including when the key was already attached (idempotent: re-attaching an attached key returns attached=true with the same product list, not an error). `license_id` and `products_activated` come straight from the WP.com Subscription Server response (license_id may be null when the key was already attached and the server does not surface it again). On failure `attached` is false and `error` is { code, message }; common codes are jetpack_licensing_not_connected (no connection owner — connect Jetpack first), jetpack_licensing_invalid_key (revoked / unknown / mistyped key), and jetpack_licensing_request_failed (the WP.com XML-RPC call itself errored). After a failure, call jetpack-licensing/get-error-info for the same message stored on-site for the UI. Precondition: site must have a connected Jetpack owner.',
+				'jetpack-licensing'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'license_key' ),
+				'properties'           => array(
+					'license_key' => array(
+						'type'        => 'string',
+						'description' => __( 'The Jetpack license key to attach. Trimmed and sanitized server-side.', 'jetpack-licensing' ),
+						'minLength'   => 1,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'attached'           => array( 'type' => 'boolean' ),
+					'license_id'         => array( 'type' => array( 'integer', 'null' ) ),
+					'products_activated' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+					'error'              => array( 'type' => array( 'object', 'null' ) ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'attach_license' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_licensing' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool',
+				),
+			),
+		);
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Both reads and writes share `manage_options` — the same gate the
+	 * existing /jetpack/v4/licensing REST surface uses (see
+	 * Endpoints::can_manage_options_check). Keeping a single callback rather
+	 * than splitting read/write avoids a divergence the REST surface itself
+	 * never made; if the underlying endpoint cap changes later, this is the
+	 * one place to update.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_licensing(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-licenses.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function list_licenses( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$status     = isset( $input['status'] ) && in_array( $input['status'], self::STATUSES, true ) ? $input['status'] : null;
+		$license_id = isset( $input['license_id'] ) && is_numeric( $input['license_id'] ) && (int) $input['license_id'] > 0
+			? (int) $input['license_id']
+			: null;
+		$page       = self::clamp_int( $input['page'] ?? 1, 1, PHP_INT_MAX, 1 );
+		$per_page   = self::clamp_int( $input['per_page'] ?? self::DEFAULT_PER_PAGE, 1, self::MAX_PER_PAGE, self::DEFAULT_PER_PAGE );
+
+		$items = static::fetch_user_licenses();
+		if ( is_wp_error( $items ) ) {
+			return $items;
+		}
+
+		$normalized = array();
+		foreach ( $items as $item ) {
+			$entry = self::normalize_license( $item );
+			if ( null === $entry ) {
+				continue;
+			}
+			if ( null !== $license_id && $entry['id'] !== $license_id ) {
+				continue;
+			}
+			if ( null !== $status && ! self::matches_status_filter( $entry, $status ) ) {
+				continue;
+			}
+			$normalized[] = $entry;
+		}
+
+		// Apply pagination AFTER filtering so callers see a stable result-set
+		// rather than empty pages at the tail of an unrelated filter.
+		$offset = ( $page - 1 ) * $per_page;
+		return array_slice( $normalized, $offset, $per_page );
+	}
+
+	/**
+	 * Execute: get-error-info.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_error_info( $input = null ) {
+		unset( $input );
+
+		$message = (string) static::get_licensing()->last_error();
+
+		return array(
+			'has_error'       => '' !== $message,
+			'message'         => $message,
+			// The underlying option stores only the message string; code and
+			// timestamp are not tracked. Returning explicit nulls (rather than
+			// dropping the keys) keeps the response shape uniform.
+			'code'            => null,
+			'last_attempt_at' => null,
+		);
+	}
+
+	/**
+	 * Execute: attach-license.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function attach_license( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['license_key'] ) || ! is_string( $input['license_key'] ) || '' === trim( $input['license_key'] ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_license_key',
+				__( 'A non-empty `license_key` string is required.', 'jetpack-licensing' )
+			);
+		}
+
+		$license_key = trim( sanitize_text_field( $input['license_key'] ) );
+
+		$results = static::get_licensing()->attach_licenses( array( $license_key ) );
+
+		if ( is_wp_error( $results ) ) {
+			// Underlying `attach_licenses()` returns a top-level WP_Error only for
+			// not-connected / request-failure cases. Surface as a structured
+			// failure response so the agent can branch on `attached` rather than
+			// having to differentiate WP_Error vs. array.
+			return array(
+				'attached'           => false,
+				'license_id'         => null,
+				'products_activated' => array(),
+				'error'              => array(
+					'code'    => self::map_error_code( $results->get_error_code() ),
+					'message' => (string) $results->get_error_message(),
+				),
+			);
+		}
+
+		// Expected: one entry corresponding to the one license key we sent.
+		$first = isset( $results[0] ) ? $results[0] : null;
+
+		if ( is_wp_error( $first ) ) {
+			return array(
+				'attached'           => false,
+				'license_id'         => null,
+				'products_activated' => array(),
+				'error'              => array(
+					'code'    => self::ERROR_PREFIX . 'invalid_key',
+					'message' => (string) $first->get_error_message(),
+				),
+			);
+		}
+
+		// `true` is the legacy multicall ack for "already attached, nothing new
+		// to activate" — treat as a successful idempotent attach.
+		if ( true === $first ) {
+			return array(
+				'attached'           => true,
+				'license_id'         => null,
+				'products_activated' => array(),
+				'error'              => null,
+			);
+		}
+
+		$entry = is_array( $first ) ? $first : array();
+
+		$license_id         = isset( $entry['license_id'] ) ? (int) $entry['license_id'] : null;
+		$products_activated = array();
+
+		// The XML-RPC response uses `activatedProductId` (singular) for the
+		// canonical single-license response, but agents prefer a list. Promote
+		// a singleton to a one-element array of the product slug or numeric id.
+		if ( isset( $entry['activatedProductId'] ) ) {
+			$products_activated[] = (string) $entry['activatedProductId'];
+		}
+		if ( isset( $entry['products'] ) && is_array( $entry['products'] ) ) {
+			foreach ( $entry['products'] as $product ) {
+				if ( is_string( $product ) || is_numeric( $product ) ) {
+					$products_activated[] = (string) $product;
+				}
+			}
+		}
+
+		return array(
+			'attached'           => true,
+			'license_id'         => $license_id,
+			'products_activated' => array_values( array_unique( $products_activated ) ),
+			'error'              => null,
+		);
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Return a Licensing singleton. Extracted as a seam so tests can swap in
+	 * a partial mock without needing to install a real Jetpack connection.
+	 *
+	 * @return Licensing
+	 */
+	protected static function get_licensing(): Licensing {
+		return Licensing::instance();
+	}
+
+	/**
+	 * Fetch the current user's licenses from WP.com.
+	 *
+	 * Returns either the list of license items (objects), an empty array, or
+	 * a WP_Error when the request failed. `Licensing::get_user_licenses()`
+	 * itself returns `[]` on failure and on success; we use the underlying
+	 * `Endpoints::get_user_licenses()` directly so genuine fetch failures
+	 * surface as a structured WP_Error instead of looking like "no licenses".
+	 *
+	 * @return array|WP_Error
+	 */
+	protected static function fetch_user_licenses() {
+		$licenses = \Automattic\Jetpack\Licensing\Endpoints::get_user_licenses();
+		if ( is_wp_error( $licenses ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'data_unavailable',
+				__( 'Could not fetch your Jetpack licenses from WordPress.com. Confirm the site has a connected user and try again.', 'jetpack-licensing' )
+			);
+		}
+
+		if ( empty( $licenses ) || empty( $licenses->items ) || ! is_array( $licenses->items ) ) {
+			return array();
+		}
+
+		return $licenses->items;
+	}
+
+	/**
+	 * Normalize a single WP.com license object into the response shape.
+	 *
+	 * @param object|array|mixed $item Raw license entry from WP.com.
+	 * @return array|null Normalized license or null when the entry is unusable.
+	 */
+	private static function normalize_license( $item ): ?array {
+		if ( is_object( $item ) ) {
+			$item = (array) $item;
+		}
+		if ( ! is_array( $item ) ) {
+			return null;
+		}
+
+		$id           = isset( $item['id'] ) ? (int) $item['id'] : 0;
+		$attached_at  = self::nullable_string( $item, 'attached_at' );
+		$revoked_at   = self::nullable_string( $item, 'revoked_at' );
+		$expires_at   = self::nullable_string( $item, 'expires_at' );
+		$product_name = isset( $item['product_name'] ) ? (string) $item['product_name'] : '';
+		$slug         = isset( $item['product_slug'] ) ? (string) $item['product_slug'] : ( isset( $item['slug'] ) ? (string) $item['slug'] : '' );
+
+		return array(
+			'id'           => $id,
+			'slug'         => $slug,
+			'product_name' => $product_name,
+			'attached_at'  => $attached_at,
+			'status'       => self::compute_status( $attached_at, $revoked_at, $expires_at ),
+			'expires_at'   => $expires_at,
+		);
+	}
+
+	/**
+	 * Derive the canonical `status` string from raw attach / revoke / expiry
+	 * timestamps. This is the single value returned in the response; the
+	 * `attached` filter category (legacy / "did this license ever attach,
+	 * regardless of expiry?") is honored separately by `matches_status_filter`
+	 * to avoid drift between display state and filter state.
+	 *
+	 * @param string|null $attached_at Attach timestamp or null.
+	 * @param string|null $revoked_at  Revoke timestamp or null.
+	 * @param string|null $expires_at  Expiry timestamp or null.
+	 * @return string One of `active`, `expired`, `detached`.
+	 */
+	private static function compute_status( ?string $attached_at, ?string $revoked_at, ?string $expires_at ): string {
+		if ( null !== $revoked_at ) {
+			return 'expired';
+		}
+		if ( null !== $expires_at && self::is_past( $expires_at ) ) {
+			return 'expired';
+		}
+		if ( null === $attached_at ) {
+			return 'detached';
+		}
+		return 'active';
+	}
+
+	/**
+	 * Whether a normalized license entry matches the caller's status filter.
+	 *
+	 * `active`, `expired`, `detached` are taken verbatim from the computed
+	 * status. `attached` is broader: any entry whose `attached_at` is set
+	 * (including expired entries that were attached before their expiry).
+	 *
+	 * @param array  $entry  Normalized license entry from `normalize_license`.
+	 * @param string $status Caller-supplied status filter.
+	 * @return bool
+	 */
+	private static function matches_status_filter( array $entry, string $status ): bool {
+		if ( 'attached' === $status ) {
+			return null !== $entry['attached_at'];
+		}
+		return $entry['status'] === $status;
+	}
+
+	/**
+	 * Whether the given timestamp string is in the past relative to now.
+	 *
+	 * @param string $when ISO-8601-ish timestamp.
+	 * @return bool
+	 */
+	private static function is_past( string $when ): bool {
+		$ts = strtotime( $when );
+		if ( false === $ts ) {
+			return false;
+		}
+		return $ts < time();
+	}
+
+	/**
+	 * Read a value from an array, coercing to string or null.
+	 *
+	 * @param array  $arr Source.
+	 * @param string $key Key.
+	 * @return string|null
+	 */
+	private static function nullable_string( array $arr, string $key ): ?string {
+		if ( ! array_key_exists( $key, $arr ) ) {
+			return null;
+		}
+		$value = $arr[ $key ];
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+		return (string) $value;
+	}
+
+	/**
+	 * Map an underlying error code from `attach_licenses()` onto our
+	 * vocabulary so agents can branch on stable codes.
+	 *
+	 * @param string|int $code Raw error code.
+	 * @return string
+	 */
+	private static function map_error_code( $code ): string {
+		$code = (string) $code;
+		switch ( $code ) {
+			case 'not_connected':
+				return self::ERROR_PREFIX . 'not_connected';
+			case 'request_failed':
+				return self::ERROR_PREFIX . 'request_failed';
+			default:
+				// Unknown upstream code — namespace it so callers can still
+				// distinguish jetpack-licensing failures from generic errors.
+				return self::ERROR_PREFIX . 'attach_failed';
+		}
+	}
+
+	/**
+	 * Clamp an integer into [$min, $max] with a default on bad input.
+	 *
+	 * @param mixed $raw     Raw input.
+	 * @param int   $min     Minimum.
+	 * @param int   $max     Maximum.
+	 * @param int   $default Default on bad input.
+	 * @return int
+	 */
+	private static function clamp_int( $raw, int $min, int $max, int $default ): int {
+		if ( ! is_numeric( $raw ) ) {
+			return $default;
+		}
+		$v = (int) $raw;
+		if ( $v < $min ) {
+			return $min;
+		}
+		if ( $v > $max ) {
+			return $max;
+		}
+		return $v;
+	}
+}

--- a/projects/packages/licensing/tests/php/abilities/Licensing_Abilities_Test.php
+++ b/projects/packages/licensing/tests/php/abilities/Licensing_Abilities_Test.php
@@ -1,0 +1,664 @@
+<?php
+/**
+ * Tests for the Licensing_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-licensing
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Licensing\Abilities;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_Error;
+
+require_once __DIR__ . '/class-licensing-abilities-test-stub.php';
+
+/**
+ * Unit tests for Licensing_Abilities registration and execution.
+ *
+ * Run from projects/packages/licensing:
+ *
+ *   composer phpunit -- --filter Licensing_Abilities_Test
+ *
+ * @covers \Automattic\Jetpack\Licensing\Abilities\Licensing_Abilities
+ */
+#[CoversClass( Licensing_Abilities::class )]
+class Licensing_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * The admin user id.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * The subscriber user id.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * Stubbed `get_user_licenses` response items used by the
+	 * Licensing_Abilities_Test_Stub class. Reset per-test.
+	 *
+	 * @var array
+	 */
+	public static $stub_license_items = array();
+
+	/**
+	 * Stubbed `attach_licenses` return value used by the
+	 * Licensing_Abilities_Test_Stub class. Reset per-test.
+	 *
+	 * @var mixed
+	 */
+	public static $stub_attach_return = array();
+
+	/**
+	 * Stubbed `last_error` return value used by the
+	 * Licensing_Abilities_Test_Stub class. Reset per-test.
+	 *
+	 * @var string
+	 */
+	public static $stub_last_error = '';
+
+	/**
+	 * Standard set-up.
+	 */
+	protected function set_up() {
+		self::$admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'licensing_abilities_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'licensing_abilities_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Most tests open the rollout gate; the specific "disabled by default" test closes it explicitly.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Reset any hooks a prior test may have added for the Registrar lifecycle actions.
+		remove_action( 'wp_abilities_api_categories_init', array( Licensing_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Licensing_Abilities::class, 'register_abilities' ) );
+
+		self::$stub_license_items = array();
+		self::$stub_attach_return = array();
+		self::$stub_last_error    = '';
+	}
+
+	/**
+	 * Standard tear-down.
+	 */
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_action( 'wp_abilities_api_categories_init', array( Licensing_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Licensing_Abilities::class, 'register_abilities' ) );
+		wp_set_current_user( 0 );
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$this->deregister_category_and_abilities();
+		}
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Remove our category + abilities from the registry so tests don't bleed.
+	 */
+	private function deregister_category_and_abilities(): void {
+		if ( function_exists( 'wp_has_ability' ) && function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Licensing_Abilities::get_abilities() ) as $slug ) {
+				if ( wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_has_ability_category' ) && function_exists( 'wp_unregister_ability_category' ) ) {
+			if ( wp_has_ability_category( Licensing_Abilities::CATEGORY_SLUG ) ) {
+				wp_unregister_ability_category( Licensing_Abilities::CATEGORY_SLUG );
+			}
+		}
+	}
+
+	/**
+	 * Run a callable while the given Abilities API lifecycle action appears to be firing.
+	 *
+	 * @param string   $action Action name to simulate.
+	 * @param callable $fn     Callable to run while the action is "firing".
+	 */
+	private function with_simulated_action( string $action, callable $fn ): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = $action;
+		try {
+			$fn();
+		} finally {
+			for ( $i = count( $wp_current_filter ) - 1; $i >= 0; $i-- ) {
+				if ( $wp_current_filter[ $i ] === $action ) {
+					array_splice( $wp_current_filter, $i, 1 );
+					break;
+				}
+			}
+		}
+	}
+
+	public function test_category_slug_is_jetpack_licensing(): void {
+		$this->assertSame( 'jetpack-licensing', Licensing_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description(): void {
+		$def = Licensing_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotSame( '', $def['label'] );
+		$this->assertNotSame( '', $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced(): void {
+		$abilities = Licensing_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-licensing/', $slug );
+		}
+	}
+
+	public function test_every_spec_declares_annotations_permission_and_execute(): void {
+		foreach ( Licensing_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'execute_callback', $spec, "Ability {$slug} missing execute_callback" );
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback is not callable" );
+			$this->assertArrayHasKey( 'permission_callback', $spec, "Ability {$slug} missing permission_callback" );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback is not callable" );
+			$this->assertArrayHasKey( 'meta', $spec, "Ability {$slug} missing meta" );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'], "Ability {$slug} missing meta.annotations" );
+			foreach ( array( 'readonly', 'destructive', 'idempotent' ) as $flag ) {
+				$this->assertArrayHasKey( $flag, $spec['meta']['annotations'], "Ability {$slug} missing annotation {$flag}" );
+				$this->assertIsBool( $spec['meta']['annotations'][ $flag ], "Ability {$slug} annotation {$flag} must be bool" );
+			}
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly(): void {
+		// Registrar auto-injects the category; setting it on each spec is
+		// redundant and drifts. This guard mirrors the Stats and Forms tests.
+		foreach ( Licensing_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_read_abilities_declared_readonly(): void {
+		$read_slugs = array(
+			'jetpack-licensing/list-licenses',
+			'jetpack-licensing/get-error-info',
+		);
+		$abilities  = Licensing_Abilities::get_abilities();
+		foreach ( $read_slugs as $slug ) {
+			$this->assertArrayHasKey( $slug, $abilities );
+			$ann = $abilities[ $slug ]['meta']['annotations'];
+			$this->assertTrue( $ann['readonly'], "{$slug} should be readonly" );
+			$this->assertFalse( $ann['destructive'], "{$slug} should not be destructive" );
+			$this->assertTrue( $ann['idempotent'], "{$slug} should be idempotent" );
+		}
+	}
+
+	public function test_attach_license_is_writable_idempotent_and_non_destructive(): void {
+		$abilities = Licensing_Abilities::get_abilities();
+		$ann       = $abilities['jetpack-licensing/attach-license']['meta']['annotations'];
+		$this->assertFalse( $ann['readonly'] );
+		$this->assertFalse( $ann['destructive'] );
+		$this->assertTrue( $ann['idempotent'] );
+	}
+
+	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
+		foreach ( Licensing_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertSame( true, $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
+
+	public function test_init_registers_nothing_when_gate_filter_is_false(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Licensing_Abilities::init();
+
+		$this->assertFalse(
+			has_action(
+				'wp_abilities_api_categories_init',
+				array( Licensing_Abilities::class, 'register_category' )
+			)
+		);
+		$this->assertFalse(
+			has_action(
+				'wp_abilities_api_init',
+				array( Licensing_Abilities::class, 'register_abilities' )
+			)
+		);
+
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true(): void {
+		if ( did_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_categories_init' ) ) {
+			$this->markTestSkipped( 'Abilities API lifecycle already fired in this test run; late-load path covered elsewhere.' );
+		}
+
+		Licensing_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_categories_init',
+				array( Licensing_Abilities::class, 'register_category' )
+			)
+		);
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_init',
+				array( Licensing_Abilities::class, 'register_abilities' )
+			)
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug_with_auto_injected_category(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$this->with_simulated_action(
+			'wp_abilities_api_categories_init',
+			static function () {
+				Licensing_Abilities::register_category();
+			}
+		);
+		$this->with_simulated_action(
+			'wp_abilities_api_init',
+			static function () {
+				Licensing_Abilities::register_abilities();
+			}
+		);
+
+		foreach ( array_keys( Licensing_Abilities::get_abilities() ) as $slug ) {
+			$this->assertTrue( wp_has_ability( $slug ), "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				if ( 'ability' === $type ) {
+					return 'jetpack-licensing/get-error-info' === $slug;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->with_simulated_action(
+			'wp_abilities_api_categories_init',
+			static function () {
+				Licensing_Abilities::register_category();
+			}
+		);
+		$this->with_simulated_action(
+			'wp_abilities_api_init',
+			static function () {
+				Licensing_Abilities::register_abilities();
+			}
+		);
+
+		$this->assertTrue( wp_has_ability( 'jetpack-licensing/get-error-info' ) );
+		$this->assertFalse( wp_has_ability( 'jetpack-licensing/list-licenses' ) );
+		$this->assertFalse( wp_has_ability( 'jetpack-licensing/attach-license' ) );
+	}
+
+	public function test_can_manage_licensing_allows_admin(): void {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( Licensing_Abilities::can_manage_licensing() );
+	}
+
+	public function test_can_manage_licensing_denies_subscriber(): void {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( Licensing_Abilities::can_manage_licensing() );
+	}
+
+	public function test_can_manage_licensing_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Licensing_Abilities::can_manage_licensing() );
+	}
+
+	public function test_get_error_info_when_no_error_returns_clean_shape(): void {
+		self::$stub_last_error = '';
+
+		$result = Licensing_Abilities_Test_Stub::get_error_info();
+
+		$this->assertSame(
+			array(
+				'has_error'       => false,
+				'message'         => '',
+				'code'            => null,
+				'last_attempt_at' => null,
+			),
+			$result
+		);
+	}
+
+	public function test_get_error_info_when_error_present_returns_message_and_has_error(): void {
+		self::$stub_last_error = 'License foo is revoked.';
+
+		$result = Licensing_Abilities_Test_Stub::get_error_info();
+
+		$this->assertTrue( $result['has_error'] );
+		$this->assertSame( 'License foo is revoked.', $result['message'] );
+		$this->assertNull( $result['code'] );
+		$this->assertNull( $result['last_attempt_at'] );
+	}
+
+	public function test_list_licenses_returns_normalized_shape(): void {
+		self::$stub_license_items = array(
+			(object) array(
+				'id'           => 7,
+				'product_slug' => 'jetpack_scan',
+				'product_name' => 'Jetpack Scan',
+				'attached_at'  => '2026-04-01 12:00:00',
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+		);
+
+		$result = Licensing_Abilities_Test_Stub::list_licenses( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame(
+			array(
+				'id'           => 7,
+				'slug'         => 'jetpack_scan',
+				'product_name' => 'Jetpack Scan',
+				'attached_at'  => '2026-04-01 12:00:00',
+				'status'       => 'active',
+				'expires_at'   => null,
+			),
+			$result[0]
+		);
+	}
+
+	public function test_list_licenses_status_filter_keeps_only_matching_entries(): void {
+		self::$stub_license_items = array(
+			// attached and active
+			(object) array(
+				'id'           => 1,
+				'product_slug' => 'a',
+				'product_name' => 'A',
+				'attached_at'  => '2026-04-01 12:00:00',
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+			// detached (unattached)
+			(object) array(
+				'id'           => 2,
+				'product_slug' => 'b',
+				'product_name' => 'B',
+				'attached_at'  => null,
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+			// revoked => expired
+			(object) array(
+				'id'           => 3,
+				'product_slug' => 'c',
+				'product_name' => 'C',
+				'attached_at'  => '2025-01-01 12:00:00',
+				'revoked_at'   => '2025-06-01 12:00:00',
+				'expires_at'   => null,
+			),
+			// past expiry => expired
+			(object) array(
+				'id'           => 4,
+				'product_slug' => 'd',
+				'product_name' => 'D',
+				'attached_at'  => '2024-01-01 12:00:00',
+				'revoked_at'   => null,
+				'expires_at'   => '2024-06-01 12:00:00',
+			),
+		);
+
+		$expired = Licensing_Abilities_Test_Stub::list_licenses( array( 'status' => 'expired' ) );
+		$this->assertCount( 2, $expired );
+		$ids = array_column( $expired, 'id' );
+		$this->assertContains( 3, $ids );
+		$this->assertContains( 4, $ids );
+
+		$detached = Licensing_Abilities_Test_Stub::list_licenses( array( 'status' => 'detached' ) );
+		$this->assertCount( 1, $detached );
+		$this->assertSame( 2, $detached[0]['id'] );
+
+		$active = Licensing_Abilities_Test_Stub::list_licenses( array( 'status' => 'active' ) );
+		$this->assertCount( 1, $active );
+		$this->assertSame( 1, $active[0]['id'] );
+	}
+
+	public function test_list_licenses_attached_filter_includes_all_attached_regardless_of_expiry(): void {
+		self::$stub_license_items = array(
+			// Attached + active.
+			(object) array(
+				'id'           => 1,
+				'product_slug' => 'a',
+				'product_name' => 'A',
+				'attached_at'  => '2026-04-01 12:00:00',
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+			// Attached but expired (past expiry).
+			(object) array(
+				'id'           => 2,
+				'product_slug' => 'b',
+				'product_name' => 'B',
+				'attached_at'  => '2024-01-01 12:00:00',
+				'revoked_at'   => null,
+				'expires_at'   => '2024-06-01 12:00:00',
+			),
+			// Never attached — should NOT match `attached` filter.
+			(object) array(
+				'id'           => 3,
+				'product_slug' => 'c',
+				'product_name' => 'C',
+				'attached_at'  => null,
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+		);
+
+		// `attached` is broader than `active` — it includes attached-but-expired
+		// licenses so agents can answer "what has this site ever had attached?"
+		// without re-issuing per-status calls.
+		$result = Licensing_Abilities_Test_Stub::list_licenses( array( 'status' => 'attached' ) );
+		$this->assertCount( 2, $result );
+		$ids = array_column( $result, 'id' );
+		$this->assertContains( 1, $ids );
+		$this->assertContains( 2, $ids );
+		$this->assertNotContains( 3, $ids );
+	}
+
+	public function test_list_licenses_license_id_filter_returns_single_or_empty_array(): void {
+		self::$stub_license_items = array(
+			(object) array(
+				'id'           => 1,
+				'product_slug' => 'a',
+				'product_name' => 'A',
+				'attached_at'  => null,
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+			(object) array(
+				'id'           => 2,
+				'product_slug' => 'b',
+				'product_name' => 'B',
+				'attached_at'  => null,
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			),
+		);
+
+		$found = Licensing_Abilities_Test_Stub::list_licenses( array( 'license_id' => 2 ) );
+		$this->assertCount( 1, $found );
+		$this->assertSame( 2, $found[0]['id'] );
+
+		$missing = Licensing_Abilities_Test_Stub::list_licenses( array( 'license_id' => 99 ) );
+		$this->assertSame( array(), $missing );
+	}
+
+	public function test_list_licenses_pagination_caps_per_page_at_100(): void {
+		$items = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$items[] = (object) array(
+				'id'           => $i,
+				'product_slug' => "p{$i}",
+				'product_name' => "P{$i}",
+				'attached_at'  => null,
+				'revoked_at'   => null,
+				'expires_at'   => null,
+			);
+		}
+		self::$stub_license_items = $items;
+
+		$page1 = Licensing_Abilities_Test_Stub::list_licenses(
+			array(
+				'page'     => 1,
+				'per_page' => 2,
+			)
+		);
+		$this->assertCount( 2, $page1 );
+		$this->assertSame( 1, $page1[0]['id'] );
+
+		$page2 = Licensing_Abilities_Test_Stub::list_licenses(
+			array(
+				'page'     => 2,
+				'per_page' => 2,
+			)
+		);
+		$this->assertCount( 2, $page2 );
+		$this->assertSame( 3, $page2[0]['id'] );
+
+		// Out-of-range per_page is clamped, not rejected.
+		$capped = Licensing_Abilities_Test_Stub::list_licenses( array( 'per_page' => 9999 ) );
+		$this->assertCount( 5, $capped );
+	}
+
+	public function test_list_licenses_returns_wp_error_when_fetch_fails(): void {
+		Licensing_Abilities_Test_Stub::$stub_fetch_error = new WP_Error(
+			'jetpack_licensing_data_unavailable',
+			'boom'
+		);
+
+		$result = Licensing_Abilities_Test_Stub::list_licenses( array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_licensing_data_unavailable', $result->get_error_code() );
+
+		Licensing_Abilities_Test_Stub::$stub_fetch_error = null;
+	}
+
+	public function test_attach_license_rejects_missing_key(): void {
+		$result = Licensing_Abilities_Test_Stub::attach_license( array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_licensing_missing_license_key', $result->get_error_code() );
+	}
+
+	public function test_attach_license_rejects_empty_string(): void {
+		$result = Licensing_Abilities_Test_Stub::attach_license( array( 'license_key' => '   ' ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_licensing_missing_license_key', $result->get_error_code() );
+	}
+
+	public function test_attach_license_happy_path_returns_attached_true_with_products(): void {
+		self::$stub_attach_return = array(
+			array(
+				'license_id'         => 42,
+				'activatedProductId' => 'jetpack_scan',
+			),
+		);
+
+		$result = Licensing_Abilities_Test_Stub::attach_license( array( 'license_key' => 'abcdef' ) );
+
+		$this->assertSame(
+			array(
+				'attached'           => true,
+				'license_id'         => 42,
+				'products_activated' => array( 'jetpack_scan' ),
+				'error'              => null,
+			),
+			$result
+		);
+	}
+
+	public function test_attach_license_already_attached_idempotent_returns_attached_true(): void {
+		// `true` is the legacy multicall ack the server returns when the key
+		// is already attached and there's nothing new to activate. The agent
+		// MUST see attached=true here, not an error, so the same call is safe
+		// to retry.
+		self::$stub_attach_return = array( true );
+
+		$result = Licensing_Abilities_Test_Stub::attach_license( array( 'license_key' => 'already-attached-key' ) );
+
+		$this->assertTrue( $result['attached'] );
+		$this->assertNull( $result['license_id'] );
+		$this->assertSame( array(), $result['products_activated'] );
+		$this->assertNull( $result['error'] );
+	}
+
+	public function test_attach_license_per_key_error_returns_structured_failure(): void {
+		self::$stub_attach_return = array(
+			new WP_Error( 'invalid_license_key', 'License key is invalid.' ),
+		);
+
+		$result = Licensing_Abilities_Test_Stub::attach_license( array( 'license_key' => 'bad-key' ) );
+
+		$this->assertFalse( $result['attached'] );
+		$this->assertNull( $result['license_id'] );
+		$this->assertSame( array(), $result['products_activated'] );
+		$this->assertIsArray( $result['error'] );
+		$this->assertSame( 'jetpack_licensing_invalid_key', $result['error']['code'] );
+		$this->assertSame( 'License key is invalid.', $result['error']['message'] );
+	}
+
+	public function test_attach_license_top_level_wp_error_returns_mapped_failure_code(): void {
+		self::$stub_attach_return = new WP_Error( 'not_connected', 'Not connected.' );
+
+		$result = Licensing_Abilities_Test_Stub::attach_license( array( 'license_key' => 'abc' ) );
+
+		$this->assertFalse( $result['attached'] );
+		$this->assertSame( 'jetpack_licensing_not_connected', $result['error']['code'] );
+		$this->assertSame( 'Not connected.', $result['error']['message'] );
+	}
+
+	public function test_attach_license_request_failed_maps_to_namespaced_code(): void {
+		self::$stub_attach_return = new WP_Error( 'request_failed', 'XMLRPC blew up.' );
+
+		$result = Licensing_Abilities_Test_Stub::attach_license( array( 'license_key' => 'abc' ) );
+
+		$this->assertFalse( $result['attached'] );
+		$this->assertSame( 'jetpack_licensing_request_failed', $result['error']['code'] );
+	}
+}

--- a/projects/packages/licensing/tests/php/abilities/class-licensing-abilities-test-stub.php
+++ b/projects/packages/licensing/tests/php/abilities/class-licensing-abilities-test-stub.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Subclass that swaps in stub seams for Licensing_Abilities tests.
+ *
+ * Lets the tests drive `attach_licenses`, `last_error`, and the underlying
+ * `fetch_user_licenses` hook without depending on a real Jetpack connection
+ * or hitting WordPress.com over the network.
+ *
+ * @package automattic/jetpack-licensing
+ */
+
+namespace Automattic\Jetpack\Licensing\Abilities;
+
+use Automattic\Jetpack\Licensing;
+use WP_Error;
+
+/**
+ * Test stub for Licensing_Abilities.
+ */
+class Licensing_Abilities_Test_Stub extends Licensing_Abilities {
+
+	/**
+	 * Optional WP_Error injection for the fetch seam. When set, overrides any
+	 * value in `Licensing_Abilities_Test::$stub_license_items`.
+	 *
+	 * @var WP_Error|null
+	 */
+	public static $stub_fetch_error = null;
+
+	/**
+	 * Return a minimal anonymous Licensing-compatible object that proxies
+	 * `attach_licenses` and `last_error` to test-controlled scalars.
+	 *
+	 * @return Licensing
+	 */
+	protected static function get_licensing(): Licensing {
+		// Anonymous subclass keeps the type contract (`extends Licensing`)
+		// without instantiating the parent's hook surface.
+		return new class() extends Licensing {
+			// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+			public function attach_licenses( array $licenses ) {
+				unset( $licenses ); // Stub: tests assert on caller, not arg shape.
+				return Licensing_Abilities_Test::$stub_attach_return;
+			}
+
+			public function last_error() {
+				return Licensing_Abilities_Test::$stub_last_error;
+			}
+			// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+		};
+	}
+
+	/**
+	 * Override the WP.com fetch with the test fixture.
+	 *
+	 * @return array|WP_Error
+	 */
+	protected static function fetch_user_licenses() {
+		if ( null !== self::$stub_fetch_error ) {
+			return self::$stub_fetch_error;
+		}
+		return Licensing_Abilities_Test::$stub_license_items;
+	}
+}


### PR DESCRIPTION
## Summary

Ships three Jetpack Licensing abilities through the WordPress Abilities API (per RSM Abilities Everywhere plan §4.2):

- `jetpack-licensing/list-licenses` — Filtered read over `Licensing::get_user_licenses()` with `status` (`active` | `expired` | `attached` | `detached`), `license_id`, and pagination. Returns a uniform `{ id, slug, product_name, attached_at, status, expires_at }` array.
- `jetpack-licensing/get-error-info` — Reads the latest license-attach error stored by the Licensing package (`Licensing::last_error`). Read-only.
- `jetpack-licensing/attach-license` — Wraps `Licensing::attach_licenses()`. Idempotent: re-attaching an already-attached key returns `attached=true`. On failure returns `{ attached: false, error: { code, message } }` with the upstream code mapped to the `jetpack_licensing_*` vocabulary.

Wiring is done via `projects/packages/licensing/actions.php` (canonical guarded pattern matching publicize / connection). Registration is gated by `jetpack_wp_abilities_enabled` (default false) through the `Registrar` base class.

Permissions reuse the existing `Endpoints::can_manage_options_check` gate (`current_user_can( 'manage_options' )`) so the abilities don't drift from the REST surface they wrap.

## Test plan

- [x] `cd projects/packages/licensing && composer phpunit -- --filter Licensing_Abilities_Test` — 30 tests, 127 assertions, all green.
- [x] Full package suite (`composer phpunit`) — 46 tests, 188 assertions, all green.
- [x] `pnpm php:lint` clean on new files.
- [ ] Manual: with `jetpack_wp_abilities_enabled` filter set true on a Jetpack-connected site, `wp_get_abilities()` lists the three new slugs and `/wp-json/wp-abilities/v1/abilities` exposes them.