### PR TITLE
Classic Theme Helper: expose Nova CPT and taxonomies to REST

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-nova-cpt-show-in-rest
+++ b/projects/packages/classic-theme-helper/changelog/fix-nova-cpt-show-in-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Nova Restaurant CPT: expose post type and taxonomies to the REST API so the Food Menus entry appears in the Calypso dashboard sidebar on Simple sites.

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-nova-restaurant.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-nova-restaurant.php
@@ -207,6 +207,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Nova_Restaurant' ) ) {
 						),
 						'no_tagcloud'  => __( 'No Labels found', 'jetpack-classic-theme-helper' ),
 						'hierarchical' => false,
+						'show_in_rest' => true,
 					)
 				);
 			}
@@ -250,6 +251,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Nova_Restaurant' ) ) {
 						'hierarchical'  => true,
 						'show_tagcloud' => false,
 						'query_var'     => 'menu',
+						'show_in_rest'  => true,
 					)
 				);
 			}
@@ -318,6 +320,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Nova_Restaurant' ) ) {
 					'map_meta_cap'         => true,
 					'has_archive'          => false,
 					'query_var'            => 'item',
+					'show_in_rest'         => true,
 				)
 			);
 		}

--- a/projects/plugins/jetpack/changelog/fix-nova-cpt-show-in-rest
+++ b/projects/plugins/jetpack/changelog/fix-nova-cpt-show-in-rest
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: bugfix
 
 Nova Restaurant CPT: expose post type and taxonomies to the REST API so the Food Menus entry appears in the Calypso dashboard sidebar on Simple sites.

--- a/projects/plugins/jetpack/changelog/fix-nova-cpt-show-in-rest
+++ b/projects/plugins/jetpack/changelog/fix-nova-cpt-show-in-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Nova Restaurant CPT: expose post type and taxonomies to the REST API so the Food Menus entry appears in the Calypso dashboard sidebar on Simple sites.


### PR DESCRIPTION
## Summary

The Nova Restaurant CPT (`nova_menu_item`) and its two taxonomies (`nova_menu`, `nova_menu_item_label`) were registered without `show_in_rest => true`. This makes them invisible to consumers that build UI from `GET /wp/v2/types`, including the WordPress.com Calypso dashboard sidebar on Simple sites.

As a result, sites running the Canape (and Confit) theme — which call `add_theme_support( 'nova_menu_item' )` — have a working **Food Menus** menu in classic wp-admin but no equivalent entry in the Calypso sidebar.

This PR adds `show_in_rest => true` to the CPT and both taxonomies, matching the existing pattern in `class-jetpack-portfolio.php` (lines 437, 465, 499) and `class-jetpack-testimonial.php` (line 426).

## Scope is automatic

Nova is gated by `Nova_Restaurant::site_supports_nova()`, which only returns true when:

1. WordPress.com site vertical is `nova_menu`, **or**
2. The active theme calls `add_theme_support( 'nova_menu_item' )`, **or**
3. The `jetpack_enable_cpt` filter returns true for `nova_menu_item`.

Themes that don't opt in get nothing — including the new REST flag. The only themes affected on WordPress.com are **Canape** and **Confit**.

## Fixes

- https://github.com/Automattic/wp-calypso/issues/70753
- Linear: DOTTHEM-133

## Does this pull request change what data or activity we track or use?

No. This PR only changes how an existing post type and its taxonomies are exposed to the WordPress REST API. No new data is collected, stored, or transmitted; no new tracking is introduced.

## Testing instructions

- [ ] On a site with Canape (or Confit) activated and the Custom Content Types Jetpack module enabled, confirm `get_post_type_object( 'nova_menu_item' )->show_in_rest === true`.
- [ ] `GET /wp-json/wp/v2/types/nova_menu_item` returns 200.
- [ ] `GET /wp-json/wp/v2/types` includes `nova_menu_item`.
- [ ] On a sandboxed Simple site, confirm the **Food Menus** entry appears in the Calypso sidebar at `https://wordpress.com/sites/`.
- [ ] Existing wp-admin "Food Menus" submenu (Menu Items / Add Menu Item / Add Many Items / Menu Item Labels / Menu Sections) still works.
- [ ] Editing a menu item still saves the price meta box.
