### PR TITLE
Search: default to new pricing when the WPCOM pricing fetch errors

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-search-pricing-fallback
+++ b/projects/packages/my-jetpack/changelog/fix-search-pricing-fallback
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Search: default to the current pricing experience when the WPCOM pricing fetch fails, instead of falling back to the legacy upsell view.
+Comment: Search: default to the current pricing experience and a USD starting price when the WPCOM pricing fetch fails, instead of falling back to the legacy upsell view or showing no price.

--- a/projects/packages/my-jetpack/changelog/fix-search-pricing-fallback
+++ b/projects/packages/my-jetpack/changelog/fix-search-pricing-fallback
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Search: default to the current pricing experience and a USD starting price when the WPCOM pricing fetch fails, instead of falling back to the legacy upsell view or showing no price.
+Comment: Search: default to the current pricing experience and a USD starting price when the WPCOM pricing fetch fails, instead of falling back to the legacy upsell view or showing no price. The failed fetch is also cached per request to avoid a duplicate timeout.

--- a/projects/packages/my-jetpack/changelog/fix-search-pricing-fallback
+++ b/projects/packages/my-jetpack/changelog/fix-search-pricing-fallback
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Search: default to the current pricing experience when the WPCOM pricing fetch fails, instead of falling back to the legacy upsell view.

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -296,7 +296,10 @@ class Search extends Hybrid_Product {
 		}
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'search_pricing_fetch_failed' );
+			// Cache the failure too: get_pricing_for_ui() reaches this twice per request
+			// (once via has_trial_support(), once directly), and each miss is a 5s timeout.
+			$pricings[ $record_count ] = new WP_Error( 'search_pricing_fetch_failed' );
+			return $pricings[ $record_count ];
 		}
 
 		$body                      = wp_remote_retrieve_body( $response );

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Search\Module_Control as Search_Module_Control;
+use Automattic\Jetpack\Search\Plan as Search_Plan;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -168,6 +169,9 @@ class Search extends Hybrid_Product {
 		$search_pricing = static::get_pricing_from_wpcom( $record_count );
 
 		if ( is_wp_error( $search_pricing ) ) {
+			// Default to the current pricing experience when the WPCOM fetch fails so the
+			// dashboard degrades to the production default, not the legacy single-card view.
+			$pricing['pricing_version'] = Search_Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
 			return $pricing;
 		}
 
@@ -215,10 +219,11 @@ class Search extends Hybrid_Product {
 		$record_count   = intval( Search_Stats::estimate_count() );
 		$search_pricing = static::get_pricing_from_wpcom( $record_count );
 		if ( is_wp_error( $search_pricing ) ) {
-			return false;
+			// Default to the current pricing experience when the WPCOM fetch fails.
+			return true;
 		}
 
-		return '202208' === $search_pricing['pricing_version'];
+		return Search_Plan::JETPACK_SEARCH_NEW_PRICING_VERSION === $search_pricing['pricing_version'];
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -25,6 +25,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Search extends Hybrid_Product {
 	/**
+	 * Fallback starting price (USD, billed yearly) for the entry record tier, used when
+	 * the WPCOM pricing fetch fails so the dashboard still shows a price, not "$0".
+	 *
+	 * @var float
+	 */
+	const FALLBACK_STARTING_PRICE_USD = 100;
+
+	/**
 	 * The product slug
 	 *
 	 * @var string
@@ -172,6 +180,15 @@ class Search extends Hybrid_Product {
 			// Default to the current pricing experience when the WPCOM fetch fails so the
 			// dashboard degrades to the production default, not the legacy single-card view.
 			$pricing['pricing_version'] = Search_Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
+
+			// If the generic product pricing was also unavailable, fall back to a USD
+			// starting price so the pricing grid renders a price instead of "$0".
+			if ( empty( $pricing['full_price'] ) ) {
+				$pricing['currency_code']  = 'USD';
+				$pricing['full_price']     = self::FALLBACK_STARTING_PRICE_USD;
+				$pricing['discount_price'] = self::FALLBACK_STARTING_PRICE_USD;
+			}
+
 			return $pricing;
 		}
 

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -168,6 +168,42 @@ class Search_Product_Test extends TestCase {
 	}
 
 	/**
+	 * Counts outbound HTTP attempts while forcing them to fail.
+	 *
+	 * @var int
+	 */
+	private $http_error_calls = 0;
+
+	/**
+	 * Forces outbound HTTP requests to fail and tallies how many were attempted.
+	 *
+	 * @return \WP_Error
+	 */
+	public function count_http_error() {
+		++$this->http_error_calls;
+		return new \WP_Error( 'http_request_failed', 'Simulated WPCOM failure.' );
+	}
+
+	/**
+	 * A failed pricing fetch is cached for the request, so the two callers in
+	 * get_pricing_for_ui() share a single failed attempt instead of two 5s timeouts.
+	 */
+	public function test_failed_pricing_fetch_is_cached() {
+		$this->http_error_calls = 0;
+		add_filter( 'pre_http_request', array( $this, 'count_http_error' ) );
+
+		$record_count = 987654;
+		$first        = Search::get_pricing_from_wpcom( $record_count );
+		$second       = Search::get_pricing_from_wpcom( $record_count );
+
+		remove_filter( 'pre_http_request', array( $this, 'count_http_error' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $first );
+		$this->assertInstanceOf( \WP_Error::class, $second );
+		$this->assertSame( 1, $this->http_error_calls );
+	}
+
+	/**
 	 * When the WPCOM pricing fetch errors, the UI pricing payload should still default to
 	 * the new pricing version so the dashboard renders the current grid, not the legacy view.
 	 */

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -157,4 +157,41 @@ class Search_Product_Test extends TestCase {
 		activate_plugins( Search::get_installed_plugin_filename() );
 		$this->assertSame( '', Search::get_post_activation_url() );
 	}
+
+	/**
+	 * Forces every outbound HTTP request to fail so the WPCOM pricing fetch errors.
+	 *
+	 * @return \WP_Error
+	 */
+	public function force_http_error() {
+		return new \WP_Error( 'http_request_failed', 'Simulated WPCOM failure.' );
+	}
+
+	/**
+	 * When the WPCOM pricing fetch errors, the UI pricing payload should still default to
+	 * the new pricing version so the dashboard renders the current grid, not the legacy view.
+	 */
+	public function test_get_pricing_for_ui_defaults_to_new_pricing_on_fetch_error() {
+		add_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+
+		$pricing = Search::get_pricing_for_ui();
+
+		remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+
+		$this->assertArrayHasKey( 'pricing_version', $pricing );
+		$this->assertSame( '202208', $pricing['pricing_version'] );
+	}
+
+	/**
+	 * When the WPCOM pricing fetch errors, is_new_pricing_202208() should default to true.
+	 */
+	public function test_is_new_pricing_202208_true_on_fetch_error() {
+		add_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+
+		$is_new_pricing = Search::is_new_pricing_202208();
+
+		remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+
+		$this->assertTrue( $is_new_pricing );
+	}
 }

--- a/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Search_Product_Test.php
@@ -183,6 +183,22 @@ class Search_Product_Test extends TestCase {
 	}
 
 	/**
+	 * When the WPCOM pricing fetch errors and no generic product pricing is available,
+	 * the payload should fall back to a USD starting price so the grid renders a price.
+	 */
+	public function test_get_pricing_for_ui_falls_back_to_usd_starting_price_on_fetch_error() {
+		add_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+
+		$pricing = Search::get_pricing_for_ui();
+
+		remove_filter( 'pre_http_request', array( $this, 'force_http_error' ) );
+
+		$this->assertSame( 'USD', $pricing['currency_code'] );
+		$this->assertSame( Search::FALLBACK_STARTING_PRICE_USD, $pricing['full_price'] );
+		$this->assertSame( Search::FALLBACK_STARTING_PRICE_USD, $pricing['discount_price'] );
+	}
+
+	/**
 	 * When the WPCOM pricing fetch errors, is_new_pricing_202208() should default to true.
 	 */
 	public function test_is_new_pricing_202208_true_on_fetch_error() {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-196/default-to-new-pricing-when-the-dotcom-pricing-fetch-errors

## Why

When the WordPress.com pricing fetch fails (disconnected site, transient WPCOM error, network failure), the Search dashboard upsell page silently fell back to a years-old single-card pricing view instead of the current two-column free-vs-paid grid. A fetch failure should degrade to the production-default UX, not a legacy one. As added depth, if the generic product pricing is also unavailable the grid would render `$0`; it now falls back to a USD starting price so a price always shows.

## Proposed changes

* `Search_Product::get_pricing_for_ui()`: on the WPCOM fetch error path, default `pricing_version` to `Plan::JETPACK_SEARCH_NEW_PRICING_VERSION` (`202208`) instead of returning without the key.
* `Search_Product::is_new_pricing_202208()`: default to `true` on the fetch error path instead of `false`.
* `Search_Product::get_pricing_for_ui()`: if the generic product pricing is *also* unavailable on the error path (`full_price` empty), fall back to a USD starting price (`$100/yr` entry tier) so the grid shows a price instead of `$0`. No-op in the common SEARCH-196 case, where the generic product pricing still populates a price in the user's currency.
* The successful-fetch path is untouched.
* Added unit coverage for the error-fallback path and the USD fallback (`Search_Product_Test`).

## Screenshots

Captured at `/wp-admin/admin.php?page=jetpack-search` via local docker at 1440×900. "Before" is trunk with the WPCOM pricing fetch forced to error (legacy single-card). "After" is this branch with the pricing fetch *and* the generic product pricing forced to error, exercising the full degraded path — the new grid renders with the USD starting-price fallback.

| Before (legacy single-card) | After (current grid, USD fallback) |
|---|---|
| ![before](https://github.com/user-attachments/assets/ce897266-2c01-4756-b011-c2413dd4d9ca) | ![after](https://github.com/user-attachments/assets/089008c6-fe18-4f16-85f3-d78e47335b42) |

## API changes

`GET /wp-json/jetpack/v4/search/pricing` — on the WPCOM-fetch-error path the response now includes `"pricing_version": "202208"` (previously absent, which made the dashboard render the legacy view). When the generic product pricing is also unavailable, `currency_code`/`full_price`/`discount_price` default to a USD starting price instead of being absent (which rendered `$0`). The successful-fetch response shape is unchanged.

<details>
<summary>Request</summary>

```http
GET /wp-json/jetpack/v4/search/pricing
```

</details>

<details>
<summary>Response (pricing fetch + generic product pricing both forced to error)</summary>

```json
{
    "pricing_version": "202208",
    "currency_code": "USD",
    "full_price": 100,
    "discount_price": 100
}
```

</details>

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-196/default-to-new-pricing-when-the-dotcom-pricing-fetch-errors
* Discovered while working on SEARCH-195 (adding feature rows to the new pricing grid).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria (from SEARCH-196):

* [ ] With the WPCOM pricing fetch failing (disconnected site or simulated error), the Search dashboard renders the new pricing grid, not the legacy single-card view.
* [ ] The successful-fetch path is unchanged.
* [ ] Test coverage for the error-fallback path.

To reproduce/verify:

* Simulate the failure by filtering `pre_http_request` to return a `WP_Error` for any URL containing `jetpack-search/pricing` (or disconnect the site).
* Go to **Jetpack → Search** (`/wp-admin/admin.php?page=jetpack-search`) on a site without a Search plan — the new two-column pricing grid should render (see "After" screenshot), not the legacy single card.
* For the USD fallback: additionally fail any URL containing `/products` and clear the my-jetpack products cache (`wp user meta delete <id> my-jetpack-cache`) — the grid should show a USD starting price (`$100/yr` → `$8.33/mo`) instead of `$0`.
* Remove the filter / restore the connection — confirm the successful-fetch pricing view is unchanged.
* Run `composer phpunit -- tests/php/Search_Product_Test.php` in `projects/packages/my-jetpack` — all tests pass, including the new error-fallback and USD-fallback coverage.
