### PR TITLE
Search: sync canonical experience option from legacy ModuleControl toggle (RSM-3170)

### DIFF
--- a/projects/packages/search/changelog/RSM-3170-instant-search-toggle-experience-sync
+++ b/projects/packages/search/changelog/RSM-3170-instant-search-toggle-experience-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Search: legacy ModuleControl Instant Search toggle now syncs the canonical `jetpack_search_experience` option, so it works again on sites where the experience option is set to `'embedded'` or `'inline'`.
+
+

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -179,6 +179,13 @@ class Module_Control {
 
 	/**
 	 * Enable Instant Search Experience
+	 *
+	 * Also writes `'overlay'` to the canonical experience option so callers that
+	 * arrive here through the legacy entry points (`update_instant_search_status`,
+	 * the legacy auto-setup REST endpoint, etc.) leave the option in agreement
+	 * with the boolean. Without this, a stale `'embedded'` / `'inline'` in the
+	 * experience option keeps `is_instant_search_enabled()` returning false even
+	 * though the legacy boolean was just set true.
 	 */
 	public function enable_instant_search() {
 		if ( ! $this->is_active() ) {
@@ -187,15 +194,27 @@ class Module_Control {
 		if ( ! $this->plan->supports_instant_search() ) {
 			return new WP_Error( 'not_supported', __( 'Your plan does not support Instant Search.', 'jetpack-search-pkg' ) );
 		}
+		update_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, self::EXPERIENCE_OVERLAY );
 		return update_option( self::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY, true );
 	}
 
 	/**
 	 * Update instant search status
 	 *
+	 * When disabling via this legacy path we also clear the canonical experience
+	 * option — the user is asking for "not Overlay", and leaving a stale
+	 * `'overlay'` in the option would keep `is_instant_search_enabled()`
+	 * returning true. We don't clear from `disable_instant_search` itself
+	 * because `deactivate()` calls that to flip the legacy boolean, and
+	 * deactivation is meant to preserve the user's experience choice for the
+	 * next re-activation.
+	 *
 	 * @param boolean $enabled - true to enable, false to disable.
 	 */
 	public function update_instant_search_status( $enabled ) {
+		if ( ! $enabled ) {
+			update_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, '' );
+		}
 		return $enabled ? $this->enable_instant_search() : $this->disable_instant_search();
 	}
 

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -222,6 +222,47 @@ class Module_Control_Test extends Search_TestCase {
 	}
 
 	/**
+	 * Enabling Instant Search must also write 'overlay' to the canonical
+	 * experience option so is_instant_search_enabled() agrees. Without this
+	 * sync, a stale 'embedded' / 'inline' in the experience option keeps
+	 * the canonical read at false even after the legacy boolean flips true.
+	 */
+	public function test_enable_instant_search_syncs_experience_overlay() {
+		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		static::$search_module->enable_instant_search();
+
+		$this->assertEquals(
+			Module_Control::EXPERIENCE_OVERLAY,
+			get_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY )
+		);
+		$this->assertTrue( static::$search_module->is_instant_search_enabled() );
+
+		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * The legacy ModuleControl toggle, when turning Instant Search off,
+	 * clears the canonical experience option so a stale 'overlay' doesn't
+	 * keep is_instant_search_enabled() returning true.
+	 */
+	public function test_update_instant_search_status_false_clears_experience() {
+		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
+		update_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY, true );
+
+		static::$search_module->update_instant_search_status( false );
+
+		$this->assertSame( '', get_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY ) );
+		$this->assertFalse( static::$search_module->is_instant_search_enabled() );
+
+		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
 	 * Inactive module always reads as 'off' regardless of any saved experience
 	 * option — off lives in jetpack_active_modules, not in the package's option.
 	 */


