### PR TITLE
Charts: smooth area-chart legend toggle and freeze y-axis

### DIFF
--- a/projects/js-packages/charts/changelog/charts-area-chart-smooth-legend-toggle
+++ b/projects/js-packages/charts/changelog/charts-area-chart-smooth-legend-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: keep stacked area chart paths mounted on legend toggle so only the hidden series animates down and the y-axis stays fixed.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -137,24 +137,38 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 
 		// Computed from the full data set (ignoring legend visibility) so the y-axis stays
 		// fixed when series are toggled off — otherwise visx auto-fits to the remaining data
-		// and the chart appears to rescale.
+		// and the chart appears to rescale. Skipped for non-default stack offsets, which
+		// reshape the y-extent (`expand` → [0,1], `wiggle`/`silhouette` → centred around
+		// zero) — letting visx derive the domain is correct there.
 		const fixedYDomain = useMemo< [ number, number ] | undefined >( () => {
-			if ( ! legendInteractive || ! dataSorted.length || ! dataSorted[ 0 ].data.length ) {
+			if (
+				! legendInteractive ||
+				! dataSorted.length ||
+				! dataSorted[ 0 ].data.length ||
+				( stacked && stackOffset !== 'none' )
+			) {
 				return undefined;
 			}
 
 			if ( stacked ) {
-				const numPoints = dataSorted[ 0 ].data.length;
-				let max = 0;
+				// d3-stack with `offset: 'none'` stacks positives upward from 0 and
+				// negatives downward from 0, so we need both extremes.
+				const numPoints = Math.max( ...dataSorted.map( s => s.data.length ) );
+				let posMax = 0;
+				let negMin = 0;
 				for ( let i = 0; i < numPoints; i++ ) {
-					let sum = 0;
+					let posSum = 0;
+					let negSum = 0;
 					for ( const series of dataSorted ) {
 						const v = Number( series.data[ i ]?.value );
-						if ( ! Number.isNaN( v ) ) sum += v;
+						if ( Number.isNaN( v ) ) continue;
+						if ( v >= 0 ) posSum += v;
+						else negSum += v;
 					}
-					if ( sum > max ) max = sum;
+					if ( posSum > posMax ) posMax = posSum;
+					if ( negSum < negMin ) negMin = negSum;
 				}
-				return [ 0, max ];
+				return [ negMin, posMax ];
 			}
 
 			let max = -Infinity;
@@ -170,7 +184,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 			}
 			if ( max === -Infinity ) return undefined;
 			return [ Math.min( 0, min ), max ];
-		}, [ dataSorted, stacked, legendInteractive ] );
+		}, [ dataSorted, stacked, stackOffset, legendInteractive ] );
 
 		const chartOptions = useMemo( () => {
 			const formatter = options?.axis?.x?.tickFormat || getFormatter( dataSorted );
@@ -251,11 +265,21 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 				const filtered = Object.fromEntries(
 					Object.entries( datumByKey ).filter( ( [ key ] ) => visibleLabels.has( key ) )
 				);
+				if ( Object.keys( filtered ).length === 0 ) return null;
+				// `nearestDatum` may still point at a hidden series; re-point it at the first
+				// visible entry so consumers that read it (e.g. for the tooltip heading) don't
+				// surface hidden-series state.
+				const nearestDatum = params?.tooltipData?.nearestDatum;
+				const nextNearest =
+					nearestDatum && visibleLabels.has( nearestDatum.key )
+						? nearestDatum
+						: { ...Object.values( filtered )[ 0 ], distance: nearestDatum?.distance ?? 0 };
 				return renderTooltip( {
 					...params,
 					tooltipData: {
 						...params.tooltipData,
 						datumByKey: filtered,
+						nearestDatum: nextNearest,
 					} as typeof params.tooltipData,
 				} );
 			},

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -1,5 +1,5 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
-import { XYChart, AreaSeries, AreaStack, Grid, Axis } from '@visx/xychart';
+import { XYChart, AnimatedAreaSeries, AnimatedAreaStack, Grid, Axis } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import {
@@ -135,6 +135,43 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 			totalPoints: dataSorted[ 0 ]?.data.length || 0,
 		} );
 
