### PR TITLE
Search: accept canonical `search_experience` on plan/activate (SEARCH-191)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-191-activate-plan-search-experience
+++ b/projects/packages/search/changelog/SEARCH-191-activate-plan-search-experience
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST: `POST /jetpack/v4/search/plan/activate` accepts a new `search_experience` parameter (`overlay` | `inline` | `embedded`). When present it routes the activation through `Module_Control::update_experience()` — writing the canonical `jetpack_search_experience` option — so WPCOM can change the default experience without a Jetpack code change. The legacy `enable_search` / `enable_instant_search` parameters keep working as a fallback for older callers.

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -447,7 +447,6 @@ class REST_Controller {
 	public function activate_plan( $request ) {
 		$default_options = array(
 			'search_plan_info'      => null,
-			'enable_search'         => true,
 			'enable_instant_search' => true,
 			'search_experience'     => null,
 			'auto_config_search'    => true,
@@ -455,38 +454,64 @@ class REST_Controller {
 		$payload         = $request->get_json_params();
 		$payload         = wp_parse_args( $payload, $default_options );
 
+		// Validate `search_experience` up front. `update_experience` accepts
+		// `off` as a deactivation signal, but that has its own endpoint —
+		// allowing it here would let a `/plan/activate` call silently turn
+		// Search off. The type guard mirrors `update_settings()` and turns a
+		// non-string payload into a 400 instead of a `TypeError`.
+		if ( $payload['search_experience'] !== null ) {
+			$valid_experiences = array(
+				Module_Control::EXPERIENCE_OVERLAY,
+				Module_Control::EXPERIENCE_INLINE,
+				Module_Control::EXPERIENCE_EMBEDDED,
+			);
+			if ( ! is_string( $payload['search_experience'] )
+				|| ! in_array( $payload['search_experience'], $valid_experiences, true )
+			) {
+				return new WP_Error(
+					'invalid_experience',
+					__( 'Invalid experience value.', 'jetpack-search-pkg' ),
+					array( 'status' => 400 )
+				);
+			}
+			$payload['search_experience'] = sanitize_text_field( $payload['search_experience'] );
+		}
+
 		// Update plan data, plan info is in the request body.
 		// We do this to avoid another call to WPCOM and reduce latency.
 		if ( $payload['search_plan_info'] === null || ! $this->plan->set_plan_options( $payload['search_plan_info'] ) ) {
 			$this->plan->get_plan_info_from_wpcom();
 		}
 
+		// `/plan/activate` always implies the caller wants Search on, so
+		// activation is unconditional. Eligibility (offline mode, connection,
+		// plan support) is enforced inside `activate()`.
+		$ret = $this->search_module->activate();
+		if ( is_wp_error( $ret ) ) {
+			return $ret;
+		}
+
 		if ( $payload['search_experience'] !== null ) {
-			// Canonical path: set the experience directly. `update_experience` handles module
-			// activation and keeps the legacy `instant_search_enabled` boolean in sync.
+			// Canonical path: route through the same setter the in-product UI
+			// uses, so the experience option and legacy boolean stay in sync.
 			$ret = $this->search_module->update_experience( $payload['search_experience'] );
 			if ( is_wp_error( $ret ) ) {
 				return $ret;
 			}
-		} else {
-			// Legacy path for older WPCOM callers that send enable_search / enable_instant_search.
-			if ( false !== $payload['enable_search'] ) {
-				$ret = $this->search_module->activate();
-				if ( is_wp_error( $ret ) ) {
-					return $ret;
-				}
-			}
-
-			if ( false !== $payload['enable_instant_search'] ) {
-				$ret = $this->search_module->enable_instant_search();
-				if ( is_wp_error( $ret ) ) {
-					return $ret;
-				}
+		} elseif ( false !== $payload['enable_instant_search'] ) {
+			// Legacy path: old WPCOM callers send `enable_instant_search`
+			// instead of `search_experience`. Default-true matches the
+			// pre-refactor behavior.
+			$ret = $this->search_module->enable_instant_search();
+			if ( is_wp_error( $ret ) ) {
+				return $ret;
 			}
 		}
 
-		// Automatically configure necessary settings for instant search, unless `auto_config_search` is explicitly set to boolean `false`.
-		if ( false !== $payload['auto_config_search'] ) {
+		// `auto_config_search` wires up Overlay sidebar widgets — only meaningful
+		// when Overlay is the resulting experience. For Inline / Embedded, the
+		// caller would otherwise get widget side effects they didn't ask for.
+		if ( false !== $payload['auto_config_search'] && $this->search_module->is_instant_search_enabled() ) {
 			Instant_Search::instance( $this->get_blog_id() )->auto_config_search();
 		}
 

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -461,12 +461,7 @@ class REST_Controller {
 			$this->plan->get_plan_info_from_wpcom();
 		}
 
-		// Activation is the precondition for the experience handling below —
-		// not a consequence of which payload variant the caller sent — so it
-		// runs first for both canonical and legacy callers. The `enable_search`
-		// flag stays as the single opt-out (defaults to true). Eligibility
-		// (offline mode, connection, plan support) is enforced inside
-		// `activate()`.
+		// Enable search module by default, unless `enable_search` is explicitly set to boolean `false`.
 		if ( false !== $payload['enable_search'] ) {
 			$ret = $this->search_module->activate();
 			if ( is_wp_error( $ret ) ) {

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -447,6 +447,7 @@ class REST_Controller {
 	public function activate_plan( $request ) {
 		$default_options = array(
 			'search_plan_info'      => null,
+			'enable_search'         => true,
 			'enable_instant_search' => true,
 			'search_experience'     => null,
 			'auto_config_search'    => true,
@@ -454,12 +455,29 @@ class REST_Controller {
 		$payload         = $request->get_json_params();
 		$payload         = wp_parse_args( $payload, $default_options );
 
-		// Validate `search_experience` up front. `update_experience` accepts
-		// `off` as a deactivation signal, but that has its own endpoint —
-		// allowing it here would let a `/plan/activate` call silently turn
-		// Search off. The type guard mirrors `update_settings()` and turns a
-		// non-string payload into a 400 instead of a `TypeError`.
+		// Update plan data, plan info is in the request body.
+		// We do this to avoid another call to WPCOM and reduce latency.
+		if ( $payload['search_plan_info'] === null || ! $this->plan->set_plan_options( $payload['search_plan_info'] ) ) {
+			$this->plan->get_plan_info_from_wpcom();
+		}
+
+		// Activation is the precondition for the experience handling below —
+		// not a consequence of which payload variant the caller sent — so it
+		// runs first for both canonical and legacy callers. The `enable_search`
+		// flag stays as the single opt-out (defaults to true). Eligibility
+		// (offline mode, connection, plan support) is enforced inside
+		// `activate()`.
+		if ( false !== $payload['enable_search'] ) {
+			$ret = $this->search_module->activate();
+			if ( is_wp_error( $ret ) ) {
+				return $ret;
+			}
+		}
+
 		if ( $payload['search_experience'] !== null ) {
+			// Canonical path. Restrict to activate-able experiences — `off`
+			// belongs on `/plan/deactivate`, and a non-string payload would
+			// blow up `update_experience(string $experience)`.
 			$valid_experiences = array(
 				Module_Control::EXPERIENCE_OVERLAY,
 				Module_Control::EXPERIENCE_INLINE,
@@ -474,27 +492,7 @@ class REST_Controller {
 					array( 'status' => 400 )
 				);
 			}
-			$payload['search_experience'] = sanitize_text_field( $payload['search_experience'] );
-		}
-
-		// Update plan data, plan info is in the request body.
-		// We do this to avoid another call to WPCOM and reduce latency.
-		if ( $payload['search_plan_info'] === null || ! $this->plan->set_plan_options( $payload['search_plan_info'] ) ) {
-			$this->plan->get_plan_info_from_wpcom();
-		}
-
-		// `/plan/activate` always implies the caller wants Search on, so
-		// activation is unconditional. Eligibility (offline mode, connection,
-		// plan support) is enforced inside `activate()`.
-		$ret = $this->search_module->activate();
-		if ( is_wp_error( $ret ) ) {
-			return $ret;
-		}
-
-		if ( $payload['search_experience'] !== null ) {
-			// Canonical path: route through the same setter the in-product UI
-			// uses, so the experience option and legacy boolean stay in sync.
-			$ret = $this->search_module->update_experience( $payload['search_experience'] );
+			$ret = $this->search_module->update_experience( sanitize_text_field( $payload['search_experience'] ) );
 			if ( is_wp_error( $ret ) ) {
 				return $ret;
 			}

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -491,14 +491,14 @@ class REST_Controller {
 			if ( is_wp_error( $ret ) ) {
 				return $ret;
 			}
-		} elseif ( false !== $payload['enable_instant_search'] ) {
+		}
+
+		if ( false !== $payload['enable_instant_search'] ) {
 			// Legacy path: old WPCOM callers send `enable_instant_search`
 			// instead of `search_experience`. Default-true matches the
 			// pre-refactor behavior.
+			// We intentionally skipped error handling for invalid `enable_instant_search` value since it's legacy option now.
 			$ret = $this->search_module->enable_instant_search();
-			if ( is_wp_error( $ret ) ) {
-				return $ret;
-			}
 		}
 
 		// `auto_config_search` wires up Overlay sidebar widgets — only meaningful

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -493,11 +493,12 @@ class REST_Controller {
 			}
 		}
 
-		if ( false !== $payload['enable_instant_search'] ) {
+		if ( $payload['search_experience'] === null && false !== $payload['enable_instant_search'] ) {
 			// Legacy path: old WPCOM callers send `enable_instant_search`
-			// instead of `search_experience`. Default-true matches the
-			// pre-refactor behavior.
-			// We intentionally skipped error handling for invalid `enable_instant_search` value since it's legacy option now.
+			// instead of `search_experience`. Gated on the canonical value
+			// being absent so it doesn't overwrite a non-overlay experience
+			// the caller just set.
+			// Error handling intentionally skipped — this is the legacy fallback.
 			$ret = $this->search_module->enable_instant_search();
 		}
 

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -449,6 +449,7 @@ class REST_Controller {
 			'search_plan_info'      => null,
 			'enable_search'         => true,
 			'enable_instant_search' => true,
+			'search_experience'     => null,
 			'auto_config_search'    => true,
 		);
 		$payload         = $request->get_json_params();
@@ -460,21 +461,27 @@ class REST_Controller {
 			$this->plan->get_plan_info_from_wpcom();
 		}
 
-		// Enable search module by default, unless `enable_search` is explicitly set to boolean `false`.
-		if ( false !== $payload['enable_search'] ) {
-			// Eligibility is checked in `activate` function.
-			$ret = $this->search_module->activate();
+		if ( $payload['search_experience'] !== null ) {
+			// Canonical path: set the experience directly. `update_experience` handles module
+			// activation and keeps the legacy `instant_search_enabled` boolean in sync.
+			$ret = $this->search_module->update_experience( $payload['search_experience'] );
 			if ( is_wp_error( $ret ) ) {
 				return $ret;
 			}
-		}
+		} else {
+			// Legacy path for older WPCOM callers that send enable_search / enable_instant_search.
+			if ( false !== $payload['enable_search'] ) {
+				$ret = $this->search_module->activate();
+				if ( is_wp_error( $ret ) ) {
+					return $ret;
+				}
+			}
 
-		// Enable instant search by default, unless `enable_instant_search` is explicitly set to boolean `false`.
-		if ( false !== $payload['enable_instant_search'] ) {
-			// Eligibility is checked in `enable_instant_search` function.
-			$ret = $this->search_module->enable_instant_search();
-			if ( is_wp_error( $ret ) ) {
-				return $ret;
+			if ( false !== $payload['enable_instant_search'] ) {
+				$ret = $this->search_module->enable_instant_search();
+				if ( is_wp_error( $ret ) ) {
+					return $ret;
+				}
 			}
 		}
 

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -667,8 +667,8 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
-	 * `POST /jetpack/v4/search/plan/activate` with an unknown `search_experience` value
-	 * surfaces the `update_experience` validation error.
+	 * `POST /jetpack/v4/search/plan/activate` rejects an unknown `search_experience`
+	 * value with a 400 `invalid_experience` error.
 	 */
 	public function test_activate_plan_admin_with_invalid_search_experience() {
 		wp_set_current_user( $this->admin_id );
@@ -677,7 +677,38 @@ class REST_Controller_Test extends Search_TestCase {
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( '{"search_plan_info":' . Search_TestCase::PLAN_INFO_FIXTURE . ',"search_experience":"bogus"}' );
 		$response = $this->server->dispatch( $request );
-		$this->assertNotEquals( 200, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'invalid_experience', $response->get_data()['code'] );
+	}
+
+	/**
+	 * `search_experience: "off"` is reserved for `/plan/deactivate`. Sending it to
+	 * the activate endpoint must not silently deactivate Search.
+	 */
+	public function test_activate_plan_admin_rejects_off_experience() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( '{"search_plan_info":' . Search_TestCase::PLAN_INFO_FIXTURE . ',"search_experience":"off"}' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'invalid_experience', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Non-string `search_experience` payloads must surface as a 400, not a TypeError
+	 * from `update_experience(string $experience)`.
+	 */
+	public function test_activate_plan_admin_rejects_non_string_experience() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( '{"search_plan_info":' . Search_TestCase::PLAN_INFO_FIXTURE . ',"search_experience":["overlay"]}' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'invalid_experience', $response->get_data()['code'] );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -652,6 +652,35 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
+	 * `POST /jetpack/v4/search/plan/activate` with the canonical `search_experience`
+	 * parameter writes the experience option and routes through `update_experience`.
+	 */
+	public function test_activate_plan_admin_with_search_experience() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( '{"search_plan_info":' . Search_TestCase::PLAN_INFO_FIXTURE . ',"search_experience":"embedded"}' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'embedded', get_option( 'jetpack_search_experience' ) );
+	}
+
+	/**
+	 * `POST /jetpack/v4/search/plan/activate` with an unknown `search_experience` value
+	 * surfaces the `update_experience` validation error.
+	 */
+	public function test_activate_plan_admin_with_invalid_search_experience() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/plan/activate' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( '{"search_plan_info":' . Search_TestCase::PLAN_INFO_FIXTURE . ',"search_experience":"bogus"}' );
+		$response = $this->server->dispatch( $request );
+		$this->assertNotEquals( 200, $response->get_status() );
+	}
+
+	/**
 	 * Testing the `POST /jetpack/v4/search/plan/deactivate` endpoint with no user.
 	 */
 	public function test_deactivate_plan_authorized() {


### PR DESCRIPTION
Fixes <https://linear.app/a8c/issue/SEARCH-191/wpcom-set-jetpack-search-experience-option-on-search-plan-activation>.

## Why

When WPCOM provisions a Jetpack Search plan it POSTs to `/jetpack/v4/search/plan/activate`, which currently flips the legacy `instant_search_enabled` boolean. That tightly couples WPCOM to one default experience — Overlay — and means changing the default to e.g. Embedded requires a Jetpack release.

This change adds a canonical `search_experience` parameter (`overlay` | `inline` | `embedded`) to the endpoint, routing it through `Module_Control::update_experience()` — the same setter the in-product UI uses. WPCOM can now pick the activation default by passing a string; future flips become a one-line WPCOM edit. No user-visible change today: WPCOM PR 217611-ghe-Automattic/wpcom ships `search_experience => 'overlay'`, which produces the same option state as the legacy path.

## Proposed changes

* `class-rest-controller.php`: `activate_plan` accepts `search_experience`. When non-null, route through `Module_Control::update_experience()` (which handles module activation, the experience option, and the legacy boolean in one place). When null, keep the existing `enable_search` / `enable_instant_search` branches for backwards-compat with older callers.
* `REST_Controller_Test.php`: cover the new canonical path (`search_experience => 'embedded'` writes the option) and the validation error path (`search_experience => 'bogus'` returns 400).

## Related product discussion/links

* Linear: [SEARCH-191](https://linear.app/a8c/issue/SEARCH-191/wpcom-set-jetpack-search-experience-option-on-search-plan-activation)
* WPCOM caller: [Automattic/wpcom#217611](217611-ghe-Automattic/wpcom)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The change is REST-only — no user-visible UI. Verify the contract on a local Jetpack-connected site (or with the offline-mode filter disabled, as below).

* [ ] `POST /jetpack/v4/search/plan/activate` with body `{"search_experience":"embedded"}` returns 200, sets `jetpack_search_experience` option to `embedded`, leaves `instant_search_enabled` false, activates the Search module.
* [ ] Same with `{"search_experience":"overlay"}` returns 200, sets `jetpack_search_experience` to `overlay`, sets `instant_search_enabled` true.
* [ ] Same with `{"search_experience":"bogus"}` returns 400 with `code: invalid_experience` and writes no options.
* [ ] Legacy call body with no `search_experience` (e.g. `{}`) still works — module activates, `instant_search_enabled` is set to true.

## API changes

`POST /jetpack/v4/search/plan/activate` accepts a new optional parameter:

```
search_experience: "overlay" | "inline" | "embedded" | null   (default: null)
```

When non-null, this takes precedence over `enable_search` / `enable_instant_search`.

<details>
<summary>Live verification against a local dev env (nova)</summary>

```text
=== 1. Legacy (no search_experience) ===
Payload: {"auto_config_search":false}
Status:  200
Body:    {"code":"success"}
Options after call:
  jetpack_search_experience = 'overlay'
  instant_search_enabled    = true
  search module active      = true

=== 2. New canonical: embedded ===
Payload: {"auto_config_search":false,"search_experience":"embedded"}
Status:  200
Body:    {"code":"success"}
Options after call:
  jetpack_search_experience = 'embedded'
  instant_search_enabled    = false
  search module active      = true

=== 3. New canonical: overlay ===
Payload: {"auto_config_search":false,"search_experience":"overlay"}
Status:  200
Body:    {"code":"success"}
Options after call:
  jetpack_search_experience = 'overlay'
  instant_search_enabled    = true
  search module active      = true

=== 4. Invalid experience value ===
Payload: {"auto_config_search":false,"search_experience":"bogus"}
Status:  400
Body:    {"code":"invalid_experience","message":"Invalid experience value.","data":{"status":400}}
Options after call:
  jetpack_search_experience = false
  instant_search_enabled    = false
  search module active      = false
```
</details>

PHPUnit: the full `projects/packages/search/tests/php/` suite (447 tests, 1012 assertions) passes locally, including the two new `activate_plan` cases.