### PR TITLE
Search dashboard: render AI Answers "Preview" qualifier as a superscript (RSM-3319)

### DIFF
--- a/projects/packages/search/changelog/rsm-3319-ai-answers-preview-superscript
+++ b/projects/packages/search/changelog/rsm-3319-ai-answers-preview-superscript
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Dashboard: render the "Preview" qualifier on the AI Answers tab as a semantic `<sup>` superscript — smaller, raised above the baseline and tinted with the secondary-foreground token — instead of inline parenthetical text, so it reads as a status marker rather than part of the tab title.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -1,7 +1,7 @@
 import { AdminPage, Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Stack, Tabs } from '@wordpress/ui';
 import { useState } from 'react';
 import AiAnswersTab from 'components/ai-answers-tab';
@@ -170,9 +170,13 @@ export default function DashboardPage( { isLoading = false } ) {
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="ai-answers">
 								{ __( 'AI Answers', 'jetpack-search-pkg' ) }
-								<span className="jp-search-dashboard-tabs__tab-preview-label">
-									&nbsp;{ __( '(Preview)', 'jetpack-search-pkg' ) }
-								</span>
+								<sup className="jp-search-dashboard-tabs__tab-preview-label">
+									{ _x(
+										'Preview',
+										'Status badge on the AI Answers tab marking the feature as in preview',
+										'jetpack-search-pkg'
+									) }
+								</sup>
 							</Tabs.Tab>
 						</Tabs.List>
 					</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -27,6 +27,18 @@ body.jetpack_page_jetpack-search .jp-search-dashboard-page {
 	.jp-admin-page-tabs {
 		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
 	}
+
+	// "Preview" qualifier on the AI Answers tab. Rendered as a semantic
+	// <sup> so assistive tech announces it as supplementary; visually we
+	// keep the UA `vertical-align: super` baseline shift and just dial the
+	// font size down and tint the text with the muted neutral-weak token
+	// so it reads as metadata rather than competing with the tab title.
+	.jp-search-dashboard-tabs__tab-preview-label {
+		margin-inline-start: var(--wpds-dimension-padding-xs, 4px);
+		font-size: 0.7em;
+		font-weight: 500;
+		color: var(--wpds-color-fg-content-neutral-weak, #50575e);
+	}
 }
 
 #jp-search-dashboard {

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -30,13 +30,16 @@ body.jetpack_page_jetpack-search .jp-search-dashboard-page {
 
 	// "Preview" qualifier on the AI Answers tab. Rendered as a semantic
 	// <sup> so assistive tech announces it as supplementary; visually we
-	// keep the UA `vertical-align: super` baseline shift and just dial the
-	// font size down and tint the text with the muted neutral-weak token
-	// so it reads as metadata rather than competing with the tab title.
+	// just dial the font size down, tint the text with the muted
+	// neutral-weak token, and pin `vertical-align: super` + `line-height: 1`
+	// explicitly (instead of leaning on the UA stylesheet) so the qualifier
+	// can't accidentally inflate the tab line-box if a future reset strips
+	// the UA baseline shift.
 	.jp-search-dashboard-tabs__tab-preview-label {
 		margin-inline-start: var(--wpds-dimension-padding-xs, 4px);
 		font-size: 0.7em;
-		font-weight: 500;
+		line-height: 1;
+		vertical-align: super;
 		color: var(--wpds-color-fg-content-neutral-weak, #50575e);
 	}
 }


### PR DESCRIPTION
Fixes [RSM-3319](https://linear.app/a8c/issue/RSM-3319/search-dashboard-render-the-ai-answers-tab-preview-qualifier-as-a)

## Why
The "Preview" qualifier on the AI Answers tab read as part of the title — `AI Answers (Preview)` in body weight, with parentheses doing the only work to separate it. Promoting it to a proper superscript turns it into a status marker the eye skims over instead of competing with the tab name, which is what every comparable design system (Material, Atlassian, GitHub, Carbon) does for in-line "Preview" / "Beta" / "New" labels.

## Proposed changes
* `dashboard-page.jsx`: swap the `<span>` around `(Preview)` for a semantic `<sup>` and drop the parentheses (the visual treatment now does the separating).
* Move the translation call to `_x()` with a context note so translators see the badge intent rather than just the bare word.
* `dashboard-page.scss`: keep the UA's `vertical-align: super` baseline shift; only override `font-size` (`0.7em`), tint with the muted `--wpds-color-fg-content-neutral-weak` token, and add a 4px inline-start margin so the qualifier reads as metadata.
* Removes the `&nbsp;` workaround that #48850 had to add against the new flex-based `Tabs.Tab` — the text now lives inside `<sup>` so the UA superscript handles its own separation from the tab title.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/ac2c3d40-9bcc-42ac-ab77-3c2ca37ed797) | ![after](https://github.com/user-attachments/assets/81297f49-3703-46ef-8ddc-757b5519277a) |

> Captures rendered via Playwright against a self-contained reproduction of the `<Tabs.List variant="minimal">` chrome with the actual built CSS rule applied. The dashboard requires a real Jetpack ↔ WPCOM connection to render in a docker env, which the per-agent dev env can't establish autonomously, so a minimal faithful reproduction was used instead. The DOM under inspection — `<sup class="jp-search-dashboard-tabs__tab-preview-label">Preview</sup>` and the new SCSS rule — is exactly what ships.

## Related product discussion/links
* Linear: [RSM-3319](https://linear.app/a8c/issue/RSM-3319/search-dashboard-render-the-ai-answers-tab-preview-qualifier-as-a) (Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586/overview))
* Parent PR (the unified `@wordpress/ui` tab migration that introduced this label rendering): #48846 — RSM-3299
* Whitespace-fix predecessor: #48850 — drops the `&nbsp;` workaround it had to add
* Original review comment that surfaced the visual debt: https://github.com/Automattic/jetpack/pull/48846#discussion_r3245711759

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Per the issue's acceptance criteria:

- [ ] AI Answers tab renders as `AI Answers ᴾʳᵉᵛⁱᵉʷ` — `Preview` raised above the baseline, smaller, in the secondary-foreground tone.
- [ ] No parentheses around `Preview`.
- [ ] DOM uses `<sup class="jp-search-dashboard-tabs__tab-preview-label">` rather than `<span>`.
- [ ] Translation call uses `_x()` with the badge-status context note.
- [ ] Active-tab indicator and the other two tabs (Plan & Usage, Settings) render unchanged.
- [ ] Before/after screenshots attached to the PR.

To verify against a real Jetpack ↔ WPCOM connection (Jurassic Ninja or a connected docker env):

1. `jp build packages/my-jetpack && jp build plugins/jetpack && jp build packages/search && jp build plugins/search`
2. Open **Jetpack → Search** in wp-admin.
3. Inspect the third tab — verify the markup is `<sup class="jp-search-dashboard-tabs__tab-preview-label">Preview</sup>` and the visual treatment matches the After screenshot.
