### PR TITLE
VideoPress: stats REST proxy + Initial State for modernized Overview (Phases 5+7)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4552,6 +4552,9 @@ importers:
       '@automattic/jetpack-script-data':
         specifier: workspace:*
         version: link:../../js-packages/script-data
+      '@tanstack/react-query':
+        specifier: 5.90.8
+        version: 5.90.8(react@18.3.1)
       '@wordpress/admin-ui':
         specifier: 2.0.0
         version: 2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/packages/videopress/changelog/update-videopress-modernization-phase-7
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-phase-7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Adds a user-signed REST proxy for VideoPress stats and seeds the modernized dashboard's React initial state.

--- a/projects/packages/videopress/changelog/update-videopress-modernization-phase-7
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-phase-7
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: added
 
-Comment: Adds a user-signed REST proxy for VideoPress stats and seeds the modernized dashboard's React initial state.
+Comment: Adds a user-signed REST proxy for VideoPress stats and seeds the modernized dashboard's React initial state behind the existing modernization filter.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -36,6 +36,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
 		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/base-styles": "6.20.0",

--- a/projects/packages/videopress/routes/overview/package.json
+++ b/projects/packages/videopress/routes/overview/package.json
@@ -5,14 +5,17 @@
 	"dependencies": {
 		"@automattic/charts": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
 		"@types/react": "18.3.28",
+		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0"
+		"@wordpress/ui": "0.11.0",
+		"@wordpress/url": "4.44.0"
 	},
 	"route": {
 		"path": "/",

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -516,7 +516,7 @@ class Admin_UI {
 	 *
 	 * @return bool
 	 */
-	private static function is_modernized() {
+	public static function is_modernized() {
 		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
 	}
 

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * The modernized VideoPress dashboard React initial state.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
+use Jetpack_Options;
+use function admin_url;
+use function esc_url_raw;
+use function get_bloginfo;
+use function get_locale;
+use function get_option;
+use function get_site_url;
+use function plugins_url;
+use function rest_url;
+use function wp_add_inline_script;
+use function wp_create_nonce;
+use function wp_json_encode;
+use function wp_parse_url;
+use function wp_script_is;
+
+/**
+ * The modernized VideoPress dashboard React initial state.
+ *
+ * Mirrors the Activity Log dashboard pattern: a small structured payload
+ * inlined as `var JPVIDEOPRESS_INITIAL_STATE=...` before the wp-build boot
+ * script runs. Phases 6 and 8 will consume the payload via per-file
+ * `declare const` ambient types.
+ */
+class Initial_State {
+
+	const SCRIPT_HANDLE = 'jetpack-videopress-dashboard-wp-admin-prerequisites';
+
+	/**
+	 * Register the inline-state enqueue hook.
+	 *
+	 * Hooks `admin_enqueue_scripts` at priority 11 so the wp-build page
+	 * (`build/pages/jetpack-videopress-dashboard/page-wp-admin.php`) has
+	 * already registered the prerequisites handle at its default priority 10.
+	 * The `wp_script_is( ..., 'registered' )` check inside the callback
+	 * doubles as the page guard.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue' ), 11 );
+	}
+
+	/**
+	 * Inline the initial-state payload before the wp-build boot script.
+	 *
+	 * @return void
+	 */
+	public static function enqueue() {
+		if ( ! Admin_UI::is_modernized() ) {
+			return;
+		}
+
+		if ( ! wp_script_is( self::SCRIPT_HANDLE, 'registered' ) ) {
+			return;
+		}
+
+		wp_add_inline_script( self::SCRIPT_HANDLE, ( new self() )->render(), 'before' );
+	}
+
+	/**
+	 * Get the initial state data.
+	 *
+	 * @return array
+	 */
+	private function get_data() {
+		$gmt_offset      = get_option( 'gmt_offset' );
+		$timezone_string = get_option( 'timezone_string' );
+		$home_host       = wp_parse_url( get_site_url(), PHP_URL_HOST );
+
+		return array(
+			'API'           => array(
+				'WP_API_root'  => esc_url_raw( rest_url() ),
+				'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
+			),
+			'jetpackStatus' => array(
+				'calypsoSlug' => ( new Status() )->get_site_suffix(),
+			),
+			'siteData'      => array(
+				'id'                  => Jetpack_Options::get_option( 'id' ),
+				'title'               => get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url(),
+				'adminUrl'            => esc_url_raw( admin_url() ),
+				'slug'                => is_string( $home_host ) ? $home_host : '',
+				'gmtOffset'           => is_numeric( $gmt_offset ) ? (float) $gmt_offset : 0.0,
+				'timezoneString'      => is_string( $timezone_string ) ? $timezone_string : '',
+				'locale'              => str_replace( '_', '-', (string) get_locale() ),
+				// Paid-tier capability check. Drives the free-tier UX
+				// (callout / DataViews configuration) once designer input
+				// lands. Backed by `Product::get_site_features_from_wpcom()`,
+				// which caches the WPCOM `/sites/%d/features` response in a
+				// 15-second site transient. On a cache miss this issues a
+				// synchronous WPCOM request that blocks page rendering until
+				// it returns.
+				'hasVideoPressAccess' => self::has_videopress_access(),
+			),
+			'assets'        => array(
+				'buildUrl' => plugins_url( '../build/', __FILE__ ),
+			),
+		);
+	}
+
+	/**
+	 * Whether the site has a paid VideoPress plan.
+	 *
+	 * Matches the active-features check used by the existing
+	 * `videopress/v1/features` REST endpoint: any of the storage tiers
+	 * counts as paid access. On WPCOM the legacy `videopress` slug also
+	 * grants access.
+	 *
+	 * @return bool
+	 */
+	public static function has_videopress_access() {
+		$features = Product::get_site_features_from_wpcom();
+
+		if ( is_wp_error( $features ) ) {
+			return false;
+		}
+
+		$active = $features['active'] ?? array();
+
+		return in_array( 'videopress-1tb-storage', $active, true )
+			|| in_array( 'videopress-unlimited-storage', $active, true )
+			|| ( ( new Host() )->is_wpcom_platform() && in_array( 'videopress', $active, true ) );
+	}
+
+	/**
+	 * Render the initial state into a JavaScript variable.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		return 'var JPVIDEOPRESS_INITIAL_STATE=' . wp_json_encode( $this->get_data(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
+	}
+}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -122,6 +122,8 @@ class Initializer {
 		Attachment_Handler::init();
 		Jwt_Token_Bridge::init();
 		Uploader_Rest_Endpoints::init();
+		Rest_Controller::init();
+		Initial_State::init();
 		VideoPress_Rest_Api_V1_Stats::init();
 		VideoPress_Rest_Api_V1_Site::init();
 		VideoPress_Rest_Api_V1_Settings::init();

--- a/projects/packages/videopress/src/class-rest-controller.php
+++ b/projects/packages/videopress/src/class-rest-controller.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * The VideoPress REST Controller.
+ *
+ * Registers the `/jetpack/v4/videopress/*` routes backing the
+ * modernized wp-build dashboard. Currently exposes one route — a
+ * user-signed proxy to the WPCOM `sites/{id}/stats/video-plays`
+ * endpoint — needed by the Overview screen's KPI / trends / top-N
+ * cards.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Jetpack_Options;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * REST routes for the modernized VideoPress admin UI.
+ */
+class Rest_Controller {
+
+	/**
+	 * REST namespace used by this package's modernization routes.
+	 *
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'jetpack/v4/videopress';
+
+	/**
+	 * Hook the route registration on `rest_api_init`.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Register the VideoPress REST routes.
+	 *
+	 * @return void
+	 */
+	public static function register_rest_routes() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			'/stats/video-plays',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_stats_video_plays' ),
+				'permission_callback' => array( __CLASS__, 'permissions_callback' ),
+				'args'                => self::stats_video_plays_args(),
+			)
+		);
+	}
+
+	/**
+	 * Query params accepted by the video-plays proxy. Forwarded verbatim
+	 * to WPCOM after permission and shape validation; `complete_stats` is
+	 * always forced to `true` (the only mode the Overview cares about)
+	 * and is therefore not exposed as an incoming param.
+	 *
+	 * @return array
+	 */
+	private static function stats_video_plays_args() {
+		return array(
+			'period'     => array(
+				'description' => __( 'Period unit: day, week, month, or year.', 'jetpack-videopress-pkg' ),
+				'type'        => 'string',
+				'enum'        => array( 'day', 'week', 'month', 'year' ),
+			),
+			'num'        => array(
+				'description' => __( 'Number of periods to include.', 'jetpack-videopress-pkg' ),
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'maximum'     => 365,
+			),
+			'date'       => array(
+				'description' => __( 'Most recent day to include in results (YYYY-MM-DD).', 'jetpack-videopress-pkg' ),
+				'type'        => 'string',
+				'format'      => 'date',
+			),
+			'start_date' => array(
+				'description' => __( 'Starting date for range queries (YYYY-MM-DD).', 'jetpack-videopress-pkg' ),
+				'type'        => 'string',
+				'format'      => 'date',
+			),
+		);
+	}
+
+	/**
+	 * Permission callback. Admin-gated and requires a user-level WPCOM
+	 * connection — the upstream stats endpoint is user-signed, and
+	 * signing as the blog returns "Only Administrators can query
+	 * information about the current site."
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function permissions_callback() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
+			return new WP_Error(
+				'videopress_stats_user_not_connected',
+				esc_html__(
+					'Your WordPress.com account is not connected to this site. Connect it to view VideoPress stats.',
+					'jetpack-videopress-pkg'
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Proxy the video-plays stats endpoint.
+	 *
+	 * Forwards the whitelisted query params to WPCOM, signs as the
+	 * current user, and forces `complete_stats=true` so each day entry
+	 * carries `total.views`, `total.impressions`, and `total.watch_time`
+	 * alongside the per-video `plays[]` list the Overview's top-N cards
+	 * consume.
+	 *
+	 * @param WP_REST_Request $request Incoming request.
+	 * @return mixed Decoded JSON response from WPCOM, or WP_Error on failure.
+	 */
+	public static function get_stats_video_plays( WP_REST_Request $request ) {
+		$blog_id = (int) Jetpack_Options::get_option( 'id' );
+		if ( ! $blog_id ) {
+			return new WP_Error(
+				'videopress_stats_not_connected',
+				esc_html__( 'This site is not connected to WordPress.com.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$params = array( 'complete_stats' => 'true' );
+		foreach ( array_keys( self::stats_video_plays_args() ) as $key ) {
+			$value = $request->get_param( $key );
+			if ( $value !== null && $value !== '' ) {
+				$params[ $key ] = $value;
+			}
+		}
+
+		$path     = sprintf(
+			'/sites/%d/stats/video-plays?%s',
+			$blog_id,
+			http_build_query( $params )
+		);
+		$response = Client::wpcom_json_api_request_as_user( $path );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'videopress_stats_request_failed',
+				$response->get_error_message(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $status ) {
+			$message = is_array( $body ) && isset( $body['message'] )
+				? (string) $body['message']
+				: esc_html__( 'Unable to fetch VideoPress stats.', 'jetpack-videopress-pkg' );
+			return new WP_Error(
+				'videopress_stats_request_failed',
+				$message,
+				array( 'status' => $status ? $status : 500 )
+			);
+		}
+
+		return rest_ensure_response( $body );
+	}
+}

--- a/projects/packages/videopress/src/class-rest-controller.php
+++ b/projects/packages/videopress/src/class-rest-controller.php
@@ -14,7 +14,6 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Request;
@@ -94,40 +93,24 @@ class Rest_Controller {
 	}
 
 	/**
-	 * Permission callback. Admin-gated and requires a user-level WPCOM
-	 * connection — the upstream stats endpoint is user-signed, and
-	 * signing as the blog returns "Only Administrators can query
-	 * information about the current site."
+	 * Permission callback. Admin-gated. The upstream call is blog-signed,
+	 * matching the existing `Stats::fetch_video_plays` path; no user-level
+	 * WPCOM connection is required.
 	 *
-	 * @return bool|WP_Error
+	 * @return bool
 	 */
 	public static function permissions_callback() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
-
-		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
-			return new WP_Error(
-				'videopress_stats_user_not_connected',
-				esc_html__(
-					'Your WordPress.com account is not connected to this site. Connect it to view VideoPress stats.',
-					'jetpack-videopress-pkg'
-				),
-				array( 'status' => 403 )
-			);
-		}
-
-		return true;
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
 	 * Proxy the video-plays stats endpoint.
 	 *
-	 * Forwards the whitelisted query params to WPCOM, signs as the
-	 * current user, and forces `complete_stats=true` so each day entry
-	 * carries `total.views`, `total.impressions`, and `total.watch_time`
-	 * alongside the per-video `plays[]` list the Overview's top-N cards
-	 * consume.
+	 * Forwards the whitelisted query params to WPCOM (REST v1.1, blog-signed
+	 * — matching the existing `Stats::fetch_video_plays` path) and forces
+	 * `complete_stats=true` so each day entry carries `total.views`,
+	 * `total.impressions`, and `total.watch_time` alongside the per-video
+	 * `plays[]` list the Overview's top-N cards consume.
 	 *
 	 * @param WP_REST_Request $request Incoming request.
 	 * @return mixed Decoded JSON response from WPCOM, or WP_Error on failure.
@@ -151,11 +134,11 @@ class Rest_Controller {
 		}
 
 		$path     = sprintf(
-			'/sites/%d/stats/video-plays?%s',
+			'sites/%d/stats/video-plays?%s',
 			$blog_id,
 			http_build_query( $params )
 		);
-		$response = Client::wpcom_json_api_request_as_user( $path );
+		$response = Client::wpcom_json_api_request_as_blog( $path );
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_Error(

--- a/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
@@ -15,12 +15,11 @@ import type {
 } from '../types/stats';
 
 // Raw WPCOM `sites/{id}/stats/video-plays?complete_stats=true` shape.
-// Per the existing class-stats.php consumer and the Stats_Abilities top-
-// content normalizer, each day carries a per-period total and a per-
-// video plays[] list. Per-video watch_time / views fields are best-
-// effort: the existing Jetpack consumers don't read them, so Phase 8
-// manual validation should confirm what the endpoint actually returns
-// for paid VideoPress sites.
+// Each day carries a per-period `total` ({ views, impressions,
+// watch_time }) and a per-video `data[]` array. Per-video watch_time
+// / views fields are best-effort: confirmed empty for sites with no
+// traffic but undocumented for sites with plays — the transformer
+// falls back to the per-video plays count when they're absent.
 type VideoPlayEntry = {
 	post_id?: number | string;
 	title?: string;
@@ -35,9 +34,7 @@ type DayEntry = {
 		impressions?: number;
 		watch_time?: number;
 	};
-	plays?: VideoPlayEntry[];
-	other_plays?: number;
-	total_plays?: number;
+	data?: VideoPlayEntry[];
 };
 
 type VideoPlaysResponse = {
@@ -199,10 +196,10 @@ function aggregateTopVideos( response: VideoPlaysResponse | undefined ): Map< st
 		return acc;
 	}
 	for ( const day of Object.values( response.days ) ) {
-		if ( ! day.plays ) {
+		if ( ! day.data ) {
 			continue;
 		}
-		for ( const entry of day.plays ) {
+		for ( const entry of day.data ) {
 			const id = String( entry.post_id ?? entry.title ?? '' );
 			if ( ! id ) {
 				continue;

--- a/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
@@ -1,0 +1,403 @@
+import { queryOptions, useQueries } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+import { DATE_RANGE_DAYS } from '../types/stats';
+import type {
+	ActiveMetric,
+	ChartCompare,
+	DateRange,
+	Granularity,
+	KpiSummary,
+	OverviewStats,
+	StatsSeriesPoint,
+	TopVideo,
+} from '../types/stats';
+
+// Raw WPCOM `sites/{id}/stats/video-plays?complete_stats=true` shape.
+// Per the existing class-stats.php consumer and the Stats_Abilities top-
+// content normalizer, each day carries a per-period total and a per-
+// video plays[] list. Per-video watch_time / views fields are best-
+// effort: the existing Jetpack consumers don't read them, so Phase 8
+// manual validation should confirm what the endpoint actually returns
+// for paid VideoPress sites.
+type VideoPlayEntry = {
+	post_id?: number | string;
+	title?: string;
+	plays?: number;
+	views?: number;
+	watch_time?: number;
+};
+
+type DayEntry = {
+	total?: {
+		views?: number;
+		impressions?: number;
+		watch_time?: number;
+	};
+	plays?: VideoPlayEntry[];
+	other_plays?: number;
+	total_plays?: number;
+};
+
+type VideoPlaysResponse = {
+	date?: string;
+	period?: string;
+	days?: Record< string, DayEntry >;
+};
+
+type StatsQueryParams = {
+	num: number;
+	date: string; // YYYY-MM-DD, most recent day included
+};
+
+const REST_PATH = '/jetpack/v4/videopress/stats/video-plays';
+const TOP_VIDEOS_LIMIT = 5;
+const ZERO_SUMMARY: KpiSummary = { current: 0, previousPeriod: 0 };
+
+const EMPTY_STATS: OverviewStats = {
+	views: ZERO_SUMMARY,
+	impressions: ZERO_SUMMARY,
+	watchTimeSeconds: ZERO_SUMMARY,
+	series: [],
+	topVideos: [],
+	topVideosByWatchTime: [],
+};
+
+const DEFAULTS = {
+	dateRange: 'last_30_days' as DateRange,
+	granularity: 'days' as Granularity,
+	activeMetric: 'views' as ActiveMetric,
+	compare: 'secondary_and_previous_period' as ChartCompare,
+};
+
+const COMPARE_FALLBACK_FOR_WATCH_TIME: ChartCompare = 'previous_period';
+
+/**
+ * Today's ISO date in UTC (YYYY-MM-DD). Memoized per render of the
+ * hook so the two window-param computations agree.
+ *
+ * @return UTC date string.
+ */
+function todayIso(): string {
+	return new Date().toISOString().slice( 0, 10 );
+}
+
+/**
+ * Shift an ISO YYYY-MM-DD date by `days` days, in UTC. Negative values
+ * shift backward.
+ *
+ * @param iso  - Base date.
+ * @param days - Day delta.
+ * @return Shifted date in YYYY-MM-DD.
+ */
+function shiftIsoDate( iso: string, days: number ): string {
+	const ms = Date.parse( `${ iso }T00:00:00Z` ) + days * 86_400_000;
+	return new Date( ms ).toISOString().slice( 0, 10 );
+}
+
+/**
+ * Compute the WPCOM video-plays params for the current and previous
+ * windows of equal length. Each window asks WPCOM for `rangeDays` of
+ * day-period results, anchored to its most recent day; the two windows
+ * abut without overlap.
+ *
+ * @param rangeDays - Active range length in days.
+ * @return Two parameter sets ready to feed `videoPlaysQueryOptions`.
+ */
+function computeWindows( rangeDays: number ): {
+	current: StatsQueryParams;
+	previous: StatsQueryParams;
+} {
+	const today = todayIso();
+	return {
+		current: { num: rangeDays, date: today },
+		previous: { num: rangeDays, date: shiftIsoDate( today, -rangeDays ) },
+	};
+}
+
+/**
+ * TanStack Query options for one `stats/video-plays` window. Server-side
+ * forces `complete_stats=true`, so each day entry carries
+ * `total.{views,impressions,watch_time}` and a per-video `plays[]`
+ * list.
+ *
+ * @param params - Window parameters.
+ * @return queryOptions ready to pass to `useQuery` / `useQueries`.
+ */
+export function videoPlaysQueryOptions( params: StatsQueryParams ) {
+	return queryOptions( {
+		queryKey: [ 'jetpack-videopress-stats', 'video-plays', params ],
+		queryFn: () =>
+			apiFetch< VideoPlaysResponse >( {
+				path: addQueryArgs( REST_PATH, { period: 'day', ...params } ),
+			} ),
+	} );
+}
+
+/**
+ * Bucket key for grouping a day-keyed entry into the active
+ * granularity. Day → ISO date; weeks → ISO Monday in UTC; months →
+ * first-of-month in UTC. Mirrors `fixtures/stats.ts`'s implementation
+ * exactly so the chart's tick layout stays stable across mock/real.
+ *
+ * @param iso         - YYYY-MM-DD date.
+ * @param granularity - Active bucketing.
+ * @return Stable bucket key string.
+ */
+function bucketKey( iso: string, granularity: Granularity ): string {
+	if ( granularity === 'days' ) {
+		return iso;
+	}
+	const d = new Date( `${ iso }T00:00:00Z` );
+	if ( granularity === 'weeks' ) {
+		const utcDay = d.getUTCDay() || 7;
+		d.setUTCDate( d.getUTCDate() - ( utcDay - 1 ) );
+		return d.toISOString().slice( 0, 10 );
+	}
+	return `${ d.getUTCFullYear() }-${ String( d.getUTCMonth() + 1 ).padStart( 2, '0' ) }-01`;
+}
+
+/**
+ * Sum the per-day totals for one metric across every day in the
+ * response. Days without a `total` block contribute zero.
+ *
+ * @param response - One `stats/video-plays` response, or undefined.
+ * @param field    - Which `total` field to sum.
+ * @return Period total.
+ */
+function sumTotal(
+	response: VideoPlaysResponse | undefined,
+	field: 'views' | 'impressions' | 'watch_time'
+): number {
+	if ( ! response?.days ) {
+		return 0;
+	}
+	let total = 0;
+	for ( const day of Object.values( response.days ) ) {
+		total += day.total?.[ field ] ?? 0;
+	}
+	return total;
+}
+
+/**
+ * Aggregate per-video metrics across every day in the response, keyed
+ * by `post_id` (falling back to `title` when WPCOM omits the id).
+ *
+ * Per-video `views` / `watch_time` are not consistently documented for
+ * `stats/video-plays?complete_stats=true`; when they're absent we fall
+ * back to using the per-video `plays` count for both. That keeps the
+ * Top-by-watch-time card from breaking before Phase 8 confirms the
+ * shape against a real paid site.
+ *
+ * @param response - One `stats/video-plays` response, or undefined.
+ * @return Map keyed by stable per-video key → cumulative metrics.
+ */
+function aggregateTopVideos( response: VideoPlaysResponse | undefined ): Map< string, TopVideo > {
+	const acc = new Map< string, TopVideo >();
+	if ( ! response?.days ) {
+		return acc;
+	}
+	for ( const day of Object.values( response.days ) ) {
+		if ( ! day.plays ) {
+			continue;
+		}
+		for ( const entry of day.plays ) {
+			const id = String( entry.post_id ?? entry.title ?? '' );
+			if ( ! id ) {
+				continue;
+			}
+			const plays = entry.plays ?? 0;
+			const views = entry.views ?? plays;
+			const watch = entry.watch_time ?? plays;
+			const existing = acc.get( id );
+			if ( existing ) {
+				existing.views += views;
+				existing.watchTimeSeconds += watch;
+			} else {
+				acc.set( id, {
+					id,
+					title: entry.title ?? id,
+					views,
+					watchTimeSeconds: watch,
+				} );
+			}
+		}
+	}
+	return acc;
+}
+
+/**
+ * Build chart-series points from the current and previous responses,
+ * aligned to the active granularity. Previous-period values map to the
+ * matching current-period bucket by ordinal position (bucket 0 of
+ * previous → bucket 0 of current), which mirrors `fixtures/stats.ts`.
+ *
+ * @param current     - Current-window response.
+ * @param previous    - Previous-window response.
+ * @param granularity - Active bucketing.
+ * @return Sorted series points.
+ */
+function buildSeries(
+	current: VideoPlaysResponse | undefined,
+	previous: VideoPlaysResponse | undefined,
+	granularity: Granularity
+): StatsSeriesPoint[] {
+	const currentBuckets = bucketDays( current, granularity );
+	const previousBuckets = bucketDays( previous, granularity );
+	const previousByIndex = Array.from( previousBuckets.values() );
+
+	const out: StatsSeriesPoint[] = [];
+	let index = 0;
+	for ( const [ date, bucket ] of currentBuckets ) {
+		const prev = previousByIndex[ index ];
+		out.push( {
+			date,
+			views: bucket.views,
+			impressions: bucket.impressions,
+			watchTimeSeconds: bucket.watchTimeSeconds,
+			previousPeriodViews: prev?.views ?? 0,
+			previousPeriodImpressions: prev?.impressions ?? 0,
+			previousPeriodWatchTimeSeconds: prev?.watchTimeSeconds ?? 0,
+		} );
+		index += 1;
+	}
+	return out;
+}
+
+type DayBucket = { views: number; impressions: number; watchTimeSeconds: number };
+
+/**
+ * Group day-keyed totals into bucketed sums for the active
+ * granularity. Returns a Map preserving insertion order so callers can
+ * align two responses by ordinal bucket position.
+ *
+ * @param response    - One `stats/video-plays` response, or undefined.
+ * @param granularity - Active bucketing.
+ * @return Bucket key → summed metrics.
+ */
+function bucketDays(
+	response: VideoPlaysResponse | undefined,
+	granularity: Granularity
+): Map< string, DayBucket > {
+	const buckets = new Map< string, DayBucket >();
+	if ( ! response?.days ) {
+		return buckets;
+	}
+	const sortedDates = Object.keys( response.days ).sort();
+	for ( const date of sortedDates ) {
+		const day = response.days[ date ];
+		const key = bucketKey( date, granularity );
+		const existing = buckets.get( key );
+		const views = day.total?.views ?? 0;
+		const impressions = day.total?.impressions ?? 0;
+		const watchTime = day.total?.watch_time ?? 0;
+		if ( existing ) {
+			existing.views += views;
+			existing.impressions += impressions;
+			existing.watchTimeSeconds += watchTime;
+		} else {
+			buckets.set( key, { views, impressions, watchTimeSeconds: watchTime } );
+		}
+	}
+	return buckets;
+}
+
+/**
+ * Pure transformer that combines the current and previous window
+ * responses into the `OverviewStats` shape the Overview screen
+ * consumes. Exported separately from `useStats` so the same transform
+ * is testable / reusable.
+ *
+ * @param current     - Current-window response, if loaded.
+ * @param previous    - Previous-window response, if loaded.
+ * @param granularity - Active series bucketing.
+ * @return Stats payload, or `EMPTY_STATS` when both responses are missing.
+ */
+export function transformVideoPlays(
+	current: VideoPlaysResponse | undefined,
+	previous: VideoPlaysResponse | undefined,
+	granularity: Granularity
+): OverviewStats {
+	if ( ! current && ! previous ) {
+		return EMPTY_STATS;
+	}
+
+	const topVideos = Array.from( aggregateTopVideos( current ).values() );
+
+	return {
+		views: {
+			current: sumTotal( current, 'views' ),
+			previousPeriod: sumTotal( previous, 'views' ),
+		},
+		impressions: {
+			current: sumTotal( current, 'impressions' ),
+			previousPeriod: sumTotal( previous, 'impressions' ),
+		},
+		watchTimeSeconds: {
+			current: sumTotal( current, 'watch_time' ),
+			previousPeriod: sumTotal( previous, 'watch_time' ),
+		},
+		series: buildSeries( current, previous, granularity ),
+		topVideos: [ ...topVideos ].sort( ( a, b ) => b.views - a.views ).slice( 0, TOP_VIDEOS_LIMIT ),
+		topVideosByWatchTime: [ ...topVideos ]
+			.sort( ( a, b ) => b.watchTimeSeconds - a.watchTimeSeconds )
+			.slice( 0, TOP_VIDEOS_LIMIT ),
+	};
+}
+
+/**
+ * Live-data hook for the Overview tab. API mirrors `useMockStats` so
+ * Phase 8 swaps it in by changing the import. Settings live in local
+ * React state; data is fetched as two `useQuery` calls (current +
+ * previous window) coordinated via `useQueries`.
+ *
+ * @return Stats state and setters.
+ */
+export function useStats() {
+	const [ dateRange, setDateRange ] = useState< DateRange >( DEFAULTS.dateRange );
+	const [ granularity, setGranularity ] = useState< Granularity >( DEFAULTS.granularity );
+	const [ activeMetric, setActiveMetricRaw ] = useState< ActiveMetric >( DEFAULTS.activeMetric );
+	const [ compare, setCompare ] = useState< ChartCompare >( DEFAULTS.compare );
+
+	const rangeDays = DATE_RANGE_DAYS[ dateRange ];
+	const windows = useMemo( () => computeWindows( rangeDays ), [ rangeDays ] );
+
+	const [ currentQuery, previousQuery ] = useQueries( {
+		queries: [
+			videoPlaysQueryOptions( windows.current ),
+			videoPlaysQueryOptions( windows.previous ),
+		],
+	} );
+
+	const stats = useMemo(
+		() => transformVideoPlays( currentQuery.data, previousQuery.data, granularity ),
+		[ currentQuery.data, previousQuery.data, granularity ]
+	);
+
+	// When Watch time becomes the active metric, `secondary` and
+	// `secondary_and_previous_period` no longer make sense (no other
+	// metric shares its unit). Fall back to `previous_period`, matching
+	// the existing useMockStats behavior.
+	const setActiveMetric = useCallback( ( next: ActiveMetric ) => {
+		setActiveMetricRaw( next );
+		if ( next === 'watch_time' ) {
+			setCompare( prev => ( prev === 'previous_period' ? prev : COMPARE_FALLBACK_FOR_WATCH_TIME ) );
+		}
+	}, [] );
+
+	return {
+		stats,
+		isLoading: currentQuery.isLoading || previousQuery.isLoading,
+		dateRange,
+		granularity,
+		activeMetric,
+		compare,
+		setDateRange,
+		setGranularity,
+		setActiveMetric,
+		setCompare,
+	};
+}
+
+export type UseStats = ReturnType< typeof useStats >;

--- a/projects/packages/videopress/tsconfig.json
+++ b/projects/packages/videopress/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
 	// List all sources and source-containing subdirs.
-	"include": [ "./src/client", "routes/**/*", "./declarations.d.ts" ],
+	"include": [ "./src/client", "./src/dashboard", "routes/**/*", "./declarations.d.ts" ],
 	"files": [ "./global.d.ts" ]
 }


### PR DESCRIPTION
Related to #48506.

## Proposed changes

Completes Phases 5 and 7 of the VideoPress dashboard modernization. Backend scaffolding only — the modernized dashboard remains hidden behind the `rsm_jetpack_ui_modernization_videopress` filter (off by default).

* **REST proxy (Phase 7)** — New `Rest_Controller` registers `GET /jetpack/v4/videopress/stats/video-plays` under the modernization namespace `jetpack/v4/videopress`. Signs as the blog (matching the existing `Stats::fetch_video_plays` pattern) and forces `complete_stats=true` so each day entry carries `total.{views,impressions,watch_time}` and a per-video `data[]` — everything the Overview's KPI / trends / top-N cards consume in one round-trip per window. Permission: `manage_options`. Query params (`period`, `num`, `date`, `start_date`) validated and forwarded.
* **Initial State (Phase 5)** — New `Initial_State` class inlines a `var JPVIDEOPRESS_INITIAL_STATE = {...};` blob before the wp-build boot script. Payload: `API` (root + wp_rest nonce), `jetpackStatus.calypsoSlug`, `siteData` (id, title, adminUrl, slug, gmtOffset, timezoneString, locale, `hasVideoPressAccess`), `assets.buildUrl`. The paid-tier flag resolves via `Product::get_site_features_from_wpcom()` (15s site-transient cache) and matches the active-features check in `videopress/v1/features`.
* **Hook timing** — The wp-build action `jetpack-videopress-dashboard-wp-admin_init` fires *before* the prerequisites script handle is registered, so the inline-state attaches via `admin_enqueue_scripts` priority 11 instead. `wp_script_is( 'jetpack-videopress-dashboard-wp-admin-prerequisites', 'registered' )` doubles as the page guard.
* **TanStack Query hook** — New `use-stats.ts` (`videoPlaysQueryOptions`, `transformVideoPlays`, `useStats()`) mirrors `useMockStats`'s surface so Phase 8's swap is a one-line import change. No JS consumer in this PR.
* **Phase 5 wrappers intentionally skipped** — The originally-planned wrappers for `videopress/v1/{settings,site,features}`, `/wp/v2/media`, and `/wpcom/v2/videopress/{meta,playback-jwt}` are *not* included. Those routes are already local Jetpack REST endpoints callable directly via `apiFetch`; wrapping them under `/jetpack/v4/videopress/*` would add a layer without adding capability. Phase 6 (Library / Video details / Settings wiring) will call them directly.
* **Visibility change** — `Admin_UI::is_modernized()` promoted from `private` to `public` so `Initial_State::enqueue()` can gate on the same canonical modernization filter.

## Related product discussion/links

* Tracking issue: #48506 — see the "Phase 7 discovery outcome (2026-05-11)" section for the rationale behind combining Phases 5 and 7 in a single PR (shared `Rest_Controller` scaffolding + reduced Phase 7 scope after WPCOM-side discovery).
* Reference architecture: `projects/packages/activity-log/` — Initial State shape mirrors that package. The stats proxy is blog-signed, following the existing `Stats::fetch_video_plays` pattern in this package.

## Does this pull request change what data or activity we track or use?

No new tracking, no new data collection. The REST proxy forwards requests to an existing WPCOM endpoint (`stats/video-plays?complete_stats=true`) that the legacy dashboard already consumes via different paths. The `Initial_State` payload is standard site-identity data already exposed by other Jetpack admin pages plus a single paid-tier capability flag derived from WPCOM features data the package already reads in `VideoPress_Rest_Api_V1_Features`.

## Testing instructions

This is a backend/scaffolding PR with **no visible UI changes**. The modernized dashboard remains hidden behind the `rsm_jetpack_ui_modernization_videopress` filter — every test step assumes the filter is enabled on a connected Jetpack site with `manage_options`.

### Setup

Enable the modernization filter via a mu-plugin or theme `functions.php`:

```php
add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );
```

Build the package if you haven't already:

```bash
jp build packages/videopress
```

### 1. REST proxy registration and shape

From the dashboard page's DevTools console (or any wp-admin page after auth):

```js
wp.apiFetch( { path: '/jetpack/v4/videopress/stats/video-plays?period=day&num=7' } )
    .then( console.log );
```

Expected:
* HTTP 200 with `{ date, period, days }`. `days` is keyed by `YYYY-MM-DD`; each entry has `total: { views, impressions, watch_time }` and `data: [{ post_id, plays, … }]`. On sites with no traffic in the window, `data` is empty `[]` and `total` values are all `0` — this is the correct shape, not a bug.
* HTTP 403 if the user lacks `manage_options`.
* HTTP 400 on bad params, e.g.:
  ```js
  wp.apiFetch( { path: '/jetpack/v4/videopress/stats/video-plays?period=invalid' } );
  ```

Equivalent `curl` from the host shell (substitute your cookie jar and a valid `wp_rest` nonce):

```bash
curl -sb cookies.txt \
  -H "X-WP-Nonce: <nonce-from-window.wpApiSettings>" \
  "https://<your-site>/wp-json/jetpack/v4/videopress/stats/video-plays?period=day&num=7" | jq .
```

### 2. Initial State payload

Visit `/wp-admin/admin.php?page=jetpack-videopress-dashboard-wp-admin` (or `?page=jetpack-videopress` on hosts where the legacy slug is aliased). In the DevTools console:

```js
JPVIDEOPRESS_INITIAL_STATE
```

Expected shape:

```js
{
  API: { WP_API_root: 'https://.../wp-json/', WP_API_nonce: '…' },
  jetpackStatus: { calypsoSlug: 'your-site.com' },
  siteData: {
    id: <number>,
    title: '<site title>',
    adminUrl: 'https://.../wp-admin/',
    slug: 'your-site.com',
    gmtOffset: <number>,
    timezoneString: '<tz or empty>',
    locale: 'en-US',
    hasVideoPressAccess: <bool>
  },
  assets: { buildUrl: 'https://.../videopress/build/' }
}
```

### 3. Hook timing & rendered order

View page source on the modernized dashboard page. The inline `var JPVIDEOPRESS_INITIAL_STATE = {...};` `<script>` tag should appear **before** the wp-build boot `import("@wordpress/boot").then(mod => mod.initSinglePage(...))` script. Both are attached to the `jetpack-videopress-dashboard-wp-admin-prerequisites` handle — ours via `'before'` position at `admin_enqueue_scripts` priority 11, the boot import via the default `'after'` position from wp-build's auto-generated `page-wp-admin.php`.

### 4. Page guard

Visit any *other* wp-admin page (e.g. `/wp-admin/`). In the console:

```js
typeof JPVIDEOPRESS_INITIAL_STATE
```

Expected: `'undefined'`. The `wp_script_is( ..., 'registered' )` guard inside `Initial_State::enqueue()` prevents the inline script from attaching on pages where wp-build hasn't registered the prerequisites handle.

### 5. Filter gate

Remove `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' )` and visit the modernized URL. Expected:
* The legacy dashboard renders.
* `typeof JPVIDEOPRESS_INITIAL_STATE === 'undefined'` (the `Admin_UI::is_modernized()` short-circuit returns before `wp_add_inline_script` runs).

### 6. Paid-tier flag (`hasVideoPressAccess`)

Cross-check the flag against the existing features endpoint — both read the same WPCOM `/sites/%d/features` response, so values must match:

```js
const features = await wp.apiFetch( { path: '/videopress/v1/features' } );
const expected = features.isVideoPress1TBSupported || features.isVideoPressUnlimitedSupported;
const actual = JPVIDEOPRESS_INITIAL_STATE.siteData.hasVideoPressAccess;
console.log( { expected, actual, match: expected === actual } );
```

* Site without a paid plan → both `false`.
* Site with `videopress-1tb-storage` or `videopress-unlimited-storage` in active features → both `true`.
* On a WPCOM (Simple) host, the legacy `videopress` slug also flips the flag to `true`.

The flag is backed by a 15s site transient (`Product::get_site_features_from_wpcom`); to force-refresh, delete the transient:

```bash
wp transient delete jetpack_my_jetpack_site_features
```

### 7. Build & static analysis sanity

```bash
jp build packages/videopress
jp phan packages/videopress
```

Phan should report no new issues (one pre-existing `PhanPluginNeverReturnFunction` warning in `build/pages/jetpack-videopress-dashboard/page.php` is unrelated and from generated code).

### What's *not* in this PR

* No UI changes — Overview still renders mock data from `useMockStats`. Phase 8 will swap to `useStats` and validate against a real paid site.
* No `apiFetch` middleware bootstrap — WordPress core already auto-bootstraps `wp.apiFetch` with the REST root + nonce on any admin page depending on `wp-api-fetch`.
* No TypeScript ambient declaration for `JPVIDEOPRESS_INITIAL_STATE` — Phases 6/8 will declare the type per consumer file (Activity Log's pattern).
