### PR TITLE
Newsletter: pass apiRoot/apiNonce to AdminPage so saves keep the real REST root

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-save-settings
+++ b/projects/packages/newsletter/changelog/fix-newsletter-save-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix saving settings on the Newsletter admin page on Atomic and self-hosted sites.

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -3,7 +3,7 @@
  */
 import { AdminPage, Col, Container, GlobalNotices } from '@automattic/jetpack-components';
 import { useConnection, getUserConnectionUrl } from '@automattic/jetpack-connection';
-import { isSimpleSite } from '@automattic/jetpack-script-data';
+import { getSiteData, isSimpleSite } from '@automattic/jetpack-script-data';
 import { createRoot, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
@@ -36,6 +36,12 @@ export function NewsletterSettingsApp(): JSX.Element {
 		[]
 	);
 
+	// `AdminPage` writes these into the shared `restApi` client on mount,
+	// defaulting to '' when omitted — which clobbers the root the settings
+	// API set up itself and breaks saves with a 404. Feed it the real values
+	// from script data so it stays consistent with `./api.ts`.
+	const siteData = getSiteData();
+
 	return (
 		<AdminPage
 			title={ 'Newsletter' /** "Newsletter" is a product name, do not translate. */ }
@@ -43,6 +49,8 @@ export function NewsletterSettingsApp(): JSX.Element {
 				'Transform your blog posts into newsletters to easily reach your subscribers.',
 				'jetpack-newsletter'
 			) }
+			apiRoot={ siteData?.rest_root }
+			apiNonce={ siteData?.rest_nonce }
 		>
 			<GlobalNotices />
 			<Container horizontalSpacing={ 0 }>


### PR DESCRIPTION
Fixes NL-622 — https://linear.app/a8c/issue/NL-622/attempting-to-toggle-newsletter-settings-returns-a-404-and-failed-to

## Proposed changes
* `NewsletterSettingsApp` now passes `apiRoot` and `apiNonce` (from `getSiteData()`) through to `<AdminPage>`. Without them, the `useEffect` inside `AdminPage` was writing the default `''` into the shared `@automattic/jetpack-api` client on mount, clobbering the root that `./api.ts` had configured. As a result, toggling a Newsletter setting POSTed to the unresolved relative path `jetpack/v4/settings`, which the browser resolved against the current page as `/wp-admin/jetpack/v4/settings` and returned a 404 with a "Failed to save settings" snackbar.
* This worked before #48607 / d80fdfd because `fetchSettings()` lived in the parent component of `<AdminPage>`, so the child-first effect order meant the clobber fired before the recovery `setApiRoot(rest_root)`. After the body was lifted into the deeper `NewsletterSettingsBody`, the order flipped and the clobber won. Passing the real values up-front removes the dependence on effect ordering entirely.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/NL-622/attempting-to-toggle-newsletter-settings-returns-a-404-and-failed-to
* Suspected/confirmed regression source: #48607 — commit d80fdfd "Newsletter: lift the settings body out of the legacy AdminPage chrome"

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
On a Jetpack-connected site that is **not** WordPress.com Simple (Atomic, WoA, Jurassic Ninja, or self-hosted):

1. Visit `wp-admin/admin.php?page=jetpack-newsletter`.
2. Open DevTools → Network and filter for `settings`.
3. Toggle "Let visitors subscribe to this site and receive emails when you publish a post" (or any other setting on the page).

**Before this PR:** the POST goes to `wp-admin/jetpack/v4/settings`, returns **404**, and a "Failed to save settings" snackbar appears.

**After this PR:** the POST goes to `wp-json/jetpack/v4/settings`, returns **200**, the toggle stays in its new state on reload, and the success snackbar appears.

Verified on both a Jurassic Ninja tunnel and an Atomic site.
