### PR TITLE
ADS-1092: Add Blaze MCP stop-campaign ability with preview and confirm

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1092-stop-campaign
+++ b/projects/packages/blaze/changelog/add-ads-1092-stop-campaign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze MCP: Add stop-campaign preview and confirm ability.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -37,6 +37,7 @@ class Blaze_Abilities extends Registrar {
 	const CATEGORY_SLUG            = 'blaze-ads';
 	const ABILITY_LIST_CAMPAIGNS   = 'blaze-ads/list-campaigns';
 	const ABILITY_PREPARE_CAMPAIGN = 'blaze-ads/prepare-campaign';
+	const ABILITY_STOP_CAMPAIGN    = 'blaze-ads/stop-campaign';
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
@@ -44,6 +45,7 @@ class Blaze_Abilities extends Registrar {
 	const OWNED_ABILITY_SLUGS = array(
 		self::ABILITY_LIST_CAMPAIGNS,
 		self::ABILITY_PREPARE_CAMPAIGN,
+		self::ABILITY_STOP_CAMPAIGN,
 	);
 
 	/**
@@ -438,6 +440,61 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
+			self::ABILITY_STOP_CAMPAIGN    => array(
+				'label'               => __( 'Stop a Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Preview or confirm stopping delivery for an existing Blaze campaign. Pass the numeric DSP campaign_id. By default this returns the current campaign context and consequence text without calling the DSP stop endpoint. Set confirm to true only after the merchant explicitly confirms they want to stop serving; confirm mode re-fetches campaign context and delegates stop eligibility to the existing DSP stop endpoint.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Numeric DSP campaign ID to stop.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'confirm'     => array(
+							'type'        => 'boolean',
+							'description' => __( 'Set to true only after the merchant explicitly confirms they want this campaign stopped from serving. Defaults to false, which previews the consequence without stopping the campaign.', 'jetpack-blaze' ),
+							'default'     => false,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Stop-campaign preview or confirmation response with campaign context and merchant-facing wording.', 'jetpack-blaze' ),
+					'required'    => array( 'status', 'message', 'campaign' ),
+					'properties'  => array(
+						'status'      => array(
+							'type'        => 'string',
+							'description' => __( 'pending_confirmation for preview responses, or stopped for successful confirm responses.', 'jetpack-blaze' ),
+							'enum'        => array( 'pending_confirmation', 'stopped' ),
+						),
+						'message'     => array(
+							'type'        => 'string',
+							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant.', 'jetpack-blaze' ),
+						),
+						'campaign'    => array(
+							'type'        => 'object',
+							'description' => __( 'Current campaign context fetched from the Blaze DSP API.', 'jetpack-blaze' ),
+						),
+						'consequence' => array(
+							'type'        => 'string',
+							'description' => __( 'Clear consequence text explaining that confirmation stops the campaign from serving.', 'jetpack-blaze' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'stop_campaign' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			),
 		);
 	}
 
@@ -527,6 +584,310 @@ class Blaze_Abilities extends Registrar {
 			'campaign_preview' => self::build_campaign_preview( $proposal ),
 			'forecast_summary' => self::build_forecast_summary( $proposal ),
 		) + $proposal;
+	}
+
+	/**
+	 * Preview or confirm stopping a Blaze campaign from serving.
+	 *
+	 * Preview mode fetches current campaign context and returns consequence
+	 * text without calling the DSP stop endpoint. Confirm mode re-fetches the
+	 * same context, then delegates stop eligibility and state handling to DSP.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function stop_campaign( $args = array() ) {
+		$args = is_array( $args ) ? $args : array();
+
+		$campaign_id = isset( $args['campaign_id'] ) ? (int) $args['campaign_id'] : 0;
+		if ( $campaign_id < 1 ) {
+			return new \WP_Error(
+				'blaze_invalid_campaign_id',
+				__( 'A numeric DSP campaign_id is required to stop a Blaze campaign.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$context = self::fetch_stop_campaign_context( $campaign_id );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$campaign    = self::normalize_stop_campaign_context( $campaign_id, $context );
+		$consequence = self::build_stop_campaign_consequence( $campaign );
+		$confirmed   = isset( $args['confirm'] ) && true === $args['confirm'];
+
+		if ( ! $confirmed ) {
+			return array(
+				'status'      => 'pending_confirmation',
+				'message'     => self::format_stop_campaign_preview_message( $campaign, $consequence ),
+				'campaign'    => $campaign,
+				'consequence' => $consequence,
+			);
+		}
+
+		$stop_response = self::call_stop_campaign_endpoint( $campaign_id );
+		if ( is_wp_error( $stop_response ) ) {
+			return $stop_response;
+		}
+
+		return array(
+			'status'        => 'stopped',
+			'message'       => self::format_stop_campaign_confirmation_message( $campaign ),
+			'campaign'      => $campaign,
+			'consequence'   => __( 'The campaign was stopped from serving immediately.', 'jetpack-blaze' ),
+			'stop_response' => $stop_response,
+		);
+	}
+
+	/**
+	 * Fetch current campaign context through the existing Blaze proxy route.
+	 *
+	 * @param int $campaign_id Numeric DSP campaign ID.
+	 * @return array|\WP_Error
+	 */
+	private static function fetch_stop_campaign_context( int $campaign_id ) {
+		$route = self::get_dsp_campaign_route( $campaign_id );
+		if ( is_wp_error( $route ) ) {
+			return $route;
+		}
+
+		$request = new WP_REST_Request( 'GET', $route );
+		return self::dispatch_stop_campaign_rest_request( $request );
+	}
+
+	/**
+	 * Call the existing DSP stop endpoint through the Blaze proxy route.
+	 *
+	 * @param int $campaign_id Numeric DSP campaign ID.
+	 * @return array|\WP_Error
+	 */
+	private static function call_stop_campaign_endpoint( int $campaign_id ) {
+		$route = self::get_dsp_campaign_route( $campaign_id, '/stop' );
+		if ( is_wp_error( $route ) ) {
+			return $route;
+		}
+
+		$request = new WP_REST_Request( 'POST', $route );
+		return self::dispatch_stop_campaign_rest_request( $request );
+	}
+
+	/**
+	 * Build the local REST proxy route for a DSP campaign endpoint.
+	 *
+	 * @param int    $campaign_id Numeric DSP campaign ID.
+	 * @param string $suffix      Optional subpath suffix, e.g. /stop.
+	 * @return string|\WP_Error
+	 */
+	private static function get_dsp_campaign_route( int $campaign_id, string $suffix = '' ) {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		return sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns/%d%s', $site_id, $campaign_id, $suffix );
+	}
+
+	/**
+	 * Dispatch a stop-campaign REST proxy request and normalize error output.
+	 *
+	 * @param WP_REST_Request $request Request to dispatch.
+	 * @return array|\WP_Error
+	 */
+	private static function dispatch_stop_campaign_rest_request( WP_REST_Request $request ) {
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$status = $response->get_status();
+		$data   = $response->get_data();
+		if ( $status >= 400 ) {
+			return self::rest_response_to_wp_error( is_array( $data ) ? $data : array(), $status );
+		}
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Convert non-2xx REST proxy responses into WP_Error for Abilities/MCP.
+	 *
+	 * @param array $data   REST response data.
+	 * @param int   $status HTTP status.
+	 * @return \WP_Error
+	 */
+	private static function rest_response_to_wp_error( array $data, int $status ): \WP_Error {
+		$code = isset( $data['code'] ) ? (string) $data['code'] : 'blaze_dsp_error';
+
+		$message = '';
+		foreach ( array( 'message', 'errorMessage', 'error' ) as $message_key ) {
+			if ( isset( $data[ $message_key ] ) && '' !== (string) $data[ $message_key ] ) {
+				$message = (string) $data[ $message_key ];
+				break;
+			}
+		}
+		if ( '' === $message ) {
+			$message = __( 'The Blaze DSP API could not stop this campaign.', 'jetpack-blaze' );
+		}
+
+		$data['status'] = $status;
+		return new \WP_Error( $code, $message, $data );
+	}
+
+	/**
+	 * Normalize the DSP campaign shape into the MCP-facing context fields.
+	 *
+	 * @param int   $campaign_id Numeric DSP campaign ID requested by the caller.
+	 * @param array $context     Raw DSP campaign context.
+	 * @return array
+	 */
+	private static function normalize_stop_campaign_context( int $campaign_id, array $context ): array {
+		$campaign = isset( $context['campaign'] ) && is_array( $context['campaign'] ) ? $context['campaign'] : $context;
+
+		return array(
+			'campaign_id' => self::get_first_integer_value( $campaign, array( 'campaign_id', 'id' ), $campaign_id ),
+			'title'       => self::get_first_string_value( $campaign, array( 'title', 'name', 'campaign_name' ) ),
+			'status'      => self::get_first_string_value( $campaign, array( 'status', 'state' ) ),
+			'start_date'  => self::get_first_string_value( $campaign, array( 'start_date', 'startDate', 'start_at', 'startAt', 'start' ) ),
+			'end_date'    => self::get_first_string_value( $campaign, array( 'end_date', 'endDate', 'end_at', 'endAt', 'end' ) ),
+			'target_url'  => self::get_first_string_value( $campaign, array( 'target_url', 'targetUrl', 'destination_url', 'destinationUrl', 'landing_page', 'landingPage', 'url' ) ),
+			'target_urn'  => self::get_first_string_value( $campaign, array( 'target_urn', 'targetUrn', 'urn' ) ),
+		);
+	}
+
+	/**
+	 * Return the first non-empty string value for a set of keys.
+	 *
+	 * @param array $source Source array.
+	 * @param array $keys   Candidate keys.
+	 * @return string
+	 */
+	private static function get_first_string_value( array $source, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && '' !== (string) $source[ $key ] ) {
+				return (string) $source[ $key ];
+			}
+		}
+
+		if ( isset( $source['target'] ) && is_array( $source['target'] ) ) {
+			foreach ( $keys as $key ) {
+				if ( isset( $source['target'][ $key ] ) && '' !== (string) $source['target'][ $key ] ) {
+					return (string) $source['target'][ $key ];
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return the first positive integer value for a set of keys.
+	 *
+	 * @param array $source  Source array.
+	 * @param array $keys    Candidate keys.
+	 * @param int   $default Default value.
+	 * @return int
+	 */
+	private static function get_first_integer_value( array $source, array $keys, int $default ): int {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && (int) $source[ $key ] > 0 ) {
+				return (int) $source[ $key ];
+			}
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Build consequence text for preview mode.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function build_stop_campaign_consequence( array $campaign ): string {
+		return sprintf(
+			/* translators: %s: campaign title or ID. */
+			__( 'If confirmed, campaign "%s" will be stopped from serving immediately. This MCP tool cannot resume the campaign after it is stopped.', 'jetpack-blaze' ),
+			self::get_stop_campaign_display_name( $campaign )
+		);
+	}
+
+	/**
+	 * Format the preview response for chat clients.
+	 *
+	 * @param array  $campaign    Normalized campaign context.
+	 * @param string $consequence Consequence text.
+	 * @return string
+	 */
+	private static function format_stop_campaign_preview_message( array $campaign, string $consequence ): string {
+		$message  = __( 'Preview only: this campaign has not been stopped.', 'jetpack-blaze' ) . "\n\n";
+		$message .= self::format_stop_campaign_context_table( $campaign );
+		$message .= "\n" . $consequence;
+		$message .= "\n\n" . __( 'To stop serving, call this ability again with confirm set to true after the merchant explicitly confirms.', 'jetpack-blaze' );
+
+		return $message;
+	}
+
+	/**
+	 * Format the confirmation response for chat clients.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function format_stop_campaign_confirmation_message( array $campaign ): string {
+		return sprintf(
+			/* translators: %s: campaign title or ID. */
+			__( 'Campaign "%s" was stopped from serving.', 'jetpack-blaze' ),
+			self::get_stop_campaign_display_name( $campaign )
+		);
+	}
+
+	/**
+	 * Format normalized campaign context as a compact Markdown table.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function format_stop_campaign_context_table( array $campaign ): string {
+		$message  = '| ' . __( 'Campaign', 'jetpack-blaze' ) . ' | ' . __( 'Current value', 'jetpack-blaze' ) . " |\n";
+		$message .= "| --- | --- |\n";
+
+		$rows = array(
+			__( 'ID', 'jetpack-blaze' )         => $campaign['campaign_id'] ?? '',
+			__( 'Title', 'jetpack-blaze' )      => $campaign['title'] ?? '',
+			__( 'Status', 'jetpack-blaze' )     => $campaign['status'] ?? '',
+			__( 'Start date', 'jetpack-blaze' ) => $campaign['start_date'] ?? '',
+			__( 'End date', 'jetpack-blaze' )   => $campaign['end_date'] ?? '',
+			__( 'Target URL', 'jetpack-blaze' ) => $campaign['target_url'] ?? '',
+			__( 'Target URN', 'jetpack-blaze' ) => $campaign['target_urn'] ?? '',
+		);
+
+		foreach ( $rows as $label => $value ) {
+			if ( '' === (string) $value ) {
+				continue;
+			}
+			$message .= '| ' . self::format_markdown_table_cell( $label ) . ' | ' . self::format_markdown_table_cell( $value ) . " |\n";
+		}
+
+		return rtrim( $message, "\n" );
+	}
+
+	/**
+	 * Human-readable campaign name fallback.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function get_stop_campaign_display_name( array $campaign ): string {
+		if ( ! empty( $campaign['title'] ) ) {
+			return (string) $campaign['title'];
+		}
+
+		return sprintf(
+			/* translators: %d: numeric DSP campaign ID. */
+			__( 'Campaign %d', 'jetpack-blaze' ),
+			(int) ( $campaign['campaign_id'] ?? 0 )
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -106,6 +106,32 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The stop-campaign ability is a destructive write tool with an
+	 * explicit preview/confirm contract.
+	 */
+	public function test_stop_campaign_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( Blaze_Abilities::ABILITY_STOP_CAMPAIGN, $abilities );
+
+		$ability = $abilities[ Blaze_Abilities::ABILITY_STOP_CAMPAIGN ];
+		$this->assertSame( array( Blaze_Abilities::class, 'stop_campaign' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertFalse( $ability['meta']['annotations']['readonly'] );
+		$this->assertTrue( $ability['meta']['annotations']['destructive'] );
+		$this->assertFalse( $ability['meta']['annotations']['idempotent'] );
+
+		$schema = $ability['input_schema'];
+		$this->assertSame( array( 'campaign_id' ), $schema['required'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertSame( 'integer', $schema['properties']['campaign_id']['type'] );
+		$this->assertSame( 1, $schema['properties']['campaign_id']['minimum'] );
+		$this->assertSame( 'boolean', $schema['properties']['confirm']['type'] );
+		$this->assertFalse( $schema['properties']['confirm']['default'] );
+	}
+
+	/**
 	 * The double-register guard preserves an existing disabled decision.
 	 */
 	public function test_guard_against_double_register_preserves_disabled_decision() {
@@ -427,6 +453,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
 		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
 		$this->assertContains( Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_STOP_CAMPAIGN, $owned );
 
 		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
 		// wrapped. We exercise prepare-campaign here as the canonical write slug.
@@ -437,6 +464,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
+
+		$out = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_STOP_CAMPAIGN );
 		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
 	}
 
@@ -476,6 +506,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	public function test_opt_into_woo_mcp_for_owned_slugs() {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_STOP_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
 		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'jetpack-forms/get-responses' ) );
@@ -586,6 +617,42 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Register a test campaign detail route for stop-campaign previews.
+	 *
+	 * @param int      $campaign_id Numeric DSP campaign ID.
+	 * @param callable $callback    Route callback.
+	 */
+	private function register_campaign_context_route( int $campaign_id, callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/campaigns/%d', self::TEST_SITE_ID, $campaign_id ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Register a test campaign stop route for confirm-mode calls.
+	 *
+	 * @param int      $campaign_id Numeric DSP campaign ID.
+	 * @param callable $callback    Route callback.
+	 */
+	private function register_campaign_stop_route( int $campaign_id, callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/campaigns/%d/stop', self::TEST_SITE_ID, $campaign_id ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
 	 * Invalid target_urn returns a WP_Error with status 400, not a partial proposal.
 	 */
 	public function test_prepare_campaign_returns_error_for_invalid_target_urn() {
@@ -615,6 +682,137 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'blaze_post_not_found', $result->get_error_code() );
 		$data = $result->get_error_data();
 		$this->assertSame( 404, $data['status'] ?? null );
+	}
+
+	/**
+	 * Preview mode fetches campaign context but does not call the DSP stop
+	 * endpoint.
+	 */
+	public function test_stop_campaign_preview_fetches_context_without_stop_call() {
+		$stop_calls = 0;
+		$this->register_campaign_context_route(
+			987,
+			static function () {
+				return array(
+					'id'         => 987,
+					'name'       => 'Spring launch',
+					'status'     => 'active',
+					'start_date' => '2026-05-01',
+					'end_date'   => '2026-05-31',
+					'target_url' => 'https://example.com/spring',
+					'target_urn' => 'urn:wpcom:post:12345:42',
+				);
+			}
+		);
+		$this->register_campaign_stop_route(
+			987,
+			static function () use ( &$stop_calls ) {
+				++$stop_calls;
+				return array( 'status' => 'stopped' );
+			}
+		);
+
+		$result = Blaze_Abilities::stop_campaign( array( 'campaign_id' => 987 ) );
+
+		$this->assertSame( 0, $stop_calls, 'Preview mode must not call the DSP stop endpoint.' );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_confirmation', $result['status'] );
+		$this->assertSame( 987, $result['campaign']['campaign_id'] );
+		$this->assertSame( 'Spring launch', $result['campaign']['title'] );
+		$this->assertSame( 'active', $result['campaign']['status'] );
+		$this->assertSame( '2026-05-01', $result['campaign']['start_date'] );
+		$this->assertSame( '2026-05-31', $result['campaign']['end_date'] );
+		$this->assertSame( 'https://example.com/spring', $result['campaign']['target_url'] );
+		$this->assertSame( 'urn:wpcom:post:12345:42', $result['campaign']['target_urn'] );
+		$this->assertStringContainsString( 'will be stopped from serving', $result['consequence'] );
+		$this->assertStringContainsString( 'Preview only', $result['message'] );
+		$this->assertStringContainsString( 'Spring launch', $result['message'] );
+	}
+
+	/**
+	 * Confirm mode re-fetches campaign context and delegates to the DSP stop
+	 * endpoint through the Jetpack Blaze proxy.
+	 */
+	public function test_stop_campaign_confirm_refetches_context_and_calls_stop_endpoint() {
+		$context_calls = 0;
+		$stop_calls    = 0;
+		$this->register_campaign_context_route(
+			987,
+			static function () use ( &$context_calls ) {
+				++$context_calls;
+				return array(
+					'id'         => 987,
+					'title'      => 'Spring launch',
+					'status'     => 'active',
+					'start_date' => '2026-05-01',
+					'end_date'   => '2026-05-31',
+					'target_url' => 'https://example.com/spring',
+				);
+			}
+		);
+		$this->register_campaign_stop_route(
+			987,
+			static function () use ( &$stop_calls ) {
+				++$stop_calls;
+				return array(
+					'id'     => 987,
+					'status' => 'stopped',
+				);
+			}
+		);
+
+		$result = Blaze_Abilities::stop_campaign(
+			array(
+				'campaign_id' => 987,
+				'confirm'     => true,
+			)
+		);
+
+		$this->assertSame( 1, $context_calls );
+		$this->assertSame( 1, $stop_calls );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'stopped', $result['status'] );
+		$this->assertSame( 'Spring launch', $result['campaign']['title'] );
+		$this->assertSame( array( 'id' => 987, 'status' => 'stopped' ), $result['stop_response'] );
+		$this->assertStringContainsString( 'Campaign "Spring launch" was stopped from serving.', $result['message'] );
+		$this->assertStringNotContainsString( 'deleted', strtolower( $result['message'] ) );
+		$this->assertStringNotContainsString( 'archived', strtolower( $result['message'] ) );
+	}
+
+	/**
+	 * DSP stop errors pass through without duplicating stop eligibility
+	 * rules in Jetpack.
+	 */
+	public function test_stop_campaign_confirm_passes_through_dsp_stop_error() {
+		$this->register_campaign_context_route(
+			987,
+			static function () {
+				return array(
+					'id'     => 987,
+					'title'  => 'Spring launch',
+					'status' => 'completed',
+				);
+			}
+		);
+		$this->register_campaign_stop_route(
+			987,
+			static function () {
+				return new WP_Error( 'campaign_not_stoppable', 'Campaign cannot be stopped from its current state.', array( 'status' => 409 ) );
+			}
+		);
+
+		$result = Blaze_Abilities::stop_campaign(
+			array(
+				'campaign_id' => 987,
+				'confirm'     => true,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'campaign_not_stoppable', $result->get_error_code() );
+		$this->assertSame( 'Campaign cannot be stopped from its current state.', $result->get_error_message() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] ?? null );
 	}
 
 	/**


### PR DESCRIPTION
🤖 Draft agent PR for https://linear.app/a8c/issue/ADS-1092/add-blaze-mcp-stop-campaign-ability-with-preview-and-confirm.

Sandcastle run log is local at `.agent-runs/jetpack/ADS-1092-2026-05-13T13-43-13-542Z/sandcastle.log`.

This PR was created as draft and must be reviewed by a human before merge.