### PR TITLE
Search dashboard: gate new pricing rows behind jetpack_search_blocks_enabled

### DIFF
--- a/projects/packages/search/changelog/SEARCH-195-gate-pricing-rows
+++ b/projects/packages/search/changelog/SEARCH-195-gate-pricing-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Gate the "Jetpack Search blocks" and "Embedded search page" pricing rows behind the `jetpack_search_blocks_enabled` flag, matching the front-end gating of the Search blocks.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -189,6 +189,14 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 	);
 	const { hasConnectionError } = useConnectionErrorNotice();
 
+	const isSearchBlocksEnabled = useSelect(
+		select => select( STORE_ID ).isSearchBlocksEnabled(),
+		[]
+	);
+	const pricingArgs = isSearchBlocksEnabled
+		? { ...newPricingArgs, items: [ ...newPricingArgs.items, ...searchBlocksPricingItems ] }
+		: newPricingArgs;
+
 	const paidRecordsLimitRaw = useSelect( select => select( STORE_ID ).getPaidRecordsLimit(), [] );
 	const paidRecordsLimit = new Intl.NumberFormat( localeSlug, {
 		notation: 'compact',
@@ -222,7 +230,7 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 
 			<Col lg={ 12 } md={ 12 } sm={ 12 }>
 				<ThemeProvider>
-					<PricingTable { ...newPricingArgs }>
+					<PricingTable { ...pricingArgs }>
 						<PricingTableColumn primary>
 							<PricingTableHeader>
 								<ProductPrice
@@ -314,8 +322,9 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
-							<PricingTableItem isIncluded={ true } />
-							<PricingTableItem isIncluded={ true } />
+							{ ( isSearchBlocksEnabled ? searchBlocksPricingItems : [] ).map( item => (
+								<PricingTableItem key={ item.name } isIncluded={ true } />
+							) ) }
 						</PricingTableColumn>
 						<PricingTableColumn>
 							<PricingTableHeader>
@@ -402,8 +411,9 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
-							<PricingTableItem isIncluded={ true } />
-							<PricingTableItem isIncluded={ true } />
+							{ ( isSearchBlocksEnabled ? searchBlocksPricingItems : [] ).map( item => (
+								<PricingTableItem key={ item.name } isIncluded={ true } />
+							) ) }
 						</PricingTableColumn>
 					</PricingTable>
 				</ThemeProvider>
@@ -500,19 +510,25 @@ const newPricingArgs = {
 				'jetpack-search-pkg'
 			),
 		},
-		{
-			name: __( 'Jetpack Search blocks', 'jetpack-search-pkg' ),
-			tooltipInfo: __(
-				'Design your own search experience in the block editor. Drop in dedicated search, filtering, and sorting blocks to build a results page that matches your site — no code required.',
-				'jetpack-search-pkg'
-			),
-		},
-		{
-			name: __( 'Embedded search page', 'jetpack-search-pkg' ),
-			tooltipInfo: __(
-				"Don't want to build one yourself? Enable the ready-made Jetpack Search template in a single click for a polished, fully featured search page right out of the box.",
-				'jetpack-search-pkg'
-			),
-		},
 	],
 };
+
+// Rows gated behind the `jetpack_search_blocks_enabled` flag (mirrored to the
+// dashboard as `searchBlocksEnabled`), so the pricing table advertises the
+// Search blocks features only when the blocks themselves are registered.
+const searchBlocksPricingItems = [
+	{
+		name: __( 'Jetpack Search blocks', 'jetpack-search-pkg' ),
+		tooltipInfo: __(
+			'Design your own search experience in the block editor. Drop in dedicated search, filtering, and sorting blocks to build a results page that matches your site — no code required.',
+			'jetpack-search-pkg'
+		),
+	},
+	{
+		name: __( 'Embedded search page', 'jetpack-search-pkg' ),
+		tooltipInfo: __(
+			"Don't want to build one yourself? Enable the ready-made Jetpack Search template in a single click for a polished, fully featured search page right out of the box.",
+			'jetpack-search-pkg'
+		),
+	},
+];

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -21,7 +21,7 @@ import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import Loading from 'components/loading';
 import Price from 'components/price';
 import SearchPromotionBlock from 'components/search-promotion';
@@ -193,9 +193,13 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 		select => select( STORE_ID ).isSearchBlocksEnabled(),
 		[]
 	);
