### PR TITLE
Podcast Episodes: clicking a play count opens the episode stats drilldown

### DIFF
--- a/projects/packages/podcast/.gitignore
+++ b/projects/packages/podcast/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 build/
 dist/
 composer.lock
+
+# wp-build generated entry files
+/routes/**/.content-entry.js

--- a/projects/packages/podcast/changelog/update-podcast-episodes-plays-drilldown
+++ b/projects/packages/podcast/changelog/update-podcast-episodes-plays-drilldown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast Episodes: clicking a play count opens the episode stats drilldown in the Stats tab.

--- a/projects/packages/podcast/changelog/update-podcast-episodes-plays-drilldown
+++ b/projects/packages/podcast/changelog/update-podcast-episodes-plays-drilldown
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Podcast Episodes: clicking a play count opens the episode stats drilldown in the Stats tab.
+Podcast Episodes: open the episode stats drilldown from a play-count click in the Episodes tab.

--- a/projects/packages/podcast/routes/dashboard/.content-entry.js
+++ b/projects/packages/podcast/routes/dashboard/.content-entry.js
@@ -1,1 +1,0 @@
-export { stage } from './stage';

--- a/projects/packages/podcast/routes/dashboard/.content-entry.js
+++ b/projects/packages/podcast/routes/dashboard/.content-entry.js
@@ -1,0 +1,1 @@
+export { stage } from './stage';

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -107,6 +107,9 @@ const EpisodesTab = () => {
 					...prev,
 					tab,
 					episode: episodeId,
+					// Episodes tab shows all-time plays, so open the drilldown at the
+					// widest window the episode endpoint supports ("Last year").
+					period: 'all',
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import { DataViews, type Action, type View, type ViewTable } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { usePodcastSettings } from '../hooks/use-podcast-settings';
 import './style.scss';
@@ -68,13 +68,22 @@ const getEpisodeRowId = ( item: EpisodeRow ) => String( item.id );
 type PlaysCellProps = {
 	count: number;
 	episodeId: number;
+	episodeTitle: string;
 	onOpen: ( episodeId: number ) => void;
 };
 
-const PlaysCell = ( { count, episodeId, onOpen }: PlaysCellProps ) => {
+const PlaysCell = ( { count, episodeId, episodeTitle, onOpen }: PlaysCellProps ) => {
 	const handleClick = useCallback( () => onOpen( episodeId ), [ onOpen, episodeId ] );
 	return count > 0 ? (
-		<Button variant="link" onClick={ handleClick }>
+		<Button
+			variant="link"
+			onClick={ handleClick }
+			aria-label={ sprintf(
+				/* translators: %s: episode title */
+				__( 'View stats for %s', 'jetpack-podcast' ),
+				episodeTitle || __( '(Untitled)', 'jetpack-podcast' )
+			) }
+		>
 			{ count }
 		</Button>
 	) : (
@@ -218,7 +227,12 @@ const EpisodesTab = () => {
 				label: __( 'Plays', 'jetpack-podcast' ),
 				getValue: ( { item }: { item: EpisodeRow } ) => item.playsAll,
 				render: ( { item }: { item: EpisodeRow } ) => (
-					<PlaysCell count={ item.playsAll } episodeId={ item.id } onOpen={ openEpisodeStats } />
+					<PlaysCell
+						count={ item.playsAll }
+						episodeId={ item.id }
+						episodeTitle={ item.title }
+						onOpen={ openEpisodeStats }
+					/>
 				),
 				enableSorting: false,
 			},

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -2,10 +2,12 @@
 // merged client-side, so those columns are display-only (not sortable).
 
 import { getSiteData } from '@automattic/jetpack-script-data';
+import { Button } from '@wordpress/components';
 import { DataViews, type Action, type View, type ViewTable } from '@wordpress/dataviews';
-import { useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { useNavigate } from '@wordpress/route';
 import { usePodcastSettings } from '../hooks/use-podcast-settings';
 import './style.scss';
 import { useEpisodeStatsQuery } from './use-episode-stats-query';
@@ -63,6 +65,24 @@ const defaultView: ViewTable = {
 
 const getEpisodeRowId = ( item: EpisodeRow ) => String( item.id );
 
+type PlaysCellProps = {
+	count: number;
+	episodeId: number;
+	onOpen: ( episodeId: number ) => void;
+};
+
+const PlaysCell = ( { count, episodeId, onOpen }: PlaysCellProps ) => {
+	const handleClick = useCallback( () => onOpen( episodeId ), [ onOpen, episodeId ] );
+	if ( count <= 0 ) {
+		return <>{ count }</>;
+	}
+	return (
+		<Button variant="link" onClick={ handleClick }>
+			{ count }
+		</Button>
+	);
+};
+
 const STATUS_LABELS: Record< string, string > = {
 	publish: __( 'Published', 'jetpack-podcast' ),
 	future: __( 'Scheduled', 'jetpack-podcast' ),
@@ -77,6 +97,21 @@ const EpisodesTab = () => {
 	const showCoverImage = settings?.podcasting_image ?? '';
 
 	const [ view, setView ] = useState< View >( defaultView );
+
+	const navigate = useNavigate();
+
+	const openEpisodeStats = useCallback(
+		( episodeId: number ) => {
+			navigate( {
+				search: ( prev: Record< string, unknown > ) => ( {
+					...prev,
+					tab: 'stats',
+					episode: episodeId,
+				} ),
+			} as unknown as Parameters< typeof navigate >[ 0 ] );
+		},
+		[ navigate ]
+	);
 
 	const queryArgs = useMemo( () => {
 		const sortField = view.sort?.field;
@@ -179,6 +214,9 @@ const EpisodesTab = () => {
 				type: 'integer' as const,
 				label: __( 'Plays', 'jetpack-podcast' ),
 				getValue: ( { item }: { item: EpisodeRow } ) => item.playsAll,
+				render: ( { item }: { item: EpisodeRow } ) => (
+					<PlaysCell count={ item.playsAll } episodeId={ item.id } onOpen={ openEpisodeStats } />
+				),
 				enableSorting: false,
 			},
 			{
@@ -202,7 +240,7 @@ const EpisodesTab = () => {
 				enableSorting: true,
 			},
 		],
-		[]
+		[ openEpisodeStats ]
 	);
 
 	const actions = useMemo< Action< EpisodeRow >[] >(

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -12,7 +12,7 @@ import { usePodcastSettings } from '../hooks/use-podcast-settings';
 import './style.scss';
 import { useEpisodeStatsQuery } from './use-episode-stats-query';
 import { useEpisodesQuery } from './use-episodes-query';
-import type { EpisodeStats } from '../types';
+import type { EpisodeStats, TabName } from '../types';
 
 const ADMIN_URL = getSiteData()?.admin_url ?? '/wp-admin/';
 
@@ -73,13 +73,12 @@ type PlaysCellProps = {
 
 const PlaysCell = ( { count, episodeId, onOpen }: PlaysCellProps ) => {
 	const handleClick = useCallback( () => onOpen( episodeId ), [ onOpen, episodeId ] );
-	if ( count <= 0 ) {
-		return <>{ count }</>;
-	}
-	return (
+	return count > 0 ? (
 		<Button variant="link" onClick={ handleClick }>
 			{ count }
 		</Button>
+	) : (
+		<>{ count }</>
 	);
 };
 
@@ -102,10 +101,11 @@ const EpisodesTab = () => {
 
 	const openEpisodeStats = useCallback(
 		( episodeId: number ) => {
+			const tab: TabName = 'stats';
 			navigate( {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
-					tab: 'stats',
+					tab,
 					episode: episodeId,
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -52,13 +52,13 @@ const Stats = () => {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
 					episode: item.post_id,
-					// Top Episodes click inherits the show-level period via local state,
-					// so no `?period=` deep-link override is needed.
-					period: undefined,
+					// Carry the show-level period into the URL so refresh/share
+					// reopens the drilldown at the same window the user selected.
+					period,
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},
-		[ navigate ]
+		[ navigate, period ]
 	);
 
 	const handleBack = useCallback( () => {

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -6,7 +6,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
 import EpisodeStats from './components/episode-stats';
-import PeriodControl, { getPeriodHeading } from './components/period-control';
+import PeriodControl, { getPeriodHeading, isPeriod } from './components/period-control';
 import StatsByApp from './components/stats-by-app';
 import StatsByDayChart from './components/stats-by-day-chart';
 import StatsLocations from './components/stats-locations';
@@ -16,7 +16,10 @@ import './style.scss';
 import { useShowStatsQuery } from './use-show-stats-query';
 import type { PodcastStatsPeriod, PodcastStatsTopEpisode } from './types';
 
-type StatsSearch = Record< string, unknown > & { episode?: string | number };
+type StatsSearch = Record< string, unknown > & {
+	episode?: string | number;
+	period?: string;
+};
 
 const Stats = () => {
 	const blogId = Number( getSiteData()?.wpcom?.blog_id ?? 0 );
@@ -29,6 +32,11 @@ const Stats = () => {
 
 	const rawEpisode = Number( search.episode );
 	const selectedPostId = rawEpisode > 0 ? rawEpisode : null;
+
+	// `?period=` lets the Episodes-tab plays-click open the drilldown at the
+	// widest window. The show-level period is still owned by local state.
+	const urlPeriod =
+		typeof search.period === 'string' && isPeriod( search.period ) ? search.period : null;
 
 	// Episodes-tab plays-clicks deep-link with only the id, so the title is
 	// hydrated client-side via core-data.
@@ -44,6 +52,9 @@ const Stats = () => {
 				search: ( prev: Record< string, unknown > ) => ( {
 					...prev,
 					episode: item.post_id,
+					// Top Episodes click inherits the show-level period via local state,
+					// so no `?period=` deep-link override is needed.
+					period: undefined,
 				} ),
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},
@@ -55,6 +66,7 @@ const Stats = () => {
 			search: ( prev: Record< string, unknown > ) => ( {
 				...prev,
 				episode: undefined,
+				period: undefined,
 			} ),
 		} as unknown as Parameters< typeof navigate >[ 0 ] );
 	}, [ navigate ] );
@@ -90,7 +102,7 @@ const Stats = () => {
 				postId={ selectedPostId }
 				title={ title || __( '(Untitled)', 'jetpack-podcast' ) }
 				onBack={ handleBack }
-				initialPeriod={ period }
+				initialPeriod={ urlPeriod ?? period }
 			/>
 		);
 	}

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -1,7 +1,7 @@
 import { getSiteData } from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
 import { useEntityRecord } from '@wordpress/core-data';
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
@@ -27,17 +27,14 @@ const Stats = () => {
 	const search = useSearch( { from: '/' as unknown as never, strict: false } ) as StatsSearch;
 	const navigate = useNavigate();
 
-	const selectedPostId = useMemo( () => {
-		const raw = search.episode;
-		const n = typeof raw === 'number' ? raw : Number( raw );
-		return Number.isFinite( n ) && n > 0 ? n : null;
-	}, [ search.episode ] );
+	const rawEpisode = Number( search.episode );
+	const selectedPostId = rawEpisode > 0 ? rawEpisode : null;
 
-	// Fetch the post title for the URL-selected episode. Episodes-tab clicks
-	// supply only the id, so the title is hydrated client-side here.
+	// Episodes-tab plays-clicks deep-link with only the id, so the title is
+	// hydrated client-side via core-data.
 	const { record: selectedPost } = useEntityRecord< {
 		title?: { rendered?: string };
-	} >( 'postType', 'post', selectedPostId ?? 0 );
+	} >( 'postType', 'post', selectedPostId ?? 0, { enabled: selectedPostId !== null } );
 
 	const { data: stats, isLoading, isError } = useShowStatsQuery( period );
 

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -94,9 +94,14 @@ const Stats = () => {
 	}
 
 	if ( selectedPostId ) {
+		// Prefer the resolved entity record; fall back to the top_episodes list
+		// (already in memory) so the heading is correct immediately when the user
+		// clicks from the in-page Top Episodes list, before useEntityRecord settles.
+		const fallbackTitle =
+			stats?.top_episodes?.find( ep => ep.post_id === selectedPostId )?.title ?? '';
 		const title = selectedPost?.title?.rendered
 			? decodeEntities( selectedPost.title.rendered )
-			: '';
+			: fallbackTitle;
 		return (
 			<EpisodeStats
 				postId={ selectedPostId }

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -1,7 +1,10 @@
 import { getSiteData } from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
 import EpisodeStats from './components/episode-stats';
 import PeriodControl, { getPeriodHeading } from './components/period-control';
 import StatsByApp from './components/stats-by-app';
@@ -13,24 +16,60 @@ import './style.scss';
 import { useShowStatsQuery } from './use-show-stats-query';
 import type { PodcastStatsPeriod, PodcastStatsTopEpisode } from './types';
 
+type StatsSearch = Record< string, unknown > & { episode?: string | number };
+
 const Stats = () => {
 	const blogId = Number( getSiteData()?.wpcom?.blog_id ?? 0 );
 	const [ period, setPeriod ] = useState< PodcastStatsPeriod >( '30d' );
-	const [ selected, setSelected ] = useState< PodcastStatsTopEpisode | null >( null );
 	const headingRef = useRef< HTMLHeadingElement | null >( null );
-	const prevSelectedRef = useRef< PodcastStatsTopEpisode | null >( null );
+
+	// `?episode=` owns the drilldown so Episodes-tab plays-clicks deep-link in.
+	const search = useSearch( { from: '/' as unknown as never, strict: false } ) as StatsSearch;
+	const navigate = useNavigate();
+
+	const selectedPostId = useMemo( () => {
+		const raw = search.episode;
+		const n = typeof raw === 'number' ? raw : Number( raw );
+		return Number.isFinite( n ) && n > 0 ? n : null;
+	}, [ search.episode ] );
+
+	// Fetch the post title for the URL-selected episode. Episodes-tab clicks
+	// supply only the id, so the title is hydrated client-side here.
+	const { record: selectedPost } = useEntityRecord< {
+		title?: { rendered?: string };
+	} >( 'postType', 'post', selectedPostId ?? 0 );
 
 	const { data: stats, isLoading, isError } = useShowStatsQuery( period );
 
-	const handleBack = useCallback( () => setSelected( null ), [] );
+	const handleSelect = useCallback(
+		( item: PodcastStatsTopEpisode ) => {
+			navigate( {
+				search: ( prev: Record< string, unknown > ) => ( {
+					...prev,
+					episode: item.post_id,
+				} ),
+			} as unknown as Parameters< typeof navigate >[ 0 ] );
+		},
+		[ navigate ]
+	);
+
+	const handleBack = useCallback( () => {
+		navigate( {
+			search: ( prev: Record< string, unknown > ) => ( {
+				...prev,
+				episode: undefined,
+			} ),
+		} as unknown as Parameters< typeof navigate >[ 0 ] );
+	}, [ navigate ] );
 
 	// Return focus to the heading after leaving the drilldown; the back button has unmounted.
+	const prevSelectedIdRef = useRef< number | null >( null );
 	useEffect( () => {
-		if ( prevSelectedRef.current !== null && selected === null ) {
+		if ( prevSelectedIdRef.current !== null && selectedPostId === null ) {
 			headingRef.current?.focus();
 		}
-		prevSelectedRef.current = selected;
-	}, [ selected ] );
+		prevSelectedIdRef.current = selectedPostId;
+	}, [ selectedPostId ] );
 
 	if ( ! blogId ) {
 		return (
@@ -45,11 +84,14 @@ const Stats = () => {
 		);
 	}
 
-	if ( selected ) {
+	if ( selectedPostId ) {
+		const title = selectedPost?.title?.rendered
+			? decodeEntities( selectedPost.title.rendered )
+			: '';
 		return (
 			<EpisodeStats
-				postId={ selected.post_id }
-				title={ selected.title || __( '(Untitled)', 'jetpack-podcast' ) }
+				postId={ selectedPostId }
+				title={ title || __( '(Untitled)', 'jetpack-podcast' ) }
 				onBack={ handleBack }
 				initialPeriod={ period }
 			/>
@@ -120,7 +162,7 @@ const Stats = () => {
 						<StatsTopEpisodes
 							episodes={ stats?.top_episodes }
 							isLoading={ isLoading }
-							onSelect={ setSelected }
+							onSelect={ handleSelect }
 						/>
 						<StatsByApp rows={ stats?.by_app } isLoading={ isLoading } />
 					</div>


### PR DESCRIPTION
## Summary

- Stacked on top of [#48790](https://github.com/Automattic/jetpack/pull/48790) (image fallback). Will rebase to `trunk` once that lands.
- Episodes tab plays cell becomes a link `Button` when count > 0. Clicking it deep-links to `?tab=stats&episode=<id>`, opening the Stats tab drilldown. Zero stays as plain text.
- Stats tab treats `?episode=` as the source of truth for which episode is selected. The existing Top Episodes click also goes through the URL. The post title for the deep-linked episode is hydrated client-side via `useEntityRecord` since the URL only carries the id.

## Test plan

- [ ] On [lookmaitsapodcast.home.blog](https://lookmaitsapodcast.home.blog), open the Podcast dashboard, then the Episodes tab.
- [ ] Click a play count > 0. URL changes to `?tab=stats&episode=<id>`, Stats opens with the episode drilldown, episode title appears once the post record resolves.
- [ ] Click "Back to stats". URL drops `episode=` and returns to the show-level Stats view.
- [ ] On the Stats tab, click an entry in Top Episodes. Same drilldown opens (now URL-driven).
- [ ] Episodes with zero plays render the count as plain text, no link.

Generated with [Claude Code](https://claude.com/claude-code)
