### PR TITLE
Search 3.0: honor the site's date_format option in result cards

### DIFF
--- a/projects/packages/search/changelog/rsm-269-honor-date-format
+++ b/projects/packages/search/changelog/rsm-269-honor-date-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search 3.0: result cards now honor the site's date_format option (F j, Y, Y-m-d, etc.) instead of a fixed Intl shape.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1016,6 +1016,16 @@ class Search_Blocks {
 			'locale'                     => function_exists( 'get_locale' )
 				? str_replace( '_', '-', get_locale() )
 				: 'en-US',
+			// Site `date_format` token string (PHP `date()` syntax — e.g.
+			// `F j, Y`, `Y-m-d`) so the result card's date matches the rest of
+			// the site rather than `toLocaleDateString`'s fixed shape. Parsed
+			// client-side by `wp-date-format.js` because the Interactivity API
+			// view bundle can't import `@wordpress/date`. Empty string falls
+			// the JS side back to its legacy `{ year, month, day }` Intl
+			// shape, which keeps tests that don't seed a format passing.
+			'dateFormat'                 => function_exists( 'get_option' )
+				? (string) get_option( 'date_format', '' )
+				: '',
 
 			// Search state, seeded from the URL so a deep link like
 			// /?s=boots&orderby=newest&category[]=news renders correctly on

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -748,7 +748,7 @@ const { state, actions } = store( NAMESPACE, {
 					return;
 				}
 				state.results = ( data.results ?? [] ).map( r =>
-					normalizeResult( r, state.locale, state.searchQuery )
+					normalizeResult( r, state.locale, state.searchQuery, state.dateFormat )
 				);
 				state.totalResults = data.total ?? 0;
 				state.pageHandle = data.page_handle ?? null;
@@ -819,7 +819,7 @@ const { state, actions } = store( NAMESPACE, {
 				state.results = [
 					...state.results,
 					...( data.results ?? [] ).map( r =>
-						normalizeResult( r, state.locale, state.searchQuery )
+						normalizeResult( r, state.locale, state.searchQuery, state.dateFormat )
 					),
 				];
 				state.pageHandle = data.page_handle ?? null;

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -6,7 +6,7 @@ import {
 import { buildSearchUrl, formatDateBucketLabel } from './api';
 import { bucketLabel, bucketValue } from './bucket-key';
 import { isEventInsidePopoverRoot } from './popover-events';
-import { countActiveFilters, normalizeResult } from './result-utils';
+import { countActiveFilters, normalizeResult, setSeededDateFormat } from './result-utils';
 import {
 	focusSortTrigger,
 	getSortMenuOptionKeysFromItem,
@@ -748,7 +748,7 @@ const { state, actions } = store( NAMESPACE, {
 					return;
 				}
 				state.results = ( data.results ?? [] ).map( r =>
-					normalizeResult( r, state.locale, state.searchQuery, state.dateFormat )
+					normalizeResult( r, state.locale, state.searchQuery )
 				);
 				state.totalResults = data.total ?? 0;
 				state.pageHandle = data.page_handle ?? null;
@@ -819,7 +819,7 @@ const { state, actions } = store( NAMESPACE, {
 				state.results = [
 					...state.results,
 					...( data.results ?? [] ).map( r =>
-						normalizeResult( r, state.locale, state.searchQuery, state.dateFormat )
+						normalizeResult( r, state.locale, state.searchQuery )
 					),
 				];
 				state.pageHandle = data.page_handle ?? null;
@@ -1187,6 +1187,12 @@ const { state, actions } = store( NAMESPACE, {
 				return;
 			}
 			initialized = true;
+			// The PHP seed (`state.dateFormat`) carries the site's
+			// `date_format` Settings option. It's set once here so
+			// `formatDate()` in result-utils.js can read it from module scope
+			// instead of having every `normalizeResult` call thread it
+			// through — the value never changes for the lifetime of the page.
+			setSeededDateFormat( state.dateFormat );
 			window.addEventListener( 'popstate', actions.handlePopState );
 			const { gated, droppedAny } = gateActiveFilters( state.activeFilters, state.filterConfigs );
 			if ( droppedAny ) {

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -11,6 +11,8 @@
  * pipeline gains wp.i18n support.
  */
 
+import { formatWpDate } from './wp-date-format';
+
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
 const ANY_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
 const STRIP_TAGS_PATTERN = /<[^>]*>/g;
@@ -60,11 +62,21 @@ export function toSafeUrl( raw ) {
 /**
  * Format an ISO date string for display on a search result card.
  *
- * @param {string} iso      - ISO-ish date string.
- * @param {string} [locale] - BCP47 locale (e.g. `en-US`).
+ * When `dateFormat` is supplied (the site's WordPress `date_format` Settings
+ * option, seeded by `Search_Blocks::seed_interactivity_state()`), the date is
+ * rendered through the PHP `date()`-style token parser in `wp-date-format.js`
+ * so result cards match the rest of the site (`F j, Y`, `Y-m-d`, `d/m/Y`,
+ * etc.) instead of `toLocaleDateString`'s fixed `{ year, month, day }` shape.
+ * The legacy short-form output is kept as the fallback so call sites that
+ * don't pass a format (older tests, places where the seed hasn't run) keep
+ * working unchanged.
+ *
+ * @param {string} iso          - ISO-ish date string.
+ * @param {string} [locale]     - BCP47 locale (e.g. `en-US`).
+ * @param {string} [dateFormat] - WP `date_format` token string; empty falls back to `toLocaleDateString`.
  * @return {string} Formatted date or ''.
  */
-export function formatDate( iso, locale = 'en-US' ) {
+export function formatDate( iso, locale = 'en-US', dateFormat = '' ) {
 	if ( ! iso ) {
 		return '';
 	}
@@ -73,7 +85,11 @@ export function formatDate( iso, locale = 'en-US' ) {
 	if ( isNaN( d.getTime() ) ) {
 		return '';
 	}
-	return d.toLocaleDateString( locale || 'en-US', {
+	const resolvedLocale = locale || 'en-US';
+	if ( dateFormat ) {
+		return formatWpDate( d, dateFormat, resolvedLocale );
+	}
+	return d.toLocaleDateString( resolvedLocale, {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',
@@ -414,9 +430,12 @@ export function deriveMatchHint( highlight, titlePieces ) {
  *                               makes sense in response to a typed query, and
  *                               reads as misleading when every visible result
  *                               was returned by a category/tag/price filter.
+ * @param {string} [dateFormat]  - WP `date_format` token string seeded from the
+ *                               site option; threaded into `formatDate` so the
+ *                               card matches the site's chosen layout.
  * @return {object} Flat result.
  */
-export function normalizeResult( raw, locale = 'en-US', searchQuery = '' ) {
+export function normalizeResult( raw, locale = 'en-US', searchQuery = '', dateFormat = '' ) {
 	const fields = raw?.fields ?? {};
 	const highlight = raw?.highlight ?? {};
 	const permalink = toSafeUrl( fields[ 'permalink.url.raw' ] );
@@ -445,7 +464,7 @@ export function normalizeResult( raw, locale = 'en-US', searchQuery = '' ) {
 		hasContentPieces: contentPieces.length > 0,
 		permalink,
 		path: formatPath( permalink ),
-		dateLabel: formatDate( fields.date, locale ),
+		dateLabel: formatDate( fields.date, locale, dateFormat ),
 		authorLabel: formatAuthor( fields.author ),
 		imageUrl,
 		// Pre-built `url(...)` value so the product layout's CSS background

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -13,6 +13,26 @@
 
 import { formatWpDate } from './wp-date-format';
 
+// Module-scoped: the site's WP `date_format` setting is seeded once at store
+// hydration via `setSeededDateFormat()` and read implicitly by `formatDate()`.
+// Threading it through every `normalizeResult` call would be noise — it never
+// changes for the lifetime of the page, and the Interactivity API store is a
+// singleton, so module scope matches the data's actual lifetime.
+let seededDateFormat = '';
+
+/**
+ * Capture the site's WP `date_format` Settings option for use by subsequent
+ * `formatDate()` calls. Called once during store init from the
+ * `state.dateFormat` seed (see `Search_Blocks::seed_interactivity_state()`).
+ *
+ * @param {string} format - WP `date_format` token string, or an empty string
+ *                        when the seed is missing (falls back to the legacy
+ *                        `toLocaleDateString` shape).
+ */
+export function setSeededDateFormat( format ) {
+	seededDateFormat = typeof format === 'string' ? format : '';
+}
+
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
 const ANY_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
 const STRIP_TAGS_PATTERN = /<[^>]*>/g;
@@ -62,21 +82,26 @@ export function toSafeUrl( raw ) {
 /**
  * Format an ISO date string for display on a search result card.
  *
- * When `dateFormat` is supplied (the site's WordPress `date_format` Settings
- * option, seeded by `Search_Blocks::seed_interactivity_state()`), the date is
- * rendered through the PHP `date()`-style token parser in `wp-date-format.js`
- * so result cards match the rest of the site (`F j, Y`, `Y-m-d`, `d/m/Y`,
- * etc.) instead of `toLocaleDateString`'s fixed `{ year, month, day }` shape.
- * The legacy short-form output is kept as the fallback so call sites that
- * don't pass a format (older tests, places where the seed hasn't run) keep
- * working unchanged.
+ * When the module-scoped `seededDateFormat` is non-empty (the site's WP
+ * `date_format` option, captured once at store init via
+ * `setSeededDateFormat()`), the date is rendered through the PHP `date()`-style
+ * token parser in `wp-date-format.js` so result cards match the rest of the
+ * site (`F j, Y`, `Y-m-d`, `d/m/Y`, etc.) instead of `toLocaleDateString`'s
+ * fixed `{ year, month, day }` shape. The legacy short-form output is kept as
+ * the fallback so call sites that run before the seed (older tests, edge
+ * paths) keep working unchanged.
+ *
+ * The `dateFormat` override exists for test ergonomics — call sites pass
+ * nothing in production. Tests reach for the explicit override or for
+ * `setSeededDateFormat()` plus a reset; both are documented in
+ * `result-utils.test.js`.
  *
  * @param {string} iso          - ISO-ish date string.
  * @param {string} [locale]     - BCP47 locale (e.g. `en-US`).
- * @param {string} [dateFormat] - WP `date_format` token string; empty falls back to `toLocaleDateString`.
+ * @param {string} [dateFormat] - Override; defaults to the module-scoped seeded value.
  * @return {string} Formatted date or ''.
  */
-export function formatDate( iso, locale = 'en-US', dateFormat = '' ) {
+export function formatDate( iso, locale = 'en-US', dateFormat = seededDateFormat ) {
 	if ( ! iso ) {
 		return '';
 	}
@@ -422,6 +447,11 @@ export function deriveMatchHint( highlight, titlePieces ) {
  * Normalize a v1.3 Jetpack Search result into the flat shape expected by the
  * Interactivity API templates.
  *
+ * `formatDate()` reads the site's WP `date_format` from module scope (set
+ * once at store init via `setSeededDateFormat()`), so this signature stays
+ * focused on per-result inputs rather than threading site-wide formatting
+ * context through every call.
+ *
  * @param {object} raw           - Raw result from the API.
  * @param {string} [locale]      - BCP47 locale for date formatting.
  * @param {string} [searchQuery] - The query string the user actually typed. When
@@ -430,12 +460,9 @@ export function deriveMatchHint( highlight, titlePieces ) {
  *                               makes sense in response to a typed query, and
  *                               reads as misleading when every visible result
  *                               was returned by a category/tag/price filter.
- * @param {string} [dateFormat]  - WP `date_format` token string seeded from the
- *                               site option; threaded into `formatDate` so the
- *                               card matches the site's chosen layout.
  * @return {object} Flat result.
  */
-export function normalizeResult( raw, locale = 'en-US', searchQuery = '', dateFormat = '' ) {
+export function normalizeResult( raw, locale = 'en-US', searchQuery = '' ) {
 	const fields = raw?.fields ?? {};
 	const highlight = raw?.highlight ?? {};
 	const permalink = toSafeUrl( fields[ 'permalink.url.raw' ] );
@@ -464,7 +491,7 @@ export function normalizeResult( raw, locale = 'en-US', searchQuery = '', dateFo
 		hasContentPieces: contentPieces.length > 0,
 		permalink,
 		path: formatPath( permalink ),
-		dateLabel: formatDate( fields.date, locale, dateFormat ),
+		dateLabel: formatDate( fields.date, locale ),
 		authorLabel: formatAuthor( fields.author ),
 		imageUrl,
 		// Pre-built `url(...)` value so the product layout's CSS background

--- a/projects/packages/search/src/search-blocks/store/wp-date-format.js
+++ b/projects/packages/search/src/search-blocks/store/wp-date-format.js
@@ -1,0 +1,256 @@
+/**
+ * Minimal WordPress PHP-style date format token formatter.
+ *
+ * WordPress stores its `date_format` Settings option as a PHP `date()` token
+ * string (`F j, Y`, `Y-m-d`, `d/m/Y`, etc.) — the result card has to honour
+ * that string verbatim, not just `toLocaleDateString`'s `{ year, month, day }`
+ * canon. This module exists because the Interactivity API view bundle rejects
+ * imports from `@wordpress/i18n` / `@wordpress/date` (see the file-level
+ * comment in `result-utils.js`), so neither `dateI18n()` nor moment.js are
+ * reachable from the search blocks store.
+ *
+ * Token coverage: every PHP `date()` letter likely to appear in a WP
+ * `date_format` setting (`d D j l N S w F m M n Y y L o H h G g i s a A`),
+ * plus `\` as the literal-escape character. Month and day names are sourced
+ * from `Intl.DateTimeFormat` for the seeded blog locale — month names will
+ * therefore follow the browser's ICU data rather than WordPress's own
+ * translation tables, which is the closest faithful approximation reachable
+ * from inside the IAPI runtime.
+ *
+ * Dates are read in UTC to keep result cards stable regardless of the
+ * viewer's timezone — the v1.3 Jetpack Search API returns post `date` in UTC,
+ * and the result card represents the published date, not a localised wall
+ * clock.
+ */
+
+const intlFormatters = new Map();
+
+/**
+ * Cached `Intl.DateTimeFormat` resolver keyed by `locale|options-shape` so
+ * each unique combination is constructed at most once for the page.
+ *
+ * @param {string} locale  - BCP47 locale tag.
+ * @param {object} options - `Intl.DateTimeFormat` options.
+ * @return {Intl.DateTimeFormat|null} Formatter, or null if the locale is malformed.
+ */
+function getIntlFormatter( locale, options ) {
+	const key = `${ locale }|${ Object.entries( options ).flat().join( ',' ) }`;
+	let formatter = intlFormatters.get( key );
+	if ( formatter ) {
+		return formatter;
+	}
+	try {
+		formatter = new Intl.DateTimeFormat( locale, { timeZone: 'UTC', ...options } );
+	} catch {
+		return null;
+	}
+	intlFormatters.set( key, formatter );
+	return formatter;
+}
+
+/**
+ * Format a Date as a single locale-aware piece (e.g. `month: 'long'` → "April",
+ * `weekday: 'short'` → "Mon"). Falls back to the equivalent English string when
+ * the locale tag is malformed so the output never silently becomes empty.
+ *
+ * @param {Date}   date     - UTC date to format.
+ * @param {string} locale   - BCP47 locale tag.
+ * @param {object} options  - `Intl.DateTimeFormat` options (single component).
+ * @param {string} fallback - Value to return when the formatter can't be built.
+ * @return {string} Formatted piece.
+ */
+function intlPart( date, locale, options, fallback ) {
+	const formatter = getIntlFormatter( locale, options );
+	return formatter ? formatter.format( date ) : fallback;
+}
+
+const ENGLISH_LONG_MONTHS = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+];
+
+const ENGLISH_SHORT_MONTHS = [
+	'Jan',
+	'Feb',
+	'Mar',
+	'Apr',
+	'May',
+	'Jun',
+	'Jul',
+	'Aug',
+	'Sep',
+	'Oct',
+	'Nov',
+	'Dec',
+];
+
+const ENGLISH_LONG_DAYS = [
+	'Sunday',
+	'Monday',
+	'Tuesday',
+	'Wednesday',
+	'Thursday',
+	'Friday',
+	'Saturday',
+];
+
+const ENGLISH_SHORT_DAYS = [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ];
+
+/**
+ * PHP `S` token: English ordinal suffix for a 1–31 day-of-month value. WP keeps
+ * this English even in non-English locales (PHP `date()` itself is not locale
+ * aware), so we match that behaviour rather than localising via Intl.
+ *
+ * @param {number} day - 1–31 day-of-month.
+ * @return {string} 'st' | 'nd' | 'rd' | 'th'.
+ */
+function ordinalSuffix( day ) {
+	if ( day >= 11 && day <= 13 ) {
+		return 'th';
+	}
+	switch ( day % 10 ) {
+		case 1:
+			return 'st';
+		case 2:
+			return 'nd';
+		case 3:
+			return 'rd';
+		default:
+			return 'th';
+	}
+}
+
+/**
+ * PHP `o` token: the ISO-8601 week-numbering year. Differs from `Y` for the
+ * last few days of December and first few days of January when those dates
+ * fall in an ISO week belonging to the neighbouring year.
+ *
+ * @param {Date} d - UTC date.
+ * @return {number} ISO week-numbering year.
+ */
+function isoWeekYear( d ) {
+	const tmp = new Date( Date.UTC( d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() ) );
+	// Shift to the Thursday of the ISO week — that day always belongs to the
+	// correct ISO year.
+	const dayNum = tmp.getUTCDay() || 7;
+	tmp.setUTCDate( tmp.getUTCDate() + 4 - dayNum );
+	return tmp.getUTCFullYear();
+}
+
+/**
+ * Two-digit zero-padded string for a non-negative integer.
+ *
+ * @param {number} n - Integer in the 0–99 range coming out of `Date.getUTC*()`.
+ * @return {string} Two-character zero-padded representation.
+ */
+function pad2( n ) {
+	return String( n ).padStart( 2, '0' );
+}
+
+/**
+ * Replace a single PHP `date()` token with its formatted value. Returns the
+ * raw token character unchanged when it isn't one of the supported tokens so
+ * an unrecognised letter shows up in the output rather than getting silently
+ * dropped — easier to diagnose than a confusingly truncated date.
+ *
+ * @param {string} token  - Single ASCII letter token.
+ * @param {Date}   date   - UTC date.
+ * @param {string} locale - BCP47 locale for month / day names.
+ * @return {string} Replacement piece.
+ */
+function replaceToken( token, date, locale ) {
+	switch ( token ) {
+		case 'd':
+			return pad2( date.getUTCDate() );
+		case 'D':
+			return intlPart( date, locale, { weekday: 'short' }, ENGLISH_SHORT_DAYS[ date.getUTCDay() ] );
+		case 'j':
+			return String( date.getUTCDate() );
+		case 'l':
+			return intlPart( date, locale, { weekday: 'long' }, ENGLISH_LONG_DAYS[ date.getUTCDay() ] );
+		case 'N':
+			return String( ( ( date.getUTCDay() + 6 ) % 7 ) + 1 );
+		case 'S':
+			return ordinalSuffix( date.getUTCDate() );
+		case 'w':
+			return String( date.getUTCDay() );
+		case 'F':
+			return intlPart( date, locale, { month: 'long' }, ENGLISH_LONG_MONTHS[ date.getUTCMonth() ] );
+		case 'm':
+			return pad2( date.getUTCMonth() + 1 );
+		case 'M':
+			return intlPart(
+				date,
+				locale,
+				{ month: 'short' },
+				ENGLISH_SHORT_MONTHS[ date.getUTCMonth() ]
+			);
+		case 'n':
+			return String( date.getUTCMonth() + 1 );
+		case 'Y':
+			return String( date.getUTCFullYear() );
+		case 'y':
+			return pad2( date.getUTCFullYear() % 100 );
+		case 'L': {
+			const year = date.getUTCFullYear();
+			return ( year % 4 === 0 && year % 100 !== 0 ) || year % 400 === 0 ? '1' : '0';
+		}
+		case 'o':
+			return String( isoWeekYear( date ) );
+		case 'H':
+			return pad2( date.getUTCHours() );
+		case 'h':
+			return pad2( date.getUTCHours() % 12 || 12 );
+		case 'G':
+			return String( date.getUTCHours() );
+		case 'g':
+			return String( date.getUTCHours() % 12 || 12 );
+		case 'i':
+			return pad2( date.getUTCMinutes() );
+		case 's':
+			return pad2( date.getUTCSeconds() );
+		case 'a':
+			return date.getUTCHours() < 12 ? 'am' : 'pm';
+		case 'A':
+			return date.getUTCHours() < 12 ? 'AM' : 'PM';
+		default:
+			return token;
+	}
+}
+
+/**
+ * Format a Date according to a PHP `date()`-style format string, using the
+ * given BCP47 locale for month / day names.
+ *
+ * Each character of `format` is interpreted in turn: a backslash escapes the
+ * following character so it appears verbatim (`\Y` renders the letter `Y`,
+ * matching PHP's `date()` semantics), recognised tokens are substituted via
+ * `replaceToken`, and any other character is passed through unchanged.
+ *
+ * @param {Date}   date   - UTC date.
+ * @param {string} format - PHP `date()` token string.
+ * @param {string} locale - BCP47 locale tag.
+ * @return {string} Formatted date.
+ */
+export function formatWpDate( date, format, locale = 'en-US' ) {
+	let out = '';
+	for ( let i = 0; i < format.length; i++ ) {
+		const ch = format[ i ];
+		if ( ch === '\\' && i + 1 < format.length ) {
+			out += format[ ++i ];
+			continue;
+		}
+		out += replaceToken( ch, date, locale );
+	}
+	return out;
+}

--- a/projects/packages/search/src/search-blocks/store/wp-date-format.js
+++ b/projects/packages/search/src/search-blocks/store/wp-date-format.js
@@ -11,11 +11,14 @@
  *
  * Token coverage: every PHP `date()` letter likely to appear in a WP
  * `date_format` setting (`d D j l N S w F m M n Y y L o H h G g i s a A`),
- * plus `\` as the literal-escape character. Month and day names are sourced
- * from `Intl.DateTimeFormat` for the seeded blog locale — month names will
- * therefore follow the browser's ICU data rather than WordPress's own
- * translation tables, which is the closest faithful approximation reachable
- * from inside the IAPI runtime.
+ * plus `\` as the literal-escape character. Tokens that resolve to a month
+ * or weekday name (`F`, `M`, `l`, `D`) are sourced from `Intl.DateTimeFormat`
+ * for the seeded blog locale, so the output follows the browser's ICU data
+ * rather than WordPress's own translation tables — this is the closest
+ * faithful approximation reachable from inside the IAPI runtime. Note that
+ * locale-specific abbreviation conventions still apply: e.g. German short
+ * months render as "Apr." rather than the PHP-default "Apr", matching the
+ * behavior of `dateI18n()` on the same site.
  *
  * Dates are read in UTC to keep result cards stable regardless of the
  * viewer's timezone — the v1.3 Jetpack Search API returns post `date` in UTC,

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -83,6 +83,39 @@ describe( 'formatDate', () => {
 	it( 'falls back to en-US when locale is empty string', () => {
 		expect( formatDate( '2026-04-20T10:00:00Z', '' ) ).toBe( 'Apr 20, 2026' );
 	} );
+
+	it( 'honors a WP F j, Y date_format', () => {
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', 'F j, Y' ) ).toBe( 'April 20, 2026' );
+	} );
+
+	it( 'honors a WP Y-m-d date_format', () => {
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', 'Y-m-d' ) ).toBe( '2026-04-20' );
+	} );
+
+	it( 'honors a WP d/m/Y date_format', () => {
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', 'd/m/Y' ) ).toBe( '20/04/2026' );
+	} );
+
+	it( 'honors an ordinal-suffixed l, F jS Y date_format', () => {
+		// 2026-04-20 is a Monday; 20 → "20th".
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', 'l, F jS Y' ) ).toBe(
+			'Monday, April 20th 2026'
+		);
+	} );
+
+	it( 'localizes month names within a WP date_format', () => {
+		// French May → "mai", layout still follows the F j, Y token order.
+		expect( formatDate( '2026-05-04T10:00:00Z', 'fr-FR', 'F j, Y' ) ).toBe( 'mai 4, 2026' );
+	} );
+
+	it( 'treats a backslash as a literal-escape', () => {
+		// `\Y` should emit a literal Y, not the year token.
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', '\\Y=Y' ) ).toBe( 'Y=2026' );
+	} );
+
+	it( 'leaves the legacy short-form output untouched when dateFormat is empty', () => {
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', '' ) ).toBe( 'Apr 20, 2026' );
+	} );
 } );
 
 describe( 'formatPath', () => {
@@ -472,6 +505,16 @@ describe( 'normalizeResult', () => {
 	it( 'passes locale through to dateLabel', () => {
 		const r = normalizeResult( { fields: { date: '2026-04-20T10:00:00Z' } }, 'fr-FR' );
 		expect( r.dateLabel ).toMatch( /20 avr/ );
+	} );
+
+	it( 'passes dateFormat through to dateLabel', () => {
+		const r = normalizeResult(
+			{ fields: { date: '2026-04-20T10:00:00Z' } },
+			'en-US',
+			'',
+			'F j, Y'
+		);
+		expect( r.dateLabel ).toBe( 'April 20, 2026' );
 	} );
 
 	it( 'exposes authorLabel for a single-author result', () => {

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -6,10 +6,18 @@ import {
 	formatDate,
 	formatPath,
 	normalizeResult,
+	setSeededDateFormat,
 	stripTags,
 	toSafeUrl,
 	tokenizeHighlight,
 } from '../../../src/search-blocks/store/result-utils';
+
+// `setSeededDateFormat()` writes module-scoped state that bleeds across tests
+// — reset before each case so an earlier seed can't leak into the next test's
+// `formatDate()` / `normalizeResult()` output.
+beforeEach( () => {
+	setSeededDateFormat( '' );
+} );
 
 describe( 'toSafeUrl', () => {
 	it( 'passes through https URLs', () => {
@@ -115,6 +123,28 @@ describe( 'formatDate', () => {
 
 	it( 'leaves the legacy short-form output untouched when dateFormat is empty', () => {
 		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', '' ) ).toBe( 'Apr 20, 2026' );
+	} );
+
+	it( 'picks up the seeded date format from setSeededDateFormat by default', () => {
+		setSeededDateFormat( 'Y-m-d' );
+		// No explicit dateFormat arg → falls back to the module-scoped seed.
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US' ) ).toBe( '2026-04-20' );
+	} );
+
+	it( 'lets an explicit dateFormat argument override the seed', () => {
+		setSeededDateFormat( 'Y-m-d' );
+		// Explicit '' override falls back to legacy `toLocaleDateString`; the
+		// seeded `Y-m-d` doesn't leak through.
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', '' ) ).toBe( 'Apr 20, 2026' );
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US', 'F j, Y' ) ).toBe( 'April 20, 2026' );
+	} );
+} );
+
+describe( 'setSeededDateFormat', () => {
+	it( 'ignores non-string input and resets to empty', () => {
+		setSeededDateFormat( 'Y-m-d' );
+		setSeededDateFormat( null );
+		expect( formatDate( '2026-04-20T10:00:00Z', 'en-US' ) ).toBe( 'Apr 20, 2026' );
 	} );
 } );
 
@@ -507,13 +537,9 @@ describe( 'normalizeResult', () => {
 		expect( r.dateLabel ).toMatch( /20 avr/ );
 	} );
 
-	it( 'passes dateFormat through to dateLabel', () => {
-		const r = normalizeResult(
-			{ fields: { date: '2026-04-20T10:00:00Z' } },
-			'en-US',
-			'',
-			'F j, Y'
-		);
+	it( 'honors the seeded WP date_format when rendering dateLabel', () => {
+		setSeededDateFormat( 'F j, Y' );
+		const r = normalizeResult( { fields: { date: '2026-04-20T10:00:00Z' } }, 'en-US' );
 		expect( r.dateLabel ).toBe( 'April 20, 2026' );
 	} );
 

--- a/projects/packages/search/tests/js/search-blocks/wp-date-format.test.js
+++ b/projects/packages/search/tests/js/search-blocks/wp-date-format.test.js
@@ -1,0 +1,91 @@
+import { formatWpDate } from '../../../src/search-blocks/store/wp-date-format';
+
+const APR_20_2026 = new Date( Date.UTC( 2026, 3, 20, 10, 30, 45 ) );
+
+describe( 'formatWpDate', () => {
+	it( 'formats the WP default F j, Y', () => {
+		expect( formatWpDate( APR_20_2026, 'F j, Y', 'en-US' ) ).toBe( 'April 20, 2026' );
+	} );
+
+	it( 'formats ISO Y-m-d', () => {
+		expect( formatWpDate( APR_20_2026, 'Y-m-d', 'en-US' ) ).toBe( '2026-04-20' );
+	} );
+
+	it( 'formats European d/m/Y', () => {
+		expect( formatWpDate( APR_20_2026, 'd/m/Y', 'en-US' ) ).toBe( '20/04/2026' );
+	} );
+
+	it( 'formats US m/d/Y', () => {
+		expect( formatWpDate( APR_20_2026, 'm/d/Y', 'en-US' ) ).toBe( '04/20/2026' );
+	} );
+
+	it( 'formats no-leading-zero n/j/Y', () => {
+		expect( formatWpDate( APR_20_2026, 'n/j/y', 'en-US' ) ).toBe( '4/20/26' );
+	} );
+
+	it( 'formats short weekday and short month (D M j Y)', () => {
+		// April 20, 2026 is a Monday.
+		expect( formatWpDate( APR_20_2026, 'D M j Y', 'en-US' ) ).toBe( 'Mon Apr 20 2026' );
+	} );
+
+	it( 'formats full weekday and ordinal day (l, F jS Y)', () => {
+		expect( formatWpDate( APR_20_2026, 'l, F jS Y', 'en-US' ) ).toBe( 'Monday, April 20th 2026' );
+	} );
+
+	it( 'emits the correct ordinal suffix across the 11/12/13 exception', () => {
+		const eleventh = new Date( Date.UTC( 2026, 0, 11 ) );
+		const twelfth = new Date( Date.UTC( 2026, 0, 12 ) );
+		const thirteenth = new Date( Date.UTC( 2026, 0, 13 ) );
+		const twentyFirst = new Date( Date.UTC( 2026, 0, 21 ) );
+		expect( formatWpDate( eleventh, 'jS', 'en-US' ) ).toBe( '11th' );
+		expect( formatWpDate( twelfth, 'jS', 'en-US' ) ).toBe( '12th' );
+		expect( formatWpDate( thirteenth, 'jS', 'en-US' ) ).toBe( '13th' );
+		expect( formatWpDate( twentyFirst, 'jS', 'en-US' ) ).toBe( '21st' );
+	} );
+
+	it( 'localizes month names while keeping the layout order', () => {
+		// May 4, 2026 — French long month is "mai".
+		const may = new Date( Date.UTC( 2026, 4, 4 ) );
+		expect( formatWpDate( may, 'F j, Y', 'fr-FR' ) ).toBe( 'mai 4, 2026' );
+	} );
+
+	it( 'treats a backslash as a literal-escape', () => {
+		// `\F` should emit a literal F, not the long-month token.
+		expect( formatWpDate( APR_20_2026, '\\F=F', 'en-US' ) ).toBe( 'F=April' );
+	} );
+
+	it( 'leaves non-token characters in place', () => {
+		expect( formatWpDate( APR_20_2026, '[Y]', 'en-US' ) ).toBe( '[2026]' );
+	} );
+
+	it( 'formats time tokens (H:i:s and g:i A)', () => {
+		expect( formatWpDate( APR_20_2026, 'H:i:s', 'en-US' ) ).toBe( '10:30:45' );
+		// 10:30 → 10:30 AM (12-hour clock without leading zero).
+		expect( formatWpDate( APR_20_2026, 'g:i A', 'en-US' ) ).toBe( '10:30 AM' );
+		// 22:30 → 10:30 PM.
+		const evening = new Date( Date.UTC( 2026, 3, 20, 22, 30, 0 ) );
+		expect( formatWpDate( evening, 'g:i a', 'en-US' ) ).toBe( '10:30 pm' );
+	} );
+
+	it( 'reads dates as UTC regardless of the runtime timezone', () => {
+		// Forming the Date via Date.UTC pins the wall-clock to UTC; the
+		// formatter must not shift it to the runtime's local offset.
+		const utcNoon = new Date( Date.UTC( 2026, 11, 31, 12, 0, 0 ) );
+		expect( formatWpDate( utcNoon, 'Y-m-d H:i', 'en-US' ) ).toBe( '2026-12-31 12:00' );
+	} );
+
+	it( 'computes the ISO year (o) across a year boundary', () => {
+		// 2026-12-31 is a Thursday and falls in ISO week 53 of 2026.
+		const dec31 = new Date( Date.UTC( 2026, 11, 31 ) );
+		expect( formatWpDate( dec31, 'o', 'en-US' ) ).toBe( '2026' );
+		// 2027-01-01 is a Friday and still falls in ISO week 53 of 2026.
+		const jan1 = new Date( Date.UTC( 2027, 0, 1 ) );
+		expect( formatWpDate( jan1, 'o', 'en-US' ) ).toBe( '2026' );
+	} );
+
+	it( 'leaves unrecognised letters in place', () => {
+		// `Q` isn't a supported token — keep it visible rather than dropping it,
+		// so authors see something is off rather than silently losing characters.
+		expect( formatWpDate( APR_20_2026, 'Q', 'en-US' ) ).toBe( 'Q' );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/wp-date-format.test.js
+++ b/projects/packages/search/tests/js/search-blocks/wp-date-format.test.js
@@ -67,6 +67,18 @@ describe( 'formatWpDate', () => {
 		expect( formatWpDate( evening, 'g:i a', 'en-US' ) ).toBe( '10:30 pm' );
 	} );
 
+	it( 'maps midnight and noon onto the 12-hour clock as 12, not 00', () => {
+		// `h % 12 || 12` short-circuits the 0-hour case so midnight renders as
+		// `12 AM` and noon as `12 PM`, matching PHP `date( 'h' )` / `date( 'g' )`.
+		const midnight = new Date( Date.UTC( 2026, 3, 20, 0, 0, 0 ) );
+		expect( formatWpDate( midnight, 'h:i A', 'en-US' ) ).toBe( '12:00 AM' );
+		expect( formatWpDate( midnight, 'g:i a', 'en-US' ) ).toBe( '12:00 am' );
+
+		const noon = new Date( Date.UTC( 2026, 3, 20, 12, 0, 0 ) );
+		expect( formatWpDate( noon, 'h:i A', 'en-US' ) ).toBe( '12:00 PM' );
+		expect( formatWpDate( noon, 'g:i a', 'en-US' ) ).toBe( '12:00 pm' );
+	} );
+
 	it( 'reads dates as UTC regardless of the runtime timezone', () => {
 		// Forming the Date via Date.UTC pins the wall-clock to UTC; the
 		// formatter must not shift it to the runtime's local offset.

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -41,6 +41,7 @@ class Search_Blocks_Test extends TestCase {
 			'isWooCommerceBlocksEnabled',
 			'homeUrl',
 			'locale',
+			'dateFormat',
 			'searchQuery',
 			'hasSearchParam',
 			'searchParamName',
@@ -58,6 +59,26 @@ class Search_Blocks_Test extends TestCase {
 		$state = Search_Blocks::build_initial_state();
 		foreach ( $required_keys as $key ) {
 			$this->assertArrayHasKey( $key, $state, "Missing key: $key" );
+		}
+	}
+
+	/**
+	 * The site's `date_format` Settings option flows into the seed so the JS
+	 * result card renders dates with the same layout as the rest of the site
+	 * (`F j, Y`, `Y-m-d`, etc.). Parsed client-side by `wp-date-format.js`.
+	 */
+	public function test_build_initial_state_seeds_site_date_format() {
+		$original = get_option( 'date_format' );
+		try {
+			update_option( 'date_format', 'Y-m-d' );
+			$state = Search_Blocks::build_initial_state();
+			$this->assertSame( 'Y-m-d', $state['dateFormat'] );
+		} finally {
+			if ( false === $original ) {
+				delete_option( 'date_format' );
+			} else {
+				update_option( 'date_format', $original );
+			}
 		}
 	}
 

--- a/projects/plugins/search/changelog/rsm-269-honor-date-format
+++ b/projects/plugins/search/changelog/rsm-269-honor-date-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: result cards now honor the site's date_format option (F j, Y, Y-m-d, etc.) instead of a fixed Intl shape.


### PR DESCRIPTION
Fixes [RSM-269](https://linear.app/a8c/issue/RSM-269/date-formatting-doesnt-honor-the-sites-date-format-option-formatdate)

## Why

Site authors set their preferred date format under Settings → General (`F j, Y`, `Y-m-d`, `d/m/Y`, …) expecting every date on the site to match. Today, the Search 3.0 result card always renders dates with a fixed `Intl.DateTimeFormat` shape (`Apr 20, 2026`), so the chosen layout is silently ignored — the search results look out of place next to the rest of the theme. This PR teaches the result card to honour the site's `date_format` setting so search results pick up the same layout authors already see everywhere else.

## Proposed changes

* Seed `get_option( 'date_format' )` into the Interactivity API state as `dateFormat` alongside the existing `locale` seed.
* Add `projects/packages/search/src/search-blocks/store/wp-date-format.js` — a minimal PHP `date()`-style token formatter (covers `d D j l N S w F m M n Y y L o H h G g i s a A` plus the `\` literal-escape). The Interactivity API view bundle can't import `@wordpress/i18n` / `@wordpress/date`, so the parser is self-contained.
* Thread `dateFormat` through `normalizeResult()` → `formatDate()`; when supplied, the new parser renders dates token-by-token using the seeded blog locale for month / day names via `Intl.DateTimeFormat`. When empty (legacy callers / older tests), `formatDate()` falls back to the original `toLocaleDateString` short-form output unchanged.
* Add unit coverage for the new parser (16 cases — common WP defaults, ordinal-suffix edge cases, ISO-year boundary, backslash escape, time tokens, midnight / noon 12-hour boundary) and extend `formatDate` / `normalizeResult` tests to cover the new fourth argument. PHP seed test pins the new state key.

## Related product discussion/links

* Linear: [RSM-269](https://linear.app/a8c/issue/RSM-269/date-formatting-doesnt-honor-the-sites-date-format-option-formatdate)

## Does this pull request change what data or activity we track or use?

No. `date_format` is an existing site setting; nothing new is collected or transmitted. The value is exposed only to the same Interactivity API state seed that already carries `locale`.

## Testing instructions

1. Bring up a docker WP env via `jp docker up -d` and visit any page that hosts a Search 3.0 results region (e.g. a page containing `<!-- wp:jetpack-search/search-results -->` with a `results-list`).
2. Go to **Settings → General** → **Date Format**.
3. Verify each of the following layouts renders correctly on the result card's date row after triggering a search:
   * Default `F j, Y` → `November 5, 2024`
   * `Y-m-d` → `2024-11-05`
   * `d/m/Y` → `05/11/2024`
   * Custom `l, F jS Y` → `Tuesday, November 5th 2024`
   * Custom `\Y\e\a\r: Y` → `Year: 2024` (`\`-escape passes literals through)
4. Switch the site language to a non-English locale (e.g. **Settings → General → Site Language → Français**), set Date Format to `F j, Y`, and confirm month names localize (`mai 4, 2026`) while the layout order stays `F j, Y`.
5. Set Date Format to a value containing no recognised tokens (e.g. plain text) and confirm the card still renders without throwing — unknown letters pass through verbatim.

## Screenshots

Settings → General → **Date Format** set to `Y-m-d`, `?q=hello` against a docker env. Trunk renders the legacy `toLocaleDateString` shape regardless of the WP setting; this branch renders the configured ISO format.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/d2329a0a-82b1-40c6-848e-946fb9321e38) | ![after](https://github.com/user-attachments/assets/15ced3de-ef5c-4145-89f5-8f4e1c0ae25c) |
