### PR TITLE
ADS-1091: Add Blaze MCP get-campaign-stats ability with derived metrics

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1091-get-campaign-stats
+++ b/projects/packages/blaze/changelog/add-ads-1091-get-campaign-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: Add a read-only `blaze-ads/get-campaign-stats` ability with derived display ad metrics.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -34,15 +34,17 @@ use WP_REST_Request;
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG            = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS   = 'blaze-ads/list-campaigns';
-	const ABILITY_PREPARE_CAMPAIGN = 'blaze-ads/prepare-campaign';
+	const CATEGORY_SLUG                = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS       = 'blaze-ads/list-campaigns';
+	const ABILITY_GET_CAMPAIGN_STATS   = 'blaze-ads/get-campaign-stats';
+	const ABILITY_PREPARE_CAMPAIGN     = 'blaze-ads/prepare-campaign';
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
 	 */
 	const OWNED_ABILITY_SLUGS = array(
 		self::ABILITY_LIST_CAMPAIGNS,
+		self::ABILITY_GET_CAMPAIGN_STATS,
 		self::ABILITY_PREPARE_CAMPAIGN,
 	);
 
@@ -207,6 +209,116 @@ class Blaze_Abilities extends Registrar {
 					'description' => __( 'Campaigns payload as returned by the Blaze DSP API.', 'jetpack-blaze' ),
 				),
 				'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+			self::ABILITY_GET_CAMPAIGN_STATS => array(
