### PR TITLE
CI: Pass empty token to Composer auth config

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -62,6 +62,14 @@ runs:
         extensions: mysql, imagick
         coverage: ${{ inputs.coverage }}
 
+    # Composer doesn't need this token (we use git clone via `use-github-api=false`),
+    # and a malformed token can trip composer's validation and leak the token in the error.
+    # See: https://github.com/composer/composer/issues/12849
+    - name: Unset GITHUB_TOKEN
+      if: steps.versions.outputs.php-version != 'false'
+      shell: bash
+      run: echo "GITHUB_TOKEN=" >> "$GITHUB_ENV"
+
     - name: Configure composer
       if: steps.versions.outputs.php-version != 'false'
       shell: bash

--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -57,18 +57,15 @@ runs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ steps.versions.outputs.php-version }}
+        # Pass an empty token so setup-php doesn't persist GITHUB_TOKEN to Composer's
+        # config. Composer rejects the new GITHUB_TOKEN token format.
+        # See: https://github.com/composer/composer/issues/12849
+        # https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
+        github-token: ''
         ini-values: error_reporting=E_ALL, display_errors=On, zend.assertions=1
         tools: composer:${{ steps.versions.outputs.composer-version }}
         extensions: mysql, imagick
         coverage: ${{ inputs.coverage }}
-
-    # Composer doesn't need this token (we use git clone via `use-github-api=false`),
-    # and a malformed token can trip composer's validation and leak the token in the error.
-    # See: https://github.com/composer/composer/issues/12849
-    - name: Unset GITHUB_TOKEN
-      if: steps.versions.outputs.php-version != 'false'
-      shell: bash
-      run: echo "GITHUB_TOKEN=" >> "$GITHUB_ENV"
 
     - name: Configure composer
       if: steps.versions.outputs.php-version != 'false'


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
GitHub Actions are getting a new `GITHUB_TOKEN` format from time to time:
https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/

Composer has incorrect validation, and if it thinks the token is malformed, it'll throw an error. We don't even need the token, so let's pass a blank string as the token and it'll store that in the auth, bypassing the error.

One concern I have is that this probably triggers unauthenticated calls to the API, which have [a much lower rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1778625431151099-slack-C02AVAR9B
* composer/composer#12849

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI should be happy.