### PR TITLE
Podcast: refresh welcome-screen copy

### DIFF
--- a/projects/packages/podcast/changelog/update-podcast-welcome-copy
+++ b/projects/packages/podcast/changelog/update-podcast-welcome-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update welcome screen copy to lead with the blog and newsletter story, and refresh the feature boxes and how-it-works steps.

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -22,7 +22,7 @@ const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string 
 		icon: <Icon icon={ megaphone } />,
 		title: __( 'Reach listeners in every app', 'jetpack-podcast' ),
 		body: __(
-			'One feed distributes to Apple Podcasts, Spotify, Overcast, Pocket Casts, and every directory that accepts RSS.',
+			'One feed distributes to Apple Podcasts, Spotify, Overcast, Pocket Casts, and every directory that accepts RSS.',
 			'jetpack-podcast'
 		),
 	},
@@ -77,7 +77,7 @@ const Welcome = ( { onEnable }: WelcomeProps ) => (
 				</h2>
 				<Text variant="muted">
 					{ __(
-						'Publish your show on the same site as your blog and newsletter. Reach fans on Apple, Spotify, Pocket Casts, and every major podcast app.',
+						'Publish your show on the same site as your blog and newsletter. Reach fans on Apple, Spotify, Pocket Casts, and every major podcast app.',
 						'jetpack-podcast'
 					) }
 				</Text>

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -10,7 +10,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, audio, layout, megaphone } from '@wordpress/icons';
+import { Icon, globe, layout, megaphone } from '@wordpress/icons';
 import './style.scss';
 
 interface WelcomeProps {
@@ -27,18 +27,18 @@ const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string 
 		),
 	},
 	{
-		icon: <Icon icon={ audio } />,
-		title: __( 'Works with the editor you already use', 'jetpack-podcast' ),
-		body: __(
-			'Drop an audio block into a post, assign the podcast category, hit publish. That is the whole workflow.',
-			'jetpack-podcast'
-		),
-	},
-	{
 		icon: <Icon icon={ layout } />,
 		title: __( 'One home for writing, email, and audio', 'jetpack-podcast' ),
 		body: __(
 			'One site, one audience, one subscriber list. Your posts, newsletters, and episodes all live in the same place.',
+			'jetpack-podcast'
+		),
+	},
+	{
+		icon: <Icon icon={ globe } />,
+		title: __( 'Own your feed forever', 'jetpack-podcast' ),
+		body: __(
+			'Your podcast lives on your domain with your data and your subscribers. Everything can move with you at any time.',
 			'jetpack-podcast'
 		),
 	},
@@ -54,15 +54,15 @@ const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = 
 		number: '2',
 		title: __( 'Publish a post with audio', 'jetpack-podcast' ),
 		body: __(
-			'Add an audio block to any post and assign it to your podcast category.',
+			'Add an audio or podcast episode block to any post and assign it to your podcast category.',
 			'jetpack-podcast'
 		),
 	},
 	{
 		number: '3',
-		title: __( 'Submit your feed once', 'jetpack-podcast' ),
+		title: __( 'Submit your feed', 'jetpack-podcast' ),
 		body: __(
-			'Copy the feed URL, submit it to Apple Podcasts and Spotify, and you are live.',
+			"Use our simple distribution tool to submit to Apple, Spotify, and others. That's it!",
 			'jetpack-podcast'
 		),
 	},
@@ -73,11 +73,11 @@ const Welcome = ( { onEnable }: WelcomeProps ) => (
 		<section className="podcast__welcome-hero">
 			<VStack spacing={ 4 } className="podcast__welcome-hero-copy">
 				<h2 className="podcast__welcome-title">
-					{ __( 'Turn your posts into a podcast', 'jetpack-podcast' ) }
+					{ __( 'Your podcast belongs with your blog', 'jetpack-podcast' ) }
 				</h2>
 				<Text variant="muted">
 					{ __(
-						'Publish audio alongside your writing and get distributed to Apple Podcasts, Spotify, and every major app, without leaving your site.',
+						'Publish your show on the same site as your blog and newsletter. Reach fans on Apple, Spotify, Pocket Casts, and every major podcast app.',
 						'jetpack-podcast'
 					) }
 				</Text>


### PR DESCRIPTION
## Proposed changes

Refreshes the welcome screen copy in the `@automattic/jetpack-podcast` package so the enable flow leads with the "podcast belongs with your blog" wedge rather than the more generic "turn your posts into a podcast" line. Three things change in `welcome/index.tsx`:

* Hero headline and subtitle now lead with the blog + newsletter story.
* Box 2 now carries the "one home for writing, email, and audio" message, and box 3 replaces the duplicate "editor" box with a new "own your feed forever" message (with a globe icon).
* "How it works" step 2 mentions the podcast episode block alongside the audio block, and step 3 drops the "submit once" framing in favor of the new distribution tool.

No behavior, structural, or markup changes, just copy plus two icon swaps.

## Related product discussion/links

Part of the Radical Speed Month podcasting workstream.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a copy-only change to the podcast welcome screen.

* Enable the `jetpack_podcast_untangle` feature flag.
* Visit `wp-admin/admin.php?page=jetpack-podcast` on a site that has not yet picked a podcasting category (so the welcome view renders, not the settings tab).
* Confirm:
  * Hero headline reads "Your podcast belongs with your blog".
  * Subtitle mentions Apple, Spotify, Pocket Casts.
  * Three feature boxes render in order: "Reach listeners in every app" (megaphone), "One home for writing, email, and audio" (layout), "Own your feed forever" (globe).
  * "How it works" step 3 title is "Submit your feed" (no "once") and the body references the distribution tool.
