### PR TITLE
Backport package release cycle for 2026-05

### DIFF
--- a/projects/js-packages/jetpack-cli/CHANGELOG.md
+++ b/projects/js-packages/jetpack-cli/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2026-05-13
+### Security
+- Rsync: Make it harder for a host-system attacker to attack the rsync proxy. [#47736]
+
+### Added
+- Add composer command for running Composer in the monorepo root or a specific project. [#47201]
+- Add pnpm command for running pnpm in the monorepo root or a specific project. [#47201]
+- Add SSH proxy support for rsync to enable Secure Enclave SSH keys that cannot be forwarded into Docker. [#46867]
+
+### Changed
+- Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency. [#48225]
+- Make it explicit that this package has no JS exports by setting `exports` in package.json. [#47283]
+- Remove Docker auto-install wrapper for worktrees; husky hooks now use pnpm exec for automatic dependency installation via verifyDepsBeforeRun. [#47354]
+- Set `.repository.url` in `package.json` to the mirror repo rather than the monorepo. Required for enabling provenance. [#47149]
+- Update legacy Node calls. [#47770]
+
 ## 1.1.1 - 2026-02-13
 ### Fixed
 - Git hooks: Resolve hooks directory correctly in Git worktrees. [#47037]

--- a/projects/js-packages/jetpack-cli/changelog/experiment-rsync-socat-proxy
+++ b/projects/js-packages/jetpack-cli/changelog/experiment-rsync-socat-proxy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add SSH proxy support for rsync to enable Secure Enclave SSH keys that cannot be forwarded into Docker.

--- a/projects/js-packages/jetpack-cli/changelog/fix-jp-rsync-proxy-security
+++ b/projects/js-packages/jetpack-cli/changelog/fix-jp-rsync-proxy-security
@@ -1,4 +1,0 @@
-Significance: major
-Type: security
-
-Rsync: Make it harder for a host-system attacker to attack the rsync proxy.

--- a/projects/js-packages/jetpack-cli/changelog/husky-pnpm-exec
+++ b/projects/js-packages/jetpack-cli/changelog/husky-pnpm-exec
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove Docker auto-install wrapper for worktrees; husky hooks now use pnpm exec for automatic dependency installation via verifyDepsBeforeRun.

--- a/projects/js-packages/jetpack-cli/changelog/jp-composer-command
+++ b/projects/js-packages/jetpack-cli/changelog/jp-composer-command
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add composer command for running Composer in the monorepo root or a specific project.

--- a/projects/js-packages/jetpack-cli/changelog/jp-pnpm-command
+++ b/projects/js-packages/jetpack-cli/changelog/jp-pnpm-command
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add pnpm command for running pnpm in the monorepo root or a specific project.

--- a/projects/js-packages/jetpack-cli/changelog/renovate-eslint-packages
+++ b/projects/js-packages/jetpack-cli/changelog/renovate-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Make it explicit that this package has no JS exports by setting `exports` in package.json.

--- a/projects/js-packages/jetpack-cli/changelog/update-changelogger-remove_per_project_dep
+++ b/projects/js-packages/jetpack-cli/changelog/update-changelogger-remove_per_project_dep
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency.

--- a/projects/js-packages/jetpack-cli/changelog/update-js-package-repository-url
+++ b/projects/js-packages/jetpack-cli/changelog/update-js-package-repository-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Set `.repository.url` in `package.json` to the mirror repo rather than the monorepo. Required for enabling provenance.

--- a/projects/js-packages/jetpack-cli/changelog/update-legacy_node_calls
+++ b/projects/js-packages/jetpack-cli/changelog/update-legacy_node_calls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update legacy Node calls.

--- a/projects/js-packages/jetpack-cli/package.json
+++ b/projects/js-packages/jetpack-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-cli",
-	"version": "1.1.1",
+	"version": "2.0.0",
 	"description": "Docker-based CLI for Jetpack development",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/jetpack-cli/#readme",
 	"author": "Automattic",

--- a/projects/packages/stub-generator/CHANGELOG.md
+++ b/projects/packages/stub-generator/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-13
+### Added
+- Allow extracting enum stubs. [#47233]
+
+### Changed
+- Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency. [#48225]
+
 ## [2.0.1] - 2026-01-12
 ### Changed
 - Internal updates.
@@ -25,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial version.
 
+[2.1.0]: https://github.com/Automattic/jetpack-stub-generator/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/Automattic/jetpack-stub-generator/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-stub-generator/compare/v1.0.1...v2.0.0
 [1.0.1]: https://github.com/Automattic/jetpack-stub-generator/compare/v1.0.0...v1.0.1

--- a/projects/packages/stub-generator/changelog/add-stub-generator-extract-enums
+++ b/projects/packages/stub-generator/changelog/add-stub-generator-extract-enums
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Allow extracting enum stubs too.

--- a/projects/packages/stub-generator/changelog/update-changelogger-remove_per_project_dep
+++ b/projects/packages/stub-generator/changelog/update-changelogger-remove_per_project_dep
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency.

--- a/projects/packages/stub-generator/composer.json
+++ b/projects/packages/stub-generator/composer.json
@@ -56,7 +56,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "2.0.x-dev"
+			"dev-trunk": "2.1.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-stub-generator/compare/v${old}...v${new}"

--- a/projects/packages/stub-generator/src/Application.php
+++ b/projects/packages/stub-generator/src/Application.php
@@ -28,7 +28,7 @@ use Throwable;
  */
 class Application extends SingleCommandApplication {
 
-	const VERSION = '2.0.1';
+	const VERSION = '2.1.0';
 
 	/**
 	 * Exit code to use.


### PR DESCRIPTION
This releases the following:

* js-packages/jetpack-cli 2.0.0 
* packages/stub-generator 2.1.0

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
