### PR TITLE
Search Dashboard: restore visible space between "AI Answers" and "(Preview)" tab label

### DIFF
--- a/projects/packages/search/changelog/fix-search-tab-preview-space
+++ b/projects/packages/search/changelog/fix-search-tab-preview-space
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: restore the visible space between "AI Answers" and "(Preview)" in the dashboard tab label — the new flex-based `Tabs.Tab` layout was collapsing the previous JSX whitespace, so move a non-breaking space inside the preview span.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -169,9 +169,9 @@ export default function DashboardPage( { isLoading = false } ) {
 							<Tabs.Tab value="plan-usage">{ __( 'Plan & Usage', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="ai-answers">
-								{ __( 'AI Answers', 'jetpack-search-pkg' ) }{ ' ' }
+								{ __( 'AI Answers', 'jetpack-search-pkg' ) }
 								<span className="jp-search-dashboard-tabs__tab-preview-label">
-									{ __( '(Preview)', 'jetpack-search-pkg' ) }
+									&nbsp;{ __( '(Preview)', 'jetpack-search-pkg' ) }
 								</span>
 							</Tabs.Tab>
 						</Tabs.List>


### PR DESCRIPTION
Fixes nothing — follow-up to #48846 review comment https://github.com/Automattic/jetpack/pull/48846#discussion_r3245711759.

## Proposed changes
* In `dashboard-page.jsx`, the "AI Answers (Preview)" tab label was rendering as `AI Answers(Preview)` after the migration to the unified `Tabs.Tab` (variant `"minimal"`) chassis from `@wordpress/components`. The new flex-based tab layout collapses the JSX `{ ' ' }` text node sitting between two sibling elements, so the visible separator disappeared.
* Drop the now-useless `{ ' ' }` and instead place a non-breaking space (`&nbsp;`) inside the `.jp-search-dashboard-tabs__tab-preview-label` `<span>` itself, right before the localized `(Preview)` string. A space inside the element's text content is not subject to flex sibling-whitespace collapsing, so the gap renders reliably.

## Related product discussion/links
* PR #48846 (parent) — https://github.com/Automattic/jetpack/pull/48846
* Review comment — https://github.com/Automattic/jetpack/pull/48846#discussion_r3245711759

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Build the Search package: `jp build search --deps`.
2. Open the Jetpack Search dashboard on a site with the AI Answers tab visible.
3. Confirm the third tab reads **"AI Answers (Preview)"** with a clear space between the title and the parenthesized "(Preview)" qualifier — no longer **"AI Answers(Preview)"**.
4. Sanity-check the other two tabs ("Plan & Usage", "Settings") still render normally and the active-tab indicator is unaffected.