+		// Computed from the full data set (ignoring legend visibility) so the y-axis stays
+		// fixed when series are toggled off — otherwise visx auto-fits to the remaining data
+		// and the chart appears to rescale.
+		const fixedYDomain = useMemo< [ number, number ] | undefined >( () => {
+			if ( ! legendInteractive || ! dataSorted.length || ! dataSorted[ 0 ].data.length ) {
+				return undefined;
+			}
+
+			if ( stacked ) {
+				const numPoints = dataSorted[ 0 ].data.length;
+				let max = 0;
+				for ( let i = 0; i < numPoints; i++ ) {
+					let sum = 0;
+					for ( const series of dataSorted ) {
+						const v = Number( series.data[ i ]?.value );
+						if ( ! Number.isNaN( v ) ) sum += v;
+					}
+					if ( sum > max ) max = sum;
+				}
+				return [ 0, max ];
+			}
+
+			let max = -Infinity;
+			let min = Infinity;
+			for ( const series of dataSorted ) {
+				for ( const point of series.data ) {
+					const v = Number( point?.value );
+					if ( ! Number.isNaN( v ) ) {
+						if ( v > max ) max = v;
+						if ( v < min ) min = v;
+					}
+				}
+			}
+			if ( max === -Infinity ) return undefined;
+			return [ Math.min( 0, min ), max ];
+		}, [ dataSorted, stacked, legendInteractive ] );
+
 		const chartOptions = useMemo( () => {
 			const formatter = options?.axis?.x?.tickFormat || getFormatter( dataSorted );
 
@@ -164,10 +201,11 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 					nice: true,
 					// Stacked areas should always include zero so the baseline is meaningful.
 					zero: stacked,
+					...( fixedYDomain ? { domain: fixedYDomain } : {} ),
 					...options?.yScale,
 				},
 			};
-		}, [ options, dataSorted, width, stacked ] );
+		}, [ options, dataSorted, width, stacked, fixedYDomain ] );
 
 		const defaultMargin = useChartMargin( height, chartOptions, dataSorted, theme );
 
@@ -191,11 +229,38 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		} );
 
 		const prefersReducedMotion = usePrefersReducedMotion();
+		const animationEnabled = !! animation && ! prefersReducedMotion;
 
 		const accessors = {
 			xAccessor: ( d: DataPointDate ) => d?.date,
 			yAccessor: ( d: DataPointDate ) => d?.value,
 		};
+		const zeroYAccessor = useCallback( () => 0, [] );
+
+		// Hidden series are still registered with visx (so paths can interpolate), but their
+		// data points should not appear in the tooltip.
+		const visibleLabels = useMemo(
+			() => new Set( seriesWithVisibility.filter( s => s.isVisible ).map( s => s.series.label ) ),
+			[ seriesWithVisibility ]
+		);
+		const filteredRenderTooltip = useCallback(
+			( params: Parameters< typeof renderTooltip >[ 0 ] ) => {
+				if ( ! legendInteractive ) return renderTooltip( params );
+				const datumByKey = params?.tooltipData?.datumByKey;
+				if ( ! datumByKey ) return renderTooltip( params );
+				const filtered = Object.fromEntries(
+					Object.entries( datumByKey ).filter( ( [ key ] ) => visibleLabels.has( key ) )
+				);
+				return renderTooltip( {
+					...params,
+					tooltipData: {
+						...params.tooltipData,
+						datumByKey: filtered,
+					} as typeof params.tooltipData,
+				} );
+			},
+			[ renderTooltip, legendInteractive, visibleLabels ]
+		);
 
 		// Defaults that depend on stacked vs overlapping mode.
 		const resolvedFillOpacity = fillOpacity ?? ( stacked ? 0.85 : 0.4 );
