### PR TITLE
Plugin Conflicts Guardian: fix logstash feature bucket so events pass the whitelist

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-pcg-logstash-feature-bucket
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-pcg-logstash-feature-bucket
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Plugin Conflicts Guardian: rename the logstash feature bucket to `atomic_plugin_conflicts_guardian`.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -818,7 +818,7 @@ class Jetpack_Mu_Wpcom {
 	 *
 	 * Best-effort: a logging failure must never escalate into a fatal for the caller.
 	 *
-	 * @param string $feature Logstash `feature` bucket (e.g. "plugin-conflicts-guardian").
+	 * @param string $feature Logstash `feature` bucket; should start with the `atomic_` prefix (e.g. "atomic_plugin_conflicts_guardian").
 	 * @param string $message Event message slug.
 	 * @param array  $extra   Event-specific properties; JSON-encoded into the `extra` field.
 	 * @return void

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/pcg-log.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Emit an event to the `plugin-conflicts-guardian` logstash bucket.
+ * Emit an event to the `atomic_plugin_conflicts_guardian` logstash bucket.
  *
  * Thin wrapper around `Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash()`
  * that pins the feature bucket and redacts ABSPATH/WP_CONTENT_DIR prefixes
@@ -18,7 +18,7 @@
  */
 function pcg_log_event( $message, array $extra ) {
 	\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
-		'plugin-conflicts-guardian',
+		'atomic_plugin_conflicts_guardian',
 		$message,
 		pcg_log_redact_paths( $extra )
 	);


### PR DESCRIPTION
## Summary

- Follow-up to #48787. Even with the shutdown-deferred logstash dispatch, the `Activation blocked` event never showed in Kibana on Atomic.
- Root cause: the public-api `/rest/v1.1/logstash` endpoint validates `feature` against a whitelist, and `plugin-conflicts-guardian` matched none of the accepted names or prefixes, so every PCG event was silently rejected with a 400 `invalid_input`.
- Fix: rename the bucket to `atomic_plugin_conflicts_guardian` so it passes via the `atomic` prefix. Repo convention for this endpoint is underscore-separated (`atomic_extension_conflict`, `atomic_global_styles_gate`).
- Noted on `Jetpack_Mu_Wpcom::log2logstash()` that `feature` should start with the `atomic_` prefix.
- Dropped the `bump_stats_extras` reachability ping — it was a workaround for the missing events, and with the real cause fixed it's redundant. (It was also Simple-only, so it never told us anything on Atomic anyway.)

## Does this pull request change what data or activity we track or use?

No new data. This restores delivery of the existing PCG logstash events (`Activation blocked`, `Update blocked`, `Update rolled back`) on Atomic by moving them to an accepted `feature` bucket. The mc-stats counter that an earlier revision of this branch added is removed.

## Testing instructions

- [ ] Sync to an Atomic dev site via `jetpack rsync`.
- [ ] Activate a plugin that fatals on load.
- [ ] Confirm the activation is blocked and the `Activation blocked` event lands in Kibana under `feature:"atomic_plugin_conflicts_guardian"`.
- [ ] Trigger the upgrader paths (`update-guard`, `update-healthcheck`) and confirm those events also land under the same bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)