### PR TITLE
Podcast: skip RSS enclosure rewrite for externally hosted episodes

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-feed-skip-untrusted-enclosure-rewrite
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-skip-untrusted-enclosure-rewrite
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Podcast: skip rewriting the RSS enclosure URL through the stats endpoint when the URL does not resolve to a local attachment, so externally hosted enclosures stay playable.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-skip-untrusted-enclosure-rewrite
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-skip-untrusted-enclosure-rewrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Podcast: skip rewriting the RSS enclosure URL through the stats endpoint when the URL does not resolve to a local attachment, so externally hosted enclosures stay playable.

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -244,11 +244,7 @@ class Customize_Feed {
 		 */
 		$enable = (bool) apply_filters( 'wpcom_podcasting_enable_play_tracking', true, $post_obj );
 
-		// The wpcom redirect handler (`Automattic_Podcasting_Tracked_Play::handle_play`)
-		// 404s on enclosures that don't resolve to a local attachment. Externally
-		// hosted enclosures (Podtrac, Megaphone, Art19) won't resolve, so rewriting
-		// them to the stats URL would publish broken URLs to subscribers. Skip the
-		// rewrite for those and emit the original URL as-is.
+		// Skip rewrite for externally hosted enclosures — the stats endpoint 404s anything that isn't a local attachment.
 		$attachment_id = attachment_url_to_postid( $original_url );
 
 		if ( null !== $post_obj && $enable && $attachment_id > 0 ) {

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -244,7 +244,14 @@ class Customize_Feed {
 		 */
 		$enable = (bool) apply_filters( 'wpcom_podcasting_enable_play_tracking', true, $post_obj );
 
-		if ( null !== $post_obj && $enable ) {
+		// The wpcom redirect handler (`Automattic_Podcasting_Tracked_Play::handle_play`)
+		// 404s on enclosures that don't resolve to a local attachment. Externally
+		// hosted enclosures (Podtrac, Megaphone, Art19) won't resolve, so rewriting
+		// them to the stats URL would publish broken URLs to subscribers. Skip the
+		// rewrite for those and emit the original URL as-is.
+		$attachment_id = attachment_url_to_postid( $original_url );
+
+		if ( null !== $post_obj && $enable && $attachment_id > 0 ) {
 			/**
 			 * Override the blog ID baked into the stats URL. Atomic / non-Simple
 			 * sites should return the WPCOM shadow ID so the public-api endpoint
@@ -274,7 +281,6 @@ class Customize_Feed {
 			);
 		}
 
-		$attachment_id = attachment_url_to_postid( $original_url );
 		if ( 0 === $attachment_id ) {
 			return $enclosure;
 		}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -33,6 +33,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		delete_option( 'podcasting_title' );
 		delete_option( 'podcasting_category_id' );
 		delete_option( 'podcasting_archive' );
+		remove_all_filters( 'pre_attachment_url_to_postid' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
 		unset( $GLOBALS['post'] );

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -196,6 +196,25 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_filter( 'terms_pre_query', $callback, 10 );
 	}
 
+	/**
+	 * Stub `attachment_url_to_postid` so a fake attachment ID is returned for
+	 * the given URL — lets us exercise the rewrite path without needing a real
+	 * attachment post in the test DB.
+	 *
+	 * @param string $url            Enclosure URL to claim ownership of.
+	 * @param int    $attachment_id  Attachment ID to return.
+	 */
+	private function stub_attachment_resolution( string $url, int $attachment_id ): void {
+		add_filter(
+			'pre_attachment_url_to_postid',
+			static function ( $pre, $lookup_url ) use ( $url, $attachment_id ) {
+				return $lookup_url === $url ? $attachment_id : $pre;
+			},
+			10,
+			2
+		);
+	}
+
 	public function test_rewrite_enclosure_replaces_url_with_canonical_stats_endpoint() {
 		global $post;
 		$post = new WP_Post(
@@ -212,6 +231,8 @@ class Customize_Feed_Test extends BaseTestCase {
 				return 12345;
 			}
 		);
+
+		$this->stub_attachment_resolution( 'https://example.com/path/episode.M4A?v=1', 9001 );
 
 		$original = '<enclosure url="https://example.com/path/episode.M4A?v=1" length="123" type="audio/m4a" />';
 		$result   = Customize_Feed::rewrite_enclosure( $original );
@@ -237,6 +258,8 @@ class Customize_Feed_Test extends BaseTestCase {
 				return 99;
 			}
 		);
+
+		$this->stub_attachment_resolution( 'https://example.com/episode.exe', 9002 );
 
 		$original = '<enclosure url="https://example.com/episode.exe" length="1" type="audio/mpeg" />';
 		$result   = Customize_Feed::rewrite_enclosure( $original );
@@ -264,11 +287,43 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 
 		add_filter( 'wpcom_podcasting_enable_play_tracking', '__return_false' );
+		$this->stub_attachment_resolution( 'https://example.com/episode.mp3', 9003 );
 
 		$original = '<enclosure url="https://example.com/episode.mp3" length="12345" type="audio/mpeg" />';
 		$result   = Customize_Feed::rewrite_enclosure( $original );
 
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', $result );
+		$this->assertStringNotContainsString( 'public-api.wordpress.com', $result );
+	}
+
+	/**
+	 * Externally hosted enclosures (Podtrac, Megaphone, Art19, etc.) don't
+	 * resolve to a local attachment. The wpcom redirect handler 404s those, so
+	 * minting a tracked URL would publish a broken link to subscribers. Leave
+	 * the original URL in the feed instead.
+	 */
+	public function test_rewrite_enclosure_skips_external_url_with_no_local_attachment() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'         => 555,
+				'post_type'  => 'post',
+				'post_title' => 'Externally Hosted Episode',
+			)
+		);
+
+		add_filter(
+			'wpcom_podcasting_tracked_blog_id',
+			static function () {
+				return 7777;
+			}
+		);
+
+		// No stub_attachment_resolution call — attachment_url_to_postid returns 0.
+		$original = '<enclosure url="https://cdn.podtrac.com/foo/episode-3.mp3" length="100" type="audio/mpeg" />';
+		$result   = Customize_Feed::rewrite_enclosure( $original );
+
+		$this->assertStringContainsString( 'url="https://cdn.podtrac.com/foo/episode-3.mp3"', $result );
 		$this->assertStringNotContainsString( 'public-api.wordpress.com', $result );
 	}
 

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -216,7 +216,9 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		add_filter(
 			'pre_attachment_url_to_postid',
-			static fn( $pre, $url ) => 'https://example.com/path/episode.M4A?v=1' === $url ? 9001 : $pre,
+			static function ( $pre, $url ) {
+				return 'https://example.com/path/episode.M4A?v=1' === $url ? 9001 : $pre;
+			},
 			10,
 			2
 		);
@@ -248,7 +250,9 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		add_filter(
 			'pre_attachment_url_to_postid',
-			static fn( $pre, $url ) => 'https://example.com/episode.exe' === $url ? 9002 : $pre,
+			static function ( $pre, $url ) {
+				return 'https://example.com/episode.exe' === $url ? 9002 : $pre;
+			},
 			10,
 			2
 		);

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -197,25 +197,6 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_filter( 'terms_pre_query', $callback, 10 );
 	}
 
