### PR TITLE
Social: default modernized dashboard on; keep filter + legacy shell as kill switch (#48824 PR 5)

### DIFF
--- a/projects/packages/publicize/changelog/retire-modernization-gate
+++ b/projects/packages/publicize/changelog/retire-modernization-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Refreshed Social dashboard with separate Overview and Settings tabs — manage your connected accounts, see what drives traffic, and tweak sharing controls in a faster, cleaner interface.

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -28,9 +28,10 @@ class Social_Admin_Page {
 	/**
 	 * Filter name that gates the wp-build–based dashboard.
 	 *
-	 * When this filter returns true, "Jetpack > Social" renders the new
-	 * wp-build dashboard (Overview + Settings tabs) instead of the legacy
-	 * single-page React app.
+	 * "Jetpack > Social" renders the new wp-build dashboard (Overview +
+	 * Settings tabs) by default. Returning false from this filter falls
+	 * back to the legacy single-page React app — kept as an emergency
+	 * kill switch in case a regression is found in production.
 	 */
 	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_social';
 
@@ -258,12 +259,16 @@ class Social_Admin_Page {
 	}
 
 	/**
-	 * Returns true when the wp-build modernization filter is enabled.
+	 * Returns true when the wp-build modernized dashboard should render.
+	 *
+	 * Defaults on; the `MODERNIZATION_FILTER` filter is an emergency
+	 * kill switch — returning false from it falls back to the legacy
+	 * single-page admin shell.
 	 *
 	 * @return bool
 	 */
 	private static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Flips the `rsm_jetpack_ui_modernization_social` feature filter's default from `false` to `true`: the wp-build chassis (Overview + Settings tabs) is now the **default** surface for "Jetpack > Social". No mu-plugin / Code Snippets / filter override needed any more for normal use.
- Keeps the filter and the legacy single-page admin shell in place as an emergency kill switch: operators can fall back to the legacy surface per-site via `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_false' );` (e.g. via Code Snippets) if a regression surfaces in production.
- Once we're confident in the rollout, the filter + legacy shell can retire in a follow-up.

## Change of focus

This PR previously deleted the filter and the legacy `SocialAdminPage` shell outright. After review we split that work:

- The `jetpack_social_tab_view` Tracks instrumentation moved to its own PR: #49240.
- The legacy-shell deletions were dropped. The branch has since been **squashed to a single commit** whose only net change against `trunk` is the default flip in `Social_Admin_Page::is_modernized()` + opt-out docblocks on `MODERNIZATION_FILTER` and `is_modernized()` (2 files, +14 / -5 lines).

## Highlights

- **Filter default flipped.** `Social_Admin_Page::is_modernized()` now returns `(bool) apply_filters( self::MODERNIZATION_FILTER, true )`. Docblocks on the const and the method explain the opt-out semantics.
- **Legacy shell unchanged.** `_inc/components/admin-page/index.tsx`, the `Header` / `InfoSection` / `MessageTemplateSection` / toggle bank, and their tests stay byte-identical to trunk. The wp-build chassis loads on the happy path; the legacy menu callback handles the kill-switch path.
- **Connection / pricing gating now lives in the chassis.** As of #49260 (already on trunk), the modernized dashboard gates connection and pricing flows internally via `_inc/components/social-gate/` (`ConnectionGate` / `PricingGate`, decided by `useSocialGate()`). The old PHP-layer `should_preempt_to_legacy()` pre-empt was removed by that PR — this PR does not reinstate it. On the kill-switch (legacy) path, the legacy shell self-gates to `ConnectionScreen` / `PricingPage` as before.

## Screenshots

> Chassis renders by default after this PR — no mu-plugin, no opt-in.

**Overview tab — default rendering**

![Overview, default](https://github.com/keoshi/automated-screenshot-tool/releases/download/social-pr-48867-screenshots/overview-default.png)

**Settings tab — default rendering**

![Settings, default](https://github.com/keoshi/automated-screenshot-tool/releases/download/social-pr-48867-screenshots/settings-default.png)

## Testing instructions

* Pull this branch and `pnpm jetpack build packages/publicize`.
* Hard-reload `wp-admin/admin.php?page=jetpack-social` on a connected paid site.
* Confirm the modernized chassis renders by default — **no** `rsm_jetpack_ui_modernization_social` filter required. (Before this PR this required an opt-in snippet.)
* Sanity check that the legacy shell still exists on disk: `git diff origin/trunk..HEAD -- projects/packages/publicize/_inc/components/admin-page/` should show no changes.

**Kill-switch path:**

* Add `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_false' );` via Code Snippets (or an mu-plugin).
* Hard-reload the Social admin page. The legacy single-page `SocialAdminPage` (Header, AdminSection toggle bank, InfoSection) should render — the same surface as on trunk before this PR.
* Toggle the snippet back off, hard-reload, confirm the chassis returns.

**Gating (now in-chassis):**

* On the default chassis: disconnect Jetpack on a self-hosted site, visit the Social admin page, and confirm the `ConnectionGate` renders inside the dashboard. Re-connect, then (on a free Jetpack site that hasn't dismissed the pricing nudge) confirm the `PricingGate` renders.
* On the kill-switch (legacy) path: with `__return_false` applied, confirm the legacy shell still routes disconnected → `ConnectionScreen` and free → `PricingPage` internally.

**Smoke check the chassis surfaces (happy path):**

* From Overview: Add account modal still works; connection list renders; Add account button in the Page header is functional.
* From Settings: the Default share message editor, Customize media (SIG) toggle + Change defaults modal, Customize links (UTM) toggle still save / load.

## Does this pull request change what data or activity we track or use?

No. The `jetpack_social_tab_view` Tracks event mentioned in earlier revisions of this PR has been split into #49240 and is no longer part of this change.
