### PR TITLE
Performance settings: simplify Search section to a dashboard link

### DIFF
--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -44,7 +44,7 @@ function Search( props ) {
 				<Card
 					compact
 					className="jp-settings-card__configure-link"
-					href="admin.php?page=jetpack-search"
+					href="admin.php?page=jetpack-search&tab=settings"
 				>
 					{ SEARCH_DASHBOARD_CTA }
 				</Card>

--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -1,70 +1,33 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Fragment, useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import Card from 'components/card';
-import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
-import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { FEATURE_SEARCH_JETPACK } from 'lib/plans/constants';
 import { isOfflineMode } from 'state/connection';
-import { currentThemeSupports } from 'state/initial-state';
-import { hasUpdatedSetting, isSettingActivated, isUpdatingSetting } from 'state/settings';
-import { siteHasFeature, isFetchingSitePurchases } from 'state/site';
 
 const SEARCH_DESCRIPTION = __(
-	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.',
+	'Jetpack Search helps your visitors instantly find the right content. Choose how Search appears on your site — as an embedded results page, an overlay, or in place of your theme’s default search.',
 	'jetpack'
 );
-const SEARCH_CUSTOMIZE_CTA = __( 'Customize your Search experience.', 'jetpack' );
+const SEARCH_DASHBOARD_CTA = __( 'Manage Search settings', 'jetpack' );
 const SEARCH_SUPPORT = __( 'Search supports many customizations.', 'jetpack' );
 
 /**
- * Search settings component to be used within the Performance section.
+ * Search settings entry for the Performance section. The actual experience
+ * picker and per-experience configuration live on the Search dashboard, so
+ * this section is intentionally a short intro plus a link there.
  *
  * @param {object} props - Component properties.
  * @return {import('react').Component} Search settings component.
  */
 function Search( props ) {
-	const { failedToEnableSearch, hasInstantSearch, updateOptions } = props;
-	const isModuleEnabled = props.getOptionValue( 'search' );
-	const isInstantSearchEnabled = props.getOptionValue( 'instant_search_enabled', 'search' );
-
-	const toggleSearchModule = useCallback( () => {
-		const newOption = { search: ! isModuleEnabled };
-		if ( isInstantSearchEnabled !== ( hasInstantSearch && ! isModuleEnabled ) ) {
-			newOption.instant_search_enabled = hasInstantSearch && ! isModuleEnabled;
-		}
-		updateOptions( newOption );
-	}, [ hasInstantSearch, isInstantSearchEnabled, isModuleEnabled, updateOptions ] );
-
-	const toggleInstantSearch = useCallback( () => {
-		const newOption = {
-			instant_search_enabled: hasInstantSearch && ! isInstantSearchEnabled,
-		};
-		if ( newOption.instant_search_enabled && ! isModuleEnabled ) {
-			newOption.search = true;
-		}
-		updateOptions( newOption );
-	}, [ hasInstantSearch, isInstantSearchEnabled, isModuleEnabled, updateOptions ] );
-
-	useEffect( () => {
-		if ( failedToEnableSearch && hasInstantSearch ) {
-			updateOptions( { has_jetpack_search_product: true } );
-			toggleSearchModule();
-		}
-	}, [ failedToEnableSearch, hasInstantSearch, updateOptions, toggleSearchModule ] );
-
-	const togglingModule = !! props.isSavingAnyOption( 'search' );
-	const togglingInstantSearch = !! props.isSavingAnyOption( 'instant_search_enabled' );
 	return (
 		<SettingsCard { ...props } module="search" feature={ FEATURE_SEARCH_JETPACK } hideButton>
 			<SettingsGroup
 				disableInOfflineMode
-				hasChild
 				module={ { module: 'search' } }
 				support={ {
 					text: SEARCH_SUPPORT,
@@ -76,81 +39,20 @@ function Search( props ) {
 						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: SEARCH_DESCRIPTION }
 				</p>
-				{ props.isLoading && __( 'Loading…', 'jetpack' ) }
-				{ ! props.isLoading && ( props.hasClassicSearch || props.hasInstantSearch ) && (
-					<Fragment>
-						<ModuleToggle
-							activated={ isModuleEnabled }
-							compact
-							disabled={ togglingModule }
-							slug="search"
-							toggleModule={ toggleSearchModule }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Enable Search', 'jetpack' ) }
-							</span>
-						</ModuleToggle>
-
-						<FormFieldset>
-							<ToggleControl
-								__nextHasNoMarginBottom
-								checked={ isModuleEnabled && isInstantSearchEnabled }
-								disabled={ togglingModule || ! props.hasInstantSearch || togglingInstantSearch }
-								onChange={ toggleInstantSearch }
-								label={
-									<span className="jp-form-toggle-explanation">
-										{ __( 'Enable instant search experience (recommended)', 'jetpack' ) }
-									</span>
-								}
-								help={
-									<span className="jp-form-setting-explanation jp-form-search-setting-explanation">
-										{ __(
-											'Instant search will allow your visitors to get search results as soon as they start typing. If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.',
-											'jetpack'
-										) }
-									</span>
-								}
-							/>
-						</FormFieldset>
-					</Fragment>
-				) }
 			</SettingsGroup>
-			{ ! props.isLoading &&
-				props.isWidgetsSupported &&
-				( props.hasClassicSearch || props.hasInstantSearch ) &&
-				isModuleEnabled &&
-				! isInstantSearchEnabled && (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						href="customize.php?autofocus[panel]=widgets"
-					>
-						{ __( 'Add Jetpack Search Widget', 'jetpack' ) }
-					</Card>
-				) }
-			{ props.hasInstantSearch && isModuleEnabled && isInstantSearchEnabled && (
+			{ ! props.inOfflineMode && (
 				<Card
-					className="jp-settings-card__configure-link"
 					compact
-					href="admin.php?page=jetpack-search-configure"
+					className="jp-settings-card__configure-link"
+					href="admin.php?page=jetpack-search"
 				>
-					{ SEARCH_CUSTOMIZE_CTA }
+					{ SEARCH_DASHBOARD_CTA }
 				</Card>
 			) }
 		</SettingsCard>
 	);
 }
 
-export default connect( state => {
-	return {
-		isLoading: isFetchingSitePurchases( state ),
-		inOfflineMode: isOfflineMode( state ),
-		hasClassicSearch: siteHasFeature( state, 'search' ),
-		hasInstantSearch: siteHasFeature( state, 'instant-search' ),
-		failedToEnableSearch:
-			! isSettingActivated( state, 'search' ) &&
-			! isUpdatingSetting( state, 'search' ) &&
-			false === hasUpdatedSetting( state, 'search' ),
-		isWidgetsSupported: currentThemeSupports( state, 'widgets' ),
-	};
-} )( withModuleSettingsFormHelpers( Search ) );
+export default connect( state => ( {
+	inOfflineMode: isOfflineMode( state ),
+} ) )( withModuleSettingsFormHelpers( Search ) );

--- a/projects/plugins/jetpack/_inc/client/performance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/component.js
@@ -3,19 +3,20 @@ import Search from '../search';
 import { buildInitialState } from './fixtures';
 
 describe( 'Performance tab', () => {
-	it( 'shows Jetpack Search Widget button if theme supports it', () => {
-		render( <Search />, {
-			initialState: buildInitialState( { themeSupportsWidgets: true } ),
-		} );
+	it( 'links to the Search dashboard', () => {
+		render( <Search />, { initialState: buildInitialState() } );
 
-		expect( screen.getByText( 'Add Jetpack Search Widget' ) ).toBeInTheDocument();
+		const link = screen.getByRole( 'link', { name: 'Manage Search settings' } );
+		expect( link ).toBeInTheDocument();
+		expect( link ).toHaveAttribute( 'href', 'admin.php?page=jetpack-search' );
 	} );
 
-	it( 'hides Jetpack Search Widget button if theme does not support it', () => {
-		render( <Search />, {
-			initialState: buildInitialState( { themeSupportsWidgets: false } ),
-		} );
+	it( 'hides the Search dashboard link in offline mode', () => {
+		render( <Search />, { initialState: buildInitialState( { offlineMode: true } ) } );
 
-		expect( screen.queryByText( 'Add Jetpack Search Widget' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'Manage Search settings' } )
+		).not.toBeInTheDocument();
+		expect( screen.getByText( 'Unavailable in Offline Mode' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/performance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/component.js
@@ -8,7 +8,7 @@ describe( 'Performance tab', () => {
 
 		const link = screen.getByRole( 'link', { name: 'Manage Search settings' } );
 		expect( link ).toBeInTheDocument();
-		expect( link ).toHaveAttribute( 'href', 'admin.php?page=jetpack-search' );
+		expect( link ).toHaveAttribute( 'href', 'admin.php?page=jetpack-search&tab=settings' );
 	} );
 
 	it( 'hides the Search dashboard link in offline mode', () => {

--- a/projects/plugins/jetpack/_inc/client/performance/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/fixtures.js
@@ -22,11 +22,11 @@ function siteDataFixture() {
 /**
  * Build an object that can be used as a Redux store initial state.
  *
- * @param {object}  options                      - Options
- * @param {boolean} options.themeSupportsWidgets - whether the current theme supports widgets
+ * @param {object}  options             - Options
+ * @param {boolean} options.offlineMode - whether the site is in Jetpack offline mode
  * @return {object} – initial Redux state
  */
-export function buildInitialState( { themeSupportsWidgets = false } = {} ) {
+export function buildInitialState( { offlineMode = false } = {} ) {
 	return {
 		jetpack: {
 			initialState: {
@@ -39,7 +39,7 @@ export function buildInitialState( { themeSupportsWidgets = false } = {} ) {
 				},
 				themeData: {
 					support: {
-						widgets: themeSupportsWidgets,
+						widgets: false,
 					},
 				},
 			},
@@ -55,7 +55,7 @@ export function buildInitialState( { themeSupportsWidgets = false } = {} ) {
 				status: {
 					siteConnected: {
 						offlineMode: {
-							isActive: false,
+							isActive: offlineMode,
 						},
 						isActive: true,
 					},

--- a/projects/plugins/jetpack/changelog/update-performance-search-section-to-dashboard-link
+++ b/projects/plugins/jetpack/changelog/update-performance-search-section-to-dashboard-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Performance settings: simplify the Search section to a short intro and a link to the Search dashboard, so the experience picker (embedded, overlay, theme search) lives in one place instead of being partially duplicated under Performance.

--- a/projects/plugins/jetpack/changelog/update-performance-search-section-to-dashboard-link
+++ b/projects/plugins/jetpack/changelog/update-performance-search-section-to-dashboard-link
@@ -1,4 +1,4 @@
 Significance: minor
-Type: changed
+Type: enhancement
 
 Performance settings: simplify the Search section to a short intro and a link to the Search dashboard, so the experience picker (embedded, overlay, theme search) lives in one place instead of being partially duplicated under Performance.


### PR DESCRIPTION
Fixes SEARCH-161

## Proposed changes

* Removes the duplicate Classic/Instant Search toggles from **Jetpack → Settings → Performance**, plus the two contextual cards underneath (Add Search Widget, Customize search experience).
* Replaces them with a short intro that names the available experiences (embedded results page, overlay, theme search) and a single "Manage Search settings" link pointing to `admin.php?page=jetpack-search`, where the full experience picker (Embedded / Overlay / Theme search / Off) already lives.
* The `SettingsCard` upsell banner for sites without a Search plan continues to render automatically — that path was driven by `feature={ FEATURE_SEARCH_JETPACK }`, not by anything removed here.

The previous UI predates the new feature selector and had no entry point for the embedded experience. Two surfaces showing similar-but-not-identical toggles was confusing, so this PR collapses Performance down to the description + link agreed on in the issue thread.

## Before / after

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/6e0c0fe6-b493-412e-b53d-d79a757e2b28) | ![after](https://github.com/user-attachments/assets/244f24fe-34aa-4729-a0c7-32200b9b2cb6) |

## Related product discussion/links

* SEARCH-161

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the Jetpack plugin (`pnpm jetpack build plugins/jetpack`).
2. On a site **with** Jetpack Search active: visit `wp-admin → Jetpack → Settings → Performance`.
    * Expect: the **Search** card now shows only the intro paragraph and a **Manage Search settings** link.
    * Click the link — it should go to `admin.php?page=jetpack-search`.
3. On a site **without** Jetpack Search: same page.
    * Expect: the existing Jetpack Search upsell banner renders inside the card (unchanged behavior).
4. With the site in **Offline Mode**: same page.
    * Expect: card shows "Unavailable in Offline Mode" and the dashboard link is hidden.
5. Run the gui tests: `pnpm test-gui -- _inc/client/performance/test/component.js`.

## Checklist
- [x] My code is tested.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) for PHP, JS, and accessibility.
- [x] My code has proper inline documentation.
- [x] I have added [changelog files](https://github.com/Automattic/jetpack/blob/HEAD/docs/writing-a-good-changelog-entry.md), or determined they are not needed.
