### PR TITLE
Search: fix 'Show more' button text invisible on hover

### DIFF
--- a/projects/packages/search/changelog/fix-RSM-3090-show-more-hover
+++ b/projects/packages/search/changelog/fix-RSM-3090-show-more-hover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Fix AI Answers "Show more" button text becoming invisible on hover on sites with global button hover styles.

--- a/projects/packages/search/src/instant-search/components/answers-panel.scss
+++ b/projects/packages/search/src/instant-search/components/answers-panel.scss
@@ -162,8 +162,11 @@
 	padding: 9px 0;
 	width: 100%;
 
-	&:hover {
+	&:hover,
+	&:focus,
+	&:active {
 		background: helper.$color-surface-alt;
+		color: helper.$color-link;
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [RSM-3090](https://linear.app/a8c/issue/RSM-3090/hover-over-show-more-button-has-bad-style). The AI Answers "Show more" toggle in the search overlay only specified a hover background, leaving the text color to inherit from the embedding site. On Fieldguide (and any host that has a global `button:hover { color: ... }` rule), the text turns white on a near-white background and becomes invisible.

This change sets `color: \$color-link` explicitly on `:hover`, `:focus`, and `:active`, plus uses a single-class selector with `:hover` (specificity 0,0,2,0) so it beats element-level overrides on the host page.

Working:

<img width="1019" height="343" alt="Screenshot 2026-05-14 at 14 44 33" src="https://github.com/user-attachments/assets/27e9829b-3b8d-4065-8cd7-5fde88fc6d81" />


## Changes

- ``projects/packages/search/src/instant-search/components/answers-panel.scss`` – set toggle button color explicitly on hover/focus/active.
- Changelog entry.

## Test plan

- [ ] On Fieldguide search, hover the "Show more" button below an AI answer — text should stay blue and remain legible.
- [ ] Same check in a stand-alone Jetpack Search overlay where there are no host hover rules — appearance unchanged.
- [ ] Keyboard focus on the button shows legible blue text on the gray-0 background.
