### PR TITLE
Write editor: implement undo/redo (Cmd+Z / toolbar buttons)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-1906-undoredo-is-unpredictable
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-1906-undoredo-is-unpredictable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: implement undo/redo history stack (Cmd+Z / Cmd+Shift+Z) with toolbar buttons

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -22,6 +22,7 @@
 		"clean": "rm -rf src/build/ src/build-module/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
+		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"
 	},

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/test/undo-history.test.mjs
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/test/undo-history.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createUndoHistory } from '../undo-history.js';
+
+describe( 'createUndoHistory', () => {
+	it( 'starts empty — canUndo and canRedo are false', () => {
+		const h = createUndoHistory();
+		assert.equal( h.canUndo, false );
+		assert.equal( h.canRedo, false );
+		assert.equal( h.current, null );
+	} );
+
+	it( 'after one push — canUndo is false, canRedo is false', () => {
+		const h = createUndoHistory();
+		h.push( { html: '<p>hello</p>', title: '' } );
+		assert.equal( h.canUndo, false );
+		assert.equal( h.canRedo, false );
+	} );
+
+	it( 'current returns the most recently pushed snapshot', () => {
+		const h = createUndoHistory();
+		const snap = { html: '<p>hello</p>', title: 'My Post' };
+		h.push( snap );
+		assert.deepEqual( h.current, snap );
+	} );
+
+	it( 'after two pushes — canUndo is true, canRedo is false', () => {
+		const h = createUndoHistory();
+		h.push( { html: '<p>a</p>', title: '' } );
+		h.push( { html: '<p>b</p>', title: '' } );
+		assert.equal( h.canUndo, true );
+		assert.equal( h.canRedo, false );
+	} );
+
+	it( 'undo returns the previous snapshot', () => {
+		const h = createUndoHistory();
+		const first = { html: '<p>a</p>', title: '' };
+		h.push( first );
+		h.push( { html: '<p>b</p>', title: '' } );
+		const result = h.undo();
+		assert.deepEqual( result, first );
+		assert.deepEqual( h.current, first );
+	} );
+
+	it( 'undo at the bottom of the stack has no effect and returns current', () => {
+		const h = createUndoHistory();
+		const only = { html: '<p>a</p>', title: '' };
+		h.push( only );
+		const result = h.undo();
+		assert.deepEqual( result, only );
+		assert.deepEqual( h.current, only );
+	} );
+
+	it( 'after undo — canRedo is true', () => {
+		const h = createUndoHistory();
+		h.push( { html: '<p>a</p>', title: '' } );
+		h.push( { html: '<p>b</p>', title: '' } );
+		h.undo();
+		assert.equal( h.canRedo, true );
+	} );
+
+	it( 'redo returns the next snapshot after an undo', () => {
+		const h = createUndoHistory();
+		h.push( { html: '<p>a</p>', title: '' } );
+		const second = { html: '<p>b</p>', title: '' };
+		h.push( second );
+		h.undo();
+		const result = h.redo();
+		assert.deepEqual( result, second );
+		assert.deepEqual( h.current, second );
+	} );
+
+	it( 'redo at the top of the stack has no effect and returns current', () => {
+		const h = createUndoHistory();
+		h.push( { html: '<p>a</p>', title: '' } );
+		const second = { html: '<p>b</p>', title: '' };
+		h.push( second );
+		const result = h.redo();
+		assert.deepEqual( result, second );
+	} );
+
+	it( 'pushing after undo discards redo history', () => {
+		const h = createUndoHistory();
+		h.push( { html: '<p>a</p>', title: '' } );
+		h.push( { html: '<p>b</p>', title: '' } );
+		h.undo();
+		const branch = { html: '<p>c</p>', title: '' };
+		h.push( branch );
+		assert.equal( h.canRedo, false );
+		assert.deepEqual( h.current, branch );
+	} );
+
+	it( 'does not exceed maxSize entries', () => {
+		const h = createUndoHistory( { maxSize: 3 } );
+		h.push( { html: '<p>1</p>', title: '' } );
+		h.push( { html: '<p>2</p>', title: '' } );
+		h.push( { html: '<p>3</p>', title: '' } );
+		h.push( { html: '<p>4</p>', title: '' } );
+		// Oldest entry is evicted; undo twice should land on <p>2</p>
+		h.undo();
+		h.undo();
+		assert.equal( h.current.html, '<p>2</p>' );
+		assert.equal( h.canUndo, false );
+	} );
+
+	it( 'supports opaque cursor data attached to each snapshot', () => {
+		const h = createUndoHistory();
+		const cursor = { path: [ 0, 1 ], offset: 5 };
+		h.push( { html: '<p>hello</p>', title: '', cursor } );
+		assert.deepEqual( h.current.cursor, cursor );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/undo-history.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/undo-history.js
@@ -1,0 +1,63 @@
+/**
+ * Write — undo/redo history stack.
+ *
+ * Pure module: no DOM or Interactivity API dependencies.
+ * Each snapshot is an opaque object; callers attach whatever fields they need
+ * (html, title, cursor, …).
+ */
+
+/**
+ * @typedef {{ html: string, title: string, cursor?: * }} Snapshot
+ */
+
+/**
+ * Create a bounded undo/redo history stack.
+ *
+ * @param {{ maxSize?: number }} options           - Configuration options.
+ * @param {number}               [options.maxSize] - Maximum number of snapshots to retain (default 100).
+ * @return {object} History instance with push, undo, redo, canUndo, canRedo, and current.
+ */
+export function createUndoHistory( { maxSize = 100 } = {} ) {
+	/** @type {Snapshot[]} */
+	const stack = [];
+	let position = -1;
+
+	return {
+		push( snapshot ) {
+			// Discard any redo future.
+			stack.splice( position + 1 );
+			stack.push( snapshot );
+			// Evict oldest entry when the stack exceeds maxSize.
+			if ( stack.length > maxSize ) {
+				stack.shift();
+			}
+			position = stack.length - 1;
+		},
+
+		undo() {
+			if ( position > 0 ) {
+				position--;
+			}
+			return stack[ position ] ?? null;
+		},
+
+		redo() {
+			if ( position < stack.length - 1 ) {
+				position++;
+			}
+			return stack[ position ] ?? null;
+		},
+
+		get canUndo() {
+			return position > 0;
+		},
+
+		get canRedo() {
+			return position < stack.length - 1;
+		},
+
+		get current() {
+			return stack[ position ] ?? null;
+		},
+	};
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2184,16 +2184,19 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
+			// Normalize via toLowerCase so Shift+Z and CapsLock don't bypass these
+			// shortcuts — some browser/platform combinations report uppercase keys.
+			const lowerKey = event.key.toLowerCase();
 			// Undo (Cmd+Z / Ctrl+Z).
-			if ( ( event.ctrlKey || event.metaKey ) && event.key === 'z' && ! event.shiftKey ) {
+			if ( ( event.ctrlKey || event.metaKey ) && lowerKey === 'z' && ! event.shiftKey ) {
 				event.preventDefault();
 				performUndo();
 				return;
 			}
 			// Redo (Cmd+Shift+Z / Ctrl+Shift+Z / Ctrl+Y).
 			if (
-				( ( event.ctrlKey || event.metaKey ) && event.key === 'z' && event.shiftKey ) ||
-				( event.ctrlKey && event.key === 'y' )
+				( ( event.ctrlKey || event.metaKey ) && lowerKey === 'z' && event.shiftKey ) ||
+				( event.ctrlKey && lowerKey === 'y' )
 			) {
 				event.preventDefault();
 				performRedo();
@@ -2201,7 +2204,7 @@ const { state } = store( 'wpcom-write', {
 			}
 
 			// Ctrl+K / Cmd+K to toggle link input.
-			if ( ( event.ctrlKey || event.metaKey ) && event.key === 'k' ) {
+			if ( ( event.ctrlKey || event.metaKey ) && lowerKey === 'k' ) {
 				event.preventDefault();
 				const { actions: a } = store( 'wpcom-write' );
 				a.toggleLinkInput();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -9,6 +9,8 @@
 
 // eslint-disable-next-line import/no-unresolved -- Provided by WordPress at runtime via wp_register_script_module.
 import { store, getElement } from '@wordpress/interactivity';
+// eslint-disable-next-line import/no-unresolved -- Provided by WordPress at runtime via wp_register_script_module.
+import { createUndoHistory } from 'wpcom-write/undo-history';
 
 // Translated strings passed from PHP via wp_print_inline_script_tag.
 const i18n = window.wpcomWriteStrings || {};
@@ -23,6 +25,10 @@ const DISCLAIMER_STORAGE_KEY = 'wpcom-write-disclaimer-dismissed';
 let lastSavedSnapshot = { title: '', content: '' };
 let autosaveTimer = null;
 let allowLeave = false;
+
+// Undo/redo history — tracked outside the store to avoid triggering reactivity.
+const undoHistory = createUndoHistory();
+let undoPendingTimer = null;
 
 /**
  * Get the current content snapshot for dirty-state comparison.
@@ -86,6 +92,188 @@ let selectedFigure = null;
 let preFigureSelectionRange = null;
 
 let cachedContent = null;
+
+// --- Undo/redo helpers ---
+
+/**
+ * Serialise the current selection as a root-relative node path so it can be
+ * restored after innerHTML is replaced.
+ *
+ * @param {Element} root - The contenteditable container.
+ * @return {Object|null} Cursor descriptor, or null when there is no selection.
+ */
+function serializeCursor( root ) {
+	const sel = window.getSelection();
+	if ( ! sel || sel.rangeCount === 0 ) return null;
+	const range = sel.getRangeAt( 0 );
+	if ( ! root.contains( range.startContainer ) ) return null;
+
+	/**
+	 * Walk from node up to root, recording child indices at each level.
+	 *
+	 * @param {Node} node - The node to build a path for.
+	 * @return {number[]|null} Child-index path from root to node, or null if node is not inside root.
+	 */
+	function getNodePath( node ) {
+		const path = [];
+		let current = node;
+		while ( current !== root ) {
+			const parent = current.parentNode;
+			if ( ! parent ) return null;
+			path.unshift( Array.prototype.indexOf.call( parent.childNodes, current ) );
+			current = parent;
+		}
+		return path;
+	}
+
+	const anchorPath = getNodePath( range.startContainer );
+	const focusPath = getNodePath( range.endContainer );
+	if ( ! anchorPath || ! focusPath ) return null;
+
+	return {
+		anchorPath,
+		anchorOffset: range.startOffset,
+		focusPath,
+		focusOffset: range.endOffset,
+	};
+}
+
+/**
+ * Restore a cursor position previously captured by serializeCursor.
+ * Falls back to the first paragraph when the serialised path can no longer
+ * be resolved (e.g. after a large structural undo).
+ *
+ * @param {Element}     root       - The contenteditable container.
+ * @param {Object|null} cursorInfo - Descriptor returned by serializeCursor, or null.
+ * @return {void}
+ */
+function restoreUndoCursor( root, cursorInfo ) {
+	/** Place the cursor at the start of the first paragraph as a safe fallback. */
+	function fallback() {
+		const p = root.querySelector( 'p' );
+		if ( p ) placeCursorAt( p );
+	}
+
+	/**
+	 * Resolve a root-relative node path to a { node, offset } pair.
+	 *
+	 * @param {number[]} path   - Child-index path from root to the target node.
+	 * @param {number}   offset - Character or child offset within that node.
+	 * @return {Object|null} Resolved node + clamped offset, or null when path is stale.
+	 */
+	function resolvePath( path, offset ) {
+		let node = root;
+		for ( const idx of path ) {
+			node = node.childNodes[ idx ];
+			if ( ! node ) return null;
+		}
+		const maxOffset = node.nodeType === Node.TEXT_NODE ? node.length : node.childNodes.length;
+		return { node, offset: Math.min( offset, maxOffset ) };
+	}
+
+	if ( ! cursorInfo ) return fallback();
+
+	const anchor = resolvePath( cursorInfo.anchorPath, cursorInfo.anchorOffset );
+	const focus = resolvePath( cursorInfo.focusPath, cursorInfo.focusOffset );
+	if ( ! anchor || ! focus ) return fallback();
+
+	try {
+		const sel = window.getSelection();
+		const range = document.createRange();
+		range.setStart( anchor.node, anchor.offset );
+		range.setEnd( focus.node, focus.offset );
+		sel.removeAllRanges();
+		sel.addRange( range );
+	} catch {
+		fallback();
+	}
+}
+
+/**
+ * Capture the current editor state as an undo snapshot.
+ *
+ * @return {object} Snapshot containing html, title, and cursor.
+ */
+function captureUndoSnapshot() {
+	const content = getContent();
+	return {
+		html: content ? content.innerHTML : '',
+		title: state.title || '',
+		cursor: content ? serializeCursor( content ) : null,
+	};
+}
+
+/**
+ * Restore editor content and cursor from an undo snapshot.
+ *
+ * @param {object} snapshot - Snapshot previously created by captureUndoSnapshot.
+ */
+function applyUndoSnapshot( snapshot ) {
+	const content = getContent();
+	if ( content ) {
+		content.innerHTML = snapshot.html;
+		ensureBlockStructure();
+		restoreUndoCursor( content, snapshot.cursor );
+	}
+	const titleEl = document.querySelector( '.bw-title' );
+	if ( titleEl ) {
+		titleEl.value = snapshot.title;
+		state.title = snapshot.title;
+		titleEl.style.height = 'auto';
+		titleEl.style.height = titleEl.scrollHeight + 'px';
+	}
+}
+
+/** Mirror undoHistory.canUndo/canRedo into reactive store state so buttons update. */
+function syncUndoState() {
+	state.canUndo = undoHistory.canUndo;
+	state.canRedo = undoHistory.canRedo;
+}
+
+/** Push the current editor state onto the undo stack (no-op when content is unchanged). */
+function pushToUndoHistory() {
+	undoPendingTimer = null;
+	const snapshot = captureUndoSnapshot();
+	const last = undoHistory.current;
+	if ( last && last.html === snapshot.html && last.title === snapshot.title ) return;
+	undoHistory.push( snapshot );
+	syncUndoState();
+}
+
+/** Schedule a history push 500 ms after the last keystroke. */
+function pushToUndoHistoryDebounced() {
+	if ( undoPendingTimer ) clearTimeout( undoPendingTimer );
+	undoPendingTimer = setTimeout( pushToUndoHistory, 500 );
+}
+
+/** Commit any pending debounced snapshot immediately. */
+function flushUndoDebounce() {
+	if ( undoPendingTimer ) {
+		clearTimeout( undoPendingTimer );
+		pushToUndoHistory();
+	}
+}
+
+/** Flush pending text input then step back one entry in the undo stack. */
+function performUndo() {
+	flushUndoDebounce();
+	if ( ! undoHistory.canUndo ) return;
+	const snap = undoHistory.undo();
+	if ( snap ) applyUndoSnapshot( snap );
+	syncUndoState();
+}
+
+/** Discard pending text input and step forward one entry in the undo stack. */
+function performRedo() {
+	if ( undoPendingTimer ) {
+		clearTimeout( undoPendingTimer );
+		undoPendingTimer = null;
+	}
+	if ( ! undoHistory.canRedo ) return;
+	const snap = undoHistory.redo();
+	if ( snap ) applyUndoSnapshot( snap );
+	syncUndoState();
+}
 
 /**
  * Get the content editable element, caching the reference.
@@ -757,6 +945,7 @@ function animateAndDeleteFigure( fig ) {
 		fig.remove();
 		ensureBlockStructure();
 		placeCursorAfterFigureDelete( next, prev );
+		pushToUndoHistory();
 	}, 200 );
 }
 
@@ -1720,6 +1909,8 @@ const { state } = store( 'wpcom-write', {
 		formatQuote: false,
 		imageUrl: '',
 		headingLabel: i18n.normal || 'Normal',
+		canUndo: false,
+		canRedo: false,
 		get headerLabel() {
 			return state.title.trim() || i18n.untitled || 'Untitled';
 		},
@@ -1925,6 +2116,15 @@ const { state } = store( 'wpcom-write', {
 			// Backspace can unwrap a neighbouring <p>).
 			promoteGapAtCursor();
 			ensureBlockStructure();
+			pushToUndoHistoryDebounced();
+		},
+
+		undo() {
+			performUndo();
+		},
+
+		redo() {
+			performRedo();
 		},
 
 		handleKeyDown( event ) {
@@ -1972,9 +2172,19 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
-			// Block undo/redo (Ctrl+Z, Ctrl+Shift+Z, Ctrl+Y).
-			if ( ( event.ctrlKey || event.metaKey ) && /^[zy]$/i.test( event.key ) ) {
+			// Undo (Cmd+Z / Ctrl+Z).
+			if ( ( event.ctrlKey || event.metaKey ) && event.key === 'z' && ! event.shiftKey ) {
 				event.preventDefault();
+				performUndo();
+				return;
+			}
+			// Redo (Cmd+Shift+Z / Ctrl+Shift+Z / Ctrl+Y).
+			if (
+				( ( event.ctrlKey || event.metaKey ) && event.key === 'z' && event.shiftKey ) ||
+				( event.ctrlKey && event.key === 'y' )
+			) {
+				event.preventDefault();
+				performRedo();
 				return;
 			}
 
@@ -2186,9 +2396,13 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		handleBeforeInput( event ) {
-			// Block undo/redo triggered via browser Edit menu.
-			if ( event.inputType === 'historyUndo' || event.inputType === 'historyRedo' ) {
+			// Route Edit menu undo/redo through our history stack.
+			if ( event.inputType === 'historyUndo' ) {
 				event.preventDefault();
+				performUndo();
+			} else if ( event.inputType === 'historyRedo' ) {
+				event.preventDefault();
+				performRedo();
 			}
 		},
 
@@ -2811,6 +3025,7 @@ const { state } = store( 'wpcom-write', {
 
 			state.showImageModal = false;
 			resetUploadZone();
+			pushToUndoHistory();
 		},
 
 		async uploadImage() {
@@ -2863,10 +3078,13 @@ const { state } = store( 'wpcom-write', {
 		// --- Slash commands ---
 
 		insertHeading() {
+			flushUndoDebounce();
 			insertNewBlock( 'h2' );
+			pushToUndoHistory();
 		},
 
 		insertImage() {
+			flushUndoDebounce();
 			clearSlashText();
 			clearSlashActive();
 			state.showSlashMenu = false;
@@ -2880,15 +3098,21 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		insertBulletedList() {
+			flushUndoDebounce();
 			insertNewList( 'ul' );
+			pushToUndoHistory();
 		},
 
 		insertNumberedList() {
+			flushUndoDebounce();
 			insertNewList( 'ol' );
+			pushToUndoHistory();
 		},
 
 		insertQuote() {
+			flushUndoDebounce();
 			insertNewBlock( 'blockquote' );
+			pushToUndoHistory();
 		},
 
 		insertVideo() {
@@ -2979,9 +3203,11 @@ const { state } = store( 'wpcom-write', {
 			}
 
 			state.showVideoModal = false;
+			pushToUndoHistory();
 		},
 
 		insertDivider() {
+			flushUndoDebounce();
 			clearSlashText();
 			const hr = document.createElement( 'hr' );
 			const p = document.createElement( 'p' );
@@ -3013,6 +3239,7 @@ const { state } = store( 'wpcom-write', {
 			}
 			clearSlashActive();
 			state.showSlashMenu = false;
+			pushToUndoHistory();
 		},
 
 		// --- UI toggles ---
@@ -3384,6 +3611,8 @@ const autosaveReady = setInterval( () => {
 
 	// Capture the initial snapshot so edits are detected relative to load state.
 	updateSavedSnapshot();
+	// Seed the undo history with the initial content so Cmd+Z can return to it.
+	pushToUndoHistory();
 
 	// Start the periodic autosave timer.
 	const { actions } = store( 'wpcom-write' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1194,9 +1194,8 @@ const contentReady2 = setInterval( () => {
 	ensureBlockStructure();
 	if ( ! contentEl.textContent.trim() && ! contentEl.querySelector( 'img, video, figure' ) ) {
 		// bw-is-empty drives the CSS ::before placeholder on the outer .bw-content.
-		// Input events in a contenteditable fire on the contenteditable host (the
-		// outer .bw-content), not on inner descendants — so attach the cleanup
-		// listener to the outer element.
+		// Input events from the inner contenteditable bubble up to the outer,
+		// so a single listener on the outer is enough to detect the first edit.
 		const outerContentEl = document.querySelector( '.bw-content' );
 		outerContentEl?.classList.add( 'bw-is-empty' );
 		outerContentEl?.addEventListener(
@@ -1941,6 +1940,24 @@ function syncCatDropdownItems() {
 }
 
 const { state } = store( 'wpcom-write', {
+	callbacks: {
+		/**
+		 * Mirror reactive slash-menu state onto the .bw-content-inner element.
+		 *
+		 * .bw-content-inner has `data-wp-ignore` (so Preact treats its children
+		 * as opaque and won't re-attach detached nodes during undo/redo) — but
+		 * that directive strips any sibling `data-wp-bind--*` directives. To
+		 * keep the combobox aria attributes reactive, we sync them imperatively
+		 * via `data-wp-watch` on the outer wrapper: reading state.showSlashMenu
+		 * and state.slashActiveId here subscribes the watcher to their signals.
+		 */
+		syncComboboxAria() {
+			const inner = document.querySelector( '.bw-content-inner' );
+			if ( ! inner ) return;
+			inner.setAttribute( 'aria-expanded', state.showSlashMenu ? 'true' : 'false' );
+			inner.setAttribute( 'aria-activedescendant', state.slashActiveId || '' );
+		},
+	},
 	state: {
 		formatBold: false,
 		formatItalic: false,
@@ -3021,8 +3038,7 @@ const { state } = store( 'wpcom-write', {
 			state.uploadedMediaId = 0;
 			resetUploadZone();
 			restoreSelection();
-			const content = document.querySelector( '.bw-content' );
-			if ( content ) content.focus();
+			getContent()?.focus();
 		},
 
 		handleImageModalKeyDown( event ) {
@@ -3200,8 +3216,7 @@ const { state } = store( 'wpcom-write', {
 			state.showVideoModal = false;
 			state.videoUrl = '';
 			restoreSelection();
-			const content = document.querySelector( '.bw-content' );
-			if ( content ) content.focus();
+			getContent()?.focus();
 		},
 
 		handleVideoModalKeyDown( event ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -282,7 +282,12 @@ function performRedo() {
  */
 function getContent() {
 	if ( ! cachedContent || ! cachedContent.isConnected ) {
-		cachedContent = document.querySelector( '.bw-content' );
+		// The inner wrapper holds user-editable content. The outer .bw-content
+		// keeps Preact's reactive bindings (event handlers, aria attributes),
+		// while .bw-content-inner has data-wp-ignore so Preact treats its
+		// children as opaque — preventing the reconciler from re-attaching
+		// stale Preact-tracked nodes after we replace innerHTML during undo.
+		cachedContent = document.querySelector( '.bw-content-inner' );
 	}
 	return cachedContent;
 }
@@ -1161,10 +1166,17 @@ const contentReady2 = setInterval( () => {
 	// inserted and the user can start editing right away.
 	ensureBlockStructure();
 	if ( ! contentEl.textContent.trim() && ! contentEl.querySelector( 'img, video, figure' ) ) {
-		contentEl.classList.add( 'bw-is-empty' );
-		contentEl.addEventListener( 'input', () => contentEl.classList.remove( 'bw-is-empty' ), {
-			once: true,
-		} );
+		// bw-is-empty drives the CSS ::before placeholder on the outer .bw-content.
+		// Input events in a contenteditable fire on the contenteditable host (the
+		// outer .bw-content), not on inner descendants — so attach the cleanup
+		// listener to the outer element.
+		const outerContentEl = document.querySelector( '.bw-content' );
+		outerContentEl?.classList.add( 'bw-is-empty' );
+		outerContentEl?.addEventListener(
+			'input',
+			() => outerContentEl.classList.remove( 'bw-is-empty' ),
+			{ once: true }
+		);
 	}
 }, 200 );
 
@@ -3221,7 +3233,7 @@ const { state } = store( 'wpcom-write', {
 				while (
 					block &&
 					block.parentNode &&
-					! block.parentNode.classList.contains( 'bw-content' )
+					! block.parentNode.classList.contains( 'bw-content-inner' )
 				) {
 					block = block.parentNode;
 				}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -190,16 +190,43 @@ function restoreUndoCursor( root, cursorInfo ) {
 }
 
 /**
+ * Strip runtime-injected figure controls from a content subtree.
+ *
+ * The img-controls wrapper and the delete / alt / caption buttons are added
+ * at runtime by addDeleteButtons() with live event listeners attached. Those
+ * listeners do not survive an innerHTML round-trip, so we drop the markup
+ * before serialising — the MutationObserver in addDeleteButtons() will
+ * re-add buttons (with listeners) when the figure reappears after undo/redo.
+ *
+ * @param {Element} root - Detached root (typically a clone of .bw-content-inner).
+ */
+function stripRuntimeFigureControls( root ) {
+	root.querySelectorAll( '.bw-img-controls' ).forEach( wrapper => {
+		const img = wrapper.querySelector( 'img' );
+		if ( img ) wrapper.before( img );
+		wrapper.remove();
+	} );
+	root
+		.querySelectorAll( '.bw-img-delete, .bw-img-alt, .bw-img-alt-input, .bw-img-caption-btn' )
+		.forEach( el => el.remove() );
+}
+
+/**
  * Capture the current editor state as an undo snapshot.
  *
  * @return {object} Snapshot containing html, title, and cursor.
  */
 function captureUndoSnapshot() {
 	const content = getContent();
+	if ( ! content ) {
+		return { html: '', title: state.title || '', cursor: null };
+	}
+	const clone = content.cloneNode( true );
+	stripRuntimeFigureControls( clone );
 	return {
-		html: content ? content.innerHTML : '',
+		html: clone.innerHTML,
 		title: state.title || '',
-		cursor: content ? serializeCursor( content ) : null,
+		cursor: serializeCursor( content ),
 	};
 }
 
@@ -2324,6 +2351,35 @@ const { state } = store( 'wpcom-write', {
 				// No adjacent figure — fall through to native Backspace/Delete.
 			}
 
+			// Block Backspace at the very start of the first block. With nothing
+			// to merge into, some browsers respond by unwrapping the structure
+			// — including the .bw-content-inner wrapper that protects user
+			// content from the Interactivity API reconciler. Losing the wrapper
+			// breaks undo/redo, so we no-op this keystroke instead.
+			if ( event.key === 'Backspace' ) {
+				const sel = window.getSelection();
+				if ( sel.rangeCount && sel.isCollapsed ) {
+					const range = sel.getRangeAt( 0 );
+					const content = getContent();
+					if ( content && content.firstElementChild ) {
+						// Walk up from the cursor to the direct child of .bw-content-inner.
+						let block = range.startContainer;
+						while ( block && block.parentNode !== content ) {
+							block = block.parentNode;
+						}
+						if ( block && block === content.firstElementChild ) {
+							const beforeRange = document.createRange();
+							beforeRange.setStart( block, 0 );
+							beforeRange.setEnd( range.startContainer, range.startOffset );
+							if ( beforeRange.toString() === '' ) {
+								event.preventDefault();
+								return;
+							}
+						}
+					}
+				}
+			}
+
 			// Tab / Shift-Tab inside a list: indent / outdent.
 			if ( event.key === 'Tab' ) {
 				const sel = window.getSelection();
@@ -3473,19 +3529,7 @@ async function savePost( postStatus, isAutosave = false ) {
 	clone.querySelectorAll( 'figure[contenteditable]' ).forEach( el => {
 		el.removeAttribute( 'contenteditable' );
 	} );
-	// Strip runtime control wrappers and buttons from figures so only
-	// the original media elements are saved.
-	clone.querySelectorAll( '.bw-img-controls' ).forEach( wrapper => {
-		// Move the img back out of the wrapper.
-		const img = wrapper.querySelector( 'img' );
-		if ( img ) {
-			wrapper.before( img );
-		}
-		wrapper.remove();
-	} );
-	clone
-		.querySelectorAll( '.bw-img-delete, .bw-img-alt, .bw-img-alt-input, .bw-img-caption-btn' )
-		.forEach( el => el.remove() );
+	stripRuntimeFigureControls( clone );
 
 	// Safety net: if stripping editor-only elements left the clone
 	// empty, treat it the same as no content.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1149,28 +1149,33 @@ function addDeleteButtons() {
 			figcaption.setAttribute( 'data-placeholder', i18n.writeCaption || 'Write a caption...' );
 			figcaption.addEventListener( 'click', ev => ev.stopPropagation() );
 			fig.appendChild( figcaption );
-
-			// Listen on the figure for keydown so we catch it before the content area.
-			fig.addEventListener( 'keydown', ev => {
-				if (
-					ev.key === 'Enter' &&
-					fig.querySelector( 'figcaption' ) &&
-					fig.querySelector( 'figcaption' ).contains( document.getSelection().anchorNode )
-				) {
-					ev.preventDefault();
-					ev.stopImmediatePropagation();
-					let next = fig.nextElementSibling;
-					if ( ! next || next.tagName === 'FIGURE' ) {
-						next = document.createElement( 'p' );
-						next.innerHTML = '<br>';
-						fig.after( next );
-					}
-					placeCursorAt( next );
-				}
-			} );
 			figcaption.focus();
 		} );
 		controls.appendChild( capBtn );
+
+		// Enter inside the figcaption exits to the next block. Attached on every
+		// figure init (not just on first caption-button click) so it survives an
+		// undo that restored a figure with a pre-existing figcaption — the
+		// MutationObserver re-runs addDeleteButtons, and the early-return at the
+		// top of this loop keeps the listener from being attached twice.
+		fig.addEventListener( 'keydown', ev => {
+			const figcaption = fig.querySelector( 'figcaption' );
+			if (
+				ev.key === 'Enter' &&
+				figcaption &&
+				figcaption.contains( document.getSelection().anchorNode )
+			) {
+				ev.preventDefault();
+				ev.stopImmediatePropagation();
+				let next = fig.nextElementSibling;
+				if ( ! next || next.tagName === 'FIGURE' ) {
+					next = document.createElement( 'p' );
+					next.innerHTML = '<br>';
+					fig.after( next );
+				}
+				placeCursorAt( next );
+			}
+		} );
 	} );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -624,7 +624,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--keydown="actions.handleKeyDown"
 				data-wp-on--beforeinput="actions.handleBeforeInput"
 				data-placeholder="<?php echo esc_attr__( 'Tell your story...', 'jetpack-mu-wpcom' ); ?>"
-			>
+			><div class="bw-content-inner" data-wp-ignore>
 			<?php
 			if ( $edit_content ) {
 				// Sanitize through wp_kses_post — video embed tokens (HTML comments)
@@ -639,7 +639,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				echo '<p><br></p>';
 			}
 			?>
-			</div>
+			</div></div>
 		</div>
 	</main>
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	// Use file modification time to bust CDN caches when files change.
-	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ) ) );
+	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ), filemtime( __DIR__ . '/undo-history.js' ) ) );
 }
 
 /**
@@ -59,9 +59,15 @@ add_action(
 	'init',
 	function () {
 		wp_register_script_module(
+			'wpcom-write/undo-history',
+			wpcom_write_asset_url( 'undo-history.js' ),
+			array(),
+			WPCOM_WRITE_VERSION
+		);
+		wp_register_script_module(
 			'wpcom-write/view',
 			wpcom_write_asset_url( 'view.js' ),
-			array( '@wordpress/interactivity' ),
+			array( '@wordpress/interactivity', 'wpcom-write/undo-history' ),
 			WPCOM_WRITE_VERSION
 		);
 	}
@@ -479,6 +485,10 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		data-wp-on--keydown="actions.handleToolbarKeyDown"
 	>
 		<div class="bw-toolbar-scroll">
+			<!-- Undo / Redo -->
+			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Undo', 'jetpack-mu-wpcom' ); ?>" tabindex="0" data-wp-on--click="actions.undo" data-wp-bind--disabled="!state.canUndo" title="<?php echo esc_attr__( 'Undo', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-undo"></span></button>
+			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Redo', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.redo" data-wp-bind--disabled="!state.canRedo" title="<?php echo esc_attr__( 'Redo', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-redo"></span></button>
+			<span class="bw-tool-divider"></span>
 			<!-- Heading dropdown -->
 			<div class="bw-tool-dropdown-wrap">
 				<button class="bw-tool bw-tool-heading-toggle" aria-label="<?php echo esc_attr__( 'Text style', 'jetpack-mu-wpcom' ); ?>" aria-haspopup="menu" aria-expanded="false" tabindex="0" data-wp-bind--aria-expanded="state.showHeadingMenu" data-wp-on--click="actions.toggleHeadingMenu" data-wp-class--bw-tool-active="state.formatHeading" title="<?php echo esc_attr__( 'Text style', 'jetpack-mu-wpcom' ); ?>">

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -486,7 +486,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	>
 		<div class="bw-toolbar-scroll">
 			<!-- Undo / Redo -->
-			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Undo', 'jetpack-mu-wpcom' ); ?>" tabindex="0" data-wp-on--click="actions.undo" data-wp-bind--disabled="!state.canUndo" title="<?php echo esc_attr__( 'Undo', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-undo"></span></button>
+			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Undo', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.undo" data-wp-bind--disabled="!state.canUndo" title="<?php echo esc_attr__( 'Undo', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-undo"></span></button>
 			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Redo', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.redo" data-wp-bind--disabled="!state.canRedo" title="<?php echo esc_attr__( 'Redo', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-redo"></span></button>
 			<span class="bw-tool-divider"></span>
 			<!-- Heading dropdown -->

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -608,15 +608,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<div class="bw-separator"></div>
 			<div
 				class="bw-content<?php echo $edit_content ? '' : ' bw-is-empty'; ?>"
-				contenteditable="true"
-				role="combobox"
-				aria-label="<?php echo esc_attr__( 'Post content', 'jetpack-mu-wpcom' ); ?>"
-				aria-autocomplete="list"
-				aria-haspopup="listbox"
-				aria-expanded="false"
-				aria-controls="bw-slash-menu"
-				data-wp-bind--aria-expanded="state.showSlashMenu"
-				data-wp-bind--aria-activedescendant="state.slashActiveId"
+				data-wp-watch="callbacks.syncComboboxAria"
 				data-wp-on--mouseup="actions.checkFormatting"
 				data-wp-on--keyup="actions.checkFormatting"
 				data-wp-on--click="actions.handleContentClick"
@@ -624,7 +616,17 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--keydown="actions.handleKeyDown"
 				data-wp-on--beforeinput="actions.handleBeforeInput"
 				data-placeholder="<?php echo esc_attr__( 'Tell your story...', 'jetpack-mu-wpcom' ); ?>"
-			><div class="bw-content-inner" data-wp-ignore>
+			><div
+				class="bw-content-inner"
+				contenteditable="true"
+				role="combobox"
+				aria-label="<?php echo esc_attr__( 'Post content', 'jetpack-mu-wpcom' ); ?>"
+				aria-autocomplete="list"
+				aria-haspopup="listbox"
+				aria-expanded="false"
+				aria-controls="bw-slash-menu"
+				data-wp-ignore
+			>
 			<?php
 			if ( $edit_content ) {
 				// Sanitize through wp_kses_post — video embed tokens (HTML comments)


### PR DESCRIPTION
Fixes RSM-1906

## Proposed changes

* Implement a snapshot-based undo/redo history stack for the Write editor — previously `Cmd+Z` / `Cmd+Shift+Z` were explicitly blocked with no replacement
* Add **Undo** and **Redo** buttons at the left of the formatting toolbar, disabled when no history is available
* Block insertions (divider, heading, image, video, lists, quote) each push a snapshot immediately after insertion
* Text edits are debounced at 500 ms so rapid typing collapses into one undo step rather than per-keystroke entries
* Cursor position is serialised via DOM node paths so it is restored correctly after an `innerHTML` replacement
* Extract `undo-history.js` as a pure, testable module registered as its own WordPress Script Module (`wpcom-write/undo-history`)
* Add 12 unit tests for the history stack via Node's built-in test runner; add a `pnpm test` script to the package


https://github.com/user-attachments/assets/1e07e8a5-f474-40be-bb7a-c73f7db06db3



## Implementation note: protecting user content from the Interactivity API reconciler

During testing on Atomic and Simple we hit a "ghost text" bug: after undoing typed text and then typing a slash command, previously-typed content reappeared in the editor. Root cause was the Interactivity API's Preact reconciler holding DOM references to the original SSR'd children of `.bw-content` from hydration. When `applyUndoSnapshot` replaced `innerHTML`, those tracked nodes became detached. The next state mutation (e.g. `syncUndoState` updating `state.canUndo`) triggered Preact reconciliation, which re-attached the still-referenced detached nodes — producing the ghost.

Things we tried that did **not** work:

* Granular `removeChild` / `appendChild` instead of `innerHTML =` — the reconciler still re-attached its tracked references after the fact
* Adding `data-wp-ignore` directly on `.bw-content` — works for the reconciler, but [`vdom.js:113-121`](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/src/vdom.ts) early-returns when `data-wp-ignore` is set, dropping all other directives on the same element. All `data-wp-on--*` and `data-wp-bind--*` directives were silently stripped, so typing did nothing.

The fix that works: wrap user-editable content in an inner `<div class="bw-content-inner" data-wp-ignore>` inside `.bw-content`. The outer `.bw-content` keeps all reactive bindings (event handlers, `aria-expanded`, `aria-activedescendant`, `role="combobox"`); the inner wrapper has `data-wp-ignore` so Preact treats its children as opaque HTML and stops tracking them. `getContent()` returns the inner element, so existing content-manipulation code continues to work unchanged.

## Related product discussion/links

RSM-1906

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Setup:** Open the Write editor at `wp-admin/?page=write` on a WordPress.com site or local dev environment. Test on Simple and Atomic, and in Chrome / Safari / Firefox.

**Keyboard shortcuts:**

1. Type some text in the editor body
2. Press `Cmd+Z` (Mac) or `Ctrl+Z` (Windows/Linux) — the typed text should be removed
3. Press `Cmd+Shift+Z` (Mac) or `Ctrl+Shift+Z` / `Ctrl+Y` (Windows/Linux) — the text should reappear

**Toolbar buttons:**

4. Confirm the Undo and Redo buttons appear at the left of the formatting toolbar
5. Undo button should be disabled (greyed out) when there is nothing to undo; Redo button disabled when there is nothing to redo

**Block insertions (the original bug — dividers):**

6. Type some text, then use the slash menu (`/`) to insert a **Divider**
7. Press `Cmd+Z` — the divider should be removed and the text before it restored
8. Press `Cmd+Z` again — the typed text should be removed

**Other block types:**

9. Repeat step 6–7 with Heading, Quote, Bulleted list, and Numbered list — each should undo cleanly

**Image / Video:**

10. Insert an image via the toolbar Image button; after insertion press `Cmd+Z` — the image should be removed

**Debounce behaviour:**

11. Type a sentence rapidly, pause 0.5 s, type another sentence, then press `Cmd+Z` — should undo the second sentence as a unit, not character-by-character

**Figure deletion:**

12. Insert an image, press `Backspace` twice to delete it, then `Cmd+Z` — the image should reappear

**Ghost text regression check (Atomic + Simple specifically):**

13. Type some text, press `Cmd+Z`, then type `/` to open the slash menu and pick any item — no duplicate of the previously typed text should appear in the editor

Known issue: Videos/images sometimes reload when other content is undone/redone.

## Deploy ordering note

`view.js` now imports `wpcom-write/undo-history`, a script module registered in `write.php`. If JS lands before PHP during a staged deploy, the import won't resolve and the editor will fail to load for anyone who hits a mismatched server until the deploy completes. Acceptable for the current <20-user beta (worst case: reload), but should be addressed in future rollouts.
