### PR TITLE
Subscribers Dashboard abilities: register subscriber reads + delete via Registrar

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -795,3 +795,10 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 }
 
 wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Subscribers_List' );
+
+// Register Subscribers Dashboard abilities (WordPress Abilities API, WP 6.9+).
+// Co-located with the REST controller because the abilities are a thin wrapper
+// over its routes, so they must share the same modernization gate to register.
+if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
+	\Automattic\Jetpack\Plugin\Abilities\Subscribers_Dashboard_Abilities::init();
+}

--- a/projects/plugins/jetpack/changelog/add-subscribers-dashboard-abilities
+++ b/projects/plugins/jetpack/changelog/add-subscribers-dashboard-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Abilities API: register jetpack-subscribers/list-subscribers, /get-summary, /delete-subscriber, and /bulk-delete-subscribers for WP 6.9+, gated behind the newsletter modernization filter.

--- a/projects/plugins/jetpack/src/abilities/class-subscribers-dashboard-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-subscribers-dashboard-abilities.php
@@ -1,0 +1,454 @@
+<?php
+/**
+ * Jetpack Subscribers Dashboard Abilities Registration
+ *
+ * Registers Subscribers Dashboard abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_REST_Request;
+
+/**
+ * Registers Subscribers Dashboard abilities with the WordPress Abilities API.
+ *
+ * Exposes read access to the site's subscriber list and totals, plus a
+ * single-item and bulk delete, by delegating to the existing
+ * `WPCOM_REST_API_V2_Endpoint_Subscribers_List` controller (the same one the
+ * dashboard React UI calls). Keeping the abilities as a thin wrapper means
+ * the controller stays the single source of truth for permission gates,
+ * pagination semantics, and the WPCOM proxy shape — and lets agents and the
+ * dashboard share identical results.
+ *
+ * Only registered when the `rsm_jetpack_ui_modernization_newsletter` filter
+ * returns true, mirroring the controller's own registration gate.
+ */
+class Subscribers_Dashboard_Abilities extends Registrar {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-subscribers';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			'label'       => __( 'Jetpack Subscribers', 'jetpack' ),
+			'description' => __( 'Abilities for inspecting and managing newsletter subscribers via the Subscribers Dashboard.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-subscribers/list-subscribers'        => array(
+				'label'               => __( 'List newsletter subscribers', 'jetpack' ),
+				'description'         => __( 'Return a page of the site\'s subscribers (free + paid, email + WPCOM). Mirrors the Subscribers Dashboard list view: page/per_page pagination, optional search, optional filters[] (e.g. "email_subscriber", "wpcom_subscriber", "paid", "unconfirmed"), and a sort/sort_order pair. The response passes through the WPCOM `/sites/{id}/subscribers` body unchanged so callers see the same shape the dashboard renders. These abilities are only registered when the newsletter modernization filter is on; if they are absent from wp_get_abilities() the modernization rollout has not reached this site yet.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'page'       => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'default'     => 1,
+							'description' => __( '1-based page number.', 'jetpack' ),
+						),
+						'per_page'   => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 100,
+							'default'     => 10,
+							'description' => __( 'Subscribers per page (1-100).', 'jetpack' ),
+						),
+						'search'     => array(
+							'type'        => 'string',
+							'default'     => '',
+							'description' => __( 'Optional case-insensitive substring match against subscriber name or email.', 'jetpack' ),
+						),
+						'sort'       => array(
+							'type'        => 'string',
+							'enum'        => array( 'date_subscribed', 'name', 'plan', 'subscription_status' ),
+							'default'     => 'date_subscribed',
+							'description' => __( 'Sort column.', 'jetpack' ),
+						),
+						'sort_order' => array(
+							'type'        => 'string',
+							'enum'        => array( 'asc', 'desc' ),
+							'default'     => 'desc',
+							'description' => __( 'Sort direction.', 'jetpack' ),
+						),
+						'filters'    => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'default'     => array( 'all' ),
+							'description' => __( 'Filter slugs passed through to WPCOM, e.g. ["all"], ["email_subscriber"], ["paid"].', 'jetpack' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'WPCOM `/sites/{id}/subscribers` response (passthrough). Typically includes `subscribers` and `total` keys.', 'jetpack' ),
+				),
+				'execute_callback'    => array( __CLASS__, 'list_subscribers' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_subscribers' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-subscribers/get-summary'             => array(
+				'label'               => __( 'Get subscriber totals summary', 'jetpack' ),
+				'description'         => __( 'Zero-arg summary of the site\'s subscriber counts (totals across email/WPCOM/paid/unconfirmed buckets). Passthrough of the WPCOM `/sites/{id}/subscribers/counts` response. Read-only and idempotent.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'WPCOM `/sites/{id}/subscribers/counts` response (passthrough).', 'jetpack' ),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_summary' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_subscribers' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-subscribers/delete-subscriber'       => array(
+				'label'               => __( 'Delete a subscriber', 'jetpack' ),
+				'description'         => __( 'Remove a single subscriber. A subscriber on WP.com is the union of up to three records: a wpcom follower (user_id), an email-only follower (email_subscription_id), and zero or more paid memberships (paid_subscription_ids). Provide whichever identifiers apply to the subscriber returned by list-subscribers — at least one is required. The underlying remove call is best-effort per step and surfaces partial failures in `errors`. Returns { ok, errors } where ok is true only when every step succeeded. Destructive.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'user_id'               => array(
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'default'     => 0,
+							'description' => __( 'WPCOM follower user id. 0 (or omit) when the subscriber is email-only.', 'jetpack' ),
+						),
+						'email_subscription_id' => array(
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'default'     => 0,
+							'description' => __( 'Email follower subscription id. 0 (or omit) when the subscriber is WPCOM-only.', 'jetpack' ),
+						),
+						'paid_subscription_ids' => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'default'     => array(),
+							'description' => __( 'Memberships subscription ids to cancel before removal. Empty when the subscriber has no paid plans.', 'jetpack' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'ok'     => array( 'type' => 'boolean' ),
+						'errors' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'step'  => array( 'type' => 'string' ),
+									'id'    => array( 'type' => 'string' ),
+									'error' => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'delete_subscriber' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_subscribers' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-subscribers/bulk-delete-subscribers' => array(
+				'label'               => __( 'Bulk-delete subscribers', 'jetpack' ),
+				'description'         => __( 'Delete up to 100 subscribers in a single call. Each item is processed via the same per-subscriber remove flow as jetpack-subscribers/delete-subscriber; partial failures are reported per item in `failed[]` while successful removals appear in `deleted[]`. The aggregate `ok` is true only when every item succeeded. Destructive.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'subscribers' ),
+					'properties'           => array(
+						'subscribers' => array(
+							'type'        => 'array',
+							'minItems'    => 1,
+							'maxItems'    => 100,
+							'description' => __( 'List of per-subscriber identifier objects (same shape as jetpack-subscribers/delete-subscriber input).', 'jetpack' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'user_id' => array(
+										'type'    => 'integer',
+										'minimum' => 0,
+										'default' => 0,
+									),
+									'email_subscription_id' => array(
+										'type'    => 'integer',
+										'minimum' => 0,
+										'default' => 0,
+									),
+									'paid_subscription_ids' => array(
+										'type'    => 'array',
+										'items'   => array( 'type' => 'string' ),
+										'default' => array(),
+									),
+								),
+								'additionalProperties' => false,
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'ok'      => array( 'type' => 'boolean' ),
+						'deleted' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'index'   => array( 'type' => 'integer' ),
+									'user_id' => array( 'type' => 'integer' ),
+									'email_subscription_id' => array( 'type' => 'integer' ),
+								),
+							),
+						),
+						'failed'  => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'index'  => array( 'type' => 'integer' ),
+									'errors' => array(
+										'type'  => 'array',
+										'items' => array(
+											'type'       => 'object',
+											'properties' => array(
+												'step'  => array( 'type' => 'string' ),
+												'id'    => array( 'type' => 'string' ),
+												'error' => array( 'type' => 'string' ),
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'bulk_delete_subscribers' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_subscribers' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check — `manage_options` matches the wp-admin Subscribers menu cap
+	 * and the underlying REST controller's gate.
+	 */
+	public static function can_manage_subscribers(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: list subscribers. Thin wrapper around the existing
+	 * `/wpcom/v2/subscribers/list` controller so the abilities surface and the
+	 * dashboard UI return identical results.
+	 *
+	 * @param array|null $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function list_subscribers( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/subscribers/list' );
+		foreach (
+			array(
+				'page',
+				'per_page',
+				'search',
+				'sort',
+				'sort_order',
+				'filters',
+			) as $param
+		) {
+			if ( array_key_exists( $param, $input ) ) {
+				$request->set_param( $param, $input[ $param ] );
+			}
+		}
+
+		return static::dispatch( $request );
+	}
+
+	/**
+	 * Execute: summary totals. Thin wrapper around `/wpcom/v2/subscribers/totals`.
+	 *
+	 * @param array|null $input Ignored (zero-arg).
+	 * @return array|\WP_Error
+	 */
+	public static function get_summary( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/subscribers/totals' );
+		return static::dispatch( $request );
+	}
+
+	/**
+	 * Execute: delete a single subscriber via the existing per-subscriber remove
+	 * flow on the REST controller. Preserves the controller's partial-failure
+	 * shape (`{ ok, errors }`) so callers can distinguish full success from
+	 * partial success.
+	 *
+	 * @param array|null $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function delete_subscriber( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$user_id               = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
+		$email_subscription_id = isset( $input['email_subscription_id'] ) ? (int) $input['email_subscription_id'] : 0;
+		$paid_subscription_ids = isset( $input['paid_subscription_ids'] ) && is_array( $input['paid_subscription_ids'] )
+			? array_values( $input['paid_subscription_ids'] )
+			: array();
+
+		if ( ! $user_id && ! $email_subscription_id && empty( $paid_subscription_ids ) ) {
+			return new \WP_Error(
+				'jetpack_subscribers_delete_invalid',
+				__( 'Provide at least one identifier (user_id, email_subscription_id, or paid_subscription_ids) for the subscriber to delete.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/subscribers/remove' );
+		$request->set_param( 'user_id', $user_id );
+		$request->set_param( 'email_subscription_id', $email_subscription_id );
+		$request->set_param( 'paid_subscription_ids', $paid_subscription_ids );
+
+		return static::dispatch( $request );
+	}
+
+	/**
+	 * Execute: bulk delete. Iterates over the singular delete because the
+	 * underlying WPCOM API does not expose a bulk endpoint, and we want the
+	 * same per-step partial-failure visibility users get from the single-item
+	 * dashboard delete.
+	 *
+	 * Capped at 100 by the input schema. The cap matches the dashboard's
+	 * pagination ceiling and keeps the operation bounded in a single request.
+	 *
+	 * @param array|null $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public static function bulk_delete_subscribers( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+		if ( ! isset( $input['subscribers'] ) || ! is_array( $input['subscribers'] ) || empty( $input['subscribers'] ) ) {
+			return new \WP_Error(
+				'jetpack_subscribers_bulk_delete_empty',
+				__( 'Provide a non-empty subscribers[] array.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$deleted = array();
+		$failed  = array();
+
+		foreach ( $input['subscribers'] as $index => $entry ) {
+			$entry  = is_array( $entry ) ? $entry : array();
+			$result = static::delete_subscriber( $entry );
+
+			$user_id               = isset( $entry['user_id'] ) ? (int) $entry['user_id'] : 0;
+			$email_subscription_id = isset( $entry['email_subscription_id'] ) ? (int) $entry['email_subscription_id'] : 0;
+
+			if ( is_wp_error( $result ) ) {
+				$failed[] = array(
+					'index'  => (int) $index,
+					'errors' => array(
+						array(
+							'step'  => 'dispatch',
+							'id'    => '',
+							'error' => $result->get_error_message(),
+						),
+					),
+				);
+				continue;
+			}
+
+			$ok          = isset( $result['ok'] ) ? (bool) $result['ok'] : false;
+			$step_errors = isset( $result['errors'] ) && is_array( $result['errors'] ) ? $result['errors'] : array();
+
+			if ( $ok && empty( $step_errors ) ) {
+				$deleted[] = array(
+					'index'                 => (int) $index,
+					'user_id'               => $user_id,
+					'email_subscription_id' => $email_subscription_id,
+				);
+			} else {
+				$failed[] = array(
+					'index'  => (int) $index,
+					'errors' => $step_errors,
+				);
+			}
+		}
+
+		return array(
+			'ok'      => empty( $failed ),
+			'deleted' => $deleted,
+			'failed'  => $failed,
+		);
+	}
+
+	/**
+	 * Dispatch a `WP_REST_Request` through the REST server and normalize the
+	 * response into the ability return shape. Extracted as a protected seam so
+	 * tests can stub the REST hop without booting the full server.
+	 *
+	 * @param WP_REST_Request $request Request to dispatch.
+	 * @return array|\WP_Error
+	 */
+	protected static function dispatch( WP_REST_Request $request ) {
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$data = $response->get_data();
+		return is_array( $data ) ? $data : array( 'data' => $data );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Subscribers_Dashboard_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Subscribers_Dashboard_Abilities_Test.php
@@ -1,0 +1,591 @@
+<?php
+/**
+ * Tests for the Subscribers_Dashboard_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Plugin\Abilities\Subscribers_Dashboard_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once __DIR__ . '/class-subscribers-dashboard-abilities-test-stub.php';
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Subscribers_Dashboard_Abilities
+ */
+#[CoversClass( Subscribers_Dashboard_Abilities::class )]
+class Subscribers_Dashboard_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Administrator user id, created once per test.
+	 *
+	 * @var integer
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id, created once per test.
+	 *
+	 * @var integer
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'subs_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'subs_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		Subscribers_Dashboard_Abilities_Test_Stub::reset();
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_abilities' ) );
+
+		// Unregister anything this test left behind so the singleton registry stays clean
+		// between tests (the WP Abilities Registry persists across tests within a process).
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Subscribers_Dashboard_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Subscribers_Dashboard_Abilities::get_category_slug() );
+		}
+
+		Subscribers_Dashboard_Abilities_Test_Stub::reset();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so registrations
+	 * happen inside the action callstack — `wp_register_ability(_category)` enforces
+	 * `doing_action()`, so direct invocation outside the hook is rejected.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	/**
+	 * Category slug is namespaced under the plugin.
+	 */
+	public function test_category_slug_is_namespaced() {
+		$this->assertSame( 'jetpack-subscribers', Subscribers_Dashboard_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Subscribers_Dashboard_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Subscribers_Dashboard_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-subscribers/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Subscribers_Dashboard_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_surface_exposes_expected_abilities() {
+		$abilities = Subscribers_Dashboard_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-subscribers/list-subscribers', $abilities );
+		$this->assertArrayHasKey( 'jetpack-subscribers/get-summary', $abilities );
+		$this->assertArrayHasKey( 'jetpack-subscribers/delete-subscriber', $abilities );
+		$this->assertArrayHasKey( 'jetpack-subscribers/bulk-delete-subscribers', $abilities );
+	}
+
+	public function test_list_subscribers_is_annotated_readonly_idempotent() {
+		$spec = Subscribers_Dashboard_Abilities::get_abilities()['jetpack-subscribers/list-subscribers'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_get_summary_is_annotated_readonly_idempotent() {
+		$spec = Subscribers_Dashboard_Abilities::get_abilities()['jetpack-subscribers/get-summary'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_delete_subscriber_is_annotated_destructive() {
+		$spec = Subscribers_Dashboard_Abilities::get_abilities()['jetpack-subscribers/delete-subscriber'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertTrue( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_bulk_delete_subscribers_is_annotated_destructive() {
+		$spec = Subscribers_Dashboard_Abilities::get_abilities()['jetpack-subscribers/bulk-delete-subscribers'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertTrue( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_bulk_delete_caps_input_at_100() {
+		$spec = Subscribers_Dashboard_Abilities::get_abilities()['jetpack-subscribers/bulk-delete-subscribers'];
+		$this->assertSame( 100, $spec['input_schema']['properties']['subscribers']['maxItems'] );
+		$this->assertSame( 1, $spec['input_schema']['properties']['subscribers']['minItems'] );
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	/**
+	 * Gate filter false => init() short-circuits and hooks nothing.
+	 */
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Subscribers_Dashboard_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Subscribers_Dashboard_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Subscribers_Dashboard_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-subscribers/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( Subscribers_Dashboard_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static function ( $a ) {
+				return $a->get_name();
+			},
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Subscribers_Dashboard_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Subscribers_Dashboard_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-subscribers',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	// -------------------- Permission callback --------------------
+
+	/**
+	 * Admins can manage subscribers.
+	 */
+	public function test_can_manage_subscribers_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Subscribers_Dashboard_Abilities::can_manage_subscribers() );
+	}
+
+	public function test_can_manage_subscribers_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Subscribers_Dashboard_Abilities::can_manage_subscribers() );
+	}
+
+	public function test_can_manage_subscribers_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Subscribers_Dashboard_Abilities::can_manage_subscribers() );
+	}
+
+	// -------------------- Input validation --------------------
+
+	/**
+	 * Refuses to dispatch when no identifier is provided.
+	 */
+	public function test_delete_subscriber_rejects_empty_input() {
+		wp_set_current_user( $this->admin_id );
+		$result = Subscribers_Dashboard_Abilities::delete_subscriber( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_subscribers_delete_invalid', $result->get_error_code() );
+	}
+
+	public function test_delete_subscriber_rejects_null_input() {
+		wp_set_current_user( $this->admin_id );
+		$result = Subscribers_Dashboard_Abilities::delete_subscriber( null );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_subscribers_delete_invalid', $result->get_error_code() );
+	}
+
+	public function test_delete_subscriber_rejects_zero_only_identifiers() {
+		// All identifiers present but all zero/empty — same effective state as omitting them,
+		// so the validator should refuse the call before dispatching.
+		wp_set_current_user( $this->admin_id );
+		$result = Subscribers_Dashboard_Abilities::delete_subscriber(
+			array(
+				'user_id'               => 0,
+				'email_subscription_id' => 0,
+				'paid_subscription_ids' => array(),
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_subscribers_delete_invalid', $result->get_error_code() );
+	}
+
+	public function test_bulk_delete_rejects_missing_subscribers_key() {
+		wp_set_current_user( $this->admin_id );
+		$result = Subscribers_Dashboard_Abilities::bulk_delete_subscribers( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_subscribers_bulk_delete_empty', $result->get_error_code() );
+	}
+
+	public function test_bulk_delete_rejects_empty_subscribers_array() {
+		wp_set_current_user( $this->admin_id );
+		$result = Subscribers_Dashboard_Abilities::bulk_delete_subscribers( array( 'subscribers' => array() ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_subscribers_bulk_delete_empty', $result->get_error_code() );
+	}
+
+	// -------------------- Execute happy paths (via stub) --------------------
+
+	/**
+	 * Forwards every recognized input parameter onto the dispatched
+	 * WP_REST_Request so the controller sees the same shape.
+	 */
+	public function test_list_subscribers_passes_input_through_to_dispatched_request() {
+		wp_set_current_user( $this->admin_id );
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'subscribers' => array(),
+				'total'       => 0,
+			)
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::list_subscribers(
+			array(
+				'page'       => 2,
+				'per_page'   => 25,
+				'search'     => 'bob',
+				'sort'       => 'name',
+				'sort_order' => 'asc',
+				'filters'    => array( 'email_subscriber' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'subscribers' => array(),
+				'total'       => 0,
+			),
+			$result
+		);
+		$this->assertSame( 1, Subscribers_Dashboard_Abilities_Test_Stub::$dispatch_calls );
+
+		$request = Subscribers_Dashboard_Abilities_Test_Stub::$last_request;
+		$this->assertInstanceOf( \WP_REST_Request::class, $request );
+		$this->assertSame( '/wpcom/v2/subscribers/list', $request->get_route() );
+		$this->assertSame( 'GET', $request->get_method() );
+		$this->assertSame( 2, $request->get_param( 'page' ) );
+		$this->assertSame( 25, $request->get_param( 'per_page' ) );
+		$this->assertSame( 'bob', $request->get_param( 'search' ) );
+		$this->assertSame( 'name', $request->get_param( 'sort' ) );
+		$this->assertSame( 'asc', $request->get_param( 'sort_order' ) );
+		$this->assertSame( array( 'email_subscriber' ), $request->get_param( 'filters' ) );
+	}
+
+	public function test_list_subscribers_returns_wp_error_on_dispatch_failure() {
+		wp_set_current_user( $this->admin_id );
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			new \WP_Error( 'subscribers_list_failed', 'wpcom is sad', array( 'status' => 502 ) )
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::list_subscribers( array( 'page' => 1 ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'subscribers_list_failed', $result->get_error_code() );
+	}
+
+	public function test_get_summary_dispatches_totals_route_with_no_params() {
+		wp_set_current_user( $this->admin_id );
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'counts' => array(
+					'total_subscribers' => 42,
+					'email_subscribers' => 30,
+					'social_followers'  => 10,
+					'paid_subscribers'  => 2,
+				),
+			)
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::get_summary();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 42, $result['counts']['total_subscribers'] );
+		$request = Subscribers_Dashboard_Abilities_Test_Stub::$last_request;
+		$this->assertSame( '/wpcom/v2/subscribers/totals', $request->get_route() );
+		$this->assertSame( 'GET', $request->get_method() );
+	}
+
+	public function test_delete_subscriber_dispatches_remove_route_with_all_ids() {
+		wp_set_current_user( $this->admin_id );
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'ok'     => true,
+				'errors' => array(),
+			)
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::delete_subscriber(
+			array(
+				'user_id'               => 7,
+				'email_subscription_id' => 0,
+				'paid_subscription_ids' => array( 'sub_42' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['ok'] );
+		$this->assertSame( array(), $result['errors'] );
+
+		$request = Subscribers_Dashboard_Abilities_Test_Stub::$last_request;
+		$this->assertSame( '/wpcom/v2/subscribers/remove', $request->get_route() );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( 7, $request->get_param( 'user_id' ) );
+		$this->assertSame( 0, $request->get_param( 'email_subscription_id' ) );
+		$this->assertSame( array( 'sub_42' ), $request->get_param( 'paid_subscription_ids' ) );
+	}
+
+	public function test_delete_subscriber_passes_through_partial_failure_shape() {
+		// Controller signals partial failure with ok=false + per-step errors[]; abilities
+		// must surface that exactly, not mask it as a WP_Error.
+		wp_set_current_user( $this->admin_id );
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'ok'     => false,
+				'errors' => array(
+					array(
+						'step'  => 'cancel_paid_subscription',
+						'id'    => 'sub_42',
+						'error' => 'wpcom said no',
+					),
+				),
+			)
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::delete_subscriber(
+			array(
+				'user_id'               => 7,
+				'paid_subscription_ids' => array( 'sub_42' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['ok'] );
+		$this->assertCount( 1, $result['errors'] );
+		$this->assertSame( 'cancel_paid_subscription', $result['errors'][0]['step'] );
+	}
+
+	public function test_bulk_delete_aggregates_successes_and_failures() {
+		// Three subscribers: first succeeds, second fails per-step (controller ok=false),
+		// third fails at dispatch (WP_Error). The aggregate `ok` is false because at least
+		// one entry failed, and each failure surfaces with its 0-based index for callers.
+		wp_set_current_user( $this->admin_id );
+
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'ok'     => true,
+				'errors' => array(),
+			)
+		);
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'ok'     => false,
+				'errors' => array(
+					array(
+						'step'  => 'delete_follower',
+						'id'    => '7',
+						'error' => 'wpcom said no',
+					),
+				),
+			)
+		);
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			new \WP_Error( 'subscribers_list_failed', 'transport down', array( 'status' => 502 ) )
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::bulk_delete_subscribers(
+			array(
+				'subscribers' => array(
+					array( 'user_id' => 1 ),
+					array( 'user_id' => 7 ),
+					array( 'email_subscription_id' => 99 ),
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['ok'] );
+
+		$this->assertCount( 1, $result['deleted'] );
+		$this->assertSame( 0, $result['deleted'][0]['index'] );
+		$this->assertSame( 1, $result['deleted'][0]['user_id'] );
+
+		$this->assertCount( 2, $result['failed'] );
+		$this->assertSame( 1, $result['failed'][0]['index'] );
+		$this->assertSame( 'delete_follower', $result['failed'][0]['errors'][0]['step'] );
+		$this->assertSame( 2, $result['failed'][1]['index'] );
+		$this->assertSame( 'dispatch', $result['failed'][1]['errors'][0]['step'] );
+
+		// Every input entry should have triggered exactly one dispatch.
+		$this->assertSame( 3, Subscribers_Dashboard_Abilities_Test_Stub::$dispatch_calls );
+	}
+
+	public function test_bulk_delete_short_circuits_on_invalid_entry_without_dispatch() {
+		// Bulk delegates to delete_subscriber(), which validates each entry up-front.
+		// An entry with no identifiers must fail fast and contribute to failed[] without
+		// reaching the dispatch seam.
+		wp_set_current_user( $this->admin_id );
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::bulk_delete_subscribers(
+			array(
+				'subscribers' => array(
+					array(),
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['ok'] );
+		$this->assertSame( array(), $result['deleted'] );
+		$this->assertCount( 1, $result['failed'] );
+		$this->assertSame( 0, $result['failed'][0]['index'] );
+		$this->assertSame( 'dispatch', $result['failed'][0]['errors'][0]['step'] );
+		$this->assertSame( 0, Subscribers_Dashboard_Abilities_Test_Stub::$dispatch_calls );
+	}
+
+	public function test_bulk_delete_all_success_marks_ok_true() {
+		wp_set_current_user( $this->admin_id );
+
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'ok'     => true,
+				'errors' => array(),
+			)
+		);
+		Subscribers_Dashboard_Abilities_Test_Stub::enqueue_response(
+			array(
+				'ok'     => true,
+				'errors' => array(),
+			)
+		);
+
+		$result = Subscribers_Dashboard_Abilities_Test_Stub::bulk_delete_subscribers(
+			array(
+				'subscribers' => array(
+					array( 'user_id' => 1 ),
+					array( 'email_subscription_id' => 5 ),
+				),
+			)
+		);
+
+		$this->assertTrue( $result['ok'] );
+		$this->assertCount( 2, $result['deleted'] );
+		$this->assertSame( array(), $result['failed'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/class-subscribers-dashboard-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-subscribers-dashboard-abilities-test-stub.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Test-only subclass of Subscribers_Dashboard_Abilities that overrides the
+ * REST dispatch seam so callbacks can be exercised end-to-end without booting
+ * the real REST server or hitting the WPCOM proxy.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Plugin\Abilities\Subscribers_Dashboard_Abilities;
+
+/**
+ * Test double overriding the dispatch seam on Subscribers_Dashboard_Abilities.
+ *
+ * - Each test queues responses via `enqueue_response()`; calls pop from the
+ *   queue in FIFO order so a single test can verify a per-item bulk delete
+ *   sequence that mixes successes and failures.
+ * - `last_request` captures the most recent dispatched WP_REST_Request so
+ *   tests can assert the route and parameters passed through.
+ */
+class Subscribers_Dashboard_Abilities_Test_Stub extends Subscribers_Dashboard_Abilities {
+
+	/**
+	 * FIFO queue of seeded responses.
+	 *
+	 * @var array<int, array|\WP_Error>
+	 */
+	public static $responses = array();
+
+	/**
+	 * Number of dispatch() calls captured.
+	 *
+	 * @var integer
+	 */
+	public static $dispatch_calls = 0;
+
+	/**
+	 * The most recent dispatched request.
+	 *
+	 * @var \WP_REST_Request|null
+	 */
+	public static $last_request = null;
+
+	/**
+	 * Reset all captured state between tests.
+	 */
+	public static function reset(): void {
+		self::$responses      = array();
+		self::$dispatch_calls = 0;
+		self::$last_request   = null;
+	}
+
+	/**
+	 * Push a single response onto the queue.
+	 *
+	 * @param array|\WP_Error $response Response shape (array) or error.
+	 */
+	public static function enqueue_response( $response ): void {
+		self::$responses[] = $response;
+	}
+
+	/**
+	 * Override the dispatch seam: pop the next seeded response without touching
+	 * the REST server. Falls through to an empty array if the test under-seeds.
+	 *
+	 * @param \WP_REST_Request $request Request that would have been dispatched.
+	 *
+	 * @return array|\WP_Error
+	 */
+	protected static function dispatch( \WP_REST_Request $request ) {
+		++self::$dispatch_calls;
+		self::$last_request = $request;
+
+		if ( empty( self::$responses ) ) {
+			return array();
+		}
+		return array_shift( self::$responses );
+	}
+}


### PR DESCRIPTION
## Summary

Registers the first batch of Subscribers Dashboard abilities via the `Registrar` base class, exposing them on the standard `wp-abilities/v1` REST surface so agents and other clients can drive the dashboard programmatically.

Surface (category `jetpack-subscribers`):

- `jetpack-subscribers/list-subscribers` — read-only, idempotent. Paged + filtered subscriber list. Thin wrapper over `/wpcom/v2/subscribers/list`.
- `jetpack-subscribers/get-summary` — read-only, idempotent. Zero-arg counts summary. Wrapper over `/wpcom/v2/subscribers/totals`.
- `jetpack-subscribers/delete-subscriber` — destructive, idempotent. Removes one subscriber via composite `{ user_id, email_subscription_id, paid_subscription_ids }`. Wrapper over `/wpcom/v2/subscribers/remove`. Preserves the controller's per-step partial-failure shape (`{ ok, errors }`).
- `jetpack-subscribers/bulk-delete-subscribers` — destructive, idempotent. Iterates the singular delete (cap: 100), aggregates results into `{ ok, deleted, failed }`.

Implementation notes:

- Class lives at `projects/plugins/jetpack/src/abilities/class-subscribers-dashboard-abilities.php` and mirrors the Monitor abilities precedent — the abilities wrap REST controllers that already live in the Jetpack plugin (not in the `subscribers-dashboard` package, which only ships the wp-admin menu shell + React entry point).
- Registration is wired from inside `class-wpcom-rest-api-v2-endpoint-subscribers-list.php` and gated behind the same `rsm_jetpack_ui_modernization_newsletter` filter the underlying REST controller uses. When the filter is off, the abilities are simply absent from `wp_get_abilities()`.
- Permission gate: `current_user_can( 'manage_options' )` — matches the REST controller's `permission_check`.
- Dispatch is implemented as a `protected static` seam (`dispatch()`) so the WP_UnitTestCase suite can stub the REST hop without booting the controller / WPCOM round-trip.

Plan reference: §4.2.

Deferred (per plan): `jetpack-subscribers/export-subscribers` — heavy operation, defer.

Contract deltas from the original plan, all driven by the actual REST surface in the Jetpack plugin:

- `list-subscribers` returns the WPCOM list passthrough (`subscribers` + `total`), not a normalized per-entry shape. The controller is the source of truth for fields.
- `delete-subscriber` takes the composite-id triple instead of a single integer `id` — that's how the wpcom remove flow is structured (a single "subscriber" is up to three records: wpcom follower, email follower, paid memberships).
- `bulk-delete-subscribers` accepts a `subscribers[]` of those same id objects since there is no remote bulk endpoint; the abilities loop the singular delete with per-item partial-failure surfacing.
- `get-summary` returns the WPCOM `/subscribers/counts` body verbatim instead of a normalized field set.

## Test plan

- [ ] CI green on `Subscribers_Dashboard_Abilities_Test` (PHP 7.2 - latest) — local PHPUnit can't run WP_UnitTestCase without docker; tests pre-validated via PHP smoke runs (input validation, bulk aggregation, list/summary parameter passthrough).
- [ ] Manually verify with the modernization filter on: `wp ability list --category=jetpack-subscribers` returns all 4 slugs.
- [ ] With the filter off, `wp ability list --category=jetpack-subscribers` is empty.
- [ ] As an admin, `wp ability execute jetpack-subscribers/get-summary` returns the same body the dashboard's totals call shows.
- [ ] As an admin, `wp ability execute jetpack-subscribers/list-subscribers '{"page":1,"per_page":5}'` returns the same shape the dashboard's list call shows.
- [ ] As a subscriber-role user, every ability is rejected by the permission gate.