### PR TITLE
jetpack-mu-wpcom: fix dropped log2logstash events on activation-block path

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-pcg-logstash-shutdown-defer
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-pcg-logstash-shutdown-defer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Plugin Conflicts Guardian: defer logstash dispatch to shutdown so events from the activation-block path are no longer dropped before transmission.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -845,16 +845,50 @@ class Jetpack_Mu_Wpcom {
 				return;
 			}
 
-			wp_remote_post(
-				'https://public-api.wordpress.com/rest/v1.1/logstash',
-				array(
-					'body'     => array( 'params' => wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ) ),
-					'blocking' => false,
-					'timeout'  => 1,
-				)
-			);
+			// Defer the HTTP POST to shutdown. Dispatching inline as a
+			// non-blocking request loses the event when the caller `exit`s
+			// or `wp_safe_redirect`s right after (e.g. the activation-guard
+			// block path), because the cURL handle is torn down before the
+			// TLS handshake completes. Draining at shutdown with a blocking
+			// POST guarantees delivery without adding latency to the
+			// user-visible response.
+			self::queue_logstash_http( $payload );
 		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must never escalate into a fatal for the caller.
 			unset( $e );
 		}
+	}
+
+	/**
+	 * Append a logstash payload to the shutdown drain queue, registering
+	 * the drain hook on first enqueue. See `log2logstash()` for why
+	 * dispatch is deferred.
+	 *
+	 * @param array $payload Logstash record (`blog_id`, `feature`, `message`, `extra`).
+	 * @return void
+	 */
+	private static function queue_logstash_http( array $payload ) {
+		static $queue = null;
+		if ( null === $queue ) {
+			$queue = array();
+			register_shutdown_function(
+				static function () use ( &$queue ) {
+					foreach ( $queue as $entry ) {
+						try {
+							wp_remote_post(
+								'https://public-api.wordpress.com/rest/v1.1/logstash',
+								array(
+									'body'    => array( 'params' => wp_json_encode( $entry, JSON_UNESCAPED_SLASHES ) ),
+									'timeout' => 5,
+								)
+							);
+						} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: a logging failure must never escalate into a fatal at shutdown.
+							unset( $e );
+						}
+					}
+					$queue = array();
+				}
+			);
+		}
+		$queue[] = $payload;
 	}
 }


### PR DESCRIPTION
## Summary

- The Atomic HTTP path of `Jetpack_Mu_Wpcom::log2logstash()` was firing `wp_remote_post` with `blocking => false` and `timeout => 1`, then returning to a caller that immediately `wp_safe_redirect`+`exit`s (Plugin Conflicts Guardian's activation-block path). PHP tore down the cURL handle mid-TLS-handshake and the POST never reached `public-api.wordpress.com/rest/v1.1/logstash`, so "Activation blocked" events were missing from Kibana while upgrader-path events still showed up.
- Queue payloads instead and drain them in a `register_shutdown_function` with blocking POSTs, mirroring `WPCOMSH_Log::send_to_api()`. Delivery is reliable, no added latency on the user-visible response.
- Only call site of this method today is the Plugin Conflicts Guardian feature; other in-tree `log2logstash(` calls go to the global Simple-only function and are unaffected.

## Does this pull request change what data or activity we track or use?

No. Same payloads to the same `logstash` endpoint — only the dispatch timing changes (queued and flushed on shutdown instead of fired inline).

## Testing instructions

- [ ] Sync this branch to an Atomic dev site via \`jetpack rsync\`.
- [ ] Trigger the activation-block path by activating a plugin that fatals on load.
- [ ] Confirm in Kibana that an \`Activation blocked\` event lands under \`feature:\"plugin-conflicts-guardian\"\` (previously missing).
- [ ] Verify existing upgrader-path events (\`update-healthcheck\`, \`update-guard\`) still arrive — they were working before, should keep working.
- [ ] Spot-check that the activation-block admin notice still renders and the redirect still happens promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)