### PR TITLE
Podcast: align bottom Stats cards with wpcom Stats card module look

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-stats-bottom-cards-wpcom-styling
+++ b/projects/packages/podcast/changelog/update-podcast-stats-bottom-cards-wpcom-styling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Podcast: visually align the Top episodes, By app, and Locations Stats cards with the wpcom Stats card module look (real border, larger header, 24px padding).
+Stats tab: Align Top episodes, By app, and Locations cards with the WordPress.com Stats card module look (real border, larger header, and 24px padding).

--- a/projects/packages/podcast/changelog/update-podcast-stats-bottom-cards-wpcom-styling
+++ b/projects/packages/podcast/changelog/update-podcast-stats-bottom-cards-wpcom-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: visually align the Top episodes, By app, and Locations Stats cards with the wpcom Stats card module look (real border, larger header, 24px padding).

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -3,8 +3,6 @@
 // Match other dashboard tabs; avoid --wp-admin-theme-color-darker-20.
 $text: #1e1e1e;
 $muted: #757575;
-$bar-bg: #f0f0f0;
-$bar-bg-hover: #e5e5e5;
 $bar-fill: #2271b1;
 
 %eyebrow {
@@ -272,7 +270,6 @@ $bar-fill: #2271b1;
 		gap: 8px;
 		padding: 6px 8px;
 		border-radius: 4px;
-		background: $bar-bg;
 		width: 100%;
 		text-align: start;
 		border: 0;
@@ -282,11 +279,11 @@ $bar-fill: #2271b1;
 			cursor: pointer;
 
 			&:hover {
-				background: $bar-bg-hover;
+				background: rgba(34, 113, 177, 0.06);
 			}
 
 			&:focus-visible {
-				background: $bar-bg-hover;
+				background: rgba(34, 113, 177, 0.06);
 				outline: 2px solid $bar-fill;
 				outline-offset: 2px;
 			}
@@ -318,7 +315,7 @@ $bar-fill: #2271b1;
 		inset-block: 0;
 		inset-inline-start: 0;
 		background: $bar-fill;
-		opacity: 0.08;
+		opacity: 0.18;
 		border-radius: 4px;
 		pointer-events: none;
 	}

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -78,14 +78,15 @@ $bar-fill: #2271b1;
 			box-shadow: none;
 
 			.components-card__header {
-				padding: 24px 24px 12px;
+				padding-block: 24px 12px;
+				padding-inline: 24px;
 				border-block-end: 0;
 				min-height: 0;
-				background: transparent;
 			}
 
 			.components-card__body {
-				padding: 0 24px 24px;
+				padding-block: 0 24px;
+				padding-inline: 24px;
 			}
 
 			.podcast-stats__section-title {

--- a/projects/packages/podcast/src/dashboard/stats/style.scss
+++ b/projects/packages/podcast/src/dashboard/stats/style.scss
@@ -68,6 +68,32 @@ $bar-fill: #2271b1;
 
 	&__section-card {
 		min-width: 0;
+
+		// Calypso Stats card-module look: real border, no shadow, larger header,
+		// 24px content padding. Scoped off the Downloads chart card.
+		&:not(.podcast-stats-chart) {
+			background: #fff;
+			border: 1px solid #dcdcde;
+			border-radius: 5px;
+			box-shadow: none;
+
+			.components-card__header {
+				padding: 24px 24px 12px;
+				border-block-end: 0;
+				min-height: 0;
+				background: transparent;
+			}
+
+			.components-card__body {
+				padding: 0 24px 24px;
+			}
+
+			.podcast-stats__section-title {
+				font-size: 20px;
+				font-weight: 500;
+				line-height: 1.3;
+			}
+		}
 	}
 
 	&__section-title {


### PR DESCRIPTION
## Summary

Visually align the Top episodes, By app, and Locations Stats cards with the wpcom Stats card module look so the Stats tab reads as one consistent surface.

- Real 1px border + 5px radius, no shadow.
- Larger 20px / 500-weight section titles.
- 24px content padding; header pads 24/24/12 with no divider.
- Scoped via `&:not(.podcast-stats-chart)` so the Downloads chart card stays as-is.

## Test plan

- [ ] On the podcast Stats tab, confirm Top episodes, By app, and Locations cards show the new border, radius, header padding, and 20px title.
- [ ] Confirm the Downloads chart card (4 summary tiles + chart) is unchanged.
- [ ] Confirm the per-episode Stats view inherits the same look on its bottom cards.
- [ ] RTL spot-check (logical padding properties).
