### PR TITLE
Write: block editing for posts with unsupported content

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_unsupported_blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_unsupported_blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: warn when opening posts with formatting that Write cannot preserve (unsupported block types, styling attributes, non-video embeds, or classic editor content)

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -867,6 +867,109 @@
 	color: #fff;
 }
 
+/* Unsupported content warning */
+.bw-unsupported-overlay {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 1000001;
+	background-color: rgba(0, 0, 0, 0.6);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: bw-fade-in 0.1s ease-out;
+}
+
+.bw-unsupported-overlay[hidden] {
+	display: none;
+}
+
+.bw-unsupported-modal {
+	background: #fff;
+	border-radius: 8px;
+	box-shadow: 0 0.7px 1px rgba(0, 0, 0, 0.1), 0 1.2px 1.7px -0.2px rgba(0, 0, 0, 0.1), 0 2.3px 3.3px -0.5px rgba(0, 0, 0, 0.1);
+	width: 420px;
+	max-width: calc(100% - 32px);
+	padding: 24px;
+	color: #1e1e1e;
+	animation: bw-modal-appear 0.1s ease-out;
+	box-sizing: border-box;
+}
+
+.bw-unsupported-title {
+	font-size: 15px;
+	font-weight: 600;
+	margin: 0 0 8px;
+	color: #1e1e1e;
+}
+
+.bw-unsupported-desc {
+	font-size: 13px;
+	line-height: 1.5;
+	margin: 0 0 24px;
+	color: #757575;
+}
+
+.bw-unsupported-desc[hidden] {
+	display: none;
+}
+
+.bw-unsupported-actions {
+	display: flex;
+	gap: 12px;
+	justify-content: flex-end;
+}
+
+.bw-unsupported-back {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: 40px;
+	padding: 6px 12px;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--wp-components-color-accent, #3858e9);
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
+	cursor: pointer;
+	transition: color 0.1s ease;
+}
+
+.bw-unsupported-back:hover {
+	color: var(--wp-components-color-accent-darker-10, #2145e6);
+}
+
+.bw-unsupported-open-editor {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 6px 12px;
+	box-sizing: border-box;
+	border: none;
+	border-radius: 4px;
+	background: var(--wp-components-color-accent, #3858e9);
+	color: #fff;
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
+	cursor: pointer;
+	transition: background 0.1s ease;
+}
+
+.bw-unsupported-open-editor:hover {
+	background: var(--wp-components-color-accent-darker-10, #2145e6);
+	color: #fff;
+}
+
+.bw-unsupported-open-editor[hidden] {
+	display: none;
+}
+
 /* Slash command menu */
 .bw-slash-menu {
 	position: absolute;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1993,6 +1993,12 @@ const { state } = store( 'wpcom-write', {
 		get displayStatus() {
 			return state.message || state.headerLabel;
 		},
+		get isClassicWarning() {
+			return state.unsupportedWarning === 'classic';
+		},
+		get isBlockEditorWarning() {
+			return state.unsupportedWarning === 'block-editor';
+		},
 	},
 
 	actions: {
@@ -3457,7 +3463,13 @@ const { state } = store( 'wpcom-write', {
 		async autosave() {
 			// Skip autosave for published posts — partial edits should not go live silently.
 			// Users can still save manually via the unsaved-changes modal.
-			if ( ! isDirty() || state.isSaving || state.isPublished || state.postStatus === 'publish' ) {
+			if (
+				state.unsupportedWarning ||
+				! isDirty() ||
+				state.isSaving ||
+				state.isPublished ||
+				state.postStatus === 'publish'
+			) {
 				return;
 			}
 
@@ -3493,6 +3505,48 @@ const { state } = store( 'wpcom-write', {
 		dismissDisclaimer() {
 			localStorage.setItem( DISCLAIMER_STORAGE_KEY, '1' );
 			state.showDisclaimer = false;
+		},
+
+		// --- Unsupported content warning ---
+		goBack() {
+			if ( window.history.length > 1 ) {
+				window.history.back();
+			} else {
+				window.location.href = state.adminUrl + 'edit.php';
+			}
+		},
+
+		openEditor() {
+			if ( state.editorUrl ) {
+				window.location.href = state.editorUrl;
+			}
+		},
+
+		handleUnsupportedKeyDown( event ) {
+			if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				const { actions } = store( 'wpcom-write' );
+				actions.goBack();
+				return;
+			}
+
+			// Trap Tab within the modal.
+			if ( event.key === 'Tab' ) {
+				const modal = document.querySelector( '.bw-unsupported-modal' );
+				if ( ! modal ) return;
+				const focusable = modal.querySelectorAll( 'button:not([hidden])' );
+				if ( ! focusable.length ) return;
+				const first = focusable[ 0 ];
+				const last = focusable[ focusable.length - 1 ];
+				const active = modal.ownerDocument.activeElement;
+				if ( event.shiftKey && active === first ) {
+					event.preventDefault();
+					last.focus();
+				} else if ( ! event.shiftKey && active === last ) {
+					event.preventDefault();
+					first.focus();
+				}
+			}
 		},
 	},
 } );
@@ -3707,6 +3761,14 @@ const autosaveReady = setInterval( () => {
 	updateSavedSnapshot();
 	// Seed the undo history with the initial content so Cmd+Z can return to it.
 	pushToUndoHistory();
+
+	// Focus the unsupported-content warning modal when present on load.
+	if ( state.unsupportedWarning ) {
+		requestAnimationFrame( () => {
+			const btn = document.querySelector( '.bw-unsupported-open-editor:not([hidden])' );
+			if ( btn ) btn.focus();
+		} );
+	}
 
 	// Start the periodic autosave timer.
 	const { actions } = store( 'wpcom-write' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -530,21 +530,6 @@ function normalizeColorMarkup( container ) {
 	} );
 }
 
-/*
- * Block JSON attributes that convertToBlocks() outputs per block type.
- * wpcom_write_allowed_block_attrs() in write.php must list at least these;
- * a sync test verifies both sides match.  Update both when adding attribute
- * support.
- *
- * @write-sync paragraph: align
- * @write-sync heading: level, align
- * @write-sync image:
- * @write-sync embed: url, type, providerNameSlug, responsive
- * @write-sync quote: align
- * @write-sync list: ordered
- * @write-sync list-item:
- * @write-sync separator:
- */
 /**
  * Convert contentEditable HTML into WordPress block markup.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -530,6 +530,21 @@ function normalizeColorMarkup( container ) {
 	} );
 }
 
+/*
+ * Block JSON attributes that convertToBlocks() outputs per block type.
+ * wpcom_write_allowed_block_attrs() in write.php must list at least these;
+ * a sync test verifies both sides match.  Update both when adding attribute
+ * support.
+ *
+ * @write-sync paragraph: align
+ * @write-sync heading: level, align
+ * @write-sync image:
+ * @write-sync embed: url, type, providerNameSlug, responsive
+ * @write-sync quote: align
+ * @write-sync list: ordered
+ * @write-sync list-item:
+ * @write-sync separator:
+ */
 /**
  * Convert contentEditable HTML into WordPress block markup.
  *
@@ -1998,6 +2013,15 @@ const { state } = store( 'wpcom-write', {
 		},
 		get isBlockEditorWarning() {
 			return state.unsupportedWarning === 'block-editor';
+		},
+		get unsupportedDescId() {
+			if ( state.unsupportedWarning === 'classic-editor' ) {
+				return 'bw-unsupported-desc-classic';
+			}
+			if ( state.unsupportedWarning === 'block-editor' ) {
+				return 'bw-unsupported-desc-block';
+			}
+			return '';
 		},
 	},
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3520,7 +3520,9 @@ const { state } = store( 'wpcom-write', {
 
 		// --- Unsupported content warning ---
 		goBack() {
-			if ( window.history.length > 1 ) {
+			const sameOrigin =
+				document.referrer && new URL( document.referrer ).origin === window.location.origin;
+			if ( sameOrigin && window.history.length > 1 ) {
 				window.history.back();
 			} else {
 				window.location.href = state.adminUrl + 'edit.php';
@@ -3773,8 +3775,10 @@ const autosaveReady = setInterval( () => {
 	// Seed the undo history with the initial content so Cmd+Z can return to it.
 	pushToUndoHistory();
 
-	// Focus the unsupported-content warning modal when present on load.
+	// Focus the unsupported-content warning modal when present on load
+	// and prevent background scrolling while the overlay is visible.
 	if ( state.unsupportedWarning ) {
+		document.body.style.overflow = 'hidden';
 		requestAnimationFrame( () => {
 			const btn = document.querySelector( '.bw-unsupported-open-editor:not([hidden])' );
 			if ( btn ) btn.focus();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -571,9 +571,11 @@ function convertToBlocks( html ) {
 		// Check for text alignment.
 		const align = node.style && node.style.textAlign;
 		const alignAttr =
-			align && [ 'center', 'right' ].includes( align ) ? ` style="text-align:${ align }"` : '';
+			align && [ 'left', 'center', 'right' ].includes( align )
+				? ` style="text-align:${ align }"`
+				: '';
 		const alignJson =
-			align && [ 'center', 'right' ].includes( align ) ? `,"align":"${ align }"` : '';
+			align && [ 'left', 'center', 'right' ].includes( align ) ? `,"align":"${ align }"` : '';
 
 		if ( tag === 'p' || tag === 'div' ) {
 			blocks.push(

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1994,7 +1994,7 @@ const { state } = store( 'wpcom-write', {
 			return state.message || state.headerLabel;
 		},
 		get isClassicWarning() {
-			return state.unsupportedWarning === 'classic';
+			return state.unsupportedWarning === 'classic-editor';
 		},
 		get isBlockEditorWarning() {
 			return state.unsupportedWarning === 'block-editor';

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -300,12 +300,14 @@ function wpcom_write_detect_unsupported_content( $content ) {
 	// editor.  Match only inside class attributes to avoid false positives
 	// from plain text mentioning these class names.
 	//
-	// - has-text-align-*: block editor alignment (Write uses inline styles
-	// instead, which convertToBlocks reads via node.style.textAlign).
+	// Note: has-text-align-* is NOT checked here — those classes are
+	// converted to inline styles on load (see wpcom_write_alignment_classes_to_inline)
+	// so convertToBlocks() can read them via node.style.textAlign.
+	//
 	// - has-inline-color / has-text-color: rich-text color classes.
 	if (
-		preg_match( '/class="[^"]*has-(?:text-align-|inline-color|text-color)[^"]*"/', $content ) ||
-		preg_match( "/class='[^']*has-(?:text-align-|inline-color|text-color)[^']*'/", $content )
+		preg_match( '/class="[^"]*has-(?:inline-color|text-color)[^"]*"/', $content ) ||
+		preg_match( "/class='[^']*has-(?:inline-color|text-color)[^']*'/", $content )
 	) {
 		return 'block-editor';
 	}
@@ -340,6 +342,23 @@ function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
 
 		// Attributes beyond what Write handles for this block type.
 		$attrs = $block['attrs'] ?? array();
+
+		// The block editor stores alignment in two ways:
+		// 1. Top-level: {"align":"center"}
+		// 2. Nested style: {"style":{"typography":{"textAlign":"center"}}}
+		// Both are converted to inline styles on load, so they round-trip.
+		// Strip the style attr if it only contains typography.textAlign
+		// with a supported value, so it doesn't trigger the extra-attrs check.
+		$style_align = $attrs['style']['typography']['textAlign'] ?? '';
+		if (
+			isset( $attrs['style'] ) &&
+			$style_align &&
+			in_array( $style_align, array( 'left', 'center', 'right' ), true ) &&
+			array( 'typography' => array( 'textAlign' => $style_align ) ) === $attrs['style']
+		) {
+			unset( $attrs['style'] );
+		}
+
 		$extra = array_diff( array_keys( $attrs ), $allowed_attrs[ $name ] );
 		if ( ! empty( $extra ) ) {
 			return true;
@@ -371,6 +390,40 @@ function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
 	}
 
 	return false;
+}
+
+/**
+ * Convert block-editor alignment CSS classes to inline styles.
+ *
+ * The block editor uses `has-text-align-{left,center,right}` classes for
+ * alignment, but Write's convertToBlocks() reads alignment from
+ * node.style.textAlign.  This converts the classes to inline styles so
+ * alignment round-trips through Write.
+ *
+ * @param string $html Rendered HTML content.
+ * @return string HTML with alignment classes replaced by inline styles.
+ */
+function wpcom_write_alignment_classes_to_inline( $html ) {
+	return preg_replace_callback(
+		'/(<(?:p|h[1-6]|blockquote)\b[^>]*?)class="([^"]*has-text-align-(left|center|right)[^"]*)"([^>]*?>)/',
+		function ( $m ) {
+			$before  = $m[1];
+			$classes = $m[2];
+			$align   = $m[3];
+			$after   = $m[4];
+
+			// Remove the has-text-align-* class.
+			$classes = trim( preg_replace( '/\bhas-text-align-(?:left|center|right)\b/', '', $classes ) );
+			$classes = preg_replace( '/  +/', ' ', $classes );
+
+			// Build the new tag with inline style.
+			$class_attr = $classes ? 'class="' . $classes . '" ' : '';
+			$style      = 'style="text-align:' . $align . '"';
+
+			return $before . $class_attr . $style . $after;
+		},
+		$html
+	);
 }
 
 /**
@@ -772,6 +825,9 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			>
 			<?php
 			if ( $edit_content ) {
+				// Convert block-editor alignment classes to inline styles so
+				// convertToBlocks() can read them via node.style.textAlign.
+				$edit_content = wpcom_write_alignment_classes_to_inline( $edit_content );
 				// Sanitize through wp_kses_post — video embed tokens (HTML comments)
 				// pass through untouched, then we swap them for the real iframe HTML.
 				// This avoids the pre_kses filter that converts iframes to shortcodes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -347,8 +347,9 @@ function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
 
 		// Alignment: convertToBlocks() only preserves center and right
 		// (read from style.textAlign). Block-level values like wide/full
-		// are CSS-class-based and silently lost.
-		if ( isset( $attrs['align'] ) && ! in_array( $attrs['align'], array( 'center', 'right' ), true ) ) {
+		// are CSS-class-based and silently lost. Left is the default and
+		// renders identically to no alignment, so allow it too.
+		if ( isset( $attrs['align'] ) && ! in_array( $attrs['align'], array( 'left', 'center', 'right' ), true ) ) {
 			return true;
 		}
 
@@ -544,7 +545,7 @@ function wpcom_write_render_admin_page() {
 			'formatUList'         => false,
 			'insideList'          => false,
 			'showRecoveryBanner'  => false,
-			'unsupportedWarning'  => $unsupported_type ? $unsupported_type : false,
+			'unsupportedWarning'  => $unsupported_type,
 			'editorUrl'           => $editor_url,
 		)
 	);
@@ -694,7 +695,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 
 	<!-- Writing area -->
 	<main class="bw-main" data-wp-on--click="actions.handleMainClick">
-		<div class="bw-editor">
+		<div class="bw-editor" data-wp-bind--inert="state.unsupportedWarning">
 
 			<?php if ( $show_cat_row ) : ?>
 			<!-- Category selector — only shown when site has 2+ used categories -->

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -416,11 +416,18 @@ function wpcom_write_alignment_classes_to_inline( $html ) {
 			$classes = trim( preg_replace( '/\bhas-text-align-(?:left|center|right)\b/', '', $classes ) );
 			$classes = preg_replace( '/  +/', ' ', $classes );
 
-			// Build the new tag with inline style.
-			$class_attr = $classes ? 'class="' . $classes . '" ' : '';
-			$style      = 'style="text-align:' . $align . '"';
+			// Build the new tag, merging alignment into any existing style
+			// attribute to avoid producing invalid duplicate style attrs.
+			$class_attr = $classes ? ' class="' . $classes . '"' : '';
+			$tag        = rtrim( $before ) . $class_attr . $after;
 
-			return $before . $class_attr . $style . $after;
+			if ( preg_match( '/style="[^"]*"/', $tag ) ) {
+				$tag = preg_replace( '/style="/', 'style="text-align:' . $align . ';', $tag, 1 );
+			} else {
+				$tag = preg_replace( '/>$/', ' style="text-align:' . $align . '">', $tag );
+			}
+
+			return $tag;
 		},
 		$html
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -254,7 +254,7 @@ function wpcom_write_convert_video_embeds( $content ) {
  * they pass the allowlist check cleanly (no false warning).
  *
  * @param string $content Raw post_content (block markup).
- * @return string|false 'classic' or 'block-editor' indicating the warning
+ * @return string|false 'classic-editor' or 'block-editor' indicating the warning
  *                      type, or false when no warning is needed.
  */
 function wpcom_write_detect_unsupported_content( $content ) {
@@ -263,7 +263,7 @@ function wpcom_write_detect_unsupported_content( $content ) {
 	}
 
 	if ( ! has_blocks( $content ) ) {
-		return 'classic';
+		return 'classic-editor';
 	}
 
 	// --- Block content: allowlist check ---
@@ -369,7 +369,7 @@ function wpcom_write_render_admin_page() {
 		}
 	}
 
-	if ( 'classic' === $unsupported_type ) {
+	if ( 'classic-editor' === $unsupported_type ) {
 		$editor_url = admin_url( 'post.php?post=' . $edit_post_id . '&action=edit&classic-editor' );
 	} elseif ( 'block-editor' === $unsupported_type ) {
 		$editor_url = admin_url( 'post.php?post=' . $edit_post_id . '&action=edit&classic-editor__forget' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -247,10 +247,8 @@ function wpcom_write_convert_video_embeds( $content ) {
  *
  * Attributes listed here are safe for Write to handle — either preserved by
  * convertToBlocks() in view.js or metadata that doesn't affect visible
- * content.  Keep this in sync with convertToBlocks().
- *
- * A sync test (test_allowed_block_types_in_sync_with_convert_to_blocks)
- * verifies that the block types here match what convertToBlocks() outputs.
+ * content.  Keep this in sync with convertToBlocks(); a PHPUnit test
+ * cross-checks that both sides list the same block types.
  *
  * @return array<string, string[]> Block type → allowed attribute keys.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -243,6 +243,96 @@ function wpcom_write_convert_video_embeds( $content ) {
 }
 
 /**
+ * Detect whether a post contains features the Write editor cannot preserve.
+ *
+ * Checks for block comments in the content:
+ *  - No block comments → classic content; saving converts to blocks.
+ *  - Has block comments → allowlist check on block types, embed providers,
+ *    and styling attributes.
+ *
+ * Write-created posts produce block markup with only supported blocks, so
+ * they pass the allowlist check cleanly (no false warning).
+ *
+ * @param string $content Raw post_content (block markup).
+ * @return string|false 'classic' or 'block-editor' indicating the warning
+ *                      type, or false when no warning is needed.
+ */
+function wpcom_write_detect_unsupported_content( $content ) {
+	if ( empty( $content ) ) {
+		return false;
+	}
+
+	if ( ! has_blocks( $content ) ) {
+		return 'classic';
+	}
+
+	// --- Block content: allowlist check ---
+	// Applies to posts from the block editor OR the Write editor (both
+	// produce block markup).  Write-created posts use only supported
+	// blocks, so they pass cleanly.
+
+	// Block types that convertToBlocks() can round-trip.
+	$supported_types = array(
+		'paragraph',
+		'heading',
+		'image',
+		'embed',
+		'quote',
+		'list',
+		'list-item',
+		'separator',
+	);
+
+	// 1. Unsupported block types.
+	if ( preg_match_all( '/<!-- wp:(?:[a-z0-9-]+\/)?([a-z0-9-]+)/', $content, $matches ) ) {
+		foreach ( $matches[1] as $type ) {
+			if ( ! in_array( $type, $supported_types, true ) ) {
+				return 'block-editor';
+			}
+		}
+	}
+
+	// 2. Embed blocks: only YouTube and Vimeo video embeds round-trip.
+	if ( preg_match_all( '/<!-- wp:embed\s+(\{[^>]+?\})\s+-->/s', $content, $embed_matches ) ) {
+		foreach ( $embed_matches[1] as $json ) {
+			$attrs = json_decode( $json, true );
+			if ( ! is_array( $attrs ) ) {
+				return 'block-editor';
+			}
+			$type     = $attrs['type'] ?? '';
+			$provider = $attrs['providerNameSlug'] ?? '';
+			if ( 'video' !== $type || ! in_array( $provider, array( 'youtube', 'vimeo' ), true ) ) {
+				return 'block-editor';
+			}
+		}
+	}
+
+	// 3. Styling attributes in block JSON that Write strips on save.
+	$style_indicators = array(
+		'"textColor"',
+		'"backgroundColor"',
+		'"gradient"',
+		'"fontSize"',
+		'"style":{"color"',
+		'"style":{"typography"',
+		'"style":{"spacing"',
+		'"style":{"border"',
+	);
+	foreach ( $style_indicators as $indicator ) {
+		if ( strpos( $content, $indicator ) !== false ) {
+			return 'block-editor';
+		}
+	}
+
+	// 4. Inline color classes from the block editor's rich-text color picker.
+	if ( strpos( $content, 'has-inline-color' ) !== false || strpos( $content, 'has-text-color' ) !== false ) {
+		return 'block-editor';
+	}
+
+	return false;
+}
+
+/**
  * Render the Write admin page.
  *
  * Called by add_submenu_page as the page callback. Runs inside wp-admin's
@@ -258,6 +348,7 @@ function wpcom_write_render_admin_page() {
 	$post_status        = 'new';
 	$edit_featured_id   = 0;
 	$video_placeholders = array();
+	$unsupported_type   = false;
 
 	if ( $edit_post_id ) {
 		$edit_post = get_post( $edit_post_id );
@@ -272,9 +363,18 @@ function wpcom_write_render_admin_page() {
 			$video_placeholders = $video_result['placeholders'];
 			$post_status        = $edit_post->post_status;
 			$edit_featured_id   = (int) get_post_thumbnail_id( $edit_post_id );
+			$unsupported_type   = wpcom_write_detect_unsupported_content( $edit_post->post_content );
 		} else {
 			$edit_post_id = 0;
 		}
+	}
+
+	if ( 'classic' === $unsupported_type ) {
+		$editor_url = admin_url( 'post.php?post=' . $edit_post_id . '&action=edit&classic-editor' );
+	} elseif ( 'block-editor' === $unsupported_type ) {
+		$editor_url = admin_url( 'post.php?post=' . $edit_post_id . '&action=edit&classic-editor__forget' );
+	} else {
+		$editor_url = '';
 	}
 
 	// Determine how the user arrived at the Write editor.
@@ -404,6 +504,8 @@ function wpcom_write_render_admin_page() {
 			'formatUList'         => false,
 			'insideList'          => false,
 			'showRecoveryBanner'  => false,
+			'unsupportedWarning'  => $unsupported_type ? $unsupported_type : false,
+			'editorUrl'           => $editor_url,
 		)
 	);
 
@@ -686,6 +788,20 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				<button class="bw-leave-cancel" data-wp-on--click="actions.cancelLeave"><?php echo esc_html__( 'Cancel', 'jetpack-mu-wpcom' ); ?></button>
 				<button class="bw-leave-confirm" data-wp-on--click="actions.confirmLeave"><?php echo esc_html__( "Don't save", 'jetpack-mu-wpcom' ); ?></button>
 				<button class="bw-leave-save" data-wp-on--click="actions.saveAndLeave"><?php echo esc_html__( 'Save', 'jetpack-mu-wpcom' ); ?></button>
+			</div>
+		</div>
+	</div>
+
+	<!-- Unsupported content warning -->
+	<div class="bw-unsupported-overlay" hidden data-wp-bind--hidden="!state.unsupportedWarning" data-wp-on--keydown="actions.handleUnsupportedKeyDown">
+		<div class="bw-unsupported-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Unsupported formatting', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.stopPropagation">
+			<p class="bw-unsupported-title"><?php echo esc_html__( 'This post has formatting that Write can\'t preserve', 'jetpack-mu-wpcom' ); ?></p>
+			<p class="bw-unsupported-desc" hidden data-wp-bind--hidden="!state.isClassicWarning"><?php echo esc_html__( 'This post was created in the classic editor. Editing in Write would convert it to the block format, which may change some formatting.', 'jetpack-mu-wpcom' ); ?></p>
+			<p class="bw-unsupported-desc" hidden data-wp-bind--hidden="!state.isBlockEditorWarning"><?php echo esc_html__( 'This post uses block editor features that the Write editor doesn\'t support. Editing here could lose some of that formatting.', 'jetpack-mu-wpcom' ); ?></p>
+			<div class="bw-unsupported-actions">
+				<button class="bw-unsupported-back" data-wp-on--click="actions.goBack"><?php echo esc_html__( 'Go back', 'jetpack-mu-wpcom' ); ?></button>
+				<button class="bw-unsupported-open-editor" hidden data-wp-bind--hidden="!state.isClassicWarning" data-wp-on--click="actions.openEditor"><?php echo esc_html__( 'Open in Classic Editor', 'jetpack-mu-wpcom' ); ?></button>
+				<button class="bw-unsupported-open-editor" hidden data-wp-bind--hidden="!state.isBlockEditorWarning" data-wp-on--click="actions.openEditor"><?php echo esc_html__( 'Open in Block Editor', 'jetpack-mu-wpcom' ); ?></button>
 			</div>
 		</div>
 	</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -258,8 +258,10 @@ function wpcom_write_allowed_block_attrs() {
 	return array(
 		'paragraph' => array( 'align' ),
 		'heading'   => array( 'level', 'align' ),
+		// id/sizeSlug: media-library metadata, not visible formatting.
+		// alt: preserved via HTML element, not block JSON.
 		'image'     => array( 'id', 'sizeSlug', 'alt' ),
-		'embed'     => array( 'url', 'type', 'providerNameSlug', 'responsive', 'className', 'allowResponsive' ),
+		'embed'     => array( 'url', 'type', 'providerNameSlug', 'responsive' ),
 		'quote'     => array( 'align' ),
 		'list'      => array( 'ordered' ),
 		'list-item' => array(),

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -243,15 +243,36 @@ function wpcom_write_convert_video_embeds( $content ) {
 }
 
 /**
+ * Return the per-block-type attribute allowlist for Write.
+ *
+ * Attributes listed here are safe for Write to handle — either preserved by
+ * convertToBlocks() in view.js or metadata that doesn't affect visible
+ * content.  Keep this in sync with convertToBlocks().
+ *
+ * A sync test (test_allowed_block_types_in_sync_with_convert_to_blocks)
+ * verifies that the block types here match what convertToBlocks() outputs.
+ *
+ * @return array<string, string[]> Block type → allowed attribute keys.
+ */
+function wpcom_write_allowed_block_attrs() {
+	return array(
+		'paragraph' => array( 'align' ),
+		'heading'   => array( 'level', 'align' ),
+		'image'     => array( 'id', 'sizeSlug', 'alt' ),
+		'embed'     => array( 'url', 'type', 'providerNameSlug', 'responsive', 'className', 'allowResponsive' ),
+		'quote'     => array( 'align' ),
+		'list'      => array( 'ordered' ),
+		'list-item' => array(),
+		'separator' => array(),
+	);
+}
+
+/**
  * Detect whether a post contains features the Write editor cannot preserve.
  *
- * Checks for block comments in the content:
- *  - No block comments → classic content; saving converts to blocks.
- *  - Has block comments → allowlist check on block types, embed providers,
- *    and styling attributes.
- *
- * Write-created posts produce block markup with only supported blocks, so
- * they pass the allowlist check cleanly (no false warning).
+ * Uses parse_blocks() to inspect block types and attributes against an
+ * allowlist derived from what convertToBlocks() in view.js can round-trip.
+ * Any block type or attribute not in the allowlist will trigger a warning.
  *
  * @param string $content Raw post_content (block markup).
  * @return string|false 'classic-editor' or 'block-editor' indicating the warning
@@ -266,67 +287,86 @@ function wpcom_write_detect_unsupported_content( $content ) {
 		return 'classic-editor';
 	}
 
-	// --- Block content: allowlist check ---
-	// Applies to posts from the block editor OR the Write editor (both
-	// produce block markup).  Write-created posts use only supported
-	// blocks, so they pass cleanly.
+	$allowed_attrs = wpcom_write_allowed_block_attrs();
 
-	// Block types that convertToBlocks() can round-trip.
-	$supported_types = array(
-		'paragraph',
-		'heading',
-		'image',
-		'embed',
-		'quote',
-		'list',
-		'list-item',
-		'separator',
-	);
+	$blocks = parse_blocks( $content );
 
-	// 1. Unsupported block types.
-	if ( preg_match_all( '/<!-- wp:(?:[a-z0-9-]+\/)?([a-z0-9-]+)/', $content, $matches ) ) {
-		foreach ( $matches[1] as $type ) {
-			if ( ! in_array( $type, $supported_types, true ) ) {
-				return 'block-editor';
-			}
-		}
+	if ( wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) ) {
+		return 'block-editor';
 	}
 
-	// 2. Embed blocks: only YouTube and Vimeo video embeds round-trip.
-	if ( preg_match_all( '/<!-- wp:embed\s+(\{[^>]+?\})\s+-->/s', $content, $embed_matches ) ) {
-		foreach ( $embed_matches[1] as $json ) {
-			$attrs = json_decode( $json, true );
-			if ( ! is_array( $attrs ) ) {
-				return 'block-editor';
-			}
+	// HTML-level classes that Write can't round-trip.  convertToBlocks()
+	// reconstructs the outer element, losing any classes set by the block
+	// editor.  Match only inside class attributes to avoid false positives
+	// from plain text mentioning these class names.
+	//
+	// - has-text-align-*: block editor alignment (Write uses inline styles
+	// instead, which convertToBlocks reads via node.style.textAlign).
+	// - has-inline-color / has-text-color: rich-text color classes.
+	if (
+		preg_match( '/class="[^"]*has-(?:text-align-|inline-color|text-color)[^"]*"/', $content ) ||
+		preg_match( "/class='[^']*has-(?:text-align-|inline-color|text-color)[^']*'/", $content )
+	) {
+		return 'block-editor';
+	}
+
+	return false;
+}
+
+/**
+ * Check whether any block in the tree has an unsupported type or attributes.
+ *
+ * @param array $blocks        Parsed block array from parse_blocks().
+ * @param array $allowed_attrs Per-block-type allowed attribute keys.
+ * @return bool True if any block is unsupported.
+ */
+function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
+	foreach ( $blocks as $block ) {
+		// Skip freeform HTML / whitespace between blocks.
+		if ( empty( $block['blockName'] ) ) {
+			continue;
+		}
+
+		// Normalize: strip 'core/' namespace prefix.
+		$name = $block['blockName'];
+		if ( strpos( $name, 'core/' ) === 0 ) {
+			$name = substr( $name, 5 );
+		}
+
+		// Unknown block type (including third-party namespaced blocks).
+		if ( ! isset( $allowed_attrs[ $name ] ) ) {
+			return true;
+		}
+
+		// Attributes beyond what Write handles for this block type.
+		$attrs = $block['attrs'] ?? array();
+		$extra = array_diff( array_keys( $attrs ), $allowed_attrs[ $name ] );
+		if ( ! empty( $extra ) ) {
+			return true;
+		}
+
+		// Alignment: convertToBlocks() only preserves center and right
+		// (read from style.textAlign). Block-level values like wide/full
+		// are CSS-class-based and silently lost.
+		if ( isset( $attrs['align'] ) && ! in_array( $attrs['align'], array( 'center', 'right' ), true ) ) {
+			return true;
+		}
+
+		// Embed-specific: only YouTube and Vimeo video embeds round-trip.
+		if ( 'embed' === $name ) {
 			$type     = $attrs['type'] ?? '';
 			$provider = $attrs['providerNameSlug'] ?? '';
 			if ( 'video' !== $type || ! in_array( $provider, array( 'youtube', 'vimeo' ), true ) ) {
-				return 'block-editor';
+				return true;
 			}
 		}
-	}
 
-	// 3. Styling attributes in block JSON that Write strips on save.
-	$style_indicators = array(
-		'"textColor"',
-		'"backgroundColor"',
-		'"gradient"',
-		'"fontSize"',
-		'"style":{"color"',
-		'"style":{"typography"',
-		'"style":{"spacing"',
-		'"style":{"border"',
-	);
-	foreach ( $style_indicators as $indicator ) {
-		if ( strpos( $content, $indicator ) !== false ) {
-			return 'block-editor';
+		// Recurse into inner blocks (e.g. list → list-item).
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			if ( wpcom_write_has_unsupported_blocks( $block['innerBlocks'], $allowed_attrs ) ) {
+				return true;
+			}
 		}
-	}
-
-	// 4. Inline color classes from the block editor's rich-text color picker.
-	if ( strpos( $content, 'has-inline-color' ) !== false || strpos( $content, 'has-text-color' ) !== false ) {
-		return 'block-editor';
 	}
 
 	return false;
@@ -794,10 +834,10 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 
 	<!-- Unsupported content warning -->
 	<div class="bw-unsupported-overlay" hidden data-wp-bind--hidden="!state.unsupportedWarning" data-wp-on--keydown="actions.handleUnsupportedKeyDown">
-		<div class="bw-unsupported-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Unsupported formatting', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.stopPropagation">
+		<div class="bw-unsupported-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Unsupported formatting', 'jetpack-mu-wpcom' ); ?>" data-wp-bind--aria-describedby="state.unsupportedDescId" data-wp-on--click="actions.stopPropagation">
 			<p class="bw-unsupported-title"><?php echo esc_html__( 'This post has formatting that Write can\'t preserve', 'jetpack-mu-wpcom' ); ?></p>
-			<p class="bw-unsupported-desc" hidden data-wp-bind--hidden="!state.isClassicWarning"><?php echo esc_html__( 'This post was created in the classic editor. Editing in Write would convert it to the block format, which may change some formatting.', 'jetpack-mu-wpcom' ); ?></p>
-			<p class="bw-unsupported-desc" hidden data-wp-bind--hidden="!state.isBlockEditorWarning"><?php echo esc_html__( 'This post uses block editor features that the Write editor doesn\'t support. Editing here could lose some of that formatting.', 'jetpack-mu-wpcom' ); ?></p>
+			<p class="bw-unsupported-desc" id="bw-unsupported-desc-classic" hidden data-wp-bind--hidden="!state.isClassicWarning"><?php echo esc_html__( 'This post was created in the classic editor. Editing in Write would convert it to the block format, which may change some formatting.', 'jetpack-mu-wpcom' ); ?></p>
+			<p class="bw-unsupported-desc" id="bw-unsupported-desc-block" hidden data-wp-bind--hidden="!state.isBlockEditorWarning"><?php echo esc_html__( 'This post uses block editor features that the Write editor doesn\'t support. Editing here could lose some of that formatting.', 'jetpack-mu-wpcom' ); ?></p>
 			<div class="bw-unsupported-actions">
 				<button class="bw-unsupported-back" data-wp-on--click="actions.goBack"><?php echo esc_html__( 'Go back', 'jetpack-mu-wpcom' ); ?></button>
 				<button class="bw-unsupported-open-editor" hidden data-wp-bind--hidden="!state.isClassicWarning" data-wp-on--click="actions.openEditor"><?php echo esc_html__( 'Open in Classic Editor', 'jetpack-mu-wpcom' ); ?></button>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -793,11 +793,149 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that plain text mentioning color class names is not treated as unsupported.
+	 */
+	public function test_detect_unsupported_plain_text_class_name_mentions() {
+		$content = '<!-- wp:paragraph --><p>Use has-text-color and has-inline-color classes in your CSS.</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that center-aligned paragraph returns false (preserved by convertToBlocks).
+	 */
+	public function test_detect_unsupported_center_aligned_paragraph() {
+		$content = '<!-- wp:paragraph {"align":"center"} --><p style="text-align:center">Centered</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that block-editor-style center alignment (CSS class) returns 'block-editor'.
+	 * The block editor uses has-text-align-center class, which convertToBlocks()
+	 * can't read (it reads node.style.textAlign, which is empty for class-based alignment).
+	 */
+	public function test_detect_unsupported_block_editor_center_alignment() {
+		$content = '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">Centered</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that wide-aligned heading returns 'block-editor' (not preserved).
+	 */
+	public function test_detect_unsupported_wide_aligned_heading() {
+		$content = '<!-- wp:heading {"level":2,"align":"wide"} --><h2 class="wp-block-heading alignwide">Title</h2><!-- /wp:heading -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a custom className on a paragraph returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_custom_class_name() {
+		$content = '<!-- wp:paragraph {"className":"my-custom-class"} --><p class="my-custom-class">Styled</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a YouTube embed with className (aspect ratio) returns false.
+	 */
+	public function test_detect_unsupported_youtube_embed_with_class_name() {
+		$attrs   = '{"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"}';
+		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that an anchor attribute on a heading returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_anchor_attribute() {
+		$content = '<!-- wp:heading {"level":2,"anchor":"my-section"} --><h2 class="wp-block-heading" id="my-section">Title</h2><!-- /wp:heading -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that an embed block with malformed JSON attributes returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_embed_malformed_json() {
+		$content = '<!-- wp:embed {not-valid-json} --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
 	 * Test that mixed supported and unsupported blocks returns 'block-editor'.
 	 */
 	public function test_detect_unsupported_mixed_content() {
 		$content = '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->'
 			. '<!-- wp:gallery {"ids":[1,2]} --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
 		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	// --- Allowlist sync test ---
+
+	/**
+	 * Verify that the PHP allowlist stays in sync with convertToBlocks() in
+	 * view.js.  The JS function declares its per-block output attributes via
+	 * write-sync tags in a comment block.  This test parses those tags and
+	 * compares against wpcom_write_allowed_block_attrs() in write.php.
+	 *
+	 * If this test fails, update both sides:
+	 *  - write-sync tags in the convertToBlocks() comment (view.js)
+	 *  - wpcom_write_allowed_block_attrs() (write.php)
+	 */
+	public function test_allowed_block_types_in_sync_with_convert_to_blocks() {
+		// Read view.js relative to this test file.
+		// Test: tests/php/features/write/Write_Test.php
+		// JS:   src/features/write/view.js
+		$view_js_path = dirname( __DIR__, 4 ) . '/src/features/write/view.js';
+		$view_js      = file_get_contents( $view_js_path );
+		$this->assertNotEmpty( $view_js, 'Could not read view.js at ' . $view_js_path );
+
+		// Parse @write-sync tags from the convertToBlocks JSDoc.
+		// Format: @write-sync blocktype: attr1, attr2
+		// or:     @write-sync blocktype:       (no attrs)
+		preg_match_all( '/@write-sync\s+([a-z][a-z0-9-]*):\s*(.*)/', $view_js, $matches, PREG_SET_ORDER );
+		$this->assertNotEmpty( $matches, 'No @write-sync tags found in view.js' );
+
+		$js_sync = array();
+		foreach ( $matches as $m ) {
+			$block = $m[1];
+			$attrs = array_filter( array_map( 'trim', explode( ',', $m[2] ) ), 'strlen' );
+			sort( $attrs );
+			$js_sync[ $block ] = $attrs;
+		}
+		ksort( $js_sync );
+
+		// Get the PHP allowlist.  The PHP list may include extra metadata
+		// attrs (id, sizeSlug, alt, className, allowResponsive) that JS
+		// doesn't output but are safe to lose.  The JS attrs must be a
+		// subset of the PHP attrs for each block type.
+		$php_all = wpcom_write_allowed_block_attrs();
+		ksort( $php_all );
+
+		// Block types must match exactly.
+		$js_types  = array_keys( $js_sync );
+		$php_types = array_keys( $php_all );
+		$this->assertSame(
+			$js_types,
+			$php_types,
+			sprintf(
+				"Block types are out of sync.\n@write-sync: [%s]\nPHP:         [%s]",
+				implode( ', ', $js_types ),
+				implode( ', ', $php_types )
+			)
+		);
+
+		// For each block, every JS-declared attr must appear in the PHP list.
+		foreach ( $js_sync as $block => $js_attrs ) {
+			$php_attrs = $php_all[ $block ];
+			$missing   = array_diff( $js_attrs, $php_attrs );
+			$this->assertEmpty(
+				$missing,
+				sprintf(
+					"Block '%s': @write-sync declares attrs [%s] missing from PHP allowlist [%s].",
+					$block,
+					implode( ', ', $missing ),
+					implode( ', ', $php_attrs )
+				)
+			);
+		}
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -869,78 +869,77 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
 	}
 
-	// --- Allowlist sync test ---
+	// --- JS / PHP allowlist sync ---
 
 	/**
 	 * Verify that the PHP allowlist stays in sync with convertToBlocks() in
-	 * view.js.  The JS function declares its per-block output attributes via
-	 * write-sync tags in a comment block.  This test parses those tags and
-	 * compares against wpcom_write_allowed_block_attrs() in write.php.
+	 * view.js.
 	 *
-	 * If this test fails, update both sides:
-	 *  - write-sync tags in the convertToBlocks() comment (view.js)
-	 *  - wpcom_write_allowed_block_attrs() (write.php)
+	 * Block types are extracted directly from the `<!-- wp:type -->` comment
+	 * literals that convertToBlocks() emits, so no manual annotations are
+	 * needed for that axis.
+	 *
+	 * Attribute-level sync uses a hardcoded map of what convertToBlocks()
+	 * outputs per block type.  When you add attribute support in view.js,
+	 * update both wpcom_write_allowed_block_attrs() in write.php and
+	 * $js_attrs below.
 	 */
 	public function test_allowed_block_types_in_sync_with_convert_to_blocks() {
-		// Read view.js relative to this test file.
-		// Test: tests/php/features/write/Write_Test.php
-		// JS:   src/features/write/view.js
+		// -- Block-type sync (automatic from JS source) --
+
 		$view_js_path = dirname( __DIR__, 4 ) . '/src/features/write/view.js';
 		$view_js      = file_get_contents( $view_js_path );
 		$this->assertNotEmpty( $view_js, 'Could not read view.js at ' . $view_js_path );
 
-		// Extract only the comment block directly above convertToBlocks()
-		// so write-sync tags elsewhere in the file don't affect this test.
-		$fn_pos = strpos( $view_js, 'function convertToBlocks(' );
-		$this->assertNotFalse( $fn_pos, 'convertToBlocks() not found in view.js' );
-		$region = substr( $view_js, max( 0, $fn_pos - 2000 ), 2000 );
+		$fn_start = strpos( $view_js, 'function convertToBlocks(' );
+		$this->assertNotFalse( $fn_start, 'convertToBlocks() not found in view.js' );
+		$fn_body = substr( $view_js, $fn_start, 6000 );
 
-		// Parse write-sync tags from that region.
-		// Format: @write-sync blocktype: attr1, attr2
-		// or:     @write-sync blocktype:       (no attrs)
-		preg_match_all( '/@write-sync\s+([a-z][a-z0-9-]*):\s*(.*)/', $region, $matches, PREG_SET_ORDER );
-		$this->assertNotEmpty( $matches, 'No @write-sync tags found near convertToBlocks() in view.js' );
+		// Match opening block comments only (negative lookbehind skips closing <!-- /wp:... -->).
+		preg_match_all( '/<!-- (?!\/)wp:([a-z][a-z0-9-]*)/', $fn_body, $matches );
+		$js_types = array_values( array_unique( $matches[1] ) );
+		sort( $js_types );
+		$this->assertNotEmpty( $js_types, 'No block types found in convertToBlocks()' );
 
-		$js_sync = array();
-		foreach ( $matches as $m ) {
-			$block = $m[1];
-			$attrs = array_filter( array_map( 'trim', explode( ',', $m[2] ) ), 'strlen' );
-			sort( $attrs );
-			$js_sync[ $block ] = $attrs;
-		}
-		ksort( $js_sync );
-
-		// Get the PHP allowlist.  The PHP list may include extra metadata
-		// attrs (id, sizeSlug, alt, className, allowResponsive) that JS
-		// doesn't output but are safe to lose.  The JS attrs must be a
-		// subset of the PHP attrs for each block type.
-		$php_all = wpcom_write_allowed_block_attrs();
-		ksort( $php_all );
-
-		// Block types must match exactly.
-		$js_types  = array_keys( $js_sync );
+		$php_all   = wpcom_write_allowed_block_attrs();
 		$php_types = array_keys( $php_all );
+		sort( $php_types );
+
 		$this->assertSame(
 			$js_types,
 			$php_types,
 			sprintf(
-				"Block types are out of sync.\n@write-sync: [%s]\nPHP:         [%s]",
+				"Block types are out of sync.\nJS (view.js):  [%s]\nPHP (write.php): [%s]",
 				implode( ', ', $js_types ),
 				implode( ', ', $php_types )
 			)
 		);
 
-		// For each block, every JS-declared attr must appear in the PHP list.
-		foreach ( $js_sync as $block => $js_attrs ) {
-			$php_attrs = $php_all[ $block ];
-			$missing   = array_diff( $js_attrs, $php_attrs );
+		// -- Attribute-level sync (hardcoded JS expectations) --
+		// These are the attributes convertToBlocks() actually writes into
+		// block JSON.  Every one must appear in the PHP allowlist.
+
+		$js_attrs = array(
+			'embed'     => array( 'providerNameSlug', 'responsive', 'type', 'url' ),
+			'heading'   => array( 'align', 'level' ),
+			'image'     => array(),
+			'list'      => array( 'ordered' ),
+			'list-item' => array(),
+			'paragraph' => array( 'align' ),
+			'quote'     => array( 'align' ),
+			'separator' => array(),
+		);
+
+		foreach ( $js_attrs as $block => $expected ) {
+			$this->assertArrayHasKey( $block, $php_all, "Block '$block' missing from PHP allowlist." );
+			$missing = array_diff( $expected, $php_all[ $block ] );
 			$this->assertEmpty(
 				$missing,
 				sprintf(
-					"Block '%s': @write-sync declares attrs [%s] missing from PHP allowlist [%s].",
+					"Block '%s': JS outputs attrs [%s] missing from PHP allowlist [%s].",
 					$block,
 					implode( ', ', $missing ),
-					implode( ', ', $php_attrs )
+					implode( ', ', $php_all[ $block ] )
 				)
 			);
 		}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -835,12 +835,13 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that a YouTube embed with className (aspect ratio) returns false.
+	 * Test that a YouTube embed with className returns 'block-editor'.
+	 * className is not preserved by convertToBlocks() for any block type.
 	 */
 	public function test_detect_unsupported_youtube_embed_with_class_name() {
 		$attrs   = '{"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"}';
 		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
-		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
 	}
 
 	/**
@@ -888,11 +889,17 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$view_js      = file_get_contents( $view_js_path );
 		$this->assertNotEmpty( $view_js, 'Could not read view.js at ' . $view_js_path );
 
-		// Parse @write-sync tags from the convertToBlocks JSDoc.
+		// Extract only the comment block directly above convertToBlocks()
+		// so write-sync tags elsewhere in the file don't affect this test.
+		$fn_pos = strpos( $view_js, 'function convertToBlocks(' );
+		$this->assertNotFalse( $fn_pos, 'convertToBlocks() not found in view.js' );
+		$region = substr( $view_js, max( 0, $fn_pos - 2000 ), 2000 );
+
+		// Parse write-sync tags from that region.
 		// Format: @write-sync blocktype: attr1, attr2
 		// or:     @write-sync blocktype:       (no attrs)
-		preg_match_all( '/@write-sync\s+([a-z][a-z0-9-]*):\s*(.*)/', $view_js, $matches, PREG_SET_ORDER );
-		$this->assertNotEmpty( $matches, 'No @write-sync tags found in view.js' );
+		preg_match_all( '/@write-sync\s+([a-z][a-z0-9-]*):\s*(.*)/', $region, $matches, PREG_SET_ORDER );
+		$this->assertNotEmpty( $matches, 'No @write-sync tags found near convertToBlocks() in view.js' );
 
 		$js_sync = array();
 		foreach ( $matches as $m ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -632,4 +632,172 @@ class Write_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertSame( $original, $result );
 	}
+
+	// --- Unsupported content detection tests ---
+
+	/**
+	 * Test that empty content returns false (safe).
+	 */
+	public function test_detect_unsupported_empty_content() {
+		$this->assertFalse( wpcom_write_detect_unsupported_content( '' ) );
+	}
+
+	/**
+	 * Test that classic editor content (no block markers) returns 'classic-editor'.
+	 */
+	public function test_detect_unsupported_classic_content() {
+		$content = '<p>Hello world</p><p>This is a classic post.</p>';
+		$this->assertSame( 'classic-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that content with only supported blocks returns false.
+	 */
+	public function test_detect_unsupported_supported_blocks_only() {
+		$content = '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->'
+			. '<!-- wp:heading {"level":2} --><h2>Title</h2><!-- /wp:heading -->'
+			. '<!-- wp:separator --><hr class="wp-block-separator"/><!-- /wp:separator -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a supported list with list-items returns false.
+	 */
+	public function test_detect_unsupported_list_blocks() {
+		$content = '<!-- wp:list --><ul><!-- wp:list-item --><li>Item</li><!-- /wp:list-item --></ul><!-- /wp:list -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a supported image block returns false.
+	 */
+	public function test_detect_unsupported_image_block() {
+		$content = '<!-- wp:image {"id":42} --><figure class="wp-block-image"><img src="test.jpg" alt=""/></figure><!-- /wp:image -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a supported quote block returns false.
+	 */
+	public function test_detect_unsupported_quote_block() {
+		$content = '<!-- wp:quote --><blockquote class="wp-block-quote"><p>A quote</p></blockquote><!-- /wp:quote -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a YouTube video embed returns false (supported).
+	 */
+	public function test_detect_unsupported_youtube_embed() {
+		$attrs   = '{"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube"}';
+		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a Vimeo video embed returns false (supported).
+	 */
+	public function test_detect_unsupported_vimeo_embed() {
+		$attrs   = '{"url":"https://vimeo.com/123","type":"video","providerNameSlug":"vimeo"}';
+		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that an unsupported block type returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_gallery_block() {
+		$content = '<!-- wp:gallery {"ids":[1,2]} --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a namespaced unsupported block returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_namespaced_block() {
+		$content = '<!-- wp:core/table --><table></table><!-- /wp:core/table -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a columns block returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_columns_block() {
+		$content = '<!-- wp:columns --><div class="wp-block-columns"><!-- wp:column --><div class="wp-block-column"></div><!-- /wp:column --></div><!-- /wp:columns -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a non-video embed (e.g. Twitter) returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_twitter_embed() {
+		$attrs   = '{"url":"https://twitter.com/example/status/123","type":"rich","providerNameSlug":"twitter"}';
+		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that a non-video YouTube embed (e.g. playlist) returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_youtube_non_video_embed() {
+		$attrs   = '{"url":"https://www.youtube.com/playlist?list=abc","type":"rich","providerNameSlug":"youtube"}';
+		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"></figure><!-- /wp:embed -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that textColor attribute returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_text_color() {
+		$content = '<!-- wp:paragraph {"textColor":"vivid-red"} --><p class="has-vivid-red-color has-text-color">Red text</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that backgroundColor attribute returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_background_color() {
+		$content = '<!-- wp:paragraph {"backgroundColor":"pale-pink"} --><p class="has-pale-pink-background-color">Pink bg</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that fontSize attribute returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_font_size() {
+		$content = '<!-- wp:paragraph {"fontSize":"large"} --><p class="has-large-font-size">Big text</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that inline style typography returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_style_typography() {
+		$content = '<!-- wp:paragraph {"style":{"typography":{"fontSize":"22px"}}} --><p style="font-size:22px">Custom size</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that inline color classes return 'block-editor'.
+	 */
+	public function test_detect_unsupported_inline_color_class() {
+		$content = '<!-- wp:paragraph --><p>Some <span class="has-inline-color has-vivid-red-color">red</span> text</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that has-text-color class returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_has_text_color_class() {
+		$content = '<!-- wp:paragraph --><p class="has-text-color has-vivid-red-color">Colored</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that mixed supported and unsupported blocks returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_mixed_content() {
+		$content = '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->'
+			. '<!-- wp:gallery {"ids":[1,2]} --><figure class="wp-block-gallery"></figure><!-- /wp:gallery -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -819,13 +819,75 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that block-editor-style center alignment (CSS class) returns 'block-editor'.
-	 * The block editor uses has-text-align-center class, which convertToBlocks()
-	 * can't read (it reads node.style.textAlign, which is empty for class-based alignment).
+	 * Test that block-editor-style alignment classes are supported.
+	 * The classes are converted to inline styles on load so convertToBlocks()
+	 * can read them via node.style.textAlign.
 	 */
-	public function test_detect_unsupported_block_editor_center_alignment() {
+	public function test_detect_supported_block_editor_alignment_classes() {
 		$content = '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">Centered</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+
+		$content = '<!-- wp:paragraph {"align":"right"} --><p class="has-text-align-right">Right</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+
+		$content = '<!-- wp:paragraph {"align":"left"} --><p class="has-text-align-left">Left</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that style.typography.textAlign alignment (newer Gutenberg format) is supported.
+	 */
+	public function test_detect_supported_style_typography_text_align() {
+		$content = '<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"}}} --><p class="has-text-align-center">Centered</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+
+		$content = '<!-- wp:paragraph {"style":{"typography":{"textAlign":"right"}}} --><p class="has-text-align-right">Right</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+
+		$content = '<!-- wp:paragraph {"style":{"typography":{"textAlign":"left"}}} --><p class="has-text-align-left">Left</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that style attr with unsupported properties (not just typography.textAlign) is flagged.
+	 */
+	public function test_detect_unsupported_style_with_extra_properties() {
+		// fontSize in style → unsupported.
+		$content = '<!-- wp:paragraph {"style":{"typography":{"textAlign":"center","fontSize":"18px"}}} --><p class="has-text-align-center">Styled</p><!-- /wp:paragraph -->';
 		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+
+		// color in style → unsupported.
+		$content = '<!-- wp:paragraph {"style":{"color":{"text":"#ff0000"}}} --><p>Red</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that alignment classes are converted to inline styles.
+	 */
+	public function test_alignment_classes_to_inline() {
+		$html = '<p class="has-text-align-center wp-block-paragraph">Centered</p>';
+		$this->assertSame(
+			'<p class="wp-block-paragraph" style="text-align:center">Centered</p>',
+			wpcom_write_alignment_classes_to_inline( $html )
+		);
+
+		// Right alignment on a heading.
+		$html = '<h2 class="has-text-align-right wp-block-heading">Right</h2>';
+		$this->assertSame(
+			'<h2 class="wp-block-heading" style="text-align:right">Right</h2>',
+			wpcom_write_alignment_classes_to_inline( $html )
+		);
+
+		// Left alignment — class removed, inline style added.
+		$html = '<p class="has-text-align-left">Left</p>';
+		$this->assertSame(
+			'<p style="text-align:left">Left</p>',
+			wpcom_write_alignment_classes_to_inline( $html )
+		);
+
+		// No alignment class — unchanged.
+		$html = '<p class="wp-block-paragraph">Normal</p>';
+		$this->assertSame( $html, wpcom_write_alignment_classes_to_inline( $html ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -891,6 +891,18 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that alignment conversion merges into an existing style attribute
+	 * instead of producing invalid duplicate style attrs.
+	 */
+	public function test_alignment_classes_to_inline_with_existing_style() {
+		$html = '<p class="has-text-align-center" style="color:red">Centered</p>';
+		$this->assertSame(
+			'<p style="text-align:center;color:red">Centered</p>',
+			wpcom_write_alignment_classes_to_inline( $html )
+		);
+	}
+
+	/**
 	 * Test that wide-aligned heading returns 'block-editor' (not preserved).
 	 */
 	public function test_detect_unsupported_wide_aligned_heading() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -809,6 +809,16 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that left-aligned paragraph returns false. The block editor can
+	 * explicitly set align:left even though it's the default. Left alignment
+	 * renders identically to no alignment, so Write handles it fine.
+	 */
+	public function test_detect_unsupported_left_aligned_paragraph() {
+		$content = '<!-- wp:paragraph {"align":"left"} --><p style="text-align:left">Left</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
 	 * Test that block-editor-style center alignment (CSS class) returns 'block-editor'.
 	 * The block editor uses has-text-align-center class, which convertToBlocks()
 	 * can't read (it reads node.style.textAlign, which is empty for class-based alignment).
@@ -893,6 +903,9 @@ class Write_Test extends \WorDBless\BaseTestCase {
 
 		$fn_start = strpos( $view_js, 'function convertToBlocks(' );
 		$this->assertNotFalse( $fn_start, 'convertToBlocks() not found in view.js' );
+		// Read enough of the function body to capture all block types.
+		// If convertToBlocks() grows past this, the assertion below will
+		// catch missing types. Increase as needed.
 		$fn_body = substr( $view_js, $fn_start, 6000 );
 
 		// Match opening block comments only (negative lookbehind skips closing <!-- /wp:... -->).
@@ -930,8 +943,18 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			'separator' => array(),
 		);
 
+		// PHP-only extras: attributes the block editor adds as metadata
+		// that don't affect visible content.  Write doesn't produce these
+		// but safely ignores them.  Any PHP attr not in $js_attrs and not
+		// listed here is an error — it would let unsupported content through.
+		$php_extras = array(
+			'image' => array( 'alt', 'id', 'sizeSlug' ),
+		);
+
 		foreach ( $js_attrs as $block => $expected ) {
 			$this->assertArrayHasKey( $block, $php_all, "Block '$block' missing from PHP allowlist." );
+
+			// Every JS attr must exist in PHP.
 			$missing = array_diff( $expected, $php_all[ $block ] );
 			$this->assertEmpty(
 				$missing,
@@ -940,6 +963,18 @@ class Write_Test extends \WorDBless\BaseTestCase {
 					$block,
 					implode( ', ', $missing ),
 					implode( ', ', $php_all[ $block ] )
+				)
+			);
+
+			// Every PHP attr must be in JS or in the documented extras.
+			$allowed_extras = $php_extras[ $block ] ?? array();
+			$unexpected     = array_diff( $php_all[ $block ], $expected, $allowed_extras );
+			$this->assertEmpty(
+				$unexpected,
+				sprintf(
+					"Block '%s': PHP allows attrs [%s] not produced by JS and not in \$php_extras.",
+					$block,
+					implode( ', ', $unexpected )
 				)
 			);
 		}


### PR DESCRIPTION
Fixes RSM-2051

## Proposed changes

* Add server-side unsupported-content detection in `wpcom_write_detect_unsupported_content()` for:
  * classic-editor content (no block markers via `has_blocks()`),
  * unsupported block types,
  * unsupported attributes/styling that Write cannot round-trip,
  * unsupported embed types/providers (non-video embeds and non-YouTube/Vimeo).
* Show a non-dismissable warning modal when unsupported content is detected, to prevent editing in Write and avoid silent formatting loss.
* Route users to the appropriate editor from the modal:
  * classic content → Classic Editor (`?classic-editor`)
  * unsupported block-editor content → Block Editor (`?classic-editor__forget`)
* Add navigation safety:
  * Go back uses `history.back()` with fallback to posts list.
  * Escape triggers the same go-back behavior.
  * Tab is trapped within modal actions.
* Prevent automatic writes while blocked:
  * autosave is skipped when unsupported warning is active.
  * editor container is marked `inert` while warning is shown.
* Add derived Interactivity state for conditional rendering/accessibility wiring:
  * `isClassicWarning`, `isBlockEditorWarning`, `unsupportedDescId`.
* Expand/strengthen tests:
  * broad unsupported-content detection coverage in `Write_Test.php`
  * JS/PHP allowlist sync checks (block types + attrs, with explicit PHP-only metadata extras)
  * add coverage for `align:left` as supported behavior.

## Related product discussion/links

* RSM-2051

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Test 1: Unsupported block types

1. Create a post in Block Editor with an unsupported block (for example Gallery, Columns, Table, or any block outside: paragraph, heading, quote, list, separator).
2. Save/publish the post.
3. Open it in Write: `wp-admin/admin.php?page=write&post={ID}`.
4. **Expected:**
   - Warning modal appears with unsupported block-editor messaging.
   - Buttons:
     - **Go back** (`history.back()` or posts list fallback)
     - **Open in Block Editor** → `post.php?post={ID}&action=edit&classic-editor__forget`
   - Modal is non-dismissable by backdrop click.
   - Escape triggers go-back behavior.
   - Tab focus remains trapped in modal action buttons.

### Test 2: Unsupported styling on otherwise supported blocks

1. Create a Block Editor post using supported block types only (for example paragraph).
2. Add unsupported styling via the block editor's formatting controls (text color via the color panel, background color, font size, etc.). Note: inline color applied *within Write* uses a different format and is supported.
3. Open in Write.
4. **Expected:** Same warning modal appears (block-editor warning path).

### Test 3: Classic editor content

1. Create/edit a post in Classic Editor (requires Classic Editor plugin or legacy content without block delimiters).
2. Open in Write.
3. **Expected:**
   - Warning modal appears with classic-editor messaging.
   - **Open in Classic Editor** button goes to: `post.php?post={ID}&action=edit&classic-editor`

### Test 4: Write-safe content

1. Create/open a post that uses only supported blocks and supported attributes.
2. **Expected:** No warning modal. Write editor loads and behaves normally.

### Test 5: New post path

1. Open Write without post ID.
2. **Expected:** No warning modal. Editor loads normally.

### Test 6: Left alignment compatibility

1. Create a paragraph/heading in Block Editor with explicit `align:left`.
2. Open in Write.
3. **Expected:** No unsupported warning solely due to left alignment.

### Test 7: Editor interaction blocked while warning is shown

1. Open a post with unsupported content in Write.
2. **Expected:** The editor content area, toolbar, and title are non-interactive (cannot be focused or typed into) while the modal is showing.

## Follow-ups / known limitations

* **Image and embed blocks created in the block editor are currently flagged as unsupported.** Gutenberg adds auto-generated attributes (`className` with aspect ratio classes on embeds, `linkDestination`/`width`/`height` on images) that are not in the Write allowlist. These need to be evaluated individually — some are safe-to-lose metadata (e.g. embed aspect ratio classes) while others represent intentional user settings (e.g. image link destination, manual resize). A follow-up will expand the allowlist for attributes that are safe to lose and potentially add smarter handling for the rest.
* The JS/PHP sync test currently uses a bounded source scan of `convertToBlocks()` to discover block-type literals. This is an intentional near-term guardrail but can be brittle if function size/shape changes significantly.
* Planned follow-up: move toward a stronger shared sync contract (PHP allowlist exposed to JS + centralized attr builder) to reduce drift risk and remove source-scan fragility.
* Color applied in Write is lost on reload for self-hosted sites (`rgb()` stripped by `wp_kses_post`) — tracked separately.
* Heading toolbar label shows "Normal" for H1/H4-H6 — tracked separately.
* Bold/italic saved as `<b>`/`<i>` instead of `<strong>`/`<em>`, which causes a format flag in the block editor — tracked separately.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>