-	/**
-	 * Stub `attachment_url_to_postid` so a fake attachment ID is returned for
-	 * the given URL — lets us exercise the rewrite path without needing a real
-	 * attachment post in the test DB.
-	 *
-	 * @param string $url            Enclosure URL to claim ownership of.
-	 * @param int    $attachment_id  Attachment ID to return.
-	 */
-	private function stub_attachment_resolution( string $url, int $attachment_id ): void {
-		add_filter(
-			'pre_attachment_url_to_postid',
-			static function ( $pre, $lookup_url ) use ( $url, $attachment_id ) {
-				return $lookup_url === $url ? $attachment_id : $pre;
-			},
-			10,
-			2
-		);
-	}
-
 	public function test_rewrite_enclosure_replaces_url_with_canonical_stats_endpoint() {
 		global $post;
 		$post = new WP_Post(
@@ -233,7 +214,12 @@ class Customize_Feed_Test extends BaseTestCase {
 			}
 		);
 
-		$this->stub_attachment_resolution( 'https://example.com/path/episode.M4A?v=1', 9001 );
+		add_filter(
+			'pre_attachment_url_to_postid',
+			static fn( $pre, $url ) => 'https://example.com/path/episode.M4A?v=1' === $url ? 9001 : $pre,
+			10,
+			2
+		);
 
 		$original = '<enclosure url="https://example.com/path/episode.M4A?v=1" length="123" type="audio/m4a" />';
 		$result   = Customize_Feed::rewrite_enclosure( $original );
@@ -260,7 +246,12 @@ class Customize_Feed_Test extends BaseTestCase {
 			}
 		);
 
