### PR TITLE
Write editor: replace ambiguous '?' help button with italic 'i' icon, fix tips popover z-index

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-2656-replace-or-clarify-the-help-icon
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-2656-replace-or-clarify-the-help-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write editor: replace ambiguous '?' help button with a cleaner italic 'i' icon, and fix the tips popover appearing behind the beta/recovery banners.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -27,7 +27,7 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	z-index: 100000;
+	z-index: 100002;
 	height: 56px;
 	background: #fff;
 	border-bottom: 1px solid #f0f0f0;
@@ -56,6 +56,13 @@
 	font-family: inherit;
 }
 
+.bw-help-i {
+	font-style: italic;
+	font-size: 15px;
+	font-family: Georgia, serif;
+	line-height: 1;
+}
+
 .bw-help-toggle:hover {
 	border-color: #999;
 	color: #666;
@@ -65,7 +72,7 @@
 	position: absolute;
 	top: 48px;
 	left: 60px;
-	z-index: 200;
+	z-index: 100002;
 	background: #fff;
 	border-radius: 10px;
 	padding: 16px 20px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -428,7 +428,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<header class="bw-topbar">
 		<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-back" title="<?php echo esc_attr__( 'Back to dashboard', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Back to dashboard', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.handleBack">&larr;</a>
 		<div class="bw-help-wrap" data-wp-on--keydown="actions.handleHelpKeyDown" data-wp-on--focusout="actions.handleHelpFocusOut">
-		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="<?php echo esc_attr__( 'Shortcuts', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Shortcuts', 'jetpack-mu-wpcom' ); ?>"><span class="bw-help-i" aria-hidden="true">i</span></button>
+		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="<?php echo esc_attr__( 'Tips', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Tips', 'jetpack-mu-wpcom' ); ?>"><span class="bw-help-i" aria-hidden="true">i</span></button>
 		<div class="bw-help-popover" hidden data-wp-bind--hidden="!state.showHelp">
 			<div class="bw-help-title"><?php echo esc_html__( 'Tips', 'jetpack-mu-wpcom' ); ?></div>
 			<div class="bw-help-row"><kbd>/</kbd><span><?php echo esc_html__( 'Insert a heading, image, video, list, quote or divider', 'jetpack-mu-wpcom' ); ?></span></div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -428,7 +428,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<header class="bw-topbar">
 		<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-back" title="<?php echo esc_attr__( 'Back to dashboard', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Back to dashboard', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.handleBack">&larr;</a>
 		<div class="bw-help-wrap" data-wp-on--keydown="actions.handleHelpKeyDown" data-wp-on--focusout="actions.handleHelpFocusOut">
-		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="<?php echo esc_attr__( 'Shortcuts', 'jetpack-mu-wpcom' ); ?>">?</button>
+		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="<?php echo esc_attr__( 'Shortcuts', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Shortcuts', 'jetpack-mu-wpcom' ); ?>"><span class="bw-help-i" aria-hidden="true">i</span></button>
 		<div class="bw-help-popover" hidden data-wp-bind--hidden="!state.showHelp">
 			<div class="bw-help-title"><?php echo esc_html__( 'Tips', 'jetpack-mu-wpcom' ); ?></div>
 			<div class="bw-help-row"><kbd>/</kbd><span><?php echo esc_html__( 'Insert a heading, image, video, list, quote or divider', 'jetpack-mu-wpcom' ); ?></span></div>


### PR DESCRIPTION
Fixes RSM-2656

## Proposed changes

* Replaces the ambiguous `?` character in the Write editor's help toggle button with a styled italic `i` (serif, 15px) — the circular button border and the `i` together read as a standard info/tips icon
* Raises `.bw-topbar` z-index from `100000` to `100002` so the tips popover appears in front of the beta disclaimer and draft recovery banners (which sit at `100001`)

Before | After
---- | ----
<img width="95" height="59" alt="Screenshot 2026-05-13 at 1 30 54 PM" src="https://github.com/user-attachments/assets/e20e5311-19c3-460c-a0e7-53fb3207b789" /> | <img width="95" height="59" alt="Screenshot 2026-05-13 at 1 30 46 PM" src="https://github.com/user-attachments/assets/afb76f73-89ea-43bb-93ad-5e51de8613c3" />

## Related product discussion/links

* RSM-2656 — reported by a tester who hovered the `?` icon thinking it was a broken image

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor (`/wp-admin/admin.php?page=write`)
* Confirm the help toggle button in the top-left shows an italic `i` instead of `?`
* Click the `i` button — the Tips popover should open
* If the beta disclaimer banner or draft recovery banner is visible, confirm the popover appears **in front of** the banner, not behind it
* Confirm the tips popover content and keyboard shortcuts are unchanged

