### PR TITLE
Podcast Episode: enrich schema.org markup on the front-end

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
+++ b/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast Episode: enrich front-end schema.org markup with PodcastSeason, AudioObject/VideoObject, Clip chapters and soundbites, transcript MediaObject, and partOfSeries PodcastSeries with publisher.

--- a/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
+++ b/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Podcast Episode: enrich front-end schema.org markup with PodcastSeason, AudioObject/VideoObject, Clip chapters and soundbites, transcript MediaObject, and partOfSeries PodcastSeries with publisher.
+Podcast Episode: enrich front-end schema.org markup, route media playback through the WPCOM podcast-play stats endpoint so front-end plays count alongside RSS subscribers, and make chapter / soundbite list items click-to-seek.

--- a/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
+++ b/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Podcast Episode: enrich front-end schema.org markup, route media playback through the WPCOM podcast-play stats endpoint so front-end plays count alongside RSS subscribers, and make chapter / soundbite list items click-to-seek.
+Podcast Episode: enrich front-end schema.org markup and make chapter / soundbite list items click-to-seek in the audio player.

--- a/projects/packages/podcast/src/blocks/podcast-episode/block.json
+++ b/projects/packages/podcast/src/blocks/podcast-episode/block.json
@@ -8,7 +8,6 @@
 	"version": "1.0.0",
 	"textdomain": "jetpack-podcast",
 	"category": "embed",
