### PR TITLE
PayPal Payments abilities: register button reads via Registrar

### DIFF
--- a/projects/packages/paypal-payments/actions.php
+++ b/projects/packages/paypal-payments/actions.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Action hooks for the Jetpack PayPal Payments package.
+ *
+ * The package is loaded by both the standalone PayPal Payment Buttons
+ * plugin and the Jetpack plugin. Registering the WP Abilities API surface
+ * here ensures the abilities are visible from both contexts without each
+ * consumer needing to wire them up separately.
+ *
+ * Registration is gated by the `jetpack_wp_abilities_enabled` filter
+ * inside `Registrar::init()` (default false), so this call is safe to
+ * make unconditionally while rollout stays opt-in per site.
+ *
+ * @package automattic/jetpack-paypal-payments
+ */
+
+use Automattic\Jetpack\PayPal_Payments\Abilities\PayPal_Payments_Abilities;
+
+if ( function_exists( 'add_action' ) ) {
+	add_action(
+		'init',
+		array( PayPal_Payments_Abilities::class, 'init' ),
+		20
+	);
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['init'][20][] = array(
+		'accepted_args' => 0,
+		'function'      => array( PayPal_Payments_Abilities::class, 'init' ),
+	);
+}

--- a/projects/packages/paypal-payments/changelog/add-paypal-payments-abilities
+++ b/projects/packages/paypal-payments/changelog/add-paypal-payments-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register WP Abilities API surface for PayPal payment buttons (list-buttons).

