### PR TITLE
Podcast: wrap long titles in Stats Top episodes list

### DIFF
--- a/projects/packages/podcast/changelog/pods-top-episodes-wrap
+++ b/projects/packages/podcast/changelog/pods-top-episodes-wrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: wrap long episode titles in the Top episodes list instead of truncating them mid-title.

--- a/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
@@ -51,10 +51,7 @@ const HorizontalBarList = ( { rows, wrapLabels = false }: HorizontalBarListProps
 							{ row.leftSideItem && (
 								<span className="podcast-stats-bar-list__leading">{ row.leftSideItem }</span>
 							) }
-							<Text
-								className="podcast-stats-bar-list__label"
-								truncate={ ! wrapLabels }
-							>
+							<Text className="podcast-stats-bar-list__label" truncate={ ! wrapLabels }>
 								{ row.label }
 							</Text>
 							<Text className="podcast-stats-bar-list__value" size={ 12 } variant="muted" truncate>

--- a/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/horizontal-bar-list.tsx
@@ -23,9 +23,11 @@ export type HorizontalBarRow = {
 
 type HorizontalBarListProps = {
 	rows: HorizontalBarRow[];
+	/** Allow long labels to wrap to multiple lines instead of truncating. */
+	wrapLabels?: boolean;
 };
 
-const HorizontalBarList = ( { rows }: HorizontalBarListProps ) => {
+const HorizontalBarList = ( { rows, wrapLabels = false }: HorizontalBarListProps ) => {
 	return (
 		<ul className="podcast-stats-bar-list">
 			{ rows.map( row => {
@@ -44,12 +46,15 @@ const HorizontalBarList = ( { rows }: HorizontalBarListProps ) => {
 							className="podcast-stats-bar-list__content"
 							spacing={ 2 }
 							justify="flex-start"
-							alignment="center"
+							alignment={ wrapLabels ? 'flex-start' : 'center' }
 						>
 							{ row.leftSideItem && (
 								<span className="podcast-stats-bar-list__leading">{ row.leftSideItem }</span>
 							) }
-							<Text className="podcast-stats-bar-list__label" truncate>
+							<Text
+								className="podcast-stats-bar-list__label"
+								truncate={ ! wrapLabels }
+							>
 								{ row.label }
 							</Text>
 							<Text className="podcast-stats-bar-list__value" size={ 12 } variant="muted" truncate>

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-top-episodes.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-top-episodes.tsx
@@ -49,7 +49,7 @@ const StatsTopEpisodes = ( {
 
 	return (
 		<SectionCard title={ title }>
-			<HorizontalBarList rows={ data } />
+			<HorizontalBarList rows={ data } wrapLabels />
 		</SectionCard>
 	);
 };


### PR DESCRIPTION
Fixes #

## Proposed changes
* Stop truncating episode titles in the Stats > Top episodes list. Long titles were being cut off mid-word, so a reader couldn't tell which episode a row corresponded to. The shared `HorizontalBarList` now takes a `wrapLabels` prop; the Top episodes caller opts in (titles wrap, row grows vertically), while the Stats by app and Locations callers keep the existing single-line truncation since their labels are short.
* When wrapping is on, `HStack` aligns to `flex-start` so the value column stays anchored next to the first line of the wrapped title rather than vertically centering against the whole block.

## Related product discussion/links
* Part of the /podcast UI polish batch.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Enable the package: `add_filter( 'jetpack_podcast_untangle', '__return_true' );`
* On a site with at least one podcast episode with a very long title (>~50 chars), open `/podcast` > Stats and check the Top episodes list. Long titles should now wrap onto multiple lines; the row's translucent bar should stretch to match the row height; the play count stays on the right, top-aligned with the first line.
* Switch to the Stats by app list (same panel) and confirm app names still render on a single line with truncation (unchanged behavior).

Notes for reviewer:
- I'm an automation that can't drive a browser, so I haven't captured before/after screenshots. Visual verification still needs a sandbox check at review time.
- The opt-in shape (rather than removing truncation everywhere) keeps the visual rhythm of the by-app and Locations lists intact.

---
Spec excerpt (from the work order):

> PR 4: Stats tab episode title wrapping
> Long episode titles in the Stats "Top episodes" list should wrap instead of truncating. Current behavior cuts off mid-title.
