### PR TITLE
Import abilities: register get-config + cleanup-meta via Registrar

### DIFF
--- a/projects/packages/import/changelog/import-abilities
+++ b/projects/packages/import/changelog/import-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register Jetpack Import abilities (jetpack-import/get-config and jetpack-import/cleanup-meta) via the WordPress Abilities API. Gated behind the `jetpack_wp_abilities_enabled` filter, which defaults to false.

--- a/projects/packages/import/composer.json
+++ b/projects/packages/import/composer.json
@@ -6,11 +6,13 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/phpunit-select-config": "@dev"
+		"automattic/phpunit-select-config": "@dev",
+		"brain/monkey": "^2.6.2"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."

--- a/projects/packages/import/src/abilities/class-import-abilities.php
+++ b/projects/packages/import/src/abilities/class-import-abilities.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Jetpack Import Abilities Registration.
+ *
+ * Registers Jetpack Import abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-import
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Import\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+
+/**
+ * Registers Jetpack Import abilities with the WordPress Abilities API.
+ *
+ * The Import package is the backend half of the WPCOM Unified Importer — it
+ * exposes a set of stateless `/jetpack/v4/import/*` REST endpoints that the
+ * remote importer calls to create posts, pages, comments, menus, templates,
+ * etc. on the destination site. There is no job queue, no persistent job
+ * state, and no agent-actionable list of "imports". The two lifecycle
+ * endpoints that *are* agent-meaningful are:
+ *
+ *   - `/import/start` — returns environment limits the importer needs to plan
+ *     batches (max batch size, max execution time, allowed mime types, the
+ *     current posts auto-increment ID). Stateless read.
+ *   - `/import/end`   — purges the `_jetpack_import_id` tracking meta from
+ *     `postmeta`, `commentmeta`, and `termmeta` after an import finishes.
+ *     Stateless destructive.
+ *
+ * Those two endpoints map cleanly to two abilities. The per-entity create
+ * endpoints (posts, pages, comments, ...) are deliberately *not* exposed as
+ * abilities — they're a private RPC surface for the Unified Importer
+ * orchestrator, not something an agent would call directly.
+ */
+class Import_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-import';
+	const ERROR_PREFIX  = 'jetpack_import_';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Import',
+			'description' => __( 'Abilities for inspecting the Jetpack Import environment and cleaning up tracking meta after a content import.', 'jetpack-import' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-import/get-config'   => self::spec_get_config(),
+			'jetpack-import/cleanup-meta' => self::spec_cleanup_meta(),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-import/get-config.
+	 */
+	private static function spec_get_config(): array {
+		return array(
+			'label'               => __( 'Get Jetpack Import configuration', 'jetpack-import' ),
+			'description'         => __(
+				'Return the environment limits the Jetpack Import package reports to the WPCOM Unified Importer when an import starts. Zero-argument read. Shape: { max_batch_items, max_execution_time, max_input_time, mime_types, posts_max_id, version }. `max_batch_items` is the REST batch ceiling, `max_execution_time` and `max_input_time` are the PHP ini values in seconds (0 when unlimited), `mime_types` is the array of upload-accepted mime types from `get_allowed_mime_types()`, `posts_max_id` is the current `MAX(ID)` of `wp_posts` (the importer uses this as a watermark to distinguish pre-existing vs. imported posts), and `version` is the package version. Requires the `import` capability — same gate as wp-admin/import.php and the underlying REST endpoint.',
+				'jetpack-import'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'max_batch_items'    => array( 'type' => 'integer' ),
+					'max_execution_time' => array( 'type' => 'integer' ),
+					'max_input_time'     => array( 'type' => 'integer' ),
+					'mime_types'         => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+					'posts_max_id'       => array( 'type' => 'integer' ),
+					'version'            => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_config' ),
+			'permission_callback' => array( __CLASS__, 'can_import' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-import/cleanup-meta.
+	 */
+	private static function spec_cleanup_meta(): array {
+		return array(
+			'label'               => __( 'Clean up Jetpack Import tracking meta', 'jetpack-import' ),
+			'description'         => __(
+				'Delete the `_jetpack_import_id` tracking meta the Jetpack Import package writes to `postmeta`, `commentmeta`, and `termmeta` while importing content from a source site. Call this after the WPCOM Unified Importer finishes importing a site — it removes the cross-reference rows that map source IDs to destination IDs and serves no purpose once the import is complete. Idempotent: a second call returns zero counts because there is nothing left to delete. Destructive in the sense that the rows cannot be restored, but the rows are pure tracking metadata — no user content is touched. Shape: { postmeta_count, commentmeta_count, termmeta_count, changed } where each `*_count` is the number of rows deleted from that table (0 when nothing matched, false-equivalent on a DB error from `$wpdb->delete()`), and `changed` is true when any of the three counts is greater than zero. Requires the `import` capability.',
+				'jetpack-import'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'postmeta_count'    => array( 'type' => 'integer' ),
+					'commentmeta_count' => array( 'type' => 'integer' ),
+					'termmeta_count'    => array( 'type' => 'integer' ),
+					'changed'           => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'cleanup_meta' ),
+			'permission_callback' => array( __CLASS__, 'can_import' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Permission callback. Mirrors the REST controller's
+	 * `import_permissions_callback()` exactly — the `import` capability is the
+	 * same gate `wp-admin/import.php` uses, and reusing it here means the
+	 * abilities can't accidentally widen the surface beyond what the REST
+	 * endpoints already expose.
+	 *
+	 * @return bool
+	 */
+	public static function can_import(): bool {
+		return current_user_can( 'import' );
+	}
+
+	/**
+	 * Execute: get-config. Zero-arg snapshot of the import environment.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_config( $input = null ) {
+		unset( $input );
+
+		return array(
+			'max_batch_items'    => (int) apply_filters( 'rest_get_max_batch_size', 25 ),
+			'max_execution_time' => (int) ini_get( 'max_execution_time' ),
+			'max_input_time'     => (int) ini_get( 'max_input_time' ),
+			'mime_types'         => array_values( get_allowed_mime_types() ),
+			'posts_max_id'       => static::get_posts_max_id(),
+			'version'            => \Automattic\Jetpack\Import\Main::PACKAGE_VERSION,
+		);
+	}
+
+	/**
+	 * Execute: cleanup-meta. Removes `_jetpack_import_id` rows across the three
+	 * meta tables.
+	 *
+	 * Mirrors `Endpoints\End::cleanup_database()` so the ability and the REST
+	 * route produce identical side effects. `$wpdb->delete()` returns false on
+	 * a DB error and an integer otherwise; the spec advertises integers, so
+	 * coerce false to 0 and report `changed` based on the post-coercion sum.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array|WP_Error
+	 */
+	public static function cleanup_meta( $input = null ) {
+		unset( $input );
+
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'wpdb_unavailable',
+				__( 'The WordPress database connection is not available.', 'jetpack-import' )
+			);
+		}
+
+		$where = array( 'meta_key' => '_jetpack_import_id' );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$postmeta    = $wpdb->delete( $wpdb->postmeta, $where );
+		$commentmeta = $wpdb->delete( $wpdb->commentmeta, $where );
+		$termmeta    = $wpdb->delete( $wpdb->termmeta, $where );
+		// phpcs:enable
+
+		$postmeta    = false === $postmeta ? 0 : (int) $postmeta;
+		$commentmeta = false === $commentmeta ? 0 : (int) $commentmeta;
+		$termmeta    = false === $termmeta ? 0 : (int) $termmeta;
+
+		return array(
+			'postmeta_count'    => $postmeta,
+			'commentmeta_count' => $commentmeta,
+			'termmeta_count'    => $termmeta,
+			'changed'           => ( $postmeta + $commentmeta + $termmeta ) > 0,
+		);
+	}
+
+	/**
+	 * Read the current `MAX(ID)` of `wp_posts`. Extracted as a protected seam
+	 * so tests can stub the lookup without standing up a fixture post.
+	 *
+	 * @return int
+	 */
+	protected static function get_posts_max_id(): int {
+		global $wpdb;
+		if ( ! isset( $wpdb ) || ! is_object( $wpdb ) ) {
+			return 0;
+		}
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$max_id = $wpdb->get_var( "SELECT MAX(ID) FROM {$wpdb->posts}" );
+		// phpcs:enable
+		return (int) $max_id;
+	}
+}

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Import;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication;
+use Automattic\Jetpack\Import\Abilities\Import_Abilities;
 
 /**
  * This class will provide endpoint for the Unified Importer.
@@ -46,6 +47,16 @@ class Main {
 		if ( $connection->has_connected_owner() ) {
 			add_action( 'rest_api_init', array( __CLASS__, 'initialize_rest_api' ) );
 		}
+
+		// Register WP Abilities API surface. Gated behind the
+		// `jetpack_wp_abilities_enabled` filter inside Registrar::init(),
+		// which defaults to false — so this call is safe to make unconditionally
+		// and still opt-in per-site until the flag is flipped. Wired here
+		// rather than inside the connected-owner branch above because the
+		// underlying REST endpoints already gate on the `import` capability;
+		// the abilities reuse that exact gate, so registering them without a
+		// site-level connection check matches the REST route's behavior.
+		Import_Abilities::init();
 
 		/**
 		 * Runs right after the Jetpack Import package is initialized.

--- a/projects/packages/import/tests/.phpcs.dir.xml
+++ b/projects/packages/import/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/import/tests/php/abilities/Import_Abilities_Test.php
+++ b/projects/packages/import/tests/php/abilities/Import_Abilities_Test.php
@@ -1,0 +1,465 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\Import\Abilities\Import_Abilities.
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the Jetpack Import abilities registrar.
+ *
+ * Runs with Brain Monkey so we can stub the Abilities API + WordPress
+ * functions without spinning up a full WordPress test environment — the
+ * import package's test bootstrap is intentionally minimal.
+ *
+ * Run from `projects/packages/import`:
+ *
+ *   composer phpunit -- --filter Import_Abilities_Test
+ *
+ * @covers \Automattic\Jetpack\Import\Abilities\Import_Abilities
+ */
+#[CoversClass( Import_Abilities::class )]
+class Import_Abilities_Test extends TestCase {
+	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		// Default stubs for the small set of WP helpers our specs and
+		// callbacks touch — individual tests override these with stricter
+		// expectations when they need to.
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'esc_html__' )->returnArg( 1 );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'get_allowed_mime_types' )->justReturn(
+			array(
+				'jpg|jpeg|jpe' => 'image/jpeg',
+				'png'          => 'image/png',
+			)
+		);
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		// Reset the global $wpdb stub so tests don't leak state across runs.
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Enable the top-level gate filter for init() tests.
+	 */
+	private function enable_abilities(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_enabled' )->andReturn( true );
+	}
+
+	/**
+	 * Stub the global $wpdb with the minimum surface the cleanup callback uses.
+	 *
+	 * @param array $delete_returns Map of meta table => return value from $wpdb->delete().
+	 * @return \Mockery\MockInterface
+	 */
+	private function stub_wpdb( array $delete_returns ) {
+		$wpdb              = \Mockery::mock();
+		$wpdb->postmeta    = 'wp_postmeta';
+		$wpdb->commentmeta = 'wp_commentmeta';
+		$wpdb->termmeta    = 'wp_termmeta';
+		$wpdb->posts       = 'wp_posts';
+
+		$wpdb->shouldReceive( 'delete' )
+			->with( 'wp_postmeta', array( 'meta_key' => '_jetpack_import_id' ) )
+			->andReturn( $delete_returns['postmeta'] ?? 0 );
+		$wpdb->shouldReceive( 'delete' )
+			->with( 'wp_commentmeta', array( 'meta_key' => '_jetpack_import_id' ) )
+			->andReturn( $delete_returns['commentmeta'] ?? 0 );
+		$wpdb->shouldReceive( 'delete' )
+			->with( 'wp_termmeta', array( 'meta_key' => '_jetpack_import_id' ) )
+			->andReturn( $delete_returns['termmeta'] ?? 0 );
+
+		$GLOBALS['wpdb'] = $wpdb;
+		return $wpdb;
+	}
+
+	/**
+	 * Category slug matches the convention for jetpack-* packages.
+	 */
+	public function test_category_slug(): void {
+		self::assertSame( 'jetpack-import', Import_Abilities::get_category_slug() );
+	}
+
+	/**
+	 * Category definition surfaces a label and a description.
+	 */
+	public function test_category_definition(): void {
+		$def = Import_Abilities::get_category_definition();
+
+		self::assertArrayHasKey( 'label', $def );
+		self::assertArrayHasKey( 'description', $def );
+		self::assertNotSame( '', $def['label'] );
+		self::assertNotSame( '', $def['description'] );
+	}
+
+	/**
+	 * The expected ability slugs are returned by get_abilities().
+	 */
+	public function test_get_abilities_returns_expected_slugs(): void {
+		$abilities = Import_Abilities::get_abilities();
+
+		self::assertEqualsCanonicalizing(
+			array(
+				'jetpack-import/get-config',
+				'jetpack-import/cleanup-meta',
+			),
+			array_keys( $abilities )
+		);
+	}
+
+	/**
+	 * Every ability spec is structurally complete — the contract we promise
+	 * the Abilities API.
+	 */
+	public function test_every_ability_spec_is_structurally_complete(): void {
+		foreach ( Import_Abilities::get_abilities() as $slug => $spec ) {
+			self::assertIsArray( $spec, "Spec for {$slug} must be an array." );
+
+			foreach ( array( 'label', 'description', 'input_schema', 'output_schema', 'execute_callback', 'permission_callback', 'meta' ) as $key ) {
+				self::assertArrayHasKey( $key, $spec, "Spec for {$slug} is missing `{$key}`." );
+			}
+
+			self::assertIsCallable( $spec['execute_callback'], "execute_callback for {$slug} must be callable." );
+			self::assertIsCallable( $spec['permission_callback'], "permission_callback for {$slug} must be callable." );
+
+			self::assertArrayHasKey( 'annotations', $spec['meta'], "meta.annotations missing for {$slug}." );
+			foreach ( array( 'readonly', 'destructive', 'idempotent' ) as $annotation ) {
+				self::assertArrayHasKey( $annotation, $spec['meta']['annotations'], "annotations.{$annotation} missing for {$slug}." );
+				self::assertIsBool( $spec['meta']['annotations'][ $annotation ], "annotations.{$annotation} for {$slug} must be a boolean." );
+			}
+
+			self::assertTrue( $spec['meta']['show_in_rest'] ?? false, "show_in_rest must be true for {$slug}." );
+		}
+	}
+
+	/**
+	 * Annotation contract: get-config is read-only/idempotent/non-destructive
+	 * and cleanup-meta is the opposite end of the spectrum (non-readonly,
+	 * destructive, but idempotent — a second call returns zero counts because
+	 * there is nothing left to delete).
+	 */
+	public function test_ability_annotations_match_intent(): void {
+		$abilities = Import_Abilities::get_abilities();
+
+		self::assertSame(
+			array(
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			),
+			$abilities['jetpack-import/get-config']['meta']['annotations']
+		);
+
+		self::assertSame(
+			array(
+				'readonly'    => false,
+				'destructive' => true,
+				'idempotent'  => true,
+			),
+			$abilities['jetpack-import/cleanup-meta']['meta']['annotations']
+		);
+	}
+
+	/**
+	 * Both abilities reject extra input properties — the schemas should not
+	 * accept unrecognized keys silently.
+	 */
+	public function test_input_schemas_disallow_additional_properties(): void {
+		foreach ( Import_Abilities::get_abilities() as $slug => $spec ) {
+			self::assertSame(
+				false,
+				$spec['input_schema']['additionalProperties'] ?? null,
+				"input_schema.additionalProperties must be false for {$slug}."
+			);
+		}
+	}
+
+	/**
+	 * Permission gate matches the REST controller exactly — we reuse the
+	 * `import` capability instead of inventing a new gate.
+	 */
+	public function test_can_import_delegates_to_current_user_can(): void {
+		Functions\when( 'current_user_can' )->alias(
+			static function ( $cap ) {
+				return 'import' === $cap;
+			}
+		);
+
+		self::assertTrue( Import_Abilities::can_import() );
+
+		Functions\when( 'current_user_can' )->alias(
+			static function ( $cap ) {
+				return 'manage_options' === $cap; // anything other than `import`.
+			}
+		);
+
+		self::assertFalse( Import_Abilities::can_import() );
+	}
+
+	/**
+	 * The get-config callback returns the full snapshot shape with sane
+	 * values pulled from the (stubbed) WordPress helpers and PHP ini.
+	 */
+	public function test_get_config_returns_expected_shape(): void {
+		Filters\expectApplied( 'rest_get_max_batch_size' )
+			->once()
+			->with( 25 )
+			->andReturn( 50 );
+
+		// Stub MAX(ID) via the protected get_posts_max_id() seam — see fixture below.
+		$result = Import_Abilities_Get_Config_Stub::get_config();
+
+		self::assertIsArray( $result );
+		self::assertSame( 50, $result['max_batch_items'] );
+		self::assertIsInt( $result['max_execution_time'] );
+		self::assertIsInt( $result['max_input_time'] );
+		self::assertSame( array( 'image/jpeg', 'image/png' ), $result['mime_types'] );
+		self::assertSame( 42, $result['posts_max_id'] );
+		self::assertIsString( $result['version'] );
+		self::assertNotSame( '', $result['version'] );
+	}
+
+	/**
+	 * Input is ignored — get-config is a zero-arg ability and unexpected
+	 * input must not change the output.
+	 */
+	public function test_get_config_ignores_input(): void {
+		Filters\expectApplied( 'rest_get_max_batch_size' )
+			->zeroOrMoreTimes()
+			->andReturnUsing(
+				static function ( $value ) {
+					return $value;
+				}
+			);
+
+		$with_input    = Import_Abilities_Get_Config_Stub::get_config( array( 'unexpected' => 'value' ) );
+		$without_input = Import_Abilities_Get_Config_Stub::get_config();
+
+		self::assertSame( $without_input, $with_input );
+	}
+
+	/**
+	 * The cleanup-meta callback wires the three `$wpdb->delete()` calls
+	 * correctly and surfaces non-zero deletions as `changed=true`.
+	 */
+	public function test_cleanup_meta_reports_counts_and_changed(): void {
+		$this->stub_wpdb(
+			array(
+				'postmeta'    => 3,
+				'commentmeta' => 1,
+				'termmeta'    => 0,
+			)
+		);
+
+		$result = Import_Abilities::cleanup_meta();
+
+		self::assertSame(
+			array(
+				'postmeta_count'    => 3,
+				'commentmeta_count' => 1,
+				'termmeta_count'    => 0,
+				'changed'           => true,
+			),
+			$result
+		);
+	}
+
+	/**
+	 * When every delete returns zero, `changed` must be false — a second
+	 * cleanup call on a clean database is the canonical idempotent case.
+	 */
+	public function test_cleanup_meta_marks_changed_false_when_nothing_deleted(): void {
+		$this->stub_wpdb(
+			array(
+				'postmeta'    => 0,
+				'commentmeta' => 0,
+				'termmeta'    => 0,
+			)
+		);
+
+		$result = Import_Abilities::cleanup_meta();
+
+		self::assertSame( 0, $result['postmeta_count'] );
+		self::assertSame( 0, $result['commentmeta_count'] );
+		self::assertSame( 0, $result['termmeta_count'] );
+		self::assertFalse( $result['changed'] );
+	}
+
+	/**
+	 * `$wpdb->delete()` returns false on a DB error; the spec advertises
+	 * integers, so those must be coerced and not propagate as `changed=true`.
+	 */
+	public function test_cleanup_meta_coerces_wpdb_false_to_zero(): void {
+		$this->stub_wpdb(
+			array(
+				'postmeta'    => false,
+				'commentmeta' => false,
+				'termmeta'    => false,
+			)
+		);
+
+		$result = Import_Abilities::cleanup_meta();
+
+		self::assertSame( 0, $result['postmeta_count'] );
+		self::assertSame( 0, $result['commentmeta_count'] );
+		self::assertSame( 0, $result['termmeta_count'] );
+		self::assertFalse( $result['changed'] );
+	}
+
+	/**
+	 * When the database connection is missing entirely, cleanup-meta returns
+	 * a structured WP_Error rather than throwing or returning partial data.
+	 */
+	public function test_cleanup_meta_returns_wp_error_when_wpdb_unavailable(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		$result = Import_Abilities::cleanup_meta();
+
+		self::assertInstanceOf( \WP_Error::class, $result );
+		self::assertSame( 'jetpack_import_wpdb_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * The init() entry point wires both lifecycle hooks when neither action
+	 * has fired yet. Mirrors the wp-abilities Registrar contract for our
+	 * concrete subclass.
+	 */
+	public function test_init_adds_hooks_when_neither_action_fired(): void {
+		$this->enable_abilities();
+
+		Functions\when( 'did_action' )->justReturn( 0 );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )
+			->once()
+			->with( array( Import_Abilities::class, 'register_category' ) );
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )
+			->once()
+			->with( array( Import_Abilities::class, 'register_abilities' ) );
+
+		Functions\expect( 'wp_register_ability_category' )->never();
+		Functions\expect( 'wp_register_ability' )->never();
+
+		Import_Abilities::init();
+	}
+
+	/**
+	 * When the rollout filter returns false, init() does nothing — abilities
+	 * stay opt-in per site.
+	 */
+	public function test_init_is_disabled_by_default(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_enabled' )
+			->once()
+			->with( false )
+			->andReturn( false );
+
+		Functions\expect( 'did_action' )->never();
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->never();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->never();
+		Functions\expect( 'wp_register_ability_category' )->never();
+		Functions\expect( 'wp_register_ability' )->never();
+
+		Import_Abilities::init();
+	}
+
+	/**
+	 * The register_abilities() entry point registers every spec returned by
+	 * get_abilities() with the auto-injected category slug.
+	 */
+	public function test_register_abilities_registers_each_with_category(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->zeroOrMoreTimes()
+			->andReturn( true );
+
+		Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'jetpack-import/get-config',
+				\Mockery::on(
+					static function ( $spec ) {
+						return is_array( $spec )
+							&& 'jetpack-import' === ( $spec['category'] ?? null )
+							&& isset( $spec['execute_callback'] );
+					}
+				)
+			);
+		Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'jetpack-import/cleanup-meta',
+				\Mockery::on(
+					static function ( $spec ) {
+						return is_array( $spec )
+							&& 'jetpack-import' === ( $spec['category'] ?? null )
+							&& true === ( $spec['meta']['annotations']['destructive'] ?? false );
+					}
+				)
+			);
+
+		Import_Abilities::register_abilities();
+	}
+
+	/**
+	 * The register_category() entry point passes the slug + definition
+	 * through to wp_register_ability_category() unchanged.
+	 */
+	public function test_register_category_passes_slug_and_definition(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->zeroOrMoreTimes()
+			->andReturn( true );
+
+		Functions\expect( 'wp_register_ability_category' )
+			->once()
+			->with(
+				'jetpack-import',
+				\Mockery::on(
+					static function ( $def ) {
+						return is_array( $def )
+							&& isset( $def['label'] )
+							&& isset( $def['description'] )
+							&& '' !== $def['label']
+							&& '' !== $def['description'];
+					}
+				)
+			);
+
+		Import_Abilities::register_category();
+	}
+}
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable Squiz.Commenting.ClassComment.Missing
+
+/**
+ * Test fixture: overrides `get_posts_max_id()` so the get-config test does
+ * not need a real `$wpdb` to validate the snapshot shape. Used by the
+ * Import_Abilities_Test::test_get_config_* methods only.
+ */
+class Import_Abilities_Get_Config_Stub extends Import_Abilities {
+	protected static function get_posts_max_id(): int {
+		return 42;
+	}
+}

--- a/projects/packages/import/tests/php/bootstrap.php
+++ b/projects/packages/import/tests/php/bootstrap.php
@@ -9,3 +9,6 @@
  * Include the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Load the minimal WP_Error shim used by Brain Monkey-based tests.
+require_once __DIR__ . '/class-wp-error.php';

--- a/projects/packages/import/tests/php/class-wp-error.php
+++ b/projects/packages/import/tests/php/class-wp-error.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Minimal `WP_Error` stand-in for Brain Monkey-based tests.
+ *
+ * The Import package does not depend on a full WordPress test environment —
+ * Brain Monkey stubs the global functions but does not declare WP classes —
+ * so abilities tests that exercise the WP_Error return path need this shim.
+ * Only the methods touched by assertions are implemented.
+ *
+ * @package automattic/jetpack-import
+ */
+
+if ( ! class_exists( 'WP_Error' ) ) {
+
+	/**
+	 * Bare-bones WP_Error shim.
+	 */
+	class WP_Error {
+
+		/**
+		 * Error code.
+		 *
+		 * @var string
+		 */
+		private $code;
+
+		/**
+		 * Error message.
+		 *
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * Construct.
+		 *
+		 * @param string $code    Code.
+		 * @param string $message Message.
+		 * @param mixed  $data    Data (ignored by this stub).
+		 */
+		public function __construct( $code = '', $message = '', $data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$this->code    = (string) $code;
+			$this->message = (string) $message;
+		}
+
+		/**
+		 * Return the first error code.
+		 */
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		/**
+		 * Return the first error message.
+		 */
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the WordPress Abilities API surface for the `automattic/jetpack-import` package via a `Registrar` subclass. References plan §4.2 ("Ship Import abilities").

The Import package is the backend half of the WPCOM Unified Importer — a stateless set of `/jetpack/v4/import/*` REST endpoints. It has no job lifecycle (no queue, no persistent state, no list-of-jobs surface) and no agent-actionable start/cancel write surface beyond a per-entity create RPC that should not be exposed directly to agents. Per the ship task's "don't fabricate write endpoints" guidance, the abilities map only to endpoints that actually exist:

- **`jetpack-import/get-config`** wraps `/import/start::get_item()` — returns `{ max_batch_items, max_execution_time, max_input_time, mime_types, posts_max_id, version }`. Read-only, idempotent.
- **`jetpack-import/cleanup-meta`** wraps `/import/end::cleanup_database()` — deletes the `_jetpack_import_id` rows from `postmeta`, `commentmeta`, `termmeta`. Destructive but idempotent (second call returns zeros).

Both abilities reuse the REST controller's `current_user_can( 'import' )` gate exactly — no widening of the existing access surface. Registration is gated behind the shared `jetpack_wp_abilities_enabled` filter (defaults to `false`) inside `Registrar::init()`, so this rolls out opt-in per site.

The per-entity create endpoints (posts/pages/comments/menus/templates/…) are deliberately not exposed as abilities — they are a private RPC surface for the Unified Importer orchestrator, not direct-call surfaces for AI agents.

## Notes

- Wired via `class-main.php::configure()` (the package's existing bootstrap), mirroring the Stats package pattern. The Import package has no `actions.php`, so wiring lives in `Main` rather than a separate file.
- Tests use Brain Monkey (added to `require-dev`) since the package has no WordPress test environment — mirrors the `wp-abilities` package's own `RegistrarTest`. 17 tests, 85 assertions.
- New `tests/.phpcs.dir.xml` adopts the `Jetpack-Tests` ruleset so test-file naming + globals follow the relaxed test conventions used by the other ability-shipping packages.
- A tiny `WP_Error` shim lives in `tests/php/class-wp-error.php` so the `cleanup_meta()` error path is testable without spinning up WordPress.

## Test plan

- [ ] `cd projects/packages/import && composer phpunit -- --filter Import_Abilities_Test` — 17/17 pass.
- [ ] PHPCS clean on the added files.
- [ ] On a site with `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' )`, the WP abilities REST surface exposes the `jetpack-import` category with both abilities.
- [ ] Calling `jetpack-import/get-config` as an admin returns the env snapshot; calling as a non-`import` user returns 403.
- [ ] Calling `jetpack-import/cleanup-meta` after an import returns non-zero counts; a second call returns `{ ..., changed: false }`.