### PR TITLE
Donations Block: admin defaults (frequency/amounts/toggles)

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -9,14 +9,14 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 430+ occurrences
+    // PhanTypeMismatchArgument : 420+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 260+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 200+ occurrences
     // PhanTypeMismatchReturn : 140+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 120+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 90+ occurrences
+    // PhanTypeArraySuspiciousNullable : 70+ occurrences
     // PhanDeprecatedFunction : 60+ occurrences
-    // PhanTypeArraySuspiciousNullable : 55+ occurrences
     // PhanRedefineFunction : 45+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanTypeExpectedObjectPropAccess : 30+ occurrences
@@ -151,7 +151,6 @@ return [
         'extensions/blocks/ai-chat/ai-chat.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'extensions/blocks/blog-stats/blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/google-calendar/google-calendar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/image-compare/image-compare.php' => ['PhanTypeMismatchArgument'],

--- a/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
+++ b/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Donations Block: Add admin controls for hiding the One-Time interval, choosing the default frequency, setting a per-frequency default donation amount, and configuring the suggested custom amount. At least one frequency must remain enabled.

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -97,6 +97,12 @@
 			"type": "boolean",
 			"default": true
 		},
+		"defaultInterval": {
+			"type": "string"
+		},
+		"customAmountPlaceholder": {
+			"type": "number"
+		},
 		"chooseAmountText": {
 			"type": "string"
 		},

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -1,12 +1,18 @@
-import { CURRENCIES } from '@automattic/format-currency';
+import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { AlignmentControl, BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
 	Dashicon,
 	Dropdown,
+	ExternalLink,
+	Flex,
+	FlexBlock,
+	FlexItem,
 	MenuGroup,
 	MenuItem,
 	PanelBody,
+	SelectControl,
+	TextControl,
 	ToggleControl,
 	ToolbarGroup,
 	ToolbarItem,
@@ -15,11 +21,18 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
-import { Link } from '@wordpress/ui';
 import {
 	getDefaultDonationAmountsForCurrency,
+	minimumTransactionAmountForCurrency,
 	SUPPORTED_CURRENCIES,
 } from '../../shared/currencies';
+import { firstShownInterval } from './utils';
+
+const INTERVAL_TO_ATTRIBUTE = {
+	'one-time': 'oneTimeDonation',
+	'1 month': 'monthlyDonation',
+	'1 year': 'annualDonation',
+};
 
 const Controls = props => {
 	const { attributes, setAttributes } = props;
@@ -30,23 +43,87 @@ const Controls = props => {
 		annualDonation,
 		showCustomAmount,
 		contentAlignment,
+		defaultInterval,
+		customAmountPlaceholder,
 	} = attributes;
 
-	const toggleDonation = ( interval, show ) => {
-		const donationAttributes = {
-			'1 month': 'monthlyDonation',
-			'1 year': 'annualDonation',
-		};
-		const donationAttribute = donationAttributes[ interval ];
-		const donation = attributes[ donationAttribute ];
+	const computedCustomAmountPlaceholder = minimumTransactionAmountForCurrency( currency ) * 100;
+	const effectiveCustomAmountPlaceholder =
+		customAmountPlaceholder ?? computedCustomAmountPlaceholder;
 
+	const oneTimeOn = oneTimeDonation.show !== false;
+	const monthlyOn = !! monthlyDonation.show;
+	const annualOn = !! annualDonation.show;
+	const enabledIntervalCount = ( oneTimeOn ? 1 : 0 ) + ( monthlyOn ? 1 : 0 ) + ( annualOn ? 1 : 0 );
+	const lastEnabledHelp = __( 'At least one frequency must be enabled.', 'jetpack' );
+
+	const fallbackInterval = firstShownInterval( oneTimeOn, monthlyOn, annualOn ) ?? 'one-time';
+	const isDefaultIntervalShown =
+		( defaultInterval === 'one-time' && oneTimeOn ) ||
+		( defaultInterval === '1 month' && monthlyOn ) ||
+		( defaultInterval === '1 year' && annualOn );
+	const effectiveDefaultInterval = isDefaultIntervalShown ? defaultInterval : fallbackInterval;
+
+	const toggleDonation = ( interval, show ) => {
+		const donationAttribute = INTERVAL_TO_ATTRIBUTE[ interval ];
+		const donation = attributes[ donationAttribute ];
+		const updates = {
+			[ donationAttribute ]: { ...donation, show },
+		};
+
+		// If we're hiding the frequency that's currently the effective default, shift the
+		// default to the next still-shown interval so the form never points at a hidden one.
+		if ( ! show && effectiveDefaultInterval === interval ) {
+			const stillShown = {
+				oneTime: interval === 'one-time' ? false : oneTimeOn,
+				monthly: interval === '1 month' ? false : monthlyOn,
+				annual: interval === '1 year' ? false : annualOn,
+			};
+			const nextDefault = firstShownInterval(
+				stillShown.oneTime,
+				stillShown.monthly,
+				stillShown.annual
+			);
+			if ( nextDefault ) {
+				updates.defaultInterval = nextDefault;
+			}
+		}
+
+		setAttributes( updates );
+	};
+
+	const setDonationValue = ( interval, key, value ) => {
+		const donationAttribute = INTERVAL_TO_ATTRIBUTE[ interval ];
 		setAttributes( {
-			[ donationAttribute ]: {
-				...donation,
-				show,
-			},
+			[ donationAttribute ]: { ...attributes[ donationAttribute ], [ key ]: value },
 		} );
 	};
+
+	const intervalLabels = {
+		'one-time': __( 'One-Time', 'jetpack' ),
+		'1 month': __( 'Monthly', 'jetpack' ),
+		'1 year': __( 'Yearly', 'jetpack' ),
+	};
+	const frequencyOptions = [
+		...( oneTimeOn ? [ { value: 'one-time', label: intervalLabels[ 'one-time' ] } ] : [] ),
+		...( monthlyOn ? [ { value: '1 month', label: intervalLabels[ '1 month' ] } ] : [] ),
+		...( annualOn ? [ { value: '1 year', label: intervalLabels[ '1 year' ] } ] : [] ),
+	];
+	const buildAmountOptions = amounts => [
+		{ value: '', label: __( 'None', 'jetpack' ) },
+		...( amounts || [] ).map( ( amount, idx ) => ( {
+			value: String( idx ),
+			label: formatCurrency( amount, currency ),
+		} ) ),
+	];
+	const amountValue = donation =>
+		donation.defaultAmountIndex !== undefined ? String( donation.defaultAmountIndex ) : '';
+	const onAmountChange = interval => value =>
+		setDonationValue(
+			interval,
+			'defaultAmountIndex',
+			value === '' ? undefined : parseInt( value, 10 )
+		);
 
 	const setContentAlignment = useCallback(
 		value => setAttributes( { contentAlignment: value || '' } ),
@@ -61,6 +138,7 @@ const Controls = props => {
 			oneTimeDonation: { ...oneTimeDonation, amounts: defaultAmounts },
 			monthlyDonation: { ...monthlyDonation, amounts: defaultAmounts },
 			annualDonation: { ...annualDonation, amounts: defaultAmounts },
+			customAmountPlaceholder: undefined,
 		} );
 	};
 
@@ -122,14 +200,26 @@ const Controls = props => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 					<ToggleControl
-						checked={ monthlyDonation.show }
+						checked={ oneTimeOn }
+						onChange={ value => toggleDonation( 'one-time', value ) }
+						disabled={ oneTimeOn && enabledIntervalCount === 1 }
+						help={ oneTimeOn && enabledIntervalCount === 1 ? lastEnabledHelp : undefined }
+						label={ __( 'Show one-time donations', 'jetpack' ) }
+						__nextHasNoMarginBottom={ true }
+					/>
+					<ToggleControl
+						checked={ monthlyOn }
 						onChange={ value => toggleDonation( '1 month', value ) }
+						disabled={ monthlyOn && enabledIntervalCount === 1 }
+						help={ monthlyOn && enabledIntervalCount === 1 ? lastEnabledHelp : undefined }
 						label={ __( 'Show monthly donations', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
 					<ToggleControl
-						checked={ annualDonation.show }
+						checked={ annualOn }
 						onChange={ value => toggleDonation( '1 year', value ) }
+						disabled={ annualOn && enabledIntervalCount === 1 }
+						help={ annualOn && enabledIntervalCount === 1 ? lastEnabledHelp : undefined }
 						label={ __( 'Show annual donations', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
@@ -139,9 +229,107 @@ const Controls = props => {
 						label={ __( 'Show custom amount option', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
-					<Link openInNewTab href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
-						{ __( 'View donation earnings', 'jetpack' ) }
-					</Link>
+					<h3
+						className="jp-donations-defaults-heading"
+						style={ {
+							margin: '24px 0 8px',
+							fontSize: 13,
+							fontWeight: 600,
+							textTransform: 'none',
+						} }
+					>
+						{ __( 'Defaults', 'jetpack' ) }
+					</h3>
+					<SelectControl
+						label={ __( 'Frequency', 'jetpack' ) }
+						value={ effectiveDefaultInterval }
+						options={ frequencyOptions }
+						onChange={ value => setAttributes( { defaultInterval: value } ) }
+						__nextHasNoMarginBottom={ true }
+					/>
+					<h4
+						className="jp-donations-defaults-subheading"
+						style={ {
+							margin: '16px 0 8px',
+							fontSize: 11,
+							fontWeight: 500,
+							textTransform: 'uppercase',
+						} }
+					>
+						{ __( 'Amounts', 'jetpack' ) }
+					</h4>
+					{ oneTimeOn && (
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'One-Time', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<SelectControl
+									hideLabelFromVision
+									label={ __( 'Default amount for One-Time', 'jetpack' ) }
+									value={ amountValue( oneTimeDonation ) }
+									options={ buildAmountOptions( oneTimeDonation.amounts ) }
+									onChange={ onAmountChange( 'one-time' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
+					) }
+					{ monthlyOn && (
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'Monthly', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<SelectControl
+									hideLabelFromVision
+									label={ __( 'Default amount for Monthly', 'jetpack' ) }
+									value={ amountValue( monthlyDonation ) }
+									options={ buildAmountOptions( monthlyDonation.amounts ) }
+									onChange={ onAmountChange( '1 month' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
+					) }
+					{ annualOn && (
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'Annual', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<SelectControl
+									hideLabelFromVision
+									label={ __( 'Default amount for Annual', 'jetpack' ) }
+									value={ amountValue( annualDonation ) }
+									options={ buildAmountOptions( annualDonation.amounts ) }
+									onChange={ onAmountChange( '1 year' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
+					) }
+					{ showCustomAmount && (
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'Custom', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<TextControl
+									type="number"
+									hideLabelFromVision
+									label={ __( 'Suggested custom amount', 'jetpack' ) }
+									value={ effectiveCustomAmountPlaceholder }
+									onChange={ value =>
+										setAttributes( {
+											customAmountPlaceholder:
+												value === '' || value === undefined ? undefined : Number( value ),
+										} )
+									}
+									min={ minimumTransactionAmountForCurrency( currency ) }
+									step={ 0.01 }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
+					) }
+					<p style={ { marginTop: 24 } }>
+						<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
+							{ __( 'View donation earnings', 'jetpack' ) }
+						</ExternalLink>
+					</p>
 				</PanelBody>
 			</InspectorControls>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -93,8 +93,11 @@ function render_block( $attr, $content ) {
 	// edited) fall back to the defaults in the first array. User-cleared
 	// keys (empty strings explicitly saved) win over defaults, so
 	// "blank stays blank" and "never set" gets the default.
-	$donations = array(
-		'one-time' => array_merge(
+	// Treat `show !== false` as on, so legacy blocks (where `show` was never
+	// set on oneTimeDonation) still render the one-time interval by default.
+	$donations = array();
+	if ( false !== ( $attr['oneTimeDonation']['show'] ?? true ) ) {
+		$donations['one-time'] = array_merge(
 			array(
 				'planId'     => null,
 				'title'      => __( 'One-Time', 'jetpack' ),
@@ -103,8 +106,8 @@ function render_block( $attr, $content ) {
 				'buttonText' => $default_texts['oneTimeDonation']['buttonText'],
 			),
 			$attr['oneTimeDonation']
-		),
-	);
+		);
+	}
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(
@@ -133,26 +136,50 @@ function render_block( $attr, $content ) {
 	$choose_amount_text = $attr['chooseAmountText'] ?? $default_texts['chooseAmountText'];
 	$custom_amount_text = $attr['customAmountText'] ?? $default_texts['customAmountText'];
 	$currency           = $attr['currency'];
-	$nav                = '';
-	$headings           = '';
-	$amounts            = '';
-	$extra_text         = '';
-	$buttons            = '';
+
+	// Drop intervals whose plan no longer resolves so we can compute the active tab
+	// against the actually-rendered set, not the configured set.
+	$valid_donations = array();
+	foreach ( $donations as $interval => $donation ) {
+		$plan = get_post( (int) $donation['planId'] );
+		if ( $plan && ! is_wp_error( $plan ) ) {
+			$valid_donations[ $interval ] = $donation;
+		}
+	}
+	$donations          = $valid_donations;
+	$rendered_intervals = array_keys( $donations );
+
+	// Effective default = configured defaultInterval if it survived plan validation,
+	// otherwise the first rendered interval (one-time → monthly → annual).
+	$default_interval = $attr['defaultInterval'] ?? null;
+	if ( ! in_array( $default_interval, $rendered_intervals, true ) ) {
+		$default_interval = $rendered_intervals[0] ?? null;
+	}
+	$tab_content_class_map = array(
+		'one-time' => 'is-one-time',
+		'1 month'  => 'is-monthly',
+		'1 year'   => 'is-annual',
+	);
+	$tab_content_class     = $default_interval ? $tab_content_class_map[ $default_interval ] : '';
+
+	$nav        = '';
+	$headings   = '';
+	$amounts    = '';
+	$extra_text = '';
+	$buttons    = '';
 	foreach ( $donations as $interval => $donation ) {
 		$plan_id = (int) $donation['planId'];
-		$plan    = get_post( $plan_id );
-		if ( ! $plan || is_wp_error( $plan ) ) {
-			continue;
-		}
 
 		if ( count( $donations ) > 1 ) {
 			if ( ! $nav ) {
 				$nav .= '<div class="donations__nav">';
 			}
-			$nav .= sprintf(
-				'<div role="button" tabindex="0" class="donations__nav-item" data-interval="%1$s">%2$s</div>',
+			$is_active_class = $interval === $default_interval ? ' is-active' : '';
+			$nav            .= sprintf(
+				'<div role="button" tabindex="0" class="donations__nav-item%3$s" data-interval="%1$s">%2$s</div>',
 				esc_attr( $interval ),
-				esc_html( $donation['title'] )
+				esc_html( $donation['title'] ),
+				esc_attr( $is_active_class )
 			);
 		}
 		$heading_text = wp_kses_post( $donation['heading'] ?? '' );
@@ -163,9 +190,14 @@ function render_block( $attr, $content ) {
 				$heading_text
 			);
 		}
+		$default_index_attr = '';
+		if ( isset( $donation['defaultAmountIndex'] ) && is_numeric( $donation['defaultAmountIndex'] ) ) {
+			$default_index_attr = sprintf( ' data-default-index="%d"', (int) $donation['defaultAmountIndex'] );
+		}
 		$amounts .= sprintf(
-			'<div class="donations__amounts %s">',
-			esc_attr( $donation['class'] )
+			'<div class="donations__amounts %s"%s>',
+			esc_attr( $donation['class'] ),
+			$default_index_attr
 		);
 		foreach ( $donation['amounts'] as $amount ) {
 			$amounts .= sprintf(
@@ -200,7 +232,8 @@ function render_block( $attr, $content ) {
 		if ( '' !== trim( $custom_amount_html ) ) {
 			$custom_amount .= sprintf( '<p>%s</p>', $custom_amount_html );
 		}
-		$default_custom_amount = ( \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] ?? 1 ) * 100;
+		$default_custom_amount = $attr['customAmountPlaceholder']
+			?? ( \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] ?? 1 ) * 100;
 		$custom_amount        .= sprintf(
 			'<div class="donations__amount donations__custom-amount">
 				%1$s
@@ -217,7 +250,11 @@ function render_block( $attr, $content ) {
 	if ( isset( $attr['tabsAppearance'] ) && 'buttons' === $attr['tabsAppearance'] ) {
 		$instance_classes .= ' is-style-buttons';
 	}
-	$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $instance_classes ) );
+	$wrapper_attr_array = array( 'class' => $instance_classes );
+	if ( $default_interval ) {
+		$wrapper_attr_array['data-default-interval'] = $default_interval;
+	}
+	$wrapper_attrs = get_block_wrapper_attributes( $wrapper_attr_array );
 	$custom_styles = build_custom_styles( $attr, '.' . $instance_id );
 
 	$choose_amount_html  = wp_kses_post( $choose_amount_text );
@@ -229,7 +266,7 @@ function render_block( $attr, $content ) {
 	<div class="donations__container">
 		%2$s
 		<div class="donations__content">
-			<div class="donations__tab">
+			<div class="donations__tab %10$s">
 				%3$s
 				%4$s
 				%5$s
@@ -250,7 +287,8 @@ function render_block( $attr, $content ) {
 		$custom_amount,
 		$extra_text,
 		$buttons,
-		$custom_styles ? '<style>' . $custom_styles . '</style>' : ''
+		$custom_styles ? '<style>' . $custom_styles . '</style>' : '',
+		esc_attr( $tab_content_class )
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/tab.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tab.js
@@ -17,6 +17,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		monthlyDonation,
 		annualDonation,
 		showCustomAmount,
+		customAmountPlaceholder,
 		// Destructure defaults are only applied when the property is `undefined`.
 		// User-cleared empty strings are left as-is, so they render empty.
 		chooseAmountText = DEFAULT_TEXTS.chooseAmountText,
@@ -106,7 +107,9 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 					<Amount
 						currency={ currency }
 						label={ __( 'Custom amount', 'jetpack' ) }
-						defaultValue={ minimumTransactionAmountForCurrency( currency ) * 100 }
+						defaultValue={
+							customAmountPlaceholder ?? minimumTransactionAmountForCurrency( currency ) * 100
+						}
 						className="donations__custom-amount"
 						disabled={ true }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
@@ -3,16 +3,25 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Controls from './controls';
 import Tab from './tab';
+import { firstShownInterval } from './utils';
 
 const Tabs = props => {
 	const { attributes, products, setAttributes } = props;
-	const { oneTimeDonation, monthlyDonation, annualDonation } = attributes;
-	const [ activeTab, setActiveTab ] = useState( 'one-time' );
+	const { oneTimeDonation, monthlyDonation, annualDonation, defaultInterval } = attributes;
+	const oneTimeShown = oneTimeDonation.show !== false;
+	const fallbackInterval =
+		firstShownInterval( oneTimeShown, monthlyDonation.show, annualDonation.show ) ?? 'one-time';
+	const isDefaultShown =
+		( defaultInterval === 'one-time' && oneTimeShown ) ||
+		( defaultInterval === '1 month' && monthlyDonation.show ) ||
+		( defaultInterval === '1 year' && annualDonation.show );
+	const initialActiveTab = isDefaultShown ? defaultInterval : fallbackInterval;
+	const [ activeTab, setActiveTab ] = useState( initialActiveTab );
 
 	const isTabActive = useCallback( tab => activeTab === tab, [ activeTab ] );
 
 	const tabs = {
-		'one-time': { title: __( 'One-Time', 'jetpack' ) },
+		...( oneTimeShown && { 'one-time': { title: __( 'One-Time', 'jetpack' ) } } ),
 		...( monthlyDonation.show && { '1 month': { title: __( 'Monthly', 'jetpack' ) } } ),
 		...( annualDonation.show && { '1 year': { title: __( 'Yearly', 'jetpack' ) } } ),
 	};
@@ -40,16 +49,23 @@ const Tabs = props => {
 		} );
 	}, [ oneTimeDonation, monthlyDonation, annualDonation, setAttributes, products ] );
 
-	// Activates the one-time tab if the interval of the current active tab is disabled.
+	// If the current active tab's interval is hidden, fall back to the first
+	// still-shown interval. Tries one-time first, then monthly, then yearly.
 	useEffect( () => {
+		const fallback = firstShownInterval( oneTimeShown, monthlyDonation.show, annualDonation.show );
+		if ( fallback === null ) {
+			return;
+		}
+		if ( ! oneTimeShown && isTabActive( 'one-time' ) ) {
+			setActiveTab( fallback );
+		}
 		if ( ! monthlyDonation.show && isTabActive( '1 month' ) ) {
-			setActiveTab( 'one-time' );
+			setActiveTab( fallback );
 		}
-
 		if ( ! annualDonation.show && isTabActive( '1 year' ) ) {
-			setActiveTab( 'one-time' );
+			setActiveTab( fallback );
 		}
-	}, [ monthlyDonation, annualDonation, setActiveTab, isTabActive ] );
+	}, [ oneTimeShown, monthlyDonation, annualDonation, setActiveTab, isTabActive ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/blocks/donations/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/utils.js
@@ -1,4 +1,19 @@
 /**
+ * Returns the first interval shown in the form, in priority order: one-time, monthly, annual.
+ *
+ * @param {boolean} oneTimeShown - Whether the one-time interval is shown.
+ * @param {boolean} monthlyShown - Whether the monthly interval is shown.
+ * @param {boolean} annualShown  - Whether the annual interval is shown.
+ * @return {?string} The first interval shown, or null if none are shown.
+ */
+export function firstShownInterval( oneTimeShown, monthlyShown, annualShown ) {
+	if ( oneTimeShown ) return 'one-time';
+	if ( monthlyShown ) return '1 month';
+	if ( annualShown ) return '1 year';
+	return null;
+}
+
+/**
  * Return the default texts defined in `donations.php` and injected client side by assigning them
  * to the `Jetpack_DonationsBlock` attribute of the window object.
  *

--- a/projects/plugins/jetpack/extensions/blocks/donations/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/view.js
@@ -6,20 +6,51 @@ import { initializeMembershipButtons } from '../../shared/memberships';
 
 import './view.scss';
 
+const INTERVAL_TO_AMOUNT_CLASS = {
+	'one-time': 'donations__one-time-item',
+	'1 month': 'donations__monthly-item',
+	'1 year': 'donations__annual-item',
+};
+
 class JetpackDonations {
 	constructor( block ) {
 		this.block = block;
 		this.amount = null;
 		this.isCustomAmount = false;
-		this.interval = 'one-time';
+		this.interval = block.dataset.defaultInterval || 'one-time';
 
 		// Initialize block.
 		this.initNavigation();
 		this.handleCustomAmount();
 		this.handleChosenAmount();
+		this.applyDefaultAmount( this.interval );
 
 		// Remove loading spinner.
 		this.block.querySelector( '.donations__container' ).classList.add( 'loaded' );
+	}
+
+	applyDefaultAmount( interval ) {
+		const amountClass = INTERVAL_TO_AMOUNT_CLASS[ interval ];
+		if ( ! amountClass ) {
+			return;
+		}
+		const wrapper = this.block.querySelector( `.donations__amounts.${ amountClass }` );
+		if ( ! wrapper || wrapper.dataset.defaultIndex === undefined ) {
+			return;
+		}
+		const index = parseInt( wrapper.dataset.defaultIndex, 10 );
+		const tile = wrapper.querySelectorAll( '.donations__amount:not( .donations__custom-amount )' )[
+			index
+		];
+		if ( ! tile ) {
+			return;
+		}
+		this.resetSelectedAmount();
+		tile.classList.add( 'is-selected' );
+		this.amount = tile.dataset.amount;
+		this.isCustomAmount = false;
+		this.updateUrl();
+		this.toggleDonateButton( true );
 	}
 
 	getNavItem( interval ) {
@@ -130,6 +161,9 @@ class JetpackDonations {
 
 			// Disable donate button.
 			this.toggleDonateButton( false );
+
+			// Apply the new tab's default amount, if one is configured.
+			this.applyDefaultAmount( newInterval );
 		};
 
 		navItems.forEach( navItem => {


### PR DESCRIPTION
**Stacked on top of [#48415](https://github.com/Automattic/jetpack/pull/48415).** Reviews can wait until that lands; this PR can be tested on Jetpack Beta in parallel.

## Proposed changes

Adds admin-configurable frequency visibility controls and donation defaults to the Donations Form block.

**Frequency visibility toggles**
* New "Show one-time donations" toggle in the Settings panel, joining the existing monthly and annual toggles, so authors can hide any combination of intervals.
* Last-enabled guard: the final visible toggle is disabled and shows help text ("At least one frequency must be enabled."), preventing an empty/broken form.
* Auto-shift: hiding the interval that is currently set as the default silently shifts `defaultInterval` to the next visible interval in the same `setAttributes` call — no stale or invisible default can persist.
* **Side-effect bug fix:** previously, hiding One-Time while keeping Monthly broke the frontend — `view.js` was hardcoded to `this.interval = 'one-time'`. The fix reads the initial interval from `data-default-interval` on the wrapper instead.

**Frequency and amount defaults**
* New "Defaults" sub-section in the Settings panel with a **Frequency** selector (filtered to currently-shown intervals) and per-frequency **default amount** selects (None + the three configured dollar values).
* Default amount is stored by index, not value, so it survives admin edits to the amount values (e.g. changing $15 → $20 keeps the same slot pre-selected).
* **Suggested custom amount**: a number input for the placeholder value shown in the custom amount tile; currency-aware minimum enforced.
* On load and on each tab switch, the configured default amount tile is highlighted and the Donate button is pre-enabled. Clears and resets correctly when switching tabs.
* Currency change resets `customAmountPlaceholder` along with the existing per-interval amount reset.

## Related product discussion/links

* Part of the same internal RSM project as [#48415](https://github.com/Automattic/jetpack/pull/48415).

## Does this pull request change what data or activity we track or use?

No tracking or data changes.

## Testing instructions

**Frequency toggles**
1. Add a Donations Form block. In the Settings panel, toggle "Show one-time donations" off.
   * The One-Time tab should disappear in the editor; the active tab should fall back to Monthly (or Yearly if Monthly is also off).
   * Save and view on the frontend — the One-Time tab should be gone.
2. Toggle off Monthly as well — only Annual remains. Confirm all three toggle buttons show the last-enabled help text and are disabled, preventing an empty form.
3. Toggle One-Time back on — the tab reappears and the block is functional again.
4. Open a legacy Donations block (created before this branch, where `oneTimeDonation.show` was never set) — the One-Time toggle should show as on and the block should behave normally.

**Defaults section** [screenshot]
5. Expand the Settings panel and locate the **Defaults** sub-section below the Show/hide toggles.
   * Set **Frequency** to Monthly and **Monthly** default amount to the $15 slot.
   * Save and view on the frontend — the Monthly tab should be active on load, with the $15 tile pre-selected and the Donate button enabled without any user interaction. [demo]
6. Set a suggested custom amount (e.g. 50) — the custom amount tile placeholder on the frontend should reflect this value.
7. Change currency — the suggested custom amount should reset.
8. Hide the frequency that is set as the default — the default should automatically shift to the next visible interval without requiring a separate action.

---
_Recreated as a successor to #48464, which auto-closed when its base branch was deleted on merge of #48415. Same content; rebased onto trunk as a single squashable commit._