@@ -224,6 +289,33 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		const visibleSeries = seriesWithVisibility.filter( ( { isVisible } ) => isVisible );
 		const curve = getCurveType( curveType, smoothing );
 
+		// Visx's `<AreaStack>` keys each `<Area>` by `stackIndex-dataKey`, so filtering out
+		// a hidden series would shift indexes and remount every path. Instead we keep every
+		// series mounted and zero out hidden ones via `yAccessor` — react-spring then
+		// interpolates the `d` attribute, giving a smooth "going down" effect for the
+		// hidden area and a smooth re-flow for the rest.
+		const renderSeries = ( {
+			series: seriesData,
+			index,
+			isVisible,
+		}: ( typeof seriesWithVisibility )[ number ] ) => {
+			const { color, lineStyles } = getElementStyles( { data: seriesData, index } );
+			return (
+				<AnimatedAreaSeries
+					key={ seriesData?.label || index }
+					dataKey={ seriesData?.label }
+					data={ seriesData.data as DataPointDate[] }
+					xAccessor={ accessors.xAccessor }
+					yAccessor={ isVisible || ! legendInteractive ? accessors.yAccessor : zeroYAccessor }
+					fill={ color }
+					fillOpacity={ resolvedFillOpacity }
+					{ ...( stacked ? {} : { renderLine: resolvedWithStroke, curve } ) }
+					lineProps={ { stroke: color, ...lineStyles } }
+					data-testid={ `area-chart-series-${ index }` }
+				/>
+			);
+		};
+
 		return (
 			<SingleChartContext.Provider
 				value={ {
@@ -241,7 +333,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 					className={ clsx(
 						'area-chart',
 						styles[ 'area-chart' ],
-						{ [ styles[ 'area-chart--animated' ] ]: animation && ! prefersReducedMotion },
+						{ [ styles[ 'area-chart--animated' ] ]: animationEnabled },
 						className
 					) }
 					style={ { width, height } }
@@ -295,62 +387,16 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 											) : null }
 
 											{ ! allSeriesHidden && stacked && (
-												<AreaStack
+												<AnimatedAreaStack
 													curve={ curve }
 													offset={ stackOffset }
 													renderLine={ resolvedWithStroke }
 												>
-													{ visibleSeries.map( ( { series: seriesData, index } ) => {
-														const { color, lineStyles } = getElementStyles( {
-															data: seriesData,
-															index,
-														} );
-
-														return (
-															<AreaSeries
-																key={ seriesData?.label || index }
-																dataKey={ seriesData?.label }
-																data={ seriesData.data as DataPointDate[] }
-																{ ...accessors }
-																fill={ color }
-																fillOpacity={ resolvedFillOpacity }
-																lineProps={ {
-																	stroke: color,
-																	...lineStyles,
-																} }
-																data-testid={ `area-chart-series-${ index }` }
-															/>
-														);
-													} ) }
-												</AreaStack>
+													{ seriesWithVisibility.map( renderSeries ) }
+												</AnimatedAreaStack>
 											) }
 
-											{ ! allSeriesHidden &&
-												! stacked &&
-												visibleSeries.map( ( { series: seriesData, index } ) => {
-													const { color, lineStyles } = getElementStyles( {
-														data: seriesData,
-														index,
-													} );
-
-													return (
-														<AreaSeries
-															key={ seriesData?.label || index }
-															dataKey={ seriesData?.label }
-															data={ seriesData.data as DataPointDate[] }
-															{ ...accessors }
-															fill={ color }
-															fillOpacity={ resolvedFillOpacity }
-															renderLine={ resolvedWithStroke }
-															curve={ curve }
-															lineProps={ {
-																stroke: color,
-																...lineStyles,
-															} }
-															data-testid={ `area-chart-series-${ index }` }
-														/>
-													);
-												} ) }
+											{ ! allSeriesHidden && ! stacked && seriesWithVisibility.map( renderSeries ) }
 
 											{ withTooltips && (
 												<>
@@ -359,7 +405,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 														snapTooltipToDatumX
 														// Stacked mode: yAccessor returns raw value, not stacked y — snapping mispositions.
 														snapTooltipToDatumY={ ! stacked }
-														renderTooltip={ renderTooltip }
+														renderTooltip={ filteredRenderTooltip }
 														showVerticalCrosshair={ withTooltipCrosshairs?.showVertical }
 														showHorizontalCrosshair={ withTooltipCrosshairs?.showHorizontal }
 														selectedIndex={ selectedIndex }

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -208,6 +208,7 @@ Animation.args = {
 	...areaChartStoryArgs,
 	animation: true,
 	showLegend: true,
+	legendInteractive: true,
 };
 
 export const WithCompositionLegend: StoryObj< typeof AreaChart > = {

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -148,6 +148,70 @@ describe( 'AreaChart', () => {
 		} );
 	} );
 
+	describe( 'Interactive legend', () => {
+		test( 'keeps every series mounted after hiding one (stacked)', async () => {
+			const user = userEvent.setup();
+			renderWithProvider( {
+				showLegend: true,
+				chartId: 'test-interactive-stacked',
+				legend: { interactive: true },
+			} );
+
+			expect( screen.getByTestId( 'area-chart-series-0' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'area-chart-series-1' ) ).toBeInTheDocument();
+
+			await user.click( screen.getByText( 'Series A' ) );
+
+			// Both series remain in the DOM (hidden one is zeroed via yAccessor,
+			// not unmounted) so that visx stack indices stay stable.
+			expect( screen.getByTestId( 'area-chart-series-0' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'area-chart-series-1' ) ).toBeInTheDocument();
+		} );
+
+		test( 'keeps every series mounted after hiding one (unstacked)', async () => {
+			const user = userEvent.setup();
+			renderWithProvider( {
+				stacked: false,
+				showLegend: true,
+				chartId: 'test-interactive-unstacked',
+				legend: { interactive: true },
+			} );
+
+			await user.click( screen.getByText( 'Series A' ) );
+
+			expect( screen.getByTestId( 'area-chart-series-0' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'area-chart-series-1' ) ).toBeInTheDocument();
+		} );
+
+		test( 'tooltip omits hidden series after toggle', async () => {
+			const user = userEvent.setup();
+			renderWithProvider( {
+				showLegend: true,
+				chartId: 'test-interactive-tooltip',
+				legend: { interactive: true },
+			} );
+
+			await user.click( screen.getByText( 'Series A' ) );
+
+			// Open a tooltip via keyboard navigation, then verify the hidden
+			// series' label is absent from the rendered tooltip rows.
+			const chart = screen.getByRole( 'grid', { name: /area chart/i } );
+			chart.focus();
+			await user.keyboard( '{ArrowRight}' );
+
+			const tooltip = await screen.findByRole( 'tooltip' );
+			expect( tooltip ).not.toHaveTextContent( 'Series A' );
+			expect( tooltip ).toHaveTextContent( 'Series B' );
+		} );
+	} );
+
+	describe( 'Without GlobalChartsProvider', () => {
+		test( 'self-wraps in a provider when none is present', () => {
+			render( <AreaChartUnresponsive { ...defaultProps } /> );
+			expect( screen.getByRole( 'grid', { name: /area chart/i } ) ).toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'Accessibility', () => {
 		test( 'chart container has expected ARIA attributes', () => {
 			renderWithProvider();
@@ -227,6 +291,19 @@ describe( 'AreaChart', () => {
 
 		test( 'renders glyphs in unstacked mode', async () => {
 			renderWithProvider( { stacked: false } );
+			await focusFirstDatum();
+
+			const glyphs = screen.getAllByTestId( /^area-chart-hover-glyph-/ );
+			expect( glyphs ).toHaveLength( 2 );
+		} );
+
+		test( 'renders glyphs in unstacked mode with interactive legend', async () => {
+			renderWithProvider( {
+				stacked: false,
+				showLegend: true,
+				chartId: 'test-unstacked-interactive',
+				legend: { interactive: true },
+			} );
 			await focusFirstDatum();
 
 			const glyphs = screen.getAllByTestId( /^area-chart-hover-glyph-/ );

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -203,6 +203,124 @@ describe( 'AreaChart', () => {
 			expect( tooltip ).not.toHaveTextContent( 'Series A' );
 			expect( tooltip ).toHaveTextContent( 'Series B' );
 		} );
+
+		test( 'renderTooltip receives only visible series in datumByKey', async () => {
+			const user = userEvent.setup();
+			const renderTooltip = jest.fn( () => <div>tooltip</div> );
+			renderWithProvider( {
+				showLegend: true,
+				chartId: 'test-interactive-render-tooltip',
+				legend: { interactive: true },
+				renderTooltip,
+			} );
+
+			await user.click( screen.getByText( 'Series A' ) );
+			const chart = screen.getByRole( 'grid', { name: /area chart/i } );
+			chart.focus();
+			await user.keyboard( '{ArrowRight}' );
+
+			// `renderTooltip` may be called for non-keyboard events too, but the
+			// keyboard-driven call must have filtered datumByKey down to visible series.
+			const calls = renderTooltip.mock.calls as unknown as Array<
+				[
+					{
+						tooltipData?: {
+							datumByKey?: Record< string, unknown >;
+							nearestDatum?: { key: string };
+						};
+					},
+				]
+			>;
+			const keyboardCall = calls.find( ( [ params ] ) => params?.tooltipData?.datumByKey );
+			expect( keyboardCall ).toBeDefined();
+			const keys = Object.keys( keyboardCall![ 0 ].tooltipData!.datumByKey! );
+			expect( keys ).toContain( 'Series B' );
+			expect( keys ).not.toContain( 'Series A' );
+			// And `nearestDatum` should never point at a hidden series.
+			expect( keyboardCall![ 0 ].tooltipData?.nearestDatum?.key ).not.toBe( 'Series A' );
+		} );
+
+		test( 'y-axis domain stays fixed across legend toggles', async () => {
+			const user = userEvent.setup();
+			const ref = createRef< SingleChartRef >();
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						{ ...defaultProps }
+						showLegend
+						chartId="test-interactive-domain"
+						legend={ { interactive: true } }
+						ref={ ref }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const initialDomain = ref.current?.getScales()?.yScale?.domain();
+			expect( initialDomain ).toBeDefined();
+
+			await user.click( screen.getByText( 'Series A' ) );
+
+			const afterToggleDomain = ref.current?.getScales()?.yScale?.domain();
+			expect( afterToggleDomain ).toEqual( initialDomain );
+		} );
+
+		test( 'supports negative stacked values without clipping', () => {
+			const ref = createRef< SingleChartRef >();
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						chartId="test-interactive-negative"
+						showLegend
+						legend={ { interactive: true } }
+						data={ [
+							{
+								label: 'Pos',
+								data: [
+									{ date: new Date( '2024-01-01' ), value: 10 },
+									{ date: new Date( '2024-01-02' ), value: 20 },
+								],
+							},
+							{
+								label: 'Neg',
+								data: [
+									{ date: new Date( '2024-01-01' ), value: -5 },
+									{ date: new Date( '2024-01-02' ), value: -15 },
+								],
+							},
+						] }
+						ref={ ref }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const [ min, max ] = ref.current?.getScales()?.yScale?.domain() ?? [];
+			expect( min ).toBeLessThanOrEqual( -15 );
+			expect( max ).toBeGreaterThanOrEqual( 20 );
+		} );
+
+		test( 'does not pin domain for non-default stack offsets', () => {
+			const ref = createRef< SingleChartRef >();
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						{ ...defaultProps }
+						chartId="test-interactive-expand"
+						showLegend
+						legend={ { interactive: true } }
+						stackOffset="expand"
+						ref={ ref }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			// `expand` normalises to [0,1]; if we accidentally pinned the raw-sum
+			// domain (e.g. [0, 35]), the top of the domain would be far above 1.
+			const [ min, max ] = ref.current?.getScales()?.yScale?.domain() ?? [];
+			expect( min ).toBeGreaterThanOrEqual( 0 );
+			expect( max ).toBeLessThanOrEqual( 1.001 );
+		} );
 	} );
 
 	describe( 'Without GlobalChartsProvider', () => {

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -255,12 +255,16 @@ describe( 'AreaChart', () => {
 				</GlobalChartsProvider>
 			);
 
-			const initialDomain = ref.current?.getScales()?.yScale?.domain();
+			const initialDomain = (
+				ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined
+			 )?.domain();
 			expect( initialDomain ).toBeDefined();
 
 			await user.click( screen.getByText( 'Series A' ) );
 
-			const afterToggleDomain = ref.current?.getScales()?.yScale?.domain();
+			const afterToggleDomain = (
+				ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined
+			 )?.domain();
 			expect( afterToggleDomain ).toEqual( initialDomain );
 		} );
 
@@ -295,7 +299,9 @@ describe( 'AreaChart', () => {
 				</GlobalChartsProvider>
 			);
 
-			const [ min, max ] = ref.current?.getScales()?.yScale?.domain() ?? [];
+			const [ min, max ] =
+				( ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined )?.domain() ??
+				[];
 			expect( min ).toBeLessThanOrEqual( -15 );
 			expect( max ).toBeGreaterThanOrEqual( 20 );
 		} );
@@ -317,7 +323,9 @@ describe( 'AreaChart', () => {
 
 			// `expand` normalises to [0,1]; if we accidentally pinned the raw-sum
 			// domain (e.g. [0, 35]), the top of the domain would be far above 1.
-			const [ min, max ] = ref.current?.getScales()?.yScale?.domain() ?? [];
+			const [ min, max ] =
+				( ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined )?.domain() ??
+				[];
 			expect( min ).toBeGreaterThanOrEqual( 0 );
 			expect( max ).toBeLessThanOrEqual( 1.001 );
 		} );


### PR DESCRIPTION
## Proposed changes

<img width="800" height="400" alt="Gravação de Tela 2026-05-13 às 16 13 32" src="https://github.com/user-attachments/assets/247cd5cc-fce7-46a0-8ad8-600c2347e208" />

When the area chart's legend is interactive, toggling a series previously caused the whole chart to re-animate from the baseline and the y-axis to rescale. Root cause: visx's `<AreaStack>` keys each `<Area>` by `${stackIndex}-${dataKey}`, so filtering a series out shifted every surviving stack index and remounted every path — re-firing the CSS `rise` animation. The auto-fitted y-domain also shrank to the visible-only data.

- Keep every series mounted; zero hidden ones via `yAccessor` so the stack indexes stay stable.
- Switch to `AnimatedAreaSeries` / `AnimatedAreaStack` so react-spring interpolates the `d` attribute — the toggled-off area smoothly collapses to the baseline, and the rest re-flow to fill the freed space.
- Pin `yScale.domain` to a full-dataset domain (`[0, maxStackedSum]` for stacked, `[min, max]` for unstacked) so the axis doesn't move when series are hidden.
- Wrap the tooltip renderer to drop hidden series from `datumByKey`.
- Add `legendInteractive: true` to the Animation story so the behavior is demonstrable in Storybook.

## Related product discussion/links

* n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `pnpm --filter @automattic/jetpack-storybook run storybook:dev` and open the Area Chart → Animation story (or any area chart with `animation: true` and `legend.interactive: true`).
2. Wait for the initial rise animation to finish.
3. Click a legend item to hide a series — only that area should animate down to the baseline; the others should smoothly re-flow.
4. Confirm the y-axis ticks stay fixed across toggles.
5. Hover the chart — the tooltip should not list the hidden series.
6. Toggle back on — the area should rise back in smoothly.