### PR TITLE
Write: remove sticker gate and Automattician check

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-2645-remove-sticker-gate
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-2645-remove-sticker-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Write: remove the sticker and Automattician gating so the editor loads for all WordPress.com sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -309,13 +309,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-widgets/wpcom-widgets.php';
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 
-		// Write: distraction-free front-end editor. Enabled for sites with the sticker or for a12s.
-		$is_a12s = ( function_exists( 'is_automattician' ) && is_automattician() )
-			|| ( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) )
-			|| ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST );
-		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) || $is_a12s ) {
-			require_once __DIR__ . '/features/write/write.php';
-		}
+		require_once __DIR__ . '/features/write/write.php';
 
 		/*
 		 * Temporarily disable client-side media processing.


### PR DESCRIPTION
Fixes RSM-2645

## Proposed changes
* Always load the Write editor feature in `jetpack-mu-wpcom` instead of gating it behind the `wpcom-write-editor` blog sticker or an `is_automattician` / `A8C_PROXIED_REQUEST` check. The Write editor now loads for all WordPress.com sites.
* The page-level `publish_posts` capability check on the hidden submenu page is unchanged, so non-authors still cannot reach `admin.php?page=write`.

## Related product discussion/links
* RSM-2645

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WordPress.com site without the `wpcom-write-editor` sticker and as a non-Automattician account, visit `admin.php?page=write` and confirm the Write editor loads.
* As a user without the `publish_posts` capability (e.g. a Subscriber), confirm visiting `admin.php?page=write` is blocked by WordPress's normal capability check.
* Smoke-test the editor: open, type a draft, save it, and confirm the `wpcom_write_editor_open` and `wpcom_write_editor_draft_saved` Tracks events fire as before.