+				'label'               => __( 'Get Blaze campaign stats', 'jetpack-blaze' ),
+				'description'         => __( 'Get raw Blaze display advertising stats for a campaign, plus basic derived CTR, CPM, CPC, and clicks-per-dollar metrics.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Numeric DSP campaign ID.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'start_date'  => array(
+							'type'        => 'string',
+							'format'      => 'date',
+							'description' => __( 'Optional stats start date in YYYY-MM-DD format.', 'jetpack-blaze' ),
+						),
+						'end_date'    => array(
+							'type'        => 'string',
+							'format'      => 'date',
+							'description' => __( 'Optional stats end date in YYYY-MM-DD format.', 'jetpack-blaze' ),
+						),
+						'time_zone'   => array(
+							'type'        => 'string',
+							'description' => __( 'Optional IANA timezone name used by the DSP stats endpoint.', 'jetpack-blaze' ),
+						),
+						'resolution'  => array(
+							'type'        => 'string',
+							'description' => __( 'Optional stats time-series resolution accepted by the DSP stats endpoint.', 'jetpack-blaze' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Campaign stats payload with raw totals, time series, country breakdown, derived metrics, and lightweight display-ad context.', 'jetpack-blaze' ),
+					'required'    => array( 'raw_stats', 'totals', 'time_series', 'country_breakdown', 'derived_metrics', 'context' ),
+					'properties'  => array(
+						'raw_stats'         => array(
+							'type'        => 'object',
+							'description' => __( 'Raw campaign stats payload as returned by the Blaze DSP stats endpoint.', 'jetpack-blaze' ),
+						),
+						'totals'            => array(
+							'type'       => 'object',
+							'required'   => array( 'impressions', 'clicks', 'spend' ),
+							'properties' => array(
+								'impressions' => array(
+									'type' => 'integer',
+								),
+								'clicks'      => array(
+									'type' => 'integer',
+								),
+								'spend'       => array(
+									'type' => 'number',
+								),
+							),
+						),
+						'time_series'       => array(
+							'type'        => 'array',
+							'description' => __( 'Raw time-series rows from the stats endpoint, including impressions, clicks, and spend when present.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'object',
+							),
+						),
+						'country_breakdown' => array(
+							'type'        => 'array',
+							'description' => __( 'Raw country breakdown rows from the stats endpoint.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'object',
+							),
+						),
+						'derived_metrics'   => array(
+							'type'       => 'object',
+							'required'   => array( 'ctr', 'cpm', 'cpc', 'clicks_per_dollar' ),
+							'properties' => array(
+								'ctr'               => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Click-through rate as clicks divided by impressions.', 'jetpack-blaze' ),
+								),
+								'cpm'               => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Cost per thousand impressions.', 'jetpack-blaze' ),
+								),
+								'cpc'               => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Cost per click.', 'jetpack-blaze' ),
+								),
+								'clicks_per_dollar' => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Clicks divided by spend.', 'jetpack-blaze' ),
+								),
+							),
+						),
+						'context'           => array(
+							'type'        => 'string',
+							'description' => __( 'Lightweight display-ad framing for interpreting CTR alongside CPM, CPC, and campaign goals.', 'jetpack-blaze' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_campaign_stats' ),
 				'permission_callback' => array( __CLASS__, 'permission_callback' ),
 				'meta'                => array(
 					'show_in_rest' => true,
@@ -482,7 +594,7 @@ class Blaze_Abilities extends Registrar {
 
 		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
 		$request = new WP_REST_Request( 'GET', $route );
-		$request->set_param( 'api_version', 'v1.1' );
+		$request->set_param( 'api_version', 'v1' );
 
 		$response = rest_do_request( $request );
 		if ( $response->is_error() ) {
@@ -490,6 +602,156 @@ class Blaze_Abilities extends Registrar {
 		}
 
 		return $response->get_data();
+	}
+
+	/**
+	 * Return a Blaze campaign stats payload.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function get_campaign_stats( $args = array() ) {
+		$args            = is_array( $args ) ? $args : array();
+		$raw_campaign_id = isset( $args['campaign_id'] ) ? $args['campaign_id'] : null;
+		$campaign_id     = 0;
+
+		if ( is_int( $raw_campaign_id ) ) {
+			$campaign_id = $raw_campaign_id;
+		} elseif ( is_string( $raw_campaign_id ) && ctype_digit( $raw_campaign_id ) ) {
+			$campaign_id = (int) $raw_campaign_id;
+		}
+
+		if ( $campaign_id < 1 ) {
+			return new \WP_Error(
+				'blaze_invalid_campaign_id',
+				__( 'A numeric DSP campaign ID is required.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1/stats/%d', $site_id, $campaign_id );
+		$request = new WP_REST_Request( 'GET', $route );
+		$request->set_param( 'api_version', 'v1' );
+
+		foreach ( array( 'start_date', 'end_date', 'time_zone', 'resolution' ) as $param ) {
+			if ( isset( $args[ $param ] ) && '' !== $args[ $param ] ) {
+				$request->set_param( $param, $args[ $param ] );
+			}
+		}
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$stats  = $response->get_data();
+		$totals = is_array( $stats ) ? self::extract_campaign_stats_totals( $stats ) : array(
+			'impressions' => 0,
+			'clicks'      => 0,
+			'spend'       => 0.0,
+		);
+
+		return array(
+			'raw_stats'         => $stats,
+			'totals'            => $totals,
+			'time_series'       => is_array( $stats ) ? self::extract_campaign_stats_time_series( $stats ) : array(),
+			'country_breakdown' => is_array( $stats ) ? self::extract_campaign_stats_country_breakdown( $stats ) : array(),
+			'derived_metrics'   => self::derive_campaign_stats_metrics( $totals ),
+			'context'           => __( 'Blaze is display advertising. A low CTR should be interpreted alongside CPM, CPC, and campaign goals before drawing conclusions.', 'jetpack-blaze' ),
+		);
+	}
+
+	/**
+	 * Extract raw total metrics from known stats payload shapes.
+	 *
+	 * @param array $stats Raw stats payload.
+	 * @return array
+	 */
+	private static function extract_campaign_stats_totals( array $stats ): array {
+		$source = isset( $stats['totals'] ) && is_array( $stats['totals'] ) ? $stats['totals'] : $stats;
+
+		return array(
+			'impressions' => (int) self::get_first_numeric_value( $source, array( 'impressions', 'total_impressions' ) ),
+			'clicks'      => (int) self::get_first_numeric_value( $source, array( 'clicks', 'total_clicks' ) ),
+			'spend'       => (float) self::get_first_numeric_value( $source, array( 'spend', 'total_spend' ) ),
+		);
+	}
+
+	/**
+	 * Extract time-series rows from known stats payload shapes.
+	 *
+	 * @param array $stats Raw stats payload.
+	 * @return array
+	 */
+	private static function extract_campaign_stats_time_series( array $stats ): array {
+		if ( isset( $stats['series'] ) && is_array( $stats['series'] ) ) {
+			return $stats['series'];
+		}
+
+		if ( isset( $stats['time_series'] ) && is_array( $stats['time_series'] ) ) {
+			return $stats['time_series'];
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract country breakdown rows from known stats payload shapes.
+	 *
+	 * @param array $stats Raw stats payload.
+	 * @return array
+	 */
+	private static function extract_campaign_stats_country_breakdown( array $stats ): array {
+		if ( isset( $stats['countries'] ) && is_array( $stats['countries'] ) ) {
+			return $stats['countries'];
+		}
+
+		if ( isset( $stats['country_breakdown'] ) && is_array( $stats['country_breakdown'] ) ) {
+			return $stats['country_breakdown'];
+		}
+
+		return array();
+	}
+
+	/**
+	 * Derive simple campaign stats metrics from totals.
+	 *
+	 * @param array $totals Normalized totals.
+	 * @return array
+	 */
+	private static function derive_campaign_stats_metrics( array $totals ): array {
+		$impressions = isset( $totals['impressions'] ) ? (int) $totals['impressions'] : 0;
+		$clicks      = isset( $totals['clicks'] ) ? (int) $totals['clicks'] : 0;
+		$spend       = isset( $totals['spend'] ) ? (float) $totals['spend'] : 0.0;
+
+		return array(
+			'ctr'               => $impressions > 0 ? $clicks / $impressions : null,
+			'cpm'               => $impressions > 0 ? ( $spend / $impressions ) * 1000 : null,
+			'cpc'               => $clicks > 0 ? $spend / $clicks : null,
+			'clicks_per_dollar' => $spend > 0 ? $clicks / $spend : null,
+		);
+	}
+
+	/**
+	 * Return the first numeric value found in an array.
+	 *
+	 * @param array $source Source data.
+	 * @param array $keys Candidate keys.
+	 * @return float|int
+	 */
+	private static function get_first_numeric_value( array $source, array $keys ) {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && is_numeric( $source[ $key ] ) ) {
+				return $source[ $key ];
+			}
+		}
+
+		return 0;
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -106,6 +106,56 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The get-campaign-stats ability is read-only and exposes the DSP stats
+	 * query contract used by the Blaze proxy route.
+	 */
+	public function test_get_campaign_stats_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( 'blaze-ads/get-campaign-stats', $abilities );
+		$this->assertContains( 'blaze-ads/get-campaign-stats', Blaze_Abilities::OWNED_ABILITY_SLUGS );
+
+		$ability    = $abilities['blaze-ads/get-campaign-stats'];
+		$schema     = $ability['input_schema'];
+		$properties = $schema['properties'];
+
+		$this->assertSame( array( Blaze_Abilities::class, 'get_campaign_stats' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
+		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
+		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
+
+		$this->assertSame( array( 'campaign_id' ), $schema['required'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertSame( 'integer', $properties['campaign_id']['type'] );
+		$this->assertSame( 1, $properties['campaign_id']['minimum'] );
+		$this->assertArrayHasKey( 'start_date', $properties );
+		$this->assertArrayHasKey( 'end_date', $properties );
+		$this->assertArrayHasKey( 'time_zone', $properties );
+		$this->assertArrayHasKey( 'resolution', $properties );
+
+		$output_schema     = $ability['output_schema'];
+		$output_properties = $output_schema['properties'];
+
+		$this->assertContains( 'raw_stats', $output_schema['required'] );
+		$this->assertContains( 'totals', $output_schema['required'] );
+		$this->assertContains( 'time_series', $output_schema['required'] );
+		$this->assertContains( 'derived_metrics', $output_schema['required'] );
+		$this->assertContains( 'context', $output_schema['required'] );
+		$this->assertArrayHasKey( 'raw_stats', $output_properties );
+		$this->assertArrayHasKey( 'totals', $output_properties );
+		$this->assertArrayHasKey( 'time_series', $output_properties );
+		$this->assertArrayHasKey( 'country_breakdown', $output_properties );
+		$this->assertArrayHasKey( 'derived_metrics', $output_properties );
+		$this->assertArrayHasKey( 'ctr', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'cpm', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'cpc', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'clicks_per_dollar', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'context', $output_properties );
+	}
+
+	/**
 	 * The double-register guard preserves an existing disabled decision.
 	 */
 	public function test_guard_against_double_register_preserves_disabled_decision() {
@@ -143,7 +193,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->assertSame(
 			array(
-				'api_version' => 'v1.1',
+				'api_version' => 'v1',
 				'campaigns'   => array(
 					array(
 						'id'     => 'campaign-1',
@@ -153,6 +203,197 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			),
 			Blaze_Abilities::list_campaigns()
 		);
+	}
+
+	/**
+	 * Get_campaign_stats delegates to the existing Blaze stats proxy route
+	 * and forwards the DSP stats query options.
+	 */
+	public function test_get_campaign_stats_delegates_to_blaze_stats_rest_route() {
+		$captured_params = null;
+
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1/stats/67890',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function ( $request ) use ( &$captured_params ) {
+					$captured_params = $request->get_params();
+					return array(
+						'totals' => array(
+							'impressions' => 1000,
+							'clicks'      => 20,
+							'spend'       => 5.0,
+						),
+						'series' => array(),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_stats(
+			array(
+				'campaign_id' => 67890,
+				'start_date'  => '2026-05-01',
+				'end_date'    => '2026-05-07',
+				'time_zone'   => 'America/New_York',
+				'resolution'  => 'day',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'totals' => array(
+					'impressions' => 1000,
+					'clicks'      => 20,
+					'spend'       => 5.0,
+				),
+				'series' => array(),
+			),
+			$result['raw_stats']
+		);
+		$this->assertSame( 'v1', $captured_params['api_version'] ?? null );
+		$this->assertSame( '2026-05-01', $captured_params['start_date'] ?? null );
+		$this->assertSame( '2026-05-07', $captured_params['end_date'] ?? null );
+		$this->assertSame( 'America/New_York', $captured_params['time_zone'] ?? null );
+		$this->assertSame( 'day', $captured_params['resolution'] ?? null );
+	}
+
+	/**
+	 * Campaign stats requires a numeric DSP campaign ID at execution time.
+	 */
+	public function test_get_campaign_stats_rejects_non_numeric_campaign_id() {
+		$result = Blaze_Abilities::get_campaign_stats(
+			array(
+				'campaign_id' => '123abc',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_invalid_campaign_id', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 400, $data['status'] ?? null );
+	}
+
+	/**
+	 * Get_campaign_stats returns raw DSP stats plus simple display-ad
+	 * derived metrics.
+	 */
+	public function test_get_campaign_stats_returns_derived_metrics_and_context() {
+		$stats_payload = array(
+			'totals'    => array(
+				'impressions' => 2000,
+				'clicks'      => 50,
+				'spend'       => 25.0,
+			),
+			'series'    => array(
+				array(
+					'date'        => '2026-05-01',
+					'impressions' => 1200,
+					'clicks'      => 30,
+					'spend'       => 15.0,
+				),
+				array(
+					'date'        => '2026-05-02',
+					'impressions' => 800,
+					'clicks'      => 20,
+					'spend'       => 10.0,
+				),
+			),
+			'countries' => array(
+				array(
+					'country'     => 'US',
+					'impressions' => 1500,
+					'clicks'      => 40,
+					'spend'       => 20.0,
+				),
+			),
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1/stats/67890',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function () use ( $stats_payload ) {
+					return $stats_payload;
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_stats( array( 'campaign_id' => 67890 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $stats_payload, $result['raw_stats'] );
+		$this->assertSame( $stats_payload['totals'], $result['totals'] );
+		$this->assertSame( $stats_payload['series'], $result['time_series'] );
+		$this->assertSame( $stats_payload['countries'], $result['country_breakdown'] );
+		$this->assertSame(
+			array(
+				'ctr'               => 0.025,
+				'cpm'               => 12.5,
+				'cpc'               => 0.5,
+				'clicks_per_dollar' => 2.0,
+			),
+			$result['derived_metrics']
+		);
+		$this->assertStringContainsString( 'display advertising', $result['context'] );
+		$this->assertStringContainsString( 'low CTR', $result['context'] );
+		$this->assertStringContainsString( 'CPM', $result['context'] );
+		$this->assertStringContainsString( 'CPC', $result['context'] );
+		$this->assertStringContainsString( 'campaign goals', $result['context'] );
+		$this->assertStringNotContainsString( 'ROAS', $result['context'] );
+		$this->assertStringNotContainsString( 'revenue', $result['context'] );
+	}
+
+	/**
+	 * Zero-value stats do not cause divide-by-zero derived metrics.
+	 */
+	public function test_get_campaign_stats_handles_zero_value_derived_metrics() {
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1/stats/67890',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function () {
+					return array(
+						'totals' => array(
+							'impressions' => 0,
+							'clicks'      => 0,
+							'spend'       => 0.0,
+						),
+						'series' => array(
+							array(
+								'date'        => '2026-05-01',
+								'impressions' => 0,
+								'clicks'      => 0,
+								'spend'       => 0.0,
+							),
+						),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_stats( array( 'campaign_id' => 67890 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'ctr'               => null,
+				'cpm'               => null,
+				'cpc'               => null,
+				'clicks_per_dollar' => null,
+			),
+			$result['derived_metrics']
+		);
+		$this->assertSame( 0, $result['totals']['impressions'] );
+		$this->assertSame( 0, $result['totals']['clicks'] );
+		$this->assertSame( 0.0, $result['totals']['spend'] );
 	}
 
 	// --- Wrapper: shape and identity behaviour ---
@@ -426,6 +667,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	public function test_inheritance_documented_via_owned_slugs_constant() {
 		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
 		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_GET_CAMPAIGN_STATS, $owned );
 		$this->assertContains( Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN, $owned );
 
 		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
@@ -470,11 +712,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	// --- Woo MCP opt-in ---
 
 	/**
-	 * Both owned slugs are opted into Woo's MCP whitelist; foreign slugs
+	 * Owned slugs are opted into Woo's MCP whitelist; foreign slugs
 	 * are passed through unchanged.
 	 */
 	public function test_opt_into_woo_mcp_for_owned_slugs() {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_GET_CAMPAIGN_STATS ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).


### PR DESCRIPTION
🤖 Draft agent PR for https://linear.app/a8c/issue/ADS-1091/add-blaze-mcp-get-campaign-stats-ability-with-derived-metrics.

Sandcastle run log is local at `.agent-runs/jetpack/ADS-1091-2026-05-13T13-43-12-501Z/sandcastle.log`.

This PR was created as draft and must be reviewed by a human before merge.