### PR TITLE
VideoPress dashboard modernization: free-tier UX (Notice, disabled Upload, storage meter)

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-modernization-free-tier-ux
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-free-tier-ux
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: added
 
 Comment: Free-tier UX (Notice, disabled Upload, storage meter) for the modernized dashboard. Gated behind rsm_jetpack_ui_modernization_videopress.

--- a/projects/packages/videopress/changelog/update-videopress-modernization-free-tier-ux
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-free-tier-ux
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Free-tier UX (Notice, disabled Upload, storage meter) for the modernized dashboard. Gated behind rsm_jetpack_ui_modernization_videopress.

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -7,4 +7,29 @@ export declare global {
 			apiFetch?: ( options: Record< string, any > ) => Promise< Response >;
 		};
 	}
+
+	const JPVIDEOPRESS_INITIAL_STATE:
+		| undefined
+		| {
+				API: {
+					WP_API_root: string;
+					WP_API_nonce: string;
+				};
+				jetpackStatus: {
+					calypsoSlug: string;
+				};
+				siteData: {
+					id: number | string;
+					title: string;
+					adminUrl: string;
+					slug: string;
+					gmtOffset: number;
+					timezoneString: string;
+					locale: string;
+					hasVideoPressAccess: boolean;
+				};
+				assets: {
+					buildUrl: string;
+				};
+		  };
 }

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,4 +1,5 @@
 import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import { Tooltip } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -8,6 +9,7 @@ import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
 import { buildLibraryActions } from '../../src/dashboard/components/Library/actions';
 import { libraryFields } from '../../src/dashboard/components/Library/fields';
 import { UploadActionsProvider } from '../../src/dashboard/components/Library/upload-actions-context';
+import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
 import { useMockLibrary } from '../../src/dashboard/hooks/use-mock-library';
 import './style.scss';
 import type { LibraryItemPrivacy, MockLibraryItem } from '../../src/dashboard/types/library';
