### PR TITLE
Podcast dashboard: reorder tabs so Stats appears first

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-dashboard-tab-order
+++ b/projects/packages/podcast/changelog/update-podcast-dashboard-tab-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast dashboard: reorder tabs so Stats appears first, followed by Episodes, Distribution, and Settings.

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -40,9 +40,8 @@ const App = () => {
 	const { data: settings, isLoading } = usePodcastSettings();
 	const isSetUp = !! settings && settings.podcasting_category_id > 0;
 
-	// Set-up shows lead with Stats. Unconfigured (or post-Enable, pre-category) sites
-	// land on Settings so users can pick a category before Stats/Episodes/Distribution
-	// unlock.
+	// Stats/Episodes/Distribution are disabled until a category is picked, so the
+	// pre-set-up default has to be Settings.
 	const defaultTab: TabName = isSetUp ? 'stats' : 'settings';
 
 	// `?tab=` owns the active tab; absent `?tab=` falls back to `defaultTab`.

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -40,18 +40,24 @@ const App = () => {
 	const { data: settings, isLoading } = usePodcastSettings();
 	const isSetUp = !! settings && settings.podcasting_category_id > 0;
 
-	// Stats/Episodes/Distribution are disabled until a category is picked, so the
-	// pre-set-up default has to be Settings.
-	const defaultTab: TabName = isSetUp ? 'stats' : 'settings';
-
 	// `?tab=` owns the active tab; absent `?tab=` falls back to `defaultTab`.
 	const search = useSearch( { from: '/' as unknown as never, strict: false } ) as StageSearch;
-	const activeTab: TabName = isValidTab( search.tab ) ? search.tab : defaultTab;
 
 	// A `?tab=` deep link opts past the Welcome gate.
 	const [ hasEnabled, setHasEnabled ] = useState( () => isValidTab( search.tab ) );
 	const [ setupModalOpen, setSetupModalOpen ] = useState( false );
+	// Tracks the initial-setup flow that started at the Welcome screen, so
+	// `defaultTab` stays on Settings after the user saves their category and
+	// `isSetUp` flips true mid-edit. Without this, the post-save reflow would
+	// yank the user to Stats while they still have show fields to fill in.
+	const [ inWelcomeSetup, setInWelcomeSetup ] = useState( false );
 	const showWelcome = ! isSetUp && ! hasEnabled;
+
+	// Stats/Episodes/Distribution are disabled until a category is picked, so the
+	// pre-set-up default has to be Settings. Returning, set-up users land on Stats.
+	const defaultTab: TabName = isSetUp && ! inWelcomeSetup ? 'stats' : 'settings';
+
+	const activeTab: TabName = isValidTab( search.tab ) ? search.tab : defaultTab;
 
 	const navigate = useNavigate();
 
@@ -60,6 +66,9 @@ const App = () => {
 			if ( ! isValidTab( next ) ) {
 				return;
 			}
+			// Any explicit tab move ends the Welcome-setup pin so the URL/default
+			// switches to the returning-user shape.
+			setInWelcomeSetup( false );
 			navigate( {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
@@ -84,8 +93,8 @@ const App = () => {
 	const handleSetupSuccess = useCallback( () => {
 		setSetupModalOpen( false );
 		setHasEnabled( true );
-		handleTabChange( 'settings' );
-	}, [ handleTabChange ] );
+		setInWelcomeSetup( true );
+	}, [] );
 
 	const goToSettings = useCallback( () => {
 		handleTabChange( 'settings' );

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -66,6 +66,7 @@ const App = () => {
 			if ( ! isValidTab( next ) ) {
 				return;
 			}
+			const postClickDefaultTab: TabName = isSetUp ? 'stats' : 'settings';
 			// Any explicit tab move ends the Welcome-setup pin so the URL/default
 			// switches to the returning-user shape.
 			setInWelcomeSetup( false );
@@ -73,11 +74,11 @@ const App = () => {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
 					// Default tab keeps a clean URL.
-					tab: next === defaultTab ? undefined : next,
+					tab: next === postClickDefaultTab ? undefined : next,
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},
-		[ navigate, defaultTab ]
+		[ navigate, isSetUp ]
 	);
 
 	const handleEnable = useCallback( () => {

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -40,9 +40,14 @@ const App = () => {
 	const { data: settings, isLoading } = usePodcastSettings();
 	const isSetUp = !! settings && settings.podcasting_category_id > 0;
 
-	// `?tab=` owns the active tab; default (no `tab`) is Settings.
+	// Set-up shows lead with Stats. Unconfigured (or post-Enable, pre-category) sites
+	// land on Settings so users can pick a category before Stats/Episodes/Distribution
+	// unlock.
+	const defaultTab: TabName = isSetUp ? 'stats' : 'settings';
+
+	// `?tab=` owns the active tab; absent `?tab=` falls back to `defaultTab`.
 	const search = useSearch( { from: '/' as unknown as never, strict: false } ) as StageSearch;
-	const activeTab: TabName = isValidTab( search.tab ) ? search.tab : 'settings';
+	const activeTab: TabName = isValidTab( search.tab ) ? search.tab : defaultTab;
 
 	// A `?tab=` deep link opts past the Welcome gate.
 	const [ hasEnabled, setHasEnabled ] = useState( () => isValidTab( search.tab ) );
@@ -60,11 +65,11 @@ const App = () => {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
 					// Default tab keeps a clean URL.
-					tab: next === 'settings' ? undefined : next,
+					tab: next === defaultTab ? undefined : next,
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},
-		[ navigate ]
+		[ navigate, defaultTab ]
 	);
 
 	const handleEnable = useCallback( () => {
@@ -131,23 +136,23 @@ const App = () => {
 			<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
 				<div className="jp-admin-page-tabs">
 					<Tabs.List variant="minimal">
-						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
+						<Tabs.Tab value="stats" disabled={ ! isSetUp }>
+							{ __( 'Stats', 'jetpack-podcast' ) }
+						</Tabs.Tab>
 						<Tabs.Tab value="episodes" disabled={ ! isSetUp }>
 							{ __( 'Episodes', 'jetpack-podcast' ) }
 						</Tabs.Tab>
 						<Tabs.Tab value="distribution" disabled={ ! isSetUp }>
 							{ __( 'Distribution', 'jetpack-podcast' ) }
 						</Tabs.Tab>
-						<Tabs.Tab value="stats" disabled={ ! isSetUp }>
-							{ __( 'Stats', 'jetpack-podcast' ) }
-						</Tabs.Tab>
+						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-podcast' ) }</Tabs.Tab>
 					</Tabs.List>
 				</div>
-				<Tabs.Panel value="settings">
-					<div className="podcast__tab-content podcast__tab-content--narrow">
+				<Tabs.Panel value="stats">
+					<div className="podcast__tab-content podcast__tab-content--xwide">
 						<ErrorBoundary>
 							<Suspense fallback={ <TabFallback /> }>
-								<SettingsTab onAfterDisable={ handleAfterDisable } />
+								<StatsTab />
 							</Suspense>
 						</ErrorBoundary>
 					</div>
@@ -170,11 +175,11 @@ const App = () => {
 						</ErrorBoundary>
 					</div>
 				</Tabs.Panel>
-				<Tabs.Panel value="stats">
-					<div className="podcast__tab-content podcast__tab-content--xwide">
+				<Tabs.Panel value="settings">
+					<div className="podcast__tab-content podcast__tab-content--narrow">
 						<ErrorBoundary>
 							<Suspense fallback={ <TabFallback /> }>
-								<StatsTab />
+								<SettingsTab onAfterDisable={ handleAfterDisable } />
 							</Suspense>
 						</ErrorBoundary>
 					</div>

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -46,16 +46,11 @@ const App = () => {
 	// A `?tab=` deep link opts past the Welcome gate.
 	const [ hasEnabled, setHasEnabled ] = useState( () => isValidTab( search.tab ) );
 	const [ setupModalOpen, setSetupModalOpen ] = useState( false );
-	// Tracks the initial-setup flow that started at the Welcome screen, so
-	// `defaultTab` stays on Settings after the user saves their category and
-	// `isSetUp` flips true mid-edit. Without this, the post-save reflow would
-	// yank the user to Stats while they still have show fields to fill in.
-	const [ inWelcomeSetup, setInWelcomeSetup ] = useState( false );
 	const showWelcome = ! isSetUp && ! hasEnabled;
 
 	// Stats/Episodes/Distribution are disabled until a category is picked, so the
 	// pre-set-up default has to be Settings. Returning, set-up users land on Stats.
-	const defaultTab: TabName = isSetUp && ! inWelcomeSetup ? 'stats' : 'settings';
+	const defaultTab: TabName = isSetUp ? 'stats' : 'settings';
 
 	const activeTab: TabName = isValidTab( search.tab ) ? search.tab : defaultTab;
 
@@ -66,19 +61,15 @@ const App = () => {
 			if ( ! isValidTab( next ) ) {
 				return;
 			}
-			const postClickDefaultTab: TabName = isSetUp ? 'stats' : 'settings';
-			// Any explicit tab move ends the Welcome-setup pin so the URL/default
-			// switches to the returning-user shape.
-			setInWelcomeSetup( false );
 			navigate( {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
 					// Default tab keeps a clean URL.
-					tab: next === postClickDefaultTab ? undefined : next,
+					tab: next === defaultTab ? undefined : next,
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},
-		[ navigate, isSetUp ]
+		[ navigate, defaultTab ]
 	);
 
 	const handleEnable = useCallback( () => {
@@ -94,8 +85,8 @@ const App = () => {
 	const handleSetupSuccess = useCallback( () => {
 		setSetupModalOpen( false );
 		setHasEnabled( true );
-		setInWelcomeSetup( true );
-	}, [] );
+		handleTabChange( 'settings' );
+	}, [ handleTabChange ] );
 
 	const goToSettings = useCallback( () => {
 		handleTabChange( 'settings' );


### PR DESCRIPTION
## Summary

Tab order goes Stats, Episodes, Distribution, Settings. For set-up sites the dashboard now lands on Stats (the tab a returning podcaster actually wants); unconfigured sites still land on Settings.

- Reorder `<Tabs.Tab>` and `<Tabs.Panel>` children in `projects/packages/podcast/src/dashboard/index.tsx`.
- Introduce a `defaultTab` constant: `isSetUp ? 'stats' : 'settings'`. Used both for the absent-`?tab=` fallback and for the clean-URL branch in `handleTabChange`.
- Welcome gate still runs first for brand-new users, and the post-Enable transitional state (`hasEnabled=true`, `isSetUp=false`) keeps landing on Settings so users can pick a category.

## Test plan

- [ ] Visit `/podcast` on a set-up site (e.g. [lookmaitsapodcast.home.blog](https://lookmaitsapodcast.home.blog)). Confirm tabs render left-to-right as Stats, Episodes, Distribution, Settings, and Stats is the active tab.
- [ ] Visit `/podcast` on an unconfigured site (no `podcasting_category_id`). Confirm the Welcome screen still shows.
- [ ] Click through every tab and confirm the URL drops `?tab=` only when you land on `stats` (set-up) or `settings` (unconfigured).
- [ ] Deep-link `/podcast?tab=settings` on a set-up site. Settings tab activates.
- [ ] After clicking Enable from the Welcome screen, confirm you land on Settings (not the disabled Stats tab).