### PR TITLE
ADS-1057: Add portable Blaze prepare-campaign target inputs

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1057-portable-target-inputs
+++ b/projects/packages/blaze/changelog/add-ads-1057-portable-target-inputs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze: Allow campaign preparation from site URL plus post or product ID.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -224,11 +224,26 @@ class Blaze_Abilities extends Registrar {
 				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
-					'required'             => array( 'target_urn' ),
+					'required'             => array(),
 					'properties'           => array(
 						'target_urn'           => array(
 							'type'        => 'string',
-							'description' => __( 'The URN of the post or product to promote (e.g. urn:wpcom:post:123456:42).', 'jetpack-blaze' ),
+							'description' => __( 'The canonical URN of the post or product to promote (e.g. urn:wpcom:post:123456:42). Advanced callers may pass this directly; other callers should use site_url plus post_id or site_url plus product_id.', 'jetpack-blaze' ),
+						),
+						'site_url'             => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Optional public WordPress.com site URL or domain used with post_id or product_id when target_urn is not known.', 'jetpack-blaze' ),
+						),
+						'post_id'              => array(
+							'type'        => 'integer',
+							'description' => __( 'Optional WordPress post ID to promote with site_url when target_urn is not known. Do not send post_id and product_id together.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'product_id'           => array(
+							'type'        => 'integer',
+							'description' => __( 'Optional WooCommerce product_id to promote with site_url when target_urn is not known. This is normalized into the canonical post target URN. Do not send post_id and product_id together.', 'jetpack-blaze' ),
+							'minimum'     => 1,
 						),
 						'goal'                 => array(
 							'type'        => 'string',
@@ -1387,7 +1402,12 @@ class Blaze_Abilities extends Registrar {
 	private static function get_prepare_campaign_failure_category( \WP_Error $error ): string {
 		switch ( $error->get_error_code() ) {
 			case 'blaze_invalid_target_urn':
+			case 'blaze_missing_target':
+			case 'blaze_ambiguous_target':
 				return 'invalid_target';
+			case 'blaze_site_lookup_failed':
+			case 'blaze_site_not_connected':
+				return 'site_lookup_failed';
 			case 'blaze_post_not_found':
 				return 'target_not_found';
 			case 'blaze_setup_required':

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -41,6 +41,11 @@ class Campaign_Preparer {
 	 * @return array|\WP_Error
 	 */
 	public static function prepare( array $args ) {
+		$args = self::normalize_target_args( $args );
+		if ( is_wp_error( $args ) ) {
+			return $args;
+		}
+
 		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
 		if ( '' === $urn || ! preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $matches ) ) {
 			return new \WP_Error(
@@ -83,6 +88,81 @@ class Campaign_Preparer {
 		}
 
 		return $proposal;
+	}
+
+	/**
+	 * Normalize public target input forms into the canonical target URN.
+	 *
+	 * @param array $args Preparation input.
+	 * @return array|\WP_Error
+	 */
+	private static function normalize_target_args( array $args ) {
+		if ( isset( $args['target_urn'] ) && '' !== (string) $args['target_urn'] ) {
+			return $args;
+		}
+
+		$has_post_id    = isset( $args['post_id'] ) && '' !== (string) $args['post_id'];
+		$has_product_id = isset( $args['product_id'] ) && '' !== (string) $args['product_id'];
+
+		if ( $has_post_id && $has_product_id ) {
+			return new \WP_Error(
+				'blaze_ambiguous_target',
+				__( 'Provide only one of post_id or product_id when target_urn is omitted.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! isset( $args['site_url'] ) || '' === (string) $args['site_url'] || ( ! $has_post_id && ! $has_product_id ) ) {
+			return new \WP_Error(
+				'blaze_missing_target',
+				__( 'Provide target_urn, or provide site_url with exactly one of post_id or product_id.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$site_id = self::lookup_public_site_id( (string) $args['site_url'] );
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$target_id          = $has_product_id ? (int) $args['product_id'] : (int) $args['post_id'];
+		$args['target_urn'] = sprintf( 'urn:wpcom:post:%d:%d', (int) $site_id, $target_id );
+
+		return $args;
+	}
+
+	/**
+	 * Resolve a public WordPress.com site URL/domain to its site ID.
+	 *
+	 * @param string $site_url Public site URL or domain.
+	 * @return int|\WP_Error
+	 */
+	private static function lookup_public_site_id( string $site_url ) {
+		$response = wp_remote_get(
+			'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $site_url ),
+			array(
+				'timeout' => 5,
+			)
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return new \WP_Error(
+				'blaze_site_lookup_failed',
+				__( 'Could not resolve site_url through the public WordPress.com sites API.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $data ) || empty( $data['ID'] ) ) {
+			return new \WP_Error(
+				'blaze_site_not_connected',
+				__( 'The supplied site_url did not resolve to a connected WordPress.com site.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return (int) $data['ID'];
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -43,6 +43,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	public function tear_down() {
 		Jetpack_Options::delete_option( 'id' );
 		unset( $GLOBALS['wp_rest_server'] );
+		remove_all_filters( 'pre_http_request' );
 	}
 
 	/**
@@ -85,6 +86,29 @@ class Campaign_Preparer_Test extends BaseTestCase {
 				'callback'            => $callback,
 				'permission_callback' => '__return_true',
 			)
+		);
+	}
+
+	/**
+	 * Mock the public WordPress.com site lookup used by portable target inputs.
+	 *
+	 * @param string $expected_site_url Expected site URL.
+	 * @param array  $response          Mock HTTP response.
+	 */
+	private function mock_site_lookup( string $expected_site_url, array $response ) {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $expected_site_url, $response ) {
+				$expected_path = '/rest/v1.1/sites/' . rawurlencode( $expected_site_url );
+
+				if ( false !== strpos( $url, $expected_path ) ) {
+					return $response;
+				}
+
+				return $preempt;
+			},
+			10,
+			3
 		);
 	}
 
@@ -460,5 +484,111 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'blaze_invalid_target_urn', $result->get_error_code() );
+	}
+
+	/**
+	 * Friendly site URL + post ID inputs are normalized into the canonical
+	 * target URN before the existing proposal path runs.
+	 */
+	public function test_prepare_accepts_site_url_and_post_id() {
+		$ctx = $this->make_test_post();
+		$this->mock_site_lookup(
+			'https://example.com',
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ID' => self::TEST_SITE_ID ), JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url'      => 'https://example.com',
+				'post_id'       => $ctx['post_id'],
+				'budget_total'  => 25,
+				'duration_days' => 5,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $ctx['target_urn'], $result['prefill']['target_urn'] );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+	}
+
+	/**
+	 * Product_id is a Woo-friendly alias for the promoted post ID in the
+	 * canonical Blaze target URN.
+	 */
+	public function test_prepare_accepts_site_url_and_product_id() {
+		$ctx = $this->make_test_post( array( 'post_type' => 'product' ) );
+		$this->mock_site_lookup(
+			'https://shop.example.com',
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ID' => self::TEST_SITE_ID ), JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url'   => 'https://shop.example.com',
+				'product_id' => $ctx['post_id'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $ctx['target_urn'], $result['prefill']['target_urn'] );
+		$this->assertSame( 'product', $result['prefill']['type'] );
+	}
+
+	/**
+	 * A failed public site lookup is a clear hard stop, not a malformed URN.
+	 */
+	public function test_prepare_returns_error_when_site_lookup_fails() {
+		$ctx = $this->make_test_post();
+		$this->mock_site_lookup(
+			'https://missing.example.com',
+			array(
+				'response' => array( 'code' => 404 ),
+				'body'     => wp_json_encode( array( 'error' => 'unknown_blog' ), JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url' => 'https://missing.example.com',
+				'post_id'  => $ctx['post_id'],
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_site_lookup_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * Callers must choose either post_id or product_id for friendly inputs.
+	 */
+	public function test_prepare_returns_error_for_ambiguous_friendly_target() {
+		$ctx = $this->make_test_post();
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url'   => 'https://example.com',
+				'post_id'    => $ctx['post_id'],
+				'product_id' => $ctx['post_id'],
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_ambiguous_target', $result->get_error_code() );
+	}
+
+	/**
+	 * Missing target inputs get a specific error that can guide MCP clients.
+	 */
+	public function test_prepare_returns_error_for_missing_target_input() {
+		$result = Campaign_Preparer::prepare( array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_missing_target', $result->get_error_code() );
 	}
 }

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -531,8 +531,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$schema     = $ability['input_schema'];
 		$properties = $schema['properties'];
 
-		$this->assertSame( array( 'target_urn' ), $schema['required'] );
+		$this->assertSame( array(), $schema['required'] );
 		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertArrayHasKey( 'target_urn', $properties );
+		$this->assertArrayHasKey( 'site_url', $properties );
+		$this->assertArrayHasKey( 'post_id', $properties );
+		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'goal', $properties );
 		$this->assertArrayHasKey( 'budget_total', $properties );
 		$this->assertArrayHasKey( 'duration_days', $properties );
@@ -547,6 +551,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'interests', $properties );
 		$this->assertArrayNotHasKey( 'objective', $properties );
 		$this->assertArrayNotHasKey( 'page_topics', $properties );
+		$this->assertStringContainsString( 'site_url plus post_id', $properties['target_urn']['description'] );
+		$this->assertStringContainsString( 'public WordPress.com site URL', $properties['site_url']['description'] );
+		$this->assertStringContainsString( 'post_id', $properties['post_id']['description'] );
+		$this->assertStringContainsString( 'product_id', $properties['product_id']['description'] );
 		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
 		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
 		$this->assertSame( array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ), $properties['languages']['items']['enum'] );
@@ -773,7 +781,13 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertIsArray( $result );
 		$this->assertSame( 'stopped', $result['status'] );
 		$this->assertSame( 'Spring launch', $result['campaign']['title'] );
-		$this->assertSame( array( 'id' => 987, 'status' => 'stopped' ), $result['stop_response'] );
+		$this->assertSame(
+			array(
+				'id'     => 987,
+				'status' => 'stopped',
+			),
+			$result['stop_response']
+		);
 		$this->assertStringContainsString( 'Campaign "Spring launch" was stopped from serving.', $result['message'] );
 		$this->assertStringNotContainsString( 'deleted', strtolower( $result['message'] ) );
 		$this->assertStringNotContainsString( 'archived', strtolower( $result['message'] ) );


### PR DESCRIPTION
Fixes #ADS-1057

## Proposed changes
* Allow `blaze-ads/prepare-campaign` callers to provide `site_url` plus exactly one of `post_id` or `product_id` when they do not know the canonical `target_urn`.
* Resolve friendly targets through the public WordPress.com sites API and normalize them into the existing `urn:wpcom:post:<site_id>:<id>` shape before campaign preparation continues.
* Return specific `WP_Error` codes for missing target input, ambiguous post/product input, site lookup failure, and unresolved connected-site responses.
* Keep `target_urn` supported for advanced/backward-compatible callers and document all target forms in the ability schema.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/ADS-1057/add-portable-target-inputs-to-blaze-prepare-campaign
* Stacked on Phase 3 tip: https://github.com/Automattic/jetpack/pull/48782

## Does this pull request change what data or activity we track or use?
No. This changes target input normalization only. The existing prepare-campaign telemetry categorizes the new target/site lookup failures with low-cardinality error categories and does not include raw site URLs or target IDs.

## Testing instructions
* Run `composer phpcs:lint -- projects/packages/blaze/src/class-campaign-preparer.php projects/packages/blaze/src/abilities/class-blaze-abilities.php projects/packages/blaze/tests/php/Campaign_Preparer_Test.php projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php`.
* Run `cd projects/packages/blaze && phpunit -c phpunit.11.xml.dist --colors=always --filter 'Campaign_Preparer_Test|Blaze_Abilities_Test'`.
* Optional broader check: run `composer test-php --working-dir=projects/packages/blaze`. At the time this PR was opened, the new tests pass but the broader package command still fails on the existing `Automattic\Jetpack\Blaze\Dashboard_Test::test_load_admin_scripts` admin-script assertion.
