### PR TITLE
Infinite Scroll: Avoid PHP warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-infinite-scroll-php_warnings
+++ b/projects/plugins/jetpack/changelog/fix-infinite-scroll-php_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Infinite Scroll: Address PHP warnings.

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -637,6 +637,9 @@ class The_Neverending_Home_Page {
 
 		// grab the last posts in the stack as if the last one is title-matching the rest is title-matching as well
 		$post = end( self::wp_query()->posts );
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
 
 		// code inspired by WP_Query class
 		if ( preg_match_all( '/".*?("|$)|((?<=[\t ",+])|^)[^\t ",+]+/', self::wp_query()->get( 's' ), $matches ) ) {

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -903,7 +903,8 @@ class The_Neverending_Home_Page {
 				&& ! empty( $taxonomy->object_type )
 				&& count( $taxonomy->object_type ) < 2
 			) {
-				$post_type = $taxonomy->object_type[0];
+				// It seems [0] doesn't work, as sometimes plugins can deregister a taxonomy but not reindex.
+				$post_type = reset( $taxonomy->object_type );
 			}
 		}
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This addresses two PHP warnings in the Infinite Scroll module:
```
PHP Warning: Attempt to read property "post_title" on int in /wordpress/plugins/jetpack/15.8-beta/modules/infinite-scroll/infinity.php on line 654
```
The above is presumably triggered by some third-party code; I added a guard to ensure the var is a `WP_Post` and return early if not.

```
PHP Warning: Undefined array key 0 in /wordpress/plugins/jetpack/15.8-a.7/modules/infinite-scroll/infinity.php on line 903
```
Also likely triggered by third-party code, `$taxonomy->object_type` can be a non-empty array without a `0` index, which triggers warnings. This uses `reset()` to grab that one element.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

These are both obscure and I'm not sure how to test, but the fixes should be pretty simple to read over.