### PR TITLE
Search: expose Custom_Taxonomy_Slot_Mapping::backfill() as a wp jetpack-search CLI command (RSM-3303)

### DIFF
--- a/projects/packages/search/changelog/RSM-3303-backfill-cli-command
+++ b/projects/packages/search/changelog/RSM-3303-backfill-cli-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Add `wp jetpack-search backfill_taxonomy_slot_mapping [--mode=mirror|rebuild]` so operators can backfill the custom-taxonomy → reserved-slot projection without reaching for `wp eval`.

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -56,6 +56,59 @@ class CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * Backfill the reserved-slot taxonomy projection for any user-facing
+	 * taxonomies declared in `jetpack_search_custom_taxonomy_map`.
+	 *
+	 * Wraps `Custom_Taxonomy_Slot_Mapping::backfill()` so operators don't have
+	 * to reach for `wp eval` and a fully-qualified static call. The auto-mirror
+	 * on `set_object_terms` / `deleted_term_relationships` / `delete_term`
+	 * keeps the slot in sync from the moment the mapping is declared — this
+	 * subcommand only needs to run once after the mapping is first turned on,
+	 * or after a gap during which the auto-mirror was inactive.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--mode=<mode>]
+	 * : Backfill mode.
+	 * ---
+	 * default: mirror
+	 * options:
+	 *   - mirror
+	 *   - rebuild
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Per-post mirror — cheap, idempotent, safe to re-run.
+	 *     wp jetpack-search backfill_taxonomy_slot_mapping
+	 *
+	 *     # Full sweep — wipes the slot taxonomy first, then re-projects.
+	 *     wp jetpack-search backfill_taxonomy_slot_mapping --mode=rebuild
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Associative args. Supports `mode`.
+	 */
+	public function backfill_taxonomy_slot_mapping( $args, $assoc_args ) {
+		$mode = isset( $assoc_args['mode'] ) ? (string) $assoc_args['mode'] : 'mirror';
+		if ( ! in_array( $mode, Custom_Taxonomy_Slot_Mapping::BACKFILL_MODES, true ) ) {
+			WP_CLI::error( sprintf( 'Unknown mode "%s"; expected one of: %s.', $mode, implode( ', ', Custom_Taxonomy_Slot_Mapping::BACKFILL_MODES ) ) );
+		}
+
+		if ( empty( Custom_Taxonomy_Slot_Mapping::get_map() ) ) {
+			WP_CLI::warning( 'jetpack_search_custom_taxonomy_map is empty; nothing to backfill.' );
+			return;
+		}
+
+		WP_CLI::line( sprintf( 'Running backfill in %s mode…', $mode ) );
+		try {
+			$mirrored = Custom_Taxonomy_Slot_Mapping::backfill( $mode );
+			WP_CLI::success( sprintf( 'Mirrored %d (post, taxonomy) pair(s).', $mirrored ) );
+		} catch ( \Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Set current user by ID or login
 	 *
 	 * @param string|int $user User ID or login.

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -101,8 +101,8 @@ class CLI extends WP_CLI_Command {
 
 		WP_CLI::line( sprintf( 'Running backfill in %s mode…', $mode ) );
 		try {
-			$mirrored = Custom_Taxonomy_Slot_Mapping::backfill( $mode );
-			WP_CLI::success( sprintf( 'Backfilled %d (post, taxonomy) pair(s).', $mirrored ) );
+			$count = Custom_Taxonomy_Slot_Mapping::backfill( $mode );
+			WP_CLI::success( sprintf( 'Backfilled %d (post, taxonomy) pair(s).', $count ) );
 		} catch ( \Exception $e ) {
 			WP_CLI::error( $e->getMessage() );
 		}

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -102,7 +102,7 @@ class CLI extends WP_CLI_Command {
 		WP_CLI::line( sprintf( 'Running backfill in %s mode…', $mode ) );
 		try {
 			$mirrored = Custom_Taxonomy_Slot_Mapping::backfill( $mode );
-			WP_CLI::success( sprintf( 'Mirrored %d (post, taxonomy) pair(s).', $mirrored ) );
+			WP_CLI::success( sprintf( 'Backfilled %d (post, taxonomy) pair(s).', $mirrored ) );
 		} catch ( \Exception $e ) {
 			WP_CLI::error( $e->getMessage() );
 		}


### PR DESCRIPTION
Fixes [RSM-3303](https://linear.app/a8c/issue/RSM-3303/search-expose-custom-taxonomy-slot-mappingbackfill-as-a-wp-jetpack)

## Why

When a site declares a pcNPJE-1ow-p2 entry after it already has tagged content, the slot taxonomy starts empty and needs a one-shot backfill. Until now the only documented way to run that backfill was via `wp eval`, with a fully-qualified static call and shell-quoted namespace separators — awkward to type, no `--help`, and no parameter validation. This change exposes the same helper as a first-class `wp jetpack-search` subcommand so operators get familiar CLI ergonomics: a `--mode` flag with built-in validation, `wp help` output, and structured success/warning/error reporting.

## Proposed changes

* Add `wp jetpack-search backfill_taxonomy_slot_mapping [--mode=mirror|rebuild]` to `class-cli.php`. The subcommand is a thin wrapper around `Custom_Taxonomy_Slot_Mapping::backfill()` — the eval form keeps working unchanged.
* Up-front guard: warn (`WP_CLI::warning`) and return early when `jetpack_search_custom_taxonomy_map` is empty, so operators get a clear "nothing to do" signal instead of a silent zero count.
* Mode validation is doubly enforced: WP-CLI's parameter parser rejects unknown values via the docblock `options` list (`mirror`, `rebuild`), and an explicit `in_array()` fallback inside the method calls `WP_CLI::error()` if the docblock is ever loosened.

## Related product discussion/links

* P2 thread: <pcNPJE-1ow-p2#comment-1933>
* Linear: [RSM-3303](https://linear.app/a8c/issue/RSM-3303/search-expose-custom-taxonomy-slot-mappingbackfill-as-a-wp-jetpack)
* Previous work: #48684, #48708

## Does this pull request change what data or activity we track or use?

No — this is a CLI surface for an existing helper. No new data is read, written, or sent off-site.

## Testing instructions

The acceptance checklist from RSM-3303:

- [ ] `wp jetpack-search backfill_taxonomy_slot_mapping` runs mirror mode and reports `Success: Mirrored N (post, taxonomy) pair(s).`
- [ ] `wp jetpack-search backfill_taxonomy_slot_mapping --mode=rebuild` runs rebuild mode (wipes the slot taxonomy first, re-projects from user-side).
- [ ] `wp jetpack-search backfill_taxonomy_slot_mapping --mode=bogus` exits non-zero with an error message naming the valid modes.
- [ ] `wp help jetpack-search backfill_taxonomy_slot_mapping` shows the docblock — synopsis, options table, examples.
- [ ] With no `jetpack_search_custom_taxonomy_map` filter registered, the command prints `Warning: jetpack_search_custom_taxonomy_map is empty; nothing to backfill.` and exits 0.

To set up a test fixture (mu-plugin under `wp-content/mu-plugins/`):

```php
<?php
add_action( 'init', function () {
    register_taxonomy( 'genre', 'post', array( 'public' => true, 'show_in_rest' => true ) );
}, 5 );
add_filter( 'jetpack_search_custom_taxonomy_map', function ( $map ) {
    $map['genre'] = 'jetpack-search-tag1';
    return $map;
} );
```

Tag at least one post with a `genre` term, then run the commands above. Inspect the slot with:

```
wp eval 'foreach ( (array) get_terms( array( "taxonomy" => "jetpack-search-tag1", "hide_empty" => false ) ) as $t ) { echo "{$t->name} ({$t->count})\n"; }'
```

## Verification

Exercised end-to-end against a local Jetpack docker env (`jp-raven`) — registered a `genre` taxonomy + filter map, seeded posts and terms, then ran each command path. Output:

<details>
<summary><code>wp help jetpack-search backfill_taxonomy_slot_mapping</code></summary>

```text
NAME

  wp jetpack-search backfill_taxonomy_slot_mapping

DESCRIPTION

  Backfill the reserved-slot taxonomy projection for any user-facing
  taxonomies declared in `jetpack_search_custom_taxonomy_map`.
  ...

SYNOPSIS

  wp jetpack-search backfill_taxonomy_slot_mapping [--mode=<mode>]

OPTIONS

  [--mode=<mode>]
    Backfill mode.
    ---
    default: mirror
    options:
      - mirror
      - rebuild
    ---

EXAMPLES

    # Per-post mirror — cheap, idempotent, safe to re-run.
    wp jetpack-search backfill_taxonomy_slot_mapping

    # Full sweep — wipes the slot taxonomy first, then re-projects.
    wp jetpack-search backfill_taxonomy_slot_mapping --mode=rebuild
```
</details>

<details>
<summary>Mode validation, empty-map warning, mirror + rebuild runs</summary>

```text
$ wp jetpack-search backfill_taxonomy_slot_mapping --mode=bogus
Error: Parameter errors:
 Invalid value specified for 'mode' (Backfill mode.)
$ echo $?
1

$ wp jetpack-search backfill_taxonomy_slot_mapping   # no map filter registered
Warning: jetpack_search_custom_taxonomy_map is empty; nothing to backfill.
$ echo $?
0

$ wp jetpack-search backfill_taxonomy_slot_mapping   # map + tagged posts in place
Running backfill in mirror mode…
Success: Mirrored 63 (post, taxonomy) pair(s).

$ wp jetpack-search backfill_taxonomy_slot_mapping --mode=rebuild
Running backfill in rebuild mode…
Success: Mirrored 63 (post, taxonomy) pair(s).

$ wp eval 'foreach ( (array) get_terms( array( "taxonomy" => "jetpack-search-tag1", "hide_empty" => false ) ) as $t ) { echo "{$t->name} ({$t->count})\n"; }'
mystery (21)
romance (21)
sci-fi (21)
```
</details>