### PR TITLE
Newsletter Categories: treat unchanged save as success, not 400

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1053,12 +1053,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				case Jetpack_Newsletter_Category_Helper::NEWSLETTER_CATEGORIES_OPTION:
 					if ( ! is_array( $value ) || empty( $value ) ) {
+						$updated = true;
 						break;
 					}
 
 					// If we are already current, do nothing
 					$current_value = Jetpack_Newsletter_Category_Helper::get_category_ids();
 					if ( $value === $current_value ) {
+						$updated = true;
 						break;
 					}
 

--- a/projects/plugins/jetpack/changelog/nl-618-newsletter-category-filtering-400
+++ b/projects/plugins/jetpack/changelog/nl-618-newsletter-category-filtering-400
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter Categories: stop returning 400 when saving the same category selection that's already stored.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -725,6 +725,74 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression for NL-618: re-posting newsletter categories with the same selection the option
+	 * already holds must return 200, not a `some_updated` 400. The previous code left `$updated`
+	 * false on the "values equal" short-circuit, so any save without an actual change blew up.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_newsletter_categories_same_value_returns_success() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		$category_id = self::factory()->category->create();
+		// Pre-seed the option in canonical form, matching what the helper saves.
+		update_option( 'wpcom_newsletter_categories', array( array( 'term_id' => $category_id ) ) );
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array( 'wpcom_newsletter_categories' => array( $category_id ) ),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+	}
+
+	/**
+	 * Regression for NL-618: posting an empty array must be a no-op success, not a 400.
+	 * The frontend strips the key for empty selections, but defensive code should still treat
+	 * "nothing to save" as success rather than a failed update.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_newsletter_categories_empty_value_returns_success() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array( 'wpcom_newsletter_categories' => array() ),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+	}
+
+	/**
+	 * A real change to newsletter categories still persists through the same code path.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_newsletter_categories_new_value_is_saved() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		$category_id = self::factory()->category->create();
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array( 'wpcom_newsletter_categories' => array( $category_id ) ),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+		$this->assertSame(
+			array( $category_id ),
+			Jetpack_Newsletter_Category_Helper::get_category_ids()
+		);
+	}
+
+	/**
 	 * Test that a setting is retrieved correctly.
 	 * Here we test three types of settings:
 	 * - module settings


### PR DESCRIPTION
## Summary

Fixes [NL-618](https://linear.app/a8c/issue/NL-618). Saving newsletter category settings on a self-hosted site was returning `POST /wp-json/jetpack/v4/settings 400 (Bad Request)` whenever the submitted selection matched what was already stored — which happens any time a user clicks **Save** without actually changing the selection.

### Root cause

In `Jetpack_Core_API_Data::update_data()` the `case` for `wpcom_newsletter_categories` had two early-exit `break`s — "empty value" and "value already matches the stored selection" — that returned without setting `\$updated = true`. The surrounding loop initializes `\$updated` to `false` and `\$error` to `''`, so those no-op paths landed in `\$not_updated[\$option] = ''` and triggered a `WP_Error('some_updated', '', ['status' => 400])` with an empty message — exactly what the customer in NL-618 was seeing.

Response body the customer reported:

\`\`\`json
{"code":"some_updated","message":"","data":{"status":400}}
\`\`\`

### Fix

Set `\$updated = true` on both no-op paths. A save that doesn't change the stored selection is now reported as success, which matches what every other option in this endpoint does.

## Test plan

- [ ] On a self-hosted Jetpack site: enable Newsletter categories, pick at least one category, save.
- [ ] Click **Save** again without changing anything — should now return 200 instead of 400.
- [ ] Change the selection, save — still persists correctly.
- [ ] Automated: \`jetpack docker phpunit jetpack -- --filter 'test_wpcom_newsletter_categories'\` → 3 tests, 4 assertions pass. Full \`Jetpack_REST_API_endpoints_Test\` class still green (37/107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)