### PR TITLE
Podcast: add Free and Premium pricing card to welcome screen

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-welcome-pricing-card
+++ b/projects/packages/podcast/changelog/add-podcast-welcome-pricing-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a Free and Premium plan card to the podcast welcome screen so users can see what podcasting includes per plan before they enable.

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -14,7 +14,6 @@ body.jetpack_page_jetpack-podcast {
 
 .podcast__tab-content {
 	padding-block: 8px;
-	padding-inline: clamp(0px, 2vw, 16px);
 }
 
 // Form-style panels (Settings, Distribution, Welcome) sit in a centered

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -14,6 +14,7 @@ body.jetpack_page_jetpack-podcast {
 
 .podcast__tab-content {
 	padding-block: 8px;
+	padding-inline: clamp(0px, 2vw, 16px);
 }
 
 // Form-style panels (Settings, Distribution, Welcome) sit in a centered

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,4 +1,5 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { getSiteData } from '@automattic/jetpack-script-data';
 import {
 	Button,
@@ -20,45 +21,36 @@ interface WelcomeProps {
 	onEnable: () => void;
 }
 
-// Prefer `site.suffix` since it preserves the full Calypso site fragment
-// (e.g. `example.com::path` for mapped subdirectory sites). Fall back to
-// the admin_url host as a safety net in case suffix is unexpectedly absent.
-const getSiteSlug = (): string => {
-	const data = getSiteData();
-	if ( data?.suffix ) {
-		return data.suffix;
-	}
-	const adminUrl = data?.admin_url ?? '';
-	if ( ! adminUrl ) {
-		return '';
-	}
-	try {
-		return new URL( adminUrl ).host;
-	} catch {
-		return '';
-	}
-};
-
 const CHECKOUT_SOURCE = 'jetpack-podcast-welcome';
 
 const getPremiumCheckoutUrl = (): string => {
-	const slug = getSiteSlug();
-	const adminUrl = getSiteData()?.admin_url ?? '';
+	const data = getSiteData();
+	const adminUrl = data?.admin_url ?? '';
+
+	// Prefer `site.suffix` since it preserves the full Calypso site fragment
+	// (e.g. `example.com::path` for mapped subdirectory sites). Fall back to
+	// the admin_url host as a safety net in case suffix is unexpectedly absent.
+	let slug = data?.suffix ?? '';
+	if ( ! slug && adminUrl ) {
+		try {
+			slug = new URL( adminUrl ).host;
+		} catch {
+			// Leave slug empty; we'll fall back to the generic plan picker below.
+		}
+	}
+
+	if ( ! slug ) {
+		return 'https://wordpress.com/checkout/premium';
+	}
+
 	// `tab=settings` bypasses the welcome gate so buyers continue configuring
 	// the podcast instead of re-seeing this same pricing card after checkout.
 	const returnTo = adminUrl
 		? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
 		: '';
-	const url = new URL(
-		slug
-			? `https://wordpress.com/checkout/${ slug }/premium`
-			: 'https://wordpress.com/checkout/premium'
-	);
+	const url = new URL( getProductCheckoutUrl( 'premium', slug, returnTo, true ) );
 	// Calypso threads `source` through its downstream Tracks events.
 	url.searchParams.set( 'source', CHECKOUT_SOURCE );
-	if ( returnTo ) {
-		url.searchParams.set( 'redirect_to', returnTo );
-	}
 	return url.toString();
 };
 
@@ -129,12 +121,15 @@ const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = 
 ];
 
 const Welcome = ( { onEnable }: WelcomeProps ) => {
+	const premiumCheckoutUrl = getPremiumCheckoutUrl();
+
+	// Fire-and-forget Tracks; the anchor handles navigation so middle/cmd-click
+	// still opens checkout in a new tab and "copy link address" shows the URL.
 	const onPremiumClick = useCallback( () => {
 		const currentPlan = getSiteData()?.plan?.product_slug;
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_premium_upgrade_clicked', {
 			current_plan: currentPlan ?? '',
 		} );
-		window.location.href = getPremiumCheckoutUrl();
 	}, [] );
 
 	return (
@@ -180,7 +175,9 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 								<ul className="podcast__welcome-plan-features">
 									{ FREE_FEATURES.map( feature => (
 										<li key={ feature } className="podcast__welcome-plan-feature">
-											<Icon icon={ check } size={ 20 } />
+											<span aria-hidden="true">
+												<Icon icon={ check } size={ 20 } />
+											</span>
 											<Text>{ feature }</Text>
 										</li>
 									) ) }
@@ -211,13 +208,15 @@ const Welcome = ( { onEnable }: WelcomeProps ) => {
 										) }
 									</Text>
 								</VStack>
-								<Button variant="primary" onClick={ onPremiumClick }>
+								<Button variant="primary" href={ premiumCheckoutUrl } onClick={ onPremiumClick }>
 									{ __( 'Start your premium podcast', 'jetpack-podcast' ) }
 								</Button>
 								<ul className="podcast__welcome-plan-features">
 									{ PREMIUM_FEATURES.map( feature => (
 										<li key={ feature } className="podcast__welcome-plan-feature">
-											<Icon icon={ check } size={ 20 } />
+											<span aria-hidden="true">
+												<Icon icon={ check } size={ 20 } />
+											</span>
 											<Text>{ feature }</Text>
 										</li>
 									) ) }

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,3 +1,5 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { getSiteData } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,
@@ -9,13 +11,47 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, globe, layout, megaphone } from '@wordpress/icons';
+import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
 import './style.scss';
 
 interface WelcomeProps {
 	onEnable: () => void;
 }
