### PR TITLE
SIG: Prevent PHP warning when setting key doesn't exist

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-image-generator-php_warnings
+++ b/projects/packages/publicize/changelog/fix-social-image-generator-php_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+SIG: Prevent PHP warning when setting key doesn't exist. 

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -94,7 +94,7 @@ class Setup {
 		if (
 			! $update &&
 			'auto-draft' === $post->post_status &&
-			$settings->get_settings()['socialImageGeneratorSettings']['enabled'] &&
+			! empty( $settings->get_settings()['socialImageGeneratorSettings']['enabled'] ) &&
 			empty( $post_settings->get_settings( true ) ) &&
 			'jetpack-social-note' !== $post->post_type
 		) {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR adds a `! empty()` guard to prevent this PHP warning:
```
PHP Warning: Undefined array key "enabled" in /wordpress/plugins/jetpack/15.8-beta/jetpack_vendor/automattic/jetpack-publicize/src/social-image-generator/class-setup.php on line 97
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

I'm not sure how to reproduce this, but presumably some old version of settings was saved or something.