### PR TITLE
Search 3.0: gate block registration on a Search plan

### DIFF
--- a/projects/packages/search/changelog/SEARCH-189-block-plan-gate
+++ b/projects/packages/search/changelog/SEARCH-189-block-plan-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: Search 3.0 block registration now also requires the site to be connected and on a plan that supports Search (paid plans or the free `jetpack_search_free` product), reusing the same upstream gate that already gates Instant Search and Classic Search inside `Initializer::init()`. The `jetpack_search_blocks_enabled` feature flag is the remaining Phase 1 opt-in. Sites without a Search plan no longer see the blocks in the editor inserter, matching what the runtime can actually deliver.

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -54,6 +54,13 @@ class Initializer {
 			return;
 		}
 
+		// Register the Search 3.0 Interactivity API blocks. Connection +
+		// plan are already guaranteed by the abort above; this call only
+		// layers the Phase 1 feature flag on top, mirroring how
+		// `init_search()` layers `is_instant_search_enabled` on top of
+		// the same upstream gate.
+		static::init_search_blocks();
+
 		$blog_id = Helper::get_wpcom_site_id();
 		if ( ! $blog_id ) {
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
@@ -102,35 +109,44 @@ class Initializer {
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		// The dashboard has to be initialized before connection.
 		( new Dashboard() )->init_hooks();
-		// Register the Interactivity API search blocks. These register
-		// server-side (block types, patterns, variations) regardless of
-		// connection/plan/module state so the blocks appear in the editor on
-		// any site that has the package loaded; runtime queries still require
-		// a connected site with a Search plan.
-		//
-		// Gated behind the `jetpack_search_blocks_enabled` filter, which
-		// defaults to false. This is the feature flag for Phase 1 of Search
-		// 3.0: the blocks, pattern, and shared Interactivity API store only
-		// register when a site has explicitly opted in.
+		( new AI_Answers() )->init();
+	}
+
+	/**
+	 * Register the Search 3.0 Interactivity API blocks on this request,
+	 * gated by the Phase 1 feature flag.
+	 *
+	 * Called from `init()` after the upstream connection + Search-plan
+	 * abort, so on entry the site is guaranteed to be connected and on a
+	 * plan that supports Search (paid plans or the free
+	 * `jetpack_search_free` product). The remaining gate is the
+	 * feature-flag opt-in.
+	 *
+	 * Sits before the blog_id and module-active checks because admins
+	 * should be able to configure Search blocks in the editor regardless
+	 * of which runtime experience is enabled — matching how Instant
+	 * Search layers its own opt-in on top of the same connection + plan
+	 * gate further down in `init_search()`.
+	 */
+	protected static function init_search_blocks() {
 		/**
 		 * Filter whether the Jetpack Search 3.0 Interactivity API blocks are enabled.
 		 *
-		 * Returning true registers the blocks, the "Jetpack Search" block +
-		 * pattern categories, the "Blog Search Page" pattern, and seeds the
-		 * Interactivity API store on the front end. Default is false until
-		 * Search 3.0 ships.
+		 * Necessary but not sufficient on its own — registration also
+		 * requires the site to be connected and on a plan that supports
+		 * Search (paid plans or the free `jetpack_search_free` product).
 		 *
 		 * @param bool $enabled Default false.
 		 */
-		if ( apply_filters( 'jetpack_search_blocks_enabled', false ) ) {
-			// Phase 1 ships without WooCommerce-only Search blocks. Sites
-			// that want them back hook the same filter at priority > 10
-			// so their callback runs after this default.
-			add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' );
-			Search_Blocks::init();
+		if ( ! apply_filters( 'jetpack_search_blocks_enabled', false ) ) {
+			return;
 		}
 
-		( new AI_Answers() )->init();
+		// Phase 1 ships without WooCommerce-only Search blocks. Sites
+		// that want them back hook the same filter at priority > 10
+		// so their callback runs after this default.
+		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' );
+		Search_Blocks::init();
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -8,11 +8,22 @@
 namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Search\TestCase as Search_TestCase;
+use ReflectionMethod;
 
 /**
  * Unit tests for the Initializer class.
  */
 class Initializer_Test extends Search_TestCase {
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'jetpack_search_blocks_enabled' );
+		remove_all_filters( 'jetpack_search_woocommerce_blocks_enabled' );
+		$this->remove_search_blocks_hooks();
+		parent::tearDown();
+	}
 
 	public function test_init_fires_abort_action_when_package_filter_returns_false() {
 		$abort_reasons = array();
@@ -50,5 +61,69 @@ class Initializer_Test extends Search_TestCase {
 
 		// Only the filter-abort reason should have fired.
 		$this->assertSame( array( 'jetpack_search_init_search_package_filter' ), $reasons );
+	}
+
+	public function test_init_search_blocks_registers_when_feature_flag_on() {
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+
+		$this->invoke_init_search_blocks();
+
+		$this->assertNotFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_blocks' ) ),
+			'Search blocks should register when the Phase 1 feature flag is on. The connection + Search-plan gate is upstream in Initializer::init() and verified by the abort tests.'
+		);
+	}
+
+	public function test_init_search_blocks_does_not_register_when_feature_flag_off() {
+		// Feature flag defaults to false — no filter registered.
+		$this->invoke_init_search_blocks();
+
+		$this->assertFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_blocks' ) ),
+			'Search blocks should not register when the feature flag is off.'
+		);
+	}
+
+	public function test_init_search_blocks_sets_woocommerce_blocks_gate_off_by_default_when_enabled() {
+		// Verifies the Phase 1 default — opt-in sites get the non-WC subset
+		// unless they re-enable WC blocks at a later priority.
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+
+		$this->invoke_init_search_blocks();
+
+		$this->assertFalse(
+			(bool) apply_filters( 'jetpack_search_woocommerce_blocks_enabled', true ),
+			'WC-only Search blocks should be disabled by default in Phase 1.'
+		);
+	}
+
+	/**
+	 * Invoke the protected `init_search_blocks()` directly so the gate can
+	 * be exercised without running the rest of `init()` (rest_api_init,
+	 * Dashboard, AI_Answers hooks that would leak across the test suite
+	 * via the global `$wp_filter`).
+	 */
+	private function invoke_init_search_blocks(): void {
+		$method = new ReflectionMethod( Initializer::class, 'init_search_blocks' );
+		// setAccessible() became a no-op in 8.1 and was deprecated in 8.5,
+		// but the package supports PHP 7.2+ where the call is still required
+		// for ReflectionMethod::invoke() to reach a protected method.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( null );
+	}
+
+	/**
+	 * Remove the hooks `Search_Blocks::init()` adds so they don't leak across
+	 * tests via the global `$wp_filter`. Mirrors every `add_action` /
+	 * `add_filter` in that method.
+	 */
+	private function remove_search_blocks_hooks(): void {
+		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
+		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
+		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
+		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
+		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 	}
 }

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -117,7 +117,8 @@ class Initializer_Test extends Search_TestCase {
 	/**
 	 * Remove the hooks `Search_Blocks::init()` adds so they don't leak across
 	 * tests via the global `$wp_filter`. Mirrors every `add_action` /
-	 * `add_filter` in that method.
+	 * `add_filter` in that method, including the four hooks cascaded by
+	 * `Custom_Taxonomy_Slot_Mapping::init()`.
 	 */
 	private function remove_search_blocks_hooks(): void {
 		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
@@ -125,5 +126,9 @@ class Initializer_Test extends Search_TestCase {
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
+		remove_action( 'init', array( Custom_Taxonomy_Slot_Mapping::class, 'register_slot_taxonomies' ), 20 );
+		remove_action( 'set_object_terms', array( Custom_Taxonomy_Slot_Mapping::class, 'mirror_assignment' ) );
+		remove_action( 'deleted_term_relationships', array( Custom_Taxonomy_Slot_Mapping::class, 'mirror_removal' ) );
+		remove_action( 'delete_term', array( Custom_Taxonomy_Slot_Mapping::class, 'mirror_deletion' ) );
 	}
 }


### PR DESCRIPTION
Refs [SEARCH-189](https://linear.app/a8c/issue/SEARCH-189/search-blocks-gate-registration-behind-an-actual-search-plan-free).

## Why

End users on sites without a Search plan currently see the Search 3.0 blocks in the editor inserter — but the runtime data fetch fails there, because the site can't reach the Search backend. The inserter promises something the site can't deliver.

After this PR, the blocks only register on sites that hold a Search plan, including the free `jetpack_search_free` product. The inserter promise now matches what the site can actually run.

## Proposed changes

* Move `Search_Blocks::init()` out of `init_before_connection()` and into a new `init_search_blocks()` helper called from `Initializer::init()` **after** the connection + Search-plan abort. The broader connection + plan gate is reused from `init()` instead of duplicated at the call site — matches how `init_search()` layers its own opt-in (`is_instant_search_enabled`) on top of the same upstream gate.
* The `jetpack_search_blocks_enabled` feature flag remains the only check at the call site (Phase 1 opt-in).
* Add `Initializer_Test` coverage for the feature-flag gate and the WooCommerce-blocks Phase-1 default.

Behavior summary:

| Site state                                                        | Blocks register? |
| ----------------------------------------------------------------- | ---------------- |
| `jetpack_search_blocks_enabled = false`                           | No (unchanged)   |
| Disconnected site                                                 | No (was: yes)    |
| Connected, no Search plan (`supports_search = false`)             | No (was: yes)    |
| Connected, free `jetpack_search_free` product                     | Yes              |
| Connected, paid Search plan                                       | Yes              |

## Related product discussion/links

* [SEARCH-189](https://linear.app/a8c/issue/SEARCH-189/search-blocks-gate-registration-behind-an-actual-search-plan-free) — original report and acceptance criteria.

## Does this pull request change what data or activity we track or use?

No. Pure server-side gating of block registration. No new tracking, no new data, no exposure to the front-end.

## Testing instructions

Verified end-to-end against atlas's local docker env (`https://jp-atlas.jurassic.tube/`) by manipulating `Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY` between truthy and falsy `supports_search`, then reading the editor's block registry from the JS console.

<details>
<summary>Verification matrix (editor JS console output)</summary>

```js
JSON.stringify({
  totalBlocks: wp.blocks.getBlockTypes().length,
  jetpackSearchCount: wp.blocks.getBlockTypes().filter(b=>b.name.startsWith('jetpack-search/')).length,
})
```

| Branch / state                                                | Result                                            |
| ------------------------------------------------------------- | ------------------------------------------------- |
| **trunk** + `supports_search=false`  (the bug)                | `{"totalBlocks":373,"jetpackSearchCount":14}`     |
| **this PR** + `supports_search=false`                         | `{"totalBlocks":359,"jetpackSearchCount":0}`      |
| **this PR** + `supports_search=true`  (free Search product)   | `{"totalBlocks":373,"jetpackSearchCount":14}`     |

</details>

PHP test suite: `composer phpunit` from `projects/packages/search` — 444 tests, 1006 assertions, all green.

Reviewers can reproduce locally:

1. Bring up a per-agent docker env via `/jetpack-dev-env <agent> up` and confirm `jetpack_search_blocks_enabled` is filtered to `true` (the sandbox `mu-plugins/00-sandbox.php` already does this in atlas's clone).
2. Force a no-plan state from inside the WP container:
   ```bash
   docker exec jetpack_<agent>-wordpress-1 wp eval '
     $o = get_option("jetpack_search_plan_info"); $o["supports_search"] = false;
     update_option("jetpack_search_plan_info", $o);' --allow-root
   ```
3. Reload `/wp-admin/post-new.php` and search the inserter for "jetpack search" — no `jetpack-search/*` blocks should appear.
4. Restore the original plan info (or set `supports_search` back to `true`) and reload — the 14 Jetpack Search blocks come back.

Acceptance checklist from SEARCH-189:

* [ ] On a sandbox **without** a Search plan: no `jetpack-search/*` blocks in the editor inserter.
* [ ] On a sandbox with the **free** Search product (`jetpack_search_free`): blocks appear, and the "Powered by Jetpack" attribution is forced on the `search-results` block (existing behavior in `blocks/search-results/render.php:28`).
* [ ] On a sandbox with a **paid** Search plan: blocks appear normally.
* [ ] Unit tests cover the gate (`Initializer_Test`).
