### PR TITLE
Podcast Episodes: fall back to show cover image when episode has no featured image

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-episodes-image-fallback
+++ b/projects/packages/podcast/changelog/update-podcast-episodes-image-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast Episodes: fall back to the show cover image when an episode has no featured image.

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -74,6 +74,7 @@ const STATUS_LABELS: Record< string, string > = {
 const EpisodesTab = () => {
 	const { data: settings } = usePodcastSettings();
 	const categoryId = settings?.podcasting_category_id ?? 0;
+	const showCoverImage = settings?.podcasting_image ?? '';
 
 	const [ view, setView ] = useState< View >( defaultView );
 
@@ -116,7 +117,10 @@ const EpisodesTab = () => {
 			const media = post._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
 			const sizes = media?.media_details?.sizes;
 			const thumbnail =
-				sizes?.thumbnail?.source_url ?? sizes?.medium?.source_url ?? media?.source_url ?? '';
+				sizes?.thumbnail?.source_url ??
+				sizes?.medium?.source_url ??
+				media?.source_url ??
+				showCoverImage;
 			const stat = statsByPostId.get( post.id );
 			return {
 				id: post.id,
@@ -129,7 +133,7 @@ const EpisodesTab = () => {
 				durationSeconds: stat?.duration_seconds ?? null,
 			};
 		} );
-	}, [ posts, statsByPostId ] );
+	}, [ posts, statsByPostId, showCoverImage ] );
 
 	const fields = useMemo(
 		() => [


### PR DESCRIPTION
## Proposed changes

* When an episode has no featured image, the Episodes table now falls back to the show cover image (`settings.podcasting_image`) at the same 56x56 styling.
* Before: removing the featured image left a blank dashed-border placeholder in the thumb column.
* After: the show cover renders, and the placeholder only shows when both the post and the show have no image.

The render path in the `media` field is unchanged. Only the thumbnail resolution gains a fallback step.

## Related product discussion/links

* Spotted on Rob's test site (lookmaitsapodcast). Episode 6 showed the empty placeholder after he removed the featured image, even though the show cover was set.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a podcast site with a show cover image set (lookmaitsapodcast works), open the Jetpack Podcast dashboard.
2. In the Episodes tab, find an episode that has no featured image. Confirm the thumbnail column renders the show cover image at 56x56, not the dashed placeholder.
3. Pick an episode that has its own featured image and confirm that per-episode image still wins.
4. Remove the show cover in Podcast settings, reload Episodes, and confirm the dashed placeholder renders for episodes that also have no featured image (legitimate empty state).
