### PR TITLE
wpcomsh: Mirror POSTS_TO_PODCAST tier features from wpcom

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-posts-to-podcast-plan-quotas
+++ b/projects/plugins/wpcomsh/changelog/add-posts-to-podcast-plan-quotas
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+WPCOM Features: Add POSTS_TO_PODCAST_TIER_{1,2,3} features mapped to Personal+, Premium+, and Business+ plans respectively. Mirrors the wpcom-side change that gates the Posts-to-Podcast endpoint and its monthly generation quota.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -454,6 +454,12 @@ class WPCOM_Features {
 	public const PERFORMANCE                       = 'performance';
 	public const PERFORMANCE_HISTORY               = 'performance-history';
 	public const POLLDADDY                         = 'polldaddy';
+	// Posts-to-podcast monthly-quota tiers. The lib's quota helper picks the
+	// highest tier the site has; a Business site holds all three but is read
+	// as TIER_3 (20/mo). TIER_1 doubles as the access gate.
+	public const POSTS_TO_PODCAST_TIER_1           = 'posts-to-podcast-tier-1';
+	public const POSTS_TO_PODCAST_TIER_2           = 'posts-to-podcast-tier-2';
+	public const POSTS_TO_PODCAST_TIER_3           = 'posts-to-podcast-tier-3';
 	public const PREMIUM_CONTENT_CONTAINER         = 'premium-content/container';
 	public const PERSONAL_THEMES                   = 'personal-themes';
 	public const PREMIUM_THEMES                    = 'premium-themes';
@@ -1092,6 +1098,19 @@ class WPCOM_Features {
 		),
 		self::POLLDADDY                         => array(
 			self::JETPACK_BUSINESS_PLANS,
+		),
+		// POSTS_TO_PODCAST_TIER_{1,2,3} — generates a podcast-style episode
+		// from recent posts. Monthly quotas: TIER_1 = 5, TIER_2 = 10,
+		// TIER_3 = 20. Sites accumulate tiers via the _AND_HIGHER cascades;
+		// the lib's quota helper takes the highest tier present.
+		self::POSTS_TO_PODCAST_TIER_1           => array(
+			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+		),
+		self::POSTS_TO_PODCAST_TIER_2           => array(
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
+		),
+		self::POSTS_TO_PODCAST_TIER_3           => array(
+			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 		),
 		// PREMIUM_CONTENT_CONTAINER - premium-content requires a paid wpcom plan.
 		self::PREMIUM_CONTENT_CONTAINER         => array(

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -454,9 +454,6 @@ class WPCOM_Features {
 	public const PERFORMANCE                       = 'performance';
 	public const PERFORMANCE_HISTORY               = 'performance-history';
 	public const POLLDADDY                         = 'polldaddy';
-	// Posts-to-podcast monthly-quota tiers. The lib's quota helper picks the
-	// highest tier the site has; a Business site holds all three but is read
-	// as TIER_3 (20/mo). TIER_1 doubles as the access gate.
 	public const POSTS_TO_PODCAST_TIER_1           = 'posts-to-podcast-tier-1';
 	public const POSTS_TO_PODCAST_TIER_2           = 'posts-to-podcast-tier-2';
 	public const POSTS_TO_PODCAST_TIER_3           = 'posts-to-podcast-tier-3';


### PR DESCRIPTION
## Proposed changes

Mirrors the wpcom-side change (217049-ghe-Automattic/wpcom) that introduces plan-tiered monthly quotas for the Posts to Podcast endpoint. `wpcomsh/wpcom-features/class-wpcom-features.php` is kept in lockstep with its wpcom sibling, so the new feature constants and plan mappings need to land here too.

Adds three tiered features in `WPCOM_Features`:

| Feature | Plan mapping (`_AND_HIGHER` cascade) | Monthly quota (enforced wpcom-side) |
|---|---|---|
| `POSTS_TO_PODCAST_TIER_1` | `WPCOM_PERSONAL_AND_HIGHER_PLANS` | 5 |
| `POSTS_TO_PODCAST_TIER_2` | `WPCOM_PREMIUM_AND_HIGHER_PLANS` | 10 |
| `POSTS_TO_PODCAST_TIER_3` | `WPCOM_BUSINESS_AND_HIGHER_PLANS` | 20 |

Sites accumulate tiers through the existing `_AND_HIGHER` plan cascades — a Business site holds all three features. The quota helper on the wpcom side reads from the highest tier down and returns on the first hit, so the per-tier mappings work as cumulative grants without further coordination logic.

The quota itself is not enforced inside wpcomsh; only the feature definitions live here. This change is therefore inert until the wpcom companion PR lands and starts checking `wpcom_site_has_feature( POSTS_TO_PODCAST_TIER_1 )` on POST/GET.

## Related product discussion/links

* Companion PR (wpcom side): 217049-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?

No. This PR only adds feature-constant definitions and their plan mappings in `WPCOM_Features`. No new tracking, no new data collection, no new user data stored or exposed. The feature constants are read-only metadata describing which plans grant access; the quota counters and any usage telemetry live entirely on the wpcom side.

## Testing instructions

Functional testing requires the companion wpcom PR (217049-ghe-Automattic/wpcom) to be deployed, since this change on its own is inert. Once both are live:

1. On a **Personal** plan site, run from `wp shell` (or `wp eval-file`):
   ```php
   var_dump( wpcom_site_has_feature( 'posts-to-podcast-tier-1' ) ); // expected: bool(true)
   var_dump( wpcom_site_has_feature( 'posts-to-podcast-tier-2' ) ); // expected: bool(false)
   var_dump( wpcom_site_has_feature( 'posts-to-podcast-tier-3' ) ); // expected: bool(false)
   ```
2. On a **Premium** plan site, expect `tier-1` and `tier-2` true; `tier-3` false.
3. On a **Business / eCommerce / Pro** plan site, expect all three true.
4. On a **Free** plan site, expect all three false.
5. Confirm `php -l projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php` is clean (already verified locally).
6. Confirm Jetpack CI's PHPCS / static-analysis jobs stay green on this PR.

No UI changes; this PR is purely a feature-flag definition update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
