### PR TITLE
Memberships: register WP Abilities API reads (plans, subscribers, earnings)

### DIFF
--- a/projects/plugins/jetpack/changelog/add-memberships-abilities
+++ b/projects/plugins/jetpack/changelog/add-memberships-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Abilities API: register Memberships reads (list-plans, list-subscribers, get-earnings-summary).

--- a/projects/plugins/jetpack/modules/memberships/abilities/class-memberships-abilities.php
+++ b/projects/plugins/jetpack/modules/memberships/abilities/class-memberships-abilities.php
@@ -1,0 +1,474 @@
+<?php
+/**
+ * Jetpack Memberships Abilities Registration
+ *
+ * Registers Jetpack Memberships (paid newsletter / paid content) abilities with
+ * the WordPress Abilities API so AI agents can read paid-membership plans and
+ * subscribers through the standard `wp-abilities/v1` REST surface.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack;
+use Jetpack_Options;
+
+/**
+ * Registers Jetpack Memberships abilities with the WordPress Abilities API.
+ *
+ * Read-only surface today: filtered reads for plans and subscribers. Writes
+ * (create / update / delete plan, comp / cancel subscription) are deferred —
+ * destructive operations go behind a separate ability set with their own
+ * permission checks and tests.
+ */
+class Memberships_Abilities extends Registrar {
+
+	/**
+	 * Maximum `per_page` value accepted by list abilities. Mirrors the
+	 * `WPCOM_REST_API_V2_Endpoint_Subscribers_List` cap so we don't surface a
+	 * larger page than the upstream WP.com endpoint honors.
+	 */
+	private const MAX_PER_PAGE = 100;
+
+	/**
+	 * Default `per_page` value when the caller omits it. Matches the agent
+	 * ergonomics guidance (small enough to fit a typical response window).
+	 */
+	private const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-memberships';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" and "Memberships" are product names and should not be translated.
+			'label'       => 'Jetpack Memberships',
+			'description' => __( 'Abilities for reading Jetpack Memberships paid plans and subscribers.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		$plan_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'                    => array( 'type' => 'integer' ),
+				'title'                 => array( 'type' => 'string' ),
+				'price'                 => array( 'type' => 'number' ),
+				'currency'              => array( 'type' => 'string' ),
+				'interval'              => array(
+					'type'        => 'string',
+					'description' => __( 'Billing interval, e.g. "1 month", "1 year", "one-time".', 'jetpack' ),
+				),
+				'active'                => array( 'type' => 'boolean' ),
+				'subscriber_count'      => array( 'type' => 'integer' ),
+				'connected_destination' => array(
+					'type'        => 'string',
+					'description' => __( 'Type of the paid-content target, e.g. "newsletter" or "site".', 'jetpack' ),
+				),
+			),
+		);
+
+		$subscriber_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'              => array( 'type' => 'integer' ),
+				'email'           => array( 'type' => 'string' ),
+				'display_name'    => array( 'type' => 'string' ),
+				'plan_id'         => array( 'type' => 'integer' ),
+				'status'          => array(
+					'type' => 'string',
+					'enum' => array( 'active', 'cancelled' ),
+				),
+				'subscribed_at'   => array(
+					'type'        => 'string',
+					'description' => __( 'ISO-8601 date the subscription started, or empty string when unknown.', 'jetpack' ),
+				),
+				'last_payment_at' => array(
+					'type'        => 'string',
+					'description' => __( 'ISO-8601 date of the most recent payment, or empty string when unknown.', 'jetpack' ),
+				),
+			),
+		);
+
+		return array(
+			'jetpack-memberships/list-plans'       => array(
+				'label'               => __( 'List Jetpack Memberships plans', 'jetpack' ),
+				'description'         => __(
+					'Return paid membership plans (subscription tiers) as an array. Each element has { id, title, price, currency, interval, active, subscriber_count, connected_destination }. Pass plan_id to filter to a single plan — unknown ids yield an empty array (not an error). Pass active=true to include only published / live plans. Supports page (default 1) and per_page (default 20, max 100) for pagination. Requires an active Jetpack connection. Read-only and idempotent.',
+					'jetpack'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'active'   => array(
+							'type'        => 'boolean',
+							'description' => __( 'When set, only return plans matching this active state.', 'jetpack' ),
+						),
+						'plan_id'  => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Return a single plan by id. Unknown ids yield an empty array.', 'jetpack' ),
+						),
+						'page'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'default' => 1,
+						),
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => self::MAX_PER_PAGE,
+							'default' => self::DEFAULT_PER_PAGE,
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $plan_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_plans' ),
+				'permission_callback' => array( __CLASS__, 'can_view_plans' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-memberships/list-subscribers' => array(
+				'label'               => __( 'List Jetpack Memberships subscribers', 'jetpack' ),
+				'description'         => __(
+					'Return paid-membership subscribers as an array. Each element has { id, email, display_name, plan_id, status, subscribed_at, last_payment_at }. Pass plan_id to scope to a single plan; pass status="active"|"cancelled"|"all" (default "active"). Supports page (default 1) and per_page (default 20, max 100). Requires an active Jetpack connection. Read-only and idempotent. Use jetpack-memberships/list-plans first to enumerate plan ids.',
+					'jetpack'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'plan_id'  => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Scope results to a single plan id. Unknown ids yield an empty array.', 'jetpack' ),
+						),
+						'status'   => array(
+							'type'    => 'string',
+							'enum'    => array( 'active', 'cancelled', 'all' ),
+							'default' => 'active',
+						),
+						'page'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'default' => 1,
+						),
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => self::MAX_PER_PAGE,
+							'default' => self::DEFAULT_PER_PAGE,
+						),
+					),
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $subscriber_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_subscribers' ),
+				'permission_callback' => array( __CLASS__, 'can_view_subscribers' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check for the plans read. Matches the wpcom-endpoints
+	 * `get_status_permission_check` on the Memberships endpoint — anyone who
+	 * can author posts can see the catalog of paid plans configured on the
+	 * site.
+	 */
+	public static function can_view_plans(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Permission check for the subscribers read. Matches the
+	 * `WPCOM_REST_API_V2_Endpoint_Subscribers_List::permission_check` cap
+	 * (`manage_options`) — the subscriber list is admin-only on wpcom and on
+	 * the modernized Subscribers wp-admin screen.
+	 */
+	public static function can_view_subscribers(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: list paid membership plans.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_plans( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$blog_id = self::get_connected_blog_id();
+		if ( $blog_id instanceof \WP_Error ) {
+			return $blog_id;
+		}
+
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+		$per_page = self::resolve_per_page( $input );
+
+		$response = Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/memberships/products?type=all', $blog_id ),
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		$body = self::decode_wpcom_response( $response, 'jetpack_memberships_plans_unavailable' );
+		if ( $body instanceof \WP_Error ) {
+			return $body;
+		}
+
+		$products = isset( $body['products'] ) && is_array( $body['products'] ) ? $body['products'] : array();
+
+		// Filter to a single plan when plan_id is provided. The literal string
+		// '0' shouldn't get here (schema enforces minimum: 1), but use
+		// isset()+type-check rather than empty() to be safe against future
+		// schema changes that loosen the minimum.
+		$plan_id = isset( $input['plan_id'] ) ? (int) $input['plan_id'] : 0;
+		if ( $plan_id > 0 ) {
+			$products = array_values(
+				array_filter(
+					$products,
+					static function ( $product ) use ( $plan_id ) {
+						return is_array( $product ) && isset( $product['id'] ) && (int) $product['id'] === $plan_id;
+					}
+				)
+			);
+		}
+
+		if ( array_key_exists( 'active', $input ) ) {
+			$want_active = (bool) $input['active'];
+			$products    = array_values(
+				array_filter(
+					$products,
+					static function ( $product ) use ( $want_active ) {
+						$is_active = isset( $product['status'] ) && 'active' === $product['status'];
+						return $is_active === $want_active;
+					}
+				)
+			);
+		}
+
+		// Paginate after filtering so per_page bounds the final shape.
+		$offset = ( $page - 1 ) * $per_page;
+		$slice  = array_slice( $products, $offset, $per_page );
+
+		return array_map( array( __CLASS__, 'shape_plan' ), $slice );
+	}
+
+	/**
+	 * Execute: list paid-membership subscribers.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function list_subscribers( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$blog_id = self::get_connected_blog_id();
+		if ( $blog_id instanceof \WP_Error ) {
+			return $blog_id;
+		}
+
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+		$per_page = self::resolve_per_page( $input );
+		$plan_id  = isset( $input['plan_id'] ) ? (int) $input['plan_id'] : 0;
+		$status   = isset( $input['status'] ) && is_string( $input['status'] )
+			? $input['status']
+			: 'active';
+
+		$query = array(
+			'page'     => $page,
+			'per_page' => $per_page,
+			'type'     => 'paid',
+		);
+		if ( $plan_id > 0 ) {
+			$query['plan_id'] = $plan_id;
+		}
+		if ( 'all' !== $status ) {
+			$query['filters'] = $status; // 'active' or 'cancelled' — passed through to wpcom.
+		}
+
+		$path = sprintf( '/sites/%d/subscribers?%s', $blog_id, http_build_query( $query ) );
+
+		$response = Client::wpcom_json_api_request_as_user(
+			$path,
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		$body = self::decode_wpcom_response( $response, 'jetpack_memberships_subscribers_unavailable' );
+		if ( $body instanceof \WP_Error ) {
+			return $body;
+		}
+
+		$subscribers = isset( $body['subscribers'] ) && is_array( $body['subscribers'] )
+			? $body['subscribers']
+			: array();
+
+		return array_map( array( __CLASS__, 'shape_subscriber' ), $subscribers );
+	}
+
+	/**
+	 * Resolve `per_page` from input, clamped to [1, MAX_PER_PAGE].
+	 *
+	 * Schema defaults are not auto-injected, so callers that omit per_page
+	 * fall through to DEFAULT_PER_PAGE here.
+	 *
+	 * @param array $input Input array.
+	 * @return int
+	 */
+	private static function resolve_per_page( array $input ): int {
+		$raw = isset( $input['per_page'] ) ? (int) $input['per_page'] : self::DEFAULT_PER_PAGE;
+		if ( $raw < 1 ) {
+			return self::DEFAULT_PER_PAGE;
+		}
+		return min( $raw, self::MAX_PER_PAGE );
+	}
+
+	/**
+	 * Resolve the current blog's wpcom site id, or return a steering error.
+	 *
+	 * @return int|\WP_Error Positive integer site id, or WP_Error when not connected.
+	 */
+	private static function get_connected_blog_id() {
+		if ( ! class_exists( 'Jetpack' ) || ! Jetpack::is_connection_ready() ) {
+			return new \WP_Error(
+				'jetpack_memberships_not_connected',
+				__( 'Memberships data is only available on Jetpack-connected sites. Connect Jetpack and retry.', 'jetpack' )
+			);
+		}
+
+		$site_id = (int) Jetpack_Options::get_option( 'id' );
+		if ( $site_id <= 0 ) {
+			return new \WP_Error(
+				'jetpack_memberships_not_connected',
+				__( 'No Jetpack site ID is registered. Connect Jetpack and retry.', 'jetpack' )
+			);
+		}
+
+		return $site_id;
+	}
+
+	/**
+	 * Decode a wpcom JSON-API response into an array, mapping transport and
+	 * HTTP errors into a WP_Error with the supplied code.
+	 *
+	 * @param mixed  $response   Result of `Client::wpcom_json_api_request_as_user`.
+	 * @param string $error_code Steering error code to use on failure.
+	 * @return array|\WP_Error
+	 */
+	private static function decode_wpcom_response( $response, string $error_code ) {
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error( $error_code, $response->get_error_message() );
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new \WP_Error(
+				$error_code,
+				/* translators: %d: HTTP status code returned by WordPress.com. */
+				sprintf( __( 'WordPress.com returned an unexpected status (%d). Retry shortly.', 'jetpack' ), $status )
+			);
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		return is_array( $body ) ? $body : array();
+	}
+
+	/**
+	 * Shape a wpcom membership product into the public ability response.
+	 *
+	 * Kept narrow: we surface exactly the keys promised by the ability's
+	 * output_schema rather than the raw upstream product dump, which carries
+	 * Stripe IDs and internal flags the agent can't act on.
+	 *
+	 * @param mixed $product Raw product entry from the wpcom response.
+	 * @return array
+	 */
+	private static function shape_plan( $product ): array {
+		$product = is_array( $product ) ? $product : array();
+		return array(
+			'id'                    => isset( $product['id'] ) ? (int) $product['id'] : 0,
+			'title'                 => isset( $product['title'] ) ? (string) $product['title'] : '',
+			'price'                 => isset( $product['price'] ) ? (float) $product['price'] : 0.0,
+			'currency'              => isset( $product['currency'] ) ? (string) $product['currency'] : '',
+			'interval'              => isset( $product['interval'] ) ? (string) $product['interval'] : '',
+			'active'                => isset( $product['status'] ) && 'active' === $product['status'],
+			'subscriber_count'      => isset( $product['subscriber_count'] ) ? (int) $product['subscriber_count'] : 0,
+			'connected_destination' => isset( $product['connected_destination'] ) ? (string) $product['connected_destination'] : '',
+		);
+	}
+
+	/**
+	 * Shape a wpcom subscriber row into the public ability response.
+	 *
+	 * @param mixed $subscriber Raw subscriber entry from the wpcom response.
+	 * @return array
+	 */
+	private static function shape_subscriber( $subscriber ): array {
+		$subscriber = is_array( $subscriber ) ? $subscriber : array();
+
+		// Status normalization: wpcom historically returns "active" or
+		// "cancelled" for paid subscriptions, occasionally "inactive" for
+		// expired free trials. Map non-active to "cancelled" so the output
+		// schema's enum stays tight.
+		$raw_status = isset( $subscriber['status'] ) ? (string) $subscriber['status'] : 'active';
+		$status     = 'active' === $raw_status ? 'active' : 'cancelled';
+
+		return array(
+			'id'              => isset( $subscriber['user_id'] )
+				? (int) $subscriber['user_id']
+				: ( isset( $subscriber['id'] ) ? (int) $subscriber['id'] : 0 ),
+			'email'           => isset( $subscriber['email_address'] )
+				? (string) $subscriber['email_address']
+				: ( isset( $subscriber['email'] ) ? (string) $subscriber['email'] : '' ),
+			'display_name'    => isset( $subscriber['display_name'] ) ? (string) $subscriber['display_name'] : '',
+			'plan_id'         => isset( $subscriber['plan_id'] ) ? (int) $subscriber['plan_id'] : 0,
+			'status'          => $status,
+			'subscribed_at'   => isset( $subscriber['date_subscribed'] ) ? (string) $subscriber['date_subscribed'] : '',
+			'last_payment_at' => isset( $subscriber['last_payment_date'] ) ? (string) $subscriber['last_payment_date'] : '',
+		);
+	}
+}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -1056,3 +1056,6 @@ class Jetpack_Memberships {
 	}
 }
 Jetpack_Memberships::get_instance();
+
+require_once __DIR__ . '/abilities/class-memberships-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\Memberships_Abilities::init();

--- a/projects/plugins/jetpack/tests/php/src/Memberships_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Memberships_Abilities_Test.php
@@ -1,0 +1,556 @@
+<?php
+/**
+ * Tests for the Memberships_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+require_once __DIR__ . '/../../../modules/memberships/abilities/class-memberships-abilities.php';
+
+use Automattic\Jetpack\Plugin\Abilities\Memberships_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Memberships_Abilities
+ */
+#[CoversClass( Memberships_Abilities::class )]
+class Memberships_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/** @var int */
+	private $admin_id;
+
+	/** @var int */
+	private $author_id;
+
+	/** @var int */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->author_id     = self::factory()->user->create( array( 'role' => 'author' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// Open the abilities gate by default; specific tests override.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Pretend Jetpack is connected with a valid site id so the network-side
+		// abilities don't short-circuit on the not-connected guard.
+		\Jetpack_Options::update_option( 'id', 12345 );
+		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_filter( 'jetpack_is_connection_ready', '__return_true' );
+		remove_filter( 'jetpack_is_connection_ready', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'pre_http_request' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Memberships_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Memberships_Abilities::class, 'register_abilities' ) );
+
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Memberships_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Memberships_Abilities::get_category_slug() );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Mock the next outbound `wp_remote_*` request with a canned JSON payload.
+	 *
+	 * @param array $payload  Body, encoded as JSON.
+	 * @param int   $status   HTTP status (default 200).
+	 */
+	private function mock_wpcom_response( array $payload, int $status = 200 ): void {
+		add_filter(
+			'pre_http_request',
+			static function () use ( $payload, $status ) {
+				return array(
+					'response' => array( 'code' => $status ),
+					'headers'  => array( 'content-type' => 'application/json' ),
+					'body'     => wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ),
+				);
+			}
+		);
+	}
+
+	/**
+	 * Mock the next outbound request with a WP_Error transport failure.
+	 */
+	private function mock_wpcom_transport_error(): void {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'http_request_failed', 'Connection refused' );
+			}
+		);
+	}
+
+	/** Identity */
+	public function test_category_slug_is_jetpack_memberships() {
+		$this->assertSame( 'jetpack-memberships', Memberships_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Memberships_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotEmpty( $def['label'] );
+		$this->assertNotEmpty( $def['description'] );
+	}
+
+	public function test_abilities_map_is_namespaced() {
+		$abilities = Memberships_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		$this->assertArrayHasKey( 'jetpack-memberships/list-plans', $abilities );
+		$this->assertArrayHasKey( 'jetpack-memberships/list-subscribers', $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-memberships/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		foreach ( Memberships_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_reads_have_readonly_annotations() {
+		$abilities = Memberships_Abilities::get_abilities();
+		foreach ( $abilities as $slug => $spec ) {
+			$annotations = $spec['meta']['annotations'];
+			$this->assertTrue( $annotations['readonly'], "{$slug} is a read; readonly must be true." );
+			$this->assertFalse( $annotations['destructive'], "{$slug} is a read; destructive must be false." );
+			$this->assertTrue( $annotations['idempotent'], "{$slug} is a read; idempotent must be true." );
+			$this->assertTrue( $spec['meta']['show_in_rest'] );
+		}
+	}
+
+	/** Registrar wiring */
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Memberships_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Memberships_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Memberships_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Memberships_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Memberships_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Memberships_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_ability_class_is_colocated_with_module() {
+		$reflector = new \ReflectionClass( Memberships_Abilities::class );
+		$path      = $reflector->getFileName();
+		$this->assertStringContainsString(
+			'/modules/memberships/',
+			$path,
+			'Module-backed abilities must live inside their module directory, not in src/abilities/.'
+		);
+		$this->assertStringNotContainsString(
+			'/src/abilities/',
+			$path,
+			'Found a module-backed ability in the plugin-global src/abilities/ tree. Move it into modules/memberships/abilities/.'
+		);
+	}
+
+	public function test_not_wired_from_class_jetpack_php() {
+		$bootstrap = file_get_contents( JETPACK__PLUGIN_DIR . 'class.jetpack.php' );
+		$this->assertStringNotContainsString(
+			'Memberships_Abilities::init()',
+			$bootstrap,
+			'class.jetpack.php must not init a module-backed ability. Wire from modules/memberships/class-jetpack-memberships.php instead.'
+		);
+	}
+
+	public function test_wired_from_memberships_module_loader() {
+		$module = file_get_contents( JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php' );
+		$this->assertStringContainsString(
+			'Memberships_Abilities::init()',
+			$module,
+			'Memberships_Abilities must be initialized from modules/memberships/class-jetpack-memberships.php so registration follows module load.'
+		);
+	}
+
+	/** Permissions */
+	public function test_can_view_plans_allows_author() {
+		// list-plans matches the wpcom edit_posts cap — authors qualify.
+		wp_set_current_user( $this->author_id );
+		$this->assertTrue( Memberships_Abilities::can_view_plans() );
+	}
+
+	public function test_can_view_plans_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Memberships_Abilities::can_view_plans() );
+	}
+
+	public function test_can_view_plans_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Memberships_Abilities::can_view_plans() );
+	}
+
+	public function test_can_view_subscribers_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Memberships_Abilities::can_view_subscribers() );
+	}
+
+	public function test_can_view_subscribers_denies_author() {
+		// list-subscribers is admin-only on wpcom — authors must NOT see it.
+		wp_set_current_user( $this->author_id );
+		$this->assertFalse( Memberships_Abilities::can_view_subscribers() );
+	}
+
+	public function test_can_view_subscribers_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Memberships_Abilities::can_view_subscribers() );
+	}
+
+	/** Connection guard */
+	public function test_list_plans_returns_wp_error_when_disconnected() {
+		remove_filter( 'jetpack_is_connection_ready', '__return_true' );
+		add_filter( 'jetpack_is_connection_ready', '__return_false' );
+
+		$result = Memberships_Abilities::list_plans();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_memberships_not_connected', $result->get_error_code() );
+	}
+
+	public function test_list_subscribers_returns_wp_error_when_disconnected() {
+		remove_filter( 'jetpack_is_connection_ready', '__return_true' );
+		add_filter( 'jetpack_is_connection_ready', '__return_false' );
+
+		$result = Memberships_Abilities::list_subscribers();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_memberships_not_connected', $result->get_error_code() );
+	}
+
+	/** Execute — list-plans happy path */
+	public function test_list_plans_shapes_response_to_documented_keys() {
+		$this->mock_wpcom_response(
+			array(
+				'products' => array(
+					array(
+						'id'                    => 7,
+						'title'                 => 'Annual',
+						'price'                 => 99.0,
+						'currency'              => 'USD',
+						'interval'              => '1 year',
+						'status'                => 'active',
+						'subscriber_count'      => 42,
+						'connected_destination' => 'newsletter',
+						'stripe_account_id'     => 'acct_secret', // upstream noise that must NOT leak.
+					),
+				),
+			)
+		);
+
+		$result = Memberships_Abilities::list_plans();
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		$plan = $result[0];
+		$this->assertSame(
+			array( 'id', 'title', 'price', 'currency', 'interval', 'active', 'subscriber_count', 'connected_destination' ),
+			array_keys( $plan ),
+			'Plan response must surface only the documented keys.'
+		);
+		$this->assertSame( 7, $plan['id'] );
+		$this->assertSame( 'Annual', $plan['title'] );
+		$this->assertSame( 99.0, $plan['price'] );
+		$this->assertSame( 'USD', $plan['currency'] );
+		$this->assertSame( '1 year', $plan['interval'] );
+		$this->assertTrue( $plan['active'] );
+		$this->assertSame( 42, $plan['subscriber_count'] );
+		$this->assertSame( 'newsletter', $plan['connected_destination'] );
+	}
+
+	public function test_list_plans_with_unknown_plan_id_returns_empty_array() {
+		// Consolidated-read contract: unknown id filters to an empty array,
+		// not a WP_Error. The shape stays consistent with the happy path.
+		$this->mock_wpcom_response(
+			array(
+				'products' => array(
+					array(
+						'id'     => 1,
+						'title'  => 'Plan A',
+						'status' => 'active',
+					),
+					array(
+						'id'     => 2,
+						'title'  => 'Plan B',
+						'status' => 'inactive',
+					),
+				),
+			)
+		);
+
+		$result = Memberships_Abilities::list_plans( array( 'plan_id' => 9999 ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_list_plans_with_known_plan_id_returns_single_match() {
+		$this->mock_wpcom_response(
+			array(
+				'products' => array(
+					array(
+						'id'     => 1,
+						'title'  => 'Plan A',
+						'status' => 'active',
+					),
+					array(
+						'id'     => 2,
+						'title'  => 'Plan B',
+						'status' => 'inactive',
+					),
+				),
+			)
+		);
+
+		$result = Memberships_Abilities::list_plans( array( 'plan_id' => 2 ) );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 2, $result[0]['id'] );
+		$this->assertFalse( $result[0]['active'] );
+	}
+
+	public function test_list_plans_active_filter_returns_only_active() {
+		$this->mock_wpcom_response(
+			array(
+				'products' => array(
+					array(
+						'id'     => 1,
+						'status' => 'active',
+					),
+					array(
+						'id'     => 2,
+						'status' => 'inactive',
+					),
+					array(
+						'id'     => 3,
+						'status' => 'active',
+					),
+				),
+			)
+		);
+
+		$result = Memberships_Abilities::list_plans( array( 'active' => true ) );
+		$this->assertCount( 2, $result );
+		foreach ( $result as $plan ) {
+			$this->assertTrue( $plan['active'] );
+		}
+	}
+
+	public function test_list_plans_caps_per_page_at_max() {
+		// Per-page caller value above MAX_PER_PAGE must clamp; the slice should
+		// never exceed MAX_PER_PAGE entries even when input asks for more.
+		$products = array();
+		for ( $i = 1; $i <= 150; $i++ ) {
+			$products[] = array(
+				'id'     => $i,
+				'status' => 'active',
+			);
+		}
+		$this->mock_wpcom_response( array( 'products' => $products ) );
+
+		$result = Memberships_Abilities::list_plans( array( 'per_page' => 500 ) );
+		$this->assertLessThanOrEqual( 100, count( $result ) );
+	}
+
+	public function test_list_plans_pagination_slices_results() {
+		$products = array();
+		for ( $i = 1; $i <= 25; $i++ ) {
+			$products[] = array(
+				'id'     => $i,
+				'status' => 'active',
+			);
+		}
+		$this->mock_wpcom_response( array( 'products' => $products ) );
+
+		// per_page=10, page=2 → ids 11..20.
+		$result = Memberships_Abilities::list_plans(
+			array(
+				'per_page' => 10,
+				'page'     => 2,
+			)
+		);
+		$this->assertCount( 10, $result );
+		$this->assertSame( 11, $result[0]['id'] );
+		$this->assertSame( 20, $result[9]['id'] );
+	}
+
+	public function test_list_plans_transport_error_returns_steering_wp_error() {
+		$this->mock_wpcom_transport_error();
+		$result = Memberships_Abilities::list_plans();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_memberships_plans_unavailable', $result->get_error_code() );
+	}
+
+	public function test_list_plans_http_error_returns_steering_wp_error() {
+		$this->mock_wpcom_response( array( 'message' => 'boom' ), 500 );
+		$result = Memberships_Abilities::list_plans();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_memberships_plans_unavailable', $result->get_error_code() );
+	}
+
+	public function test_list_plans_handles_empty_products_payload() {
+		// Empty array, not WP_Error — consistent shape with happy path.
+		$this->mock_wpcom_response( array( 'products' => array() ) );
+		$result = Memberships_Abilities::list_plans();
+		$this->assertSame( array(), $result );
+	}
+
+	/** Execute — list-subscribers happy path */
+	public function test_list_subscribers_shapes_response_to_documented_keys() {
+		$this->mock_wpcom_response(
+			array(
+				'subscribers' => array(
+					array(
+						'user_id'           => 42,
+						'email_address'     => 'sub@example.test',
+						'display_name'      => 'Pat Subscriber',
+						'plan_id'           => 7,
+						'status'            => 'active',
+						'date_subscribed'   => '2026-01-01T00:00:00Z',
+						'last_payment_date' => '2026-04-01T00:00:00Z',
+						'card_last4'        => '4242', // upstream noise that must NOT leak.
+					),
+				),
+			)
+		);
+
+		$result = Memberships_Abilities::list_subscribers();
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		$sub = $result[0];
+		$this->assertSame(
+			array( 'id', 'email', 'display_name', 'plan_id', 'status', 'subscribed_at', 'last_payment_at' ),
+			array_keys( $sub ),
+			'Subscriber response must surface only the documented keys.'
+		);
+		$this->assertSame( 42, $sub['id'] );
+		$this->assertSame( 'sub@example.test', $sub['email'] );
+		$this->assertSame( 'Pat Subscriber', $sub['display_name'] );
+		$this->assertSame( 7, $sub['plan_id'] );
+		$this->assertSame( 'active', $sub['status'] );
+		$this->assertSame( '2026-01-01T00:00:00Z', $sub['subscribed_at'] );
+		$this->assertSame( '2026-04-01T00:00:00Z', $sub['last_payment_at'] );
+	}
+
+	public function test_list_subscribers_normalizes_non_active_status_to_cancelled() {
+		$this->mock_wpcom_response(
+			array(
+				'subscribers' => array(
+					array(
+						'user_id' => 1,
+						'status'  => 'inactive',
+					),
+					array(
+						'user_id' => 2,
+						'status'  => 'cancelled',
+					),
+					array(
+						'user_id' => 3,
+						'status'  => 'expired',
+					),
+				),
+			)
+		);
+
+		$result = Memberships_Abilities::list_subscribers( array( 'status' => 'all' ) );
+		$this->assertCount( 3, $result );
+		foreach ( $result as $sub ) {
+			$this->assertSame(
+				'cancelled',
+				$sub['status'],
+				'Non-active upstream statuses must collapse to "cancelled" so the output enum stays tight.'
+			);
+		}
+	}
+
+	public function test_list_subscribers_handles_missing_subscribers_key() {
+		$this->mock_wpcom_response( array() );
+		$result = Memberships_Abilities::list_subscribers();
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_list_subscribers_transport_error_returns_steering_wp_error() {
+		$this->mock_wpcom_transport_error();
+		$result = Memberships_Abilities::list_subscribers();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_memberships_subscribers_unavailable', $result->get_error_code() );
+	}
+
+	public function test_list_subscribers_http_error_returns_steering_wp_error() {
+		$this->mock_wpcom_response( array( 'message' => 'boom' ), 502 );
+		$result = Memberships_Abilities::list_subscribers();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_memberships_subscribers_unavailable', $result->get_error_code() );
+	}
+
+	/** Per-ability allow list filter */
+	public function test_per_ability_allow_list_filter_blocks_individual_slugs() {
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				if ( 'ability' === $type && str_starts_with( $slug, 'jetpack-memberships/' ) ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		Memberships_Abilities::register_abilities();
+
+		$registered_slugs = array_map(
+			static function ( $ability ) {
+				return $ability->get_name();
+			},
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Memberships_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains(
+				$slug,
+				$registered_slugs,
+				"Ability {$slug} must be filtered out by jetpack_wp_abilities_should_register."
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes
* Adds `Automattic\Jetpack\Plugin\Abilities\Memberships_Abilities`, a `Registrar`-extending class at `projects/plugins/jetpack/modules/memberships/abilities/class-memberships-abilities.php`.
* Registers three read-only abilities on WP 6.9+ under the `jetpack-memberships/*` namespace:
  - `jetpack-memberships/list-plans` — paid membership tiers with `plan_id` consolidated-read.
  - `jetpack-memberships/list-subscribers` — paid-membership subscribers with status / plan filters.
  - `jetpack-memberships/get-earnings-summary` — zero-arg earnings summary for the current period.
* Case A wiring from `modules/memberships/class-jetpack-memberships.php` — registration only happens when the Memberships module is active.
* Gated by the `jetpack_wp_abilities_enabled` filter (default `false`).
* Permission callbacks mirror the underlying wpcom endpoints (`edit_posts` for plans, `manage_options` for subscriber + earnings reads).

## Testing instructions
1. `cd projects/plugins/jetpack && composer install`.
2. `composer phpunit -- --filter Memberships_Abilities_Test`.
3. On a site with Memberships active and the gate filter enabled, curl `/wp-json/wp-abilities/v1/abilities | jq '.[] | select(.name | startswith("jetpack-memberships/")) | .name'` and confirm three slugs.

## Plan reference
Abilities rollout plan — §3.3 Memberships module.