### PR TITLE
Harden podcast feed detection state promotion

### DIFF
--- a/projects/packages/podcast/src/feed/class-feed-detection.php
+++ b/projects/packages/podcast/src/feed/class-feed-detection.php
@@ -12,8 +12,9 @@ namespace Automattic\Jetpack\Podcast\Feed;
 use Automattic\Jetpack\Podcast\Settings;
 
 /**
- * Promotes a podcatcher's `podcasting_show_states` entry to `'active'` the
- * first time we see its UA fetch the feed. Idempotent thereafter.
+ * Promotes an existing pending podcatcher `podcasting_show_states` entry to
+ * `'active'` the first time we see its UA fetch the feed. Idempotent
+ * thereafter.
  */
 class Feed_Detection {
 
@@ -65,8 +66,9 @@ class Feed_Detection {
 
 	/**
 	 * Inspect the current request's User-Agent and, if it's a directory
-	 * crawler, mark its state `'active'`. No-op if the UA is missing or not
-	 * in the directory allowlist.
+	 * crawler with an existing pending state, mark its state `'active'`.
+	 * No-op if the UA is missing, not in the directory allowlist, or the
+	 * matched directory has no pending state.
 	 */
 	public static function detect_and_record(): void {
 		$ua = isset( $_SERVER['HTTP_USER_AGENT'] )
@@ -93,7 +95,7 @@ class Feed_Detection {
 			$states = array();
 		}
 
-		if ( isset( $states[ $slug ] ) && 'active' === $states[ $slug ] ) {
+		if ( ! isset( $states[ $slug ] ) || 'pending' !== $states[ $slug ] ) {
 			return;
 		}
 

--- a/projects/packages/podcast/tests/php/Feed/Feed_Detection_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Feed_Detection_Test.php
@@ -26,7 +26,7 @@ class Feed_Detection_Test extends BaseTestCase {
 	 * regression net for the opawg sync (Amazon's spaced bot UA, the
 	 * broadened `PodcastIndex` substring, etc.).
 	 */
-	public function test_recognizes_each_tracked_directory() {
+	public function test_promotes_pending_state_for_each_tracked_directory() {
 		$cases = array(
 			'AppleCoreMedia/1.0.0.20F71 (iPhone; U; CPU OS 16_5_1)' => 'apple',
 			'Spotify/8.7.0 iOS/16.4'       => 'spotify',
@@ -37,7 +37,7 @@ class Feed_Detection_Test extends BaseTestCase {
 		);
 
 		foreach ( $cases as $ua => $expected_slug ) {
-			delete_option( 'podcasting_show_states' );
+			update_option( 'podcasting_show_states', array( $expected_slug => 'pending' ) );
 			$_SERVER['HTTP_USER_AGENT'] = $ua;
 
 			Feed_Detection::detect_and_record();
@@ -55,6 +55,41 @@ class Feed_Detection_Test extends BaseTestCase {
 
 		$states = get_option( 'podcasting_show_states', array() );
 		$this->assertSame( 'active', $states['apple'] );
+	}
+
+	public function test_does_not_create_state_for_recognized_directory_without_existing_state() {
+		$_SERVER['HTTP_USER_AGENT'] = 'AppleCoreMedia/1.0.0.20F71';
+
+		Feed_Detection::detect_and_record();
+
+		$this->assertFalse( get_option( 'podcasting_show_states', false ) );
+	}
+
+	public function test_does_not_create_state_for_recognized_directory_with_empty_states_array() {
+		update_option( 'podcasting_show_states', array() );
+		$_SERVER['HTTP_USER_AGENT'] = 'AppleCoreMedia/1.0.0.20F71';
+
+		Feed_Detection::detect_and_record();
+
+		$this->assertSame( array(), get_option( 'podcasting_show_states', array() ) );
+	}
+
+	public function test_does_not_create_state_for_recognized_directory_missing_from_existing_states() {
+		update_option( 'podcasting_show_states', array( 'spotify' => 'pending' ) );
+		$_SERVER['HTTP_USER_AGENT'] = 'AppleCoreMedia/1.0.0.20F71';
+
+		Feed_Detection::detect_and_record();
+
+		$this->assertSame( array( 'spotify' => 'pending' ), get_option( 'podcasting_show_states', array() ) );
+	}
+
+	public function test_does_not_promote_empty_state_value() {
+		update_option( 'podcasting_show_states', array( 'apple' => '' ) );
+		$_SERVER['HTTP_USER_AGENT'] = 'AppleCoreMedia/1.0.0.20F71';
+
+		Feed_Detection::detect_and_record();
+
+		$this->assertSame( array( 'apple' => '' ), get_option( 'podcasting_show_states', array() ) );
 	}
 
 	public function test_does_not_rewrite_when_already_active() {


### PR DESCRIPTION
## Summary
- only promote existing pending podcast directory states to active
- avoid creating show state entries from recognized crawler user agents alone
- add regression coverage for pending promotion and missing/empty state no-ops

## Testing
- php -l projects/packages/podcast/src/feed/class-feed-detection.php
- php -l projects/packages/podcast/tests/php/Feed/Feed_Detection_Test.php
- git diff --check origin/trunk...HEAD

## Notes
- composer test-php -- --filter Feed_Detection_Test could not run locally because phpunit-select-config is not installed in this checkout.
- direct phpunit also could not run because projects/packages/podcast/vendor/autoload.php is missing.