### PR TITLE
Podcast: add + Create episode button and post-new prefill

### DIFF
--- a/projects/packages/podcast/changelog/pods-create-episode-button
+++ b/projects/packages/podcast/changelog/pods-create-episode-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add a persistent "+ Create episode" button to the /podcast page header and a server-side prefill that assigns the configured category (and, on Premium, inserts the Podcast Episode block) when `post-new.php?podcast_episode=1` is opened.
+Add a persistent "Create episode" button to the /podcast page header and a server-side prefill that assigns the configured category (and, on Premium, inserts the Podcast Episode block) when `post-new.php?podcast_episode=1` is opened.

--- a/projects/packages/podcast/changelog/pods-create-episode-button
+++ b/projects/packages/podcast/changelog/pods-create-episode-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a persistent "+ Create episode" button to the /podcast page header and a server-side prefill that assigns the configured category (and, on Premium, inserts the Podcast Episode block) when `post-new.php?podcast_episode=1` is opened.

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -11,13 +11,13 @@ namespace Automattic\Jetpack\Podcast;
  * Prefills the new-post screen with the configured podcast category and, on
  * Premium, an inserted Podcast Episode block.
  *
- * The dashboard's "+ Create episode" button (header on every tab, CTA on the
+ * The dashboard's "Create episode" button (header on every tab, CTA on the
  * empty Episodes state) routes through `post-new.php?podcast_episode=1`. This
  * class catches that flag during auto-draft creation and:
  *
  * - Assigns the configured `podcasting_category_id` to the new post (all plans).
  * - Prefills the post content with the Podcast Episode block (Premium only,
- *   via `Podcast_Gate::has_product_access()`).
+ *   via `Podcast_Gate::has_product_access()` when that class is available).
  *
  * Free users get a plain new post and add a core Audio block themselves with
  * an externally hosted URL.
@@ -25,6 +25,14 @@ namespace Automattic\Jetpack\Podcast;
 class New_Episode_Prefill {
 
 	const QUERY_VAR = 'podcast_episode';
+
+	/**
+	 * Tracks the first auto-draft we touch so we can self-unhook and avoid
+	 * acting on any sibling auto-draft created later in the same request.
+	 *
+	 * @var int
+	 */
+	private static $handled_post_id = 0;
 
 	/**
 	 * Register hooks.
@@ -37,7 +45,7 @@ class New_Episode_Prefill {
 
 	/**
 	 * Wire the auto-draft / default-content filters only on
-	 * `post-new.php?podcast_episode=1`.
+	 * `post-new.php?podcast_episode=1` with a configured podcast category.
 	 *
 	 * We bind on `admin_init` rather than at load time so `$pagenow` is
 	 * settled.
@@ -56,9 +64,18 @@ class New_Episode_Prefill {
 			return;
 		}
 
+		// Direct URLs can hit this even when the dashboard CTA isn't visible.
+		// If no category is configured, the prefill is meaningless and the
+		// block prefill below would land on an unconfigured site; bail.
+		if ( (int) get_option( 'podcasting_category_id', 0 ) <= 0 ) {
+			return;
+		}
+
 		add_action( 'wp_insert_post', array( __CLASS__, 'assign_category' ), 10, 3 );
 
-		if ( Podcast_Gate::has_product_access() ) {
+		// `Podcast_Gate` is a future package; fail closed (no block prefill)
+		// until it exists so an unqualified call doesn't fatal.
+		if ( class_exists( __NAMESPACE__ . '\\Podcast_Gate' ) && Podcast_Gate::has_product_access() ) {
 			add_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10, 2 );
 		}
 	}
@@ -69,7 +86,8 @@ class New_Episode_Prefill {
 	 * Fires on `wp_insert_post` once for the auto-draft `post-new.php` creates;
 	 * we filter to that single insert (new, not update; post post-type;
 	 * auto-draft status) so user-driven saves later in the editor session
-	 * aren't re-overridden.
+	 * aren't re-overridden. After the first match we self-unhook so any
+	 * sibling auto-draft created later in the same request is left alone.
 	 *
 	 * @param int      $post_id Post ID.
 	 * @param \WP_Post $post    Post object.
@@ -85,6 +103,9 @@ class New_Episode_Prefill {
 		if ( 'post' !== $post->post_type || 'auto-draft' !== $post->post_status ) {
 			return;
 		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
 
 		$category_id = (int) get_option( 'podcasting_category_id', 0 );
 		if ( $category_id <= 0 ) {
@@ -92,6 +113,9 @@ class New_Episode_Prefill {
 		}
 
 		wp_set_post_categories( $post_id, array( $category_id ) );
+
+		self::$handled_post_id = (int) $post_id;
+		remove_action( 'wp_insert_post', array( __CLASS__, 'assign_category' ), 10 );
 	}
 
 	/**
@@ -99,7 +123,9 @@ class New_Episode_Prefill {
 	 *
 	 * The `default_content` filter runs once when the editor loads the
 	 * auto-draft. If a previous filter (or another plugin) has already filled
-	 * `$content`, leave it alone.
+	 * `$content`, leave it alone. Scoped to the post we already category-tagged
+	 * so a sibling auto-draft in the same request doesn't inherit the block,
+	 * then self-unhooks.
 	 *
 	 * @param string   $content Default post content.
 	 * @param \WP_Post $post    Post object.
@@ -109,9 +135,15 @@ class New_Episode_Prefill {
 		if ( ! ( $post instanceof \WP_Post ) || 'post' !== $post->post_type ) {
 			return $content;
 		}
+		if ( self::$handled_post_id > 0 && (int) $post->ID !== self::$handled_post_id ) {
+			return $content;
+		}
 		if ( '' !== trim( (string) $content ) ) {
 			return $content;
 		}
+
+		remove_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10 );
+
 		return "<!-- wp:jetpack/podcast-episode /-->\n";
 	}
 }

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -10,50 +10,25 @@ namespace Automattic\Jetpack\Podcast;
 /**
  * Prefills the new-post screen with the configured podcast category and, on
  * Premium, an inserted Podcast Episode block.
- *
- * The dashboard's "Create episode" button (header on every tab, CTA on the
- * empty Episodes state) routes through `post-new.php?podcast_episode=1`. This
- * class catches that flag during auto-draft creation and:
- *
- * - Assigns the configured `podcasting_category_id` to the new post (all plans).
- * - Prefills the post content with the Podcast Episode block (Premium only,
- *   via `Podcast_Gate::has_product_access()` when that class is available).
- *
- * Free users get a plain new post and add a core Audio block themselves with
- * an externally hosted URL.
  */
 class New_Episode_Prefill {
 
 	const QUERY_VAR = 'podcast_episode';
 
 	/**
-	 * Post type supported by this prefill flow.
-	 */
-	const POST_TYPE = 'post';
-
-	/**
-	 * Tracks the first auto-draft we touch so we can self-unhook and avoid
-	 * acting on any sibling auto-draft created later in the same request.
-	 *
 	 * @var int
 	 */
 	private static $handled_post_id = 0;
 
 	/**
 	 * Register hooks.
-	 *
-	 * Called from `Podcast::init()` inside the `is_admin()` branch.
 	 */
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'maybe_register_handlers' ) );
 	}
 
 	/**
-	 * Wire the auto-draft / default-content filters only on
-	 * `post-new.php?podcast_episode=1` with a configured podcast category.
-	 *
-	 * We bind on `admin_init` rather than at load time so `$pagenow` is
-	 * settled.
+	 * Bind on `admin_init` so `$pagenow` is settled.
 	 */
 	public static function maybe_register_handlers() {
 		global $pagenow;
@@ -69,18 +44,16 @@ class New_Episode_Prefill {
 			return;
 		}
 
-		// Direct URLs can hit this even when the dashboard CTA isn't visible.
-		// If no category is configured, the prefill is meaningless and the
-		// block prefill below would land on an unconfigured site; bail.
 		if ( (int) get_option( 'podcasting_category_id', 0 ) <= 0 ) {
 			return;
 		}
 
 		add_action( 'wp_insert_post', array( __CLASS__, 'assign_category' ), 10, 3 );
 
-		// `Podcast_Gate` is a future package; fail closed (no block prefill)
-		// until it exists so an unqualified call doesn't fatal.
-		if ( self::has_product_access() ) {
+		// Fail closed until `Podcast_Gate` ships so an unqualified call doesn't fatal.
+		$gate = array( __NAMESPACE__ . '\\Podcast_Gate', 'has_product_access' );
+		// @phan-suppress-next-line PhanUndeclaredClassInCallable -- Podcast_Gate is a future class; guarded by is_callable().
+		if ( is_callable( $gate ) && call_user_func( $gate ) ) {
 			add_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10, 2 );
 		}
 	}
