### PR TITLE
Post by Email abilities: register status read + regenerate-address via Registrar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-post-by-email-abilities
+++ b/projects/plugins/jetpack/changelog/add-post-by-email-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Post by Email abilities: register per-user status read + regenerate-address via Registrar.

--- a/projects/plugins/jetpack/modules/post-by-email.php
+++ b/projects/plugins/jetpack/modules/post-by-email.php
@@ -26,3 +26,7 @@ require_once __DIR__ . '/post-by-email/class-jetpack-post-by-email.php';
 add_action( 'jetpack_modules_loaded', array( 'Jetpack_Post_By_Email', 'init' ) );
 
 Jetpack::enable_module_configurable( __FILE__ );
+
+// Register Jetpack Post by Email abilities (WordPress Abilities API, WP 6.9+).
+require_once __DIR__ . '/post-by-email/abilities/class-post-by-email-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\Post_By_Email_Abilities::init();

--- a/projects/plugins/jetpack/modules/post-by-email/abilities/class-post-by-email-abilities.php
+++ b/projects/plugins/jetpack/modules/post-by-email/abilities/class-post-by-email-abilities.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Jetpack Post by Email Abilities Registration
+ *
+ * Registers Jetpack Post by Email abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack;
+
+/**
+ * Registers Jetpack Post by Email abilities with the WordPress Abilities API.
+ *
+ * Exposes a per-user read of the current user's Post by Email state and a
+ * declarative rotate action that mints a fresh address (invalidating the old
+ * one) so AI agents can inspect and rotate Post by Email through the standard
+ * `wp-abilities/v1` REST surface.
+ */
+class Post_By_Email_Abilities extends Registrar {
+
+	private const MODULE_SLUG = 'post-by-email';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-post-by-email';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// translators: "Jetpack" is a product name and should not be translated.
+			'label'       => __( 'Jetpack Post by Email', 'jetpack' ),
+			'description' => __( 'Abilities for inspecting and rotating the current user\'s Post by Email address.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-post-by-email/get-status'         => array(
+				'label'               => __( 'Get Jetpack Post by Email status', 'jetpack' ),
+				'description'         => __( 'Return the current user\'s Post by Email state as { active, address, address_active, last_used_at }. active is whether the Post by Email feature is enabled for the user (an address has been minted). address is the per-user Post by Email address as a string, or null when the user has not enabled Post by Email or the remote read failed transiently. address_active mirrors active and is true when a non-empty address is present. last_used_at is always null in this release — the remote service does not currently expose last-used metadata; the field is reserved so the shape can grow without breaking callers. Fails with jetpack_post_by_email_not_connected when the current user is not connected to Jetpack (connect first via the My Jetpack admin page). These abilities are only registered while the Post by Email module is active; if they are absent from wp_get_abilities(), activate the Post by Email module first. Related: jetpack-post-by-email/regenerate-address rotates the user\'s address.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'active'         => array( 'type' => 'boolean' ),
+						'address'        => array( 'type' => array( 'string', 'null' ) ),
+						'address_active' => array( 'type' => 'boolean' ),
+						'last_used_at'   => array( 'type' => array( 'integer', 'null' ) ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_post_by_email' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
+				),
+			),
+
+			'jetpack-post-by-email/regenerate-address' => array(
+				'label'               => __( 'Regenerate Jetpack Post by Email address', 'jetpack' ),
+				'description'         => __( 'Rotate the current user\'s Post by Email address. Mints a fresh address on the remote service and invalidates the previous one — destructive: any saved drafts pointing at the old address will no longer reach this site. Not idempotent — each call produces a new address even when the previous call succeeded. Returns { address, regenerated_at } where address is the new email string and regenerated_at is a Unix timestamp (seconds) recorded at call time. Preconditions: the Post by Email module must be active and the current user must be connected to Jetpack; call jetpack-post-by-email/get-status first to verify the connection. Fails with jetpack_post_by_email_module_inactive (defensive — the abilities are only registered while the module is active), jetpack_post_by_email_not_connected, or jetpack_post_by_email_service_unreachable when the remote regenerate call fails.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'address'        => array( 'type' => 'string' ),
+						'regenerated_at' => array( 'type' => 'integer' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'regenerate_address' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_post_by_email' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check: can the current user read their own Post by Email state?
+	 *
+	 * Post by Email is a per-user feature for post authors: each user who can
+	 * author posts manages their own address. `current_user_can( 'edit_posts' )`
+	 * mirrors the gate used by the existing Post by Email AJAX/REST surface
+	 * (`process_rest_proxy_request`) so subscribers — who cannot author posts —
+	 * are not exposed to a feature they cannot use.
+	 */
+	public static function can_view_post_by_email(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Permission check: can the current user rotate their own Post by Email address?
+	 *
+	 * Same gate as the read — rotating the caller's own address requires the
+	 * same authoring capability as reading it.
+	 */
+	public static function can_manage_post_by_email(): bool {
+		return self::can_view_post_by_email();
+	}
+
+	/**
+	 * Execute: per-user read. Returns the documented four-key shape on the happy
+	 * path. Surfaces precondition failures as `WP_Error` so callers (especially
+	 * AI agents) get an actionable next step instead of opaque null fields:
+	 *
+	 * - `jetpack_post_by_email_module_inactive` — defensive guard; in practice
+	 *   unreachable because the abilities are only registered while the module
+	 *   is active.
+	 * - `jetpack_post_by_email_not_connected` — the current user is not
+	 *   connected to Jetpack; the remote read needs the user's token.
+	 *
+	 * A null `address` on the happy path means either the user has not yet
+	 * enabled Post by Email or the remote read failed transiently — the
+	 * underlying `Jetpack_Post_By_Email::get_post_by_email_address()` reader
+	 * collapses both into null. Callers should treat null as "no usable
+	 * address" rather than distinguishing the two cases.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array|\WP_Error
+	 */
+	public static function get_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		if ( ! Jetpack::is_module_active( self::MODULE_SLUG ) ) {
+			return new \WP_Error(
+				'jetpack_post_by_email_module_inactive',
+				__( 'The Post by Email module is not active. Activate it before reading Post by Email status.', 'jetpack' )
+			);
+		}
+
+		if ( ! static::is_user_connected_to_jetpack() ) {
+			return new \WP_Error(
+				'jetpack_post_by_email_not_connected',
+				__( 'User is not connected to Jetpack. Connect first via the My Jetpack admin page, then retry this ability.', 'jetpack' )
+			);
+		}
+
+		$address     = static::fetch_address();
+		$has_address = is_string( $address ) && '' !== $address;
+
+		return array(
+			'active'         => $has_address,
+			'address'        => $has_address ? $address : null,
+			'address_active' => $has_address,
+			// The remote service does not currently surface last-used metadata.
+			// The field is reserved so the response shape can grow without
+			// breaking callers; callers should treat null as "unknown", not
+			// "never used".
+			'last_used_at'   => null,
+		);
+	}
+
+	/**
+	 * Execute: rotate the user's address. Always mints a new address on success
+	 * — destructive (invalidates the old one) and not idempotent (each call
+	 * produces a new value).
+	 *
+	 * @param array|null $input Input matching the ability's input_schema (no params).
+	 * @return array|\WP_Error
+	 */
+	public static function regenerate_address( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
+		if ( ! Jetpack::is_module_active( self::MODULE_SLUG ) ) {
+			return new \WP_Error(
+				'jetpack_post_by_email_module_inactive',
+				__( 'The Post by Email module is not active. Activate it before rotating the Post by Email address.', 'jetpack' )
+			);
+		}
+
+		if ( ! static::is_user_connected_to_jetpack() ) {
+			return new \WP_Error(
+				'jetpack_post_by_email_not_connected',
+				__( 'The current user is not connected to Jetpack. Connect the user to Jetpack before rotating the Post by Email address.', 'jetpack' )
+			);
+		}
+
+		$new_address = static::apply_regenerate();
+		if ( is_wp_error( $new_address ) ) {
+			return new \WP_Error(
+				'jetpack_post_by_email_service_unreachable',
+				__( 'The remote Jetpack Post by Email service is unreachable. Retry shortly; this is typically transient.', 'jetpack' ),
+				array( 'underlying' => $new_address->get_error_code() )
+			);
+		}
+
+		return array(
+			'address'        => $new_address,
+			'regenerated_at' => time(),
+		);
+	}
+
+	/**
+	 * Whether the current user is connected to Jetpack.
+	 *
+	 * Extracted as a protected seam so tests can override the connection check
+	 * without standing up a full Jetpack token fixture.
+	 */
+	protected static function is_user_connected_to_jetpack(): bool {
+		return ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
+	}
+
+	/**
+	 * Fetch the current user's Post by Email address from the remote service.
+	 *
+	 * Delegates to `Jetpack_Post_By_Email::get_post_by_email_address()` so the
+	 * abilities path and the legacy AJAX/REST path share a single reader.
+	 *
+	 * @return string|null Address string when set, or null when the user has
+	 *                     not enabled Post by Email or the remote call failed.
+	 */
+	protected static function fetch_address() {
+		return \Jetpack_Post_By_Email::init()->get_post_by_email_address();
+	}
+
+	/**
+	 * Rotate the current user's Post by Email address on the remote service.
+	 *
+	 * Delegates to `Jetpack_Post_By_Email::process_api_request( 'regenerate' )`
+	 * so the abilities path and the legacy AJAX/REST path share a single writer
+	 * (including the `post_by_email_address{user_id}` option mirror used by
+	 * `Jetpack_Core_Json_Api_Endpoints::get_remote_value`). The shared helper
+	 * returns the new address string on success or `array( 'message' => ... )`
+	 * on failure; we adapt the failure shape to WP_Error here.
+	 *
+	 * @return string|\WP_Error New address on success, WP_Error on remote failure.
+	 */
+	protected static function apply_regenerate() {
+		$result = \Jetpack_Post_By_Email::init()->process_api_request( 'regenerate' );
+
+		if ( is_string( $result ) && '' !== $result ) {
+			return $result;
+		}
+
+		$message = is_array( $result ) && isset( $result['message'] )
+			? (string) $result['message']
+			: __( 'Empty response from remote Post by Email service.', 'jetpack' );
+
+		return new \WP_Error( 'jetpack_post_by_email_regenerate_failed', $message );
+	}
+}

--- a/projects/plugins/jetpack/modules/post-by-email/abilities/class-post-by-email-abilities.php
+++ b/projects/plugins/jetpack/modules/post-by-email/abilities/class-post-by-email-abilities.php
@@ -84,7 +84,7 @@ class Post_By_Email_Abilities extends Registrar {
 
 			'jetpack-post-by-email/regenerate-address' => array(
 				'label'               => __( 'Regenerate Jetpack Post by Email address', 'jetpack' ),
-				'description'         => __( 'Rotate the current user\'s Post by Email address. Mints a fresh address on the remote service and invalidates the previous one — destructive: any saved drafts pointing at the old address will no longer reach this site. Not idempotent — each call produces a new address even when the previous call succeeded. Returns { address, regenerated_at } where address is the new email string and regenerated_at is a Unix timestamp (seconds) recorded at call time. Preconditions: the Post by Email module must be active and the current user must be connected to Jetpack; call jetpack-post-by-email/get-status first to verify the connection. Fails with jetpack_post_by_email_module_inactive (defensive — the abilities are only registered while the module is active), jetpack_post_by_email_not_connected, or jetpack_post_by_email_service_unreachable when the remote regenerate call fails.', 'jetpack' ),
+				'description'         => __( 'Ensure the current user has a Post by Email address by minting a fresh one — creating it when the user has none, or rotating (invalidating + replacing) the existing address. Destructive when an existing address is rotated: any saved drafts pointing at the old address will no longer reach this site. Not idempotent — each call produces a new address even when the previous call succeeded. Returns { address, regenerated_at } where address is the new email string and regenerated_at is a Unix timestamp (seconds) recorded at call time. Preconditions: the Post by Email module must be active and the current user must be connected to Jetpack; call jetpack-post-by-email/get-status first to verify the connection. Fails with jetpack_post_by_email_module_inactive (defensive — the abilities are only registered while the module is active), jetpack_post_by_email_not_connected, or jetpack_post_by_email_service_unreachable when the remote call fails.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,
@@ -210,7 +210,16 @@ class Post_By_Email_Abilities extends Registrar {
 			);
 		}
 
-		$new_address = static::apply_regenerate();
+		// Choose between 'create' and 'regenerate' on the underlying writer:
+		// the remote 'regenerate' endpoint expects an existing address to
+		// rotate. Calling it for a user who has never enabled Post by Email
+		// fails on the remote side. Inspect the current address first and route
+		// accordingly so a fresh user gets a usable address from the same
+		// ability instead of an opaque service error.
+		$existing = static::fetch_address();
+		$action   = is_string( $existing ) && '' !== $existing ? 'regenerate' : 'create';
+
+		$new_address = static::apply_action( $action );
 		if ( is_wp_error( $new_address ) ) {
 			return new \WP_Error(
 				'jetpack_post_by_email_service_unreachable',
@@ -249,19 +258,19 @@ class Post_By_Email_Abilities extends Registrar {
 	}
 
 	/**
-	 * Rotate the current user's Post by Email address on the remote service.
-	 *
-	 * Delegates to `Jetpack_Post_By_Email::process_api_request( 'regenerate' )`
-	 * so the abilities path and the legacy AJAX/REST path share a single writer
+	 * Mint or rotate the current user's Post by Email address on the remote
+	 * service. Delegates to `Jetpack_Post_By_Email::process_api_request()` so
+	 * the abilities path and the legacy AJAX/REST path share a single writer
 	 * (including the `post_by_email_address{user_id}` option mirror used by
 	 * `Jetpack_Core_Json_Api_Endpoints::get_remote_value`). The shared helper
 	 * returns the new address string on success or `array( 'message' => ... )`
 	 * on failure; we adapt the failure shape to WP_Error here.
 	 *
+	 * @param string $action 'create' (no existing address) or 'regenerate' (rotate existing).
 	 * @return string|\WP_Error New address on success, WP_Error on remote failure.
 	 */
-	protected static function apply_regenerate() {
-		$result = \Jetpack_Post_By_Email::init()->process_api_request( 'regenerate' );
+	protected static function apply_action( string $action ) {
+		$result = \Jetpack_Post_By_Email::init()->process_api_request( $action );
 
 		if ( is_string( $result ) && '' !== $result ) {
 			return $result;

--- a/projects/plugins/jetpack/tests/php/src/Post_By_Email_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Post_By_Email_Abilities_Test.php
@@ -1,0 +1,526 @@
+<?php
+/**
+ * Tests for the Post_By_Email_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+require_once __DIR__ . '/../../../modules/post-by-email/abilities/class-post-by-email-abilities.php';
+
+use Automattic\Jetpack\Plugin\Abilities\Post_By_Email_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once __DIR__ . '/class-post-by-email-abilities-test-stub.php';
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Post_By_Email_Abilities
+ */
+#[CoversClass( Post_By_Email_Abilities::class )]
+class Post_By_Email_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Authenticated post-authoring user id, created once per test.
+	 *
+	 * Post by Email is a per-user feature for post authors (gated on
+	 * `current_user_can( 'edit_posts' )`, matching the legacy AJAX/REST surface),
+	 * so the test uses an Author role.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Subscriber id used to assert that non-authoring users are denied.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = wp_insert_user(
+			array(
+				'user_login' => 'pbe_abilities_user_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'user_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'author',
+			)
+		);
+
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'pbe_abilities_subscriber_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_active_modules' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_abilities' ) );
+
+		// Unregister anything this test left behind so the singleton registry stays clean
+		// between tests (the WP Abilities Registry persists across tests within a process).
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Post_By_Email_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Post_By_Email_Abilities::get_category_slug() );
+		}
+
+		if ( $this->user_id ) {
+			delete_option( 'post_by_email_address' . $this->user_id );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so registrations
+	 * happen inside the action callstack — `wp_register_ability(_category)` enforces
+	 * `doing_action()`, so direct invocation outside the hook is rejected.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	/**
+	 * Activate the Post by Email module via the `jetpack_active_modules` filter
+	 * so the precondition checks pass for tests that don't care about the
+	 * inactive-module branch.
+	 */
+	private function activate_post_by_email_module(): void {
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'post-by-email';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+	}
+
+	/**
+	 * -------------------- Abstract getters --------------------
+	 */
+
+	/**
+	 * Category slug is namespaced under the plugin.
+	 */
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-post-by-email', Post_By_Email_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Post_By_Email_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Post_By_Email_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-post-by-email/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Post_By_Email_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_surface_exposes_get_status_and_regenerate_address() {
+		$abilities = Post_By_Email_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-post-by-email/get-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack-post-by-email/regenerate-address', $abilities );
+	}
+
+	public function test_get_status_is_annotated_readonly_idempotent() {
+		$spec = Post_By_Email_Abilities::get_abilities()['jetpack-post-by-email/get-status'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_regenerate_address_is_annotated_destructive_non_idempotent() {
+		$spec = Post_By_Email_Abilities::get_abilities()['jetpack-post-by-email/regenerate-address'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertTrue( $spec['meta']['annotations']['destructive'] );
+		$this->assertFalse( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	/**
+	 * -------------------- Registrar wiring --------------------
+	 */
+
+	/**
+	 * Gate filter false => init() short-circuits and hooks nothing.
+	 */
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Post_By_Email_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Post_By_Email_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Post_By_Email_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-post-by-email/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( Post_By_Email_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static function ( $a ) {
+				return $a->get_name();
+			},
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Post_By_Email_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Post_By_Email_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-post-by-email',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	/**
+	 * -------------------- Permission callbacks --------------------
+	 */
+	public function test_can_view_post_by_email_allows_post_author() {
+		wp_set_current_user( $this->user_id );
+		$this->assertTrue( Post_By_Email_Abilities::can_view_post_by_email() );
+	}
+
+	public function test_can_view_post_by_email_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Post_By_Email_Abilities::can_view_post_by_email() );
+	}
+
+	public function test_can_view_post_by_email_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Post_By_Email_Abilities::can_view_post_by_email() );
+	}
+
+	public function test_can_manage_post_by_email_allows_post_author() {
+		wp_set_current_user( $this->user_id );
+		$this->assertTrue( Post_By_Email_Abilities::can_manage_post_by_email() );
+	}
+
+	public function test_can_manage_post_by_email_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Post_By_Email_Abilities::can_manage_post_by_email() );
+	}
+
+	public function test_can_manage_post_by_email_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Post_By_Email_Abilities::can_manage_post_by_email() );
+	}
+
+	public function test_can_manage_post_by_email_matches_view_permission() {
+		// Per spec: manage gate must equal view gate so the two callbacks stay in sync.
+		wp_set_current_user( $this->user_id );
+		$this->assertSame(
+			Post_By_Email_Abilities::can_view_post_by_email(),
+			Post_By_Email_Abilities::can_manage_post_by_email()
+		);
+
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertSame(
+			Post_By_Email_Abilities::can_view_post_by_email(),
+			Post_By_Email_Abilities::can_manage_post_by_email()
+		);
+
+		wp_set_current_user( 0 );
+		$this->assertSame(
+			Post_By_Email_Abilities::can_view_post_by_email(),
+			Post_By_Email_Abilities::can_manage_post_by_email()
+		);
+	}
+
+	/**
+	 * -------------------- Execute callbacks: get_status --------------------
+	 */
+
+	/**
+	 * With the module inactive, get_status() short-circuits with
+	 * `jetpack_post_by_email_module_inactive` before any remote read.
+	 */
+	public function test_get_status_errors_when_module_inactive() {
+		wp_set_current_user( $this->user_id );
+
+		$result = Post_By_Email_Abilities::get_status();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_post_by_email_module_inactive', $result->get_error_code() );
+	}
+
+	/**
+	 * Module active but no Jetpack user connection — get_status() returns
+	 * `jetpack_post_by_email_not_connected` with a message that steers the
+	 * caller to the My Jetpack admin page.
+	 */
+	public function test_get_status_errors_when_user_not_connected() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		$result = Post_By_Email_Abilities::get_status();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_post_by_email_not_connected', $result->get_error_code() );
+		$this->assertStringContainsString( 'My Jetpack', $result->get_error_message() );
+	}
+
+	/**
+	 * Happy path: module active, user connected, remote returns an address.
+	 * Asserts the documented four-key shape with non-null address.
+	 */
+	public function test_get_status_returns_full_shape_when_address_present() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		Post_By_Email_Abilities_Test_Stub::reset( 'pbe-existing@example.test' );
+
+		$result = Post_By_Email_Abilities_Test_Stub::get_status();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['active'] );
+		$this->assertSame( 'pbe-existing@example.test', $result['address'] );
+		$this->assertTrue( $result['address_active'] );
+		$this->assertNull( $result['last_used_at'] );
+	}
+
+	/**
+	 * Happy path: module active, user connected, remote returns null
+	 * (user has not enabled PBE yet). active and address_active are false,
+	 * address is null. This is a legitimate signal — not a failure.
+	 */
+	public function test_get_status_returns_null_address_when_not_enabled() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		Post_By_Email_Abilities_Test_Stub::reset( null );
+
+		$result = Post_By_Email_Abilities_Test_Stub::get_status();
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['active'] );
+		$this->assertNull( $result['address'] );
+		$this->assertFalse( $result['address_active'] );
+		$this->assertNull( $result['last_used_at'] );
+	}
+
+	/**
+	 * -------------------- Execute callbacks: regenerate_address --------------------
+	 */
+	public function test_regenerate_address_errors_when_module_inactive() {
+		wp_set_current_user( $this->user_id );
+
+		$result = Post_By_Email_Abilities::regenerate_address();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_post_by_email_module_inactive', $result->get_error_code() );
+	}
+
+	public function test_regenerate_address_errors_when_user_not_connected() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		$result = Post_By_Email_Abilities::regenerate_address();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_post_by_email_not_connected', $result->get_error_code() );
+	}
+
+	/**
+	 * Happy path: regenerate returns a fresh address and the documented
+	 * { address, regenerated_at } shape with regenerated_at a positive int.
+	 * Critically, asserts the new address differs from the old one — this is
+	 * the load-bearing invariant of "rotate".
+	 */
+	public function test_regenerate_address_returns_new_address_and_timestamp() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		$old_address = 'pbe-original@example.test';
+		$new_address = 'pbe-fresh@example.test';
+		Post_By_Email_Abilities_Test_Stub::reset( $old_address, $new_address );
+
+		$before = time();
+		$result = Post_By_Email_Abilities_Test_Stub::regenerate_address();
+		$after  = time();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $new_address, $result['address'] );
+		$this->assertNotSame( $old_address, $result['address'], 'Rotate must produce a new address.' );
+		$this->assertIsInt( $result['regenerated_at'] );
+		$this->assertGreaterThanOrEqual( $before, $result['regenerated_at'] );
+		$this->assertLessThanOrEqual( $after, $result['regenerated_at'] );
+		$this->assertSame( 1, Post_By_Email_Abilities_Test_Stub::$apply_calls );
+	}
+
+	/**
+	 * Two consecutive successful calls mint two distinct addresses — codifies
+	 * the non-idempotent contract declared in the ability annotation.
+	 */
+	public function test_regenerate_address_is_not_idempotent_across_calls() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		Post_By_Email_Abilities_Test_Stub::reset( 'pbe-original@example.test' );
+
+		$first  = Post_By_Email_Abilities_Test_Stub::regenerate_address();
+		$second = Post_By_Email_Abilities_Test_Stub::regenerate_address();
+
+		$this->assertIsArray( $first );
+		$this->assertIsArray( $second );
+		$this->assertNotSame( $first['address'], $second['address'], 'Each regenerate call must produce a distinct address.' );
+		$this->assertSame( 2, Post_By_Email_Abilities_Test_Stub::$apply_calls );
+	}
+
+	/**
+	 * Remote regenerate fails → surface as
+	 * `jetpack_post_by_email_service_unreachable` so callers know to retry.
+	 */
+	public function test_regenerate_address_errors_when_remote_fails() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		Post_By_Email_Abilities_Test_Stub::reset(
+			'pbe-original@example.test',
+			new \WP_Error( 'jetpack_post_by_email_regenerate_failed', 'remote down' )
+		);
+
+		$result = Post_By_Email_Abilities_Test_Stub::regenerate_address();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_post_by_email_service_unreachable', $result->get_error_code() );
+	}
+
+	/**
+	 * -------------------- Real bootstrap path --------------------
+	 */
+
+	/**
+	 * When the Post by Email module is inactive, modules/post-by-email.php is
+	 * never loaded by Jetpack, so the Post_By_Email_Abilities::init() call
+	 * inside it never runs and the abilities are not registered. This codifies
+	 * the gated-registration contract.
+	 */
+	public function test_abilities_are_not_registered_when_post_by_email_module_is_inactive() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		// Do NOT fire the lifecycle or call init() — this mirrors the real
+		// bootstrap path when post-by-email.php has not been included by Jetpack.
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-post-by-email/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		$this->assertSame(
+			array(),
+			$registered_slugs,
+			'Post by Email abilities must not be registered while the Post by Email module is inactive (modules/post-by-email.php not loaded).'
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Post_By_Email_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Post_By_Email_Abilities_Test.php
@@ -452,6 +452,56 @@ class Post_By_Email_Abilities_Test extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( $before, $result['regenerated_at'] );
 		$this->assertLessThanOrEqual( $after, $result['regenerated_at'] );
 		$this->assertSame( 1, Post_By_Email_Abilities_Test_Stub::$apply_calls );
+		$this->assertSame(
+			array( 'regenerate' ),
+			Post_By_Email_Abilities_Test_Stub::$apply_actions,
+			'With an existing address the underlying writer must be called with the regenerate action.'
+		);
+	}
+
+	/**
+	 * When the user has no current address, the ability must call the underlying
+	 * writer with the 'create' action — the remote 'regenerate' endpoint expects
+	 * an existing address to rotate, so calling it for a fresh user would error.
+	 */
+	public function test_regenerate_address_uses_create_action_when_no_existing_address() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		Post_By_Email_Abilities_Test_Stub::reset( null, 'pbe-newly-created@example.test' );
+
+		$result = Post_By_Email_Abilities_Test_Stub::regenerate_address();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pbe-newly-created@example.test', $result['address'] );
+		$this->assertSame( 1, Post_By_Email_Abilities_Test_Stub::$apply_calls );
+		$this->assertSame(
+			array( 'create' ),
+			Post_By_Email_Abilities_Test_Stub::$apply_actions,
+			'A user without an existing address must trigger the create action, not regenerate.'
+		);
+	}
+
+	/**
+	 * Same as above but the current address is the empty string (not just null) —
+	 * the routing logic must treat "" identically to null since an empty address
+	 * means the user has not been provisioned on the remote service.
+	 */
+	public function test_regenerate_address_uses_create_action_when_existing_address_is_empty_string() {
+		wp_set_current_user( $this->user_id );
+		$this->activate_post_by_email_module();
+
+		Post_By_Email_Abilities_Test_Stub::reset( '', 'pbe-newly-created@example.test' );
+
+		$result = Post_By_Email_Abilities_Test_Stub::regenerate_address();
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array( 'create' ),
+			Post_By_Email_Abilities_Test_Stub::$apply_actions,
+			'Empty current address must be treated the same as null and route to create.'
+		);
+		$this->assertSame( 'pbe-newly-created@example.test', $result['address'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/class-post-by-email-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-post-by-email-abilities-test-stub.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Test-only subclass of Post_By_Email_Abilities that overrides the protected
+ * seams (user-connection check, remote address fetch, remote regenerate apply)
+ * so the success path can be exercised without a Jetpack token fixture or live
+ * IXR endpoint.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Plugin\Abilities\Post_By_Email_Abilities;
+
+/**
+ * Test-only subclass overriding Post_By_Email_Abilities's protected seams.
+ *
+ * - is_user_connected_to_jetpack(): always true.
+ * - fetch_address(): returns the seeded address (string|null).
+ * - apply_regenerate(): returns the seeded next address (string|WP_Error) and
+ *   records each call instead of hitting IXR.
+ */
+class Post_By_Email_Abilities_Test_Stub extends Post_By_Email_Abilities {
+
+	/**
+	 * Seeded remote address for fetch_address().
+	 *
+	 * @var string|null
+	 */
+	public static $current_address = null;
+
+	/**
+	 * Seeded next address for apply_regenerate(). When `null` the stub mints a
+	 * deterministic placeholder that differs from $current_address so callers
+	 * can assert "new != old" without seeding both fields manually.
+	 *
+	 * @var string|null|\WP_Error
+	 */
+	public static $next_address = null;
+
+	/**
+	 * Number of apply_regenerate() calls in the current test.
+	 *
+	 * @var int
+	 */
+	public static $apply_calls = 0;
+
+	/**
+	 * Reset test-double state and seed the simulated remote state.
+	 *
+	 * @param string|null           $current_address Simulated current address.
+	 * @param string|null|\WP_Error $next_address    Simulated next address from regenerate.
+	 */
+	public static function reset( $current_address = null, $next_address = null ): void {
+		self::$current_address = $current_address;
+		self::$next_address    = $next_address;
+		self::$apply_calls     = 0;
+	}
+
+	/**
+	 * Always-connected for tests — bypasses the real Connection_Manager check.
+	 */
+	protected static function is_user_connected_to_jetpack(): bool {
+		return true;
+	}
+
+	/**
+	 * Return the seeded simulated remote address.
+	 *
+	 * @return string|null
+	 */
+	protected static function fetch_address() {
+		return self::$current_address;
+	}
+
+	/**
+	 * Record the call and return the seeded next address (or a deterministic
+	 * placeholder that differs from the current address).
+	 *
+	 * @return string|\WP_Error
+	 */
+	protected static function apply_regenerate() {
+		++self::$apply_calls;
+
+		if ( self::$next_address instanceof \WP_Error ) {
+			return self::$next_address;
+		}
+
+		$new = self::$next_address;
+		if ( null === $new ) {
+			$base = is_string( self::$current_address ) && '' !== self::$current_address
+				? self::$current_address
+				: 'pbe-original@example.test';
+			$new  = 'pbe-rotated-' . self::$apply_calls . '@example.test';
+			// Defensive: if a caller seeded a current address equal to the
+			// placeholder, perturb so the assertion "new !== old" is meaningful.
+			if ( $new === $base ) {
+				$new = 'pbe-rotated-alt-' . self::$apply_calls . '@example.test';
+			}
+		}
+
+		self::$current_address = $new;
+		return $new;
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/class-post-by-email-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-post-by-email-abilities-test-stub.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Test-only subclass of Post_By_Email_Abilities that overrides the protected
- * seams (user-connection check, remote address fetch, remote regenerate apply)
- * so the success path can be exercised without a Jetpack token fixture or live
+ * seams (user-connection check, remote address fetch, remote write apply) so
+ * the success path can be exercised without a Jetpack token fixture or live
  * IXR endpoint.
  *
  * @package automattic/jetpack
@@ -15,8 +15,8 @@ use Automattic\Jetpack\Plugin\Abilities\Post_By_Email_Abilities;
  *
  * - is_user_connected_to_jetpack(): always true.
  * - fetch_address(): returns the seeded address (string|null).
- * - apply_regenerate(): returns the seeded next address (string|WP_Error) and
- *   records each call instead of hitting IXR.
+ * - apply_action(): returns the seeded next address (string|WP_Error) and
+ *   records each call (plus the chosen action) instead of hitting IXR.
  */
 class Post_By_Email_Abilities_Test_Stub extends Post_By_Email_Abilities {
 
@@ -28,7 +28,7 @@ class Post_By_Email_Abilities_Test_Stub extends Post_By_Email_Abilities {
 	public static $current_address = null;
 
 	/**
-	 * Seeded next address for apply_regenerate(). When `null` the stub mints a
+	 * Seeded next address for apply_action(). When `null` the stub mints a
 	 * deterministic placeholder that differs from $current_address so callers
 	 * can assert "new != old" without seeding both fields manually.
 	 *
@@ -37,22 +37,31 @@ class Post_By_Email_Abilities_Test_Stub extends Post_By_Email_Abilities {
 	public static $next_address = null;
 
 	/**
-	 * Number of apply_regenerate() calls in the current test.
+	 * Number of apply_action() calls in the current test.
 	 *
 	 * @var int
 	 */
 	public static $apply_calls = 0;
 
 	/**
+	 * Action strings ('create' / 'regenerate') recorded in call order, so
+	 * tests can assert the create-vs-regenerate routing.
+	 *
+	 * @var array<int, string>
+	 */
+	public static $apply_actions = array();
+
+	/**
 	 * Reset test-double state and seed the simulated remote state.
 	 *
 	 * @param string|null           $current_address Simulated current address.
-	 * @param string|null|\WP_Error $next_address    Simulated next address from regenerate.
+	 * @param string|null|\WP_Error $next_address    Simulated next address from apply_action.
 	 */
 	public static function reset( $current_address = null, $next_address = null ): void {
 		self::$current_address = $current_address;
 		self::$next_address    = $next_address;
 		self::$apply_calls     = 0;
+		self::$apply_actions   = array();
 	}
 
 	/**
@@ -72,13 +81,15 @@ class Post_By_Email_Abilities_Test_Stub extends Post_By_Email_Abilities {
 	}
 
 	/**
-	 * Record the call and return the seeded next address (or a deterministic
-	 * placeholder that differs from the current address).
+	 * Record the call (and chosen action) and return the seeded next address
+	 * (or a deterministic placeholder that differs from the current address).
 	 *
+	 * @param string $action 'create' or 'regenerate' — recorded for assertions.
 	 * @return string|\WP_Error
 	 */
-	protected static function apply_regenerate() {
+	protected static function apply_action( string $action ) {
 		++self::$apply_calls;
+		self::$apply_actions[] = $action;
 
 		if ( self::$next_address instanceof \WP_Error ) {
 			return self::$next_address;


### PR DESCRIPTION
## Summary

Adds two abilities for the Post by Email module via the standard `wp-abilities/v1` REST surface, mirroring the Monitor abilities pattern.

- `jetpack-post-by-email/get-status` — per-user read of `{ active, address, address_active, last_used_at }`. `address` is `null` when the user has not enabled PBE; `last_used_at` is reserved (always `null` in this release) since the remote service does not currently expose last-used metadata.
- `jetpack-post-by-email/regenerate-address` — rotates the user's address; annotated `readonly=false`, `destructive=true` (invalidates the previous address — saved drafts pointing at it will no longer reach the site), `idempotent=false` (each call mints a new address).

Both abilities are gated on `is_user_logged_in()` — Post by Email is a per-user feature; the remote service uses the caller's Jetpack user token, so users cannot view or rotate anyone else's address.

## Implementation

- `Post_By_Email_Abilities` extends `Registrar`, lives at `projects/plugins/jetpack/modules/post-by-email/abilities/class-post-by-email-abilities.php` (Case A — module-colocated).
- Wired from `modules/post-by-email.php`, so abilities only register while the Post by Email module is active (`load_modules()` only includes the module file when it's on).
- Protected seams (`is_user_connected_to_jetpack`, `fetch_address`, `apply_regenerate`) allow tests to drive both happy paths and remote-failure paths without a Jetpack token fixture or live IXR endpoint.
- Precondition and transport failures surface as `WP_Error` with the shared `jetpack_post_by_email_*` vocabulary so callers (agents) get an actionable next step rather than opaque nulls.
- Mirrors the post-rotate response to the legacy `post_by_email_address{user_id}` option so `Jetpack_Core_Json_Api_Endpoints::get_remote_value` stays in sync.

## Test plan

- [ ] CI: `Post_By_Email_Abilities_Test` passes — Registrar wiring (gate filter, lifecycle hooks, per-ability allow-list, category auto-injection), permission callbacks, execute callbacks (module-inactive, not-connected, happy paths, service-unreachable, non-idempotency across calls), and the activation-gating bootstrap assertion.
- [ ] On a connected WP 6.9+ site with the `jetpack_wp_abilities_enabled` filter true and the Post by Email module active, confirm `/wp-json/wp-abilities/v1/abilities` lists `jetpack-post-by-email/get-status` and `jetpack-post-by-email/regenerate-address`, and `get-status` returns the documented shape.
- [ ] Deactivate the Post by Email module and confirm the two slugs disappear from `wp_get_abilities()`.

Local phpunit could not run in this environment (the host's `phpunit-select-config` shim is not on PATH outside Docker) — relying on CI.

Plan reference: §3.3 (Post by Email).