+
+// Prefer `site.suffix` since it preserves the full Calypso site fragment
+// (e.g. `example.com::path` for mapped subdirectory sites). Fall back to
+// the admin_url host as a safety net in case suffix is unexpectedly absent.
+const getSiteSlug = (): string => {
+	const data = getSiteData();
+	if ( data?.suffix ) {
+		return data.suffix;
+	}
+	const adminUrl = data?.admin_url ?? '';
+	if ( ! adminUrl ) {
+		return '';
+	}
+	try {
+		return new URL( adminUrl ).host;
+	} catch {
+		return '';
+	}
+};
+
+const getPremiumCheckoutUrl = (): string => {
+	const slug = getSiteSlug();
+	const adminUrl = getSiteData()?.admin_url ?? '';
+	// `tab=settings` bypasses the welcome gate so buyers continue configuring
+	// the podcast instead of re-seeing this same pricing card after checkout.
+	const returnTo = adminUrl
+		? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
+		: '';
+	const base = slug
+		? `https://wordpress.com/checkout/${ slug }/premium`
+		: 'https://wordpress.com/checkout/premium';
+	return returnTo ? `${ base }?redirect_to=${ encodeURIComponent( returnTo ) }` : base;
+};
 
 const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string } > = [
 	{
@@ -44,6 +80,21 @@ const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string 
 	},
 ];
 
+const FREE_FEATURES: ReadonlyArray< string > = [
+	__( 'Publish a podcast with audio hosted on another site', 'jetpack-podcast' ),
+	__( 'Distribute to Apple, Spotify, and every major app', 'jetpack-podcast' ),
+	__( 'Submission-ready RSS feed for every directory', 'jetpack-podcast' ),
+];
+
+const PREMIUM_FEATURES: ReadonlyArray< string > = [
+	__( 'Host your podcast on WordPress.com with 13 GB of storage', 'jetpack-podcast' ),
+	__( 'Distribute to Apple, Spotify, and every major app', 'jetpack-podcast' ),
+	__( 'Submission-ready RSS feed for every directory', 'jetpack-podcast' ),
+	__( 'Podcast stats including downloads by app and country', 'jetpack-podcast' ),
+	__( 'Episode dashboard', 'jetpack-podcast' ),
+	__( 'Episode player block for your posts', 'jetpack-podcast' ),
+];
+
 const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = [
 	{
 		number: '1',
@@ -68,64 +119,144 @@ const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = 
 	},
 ];
 
