### PR TITLE
Search dashboard: adopt the unified @wordpress/ui tab pattern

### DIFF
--- a/projects/packages/search/changelog/RSM-3299-match-my-jetpack-tabs
+++ b/projects/packages/search/changelog/RSM-3299-match-my-jetpack-tabs
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Search dashboard: render the tab strip with the canonical `jp-admin-page-tabs` wrapper and `Tabs.List` `variant="minimal"`, matching the other modernized Jetpack admin pages (Podcast, Protect, Scan).

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -164,16 +164,18 @@ export default function DashboardPage( { isLoading = false } ) {
 					handleLocalNoticeDismissClick={ handleLocalNoticeDismissClick }
 				/>
 				<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
-					<Tabs.List>
-						<Tabs.Tab value="plan-usage">{ __( 'Plan & Usage', 'jetpack-search-pkg' ) }</Tabs.Tab>
-						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
-						<Tabs.Tab value="ai-answers">
-							{ __( 'AI Answers', 'jetpack-search-pkg' ) }{ ' ' }
-							<span className="jp-search-dashboard-tabs__tab-preview-label">
-								{ __( '(Preview)', 'jetpack-search-pkg' ) }
-							</span>
-						</Tabs.Tab>
-					</Tabs.List>
+					<div className="jp-admin-page-tabs">
+						<Tabs.List variant="minimal">
+							<Tabs.Tab value="plan-usage">{ __( 'Plan & Usage', 'jetpack-search-pkg' ) }</Tabs.Tab>
+							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
+							<Tabs.Tab value="ai-answers">
+								{ __( 'AI Answers', 'jetpack-search-pkg' ) }{ ' ' }
+								<span className="jp-search-dashboard-tabs__tab-preview-label">
+									{ __( '(Preview)', 'jetpack-search-pkg' ) }
+								</span>
+							</Tabs.Tab>
+						</Tabs.List>
+					</div>
 					<Tabs.Panel value="plan-usage">
 						<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
 							{ /* Always in the DOM so JITM JS finds it immediately (Path A). */ }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -1,6 +1,34 @@
 @use "scss/variables";
 @use "scss/rna-styles";
 
+// Body-scoped to beat the `body.jetpack_page_jetpack-search`-prefixed rules
+// from `@automattic/jetpack-base-styles/admin-page-layout` on specificity.
+body.jetpack_page_jetpack-search .jp-search-dashboard-page {
+
+	// Make `<Tabs.Tab>` actually use its design token. `@wordpress/ui` declares
+	// `font-size: var(--wpds-typography-font-size-md)` inside `@layer
+	// wp-ui-components`, but wp-admin core ships an unlayered
+	// `button { font-size: inherit }` reset that wins over any layered rule —
+	// so the tab silently inherits 16px from its surrounding context instead
+	// of the 13px the token specifies. Re-applying the token from an
+	// unlayered selector lets the design system land as intended (tab text
+	// smaller than the 15px page title — visual hierarchy restored).
+	.jp-admin-page-tabs [role="tab"] {
+		font-size: var(--wpds-typography-font-size-md, 13px);
+	}
+
+	// Align the first tab's content edge with the page header's start.
+	// admin-ui's page header sits at padding-inline 2xl (24px). The shared
+	// `.jp-admin-page-tabs` wrapper adds only 8px (designed for the default
+	// <Tabs.Tab> which ships with padding-inline lg = 16px, so 8 + 16 = 24
+	// matches the header). With `variant="minimal"`, <Tabs.Tab> has 0 inline
+	// padding, so the wrapper has to provide the full 2xl itself to keep
+	// the first tab flush with the header content edge across all widths.
+	.jp-admin-page-tabs {
+		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	}
+}
+
 #jp-search-dashboard {
 	color: variables.$black;
 	font-size: 16px;


### PR DESCRIPTION
Fixes [RSM-3299](https://linear.app/a8c/issue/RSM-3299/search-dashboard-match-tab-styling-to-my-jetpack-page).

## Why

The Search dashboard's tab strip didn't follow the unified `@wordpress/ui` `Tabs` pattern that the rest of the modernized Jetpack admin pages adopt (Podcast, Newsletter, Scan, VideoPress, Protect). Two specific problems were visible:

1. **Tabs read as the loudest element in the header.** `<Tabs.Tab>` from `@wordpress/ui` declares `font-size: var(--wpds-typography-font-size-md)` inside `@layer wp-ui-components`. wp-admin core ships an unlayered `button { font-size: inherit }` reset, and unlayered rules win over layered ones, so the tab text was silently inheriting 16px from its surrounding context instead of the 13px the design token specifies. Result: tab labels were taller than the 15px page title — visual hierarchy inverted.
2. **The first tab wasn't aligned with the page header content edge.** The shared `.jp-admin-page-tabs` wrapper adds only 8px of inline padding, designed to compose with the default `<Tabs.Tab>`'s 16px (8 + 16 = 24px = the admin-ui Page header's 2xl padding). With `variant="minimal"` the per-tab padding is 0, so the first tab started 16px shy of the title's left edge.

## Proposed changes

* Wrap `<Tabs.List variant="minimal">` in `<div className="jp-admin-page-tabs">` — the canonical wrapper from [`@automattic/jetpack-base-styles/admin-page-layout`](../blob/trunk/projects/js-packages/base-styles/admin-page-layout.scss) used by every recently modernized Jetpack admin dashboard. It sticky-pins the strip, applies the `--wpds-*` border + background tokens that match `@wordpress/admin-ui`'s page-header treatment, and now provides 24px of inline padding so the first tab is flush with the header start across all widths.
* Re-apply `--wpds-typography-font-size-md` to `[role="tab"]` from an **unlayered** selector so the design token actually lands. This compensates for wp-admin's `button { font-size: inherit }` reset shadowing the layered `@wordpress/ui` declaration.
* All `var(--wpds-*)` usages carry the token's literal value as a fallback, matching the convention in `@automattic/jetpack-base-styles` and other Jetpack packages.

No changes to `<AdminPage>` props, the page title, or the subtitle — they all keep their canonical token-driven values.

## Screenshots

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/2ebd28ca-ad7c-4669-922e-4830f98435e1) | ![after](https://github.com/user-attachments/assets/ae1355b4-ec2f-41e6-bb5f-49a38e099d61) |

## Related product discussion/links

* Linear: [RSM-3299](https://linear.app/a8c/issue/RSM-3299/search-dashboard-match-tab-styling-to-my-jetpack-page) (Jetpack Search blocks project)
* Design direction: phcsdm-PK-p2 · fBCpFRsWEkIP0rx9AXNIJt-fi-5677_64248
* Same pattern in: Podcast (`projects/packages/podcast/src/dashboard/index.tsx`), Newsletter (`projects/packages/newsletter/_inc/components/newsletter-page.tsx`), Scan, VideoPress, Protect.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jetpack site with Search active, go to **Jetpack → Search** in wp-admin.
2. Open DevTools and verify the design tokens are landing:
   - [ ] Tab text computes to `font-size: 13px` (the value of `--wpds-typography-font-size-md`).
   - [ ] Page title `<h1>` stays at its native `15px` (admin-ui `<Text variant="heading-lg">`).
   - [ ] Tab labels are *smaller* than the title — visual hierarchy is title > tabs.
3. Check alignment:
   - [ ] The first tab's left edge is flush with the Jetpack icon at the page header start (24px from the page-content edge).
   - [ ] Resize the window between mobile (~600px), tablet (~900px), and desktop (1440px+). The alignment holds at every width.
4. Click each tab (Plan & Usage / Settings / AI Answers (Preview)) and confirm:
   - URL `tab=` query param updates (`?tab=plan-usage` / `?tab=settings` / `?tab=ai-answers`).
   - Reloading the page on a given tab keeps that tab selected.
   - Active-tab indicator slides correctly.
5. Scroll the content area and confirm the tab strip stays pinned at the top.