--- a/projects/packages/paypal-payments/composer.json
+++ b/projects/packages/paypal-payments/composer.json
@@ -9,7 +9,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-blocks": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
@@ -19,6 +20,9 @@
 	"autoload": {
 		"classmap": [
 			"src/"
+		],
+		"files": [
+			"actions.php"
 		]
 	},
 	"scripts": {

--- a/projects/packages/paypal-payments/src/abilities/class-paypal-payments-abilities.php
+++ b/projects/packages/paypal-payments/src/abilities/class-paypal-payments-abilities.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * PayPal Payments Abilities Registration.
+ *
+ * Registers PayPal Payments (Simple Payments) abilities with the WordPress
+ * Abilities API. The package backs both the standalone PayPal Payment Buttons
+ * plugin and the Jetpack plugin, so registering here surfaces the abilities
+ * uniformly in both contexts.
+ *
+ * @package automattic/jetpack-paypal-payments
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\PayPal_Payments\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+use WP_Query;
+
+/**
+ * Registers PayPal Payments abilities with the WordPress Abilities API.
+ *
+ * Exposes a read-only surface for listing/inspecting PayPal Simple Payments
+ * buttons stored as `jp_pay_product` posts so AI agents can answer
+ * site-owner questions through the standard `wp-abilities/v1` REST surface.
+ * Create / update / delete writes are deliberately deferred.
+ */
+class PayPal_Payments_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-paypal-payments';
+	const ERROR_PREFIX  = 'jetpack_paypal_payments_';
+
+	/**
+	 * The `jp_pay_product` post type slug owned by Simple_Payments.
+	 *
+	 * Hardcoded here so this class doesn't have to load the legacy
+	 * Simple_Payments class — which side-effects (registers hooks,
+	 * enqueues scripts) on autoload — just to read a constant.
+	 */
+	const POST_TYPE = 'jp_pay_product';
+
+	/**
+	 * Statuses accepted by `list-buttons`.
+	 */
+	const LIST_STATUSES = array( 'publish', 'draft', 'all' );
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "PayPal" and "Jetpack" are product names and should not be translated.
+			'label'       => 'Jetpack PayPal Payments',
+			'description' => __( 'Abilities for reading PayPal Simple Payments buttons stored as jp_pay_product posts.', 'jetpack-paypal-payments' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-paypal-payments/list-buttons' => self::spec_list_buttons(),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-paypal-payments/list-buttons.
+	 */
+	private static function spec_list_buttons(): array {
+		return array(
+			'label'               => __( 'List PayPal payment buttons', 'jetpack-paypal-payments' ),
+			'description'         => __(
+				'List PayPal Simple Payments buttons (jp_pay_product posts) with optional status / search filters and pagination. Pass `button_id` to fetch a single button by ID — returns a zero- or one-element array; unknown ids return []. Each entry shape: { id, title, price, currency, recipient_email, button_image_url, edit_url, status, created_at }. Read-only.',
+				'jetpack-paypal-payments'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'default'              => array(),
+				'properties'           => array(
+					'status'    => array(
+						'type'        => 'string',
+						'description' => __( 'Filter by post status. "all" returns publish + draft.', 'jetpack-paypal-payments' ),
+						'enum'        => self::LIST_STATUSES,
+						'default'     => 'publish',
+					),
+					'search'    => array(
+						'type'        => 'string',
+						'description' => __( 'Search by button title.', 'jetpack-paypal-payments' ),
+					),
+					'page'      => array(
+						'type'        => 'integer',
+						'description' => __( 'Page number for paginated results.', 'jetpack-paypal-payments' ),
+						'default'     => 1,
+						'minimum'     => 1,
+					),
+					'per_page'  => array(
+						'type'        => 'integer',
+						'description' => __( 'Number of buttons per page.', 'jetpack-paypal-payments' ),
+						'default'     => 20,
+						'minimum'     => 1,
+						'maximum'     => 100,
+					),
+					'button_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Fetch a single button by ID. When set, returns a 0- or 1-element array and other filters are ignored.', 'jetpack-paypal-payments' ),
+						'minimum'     => 1,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'properties' => self::button_output_properties(),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'list_buttons' ),
+			'permission_callback' => array( __CLASS__, 'can_view_buttons' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Output schema properties shared by every list entry.
+	 *
+	 * @return array
+	 */
+	private static function button_output_properties(): array {
+		return array(
+			'id'               => array( 'type' => 'integer' ),
+			'title'            => array( 'type' => 'string' ),
+			'price'            => array( 'type' => array( 'number', 'string', 'null' ) ),
+			'currency'         => array( 'type' => 'string' ),
+			'recipient_email'  => array( 'type' => 'string' ),
+			'button_image_url' => array( 'type' => 'string' ),
+			'edit_url'         => array( 'type' => 'string' ),
+			'status'           => array( 'type' => 'string' ),
+			'created_at'       => array( 'type' => 'string' ),
+		);
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Read-side permission gate.
+	 *
+	 * The `jp_pay_product` CPT registers `edit_others_posts` for the
+	 * `edit_others_posts` cap map and `read_private_posts` for reads;
+	 * the simplest authoritative check that matches the CPT's own
+	 * meta-cap is `edit_posts`, which every editor / admin has and
+	 * which excludes subscribers and contributors. Aligns with the
+	 * CPT's published `capabilities` map (`edit_posts` is the
+	 * underlying primitive).
+	 *
+	 * @return bool
+	 */
+	public static function can_view_buttons(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: list-buttons.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function list_buttons( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$post_type = self::POST_TYPE;
+		if ( ! post_type_exists( $post_type ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'cpt_unavailable',
+				__( 'PayPal Simple Payments are not enabled on this site. Confirm the Simple Payments module / package bootstrap is loaded before retrying.', 'jetpack-paypal-payments' )
+			);
+		}
+
+		// `button_id` short-circuit: collapses get-button into list-buttons.
+		if ( isset( $input['button_id'] ) ) {
+			$id = (int) $input['button_id'];
+			if ( $id <= 0 ) {
+				return array();
+			}
+			$post = get_post( $id );
+			if ( ! $post || $post->post_type !== $post_type ) {
+				return array();
+			}
+			return array( self::format_button( $post ) );
+		}
+
+		$status   = self::pick_status( $input['status'] ?? null );
+		$page     = self::clamp_int( $input['page'] ?? 1, 1, PHP_INT_MAX, 1 );
+		$per_page = self::clamp_int( $input['per_page'] ?? 20, 1, 100, 20 );
+		$search   = isset( $input['search'] ) && is_string( $input['search'] ) ? trim( $input['search'] ) : '';
+
+		$query_args = array(
+			'post_type'      => $post_type,
+			'post_status'    => 'all' === $status ? array( 'publish', 'draft' ) : $status,
+			'posts_per_page' => $per_page,
+			'paged'          => $page,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			// Suppress filters that admin Simple Payments code attaches to the_content; we never render here.
+			'no_found_rows'  => true,
+		);
+		if ( '' !== $search ) {
+			$query_args['s'] = $search;
+		}
+
+		$query = new WP_Query( $query_args );
+
+		$out = array();
+		foreach ( $query->posts as $post ) {
+			$out[] = self::format_button( $post );
+		}
+		return $out;
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Project a `jp_pay_product` post into the uniform list entry shape.
+	 *
+	 * @param \WP_Post $post Product post.
+	 * @return array
+	 */
+	private static function format_button( $post ): array {
+		$id        = (int) $post->ID;
+		$thumb_id  = (int) get_post_thumbnail_id( $id );
+		$thumb_url = $thumb_id > 0 ? (string) wp_get_attachment_url( $thumb_id ) : '';
+
+		$edit_url = get_edit_post_link( $id, 'raw' );
+		if ( ! is_string( $edit_url ) ) {
+			$edit_url = '';
+		}
+
+		$price_raw = get_post_meta( $id, 'spay_price', true );
+		$price     = '' === $price_raw || null === $price_raw ? null : ( is_numeric( $price_raw ) ? (float) $price_raw : (string) $price_raw );
+
+		return array(
+			'id'               => $id,
+			'title'            => (string) get_the_title( $post ),
+			'price'            => $price,
+			'currency'         => (string) get_post_meta( $id, 'spay_currency', true ),
+			'recipient_email'  => (string) get_post_meta( $id, 'spay_email', true ),
+			'button_image_url' => $thumb_url,
+			'edit_url'         => $edit_url,
+			'status'           => (string) $post->post_status,
+			'created_at'       => (string) $post->post_date_gmt,
+		);
+	}
+
+	/**
+	 * Resolve a status enum from raw input, defaulting to `publish`.
+	 *
+	 * @param mixed $raw Raw input value.
+	 * @return string One of self::LIST_STATUSES.
+	 */
+	private static function pick_status( $raw ): string {
+		return is_string( $raw ) && in_array( $raw, self::LIST_STATUSES, true ) ? $raw : 'publish';
+	}
+
+	/**
+	 * Clamp an integer into [$min, $max] with a default on bad input.
+	 *
+	 * @param mixed $raw         Raw input.
+	 * @param int   $min         Minimum.
+	 * @param int   $max         Maximum.
+	 * @param int   $default_val Default on bad input.
+	 * @return int
+	 */
+	private static function clamp_int( $raw, int $min, int $max, int $default_val ): int {
+		if ( ! is_numeric( $raw ) ) {
+			return $default_val;
+		}
+		$v = (int) $raw;
+		if ( $v < $min ) {
+			return $min;
+		}
+		if ( $v > $max ) {
+			return $max;
+		}
+		return $v;
+	}
+}

--- a/projects/packages/paypal-payments/tests/php/abilities/PayPal_Payments_Abilities_Test.php
+++ b/projects/packages/paypal-payments/tests/php/abilities/PayPal_Payments_Abilities_Test.php
@@ -1,0 +1,532 @@
+<?php
+/**
+ * Unit tests for PayPal Payments Abilities.
+ *
+ * @package automattic/jetpack-paypal-payments
+ * @phan-file-suppress PhanPluginUnreachableCode -- markTestSkipped throws but Phan doesn't know that
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9, but then we need a suppression for the WP 6.8 compat run. @todo Remove this line when we drop WP <6.9.
+
+namespace Automattic\Jetpack\PayPal_Payments\Abilities;
+
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+/**
+ * Unit tests for PayPal_Payments_Abilities registration and execution.
+ */
+class PayPal_Payments_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Admin (editor capability) user id.
+	 *
+	 * @var int
+	 */
+	private static $admin_user_id;
+
+	/**
+	 * Subscriber user id used for permission denial.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_user_id;
+
+	/**
+	 * Register the jp_pay_product CPT, install the WP_Query shim, and create
+	 * the two test users.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		register_post_type(
+			PayPal_Payments_Abilities::POST_TYPE,
+			array(
+				'label'        => 'Product',
+				'public'       => false,
+				'show_in_rest' => true,
+				'supports'     => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'author' ),
+			)
+		);
+
+		// WorDBless does not back WP_Query with a real wpdb, so intercept
+		// posts_pre_query to project the in-memory posts store for the
+		// jp_pay_product CPT. The shim mirrors the small slice of WP_Query
+		// behavior list_buttons() relies on: status filter (string or array),
+		// `s` title search, `posts_per_page`, and `paged`.
+		add_filter( 'posts_pre_query', array( $this, 'wordbless_wp_query_shim' ), 10, 2 );
+
+		self::$admin_user_id = wp_insert_user(
+			array(
+				'user_login' => 'pp_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$admin_user_id );
+
+		self::$subscriber_user_id = wp_insert_user(
+			array(
+				'user_login' => 'pp_subscriber',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Tear down — unregister the CPT, drop the WP_Query shim, reset users.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'posts_pre_query', array( $this, 'wordbless_wp_query_shim' ), 10 );
+		unregister_post_type( PayPal_Payments_Abilities::POST_TYPE );
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * WP_Query short-circuit that projects WorDBless's in-memory post store
+	 * for the jp_pay_product CPT. Returns null for any other post type so the
+	 * normal WP_Query path runs.
+	 *
+	 * @param array|null $posts Pre-query posts (null lets WP_Query run normally).
+	 * @param \WP_Query  $query Query instance.
+	 * @return array|null
+	 */
+	public function wordbless_wp_query_shim( $posts, $query ) {
+		if ( $query->get( 'post_type' ) !== PayPal_Payments_Abilities::POST_TYPE ) {
+			return $posts;
+		}
+
+		$status_raw = $query->get( 'post_status' );
+		$statuses   = is_array( $status_raw ) ? $status_raw : array( $status_raw );
+
+		$search = (string) $query->get( 's' );
+
+		$all     = \WorDBless\Posts::init()->posts;
+		$matched = array();
+		foreach ( $all as $p ) {
+			if ( $p->post_type !== PayPal_Payments_Abilities::POST_TYPE ) {
+				continue;
+			}
+			if ( ! in_array( $p->post_status, $statuses, true ) && ! in_array( 'any', $statuses, true ) ) {
+				continue;
+			}
+			if ( '' !== $search && false === stripos( $p->post_title, $search ) ) {
+				continue;
+			}
+			$matched[] = $p;
+		}
+
+		// Mirror orderby=date DESC by sorting on post_date_gmt (insertion order is a
+		// good-enough proxy since tests do not backdate posts).
+		usort(
+			$matched,
+			function ( $a, $b ) {
+				return strcmp( (string) $b->post_date_gmt, (string) $a->post_date_gmt );
+			}
+		);
+
+		// Honor posts_per_page + paged for pagination tests.
+		$per_page = (int) $query->get( 'posts_per_page' );
+		if ( $per_page > 0 ) {
+			$paged   = max( 1, (int) $query->get( 'paged' ) );
+			$offset  = ( $paged - 1 ) * $per_page;
+			$matched = array_slice( $matched, $offset, $per_page );
+		}
+
+		return $matched;
+	}
+
+	/**
+	 * Insert a button (jp_pay_product) post.
+	 *
+	 * @param array $args Post + meta overrides.
+	 * @return int
+	 */
+	private static function make_button( array $args = array() ): int {
+		$defaults = array(
+			'title'    => 'Test Button',
+			'content'  => 'A test product description.',
+			'status'   => 'publish',
+			'price'    => '12.50',
+			'currency' => 'USD',
+			'email'    => 'seller@example.com',
+		);
+		$args     = array_merge( $defaults, $args );
+
+		$post_id = (int) wp_insert_post(
+			array(
+				'post_type'    => PayPal_Payments_Abilities::POST_TYPE,
+				'post_title'   => $args['title'],
+				'post_content' => $args['content'],
+				'post_status'  => $args['status'],
+			)
+		);
+		update_post_meta( $post_id, 'spay_price', $args['price'] );
+		update_post_meta( $post_id, 'spay_currency', $args['currency'] );
+		update_post_meta( $post_id, 'spay_email', $args['email'] );
+		return $post_id;
+	}
+
+	/**
+	 * Simulates the `wp_abilities_api_categories_init` action.
+	 */
+	private function simulate_doing_wp_abilities_categories_init_action() {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+	}
+
+	/**
+	 * Simulates the `wp_abilities_api_init` action.
+	 */
+	private function simulate_doing_wp_abilities_init_action() {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Registration tests
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Default rollout filter is false, so init() must wire nothing.
+	 *
+	 * We deliberately verify behavior at the hook level (no callbacks added)
+	 * rather than firing the Abilities API actions — firing them would
+	 * register WordPress's core abilities a second time and trip the
+	 * "already registered" notice on every subsequent test.
+	 */
+	public function test_init_skips_when_rollout_filter_disabled() {
+		// Strip any existing hooks so we only observe what init() adds.
+		remove_all_actions( 'wp_abilities_api_categories_init' );
+		remove_all_actions( 'wp_abilities_api_init' );
+
+		PayPal_Payments_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( PayPal_Payments_Abilities::class, 'register_category' ) ),
+			'Category callback must NOT be hooked when jetpack_wp_abilities_enabled is false (default).'
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( PayPal_Payments_Abilities::class, 'register_abilities' ) ),
+			'Abilities callback must NOT be hooked when jetpack_wp_abilities_enabled is false (default).'
+		);
+	}
+
+	/**
+	 * With the rollout filter enabled, init() must wire the registration callbacks.
+	 *
+	 * Same hook-level assertion as the disabled-path test — we don't fire
+	 * the Abilities API actions to avoid re-registering core categories
+	 * (which the WP_Abilities API treats as a notice, and our phpunit
+	 * config has `failOnNotice="true"`).
+	 */
+	public function test_init_registers_when_rollout_filter_enabled() {
+		remove_all_actions( 'wp_abilities_api_categories_init' );
+		remove_all_actions( 'wp_abilities_api_init' );
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		try {
+			PayPal_Payments_Abilities::init();
+
+			$this->assertNotFalse(
+				has_action( 'wp_abilities_api_categories_init', array( PayPal_Payments_Abilities::class, 'register_category' ) ),
+				'Category callback must be hooked when the rollout filter is enabled.'
+			);
+			$this->assertNotFalse(
+				has_action( 'wp_abilities_api_init', array( PayPal_Payments_Abilities::class, 'register_abilities' ) ),
+				'Abilities callback must be hooked when the rollout filter is enabled.'
+			);
+		} finally {
+			remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		}
+	}
+
+	/**
+	 * Direct register_category() / register_abilities() calls land the ability
+	 * in the registry. We avoid firing the lifecycle actions to keep core's
+	 * own ability registrations out of the picture.
+	 */
+	public function test_register_abilities_lands_in_registry() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available' );
+			return;
+		}
+
+		$slug = 'jetpack-paypal-payments/list-buttons';
+
+		// Clean slate: remove our category + ability if a previous test left them.
+		if ( function_exists( 'wp_has_ability' ) && wp_has_ability( $slug ) ) {
+			wp_unregister_ability( $slug );
+		}
+		if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( PayPal_Payments_Abilities::CATEGORY_SLUG ) ) {
+			wp_unregister_ability_category( PayPal_Payments_Abilities::CATEGORY_SLUG );
+		}
+
+		$this->simulate_doing_wp_abilities_categories_init_action();
+		PayPal_Payments_Abilities::register_category();
+
+		$this->simulate_doing_wp_abilities_init_action();
+		PayPal_Payments_Abilities::register_abilities();
+
+		$this->assertNotNull(
+			wp_get_ability( $slug ),
+			'list-buttons must be registered after register_abilities() runs.'
+		);
+
+		// Clean up so we don't leak into the next test.
+		if ( wp_has_ability( $slug ) ) {
+			wp_unregister_ability( $slug );
+		}
+		if ( wp_has_ability_category( PayPal_Payments_Abilities::CATEGORY_SLUG ) ) {
+			wp_unregister_ability_category( PayPal_Payments_Abilities::CATEGORY_SLUG );
+		}
+	}
+
+	/**
+	 * The category slug + ability slug + execute callback should agree.
+	 */
+	public function test_get_abilities_shape() {
+		$this->assertSame( 'jetpack-paypal-payments', PayPal_Payments_Abilities::get_category_slug() );
+
+		$abilities = PayPal_Payments_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-paypal-payments/list-buttons', $abilities );
+
+		$spec = $abilities['jetpack-paypal-payments/list-buttons'];
+		$this->assertIsCallable( $spec['execute_callback'] );
+		$this->assertIsCallable( $spec['permission_callback'] );
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * Permission callback tests
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Admins (have edit_posts) can view buttons.
+	 */
+	public function test_can_view_buttons_allows_admins() {
+		wp_set_current_user( self::$admin_user_id );
+		$this->assertTrue( PayPal_Payments_Abilities::can_view_buttons() );
+	}
+
+	/**
+	 * Subscribers (no edit_posts) cannot view buttons.
+	 */
+	public function test_can_view_buttons_denies_subscribers() {
+		wp_set_current_user( self::$subscriber_user_id );
+		$this->assertFalse( PayPal_Payments_Abilities::can_view_buttons() );
+	}
+
+	/*
+	---------------------------------------------------------------------
+	 * list_buttons() execute callback tests
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Returns WP_Error when the CPT isn't registered (Simple Payments not loaded).
+	 */
+	public function test_list_buttons_returns_wp_error_when_cpt_unavailable() {
+		unregister_post_type( PayPal_Payments_Abilities::POST_TYPE );
+
+		$result = PayPal_Payments_Abilities::list_buttons( array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_paypal_payments_cpt_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * Returns an empty array when there are no buttons.
+	 */
+	public function test_list_buttons_returns_empty_when_no_buttons() {
+		$result = PayPal_Payments_Abilities::list_buttons( array() );
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Returns expected uniform shape for a published button.
+	 */
+	public function test_list_buttons_returns_expected_shape() {
+		$id = self::make_button(
+			array(
+				'title'    => 'Coffee',
+				'price'    => '4.25',
+				'currency' => 'USD',
+				'email'    => 'coffee@example.com',
+			)
+		);
+
+		$result = PayPal_Payments_Abilities::list_buttons( array() );
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		$entry = $result[0];
+		$this->assertSame( $id, $entry['id'] );
+		$this->assertSame( 'Coffee', $entry['title'] );
+		$this->assertSame( 4.25, $entry['price'] );
+		$this->assertSame( 'USD', $entry['currency'] );
+		$this->assertSame( 'coffee@example.com', $entry['recipient_email'] );
+		$this->assertSame( '', $entry['button_image_url'] );
+		$this->assertSame( 'publish', $entry['status'] );
+		$this->assertArrayHasKey( 'edit_url', $entry );
+		$this->assertArrayHasKey( 'created_at', $entry );
+	}
+
+	/**
+	 * Default status (`publish`) excludes drafts.
+	 */
+	public function test_list_buttons_defaults_to_publish_status() {
+		self::make_button(
+			array(
+				'title'  => 'Live',
+				'status' => 'publish',
+			)
+		);
+		self::make_button(
+			array(
+				'title'  => 'Draft',
+				'status' => 'draft',
+			)
+		);
+
+		$result = PayPal_Payments_Abilities::list_buttons( array() );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'Live', $result[0]['title'] );
+	}
+
+	/**
+	 * `status=draft` returns drafts only.
+	 */
+	public function test_list_buttons_status_draft() {
+		self::make_button(
+			array(
+				'title'  => 'Live',
+				'status' => 'publish',
+			)
+		);
+		self::make_button(
+			array(
+				'title'  => 'Draft',
+				'status' => 'draft',
+			)
+		);
+
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'status' => 'draft' ) );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'Draft', $result[0]['title'] );
+	}
+
+	/**
+	 * `status=all` returns publish + draft.
+	 */
+	public function test_list_buttons_status_all() {
+		self::make_button(
+			array(
+				'title'  => 'Live',
+				'status' => 'publish',
+			)
+		);
+		self::make_button(
+			array(
+				'title'  => 'Draft',
+				'status' => 'draft',
+			)
+		);
+
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'status' => 'all' ) );
+		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * `per_page` caps the response size.
+	 */
+	public function test_list_buttons_respects_per_page() {
+		self::make_button( array( 'title' => 'A' ) );
+		self::make_button( array( 'title' => 'B' ) );
+		self::make_button( array( 'title' => 'C' ) );
+
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'per_page' => 2 ) );
+		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * `per_page` is clamped to [1, 100].
+	 */
+	public function test_list_buttons_clamps_per_page() {
+		self::make_button( array( 'title' => 'A' ) );
+
+		// Above-max is clamped to 100 (still returns the one row).
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'per_page' => 9999 ) );
+		$this->assertCount( 1, $result );
+
+		// Below-min is clamped to 1.
+		self::make_button( array( 'title' => 'B' ) );
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'per_page' => 0 ) );
+		$this->assertCount( 1, $result );
+	}
+
+	/**
+	 * `search` filters by title.
+	 */
+	public function test_list_buttons_search_filters_by_title() {
+		self::make_button( array( 'title' => 'Espresso' ) );
+		self::make_button( array( 'title' => 'Cold Brew' ) );
+
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'search' => 'Espresso' ) );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'Espresso', $result[0]['title'] );
+	}
+
+	/**
+	 * `button_id` short-circuit returns a single-element array on hit.
+	 */
+	public function test_list_buttons_button_id_returns_single_entry() {
+		$a = self::make_button( array( 'title' => 'A' ) );
+		$b = self::make_button( array( 'title' => 'B' ) );
+
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'button_id' => $b ) );
+		$this->assertCount( 1, $result );
+		$this->assertSame( $b, $result[0]['id'] );
+		$this->assertSame( 'B', $result[0]['title'] );
+		// Confirm we did not leak the other button.
+		$this->assertNotSame( $a, $result[0]['id'] );
+	}
+
+	/**
+	 * `button_id` for an unknown id returns an empty array, not WP_Error.
+	 */
+	public function test_list_buttons_button_id_unknown_returns_empty() {
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'button_id' => 999999 ) );
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * `button_id` for a non-product post returns an empty array.
+	 */
+	public function test_list_buttons_button_id_wrong_post_type_returns_empty() {
+		$page_id = (int) wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Not a button',
+				'post_status' => 'publish',
+			)
+		);
+
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'button_id' => $page_id ) );
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * `button_id <= 0` is treated as unknown id and returns [].
+	 */
+	public function test_list_buttons_button_id_zero_returns_empty() {
+		$result = PayPal_Payments_Abilities::list_buttons( array( 'button_id' => 0 ) );
+		$this->assertSame( array(), $result );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `jetpack-paypal-payments/list-buttons` ability to the `packages/paypal-payments` package, exposing PayPal Simple Payments buttons (`jp_pay_product` posts) through the WordPress Abilities API.
- `list-buttons` accepts `status` (publish/draft/all), `search`, `page`, `per_page` (1-100), and `button_id` (single-button short-circuit so a separate `get-button` reader isn't needed). Output: `{ id, title, price, currency, recipient_email, button_image_url, edit_url, status, created_at }`.
- Read-only. `create-button` / `update-button` / `delete-button` are deliberately deferred.
- Wired via `packages/paypal-payments/actions.php` and gated behind `Registrar::init()`'s `jetpack_wp_abilities_enabled` filter (default false), so the abilities surface in both the standalone PayPal Payment Buttons plugin and Jetpack core consumers, but rollout stays opt-in per site.
- Permission gate: `current_user_can( 'edit_posts' )`, matching the `jp_pay_product` CPT's capability map.
- Plan reference: §4.2 (PayPal payment buttons logic lives in `packages/paypal-payments`; plugin is a thin wrapper) and §2.10 (gated registrar pattern).

## Test plan

- [x] `composer phpunit -- --filter PayPal_Payments_Abilities_Test` — 19 tests, 43 assertions, all green.
- [x] Full package suite stays green (44 tests, 85 assertions).
- [x] PHPCS clean on the new files.
- [ ] Confirm in a Jetpack / PayPal Payment Buttons site (with `jetpack_wp_abilities_enabled` flipped to `true`) that `GET /wp-json/wp-abilities/v1/abilities/jetpack-paypal-payments/list-buttons` returns the expected entries for an editor user.