### PR TITLE
Podcast: always show Disable card on settings tab

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-disable-always-visible
+++ b/projects/packages/podcast/changelog/fix-podcast-disable-always-visible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Always show the Disable podcasting card on the settings tab so users can back out before choosing a category.

--- a/projects/packages/podcast/changelog/fix-podcast-disable-always-visible
+++ b/projects/packages/podcast/changelog/fix-podcast-disable-always-visible
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Always show the Disable podcasting card on the settings tab so users can back out before choosing a category.
+Always show the Disable podcasting card on the settings tab, and return the user to the welcome screen after disabling, so the back-out flow works before a category has been chosen.

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -83,6 +83,10 @@ const App = () => {
 		handleTabChange( 'settings' );
 	}, [ handleTabChange ] );
 
+	const handleAfterDisable = useCallback( () => {
+		setHasEnabled( false );
+	}, [] );
+
 	if ( isLoading ) {
 		return (
 			<AdminPage title={ PAGE_TITLE } subTitle={ PAGE_SUBTITLE }>
@@ -128,7 +132,7 @@ const App = () => {
 					<div className="podcast__tab-content podcast__tab-content--narrow">
 						<ErrorBoundary>
 							<Suspense fallback={ <TabFallback /> }>
-								<SettingsTab />
+								<SettingsTab onAfterDisable={ handleAfterDisable } />
 							</Suspense>
 						</ErrorBoundary>
 					</div>

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -85,7 +85,11 @@ const useFieldEditor = (
 	};
 };
 
-const SettingsTab = () => {
+interface SettingsTabProps {
+	onAfterDisable?: () => void;
+}
+
+const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	const { data: settings, isLoading } = usePodcastSettings();
 	const { mutate: saveSettings } = useUpdatePodcastSettings();
 
@@ -207,7 +211,8 @@ const SettingsTab = () => {
 	const onDisablePodcasting = useCallback( () => {
 		setConfirmDisable( false );
 		commit( { podcasting_category_id: 0 } );
-	}, [ commit ] );
+		onAfterDisable?.();
+	}, [ commit, onAfterDisable ] );
 
 	if ( isLoading || ! draft ) {
 		return null;

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -360,28 +360,26 @@ const SettingsTab = () => {
 				</CardBody>
 			</Card>
 
-			{ draft.podcasting_category_id > 0 && (
-				<Card>
-					<CardHeader>
-						<h2 className="podcast__section-heading">
-							{ __( 'Disable podcasting', 'jetpack-podcast' ) }
-						</h2>
-					</CardHeader>
-					<CardBody>
-						<VStack spacing={ 3 } alignment="flex-start">
-							<Text variant="muted">
-								{ __(
-									'Stops publishing your podcast feed. Your show details stay saved, so you can set it up again later.',
-									'jetpack-podcast'
-								) }
-							</Text>
-							<Button variant="secondary" isDestructive onClick={ openConfirmDisable }>
-								{ __( 'Disable', 'jetpack-podcast' ) }
-							</Button>
-						</VStack>
-					</CardBody>
-				</Card>
-			) }
+			<Card>
+				<CardHeader>
+					<h2 className="podcast__section-heading">
+						{ __( 'Disable podcasting', 'jetpack-podcast' ) }
+					</h2>
+				</CardHeader>
+				<CardBody>
+					<VStack spacing={ 3 } alignment="flex-start">
+						<Text variant="muted">
+							{ __(
+								'Stops publishing your podcast feed. Your show details stay saved, so you can set it up again later.',
+								'jetpack-podcast'
+							) }
+						</Text>
+						<Button variant="secondary" isDestructive onClick={ openConfirmDisable }>
+							{ __( 'Disable', 'jetpack-podcast' ) }
+						</Button>
+					</VStack>
+				</CardBody>
+			</Card>
 
 			{ confirmDisable && (
 				<Modal

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -210,9 +210,8 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	const closeConfirmDisable = useCallback( () => setConfirmDisable( false ), [] );
 	const onDisablePodcasting = useCallback( () => {
 		setConfirmDisable( false );
-		commit( { podcasting_category_id: 0 } );
-		onAfterDisable?.();
-	}, [ commit, onAfterDisable ] );
+		saveSettings( { podcasting_category_id: 0 }, { onSuccess: () => onAfterDisable?.() } );
+	}, [ saveSettings, onAfterDisable ] );
 
 	if ( isLoading || ! draft ) {
 		return null;


### PR DESCRIPTION
## Proposed changes

This PR is all disable all the time
Disable button shows up before you pick a category. 
Disable button bounces you back to Welcome. 
Disable button still works after you've picked a category. 


After clicking Enable on the welcome screen, the dashboard saves a placeholder `podcasting_title` but leaves `podcasting_category_id` at 0. The settings tab then renders, but the Disable card was gated on `podcasting_category_id > 0`, so users had no way out until they picked a category. The welcome screen itself is gated by a local `hasEnabled` state, which never flips back to false on its own.

This PR does two things:

* `settings/index.tsx`: drop the gate so the Disable card always renders on the settings tab.
* `dashboard/index.tsx` and `settings/index.tsx`: thread an `onAfterDisable` callback from `App` into `SettingsTab` so the disable click resets `hasEnabled` and brings the welcome view back. Without that handoff the user would still be stranded on an empty settings tab after disabling pre-category.

The confirm Modal is still gated on its own `confirmDisable` state, so no change there. The disable handler is a server clear (`commit({ podcasting_category_id: 0 })`) and is safe to call when no category has been saved yet.

## Related product discussion/links

Part of the Radical Speed Month podcasting workstream.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Enable the `jetpack_podcast_untangle` feature flag.
* On a site that has never configured a podcasting category:
  * Visit `wp-admin/admin.php?page=jetpack-podcast`. Welcome screen renders.
  * Click "Enable podcasting". You land on the settings tab.
  * Scroll down. The "Disable podcasting" card is visible.
  * Click Disable, confirm in the modal. The URL clears and you return to the welcome screen.
* On a site that already has a podcasting category set:
  * The Disable card still renders and still works.
* Switch tabs (e.g., to Episodes) and back. Disable card behavior is unchanged across tab changes.
