### PR TITLE
Copy Post: fix backslash characters being stripped when duplicating a post

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-copy-post-backslash-stripping
+++ b/projects/plugins/jetpack/changelog/fix-copy-post-backslash-stripping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Copy Post: fix backslash characters being stripped from post content, title, and excerpt when duplicating a post.

--- a/projects/plugins/jetpack/modules/copy-post.php
+++ b/projects/plugins/jetpack/modules/copy-post.php
@@ -171,7 +171,7 @@ class Jetpack_Copy_Post {
 		 * @param int     $target_post_id Target post ID.
 		 */
 		$data = apply_filters( 'jetpack_copy_post_data', $data, $source_post, $target_post_id );
-		return wp_update_post( $data );
+		return wp_update_post( wp_slash( $data ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
@@ -272,10 +272,12 @@ class Copy_Post_Test extends WP_UnitTestCase {
 		$source_title   = "Title with \\t tab";
 
 		$source_post_id = self::factory()->post->create(
-			array(
-				'post_content' => $source_content,
-				'post_excerpt' => $source_excerpt,
-				'post_title'   => $source_title,
+			wp_slash(
+				array(
+					'post_content' => $source_content,
+					'post_excerpt' => $source_excerpt,
+					'post_title'   => $source_title,
+				)
 			)
 		);
 		$source_post    = get_post( $source_post_id );

--- a/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
@@ -260,9 +260,6 @@ class Copy_Post_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test that update_content preserves backslashes in post fields.
-	 *
-	 * wp_update_post() calls wp_unslash() internally, so content must be
-	 * passed through wp_slash() first to prevent backslashes from being stripped.
 	 */
 	public function test_update_content_preserves_backslashes() {
 		$copy_post = new Jetpack_Copy_Post();
@@ -284,7 +281,9 @@ class Copy_Post_Test extends WP_UnitTestCase {
 		$target_post_id = self::factory()->post->create();
 
 		$method = new ReflectionMethod( Jetpack_Copy_Post::class, 'update_content' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		$method->invoke( $copy_post, $source_post, $target_post_id );
 
 		$target_post = get_post( $target_post_id );

--- a/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
@@ -257,4 +257,37 @@ class Copy_Post_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $target_footnotes );
 		$this->assertEquals( $footnote_content, $target_footnotes[0]['content'] );
 	}
+
+	/**
+	 * Test that update_content preserves backslashes in post fields.
+	 *
+	 * wp_update_post() calls wp_unslash() internally, so content must be
+	 * passed through wp_slash() first to prevent backslashes from being stripped.
+	 */
+	public function test_update_content_preserves_backslashes() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$source_content = "Code: \\t is a tab, \\n is a newline, \\\\ is a backslash";
+		$source_excerpt = "Excerpt with \\t tab";
+		$source_title   = "Title with \\t tab";
+
+		$source_post_id = self::factory()->post->create(
+			array(
+				'post_content' => $source_content,
+				'post_excerpt' => $source_excerpt,
+				'post_title'   => $source_title,
+			)
+		);
+		$source_post    = get_post( $source_post_id );
+		$target_post_id = self::factory()->post->create();
+
+		$method = new ReflectionMethod( Jetpack_Copy_Post::class, 'update_content' );
+		$method->setAccessible( true );
+		$method->invoke( $copy_post, $source_post, $target_post_id );
+
+		$target_post = get_post( $target_post_id );
+		$this->assertSame( $source_content, $target_post->post_content, 'Backslashes in post_content should be preserved' );
+		$this->assertSame( $source_excerpt, $target_post->post_excerpt, 'Backslashes in post_excerpt should be preserved' );
+		$this->assertSame( $source_title, $target_post->post_title, 'Backslashes in post_title should be preserved' );
+	}
 }


### PR DESCRIPTION
Fixes #46020

## Proposed changes

`wp_update_post()` calls `wp_unslash()` internally because it expects WordPress-style slashed data (as received from `$_POST`). The Copy Post module passed raw database content from `get_post()` directly — content that is already unslashed — so backslash sequences like `\t`, `\n`, `\\`, and `\f` were silently stripped from `post_content`, `post_title`, and `post_excerpt` when duplicating a post.

**Fix:** wrap the data array with `wp_slash()` before calling `wp_update_post()` in `update_content()`, which is the standard WordPress pattern for passing programmatically-constructed post data.

One-line change:
```php
// Before
return wp_update_post( $data );

// After
return wp_update_post( wp_slash( $data ) );
```

Also adds a regression test using `ReflectionMethod` to invoke the protected `update_content()` method and assert that backslashes in all three fields are preserved after the copy.

## Does this pull request change what data or activity we track or use?

No. This is a bug fix for data fidelity during post duplication. No tracking or privacy-relevant behaviour is changed.

## Testing instructions

1. Enable the **Copy Post** module in Jetpack → Settings → Writing.
2. Create a post containing backslash characters, e.g. add a Code block with the text `\t is a tab` and a paragraph with `\\escaped\\`.
3. Save and publish the post.
4. Go to Posts → All Posts, find the post, and click **Duplicate**.
5. Open the duplicated post — the content should be identical to the original, with all backslashes intact.
   - **Before this fix:** `\t is a tab` becomes `t is a tab`; `\\escaped\\` becomes `\escaped\`
   - **After this fix:** content is preserved exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)