### PR TITLE
ship-wp-ability skill: warn against setExpectedIncorrectUsage anti-pattern in tests

### DIFF
--- a/.agents/skills/ship-wp-ability.md
+++ b/.agents/skills/ship-wp-ability.md
@@ -188,7 +188,17 @@ If `composer update automattic/jetpack-wp-abilities` reports "Nothing to modify 
 
 ### 10) Write tests
 
-Follow `references/test-templates.md`. The test file lives at:
+Follow `references/test-templates.md`. **In particular, do NOT add
+`setExpectedIncorrectUsage('WP_Ability_Categories_Registry::register')` or
+`setExpectedIncorrectUsage('WP_Abilities_Registry::register')` to test
+helpers that re-fire the Abilities API lifecycle actions — that's a
+mandatory assertion, and the underlying core listeners don't always emit
+the expected notice in CI, which fails every test that uses the helper.
+See the "Anti-pattern" entry in `references/test-templates.md` for the full
+story. Mirror the Monitor test pattern (just `do_action()` twice, no
+incorrect-usage expectations).**
+
+The test file lives at:
 
 - Plugin context: `projects/plugins/jetpack/tests/php/src/<Name>_Abilities_Test.php` (extends `WP_UnitTestCase`, uses `WP_UnitTestCase_Fix` trait + `#[CoversClass]` attribute).
 - Package context: `projects/packages/<pkg>/tests/php/abilities/<Name>AbilitiesTest.php` (extends `PHPUnit\Framework\TestCase`, uses Brain Monkey + Mockery).
@@ -313,6 +323,7 @@ Mark the PR ready-for-review only after the review loop converges (no open block
 - **Adding `if ( Jetpack::is_module_active( '<slug>' ) )` around the `::init()` call in `class.jetpack.php`.** Better than not guarding, but still wrong — you're re-implementing what `load_modules()` does for free. Move the wiring into the module file instead.
 - **Duplicate `category` in a spec.** Silent smell — `Registrar` injects the slug when missing. Setting `'category' => self::CATEGORY_SLUG` in each spec is redundant and drifts.
 - **Annotation mismatch** (`readonly: true` on a writer, `destructive: false` on a deleter). `wp-abilities-verify` is the source of truth; this skill doesn't re-check annotation correctness.
+- **CI fails with "Failed to assert that `WP_Ability_Categories_Registry::register` triggered an incorrect usage notice."** A previous version of the test added `setExpectedIncorrectUsage()` calls as a "whitelist" inside a `trigger_registration()` helper. `setExpectedIncorrectUsage` is a *mandatory* assertion — the test fails when the notice doesn't fire, which it usually doesn't in CI because core's site-category / `get-site-info` listeners aren't loaded. Fix: delete the `setExpectedIncorrectUsage` lines from the helper. See `references/test-templates.md` "Anti-pattern" note and PR #48335 commit `af3cdfb51a`.
 - **Description is a label, not a spec.** `"Activate a module."` tells the agent nothing. Rewrite to include return shape, idempotency, preconditions, and which abilities typically precede or follow. See `references/agent-ergonomics.md`.
 - **Raw backing-object dump in the response.** Returning `Jetpack::get_module()` verbatim, a full `WP_Post`, or a REST controller payload unadapted leaks internal fields the agent can't use and wastes context. Summarize to the shape the agent actually consumes.
 - **Unbounded list response.** A `list-*` / `get-*s` read with no `per_page` or `limit` ceiling is a latent OOM on the agent side. Cap at ~100 items, paginate past that.

--- a/.agents/skills/ship-wp-ability/references/test-templates.md
+++ b/.agents/skills/ship-wp-ability/references/test-templates.md
@@ -530,6 +530,21 @@ class <Name>AbilitiesTest extends TestCase {
 
 ## Notes
 
+- **Anti-pattern: `setExpectedIncorrectUsage()` as a "whitelist" for re-fired
+  Abilities API actions.** When tests drive registration by re-firing
+  `wp_abilities_api_categories_init` / `wp_abilities_api_init` directly with
+  `do_action()`, **do not** add `setExpectedIncorrectUsage(
+  'WP_Ability_Categories_Registry::register' )` /
+  `setExpectedIncorrectUsage( 'WP_Abilities_Registry::register' )` as a
+  defensive "whitelist" against expected "already registered" notices.
+  `setExpectedIncorrectUsage` is a *mandatory* assertion in `WP_UnitTestCase`
+  — the test fails if the named notice does **not** fire. In CI's test
+  environment the core listeners (site category + `get-site-info` ability)
+  often are not loaded, so the notice never fires and every test using the
+  helper goes red with "Failed to assert that ... triggered an incorrect
+  usage notice." This bit PR #48335 (Related Posts) across all PHP versions.
+  Mirror the Monitor pattern: call `do_action()` twice and assert on the
+  registry afterward — no incorrect-usage expectations needed.
 - Brain Monkey's `Functions\expect()` vs `Functions\when()`: use `expect()` for behavior that must happen (call counts); use `when()` for stubs that answer whenever called.
 - The Mockery `\Mockery::on(...)` matcher lets you assert on the full spec shape — use it to confirm category injection happened, annotations are present, etc.
 - When testing a `WP_Error` return from a package-context test, make sure `\WP_Error` is autoloaded. The `jetpack-wp-abilities` package already depends on `yoast/phpunit-polyfills` and `brain/monkey`; if the package test bootstrap doesn't pull in a WP test-utility shim that declares `WP_Error`, either add one or exercise the error case in the plugin-context test suite instead.


### PR DESCRIPTION
## Why

PR #48335 (Related Posts abilities) broke CI on every PHP version after merge with five identical failures:

```
1) Related_Posts_Abilities_Test::test_register_abilities_registers_every_slug
Failed to assert that WP_Ability_Categories_Registry::register triggered an incorrect usage notice.
Failed to assert that WP_Abilities_Registry::register triggered an incorrect usage notice.
Failed asserting that an array is empty.
```

Root cause: the test helper called `setExpectedIncorrectUsage('WP_Ability_Categories_Registry::register')` + `setExpectedIncorrectUsage('WP_Abilities_Registry::register')` as a defensive "whitelist" for "already registered" notices it expected re-fired Abilities API lifecycle actions to emit. `setExpectedIncorrectUsage` is a *mandatory* assertion in `WP_UnitTestCase` — the test fails when the notice doesn't fire. In CI's environment those core listeners (site category + `get-site-info` ability) often aren't loaded, so the notice never fires and the test goes red.

Fix was a one-line drop of both `setExpectedIncorrectUsage` calls (PR #48335, commit `af3cdfb51a`). This PR documents the anti-pattern in the `ship-wp-ability` skill so future agent runs don't reintroduce it.

## What this PR changes

- `.agents/skills/ship-wp-ability.md` — step 10 (Write tests) now explicitly forbids the `setExpectedIncorrectUsage` whitelist pattern, with a pointer to the test-templates anti-pattern note. Adds a Failure-modes entry for the diagnostic ("CI fails with 'Failed to assert that …::register triggered an incorrect usage notice.'").
- `.agents/skills/ship-wp-ability/references/test-templates.md` — Notes section gets a leading anti-pattern entry explaining why `setExpectedIncorrectUsage` is wrong here, what the symptom looks like, and the correct pattern (Monitor's: just `do_action()` twice, no incorrect-usage expectations).

## Testing

Doc-only change. No code paths exercised. CI lint should pass.