### PR TITLE
Social: align render-messages endpoint with the WPCOM rename + slim-down (SOCIAL-484)

### DIFF
--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -107,7 +107,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 	const baseMessage = (
 		isPerNetworkMode ? connection.message ?? siteMessageTemplate : globalMessage
 	).trim();
-	const currentRenderItem = items.find( item => item.id === connection.connection_id );
+	const currentRenderItem = items.find( item => item.connection_id === connection.connection_id );
 
 	const { rendered, isLoadingRendered } = useSelect(
 		select => {

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -323,8 +323,7 @@ describe( 'useConnectionPreviewData', () => {
 		mockUseRenderMessageInputs.mockReturnValue( {
 			items: [
 				{
-					id: '123',
-					network: 'tumblr',
+					connection_id: '123',
 					message: 'Old template',
 					is_social_post: false,
 				},
@@ -349,8 +348,7 @@ describe( 'useConnectionPreviewData', () => {
 		mockUseRenderMessageInputs.mockReturnValue( {
 			items: [
 				{
-					id: '123',
-					network: 'tumblr',
+					connection_id: '123',
 					message: 'Global message',
 					is_social_post: false,
 				},
@@ -371,8 +369,7 @@ describe( 'useConnectionPreviewData', () => {
 		mockUseRenderMessageInputs.mockReturnValue( {
 			items: [
 				{
-					id: '123',
-					network: 'tumblr',
+					connection_id: '123',
 					message: 'New template {excerpt}',
 					is_social_post: false,
 				},
@@ -399,8 +396,7 @@ describe( 'useConnectionPreviewData', () => {
 		mockUseRenderMessageInputs.mockReturnValue( {
 			items: [
 				{
-					id: '123',
-					network: 'tumblr',
+					connection_id: '123',
 					message: 'Different debounced template',
 					is_social_post: false,
 				},

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -178,8 +178,7 @@ export function useRenderMessageInputs(): {
 			 */
 			const raw = ctx.isPerNetworkMode ? connection.message ?? siteMessageTemplate : globalMessage;
 			return {
-				id: connection.connection_id,
-				network: connection.service_name ?? '',
+				connection_id: connection.connection_id,
 				message: raw.trim(),
 				is_social_post: connectionHasMedia( connection, ctx ),
 			};

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/test/index.test.ts
@@ -203,14 +203,12 @@ describe( 'useRenderMessageItems', () => {
 
 		expect( result.current ).toEqual( [
 			{
-				id: 'a',
-				network: 'x',
+				connection_id: 'a',
 				message: 'Global',
 				is_social_post: false,
 			},
 			{
-				id: 'b',
-				network: 'facebook',
+				connection_id: 'b',
 				message: 'Global',
 				is_social_post: false,
 			},
@@ -230,8 +228,8 @@ describe( 'useRenderMessageItems', () => {
 		const { result } = renderHook( () => useRenderMessageItems() );
 
 		expect( result.current ).toEqual( [
-			{ id: 'a', network: 'x', message: 'A', is_social_post: false },
-			{ id: 'b', network: 'facebook', message: 'Site template', is_social_post: false },
+			{ connection_id: 'a', message: 'A', is_social_post: false },
+			{ connection_id: 'b', message: 'Site template', is_social_post: false },
 		] );
 	} );
 

--- a/projects/packages/publicize/_inc/social-store/resolvers.ts
+++ b/projects/packages/publicize/_inc/social-store/resolvers.ts
@@ -121,7 +121,7 @@ export function getRenderedMessages(
 				if ( record.error ) {
 					slot.error = record.error;
 				}
-				batch[ record.id ] = slot;
+				batch[ record.connection_id ] = slot;
 			}
 
 			dispatch( receiveRenderedMessages( postId, items, batch, postIntent ) );

--- a/projects/packages/publicize/_inc/social-store/selectors/test/rendered-messages.test.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/test/rendered-messages.test.ts
@@ -2,9 +2,8 @@ import { renderMessagesCacheKey, type RenderItem } from '../../../utils/render-m
 import { getRenderedMessages, isLoadingRenderedMessages } from '../rendered-messages';
 import type { RenderedMessages, SocialStoreState } from '../../types';
 
-const item = ( id: string, message = '' ): RenderItem => ( {
-	id,
-	network: 'x',
+const item = ( connection_id: string, message = '' ): RenderItem => ( {
+	connection_id,
 	message,
 	is_social_post: false,
 } );

--- a/projects/packages/publicize/_inc/utils/render-messages.ts
+++ b/projects/packages/publicize/_inc/utils/render-messages.ts
@@ -12,8 +12,7 @@
  */
 
 export type RenderItem = {
-	id: string;
-	network: string;
+	connection_id: string;
 	message?: string;
 	is_social_post?: boolean;
 };
@@ -25,7 +24,7 @@ export type RenderPostIntent = {
 };
 
 export type RenderResult = {
-	id: string;
+	connection_id: string;
 	rendered_message?: string;
 	error?: { code: string; message: string };
 };
@@ -60,7 +59,7 @@ export function hashRenderItems( items: RenderItem[], postIntent: RenderPostInte
 	}
 
 	return JSON.stringify( [
-		items.map( i => [ i.id, i.network, i.message ?? '', Boolean( i.is_social_post ) ] ),
+		items.map( i => [ i.connection_id, i.message ?? '', Boolean( i.is_social_post ) ] ),
 		postIntent.title ?? '',
 		postIntent.excerpt ?? '',
 		hashString( postIntent.content ?? '' ),

--- a/projects/packages/publicize/_inc/utils/test/render-messages.test.ts
+++ b/projects/packages/publicize/_inc/utils/test/render-messages.test.ts
@@ -1,8 +1,7 @@
 import { hashRenderItems, type RenderItem } from '../render-messages';
 
 const item = ( overrides: Partial< RenderItem > = {} ): RenderItem => ( {
-	id: 'a',
-	network: 'x',
+	connection_id: 'a',
 	message: '',
 	is_social_post: false,
 	...overrides,
@@ -14,14 +13,14 @@ describe( 'hashRenderItems', () => {
 	} );
 
 	it( 'produces the same hash for equivalent inputs', () => {
-		const a = [ item( { id: '1', message: 'hello' } ) ];
-		const b = [ item( { id: '1', message: 'hello' } ) ];
+		const a = [ item( { connection_id: '1', message: 'hello' } ) ];
+		const b = [ item( { connection_id: '1', message: 'hello' } ) ];
 		expect( hashRenderItems( a ) ).toBe( hashRenderItems( b ) );
 	} );
 
 	it( 'differs when message changes', () => {
-		const a = [ item( { id: '1', message: 'hello' } ) ];
-		const b = [ item( { id: '1', message: 'world' } ) ];
+		const a = [ item( { connection_id: '1', message: 'hello' } ) ];
+		const b = [ item( { connection_id: '1', message: 'world' } ) ];
 		expect( hashRenderItems( a ) ).not.toBe( hashRenderItems( b ) );
 	} );
 
@@ -32,20 +31,23 @@ describe( 'hashRenderItems', () => {
 	} );
 
 	it( 'differs when items are reordered', () => {
-		const ab = [ item( { id: 'a' } ), item( { id: 'b' } ) ];
-		const ba = [ item( { id: 'b' } ), item( { id: 'a' } ) ];
+		const ab = [ item( { connection_id: 'a' } ), item( { connection_id: 'b' } ) ];
+		const ba = [ item( { connection_id: 'b' } ), item( { connection_id: 'a' } ) ];
 		expect( hashRenderItems( ab ) ).not.toBe( hashRenderItems( ba ) );
 	} );
 
 	it( 'distinguishes ["a","b"] from ["ab"] (no separator collision)', () => {
-		const split = [ item( { id: '1', message: 'a' } ), item( { id: '2', message: 'b' } ) ];
-		const joined = [ item( { id: '1', message: 'ab' } ) ];
+		const split = [
+			item( { connection_id: '1', message: 'a' } ),
+			item( { connection_id: '2', message: 'b' } ),
+		];
+		const joined = [ item( { connection_id: '1', message: 'ab' } ) ];
 		expect( hashRenderItems( split ) ).not.toBe( hashRenderItems( joined ) );
 	} );
 
 	it( 'normalises missing message and is_social_post defaults', () => {
-		const explicit = [ item( { id: '1', message: '', is_social_post: false } ) ];
-		const implicit = [ { id: '1', network: 'x' } as RenderItem ];
+		const explicit = [ item( { connection_id: '1', message: '', is_social_post: false } ) ];
+		const implicit = [ { connection_id: '1' } as RenderItem ];
 		expect( hashRenderItems( explicit ) ).toBe( hashRenderItems( implicit ) );
 	} );
 } );

--- a/projects/packages/publicize/changelog/update-social-simplify-render-messages-api
+++ b/projects/packages/publicize/changelog/update-social-simplify-render-messages-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: Simplify preview render API by using the connction id as the source of truth.

--- a/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
@@ -26,9 +26,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * `social-message-templates` feature is enabled.
  *
  * POST takes a JSON body of `{ post_id, items: [...], post_intent: {...} }`
- * and returns one record per input item, in input order, keyed by
- * client-supplied `id` (typically the connection_id). Body-based POST is used
- * instead of a GET collection so multi-connection / long-message batches don't hit
+ * and returns one record per input item, in input order, keyed by the
+ * client-supplied `connection_id`. Body-based POST is used instead of a GET
+ * collection so multi-connection / long-message batches don't hit
  * infrastructure URL caps.
  *
  * @phan-constructor-used-for-side-effects
@@ -82,18 +82,14 @@ class Render_Messages_Controller extends Base_Controller {
 						'items'       => array(
 							'type'                 => 'object',
 							'additionalProperties' => false,
-							'required'             => array( 'id', 'network' ),
+							'required'             => array( 'connection_id' ),
 							'properties'           => array(
-								'id'             => array(
-									'description' => __( 'Client-supplied identifier echoed back in the response (typically the connection_id).', 'jetpack-publicize-pkg' ),
-									'type'        => 'string',
-								),
-								'network'        => array(
-									'description' => __( 'The social network slug (e.g. facebook, x, linkedin).', 'jetpack-publicize-pkg' ),
+								'connection_id'  => array(
+									'description' => __( 'Publicize connection ID — used to dispatch the renderer and resolve the per-connection template.', 'jetpack-publicize-pkg' ),
 									'type'        => 'string',
 								),
 								'message'        => array(
-									'description' => __( 'The message template to render. Empty uses the network default.', 'jetpack-publicize-pkg' ),
+									'description' => __( 'Optional message override. Empty walks the per-connection / site / network-default chain.', 'jetpack-publicize-pkg' ),
 									'type'        => 'string',
 									'default'     => '',
 								),
@@ -145,8 +141,8 @@ class Render_Messages_Controller extends Base_Controller {
 			'title'      => 'publicize-render-messages-item',
 			'type'       => 'object',
 			'properties' => array(
-				'id'               => array(
-					'description' => __( 'Client-supplied identifier echoed back from the request.', 'jetpack-publicize-pkg' ),
+				'connection_id'    => array(
+					'description' => __( 'Connection identifier echoed back from the request.', 'jetpack-publicize-pkg' ),
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
@@ -244,7 +240,7 @@ class Render_Messages_Controller extends Base_Controller {
 			}
 
 			return rest_ensure_response(
-				\Publicize\render_messages_for_networks( $post, $items, $intent )
+				\Publicize\render_messages( $post, $items, $intent )
 			);
 		}
 

--- a/projects/packages/publicize/tests/php/Render_Messages_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Render_Messages_Controller_Test.php
@@ -106,8 +106,7 @@ class Render_Messages_Controller_Test extends TestCase {
 				'post_id' => $this->post_id,
 				'items'   => array(
 					array(
-						'id'      => 'a',
-						'network' => 'x',
+						'connection_id' => 'a',
 					),
 				),
 			)
@@ -150,22 +149,19 @@ class Render_Messages_Controller_Test extends TestCase {
 	}
 
 	/**
-	 * Items missing required fields fail validation.
+	 * Items missing the required `connection_id` field fail schema validation.
 	 */
-	public function test_render_messages_rejects_item_missing_required_fields() {
+	public function test_render_messages_rejects_item_missing_connection_id() {
 		wp_set_current_user( $this->admin_id );
 
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/publicize/render-messages' );
 		$request->set_body_params(
 			array(
 				'post_id' => $this->post_id,
-				// Missing `network` on the second item.
+				// Missing `connection_id` on the second item.
 				'items'   => array(
-					array(
-						'id'      => 'a',
-						'network' => 'x',
-					),
-					array( 'id' => 'b' ),
+					array( 'connection_id' => 'a' ),
+					array( 'message' => 'no id' ),
 				),
 			)
 		);
@@ -195,8 +191,7 @@ class Render_Messages_Controller_Test extends TestCase {
 				'post_id' => $this->post_id,
 				'items'   => array(
 					array(
-						'id'      => 'a',
-						'network' => 'x',
+						'connection_id' => 'a',
 					),
 				),
 			)
@@ -218,12 +213,10 @@ class Render_Messages_Controller_Test extends TestCase {
 				'post_id' => $this->post_id,
 				'items'   => array(
 					array(
-						'id'      => 'conn_a',
-						'network' => 'x',
+						'connection_id' => 'conn_a',
 					),
 					array(
-						'id'      => 'conn_b',
-						'network' => 'facebook',
+						'connection_id' => 'conn_b',
 					),
 				),
 			)
@@ -237,11 +230,11 @@ class Render_Messages_Controller_Test extends TestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'               => 'conn_a',
+					'connection_id'    => 'conn_a',
 					'rendered_message' => 'A',
 				),
 				array(
-					'id'               => 'conn_b',
+					'connection_id'    => 'conn_b',
 					'rendered_message' => 'B',
 				),
 			),
@@ -261,8 +254,7 @@ class Render_Messages_Controller_Test extends TestCase {
 				'post_id'     => $this->post_id,
 				'items'       => array(
 					array(
-						'id'      => 'conn_a',
-						'network' => 'x',
+						'connection_id' => 'conn_a',
 					),
 				),
 				'post_intent' => array(
@@ -292,8 +284,7 @@ class Render_Messages_Controller_Test extends TestCase {
 				'post_id' => $this->post_id,
 				'items'   => array(
 					array(
-						'id'             => 'a',
-						'network'        => 'x',
+						'connection_id'  => 'a',
 						'is_social_post' => 'not-a-bool',
 					),
 				),
@@ -314,11 +305,11 @@ class Render_Messages_Controller_Test extends TestCase {
 			'body'     => wp_json_encode(
 				array(
 					array(
-						'id'               => 'conn_a',
+						'connection_id'    => 'conn_a',
 						'rendered_message' => 'A',
 					),
 					array(
-						'id'               => 'conn_b',
+						'connection_id'    => 'conn_b',
 						'rendered_message' => 'B',
 					),
 				),


### PR DESCRIPTION
Closes SOCIAL-484

## Proposed changes

Aligns the Jetpack-side `wpcom/v2/publicize/render-messages` controller and JS callers with the WPCOM rename + slim-down (Automattic/wpcom#217401).

- **Schema**: items require only `connection_id`. `network` is dropped (the renderer derives it from the connection — items pointing at unknown connections now return `connection_not_found` instead of silently degrading). `id` is dropped (renamed to `connection_id` for clarity).
- **Item response schema** declares `connection_id` (no longer `id`).
- **Controller** forwards to `\Publicize\render_messages()` — the new helper name. The old `render_messages_for_networks` is the deprecated wrapper on WPCOM and we no longer call it.
- **JS `RenderItem`** drops `network`; the only carry-over fields are `connection_id`, `message`, `is_social_post`.
- `useRenderMessageItems` no longer sets `network`. `hashRenderItems` no longer hashes it.
- Resolver keys batches by `record.connection_id`. `useConnectionPreviewData` matches the current item by `item.connection_id === connection.connection_id`.
- **PHP tests**: dropped `network` from item fixtures; replaced the `network`-required test with a `connection_id`-required one; response fixture echoes `connection_id`.
- **JS tests**: dropped `network` from items fixtures and expected items arrays.

## Related product discussion/links

-

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
0. Apply this PR and the WPCOM PR (217401-ghe-Automattic/wpcom) to your sandbox and then point your site and the public api to your sandbox
1. On a site with the `jetpack-social-message-templates` and `publicize-enhanced-publishing` stickers, set:
   - A site-wide template in Jetpack Social settings.
   - A per-connection template on one connection (Connections Management).
2. Open the social previews modal in the editor with multiple connections enabled.
3. Confirm the connection with the per-connection template renders against it.
4. Clear the per-connection message field in the modal — confirm the preview falls through to the **connection's saved template**, not directly to the site template (this was the SOCIAL-484 regression).
5. The connection without a per-connection template should render against the site template.
6. Verify in DevTools that the request body to `/wp-json/wpcom/v2/publicize/render-messages` is `{ post_id, items: [{ connection_id, message?, is_social_post? }, ...] }` — no `network`, no `id`. Each response item is `{ connection_id, rendered_message }` or `{ connection_id, error: { code, message } }`.
7. (Optional) curl smoke:

    ```bash
    curl -sS -X POST "${SITE_URL}/wp-json/wpcom/v2/publicize/render-messages" \
      -H 'Content-Type: application/json' \
      -d '{
        "post_id": 123,
        "items": [
          { "connection_id": "456" },
          { "connection_id": "789", "message": "Custom: {title}" }
        ]
      }' | jq .
    ```

    Expect each result record to have `connection_id` + `rendered_message` (or `connection_id` + `error: { code, message }`).