### PR TITLE
Search dashboard: add Jetpack Search blocks and Embedded search page to the pricing grid

### DIFF
--- a/projects/packages/search/changelog/SEARCH-195-search-blocks-pricing-grid
+++ b/projects/packages/search/changelog/SEARCH-195-search-blocks-pricing-grid
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: Add "Jetpack Search blocks" and "Embedded search page" to the pricing comparison grid, shown as included on both the free and paid plans.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -314,6 +314,8 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
+							<PricingTableItem isIncluded={ true } />
+							<PricingTableItem isIncluded={ true } />
 						</PricingTableColumn>
 						<PricingTableColumn>
 							<PricingTableHeader>
@@ -396,6 +398,8 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 								label={ __( 'Shows Jetpack logo', 'jetpack-search-pkg' ) }
 							/>
 							<PricingTableItem isIncluded={ false } />
+							<PricingTableItem isIncluded={ true } />
+							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
@@ -493,6 +497,20 @@ const newPricingArgs = {
 			name: __( 'Spelling correction', 'jetpack-search-pkg' ),
 			tooltipInfo: __(
 				'Quick and accurate spelling correction for when your site visitors mistype their search.',
+				'jetpack-search-pkg'
+			),
+		},
+		{
+			name: __( 'Jetpack Search blocks', 'jetpack-search-pkg' ),
+			tooltipInfo: __(
+				'Design your own search experience in the block editor. Drop in dedicated search, filtering, and sorting blocks to build a results page that matches your site — no code required.',
+				'jetpack-search-pkg'
+			),
+		},
+		{
+			name: __( 'Embedded search page', 'jetpack-search-pkg' ),
+			tooltipInfo: __(
+				"Don't want to build one yourself? Enable the ready-made Jetpack Search template in a single click for a polished, fully featured search page right out of the box.",
 				'jetpack-search-pkg'
 			),
 		},


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-195

## Why

When comparing the free and paid Jetpack Search plans, customers couldn't see that they can build their own customizable search experience with the Jetpack Search blocks, or enable the ready-made Jetpack Search template in one click. Both capabilities are available on every plan, so leaving them off the comparison grid understated the value of both the free and paid offerings. This adds them so customers can make a more informed choice.

## Proposed changes

* Add a **Jetpack Search blocks** row to the pricing comparison grid (`NewPricingComponent`), with a tooltip describing the block-editor search experience.
* Add an **Embedded search page** row, with a tooltip describing the one-click preset Jetpack Search template (the existing "Embedded search" experience).
* Both rows are marked as included (✓) in the paid **and** free columns, keeping the `newPricingArgs.items` ↔ `PricingTableItem` mapping 1:1.

## Screenshots

Captured at `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1` via local docker at 1440×900.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/de32c43b-fc20-4307-a109-61408e0f5071) | ![after](https://github.com/user-attachments/assets/4dc8a029-799d-4a45-9860-7820c6068a30) |

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-195

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Spin up a WP env with the Jetpack Search plugin active.
* Go to **Jetpack → Search**. To force the new pricing grid on a local/disconnected env, append `&new_pricing_202208=1` to the upsell page URL (`admin.php?page=jetpack-search&new_pricing_202208=1`).
* Scroll to the feature comparison grid and confirm:
  * A **Jetpack Search blocks** row renders, shown as included (✓) in both the paid and free columns.
  * An **Embedded search page** row renders, shown as included (✓) in both the paid and free columns.
  * Hovering each row's info icon shows a clear, professional tooltip.
  * Every existing feature row still aligns with the correct paid/free included state (no off-by-one in the grid).
