### PR TITLE
CI: Only use blank token for Composer when it's the new format

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -52,16 +52,36 @@ runs:
           done
         done
 
+    # Composer <=2.9.7 rejects the new GITHUB_TOKEN token format.
+    # It validates GH tokens against `^[.A-Za-z0-9_]+$`:
+    #   https://github.com/composer/composer/blob/2.9.7/src/Composer/IO/BaseIO.php#L142-L144
+    #
+    # When we get a new-format token, let's pass a blank string so it uses an unauth call,
+    # but keep using the old-format token when issued to reduce the chances rate limiting.
+    #
+    # See: https://github.com/composer/composer/issues/12849
+    #      https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
+    - name: Check github-token format for setup-php
+      id: gh_token_check
+      if: steps.versions.outputs.php-version != 'false'
+      shell: bash
+      env:
+        RAW: ${{ github.token }}
+      run: |
+        if [[ "$RAW" =~ ^[.A-Za-z0-9_]+$ ]]; then
+          echo "Old-format token will be accepted by composer, so it's safe to use."
+          echo "oldschooltoken=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "New-format token would be rejected by composer; let's use a blank token."
+          echo "oldschooltoken=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Setup PHP
       if: steps.versions.outputs.php-version != 'false'
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ steps.versions.outputs.php-version }}
-        # Pass an empty token so setup-php doesn't persist GITHUB_TOKEN to Composer's
-        # config. Composer rejects the new GITHUB_TOKEN token format.
-        # See: https://github.com/composer/composer/issues/12849
-        # https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
-        github-token: ''
+        github-token: ${{ steps.gh_token_check.outputs.oldschooltoken == 'true' && github.token || '' }}
         ini-values: error_reporting=E_ALL, display_errors=On, zend.assertions=1
         tools: composer:${{ steps.versions.outputs.composer-version }}
         extensions: mysql, imagick


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is a follow-up to #48762 that should prevent rate-limiting (if that's really a concern).

* old-format tokens continue to be used
* new-format tokens are blanked out

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1778625431151099-slack-C02AVAR9B
* composer/composer#12849

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI still should be happy.

* Old-format token: https://github.com/Automattic/jetpack/actions/runs/25776571550/job/75710491619?pr=48764#step:3:53
* New-format token: https://github.com/Automattic/jetpack/actions/runs/25776571550/job/75710491618?pr=48764#step:3:53