### PR TITLE
ADS-1090: Expose Blaze campaign list filters and agent-friendly context

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1090-list-campaigns-context
+++ b/projects/packages/blaze/changelog/add-ads-1090-list-campaigns-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Abilities: Expose campaign status filtering and campaign context in list-campaigns.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -195,16 +195,78 @@ class Blaze_Abilities extends Registrar {
 		return array(
 			self::ABILITY_LIST_CAMPAIGNS   => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
-				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
+				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including numeric campaign_id, campaign title/name, DSP status, schedule, spend, target, and performance context. Use campaign_id for follow-up operations; title/name is human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'default'              => array(),
-					'properties'           => new \stdClass(),
+					'properties'           => array(
+						'status' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional DSP campaign status filter. Values pass through to the existing Blaze DSP campaigns route; clients should use DSP status vocabulary returned by this ability rather than inventing MCP-only states.', 'jetpack-blaze' ),
+						),
+					),
 					'additionalProperties' => false,
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Campaigns payload as returned by the Blaze DSP API.', 'jetpack-blaze' ),
+					'properties'  => array(
+						'campaigns' => array(
+							'type'        => 'array',
+							'description' => __( 'Blaze campaigns returned by DSP. MCP clients should show these fields so the merchant can choose the right campaign before requesting stats or stop operations.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'additionalProperties' => true,
+								'properties'           => array(
+									'campaign_id'   => array(
+										'type'        => 'integer',
+										'description' => __( 'The numeric operation identifier for follow-up campaign operations such as stats or stop.', 'jetpack-blaze' ),
+									),
+									'title'         => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign title shown as human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
+									),
+									'name'          => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign name shown as human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
+									),
+									'status'        => array(
+										'type'        => 'string',
+										'description' => __( 'DSP status for the campaign, using the status vocabulary returned by Blaze/DSP.', 'jetpack-blaze' ),
+									),
+									'ui_status'     => array(
+										'type'        => 'string',
+										'description' => __( 'Display status returned by DSP for merchant-facing UI context, when available.', 'jetpack-blaze' ),
+									),
+									'start_date'    => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign start date returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+									'end_date'      => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign end date returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+									'target_url'    => array(
+										'type'        => 'string',
+										'format'      => 'uri',
+										'description' => __( 'Target URL promoted by the campaign, when available.', 'jetpack-blaze' ),
+									),
+									'target_urn'    => array(
+										'type'        => 'string',
+										'description' => __( 'Target URN promoted by the campaign, when available.', 'jetpack-blaze' ),
+									),
+									'budget'        => array(
+										'type'        => 'object',
+										'description' => __( 'Campaign budget details returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+									'summary_stats' => array(
+										'type'        => 'object',
+										'description' => __( 'Existing campaign summary stats returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+								),
+							),
+						),
+					),
 				),
 				'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
 				'permission_callback' => array( __CLASS__, 'permission_callback' ),
@@ -469,11 +531,11 @@ class Blaze_Abilities extends Registrar {
 	 * directly so we inherit the standard request lifecycle, permission
 	 * checks, and any third-party filters wired onto that route.
 	 *
-	 * @param array $args Ability input. Currently unused; reserved for future filtering params.
+	 * @param array $args Ability input.
 	 * @return array|\WP_Error
 	 */
 	public static function list_campaigns( $args = array() ) {
-		unset( $args );
+		$args = is_array( $args ) ? $args : array();
 
 		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
 		if ( is_wp_error( $site_id ) ) {
@@ -483,6 +545,9 @@ class Blaze_Abilities extends Registrar {
 		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
 		$request = new WP_REST_Request( 'GET', $route );
 		$request->set_param( 'api_version', 'v1.1' );
+		if ( isset( $args['status'] ) ) {
+			$request->set_param( 'status', $args['status'] );
+		}
 
 		$response = rest_do_request( $request );
 		if ( $response->is_error() ) {

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -103,6 +103,40 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
 		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
 		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+
+		$properties = $ability['input_schema']['properties'];
+		$this->assertIsArray( $properties );
+		$this->assertArrayHasKey( 'status', $properties );
+		$this->assertSame( 'string', $properties['status']['type'] );
+		$this->assertStringContainsString( 'DSP campaign status', $properties['status']['description'] );
+		$this->assertStringContainsString( 'pass through', $properties['status']['description'] );
+	}
+
+	/**
+	 * The list-campaigns output schema documents the campaign context agents
+	 * should show before follow-up operations.
+	 */
+	public function test_list_campaigns_output_schema_documents_agent_context() {
+		$abilities = Blaze_Abilities::get_abilities();
+		$ability   = $abilities[ Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ];
+
+		$this->assertStringContainsString( 'campaign_id', $ability['description'] );
+		$this->assertStringContainsString( 'title/name', $ability['description'] );
+		$this->assertStringContainsString( 'not as the operation identifier', $ability['description'] );
+
+		$output_properties = $ability['output_schema']['properties'];
+		$this->assertArrayHasKey( 'campaigns', $output_properties );
+
+		$campaign_properties = $output_properties['campaigns']['items']['properties'];
+		foreach ( array( 'campaign_id', 'title', 'name', 'status', 'ui_status', 'start_date', 'end_date', 'target_url', 'target_urn', 'budget', 'summary_stats' ) as $field ) {
+			$this->assertArrayHasKey( $field, $campaign_properties );
+		}
+
+		$this->assertStringContainsString( 'numeric operation identifier', $campaign_properties['campaign_id']['description'] );
+		$this->assertStringContainsString( 'human-readable context', $campaign_properties['title']['description'] );
+		$this->assertStringContainsString( 'not as the operation identifier', $campaign_properties['title']['description'] );
+		$this->assertStringContainsString( 'DSP status', $campaign_properties['status']['description'] );
+		$this->assertStringContainsString( 'when available', $campaign_properties['summary_stats']['description'] );
 	}
 
 	/**
@@ -150,6 +184,82 @@ class Blaze_Abilities_Test extends BaseTestCase {
 						'status' => 'active',
 					),
 				),
+			),
+			Blaze_Abilities::list_campaigns()
+		);
+	}
+
+	/**
+	 * List_campaigns forwards the optional status filter to the existing DSP route.
+	 */
+	public function test_list_campaigns_forwards_status_filter_to_blaze_rest_route() {
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1.1/campaigns',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function ( $request ) {
+					return array(
+						'status' => $request->get_param( 'status' ),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'status' => 'active',
+			),
+			Blaze_Abilities::list_campaigns(
+				array(
+					'status' => 'active',
+				)
+			)
+		);
+	}
+
+	/**
+	 * List_campaigns preserves campaign context returned by DSP for agent display.
+	 */
+	public function test_list_campaigns_preserves_campaign_context_from_blaze_rest_route() {
+		$campaign = array(
+			'campaign_id'   => 123,
+			'title'         => 'Spring product launch',
+			'name'          => 'Spring launch',
+			'status'        => 'active',
+			'ui_status'     => 'Running',
+			'start_date'    => '2026-05-01',
+			'end_date'      => '2026-05-31',
+			'target_url'    => 'https://example.com/product',
+			'target_urn'    => 'urn:wpcom:post:12345:678',
+			'budget'        => array(
+				'amount'   => 50,
+				'currency' => 'USD',
+			),
+			'summary_stats' => array(
+				'impressions' => 1000,
+				'clicks'      => 40,
+			),
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1.1/campaigns',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function () use ( $campaign ) {
+					return array(
+						'campaigns' => array( $campaign ),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'campaigns' => array( $campaign ),
 			),
 			Blaze_Abilities::list_campaigns()
 		);


### PR DESCRIPTION
🤖 Draft agent PR for https://linear.app/a8c/issue/ADS-1090/expose-blaze-campaign-list-filters-and-agent-friendly-context.

Sandcastle run log is local at `.agent-runs/jetpack/ADS-1090-2026-05-13T13-43-11-436Z/sandcastle.log`.

This PR was created as draft and must be reviewed by a human before merge.