### PR TITLE
Write editor: Fix link popover hidden behind toolbar when banners are visible

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write_banner_link_display
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write_banner_link_display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: Fix link popover hidden behind toolbar when banners are visible

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -247,9 +247,14 @@
 	color: #333;
 }
 
-/* Push toolbar and content down when recovery banner is visible */
+/* Push toolbar, link popover, and content down
+   when recovery banner is visible */
 .bw-recovery-banner:not([hidden]) ~ .bw-toolbar {
 	top: 100px;
+}
+
+.bw-recovery-banner:not([hidden]) ~ .bw-link-popover {
+	top: 144px;
 }
 
 .bw-recovery-banner:not([hidden]) ~ .bw-main {
@@ -297,9 +302,14 @@
 	color: #333;
 }
 
-/* Push toolbar and content down when disclaimer banner is visible */
+/* Push toolbar, link popover, and content down
+   when disclaimer banner is visible */
 .bw-disclaimer-banner:not([hidden]) ~ .bw-toolbar {
 	top: 100px;
+}
+
+.bw-disclaimer-banner:not([hidden]) ~ .bw-link-popover {
+	top: 144px;
 }
 
 .bw-disclaimer-banner:not([hidden]) ~ .bw-main {
@@ -313,6 +323,10 @@
 
 .bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-toolbar {
 	top: 144px;
+}
+
+.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-link-popover {
+	top: 188px;
 }
 
 .bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-main {


### PR DESCRIPTION
Fixes RSM-3078

## Proposed changes

* Fix the link popover being hidden behind the toolbar when the disclaimer banner and/or recovery banner is visible in the Write editor.
* The link popover had a hardcoded `top: 100px` but no CSS sibling rules to shift it down when banners appeared. The toolbar (z-index 99999) would slide over the popover (z-index 201), hiding it.
* Add CSS sibling-selector positioning rules for `.bw-link-popover` matching the existing pattern used for `.bw-toolbar` and `.bw-main`, covering: single disclaimer banner, single recovery banner, and both banners visible simultaneously.

## Related product discussion/links

* RSM-3078

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to a WordPress.com site with the Write editor enabled (e.g. via a Jurassic Ninja site with the `jetpack-mu-wpcom` package).
* Open the Write editor at `/write`.
* Ensure the beta disclaimer banner is visible (clear `wpcom-write-disclaimer-dismissed` from localStorage if previously dismissed).
* Select some text in the editor, then click the **Link** button in the toolbar.
* Verify the link popover appears directly below the toolbar and is fully visible and usable.
* Dismiss the disclaimer banner. Trigger the recovery banner by creating a draft, navigating away, and returning.
* Repeat the link popover test with only the recovery banner visible — confirm the popover still appears below the toolbar.
* If possible, test with both banners visible simultaneously and confirm the link popover remains correctly positioned below the toolbar.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