@@ -88,11 +61,9 @@ class New_Episode_Prefill {
 	/**
 	 * Assign the configured podcast category to the new auto-draft.
 	 *
-	 * Fires on `wp_insert_post` once for the auto-draft `post-new.php` creates;
-	 * we filter to that single insert (new, not update; post post-type;
-	 * auto-draft status) so user-driven saves later in the editor session
-	 * aren't re-overridden. After the first match we self-unhook so any
-	 * sibling auto-draft created later in the same request is left alone.
+	 * Narrowed to the initial auto-draft so user-driven saves later in the
+	 * session aren't re-overridden; self-unhooks so sibling auto-drafts in the
+	 * same request are left alone.
 	 *
 	 * @param int      $post_id Post ID.
 	 * @param \WP_Post $post    Post object.
@@ -126,11 +97,8 @@ class New_Episode_Prefill {
 	/**
 	 * Inject a Podcast Episode block as the new post's initial content.
 	 *
-	 * The `default_content` filter runs once when the editor loads the
-	 * auto-draft. If a previous filter (or another plugin) has already filled
-	 * `$content`, leave it alone. Scoped to the post we already category-tagged
-	 * so a sibling auto-draft in the same request doesn't inherit the block,
-	 * then self-unhooks.
+	 * No-op if another plugin has already filled `$content`, so this composes
+	 * politely.
 	 *
 	 * @param string   $content Default post content.
 	 * @param \WP_Post $post    Post object.
@@ -153,23 +121,10 @@ class New_Episode_Prefill {
 	}
 
 	/**
-	 * Whether the post is a core post object we support for new-episode prefill.
-	 *
 	 * @param mixed $post Candidate post object.
 	 * @return bool
 	 */
 	private static function is_supported_post( $post ) {
-		return $post instanceof \WP_Post && self::POST_TYPE === $post->post_type;
-	}
-
-	/**
-	 * Whether Podcast_Gate is available and grants podcast product access.
-	 *
-	 * @return bool
-	 */
-	private static function has_product_access() {
-		$callback = array( __NAMESPACE__ . '\\Podcast_Gate', 'has_product_access' );
-		// @phan-suppress-next-line PhanUndeclaredClassInCallable -- Podcast_Gate is a future class; guarded by is_callable().
-		return is_callable( $callback ) && call_user_func( $callback );
+		return $post instanceof \WP_Post && 'post' === $post->post_type;
 	}
 }

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -25,6 +25,10 @@ namespace Automattic\Jetpack\Podcast;
 class New_Episode_Prefill {
 
 	const QUERY_VAR = 'podcast_episode';
+
+	/**
+	 * Post type supported by this prefill flow.
+	 */
 	const POST_TYPE = 'post';
 
 	/**
@@ -76,8 +80,7 @@ class New_Episode_Prefill {
 
 		// `Podcast_Gate` is a future package; fail closed (no block prefill)
 		// until it exists so an unqualified call doesn't fatal.
-		$has_product_access = __NAMESPACE__ . '\\Podcast_Gate::has_product_access';
-		if ( is_callable( $has_product_access ) && call_user_func( $has_product_access ) ) {
+		if ( self::has_product_access() ) {
 			add_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10, 2 );
 		}
 	}
@@ -157,5 +160,15 @@ class New_Episode_Prefill {
 	 */
 	private static function is_supported_post( $post ) {
 		return $post instanceof \WP_Post && self::POST_TYPE === $post->post_type;
+	}
+
+	/**
+	 * Whether Podcast_Gate is available and grants podcast product access.
+	 *
+	 * @return bool
+	 */
+	private static function has_product_access() {
+		$callback = array( __NAMESPACE__ . '\\Podcast_Gate', 'has_product_access' );
+		return is_callable( $callback ) && call_user_func( $callback );
 	}
 }

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Server-side prefill for `post-new.php?podcast_episode=1`.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast;
+
+/**
+ * Prefills the new-post screen with the configured podcast category and, on
+ * Premium, an inserted Podcast Episode block.
+ *
+ * The dashboard's "+ Create episode" button (header on every tab, CTA on the
+ * empty Episodes state) routes through `post-new.php?podcast_episode=1`. This
+ * class catches that flag during auto-draft creation and:
+ *
+ * - Assigns the configured `podcasting_category_id` to the new post (all plans).
+ * - Prefills the post content with the Podcast Episode block (Premium only,
+ *   via `Podcast_Gate::has_product_access()`).
+ *
+ * Free users get a plain new post and add a core Audio block themselves with
+ * an externally hosted URL.
+ */
+class New_Episode_Prefill {
+
+	const QUERY_VAR = 'podcast_episode';
+
+	/**
+	 * Register hooks.
+	 *
+	 * Called from `Podcast::init()` inside the `is_admin()` branch.
+	 */
+	public static function init() {
+		add_action( 'admin_init', array( __CLASS__, 'maybe_register_handlers' ) );
+	}
+
+	/**
+	 * Wire the auto-draft / default-content filters only on
+	 * `post-new.php?podcast_episode=1`.
+	 *
+	 * We bind on `admin_init` rather than at load time so `$pagenow` is
+	 * settled.
+	 */
+	public static function maybe_register_handlers() {
+		global $pagenow;
+		if ( 'post-new.php' !== $pagenow ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET[ self::QUERY_VAR ] ) || '1' !== (string) $_GET[ self::QUERY_VAR ] ) {
+			return;
+		}
+
+		add_action( 'wp_insert_post', array( __CLASS__, 'assign_category' ), 10, 3 );
+
+		if ( Podcast_Gate::has_product_access() ) {
+			add_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Assign the configured podcast category to the new auto-draft.
+	 *
+	 * Fires on `wp_insert_post` once for the auto-draft `post-new.php` creates;
+	 * we filter to that single insert (new, not update; post post-type;
+	 * auto-draft status) so user-driven saves later in the editor session
+	 * aren't re-overridden.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 * @param bool     $update  True for updates, false for inserts.
+	 */
+	public static function assign_category( $post_id, $post, $update ) {
+		if ( $update ) {
+			return;
+		}
+		if ( ! ( $post instanceof \WP_Post ) ) {
+			return;
+		}
+		if ( 'post' !== $post->post_type || 'auto-draft' !== $post->post_status ) {
+			return;
+		}
+
+		$category_id = (int) get_option( 'podcasting_category_id', 0 );
+		if ( $category_id <= 0 ) {
+			return;
+		}
+
+		wp_set_post_categories( $post_id, array( $category_id ) );
+	}
+
+	/**
+	 * Inject a Podcast Episode block as the new post's initial content.
+	 *
+	 * The `default_content` filter runs once when the editor loads the
+	 * auto-draft. If a previous filter (or another plugin) has already filled
+	 * `$content`, leave it alone.
+	 *
+	 * @param string   $content Default post content.
+	 * @param \WP_Post $post    Post object.
+	 * @return string
+	 */
+	public static function prefill_block_content( $content, $post ) {
+		if ( ! ( $post instanceof \WP_Post ) || 'post' !== $post->post_type ) {
+			return $content;
+		}
+		if ( '' !== trim( (string) $content ) ) {
+			return $content;
+		}
+		return "<!-- wp:jetpack/podcast-episode /-->\n";
+	}
+}

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -48,7 +48,11 @@ class New_Episode_Prefill {
 			return;
 		}
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET[ self::QUERY_VAR ] ) || '1' !== (string) $_GET[ self::QUERY_VAR ] ) {
+		if ( ! isset( $_GET[ self::QUERY_VAR ] ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( '1' !== sanitize_text_field( wp_unslash( $_GET[ self::QUERY_VAR ] ) ) ) {
 			return;
 		}
 

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -50,10 +50,7 @@ class New_Episode_Prefill {
 
 		add_action( 'wp_insert_post', array( __CLASS__, 'assign_category' ), 10, 3 );
 
-		// Fail closed until `Podcast_Gate` ships so an unqualified call doesn't fatal.
-		$gate = array( __NAMESPACE__ . '\\Podcast_Gate', 'has_product_access' );
-		// @phan-suppress-next-line PhanUndeclaredClassInCallable -- Podcast_Gate is a future class; guarded by is_callable().
-		if ( is_callable( $gate ) && call_user_func( $gate ) ) {
+		if ( Podcast_Gate::has_product_access() ) {
 			add_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10, 2 );
 		}
 	}

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -16,6 +16,8 @@ class New_Episode_Prefill {
 	const QUERY_VAR = 'podcast_episode';
 
 	/**
+	 * ID of the auto-draft we've already handled this request.
+	 *
 	 * @var int
 	 */
 	private static $handled_post_id = 0;
@@ -118,6 +120,8 @@ class New_Episode_Prefill {
 	}
 
 	/**
+	 * Whether the post is a core `post` we prefill for.
+	 *
 	 * @param mixed $post Candidate post object.
 	 * @return bool
 	 */

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -169,6 +169,7 @@ class New_Episode_Prefill {
 	 */
 	private static function has_product_access() {
 		$callback = array( __NAMESPACE__ . '\\Podcast_Gate', 'has_product_access' );
+		// @phan-suppress-next-line PhanUndeclaredClassInCallable -- Podcast_Gate is a future class; guarded by is_callable().
 		return is_callable( $callback ) && call_user_func( $callback );
 	}
 }

--- a/projects/packages/podcast/src/class-new-episode-prefill.php
+++ b/projects/packages/podcast/src/class-new-episode-prefill.php
@@ -25,6 +25,7 @@ namespace Automattic\Jetpack\Podcast;
 class New_Episode_Prefill {
 
 	const QUERY_VAR = 'podcast_episode';
+	const POST_TYPE = 'post';
 
 	/**
 	 * Tracks the first auto-draft we touch so we can self-unhook and avoid
@@ -75,7 +76,8 @@ class New_Episode_Prefill {
 
 		// `Podcast_Gate` is a future package; fail closed (no block prefill)
 		// until it exists so an unqualified call doesn't fatal.
-		if ( class_exists( __NAMESPACE__ . '\\Podcast_Gate' ) && Podcast_Gate::has_product_access() ) {
+		$has_product_access = __NAMESPACE__ . '\\Podcast_Gate::has_product_access';
+		if ( is_callable( $has_product_access ) && call_user_func( $has_product_access ) ) {
 			add_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10, 2 );
 		}
 	}
@@ -100,7 +102,7 @@ class New_Episode_Prefill {
 		if ( ! ( $post instanceof \WP_Post ) ) {
 			return;
 		}
-		if ( 'post' !== $post->post_type || 'auto-draft' !== $post->post_status ) {
+		if ( ! self::is_supported_post( $post ) || 'auto-draft' !== $post->post_status ) {
 			return;
 		}
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
@@ -132,7 +134,7 @@ class New_Episode_Prefill {
 	 * @return string
 	 */
 	public static function prefill_block_content( $content, $post ) {
-		if ( ! ( $post instanceof \WP_Post ) || 'post' !== $post->post_type ) {
+		if ( ! self::is_supported_post( $post ) ) {
 			return $content;
 		}
 		if ( self::$handled_post_id > 0 && (int) $post->ID !== self::$handled_post_id ) {
@@ -145,5 +147,15 @@ class New_Episode_Prefill {
 		remove_filter( 'default_content', array( __CLASS__, 'prefill_block_content' ), 10 );
 
 		return "<!-- wp:jetpack/podcast-episode /-->\n";
+	}
+
+	/**
+	 * Whether the post is a core post object we support for new-episode prefill.
+	 *
+	 * @param mixed $post Candidate post object.
+	 * @return bool
+	 */
+	private static function is_supported_post( $post ) {
+		return $post instanceof \WP_Post && self::POST_TYPE === $post->post_type;
 	}
 }

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -82,8 +82,6 @@ class Podcast {
 		// via Admin_Page::add_wp_admin_submenu() at admin_menu priority 999999.
 		if ( is_admin() ) {
 			Admin_Page::init();
-			// Server-side prefill for `post-new.php?podcast_episode=1` from the
-			// dashboard's "+ Create episode" entry points.
 			New_Episode_Prefill::init();
 		}
 

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -82,6 +82,9 @@ class Podcast {
 		// via Admin_Page::add_wp_admin_submenu() at admin_menu priority 999999.
 		if ( is_admin() ) {
 			Admin_Page::init();
+			// Server-side prefill for `post-new.php?podcast_episode=1` from the
+			// dashboard's "+ Create episode" entry points.
+			New_Episode_Prefill::init();
 		}
 
 		// Posts to Podcast lives behind its own filter so the Create AI

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,10 +1,10 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';
-import { Button, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
-import { Tabs } from '@wordpress/ui';
+import { Button, Tabs } from '@wordpress/ui';
 import ErrorBoundary from './error-boundary';
 import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
@@ -173,7 +173,7 @@ const App = () => {
 
 	// Same destination + label for every plan; `New_Episode_Prefill` keys off `?podcast_episode=1`.
 	const headerActions = isSetUp ? (
-		<Button variant="primary" href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }>
+		<Button size="compact" variant="primary" href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>
 	) : undefined;

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -183,7 +183,7 @@ const App = () => {
 	// not at this button. Free users get a plain new post.
 	const headerActions = isSetUp ? (
 		<Button variant="primary" href={ NEW_EPISODE_URL }>
-			{ __( '+ Create episode', 'jetpack-podcast' ) }
+			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>
 	) : undefined;
 

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -175,8 +175,13 @@ const App = () => {
 	const headerActions = isSetUp ? (
 		<Button
 			size="compact"
-			variant="primary"
-			href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
+			variant="solid"
+			render={
+				<a
+					className="podcast__header-cta"
+					href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
+				/>
+			}
 		>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -10,10 +10,6 @@ import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
 import type { TabName } from './types';
 
-// Server-side filters key off `?podcast_episode=1` to apply the configured
-// podcast category (and, on Premium, prefill the Podcast Episode block).
-const NEW_EPISODE_URL = getAdminUrl( 'post-new.php?podcast_episode=1' );
-
 const Welcome = lazy( () => import( './welcome' ) );
 const CategorySetupModal = lazy( () => import( './welcome/category-setup-modal' ) );
 const SettingsTab = lazy( () => import( './settings' ) );
@@ -175,12 +171,9 @@ const App = () => {
 		);
 	}
 
-	// Header CTA: visible once the show is configured. Same destination and
-	// label for every plan — the Premium value-add lives inside the editor
-	// (the server-side default-content filter inserts the Podcast Episode block on load),
-	// not at this button. Free users get a plain new post.
+	// Same destination + label for every plan; `New_Episode_Prefill` keys off `?podcast_episode=1`.
 	const headerActions = isSetUp ? (
-		<Button variant="primary" href={ NEW_EPISODE_URL }>
+		<Button variant="primary" href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>
 	) : undefined;

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -173,7 +173,11 @@ const App = () => {
 
 	// Same destination + label for every plan; `New_Episode_Prefill` keys off `?podcast_episode=1`.
 	const headerActions = isSetUp ? (
-		<Button size="compact" variant="primary" href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }>
+		<Button
+			size="compact"
+			variant="primary"
+			href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
+		>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
 		</Button>
 	) : undefined;

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
-import { Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
@@ -9,6 +9,12 @@ import ErrorBoundary from './error-boundary';
 import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
 import type { TabName } from './types';
+
+const ADMIN_URL = getSiteData()?.admin_url ?? '/wp-admin/';
+
+// Server-side filters key off `?podcast_episode=1` to apply the configured
+// podcast category (and, on Premium, prefill the Podcast Episode block).
+const NEW_EPISODE_URL = `${ ADMIN_URL }post-new.php?podcast_episode=1`;
 
 const Welcome = lazy( () => import( './welcome' ) );
 const CategorySetupModal = lazy( () => import( './welcome/category-setup-modal' ) );
@@ -171,8 +177,18 @@ const App = () => {
 		);
 	}
 
+	// Header CTA: visible once the show is configured. Same destination and
+	// label for every plan — the Premium value-add lives inside the editor
+	// (PR 7's server-side filter inserts the Podcast Episode block on load),
+	// not at this button. Free users get a plain new post.
+	const headerActions = isSetUp ? (
+		<Button variant="primary" href={ NEW_EPISODE_URL }>
+			{ __( '+ Create episode', 'jetpack-podcast' ) }
+		</Button>
+	) : undefined;
+
 	return (
-		<AdminPage title={ PAGE_TITLE } subTitle={ PAGE_SUBTITLE }>
+		<AdminPage title={ PAGE_TITLE } subTitle={ PAGE_SUBTITLE } actions={ headerActions }>
 			<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
 				<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal" ref={ tablistRef }>
 					<Tabs.List variant="minimal">

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -1,5 +1,5 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
-import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
+import { getAdminUrl, getScriptData, getSiteData } from '@automattic/jetpack-script-data';
 import { Button, Spinner } from '@wordpress/components';
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,11 +10,9 @@ import { usePodcastSettings } from './hooks/use-podcast-settings';
 import './style.scss';
 import type { TabName } from './types';
 
-const ADMIN_URL = getSiteData()?.admin_url ?? '/wp-admin/';
-
 // Server-side filters key off `?podcast_episode=1` to apply the configured
 // podcast category (and, on Premium, prefill the Podcast Episode block).
-const NEW_EPISODE_URL = `${ ADMIN_URL }post-new.php?podcast_episode=1`;
+const NEW_EPISODE_URL = getAdminUrl( 'post-new.php?podcast_episode=1' );
 
 const Welcome = lazy( () => import( './welcome' ) );
 const CategorySetupModal = lazy( () => import( './welcome/category-setup-modal' ) );
@@ -179,7 +177,7 @@ const App = () => {
 
 	// Header CTA: visible once the show is configured. Same destination and
 	// label for every plan — the Premium value-add lives inside the editor
-	// (PR 7's server-side filter inserts the Podcast Episode block on load),
+	// (the server-side default-content filter inserts the Podcast Episode block on load),
 	// not at this button. Free users get a plain new post.
 	const headerActions = isSetUp ? (
 		<Button variant="primary" href={ NEW_EPISODE_URL }>

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -12,6 +12,14 @@ body.jetpack_page_jetpack-podcast {
 	padding: 48px 0;
 }
 
+// The header CTA is a WP UI solid Button rendered as an `<a>`. wp-admin's
+// global, unlayered `a { color: #2271b1 }` beats the button's layered
+// foreground color, tinting the label blue. Restore it with an unlayered rule
+// pointing at the button's own variable so it tracks the variant.
+.podcast__header-cta {
+	color: var(--wp-ui-button-foreground-color);
+}
+
 .podcast__tab-content {
 	padding-block: 8px;
 }

--- a/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
+++ b/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\New_Episode_Prefill;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\Podcast\New_Episode_Prefill
+ */
+#[CoversClass( New_Episode_Prefill::class )]
+class New_Episode_Prefill_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->reset_prefill_state();
+	}
+
+	protected function tearDown(): void {
+		remove_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ), 10 );
+		remove_filter( 'default_content', array( New_Episode_Prefill::class, 'prefill_block_content' ), 10 );
+		delete_option( 'podcasting_category_id' );
+		unset( $_GET[ New_Episode_Prefill::QUERY_VAR ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->reset_prefill_state();
+		parent::tearDown();
+	}
+
+	public function test_maybe_register_handlers_requires_flagged_post_new_screen_and_configured_category() {
+		global $pagenow;
+		$pagenow = 'post-new.php';
+
+		$_GET[ New_Episode_Prefill::QUERY_VAR ] = '1'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		New_Episode_Prefill::maybe_register_handlers();
+
+		$this->assertFalse( has_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ) ) );
+
+		update_option( 'podcasting_category_id', 123 );
+		New_Episode_Prefill::maybe_register_handlers();
+
+		$this->assertSame( 10, has_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ) ) );
+		$this->assertFalse( has_filter( 'default_content', array( New_Episode_Prefill::class, 'prefill_block_content' ) ) );
+	}
+
+	public function test_assign_category_sets_configured_category_for_initial_auto_draft() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'prefill-author',
+				'user_pass'  => 'pass',
+				'user_email' => 'prefill-author@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$category_id = wp_create_category( 'Podcast Category' );
+		update_option( 'podcasting_category_id', $category_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Auto Draft',
+				'post_type'   => 'post',
+				'post_status' => 'auto-draft',
+			)
+		);
+
+		add_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ), 10, 3 );
+		New_Episode_Prefill::assign_category( $post_id, get_post( $post_id ), false );
+
+		$this->assertSame( array( $category_id ), wp_get_post_categories( $post_id ) );
+		$this->assertFalse( has_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ) ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_user( $user_id );
+		wp_delete_category( $category_id );
+	}
+
+	public function test_assign_category_does_not_override_updates_or_non_auto_drafts() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'prefill-updater',
+				'user_pass'  => 'pass',
+				'user_email' => 'prefill-updater@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$current_category = wp_create_category( 'Current Category' );
+		$podcast_category = wp_create_category( 'Podcast Category' );
+		update_option( 'podcasting_category_id', $podcast_category );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'    => 'Draft',
+				'post_type'     => 'post',
+				'post_status'   => 'draft',
+				'post_category' => array( $current_category ),
+			)
+		);
+
+		New_Episode_Prefill::assign_category( $post_id, get_post( $post_id ), true );
+		New_Episode_Prefill::assign_category( $post_id, get_post( $post_id ), false );
+
+		$this->assertSame( array( $current_category ), wp_get_post_categories( $post_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_user( $user_id );
+		wp_delete_category( $current_category );
+		wp_delete_category( $podcast_category );
+	}
+
+	public function test_prefill_block_content_only_inserts_for_empty_post_content() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Auto Draft',
+				'post_type'   => 'post',
+				'post_status' => 'auto-draft',
+			)
+		);
+		$post = get_post( $post_id );
+
+		$this->assertSame(
+			'Already set',
+			New_Episode_Prefill::prefill_block_content( 'Already set', $post )
+		);
+
+		$this->assertSame(
+			"<!-- wp:jetpack/podcast-episode /-->\n",
+			New_Episode_Prefill::prefill_block_content( '', $post )
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Reset static state shared across tests.
+	 */
+	private function reset_prefill_state() {
+		$property = new \ReflectionProperty( New_Episode_Prefill::class, 'handled_post_id' );
+		$property->setAccessible( true );
+		$property->setValue( 0 );
+	}
+}

--- a/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
+++ b/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
@@ -21,10 +21,14 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 	}
 
 	protected function tearDown(): void {
-		remove_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ), 10 );
-		remove_filter( 'default_content', array( New_Episode_Prefill::class, 'prefill_block_content' ), 10 );
+		if ( has_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ) ) ) {
+			remove_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ), 10 );
+		}
+		if ( has_filter( 'default_content', array( New_Episode_Prefill::class, 'prefill_block_content' ) ) ) {
+			remove_filter( 'default_content', array( New_Episode_Prefill::class, 'prefill_block_content' ), 10 );
+		}
 		delete_option( 'podcasting_category_id' );