@@ -44,6 +46,7 @@ const defaultLayouts = {
 const Stage = () => {
 	const { items, isLoading, startUpload, promoteLocal, retryUpload, deleteItems, setPrivacy } =
 		useMockLibrary();
+	const { isAtLimit } = useFreeTier();
 
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ selection, setSelection ] = useState< string[] >( [] );
@@ -62,8 +65,11 @@ const Stage = () => {
 
 	const filePickerRef = useRef< HTMLInputElement >( null );
 	const onClickHeaderUpload = useCallback( () => {
+		if ( isAtLimit ) {
+			return;
+		}
 		filePickerRef.current?.click();
-	}, [] );
+	}, [ isAtLimit ] );
 	const onFilePicked = useCallback(
 		( event: ChangeEvent< HTMLInputElement > ) => {
 			const file = event.target.files?.[ 0 ];
@@ -196,9 +202,25 @@ const Stage = () => {
 						style={ { display: 'none' } }
 						onChange={ onFilePicked }
 					/>
-					<Button size="compact" onClick={ onClickHeaderUpload }>
-						{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
-					</Button>
+					<Tooltip
+						text={
+							isAtLimit
+								? __(
+										'You’ve reached the free plan’s 1-video limit. Upgrade to upload more.',
+										'jetpack-videopress-pkg'
+								  )
+								: __( 'Upload a new video', 'jetpack-videopress-pkg' )
+						}
+					>
+						<Button
+							className="vp-library__upload-button"
+							size="compact"
+							onClick={ onClickHeaderUpload }
+							aria-disabled={ isAtLimit }
+						>
+							{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
+						</Button>
+					</Tooltip>
 				</>
 			}
 		>

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -3,6 +3,15 @@
 
 .vp-library {
 
+	// `aria-disabled` rather than `disabled` so the button stays in the
+	// focus tree and the `@wordpress/components` Tooltip can fire on
+	// hover and focus. The onClick guard in stage.tsx short-circuits the
+	// file picker when at the free-tier limit.
+	&__upload-button[aria-disabled="true"] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
 	&__viewport {
 		display: flex;
 		flex-direction: column;

--- a/projects/packages/videopress/routes/overview/stage.tsx
+++ b/projects/packages/videopress/routes/overview/stage.tsx
@@ -33,9 +33,9 @@ const Stage = () => {
 		compare,
 		setCompare,
 	} = useMockStats();
-	const { isFree, isAtomic, isUnlimited, uploadCount } = useFreeTier();
+	const { isFree, isAtomic, isUnlimited, videoCount } = useFreeTier();
 
-	const showStorageMeter = ! isFree && uploadCount > 0 && ! isUnlimited && ! isAtomic;
+	const showStorageMeter = ! isFree && videoCount > 0 && ! isUnlimited && ! isAtomic;
 
 	return (
 		<DashboardLayout

--- a/projects/packages/videopress/routes/overview/stage.tsx
+++ b/projects/packages/videopress/routes/overview/stage.tsx
@@ -1,9 +1,12 @@
 import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
 import DateRangeSelector from '../../src/dashboard/components/Overview/date-range-selector';
+import FreeTierNotice from '../../src/dashboard/components/Overview/free-tier-notice';
 import KpiCardsRow from '../../src/dashboard/components/Overview/kpi-cards-row';
 import MostViewedCard from '../../src/dashboard/components/Overview/most-viewed-card';
+import StorageMeterCard from '../../src/dashboard/components/Overview/storage-meter-card';
 import TopByWatchTimeCard from '../../src/dashboard/components/Overview/top-by-watch-time-card';
 import ViewsTrendsCard from '../../src/dashboard/components/Overview/views-trends-card';
+import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
 import { useMockStats } from '../../src/dashboard/hooks/use-mock-stats';
 import './style.scss';
 import type { ActiveMetric } from '../../src/dashboard/types/stats';
@@ -30,6 +33,9 @@ const Stage = () => {
 		compare,
 		setCompare,
 	} = useMockStats();
+	const { isFree, isAtomic, isUnlimited, uploadCount } = useFreeTier();
+
+	const showStorageMeter = ! isFree && uploadCount > 0 && ! isUnlimited && ! isAtomic;
 
 	return (
 		<DashboardLayout
@@ -37,6 +43,7 @@ const Stage = () => {
 			actions={ <DateRangeSelector value={ dateRange } onChange={ setDateRange } /> }
 		>
 			<div className="vp-overview">
+				{ isFree && <FreeTierNotice /> }
 				<KpiCardsRow
 					views={ stats.views }
 					impressions={ stats.impressions }
@@ -58,6 +65,7 @@ const Stage = () => {
 					panelId={ TRENDS_PANEL_ID }
 					activeTabId={ KPI_TAB_IDS[ activeMetric ] }
 				/>
+				{ showStorageMeter && <StorageMeterCard usedBytes={ stats.storageUsedBytes } /> }
 				<div className="vp-overview__row--bottom">
 					<MostViewedCard videos={ stats.topVideos } isLoading={ isLoading } />
 					<TopByWatchTimeCard videos={ stats.topVideosByWatchTime } isLoading={ isLoading } />

--- a/projects/packages/videopress/routes/overview/style.scss
+++ b/projects/packages/videopress/routes/overview/style.scss
@@ -224,4 +224,25 @@
 		font-weight: var(--wpds-typography-font-weight-medium, 499);
 		padding-right: var(--wpds-dimension-padding-lg, 16px);
 	}
+
+	&__storage-meter {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		// `@wordpress/components` `ProgressBar` ships with a fixed default
+		// width and renders narrow inside flex containers. Match the
+		// legacy `VideoStorageMeter` approach of forcing the inner bar
+		// element to fill the strip. Targets `> div` rather than a
+		// `.components-progress-bar` class so we don't couple to a
+		// `__experimentalProgressBar` internal class name.
+		> div {
+			width: 100%;
+		}
+	}
+
+	&__storage-meter-label {
+		font-size: 13px;
+		color: #50575e;
+	}
 }

--- a/projects/packages/videopress/routes/overview/style.scss
+++ b/projects/packages/videopress/routes/overview/style.scss
@@ -233,10 +233,11 @@
 		// `@wordpress/components` `ProgressBar` ships with a fixed default
 		// width and renders narrow inside flex containers. Match the
 		// legacy `VideoStorageMeter` approach of forcing the inner bar
-		// element to fill the strip. Targets `> div` rather than a
-		// `.components-progress-bar` class so we don't couple to a
-		// `__experimentalProgressBar` internal class name.
-		> div {
+		// element to fill the strip. The label is a `<span>`, so the
+		// last direct-child `div` is unambiguously the `ProgressBar`
+		// wrapper — avoids coupling to its internal
+		// `__experimentalProgressBar` class name.
+		> div:last-child {
 			width: 100%;
 		}
 	}

--- a/projects/packages/videopress/src/dashboard/components/Overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Overview/free-tier-notice.tsx
@@ -1,0 +1,48 @@
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
+import type { ReactElement } from 'react';
+
+/**
+ * Build the WPCOM checkout URL for the VideoPress upgrade CTA. The slug
+ * is read from `JPVIDEOPRESS_INITIAL_STATE.jetpackStatus.calypsoSlug`,
+ * set on every initial-state render (`class-initial-state.php`). Falls
+ * back to bare `/checkout/videopress` when the slug isn't available so
+ * the link still works (WPCOM resolves the active site server-side).
+ *
+ * @return Absolute checkout URL.
+ */
+function buildUpgradeUrl(): string {
+	const base = 'https://wordpress.com/checkout';
+	const slug =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+			? JPVIDEOPRESS_INITIAL_STATE?.jetpackStatus?.calypsoSlug
+			: '';
+	return slug ? `${ base }/${ slug }/videopress` : `${ base }/videopress`;
+}
+
+/**
+ * Permanent (non-dismissible) free-plan Notice rendered at the top of
+ * the Overview tab. The `@wordpress/ui` Notice compound API expresses
+ * non-dismissibility by omitting `<Notice.CloseIcon>` rather than via a
+ * boolean prop. Uses `ActionLink` (not `ActionButton`) because the CTA
+ * navigates to WPCOM checkout.
+ *
+ * @return The Notice element.
+ */
+export default function FreeTierNotice(): ReactElement {
+	return (
+		<Notice.Root intent="info">
+			<Notice.Description>
+				{ __(
+					'You’re on the free plan, which allows 1 video upload. Upgrade for more storage and unlimited uploads.',
+					'jetpack-videopress-pkg'
+				) }
+			</Notice.Description>
+			<Notice.Actions>
+				<Notice.ActionLink href={ buildUpgradeUrl() }>
+					{ __( 'Upgrade', 'jetpack-videopress-pkg' ) }
+				</Notice.ActionLink>
+			</Notice.Actions>
+		</Notice.Root>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/Overview/storage-meter-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Overview/storage-meter-card.tsx
@@ -1,0 +1,48 @@
+import { ProgressBar } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { filesize } from 'filesize';
+import type { ReactElement } from 'react';
+
+const TOTAL_BYTES = 1_000_000_000_000; // 1 TB — same as legacy VideoStorageMeter.
+
+type Props = {
+	usedBytes: number;
+};
+
+/**
+ * Storage meter strip rendered below the Overview's trends chart and
+ * above the bottom row. Ported from the legacy `VideoStorageMeter`:
+ * same string, same denominator, same percentage-of-1-TB display. The
+ * caller is responsible for the hide rules (free / atomic / unlimited /
+ * no uploads) — keeping that logic at the call site keeps this
+ * component pure.
+ *
+ * Falls back to a no-op `null` render when `usedBytes` is non-positive,
+ * which gracefully handles the loading state and any future "API
+ * returned 0 bytes" case.
+ *
+ * @param props           - Component props.
+ * @param props.usedBytes - Cumulative bytes used across the site's VideoPress library.
+ * @return The meter strip, or `null` when there's nothing to render.
+ */
+export default function StorageMeterCard( { usedBytes }: Props ): ReactElement | null {
+	if ( usedBytes <= 0 ) {
+		return null;
+	}
+	const progress = usedBytes / TOTAL_BYTES;
+	const progressLabel = `${ ( progress * 100 ).toFixed() }%`;
+	const totalLabel = filesize( TOTAL_BYTES, { base: 10 } );
+	return (
+		<div className="vp-overview__storage-meter">
+			<span className="vp-overview__storage-meter-label">
+				{ sprintf(
+					/* translators: %1$s is the storage percentage, from 0% to 100%, %2$s is the total storage. */
+					__( '%1$s of %2$s of cloud video storage', 'jetpack-videopress-pkg' ),
+					progressLabel,
+					totalLabel
+				) }
+			</span>
+			<ProgressBar value={ Math.min( progress * 100, 100 ) } />
+		</div>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/fixtures/stats.ts
+++ b/projects/packages/videopress/src/dashboard/fixtures/stats.ts
@@ -268,5 +268,9 @@ export function generateMockStats( dateRange: DateRange, granularity: Granularit
 		topVideosByWatchTime: [ ...scaledVideos ].sort(
 			( a, b ) => b.watchTimeSeconds - a.watchTimeSeconds
 		),
+		// ~42% of 1 TB — enough that the meter is visually meaningful and
+		// not so high that it implies the user is at capacity. Storage is
+		// a snapshot, so it does not vary with `dateRange` / `granularity`.
+		storageUsedBytes: 420_000_000_000,
 	};
 }

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -4,7 +4,7 @@ export type FreeTierState = {
 	isFree: boolean;
 	isAtomic: boolean;
 	isUnlimited: boolean;
-	uploadCount: number;
+	videoCount: number;
 	limit: number;
 	isAtLimit: boolean;
 };
@@ -75,14 +75,18 @@ function readHasAccess(): boolean {
 export function useFreeTier(): FreeTierState {
 	const { items } = useMockLibrary();
 	const isFree = FREE_OVERRIDE !== null ? FREE_OVERRIDE : ! readHasAccess();
-	const realUploadCount = items.length;
-	const uploadCount = AT_LIMIT_OVERRIDE === true ? FREE_TIER_UPLOAD_LIMIT : realUploadCount;
-	const isAtLimit = isFree && uploadCount >= FREE_TIER_UPLOAD_LIMIT;
+	// Mock-library items are all "completed", so `items.length` matches
+	// the legacy `uploadedVideoCount` semantics here. The Phase 6/8 swap
+	// must filter the real query result to completed uploads (exclude
+	// in-progress and failed) before assigning to `videoCount`.
+	const realVideoCount = items.length;
+	const videoCount = AT_LIMIT_OVERRIDE === true ? FREE_TIER_UPLOAD_LIMIT : realVideoCount;
+	const isAtLimit = isFree && videoCount >= FREE_TIER_UPLOAD_LIMIT;
 	return {
 		isFree,
 		isAtomic: false,
 		isUnlimited: false,
-		uploadCount,
+		videoCount,
 		limit: FREE_TIER_UPLOAD_LIMIT,
 		isAtLimit,
 	};

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -1,0 +1,89 @@
+import { useMockLibrary } from './use-mock-library';
+
+export type FreeTierState = {
+	isFree: boolean;
+	isAtomic: boolean;
+	isUnlimited: boolean;
+	uploadCount: number;
+	limit: number;
+	isAtLimit: boolean;
+};
+
+const FREE_TIER_UPLOAD_LIMIT = 1;
+
+type Override = boolean | null;
+
+/**
+ * Parse a `?vp_free=…` / `?vp_at_limit=…`-style query param into a
+ * tri-state override: `true` when present and truthy, `false` when
+ * present and falsy, `null` when absent.
+ *
+ * Designer/QA toggles are read once on first call and frozen. They are
+ * deliberately non-reactive because they require a full page reload to
+ * change in practice; this keeps the swap to a TanStack Query hook
+ * (Phase 6/8) a no-op at the call sites.
+ *
+ * @param search - The query string (with or without leading `?`).
+ * @param key    - Param name to read.
+ * @return The override, or `null` when absent.
+ */
+function parseOverride( search: string, key: string ): Override {
+	const params = new URLSearchParams( search );
+	if ( ! params.has( key ) ) {
+		return null;
+	}
+	const raw = params.get( key );
+	if ( raw === null ) {
+		return null;
+	}
+	const normalized = raw.toLowerCase();
+	return ! ( normalized === '0' || normalized === 'false' || normalized === '' );
+}
+
+const SEARCH = typeof window === 'undefined' ? '' : window.location.search;
+const FREE_OVERRIDE: Override = parseOverride( SEARCH, 'vp_free' );
+const AT_LIMIT_OVERRIDE: Override = parseOverride( SEARCH, 'vp_at_limit' );
+
+/**
+ * Read `hasVideoPressAccess` from the inlined initial state. Returns
+ * `false` (i.e., free tier) when the global is missing — matches the
+ * legacy dashboard's behavior of treating unknown plan state as "no
+ * paid access".
+ *
+ * @return Whether the site has a paid VideoPress plan.
+ */
+function readHasAccess(): boolean {
+	if ( typeof JPVIDEOPRESS_INITIAL_STATE === 'undefined' ) {
+		return false;
+	}
+	return Boolean( JPVIDEOPRESS_INITIAL_STATE?.siteData?.hasVideoPressAccess );
+}
+
+/**
+ * Single source of truth for free-tier state across the modernized
+ * VideoPress dashboard. Returns the same shape Phase 6/8 will return
+ * from a TanStack Query hook — call sites swap mock for real with no
+ * structural change.
+ *
+ * The legacy `VideoStorageMeter` hides on Atomic and unlimited plans;
+ * those signals aren't wired through the modernized initial-state
+ * payload yet, so this PR hard-codes them to `false`. Phase 6 replaces
+ * those hard-codes with the corresponding settings/features hooks.
+ *
+ * @return Free-tier state for the page session.
+ */
+export function useFreeTier(): FreeTierState {
+	const { items } = useMockLibrary();
+	const isFree = FREE_OVERRIDE !== null ? FREE_OVERRIDE : ! readHasAccess();
+	const realUploadCount = items.length;
+	const uploadCount = AT_LIMIT_OVERRIDE === true ? FREE_TIER_UPLOAD_LIMIT : realUploadCount;
+	const isAtLimit = isFree && uploadCount >= FREE_TIER_UPLOAD_LIMIT;
+	return {
+		isFree,
+		isAtomic: false,
+		isUnlimited: false,
+		uploadCount,
+		limit: FREE_TIER_UPLOAD_LIMIT,
+		isAtLimit,
+	};
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
@@ -115,8 +115,14 @@ const STORE_KEY = '__jetpackVideopressMockLibrary' as const;
  */
 function getStore(): GlobalStore {
 	if ( ! window[ STORE_KEY ] ) {
+		// `?vp_free=1` is the designer/QA toggle that flips the dashboard
+		// into the free-tier view (see `useFreeTier`). Starting the
+		// library empty under that flag lets the same toggle reach both
+		// "free, can still upload" and (with `?vp_at_limit=1`) "free,
+		// at limit" states without dropping a video by hand.
+		const isFreeToggle = new URLSearchParams( window.location.search ).get( 'vp_free' ) === '1';
 		window[ STORE_KEY ] = {
-			items: generateMockLibrary( 50 ),
+			items: isFreeToggle ? [] : generateMockLibrary( 50 ),
 			isLoading: true,
 			subscribers: new Set(),
 			intervals: new Map(),

--- a/projects/packages/videopress/src/dashboard/types/stats.ts
+++ b/projects/packages/videopress/src/dashboard/types/stats.ts
@@ -37,6 +37,7 @@ export interface OverviewStats {
 	series: StatsSeriesPoint[];
 	topVideos: TopVideo[];
 	topVideosByWatchTime: TopVideo[];
+	storageUsedBytes: number;
 }
 
 export const DATE_RANGE_DAYS: Record< DateRange, number > = {


### PR DESCRIPTION
Part of #48506 (partial — closes the two "Standalone investigations" listed in the tracking issue: "Free-tier UX" and "Storage meter placement")

## Proposed changes

UI-only follow-up to the modernized VideoPress dashboard scaffolding. Fills the three gaps left open by the tracking issue after the designer review:

* **Free-tier Notice on Overview** — permanent (non-dismissible) `@wordpress/ui` `Notice` at the top of the Overview tab when the site is on the free plan: "You're on the free plan, which allows 1 video upload. Upgrade for more storage and unlimited uploads." with an inline Upgrade link.
* **Disabled Upload button + tooltip on Library** — when the free-tier 1-video limit is hit, the "Upload video" button greys out (50 % opacity, `aria-disabled="true"`) and a tooltip on hover/focus reads: "You've reached the free plan's 1-video limit. Upgrade to upload more." When not at the limit, the tooltip reads: "Upload a new video."
* **Storage meter on Overview** — `@wordpress/components` `ProgressBar` below the trends chart (above the bottom row), showing "X% of 1 TB of cloud video storage". Ported from the legacy `VideoStorageMeter` with the same hide rules (Atomic, unlimited plan, no uploads — plus now: free tier, where the Notice plays the equivalent role).

State plumbing lives in one new `useFreeTier()` hook (`src/dashboard/hooks/use-free-tier.ts`), single source of truth across both screens. It reads `JPVIDEOPRESS_INITIAL_STATE.siteData.hasVideoPressAccess` (already wired in Phase 5+7) for the free-tier signal, plus two designer/QA URL toggles (`?vp_free=…`, `?vp_at_limit=…`) so the new states can be reviewed without uploading fixture videos.

This is a UI-only PR with mocked state. Real wiring to backend signals (Atomic / unlimited plan, real `uploadCount` from the videos query, real `storageUsedBytes`) is part of Phase 6/8 — the hook's return shape is what those phases will return, so the swap is a one-file diff.

All work is gated behind the existing `rsm_jetpack_ui_modernization_videopress` filter (default off). No user-visible behavior change.

### Notes for reviewers

* `@wordpress/ui` does not yet ship a `ProgressBar`, so the storage meter falls back to `@wordpress/components` `ProgressBar` — the exact primitive the designer asked for.
* `@wordpress/ui`'s `Tooltip` is Trigger-IS-the-button compound primitive and can't wrap an existing `Button` without the underlying base-ui `render` prop (not exposed in `@wordpress/ui`'s types). The Library uses `@wordpress/components` `Tooltip` (wrapper API) — the established Jetpack pattern for this case.
* The disabled-button uses `aria-disabled` + onClick guard rather than the HTML `disabled` attribute. Standard `<button disabled>` removes the element from the focus tree, breaking the focus-triggered tooltip the designer asked for; `aria-disabled` keeps it focusable while still suppressing the click handler.

### Open follow-ups (deferred from this PR)

* Real `useProductCheckoutWorkflow` integration for the Upgrade CTA — currently a static `wordpress.com/checkout/<slug>/videopress` URL.
* `isAtomic` / `isUnlimited` are hard-coded `false` in the hook; Phase 6 swaps them for real settings/features hook reads.
* `uploadCount` reads `useMockLibrary().items.length`; Phase 6/8 swaps for the TanStack Query hook.

## Related product discussion/links

* Tracking issue: #48506
* Designer feedback that drove this PR: thread on the modernization tracking issue (free-tier UX, storage meter placement, disabled upload behavior).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The modernization filter is default-off. To see the new dashboard, enable `rsm_jetpack_ui_modernization_videopress` on a JN site, then navigate to **Jetpack → VideoPress**.

### Overview tab — four toggle matrix

| URL | Notice | Storage meter |
|---|---|---|
| `/admin.php?page=jetpack-videopress` | hidden (paid) | visible, ~42 % full-width bar |
| `…&vp_free=1` | visible | hidden |
| `…&vp_free=1&vp_at_limit=1` | visible | hidden |
| `…&vp_free=0&vp_at_limit=1` | hidden | visible |

### Library tab — four toggle matrix

| URL | Upload button | Tooltip on hover / focus |
|---|---|---|
| `/admin.php?page=jetpack-videopress` then click **Library** | enabled | "Upload a new video" |
| `…&vp_free=1` then click **Library** | enabled (count 0) | "Upload a new video" |
| `…&vp_free=1&vp_at_limit=1` then click **Library** | **disabled (50 % opacity)** | "You've reached the free plan's 1-video limit. Upgrade to upload more." |
| `…&vp_free=0&vp_at_limit=1` then click **Library** | enabled (override) | "Upload a new video" |

The same `?vp_free=…` / `?vp_at_limit=…` URL toggle affects both screens consistently — flipping into free tier on one tab will also flip the other.

### Cross-cutting

* Tab to the disabled Upload button to confirm the tooltip fires on focus (not just hover).
* On the paid-tier Overview, confirm the ProgressBar fills its container width and shows roughly 42 % filled.

## Status

Draft / In progress — opening this for designer input before pushing further. Please review:

1. The Notice copy and the "Upgrade" CTA label.
2. The placement of the storage meter (currently between trends chart and the Most-viewed / Top-by-watch-time row — chosen because the KPI cards are an ARIA tablist for the trends chart, so inserting anything between them on smaller viewports breaks the visual relationship).
3. The disabled-button tooltip copy.
4. Whether the meter should also appear on the Library tab (currently Overview-only — happy to also surface it on Library if that's the call).
