### PR TITLE
Fixed Jetpack Aearch AI answers toggle

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack-search-ai-answers-disable-toggle
+++ b/projects/packages/search/changelog/fix-jetpack-search-ai-answers-disable-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI answers feature disable toggle was not working. Fixed.

--- a/projects/packages/search/src/dashboard/components/ai-answers-tab/index.jsx
+++ b/projects/packages/search/src/dashboard/components/ai-answers-tab/index.jsx
@@ -108,7 +108,7 @@ export default function AiAnswersTab() {
 								checked={ isAiAnswersEnabled }
 								onChange={ setAiAnswersEnabled }
 								className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
-								disabled={ ! isInstantSearchEnabled }
+								disabled={ ! isInstantSearchEnabled && ! isAiAnswersEnabled }
 							/>
 
 							{ ! isLoading && ! isUnavailable && (

--- a/projects/packages/search/src/dashboard/components/test/ai-answers-tab.test.jsx
+++ b/projects/packages/search/src/dashboard/components/test/ai-answers-tab.test.jsx
@@ -25,13 +25,14 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@wordpress/components', () => ( {
 	TextareaControl: ( { label } ) => <span>{ label }</span>,
-	ToggleControl: ( { label, checked, onChange } ) => (
+	ToggleControl: ( { label, checked, onChange, disabled } ) => (
 		<label htmlFor="toggle-control">
 			<input
 				id="toggle-control"
 				type="checkbox"
 				checked={ checked }
 				onChange={ e => onChange( e.target.checked ) }
+				disabled={ disabled }
 			/>
 			{ label }
 		</label>
@@ -154,5 +155,19 @@ describe( 'AiAnswersTab', () => {
 		await expect(
 			screen.findByText( 'Instant Search must be enabled for AI Answers to work.' )
 		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'toggle is not disabled when instant search is off but AI answers is already on', async () => {
+		setupStore( { isInstantSearchEnabled: false, isAiAnswersEnabled: true } );
+		render( <AiAnswersTab /> );
+		const toggle = await screen.findByRole( 'checkbox' );
+		expect( toggle ).toBeEnabled();
+	} );
+
+	it( 'toggle is disabled when both instant search and AI answers are off', async () => {
+		setupStore( { isInstantSearchEnabled: false, isAiAnswersEnabled: false } );
+		render( <AiAnswersTab /> );
+		const toggle = await screen.findByRole( 'checkbox' );
+		expect( toggle ).toBeDisabled();
 	} );
 } );

--- a/projects/packages/search/src/dashboard/store/actions/jetpack-settings.js
+++ b/projects/packages/search/src/dashboard/store/actions/jetpack-settings.js
@@ -26,7 +26,9 @@ const getRollbackSettings = settings =>
 				k === 'module_active' ||
 				k === 'instant_search_enabled' ||
 				k === 'experience' ||
-				k === 'reader_chat'
+				k === 'reader_chat' ||
+				k === 'ai_answers_enabled' ||
+				k === 'search_suggestions_enabled'
 		)
 	);
 


### PR DESCRIPTION
The setting to enable the AI answers feature was working fine, but toggling it to disable was not. This simply fixes that.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->
Go to the Jetpack Search settings page in wp-admin. Turn on the AI answers feature. Try a search request on the front end. You should see an AI answer in addition to the search results. Now turn off the feature and try the search again (refresh the page). You should not see an AI answer.