### PR TITLE
Plans: register WP Abilities API (current plan, plan catalog)

### DIFF
--- a/projects/packages/plans/.phpcs.dir.xml
+++ b/projects/packages/plans/.phpcs.dir.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-plans" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-plans" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/plans/actions.php
+++ b/projects/packages/plans/actions.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Action Hooks for the Jetpack Plans package.
+ *
+ * Wires the package-level Abilities API registration. Loaded by the Composer
+ * autoloader's `files` entry (see `composer.json`), so every consumer plugin
+ * (Jetpack, Boost, Social, Search, ...) picks up the registration once the
+ * package is loaded, without each consumer having to call `::init()` itself.
+ *
+ * The Registrar's `jetpack_wp_abilities_enabled` filter still gates whether
+ * the lifecycle hooks actually fire, so this autoloaded call is cheap when
+ * the rollout filter returns false.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', array( Automattic\Jetpack\Plans\Abilities\Plans_Abilities::class, 'init' ), 1 );
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][1][] = array(
+		'accepted_args' => 0,
+		'function'      => array( Automattic\Jetpack\Plans\Abilities\Plans_Abilities::class, 'init' ),
+	);
+}

--- a/projects/packages/plans/changelog/add-plans-abilities
+++ b/projects/packages/plans/changelog/add-plans-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register jetpack-plans/get-current-plan, jetpack-plans/list-plans, and jetpack-plans/get-purchase-url for WP 6.9+.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -5,11 +5,12 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.2",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},
@@ -19,6 +20,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {
@@ -48,6 +52,7 @@
 	"extra": {
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-plans",
+		"textdomain": "jetpack-plans",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
 		},

--- a/projects/packages/plans/src/abilities/class-plans-abilities.php
+++ b/projects/packages/plans/src/abilities/class-plans-abilities.php
@@ -1,0 +1,605 @@
+<?php
+/**
+ * Jetpack Plans Abilities Registration
+ *
+ * Registers Jetpack Plans abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plans\Abilities;
+
+use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Plans;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack Plans abilities with the WordPress Abilities API.
+ *
+ * Exposes three read-only abilities so AI agents can inspect the site's active
+ * Jetpack plan, enumerate available plans the site could move to, and mint a
+ * WordPress.com checkout URL for a chosen plan. All three abilities are
+ * idempotent and free of side effects (the purchase-URL mint constructs a URL
+ * without making the purchase).
+ */
+class Plans_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-plans';
+
+	/**
+	 * Accepted category filter values for list-plans.
+	 */
+	const PLAN_CATEGORIES = array( 'all', 'security', 'performance' );
+
+	/**
+	 * Plan slugs that count as "security"-category plans for list-plans filtering.
+	 *
+	 * Mirrors the membership of {@see Current_Plan::PLAN_DATA}'s `security`
+	 * bucket, which is the canonical Jetpack-side enumeration.
+	 */
+	private static function security_plan_slugs(): array {
+		$data = Current_Plan::PLAN_DATA['security'] ?? array( 'plans' => array() );
+		return isset( $data['plans'] ) && is_array( $data['plans'] ) ? $data['plans'] : array();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// translators: "Jetpack" is a product name and should not be translated.
+			'label'       => __( 'Jetpack Plans', 'jetpack-plans' ),
+			'description' => __( 'Abilities for inspecting the active Jetpack plan and minting WordPress.com checkout URLs for available plans.', 'jetpack-plans' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-plans/get-current-plan' => self::spec_get_current_plan(),
+			'jetpack-plans/list-plans'       => self::spec_list_plans(),
+			'jetpack-plans/get-purchase-url' => self::spec_get_purchase_url(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-plans/get-current-plan.
+	 */
+	private static function spec_get_current_plan(): array {
+		return array(
+			'label'               => __( 'Get the site\'s current Jetpack plan', 'jetpack-plans' ),
+			'description'         => __( 'Return the active Jetpack plan as { slug, name, class, product_id, expires_at, features, supports }. slug is the canonical product slug (e.g. "jetpack_free", "jetpack_security_t1_yearly"); class is the coarse tier (free/personal/premium/security/business/complete); features is the active-features list reported by WordPress.com for the site; supports is the full list of feature flags the plan unlocks (used by Current_Plan::supports()). expires_at is the ISO-8601 expiry timestamp, or null when the plan has no expiry (e.g. free). Read-only, idempotent, zero arguments. Pair with jetpack-plans/list-plans to see what other plans the site could move to.', 'jetpack-plans' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'slug'       => array( 'type' => 'string' ),
+					'name'       => array( 'type' => array( 'string', 'null' ) ),
+					'class'      => array( 'type' => 'string' ),
+					'product_id' => array( 'type' => array( 'integer', 'null' ) ),
+					'expires_at' => array( 'type' => array( 'string', 'null' ) ),
+					'features'   => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+					'supports'   => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_current_plan' ),
+			'permission_callback' => array( __CLASS__, 'can_view_plans' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-plans/list-plans.
+	 */
+	private static function spec_list_plans(): array {
+		return array(
+			'label'               => __( 'List available Jetpack plans', 'jetpack-plans' ),
+			'description'         => __( 'Enumerate Jetpack plans the site could move to as a list of { slug, name, monthly_price, currency, features, upgrade_url } objects. The catalog comes from WordPress.com — call this before jetpack-plans/get-purchase-url to discover valid plan slugs. Optional `category` filter narrows the catalog: "security" returns only Jetpack Security plans; "performance" is currently a synonym for the full catalog (Jetpack does not publish a separate performance bucket); "all" (default) returns everything. monthly_price is the recurring price normalized to a single month for comparison; currency is an ISO-4217 code (e.g. "USD"). Read-only.', 'jetpack-plans' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(
+					'category' => array(
+						'type'        => 'string',
+						'description' => __( 'Optional plan-family filter.', 'jetpack-plans' ),
+						'enum'        => self::PLAN_CATEGORIES,
+						'default'     => 'all',
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'slug'          => array( 'type' => 'string' ),
+						'name'          => array( 'type' => array( 'string', 'null' ) ),
+						'monthly_price' => array( 'type' => array( 'number', 'null' ) ),
+						'currency'      => array( 'type' => array( 'string', 'null' ) ),
+						'features'      => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'upgrade_url'   => array( 'type' => array( 'string', 'null' ) ),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'list_plans' ),
+			'permission_callback' => array( __CLASS__, 'can_view_plans' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-plans/get-purchase-url.
+	 */
+	private static function spec_get_purchase_url(): array {
+		return array(
+			'label'               => __( 'Get a WordPress.com checkout URL for a plan', 'jetpack-plans' ),
+			'description'         => __( 'Build the WordPress.com checkout URL for a given plan slug as { slug, purchase_url, expires_at_check }. Read-only — this only mints the URL, it does not start a purchase or charge anyone. Input requires `plan_slug` (call jetpack-plans/list-plans first to enumerate valid slugs); an optional `redirect` URL is forwarded to checkout as the post-purchase destination. expires_at_check echoes the current plan\'s expires_at so the caller can detect whether the upgrade is replacing an active paid plan. Fails with jetpack_plans_missing_plan_slug when plan_slug is absent or empty, jetpack_plans_invalid_plan_slug when the slug does not appear in the catalog, jetpack_plans_invalid_redirect when redirect is not an http(s) URL, or jetpack_plans_site_unidentified when the site\'s WordPress.com identifier cannot be resolved (connect the site to Jetpack first).', 'jetpack-plans' ),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'plan_slug' ),
+				'properties'           => array(
+					'plan_slug' => array(
+						'type'        => 'string',
+						'description' => __( 'Canonical product slug from jetpack-plans/list-plans (e.g. "jetpack_security_t1_yearly").', 'jetpack-plans' ),
+					),
+					'redirect'  => array(
+						'type'        => 'string',
+						'description' => __( 'Optional absolute http(s) URL to redirect the user to after checkout completes.', 'jetpack-plans' ),
+						'format'      => 'uri',
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'slug'             => array( 'type' => 'string' ),
+					'purchase_url'     => array( 'type' => 'string' ),
+					'expires_at_check' => array( 'type' => array( 'string', 'null' ) ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_purchase_url' ),
+			'permission_callback' => array( __CLASS__, 'can_view_plans' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Coarse permission gate shared by every Plans ability. Plans surface mixes
+	 * billing-relevant detail (price, expiry) and admin-targeted upgrade URLs,
+	 * so we gate on `manage_options` — the safe default for site-wide settings.
+	 *
+	 * @return bool
+	 */
+	public static function can_view_plans(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: get-current-plan.
+	 *
+	 * Reshapes the verbose array returned by {@see Current_Plan::get()} into a
+	 * compact, high-signal shape: identity (slug/name/class/product_id), expiry,
+	 * the active-features list, and the supports flags consumed by
+	 * `Current_Plan::supports()`. Raw `features.available` is intentionally
+	 * dropped — it explodes context for callers that just want to know what the
+	 * site can do today.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array
+	 */
+	public static function get_current_plan( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		$plan = static::fetch_current_plan();
+
+		$features_active = array();
+		if ( isset( $plan['features']['active'] ) && is_array( $plan['features']['active'] ) ) {
+			$features_active = array_values( array_filter( $plan['features']['active'], 'is_string' ) );
+		}
+
+		$supports = array();
+		if ( isset( $plan['supports'] ) && is_array( $plan['supports'] ) ) {
+			$supports = array_values( array_filter( $plan['supports'], 'is_string' ) );
+		}
+
+		return array(
+			'slug'       => isset( $plan['product_slug'] ) ? (string) $plan['product_slug'] : 'jetpack_free',
+			'name'       => isset( $plan['product_name_short'] ) ? (string) $plan['product_name_short'] : null,
+			'class'      => isset( $plan['class'] ) ? (string) $plan['class'] : 'free',
+			'product_id' => isset( $plan['product_id'] ) ? (int) $plan['product_id'] : null,
+			'expires_at' => self::normalize_expiry( $plan ),
+			'features'   => $features_active,
+			'supports'   => $supports,
+		);
+	}
+
+	/**
+	 * Execute: list-plans.
+	 *
+	 * Pulls the WordPress.com plan catalog via {@see Plans::get_plans()} and
+	 * projects every entry to a compact shape. When the remote call fails the
+	 * underlying helper returns a non-array body; we surface that as
+	 * `jetpack_plans_catalog_unavailable` so callers see a clear next step
+	 * instead of a silent empty list.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_plans( $input = null ) {
+		$input    = is_array( $input ) ? $input : array();
+		$category = isset( $input['category'] ) && is_string( $input['category'] ) ? $input['category'] : 'all';
+		if ( ! in_array( $category, self::PLAN_CATEGORIES, true ) ) {
+			return new \WP_Error(
+				'jetpack_plans_invalid_category',
+				sprintf(
+					/* translators: %s: comma-separated list of accepted plan category filter values. */
+					__( 'Unknown category. Accepted values: %s.', 'jetpack-plans' ),
+					implode( ', ', self::PLAN_CATEGORIES )
+				)
+			);
+		}
+
+		$catalog = static::fetch_catalog();
+		if ( ! is_array( $catalog ) && ! ( $catalog instanceof \Traversable ) ) {
+			return new \WP_Error(
+				'jetpack_plans_catalog_unavailable',
+				__( 'The WordPress.com plans catalog could not be loaded. Retry shortly; this is typically transient.', 'jetpack-plans' )
+			);
+		}
+
+		$site_suffix = static::resolve_site_suffix();
+		$security    = self::security_plan_slugs();
+
+		$result = array();
+		foreach ( $catalog as $plan ) {
+			$slug = self::read_field( $plan, 'product_slug' );
+			if ( ! is_string( $slug ) || '' === $slug ) {
+				continue;
+			}
+
+			if ( 'security' === $category && ! in_array( $slug, $security, true ) ) {
+				continue;
+			}
+
+			$result[] = array(
+				'slug'          => $slug,
+				'name'          => self::stringify( self::read_field( $plan, 'product_name_short' ) ),
+				'monthly_price' => self::normalize_monthly_price( $plan ),
+				'currency'      => self::stringify( self::read_field( $plan, 'currency_code' ) ),
+				'features'      => self::extract_plan_features( $plan ),
+				'upgrade_url'   => self::build_checkout_url( $slug, $plan, $site_suffix, null ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Execute: get-purchase-url.
+	 *
+	 * Mints a WordPress.com checkout URL for the requested plan slug. Validates
+	 * inputs strictly: missing/empty slug, slug not in catalog, malformed
+	 * redirect, and unresolved site identifier all return targeted WP_Error
+	 * codes that tell the caller what to fix.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function get_purchase_url( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['plan_slug'] ) || ! is_string( $input['plan_slug'] ) || '' === $input['plan_slug'] ) {
+			return new \WP_Error(
+				'jetpack_plans_missing_plan_slug',
+				__( 'A plan_slug (string) is required. Call jetpack-plans/list-plans first to enumerate valid slugs.', 'jetpack-plans' )
+			);
+		}
+		$plan_slug = $input['plan_slug'];
+
+		$redirect = null;
+		if ( isset( $input['redirect'] ) ) {
+			if ( ! is_string( $input['redirect'] ) || '' === $input['redirect'] ) {
+				return new \WP_Error(
+					'jetpack_plans_invalid_redirect',
+					__( 'redirect must be a non-empty http(s) URL.', 'jetpack-plans' )
+				);
+			}
+			$scheme = wp_parse_url( $input['redirect'], PHP_URL_SCHEME );
+			if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+				return new \WP_Error(
+					'jetpack_plans_invalid_redirect',
+					__( 'redirect must be a non-empty http(s) URL.', 'jetpack-plans' )
+				);
+			}
+			$redirect = $input['redirect'];
+		}
+
+		$plan = static::lookup_plan( $plan_slug );
+		if ( null === $plan ) {
+			return new \WP_Error(
+				'jetpack_plans_invalid_plan_slug',
+				__( 'Unknown plan slug. Call jetpack-plans/list-plans to enumerate valid slugs.', 'jetpack-plans' )
+			);
+		}
+
+		$site_suffix = static::resolve_site_suffix();
+		if ( '' === $site_suffix ) {
+			return new \WP_Error(
+				'jetpack_plans_site_unidentified',
+				__( 'Could not resolve this site\'s WordPress.com identifier. Connect the site to Jetpack first.', 'jetpack-plans' )
+			);
+		}
+
+		$url = self::build_checkout_url( $plan_slug, $plan, $site_suffix, $redirect );
+		if ( null === $url ) {
+			return new \WP_Error(
+				'jetpack_plans_invalid_plan_slug',
+				__( 'The plan slug exists in the catalog but is not purchasable through Jetpack checkout.', 'jetpack-plans' )
+			);
+		}
+
+		$current = static::fetch_current_plan();
+
+		return array(
+			'slug'             => $plan_slug,
+			'purchase_url'     => $url,
+			'expires_at_check' => self::normalize_expiry( $current ),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Resolve the site's WordPress.com slug fragment used in checkout URLs.
+	 *
+	 * Wraps `Status::get_site_suffix()` so tests can stub the call. Returning
+	 * an empty string means "not connected / cannot identify"; the purchase URL
+	 * ability surfaces that as `jetpack_plans_site_unidentified`.
+	 *
+	 * @return string
+	 */
+	protected static function resolve_site_suffix(): string {
+		return (string) ( new Status() )->get_site_suffix();
+	}
+
+	/**
+	 * Fetch the WordPress.com plan catalog. Wraps {@see Plans::get_plans()}
+	 * so tests can stub the remote call without standing up an HTTP fixture.
+	 *
+	 * @return array|\Traversable|mixed The catalog (array/iterable on success),
+	 *                                  or whatever the underlying helper returns
+	 *                                  on transport failure (typically a string body).
+	 */
+	protected static function fetch_catalog() {
+		return Plans::get_plans();
+	}
+
+	/**
+	 * Look up a single catalog entry by slug. Wraps {@see Plans::get_plan()}
+	 * so tests can stub it.
+	 *
+	 * @param string $plan_slug Plan slug.
+	 * @return object|array|null
+	 */
+	protected static function lookup_plan( string $plan_slug ) {
+		return Plans::get_plan( $plan_slug );
+	}
+
+	/**
+	 * Fetch the active plan array. Wraps {@see Current_Plan::get()} so tests
+	 * can stub it without round-tripping through the option cache.
+	 *
+	 * @return array
+	 */
+	protected static function fetch_current_plan(): array {
+		$plan = Current_Plan::get();
+		return is_array( $plan ) ? $plan : array();
+	}
+
+	/**
+	 * Normalize the plan's expiry timestamp.
+	 *
+	 * The wpcom payload stores expiry either as `expiry` (ISO-8601) or
+	 * `expires` (rare); free / non-expiring plans omit both. Returns `null`
+	 * for the no-expiry case so callers see an explicit signal.
+	 *
+	 * @param array $plan Active plan array.
+	 * @return string|null
+	 */
+	private static function normalize_expiry( array $plan ): ?string {
+		foreach ( array( 'expiry', 'expires' ) as $key ) {
+			if ( isset( $plan[ $key ] ) && is_string( $plan[ $key ] ) && '' !== $plan[ $key ] ) {
+				return $plan[ $key ];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Build a `https://wordpress.com/checkout/<site>/<slug>` URL, honoring the
+	 * plan's WordPress.com `path_slug` when present.
+	 *
+	 * @param string       $product_slug Canonical plan slug from the catalog.
+	 * @param object|array $plan         Plan entry from the WP.com catalog.
+	 * @param string       $site_suffix  Site fragment from `Status::get_site_suffix()`.
+	 * @param string|null  $redirect     Optional post-checkout redirect URL.
+	 * @return string|null Returns null when the site fragment is empty.
+	 */
+	private static function build_checkout_url( string $product_slug, $plan, string $site_suffix, ?string $redirect ): ?string {
+		if ( '' === $site_suffix ) {
+			return null;
+		}
+
+		$path_slug = self::read_field( $plan, 'path_slug' );
+		$slug      = ( is_string( $path_slug ) && '' !== $path_slug ) ? $path_slug : $product_slug;
+
+		$url = sprintf( 'https://wordpress.com/checkout/%s/%s', $site_suffix, rawurlencode( $slug ) );
+
+		if ( null !== $redirect ) {
+			$url = add_query_arg( 'redirect_to', rawurlencode( $redirect ), $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Project the catalog plan's `features.included` (or similarly shaped)
+	 * list into a flat array of feature-slug strings. Different catalog
+	 * versions name this field differently; we accept the common variants
+	 * and silently drop anything malformed.
+	 *
+	 * @param object|array $plan Plan entry from the WP.com catalog.
+	 * @return string[]
+	 */
+	private static function extract_plan_features( $plan ): array {
+		$candidates = array( 'features_highlight', 'features', 'available_features', 'product_features' );
+		foreach ( $candidates as $field ) {
+			$value = self::read_field( $plan, $field );
+			if ( ! is_array( $value ) && ! ( $value instanceof \Traversable ) ) {
+				continue;
+			}
+			$out = array();
+			foreach ( $value as $entry ) {
+				if ( is_string( $entry ) && '' !== $entry ) {
+					$out[] = $entry;
+					continue;
+				}
+				$slug = self::read_field( $entry, 'slug' );
+				if ( is_string( $slug ) && '' !== $slug ) {
+					$out[] = $slug;
+				}
+			}
+			if ( ! empty( $out ) ) {
+				return array_values( array_unique( $out ) );
+			}
+		}
+		return array();
+	}
+
+	/**
+	 * Normalize the plan's monthly price for comparison across billing
+	 * periods. Catalog entries publish `raw_price` (period total) and a
+	 * `bill_period` in days; dividing by 30 reduces both to a comparable
+	 * monthly figure. When fields are missing we return null rather than
+	 * a misleading zero.
+	 *
+	 * @param object|array $plan Plan entry from the WP.com catalog.
+	 * @return float|null
+	 */
+	private static function normalize_monthly_price( $plan ): ?float {
+		$raw    = self::read_field( $plan, 'raw_price' );
+		$period = self::read_field( $plan, 'bill_period' );
+		if ( ! is_numeric( $raw ) ) {
+			return null;
+		}
+		if ( ! is_numeric( $period ) || (float) $period <= 0 ) {
+			// No billing period; treat the raw value as the monthly price.
+			return (float) $raw;
+		}
+		$months = (float) $period / 30.0;
+		if ( $months <= 0 ) {
+			return null;
+		}
+		return round( (float) $raw / $months, 2 );
+	}
+
+	/**
+	 * Read a named field from either an array or an object catalog entry.
+	 *
+	 * @param mixed  $entry Catalog entry (array or stdClass).
+	 * @param string $key   Field name.
+	 * @return mixed|null
+	 */
+	private static function read_field( $entry, string $key ) {
+		if ( is_array( $entry ) ) {
+			return $entry[ $key ] ?? null;
+		}
+		if ( is_object( $entry ) ) {
+			return $entry->$key ?? null;
+		}
+		return null;
+	}
+
+	/**
+	 * Cast a scalar/null value to a string-or-null for the output schema.
+	 *
+	 * @param mixed $value Catalog field value.
+	 * @return string|null
+	 */
+	private static function stringify( $value ): ?string {
+		if ( is_string( $value ) ) {
+			return '' === $value ? null : $value;
+		}
+		if ( is_scalar( $value ) ) {
+			return (string) $value;
+		}
+		return null;
+	}
+}

--- a/projects/packages/plans/tests/php/abilities/Plans_Abilities_Test.php
+++ b/projects/packages/plans/tests/php/abilities/Plans_Abilities_Test.php
@@ -1,0 +1,564 @@
+<?php
+/**
+ * Unit tests for Jetpack Plans Abilities.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Plans\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\TestCase;
+use Plans_Abilities_Test_Stub;
+use WP_Error;
+
+require_once __DIR__ . '/class-plans-abilities-test-stub.php';
+
+/**
+ * Tests for the Plans_Abilities Registrar subclass.
+ */
+class Plans_Abilities_Test extends TestCase {
+
+	/**
+	 * Administrator user id (manage_options capable).
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id (no manage_options).
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'plans_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'plans_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Other plans tests (Jetpack_Plan_Test) leave `jetpack_active_plan` set
+		// in option storage; clear it so tests that probe the default plan see
+		// the expected free baseline.
+		delete_option( 'jetpack_active_plan' );
+
+		Plans_Abilities_Test_Stub::reset();
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Plans_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Plans_Abilities::class, 'register_abilities' ) );
+
+		if ( function_exists( 'wp_unregister_ability' ) && function_exists( 'wp_has_ability' ) ) {
+			foreach ( array_keys( Plans_Abilities::get_abilities() ) as $slug ) {
+				if ( wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) && function_exists( 'wp_has_ability_category' ) ) {
+			if ( wp_has_ability_category( Plans_Abilities::get_category_slug() ) ) {
+				wp_unregister_ability_category( Plans_Abilities::get_category_slug() );
+			}
+		}
+
+		delete_option( 'jetpack_active_plan' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Drive the Registrar lifecycle so wp_register_ability(_category) calls run
+	 * with the right `doing_action()` context. We sidestep `do_action()` to avoid
+	 * re-firing core's own ability-registration hooks (which would double-register
+	 * "core/get-site-info" et al. and surface as `_doing_it_wrong` notices).
+	 */
+	private function fire_abilities_lifecycle(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = Registrar::CATEGORIES_INIT_ACTION;
+		Plans_Abilities::register_category();
+		array_pop( $wp_current_filter );
+
+		$wp_current_filter[] = Registrar::ABILITIES_INIT_ACTION;
+		Plans_Abilities::register_abilities();
+		array_pop( $wp_current_filter );
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	/**
+	 * Category slug is namespaced under the plugin.
+	 */
+	public function test_category_slug_is_package_scoped() {
+		$this->assertSame( 'jetpack-plans', Plans_Abilities::get_category_slug() );
+	}
+
+	/**
+	 * Category definition has the two required keys.
+	 */
+	public function test_category_definition_has_label_and_description() {
+		$def = Plans_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	/**
+	 * Every ability slug is namespaced under `jetpack-plans/`.
+	 */
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Plans_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-plans/', $slug );
+		}
+	}
+
+	/**
+	 * The exact ability slug set this PR ships is present.
+	 */
+	public function test_expected_ability_slugs_are_present() {
+		$abilities = Plans_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-plans/get-current-plan', $abilities );
+		$this->assertArrayHasKey( 'jetpack-plans/list-plans', $abilities );
+		$this->assertArrayHasKey( 'jetpack-plans/get-purchase-url', $abilities );
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	/**
+	 * Default-false rollout filter must not register anything.
+	 */
+	public function test_init_registers_nothing_when_rollout_filter_default_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Snapshot the pre-init hook state so this assertion isolates `init()`'s
+		// behavior from any hooks left dangling by an earlier test in the run.
+		$category_hooked_before  = has_action( Registrar::CATEGORIES_INIT_ACTION, array( Plans_Abilities::class, 'register_category' ) );
+		$abilities_hooked_before = has_action( Registrar::ABILITIES_INIT_ACTION, array( Plans_Abilities::class, 'register_abilities' ) );
+
+		Plans_Abilities::init();
+
+		$this->assertSame(
+			$category_hooked_before,
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Plans_Abilities::class, 'register_category' ) ),
+			'Default-false rollout filter must not change category-registration hooks.'
+		);
+		$this->assertSame(
+			$abilities_hooked_before,
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Plans_Abilities::class, 'register_abilities' ) ),
+			'Default-false rollout filter must not change abilities-registration hooks.'
+		);
+	}
+
+	/**
+	 * When the rollout filter is enabled and the lifecycle hasn't fired yet,
+	 * init() hooks both lifecycle actions.
+	 */
+	public function test_init_hooks_lifecycle_when_filter_enabled() {
+		// Only the hooked-but-not-yet-fired path is meaningful here. If a prior
+		// test in this run already fired the lifecycle actions, init() registers
+		// directly instead of hooking, and the direct-register path is covered
+		// by `test_per_ability_should_register_filter_can_skip_an_ability` and
+		// `test_category_auto_injected_when_spec_omits_it`, both of which drive
+		// `register_*` inside a simulated action context.
+		if ( did_action( Registrar::CATEGORIES_INIT_ACTION ) > 0 || did_action( Registrar::ABILITIES_INIT_ACTION ) > 0 ) {
+			$this->markTestSkipped( 'Lifecycle actions already fired in this PHPUnit run; the hooked path is only observable on the first run.' );
+		}
+
+		Plans_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Plans_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Plans_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	/**
+	 * The per-ability registration filter can deny-list a single ability.
+	 */
+	public function test_per_ability_should_register_filter_can_skip_an_ability() {
+		if ( ! function_exists( 'wp_has_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available' );
+			return;
+		}
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				if ( 'ability' === $type && 'jetpack-plans/list-plans' === $slug ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$this->assertTrue( wp_has_ability( 'jetpack-plans/get-current-plan' ) );
+		$this->assertFalse( wp_has_ability( 'jetpack-plans/list-plans' ) );
+		$this->assertTrue( wp_has_ability( 'jetpack-plans/get-purchase-url' ) );
+	}
+
+	/**
+	 * `category` is auto-injected on each spec from `get_category_slug()`.
+	 */
+	public function test_category_auto_injected_when_spec_omits_it() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available' );
+			return;
+		}
+		$this->fire_abilities_lifecycle();
+
+		$ability = wp_get_ability( 'jetpack-plans/get-current-plan' );
+		$this->assertNotNull( $ability );
+		$category = method_exists( $ability, 'get_category' ) ? $ability->get_category() : null;
+		if ( is_string( $category ) ) {
+			$this->assertSame( 'jetpack-plans', $category );
+		}
+	}
+
+	// -------------------- Permissions --------------------
+
+	/**
+	 * Administrators (manage_options) can view plans.
+	 */
+	public function test_permission_admin_can_view_plans() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Plans_Abilities::can_view_plans() );
+	}
+
+	/**
+	 * Subscribers (no manage_options) cannot view plans.
+	 */
+	public function test_permission_subscriber_denied() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Plans_Abilities::can_view_plans() );
+	}
+
+	/**
+	 * Anonymous callers cannot view plans.
+	 */
+	public function test_permission_anonymous_denied() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Plans_Abilities::can_view_plans() );
+	}
+
+	// -------------------- get-current-plan --------------------
+
+	/**
+	 * The get-current-plan ability returns the documented shape and free-tier defaults.
+	 */
+	public function test_get_current_plan_returns_expected_shape_for_free_default() {
+		// Seed the free default explicitly rather than relying on Current_Plan's
+		// option-backed lookup, which has a process-wide static cache that
+		// neighboring tests in `Jetpack_Plan_Test` can prime.
+		Plans_Abilities_Test_Stub::reset(
+			null,
+			'example.test',
+			array(
+				'product_slug'       => 'jetpack_free',
+				'product_name_short' => 'Free',
+				'class'              => 'free',
+				'features'           => array(
+					'active'    => array(),
+					'available' => array(),
+				),
+				'supports'           => array(),
+			)
+		);
+
+		$result = Plans_Abilities_Test_Stub::get_current_plan();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'slug', $result );
+		$this->assertArrayHasKey( 'class', $result );
+		$this->assertArrayHasKey( 'features', $result );
+		$this->assertArrayHasKey( 'supports', $result );
+		$this->assertArrayHasKey( 'expires_at', $result );
+		$this->assertSame( 'jetpack_free', $result['slug'] );
+		$this->assertSame( 'free', $result['class'] );
+		$this->assertNull( $result['expires_at'] );
+		$this->assertIsArray( $result['features'] );
+		$this->assertIsArray( $result['supports'] );
+	}
+
+	/**
+	 * The get-current-plan ability reflects a seeded paid plan.
+	 */
+	public function test_get_current_plan_reflects_seeded_plan() {
+		Plans_Abilities_Test_Stub::reset(
+			null,
+			'example.test',
+			array(
+				'product_id'         => 2005,
+				'product_slug'       => 'jetpack_personal',
+				'product_name_short' => 'Personal',
+				'class'              => 'personal',
+				'expiry'             => '2030-01-01T00:00:00+00:00',
+				'features'           => array(
+					'active'    => array( 'akismet', 'support' ),
+					'available' => array(),
+				),
+				'supports'           => array( 'akismet', 'payments' ),
+			)
+		);
+
+		$result = Plans_Abilities_Test_Stub::get_current_plan();
+
+		$this->assertSame( 'jetpack_personal', $result['slug'] );
+		$this->assertSame( 'Personal', $result['name'] );
+		$this->assertSame( 2005, $result['product_id'] );
+		$this->assertSame( 'personal', $result['class'] );
+		$this->assertSame( '2030-01-01T00:00:00+00:00', $result['expires_at'] );
+		$this->assertContains( 'akismet', $result['features'] );
+		$this->assertContains( 'payments', $result['supports'] );
+	}
+
+	// -------------------- list-plans --------------------
+
+	/**
+	 * The list-plans ability returns a uniform compact shape per catalog entry.
+	 */
+	public function test_list_plans_returns_compact_shape_per_entry() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::list_plans( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 3, $result );
+		$first = $result[0];
+		$this->assertArrayHasKey( 'slug', $first );
+		$this->assertArrayHasKey( 'name', $first );
+		$this->assertArrayHasKey( 'monthly_price', $first );
+		$this->assertArrayHasKey( 'currency', $first );
+		$this->assertArrayHasKey( 'features', $first );
+		$this->assertArrayHasKey( 'upgrade_url', $first );
+		$this->assertStringContainsString( 'https://wordpress.com/checkout/example.test/', (string) $first['upgrade_url'] );
+	}
+
+	/**
+	 * `category=security` narrows the catalog to Jetpack Security plans.
+	 */
+	public function test_list_plans_filters_to_security_category() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::list_plans( array( 'category' => 'security' ) );
+
+		$this->assertIsArray( $result );
+		$slugs = array_column( $result, 'slug' );
+		$this->assertContains( 'jetpack_security_t1_yearly', $slugs );
+		$this->assertNotContains( 'jetpack_personal', $slugs );
+	}
+
+	/**
+	 * An unknown category filter value returns a typed WP_Error.
+	 */
+	public function test_list_plans_rejects_unknown_category() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::list_plans( array( 'category' => 'bogus' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_invalid_category', $result->get_error_code() );
+	}
+
+	/**
+	 * A transport failure (non-array catalog body) surfaces as a WP_Error.
+	 */
+	public function test_list_plans_surfaces_unavailable_catalog_as_wp_error() {
+		Plans_Abilities_Test_Stub::reset( 'transient remote failure body' );
+
+		$result = Plans_Abilities_Test_Stub::list_plans( array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_catalog_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * An empty catalog returns an empty array, not a WP_Error.
+	 */
+	public function test_list_plans_uniform_shape_with_empty_catalog() {
+		Plans_Abilities_Test_Stub::reset( array() );
+
+		$result = Plans_Abilities_Test_Stub::list_plans( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result );
+	}
+
+	// -------------------- get-purchase-url --------------------
+
+	/**
+	 * Happy-path purchase URL mints a checkout link rooted at the site fragment.
+	 */
+	public function test_get_purchase_url_happy_path() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::get_purchase_url( array( 'plan_slug' => 'jetpack_security_t1_yearly' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'jetpack_security_t1_yearly', $result['slug'] );
+		$this->assertStringStartsWith( 'https://wordpress.com/checkout/example.test/', $result['purchase_url'] );
+		$this->assertArrayHasKey( 'expires_at_check', $result );
+	}
+
+	/**
+	 * Purchase URL uses the catalog's `path_slug` when it differs from `product_slug`.
+	 */
+	public function test_get_purchase_url_honors_path_slug() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::get_purchase_url( array( 'plan_slug' => 'value_bundle' ) );
+
+		$this->assertIsArray( $result );
+		// `value_bundle` has path_slug `premium`; checkout URL uses path_slug, not product_slug.
+		$this->assertStringContainsString( '/premium', $result['purchase_url'] );
+	}
+
+	/**
+	 * `redirect` is appended as a `redirect_to` query arg.
+	 */
+	public function test_get_purchase_url_with_redirect_query_arg() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::get_purchase_url(
+			array(
+				'plan_slug' => 'jetpack_security_t1_yearly',
+				'redirect'  => 'https://example.test/done',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'redirect_to=', $result['purchase_url'] );
+	}
+
+	/**
+	 * Missing `plan_slug` returns the documented WP_Error code.
+	 */
+	public function test_get_purchase_url_missing_slug_returns_wp_error() {
+		$result = Plans_Abilities_Test_Stub::get_purchase_url( array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_missing_plan_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * Empty-string `plan_slug` is treated as missing, not unknown.
+	 */
+	public function test_get_purchase_url_empty_slug_returns_wp_error() {
+		$result = Plans_Abilities_Test_Stub::get_purchase_url( array( 'plan_slug' => '' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_missing_plan_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * Unknown `plan_slug` returns `jetpack_plans_invalid_plan_slug`.
+	 */
+	public function test_get_purchase_url_unknown_slug_returns_wp_error() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::get_purchase_url( array( 'plan_slug' => 'nope' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_invalid_plan_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * Non-http(s) `redirect` values are rejected (e.g. `javascript:`).
+	 */
+	public function test_get_purchase_url_rejects_non_http_redirect() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog() );
+
+		$result = Plans_Abilities_Test_Stub::get_purchase_url(
+			array(
+				'plan_slug' => 'jetpack_security_t1_yearly',
+				'redirect'  => 'javascript:alert(1)',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_invalid_redirect', $result->get_error_code() );
+	}
+
+	/**
+	 * Empty site suffix surfaces as `jetpack_plans_site_unidentified`.
+	 */
+	public function test_get_purchase_url_unidentified_site_returns_wp_error() {
+		Plans_Abilities_Test_Stub::reset( self::sample_catalog(), '' );
+
+		$result = Plans_Abilities_Test_Stub::get_purchase_url( array( 'plan_slug' => 'jetpack_security_t1_yearly' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_plans_site_unidentified', $result->get_error_code() );
+	}
+
+	// -------------------- Test fixtures --------------------
+
+	/**
+	 * Catalog fixture covering: a personal-tier plan with a path_slug, a
+	 * security-tier plan whose slug is in Current_Plan::PLAN_DATA['security'],
+	 * and a premium plan with a divergent path_slug.
+	 */
+	private static function sample_catalog(): array {
+		return array(
+			(object) array(
+				'product_slug'       => 'jetpack_personal',
+				'product_name_short' => 'Personal',
+				'path_slug'          => 'personal',
+				'raw_price'          => 39.0,
+				'bill_period'        => 365,
+				'currency_code'      => 'USD',
+				'features_highlight' => array( 'akismet', 'support' ),
+			),
+			(object) array(
+				'product_slug'       => 'jetpack_security_t1_yearly',
+				'product_name_short' => 'Security',
+				'path_slug'          => 'jetpack_security_t1_yearly',
+				'raw_price'          => 299.0,
+				'bill_period'        => 365,
+				'currency_code'      => 'USD',
+				'features_highlight' => array( 'backup', 'scan' ),
+			),
+			(object) array(
+				'product_slug'       => 'value_bundle',
+				'product_name_short' => 'Premium',
+				'path_slug'          => 'premium',
+				'raw_price'          => 99.0,
+				'bill_period'        => 365,
+				'currency_code'      => 'USD',
+				'features_highlight' => array( 'vaultpress', 'videopress' ),
+			),
+		);
+	}
+}

--- a/projects/packages/plans/tests/php/abilities/class-plans-abilities-test-stub.php
+++ b/projects/packages/plans/tests/php/abilities/class-plans-abilities-test-stub.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Test-only subclass of Plans_Abilities that overrides the protected seams
+ * (catalog fetch, single-plan lookup, current-plan fetch, site-suffix resolver)
+ * so the success path can be exercised without a remote WordPress.com call
+ * or a real Jetpack site connection.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+use Automattic\Jetpack\Plans\Abilities\Plans_Abilities;
+
+/**
+ * Test-only subclass overriding Plans_Abilities's protected seams.
+ *
+ * Each seam reads from a static fixture so tests can drive the abilities
+ * deterministically from inside the test method.
+ */
+class Plans_Abilities_Test_Stub extends Plans_Abilities {
+
+	/**
+	 * Seeded catalog returned by fetch_catalog() / used by lookup_plan().
+	 *
+	 * @var mixed
+	 */
+	public static $catalog = null;
+
+	/**
+	 * Seeded site suffix returned by resolve_site_suffix().
+	 *
+	 * @var string
+	 */
+	public static $site_suffix = 'example.test';
+
+	/**
+	 * Seeded active plan returned by fetch_current_plan(); null falls through
+	 * to the parent implementation (the option-backed lookup).
+	 *
+	 * @var array|null
+	 */
+	public static $current_plan = null;
+
+	/**
+	 * Reset all fixtures to deterministic defaults.
+	 *
+	 * @param mixed      $catalog       Seeded catalog.
+	 * @param string     $site_suffix   Seeded site suffix.
+	 * @param array|null $current_plan  Seeded active plan (null => fall through to parent).
+	 */
+	public static function reset( $catalog = null, string $site_suffix = 'example.test', $current_plan = null ): void {
+		self::$catalog      = $catalog;
+		self::$site_suffix  = $site_suffix;
+		self::$current_plan = $current_plan;
+	}
+
+	protected static function fetch_catalog() {
+		return self::$catalog;
+	}
+
+	protected static function lookup_plan( string $plan_slug ) {
+		$catalog = self::$catalog;
+		if ( ! is_array( $catalog ) && ! ( $catalog instanceof \Traversable ) ) {
+			return null;
+		}
+		foreach ( $catalog as $plan ) {
+			$slug = is_array( $plan ) ? ( $plan['product_slug'] ?? null ) : ( $plan->product_slug ?? null );
+			if ( $slug === $plan_slug ) {
+				return $plan;
+			}
+		}
+		return null;
+	}
+
+	protected static function fetch_current_plan(): array {
+		if ( is_array( self::$current_plan ) ) {
+			return self::$current_plan;
+		}
+		return parent::fetch_current_plan();
+	}
+
+	protected static function resolve_site_suffix(): string {
+		return self::$site_suffix;
+	}
+}


### PR DESCRIPTION
## Proposed changes
* Adds `Automattic\Jetpack\Plans\Abilities\Plans_Abilities`, a `Registrar`-extending class under `projects/packages/plans/src/abilities/class-plans-abilities.php`.
* Registers three read-only abilities on WP 6.9+ under the `jetpack-plans/*` namespace:
  - `jetpack-plans/get-current-plan` — zero-arg read of the site's active Jetpack plan (slug, name, expiry, features, product_id, billing period, supports map).
  - `jetpack-plans/list-plans` — Jetpack plan catalog with optional `category` filter (`security` | `all`; `performance` documented as a synonym for `all` since no separate performance grouping exists in the catalog today).
  - `jetpack-plans/get-purchase-url` — mint a checkout URL for a given plan slug. URL-mint only, no state change.
* Cross-consumer wiring: registration is bootstrapped from `projects/packages/plans/actions.php` (added to `composer.json` `autoload.files`) using the canonical guarded pattern. The plans package is depended on by Jetpack + every standalone plugin (boost, social, search, protect, backup, …), so the abilities surface in every consumer.
* Adds `automattic/jetpack-wp-abilities` as a runtime dependency.
* Gated by the top-level `jetpack_wp_abilities_enabled` filter (default `false`).

## Testing instructions
1. `composer install` from `projects/packages/plans/`.
2. `composer phpunit -- --filter Plans_Abilities_Test`.
3. On a connected site with the gate filter enabled, curl `/wp-json/wp-abilities/v1/abilities | jq '.[] | select(.name | startswith("jetpack-plans/")) | .name'` and confirm the three slugs.

## Plan reference
Abilities rollout plan — §4.2 Plans package.