### PR TITLE
Search: render Reader Chat toggle in experience-selector view (RSM-3175)

### DIFF
--- a/projects/packages/search/changelog/RSM-3175-reader-chat-in-experience-selector
+++ b/projects/packages/search/changelog/RSM-3175-reader-chat-in-experience-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: Render Reader Chat toggle in the experience-selector view so it stays reachable when the search blocks flag is on.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -227,13 +227,15 @@ export default function DashboardPage( { isLoading = false } ) {
 										<div className="jp-search-dashboard-row">
 											<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 												<ExperienceSelector />
-												<ReaderChatControl
-													isAvailable={ isReaderChatAvailable }
-													isEnabled={ isReaderChatEnabled }
-													isSaving={ isSavingEitherOption }
-													guidelinesUrl={ readerChatGuidelinesUrl }
-													updateOptions={ updateOptions }
-												/>
+												<div className="jp-search-reader-chat-card">
+													<ReaderChatControl
+														isAvailable={ true }
+														isEnabled={ isReaderChatEnabled }
+														isSaving={ isSavingEitherOption }
+														guidelinesUrl={ readerChatGuidelinesUrl }
+														updateOptions={ updateOptions }
+													/>
+												</div>
 											</div>
 										</div>
 									</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -229,7 +229,7 @@ export default function DashboardPage( { isLoading = false } ) {
 												<ExperienceSelector />
 												<div className="jp-search-reader-chat-card">
 													<ReaderChatControl
-														isAvailable={ true }
+														isAvailable={ isReaderChatAvailable }
 														isEnabled={ isReaderChatEnabled }
 														isSaving={ isSavingEitherOption }
 														guidelinesUrl={ readerChatGuidelinesUrl }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -227,15 +227,17 @@ export default function DashboardPage( { isLoading = false } ) {
 										<div className="jp-search-dashboard-row">
 											<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 												<ExperienceSelector />
-												<div className="jp-search-reader-chat-card">
-													<ReaderChatControl
-														isAvailable={ isReaderChatAvailable }
-														isEnabled={ isReaderChatEnabled }
-														isSaving={ isSavingEitherOption }
-														guidelinesUrl={ readerChatGuidelinesUrl }
-														updateOptions={ updateOptions }
-													/>
-												</div>
+												{ isReaderChatAvailable && (
+													<div className="jp-search-reader-chat-card">
+														<ReaderChatControl
+															isAvailable={ isReaderChatAvailable }
+															isEnabled={ isReaderChatEnabled }
+															isSaving={ isSavingEitherOption }
+															guidelinesUrl={ readerChatGuidelinesUrl }
+															updateOptions={ updateOptions }
+														/>
+													</div>
+												) }
 											</div>
 										</div>
 									</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -10,6 +10,7 @@ import NoticesList from 'components/global-notices';
 import Loading from 'components/loading';
 import MockedSearch from 'components/mocked-search';
 import ModuleControl from 'components/module-control';
+import ReaderChatControl from 'components/reader-chat-control';
 import RecordMeter from 'components/record-meter';
 import { STORE_ID } from 'store';
 import FirstRunSection from './sections/first-run-section';
@@ -226,6 +227,13 @@ export default function DashboardPage( { isLoading = false } ) {
 										<div className="jp-search-dashboard-row">
 											<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 												<ExperienceSelector />
+												<ReaderChatControl
+													isAvailable={ isReaderChatAvailable }
+													isEnabled={ isReaderChatEnabled }
+													isSaving={ isSavingEitherOption }
+													guidelinesUrl={ readerChatGuidelinesUrl }
+													updateOptions={ updateOptions }
+												/>
 											</div>
 										</div>
 									</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -108,4 +108,15 @@
 	.jp-form-search-settings-group__toggle.is-reader-chat {
 		margin-top: 0;
 	}
+
+	// `.jp-search-dashboard-row` carries responsive horizontal margins
+	// (16/18/24px) plus a `calc(100% - …)` width that together inset its
+	// content from the dashboard edges. Inside the card we already have
+	// the card's own padding, so neutralise the row's inset to let the
+	// toggle and description sit flush with the card's content box.
+	.jp-search-dashboard-row {
+		width: 100%;
+		max-width: none;
+		margin-inline: 0;
+	}
 }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -92,3 +92,20 @@
 		margin-bottom: 0;
 	}
 }
+
+.jp-search-reader-chat-card {
+	margin-block-start: var(--wpds-dimension-gap-xl);
+	padding: var(--wpds-dimension-padding-2xl);
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-lg);
+
+	// ReaderChatControl is shared with the legacy ModuleControl, which
+	// gives `.jp-form-search-settings-group__toggle.is-reader-chat` a 4em
+	// top margin to separate it from the toggles above. Inside this card
+	// it's the only child, so reset that spacing — the card's own padding
+	// handles the gap.
+	.jp-form-search-settings-group__toggle.is-reader-chat {
+		margin-top: 0;
+	}
+}

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -94,7 +94,7 @@
 }
 
 .jp-search-reader-chat-card {
-	margin-block-start: var(--wpds-dimension-gap-xl);
+	margin-block-start: var(--wpds-dimension-padding-3xl);
 	padding: var(--wpds-dimension-padding-2xl);
 	background: var(--wpds-color-bg-surface-neutral-strong);
 	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -144,6 +144,18 @@ describe( 'DashboardPage', () => {
 		);
 	} );
 