### PR DESCRIPTION
Fixes [RSM-3170](https://linear.app/a8c/issue/RSM-3170/modulecontrol-instant-search-toggle-has-no-effect-when-a-non-overlay).

## Why

On a site where `jetpack_search_experience` is `'embedded'` or `'inline'`, toggling **Enable instant search** in the legacy ModuleControl UI silently no-ops:

```json
{
  "module_active": true,
  "instant_search_enabled": false,
  "experience": "embedded",
  "ai_answers_enabled": true
}
```

`is_instant_search_enabled()` reads `jetpack_search_experience` first (introduced in #48540) and only falls back to the legacy `instant_search_enabled` boolean when that option has never been written. The legacy toggle entry points (`enable_instant_search()` / `disable_instant_search()` via `update_instant_search_status()`) only flip the legacy boolean — they never touch the experience option — so once any code path writes the experience option, the legacy toggle is decoupled from the canonical read in both directions.

The new ExperienceSelector in #48563 is the first UI that routinely writes `'embedded'` / `'inline'` to the experience option, which is what exposed this on sites that have the blocks flag off and are still using the ModuleControl UI.

## Proposed changes

* `enable_instant_search()` also writes `'overlay'` to `jetpack_search_experience`. Centralised here so every caller (legacy toggle, the legacy auto-setup REST endpoint, `update_experience('overlay')` — which then re-writes the same value, redundant but harmless) leaves the canonical state and the legacy boolean in agreement.
* `update_instant_search_status( false )` (the legacy toggle path) clears the experience option, so a stale `'overlay'` doesn't keep `is_instant_search_enabled()` returning true after the user disables via the legacy UI.
* **Deliberately not** inside `disable_instant_search()` itself: `deactivate()` also calls that to flip the boolean, and deactivation should preserve the user's experience choice for the next re-activation.
* Adds two PHPUnit cases — one that asserts `enable_instant_search()` overwrites a stale `'embedded'` value with `'overlay'`, one that asserts `update_instant_search_status( false )` clears a stale `'overlay'`.

## Related product discussion/links

* Linear: [RSM-3170](https://linear.app/a8c/issue/RSM-3170/modulecontrol-instant-search-toggle-has-no-effect-when-a-non-overlay)
* Originated from testing #48563; the bug pre-dates that PR (introduced in #48540, partially addressed in #48745).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The bug only manifests once `jetpack_search_experience` holds a non-overlay value, and the only UI that writes those values is the new experience selector. So the flow is: **set up the broken state with the flag on, then switch to the legacy UI and verify the toggle now works.**

1. **Set up a non-overlay experience (flag on).** Enable the new experience selector by adding a mu-plugin / filter that returns true for `jetpack_search_blocks_enabled`. Reload the Jetpack Search dashboard, open the experience selector, and pick **Embedded** (or **Inline**). Confirm with `wp option get jetpack_search_experience` → `embedded` (or `inline`) and `wp option get instant_search_enabled` → `''`.

2. **Switch to the legacy ModuleControl UI.** Remove the filter so `jetpack_search_blocks_enabled` is false again. Reload — the dashboard shows the legacy Search / Instant Search toggles.

3. **Toggle Instant Search on via ModuleControl.** Without this PR the toggle silently no-ops: `instant_search_enabled` flips to `1` but `is_instant_search_enabled()` still returns false because `jetpack_search_experience` is still `embedded`/`inline`. With this PR, both options stay in lockstep. Confirm:
   * `wp option get jetpack_search_experience` → `overlay`.
   * `wp option get instant_search_enabled` → `1`.
   * `GET /wp-json/jetpack/v4/search/settings` returns `"instant_search_enabled": true`.
   * Front-end: `/?s=anything` mounts the Instant Search overlay.

4. **Toggle Instant Search off via ModuleControl.** Confirm:
   * `wp option get jetpack_search_experience` returns an empty string.
   * `wp option get instant_search_enabled` returns `''`.
   * REST endpoint returns `"instant_search_enabled": false`.

5. **`deactivate()` preserves the experience option.** Passive-correctness check on the deactivate path — `disable_instant_search()` deliberately doesn't clear the option, so non-UI re-activations (CLI, REST without an explicit `experience` field, third-party callers) see the prior choice. To verify in isolation:
   * `wp option update jetpack_search_experience embedded`
   * `wp jetpack module deactivate search`
   * `wp option get jetpack_search_experience` should still return `embedded`.
   * Note: re-enabling via the **legacy** ModuleControl Search toggle will overwrite this to `overlay` because that frontend forces `instant_search_enabled: true` on re-enable — pre-existing legacy frontend behavior (since #21888), independent of this PR.

6. Run `composer phpunit` in `projects/packages/search/`. The `Module_Control_Test` suite (including the two new cases) should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)