-		unset( $_GET[ New_Episode_Prefill::QUERY_VAR ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$_GET = array(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$this->reset_prefill_state();
 		parent::tearDown();
 	}
@@ -68,7 +72,7 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 		);
 
 		add_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ), 10, 3 );
-		New_Episode_Prefill::assign_category( $post_id, get_post( $post_id ), false );
+		do_action( 'wp_insert_post', $post_id, get_post( $post_id ), false );
 
 		$this->assertSame( array( $category_id ), wp_get_post_categories( $post_id ) );
 		$this->assertFalse( has_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ) ) );

--- a/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
+++ b/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
@@ -71,10 +71,8 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 			)
 		);
 
-		// WorDBless lacks the term-relationships table, so wp_get_post_categories
-		// can't read the assignment back. Spy on the set_object_terms action
-		// (fires at the end of wp_set_object_terms) to confirm the call was
-		// made with our category.
+		// WorDBless lacks the term-relationships table; spy on set_object_terms
+		// to verify the call instead of reading the assignment back.
 		$spy    = array();
 		$record = function ( $object_id, $terms, $tt_ids, $taxonomy ) use ( &$spy ) {
 			$spy[] = array(
@@ -131,9 +129,7 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 			)
 		);
 
-		// WorDBless lacks the term-relationships table, so wp_get_post_categories
-		// can't read the assignment back. Spy on the set_object_terms action to
-		// confirm no override call was made for our test post.
+		// Same set_object_terms spy as above; here we assert no call fires.
 		$spy    = array();
 		$record = function ( $object_id, $terms, $tt_ids, $taxonomy ) use ( &$spy, $post_id ) {
 			if ( (int) $object_id === (int) $post_id && 'category' === $taxonomy ) {
@@ -178,12 +174,9 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
-	/**
-	 * Reset static state shared across tests.
-	 */
 	private function reset_prefill_state() {
 		$property = new \ReflectionProperty( New_Episode_Prefill::class, 'handled_post_id' );
-		// setAccessible is required on PHP < 8.1; on 8.5 it's deprecated but not removed.
+		// setAccessible is required on PHP < 8.1; deprecated but still works on later versions.
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}

--- a/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
+++ b/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
@@ -71,10 +71,35 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 			)
 		);
 