+	test( 'does not render Reader Chat card in the experience selector path when unavailable', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isReaderChatAvailable' ).mockImplementation( () => false );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.getByTestId( 'experience-selector' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'reader-chat-control' ) ).not.toBeInTheDocument();
+		expect( mockReaderChatControl ).not.toHaveBeenCalled();
+	} );
+
 	test( 'hydrates active tab from the URL query string', () => {
 		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=ai-answers` );
 

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -1,4 +1,5 @@
 const mockModuleControl = jest.fn();
+const mockReaderChatControl = jest.fn();
 let mockSelectMethods;
 let mockDispatchMethods;
 
@@ -35,6 +36,10 @@ jest.mock( 'components/module-control', () => props => {
 jest.mock( 'components/experience-selector', () => () => (
 	<div data-testid="experience-selector" />
 ) );
+jest.mock( 'components/reader-chat-control', () => props => {
+	mockReaderChatControl( props );
+	return <div data-testid="reader-chat-control" />;
+} );
 jest.mock( 'components/record-meter', () => () => <div data-testid="record-meter" /> );
 jest.mock( '../sections/first-run-section', () => () => <div data-testid="first-run-section" /> );
 jest.mock( '../sections/plan-usage-section', () => () => <div data-testid="plan-usage-section" /> );
@@ -91,6 +96,7 @@ const createSelectMethods = () => ( {
 describe( 'DashboardPage', () => {
 	beforeEach( () => {
 		mockModuleControl.mockClear();
+		mockReaderChatControl.mockClear();
 		window.history.replaceState( {}, '', DEFAULT_TEST_URL );
 		mockSelectMethods = createSelectMethods();
 		mockDispatchMethods = {
@@ -116,6 +122,26 @@ describe( 'DashboardPage', () => {
 			} )
 		);
 		expect( mockSelectMethods.getReaderChatGuidelinesUrl ).toHaveBeenCalled();
+	} );
+
+	test( 'renders ReaderChatControl alongside ExperienceSelector when search blocks is enabled', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.getByTestId( 'experience-selector' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'reader-chat-control' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'module-control' ) ).not.toBeInTheDocument();
+		expect( mockReaderChatControl ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isAvailable: true,
+				isEnabled: true,
+				isSaving: false,
+				guidelinesUrl: 'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
+				updateOptions: mockDispatchMethods.updateJetpackSettings,
+			} )
+		);
 	} );
 
 	test( 'hydrates active tab from the URL query string', () => {


### PR DESCRIPTION
Fixes [RSM-3175](https://linear.app/a8c/issue/RSM-3175/search-dashboard-reader-chat-toggle-missing-when-search-blocks-flag-is)

## Why

The Reader Chat opt-in toggle (`ReaderChatControl`) lives inside the legacy `ModuleControl`. When `jetpack_search_blocks_enabled` is on, the Settings tab swaps `ModuleControl` for the new `ExperienceSelector` ([RSM-2380 / #48563](https://github.com/Automattic/jetpack/pull/48563)) — and Reader Chat goes with it. Reader Chat is orthogonal to the experience choice (Overlay / Embedded / Theme / Off), so site owners on the new UI need it back.

## Proposed changes

* Render `ReaderChatControl` as a sibling of `ExperienceSelector` inside the Settings tab when `isSearchBlocksEnabled` is true.
* Reuse the existing `ReaderChatControl` — it already returns `null` when the `reader_chat` option isn't registered (`isAvailable=false`), so non-proxied sites still see nothing.
* No changes to the component itself, the legacy `ModuleControl` path, or the store.

<img width="2764" height="2598" alt="Screenshot 2026-05-14 at 1 37 44 PM" src="https://github.com/user-attachments/assets/88a3ea9a-4608-42bf-a83d-3a1aa2340f52" />

## Related product discussion/links

* Linear: [RSM-3175](https://linear.app/a8c/issue/RSM-3175/search-dashboard-reader-chat-toggle-missing-when-search-blocks-flag-is)
* Originating feature: [RSM-2380](https://linear.app/a8c/issue/RSM-2380) / [#48563](https://github.com/Automattic/jetpack/pull/48563)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

> [!NOTE]
> **Needs a sandbox.** The `reader_chat` setting is only registered on proxied / sandboxed sites, so `isReaderChatAvailable` is `false` locally and the toggle (and its card) won't render. Run this on a sandbox where Reader Chat is available — or temporarily hard-code `isAvailable={ true }` on the `ReaderChatControl` for a quick visual check.

1. Enable the experience selector path:
   ```php
   add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
   ```
2. Visit the Jetpack Search dashboard → **Settings** tab.
3. **Before this PR:** only the experience-selector card grid is visible.
4. **With this PR:** the **Enable Reader Chat** toggle appears below the experience cards in a bordered card matching the experience-option styling. Toggling it persists like any other dashboard setting.
5. Toggle the filter back off and reload — confirm the legacy `ModuleControl` still renders the Reader Chat toggle exactly as before.
6. Confirm the control still self-hides on sites where the `reader_chat` setting isn't registered (`isReaderChatAvailable` is false) — both in the new and legacy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
