### PR TITLE
Escape podcast RSS feed metadata

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-feed-xml-escaping
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-xml-escaping
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Podcast: escape title overrides and iTunes category attribute values for the RSS feed to prevent malformed XML.
+Podcast: escape title overrides, descriptions, and iTunes category attribute values for the RSS feed to prevent malformed XML.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-xml-escaping
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-xml-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Podcast: escape title overrides and iTunes category attribute values for the RSS feed to prevent malformed XML.

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -83,14 +83,14 @@ class Customize_Feed {
 	public static function feed_title( $title ) {
 		$override = (string) get_option( 'podcasting_title', '' );
 		if ( '' !== $override ) {
-			return esc_html( $override );
+			return esc_xml( $override );
 		}
 
 		$category = get_category( self::resolve_category_id() );
 		if ( $category && ! is_wp_error( $category ) ) {
-			return esc_html( get_bloginfo( 'name' ) ) . ' &#187; ' . esc_html( $category->name );
+			return esc_xml( get_bloginfo( 'name' ) ) . ' &#187; ' . esc_xml( $category->name );
 		}
-		return esc_html( $title );
+		return esc_xml( $title );
 	}
 
 	/**
@@ -108,7 +108,7 @@ class Customize_Feed {
 		if ( 'description' !== $field ) {
 			return $value;
 		}
-		return esc_html( wp_strip_all_tags( (string) get_option( 'podcasting_summary', '' ) ) );
+		return esc_xml( wp_strip_all_tags( (string) get_option( 'podcasting_summary', '' ) ) );
 	}
 
 	/**
@@ -451,12 +451,15 @@ class Customize_Feed {
 			return '';
 		}
 
+		// `ent2ncr()` normalises named HTML entities (e.g. `&nbsp;`, `&copy;`) into
+		// numeric character references so an attribute value containing them stays
+		// well-formed XML after esc_attr().
 		$splits = explode( ',', $category );
 		if ( 2 === count( $splits ) ) {
-			return "<itunes:category text='" . esc_attr( $splits[0] ) . "'>\n"
-				. "\t<itunes:category text='" . esc_attr( $splits[1] ) . "' />\n"
+			return "<itunes:category text='" . ent2ncr( esc_attr( $splits[0] ) ) . "'>\n"
+				. "\t<itunes:category text='" . ent2ncr( esc_attr( $splits[1] ) ) . "' />\n"
 				. "</itunes:category>\n";
 		}
-		return "<itunes:category text='" . esc_attr( $category ) . "' />\n";
+		return "<itunes:category text='" . ent2ncr( esc_attr( $category ) ) . "' />\n";
 	}
 }

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -83,14 +83,14 @@ class Customize_Feed {
 	public static function feed_title( $title ) {
 		$override = (string) get_option( 'podcasting_title', '' );
 		if ( '' !== $override ) {
-			return $override;
+			return esc_html( $override );
 		}
 
 		$category = get_category( self::resolve_category_id() );
 		if ( $category && ! is_wp_error( $category ) ) {
-			return get_bloginfo( 'name' ) . ' &#187; ' . $category->name;
+			return esc_html( get_bloginfo( 'name' ) ) . ' &#187; ' . esc_html( $category->name );
 		}
-		return $title;
+		return esc_html( $title );
 	}
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -120,8 +120,8 @@ class Customize_Feed {
 		 */
 		$summary = (string) get_option( 'podcasting_summary', '' );
 		if ( '' !== $summary ) {
-			echo '<itunes:summary>' . esc_html( wp_strip_all_tags( $summary ) ) . "</itunes:summary>\n";
-			echo '<googleplay:description>' . esc_html( wp_strip_all_tags( $summary ) ) . "</googleplay:description>\n";
+			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $summary ) ) . "</itunes:summary>\n";
+			echo '<googleplay:description>' . esc_xml( wp_strip_all_tags( $summary ) ) . "</googleplay:description>\n";
 		}
 
 		/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -129,8 +129,8 @@ class Customize_Feed {
 		 */
 		$author = (string) get_option( 'podcasting_talent_name', '' );
 		if ( '' !== $author ) {
-			echo '<itunes:author>' . esc_html( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
-			echo '<googleplay:author>' . esc_html( wp_strip_all_tags( $author ) ) . "</googleplay:author>\n";
+			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
+			echo '<googleplay:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</googleplay:author>\n";
 		}
 
 		/**
@@ -138,9 +138,9 @@ class Customize_Feed {
 		 */
 		$email = wp_strip_all_tags( (string) get_option( 'podcasting_email', '' ) );
 		if ( '' !== $email ) {
-			echo '<itunes:owner><itunes:email>' . esc_html( $email ) . "</itunes:email></itunes:owner>\n";
-			echo '<googleplay:owner>' . esc_html( $email ) . "</googleplay:owner>\n";
-			echo '<googleplay:email>' . esc_html( $email ) . "</googleplay:email>\n";
+			echo '<itunes:owner><itunes:email>' . esc_xml( $email ) . "</itunes:email></itunes:owner>\n";
+			echo '<googleplay:owner>' . esc_xml( $email ) . "</googleplay:owner>\n";
+			echo '<googleplay:email>' . esc_xml( $email ) . "</googleplay:email>\n";
 		}
 
 		/**
@@ -148,7 +148,7 @@ class Customize_Feed {
 		 */
 		$copyright = (string) get_option( 'podcasting_copyright', '' );
 		if ( '' !== $copyright ) {
-			echo '<copyright>' . esc_html( wp_strip_all_tags( $copyright ) ) . "</copyright>\n";
+			echo '<copyright>' . esc_xml( wp_strip_all_tags( $copyright ) ) . "</copyright>\n";
 		}
 
 		/**
@@ -190,8 +190,8 @@ class Customize_Feed {
 			$author = (string) get_option( 'podcasting_talent_name', '' );
 		}
 		if ( '' !== $author ) {
-			echo '<itunes:author>' . esc_html( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
-			echo '<googleplay:author>' . esc_html( wp_strip_all_tags( $author ) ) . "</googleplay:author>\n";
+			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
+			echo '<googleplay:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</googleplay:author>\n";
 		}
 
 		// Per Apple / Google Play spec, the channel-level `<itunes:explicit>`
@@ -210,8 +210,8 @@ class Customize_Feed {
 		// item's `<description>`.
 		$excerpt = (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
 		if ( '' !== $excerpt ) {
-			echo '<itunes:summary>' . esc_html( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
-			echo '<googleplay:description>' . esc_html( wp_strip_all_tags( $excerpt ) ) . "</googleplay:description>\n";
+			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
+			echo '<googleplay:description>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</googleplay:description>\n";
 		}
 	}
 

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -106,6 +106,17 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertSame( 'My &lt;Podcast&gt; &amp; &quot;Friends&quot;', Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
+	public function test_feed_title_escapes_html_named_entities_for_xml() {
+		update_option( 'podcasting_title', 'Rock&nbsp;Roll &copy; Show' );
+
+		$result = Customize_Feed::feed_title( 'Default Title' );
+
+		$this->assertStringNotContainsString( '&nbsp;', $result );
+		$this->assertStringNotContainsString( '&copy;', $result );
+		$this->assertStringContainsString( '&amp;nbsp;', $result );
+		$this->assertStringContainsString( '&amp;copy;', $result );
+	}
+
 	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
 		$this->configure_podcast_category( 1234, 'Audio <News> & "Reviews"' );
 		$blogname = static function () {
@@ -171,6 +182,19 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( "<itunes:category text='Rock&#160;Roll' />", $xml );
 		$this->assertStringNotContainsString( '&nbsp;', $xml );
+	}
+
+	public function test_output_channel_tags_escapes_summary_for_xml() {
+		update_option( 'podcasting_summary', 'Rock&nbsp;Roll &copy; <strong>Show</strong>' );
+
+		ob_start();
+		Customize_Feed::output_channel_tags();
+		$xml = (string) ob_get_clean();
+
+		$this->assertStringContainsString( '<itunes:summary>Rock&amp;nbsp;Roll &amp;copy; Show</itunes:summary>', $xml );
+		$this->assertStringContainsString( '<googleplay:description>Rock&amp;nbsp;Roll &amp;copy; Show</googleplay:description>', $xml );
+		$this->assertStringNotContainsString( '&nbsp;', $xml );
+		$this->assertStringNotContainsString( '&copy;', $xml );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -106,15 +106,12 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertSame( 'My &lt;Podcast&gt; &amp; &quot;Friends&quot;', Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
-	public function test_feed_title_escapes_html_named_entities_for_xml() {
+	public function test_feed_title_normalizes_html_named_entities_to_utf8() {
+		// `&nbsp;`/`&copy;` are not predefined XML entities, so `esc_xml()`
+		// normalizes them to their Unicode code points — valid in XML.
 		update_option( 'podcasting_title', 'Rock&nbsp;Roll &copy; Show' );
 
-		$result = Customize_Feed::feed_title( 'Default Title' );
-
-		$this->assertStringNotContainsString( '&nbsp;', $result );
-		$this->assertStringNotContainsString( '&copy;', $result );
-		$this->assertStringContainsString( '&amp;nbsp;', $result );
-		$this->assertStringContainsString( '&amp;copy;', $result );
+		$this->assertSame( "Rock\u{a0}Roll \u{a9} Show", Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
 	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
@@ -191,8 +188,10 @@ class Customize_Feed_Test extends BaseTestCase {
 		Customize_Feed::output_channel_tags();
 		$xml = (string) ob_get_clean();
 
-		$this->assertStringContainsString( '<itunes:summary>Rock&amp;nbsp;Roll &amp;copy; Show</itunes:summary>', $xml );
-		$this->assertStringContainsString( '<googleplay:description>Rock&amp;nbsp;Roll &amp;copy; Show</googleplay:description>', $xml );
+		// `wp_strip_all_tags` removes the markup, then `esc_xml()` normalizes
+		// the named HTML entities into Unicode characters (well-formed XML).
+		$this->assertStringContainsString( "<itunes:summary>Rock\u{a0}Roll \u{a9} Show</itunes:summary>", $xml );
+		$this->assertStringContainsString( "<googleplay:description>Rock\u{a0}Roll \u{a9} Show</googleplay:description>", $xml );
 		$this->assertStringNotContainsString( '&nbsp;', $xml );
 		$this->assertStringNotContainsString( '&copy;', $xml );
 	}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -106,14 +106,6 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertSame( 'My &lt;Podcast&gt; &amp; &quot;Friends&quot;', Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
-	public function test_feed_title_normalizes_html_named_entities_to_utf8() {
-		// `&nbsp;`/`&copy;` are not predefined XML entities, so `esc_xml()`
-		// normalizes them to their Unicode code points — valid in XML.
-		update_option( 'podcasting_title', 'Rock&nbsp;Roll &copy; Show' );
-
-		$this->assertSame( "Rock\u{00A0}Roll \u{00A9} Show", Customize_Feed::feed_title( 'Default Title' ) );
-	}
-
 	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
 		$this->configure_podcast_category( 1234, 'Audio <News> & "Reviews"' );
 		$blogname = static function () {
@@ -179,21 +171,6 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( "<itunes:category text='Rock&#160;Roll' />", $xml );
 		$this->assertStringNotContainsString( '&nbsp;', $xml );
-	}
-
-	public function test_output_channel_tags_escapes_summary_for_xml() {
-		update_option( 'podcasting_summary', 'Rock&nbsp;Roll &copy; <strong>Show</strong>' );
-
-		ob_start();
-		Customize_Feed::output_channel_tags();
-		$xml = (string) ob_get_clean();
-
-		// `wp_strip_all_tags` removes the markup, then `esc_xml()` normalizes
-		// the named HTML entities into Unicode characters (well-formed XML).
-		$this->assertStringContainsString( "<itunes:summary>Rock\u{00A0}Roll \u{00A9} Show</itunes:summary>", $xml );
-		$this->assertStringContainsString( "<googleplay:description>Rock\u{00A0}Roll \u{00A9} Show</googleplay:description>", $xml );
-		$this->assertStringNotContainsString( '&nbsp;', $xml );
-		$this->assertStringNotContainsString( '&copy;', $xml );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -35,24 +35,8 @@ class Customize_Feed_Test extends BaseTestCase {
 		delete_option( 'podcasting_archive' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
-		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
-	}
-
-	private function configure_podcast_category( int $id, string $name ): int {
-		$term = new WP_Term(
-			(object) array(
-				'term_id'          => $id,
-				'name'             => $name,
-				'slug'             => 'podcast-' . $id,
-				'taxonomy'         => 'category',
-				'term_taxonomy_id' => $id,
-			)
-		);
-		wp_cache_set( $id, $term, 'terms' );
-		update_option( 'podcasting_category_id', $id );
-		return $id;
 	}
 
 	/**
@@ -100,29 +84,6 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertSame( 'My Podcast Show', Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
-	public function test_feed_title_escapes_override_for_rss_title() {
-		update_option( 'podcasting_title', 'My <Podcast> & "Friends"' );
-
-		$this->assertSame( 'My &lt;Podcast&gt; &amp; &quot;Friends&quot;', Customize_Feed::feed_title( 'Default Title' ) );
-	}
-
-	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
-		$this->configure_podcast_category( 1234, 'Audio <News> & "Reviews"' );
-		$blogname = static function () {
-			return 'Blog <Name> & "Site"';
-		};
-		add_filter( 'pre_option_blogname', $blogname );
-
-		try {
-			$this->assertSame(
-				'Blog &lt;Name&gt; &amp; &quot;Site&quot; &#187; Audio &lt;News&gt; &amp; &quot;Reviews&quot;',
-				Customize_Feed::feed_title( 'Default Title' )
-			);
-		} finally {
-			remove_filter( 'pre_option_blogname', $blogname );
-		}
-	}
-
 	public function test_feed_title_falls_through_when_no_override_and_no_category() {
 		update_option( 'podcasting_title', '' );
 		update_option( 'podcasting_category_id', 0 );
@@ -155,22 +116,6 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( "<itunes:category text='Technology'>", $xml );
 		$this->assertStringContainsString( "<itunes:category text='Tech News' />", $xml );
-	}
-
-	public function test_category_tag_escapes_xml_attributes() {
-		$xml = Customize_Feed::category_tag( 'Arts & <Culture>,Kids\' Shows "Daily"' );
-
-		$this->assertStringContainsString( "<itunes:category text='Arts &#38; &#60;Culture&#62;'>", $xml );
-		$this->assertStringContainsString( "<itunes:category text='Kids&#039; Shows &#34;Daily&#34;' />", $xml );
-	}
-
-	public function test_category_tag_normalizes_html_named_entities_for_xml() {
-		// `&nbsp;` is a valid HTML named entity but not defined in XML — must be
-		// converted to a numeric reference so the feed stays well-formed.
-		$xml = Customize_Feed::category_tag( 'Rock&nbsp;Roll' );
-
-		$this->assertStringContainsString( "<itunes:category text='Rock&#160;Roll' />", $xml );
-		$this->assertStringNotContainsString( '&nbsp;', $xml );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -160,8 +160,17 @@ class Customize_Feed_Test extends BaseTestCase {
 	public function test_category_tag_escapes_xml_attributes() {
 		$xml = Customize_Feed::category_tag( 'Arts & <Culture>,Kids\' Shows "Daily"' );
 
-		$this->assertStringContainsString( "<itunes:category text='Arts &amp; &lt;Culture&gt;'>", $xml );
-		$this->assertStringContainsString( "<itunes:category text='Kids&#039; Shows &quot;Daily&quot;' />", $xml );
+		$this->assertStringContainsString( "<itunes:category text='Arts &#38; &#60;Culture&#62;'>", $xml );
+		$this->assertStringContainsString( "<itunes:category text='Kids&#039; Shows &#34;Daily&#34;' />", $xml );
+	}
+
+	public function test_category_tag_normalizes_html_named_entities_for_xml() {
+		// `&nbsp;` is a valid HTML named entity but not defined in XML — must be
+		// converted to a numeric reference so the feed stays well-formed.
+		$xml = Customize_Feed::category_tag( 'Rock&nbsp;Roll' );
+
+		$this->assertStringContainsString( "<itunes:category text='Rock&#160;Roll' />", $xml );
+		$this->assertStringNotContainsString( '&nbsp;', $xml );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -111,7 +111,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		// normalizes them to their Unicode code points — valid in XML.
 		update_option( 'podcasting_title', 'Rock&nbsp;Roll &copy; Show' );
 
-		$this->assertSame( "Rock\u{a0}Roll \u{a9} Show", Customize_Feed::feed_title( 'Default Title' ) );
+		$this->assertSame( "Rock\u{00A0}Roll \u{00A9} Show", Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
 	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
@@ -190,8 +190,8 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		// `wp_strip_all_tags` removes the markup, then `esc_xml()` normalizes
 		// the named HTML entities into Unicode characters (well-formed XML).
-		$this->assertStringContainsString( "<itunes:summary>Rock\u{a0}Roll \u{a9} Show</itunes:summary>", $xml );
-		$this->assertStringContainsString( "<googleplay:description>Rock\u{a0}Roll \u{a9} Show</googleplay:description>", $xml );
+		$this->assertStringContainsString( "<itunes:summary>Rock\u{00A0}Roll \u{00A9} Show</itunes:summary>", $xml );
+		$this->assertStringContainsString( "<googleplay:description>Rock\u{00A0}Roll \u{00A9} Show</googleplay:description>", $xml );
 		$this->assertStringNotContainsString( '&nbsp;', $xml );
 		$this->assertStringNotContainsString( '&copy;', $xml );
 	}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -35,8 +35,24 @@ class Customize_Feed_Test extends BaseTestCase {
 		delete_option( 'podcasting_archive' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
+		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
+	}
+
+	private function configure_podcast_category( int $id, string $name ): int {
+		$term = new WP_Term(
+			(object) array(
+				'term_id'          => $id,
+				'name'             => $name,
+				'slug'             => 'podcast-' . $id,
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => $id,
+			)
+		);
+		wp_cache_set( $id, $term, 'terms' );
+		update_option( 'podcasting_category_id', $id );
+		return $id;
 	}
 
 	/**
@@ -84,6 +100,29 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertSame( 'My Podcast Show', Customize_Feed::feed_title( 'Default Title' ) );
 	}
 
+	public function test_feed_title_escapes_override_for_rss_title() {
+		update_option( 'podcasting_title', 'My <Podcast> & "Friends"' );
+
+		$this->assertSame( 'My &lt;Podcast&gt; &amp; &quot;Friends&quot;', Customize_Feed::feed_title( 'Default Title' ) );
+	}
+
+	public function test_feed_title_escapes_blog_and_category_fallback_for_rss_title() {
+		$this->configure_podcast_category( 1234, 'Audio <News> & "Reviews"' );
+		$blogname = static function () {
+			return 'Blog <Name> & "Site"';
+		};
+		add_filter( 'pre_option_blogname', $blogname );
+
+		try {
+			$this->assertSame(
+				'Blog &lt;Name&gt; &amp; &quot;Site&quot; &#187; Audio &lt;News&gt; &amp; &quot;Reviews&quot;',
+				Customize_Feed::feed_title( 'Default Title' )
+			);
+		} finally {
+			remove_filter( 'pre_option_blogname', $blogname );
+		}
+	}
+
 	public function test_feed_title_falls_through_when_no_override_and_no_category() {
 		update_option( 'podcasting_title', '' );
 		update_option( 'podcasting_category_id', 0 );
@@ -116,6 +155,13 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( "<itunes:category text='Technology'>", $xml );
 		$this->assertStringContainsString( "<itunes:category text='Tech News' />", $xml );
+	}
+
+	public function test_category_tag_escapes_xml_attributes() {
+		$xml = Customize_Feed::category_tag( 'Arts & <Culture>,Kids\' Shows "Daily"' );
+
+		$this->assertStringContainsString( "<itunes:category text='Arts &amp; &lt;Culture&gt;'>", $xml );
+		$this->assertStringContainsString( "<itunes:category text='Kids&#039; Shows &quot;Daily&quot;' />", $xml );
 	}
 
 	/**


### PR DESCRIPTION
## Found as part of a Codex security review

When a podcast title, description, or iTunes category contains characters like `&`, `<`, `>`, `"`, or `'`, the package's RSS feed escapes them for HTML, not XML. HTML named entities like `&nbsp;` and `&copy;` survive `esc_html()` and become malformed XML, which breaks the feed in strict podcatchers.

This switches `feed_title()`, `feed_description()`, and category attribute output in `class-customize-feed.php` to `esc_xml()`. iTunes category attribute values get wrapped with `ent2ncr()` after `esc_attr()` so named HTML entities normalize to numeric character references.

## Test plan

- [ ] On a Jetpack-enabled site with the podcast package active, set a podcast title containing `&`, `<`, `>`, `'`, and `"`.
- [ ] Pick an iTunes category containing an ampersand (e.g. "TV & Film").
- [ ] View the podcast feed source. Confirm `<title>` and `<itunes:category text='...'>` are well-formed XML with the special characters as XML entities.
- [ ] Run the feed through an RSS validator at https://validator.w3.org/feed/ and confirm it passes.

## Does this pull request change what data or activity we track or use?

No. This change only adjusts how existing feed metadata is escaped for output.
