### PR TITLE
Write editor: caption is editable after reload (RSM-3359)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-caption-editable-after-reload
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-caption-editable-after-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: caption is editable after reload (RSM-3359)

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1224,8 +1224,12 @@
 	background: rgba(33, 113, 177, 0.85);
 }
 
-/* Figcaption */
-.bw-figcaption {
+/* Figcaption.
+ * `.wp-element-caption` is the class on saved markup served by the server
+ * before JS upgrades it to `.bw-figcaption` — match both so reloaded
+ * captions don't flash left-aligned before init runs. */
+.bw-figcaption,
+.bw-content .wp-element-caption {
 	text-align: center;
 	font-size: 0.875rem;
 	color: #999;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1128,6 +1128,21 @@ function addDeleteButtons() {
 		} );
 		controls.appendChild( altBtn );
 
+		// Captions saved by the editor come back from the server with class
+		// `wp-element-caption` and no `contentEditable`, so without this any
+		// reloaded caption would be uneditable and left-aligned (missing the
+		// `bw-figcaption` style).
+		const existingFigcaption = fig.querySelector( 'figcaption' );
+		if ( existingFigcaption ) {
+			existingFigcaption.classList.add( 'bw-figcaption' );
+			existingFigcaption.contentEditable = 'true';
+			existingFigcaption.setAttribute(
+				'data-placeholder',
+				i18n.writeCaption || 'Write a caption...'
+			);
+			existingFigcaption.addEventListener( 'click', ev => ev.stopPropagation() );
+		}
+
 		// Caption button.
 		const capBtn = document.createElement( 'button' );
 		capBtn.className = 'bw-img-caption-btn';


### PR DESCRIPTION
Fixes [RSM-3359](https://linear.app/a8c/issue/RSM-3359/caption-cant-be-edited-after-save).

## Proposed changes
* Make image captions editable again after a post is saved and reloaded in the Write editor.
* Inside `addDeleteButtons()`, look up any pre-existing `<figcaption>` on each figure and give it the same `bw-figcaption` class, `contentEditable="true"`, `data-placeholder`, and click-stopPropagation listener that newly-created figcaptions already get from the caption-button click handler.

### Why the bug happened
Captions are serialized as `<figcaption class="wp-element-caption">…</figcaption>` (view.js:609-612). On reload, that markup arrives in the DOM with no `contentEditable`, and `addDeleteButtons()` only set up an editable figcaption inside the caption-button click handler when one didn't already exist. So pre-existing figcaptions never got `contentEditable="true"`, the `bw-figcaption` class (which supplies `text-align: center` in `style.css`), or the placeholder/click-stop listener. Result: uneditable caption, left-aligned because it was missing the editor's CSS class.

## Related product discussion/links
* [RSM-3359](https://linear.app/a8c/issue/RSM-3359/caption-cant-be-edited-after-save)
* Related: [PR #48395](https://github.com/Automattic/jetpack/pull/48395) (introduced caption serialization)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Open the Write editor.
2. Insert an image and add a caption.
3. Wait for autosave (or trigger it) and reload the page.
4. **Before this fix:** the caption appears left-aligned and clicking it does nothing.
5. **After this fix:** the caption appears centered (matching its in-editor styling), is editable on click, and shows the "Write a caption…" placeholder when emptied.
6. Verify a freshly inserted caption (no reload) still works — type into it, press Enter to exit, undo/redo.