### PR TITLE
ci: Avoid processing artifacts that contain a `.git` dir

### DIFF
--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -138,6 +138,11 @@ while IFS=$'\t' read -r SRC MIRROR SLUG; do
 
 	cd "$GITHUB_WORKSPACE/build/$MIRROR"
 
+	if [[ -e .git ]]; then
+		failed "$SLUG: Artifact contains a \`.git\` dir. This is not allowed, aborting check."
+		continue
+	fi
+
 	echo "::group::Initializing $SLUG"
 	git init -b "tmp" .
 	git config --local gc.auto 0

--- a/projects/github-actions/push-to-mirrors/changelog/fix-git-init-with-existing-.git-dir
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-git-init-with-existing-.git-dir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+If an artifact already contains a `.git` dir, skip it. This avoids certain attacks based on having malicious hooks or config in the artifact.

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -148,6 +148,13 @@ while read -r GIT_SLUG; do
 	CLONE_DIR="${BUILD_BASE}/${GIT_SLUG}"
 	cd "${CLONE_DIR}"
 
+	if [[ -e .git ]]; then
+		echo "::error::Artifact $GIT_SLUG contains a \`.git\` directory."
+		echo "Skipping."
+		EXIT=1
+		continue
+	fi
+
 	# Initialize the directory as a git repo, and set the remote
 	git init -b "$BRANCH" .
 	git config --local gc.auto 0


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
If the artifact already has a `.git` dir, `git init` will not complain about the re-initialization, it'll just proceed. If that `.git` dir has something malicious in `.git/config` or `.git/hooks/` or something, that could be a problem.

To be safe, reject processing artifacts that have a `.git` dir before trying to run `git init`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p3btAN-3zI-p2#comment-24225

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* To really test, I supposed you'd have to fork, break stuff, and see whether it gets caught. 🤷