-const Welcome = ( { onEnable }: WelcomeProps ) => (
-	<VStack spacing={ 8 }>
-		<section className="podcast__welcome-hero">
-			<VStack spacing={ 4 } className="podcast__welcome-hero-copy">
-				<h2 className="podcast__welcome-title">
-					{ __( 'Your podcast belongs with your blog', 'jetpack-podcast' ) }
-				</h2>
-				<Text variant="muted">
-					{ __(
-						'Publish your show on the same site as your blog and newsletter. Reach fans on Apple, Spotify, Pocket Casts, and every major podcast app.',
-						'jetpack-podcast'
-					) }
-				</Text>
-				<HStack justify="flex-start" expanded={ false }>
-					<Button variant="primary" onClick={ onEnable }>
-						{ __( 'Enable podcasting', 'jetpack-podcast' ) }
-					</Button>
-				</HStack>
-			</VStack>
-		</section>
+const Welcome = ( { onEnable }: WelcomeProps ) => {
+	const onPremiumClick = useCallback( () => {
+		const currentPlan = getSiteData()?.plan?.product_slug;
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_premium_upgrade_clicked', {
+			current_plan: currentPlan ?? '',
+		} );
+		window.location.href = getPremiumCheckoutUrl();
+	}, [] );
 
-		<HStack alignment="stretch" spacing={ 4 } wrap>
-			{ BENEFITS.map( b => (
-				<Card key={ b.title } style={ { flex: '1 1 280px' } }>
-					<CardBody>
-						<VStack spacing={ 3 }>
-							<span className="podcast__welcome-benefit-icon" aria-hidden="true">
-								{ b.icon }
-							</span>
-							<Text size="title" weight={ 500 }>
-								{ b.title }
-							</Text>
-							<Text variant="muted">{ b.body }</Text>
-						</VStack>
-					</CardBody>
-				</Card>
-			) ) }
-		</HStack>
-
-		<Card>
-			<CardBody>
-				<VStack spacing={ 5 }>
-					<Text size="title" weight={ 500 }>
-						{ __( 'How it works', 'jetpack-podcast' ) }
+	return (
+		<VStack spacing={ 8 }>
+			<section className="podcast__welcome-hero">
+				<VStack spacing={ 4 } className="podcast__welcome-hero-copy">
+					<h2 className="podcast__welcome-title">
+						{ __( 'Your podcast belongs with your blog', 'jetpack-podcast' ) }
+					</h2>
+					<Text variant="muted">
+						{ __(
+							'Publish your show on the same site as your blog and newsletter. Reach fans on Apple, Spotify, Pocket Casts, and every major podcast app.',
+							'jetpack-podcast'
+						) }
 					</Text>
-					<ol className="podcast__welcome-steps">
-						{ STEPS.map( step => (
-							<li key={ step.number } className="podcast__welcome-step">
-								<span className="podcast__welcome-step-circle">{ step.number }</span>
-								<Text weight={ 500 }>{ step.title }</Text>
-								<Text variant="muted">{ step.body }</Text>
-							</li>
-						) ) }
-					</ol>
+					<HStack justify="flex-start" expanded={ false }>
+						<Button variant="primary" onClick={ onEnable }>
+							{ __( 'Enable podcasting', 'jetpack-podcast' ) }
+						</Button>
+					</HStack>
 				</VStack>
-			</CardBody>
-		</Card>
-	</VStack>
-);
+			</section>
+
+			<section className="podcast__welcome-plans">
+				<HStack alignment="stretch" spacing={ 4 } wrap>
+					<Card className="podcast__welcome-plan" style={ { flex: '1 1 320px' } }>
+						<CardBody>
+							<VStack spacing={ 4 }>
+								<VStack spacing={ 2 }>
+									<Text size="title" weight={ 500 }>
+										{ __( 'Free', 'jetpack-podcast' ) }
+									</Text>
+									<Text variant="muted">
+										{ __(
+											'Publish your podcast alongside your blog and newsletter.',
+											'jetpack-podcast'
+										) }
+									</Text>
+								</VStack>
+								<Button variant="secondary" onClick={ onEnable }>
+									{ __( 'Start your podcast', 'jetpack-podcast' ) }
+								</Button>
+								<ul className="podcast__welcome-plan-features">
+									{ FREE_FEATURES.map( feature => (
+										<li key={ feature } className="podcast__welcome-plan-feature">
+											<Icon icon={ check } size={ 20 } />
+											<Text>{ feature }</Text>
+										</li>
+									) ) }
+								</ul>
+							</VStack>
+						</CardBody>
+					</Card>
+
+					<Card
+						className="podcast__welcome-plan podcast__welcome-plan--premium"
+						style={ { flex: '1 1 320px' } }
+					>
+						<CardBody>
+							<VStack spacing={ 4 }>
+								<VStack spacing={ 2 }>
+									<HStack justify="space-between" alignment="center">
+										<Text size="title" weight={ 500 }>
+											{ __( 'Premium', 'jetpack-podcast' ) }
+										</Text>
+										<span className="podcast__welcome-plan-badge">
+											{ __( 'Popular', 'jetpack-podcast' ) }
+										</span>
+									</HStack>
+									<Text variant="muted">
+										{ __(
+											'Host your podcast at WordPress.com and get all the advanced features.',
+											'jetpack-podcast'
+										) }
+									</Text>
+								</VStack>
+								<Button variant="primary" onClick={ onPremiumClick }>
+									{ __( 'Start your premium podcast', 'jetpack-podcast' ) }
+								</Button>
+								<ul className="podcast__welcome-plan-features">
+									{ PREMIUM_FEATURES.map( feature => (
+										<li key={ feature } className="podcast__welcome-plan-feature">
+											<Icon icon={ check } size={ 20 } />
+											<Text>{ feature }</Text>
+										</li>
+									) ) }
+								</ul>
+							</VStack>
+						</CardBody>
+					</Card>
+				</HStack>
+			</section>
+
+			<HStack alignment="stretch" spacing={ 4 } wrap>
+				{ BENEFITS.map( b => (
+					<Card key={ b.title } style={ { flex: '1 1 280px' } }>
+						<CardBody>
+							<VStack spacing={ 3 }>
+								<span className="podcast__welcome-benefit-icon" aria-hidden="true">
+									{ b.icon }
+								</span>
+								<Text size="title" weight={ 500 }>
+									{ b.title }
+								</Text>
+								<Text variant="muted">{ b.body }</Text>
+							</VStack>
+						</CardBody>
+					</Card>
+				) ) }
+			</HStack>
+
+			<Card>
+				<CardBody>
+					<VStack spacing={ 5 }>
+						<Text size="title" weight={ 500 }>
+							{ __( 'How it works', 'jetpack-podcast' ) }
+						</Text>
+						<ol className="podcast__welcome-steps">
+							{ STEPS.map( step => (
+								<li key={ step.number } className="podcast__welcome-step">
+									<span className="podcast__welcome-step-circle">{ step.number }</span>
+									<Text weight={ 500 }>{ step.title }</Text>
+									<Text variant="muted">{ step.body }</Text>
+								</li>
+							) ) }
+						</ol>
+					</VStack>
+				</CardBody>
+			</Card>
+		</VStack>
+	);
+};
 
 export default Welcome;

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -39,6 +39,8 @@ const getSiteSlug = (): string => {
 	}
 };
 