-	const pricingArgs = isSearchBlocksEnabled
-		? { ...newPricingArgs, items: [ ...newPricingArgs.items, ...searchBlocksPricingItems ] }
-		: newPricingArgs;
+	const pricingArgs = useMemo(
+		() =>
+			isSearchBlocksEnabled
+				? { ...newPricingArgs, items: [ ...newPricingArgs.items, ...searchBlocksPricingItems ] }
+				: newPricingArgs,
+		[ isSearchBlocksEnabled ]
+	);
 
 	const paidRecordsLimitRaw = useSelect( select => select( STORE_ID ).getPaidRecordsLimit(), [] );
 	const paidRecordsLimit = new Intl.NumberFormat( localeSlug, {
@@ -323,7 +327,7 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							{ ( isSearchBlocksEnabled ? searchBlocksPricingItems : [] ).map( item => (
-								<PricingTableItem key={ item.name } isIncluded={ true } />
+								<PricingTableItem key={ item.id } isIncluded={ true } />
 							) ) }
 						</PricingTableColumn>
 						<PricingTableColumn>
@@ -412,7 +416,7 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							{ ( isSearchBlocksEnabled ? searchBlocksPricingItems : [] ).map( item => (
-								<PricingTableItem key={ item.name } isIncluded={ true } />
+								<PricingTableItem key={ item.id } isIncluded={ true } />
 							) ) }
 						</PricingTableColumn>
 					</PricingTable>
@@ -518,6 +522,7 @@ const newPricingArgs = {
 // Search blocks features only when the blocks themselves are registered.
 const searchBlocksPricingItems = [
 	{
+		id: 'search-blocks',
 		name: __( 'Jetpack Search blocks', 'jetpack-search-pkg' ),
 		tooltipInfo: __(
 			'Design your own search experience in the block editor. Drop in dedicated search, filtering, and sorting blocks to build a results page that matches your site — no code required.',
@@ -525,6 +530,7 @@ const searchBlocksPricingItems = [
 		),
 	},
 	{
+		id: 'embedded-search-page',
 		name: __( 'Embedded search page', 'jetpack-search-pkg' ),
 		tooltipInfo: __(
 			"Don't want to build one yourself? Enable the ready-made Jetpack Search template in a single click for a polished, fully featured search page right out of the box.",

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/test/index.test.jsx
@@ -1,0 +1,107 @@
+let mockSelectMethods;
+
+jest.mock( '@automattic/jetpack-components', () => ( {
+	AdminPage: ( { children } ) => <div>{ children }</div>,
+	AdminSectionHero: ( { children } ) => <div>{ children }</div>,
+	Button: ( { children } ) => <button>{ children }</button>,
+	Col: ( { children } ) => <div>{ children }</div>,
+	Container: ( { children } ) => <div>{ children }</div>,
+	PricingCard: () => <div data-testid="pricing-card" />,
+	ProductPrice: ( { children } ) => <div>{ children }</div>,
+	PricingTable: ( { items, children } ) => (
+		<div data-testid="pricing-table">
+			<ul>
+				{ items.map( item => (
+					<li key={ item.name }>{ item.name }</li>
+				) ) }
+			</ul>
+			{ children }
+		</div>
+	),
+	PricingTableColumn: ( { children } ) => <div>{ children }</div>,
+	PricingTableHeader: ( { children } ) => <div>{ children }</div>,
+	PricingTableItem: () => <div data-testid="pricing-table-item" />,
+	PricingTableContext: { Provider: ( { children } ) => <div>{ children }</div> },
+	IconTooltip: ( { children } ) => <div>{ children }</div>,
+	ThemeProvider: ( { children } ) => <div>{ children }</div>,
+	getUserLocale: () => 'en',
+} ) );
+
+jest.mock( '@automattic/jetpack-api', () => ( { setApiNonce: jest.fn() } ) );
+
+jest.mock( '@automattic/jetpack-connection', () => ( {
+	ConnectionError: () => <div data-testid="connection-error" />,
+	useConnectionErrorNotice: () => ( { hasConnectionError: false } ),
+} ) );
+
+jest.mock( '@automattic/number-formatters', () => ( {
+	formatNumberCompact: n => String( n ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children } ) => <button>{ children }</button>,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { fetchSearchPlanInfo: jest.fn( () => Promise.resolve( {} ) ) } ),
+	useSelect: callback => callback( () => mockSelectMethods ),
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	createInterpolateElement: text => text,
+} ) );
+
+jest.mock( 'store', () => ( { STORE_ID: 'jetpack-search-plugin' } ) );
+jest.mock( 'components/loading', () => () => <div data-testid="loading" /> );
+jest.mock( 'components/price', () => () => <span data-testid="price" /> );
+jest.mock( 'components/search-promotion', () => () => <div data-testid="search-promotion" /> );
+jest.mock( 'hooks/use-product-checkout-workflow', () => () => ( {
+	run: jest.fn(),
+	hasCheckoutStarted: false,
+} ) );
+
+import { render, screen } from '@testing-library/react';
+import UpsellPage from '../index';
+
+const createSelectMethods = ( { isSearchBlocksEnabled } ) => ( {
+	getAPINonce: jest.fn( () => 'nonce' ),
+	isNewPricing202208: jest.fn( () => true ),
+	isWpcom: jest.fn( () => false ),
+	getSiteAdminUrl: jest.fn( () => 'https://example.com/wp-admin/' ),
+	getSearchPricing: jest.fn( () => ( {} ) ),
+	getCalypsoSlug: jest.fn( () => 'example.com' ),
+	getBlogId: jest.fn( () => 123 ),
+	isResolving: jest.fn( () => false ),
+	hasStartedResolution: jest.fn( () => true ),
+	getPriceBefore: jest.fn( () => 120 ),
+	getPriceAfter: jest.fn( () => 120 ),
+	getPriceCurrencyCode: jest.fn( () => 'USD' ),
+	getPricingDiscountPercentage: jest.fn( () => 0 ),
+	getPaidRecordsLimit: jest.fn( () => 10000 ),
+	getPaidRequestsLimit: jest.fn( () => 10000 ),
+	getAdditionalUnitPrice: jest.fn( () => 1 ),
+	getAdditionalUnitQuantity: jest.fn( () => 1000 ),
+	isSearchBlocksEnabled: jest.fn( () => isSearchBlocksEnabled ),
+} );
+
+describe( 'UpsellPage pricing grid — Search blocks gating', () => {
+	test( 'hides the Search blocks rows when the flag is disabled', () => {
+		mockSelectMethods = createSelectMethods( { isSearchBlocksEnabled: false } );
+
+		render( <UpsellPage /> );
+
+		expect( screen.queryByText( 'Jetpack Search blocks' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Embedded search page' ) ).not.toBeInTheDocument();
+		// Sanity: the base grid still renders.
+		expect( screen.getByText( 'Spelling correction' ) ).toBeInTheDocument();
+	} );
+
+	test( 'shows the Search blocks rows when the flag is enabled', () => {
+		mockSelectMethods = createSelectMethods( { isSearchBlocksEnabled: true } );
+
+		render( <UpsellPage /> );
+
+		expect( screen.getByText( 'Jetpack Search blocks' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Embedded search page' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-195

Follow-up to #48891 (now merged into trunk).

## Why

The "Jetpack Search blocks" and "Embedded search page" pricing rows added in #48891 advertise features that only exist when the Search blocks are registered — gated server-side behind `jetpack_search_blocks_enabled` (default off). The front end already gates the experience-selector UI on the same flag (mirrored to the dashboard as `searchBlocksEnabled`). This makes the pricing table honor that flag too, so we never advertise blocks that aren't available on the site.

## Proposed changes

* Read the existing `isSearchBlocksEnabled` selector (mirrors the `jetpack_search_blocks_enabled` filter) in `NewPricingComponent`.
* Move the two new rows into a `searchBlocksPricingItems` array; append them to the `PricingTable` items only when the flag is enabled.
* Render the matching `PricingTableItem`s in each column via `( isSearchBlocksEnabled ? searchBlocksPricingItems : [] ).map(...)` — an empty array when gated off, so no falsy child is passed to `PricingTableColumn`'s `Children.map` (a naïve `{ flag && <>…</> }` crashes the dashboard because that component dereferences `child.type` without a null check).

## Screenshots

`/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`, captured via local docker.

| Gate enabled (`jetpack_search_blocks_enabled` → true) | Gate disabled (default) |
|---|---|
| ![gate on](https://github.com/user-attachments/assets/50cd8a86-17e7-45de-accc-e888e2f1873d) | ![gate off](https://github.com/user-attachments/assets/27a9d31a-85fb-41ae-9b50-0ff6cb44fe65) |

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-195
* Follows #48891

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch, build the search package, and open **Jetpack → Search** with `&new_pricing_202208=1` appended.
* With `jetpack_search_blocks_enabled` **enabled** (the docker sandbox enables it by default via `tools/docker/mu-plugins/00-sandbox.php`): confirm the grid shows the **Jetpack Search blocks** and **Embedded search page** rows, included (✓) in both the paid and free columns.
* Force the flag **off** (e.g. an mu-plugin: `add_filter( 'jetpack_search_blocks_enabled', '__return_false', 999 );`): reload and confirm the grid ends at **Spelling correction**, both rows are gone, every remaining row still aligns with the correct paid/free state, and there is **no** console error / blank dashboard.
