### PR TITLE
Podcast: register sync whitelist above the untangle gate

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-sync-whitelist-above-untangle
+++ b/projects/packages/podcast/changelog/add-podcast-sync-whitelist-above-untangle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: sync the podcasting_* options to wpcom regardless of the untangle gate so Atomic sites still on the legacy bridge mirror the option to wpcom.

--- a/projects/packages/podcast/changelog/add-podcast-sync-whitelist-above-untangle
+++ b/projects/packages/podcast/changelog/add-podcast-sync-whitelist-above-untangle
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Podcast: sync the podcasting_* options to wpcom regardless of the untangle gate so Atomic sites still on the legacy bridge mirror the option to wpcom.
+Podcast: Sync podcasting_* options to wpcom regardless of the untangle gate so Atomic sites on the legacy bridge still mirror options to wpcom.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -52,6 +52,12 @@ class Podcast {
 		// late-registered filter callback still takes effect.
 		Podcast_Episode_Block::register_hooks();
 
+		// Sync `podcasting_*` to wpcom even when the untangle is off, so the
+		// Activity Log show-launched/episode-published matchers on wpcom can
+		// read `podcasting_category_id` on Atomic sites still on the legacy
+		// at-pressable-podcasting bridge.
+		Settings::register_sync_whitelist();
+
 		if ( ! self::is_enabled() ) {
 			return;
 		}

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -111,6 +111,8 @@ class Settings {
 	 * on the Atomic side. Idempotent.
 	 */
 	public static function register_sync_whitelist() {
+		// Keep this re-entrant if a test or caller removes the hook after the
+		// first registration in the same PHP process.
 		if ( self::$sync_whitelist_registered && has_filter( 'jetpack_sync_options_whitelist', array( __CLASS__, 'filter_sync_options_whitelist' ) ) ) {
 			return;
 		}

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -90,8 +90,25 @@ class Settings {
 		}
 		self::$registered = true;
 
+		self::register_sync_whitelist();
+
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_settings' ) );
+	}
+
+	/**
+	 * Add the `podcasting_*` options to Jetpack Sync's whitelist so Atomic
+	 * sites mirror them to wpcom. Split from `register()` so it can run above
+	 * the untangle gate: wpcom's Activity Log podcast matchers read
+	 * `podcasting_category_id` regardless of whether the new SPA is wired up
+	 * on the Atomic side. Idempotent.
+	 */
+	public static function register_sync_whitelist() {
+		static $done = false;
+		if ( $done ) {
+			return;
+		}
+		$done = true;
 
 		add_filter(
 			'jetpack_sync_options_whitelist',

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -108,7 +108,8 @@ class Settings {
 	 * sites mirror them to wpcom. Split from `register()` so it can run above
 	 * the untangle gate: wpcom's Activity Log podcast matchers read
 	 * `podcasting_category_id` regardless of whether the new SPA is wired up
-	 * on the Atomic side. Idempotent.
+	 * on the Atomic side. Idempotent, and re-entrant if another caller removes
+	 * the filter in the same PHP process.
 	 */
 	public static function register_sync_whitelist() {
 		// Keep this re-entrant if a test or caller removes the hook after the

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -82,6 +82,13 @@ class Settings {
 	private static $registered = false;
 
 	/**
+	 * Whether `register_sync_whitelist()` has added its filter.
+	 *
+	 * @var bool
+	 */
+	private static $sync_whitelist_registered = false;
+
+	/**
 	 * Wire option registrations + Jetpack Sync opt-in. Idempotent.
 	 */
 	public static function register() {
@@ -104,18 +111,26 @@ class Settings {
 	 * on the Atomic side. Idempotent.
 	 */
 	public static function register_sync_whitelist() {
-		static $done = false;
-		if ( $done ) {
+		if ( self::$sync_whitelist_registered && has_filter( 'jetpack_sync_options_whitelist', array( __CLASS__, 'filter_sync_options_whitelist' ) ) ) {
 			return;
 		}
-		$done = true;
 
 		add_filter(
 			'jetpack_sync_options_whitelist',
-			static function ( $options ) {
-				return array_merge( $options, self::OPTION_NAMES );
-			}
+			array( __CLASS__, 'filter_sync_options_whitelist' )
 		);
+
+		self::$sync_whitelist_registered = true;
+	}
+
+	/**
+	 * Add `podcasting_*` options to the Jetpack Sync whitelist.
+	 *
+	 * @param array $options Existing sync whitelist.
+	 * @return array
+	 */
+	public static function filter_sync_options_whitelist( $options ) {
+		return array_merge( $options, self::OPTION_NAMES );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Podcast_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Test.php
@@ -7,7 +7,9 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Podcast\Podcast;
+use Automattic\Jetpack\Podcast\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 
@@ -16,6 +18,15 @@ use WorDBless\BaseTestCase;
  */
 #[CoversClass( Podcast::class )]
 class Podcast_Test extends BaseTestCase {
+	public function tearDown(): void {
+		$this->reset_podcast_init_state();
+		$this->reset_settings_registration_state();
+		Constants::clear_single_constant( 'IS_WPCOM' );
+		remove_filter( 'jetpack_podcast_untangle', '__return_false' );
+		remove_filter( 'jetpack_sync_options_whitelist', array( Settings::class, 'filter_sync_options_whitelist' ) );
+
+		parent::tearDown();
+	}
 
 	/**
 	 * `init()` should run cleanly on every host. In test environments (and on
@@ -34,5 +45,37 @@ class Podcast_Test extends BaseTestCase {
 	 */
 	public function test_package_version_constant_is_defined() {
 		$this->assertNotEmpty( Podcast::PACKAGE_VERSION );
+	}
+
+	public function test_init_registers_sync_whitelist_when_untangle_is_disabled() {
+		$this->reset_podcast_init_state();
+		$this->reset_settings_registration_state();
+		remove_filter( 'jetpack_sync_options_whitelist', array( Settings::class, 'filter_sync_options_whitelist' ) );
+
+		Constants::set_constant( 'IS_WPCOM', true );
+		add_filter( 'jetpack_podcast_untangle', '__return_false' );
+
+		Podcast::init();
+
+		$whitelist = apply_filters( 'jetpack_sync_options_whitelist', array() );
+		foreach ( Settings::OPTION_NAMES as $name ) {
+			$this->assertContains( $name, $whitelist );
+		}
+	}
+
+	private function reset_podcast_init_state() {
+		$property = new \ReflectionProperty( Podcast::class, 'initialized' );
+		$property->setAccessible( true );
+		$property->setValue( null, false );
+	}
+
+	private function reset_settings_registration_state() {
+		$registered = new \ReflectionProperty( Settings::class, 'registered' );
+		$registered->setAccessible( true );
+		$registered->setValue( null, false );
+
+		$sync_whitelist_registered = new \ReflectionProperty( Settings::class, 'sync_whitelist_registered' );
+		$sync_whitelist_registered->setAccessible( true );
+		$sync_whitelist_registered->setValue( null, false );
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Test.php
@@ -23,6 +23,8 @@ class Podcast_Test extends BaseTestCase {
 		$this->reset_settings_registration_state();
 		Constants::clear_single_constant( 'IS_WPCOM' );
 		remove_filter( 'jetpack_podcast_untangle', '__return_false' );
+		// Resetting the static registration flag does not remove hooks that were
+		// already added, so clear the filter explicitly between tests.
 		remove_filter( 'jetpack_sync_options_whitelist', array( Settings::class, 'filter_sync_options_whitelist' ) );
 
 		parent::tearDown();

--- a/projects/packages/podcast/tests/php/Podcast_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Test.php
@@ -50,7 +50,6 @@ class Podcast_Test extends BaseTestCase {
 	public function test_init_registers_sync_whitelist_when_untangle_is_disabled() {
 		$this->reset_podcast_init_state();
 		$this->reset_settings_registration_state();
-		remove_filter( 'jetpack_sync_options_whitelist', array( Settings::class, 'filter_sync_options_whitelist' ) );
 
 		Constants::set_constant( 'IS_WPCOM', true );
 		add_filter( 'jetpack_podcast_untangle', '__return_false' );


### PR DESCRIPTION
## Proposed changes

* Extract the `jetpack_sync_options_whitelist` filter for the `podcasting_*` options into a new `Settings::register_sync_whitelist()` method.
* Call it from `Podcast::init()` above the `jetpack_podcast_untangle` gate, so Atomic sites still on the legacy at-pressable-podcasting bridge mirror `podcasting_*` to wpcom.

`Settings::register()` previously did three things together: `register_setting()` on `admin_init`, the same on `rest_api_init`, and the sync filter. The first two should stay behind the untangle gate, since they only matter once the new SPA owns the schema. The sync filter has to fire either way, because wpcom's Activity Log show-launched and episode-published matchers read `podcasting_category_id` regardless of whether the new SPA is wired up on the Atomic side.

The new method has its own idempotence flag, so it can run above the gate and again through `register()` without registering the filter twice.

## Related product discussion/links

* Part of the podcast untangle effort. cc @arcangelinis.

## Does this pull request change what data or activity we track or use?

No new events. The existing `podcasting_*` options sync from Atomic to wpcom in more cases than before.

## Testing instructions

* Run the package tests: `pnpm jetpack test php packages/podcast`. The existing `test_register_adds_options_to_jetpack_sync_whitelist` still covers the sync path through `Settings::register()`.
* On an Atomic site with the untangle filter off (default), set `podcasting_category_id` and confirm it mirrors to wpcom via Jetpack Sync.
* Flip the untangle filter on and confirm `podcasting_category_id` still mirrors, and the SPA settings flow is unaffected.
