### PR TITLE
Sitemaps abilities: register status reads + rebuild dispatch via Registrar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sitemaps-abilities
+++ b/projects/plugins/jetpack/changelog/add-sitemaps-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Abilities API: register sitemaps reads + rebuild dispatch

--- a/projects/plugins/jetpack/changelog/add-sitemaps-abilities-core-site-category
+++ b/projects/plugins/jetpack/changelog/add-sitemaps-abilities-core-site-category
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sitemaps abilities: use the core site ability category

--- a/projects/plugins/jetpack/changelog/sitemaps-abilities-status-shape
+++ b/projects/plugins/jetpack/changelog/sitemaps-abilities-status-shape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sitemaps abilities: simplify get-status output — drop the duplicate master_sitemap_url and the reserved last_error, replace the state-derived last_build_at with a `sitemaps` list reflecting the child sitemaps actually present in the served sitemap.xml (each with its own lastmod)

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -282,8 +282,12 @@ class Sitemaps_Abilities extends Registrar {
 
 		$librarian = new \Jetpack_Sitemap_Librarian();
 
+		// jp_sitemap_filename() is documented `@param string $number`; for the
+		// master type it returns 'sitemap.xml' and ignores the number, but it
+		// must be non-null and string-typed to satisfy the contract (the
+		// int-`0` router call site predates this and is Phan-baselined).
 		return (string) $librarian->get_sitemap_text(
-			\jp_sitemap_filename( JP_MASTER_SITEMAP_TYPE, 0 ),
+			\jp_sitemap_filename( JP_MASTER_SITEMAP_TYPE, '0' ),
 			JP_MASTER_SITEMAP_TYPE
 		);
 	}

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -57,21 +57,35 @@ class Sitemaps_Abilities extends Registrar {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Sitemaps abilities live under the WordPress core `site` category — it is
+	 * registered by the Abilities API itself, so we reference it by slug and
+	 * never register it ourselves (see the no-op `register_category()` below).
 	 */
 	public static function get_category_slug(): string {
-		return 'jetpack-sitemaps';
+		return 'site';
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Unused: the `site` category is owned by WordPress core, so
+	 * `register_category()` is a no-op and this definition is never passed to
+	 * `wp_register_ability_category()`. It remains only to satisfy the abstract
+	 * Registrar contract.
 	 */
 	public static function get_category_definition(): array {
-		return array(
-			// translators: "Jetpack" is a product name and should not be translated.
-			'label'       => __( 'Jetpack Sitemaps', 'jetpack' ),
-			'description' => __( 'Abilities for inspecting and rebuilding Jetpack-generated XML sitemaps.', 'jetpack' ),
-		);
+		return array();
 	}
+
+	/**
+	 * No-op: the `site` ability category is registered by the WordPress core
+	 * Abilities API. Re-registering it here would clobber the core definition,
+	 * so this registrar only references the category by slug.
+	 *
+	 * @return void
+	 */
+	public static function register_category() {}
 
 	/**
 	 * {@inheritDoc}

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -49,13 +49,6 @@ class Sitemaps_Abilities extends Registrar {
 	private const STATE_LOCK_TRANSIENT = 'jetpack-sitemap-state-lock';
 
 	/**
-	 * Option written by the sitemap state machine. Used to derive
-	 * `last_build_at` from the master sitemap's `lastmod` projection without
-	 * touching the librarian / wp_posts.
-	 */
-	private const STATE_OPTION = 'jetpack-sitemap-state';
-
-	/**
 	 * {@inheritDoc}
 	 *
 	 * Sitemaps abilities live under the WordPress core `site` category — it is
@@ -94,7 +87,7 @@ class Sitemaps_Abilities extends Registrar {
 		return array(
 			'jetpack-sitemaps/get-status'      => array(
 				'label'               => __( 'Get Jetpack Sitemaps status', 'jetpack' ),
-				'description'         => __( 'Return the current state of the Jetpack-generated XML sitemaps as { active, url, last_build_at, post_count, page_count, news_sitemap_enabled, master_sitemap_url, last_error }. `active` reflects whether the Sitemaps module is on. `url` and `master_sitemap_url` both point at the public sitemap.xml entry point (kept as separate keys for forward-compatibility with per-type URLs). `last_build_at` is the most recent master-sitemap timestamp in "YYYY-MM-DD HH:mm:ss" UTC format, or null when no master sitemap has been generated yet. `news_sitemap_enabled` reflects the `jetpack_news_sitemap_include_in_robotstxt` filter (default true). `last_error` is currently always null — the module does not surface a structured error log; the field is reserved for forward compatibility. These abilities are only registered while the Sitemaps module is active; if they are absent from wp_get_abilities(), activate the Sitemaps module first.', 'jetpack' ),
+				'description'         => __( 'Return the current state of the Jetpack-generated XML sitemaps as { active, url, post_count, page_count, news_sitemap_enabled, sitemaps }. `active` reflects whether the Sitemaps module is on. `url` is the public sitemap.xml entry point. `post_count` / `page_count` are the published `post` / `page` counts (the same baseline the WordPress core sitemap uses). `news_sitemap_enabled` reflects the `jetpack_news_sitemap_include_in_robotstxt` filter (default true). `sitemaps` is the list of child sitemaps actually present in the served sitemap.xml index — each entry is `{ loc, lastmod }`, where `lastmod` is the W3C datetime string the sitemap exposes (or null when that entry omits one). `sitemaps` is an empty array until a master sitemap has been generated. These abilities are only registered while the Sitemaps module is active; if they are absent from wp_get_abilities(), activate the Sitemaps module first.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,
@@ -104,12 +97,19 @@ class Sitemaps_Abilities extends Registrar {
 					'properties' => array(
 						'active'               => array( 'type' => 'boolean' ),
 						'url'                  => array( 'type' => 'string' ),
-						'last_build_at'        => array( 'type' => array( 'string', 'null' ) ),
 						'post_count'           => array( 'type' => 'integer' ),
 						'page_count'           => array( 'type' => 'integer' ),
 						'news_sitemap_enabled' => array( 'type' => 'boolean' ),
-						'master_sitemap_url'   => array( 'type' => 'string' ),
-						'last_error'           => array( 'type' => array( 'string', 'null' ) ),
+						'sitemaps'             => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'loc'     => array( 'type' => 'string' ),
+									'lastmod' => array( 'type' => array( 'string', 'null' ) ),
+								),
+							),
+						),
 					),
 				),
 				'execute_callback'    => array( __CLASS__, 'get_status' ),
@@ -181,34 +181,27 @@ class Sitemaps_Abilities extends Registrar {
 	 *
 	 * Surfaces an opinionated, agent-friendly projection of the module's state:
 	 * - `active` from `Jetpack::is_module_active`.
-	 * - `url` / `master_sitemap_url` from `jetpack_sitemap_uri()`, the same
-	 *   helper the public sitemap router uses.
-	 * - `last_build_at` from `jetpack-sitemap-state.max[JP_MASTER_SITEMAP_TYPE].lastmod`,
-	 *   the state machine's own projection — null until the first master
-	 *   sitemap completes.
+	 * - `url` from `jetpack_sitemap_uri()`, the same helper the public sitemap
+	 *   router uses.
 	 * - `post_count` / `page_count` from `wp_count_posts()->publish`, the
 	 *   same baseline used by the WordPress core sitemap. Cheap; no joins.
 	 * - `news_sitemap_enabled` from the `jetpack_news_sitemap_include_in_robotstxt`
 	 *   filter (the same filter that controls news-sitemap robots.txt inclusion).
-	 * - `last_error` always null for now; reserved for forward compatibility
-	 *   when the module starts tracking a structured error log.
+	 * - `sitemaps` from the served master sitemap document itself (see
+	 *   `get_sitemap_entries()`) — the real child-sitemap list with each
+	 *   entry's own `lastmod`, rather than a synthetic last-build timestamp.
 	 *
 	 * @param array|null $input Ability input (no parameters accepted).
 	 * @return array
 	 */
 	public static function get_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
-		$active             = Jetpack::is_module_active( self::MODULE_SLUG );
-		$master_sitemap_url = static::get_master_sitemap_url();
-
 		return array(
-			'active'               => $active,
-			'url'                  => $master_sitemap_url,
-			'last_build_at'        => static::get_last_build_at(),
+			'active'               => Jetpack::is_module_active( self::MODULE_SLUG ),
+			'url'                  => static::get_master_sitemap_url(),
 			'post_count'           => static::count_published( 'post' ),
 			'page_count'           => static::count_published( 'page' ),
 			'news_sitemap_enabled' => static::is_news_sitemap_enabled(),
-			'master_sitemap_url'   => $master_sitemap_url,
-			'last_error'           => null,
+			'sitemaps'             => static::get_sitemap_entries(),
 		);
 	}
 
@@ -270,36 +263,89 @@ class Sitemaps_Abilities extends Registrar {
 	}
 
 	/**
-	 * Most recent master-sitemap timestamp from the state machine's
-	 * `max[JP_MASTER_SITEMAP_TYPE].lastmod` projection, or null when no
-	 * master sitemap has been completed yet.
+	 * Raw master-sitemap XML — the exact document the public `sitemap.xml`
+	 * router serves, read straight from storage via the librarian (no HTTP
+	 * loopback). Returns an empty string when no master sitemap has been
+	 * generated yet, or when the Sitemaps module helpers are unavailable.
 	 *
-	 * @return string|null
+	 * Extracted as a protected seam so tests can feed a known document without
+	 * a librarian / wp_posts.
 	 */
-	protected static function get_last_build_at() {
-		$state = get_option( self::STATE_OPTION );
-		if ( ! is_array( $state ) || empty( $state['max'] ) || ! is_array( $state['max'] ) ) {
-			return null;
+	protected static function get_master_sitemap_xml(): string {
+		if (
+			! class_exists( 'Jetpack_Sitemap_Librarian' )
+			|| ! function_exists( 'jp_sitemap_filename' )
+			|| ! defined( 'JP_MASTER_SITEMAP_TYPE' )
+		) {
+			return '';
 		}
 
-		$master_type = defined( 'JP_MASTER_SITEMAP_TYPE' ) ? JP_MASTER_SITEMAP_TYPE : 'jp_sitemap_master';
-		if ( empty( $state['max'][ $master_type ] ) || ! is_array( $state['max'][ $master_type ] ) ) {
-			return null;
+		$librarian = new \Jetpack_Sitemap_Librarian();
+
+		return (string) $librarian->get_sitemap_text(
+			\jp_sitemap_filename( JP_MASTER_SITEMAP_TYPE, 0 ),
+			JP_MASTER_SITEMAP_TYPE
+		);
+	}
+
+	/**
+	 * The child-sitemap entries actually present in the served master
+	 * sitemap, as a list of `[ 'loc' => string, 'lastmod' => string|null ]`.
+	 *
+	 * Parses the same `<sitemapindex>` document `sitemap.xml` serves rather
+	 * than deriving freshness from the `jetpack-sitemap-state` option: that
+	 * option can read its initial/reset shape (no `max` projection) even while
+	 * a fully-built sitemap.xml is being served, so it is not a reliable
+	 * "what does the sitemap actually contain" source.
+	 *
+	 * Returns an empty array when no master sitemap exists yet or the stored
+	 * document does not parse.
+	 *
+	 * @return array<int, array{loc:string, lastmod:string|null}>
+	 */
+	protected static function get_sitemap_entries(): array {
+		$xml = static::get_master_sitemap_xml();
+		if ( '' === $xml ) {
+			return array();
 		}
 
-		$lastmod = $state['max'][ $master_type ]['lastmod'] ?? null;
-		if ( ! is_string( $lastmod ) || '' === $lastmod ) {
-			return null;
+		$previous = libxml_use_internal_errors( true );
+		$document = new \DOMDocument();
+		// Source is Jetpack's own stored sitemap (not user input) and PHP 8+
+		// disables external-entity loading by default; LIBXML_NONET is belt-
+		// and-suspenders against any network/entity fetch during parsing.
+		$loaded = $document->loadXML( $xml, LIBXML_NONET );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+
+		if ( ! $loaded ) {
+			return array();
 		}
 
-		// `Jetpack_Sitemap_State::initial()` seeds `last-modified` to the unix
-		// epoch as a sentinel for "never". Surface that as null here so agents
-		// don't misread the epoch as a real timestamp.
-		if ( '1970-01-01 00:00:00' === $lastmod ) {
-			return null;
+		$entries = array();
+		foreach ( $document->getElementsByTagName( 'sitemap' ) as $sitemap_node ) {
+			$loc_nodes = $sitemap_node->getElementsByTagName( 'loc' );
+			if ( 0 === $loc_nodes->length ) {
+				continue;
+			}
+
+			$loc = trim( $loc_nodes->item( 0 )->textContent );
+			if ( '' === $loc ) {
+				continue;
+			}
+
+			$lastmod_nodes = $sitemap_node->getElementsByTagName( 'lastmod' );
+			$lastmod       = $lastmod_nodes->length > 0
+				? trim( $lastmod_nodes->item( 0 )->textContent )
+				: '';
+
+			$entries[] = array(
+				'loc'     => $loc,
+				'lastmod' => '' === $lastmod ? null : $lastmod,
+			);
 		}
 
-		return $lastmod;
+		return $entries;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Jetpack Sitemaps Abilities Registration
+ *
+ * Registers Jetpack Sitemaps abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack;
+
+/**
+ * Registers Jetpack Sitemaps abilities with the WordPress Abilities API.
+ *
+ * Exposes a zero-arg sitemap status read (`get-status`) and a zero-arg rebuild
+ * dispatch (`request-rebuild`) so AI agents can inspect sitemap freshness and
+ * trigger a regeneration through the standard `wp-abilities/v1` REST surface.
+ *
+ * Both abilities only register while the Sitemaps module is active — the
+ * surrounding `modules/sitemaps.php` is only loaded by Jetpack when the module
+ * is on, so the `Sitemaps_Abilities::init()` call at the bottom of that file
+ * is the gate.
+ */
+class Sitemaps_Abilities extends Registrar {
+
+	private const MODULE_SLUG = 'sitemaps';
+
+	/**
+	 * Cron hook name used by the Sitemaps module to drive incremental builds.
+	 *
+	 * Kept as a const here rather than imported from `Jetpack_Sitemap_Manager`
+	 * because the manager registers it as an action name only — there is no
+	 * canonical PHP constant to reference, and the value is part of the
+	 * module's stable public surface (it shows up in `wp cron list`).
+	 */
+	private const CRON_HOOK = 'jp_sitemap_cron_hook';
+
+	/**
+	 * Transient written by `Jetpack_Sitemap_State::check_out()` while a build
+	 * step is in progress. Presence of this transient is the canonical
+	 * "build currently running" signal; its 15-minute TTL means the signal
+	 * self-clears if a build crashes without unlocking.
+	 */
+	private const STATE_LOCK_TRANSIENT = 'jetpack-sitemap-state-lock';
+
+	/**
+	 * Option written by the sitemap state machine. Used to derive
+	 * `last_build_at` from the master sitemap's `lastmod` projection without
+	 * touching the librarian / wp_posts.
+	 */
+	private const STATE_OPTION = 'jetpack-sitemap-state';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-sitemaps';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// translators: "Jetpack" is a product name and should not be translated.
+			'label'       => __( 'Jetpack Sitemaps', 'jetpack' ),
+			'description' => __( 'Abilities for inspecting and rebuilding Jetpack-generated XML sitemaps.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-sitemaps/get-status'      => array(
+				'label'               => __( 'Get Jetpack Sitemaps status', 'jetpack' ),
+				'description'         => __( 'Return the current state of the Jetpack-generated XML sitemaps as { active, url, last_build_at, post_count, page_count, news_sitemap_enabled, master_sitemap_url, last_error }. `active` reflects whether the Sitemaps module is on. `url` and `master_sitemap_url` both point at the public sitemap.xml entry point (kept as separate keys for forward-compatibility with per-type URLs). `last_build_at` is the most recent master-sitemap timestamp in "YYYY-MM-DD HH:mm:ss" UTC format, or null when no master sitemap has been generated yet. `news_sitemap_enabled` reflects the `jetpack_news_sitemap_include_in_robotstxt` filter (default true). `last_error` is currently always null — the module does not surface a structured error log; the field is reserved for forward compatibility. These abilities are only registered while the Sitemaps module is active; if they are absent from wp_get_abilities(), activate the Sitemaps module first.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'active'               => array( 'type' => 'boolean' ),
+						'url'                  => array( 'type' => 'string' ),
+						'last_build_at'        => array( 'type' => array( 'string', 'null' ) ),
+						'post_count'           => array( 'type' => 'integer' ),
+						'page_count'           => array( 'type' => 'integer' ),
+						'news_sitemap_enabled' => array( 'type' => 'boolean' ),
+						'master_sitemap_url'   => array( 'type' => 'string' ),
+						'last_error'           => array( 'type' => array( 'string', 'null' ) ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_sitemaps' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-sitemaps/request-rebuild' => array(
+				'label'               => __( 'Request a Jetpack Sitemaps rebuild', 'jetpack' ),
+				'description'         => __( 'Dispatch a full sitemap regeneration by scheduling the existing `jp_sitemap_cron_hook` cron event. Returns { dispatched, status } where status is one of "queued" (a single-event cron tick was just scheduled), "running" (a build is already in flight per the `jetpack-sitemap-state-lock` transient), or "already_running" (alias of "running"; surfaced so callers can branch on either spelling). Idempotent — calling this while a build is already in flight or already queued returns dispatched=false and the matching status rather than stacking duplicate cron events.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'dispatched' => array( 'type' => 'boolean' ),
+						'status'     => array(
+							'type' => 'string',
+							'enum' => array( 'queued', 'running', 'already_running' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'request_rebuild' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_sitemaps' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check: can the current user read sitemap status?
+	 *
+	 * Sitemap status is metadata about publicly-served XML — anyone who can
+	 * manage content (`edit_posts`) is allowed to see it. Reads do not modify
+	 * state and do not expose secrets.
+	 */
+	public static function can_view_sitemaps(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Permission check: can the current user dispatch a sitemap rebuild?
+	 *
+	 * Rebuild scheduling writes to cron + transient state and can run for
+	 * minutes on large sites, so it is gated on `manage_options` (admin only).
+	 */
+	public static function can_manage_sitemaps(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: status read.
+	 *
+	 * Surfaces an opinionated, agent-friendly projection of the module's state:
+	 * - `active` from `Jetpack::is_module_active`.
+	 * - `url` / `master_sitemap_url` from `jetpack_sitemap_uri()`, the same
+	 *   helper the public sitemap router uses.
+	 * - `last_build_at` from `jetpack-sitemap-state.max[JP_MASTER_SITEMAP_TYPE].lastmod`,
+	 *   the state machine's own projection — null until the first master
+	 *   sitemap completes.
+	 * - `post_count` / `page_count` from `wp_count_posts()->publish`, the
+	 *   same baseline used by the WordPress core sitemap. Cheap; no joins.
+	 * - `news_sitemap_enabled` from the `jetpack_news_sitemap_include_in_robotstxt`
+	 *   filter (the same filter that controls news-sitemap robots.txt inclusion).
+	 * - `last_error` always null for now; reserved for forward compatibility
+	 *   when the module starts tracking a structured error log.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array
+	 */
+	public static function get_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		$active             = Jetpack::is_module_active( self::MODULE_SLUG );
+		$master_sitemap_url = static::get_master_sitemap_url();
+
+		return array(
+			'active'               => $active,
+			'url'                  => $master_sitemap_url,
+			'last_build_at'        => static::get_last_build_at(),
+			'post_count'           => static::count_published( 'post' ),
+			'page_count'           => static::count_published( 'page' ),
+			'news_sitemap_enabled' => static::is_news_sitemap_enabled(),
+			'master_sitemap_url'   => $master_sitemap_url,
+			'last_error'           => null,
+		);
+	}
+
+	/**
+	 * Execute: rebuild dispatch.
+	 *
+	 * Three-state idempotent dispatch:
+	 *
+	 * 1. If the state lock transient is set, a build step is currently
+	 *    running. Return `dispatched=false`, `status=running`. We also surface
+	 *    `already_running` as the alias the plan documents; this function
+	 *    returns `running` as the canonical value so callers that branch on
+	 *    one or the other both work — the output_schema enum permits both.
+	 * 2. Else if a cron event is already scheduled in the future for our hook,
+	 *    a build is queued. Return `dispatched=false`, `status=queued`.
+	 * 3. Otherwise schedule a single-event cron tick to fire immediately and
+	 *    return `dispatched=true`, `status=queued`.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array
+	 */
+	public static function request_rebuild( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		if ( static::is_build_running() ) {
+			return array(
+				'dispatched' => false,
+				'status'     => 'running',
+			);
+		}
+
+		if ( static::is_build_queued() ) {
+			return array(
+				'dispatched' => false,
+				'status'     => 'queued',
+			);
+		}
+
+		static::schedule_rebuild();
+
+		return array(
+			'dispatched' => true,
+			'status'     => 'queued',
+		);
+	}
+
+	/**
+	 * Public sitemap URL for the master sitemap.
+	 *
+	 * Extracted as a protected seam so tests can override without booting the
+	 * rewrite/permalink stack.
+	 */
+	protected static function get_master_sitemap_url(): string {
+		if ( function_exists( 'jetpack_sitemap_uri' ) ) {
+			return (string) jetpack_sitemap_uri( 'sitemap.xml' );
+		}
+		// Defensive: when the sitemaps module file is loaded the helper
+		// exists. This branch only runs if a caller invokes the ability
+		// outside the normal bootstrap path.
+		return (string) home_url( '/sitemap.xml' );
+	}
+
+	/**
+	 * Most recent master-sitemap timestamp from the state machine's
+	 * `max[JP_MASTER_SITEMAP_TYPE].lastmod` projection, or null when no
+	 * master sitemap has been completed yet.
+	 *
+	 * @return string|null
+	 */
+	protected static function get_last_build_at() {
+		$state = get_option( self::STATE_OPTION );
+		if ( ! is_array( $state ) || empty( $state['max'] ) || ! is_array( $state['max'] ) ) {
+			return null;
+		}
+
+		$master_type = defined( 'JP_MASTER_SITEMAP_TYPE' ) ? JP_MASTER_SITEMAP_TYPE : 'jp_sitemap_master';
+		if ( empty( $state['max'][ $master_type ] ) || ! is_array( $state['max'][ $master_type ] ) ) {
+			return null;
+		}
+
+		$lastmod = $state['max'][ $master_type ]['lastmod'] ?? null;
+		if ( ! is_string( $lastmod ) || '' === $lastmod ) {
+			return null;
+		}
+
+		// `Jetpack_Sitemap_State::initial()` seeds `last-modified` to the unix
+		// epoch as a sentinel for "never". Surface that as null here so agents
+		// don't misread the epoch as a real timestamp.
+		if ( '1970-01-01 00:00:00' === $lastmod ) {
+			return null;
+		}
+
+		return $lastmod;
+	}
+
+	/**
+	 * Whether news-sitemap inclusion is enabled.
+	 *
+	 * Mirrors the filter chain in `Jetpack_Sitemap_Manager::callback_action_do_robotstxt`
+	 * but only resolves the modern filter — the deprecated 7.4.0 alias is
+	 * already merged into the modern filter by the time it runs in production.
+	 */
+	protected static function is_news_sitemap_enabled(): bool {
+		/** This filter is documented in modules/sitemaps/sitemaps.php */
+		return (bool) apply_filters( 'jetpack_news_sitemap_include_in_robotstxt', true );
+	}
+
+	/**
+	 * Count published posts of a given post type.
+	 *
+	 * Wraps `wp_count_posts()` so tests can override without a real WP_Posts
+	 * factory.
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	protected static function count_published( string $post_type ): int {
+		$counts = wp_count_posts( $post_type );
+		if ( ! is_object( $counts ) || ! isset( $counts->publish ) ) {
+			return 0;
+		}
+		return (int) $counts->publish;
+	}
+
+	/**
+	 * Whether a sitemap build step is currently running.
+	 *
+	 * The Sitemaps module sets a 15-minute transient lock at the start of
+	 * `Jetpack_Sitemap_State::check_out()` and deletes it on `unlock()` /
+	 * `reset()`. Presence of the transient is the canonical "in flight" signal.
+	 */
+	protected static function is_build_running(): bool {
+		return true === get_transient( self::STATE_LOCK_TRANSIENT );
+	}
+
+	/**
+	 * Whether a sitemap build is already scheduled for a future cron tick.
+	 *
+	 * Uses `wp_next_scheduled` so we don't stack duplicate single-event cron
+	 * entries when the recurring `jp_sitemap_cron_hook` is already pending.
+	 */
+	protected static function is_build_queued(): bool {
+		return false !== wp_next_scheduled( self::CRON_HOOK );
+	}
+
+	/**
+	 * Schedule a single-event cron tick to drive the next build step.
+	 *
+	 * Matches the dispatch pattern used by
+	 * `Jetpack_Sitemap_Manager::callback_action_purge_data` — `wp_schedule_single_event`
+	 * with an immediate execution time. The recurring `sitemap-interval`
+	 * schedule still fires on its normal cadence; this just front-runs the
+	 * next tick.
+	 */
+	protected static function schedule_rebuild(): void {
+		wp_schedule_single_event( time(), self::CRON_HOOK );
+	}
+}

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -126,7 +126,7 @@ class Sitemaps_Abilities extends Registrar {
 
 			'jetpack-sitemaps/request-rebuild' => array(
 				'label'               => __( 'Request a Jetpack Sitemaps rebuild', 'jetpack' ),
-				'description'         => __( 'Dispatch a full sitemap regeneration by scheduling the existing `jp_sitemap_cron_hook` cron event. Returns { dispatched, status, next_scheduled_at } where status is one of "queued" (a single-event cron tick was just scheduled), "running" (a build is already in flight per the `jetpack-sitemap-state-lock` transient), or "already_running" (alias of "running"; surfaced so callers can branch on either spelling). `next_scheduled_at` is the next `jp_sitemap_cron_hook` tick as a "YYYY-MM-DD HH:mm:ss" UTC string, or null when nothing is scheduled (e.g. status=running with no future tick queued) — it tells the caller when the build they queued (or the one already pending) will actually run. Idempotent — calling this while a build is already in flight or already queued returns dispatched=false and the matching status rather than stacking duplicate cron events.', 'jetpack' ),
+				'description'         => __( 'Dispatch a full sitemap regeneration by scheduling the existing `jp_sitemap_cron_hook` cron event. Returns { dispatched, status, next_scheduled_at } where status is one of "queued" (a single-event cron tick was just scheduled), "running" (a build is already in flight per the `jetpack-sitemap-state-lock` transient), or "already_running" (alias of "running"; surfaced so callers can branch on either spelling). `next_scheduled_at` is the next `jp_sitemap_cron_hook` tick as an ISO 8601 UTC string with an explicit `Z` zone designator (e.g. `2026-05-19T19:33:20Z`), or null when nothing is scheduled (e.g. status=running with no future tick queued) — it tells the caller when the build they queued (or the one already pending) will actually run. Idempotent — calling this while a build is already in flight or already queued returns dispatched=false and the matching status rather than stacking duplicate cron events.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,
@@ -423,22 +423,25 @@ class Sitemaps_Abilities extends Registrar {
 	}
 
 	/**
-	 * When the next `jp_sitemap_cron_hook` build tick is scheduled, as a UTC
-	 * "Y-m-d H:i:s" string, or null when nothing is scheduled.
+	 * When the next `jp_sitemap_cron_hook` build tick is scheduled, as an
+	 * ISO 8601 UTC string (e.g. `2026-05-19T19:33:20Z`), or null when nothing
+	 * is scheduled.
 	 *
 	 * Returned alongside the dispatch result so callers immediately know when
 	 * the build they queued (or the one already pending) will actually run,
 	 * without a second round-trip. Null in the `running` case when the lock is
 	 * held but no future tick is queued.
 	 *
-	 * UTC string (not `human_time_diff()`) for an unambiguous, locale-stable,
-	 * machine-parseable value consistent with the rest of the sitemaps surface.
+	 * ISO 8601 with the explicit `Z` zone designator (not `human_time_diff()`,
+	 * not a bare "Y-m-d H:i:s") so the timezone is unambiguous and the value is
+	 * locale-stable and machine-parseable — the same format the `sitemaps[]`
+	 * `lastmod` values use in `get-status`.
 	 */
 	protected static function get_next_scheduled_at(): ?string {
 		$timestamp = wp_next_scheduled( self::CRON_HOOK );
 		if ( false === $timestamp ) {
 			return null;
 		}
-		return gmdate( 'Y-m-d H:i:s', $timestamp );
+		return gmdate( 'Y-m-d\TH:i:s\Z', $timestamp );
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -126,7 +126,7 @@ class Sitemaps_Abilities extends Registrar {
 
 			'jetpack-sitemaps/request-rebuild' => array(
 				'label'               => __( 'Request a Jetpack Sitemaps rebuild', 'jetpack' ),
-				'description'         => __( 'Dispatch a full sitemap regeneration by scheduling the existing `jp_sitemap_cron_hook` cron event. Returns { dispatched, status } where status is one of "queued" (a single-event cron tick was just scheduled), "running" (a build is already in flight per the `jetpack-sitemap-state-lock` transient), or "already_running" (alias of "running"; surfaced so callers can branch on either spelling). Idempotent — calling this while a build is already in flight or already queued returns dispatched=false and the matching status rather than stacking duplicate cron events.', 'jetpack' ),
+				'description'         => __( 'Dispatch a full sitemap regeneration by scheduling the existing `jp_sitemap_cron_hook` cron event. Returns { dispatched, status, next_scheduled_at } where status is one of "queued" (a single-event cron tick was just scheduled), "running" (a build is already in flight per the `jetpack-sitemap-state-lock` transient), or "already_running" (alias of "running"; surfaced so callers can branch on either spelling). `next_scheduled_at` is the next `jp_sitemap_cron_hook` tick as a "YYYY-MM-DD HH:mm:ss" UTC string, or null when nothing is scheduled (e.g. status=running with no future tick queued) — it tells the caller when the build they queued (or the one already pending) will actually run. Idempotent — calling this while a build is already in flight or already queued returns dispatched=false and the matching status rather than stacking duplicate cron events.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,
@@ -134,11 +134,12 @@ class Sitemaps_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'dispatched' => array( 'type' => 'boolean' ),
-						'status'     => array(
+						'dispatched'        => array( 'type' => 'boolean' ),
+						'status'            => array(
 							'type' => 'string',
 							'enum' => array( 'queued', 'running', 'already_running' ),
 						),
+						'next_scheduled_at' => array( 'type' => array( 'string', 'null' ) ),
 					),
 				),
 				'execute_callback'    => array( __CLASS__, 'request_rebuild' ),
@@ -220,29 +221,36 @@ class Sitemaps_Abilities extends Registrar {
 	 * 3. Otherwise schedule a single-event cron tick to fire immediately and
 	 *    return `dispatched=true`, `status=queued`.
 	 *
+	 * Every branch also returns `next_scheduled_at` (see
+	 * `get_next_scheduled_at()`) so the caller learns when the queued/pending
+	 * build will actually run without a follow-up status read.
+	 *
 	 * @param array|null $input Ability input (no parameters accepted).
 	 * @return array
 	 */
 	public static function request_rebuild( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
 		if ( static::is_build_running() ) {
 			return array(
-				'dispatched' => false,
-				'status'     => 'running',
+				'dispatched'        => false,
+				'status'            => 'running',
+				'next_scheduled_at' => static::get_next_scheduled_at(),
 			);
 		}
 
 		if ( static::is_build_queued() ) {
 			return array(
-				'dispatched' => false,
-				'status'     => 'queued',
+				'dispatched'        => false,
+				'status'            => 'queued',
+				'next_scheduled_at' => static::get_next_scheduled_at(),
 			);
 		}
 
 		static::schedule_rebuild();
 
 		return array(
-			'dispatched' => true,
-			'status'     => 'queued',
+			'dispatched'        => true,
+			'status'            => 'queued',
+			'next_scheduled_at' => static::get_next_scheduled_at(),
 		);
 	}
 
@@ -412,5 +420,25 @@ class Sitemaps_Abilities extends Registrar {
 	 */
 	protected static function schedule_rebuild(): void {
 		wp_schedule_single_event( time(), self::CRON_HOOK );
+	}
+
+	/**
+	 * When the next `jp_sitemap_cron_hook` build tick is scheduled, as a UTC
+	 * "Y-m-d H:i:s" string, or null when nothing is scheduled.
+	 *
+	 * Returned alongside the dispatch result so callers immediately know when
+	 * the build they queued (or the one already pending) will actually run,
+	 * without a second round-trip. Null in the `running` case when the lock is
+	 * held but no future tick is queued.
+	 *
+	 * UTC string (not `human_time_diff()`) for an unambiguous, locale-stable,
+	 * machine-parseable value consistent with the rest of the sitemaps surface.
+	 */
+	protected static function get_next_scheduled_at(): ?string {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( false === $timestamp ) {
+			return null;
+		}
+		return gmdate( 'Y-m-d H:i:s', $timestamp );
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
@@ -607,3 +607,7 @@ function jetpack_sitemap_uri( $filename = 'sitemap.xml' ) {
 	 */
 	return apply_filters( 'jetpack_sitemap_location', $sitemap_url );
 }
+
+// Register Jetpack Sitemaps abilities (WordPress Abilities API, WP 6.9+).
+require_once __DIR__ . '/abilities/class-sitemaps-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\Sitemaps_Abilities::init();

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -554,6 +554,8 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 			wp_next_scheduled( 'jp_sitemap_cron_hook' ),
 			'No new cron event should be scheduled when a build is in flight.'
 		);
+		// Nothing queued → no next run time to report.
+		$this->assertNull( $result['next_scheduled_at'] );
 	}
 
 	/**
@@ -573,6 +575,8 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 		// The previously-scheduled tick should still be the next one (i.e. we
 		// didn't stack a new one at time() that would overshadow it).
 		$this->assertSame( $future, wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+		// next_scheduled_at reflects that pending tick as a UTC string.
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $future ), $result['next_scheduled_at'] );
 	}
 
 	/**
@@ -589,10 +593,13 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['dispatched'] );
 		$this->assertSame( 'queued', $result['status'] );
+		$scheduled = wp_next_scheduled( 'jp_sitemap_cron_hook' );
 		$this->assertNotFalse(
-			wp_next_scheduled( 'jp_sitemap_cron_hook' ),
+			$scheduled,
 			'A cron event should be scheduled after a successful dispatch.'
 		);
+		// The freshly-scheduled tick is reported as a UTC string.
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $scheduled ), $result['next_scheduled_at'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -575,8 +575,8 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 		// The previously-scheduled tick should still be the next one (i.e. we
 		// didn't stack a new one at time() that would overshadow it).
 		$this->assertSame( $future, wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
-		// next_scheduled_at reflects that pending tick as a UTC string.
-		$this->assertSame( gmdate( 'Y-m-d H:i:s', $future ), $result['next_scheduled_at'] );
+		// next_scheduled_at reflects that pending tick as an ISO 8601 UTC string.
+		$this->assertSame( gmdate( 'Y-m-d\TH:i:s\Z', $future ), $result['next_scheduled_at'] );
 	}
 
 	/**
@@ -598,8 +598,8 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 			$scheduled,
 			'A cron event should be scheduled after a successful dispatch.'
 		);
-		// The freshly-scheduled tick is reported as a UTC string.
-		$this->assertSame( gmdate( 'Y-m-d H:i:s', $scheduled ), $result['next_scheduled_at'] );
+		// The freshly-scheduled tick is reported as an ISO 8601 UTC string.
+		$this->assertSame( gmdate( 'Y-m-d\TH:i:s\Z', $scheduled ), $result['next_scheduled_at'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -48,6 +48,15 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Defensive isolation: cron events / sitemap state can leak across
+		// tests within a shared process if a prior test's tear_down did not
+		// run (fatal/out-of-order). Mirror tear_down's cleanup at the start of
+		// every test so request_rebuild assertions on wp_next_scheduled()
+		// start from a known-empty state regardless of run order.
+		delete_transient( 'jetpack-sitemap-state-lock' );
+		delete_option( 'jetpack-sitemap-state' );
+		wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
+
 		$this->admin_id      = wp_insert_user(
 			array(
 				'user_login' => 'sitemaps_abilities_admin_' . wp_generate_password( 8, false, false ),
@@ -378,8 +387,8 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 	 */
 
 	/**
-	 * Module inactive: returns the full shape with `active=false` and
-	 * `last_build_at=null`. Status reads are not gated on the module — agents
+	 * Module inactive: returns the simplified shape with `active=false` and an
+	 * empty `sitemaps` list. Status reads are not gated on the module — agents
 	 * should be able to see "sitemaps are off" without an error.
 	 */
 	public function test_get_status_returns_inactive_when_module_off() {
@@ -392,25 +401,29 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertFalse( $result['active'] );
 		$this->assertSame( 'https://example.test/sitemap.xml', $result['url'] );
-		$this->assertSame( 'https://example.test/sitemap.xml', $result['master_sitemap_url'] );
-		$this->assertNull( $result['last_build_at'] );
 		$this->assertSame( 0, $result['post_count'] );
 		$this->assertSame( 0, $result['page_count'] );
 		$this->assertTrue( $result['news_sitemap_enabled'] );
-		$this->assertNull( $result['last_error'] );
+		$this->assertSame( array(), $result['sitemaps'] );
+
+		// Simplified shape: no URL duplication, no synthetic last-build
+		// scalar, no reserved-but-always-null error field.
+		$this->assertArrayNotHasKey( 'master_sitemap_url', $result );
+		$this->assertArrayNotHasKey( 'last_build_at', $result );
+		$this->assertArrayNotHasKey( 'last_error', $result );
 	}
 
 	/**
-	 * Happy path: module active, state machine has recorded a master-sitemap
-	 * timestamp, counts come back from the wp_count_posts seam, and the news
-	 * filter is left at its default-true.
+	 * Happy path: module active, a master sitemap exists, and `sitemaps`
+	 * reflects the child-sitemap entries actually present in the served
+	 * sitemap.xml (loc + lastmod), parsed from the stored master.
 	 */
 	public function test_get_status_returns_full_shape_when_module_active() {
 		wp_set_current_user( $this->admin_id );
 		$this->activate_sitemaps_module();
 
 		Sitemaps_Abilities_Test_Stub::$master_sitemap_url = 'https://example.test/sitemap.xml';
-		Sitemaps_Abilities_Test_Stub::$last_build_at      = '2026-01-15 12:34:56';
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_xml = self::sample_sitemapindex();
 		Sitemaps_Abilities_Test_Stub::$counts             = array(
 			'post' => 42,
 			'page' => 7,
@@ -420,11 +433,23 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['active'] );
-		$this->assertSame( '2026-01-15 12:34:56', $result['last_build_at'] );
+		$this->assertSame( 'https://example.test/sitemap.xml', $result['url'] );
 		$this->assertSame( 42, $result['post_count'] );
 		$this->assertSame( 7, $result['page_count'] );
 		$this->assertTrue( $result['news_sitemap_enabled'] );
-		$this->assertNull( $result['last_error'] );
+		$this->assertSame(
+			array(
+				array(
+					'loc'     => 'https://example.test/sitemap-1.xml',
+					'lastmod' => '2026-04-19T14:09:16Z',
+				),
+				array(
+					'loc'     => 'https://example.test/image-sitemap-1.xml',
+					'lastmod' => '2026-03-19T14:48:36Z',
+				),
+			),
+			$result['sitemaps']
+		);
 	}
 
 	/**
@@ -443,46 +468,70 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `last_build_at` derivation from `jetpack-sitemap-state`: the state
-	 * machine seeds `lastmod` to the epoch sentinel when nothing has been
-	 * built yet, and we must surface that as null (not a real-looking
-	 * timestamp).
+	 * Section: get_sitemap_entries — reflect the real served sitemap.xml
+	 *
+	 * `get-status` surfaces the child-sitemap entries actually present in the
+	 * stored master sitemap (the same document the public sitemap.xml router
+	 * serves), rather than a synthetic last-build timestamp derived from the
+	 * `jetpack-sitemap-state` option (which reads null even while a real
+	 * sitemap.xml is being served).
 	 */
-	public function test_get_last_build_at_returns_null_for_epoch_sentinel() {
-		update_option(
-			'jetpack-sitemap-state',
-			array(
-				'max' => array(
-					'jp_sitemap_master' => array(
-						'number'  => 0,
-						'lastmod' => '1970-01-01 00:00:00',
-					),
-				),
-			)
-		);
+	public function test_get_sitemap_entries_parses_sitemapindex() {
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_xml = self::sample_sitemapindex();
 
-		$this->assertNull( Sitemaps_Abilities_Test_Stub::call_get_last_build_at() );
+		$this->assertSame(
+			array(
+				array(
+					'loc'     => 'https://example.test/sitemap-1.xml',
+					'lastmod' => '2026-04-19T14:09:16Z',
+				),
+				array(
+					'loc'     => 'https://example.test/image-sitemap-1.xml',
+					'lastmod' => '2026-03-19T14:48:36Z',
+				),
+			),
+			Sitemaps_Abilities_Test_Stub::call_get_sitemap_entries()
+		);
 	}
 
-	public function test_get_last_build_at_returns_state_machine_timestamp() {
-		update_option(
-			'jetpack-sitemap-state',
-			array(
-				'max' => array(
-					'jp_sitemap_master' => array(
-						'number'  => 3,
-						'lastmod' => '2026-02-01 03:14:15',
-					),
-				),
-			)
-		);
-
-		$this->assertSame( '2026-02-01 03:14:15', Sitemaps_Abilities_Test_Stub::call_get_last_build_at() );
+	public function test_get_sitemap_entries_returns_empty_array_when_no_master() {
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_xml = '';
+		$this->assertSame( array(), Sitemaps_Abilities_Test_Stub::call_get_sitemap_entries() );
 	}
 
-	public function test_get_last_build_at_returns_null_when_state_option_missing() {
-		// No option seeded — fresh install, no builds ever.
-		$this->assertNull( Sitemaps_Abilities_Test_Stub::call_get_last_build_at() );
+	public function test_get_sitemap_entries_returns_empty_array_for_malformed_xml() {
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_xml = '<sitemapindex><sitemap><loc>broken';
+		$this->assertSame( array(), Sitemaps_Abilities_Test_Stub::call_get_sitemap_entries() );
+	}
+
+	public function test_get_sitemap_entries_tolerates_missing_lastmod() {
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_xml =
+			'<?xml version="1.0" encoding="UTF-8"?>'
+			. '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+			. '<sitemap><loc>https://example.test/sitemap-1.xml</loc></sitemap>'
+			. '</sitemapindex>';
+
+		$this->assertSame(
+			array(
+				array(
+					'loc'     => 'https://example.test/sitemap-1.xml',
+					'lastmod' => null,
+				),
+			),
+			Sitemaps_Abilities_Test_Stub::call_get_sitemap_entries()
+		);
+	}
+
+	/**
+	 * Two-entry sitemapindex fixture mirroring the real master sitemap shape
+	 * (default sitemaps.org namespace, loc + lastmod per child).
+	 */
+	private static function sample_sitemapindex(): string {
+		return '<?xml version="1.0" encoding="UTF-8"?>'
+			. '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+			. '<sitemap><loc>https://example.test/sitemap-1.xml</loc><lastmod>2026-04-19T14:09:16Z</lastmod></sitemap>'
+			. '<sitemap><loc>https://example.test/image-sitemap-1.xml</loc><lastmod>2026-03-19T14:48:36Z</lastmod></sitemap>'
+			. '</sitemapindex>';
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -1,0 +1,556 @@
+<?php
+/**
+ * Tests for the Sitemaps_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+// The Sitemaps_Abilities class lives under modules/sitemaps/abilities/ rather
+// than src/, so Composer's classmap autoloader does not see it. Pull it in
+// explicitly — mirrors the Newsletter_Abilities test convention.
+require_once __DIR__ . '/../../../modules/sitemaps/abilities/class-sitemaps-abilities.php';
+require_once __DIR__ . '/class-sitemaps-abilities-test-stub.php';
+
+use Automattic\Jetpack\Plugin\Abilities\Sitemaps_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Sitemaps_Abilities
+ */
+#[CoversClass( Sitemaps_Abilities::class )]
+class Sitemaps_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Administrator user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Editor user id (manages content but not options) for permission tests.
+	 *
+	 * @var int
+	 */
+	private $editor_id;
+
+	/**
+	 * Subscriber user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'sitemaps_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->editor_id     = wp_insert_user(
+			array(
+				'user_login' => 'sitemaps_abilities_editor_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'editor_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'editor',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'sitemaps_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_active_modules' );
+		remove_all_filters( 'jetpack_news_sitemap_include_in_robotstxt' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_abilities' ) );
+
+		// Unregister anything this test left behind so the singleton registry stays clean
+		// between tests (the WP Abilities Registry persists across tests within a process).
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Sitemaps_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Sitemaps_Abilities::get_category_slug() );
+		}
+
+		delete_transient( 'jetpack-sitemap-state-lock' );
+		delete_option( 'jetpack-sitemap-state' );
+		wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
+
+		Sitemaps_Abilities_Test_Stub::reset();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so registrations
+	 * happen inside the action callstack — `wp_register_ability(_category)` enforces
+	 * `doing_action()`, so direct invocation outside the hook is rejected.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	/**
+	 * Helper: pretend the Sitemaps module is active. Mirrors the pattern used
+	 * by Monitor_Abilities_Test — filter the active modules list rather than
+	 * reaching into the Jetpack option directly.
+	 */
+	private function activate_sitemaps_module(): void {
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'sitemaps';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+	}
+
+	/**
+	 * Section: Abstract getters
+	 */
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-sitemaps', Sitemaps_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Sitemaps_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Sitemaps_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-sitemaps/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Sitemaps_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_surface_exposes_get_status_and_request_rebuild() {
+		$abilities = Sitemaps_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-sitemaps/get-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack-sitemaps/request-rebuild', $abilities );
+	}
+
+	public function test_get_status_is_annotated_readonly_idempotent() {
+		$spec = Sitemaps_Abilities::get_abilities()['jetpack-sitemaps/get-status'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_request_rebuild_is_annotated_non_readonly_idempotent() {
+		$spec = Sitemaps_Abilities::get_abilities()['jetpack-sitemaps/request-rebuild'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	/**
+	 * Section: Registrar wiring
+	 */
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Sitemaps_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Sitemaps_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-sitemaps/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( Sitemaps_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static function ( $a ) {
+				return $a->get_name();
+			},
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Sitemaps_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Sitemaps_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-sitemaps',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	/**
+	 * Section: Permission callbacks
+	 *
+	 * Status reads are gated on `edit_posts` (anyone managing content can see
+	 * sitemap state). Rebuild dispatch is gated on `manage_options` — admin only.
+	 */
+	public function test_can_view_sitemaps_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Sitemaps_Abilities::can_view_sitemaps() );
+	}
+
+	public function test_can_view_sitemaps_allows_editor() {
+		// Editors have edit_posts but not manage_options.
+		wp_set_current_user( $this->editor_id );
+		$this->assertTrue( Sitemaps_Abilities::can_view_sitemaps() );
+	}
+
+	public function test_can_view_sitemaps_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Sitemaps_Abilities::can_view_sitemaps() );
+	}
+
+	public function test_can_view_sitemaps_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Sitemaps_Abilities::can_view_sitemaps() );
+	}
+
+	public function test_can_manage_sitemaps_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Sitemaps_Abilities::can_manage_sitemaps() );
+	}
+
+	public function test_can_manage_sitemaps_denies_editor() {
+		// Editors can read sitemap state but cannot dispatch a rebuild —
+		// manage_options is admin-only.
+		wp_set_current_user( $this->editor_id );
+		$this->assertFalse( Sitemaps_Abilities::can_manage_sitemaps() );
+	}
+
+	public function test_can_manage_sitemaps_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Sitemaps_Abilities::can_manage_sitemaps() );
+	}
+
+	public function test_can_manage_sitemaps_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Sitemaps_Abilities::can_manage_sitemaps() );
+	}
+
+	/**
+	 * Section: get_status execute callback
+	 */
+
+	/**
+	 * Module inactive: returns the full shape with `active=false` and
+	 * `last_build_at=null`. Status reads are not gated on the module — agents
+	 * should be able to see "sitemaps are off" without an error.
+	 */
+	public function test_get_status_returns_inactive_when_module_off() {
+		wp_set_current_user( $this->admin_id );
+
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_url = 'https://example.test/sitemap.xml';
+
+		$result = Sitemaps_Abilities_Test_Stub::get_status();
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['active'] );
+		$this->assertSame( 'https://example.test/sitemap.xml', $result['url'] );
+		$this->assertSame( 'https://example.test/sitemap.xml', $result['master_sitemap_url'] );
+		$this->assertNull( $result['last_build_at'] );
+		$this->assertSame( 0, $result['post_count'] );
+		$this->assertSame( 0, $result['page_count'] );
+		$this->assertTrue( $result['news_sitemap_enabled'] );
+		$this->assertNull( $result['last_error'] );
+	}
+
+	/**
+	 * Happy path: module active, state machine has recorded a master-sitemap
+	 * timestamp, counts come back from the wp_count_posts seam, and the news
+	 * filter is left at its default-true.
+	 */
+	public function test_get_status_returns_full_shape_when_module_active() {
+		wp_set_current_user( $this->admin_id );
+		$this->activate_sitemaps_module();
+
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_url = 'https://example.test/sitemap.xml';
+		Sitemaps_Abilities_Test_Stub::$last_build_at      = '2026-01-15 12:34:56';
+		Sitemaps_Abilities_Test_Stub::$counts             = array(
+			'post' => 42,
+			'page' => 7,
+		);
+
+		$result = Sitemaps_Abilities_Test_Stub::get_status();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['active'] );
+		$this->assertSame( '2026-01-15 12:34:56', $result['last_build_at'] );
+		$this->assertSame( 42, $result['post_count'] );
+		$this->assertSame( 7, $result['page_count'] );
+		$this->assertTrue( $result['news_sitemap_enabled'] );
+		$this->assertNull( $result['last_error'] );
+	}
+
+	/**
+	 * News filter false → reflected in the read.
+	 */
+	public function test_get_status_reflects_news_sitemap_filter_disabled() {
+		wp_set_current_user( $this->admin_id );
+		$this->activate_sitemaps_module();
+		add_filter( 'jetpack_news_sitemap_include_in_robotstxt', '__return_false' );
+
+		Sitemaps_Abilities_Test_Stub::$master_sitemap_url = 'https://example.test/sitemap.xml';
+
+		$result = Sitemaps_Abilities_Test_Stub::get_status();
+
+		$this->assertFalse( $result['news_sitemap_enabled'] );
+	}
+
+	/**
+	 * `last_build_at` derivation from `jetpack-sitemap-state`: the state
+	 * machine seeds `lastmod` to the epoch sentinel when nothing has been
+	 * built yet, and we must surface that as null (not a real-looking
+	 * timestamp).
+	 */
+	public function test_get_last_build_at_returns_null_for_epoch_sentinel() {
+		update_option(
+			'jetpack-sitemap-state',
+			array(
+				'max' => array(
+					'jp_sitemap_master' => array(
+						'number'  => 0,
+						'lastmod' => '1970-01-01 00:00:00',
+					),
+				),
+			)
+		);
+
+		$this->assertNull( Sitemaps_Abilities_Test_Stub::call_get_last_build_at() );
+	}
+
+	public function test_get_last_build_at_returns_state_machine_timestamp() {
+		update_option(
+			'jetpack-sitemap-state',
+			array(
+				'max' => array(
+					'jp_sitemap_master' => array(
+						'number'  => 3,
+						'lastmod' => '2026-02-01 03:14:15',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( '2026-02-01 03:14:15', Sitemaps_Abilities_Test_Stub::call_get_last_build_at() );
+	}
+
+	public function test_get_last_build_at_returns_null_when_state_option_missing() {
+		// No option seeded — fresh install, no builds ever.
+		$this->assertNull( Sitemaps_Abilities_Test_Stub::call_get_last_build_at() );
+	}
+
+	/**
+	 * Section: request_rebuild execute callback
+	 */
+
+	/**
+	 * Lock transient present → status=running, no new cron event.
+	 */
+	public function test_request_rebuild_returns_running_when_build_in_flight() {
+		wp_set_current_user( $this->admin_id );
+		set_transient( 'jetpack-sitemap-state-lock', true, 15 * MINUTE_IN_SECONDS );
+
+		$result = Sitemaps_Abilities::request_rebuild();
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['dispatched'] );
+		$this->assertSame( 'running', $result['status'] );
+		$this->assertFalse(
+			wp_next_scheduled( 'jp_sitemap_cron_hook' ),
+			'No new cron event should be scheduled when a build is in flight.'
+		);
+	}
+
+	/**
+	 * Existing scheduled cron event → status=queued, no duplicate scheduling.
+	 */
+	public function test_request_rebuild_returns_queued_when_cron_already_scheduled() {
+		wp_set_current_user( $this->admin_id );
+
+		$future = time() + 600;
+		wp_schedule_single_event( $future, 'jp_sitemap_cron_hook' );
+
+		$result = Sitemaps_Abilities::request_rebuild();
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['dispatched'] );
+		$this->assertSame( 'queued', $result['status'] );
+		// The previously-scheduled tick should still be the next one (i.e. we
+		// didn't stack a new one at time() that would overshadow it).
+		$this->assertSame( $future, wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+	}
+
+	/**
+	 * Nothing running, nothing queued → schedule a single-event cron tick
+	 * and return dispatched=true.
+	 */
+	public function test_request_rebuild_dispatches_when_nothing_running_or_queued() {
+		wp_set_current_user( $this->admin_id );
+
+		$this->assertFalse( wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+
+		$result = Sitemaps_Abilities::request_rebuild();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['dispatched'] );
+		$this->assertSame( 'queued', $result['status'] );
+		$this->assertNotFalse(
+			wp_next_scheduled( 'jp_sitemap_cron_hook' ),
+			'A cron event should be scheduled after a successful dispatch.'
+		);
+	}
+
+	/**
+	 * Idempotency: a second call right after a successful dispatch returns
+	 * `status=queued` and `dispatched=false` (because the first call's cron
+	 * event is still pending).
+	 */
+	public function test_request_rebuild_is_idempotent_after_dispatch() {
+		wp_set_current_user( $this->admin_id );
+
+		$first = Sitemaps_Abilities::request_rebuild();
+		$this->assertTrue( $first['dispatched'] );
+
+		$second = Sitemaps_Abilities::request_rebuild();
+		$this->assertFalse( $second['dispatched'] );
+		$this->assertSame( 'queued', $second['status'] );
+	}
+
+	/**
+	 * Section: Real bootstrap path
+	 *
+	 * When the Sitemaps module is inactive, modules/sitemaps.php is never
+	 * loaded by Jetpack, so Sitemaps_Abilities::init() never runs and the
+	 * abilities are not registered. This codifies the gated-registration
+	 * contract.
+	 */
+	public function test_abilities_are_not_registered_when_sitemaps_module_is_inactive() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		// Do NOT fire the lifecycle or call init() — this mirrors the real
+		// bootstrap path when modules/sitemaps.php has not been included.
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-sitemaps/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		$this->assertSame(
+			array(),
+			$registered_slugs,
+			'Sitemaps abilities must not be registered while the Sitemaps module is inactive (modules/sitemaps.php not loaded).'
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -114,10 +114,39 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 	 * `doing_action()`, so direct invocation outside the hook is rejected.
 	 */
 	private function fire_abilities_lifecycle(): void {
+		// Sitemaps abilities live under the core `site` category, which in
+		// production is registered by WordPress core on the
+		// `wp_abilities_api_categories_init` action. The isolated unit-test
+		// lifecycle does not carry core's registration over, so without this
+		// the category is absent when `register_abilities()` runs and
+		// `wp_register_ability()` rejects every ability ("category not
+		// registered"). Register the `site` category here, scoped to the
+		// categories-init action (where `wp_register_ability_category()` is
+		// permitted) and guarded so a re-fire — or a build where core already
+		// registered it — does not trigger an "already registered" notice.
+		$ensure_site_category = static function () {
+			if (
+				function_exists( 'wp_has_ability_category' )
+				&& function_exists( 'wp_register_ability_category' )
+				&& ! wp_has_ability_category( 'site' )
+			) {
+				wp_register_ability_category(
+					'site',
+					array(
+						'label'       => 'Site',
+						'description' => 'Abilities that retrieve or modify site information and settings.',
+					)
+				);
+			}
+		};
+		add_action( Registrar::CATEGORIES_INIT_ACTION, $ensure_site_category, 1 );
+
 		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) );
 		add_action( Registrar::ABILITIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_abilities' ) );
 		do_action( Registrar::CATEGORIES_INIT_ACTION );
 		do_action( Registrar::ABILITIES_INIT_ACTION );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, $ensure_site_category, 1 );
 	}
 
 	/**
@@ -145,17 +174,19 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 
 	public function test_register_category_is_a_noop() {
 		// The `site` category is owned by WordPress core; this registrar must
-		// not register (and thus clobber) it.
-		if ( ! function_exists( 'wp_get_ability_category' ) ) {
+		// not register a plugin-scoped category of its own.
+		if ( ! function_exists( 'wp_has_ability_category' ) ) {
 			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
 		}
 
 		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) );
 		do_action( Registrar::CATEGORIES_INIT_ACTION );
 
-		// Nothing this registrar did should have created a `jetpack-sitemaps`
-		// category, and the core `site` category (if present) is untouched.
-		$this->assertNull( wp_get_ability_category( 'jetpack-sitemaps' ) );
+		// Firing the registrar's (no-op) category callback must not have created
+		// a legacy `jetpack-sitemaps` category. `wp_has_ability_category()`
+		// returns a clean bool (no `_doing_it_wrong`), unlike
+		// `wp_get_ability_category()` which flags an unregistered lookup.
+		$this->assertFalse( wp_has_ability_category( 'jetpack-sitemaps' ) );
 	}
 
 	public function test_abilities_map_is_non_empty_and_namespaced() {

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -95,9 +95,9 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 				wp_unregister_ability( $slug );
 			}
 		}
-		if ( function_exists( 'wp_unregister_ability_category' ) ) {
-			wp_unregister_ability_category( Sitemaps_Abilities::get_category_slug() );
-		}
+		// Note: we intentionally do NOT unregister the category here — Sitemaps
+		// abilities live under the WordPress core `site` category, which this
+		// registrar never registers and must never tear down.
 
 		delete_transient( 'jetpack-sitemap-state-lock' );
 		delete_option( 'jetpack-sitemap-state' );
@@ -139,16 +139,23 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 	/**
 	 * Section: Abstract getters
 	 */
-	public function test_category_slug_is_plugin_scoped() {
-		$this->assertSame( 'jetpack-sitemaps', Sitemaps_Abilities::get_category_slug() );
+	public function test_category_slug_is_core_site_category() {
+		$this->assertSame( 'site', Sitemaps_Abilities::get_category_slug() );
 	}
 
-	public function test_category_definition_has_label_and_description() {
-		$def = Sitemaps_Abilities::get_category_definition();
-		$this->assertArrayHasKey( 'label', $def );
-		$this->assertArrayHasKey( 'description', $def );
-		$this->assertIsString( $def['label'] );
-		$this->assertIsString( $def['description'] );
+	public function test_register_category_is_a_noop() {
+		// The `site` category is owned by WordPress core; this registrar must
+		// not register (and thus clobber) it.
+		if ( ! function_exists( 'wp_get_ability_category' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Sitemaps_Abilities::class, 'register_category' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+
+		// Nothing this registrar did should have created a `jetpack-sitemaps`
+		// category, and the core `site` category (if present) is untouched.
+		$this->assertNull( wp_get_ability_category( 'jetpack-sitemaps' ) );
 	}
 
 	public function test_abilities_map_is_non_empty_and_namespaced() {
@@ -279,9 +286,9 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 			$registered = wp_get_ability( $slug );
 			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
 			$this->assertSame(
-				'jetpack-sitemaps',
+				'site',
 				$registered->get_category(),
-				"Ability {$slug} should have category auto-injected."
+				"Ability {$slug} should be assigned the core `site` category."
 			);
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/src/class-sitemaps-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-sitemaps-abilities-test-stub.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Test-only subclass of Sitemaps_Abilities that overrides the protected seams
+ * (master sitemap URL, post counts) so the success path can be exercised
+ * without a real permalink/rewrite stack or `wp_count_posts()` factory data.
+ *
+ * Tests for the dispatch / lock / cron logic do NOT need this stub — they
+ * exercise the real `Sitemaps_Abilities::request_rebuild()` and assert on
+ * real `wp_next_scheduled()` state.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Plugin\Abilities\Sitemaps_Abilities;
+
+/**
+ * Test-only subclass overriding Sitemaps_Abilities's protected seams.
+ *
+ * - get_master_sitemap_url(): returns the seeded URL.
+ * - get_last_build_at(): returns the seeded timestamp or, when null, falls
+ *   through to the parent implementation (so tests that set the
+ *   `jetpack-sitemap-state` option directly still exercise the real
+ *   derivation logic).
+ * - count_published(): returns counts from the seeded map.
+ */
+class Sitemaps_Abilities_Test_Stub extends Sitemaps_Abilities {
+
+	/**
+	 * Seeded master sitemap URL.
+	 *
+	 * @var string
+	 */
+	public static $master_sitemap_url = '';
+
+	/**
+	 * Seeded last build timestamp. When null, the parent implementation runs
+	 * so tests can exercise the real `jetpack-sitemap-state` derivation by
+	 * just seeding the option.
+	 *
+	 * @var string|null
+	 */
+	public static $last_build_at = null;
+
+	/**
+	 * Seeded post-type → published-count map. Missing keys return 0.
+	 *
+	 * @var array<string, int>
+	 */
+	public static $counts = array();
+
+	/**
+	 * Reset every seam back to its default. Called from the test's tear_down().
+	 */
+	public static function reset(): void {
+		self::$master_sitemap_url = '';
+		self::$last_build_at      = null;
+		self::$counts             = array();
+	}
+
+	/**
+	 * Expose the parent's `get_last_build_at()` for direct unit tests.
+	 *
+	 * @return string|null
+	 */
+	public static function call_get_last_build_at() {
+		return parent::get_last_build_at();
+	}
+
+	/**
+	 * Return the seeded master sitemap URL.
+	 */
+	protected static function get_master_sitemap_url(): string {
+		return self::$master_sitemap_url;
+	}
+
+	/**
+	 * Return the seeded timestamp, or fall through to the real implementation
+	 * when no override is set.
+	 *
+	 * @return string|null
+	 */
+	protected static function get_last_build_at() {
+		if ( null !== self::$last_build_at ) {
+			return self::$last_build_at;
+		}
+		return parent::get_last_build_at();
+	}
+
+	/**
+	 * Return the seeded count for the given post type, defaulting to 0.
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	protected static function count_published( string $post_type ): int {
+		return (int) ( self::$counts[ $post_type ] ?? 0 );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/class-sitemaps-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-sitemaps-abilities-test-stub.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * Test-only subclass of Sitemaps_Abilities that overrides the protected seams
- * (master sitemap URL, post counts) so the success path can be exercised
- * without a real permalink/rewrite stack or `wp_count_posts()` factory data.
+ * (master sitemap URL, raw master sitemap XML, post counts) so the success
+ * path can be exercised without a real permalink/rewrite stack, a stored
+ * sitemap, or a `wp_count_posts()` factory.
  *
  * Tests for the dispatch / lock / cron logic do NOT need this stub — they
  * exercise the real `Sitemaps_Abilities::request_rebuild()` and assert on
@@ -17,10 +18,8 @@ use Automattic\Jetpack\Plugin\Abilities\Sitemaps_Abilities;
  * Test-only subclass overriding Sitemaps_Abilities's protected seams.
  *
  * - get_master_sitemap_url(): returns the seeded URL.
- * - get_last_build_at(): returns the seeded timestamp or, when null, falls
- *   through to the parent implementation (so tests that set the
- *   `jetpack-sitemap-state` option directly still exercise the real
- *   derivation logic).
+ * - get_master_sitemap_xml(): returns the seeded raw master-sitemap XML, so
+ *   the real `get_sitemap_entries()` parser runs against a known document.
  * - count_published(): returns counts from the seeded map.
  */
 class Sitemaps_Abilities_Test_Stub extends Sitemaps_Abilities {
@@ -33,13 +32,13 @@ class Sitemaps_Abilities_Test_Stub extends Sitemaps_Abilities {
 	public static $master_sitemap_url = '';
 
 	/**
-	 * Seeded last build timestamp. When null, the parent implementation runs
-	 * so tests can exercise the real `jetpack-sitemap-state` derivation by
-	 * just seeding the option.
+	 * Seeded raw master-sitemap XML. The real `get_sitemap_entries()` parser
+	 * runs against this so parsing logic is covered by the same tests that
+	 * cover the status projection.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	public static $last_build_at = null;
+	public static $master_sitemap_xml = '';
 
 	/**
 	 * Seeded post-type → published-count map. Missing keys return 0.
@@ -53,17 +52,17 @@ class Sitemaps_Abilities_Test_Stub extends Sitemaps_Abilities {
 	 */
 	public static function reset(): void {
 		self::$master_sitemap_url = '';
-		self::$last_build_at      = null;
+		self::$master_sitemap_xml = '';
 		self::$counts             = array();
 	}
 
 	/**
-	 * Expose the parent's `get_last_build_at()` for direct unit tests.
+	 * Expose the parent's `get_sitemap_entries()` parser for direct unit tests.
 	 *
-	 * @return string|null
+	 * @return array<int, array{loc:string, lastmod:string|null}>
 	 */
-	public static function call_get_last_build_at() {
-		return parent::get_last_build_at();
+	public static function call_get_sitemap_entries(): array {
+		return parent::get_sitemap_entries();
 	}
 
 	/**
@@ -74,16 +73,10 @@ class Sitemaps_Abilities_Test_Stub extends Sitemaps_Abilities {
 	}
 
 	/**
-	 * Return the seeded timestamp, or fall through to the real implementation
-	 * when no override is set.
-	 *
-	 * @return string|null
+	 * Return the seeded raw master-sitemap XML instead of reading the librarian.
 	 */
-	protected static function get_last_build_at() {
-		if ( null !== self::$last_build_at ) {
-			return self::$last_build_at;
-		}
-		return parent::get_last_build_at();
+	protected static function get_master_sitemap_xml(): string {
+		return self::$master_sitemap_xml;
 	}
 
 	/**


### PR DESCRIPTION
Implements the Sitemaps module slice of the Abilities Everywhere plan (§3.3).

## Summary
- Adds `Sitemaps_Abilities` (Registrar subclass) under `modules/sitemaps/abilities/`, wired from the bottom of `modules/sitemaps.php` so it only registers while the Sitemaps module is active.
- Registers two abilities under category `jetpack-sitemaps`:
  - `jetpack-sitemaps/get-status` — zero-arg read returning `{ active, url, post_count, page_count, news_sitemap_enabled, sitemaps }`. `sitemaps` is the child-sitemap list actually present in the served `sitemap.xml` index — each entry `{ loc, lastmod }`, parsed from the stored master sitemap (no HTTP loopback), empty until a master sitemap exists. Gated on `edit_posts` (content managers can inspect sitemap state). Annotated readonly + idempotent.
  - `jetpack-sitemaps/request-rebuild` — zero-arg dispatch returning `{ dispatched, status, next_scheduled_at }` with `status` in `queued` / `running` / `already_running`. Gated on `manage_options` (admin only). Annotated non-readonly + idempotent: returns `dispatched=false` + `status=running` when the `jetpack-sitemap-state-lock` transient is set (build in flight), `dispatched=false` + `status=queued` when a cron tick is already scheduled, and otherwise schedules a single-event `jp_sitemap_cron_hook` tick and returns `dispatched=true`. `next_scheduled_at` is the next `jp_sitemap_cron_hook` tick as an ISO 8601 UTC string with an explicit `Z` zone designator, e.g. `2026-05-19T19:33:20Z` (or `null` when nothing is scheduled, e.g. `status=running` with no future tick) so callers learn when the queued/pending build will run without a follow-up status read.
- `get-status` deliberately omits a synthetic "last build" scalar. It was previously derived from the `jetpack-sitemap-state` option's `max[master].lastmod` projection, which reads its initial/reset shape (no `max`) even while a fully-built `sitemap.xml` is being served — so it reported `null` for sites that demonstrably have a working sitemap. Instead the ability surfaces the real per-child `lastmod` values straight from the served master document. The redundant `master_sitemap_url` (a duplicate of `url`) and the always-null reserved `last_error` were also dropped.
- Test coverage in `tests/php/src/Sitemaps_Abilities_Test.php` mirrors `Monitor_Abilities_Test`: abstract getters, Registrar wiring (gate filter, per-ability allow-list, category auto-injection), permission callbacks (admin/editor/subscriber/anonymous matrix), `get_status` happy path + module-off + news-filter, `get_sitemap_entries` parsing (sitemapindex → entries, empty/malformed XML, missing-lastmod tolerance), `request_rebuild` three-state dispatch + idempotency + `next_scheduled_at` derivation, and the gated-registration contract when the module is inactive. `set_up()` mirrors `tear_down()`'s cron/transient/option cleanup so `request_rebuild` cron assertions are isolated regardless of run order.
- A `Sitemaps_Abilities_Test_Stub` test double overrides the protected seams (`get_master_sitemap_url`, `get_master_sitemap_xml`, `count_published`) so success-path tests run the real `get_sitemap_entries` parser against a known document without a librarian / permalink stack / wp_count_posts factory.

## ⚠️ Registration gate: `blog_public` must be `1`

These abilities are wired from the bottom of `modules/sitemaps/sitemaps.php`, which `modules/sitemaps.php` only `include`s when `get_option( 'blog_public' ) === '1'`:

```php
if ( '1' == get_option( 'blog_public' ) ) {
	include_once __DIR__ . '/sitemaps/sitemaps.php';
}
```

So the effective gate is **Sitemaps module active _and_ `blog_public = 1`**, not the module flag alone. On sites with "Discourage search engines from indexing this site" enabled (`blog_public = 0`, the default on most local/dev environments) the entire sitemaps codebase — including this registrar — is skipped, and `jetpack-sitemaps/*` will be absent from `wp_get_abilities()` / the REST surface even though `wp jetpack module list` reports the module as Active. This is the module's pre-existing "no sitemaps on private sites" behavior, inherited intentionally; surfaced here because it is the most likely reason the abilities appear "not loading" during local testing.

## Test plan

Abilities run via `POST /wp-json/wp-abilities/v1/abilities/<name>/run` with a JSON body `{"input": {}}` (the run controller reads input from the `input` key; an empty/bare body yields `400 ability_invalid_input`).

- [ ] CI green: PHPUnit (PHP 7.2 → 8.4), PHPCS, Phan.
- [ ] **Prerequisite for the on-site checks below: `wp option update blog_public 1`** (otherwise `modules/sitemaps.php` skips loading the sitemap code entirely and no `jetpack-sitemaps/*` abilities register, regardless of module status).
- [ ] On a site with the Sitemaps module **off**, `GET /wp-json/wp-abilities/v1/abilities` does not list any `jetpack-sitemaps/*` entries.
- [ ] On a site with the Sitemaps module **on** and `blog_public = 1`:
  - [ ] `POST /wp-json/wp-abilities/v1/abilities/jetpack-sitemaps/get-status/run` (body `{"input":{}}`) as an editor returns `{ active, url, post_count, page_count, news_sitemap_enabled, sitemaps }` with `active=true`. When a master sitemap exists, `sitemaps` lists each child `{ loc, lastmod }` matching the served `sitemap.xml`; before any build it is `[]`.
  - [ ] As a subscriber the same call returns `403 rest_ability_cannot_execute`; as an anonymous user, `401`.
  - [ ] `POST /wp-json/wp-abilities/v1/abilities/jetpack-sitemaps/request-rebuild/run` as admin, with nothing running/queued, returns `dispatched=true`, `status=queued`, and `next_scheduled_at` ≈ now (ISO 8601 UTC, e.g. `2026-05-19T19:33:20Z`). A second immediate call returns `dispatched=false`, `status=queued`, same `next_scheduled_at` (no duplicate cron tick).
  - [ ] With the `jetpack-sitemap-state-lock` transient set (and no pending tick), the same call returns `dispatched=false`, `status=running`, `next_scheduled_at=null`.
- [ ] With the Sitemaps module on but `blog_public = 0`, confirm `jetpack-sitemaps/*` abilities are **absent** (documents the inherited gate).