+		// WorDBless lacks the term-relationships table, so wp_get_post_categories
+		// can't read the assignment back. Spy on the set_object_terms action
+		// (fires at the end of wp_set_object_terms) to confirm the call was
+		// made with our category.
+		$spy = array();
+		$record = function ( $object_id, $terms, $tt_ids, $taxonomy ) use ( &$spy ) {
+			$spy[] = array(
+				'object_id' => (int) $object_id,
+				'taxonomy'  => $taxonomy,
+				'terms'     => array_map( 'intval', (array) $terms ),
+			);
+		};
+		add_action( 'set_object_terms', $record, 10, 4 );
+
 		add_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ), 10, 3 );
 		do_action( 'wp_insert_post', $post_id, get_post( $post_id ), false );
 
-		$this->assertSame( array( $category_id ), wp_get_post_categories( $post_id ) );
+		remove_action( 'set_object_terms', $record, 10 );
+
+		$this->assertSame(
+			array(
+				array(
+					'object_id' => (int) $post_id,
+					'taxonomy'  => 'category',
+					'terms'     => array( (int) $category_id ),
+				),
+			),
+			$spy
+		);
 		$this->assertFalse( has_action( 'wp_insert_post', array( New_Episode_Prefill::class, 'assign_category' ) ) );
 
 		wp_delete_post( $post_id, true );
