### PR TITLE
Newsletter Categories: treat unchanged save as success, not 400

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1053,12 +1053,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				case Jetpack_Newsletter_Category_Helper::NEWSLETTER_CATEGORIES_OPTION:
 					if ( ! is_array( $value ) || empty( $value ) ) {
+						$updated = true;
 						break;
 					}
 
 					// If we are already current, do nothing
 					$current_value = Jetpack_Newsletter_Category_Helper::get_category_ids();
 					if ( $value === $current_value ) {
+						$updated = true;
 						break;
 					}
 

--- a/projects/plugins/jetpack/changelog/nl-618-newsletter-category-filtering-400
+++ b/projects/plugins/jetpack/changelog/nl-618-newsletter-category-filtering-400
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter Categories: stop returning 400 when saving the same category selection that's already stored.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -725,6 +725,74 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression for NL-618: re-posting newsletter categories with the same selection the option
+	 * already holds must return 200, not a `some_updated` 400. The previous code left `$updated`
+	 * false on the "values equal" short-circuit, so any save without an actual change blew up.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_newsletter_categories_same_value_returns_success() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		$category_id = self::factory()->category->create();
+		// Pre-seed the option in canonical form, matching what the helper saves.
+		update_option( 'wpcom_newsletter_categories', array( array( 'term_id' => $category_id ) ) );
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array( 'wpcom_newsletter_categories' => array( $category_id ) ),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+	}
+
+	/**
+	 * Regression for NL-618: posting an empty array must be a no-op success, not a 400.
+	 * The frontend strips the key for empty selections, but defensive code should still treat
+	 * "nothing to save" as success rather than a failed update.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_newsletter_categories_empty_value_returns_success() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array( 'wpcom_newsletter_categories' => array() ),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+	}
+
+	/**
+	 * A real change to newsletter categories still persists through the same code path.
+	 *
+	 * @return void
+	 */
+	public function test_wpcom_newsletter_categories_new_value_is_saved() {
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		$category_id = self::factory()->category->create();
+
+		$response = $this->create_and_get_request(
+			'settings',
+			array( 'wpcom_newsletter_categories' => array( $category_id ) ),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+		$this->assertSame(
+			array( $category_id ),
+			Jetpack_Newsletter_Category_Helper::get_category_ids()
+		);
+	}
+
+	/**
 	 * Test that a setting is retrieved correctly.
 	 * Here we test three types of settings:
 	 * - module settings


### PR DESCRIPTION
Fixes NL-626

## Proposed changes
* Fix `Jetpack_Core_API_Data::update_data()` so re-saving newsletter categories with the same selection that's already stored returns 200 instead of a `some_updated` 400.
* The two early-exit `break`s in the `wpcom_newsletter_categories` case (empty value, value already current) now set `$updated = true`. Previously they fell through with `$updated = false` and `$error = ''`, producing `WP_Error('some_updated', '', ['status' => 400])` — exactly the body the NL-618 customer reported: `{"code":"some_updated","message":"","data":{"status":400}}`.
* Adds 3 regression tests in `Jetpack_REST_API_endpoints_Test` covering: re-saving the same selection, posting an empty array, and a real change persisting through the helper.

## Related product discussion/links
* Linear: [NL-618](https://linear.app/a8c/issue/NL-618)
* Zendesk: [#11178325](https://a8c.zendesk.com/agent/tickets/11178325)
* Related prior fix (added the helper class and `case` whose break paths this PR completes): #44537 / [CM-195](https://linear.app/a8c/issue/CM-195)
* Replaces #48864, which auto-closed when the source branch was renamed.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

On a self-hosted Jetpack site (where this endpoint is the save path):

* Go to `wp-admin → Jetpack → Settings → Newsletter`.
* Enable **Newsletter categories**, pick at least one category, click **Save settings**.
* Click **Save settings** again **without changing anything** — on `trunk` this returns `POST /wp-json/jetpack/v4/settings 400 (Bad Request)` with body `{"code":"some_updated","message":""}`. With this PR it returns 200.
* Change the selection (add or remove a category) and save — still persists correctly.

Automated:

* `jetpack docker phpunit jetpack -- --filter 'test_wpcom_newsletter_categories'` → 3 tests, 4 assertions, all green.
* `jetpack docker phpunit jetpack -- --filter 'Jetpack_REST_API_endpoints_Test'` → 37/107 still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)