### PR TITLE
Escape podcast RSS feed metadata

### DIFF
--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -83,14 +83,14 @@ class Customize_Feed {
 	public static function feed_title( $title ) {
 		$override = (string) get_option( 'podcasting_title', '' );
 		if ( '' !== $override ) {
-			return $override;
+			return esc_html( $override );
 		}
 
 		$category = get_category( self::resolve_category_id() );
 		if ( $category && ! is_wp_error( $category ) ) {
-			return get_bloginfo( 'name' ) . ' &#187; ' . $category->name;
+			return esc_html( get_bloginfo( 'name' ) ) . ' &#187; ' . esc_html( $category->name );
 		}
-		return $title;
+		return esc_html( $title );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -35,8 +35,24 @@ class Customize_Feed_Test extends BaseTestCase {
 		delete_option( 'podcasting_archive' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
+		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
+	}
+
+	private function configure_podcast_category( int $id, string $name ): int {
+		$term = new WP_Term(
+			(object) array(
+				'term_id'          => $id,
+				'name'             => $name,
+				'slug'             => 'podcast-' . $id,
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => $id,
+			)
+		);
+		wp_cache_set( $id, $term, 'terms' );
+		update_option( 'podcasting_category_id', $id );
+		return $id;
 	}
 
 	/**
@@ -84,6 +100,29 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertSame( 'My Podcast Show', Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
+	public function test_feed_title_escapes_override_for_rss_title() {
+		update_option( 'podcasting_title', 'My <Podcast> & "Friends"' );
+
+		$this->assertSame( 'My &lt;Podcast&gt; &amp; &quot;Friends&quot;', Customize_Feed::feed_title( 'Default Title' ) );
+	}
+
+	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
+		$this->configure_podcast_category( 1234, 'Audio <News> & "Reviews"' );
+		$blogname = static function () {
+			return 'Blog <Name> & "Site"';
+		};
+		add_filter( 'pre_option_blogname', $blogname );
+
+		try {
+			$this->assertSame(
+				'Blog &lt;Name&gt; &amp; &quot;Site&quot; &#187; Audio &lt;News&gt; &amp; &quot;Reviews&quot;',
+				Customize_Feed::feed_title( 'Default Title' )
+			);
+		} finally {
+			remove_filter( 'pre_option_blogname', $blogname );
+		}
+	}
+
 	public function test_feed_title_falls_through_when_no_override_and_no_category() {
 		update_option( 'podcasting_title', '' );
 		update_option( 'podcasting_category_id', 0 );
@@ -116,6 +155,13 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( "<itunes:category text='Technology'>", $xml );
 		$this->assertStringContainsString( "<itunes:category text='Tech News' />", $xml );
+	}
+
+	public function test_category_tag_escapes_xml_attributes() {
+		$xml = Customize_Feed::category_tag( 'Arts & <Culture>,Kids\' Shows "Daily"' );
+
+		$this->assertStringContainsString( "<itunes:category text='Arts &amp; &lt;Culture&gt;'>", $xml );
+		$this->assertStringContainsString( "<itunes:category text='Kids&#039; Shows &quot;Daily&quot;' />", $xml );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- escape podcast RSS title overrides and fallback title parts before output
- escape iTunes category attribute values for podcast feed metadata
- add focused feed customization tests for title and category escaping

## Testing
- php -l projects/packages/podcast/src/feed/class-customize-feed.php
- php -l projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
- git diff --check origin/trunk...HEAD

## Notes
- composer test-php -- --filter Customize_Feed_Test could not run locally because phpunit-select-config is not installed in this checkout.
- direct phpunit also could not run because projects/packages/podcast/vendor/autoload.php is missing.