### PR TITLE
Podcast: grandfather Premium access by site registration date

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-grandfather-cutoff
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-grandfather-cutoff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: grandfather Premium access by site registration date; drop the sticker-based grandfathering path.

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -18,9 +18,10 @@ use Automattic\Jetpack\Current_Plan;
  */
 class Podcast_Gate {
 
-	const GRANDFATHER_STICKER = 'podcasting-grandfathered';
-
 	const FEATURE_SLUG = 'podcasting';
+
+	// Blogs registered before this date bypass the plan check.
+	const PREMIUM_CUTOFF_DATE = '2026-05-18';
 
 	/**
 	 * Whether the current blog can use Premium podcast features.
@@ -33,13 +34,27 @@ class Podcast_Gate {
 			return false;
 		}
 
-		if (
-			function_exists( 'wpcom_has_blog_sticker' )
-			&& wpcom_has_blog_sticker( self::GRANDFATHER_STICKER, $blog_id )
-		) {
+		if ( self::blog_created_before_cutoff( $blog_id ) ) {
 			return true;
 		}
 
 		return (bool) Current_Plan::supports( self::FEATURE_SLUG );
+	}
+
+	/**
+	 * Whether the blog was registered before the Premium cutoff.
+	 *
+	 * @param int $blog_id Blog ID.
+	 * @return bool
+	 */
+	protected static function blog_created_before_cutoff( int $blog_id ): bool {
+		if ( ! function_exists( 'get_blog_details' ) ) {
+			return false;
+		}
+		$details = get_blog_details( $blog_id );
+		if ( ! $details || empty( $details->registered ) ) {
+			return false;
+		}
+		return strtotime( $details->registered ) < strtotime( self::PREMIUM_CUTOFF_DATE );
 	}
 }

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -20,7 +20,6 @@ class Podcast_Gate {
 
 	const FEATURE_SLUG = 'podcasting';
 
-	// Blogs registered before this date bypass the plan check.
 	const PREMIUM_CUTOFF_DATE = '2026-05-18';
 
 	/**
@@ -42,10 +41,9 @@ class Podcast_Gate {
 	}
 
 	/**
-	 * Whether the blog was registered before the Premium cutoff.
+	 * Whether the blog predates the Premium cutoff.
 	 *
 	 * @param int $blog_id Blog ID.
-	 * @return bool
 	 */
 	protected static function blog_created_before_cutoff( int $blog_id ): bool {
 		if ( ! function_exists( 'get_blog_details' ) ) {
@@ -55,6 +53,10 @@ class Podcast_Gate {
 		if ( ! $details || empty( $details->registered ) ) {
 			return false;
 		}
-		return strtotime( $details->registered ) < strtotime( self::PREMIUM_CUTOFF_DATE );
+		$registered_ts = strtotime( $details->registered );
+		if ( false === $registered_ts ) {
+			return false;
+		}
+		return $registered_ts < strtotime( self::PREMIUM_CUTOFF_DATE );
 	}
 }

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -20,7 +20,7 @@ class Podcast_Gate {
 
 	const FEATURE_SLUG = 'podcasting';
 
-	const PREMIUM_CUTOFF_DATE = '2026-05-18';
+	const GRANDFATHER_CUTOFF_DATE = '2026-05-18';
 
 	/**
 	 * Whether the current blog can use Premium podcast features.
@@ -41,7 +41,7 @@ class Podcast_Gate {
 	}
 
 	/**
-	 * Whether the blog predates the Premium cutoff.
+	 * Whether the blog predates the grandfather cutoff.
 	 *
 	 * @param int $blog_id Blog ID.
 	 */
@@ -57,6 +57,6 @@ class Podcast_Gate {
 		if ( false === $registered_ts ) {
 			return false;
 		}
-		return $registered_ts < strtotime( self::PREMIUM_CUTOFF_DATE );
+		return $registered_ts < strtotime( self::GRANDFATHER_CUTOFF_DATE );
 	}
 }

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -21,12 +21,12 @@ class Podcast_Gate_Test extends BaseTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$GLOBALS['jetpack_podcast_test_stickers'] = array();
+		$GLOBALS['jetpack_podcast_test_blog_details'] = array();
 		self::reset_active_plan_cache();
 	}
 
 	protected function tearDown(): void {
-		unset( $GLOBALS['jetpack_podcast_test_stickers'] );
+		unset( $GLOBALS['jetpack_podcast_test_blog_details'] );
 		WorDBless_Options::init()->clear_options();
 		self::reset_active_plan_cache();
 		parent::tearDown();
@@ -44,12 +44,6 @@ class Podcast_Gate_Test extends BaseTestCase {
 		$property->setValue( null, null );
 	}
 
-	public function test_grandfather_sticker_grants_access(): void {
-		$GLOBALS['jetpack_podcast_test_stickers'][ get_current_blog_id() ] = array( Podcast_Gate::GRANDFATHER_STICKER );
-
-		$this->assertTrue( Podcast_Gate::has_product_access() );
-	}
-
 	public function test_plan_supports_feature_grants_access(): void {
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array( Podcast_Gate::FEATURE_SLUG );
@@ -62,6 +56,54 @@ class Podcast_Gate_Test extends BaseTestCase {
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array();
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_blog_registered_before_cutoff_grants_access(): void {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
+		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
+			'registered' => '2025-01-01 00:00:00',
+		);
+
+		$this->assertTrue( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_blog_registered_on_cutoff_falls_through_to_plan(): void {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
+		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
+			'registered' => Podcast_Gate::PREMIUM_CUTOFF_DATE . ' 00:00:00',
+		);
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_blog_registered_after_cutoff_with_plan_grants_access(): void {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( Podcast_Gate::FEATURE_SLUG );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
+		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
+			'registered' => '2027-01-01 00:00:00',
+		);
+
+		$this->assertTrue( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_blog_registered_after_cutoff_without_plan_denies_access(): void {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
+		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
+			'registered' => '2027-01-01 00:00:00',
+		);
 
 		$this->assertFalse( Podcast_Gate::has_product_access() );
 	}

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -78,7 +78,7 @@ class Podcast_Gate_Test extends BaseTestCase {
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
 
 		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
-			'registered' => Podcast_Gate::PREMIUM_CUTOFF_DATE . ' 00:00:00',
+			'registered' => Podcast_Gate::GRANDFATHER_CUTOFF_DATE . ' 00:00:00',
 		);
 
 		$this->assertFalse( Podcast_Gate::has_product_access() );

--- a/projects/packages/podcast/tests/php/bootstrap.php
+++ b/projects/packages/podcast/tests/php/bootstrap.php
@@ -28,11 +28,11 @@ if ( ! function_exists( 'tracks_record_event' ) ) {
 }
 
 /**
- * Mirror the jetpack-mu-wpcom sticker dispatcher.
+ * Shim WordPress multisite `get_blog_details` for non-multisite test runs.
  */
-if ( ! function_exists( 'wpcom_has_blog_sticker' ) ) {
-	function wpcom_has_blog_sticker( $sticker, $blog_id ) {
-		$stickers = $GLOBALS['jetpack_podcast_test_stickers'][ $blog_id ] ?? array();
-		return in_array( $sticker, $stickers, true );
+if ( ! function_exists( 'get_blog_details' ) ) {
+	function get_blog_details( $blog_id = 0 ) {
+		$details = $GLOBALS['jetpack_podcast_test_blog_details'][ $blog_id ] ?? null;
+		return $details ? (object) $details : false;
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Add a `PREMIUM_CUTOFF_DATE = '2026-05-18'` constant to `Podcast_Gate`. Any blog whose `registered` timestamp is earlier than the cutoff auto-passes `has_product_access()`, regardless of plan.
- Remove the `GRANDFATHER_STICKER` constant and sticker check from `Podcast_Gate`. Date-based grandfathering supersedes per-blog stickers; one source of truth.
- Update tests + bootstrap shim accordingly.

This is purely additive to current trunk behavior: `Podcast_Gate::has_product_access()` is not yet consumed by anything in trunk, so no user-visible change ships from this PR alone. The Episodes-tab gate consumer arrives via [#48885](https://github.com/Automattic/jetpack/pull/48885); this PR ensures grandfathered users keep access the moment that consumer lands.

## Testing instructions

- `cd projects/packages/podcast && composer phpunit -- --filter Podcast_Gate_Test`
  All 6 tests pass: blog registered before cutoff → access; on/after cutoff with no plan → no access; on/after cutoff with plan → access; missing blog details → falls through to plan check.
- Full package suite: `composer phpunit` (80 tests / 198 assertions).

## Does this pull request change what data or activity we track or use?

No.