@@ -106,10 +131,23 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 			)
 		);
 
+		// WorDBless lacks the term-relationships table, so wp_get_post_categories
+		// can't read the assignment back. Spy on the set_object_terms action to
+		// confirm no override call was made for our test post.
+		$spy = array();
+		$record = function ( $object_id, $terms, $tt_ids, $taxonomy ) use ( &$spy, $post_id ) {
+			if ( (int) $object_id === (int) $post_id && 'category' === $taxonomy ) {
+				$spy[] = array_map( 'intval', (array) $terms );
+			}
+		};
+		add_action( 'set_object_terms', $record, 10, 4 );
+
 		New_Episode_Prefill::assign_category( $post_id, get_post( $post_id ), true );
 		New_Episode_Prefill::assign_category( $post_id, get_post( $post_id ), false );
 
-		$this->assertSame( array( $current_category ), wp_get_post_categories( $post_id ) );
+		remove_action( 'set_object_terms', $record, 10 );
+
+		$this->assertSame( array(), $spy );
 
 		wp_delete_post( $post_id, true );
 		wp_delete_user( $user_id );
@@ -145,7 +183,6 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 	 */
 	private function reset_prefill_state() {
 		$property = new \ReflectionProperty( New_Episode_Prefill::class, 'handled_post_id' );
-		$property->setAccessible( true );
-		$property->setValue( 0 );
+		$property->setValue( null, 0 );
 	}
 }