-		$this->stub_attachment_resolution( 'https://example.com/episode.exe', 9002 );
+		add_filter(
+			'pre_attachment_url_to_postid',
+			static fn( $pre, $url ) => 'https://example.com/episode.exe' === $url ? 9002 : $pre,
+			10,
+			2
+		);
 
 		$original = '<enclosure url="https://example.com/episode.exe" length="1" type="audio/mpeg" />';
 		$result   = Customize_Feed::rewrite_enclosure( $original );
@@ -288,43 +279,11 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 
 		add_filter( 'wpcom_podcasting_enable_play_tracking', '__return_false' );
-		$this->stub_attachment_resolution( 'https://example.com/episode.mp3', 9003 );
 
 		$original = '<enclosure url="https://example.com/episode.mp3" length="12345" type="audio/mpeg" />';
 		$result   = Customize_Feed::rewrite_enclosure( $original );
 
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', $result );
-		$this->assertStringNotContainsString( 'public-api.wordpress.com', $result );
-	}
-
-	/**
-	 * Externally hosted enclosures (Podtrac, Megaphone, Art19, etc.) don't
-	 * resolve to a local attachment. The wpcom redirect handler 404s those, so
-	 * minting a tracked URL would publish a broken link to subscribers. Leave
-	 * the original URL in the feed instead.
-	 */
-	public function test_rewrite_enclosure_skips_external_url_with_no_local_attachment() {
-		global $post;
-		$post = new WP_Post(
-			(object) array(
-				'ID'         => 555,
-				'post_type'  => 'post',
-				'post_title' => 'Externally Hosted Episode',
-			)
-		);
-
-		add_filter(
-			'wpcom_podcasting_tracked_blog_id',
-			static function () {
-				return 7777;
-			}
-		);
-
-		// No stub_attachment_resolution call — attachment_url_to_postid returns 0.
-		$original = '<enclosure url="https://cdn.podtrac.com/foo/episode-3.mp3" length="100" type="audio/mpeg" />';
-		$result   = Customize_Feed::rewrite_enclosure( $original );
-
-		$this->assertStringContainsString( 'url="https://cdn.podtrac.com/foo/episode-3.mp3"', $result );
 		$this->assertStringNotContainsString( 'public-api.wordpress.com', $result );
 	}
 


### PR DESCRIPTION
## Found as part of a Codex security review

When the Jetpack podcast package owns the RSS feed (via the `jetpack_podcast_untangle` filter), it rewrites every enclosure URL to the WPCOM stats endpoint. That endpoint 404s any URL that doesn't resolve to a local attachment, so externally hosted episodes (Podtrac, Megaphone, Art19, custom CDNs) ship with tracked URLs that no podcatcher can play.

This gates the rewrite on the existing `attachment_url_to_postid()` lookup the function already runs for duration. External URLs return `0`, the rewrite is skipped, and the original URL stays in the feed. The matching gate in the wpcom mu-plugin's `podcasting_rss_enclosure` filter handles the legacy stack.

## Test plan

- [ ] `Customize_Feed_Test::test_rewrite_enclosure_replaces_url_with_canonical_stats_endpoint` passes with `pre_attachment_url_to_postid` stubbed to a fake attachment ID.
- [ ] `test_rewrite_enclosure_falls_back_to_mp3_for_unknown_extension` and `test_legacy_filter_can_disable_stats_url_rewrite` still pass.
- [ ] New `test_rewrite_enclosure_skips_external_url_with_no_local_attachment` confirms external URLs stay unchanged.
- [ ] Manual: on a site with the new package stack active and an externally hosted enclosure, the feed keeps the original URL rather than `public-api.wordpress.com/.../podcast-play/`.

## Does this pull request change what data or activity we track or use?

No. The rewrite stops firing for URLs the wpcom stats endpoint can't redirect to. Tracking continues to fire for local enclosures.
