### PR TITLE
Verification Tools: remove trailing slash from meta void elements

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-verification-tools-meta-trailing-slash
+++ b/projects/plugins/jetpack/changelog/fix-verification-tools-meta-trailing-slash
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: other
 
 Verification Tools: remove trailing slash from meta void elements to conform with the HTML spec.

--- a/projects/plugins/jetpack/changelog/fix-verification-tools-meta-trailing-slash
+++ b/projects/plugins/jetpack/changelog/fix-verification-tools-meta-trailing-slash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Verification Tools: remove trailing slash from meta void elements to conform with the HTML spec.

--- a/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
+++ b/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
@@ -72,12 +72,12 @@ function jetpack_verification_print_meta() {
 		$ver_output = "<!-- Jetpack Site Verification Tags -->\n";
 		foreach ( jetpack_verification_services() as $name => $service ) {
 			if ( is_array( $service ) && ! empty( $verification_services_codes[ "$name" ] ) ) {
-				if ( preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" />$#i', $verification_services_codes[ "$name" ], $matches ) ) {
+				if ( preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" /?>$#i', $verification_services_codes[ "$name" ], $matches ) ) {
 					$verification_code = $matches[2];
 				} else {
 					$verification_code = $verification_services_codes[ "$name" ];
 				}
-				$ver_tag = sprintf( '<meta name="%s" content="%s" />', esc_attr( $service['key'] ), esc_attr( $verification_code ) );
+				$ver_tag = sprintf( '<meta name="%s" content="%s">', esc_attr( $service['key'] ), esc_attr( $verification_code ) );
 				/**
 				 * Filter the meta tag template used for all verification tools.
 				 *


### PR DESCRIPTION
## Proposed changes

HTML void elements (`<meta>`, `<link>`, etc.) do not take a closing slash. The trailing ` />` in the generated verification tag is invalid per the HTML spec and causes validator warnings.

**Changes:**

- `blog-verification-tools.php` line 80: `<meta name="%s" content="%s" />` → `<meta name="%s" content="%s">`
- `blog-verification-tools.php` line 75: Updated the stored-value regex from `/>$` to `/?>$` so sites that stored verification codes before this change (with the old `/>` format) continue to parse correctly.

## Testing instructions

1. Install and activate Jetpack on a test site.
2. Go to **Jetpack → Settings → Traffic** (or **Tools → Site Verification**) and enter a verification code for any service (e.g. Google: paste a raw code like `abc123`).
3. Save and view the page source — the output tag should be `<meta name="google-site-verification" content="abc123">` with no trailing slash.
4. Optionally, also paste a full meta tag (e.g. `<meta name="google-site-verification" content="abc123" />`) into the field — it should still be saved and rendered correctly (backward compat path).

## Does this pull request change what data or activity we track or use?

No. This is a purely cosmetic HTML conformance fix. No data collection, tracking, or privacy-relevant behaviour is changed.

## Other information

- No functional change — the verification code extracted and output is identical
- Backward compatible: the relaxed regex handles both `/>` (old stored values) and `>` (new output)
- No new tests needed; the existing `jetpack_verification_get_code` tests cover input parsing and are unaffected

Fixes #27185

🤖 Generated with [Claude Code](https://claude.com/claude-code)