--- a/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
+++ b/projects/packages/podcast/tests/php/New_Episode_Prefill_Test.php
@@ -75,7 +75,7 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 		// can't read the assignment back. Spy on the set_object_terms action
 		// (fires at the end of wp_set_object_terms) to confirm the call was
 		// made with our category.
-		$spy = array();
+		$spy    = array();
 		$record = function ( $object_id, $terms, $tt_ids, $taxonomy ) use ( &$spy ) {
 			$spy[] = array(
 				'object_id' => (int) $object_id,
@@ -134,7 +134,7 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 		// WorDBless lacks the term-relationships table, so wp_get_post_categories
 		// can't read the assignment back. Spy on the set_object_terms action to
 		// confirm no override call was made for our test post.
-		$spy = array();
+		$spy    = array();
 		$record = function ( $object_id, $terms, $tt_ids, $taxonomy ) use ( &$spy, $post_id ) {
 			if ( (int) $object_id === (int) $post_id && 'category' === $taxonomy ) {
 				$spy[] = array_map( 'intval', (array) $terms );
@@ -163,7 +163,7 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 				'post_status' => 'auto-draft',
 			)
 		);
-		$post = get_post( $post_id );
+		$post    = get_post( $post_id );
 
 		$this->assertSame(
 			'Already set',
@@ -183,6 +183,10 @@ class New_Episode_Prefill_Test extends BaseTestCase {
 	 */
 	private function reset_prefill_state() {
 		$property = new \ReflectionProperty( New_Episode_Prefill::class, 'handled_post_id' );
+		// setAccessible is required on PHP < 8.1; on 8.5 it's deprecated but not removed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( null, 0 );
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
Persistent "+ Create episode" header CTA on `/podcast` plus a server-side prefill behind the same URL flag.

### Dashboard
* `+ Create episode` button rendered into the AdminPage `actions` slot (top-right of the unified header). Visible whenever `isSetUp` is true (a podcast category is configured) and hidden before setup. Same label, same destination for every plan — the Premium value-add lives inside the editor, not at this button.

### Server-side prefill (new `Automattic\Jetpack\Podcast\New_Episode_Prefill`)
* Registers on `admin_init` only when `$pagenow === 'post-new.php'` and `?podcast_episode=1`.
* `wp_insert_post` action runs once on the initial auto-draft and calls `wp_set_post_categories( $post_id, [ podcasting_category_id ] )`. Guards on `! $update && post_type === 'post' && post_status === 'auto-draft'` so user-driven saves later in the session aren't re-overridden.
* On Premium (`Podcast_Gate::has_product_access()` from #48702), the `default_content` filter returns `<!-- wp:jetpack/podcast-episode /-->`. Free users get a plain new post and add a core Audio block themselves with an externally hosted URL.

## Dependencies
* **Depends on #48702** (`Podcast_Gate::has_product_access()`). CI will fail with class-not-found on `Podcast_Gate` until that merges. Once it does, this PR should rebase clean on trunk.
* **Loosely related to #48700** (`WPCOM_Features::PODCASTING`). `Podcast_Gate` currently uses the literal `'podcasting'` slug; once #48700 merges, the gate helper can swap to the constant in a separate cleanup — this PR doesn't need that.

Per Rob's override: branched from current `trunk` rather than from `pods-141-add-gate-helper-and-grandfather-sticker-constant` because that branch doesn't yet include the `jetpack/podcast-episode` block this PR's `default_content` filter references. Trunk has both the block and (after #48702 merges) the gate helper.

## Related product discussion/links
* Part of the /podcast UI polish batch.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Enable the package: `add_filter( 'jetpack_podcast_untangle', '__return_true' );`
2. **Header button visibility:**
   - With no podcast category configured (Settings > Disable podcasting), open `/podcast`. The "+ Create episode" button should NOT be visible.
   - Pick a category in the setup modal. Now the button should appear in the top-right of the header on every tab (Stats, Episodes, Distribution, Settings).
3. **Category prefill (all plans):** Click "+ Create episode". You should land on `wp-admin/post-new.php?podcast_episode=1` with your configured podcast category already ticked in the post sidebar.
4. **Premium block prefill:** With Premium (or the `podcasting-grandfathered` blog sticker), the new post should already contain an inserted Podcast Episode block ready to receive media.
5. **Free plain new post:** Without Premium and without the grandfather sticker, the new post should be empty — no block prefilled. The configured category is still ticked.
6. **No double-override:** Pick a different category in-editor before publishing. The user choice should survive the next refresh — the auto-draft hook only fires on the initial insert.

Notes for reviewer:
- I'm an automation that can't drive a browser, so I haven't captured before/after screenshots. Visual verification still needs a sandbox check at review time.
- The CTA target URL matches what PR 5's empty-Episodes-state CTA uses, by design.
- The `default_content` filter no-ops if `$content` is already non-empty, so this composes politely with other plugins that prefill new posts.

---
Spec excerpt (from the work order):

> PR 7: Create episode button
>
> Placement
> - Persistent "+ Create episode" button in the top-right of the /podcast page header.
> - Visible on every tab once the podcast category is configured. Hidden before setup.
> - Empty Episodes state also includes a "+ Create episode" CTA (covered in PR 5).
>
> Behavior on click
> - All plans: navigate to a new post URL (try /wp-admin/post-new.php?podcast_episode=1 first, or the Calypso equivalent if the dashboard's existing post-create links use that), with the configured podcast category pre-set on the new post.
> - Premium plan: server-side filter inserts the Podcast Episode block on load.
> - Free plan: plain new post. No block inserted. User adds a core Audio block themselves with an externally hosted URL.
>
> Same button and same destination for everyone. The Premium value-add lives inside the editor, not at the button. No upgrade modal at click time. No Premium indicator on the button.

Per Rob's override (out-of-office): using `Podcast_Gate::has_product_access()` from #48702. Branched from trunk so the Podcast Episode block referenced by `default_content` exists on this branch.
