### PR TITLE
Image CDN abilities: register status reads via Registrar

### DIFF
--- a/projects/packages/image-cdn/actions.php
+++ b/projects/packages/image-cdn/actions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Action Hooks for the Jetpack Image CDN package.
+ *
+ * Registers the package's WP Abilities surface from `plugins_loaded`.
+ * `Image_CDN_Abilities::init()` is gated internally by the
+ * `jetpack_wp_abilities_enabled` filter (default false), so it is safe
+ * to call unconditionally from every consumer of this package
+ * (Jetpack plugin's Photon module, Boost, etc.).
+ *
+ * @package automattic/jetpack-image-cdn
+ */
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', array( Automattic\Jetpack\Image_CDN\Abilities\Image_CDN_Abilities::class, 'init' ), 1 );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][1][] = array(
+		'accepted_args' => 0,
+		'function'      => array( Automattic\Jetpack\Image_CDN\Abilities\Image_CDN_Abilities::class, 'init' ),
+	);
+}

--- a/projects/packages/image-cdn/changelog/add-image-cdn-abilities
+++ b/projects/packages/image-cdn/changelog/add-image-cdn-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register jetpack-image-cdn/get-status for WP 6.9+.

--- a/projects/packages/image-cdn/composer.json
+++ b/projects/packages/image-cdn/composer.json
@@ -6,7 +6,8 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-assets": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-test-environment": "@dev",
@@ -19,6 +20,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/image-cdn/src/abilities/class-image-cdn-abilities.php
+++ b/projects/packages/image-cdn/src/abilities/class-image-cdn-abilities.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Jetpack Image CDN Abilities Registration.
+ *
+ * Registers Jetpack Image CDN abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-image-cdn
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Image_CDN\Abilities;
+
+use Automattic\Jetpack\Image_CDN\Image_CDN;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack Image CDN abilities with the WordPress Abilities API.
+ *
+ * Exposes a single read-only ability that lets an agent inspect whether
+ * the Image CDN (Photon) is active on the current site, the effective
+ * CDN domain, and the set of image types eligible for proxying. Reads
+ * only — no writes are exposed from this package. Consumers (Jetpack
+ * plugin's Photon module, Boost, ...) own the activation toggle and
+ * any per-site settings UI; this ability surface is intentionally a
+ * status reporter, not a controller.
+ */
+class Image_CDN_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-image-cdn';
+
+	/**
+	 * Default Photon CDN host used by Image_CDN_Core::cdn_url() when no
+	 * site-specific override is registered via the `jetpack_photon_domain`
+	 * filter. Kept in sync with class-image-cdn-core.php.
+	 */
+	const DEFAULT_CDN_DOMAIN = 'https://i0.wp.com';
+
+	/**
+	 * Map of supported file extensions to their canonical IANA MIME types.
+	 *
+	 * Mirrors Image_CDN::$extensions and converts each entry to a MIME
+	 * type so callers can match against `get_post_mime_type()` results
+	 * without re-deriving the mapping. `jpg` and `jpeg` both map to
+	 * `image/jpeg`; downstream callers should de-duplicate by MIME type
+	 * rather than by extension if they need a unique set.
+	 */
+	const EXTENSION_TO_MIME = array(
+		'gif'  => 'image/gif',
+		'jpg'  => 'image/jpeg',
+		'jpeg' => 'image/jpeg',
+		'png'  => 'image/png',
+		'webp' => 'image/webp',
+		'heic' => 'image/heic',
+	);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Image CDN',
+			'description' => __( 'Abilities for inspecting the Jetpack Image CDN (Photon) status, effective CDN domain, and supported image types.', 'jetpack-image-cdn' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-image-cdn/get-status' => self::spec_get_status(),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-image-cdn/get-status.
+	 */
+	private static function spec_get_status(): array {
+		return array(
+			'label'               => __( 'Get Image CDN status', 'jetpack-image-cdn' ),
+			'description'         => __(
+				'Return the current Image CDN (Photon) configuration for this site in one zero-argument call. Shape: { active: bool, settings: { quality: int|null, formats: [string]|null, srcset_enabled: bool, cdn_domain: string }, supported_mime_types: [string] }. `active` is true when some consumer plugin (Jetpack\'s Photon module, Boost, ...) has loaded the Image CDN; when false, the other fields describe the would-be configuration if it were enabled. `cdn_domain` is the effective host after the `jetpack_photon_domain` filter runs and defaults to `https://i0.wp.com`. `srcset_enabled` is true iff the CDN is active — the package always wires srcset substitution when loaded and exposes no per-site toggle. `quality` and `formats` are `null` because this package owns neither setting; the consumer plugin controls them. `supported_mime_types` is a deduplicated list derived from the package\'s supported extension whitelist. Read-only, idempotent — safe to poll.',
+				'jetpack-image-cdn'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'active'               => array( 'type' => 'boolean' ),
+					'settings'             => array(
+						'type'       => 'object',
+						'properties' => array(
+							'quality'        => array( 'type' => array( 'integer', 'null' ) ),
+							'formats'        => array( 'type' => array( 'array', 'null' ) ),
+							'srcset_enabled' => array( 'type' => 'boolean' ),
+							'cdn_domain'     => array( 'type' => 'string' ),
+						),
+					),
+					'supported_mime_types' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_status' ),
+			'permission_callback' => array( __CLASS__, 'can_view_status' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Permission callback: status reads require `manage_options`.
+	 *
+	 * The Image CDN package has no domain-specific capability of its own
+	 * — activation is owned by the consumer plugin. Reuse the site-admin
+	 * cap so reads are gated against the same audience that owns the
+	 * activation toggle in the consumer plugin's UI.
+	 *
+	 * @return bool
+	 */
+	public static function can_view_status(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: get-status.
+	 *
+	 * Composes the package's static state — activation flag, supported
+	 * extension list, and the effective `jetpack_photon_domain` filter
+	 * output — into the documented response shape. Always returns an
+	 * array; never errors.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_status( $input = null ) {
+		unset( $input );
+
+		$active = Image_CDN::is_enabled();
+
+		// Default applied inside Image_CDN_Core::cdn_url() — mirror the same
+		// filter call here so consumers that override the domain see their
+		// effective value reflected in the status response.
+		/** This filter is documented in src/class-image-cdn-core.php */
+		$cdn_domain = (string) apply_filters( 'jetpack_photon_domain', self::DEFAULT_CDN_DOMAIN, '' );
+		if ( '' === $cdn_domain ) {
+			$cdn_domain = self::DEFAULT_CDN_DOMAIN;
+		}
+
+		return array(
+			'active'               => $active,
+			'settings'             => array(
+				// `quality` and `formats` are owned by the consumer plugin's
+				// settings UI (Jetpack's Photon module, Boost's image
+				// optimizer, etc.) — this package does not store either, so
+				// the only honest answer is `null`. Callers that need them
+				// should consult the consumer plugin's own abilities surface.
+				'quality'        => null,
+				'formats'        => null,
+				'srcset_enabled' => $active,
+				'cdn_domain'     => $cdn_domain,
+			),
+			'supported_mime_types' => self::get_supported_mime_types(),
+		);
+	}
+
+	/**
+	 * Return the de-duplicated list of MIME types the CDN can proxy.
+	 *
+	 * Image_CDN::get_supported_extensions() returns extensions, with
+	 * `jpg` and `jpeg` both present. Project to canonical MIME types
+	 * and de-duplicate by MIME so callers see a clean set.
+	 *
+	 * @return string[]
+	 */
+	private static function get_supported_mime_types(): array {
+		$mimes = array();
+		foreach ( Image_CDN::get_supported_extensions() as $extension ) {
+			$key = strtolower( (string) $extension );
+			if ( isset( self::EXTENSION_TO_MIME[ $key ] ) ) {
+				$mimes[ self::EXTENSION_TO_MIME[ $key ] ] = true;
+			}
+		}
+		return array_keys( $mimes );
+	}
+}

--- a/projects/packages/image-cdn/tests/php/abilities/Image_CDN_Abilities_Test.php
+++ b/projects/packages/image-cdn/tests/php/abilities/Image_CDN_Abilities_Test.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * Tests for the Image_CDN_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-image-cdn
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Image_CDN\Abilities;
+
+use Automattic\Jetpack\Image_CDN\Image_CDN;
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+/**
+ * Unit tests for Image_CDN_Abilities registration and execution.
+ *
+ * Run from projects/packages/image-cdn:
+ *
+ *   composer phpunit -- --filter Image_CDN_Abilities_Test
+ */
+class Image_CDN_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Admin user ID (manage_options).
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Subscriber user ID (no manage_options).
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		self::$admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'image_cdn_abilities_admin_' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'image_cdn_abilities_sub_' . wp_generate_password( 6, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Open the rollout gate for every test except the one that explicitly closes it.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Reset hooks the Registrar may have added during a prior test.
+		remove_action( 'wp_abilities_api_categories_init', array( Image_CDN_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Image_CDN_Abilities::class, 'register_abilities' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_photon_domain' );
+		remove_action( 'wp_abilities_api_categories_init', array( Image_CDN_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Image_CDN_Abilities::class, 'register_abilities' ) );
+		wp_set_current_user( 0 );
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$this->deregister_category_and_abilities();
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Remove our category + abilities from the registry so tests don't bleed.
+	 */
+	private function deregister_category_and_abilities(): void {
+		if ( function_exists( 'wp_has_ability' ) && function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Image_CDN_Abilities::get_abilities() ) as $slug ) {
+				if ( wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_has_ability_category' ) && function_exists( 'wp_unregister_ability_category' ) ) {
+			if ( wp_has_ability_category( Image_CDN_Abilities::CATEGORY_SLUG ) ) {
+				wp_unregister_ability_category( Image_CDN_Abilities::CATEGORY_SLUG );
+			}
+		}
+	}
+
+	/**
+	 * Simulate that the given Abilities API lifecycle action is firing.
+	 *
+	 * @param string $action Action name to simulate.
+	 */
+	private function simulate_doing_action( string $action ): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = $action;
+	}
+
+	/**
+	 * --------------------------------------------------------------------
+	 * Abstract getters.
+	 * --------------------------------------------------------------------
+	 */
+	public function test_category_slug_is_jetpack_image_cdn(): void {
+		$this->assertSame( 'jetpack-image-cdn', Image_CDN_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description(): void {
+		$def = Image_CDN_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotSame( '', $def['label'] );
+		$this->assertNotSame( '', $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced(): void {
+		$abilities = Image_CDN_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-image-cdn/', $slug );
+		}
+	}
+
+	public function test_get_status_is_registered(): void {
+		$abilities = Image_CDN_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-image-cdn/get-status', $abilities );
+	}
+
+	public function test_no_spec_sets_category_explicitly(): void {
+		foreach ( Image_CDN_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_every_spec_declares_annotations_permission_and_execute(): void {
+		foreach ( Image_CDN_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'execute_callback', $spec, "Ability {$slug} missing execute_callback" );
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback is not callable" );
+			$this->assertArrayHasKey( 'permission_callback', $spec, "Ability {$slug} missing permission_callback" );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback is not callable" );
+			$this->assertArrayHasKey( 'meta', $spec, "Ability {$slug} missing meta" );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'], "Ability {$slug} missing meta.annotations" );
+			foreach ( array( 'readonly', 'destructive', 'idempotent' ) as $flag ) {
+				$this->assertArrayHasKey( $flag, $spec['meta']['annotations'], "Ability {$slug} missing annotation {$flag}" );
+				$this->assertIsBool( $spec['meta']['annotations'][ $flag ], "Ability {$slug} annotation {$flag} must be bool" );
+			}
+		}
+	}
+
+	public function test_get_status_is_readonly_idempotent_non_destructive(): void {
+		$spec = Image_CDN_Abilities::get_abilities()['jetpack-image-cdn/get-status'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	/**
+	 * --------------------------------------------------------------------
+	 * Registrar wiring.
+	 * --------------------------------------------------------------------
+	 */
+	public function test_init_with_rollout_disabled_registers_nothing(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		try {
+			Image_CDN_Abilities::init();
+
+			$this->assertFalse(
+				has_action(
+					'wp_abilities_api_categories_init',
+					array( Image_CDN_Abilities::class, 'register_category' )
+				),
+				'No category hook should be added when the rollout filter is false.'
+			);
+			$this->assertFalse(
+				has_action(
+					'wp_abilities_api_init',
+					array( Image_CDN_Abilities::class, 'register_abilities' )
+				),
+				'No abilities hook should be added when the rollout filter is false.'
+			);
+		} finally {
+			remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		}
+	}
+
+	public function test_init_with_rollout_enabled_hooks_both_lifecycle_actions(): void {
+		Image_CDN_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_categories_init',
+				array( Image_CDN_Abilities::class, 'register_category' )
+			),
+			'Category init hook must be added when the rollout filter is true.'
+		);
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_init',
+				array( Image_CDN_Abilities::class, 'register_abilities' )
+			),
+			'Abilities init hook must be added when the rollout filter is true.'
+		);
+	}
+
+	public function test_register_abilities_skips_when_should_register_filter_returns_false(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available' );
+			return;
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			function ( $enabled, $type, $slug ) {
+				if ( 'ability' === $type && 'jetpack-image-cdn/get-status' === $slug ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->simulate_doing_action( 'wp_abilities_api_init' );
+		Image_CDN_Abilities::register_abilities();
+
+		$this->assertFalse(
+			wp_has_ability( 'jetpack-image-cdn/get-status' ),
+			'should_register filter returning false must skip ability registration.'
+		);
+	}
+
+	public function test_register_abilities_registers_get_status_with_category_injected(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available' );
+			return;
+		}
+
+		$this->simulate_doing_action( 'wp_abilities_api_categories_init' );
+		Image_CDN_Abilities::register_category();
+
+		$this->simulate_doing_action( 'wp_abilities_api_init' );
+		Image_CDN_Abilities::register_abilities();
+
+		$ability = wp_get_ability( 'jetpack-image-cdn/get-status' );
+		$this->assertNotNull( $ability, 'get-status ability should be registered.' );
+	}
+
+	/**
+	 * --------------------------------------------------------------------
+	 * Permission callback.
+	 * --------------------------------------------------------------------
+	 */
+	public function test_can_view_status_allows_admin(): void {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( Image_CDN_Abilities::can_view_status() );
+	}
+
+	public function test_can_view_status_denies_subscriber(): void {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( Image_CDN_Abilities::can_view_status() );
+	}
+
+	public function test_can_view_status_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Image_CDN_Abilities::can_view_status() );
+	}
+
+	/**
+	 * --------------------------------------------------------------------
+	 * Execute callback — get-status.
+	 * --------------------------------------------------------------------
+	 */
+	public function test_get_status_returns_documented_shape(): void {
+		$result = Image_CDN_Abilities::get_status();
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'active', $result );
+		$this->assertIsBool( $result['active'] );
+
+		$this->assertArrayHasKey( 'settings', $result );
+		$this->assertIsArray( $result['settings'] );
+		foreach ( array( 'quality', 'formats', 'srcset_enabled', 'cdn_domain' ) as $key ) {
+			$this->assertArrayHasKey( $key, $result['settings'], "settings.{$key} must be present" );
+		}
+		$this->assertIsBool( $result['settings']['srcset_enabled'] );
+		$this->assertIsString( $result['settings']['cdn_domain'] );
+		// `quality` and `formats` are unknown at the package layer.
+		$this->assertNull( $result['settings']['quality'] );
+		$this->assertNull( $result['settings']['formats'] );
+
+		$this->assertArrayHasKey( 'supported_mime_types', $result );
+		$this->assertIsArray( $result['supported_mime_types'] );
+		$this->assertNotEmpty( $result['supported_mime_types'] );
+	}
+
+	public function test_get_status_active_reflects_image_cdn_state(): void {
+		// `Image_CDN::is_enabled()` is true once `instance()` has run; calling
+		// it explicitly here pins the activation flag so the assertion is
+		// independent of test-order side effects.
+		Image_CDN::instance();
+
+		$result = Image_CDN_Abilities::get_status();
+		$this->assertTrue( $result['active'] );
+		$this->assertTrue( $result['settings']['srcset_enabled'] );
+	}
+
+	public function test_get_status_uses_default_cdn_domain_when_no_filter_set(): void {
+		$result = Image_CDN_Abilities::get_status();
+		$this->assertSame( 'https://i0.wp.com', $result['settings']['cdn_domain'] );
+	}
+
+	public function test_get_status_honors_jetpack_photon_domain_filter(): void {
+		add_filter(
+			'jetpack_photon_domain',
+			static function () {
+				return 'https://cdn.example.com';
+			}
+		);
+
+		$result = Image_CDN_Abilities::get_status();
+		$this->assertSame( 'https://cdn.example.com', $result['settings']['cdn_domain'] );
+	}
+
+	public function test_get_status_falls_back_to_default_when_filter_returns_empty_string(): void {
+		add_filter(
+			'jetpack_photon_domain',
+			static function () {
+				return '';
+			}
+		);
+
+		$result = Image_CDN_Abilities::get_status();
+		$this->assertSame( 'https://i0.wp.com', $result['settings']['cdn_domain'] );
+	}
+
+	public function test_get_status_supported_mime_types_are_deduplicated(): void {
+		$result = Image_CDN_Abilities::get_status();
+		$mimes  = $result['supported_mime_types'];
+
+		// `jpg` and `jpeg` both map to image/jpeg; the response must not list it twice.
+		$this->assertSame( array_unique( $mimes ), $mimes );
+		$this->assertContains( 'image/jpeg', $mimes );
+		$this->assertContains( 'image/png', $mimes );
+		$this->assertContains( 'image/gif', $mimes );
+		$this->assertContains( 'image/webp', $mimes );
+		$this->assertContains( 'image/heic', $mimes );
+	}
+
+	public function test_get_status_ignores_input(): void {
+		// Zero-arg ability — any input must be tolerated and discarded.
+		$result_a = Image_CDN_Abilities::get_status( null );
+		$result_b = Image_CDN_Abilities::get_status( array( 'foo' => 'bar' ) );
+
+		$this->assertSame( $result_a, $result_b );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a minimal Abilities API surface to the `jetpack-image-cdn` package via the shared `Registrar` base class. Exposes a single read-only ability — `jetpack-image-cdn/get-status` — that returns the current Image CDN (Photon) activation state, effective CDN domain, srcset wiring flag, and the deduplicated list of supported MIME types.

Per RSM "Abilities Everywhere" plan §4.2, this package is consumed by both Jetpack's Photon module and Boost, so wiring lives in the package's `actions.php` (canonical guarded pattern from `projects/packages/publicize/actions.php`). Registration is gated behind the `jetpack_wp_abilities_enabled` filter (default false) inside `Registrar::init()` — no behavior change until the filter is opted in.

`get-statistics` from the original plan was dropped because the package tracks no local statistics — the audit found no bytes-saved, request-count, or last-request timestamp surface. `update-settings` and `clear-cache` writes are intentionally deferred; this PR is reads-only.

### Surface

- `jetpack-image-cdn/get-status` — `{ active, settings: { quality, formats, srcset_enabled, cdn_domain }, supported_mime_types: [string] }`. `quality` and `formats` are `null` because the consumer plugin (not this package) owns those toggles.

### Permissions

`current_user_can( 'manage_options' )` — the package has no domain-specific capability of its own; reuse the site-admin cap.

## Test plan

- [ ] `composer phpunit -- --filter Image_CDN_Abilities_Test` (21 tests, 62 assertions, all green)
- [ ] Set `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' )` on a site running this branch with the Image CDN module active; confirm `wp_get_abilities()` includes `jetpack-image-cdn/get-status` and that `/wp-json/wp-abilities/v1/abilities` exposes it.
- [ ] Confirm the rollout filter default-off path: with the filter omitted, the ability does not appear in `wp_get_abilities()`.
- [ ] Override `jetpack_photon_domain` with a custom host; confirm the returned `settings.cdn_domain` reflects it.
- [ ] CI: PHPCS, parallel-lint, and the full package suite remain green (one pre-existing test failure in `Image_CDN_Core_Test::test_photon_url_filter_url_encodes_path_parts` is unrelated to this change).