### PR TITLE
VideoPress: use stored finish timestamp for finish_date_gmt

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-finish-date-gmt-uses-current-time
+++ b/projects/packages/videopress/changelog/fix-videopress-finish-date-gmt-uses-current-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Utility: use stored processing-completion timestamp for finish_date_gmt instead of the current time.

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -529,6 +529,10 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 		$video_info->allow_download  = isset( $videopress_meta['allow_download'] ) ? $videopress_meta['allow_download'] : 0;
 		$video_info->display_embed   = isset( $videopress_meta['display_embed'] ) ? $videopress_meta['display_embed'] : 0;
 		$video_info->privacy_setting = ! isset( $videopress_meta['privacy_setting'] ) ? VIDEOPRESS_PRIVACY::SITE_DEFAULT : $videopress_meta['privacy_setting'];
+
+		if ( ! empty( $videopress_meta['finished'] ) ) {
+			$video_info->finish_date_gmt = gmdate( 'Y-m-d H:i:s', (int) $videopress_meta['finished'] );
+		}
 	}
 
 	/** Make sure we are keeping some meta keys updated for filtering purposes */
@@ -537,11 +541,6 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	}
 	if ( get_post_meta( $post_id, 'videopress_privacy_setting', true ) !== $video_info->privacy_setting ) {
 		update_post_meta( $post_id, 'videopress_privacy_setting', $video_info->privacy_setting );
-	}
-
-	$finished = videopress_is_finished_processing( $post_id );
-	if ( $finished ) {
-		$video_info->finish_date_gmt = gmdate( 'Y-m-d H:i:s', (int) $finished );
 	}
 
 	return $video_info;

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -539,8 +539,9 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 		update_post_meta( $post_id, 'videopress_privacy_setting', $video_info->privacy_setting );
 	}
 
-	if ( videopress_is_finished_processing( $post_id ) ) {
-		$video_info->finish_date_gmt = gmdate( 'Y-m-d H:i:s' );
+	$finished = videopress_is_finished_processing( $post_id );
+	if ( $finished ) {
+		$video_info->finish_date_gmt = gmdate( 'Y-m-d H:i:s', (int) $finished );
 	}
 
 	return $video_info;

--- a/projects/packages/videopress/tests/php/Utility_Functions_Test.php
+++ b/projects/packages/videopress/tests/php/Utility_Functions_Test.php
@@ -128,4 +128,44 @@ class Utility_Functions_Test extends BaseTestCase {
 		$this->assertSame( 1, $video_info->display_embed );
 		$this->assertSame( 1, $video_info->privacy_setting ); // 1 = Private
 	}
+
+	/**
+	 * Test videopress_is_finished_processing returns false when no VideoPress meta is present.
+	 */
+	public function test_videopress_is_finished_processing_without_meta() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+
+		$this->assertFalse( videopress_is_finished_processing( $post_id ) );
+	}
+
+	/**
+	 * Test videopress_is_finished_processing returns the stored finish timestamp when present.
+	 */
+	public function test_videopress_is_finished_processing_returns_timestamp() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+			)
+		);
+
+		$finish_time = time();
+		wp_update_attachment_metadata(
+			$post_id,
+			array(
+				'videopress' => array(
+					'finished' => $finish_time,
+				),
+			)
+		);
+
+		$this->assertSame( $finish_time, videopress_is_finished_processing( $post_id ) );
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* `video_get_info_by_blogpostid()` was setting `finish_date_gmt` to the current time whenever a video had finished processing, ignoring the actual completion timestamp already stored in the attachment metadata.
* Read `$meta['videopress']['finished']` directly inside the existing `wp_get_attachment_metadata()` block and pass it to `gmdate()` so `finish_date_gmt` reflects when processing actually finished — instead of routing through `videopress_is_finished_processing()`, whose `@return bool` docblock misrepresents its actual return value (the stored timestamp) and which would otherwise force a second `wp_get_attachment_metadata()` round-trip.
* Resolves the intermittent failure of `Utility_Functions_Test::test_video_get_info_by_blogpostid_videopress_post`, which crossed a one-second boundary between the stored `time()` and the `gmdate()` call inside the function (e.g. https://github.com/Automattic/jetpack/actions/runs/25939921693).

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run the videopress package PHPUnit suite: `jetpack test packages/videopress` — `test_video_get_info_by_blogpostid_videopress_post` should now pass deterministically.
* For manual verification: on a site with a finished VideoPress upload, call `video_get_info_by_blogpostid( $blog_id, $post_id )` and confirm `finish_date_gmt` matches the GMT-formatted `videopress.finished` value in the attachment metadata rather than the current time.