+const CHECKOUT_SOURCE = 'jetpack-podcast-welcome';
+
 const getPremiumCheckoutUrl = (): string => {
 	const slug = getSiteSlug();
 	const adminUrl = getSiteData()?.admin_url ?? '';
@@ -47,10 +49,17 @@ const getPremiumCheckoutUrl = (): string => {
 	const returnTo = adminUrl
 		? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
 		: '';
-	const base = slug
-		? `https://wordpress.com/checkout/${ slug }/premium`
-		: 'https://wordpress.com/checkout/premium';
-	return returnTo ? `${ base }?redirect_to=${ encodeURIComponent( returnTo ) }` : base;
+	const url = new URL(
+		slug
+			? `https://wordpress.com/checkout/${ slug }/premium`
+			: 'https://wordpress.com/checkout/premium'
+	);
+	// Calypso threads `source` through its downstream Tracks events.
+	url.searchParams.set( 'source', CHECKOUT_SOURCE );
+	if ( returnTo ) {
+		url.searchParams.set( 'redirect_to', returnTo );
+	}
+	return url.toString();
 };
 
 const BENEFITS: ReadonlyArray< { icon: JSX.Element; title: string; body: string } > = [

--- a/projects/packages/podcast/src/dashboard/welcome/style.scss
+++ b/projects/packages/podcast/src/dashboard/welcome/style.scss
@@ -55,8 +55,15 @@
 	font-weight: 600;
 }
 
+.podcast__welcome-plans {
+	padding-inline: clamp(0px, 2vw, 16px);
+}
+
+// `outline` instead of `border` so the highlight doesn't add 1px to the
+// premium card's box and offset it vs the Free card's default 1px Card border.
 .podcast__welcome-plan--premium {
-	border: 2px solid #3858e9;
+	outline: 2px solid #3858e9;
+	outline-offset: -2px;
 }
 
 .podcast__welcome-plan-badge {

--- a/projects/packages/podcast/src/dashboard/welcome/style.scss
+++ b/projects/packages/podcast/src/dashboard/welcome/style.scss
@@ -54,3 +54,40 @@
 	font-size: 14px;
 	font-weight: 600;
 }
+
+.podcast__welcome-plan--premium {
+	border: 2px solid #3858e9;
+}
+
+.podcast__welcome-plan-badge {
+	display: inline-block;
+	padding: 2px 10px;
+	border-radius: 12px;
+	background: #3858e9;
+	color: #fff;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.podcast__welcome-plan-features {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.podcast__welcome-plan-feature {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+
+	svg {
+		flex: 0 0 auto;
+		fill: #008a20;
+		margin-block-start: 2px;
+	}
+}


### PR DESCRIPTION
## Proposed changes

Reintroduces the pricing grid that was in Calypso. This puts a lighter version back, shown to everyone regardless of current plan, with no live price numbers.

<img width="2578" height="2482" alt="CleanShot 2026-05-13 at 20 28 52@2x" src="https://github.com/user-attachments/assets/cf6c9d31-515e-4b14-a34e-333b60c28e30" />

* `welcome/index.tsx`: new `<section>` between hero and feature boxes. Two cards side by side using the existing `Card` + `VStack` + `HStack` primitives.
  * **Free card**: title, blurb, "Start your podcast" CTA that fires the same `onEnable` as the hero button, three feature lines.
  * **Premium card**: "Popular" badge, "Start your premium podcast" CTA, six feature lines.
* Premium CTA fires `jetpack_podcast_premium_upgrade_clicked` Tracks event (with `current_plan` from `getSiteData()?.plan?.product_slug`) and redirects to `https://wordpress.com/checkout/{siteSlug}/premium?redirect_to=<podcast admin page>`.
* Slug comes from `getSiteData()?.suffix` first (Calypso site fragment, preserves path segments for mapped subdirectory installs), then falls back to the `admin_url` host. Self-hosted Jetpack falls back to the generic plan picker.
* `welcome/style.scss`: badge pill, premium-card highlight border, feature-list layout.

This PR is stacked on [#48796](https://github.com/Automattic/jetpack/pull/48796) (welcome-screen copy refresh). Base is `update/podcast-welcome-copy`; the diff you see is the pricing card alone.

## Related product discussion/links

Part of the Radical Speed Month podcasting workstream.

## Does this pull request change what data or activity we track or use?

Yes, adds one new Tracks event: `jetpack_podcast_premium_upgrade_clicked`, with `current_plan` (product slug) as the only property.

## Testing instructions

* Enable the `jetpack_podcast_untangle` feature flag.
* On a Free WordPress.com site:
  * Visit `wp-admin/admin.php?page=jetpack-podcast`. Welcome screen renders.
  * Confirm the two-card section appears between hero and feature boxes.
  * Click "Start your podcast" on the Free card. Same behavior as the hero "Enable podcasting" button.
  * Click "Start your premium podcast" on the Premium card. Browser navigates to `wordpress.com/checkout/<site>/premium?redirect_to=<podcast-admin-url>`.
  * Confirm the `jetpack_podcast_premium_upgrade_clicked` Tracks event fires in the console (or via Tracks debug).
* On a Premium WordPress.com site:
  * Card still renders identically (intentional per design).
* On a self-hosted Jetpack site:
  * Premium CTA links to `wordpress.com/checkout/premium` with no slug segment.
