### PR TITLE
Podcast Settings: create new categories inline from the dashboard

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-settings-category-modal
+++ b/projects/packages/podcast/changelog/update-podcast-settings-category-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast Settings: create new categories inline without leaving the podcast dashboard.

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -16,6 +16,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -95,7 +96,7 @@ const SettingsTab = () => {
 	const [ createError, setCreateError ] = useState< string | null >( null );
 	const [ creating, setCreating ] = useState( false );
 
-	const { saveEntityRecord } = useDispatch( 'core' );
+	const { saveEntityRecord } = useDispatch( coreStore );
 
 	useEffect( () => {
 		if ( settings && ! draft ) {

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -229,18 +229,38 @@ const SettingsTab = () => {
 		setCreating( true );
 		setCreateError( null );
 		try {
-			const result = ( await saveEntityRecord( 'taxonomy', 'category', { name } ) ) as
-				| { id?: number }
-				| undefined;
-			if ( result?.id ) {
-				commit( { podcasting_category_id: Number( result.id ) } );
+			// `saveEntityRecord` swallows REST failures by default and resolves
+			// `undefined`. Without `throwOnError`, a duplicate name or missing
+			// `manage_categories` capability would silently close the modal
+			// without selecting a category. Opt in so the catch below fires.
+			const result = ( await saveEntityRecord(
+				'taxonomy',
+				'category',
+				{ name },
+				{ throwOnError: true }
+			) ) as { id?: number } | undefined;
+			if ( ! result?.id ) {
+				throw new Error(
+					__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
+				);
 			}
+			commit( { podcasting_category_id: Number( result.id ) } );
 			closeCreateCategory();
 		} catch ( error ) {
-			const message =
-				error instanceof Error
-					? error.message
-					: __( 'Could not create the category. Please try again.', 'jetpack-podcast' );
+			// REST failures throw the raw response object (`{ code, message, data }`),
+			// not an Error instance, so check both shapes.
+			const fallback = __( 'Could not create the category. Please try again.', 'jetpack-podcast' );
+			let message = fallback;
+			if ( error instanceof Error ) {
+				message = error.message;
+			} else if (
+				error &&
+				typeof error === 'object' &&
+				'message' in error &&
+				typeof ( error as { message: unknown } ).message === 'string'
+			) {
+				message = ( error as { message: string } ).message;
+			}
 			setCreateError( message );
 		} finally {
 			setCreating( false );

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -17,7 +17,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
@@ -97,6 +97,14 @@ const SettingsTab = () => {
 	const [ creating, setCreating ] = useState( false );
 
 	const { saveEntityRecord } = useDispatch( coreStore );
+
+	// `canUser` returns `undefined` while resolving, then `true`/`false`. Treat
+	// the loading state as "allowed" so the button doesn't flash hidden; only
+	// hide it once the REST OPTIONS probe definitively says no.
+	const canCreateCategory = useSelect(
+		select => select( coreStore ).canUser( 'create', 'categories' ),
+		[]
+	);
 
 	useEffect( () => {
 		if ( settings && ! draft ) {
@@ -325,9 +333,11 @@ const SettingsTab = () => {
 								...categories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
 							] }
 						/>
-						<Button variant="link" onClick={ openCreateCategory }>
-							{ __( 'Create a new category', 'jetpack-podcast' ) }
-						</Button>
+						{ canCreateCategory !== false && (
+							<Button variant="link" onClick={ openCreateCategory }>
+								{ __( 'Create a new category', 'jetpack-podcast' ) }
+							</Button>
+						) }
 					</VStack>
 				</CardBody>
 			</Card>

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -215,11 +215,25 @@ const SettingsTab = () => {
 	}, [ commit ] );
 
 	const openCreateCategory = useCallback( () => setCreateCategoryOpen( true ), [] );
-	const closeCreateCategory = useCallback( () => {
-		setCreateCategoryOpen( false );
-		setNewCategoryName( '' );
-		setCreateError( null );
-	}, [] );
+	// `force` skips the in-flight guard so the success path can reset state
+	// while the finally block still has `creating === true`. The Cancel
+	// button and `onRequestClose` always pass `false` so the user can't
+	// dismiss mid-create and leave the promise to mutate settings after.
+	const closeCreateCategory = useCallback(
+		( force = false ) => {
+			if ( ! force && creating ) {
+				return;
+			}
+			setCreateCategoryOpen( false );
+			setNewCategoryName( '' );
+			setCreateError( null );
+		},
+		[ creating ]
+	);
+	const requestCloseCreateCategory = useCallback(
+		() => closeCreateCategory(),
+		[ closeCreateCategory ]
+	);
 
 	const onCreateCategory = useCallback( async () => {
 		const name = newCategoryName.trim();
@@ -245,7 +259,7 @@ const SettingsTab = () => {
 				);
 			}
 			commit( { podcasting_category_id: Number( result.id ) } );
-			closeCreateCategory();
+			closeCreateCategory( true );
 		} catch ( error ) {
 			// REST failures throw the raw response object (`{ code, message, data }`),
 			// not an Error instance, so check both shapes.
@@ -468,7 +482,7 @@ const SettingsTab = () => {
 			{ createCategoryOpen && (
 				<Modal
 					title={ __( 'Create a new category', 'jetpack-podcast' ) }
-					onRequestClose={ closeCreateCategory }
+					onRequestClose={ requestCloseCreateCategory }
 				>
 					<VStack spacing={ 4 }>
 						{ createError && (
@@ -484,7 +498,11 @@ const SettingsTab = () => {
 							onChange={ setNewCategoryName }
 						/>
 						<HStack justify="flex-end" spacing={ 3 }>
-							<Button variant="tertiary" onClick={ closeCreateCategory }>
+							<Button
+								variant="tertiary"
+								onClick={ requestCloseCreateCategory }
+								disabled={ creating }
+							>
 								{ __( 'Cancel', 'jetpack-podcast' ) }
 							</Button>
 							<Button

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -1,4 +1,3 @@
-import { getAdminUrl } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,
@@ -17,9 +16,9 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
 import { getValidationIssues } from '../hooks/use-validation-issues';
 import CoverImageControl from './cover-image-control';
@@ -91,6 +90,12 @@ const SettingsTab = () => {
 
 	const [ draft, setDraft ] = useState< PodcastSettings | null >( null );
 	const [ confirmDisable, setConfirmDisable ] = useState( false );
+	const [ createCategoryOpen, setCreateCategoryOpen ] = useState( false );
+	const [ newCategoryName, setNewCategoryName ] = useState( '' );
+	const [ createError, setCreateError ] = useState< string | null >( null );
+	const [ creating, setCreating ] = useState( false );
+
+	const { saveEntityRecord } = useDispatch( 'core' );
 
 	useEffect( () => {
 		if ( settings && ! draft ) {
@@ -209,6 +214,41 @@ const SettingsTab = () => {
 		commit( { podcasting_category_id: 0 } );
 	}, [ commit ] );
 
+	const openCreateCategory = useCallback( () => setCreateCategoryOpen( true ), [] );
+	const closeCreateCategory = useCallback( () => {
+		setCreateCategoryOpen( false );
+		setNewCategoryName( '' );
+		setCreateError( null );
+	}, [] );
+
+	const onCreateCategory = useCallback( async () => {
+		const name = newCategoryName.trim();
+		if ( ! name ) {
+			return;
+		}
+		setCreating( true );
+		setCreateError( null );
+		try {
+			const result = ( await saveEntityRecord( 'taxonomy', 'category', { name } ) ) as
+				| { id?: number }
+				| undefined;
+			if ( result?.id ) {
+				commit( { podcasting_category_id: Number( result.id ) } );
+			}
+			setCreateCategoryOpen( false );
+			setNewCategoryName( '' );
+			setCreateError( null );
+		} catch ( error ) {
+			const message =
+				error instanceof Error
+					? error.message
+					: __( 'Could not create the category. Please try again.', 'jetpack-podcast' );
+			setCreateError( message );
+		} finally {
+			setCreating( false );
+		}
+	}, [ newCategoryName, saveEntityRecord, commit ] );
+
 	if ( isLoading || ! draft ) {
 		return null;
 	}
@@ -252,9 +292,9 @@ const SettingsTab = () => {
 								...categories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
 							] }
 						/>
-						<Link openInNewTab href={ getAdminUrl( 'edit-tags.php?taxonomy=category' ) }>
+						<Button variant="link" onClick={ openCreateCategory }>
 							{ __( 'Create a new category', 'jetpack-podcast' ) }
-						</Link>
+						</Button>
 					</VStack>
 				</CardBody>
 			</Card>
@@ -401,6 +441,41 @@ const SettingsTab = () => {
 							</Button>
 							<Button variant="primary" isDestructive onClick={ onDisablePodcasting }>
 								{ __( 'Disable podcasting', 'jetpack-podcast' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				</Modal>
+			) }
+
+			{ createCategoryOpen && (
+				<Modal
+					title={ __( 'Create a new category', 'jetpack-podcast' ) }
+					onRequestClose={ closeCreateCategory }
+				>
+					<VStack spacing={ 4 }>
+						{ createError && (
+							<Notice status="error" isDismissible={ false }>
+								{ createError }
+							</Notice>
+						) }
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Name', 'jetpack-podcast' ) }
+							value={ newCategoryName }
+							onChange={ setNewCategoryName }
+						/>
+						<HStack justify="flex-end" spacing={ 3 }>
+							<Button variant="tertiary" onClick={ closeCreateCategory }>
+								{ __( 'Cancel', 'jetpack-podcast' ) }
+							</Button>
+							<Button
+								variant="primary"
+								disabled={ newCategoryName.trim() === '' || creating }
+								isBusy={ creating }
+								onClick={ onCreateCategory }
+							>
+								{ __( 'Create', 'jetpack-podcast' ) }
 							</Button>
 						</HStack>
 					</VStack>

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -235,9 +235,7 @@ const SettingsTab = () => {
 			if ( result?.id ) {
 				commit( { podcasting_category_id: Number( result.id ) } );
 			}
-			setCreateCategoryOpen( false );
-			setNewCategoryName( '' );
-			setCreateError( null );
+			closeCreateCategory();
 		} catch ( error ) {
 			const message =
 				error instanceof Error
@@ -247,7 +245,7 @@ const SettingsTab = () => {
 		} finally {
 			setCreating( false );
 		}
-	}, [ newCategoryName, saveEntityRecord, commit ] );
+	}, [ newCategoryName, saveEntityRecord, commit, closeCreateCategory ] );
 
 	if ( isLoading || ! draft ) {
 		return null;


### PR DESCRIPTION
## Summary

Replaces the wp-admin link with an inline modal so podcasters can create a new category without leaving the Settings tab.

- "Create a new category" is now a `<Button variant="link">` that opens a modal with a name field.
- On submit, the modal calls `saveEntityRecord('taxonomy', 'category', { name })`, then auto-selects the new category by committing `podcasting_category_id` through the existing settings flow.
- The `useEntityRecords` cache invalidates after the save, so the dropdown refreshes naturally.
- Errors stay in the modal as a `<Notice status="error">`. The Create button shows a busy state while saving.

## Test plan

- [ ] On the Settings tab, click "Create a new category" and confirm a modal opens.
- [ ] Enter a name, click Create, and confirm the modal closes.
- [ ] Confirm the new category appears in the Podcast category dropdown and is auto-selected.
- [ ] Refresh the page and confirm the selection persists.
- [ ] Try Create with an empty name (button stays disabled).
- [ ] Force an API error (e.g. duplicate name) and confirm the error shows inline and the modal stays open.