### PR TITLE
Search dashboard: fix Edit search template / Insert pattern URLs (SEARCH-192)

### DIFF
--- a/projects/packages/search/changelog/search-192-edit-template-url
+++ b/projects/packages/search/changelog/search-192-edit-template-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search dashboard: the "Edit search template" and "Insert pattern" links on the Embedded experience card now use the modern Site Editor URL format, so they open the Jetpack Search template view and pre-filtered patterns library instead of an empty editor.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -86,6 +86,12 @@ class Initial_State {
 				 * same flag the back end uses to register the blocks themselves.
 				 */
 				'searchBlocksEnabled'     => (bool) apply_filters( 'jetpack_search_blocks_enabled', false ),
+				/**
+				 * Active theme stylesheet — used by the experience-selector to deep-link
+				 * the "Edit search template" action to the right Site Editor entry
+				 * (`?p=/wp_template/<stylesheet>//jetpack-search`).
+				 */
+				'activeThemeStylesheet'   => get_stylesheet(),
 			),
 			'userData'        => array(
 				'currentUser' => $this->current_user_data(),

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -14,12 +14,18 @@ import OffPreview from './previews/off-preview';
 import OverlayPreview from './previews/overlay-preview';
 import './experience-option.scss';
 
-// URL constants reused verbatim from the legacy ModuleControl.
-// `sprintf( ..., encodeURIComponent( returnUrl ) )` was a no-op there
-// (the format strings had no `%s`), so we drop it here.
 const SEARCH_CUSTOMIZE_URL = 'admin.php?page=jetpack-search-configure';
 const WIDGETS_EDITOR_URL = 'widgets.php';
-const SEARCH_TEMPLATE_URL = 'site-editor.php?p=%2Ftemplate&activeView=jetpack-search';
+// The Site Editor identifies templates by `<theme-stylesheet>//<template-slug>`
+// even for plugin-registered ones, so the active theme is part of the URL. Built
+// at render time so the link follows theme switches without a re-deploy. Falls
+// back to the Templates list when the stylesheet is missing from initial state.
+const buildSearchTemplateUrl = stylesheet =>
+	stylesheet
+		? `site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
+				stylesheet
+		  ) }%2F%2Fjetpack-search&canvas=edit`
+		: 'site-editor.php?p=%2Ftemplate';
 const PATTERNS_URL = 'site-editor.php?p=%2Fpattern&search=jetpack-search';
 
 const PREVIEWS = {
@@ -98,10 +104,11 @@ const getHoverHint = experience => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const { active, isUpdating } = useSelect(
+	const { active, isUpdating, activeThemeStylesheet } = useSelect(
 		select => ( {
 			active: select( STORE_ID ).getActiveExperience(),
 			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
+			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
 		} ),
 		[]
 	);
@@ -168,7 +175,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 				>
 					<CardLink
 						label={ __( 'Edit search template', 'jetpack-search-pkg' ) }
-						href={ SEARCH_TEMPLATE_URL }
+						href={ buildSearchTemplateUrl( activeThemeStylesheet ) }
 						disabled={ linksDisabled }
 					/>
 					<CardLink

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -19,8 +19,8 @@ import './experience-option.scss';
 // (the format strings had no `%s`), so we drop it here.
 const SEARCH_CUSTOMIZE_URL = 'admin.php?page=jetpack-search-configure';
 const WIDGETS_EDITOR_URL = 'widgets.php';
-const SEARCH_TEMPLATE_URL = 'site-editor.php?postType=wp_template&postId=search';
-const PATTERNS_URL = 'site-editor.php?path=/patterns';
+const SEARCH_TEMPLATE_URL = 'site-editor.php?p=%2Ftemplate&activeView=jetpack-search';
+const PATTERNS_URL = 'site-editor.php?p=%2Fpattern&search=jetpack-search';
 
 const PREVIEWS = {
 	[ EXPERIENCE.EMBEDDED ]: EmbeddedPreview,

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -14,6 +14,7 @@ const siteDataSelectors = {
 	isWpcom: state => state.siteData?.isWpcom ?? false,
 	isPlanJustUpgraded: state => state.siteData?.isPlanJustUpgraded ?? false,
 	isSearchBlocksEnabled: state => state.siteData?.searchBlocksEnabled ?? false,
+	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 };
 
 export default siteDataSelectors;

--- a/projects/packages/search/tests/js/dashboard/experience-selector/experience-option.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/experience-selector/experience-option.test.jsx
@@ -191,4 +191,16 @@ describe( '<ExperienceOption> Embedded action links', () => {
 			'site-editor.php?p=%2Fpattern&search=jetpack-search'
 		);
 	} );
+	test( 'Edit search template percent-encodes unusual stylesheet names', () => {
+		renderWith(
+			embeddedActive,
+			{ experience: 'embedded' },
+			{},
+			{ activeThemeStylesheet: 'my theme/v2' }
+		);
+		expect( screen.getByRole( 'link', { name: /edit search template/i } ) ).toHaveAttribute(
+			'href',
+			'site-editor.php?p=%2Fwp_template%2Fmy%20theme%2Fv2%2F%2Fjetpack-search&canvas=edit'
+		);
+	} );
 } );

--- a/projects/packages/search/tests/js/dashboard/experience-selector/experience-option.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/experience-selector/experience-option.test.jsx
@@ -4,7 +4,7 @@ import { createReduxStore, createRegistry, RegistryProvider } from '@wordpress/d
 import ExperienceOption from '../../../../src/dashboard/components/experience-selector/experience-option';
 import { storeConfig, STORE_ID } from '../../../../src/dashboard/store';
 
-const renderWith = ( jetpackSettings, props, sitePlan = {} ) => {
+const renderWith = ( jetpackSettings, props, sitePlan = {}, siteData = {} ) => {
 	const registry = createRegistry();
 	const store = createReduxStore( STORE_ID, {
 		...storeConfig,
@@ -12,6 +12,7 @@ const renderWith = ( jetpackSettings, props, sitePlan = {} ) => {
 			...( storeConfig.initialState || {} ),
 			jetpackSettings,
 			sitePlan,
+			siteData,
 		},
 	} );
 	registry.register( store );
@@ -154,5 +155,40 @@ describe( '<ExperienceOption> Overlay action links', () => {
 		expect( screen.queryByRole( 'link', { name: /edit widgets/i } ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Customize' ) ).toHaveClass( 'is-disabled' );
 		expect( screen.getByText( 'Edit widgets' ) ).toHaveClass( 'is-disabled' );
+	} );
+} );
+
+describe( '<ExperienceOption> Embedded action links', () => {
+	const embeddedActive = {
+		module_active: true,
+		instant_search_enabled: false,
+		pending_experience: null,
+		experience: 'embedded',
+	};
+	test( 'Edit search template deep-links to the active theme stylesheet', () => {
+		renderWith(
+			embeddedActive,
+			{ experience: 'embedded' },
+			{},
+			{ activeThemeStylesheet: 'twentytwentyfive' }
+		);
+		expect( screen.getByRole( 'link', { name: /edit search template/i } ) ).toHaveAttribute(
+			'href',
+			'site-editor.php?p=%2Fwp_template%2Ftwentytwentyfive%2F%2Fjetpack-search&canvas=edit'
+		);
+	} );
+	test( 'Edit search template falls back to the templates list with no stylesheet', () => {
+		renderWith( embeddedActive, { experience: 'embedded' } );
+		expect( screen.getByRole( 'link', { name: /edit search template/i } ) ).toHaveAttribute(
+			'href',
+			'site-editor.php?p=%2Ftemplate'
+		);
+	} );
+	test( 'Insert pattern deep-links to the Jetpack Search pattern category', () => {
+		renderWith( embeddedActive, { experience: 'embedded' } );
+		expect( screen.getByRole( 'link', { name: /insert pattern/i } ) ).toHaveAttribute(
+			'href',
+			'site-editor.php?p=%2Fpattern&search=jetpack-search'
+		);
 	} );
 } );


### PR DESCRIPTION
## Why

The Embedded experience card in the Search dashboard has two action links — **Edit search template** and **Insert pattern** — that point at deprecated Site Editor query strings. Clicking them today lands the user on the wrong screen: the template link drops them into the templates list with no template selected, and the patterns link opens the unfiltered library of 200+ patterns from every plugin and theme. After this PR both links deep-link to exactly the Jetpack Search context, so the dashboard's "set up your search" flow actually works.

## Proposed changes

* `experience-option.jsx`: rebuild `SEARCH_TEMPLATE_URL` from the active theme stylesheet at render time so it deep-links to `site-editor.php?p=/wp_template/<stylesheet>//jetpack-search&canvas=edit` — same URL WP itself generates when you click the template card.
* `experience-option.jsx`: update `PATTERNS_URL` to the modern `site-editor.php?p=/pattern&search=jetpack-search` so the patterns library opens pre-filtered to the Jetpack Search pattern category.
* `class-initial-state.php`: expose `siteData.activeThemeStylesheet` (returns `get_stylesheet()`) so the URL builder above has the active theme available client-side.
* `site-data.js`: add `getActiveThemeStylesheet` selector.
* `experience-option.test.jsx`: add tests for both Embedded action links plus the fallback behavior when the stylesheet isn't in initial state.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/SEARCH-192

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

### Edit search template

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/05d3d89b-67bf-4f7e-a631-e38b6d9fbec8) | ![after](https://github.com/user-attachments/assets/c898bb7a-d18e-438c-9e77-86c84f6e6892) |

Old URL (`postType=wp_template&postId=search`) lands on the Templates list with nothing selected. New URL drops the user straight into the Jetpack Search Results template editor with the canvas open.

### Insert pattern

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/d12c0fe9-b1b4-4cd0-9866-f89f7ae068a5) | ![after](https://github.com/user-attachments/assets/b0b5bdbf-fe45-4a6f-8692-9f919aa7763b) |

Old URL (`path=/patterns`) opens the unfiltered patterns library (206 patterns). New URL pre-filters to the `jetpack-search` pattern category — just the Blog Search Page and Compact Search patterns.

## Testing instructions

Acceptance criteria from SEARCH-192:

* [ ] Click **Edit search template** on the Embedded card — Site Editor opens with the Jetpack Search Results template loaded in the canvas (not a 404, not an empty editor, not the bare templates list).
* [ ] Click **Insert pattern** on the Embedded card — Site Editor opens the patterns library pre-filtered to the Jetpack Search patterns (Blog Search Page + Compact Search).
* [ ] Switch the active experience to Overlay or Off — both links on the Embedded card render as non-interactive `<span>`s with the `is-disabled` class. (Existing `linksDisabled` behavior preserved — covered by tests.)
* [ ] Switch the active theme — the Edit search template link follows the new theme on the next dashboard render (the stylesheet is read from initial state at render time).

To verify locally:

* `jp build packages/my-jetpack && jp build plugins/jetpack && jp build packages/search && jp build plugins/search`
* Navigate to `wp-admin/admin.php?page=jetpack-search&tab=settings` with the Search Settings dashboard.
* Confirm the Embedded card shows the two links as active when Embedded is the saved experience.
* Click each link and confirm the Site Editor destinations match the screenshots above.
