### PR TITLE
Revert "Social: Default per-network mode from connection templates" and use backend template

### DIFF
--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -2,7 +2,7 @@ import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
 import { CUSTOMIZE_PER_NETWORK_KEY } from '../../social-store/constants';
 import { features, hasSocialPaidFeatures } from '../../utils';
@@ -23,53 +23,24 @@ export function usePerNetworkCustomization() {
 	const { editPost } = useDispatch( editorStore );
 	const { customizeConnectionById } = useDispatch( socialStore );
 	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
-	const [ templateDefaultDisabled, setTemplateDefaultDisabled ] = useState( false );
 
 	// Get featured image details for syncing to connections
 	const featuredImageId = useFeaturedImage();
 	const [ featuredImageDetails ] = useMediaDetails( featuredImageId );
 	const featuredImageUrl = featuredImageDetails?.mediaData?.sourceUrl;
 	const featuredImageMime = featuredImageDetails?.metaData?.mime ?? 'image/jpeg';
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
-	const hasConnectionTemplate = connections.some(
-		connection => typeof connection.template === 'string' && connection.template.trim() !== ''
-	);
-	const hasUserSetCustomizePerNetwork = Boolean(
-		postMeta.jetpackSocialOptions.customize_per_network_user_set
-	);
 
-	const isMetaEnabled = useSelect( select => {
+	const isEnabled = useSelect( select => {
 		const meta = select( editorStore ).getEditedPostAttribute( 'meta' );
 
 		return Boolean( meta?.[ CUSTOMIZE_PER_NETWORK_KEY ] );
 	}, [] );
-	const shouldUseTemplateDefault =
-		templatesEnabled &&
-		hasConnectionTemplate &&
-		! isMetaEnabled &&
-		! hasUserSetCustomizePerNetwork &&
-		! templateDefaultDisabled;
-	const isEnabled = hasUserSetCustomizePerNetwork
-		? isMetaEnabled
-		: isMetaEnabled || shouldUseTemplateDefault;
-
-	useEffect( () => {
-		if ( ! shouldUseTemplateDefault || ! hasSocialPaidFeatures() ) {
-			return;
-		}
-
-		editPost( {
-			meta: {
-				[ CUSTOMIZE_PER_NETWORK_KEY ]: true,
-			},
-		} );
-	}, [ shouldUseTemplateDefault, editPost ] );
 
 	const syncConnections = useCallback( () => {
 		/*
 		 * Don't sync when the message-templates feature is on. Server-side defaults
 		 */
-		if ( templatesEnabled ) {
+		if ( siteHasFeature( features.MESSAGE_TEMPLATES ) ) {
 			return;
 		}
 
@@ -101,7 +72,6 @@ export function usePerNetworkCustomization() {
 		featuredImageId,
 		featuredImageUrl,
 		featuredImageMime,
-		templatesEnabled,
 	] );
 
 	const toggle = useCallback( () => {
@@ -111,32 +81,17 @@ export function usePerNetworkCustomization() {
 			enabled: isNowEnabled,
 		} );
 
-		setTemplateDefaultDisabled( ! isNowEnabled && templatesEnabled && hasConnectionTemplate );
-
 		// Update post metadata.
 		editPost( {
 			meta: {
 				[ CUSTOMIZE_PER_NETWORK_KEY ]: isNowEnabled,
-				jetpack_social_options: {
-					...postMeta.jetpackSocialOptions,
-					customize_per_network_user_set: true,
-					version: 2,
-				},
 			},
 		} );
 
 		if ( isNowEnabled ) {
 			syncConnections();
 		}
-	}, [
-		isEnabled,
-		recordEvent,
-		templatesEnabled,
-		hasConnectionTemplate,
-		editPost,
-		postMeta.jetpackSocialOptions,
-		syncConnections,
-	] );
+	}, [ isEnabled, recordEvent, editPost, syncConnections ] );
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/test/index.test.ts
@@ -1,15 +1,6 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { act, renderHook } from '@testing-library/react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { usePerNetworkCustomization } from '../';
-
-jest.mock( '@automattic/jetpack-script-data', () => {
-	const actual = jest.requireActual( '@automattic/jetpack-script-data' );
-	return {
-		...actual,
-		siteHasFeature: jest.fn(),
-	};
-} );
 
 jest.mock( '@wordpress/data', () => {
 	const actual = jest.requireActual( '@wordpress/data' );
@@ -30,11 +21,14 @@ jest.mock( '../../use-featured-image', () => jest.fn( () => null ) );
 // Mock useMediaDetails to avoid nested useSelect calls
 jest.mock( '../../use-media-details', () => jest.fn( () => [ null ] ) );
 
-const mockUsePostMeta = jest.fn();
-
 // Mock usePostMeta to avoid nested hook calls
 jest.mock( '../../use-post-meta', () => ( {
-	usePostMeta: () => mockUsePostMeta(),
+	usePostMeta: jest.fn( () => ( {
+		attachedMedia: [],
+		imageGeneratorSettings: { enabled: false },
+		mediaSource: undefined,
+		shareMessage: '',
+	} ) ),
 } ) );
 
 // Mock useAnalytics to avoid deep dependency chain
@@ -42,17 +36,22 @@ jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	useAnalytics: jest.fn( () => ( { recordEvent: jest.fn() } ) ),
 } ) );
 
+// Mock hasSocialPaidFeatures to return true by default
+jest.mock( '../../../utils', () => {
+	const actual = jest.requireActual( '../../../utils' );
+	return {
+		...actual,
+		hasSocialPaidFeatures: jest.fn( () => true ),
+	};
+} );
+
 const mockUseDispatch = useDispatch as jest.Mock;
 const mockUseSelect = useSelect as jest.Mock;
-const mockSiteHasFeature = siteHasFeature as jest.Mock;
 
-const createMockSelect = (
-	meta: Record< string, unknown > = {},
-	connections: Array< Record< string, unknown > > = []
-) => {
+const createMockSelect = ( meta: Record< string, unknown > = {} ) => {
 	return () => ( {
 		getEditedPostAttribute: jest.fn().mockReturnValue( meta ),
-		getConnections: jest.fn().mockReturnValue( connections ),
+		getConnections: jest.fn().mockReturnValue( [] ),
 		getEnabledConnections: jest.fn().mockReturnValue( [] ),
 		getDisabledConnections: jest.fn().mockReturnValue( [] ),
 	} );
@@ -69,18 +68,6 @@ describe( 'usePerNetworkCustomization', () => {
 			editPost: mockEditPost,
 			customizeConnectionById: mockCustomizeConnectionById,
 		} );
-
-		mockUsePostMeta.mockReturnValue( {
-			attachedMedia: [],
-			imageGeneratorSettings: { enabled: false },
-			jetpackSocialOptions: {},
-			mediaSource: undefined,
-			shareMessage: '',
-		} );
-
-		mockSiteHasFeature.mockImplementation( feature =>
-			[ 'social-message-templates', 'social-enhanced-publishing' ].includes( feature )
-		);
 	} );
 
 	it( 'should return isEnabled as false when meta key is not set', () => {
@@ -91,7 +78,6 @@ describe( 'usePerNetworkCustomization', () => {
 		const { result } = renderHook( () => usePerNetworkCustomization() );
 
 		expect( result.current.isEnabled ).toBe( false );
-		expect( mockEditPost ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should return isEnabled as true when meta key is true', () => {
@@ -106,143 +92,6 @@ describe( 'usePerNetworkCustomization', () => {
 		const { result } = renderHook( () => usePerNetworkCustomization() );
 
 		expect( result.current.isEnabled ).toBe( true );
-		expect( mockEditPost ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should default to enabled when message templates are enabled and a connection has a custom template', () => {
-		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			return selector(
-				createMockSelect(
-					{
-						_wpas_customize_per_network: false,
-					},
-					[
-						{
-							connection_id: 'connection-1',
-							template: 'Custom template',
-						},
-					]
-				)
-			);
-		} );
-
-		const { result } = renderHook( () => usePerNetworkCustomization() );
-
-		expect( result.current.isEnabled ).toBe( true );
-		expect( mockEditPost ).toHaveBeenCalledWith( {
-			meta: {
-				_wpas_customize_per_network: true,
-			},
-		} );
-	} );
-
-	it( 'should respect an explicitly saved global mode when a connection has a custom template', () => {
-		mockUsePostMeta.mockReturnValue( {
-			attachedMedia: [],
-			imageGeneratorSettings: { enabled: false },
-			jetpackSocialOptions: {
-				customize_per_network_user_set: true,
-			},
-			mediaSource: undefined,
-			shareMessage: '',
-		} );
-		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			return selector(
-				createMockSelect(
-					{
-						_wpas_customize_per_network: false,
-					},
-					[
-						{
-							connection_id: 'connection-1',
-							template: 'Custom template',
-						},
-					]
-				)
-			);
-		} );
-
-		const { result } = renderHook( () => usePerNetworkCustomization() );
-
-		expect( result.current.isEnabled ).toBe( false );
-		expect( mockEditPost ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should not default to enabled when the connection template is blank', () => {
-		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			return selector(
-				createMockSelect( {}, [
-					{
-						connection_id: 'connection-1',
-						template: '   ',
-					},
-				] )
-			);
-		} );
-
-		const { result } = renderHook( () => usePerNetworkCustomization() );
-
-		expect( result.current.isEnabled ).toBe( false );
-		expect( mockEditPost ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should not default to enabled when message templates are disabled', () => {
-		mockSiteHasFeature.mockReturnValue( false );
-		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			return selector(
-				createMockSelect( {}, [
-					{
-						connection_id: 'connection-1',
-						template: 'Custom template',
-					},
-				] )
-			);
-		} );
-
-		const { result } = renderHook( () => usePerNetworkCustomization() );
-
-		expect( result.current.isEnabled ).toBe( false );
-		expect( mockEditPost ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should allow turning off the template-based default for the current editor session', () => {
-		let meta = {};
-		const connections = [
-			{
-				connection_id: 'connection-1',
-				template: 'Custom template',
-			},
-		];
-
-		mockEditPost.mockImplementation( ( update: { meta: Record< string, unknown > } ) => {
-			meta = {
-				...meta,
-				...update.meta,
-			};
-		} );
-		mockUseSelect.mockImplementation( ( selector: ( select: unknown ) => unknown ) => {
-			return selector( createMockSelect( meta, connections ) );
-		} );
-
-		const { result, rerender } = renderHook( () => usePerNetworkCustomization() );
-
-		expect( result.current.isEnabled ).toBe( true );
-
-		act( () => {
-			result.current.toggle();
-		} );
-		rerender();
-
-		expect( result.current.isEnabled ).toBe( false );
-		expect( mockEditPost ).toHaveBeenLastCalledWith( {
-			meta: {
-				_wpas_customize_per_network: false,
-				jetpack_social_options: {
-					customize_per_network_user_set: true,
-					version: 2,
-				},
-			},
-		} );
 	} );
 
 	it( 'should toggle the meta value when toggle is called', () => {
@@ -263,10 +112,6 @@ describe( 'usePerNetworkCustomization', () => {
 		expect( mockEditPost ).toHaveBeenCalledWith( {
 			meta: {
 				_wpas_customize_per_network: true,
-				jetpack_social_options: {
-					customize_per_network_user_set: true,
-					version: 2,
-				},
 			},
 		} );
 	} );

--- a/projects/packages/publicize/_inc/utils/types.ts
+++ b/projects/packages/publicize/_inc/utils/types.ts
@@ -18,7 +18,6 @@ export type MediaSourceValue = 'featured-image' | 'sig' | 'media-library' | 'upl
 
 export type JetpackSocialOptions = {
 	attached_media?: Array< AttachedMedia >;
-	customize_per_network_user_set?: boolean;
 	image_generator_settings?: SIGSettings;
 	media_source?: MediaSourceValue;
 };

--- a/projects/packages/publicize/changelog/social-482-per-network-template-default
+++ b/projects/packages/publicize/changelog/social-482-per-network-template-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Enable per-network customization by default when a custom connection template exists.

--- a/projects/packages/publicize/changelog/social-482-per-network-template-default
+++ b/projects/packages/publicize/changelog/social-482-per-network-template-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Default per-network customization to enabled only when a custom connection template exists.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1231,10 +1231,10 @@ abstract class Publicize_Base {
 				'schema' => array(
 					'type'       => 'object',
 					'properties' => array(
-						'version'                        => array(
+						'version'                  => array(
 							'type' => 'number',
 						),
-						'attached_media'                 => array(
+						'attached_media'           => array(
 							'type'  => 'array',
 							'items' => array(
 								'type'       => 'object',
@@ -1251,10 +1251,7 @@ abstract class Publicize_Base {
 								),
 							),
 						),
-						'customize_per_network_user_set' => array(
-							'type' => 'boolean',
-						),
-						'image_generator_settings'       => array(
+						'image_generator_settings' => array(
 							'type'       => 'object',
 							'properties' => array(
 								'enabled'          => array(
@@ -1283,7 +1280,7 @@ abstract class Publicize_Base {
 								),
 							),
 						),
-						'media_source'                   => array(
+						'media_source'             => array(
 							'type' => 'string',
 							'enum' => array( 'featured-image', 'sig', 'media-library', 'upload-video', 'none' ),
 						),

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1298,11 +1298,16 @@ abstract class Publicize_Base {
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 
+		$customize_per_network_default = (
+			Current_Plan::supports( 'social-message-templates' )
+			&& $this->any_connection_has_custom_template()
+		);
+
 		$customize_per_network_args = array(
 			'type'          => 'boolean',
 			'description'   => __( 'Whether to enable per-network customization.', 'jetpack-publicize-pkg' ),
 			'single'        => true,
-			'default'       => false,
+			'default'       => $customize_per_network_default,
 			'show_in_rest'  => $this->has_paid_features(),
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
@@ -1326,6 +1331,21 @@ abstract class Publicize_Base {
 			register_meta( 'post', self::POST_CONNECTION_OVERRIDES, $connection_overrides_args );
 			register_meta( 'post', self::POST_CUSTOMIZE_PER_NETWORK, $customize_per_network_args );
 		}
+	}
+
+	/**
+	 * Whether any connection available to the current user has a custom message template.
+	 *
+	 * @return bool
+	 */
+	protected function any_connection_has_custom_template() {
+		foreach ( Connections::get_all_for_user() as $connection ) {
+			if ( '' !== trim( (string) ( $connection['template'] ?? '' ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
+++ b/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Current_Plan;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -86,6 +87,7 @@ class Connections_Post_Field_Test extends TestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		self::reset_active_plan_cache();
 		global $publicize;
 		$this->publicize = $this->getMockBuilder( Publicize::class )->onlyMethods( array( 'refresh_connections', 'test_connection', 'has_paid_features' ) )->getMock();
 
@@ -174,20 +176,102 @@ class Connections_Post_Field_Test extends TestCase {
 		parent::tearDown();
 		unregister_post_type( 'example-with' );
 		unregister_post_type( 'example-without' );
-		$publicizeable_post_types = array();
-		foreach ( get_post_types() as $post_type ) {
-			if ( ! $this->publicize->post_type_is_publicizeable( $post_type ) ) {
-				continue;
-			}
-
-			$publicizeable_post_types[] = $post_type;
-			unregister_meta_key( 'post', $this->publicize->POST_MESS, $post_type );
-		}
+		$this->unregister_publicize_post_meta();
 
 		remove_post_type_support( 'post', 'publicize' );
+		delete_transient( Connections::CONNECTIONS_TRANSIENT );
+		self::reset_active_plan_cache();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Force the next `Current_Plan::get()` to re-read from the option store.
+	 */
+	private static function reset_active_plan_cache() {
+		$reflection = new \ReflectionClass( Current_Plan::class );
+		$property   = $reflection->getProperty( 'active_plan_cache' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Set the active plan features.
+	 *
+	 * @param array $features Active plan features.
+	 */
+	private function set_active_plan_features( $features ) {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = $features;
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+		self::reset_active_plan_cache();
+	}
+
+	/**
+	 * Unregister Publicize post meta keys.
+	 */
+	private function unregister_publicize_post_meta() {
+		$meta_keys = array(
+			$this->publicize->POST_MESS,
+			Publicize_Base::POST_PUBLICIZE_FEATURE_ENABLED,
+			$this->publicize->POST_DONE . 'all',
+			Publicize_Base::POST_JETPACK_SOCIAL_OPTIONS,
+			Publicize_Base::POST_CONNECTION_OVERRIDES,
+			Publicize_Base::POST_CUSTOMIZE_PER_NETWORK,
+		);
+
+		foreach ( get_post_types() as $post_type ) {
+			foreach ( $meta_keys as $meta_key ) {
+				unregister_meta_key( 'post', $meta_key, $post_type );
+			}
+		}
+	}
+
+	/**
+	 * Re-register Publicize post meta keys.
+	 */
+	private function reregister_publicize_post_meta() {
+		$this->unregister_publicize_post_meta();
+		$this->publicize->register_post_meta();
+	}
+
+	/**
+	 * Get the registered default for the per-network customization meta key.
+	 *
+	 * @return bool
+	 */
+	private function get_customize_per_network_registered_default() {
+		$registered_meta = get_registered_meta_keys( 'post', 'post' );
+
+		return $registered_meta[ Publicize_Base::POST_CUSTOMIZE_PER_NETWORK ]['default'];
+	}
+
+	/**
+	 * Set the cached connections list.
+	 *
+	 * @param string $template Connection template value.
+	 */
+	private function set_cached_connection_with_template( $template ) {
+		set_transient(
+			Connections::CONNECTIONS_TRANSIENT,
+			array(
+				array(
+					'service_name'  => 'facebook',
+					'id'            => 'facebook-1',
+					'connection_id' => 'facebook-1000',
+					'external_id'   => 'external-facebook-1',
+					'shared'        => true,
+					'template'      => $template,
+					'wpcom_user_id' => 0,
+					'status'        => 'ok',
+				),
+			),
+			HOUR_IN_SECONDS
+		);
 	}
 
 	/**
@@ -231,6 +315,68 @@ class Connections_Post_Field_Test extends TestCase {
 		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
 		$this->assertArrayHasKey( 'meta', $schema['properties'] );
 		$this->assertArrayHasKey( 'jetpack_publicize_message', $schema['properties']['meta']['properties'] );
+	}
+
+	/**
+	 * Test that per-network customization defaults on with a custom connection template.
+	 */
+	public function test_customize_per_network_defaults_on_with_custom_connection_template() {
+		$this->publicize->method( 'has_paid_features' )
+			->willReturn( true );
+		$this->set_active_plan_features( array( 'social-message-templates' ) );
+		$this->set_cached_connection_with_template( 'Custom template' );
+		$this->reregister_publicize_post_meta();
+
+		$this->assertTrue( $this->get_customize_per_network_registered_default() );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['meta'][ Publicize_Base::POST_CUSTOMIZE_PER_NETWORK ] );
+	}
+
+	/**
+	 * Test that per-network customization defaults off without a custom connection template.
+	 */
+	public function test_customize_per_network_defaults_off_without_custom_connection_template() {
+		$this->publicize->method( 'has_paid_features' )
+			->willReturn( true );
+		$this->set_active_plan_features( array( 'social-message-templates' ) );
+		$this->set_cached_connection_with_template( '   ' );
+		$this->reregister_publicize_post_meta();
+
+		$this->assertFalse( $this->get_customize_per_network_registered_default() );
+	}
+
+	/**
+	 * Test that an explicitly saved false value overrides the dynamic default.
+	 */
+	public function test_customize_per_network_explicit_false_overrides_template_default() {
+		$this->publicize->method( 'has_paid_features' )
+			->willReturn( true );
+		$this->set_active_plan_features( array( 'social-message-templates' ) );
+		$this->set_cached_connection_with_template( 'Custom template' );
+		$this->reregister_publicize_post_meta();
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$request->set_body_params(
+			array(
+				'meta' => array(
+					Publicize_Base::POST_CUSTOMIZE_PER_NETWORK => false,
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['meta'][ Publicize_Base::POST_CUSTOMIZE_PER_NETWORK ] );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['meta'][ Publicize_Base::POST_CUSTOMIZE_PER_NETWORK ] );
 	}
 
 	/**


### PR DESCRIPTION


Fixes SOCIAL-482

## Proposed changes
* Reverts Automattic/jetpack#48721 and uses backend template as mentioned in the other PR discussions. Follow testing from that PR - revert [d7d647d](https://github.com/Automattic/jetpack/pull/48785/commits/d7d647de2dcf1efd397cc8a51b15f1b024cd2b56)
* Changes of this branch - [5801108](https://github.com/Automattic/jetpack/pull/48785/commits/58011085503d5336eaa850a7794d9e84ecd1c5b7)

## Related product discussion/links
* SOCIAL-482

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Ensure Message Templates are enabled.
* In the Social admin page, save a custom template for one connection.
* Open a new or existing post that has not saved per-network customization as `true`; verify Customize each is selected by default.
* Clear the custom connection template, then open a post without per-network customization saved; verify Same for all remains selected.
* Run `pnpm --filter @automattic/jetpack-publicize test -- _inc/hooks/use-per-network-customization/test/index.test.ts`.
* Run `pnpm --filter @automattic/jetpack-publicize test`.
* Run `pnpm --filter @automattic/jetpack-publicize typecheck`.