-	"viewScript": "file:./view.js",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z'/></svg>",
 	"usesContext": [ "postId", "postType" ],
 	"supports": {

--- a/projects/packages/podcast/src/blocks/podcast-episode/block.json
+++ b/projects/packages/podcast/src/blocks/podcast-episode/block.json
@@ -10,7 +10,7 @@
 	"category": "embed",
 	"viewScript": "file:./view.js",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z'/></svg>",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [ "postId", "postType" ],
 	"supports": {
 		"spacing": {
 			"padding": true,

--- a/projects/packages/podcast/src/blocks/podcast-episode/block.json
+++ b/projects/packages/podcast/src/blocks/podcast-episode/block.json
@@ -8,6 +8,7 @@
 	"version": "1.0.0",
 	"textdomain": "jetpack-podcast",
 	"category": "embed",
+	"viewScript": "file:../../../dist/blocks/podcast-episode/view.js",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z'/></svg>",
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"supports": {

--- a/projects/packages/podcast/src/blocks/podcast-episode/block.json
+++ b/projects/packages/podcast/src/blocks/podcast-episode/block.json
@@ -8,7 +8,7 @@
 	"version": "1.0.0",
 	"textdomain": "jetpack-podcast",
 	"category": "embed",
-	"viewScript": "file:../../../dist/blocks/podcast-episode/view.js",
+	"viewScript": "file:./view.js",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z'/></svg>",
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"supports": {

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -265,13 +265,23 @@ class Podcast_Episode_Block {
 		$show_image_url = (string) get_option( 'podcasting_image', '' );
 		$show_email     = (string) get_option( 'podcasting_email', '' );
 
-		// Cover art: episode-specific override → show-level podcasting_image option → none.
+		// Cover art chain: episode override → post featured image → show-level cover → none.
 		// Resolved unconditionally so schema metadata always carries the image; the
 		// `$show_poster` toggle only gates the visible figure and the video poster.
+		$image_url = '';
 		if ( isset( $attributes['coverArt'] ) && is_array( $attributes['coverArt'] ) && ! empty( $attributes['coverArt']['url'] ) ) {
 			$image_url = esc_url_raw( $attributes['coverArt']['url'] );
 		} else {
-			$image_url = $show_image_url;
+			$featured_id = (int) get_post_thumbnail_id( $post );
+			if ( $featured_id ) {
+				$featured_url = (string) wp_get_attachment_image_url( $featured_id, 'full' );
+				if ( '' !== $featured_url ) {
+					$image_url = $featured_url;
+				}
+			}
+			if ( '' === $image_url ) {
+				$image_url = $show_image_url;
+			}
 		}
 
 		// AudioObject/VideoObject @type for the embedded media.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Podcast;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Automattic\Jetpack\Status\Request;
 
 /**
@@ -243,17 +242,6 @@ class Podcast_Episode_Block {
 
 		// AudioObject/VideoObject @type for the embedded media.
 		$media_object_type = 'video' === $media_type ? 'VideoObject' : 'AudioObject';
-
-		// Route the player through the same WPCOM stats endpoint the RSS feed
-		// rewrites enclosures to, so front-end plays count alongside RSS
-		// subscriber plays. Mirrors the gating used in Customize_Feed.
-		/** This filter is documented in projects/packages/podcast/src/feed/class-customize-feed.php */
-		$track_plays = (bool) apply_filters( 'wpcom_podcasting_enable_play_tracking', true, $post );
-		if ( $track_plays ) {
-			/** This filter is documented in projects/packages/podcast/src/feed/class-customize-feed.php */
-			$tracked_blog_id = (int) apply_filters( 'wpcom_podcasting_tracked_blog_id', get_current_blog_id(), $post );
-			$media_url       = Customize_Feed::build_stats_url( $tracked_blog_id, (int) $post->ID, $media_url );
-		}
 
 		$wrapper_attributes = get_block_wrapper_attributes();
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -226,8 +226,6 @@ class Podcast_Episode_Block {
 			return '';
 		}
 
-		self::enqueue_view_script();
-
 		$media_type     = isset( $attributes['mediaType'] ) && 'video' === $attributes['mediaType'] ? 'video' : 'audio';
 		$mime_type      = isset( $attributes['mediaMimeType'] ) ? (string) $attributes['mediaMimeType'] : '';
 		$episode_number = isset( $attributes['episodeNumber'] ) ? (int) $attributes['episodeNumber'] : 0;
@@ -245,6 +243,11 @@ class Podcast_Episode_Block {
 
 		$soundbites           = isset( $attributes['soundbites'] ) && is_array( $attributes['soundbites'] ) ? $attributes['soundbites'] : array();
 		$alternate_enclosures = isset( $attributes['alternateEnclosures'] ) && is_array( $attributes['alternateEnclosures'] ) ? $attributes['alternateEnclosures'] : array();
+
+		// Only ship the click-to-seek script on episodes that actually have chapters or soundbites to wire.
+		if ( ! empty( $chapters ) || ! empty( $soundbites ) ) {
+			self::enqueue_view_script();
+		}
 
 		if ( '' !== $transcript_url && ! wp_http_validate_url( $transcript_url ) ) {
 			$transcript_url = '';
@@ -322,7 +325,8 @@ class Podcast_Episode_Block {
 								</span>
 							<?php endif; ?>
 							<?php if ( $episode_number ) : ?>
-								<span class="jetpack-podcast-episode__episode-number" itemprop="episodeNumber">
+								<span class="jetpack-podcast-episode__episode-number">
+									<meta itemprop="episodeNumber" content="<?php echo esc_attr( (string) $episode_number ); ?>" />
 									<?php
 									/* translators: %d: episode number. */
 									echo esc_html( sprintf( __( 'Episode %d', 'jetpack-podcast' ), $episode_number ) );

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Podcast;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Automattic\Jetpack\Status\Request;
 
 /**
@@ -243,6 +244,17 @@ class Podcast_Episode_Block {
 		// AudioObject/VideoObject @type for the embedded media.
 		$media_object_type = 'video' === $media_type ? 'VideoObject' : 'AudioObject';
 
+		// Route the player through the same WPCOM stats endpoint the RSS feed
+		// rewrites enclosures to, so front-end plays count alongside RSS
+		// subscriber plays. Mirrors the gating used in Customize_Feed.
+		/** This filter is documented in projects/packages/podcast/src/feed/class-customize-feed.php */
+		$track_plays = (bool) apply_filters( 'wpcom_podcasting_enable_play_tracking', true, $post );
+		if ( $track_plays ) {
+			/** This filter is documented in projects/packages/podcast/src/feed/class-customize-feed.php */
+			$tracked_blog_id = (int) apply_filters( 'wpcom_podcasting_tracked_blog_id', get_current_blog_id(), $post );
+			$media_url       = Customize_Feed::build_stats_url( $tracked_blog_id, (int) $post->ID, $media_url );
+		}
+
 		$wrapper_attributes = get_block_wrapper_attributes();
 
 		ob_start();
@@ -384,6 +396,7 @@ class Podcast_Episode_Block {
 									itemprop="hasPart"
 									itemscope
 									itemtype="https://schema.org/Clip"
+									data-start-time="<?php echo esc_attr( (string) $start_seconds ); ?>"
 								>
 									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) $start_seconds ); ?>" />
 									<?php if ( null !== $end_seconds ) : ?>
@@ -425,6 +438,7 @@ class Podcast_Episode_Block {
 									itemprop="hasPart"
 									itemscope
 									itemtype="https://schema.org/Clip"
+									data-start-time="<?php echo esc_attr( (string) $chapter_start_seconds ); ?>"
 								>
 									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) $chapter_start_seconds ); ?>" />
 									<time class="jetpack-podcast-episode__chapter-time"><?php echo esc_html( self::format_seconds_label( $chapter['startTime'] ) ); ?></time>

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -419,7 +419,7 @@ class Podcast_Episode_Block {
 					<?php if ( ! empty( $rendered_chapters ) ) : ?>
 						<ol class="jetpack-podcast-episode__chapters">
 							<?php foreach ( $rendered_chapters as $chapter ) : ?>
-								<?php $chapter_start_seconds = (int) floor( max( 0, (float) $chapter['startTime'] ) ); ?>
+								<?php $chapter_start_seconds = (int) floor( max( 0, $chapter['startTime'] ) ); ?>
 								<li
 									class="jetpack-podcast-episode__chapter"
 									itemprop="hasPart"

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -208,9 +208,6 @@ class Podcast_Episode_Block {
 		$duration       = isset( $attributes['duration'] ) ? (string) $attributes['duration'] : '';
 		$show_poster    = ! isset( $attributes['showPoster'] ) || ! empty( $attributes['showPoster'] );
 		$transcript_url = isset( $attributes['transcriptUrl'] ) ? esc_url_raw( $attributes['transcriptUrl'] ) : '';
-		if ( '' !== $transcript_url && ! wp_http_validate_url( $transcript_url ) ) {
-			$transcript_url = '';
-		}
 		$chapters       = isset( $attributes['chapters'] ) && is_array( $attributes['chapters'] ) ? $attributes['chapters'] : array();
 		$location_name  = isset( $attributes['locationName'] ) ? (string) $attributes['locationName'] : '';
 		$license        = isset( $attributes['license'] ) ? (string) $attributes['license'] : '';
@@ -219,6 +216,10 @@ class Podcast_Episode_Block {
 
 		$soundbites           = isset( $attributes['soundbites'] ) && is_array( $attributes['soundbites'] ) ? $attributes['soundbites'] : array();
 		$alternate_enclosures = isset( $attributes['alternateEnclosures'] ) && is_array( $attributes['alternateEnclosures'] ) ? $attributes['alternateEnclosures'] : array();
+
+		if ( '' !== $transcript_url && ! wp_http_validate_url( $transcript_url ) ) {
+			$transcript_url = '';
+		}
 
 		$author_id        = (int) $post->post_author;
 		$title            = get_the_title( $post );

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -371,7 +371,7 @@ class Podcast_Episode_Block {
 								</time>
 							<?php endif; ?>
 							<?php if ( $duration ) : ?>
-								<span class="jetpack-podcast-episode__duration" itemprop="duration"><?php echo esc_html( $duration ); ?></span>
+								<span class="jetpack-podcast-episode__duration"><?php echo esc_html( $duration ); ?></span>
 							<?php endif; ?>
 						</p>
 					<?php endif; ?>
@@ -388,9 +388,6 @@ class Podcast_Episode_Block {
 						<?php endif; ?>
 						<?php if ( $duration ) : ?>
 							<meta itemprop="duration" content="<?php echo esc_attr( $duration ); ?>" />
-						<?php endif; ?>
-						<?php if ( $title ) : ?>
-							<meta itemprop="name" content="<?php echo esc_attr( $title ); ?>" />
 						<?php endif; ?>
 						<?php if ( 'video' === $media_type ) : ?>
 							<video
@@ -584,7 +581,6 @@ class Podcast_Episode_Block {
 							<?php endif; ?>
 							<?php if ( $show_email ) : ?>
 								<span itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
-									<meta itemprop="name" content="<?php echo esc_attr( $show_title ); ?>" />
 									<meta itemprop="email" content="<?php echo esc_attr( $show_email ); ?>" />
 								</span>
 							<?php endif; ?>

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -384,16 +384,21 @@ class Podcast_Episode_Block {
 									itemprop="hasPart"
 									itemscope
 									itemtype="https://schema.org/Clip"
-									data-start-time="<?php echo esc_attr( (string) $start_seconds ); ?>"
 								>
 									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) $start_seconds ); ?>" />
 									<?php if ( null !== $end_seconds ) : ?>
 										<meta itemprop="endOffset" content="<?php echo esc_attr( (string) $end_seconds ); ?>" />
 									<?php endif; ?>
-									<time class="jetpack-podcast-episode__soundbite-time"><?php echo esc_html( $start_label ); ?></time>
-									<?php if ( '' !== $soundbite_title ) : ?>
-										<span class="jetpack-podcast-episode__soundbite-title" itemprop="name"><?php echo esc_html( $soundbite_title ); ?></span>
-									<?php endif; ?>
+									<button
+										type="button"
+										class="jetpack-podcast-episode__soundbite-button"
+										data-start-time="<?php echo esc_attr( (string) $start_seconds ); ?>"
+									>
+										<time class="jetpack-podcast-episode__soundbite-time"><?php echo esc_html( $start_label ); ?></time>
+										<?php if ( '' !== $soundbite_title ) : ?>
+											<span class="jetpack-podcast-episode__soundbite-title" itemprop="name"><?php echo esc_html( $soundbite_title ); ?></span>
+										<?php endif; ?>
+									</button>
 								</li>
 							<?php endforeach; ?>
 						</ul>
@@ -426,13 +431,18 @@ class Podcast_Episode_Block {
 									itemprop="hasPart"
 									itemscope
 									itemtype="https://schema.org/Clip"
-									data-start-time="<?php echo esc_attr( (string) $chapter_start_seconds ); ?>"
 								>
 									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) $chapter_start_seconds ); ?>" />
-									<time class="jetpack-podcast-episode__chapter-time"><?php echo esc_html( self::format_seconds_label( $chapter['startTime'] ) ); ?></time>
-									<?php if ( '' !== $chapter['title'] ) : ?>
-										<span class="jetpack-podcast-episode__chapter-title" itemprop="name"><?php echo esc_html( $chapter['title'] ); ?></span>
-									<?php endif; ?>
+									<button
+										type="button"
+										class="jetpack-podcast-episode__chapter-button"
+										data-start-time="<?php echo esc_attr( (string) $chapter_start_seconds ); ?>"
+									>
+										<time class="jetpack-podcast-episode__chapter-time"><?php echo esc_html( self::format_seconds_label( $chapter['startTime'] ) ); ?></time>
+										<?php if ( '' !== $chapter['title'] ) : ?>
+											<span class="jetpack-podcast-episode__chapter-title" itemprop="name"><?php echo esc_html( $chapter['title'] ); ?></span>
+										<?php endif; ?>
+									</button>
 								</li>
 							<?php endforeach; ?>
 						</ol>

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -266,13 +266,12 @@ class Podcast_Episode_Block {
 		$show_email     = (string) get_option( 'podcasting_email', '' );
 
 		// Cover art: episode-specific override → show-level podcasting_image option → none.
-		$image_url = '';
-		if ( $show_poster ) {
-			if ( isset( $attributes['coverArt'] ) && is_array( $attributes['coverArt'] ) && ! empty( $attributes['coverArt']['url'] ) ) {
-				$image_url = esc_url_raw( $attributes['coverArt']['url'] );
-			} else {
-				$image_url = $show_image_url;
-			}
+		// Resolved unconditionally so schema metadata always carries the image; the
+		// `$show_poster` toggle only gates the visible figure and the video poster.
+		if ( isset( $attributes['coverArt'] ) && is_array( $attributes['coverArt'] ) && ! empty( $attributes['coverArt']['url'] ) ) {
+			$image_url = esc_url_raw( $attributes['coverArt']['url'] );
+		} else {
+			$image_url = $show_image_url;
 		}
 
 		// AudioObject/VideoObject @type for the embedded media.
@@ -287,7 +286,7 @@ class Podcast_Episode_Block {
 				<?php if ( $episode_url ) : ?>
 					<link itemprop="url" href="<?php echo esc_url( $episode_url ); ?>" />
 				<?php endif; ?>
-				<?php if ( $image_url ) : ?>
+				<?php if ( $image_url && $show_poster ) : ?>
 					<figure class="jetpack-podcast-episode__poster">
 						<img
 							src="<?php echo esc_url( $image_url ); ?>"
@@ -296,6 +295,8 @@ class Podcast_Episode_Block {
 							loading="lazy"
 						/>
 					</figure>
+				<?php elseif ( $image_url ) : ?>
+					<meta itemprop="image" content="<?php echo esc_url( $image_url ); ?>" />
 				<?php endif; ?>
 
 				<div class="jetpack-podcast-episode__body">
@@ -384,7 +385,7 @@ class Podcast_Episode_Block {
 								preload="none"
 								src="<?php echo esc_url( $media_url ); ?>"
 								<?php
-								if ( $image_url ) :
+								if ( $image_url && $show_poster ) :
 									?>
 									poster="<?php echo esc_url( $image_url ); ?>"<?php endif; ?>
 								<?php

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -222,6 +222,13 @@ class Podcast_Episode_Block {
 		$publish_date_iso = get_the_date( 'c', $post );
 		$publish_date     = get_the_date( '', $post );
 		$episode_url      = get_permalink( $post );
+		$transcript_type  = isset( $attributes['transcriptType'] ) ? (string) $attributes['transcriptType'] : '';
+
+		// Show-level data backs the `partOfSeries` PodcastSeries reference so
+		// search engines can connect the episode to its parent show.
+		$show_title     = (string) get_option( 'podcasting_title', '' );
+		$show_image_url = (string) get_option( 'podcasting_image', '' );
+		$show_email     = (string) get_option( 'podcasting_email', '' );
 
 		// Cover art: episode-specific override → show-level podcasting_image option → none.
 		$image_url = '';
@@ -229,15 +236,10 @@ class Podcast_Episode_Block {
 			if ( isset( $attributes['coverArt'] ) && is_array( $attributes['coverArt'] ) && ! empty( $attributes['coverArt']['url'] ) ) {
 				$image_url = esc_url_raw( $attributes['coverArt']['url'] );
 			} else {
-				$image_url = (string) get_option( 'podcasting_image', '' );
+				$image_url = $show_image_url;
 			}
 		}
 
-		// Show-level data backs the `partOfSeries` PodcastSeries reference so
-		// search engines can connect the episode to its parent show.
-		$show_title     = (string) get_option( 'podcasting_title', '' );
-		$show_image_url = (string) get_option( 'podcasting_image', '' );
-		$show_email     = (string) get_option( 'podcasting_email', '' );
 		// AudioObject/VideoObject @type for the embedded media.
 		$media_object_type = 'video' === $media_type ? 'VideoObject' : 'AudioObject';
 
@@ -417,13 +419,14 @@ class Podcast_Episode_Block {
 					<?php if ( ! empty( $rendered_chapters ) ) : ?>
 						<ol class="jetpack-podcast-episode__chapters">
 							<?php foreach ( $rendered_chapters as $chapter ) : ?>
+								<?php $chapter_start_seconds = (int) floor( max( 0, (float) $chapter['startTime'] ) ); ?>
 								<li
 									class="jetpack-podcast-episode__chapter"
 									itemprop="hasPart"
 									itemscope
 									itemtype="https://schema.org/Clip"
 								>
-									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) (int) $chapter['startTime'] ); ?>" />
+									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) $chapter_start_seconds ); ?>" />
 									<time class="jetpack-podcast-episode__chapter-time"><?php echo esc_html( self::format_seconds_label( $chapter['startTime'] ) ); ?></time>
 									<?php if ( '' !== $chapter['title'] ) : ?>
 										<span class="jetpack-podcast-episode__chapter-title" itemprop="name"><?php echo esc_html( $chapter['title'] ); ?></span>
@@ -512,7 +515,10 @@ class Podcast_Episode_Block {
 								<meta itemprop="image" content="<?php echo esc_url( $show_image_url ); ?>" />
 							<?php endif; ?>
 							<?php if ( $show_email ) : ?>
-								<meta itemprop="email" content="<?php echo esc_attr( $show_email ); ?>" />
+								<span itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+									<meta itemprop="name" content="<?php echo esc_attr( $show_title ); ?>" />
+									<meta itemprop="email" content="<?php echo esc_attr( $show_email ); ?>" />
+								</span>
 							<?php endif; ?>
 						</div>
 					<?php endif; ?>
@@ -522,8 +528,8 @@ class Podcast_Episode_Block {
 							<?php if ( $transcript_url ) : ?>
 								<li itemprop="transcript" itemscope itemtype="https://schema.org/MediaObject">
 									<meta itemprop="contentUrl" content="<?php echo esc_url( $transcript_url ); ?>" />
-									<?php if ( ! empty( $attributes['transcriptType'] ) ) : ?>
-										<meta itemprop="encodingFormat" content="<?php echo esc_attr( (string) $attributes['transcriptType'] ); ?>" />
+									<?php if ( '' !== $transcript_type ) : ?>
+										<meta itemprop="encodingFormat" content="<?php echo esc_attr( $transcript_type ); ?>" />
 									<?php endif; ?>
 									<a href="<?php echo esc_url( $transcript_url ); ?>" class="jetpack-podcast-episode__transcript-link">
 										<?php esc_html_e( 'Read transcript', 'jetpack-podcast' ); ?>

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -208,6 +208,9 @@ class Podcast_Episode_Block {
 		$duration       = isset( $attributes['duration'] ) ? (string) $attributes['duration'] : '';
 		$show_poster    = ! isset( $attributes['showPoster'] ) || ! empty( $attributes['showPoster'] );
 		$transcript_url = isset( $attributes['transcriptUrl'] ) ? esc_url_raw( $attributes['transcriptUrl'] ) : '';
+		if ( '' !== $transcript_url && ! wp_http_validate_url( $transcript_url ) ) {
+			$transcript_url = '';
+		}
 		$chapters       = isset( $attributes['chapters'] ) && is_array( $attributes['chapters'] ) ? $attributes['chapters'] : array();
 		$location_name  = isset( $attributes['locationName'] ) ? (string) $attributes['locationName'] : '';
 		$license        = isset( $attributes['license'] ) ? (string) $attributes['license'] : '';
@@ -217,8 +220,10 @@ class Podcast_Episode_Block {
 		$soundbites           = isset( $attributes['soundbites'] ) && is_array( $attributes['soundbites'] ) ? $attributes['soundbites'] : array();
 		$alternate_enclosures = isset( $attributes['alternateEnclosures'] ) && is_array( $attributes['alternateEnclosures'] ) ? $attributes['alternateEnclosures'] : array();
 
+		$author_id        = (int) $post->post_author;
 		$title            = get_the_title( $post );
-		$author_name      = get_the_author_meta( 'display_name', (int) $post->post_author );
+		$author_name      = get_the_author_meta( 'display_name', $author_id );
+		$author_url       = esc_url_raw( (string) get_the_author_meta( 'url', $author_id ) );
 		$publish_date_iso = get_the_date( 'c', $post );
 		$publish_date     = get_the_date( '', $post );
 		$episode_url      = get_permalink( $post );
@@ -302,7 +307,13 @@ class Podcast_Episode_Block {
 						<p class="jetpack-podcast-episode__byline">
 							<?php if ( $author_name ) : ?>
 								<span class="jetpack-podcast-episode__author" itemprop="author" itemscope itemtype="https://schema.org/Person">
-									<span itemprop="name"><?php echo esc_html( $author_name ); ?></span>
+									<?php if ( $author_url ) : ?>
+										<a href="<?php echo esc_url( $author_url ); ?>" itemprop="url">
+											<span itemprop="name"><?php echo esc_html( $author_name ); ?></span>
+										</a>
+									<?php else : ?>
+										<span itemprop="name"><?php echo esc_html( $author_name ); ?></span>
+									<?php endif; ?>
 								</span>
 							<?php endif; ?>
 							<?php if ( $publish_date ) : ?>
@@ -340,7 +351,7 @@ class Podcast_Episode_Block {
 							<video
 								class="jetpack-podcast-episode__video"
 								controls
-								preload="metadata"
+								preload="none"
 								src="<?php echo esc_url( $media_url ); ?>"
 								<?php
 								if ( $image_url ) :
@@ -355,7 +366,7 @@ class Podcast_Episode_Block {
 							<audio
 								class="jetpack-podcast-episode__audio"
 								controls
-								preload="metadata"
+								preload="none"
 								src="<?php echo esc_url( $media_url ); ?>"
 								<?php
 								if ( $mime_type ) :

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -33,6 +33,13 @@ class Podcast_Episode_Block {
 	const STYLE_HANDLE = 'jetpack-podcast-episode-style';
 
 	/**
+	 * Front-end view script handle. Enqueued from the render callback
+	 * because the block.json `viewScript` field can't resolve to the
+	 * package's dist directory from the deployed src location.
+	 */
+	const VIEW_HANDLE = 'jetpack-podcast-episode-view';
+
+	/**
 	 * Wire the block's actions. Hooks are added unconditionally; each
 	 * callback re-checks the untangle filter and short-circuits when off.
 	 */
@@ -80,6 +87,26 @@ class Podcast_Episode_Block {
 			array(
 				'render_callback' => array( __CLASS__, 'render_block' ),
 				'style'           => self::STYLE_HANDLE,
+			)
+		);
+	}
+
+	/**
+	 * Register and enqueue the front-end view script that wires chapter and
+	 * soundbite buttons to the audio player. Called from the render callback
+	 * so the script only ships on pages that actually contain the block.
+	 *
+	 * `Assets::register_script` dedups internally, so calling this for each
+	 * rendered instance of the block is safe.
+	 */
+	private static function enqueue_view_script() {
+		Assets::register_script(
+			self::VIEW_HANDLE,
+			'../../../dist/blocks/podcast-episode/view.js',
+			__FILE__,
+			array(
+				'in_footer' => true,
+				'enqueue'   => true,
 			)
 		);
 	}
@@ -198,6 +225,8 @@ class Podcast_Episode_Block {
 		if ( ! wp_http_validate_url( $media_url ) ) {
 			return '';
 		}
+
+		self::enqueue_view_script();
 
 		$media_type     = isset( $attributes['mediaType'] ) && 'video' === $attributes['mediaType'] ? 'video' : 'audio';
 		$mime_type      = isset( $attributes['mediaMimeType'] ) ? (string) $attributes['mediaMimeType'] : '';

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -221,6 +221,7 @@ class Podcast_Episode_Block {
 		$author_name      = get_the_author_meta( 'display_name', (int) $post->post_author );
 		$publish_date_iso = get_the_date( 'c', $post );
 		$publish_date     = get_the_date( '', $post );
+		$episode_url      = get_permalink( $post );
 
 		// Cover art: episode-specific override → show-level podcasting_image option → none.
 		$image_url = '';
@@ -232,12 +233,23 @@ class Podcast_Episode_Block {
 			}
 		}
 
+		// Show-level data backs the `partOfSeries` PodcastSeries reference so
+		// search engines can connect the episode to its parent show.
+		$show_title     = (string) get_option( 'podcasting_title', '' );
+		$show_image_url = (string) get_option( 'podcasting_image', '' );
+		$show_email     = (string) get_option( 'podcasting_email', '' );
+		// AudioObject/VideoObject @type for the embedded media.
+		$media_object_type = 'video' === $media_type ? 'VideoObject' : 'AudioObject';
+
 		$wrapper_attributes = get_block_wrapper_attributes();
 
 		ob_start();
 		?>
 		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_block_wrapper_attributes() returns pre-escaped attribute output. ?>>
 			<article class="jetpack-podcast-episode" itemscope itemtype="https://schema.org/PodcastEpisode">
+				<?php if ( $episode_url ) : ?>
+					<link itemprop="url" href="<?php echo esc_url( $episode_url ); ?>" />
+				<?php endif; ?>
 				<?php if ( $image_url ) : ?>
 					<figure class="jetpack-podcast-episode__poster">
 						<img
@@ -253,7 +265,8 @@ class Podcast_Episode_Block {
 					<?php if ( $season_number || $episode_number || 'full' !== $episode_type || $is_explicit ) : ?>
 						<p class="jetpack-podcast-episode__meta-line">
 							<?php if ( $season_number ) : ?>
-								<span class="jetpack-podcast-episode__season">
+								<span class="jetpack-podcast-episode__season" itemprop="partOfSeason" itemscope itemtype="https://schema.org/PodcastSeason">
+									<meta itemprop="seasonNumber" content="<?php echo esc_attr( (string) $season_number ); ?>" />
 									<?php
 									/* translators: %d: season number. */
 									echo esc_html( sprintf( __( 'Season %d', 'jetpack-podcast' ), $season_number ) );
@@ -305,7 +318,22 @@ class Podcast_Episode_Block {
 						</p>
 					<?php endif; ?>
 
-					<div class="jetpack-podcast-episode__player">
+					<div
+						class="jetpack-podcast-episode__player"
+						itemprop="<?php echo 'video' === $media_type ? 'video' : 'audio'; ?>"
+						itemscope
+						itemtype="https://schema.org/<?php echo esc_attr( $media_object_type ); ?>"
+					>
+						<meta itemprop="contentUrl" content="<?php echo esc_url( $media_url ); ?>" />
+						<?php if ( $mime_type ) : ?>
+							<meta itemprop="encodingFormat" content="<?php echo esc_attr( $mime_type ); ?>" />
+						<?php endif; ?>
+						<?php if ( $duration ) : ?>
+							<meta itemprop="duration" content="<?php echo esc_attr( $duration ); ?>" />
+						<?php endif; ?>
+						<?php if ( $title ) : ?>
+							<meta itemprop="name" content="<?php echo esc_attr( $title ); ?>" />
+						<?php endif; ?>
 						<?php if ( 'video' === $media_type ) : ?>
 							<video
 								class="jetpack-podcast-episode__video"
@@ -320,7 +348,6 @@ class Podcast_Episode_Block {
 								if ( $mime_type ) :
 									?>
 									data-mime="<?php echo esc_attr( $mime_type ); ?>"<?php endif; ?>
-								itemprop="associatedMedia"
 							></video>
 						<?php else : ?>
 							<audio
@@ -332,7 +359,6 @@ class Podcast_Episode_Block {
 								if ( $mime_type ) :
 									?>
 									data-mime="<?php echo esc_attr( $mime_type ); ?>"<?php endif; ?>
-								itemprop="associatedMedia"
 							></audio>
 						<?php endif; ?>
 					</div>
@@ -346,11 +372,24 @@ class Podcast_Episode_Block {
 								}
 								$start_label     = self::format_seconds_label( $soundbite['startTime'] );
 								$soundbite_title = isset( $soundbite['title'] ) ? trim( (string) $soundbite['title'] ) : '';
+								$start_seconds   = (int) floor( max( 0, (float) $soundbite['startTime'] ) );
+								$end_seconds     = isset( $soundbite['duration'] )
+									? $start_seconds + (int) floor( max( 0, (float) $soundbite['duration'] ) )
+									: null;
 								?>
-								<li class="jetpack-podcast-episode__soundbite">
+								<li
+									class="jetpack-podcast-episode__soundbite"
+									itemprop="hasPart"
+									itemscope
+									itemtype="https://schema.org/Clip"
+								>
+									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) $start_seconds ); ?>" />
+									<?php if ( null !== $end_seconds ) : ?>
+										<meta itemprop="endOffset" content="<?php echo esc_attr( (string) $end_seconds ); ?>" />
+									<?php endif; ?>
 									<time class="jetpack-podcast-episode__soundbite-time"><?php echo esc_html( $start_label ); ?></time>
 									<?php if ( '' !== $soundbite_title ) : ?>
-										<span class="jetpack-podcast-episode__soundbite-title"><?php echo esc_html( $soundbite_title ); ?></span>
+										<span class="jetpack-podcast-episode__soundbite-title" itemprop="name"><?php echo esc_html( $soundbite_title ); ?></span>
 									<?php endif; ?>
 								</li>
 							<?php endforeach; ?>
@@ -378,10 +417,16 @@ class Podcast_Episode_Block {
 					<?php if ( ! empty( $rendered_chapters ) ) : ?>
 						<ol class="jetpack-podcast-episode__chapters">
 							<?php foreach ( $rendered_chapters as $chapter ) : ?>
-								<li class="jetpack-podcast-episode__chapter">
+								<li
+									class="jetpack-podcast-episode__chapter"
+									itemprop="hasPart"
+									itemscope
+									itemtype="https://schema.org/Clip"
+								>
+									<meta itemprop="startOffset" content="<?php echo esc_attr( (string) (int) $chapter['startTime'] ); ?>" />
 									<time class="jetpack-podcast-episode__chapter-time"><?php echo esc_html( self::format_seconds_label( $chapter['startTime'] ) ); ?></time>
 									<?php if ( '' !== $chapter['title'] ) : ?>
-										<span class="jetpack-podcast-episode__chapter-title"><?php echo esc_html( $chapter['title'] ); ?></span>
+										<span class="jetpack-podcast-episode__chapter-title" itemprop="name"><?php echo esc_html( $chapter['title'] ); ?></span>
 									<?php endif; ?>
 								</li>
 							<?php endforeach; ?>
@@ -460,10 +505,26 @@ class Podcast_Episode_Block {
 						</ul>
 					<?php endif; ?>
 
+					<?php if ( '' !== $show_title ) : ?>
+						<div class="jetpack-podcast-episode__series" itemprop="partOfSeries" itemscope itemtype="https://schema.org/PodcastSeries">
+							<meta itemprop="name" content="<?php echo esc_attr( $show_title ); ?>" />
+							<?php if ( $show_image_url ) : ?>
+								<meta itemprop="image" content="<?php echo esc_url( $show_image_url ); ?>" />
+							<?php endif; ?>
+							<?php if ( $show_email ) : ?>
+								<meta itemprop="email" content="<?php echo esc_attr( $show_email ); ?>" />
+							<?php endif; ?>
+						</div>
+					<?php endif; ?>
+
 					<?php if ( $transcript_url || $location_name || $license ) : ?>
 						<ul class="jetpack-podcast-episode__links">
 							<?php if ( $transcript_url ) : ?>
-								<li>
+								<li itemprop="transcript" itemscope itemtype="https://schema.org/MediaObject">
+									<meta itemprop="contentUrl" content="<?php echo esc_url( $transcript_url ); ?>" />
+									<?php if ( ! empty( $attributes['transcriptType'] ) ) : ?>
+										<meta itemprop="encodingFormat" content="<?php echo esc_attr( (string) $attributes['transcriptType'] ); ?>" />
+									<?php endif; ?>
 									<a href="<?php echo esc_url( $transcript_url ); ?>" class="jetpack-podcast-episode__transcript-link">
 										<?php esc_html_e( 'Read transcript', 'jetpack-podcast' ); ?>
 									</a>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -102,8 +102,6 @@ const TRANSCRIPT_TYPE_OPTIONS = [
 	{ label: __( 'JSON (application/json)', 'jetpack-podcast' ), value: 'application/json' },
 ];
 
-const PERSON_ROW_STYLE = { marginBottom: '1em' };
-
 const formatTimeCode = ( seconds: number | undefined ): string => {
 	if ( typeof seconds !== 'number' || seconds < 0 || Number.isNaN( seconds ) ) {
 		return '';
@@ -202,9 +200,10 @@ function PeopleEditor( { people, onChange }: PeopleEditorProps ) {
 		<>
 			{ people.map( ( person, index ) => (
 				<div
-					className="jetpack-podcast-episode__person-editor"
+					className={ clsx( 'jetpack-podcast-episode__person-editor', {
+						'jetpack-podcast-episode__person-editor--alt': index % 2 === 1,
+					} ) }
 					key={ index }
-					style={ PERSON_ROW_STYLE }
 				>
 					<TextControl
 						label={ __( 'Name', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -21,7 +21,7 @@ import {
 import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import metadata from './block.json';
@@ -83,7 +83,6 @@ interface EditProps {
 	context?: {
 		postId?: number;
 		postType?: string;
-		queryId?: number;
 	};
 }
 
@@ -249,10 +248,10 @@ function PeopleEditor( { people, onChange }: PeopleEditorProps ) {
 }
 
 export default function PodcastEpisodeEdit( { attributes, setAttributes, context }: EditProps ) {
-	const validated = getValidatedAttributes(
-		metadata.attributes,
-		attributes
-	) as PodcastEpisodeAttributes;
+	const validated = useMemo(
+		() => getValidatedAttributes( metadata.attributes, attributes ) as PodcastEpisodeAttributes,
+		[ attributes ]
+	);
 	const {
 		mediaId,
 		mediaUrl,
@@ -595,8 +594,19 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Podcasting 2.0', 'jetpack-podcast' ) } initialOpen={ false }>
 					<BaseControl __nextHasNoMarginBottom>
-						<BaseControl.VisualLabel>{ __( 'People', 'jetpack-podcast' ) }</BaseControl.VisualLabel>
+						<BaseControl.VisualLabel>
+							{ __( 'Guests & credits', 'jetpack-podcast' ) }
+						</BaseControl.VisualLabel>
+						<p className="components-base-control__help">
+							{ __(
+								'Credit hosts, guests, and producers. Read by Podcasting 2.0 apps (Podverse, Fountain, Podcast Addict) and rendered as a credits list on the post page.',
+								'jetpack-podcast'
+							) }
+						</p>
 						<PeopleEditor
 							people={ people }
 							onChange={ value => setAttributes( { people: value } ) }
@@ -678,12 +688,12 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 							<video
 								src={ mediaUrl }
 								controls
-								preload="metadata"
+								preload="none"
 								poster={ showPoster ? coverArtUrl : undefined }
 								data-mime={ mediaMimeType || undefined }
 							/>
 						) : (
-							<audio src={ mediaUrl } controls preload="metadata" />
+							<audio src={ mediaUrl } controls preload="none" />
 						) }
 					</div>
 				</div>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -463,71 +463,72 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 					/>
 					<ToggleControl
 						label={ __( 'Show cover art', 'jetpack-podcast' ) }
-						help={ __( 'Display cover art alongside the player.', 'jetpack-podcast' ) }
+						help={ __(
+							'Display cover art alongside the player on the post page. Cover art stays in schema metadata either way.',
+							'jetpack-podcast'
+						) }
 						checked={ !! showPoster }
 						onChange={ value => setAttributes( { showPoster: value } ) }
 						__nextHasNoMarginBottom
 					/>
-					{ showPoster && (
-						<BaseControl __nextHasNoMarginBottom>
-							<BaseControl.VisualLabel>
-								{ __( 'Cover art', 'jetpack-podcast' ) }
-							</BaseControl.VisualLabel>
-							<MediaUploadCheck>
-								<MediaUpload
-									onSelect={ ( media: MediaAttachment ) =>
-										setAttributes( {
-											coverArt: media?.url ? { id: media.id, url: media.url } : {},
-										} )
-									}
-									allowedTypes={ [ 'image' ] }
-									value={ coverArt?.id }
-									render={ ( { open }: { open: () => void } ) => (
-										<div className="jetpack-podcast-episode__cover-picker">
-											<Button
-												variant="secondary"
-												className={ clsx( 'jetpack-podcast-episode__cover-button', {
-													'jetpack-podcast-episode__cover-button--empty': ! coverArtUrl,
-												} ) }
-												onClick={ open }
-												aria-label={
-													coverArt?.url
-														? __( 'Replace cover art', 'jetpack-podcast' )
-														: __( 'Set episode cover art', 'jetpack-podcast' )
-												}
-											>
-												{ coverArtUrl ? (
-													<img src={ coverArtUrl } alt="" />
-												) : (
-													<span>{ __( 'Set episode cover art', 'jetpack-podcast' ) }</span>
-												) }
-											</Button>
-											{ coverArt?.url && (
-												<div className="jetpack-podcast-episode__cover-actions">
-													<Button variant="link" onClick={ open }>
-														{ __( 'Replace', 'jetpack-podcast' ) }
-													</Button>
-													<Button
-														variant="link"
-														isDestructive
-														onClick={ () => setAttributes( { coverArt: {} } ) }
-													>
-														{ __( 'Remove', 'jetpack-podcast' ) }
-													</Button>
-												</div>
+					<BaseControl __nextHasNoMarginBottom>
+						<BaseControl.VisualLabel>
+							{ __( 'Cover art', 'jetpack-podcast' ) }
+						</BaseControl.VisualLabel>
+						<MediaUploadCheck>
+							<MediaUpload
+								onSelect={ ( media: MediaAttachment ) =>
+									setAttributes( {
+										coverArt: media?.url ? { id: media.id, url: media.url } : {},
+									} )
+								}
+								allowedTypes={ [ 'image' ] }
+								value={ coverArt?.id }
+								render={ ( { open }: { open: () => void } ) => (
+									<div className="jetpack-podcast-episode__cover-picker">
+										<Button
+											variant="secondary"
+											className={ clsx( 'jetpack-podcast-episode__cover-button', {
+												'jetpack-podcast-episode__cover-button--empty': ! coverArtUrl,
+											} ) }
+											onClick={ open }
+											aria-label={
+												coverArt?.url
+													? __( 'Replace cover art', 'jetpack-podcast' )
+													: __( 'Set episode cover art', 'jetpack-podcast' )
+											}
+										>
+											{ coverArtUrl ? (
+												<img src={ coverArtUrl } alt="" />
+											) : (
+												<span>{ __( 'Set episode cover art', 'jetpack-podcast' ) }</span>
 											) }
-										</div>
-									) }
-								/>
-							</MediaUploadCheck>
-							<p className="components-base-control__help">
-								{ __(
-									'Defaults to the show cover art set in Settings → Writing → Podcasting.',
-									'jetpack-podcast'
+										</Button>
+										{ coverArt?.url && (
+											<div className="jetpack-podcast-episode__cover-actions">
+												<Button variant="link" onClick={ open }>
+													{ __( 'Replace', 'jetpack-podcast' ) }
+												</Button>
+												<Button
+													variant="link"
+													isDestructive
+													onClick={ () => setAttributes( { coverArt: {} } ) }
+												>
+													{ __( 'Remove', 'jetpack-podcast' ) }
+												</Button>
+											</div>
+										) }
+									</div>
 								) }
-							</p>
-						</BaseControl>
-					) }
+							/>
+						</MediaUploadCheck>
+						<p className="components-base-control__help">
+							{ __(
+								'Defaults to the show cover art set in Settings → Writing → Podcasting.',
+								'jetpack-podcast'
+							) }
+						</p>
+					</BaseControl>
 				</PanelBody>
 
 				<PanelBody title={ __( 'Audio', 'jetpack-podcast' ) }>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -152,7 +152,12 @@ function ChaptersEditor( { chapters, onChange }: ChaptersEditorProps ) {
 	return (
 		<>
 			{ chapters.map( ( chapter, index ) => (
-				<div className="jetpack-podcast-episode__chapter-row" key={ index }>
+				<div
+					className={ clsx( 'jetpack-podcast-episode__chapter-row', {
+						'jetpack-podcast-episode__chapter-row--alt': index % 2 === 1,
+					} ) }
+					key={ index }
+				>
 					<TextControl
 						label={ __( 'Start', 'jetpack-podcast' ) }
 						help={ __( 'HH:MM:SS or MM:SS.', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -481,8 +481,8 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 									value={ coverArt?.id }
 									render={ ( { open }: { open: () => void } ) => (
 										<div className="jetpack-podcast-episode__cover-picker">
-											<button
-												type="button"
+											<Button
+												variant="secondary"
 												className={ clsx( 'jetpack-podcast-episode__cover-button', {
 													'jetpack-podcast-episode__cover-button--empty': ! coverArtUrl,
 												} ) }
@@ -498,7 +498,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 												) : (
 													<span>{ __( 'Set episode cover art', 'jetpack-podcast' ) }</span>
 												) }
-											</button>
+											</Button>
 											{ coverArt?.url && (
 												<div className="jetpack-podcast-episode__cover-actions">
 													<Button variant="link" onClick={ open }>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -278,6 +278,12 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 	const [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	const [ postDate ] = useEntityProp( 'postType', postType, 'date', postId );
 	const [ authorId ] = useEntityProp( 'postType', postType, 'author', postId );
+	const [ featuredImageId ] = useEntityProp< number >(
+		'postType',
+		postType,
+		'featured_media',
+		postId
+	);
 
 	// Source the show-level cover from the same REST surface the dashboard
 	// reads: /wp/v2/settings exposes `podcasting_image` (registered in
@@ -297,7 +303,23 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 		[ authorId ]
 	);
 
-	const coverArtUrl = coverArt?.url || showCoverUrl;
+	const featuredImageUrl = useSelect(
+		select => {
+			if ( ! featuredImageId ) {
+				return '';
+			}
+			const media = (
+				select( coreStore ) as {
+					getMedia: ( id: number ) => { source_url?: string } | null;
+				}
+			 ).getMedia( featuredImageId );
+			return media?.source_url || '';
+		},
+		[ featuredImageId ]
+	);
+
+	// Editor preview mirrors the PHP chain: episode override → featured image → show cover.
+	const coverArtUrl = coverArt?.url || featuredImageUrl || showCoverUrl;
 
 	const blockProps = useBlockProps();
 	const [ uploadError, setUploadError ] = useState< string | null >( null );
@@ -524,7 +546,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 						</MediaUploadCheck>
 						<p className="components-base-control__help">
 							{ __(
-								'Defaults to the show cover art set in Settings → Writing → Podcasting.',
+								'Defaults to the post’s featured image, then the show cover art from Settings → Writing → Podcasting.',
 								'jetpack-podcast'
 							) }
 						</p>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -687,10 +687,6 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 							<audio src={ mediaUrl } controls preload="metadata" />
 						) }
 					</div>
-
-					<p className="jetpack-podcast-episode__notes-hint">
-						{ __( 'Add episode show notes in the post content below.', 'jetpack-podcast' ) }
-					</p>
 				</div>
 			</article>
 		</div>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -105,7 +105,7 @@ const TRANSCRIPT_TYPE_OPTIONS = [
 const PERSON_ROW_STYLE = { marginBottom: '1em' };
 
 const formatTimeCode = ( seconds: number | undefined ): string => {
-	if ( ! seconds || seconds < 0 || Number.isNaN( seconds ) ) {
+	if ( typeof seconds !== 'number' || seconds < 0 || Number.isNaN( seconds ) ) {
 		return '';
 	}
 	const total = Math.floor( seconds );

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -23,6 +23,7 @@ import { useSelect } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
+import clsx from 'clsx';
 import metadata from './block.json';
 import { microphone } from './icons';
 import { getValidatedAttributes } from './util/get-validated-attributes';
@@ -480,12 +481,11 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 									value={ coverArt?.id }
 									render={ ( { open }: { open: () => void } ) => (
 										<div className="jetpack-podcast-episode__cover-picker">
-											<Button
-												className={
-													coverArtUrl
-														? 'jetpack-podcast-episode__cover-button'
-														: 'jetpack-podcast-episode__cover-button jetpack-podcast-episode__cover-button--empty'
-												}
+											<button
+												type="button"
+												className={ clsx( 'jetpack-podcast-episode__cover-button', {
+													'jetpack-podcast-episode__cover-button--empty': ! coverArtUrl,
+												} ) }
 												onClick={ open }
 												aria-label={
 													coverArt?.url
@@ -498,7 +498,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 												) : (
 													<span>{ __( 'Set episode cover art', 'jetpack-podcast' ) }</span>
 												) }
-											</Button>
+											</button>
 											{ coverArt?.url && (
 												<div className="jetpack-podcast-episode__cover-actions">
 													<Button variant="link" onClick={ open }>

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
@@ -21,8 +21,10 @@
 		border-radius: 4px;
 	}
 
-	// Alternate the chapter row background so a stack reads as distinct cards.
-	.jetpack-podcast-episode__chapter-row--alt {
+	// Alternate the row background so a stack of chapter / person editors
+	// reads as distinct cards instead of merging visually.
+	.jetpack-podcast-episode__chapter-row--alt,
+	.jetpack-podcast-episode__person-editor--alt {
 		background: #f6f7f7;
 	}
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
@@ -1,87 +1,85 @@
 /**
  * Podcast Episode block — editor-only styles.
  *
- * Sidebar editors live inside the InspectorControls panel, whose content box
- * is a fixed width (~280px). Everything below is scoped to fill 100% of that
- * box so opening / closing panels doesn't reflow the column width.
+ * These rules target sidebar controls (InspectorControls) which Gutenberg
+ * portals out of the block tree, so they cannot be nested under the block
+ * wrapper class. Class names are uniquely prefixed `jetpack-podcast-episode__`
+ * to keep root-level selectors collision-safe.
  */
 
-.wp-block-jetpack-podcast-episode {
+.jetpack-podcast-episode__person-editor,
+.jetpack-podcast-episode__chapter-row {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	box-sizing: border-box;
+	width: 100%;
+	padding: 12px;
+	margin-bottom: 12px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+}
 
-	.jetpack-podcast-episode__person-editor,
-	.jetpack-podcast-episode__chapter-row {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-		box-sizing: border-box;
-		width: 100%;
-		padding: 12px;
-		margin-bottom: 12px;
-		border: 1px solid #ddd;
-		border-radius: 4px;
+// Alternate the row background so a stack of chapter / person editors
+// reads as distinct cards instead of merging visually.
+.jetpack-podcast-episode__chapter-row--alt,
+.jetpack-podcast-episode__person-editor--alt {
+	background: #f6f7f7;
+}
+
+// Featured-image-style cover picker: full-width clickable preview that
+// opens the media library, with Replace / Remove links underneath.
+.jetpack-podcast-episode__cover-picker {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-bottom: 8px;
+	width: 100%;
+}
+
+// `<Button>` defaults to `display: inline-flex; height: 36px;` which makes
+// the image overflow the bounds when we drop it inside. Force the button to
+// act as a block container that grows to wrap whatever it holds.
+.jetpack-podcast-episode__cover-button {
+	box-sizing: border-box;
+	display: block;
+	width: 100%;
+	height: auto;
+	min-height: 0;
+	padding: 0;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	background: transparent;
+	overflow: hidden;
+	cursor: pointer;
+
+	&:hover,
+	&:focus-visible {
+		border-color: var(--wp-admin-theme-color, #007cba);
 	}
 
-	// Alternate the row background so a stack of chapter / person editors
-	// reads as distinct cards instead of merging visually.
-	.jetpack-podcast-episode__chapter-row--alt,
-	.jetpack-podcast-episode__person-editor--alt {
-		background: #f6f7f7;
-	}
-
-	// Featured-image-style cover picker: full-width clickable preview that
-	// opens the media library, with Replace / Remove links underneath.
-	.jetpack-podcast-episode__cover-picker {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-		margin-bottom: 8px;
-		width: 100%;
-	}
-
-	// `<Button>` defaults to `display: inline-flex; height: 36px;` which makes
-	// the image overflow the bounds when we drop it inside. Force the button to
-	// act as a block container that grows to wrap whatever it holds.
-	.jetpack-podcast-episode__cover-button {
-		box-sizing: border-box;
+	img {
 		display: block;
 		width: 100%;
 		height: auto;
-		min-height: 0;
-		padding: 0;
-		border: 1px solid #ddd;
-		border-radius: 4px;
-		background: transparent;
-		overflow: hidden;
-		cursor: pointer;
-
-		&:hover,
-		&:focus-visible {
-			border-color: var(--wp-admin-theme-color, #007cba);
-		}
-
-		img {
-			display: block;
-			width: 100%;
-			height: auto;
-			max-width: 100%;
-		}
+		max-width: 100%;
 	}
+}
 
-	.jetpack-podcast-episode__cover-button--empty {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		min-height: 92px;
-		border-style: dashed;
+.jetpack-podcast-episode__cover-button--empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 92px;
+	border-style: dashed;
 
-		span {
-			color: var(--wp-admin-theme-color, #007cba);
-			font-weight: 500;
-		}
+	span {
+		color: var(--wp-admin-theme-color, #007cba);
+		font-weight: 500;
 	}
+}
 
-	.jetpack-podcast-episode__cover-actions {
-		display: flex;
-		gap: 12px;
-	}
+.jetpack-podcast-episode__cover-actions {
+	display: flex;
+	gap: 12px;
 }

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
@@ -21,6 +21,11 @@
 		border-radius: 4px;
 	}
 
+	// Alternate the chapter row background so a stack reads as distinct cards.
+	.jetpack-podcast-episode__chapter-row--alt {
+		background: #f6f7f7;
+	}
+
 	.jetpack-podcast-episode__notes-hint {
 		margin-top: 12px;
 		color: #757575;
@@ -38,10 +43,15 @@
 		width: 100%;
 	}
 
+	// `<Button>` defaults to `display: inline-flex; height: 36px;` which makes
+	// the image overflow the bounds when we drop it inside. Force the button to
+	// act as a block container that grows to wrap whatever it holds.
 	.jetpack-podcast-episode__cover-button {
 		box-sizing: border-box;
+		display: block;
 		width: 100%;
 		height: auto;
+		min-height: 0;
 		padding: 0;
 		border: 1px solid #ddd;
 		border-radius: 4px;
@@ -63,11 +73,11 @@
 	}
 
 	.jetpack-podcast-episode__cover-button--empty {
-		min-height: 92px;
-		border-style: dashed;
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		min-height: 92px;
+		border-style: dashed;
 
 		span {
 			color: var(--wp-admin-theme-color, #007cba);

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
@@ -26,13 +26,6 @@
 		background: #f6f7f7;
 	}
 
-	.jetpack-podcast-episode__notes-hint {
-		margin-top: 12px;
-		color: #757575;
-		font-style: italic;
-		font-size: 13px;
-	}
-
 	// Featured-image-style cover picker: full-width clickable preview that
 	// opens the media library, with Replace / Remove links underneath.
 	.jetpack-podcast-episode__cover-picker {

--- a/projects/packages/podcast/src/blocks/podcast-episode/style.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/style.scss
@@ -170,23 +170,27 @@ $jetpack-podcast-episode-gap: 16px;
 		font-size: 0.9em;
 	}
 
-	.jetpack-podcast-episode__chapter {
-		display: flex;
-		gap: 12px;
-		align-items: baseline;
-	}
-
 	.jetpack-podcast-episode__chapter-time {
 		flex: 0 0 auto;
 		font-variant-numeric: tabular-nums;
 		color: gb.$gray-700;
 	}
 
-	// The view script tags chapters and soundbites with .is-clickable once
-	// it has wired the play/seek handlers; the style only applies when JS
-	// has hydrated, so non-JS readers see static lists with no hover affordance.
-	.jetpack-podcast-episode__chapter.is-clickable,
-	.jetpack-podcast-episode__soundbite.is-clickable {
+	// Click-to-seek buttons render in place of plain rows. Reset the browser's
+	// default <button> chrome so they read as regular list items, then add a
+	// hover/focus affordance to signal interactivity.
+	.jetpack-podcast-episode__chapter-button,
+	.jetpack-podcast-episode__soundbite-button {
+		display: flex;
+		gap: 12px;
+		align-items: baseline;
+		width: 100%;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		text-align: inherit;
 		cursor: pointer;
 		border-radius: 2px;
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/style.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/style.scss
@@ -182,6 +182,25 @@ $jetpack-podcast-episode-gap: 16px;
 		color: gb.$gray-700;
 	}
 
+	// The view script tags chapters and soundbites with .is-clickable once
+	// it has wired the play/seek handlers; the style only applies when JS
+	// has hydrated, so non-JS readers see static lists with no hover affordance.
+	.jetpack-podcast-episode__chapter.is-clickable,
+	.jetpack-podcast-episode__soundbite.is-clickable {
+		cursor: pointer;
+		border-radius: 2px;
+
+		&:hover .jetpack-podcast-episode__chapter-title,
+		&:hover .jetpack-podcast-episode__soundbite-title {
+			text-decoration: underline;
+		}
+
+		&:focus-visible {
+			outline: 2px solid currentColor;
+			outline-offset: 2px;
+		}
+	}
+
 	.jetpack-podcast-episode__links {
 		list-style: none;
 		margin: 0;

--- a/projects/packages/podcast/src/blocks/podcast-episode/style.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/style.scss
@@ -170,15 +170,26 @@ $jetpack-podcast-episode-gap: 16px;
 		font-size: 0.9em;
 	}
 
-	.jetpack-podcast-episode__chapter-time {
+	// Layout sits on the <li> so theme overrides that target these classes
+	// (rather than the inner button) keep working.
+	.jetpack-podcast-episode__chapter,
+	.jetpack-podcast-episode__soundbite {
+		display: flex;
+		gap: 12px;
+		align-items: baseline;
+	}
+
+	.jetpack-podcast-episode__chapter-time,
+	.jetpack-podcast-episode__soundbite-time {
 		flex: 0 0 auto;
 		font-variant-numeric: tabular-nums;
 		color: gb.$gray-700;
 	}
 
-	// Click-to-seek buttons render in place of plain rows. Reset the browser's
-	// default <button> chrome so they read as regular list items, then add a
-	// hover/focus affordance to signal interactivity.
+	// Click-to-seek button wraps the row content. Reset the browser's default
+	// <button> chrome so it reads as a regular list row, then add a hover /
+	// focus affordance to signal interactivity. Inherits flex layout from the
+	// parent <li> to lay out the time and title inline.
 	.jetpack-podcast-episode__chapter-button,
 	.jetpack-podcast-episode__soundbite-button {
 		display: flex;

--- a/projects/packages/podcast/src/blocks/podcast-episode/view.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/view.ts
@@ -1,30 +1,10 @@
 /**
  * Front-end view script for the Podcast Episode block.
  *
- * Wires chapter and soundbite list items so a click (or Enter/Space) seeks the
- * associated audio/video element to that timestamp and starts playback. Items
- * carry the timestamp on `data-start-time` (seconds, integer) — emitted by the
- * server-side render callback.
+ * Chapters and soundbites render as real `<button data-start-time="…">`
+ * elements so the browser handles keyboard, focus, and a11y natively. We
+ * just need one delegated click listener per episode to seek the player.
  */
-
-const seekToTime = ( media: HTMLMediaElement, seconds: number ): void => {
-	if ( Number.isNaN( seconds ) || seconds < 0 ) {
-		return;
-	}
-	try {
-		media.currentTime = seconds;
-	} catch {
-		// Some browsers throw if the media isn't ready yet — ignore and let
-		// the play() below resume from wherever the element starts.
-	}
-	const playResult = media.play();
-	if ( playResult && typeof playResult.catch === 'function' ) {
-		playResult.catch( () => {
-			// Autoplay can fail without a user gesture; the click satisfies that,
-			// but mute restrictions or denied media permissions can still reject.
-		} );
-	}
-};
 
 const wireEpisode = ( root: Element ): void => {
 	const media = root.querySelector< HTMLMediaElement >(
@@ -34,22 +14,29 @@ const wireEpisode = ( root: Element ): void => {
 		return;
 	}
 
-	const cues = root.querySelectorAll< HTMLElement >( '[data-start-time]' );
-	cues.forEach( cue => {
-		const start = Number( cue.dataset.startTime );
-		if ( Number.isNaN( start ) ) {
+	root.addEventListener( 'click', event => {
+		const button = ( event.target as Element | null )?.closest< HTMLButtonElement >(
+			'button[data-start-time]'
+		);
+		if ( ! button ) {
 			return;
 		}
-		cue.setAttribute( 'role', 'button' );
-		cue.setAttribute( 'tabindex', '0' );
-		cue.classList.add( 'is-clickable' );
-		cue.addEventListener( 'click', () => seekToTime( media, start ) );
-		cue.addEventListener( 'keydown', event => {
-			if ( event.key === 'Enter' || event.key === ' ' ) {
-				event.preventDefault();
-				seekToTime( media, start );
-			}
-		} );
+		const seconds = Number( button.dataset.startTime );
+		if ( Number.isNaN( seconds ) || seconds < 0 ) {
+			return;
+		}
+		try {
+			media.currentTime = seconds;
+		} catch {
+			// Some browsers throw if the media isn't ready yet — ignore and let
+			// play() resume from wherever the element starts.
+		}
+		const playResult = media.play();
+		if ( playResult && typeof playResult.catch === 'function' ) {
+			playResult.catch( () => {
+				// Autoplay restrictions can still reject even after a user click.
+			} );
+		}
 	} );
 };
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/view.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/view.ts
@@ -6,6 +6,34 @@
  * just need one delegated click listener per episode to seek the player.
  */
 
+const seekAndPlay = ( media: HTMLMediaElement, seconds: number ): void => {
+	const seek = () => {
+		try {
+			media.currentTime = seconds;
+		} catch {
+			// Edge case: setting currentTime may still throw if the media never
+			// got past HAVE_NOTHING — ignore and let play() start where it can.
+		}
+	};
+
+	// With preload="none" the element is in readyState 0 (HAVE_NOTHING) until
+	// play() is called. Setting currentTime now would throw INVALID_STATE_ERR
+	// per the HTML spec, so wait for loadedmetadata if we're not there yet.
+	if ( media.readyState >= 1 ) {
+		seek();
+	} else {
+		media.addEventListener( 'loadedmetadata', seek, { once: true } );
+		media.load();
+	}
+
+	const playResult = media.play();
+	if ( playResult && typeof playResult.catch === 'function' ) {
+		playResult.catch( () => {
+			// Autoplay restrictions can still reject even after a user click.
+		} );
+	}
+};
+
 const wireEpisode = ( root: Element ): void => {
 	const media = root.querySelector< HTMLMediaElement >(
 		'.jetpack-podcast-episode__audio, .jetpack-podcast-episode__video'
@@ -25,18 +53,7 @@ const wireEpisode = ( root: Element ): void => {
 		if ( Number.isNaN( seconds ) || seconds < 0 ) {
 			return;
 		}
-		try {
-			media.currentTime = seconds;
-		} catch {
-			// Some browsers throw if the media isn't ready yet — ignore and let
-			// play() resume from wherever the element starts.
-		}
-		const playResult = media.play();
-		if ( playResult && typeof playResult.catch === 'function' ) {
-			playResult.catch( () => {
-				// Autoplay restrictions can still reject even after a user click.
-			} );
-		}
+		seekAndPlay( media, seconds );
 	} );
 };
 

--- a/projects/packages/podcast/src/blocks/podcast-episode/view.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/view.ts
@@ -1,0 +1,66 @@
+/**
+ * Front-end view script for the Podcast Episode block.
+ *
+ * Wires chapter and soundbite list items so a click (or Enter/Space) seeks the
+ * associated audio/video element to that timestamp and starts playback. Items
+ * carry the timestamp on `data-start-time` (seconds, integer) — emitted by the
+ * server-side render callback.
+ */
+
+const seekToTime = ( media: HTMLMediaElement, seconds: number ): void => {
+	if ( Number.isNaN( seconds ) || seconds < 0 ) {
+		return;
+	}
+	try {
+		media.currentTime = seconds;
+	} catch {
+		// Some browsers throw if the media isn't ready yet — ignore and let
+		// the play() below resume from wherever the element starts.
+	}
+	const playResult = media.play();
+	if ( playResult && typeof playResult.catch === 'function' ) {
+		playResult.catch( () => {
+			// Autoplay can fail without a user gesture; the click satisfies that,
+			// but mute restrictions or denied media permissions can still reject.
+		} );
+	}
+};
+
+const wireEpisode = ( root: Element ): void => {
+	const media = root.querySelector< HTMLMediaElement >(
+		'.jetpack-podcast-episode__audio, .jetpack-podcast-episode__video'
+	);
+	if ( ! media ) {
+		return;
+	}
+
+	const cues = root.querySelectorAll< HTMLElement >( '[data-start-time]' );
+	cues.forEach( cue => {
+		const start = Number( cue.dataset.startTime );
+		if ( Number.isNaN( start ) ) {
+			return;
+		}
+		cue.setAttribute( 'role', 'button' );
+		cue.setAttribute( 'tabindex', '0' );
+		cue.classList.add( 'is-clickable' );
+		cue.addEventListener( 'click', () => seekToTime( media, start ) );
+		cue.addEventListener( 'keydown', event => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				seekToTime( media, start );
+			}
+		} );
+	} );
+};
+
+const init = (): void => {
+	document
+		.querySelectorAll< HTMLElement >( '.wp-block-jetpack-podcast-episode' )
+		.forEach( wireEpisode );
+};
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', init );
+} else {
+	init();
+}

--- a/projects/packages/podcast/src/blocks/podcast-episode/view.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/view.ts
@@ -6,33 +6,57 @@
  * just need one delegated click listener per episode to seek the player.
  */
 
+// Concurrent clicks coalesce into a single pending target so the user lands
+// on the last button pressed instead of seeing each intermediate seek flash by.
+const pendingSeeks = new WeakMap< HTMLMediaElement, number >();
+const awaitingMetadata = new WeakSet< HTMLMediaElement >();
+
+const applyPendingSeek = ( media: HTMLMediaElement ): void => {
+	const target = pendingSeeks.get( media );
+	if ( typeof target !== 'number' ) {
+		return;
+	}
+	pendingSeeks.delete( media );
+	try {
+		media.currentTime = target;
+	} catch {
+		// Setting currentTime may still throw if the media never got past
+		// HAVE_NOTHING — ignore and let play() start where it can.
+	}
+	const playResult = media.play();
+	if ( playResult && typeof playResult.catch === 'function' ) {
+		playResult.catch( () => {
+			// Autoplay restrictions can still reject even after a user click.
+		} );
+	}
+};
+
 const seekAndPlay = ( media: HTMLMediaElement, seconds: number ): void => {
-	const seekThenPlay = () => {
-		try {
-			media.currentTime = seconds;
-		} catch {
-			// Edge case: setting currentTime may still throw if the media never
-			// got past HAVE_NOTHING — ignore and let play() start where it can.
-		}
-		const playResult = media.play();
-		if ( playResult && typeof playResult.catch === 'function' ) {
-			playResult.catch( () => {
-				// Autoplay restrictions can still reject even after a user click.
-			} );
-		}
-	};
+	pendingSeeks.set( media, seconds );
+
+	if ( media.readyState >= 1 ) {
+		applyPendingSeek( media );
+		return;
+	}
 
 	// With preload="none" the element is in readyState 0 (HAVE_NOTHING) until
 	// the resource selection algorithm runs. Setting currentTime now would throw
 	// INVALID_STATE_ERR per the HTML spec, so wait for loadedmetadata first.
-	// play() is deferred too so playback never starts from 0 before the seek
-	// lands; transient user activation lasts long enough for the metadata load.
-	if ( media.readyState >= 1 ) {
-		seekThenPlay();
-	} else {
-		media.addEventListener( 'loadedmetadata', seekThenPlay, { once: true } );
-		media.load();
+	// A second click while we're already waiting just updates pendingSeeks; the
+	// single listener applies the latest target.
+	if ( awaitingMetadata.has( media ) ) {
+		return;
 	}
+	awaitingMetadata.add( media );
+	media.addEventListener(
+		'loadedmetadata',
+		() => {
+			awaitingMetadata.delete( media );
+			applyPendingSeek( media );
+		},
+		{ once: true }
+	);
+	media.load();
 };
 
 const wireEpisode = ( root: Element ): void => {

--- a/projects/packages/podcast/src/blocks/podcast-episode/view.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/view.ts
@@ -7,30 +7,31 @@
  */
 
 const seekAndPlay = ( media: HTMLMediaElement, seconds: number ): void => {
-	const seek = () => {
+	const seekThenPlay = () => {
 		try {
 			media.currentTime = seconds;
 		} catch {
 			// Edge case: setting currentTime may still throw if the media never
 			// got past HAVE_NOTHING — ignore and let play() start where it can.
 		}
+		const playResult = media.play();
+		if ( playResult && typeof playResult.catch === 'function' ) {
+			playResult.catch( () => {
+				// Autoplay restrictions can still reject even after a user click.
+			} );
+		}
 	};
 
 	// With preload="none" the element is in readyState 0 (HAVE_NOTHING) until
-	// play() is called. Setting currentTime now would throw INVALID_STATE_ERR
-	// per the HTML spec, so wait for loadedmetadata if we're not there yet.
+	// the resource selection algorithm runs. Setting currentTime now would throw
+	// INVALID_STATE_ERR per the HTML spec, so wait for loadedmetadata first.
+	// play() is deferred too so playback never starts from 0 before the seek
+	// lands; transient user activation lasts long enough for the metadata load.
 	if ( media.readyState >= 1 ) {
-		seek();
+		seekThenPlay();
 	} else {
-		media.addEventListener( 'loadedmetadata', seek, { once: true } );
+		media.addEventListener( 'loadedmetadata', seekThenPlay, { once: true } );
 		media.load();
-	}
-
-	const playResult = media.play();
-	if ( playResult && typeof playResult.catch === 'function' ) {
-		playResult.catch( () => {
-			// Autoplay restrictions can still reject even after a user click.
-		} );
 	}
 };
 

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -352,7 +352,7 @@ class Customize_Feed {
 	 * @param string $original_url Original enclosure URL — extension is pulled from here.
 	 * @return string
 	 */
-	public static function build_stats_url( int $blog_id, int $post_id, string $original_url ): string {
+	private static function build_stats_url( int $blog_id, int $post_id, string $original_url ): string {
 		$path = (string) wp_parse_url( $original_url, PHP_URL_PATH );
 		$ext  = (string) preg_replace( '/[^a-z0-9]/', '', strtolower( (string) pathinfo( $path, PATHINFO_EXTENSION ) ) );
 		if ( ! in_array( $ext, array( 'mp3', 'm4a', 'm4b', 'aac', 'ogg', 'oga', 'opus', 'wav', 'flac', 'mp4', 'm4v', 'mov' ), true ) ) {

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -352,7 +352,7 @@ class Customize_Feed {
 	 * @param string $original_url Original enclosure URL — extension is pulled from here.
 	 * @return string
 	 */
-	private static function build_stats_url( int $blog_id, int $post_id, string $original_url ): string {
+	public static function build_stats_url( int $blog_id, int $post_id, string $original_url ): string {
 		$path = (string) wp_parse_url( $original_url, PHP_URL_PATH );
 		$ext  = (string) preg_replace( '/[^a-z0-9]/', '', strtolower( (string) pathinfo( $path, PATHINFO_EXTENSION ) ) );
 		if ( ! in_array( $ext, array( 'mp3', 'm4a', 'm4b', 'aac', 'ogg', 'oga', 'opus', 'wav', 'flac', 'mp4', 'm4v', 'mov' ), true ) ) {

--- a/projects/packages/podcast/webpack.config.blocks.js
+++ b/projects/packages/podcast/webpack.config.blocks.js
@@ -17,6 +17,7 @@ const sharedWebpackConfig = {
 	entry: {
 		'podcast-episode/editor': './src/blocks/podcast-episode/editor.ts',
 		'podcast-episode/style': './src/blocks/podcast-episode/style.scss',
+		'podcast-episode/view': './src/blocks/podcast-episode/view.ts',
 	},
 	output: {
 		...jetpackWebpackConfig.output,


### PR DESCRIPTION
## Proposed changes
* Translate the Podcast Episode block's front-end output to fuller `schema.org/PodcastEpisode` microdata so the audio block, chapter list, and cover art are all readable by feed readers and search engines.
* Add `url` (episode permalink), wrap season number in a nested `PodcastSeason`, mark the audio/video player as a proper `AudioObject` / `VideoObject` with `contentUrl`, `encodingFormat`, `duration`, and `name`.
* Mark chapters and Podcasting 2.0 soundbites as `hasPart` Clip entries with `startOffset` (+ `endOffset` for soundbites that carry a duration) and `name`.
* Expose the transcript URL as a `transcript` MediaObject with its declared `encodingFormat`.
* Pull the show-level `podcasting_title` / `podcasting_image` / `podcasting_email` settings into a `partOfSeries` PodcastSeries reference so each episode connects to its parent show.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Install Jetpack Beta on a test site and switch to this branch.
* Create a podcast post, insert the Podcast Episode block, and publish.
* On the published post, view source and confirm the outer `<article>` carries `itemscope itemtype="https://schema.org/PodcastEpisode"` and contains:
  * `<link itemprop="url">` with the post permalink.
  * `partOfSeason` block with a `seasonNumber` meta when a season is set.
  * `episodeNumber` itemprop when an episode number is set.
  * `audio` / `video` itemprop on the player div, scoped to `AudioObject` or `VideoObject`, with `contentUrl`, `encodingFormat`, `duration`, `name` metas.
  * Each chapter `<li>` carries `itemprop="hasPart"` with `itemtype="https://schema.org/Clip"` and a `startOffset` meta in seconds. Same for soundbites (with `endOffset` when applicable).
  * Transcript link wrapped in `transcript` MediaObject when a transcript URL is set.
  * `partOfSeries` PodcastSeries block at the bottom of the body with the show title, image, and email pulled from Settings → Writing → Podcasting.
* Paste the URL into the Schema Markup Validator at https://validator.schema.org/ and confirm it parses a `PodcastEpisode` with the expected nested types and no errors.
* Confirm visuals still render: cover art, audio/video player, chapter list, transcript link.
