### PR TITLE
Search dashboard: show search suggestions toggle in the blocks experience

### DIFF
--- a/projects/packages/search/changelog/search-198-search-suggestions-blocks
+++ b/projects/packages/search/changelog/search-198-search-suggestions-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search dashboard: restore the "Enable search suggestions" toggle on the Settings tab when the search blocks experience is enabled, so instant search sites can still control autocomplete suggestions.

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { Fragment, useCallback } from 'react';
 import Card from 'components/card';
 import ReaderChatControl from 'components/reader-chat-control';
+import SearchSuggestionsControl from 'components/search-suggestions-control';
 import InstantSearchUpsellNudge from 'components/upsell-nudge';
 import { STORE_ID } from 'store';
 
@@ -117,15 +118,6 @@ export default function SearchModuleControl( {
 		analytics.tracks.recordEvent( 'jetpack_search_instant_toggle', newOption );
 	}, [ supportsInstantSearch, isInstantSearchEnabled, updateOptions, isDisabledFromOverLimit ] );
 
-	const toggleSearchSuggestions = useCallback( () => {
-		if ( isDisabledFromOverLimit ) {
-			return;
-		}
-		const newOption = { search_suggestions_enabled: ! isSearchSuggestionsEnabled };
-		updateOptions( newOption );
-		analytics.tracks.recordEvent( 'jetpack_search_suggestions_toggle', newOption );
-	}, [ isSearchSuggestionsEnabled, updateOptions, isDisabledFromOverLimit ] );
-
 	return (
 		<div
 			className={ clsx( {
@@ -170,15 +162,14 @@ export default function SearchModuleControl( {
 						updateOptions={ updateOptions }
 					/>
 
-					{ supportsInstantSearch && isInstantSearchEnabled && (
-						<SearchSuggestionsToggle
-							isSearchSuggestionsEnabled={ isSearchSuggestionsEnabled }
-							isInstantSearchEnabled={ isInstantSearchEnabled }
-							isSavingEitherOption={ isSavingEitherOption }
-							isDisabledFromOverLimit={ isDisabledFromOverLimit }
-							toggleSearchSuggestions={ toggleSearchSuggestions }
-						/>
-					) }
+					<SearchSuggestionsControl
+						isEnabled={ isSearchSuggestionsEnabled }
+						isInstantSearchEnabled={ isInstantSearchEnabled }
+						supportsInstantSearch={ supportsInstantSearch }
+						isSaving={ isSavingEitherOption }
+						isDisabledFromOverLimit={ isDisabledFromOverLimit }
+						updateOptions={ updateOptions }
+					/>
 				</div>
 			</Card>
 		</div>
@@ -327,42 +318,6 @@ const SearchToggle = ( {
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ SEARCH_DESCRIPTION }
-					</p>
-				</div>
-			</div>
-		</div>
-	);
-};
-
-const SearchSuggestionsToggle = ( {
-	isSearchSuggestionsEnabled,
-	isInstantSearchEnabled,
-	isSavingEitherOption,
-	isDisabledFromOverLimit,
-	toggleSearchSuggestions,
-} ) => {
-	const isToggleDisabled =
-		isSavingEitherOption || ! isInstantSearchEnabled || isDisabledFromOverLimit;
-
-	return (
-		<div className="jp-form-search-settings-group__toggle is-search-suggestions jp-search-dashboard-wrap">
-			<div className="jp-search-dashboard-row">
-				<ToggleControl
-					checked={ !! isSearchSuggestionsEnabled && ! isDisabledFromOverLimit }
-					disabled={ isToggleDisabled }
-					onChange={ toggleSearchSuggestions }
-					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
-					label={ __( 'Enable search suggestions', 'jetpack-search-pkg' ) }
-					__nextHasNoMarginBottom={ true }
-				/>
-			</div>
-			<div className="jp-search-dashboard-row">
-				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
-					<p className="jp-form-search-settings-group__toggle-explanation">
-						{ __(
-							'Show autocomplete query suggestions as visitors type, instead of updating search results on every keystroke.',
-							'jetpack-search-pkg'
-						) }
 					</p>
 				</div>
 			</div>

--- a/projects/packages/search/src/dashboard/components/module-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/test/index.test.jsx
@@ -1,4 +1,5 @@
 const mockReaderChatControl = jest.fn();
+const mockSearchSuggestionsControl = jest.fn();
 
 jest.mock( '@automattic/jetpack-analytics', () => ( {
 	__esModule: true,
@@ -60,6 +61,11 @@ jest.mock( 'components/reader-chat-control', () => props => {
 	return <div data-testid="reader-chat-control" />;
 } );
 
+jest.mock( 'components/search-suggestions-control', () => props => {
+	mockSearchSuggestionsControl( props );
+	return <div data-testid="search-suggestions-control" />;
+} );
+
 jest.mock( 'components/upsell-nudge', () => () => <div data-testid="instant-search-upsell" /> );
 
 jest.mock( 'store', () => ( {
@@ -85,6 +91,7 @@ const defaultProps = {
 	supportsInstantSearch: true,
 	isTogglingModule: false,
 	isTogglingInstantSearch: false,
+	isSearchSuggestionsEnabled: false,
 	readerChatGuidelinesUrl:
 		'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
 };
@@ -92,14 +99,20 @@ const defaultProps = {
 describe( 'ModuleControl', () => {
 	beforeEach( () => {
 		mockReaderChatControl.mockClear();
+		mockSearchSuggestionsControl.mockClear();
 	} );
 
-	test( 'renders the Reader Chat control after the Instant Search setting', () => {
+	test( 'renders the Reader Chat and Search Suggestions controls after the Instant Search setting', () => {
 		render( <ModuleControl { ...defaultProps } /> );
 
-		expect( screen.getAllByTestId( /^(instant-search-toggle|reader-chat-control)$/ ) ).toEqual( [
+		expect(
+			screen.getAllByTestId(
+				/^(instant-search-toggle|reader-chat-control|search-suggestions-control)$/
+			)
+		).toEqual( [
 			screen.getByTestId( 'instant-search-toggle' ),
 			screen.getByTestId( 'reader-chat-control' ),
+			screen.getByTestId( 'search-suggestions-control' ),
 		] );
 		expect( mockReaderChatControl ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -107,6 +120,16 @@ describe( 'ModuleControl', () => {
 				isEnabled: true,
 				isSaving: false,
 				guidelinesUrl: 'https://example.com/wp-admin/options-general.php?page=guidelines-wp-admin',
+				updateOptions: defaultProps.updateOptions,
+			} )
+		);
+		expect( mockSearchSuggestionsControl ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isEnabled: false,
+				isInstantSearchEnabled: true,
+				supportsInstantSearch: true,
+				isSaving: false,
+				isDisabledFromOverLimit: false,
 				updateOptions: defaultProps.updateOptions,
 			} )
 		);

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -12,6 +12,7 @@ import MockedSearch from 'components/mocked-search';
 import ModuleControl from 'components/module-control';
 import ReaderChatControl from 'components/reader-chat-control';
 import RecordMeter from 'components/record-meter';
+import SearchSuggestionsControl from 'components/search-suggestions-control';
 import { STORE_ID } from 'store';
 import FirstRunSection from './sections/first-run-section';
 import PlanUsageSection from './sections/plan-usage-section';
@@ -234,12 +235,24 @@ export default function DashboardPage( { isLoading = false } ) {
 												<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 													<ExperienceSelector />
 													{ isReaderChatAvailable && (
-														<div className="jp-search-reader-chat-card">
+														<div className="jp-search-settings-card">
 															<ReaderChatControl
 																isAvailable={ isReaderChatAvailable }
 																isEnabled={ isReaderChatEnabled }
 																isSaving={ isSavingEitherOption }
 																guidelinesUrl={ readerChatGuidelinesUrl }
+																updateOptions={ updateOptions }
+															/>
+														</div>
+													) }
+													{ supportsInstantSearch && isInstantSearchEnabled && (
+														<div className="jp-search-settings-card">
+															<SearchSuggestionsControl
+																isEnabled={ isSearchSuggestionsEnabled }
+																isInstantSearchEnabled={ isInstantSearchEnabled }
+																supportsInstantSearch={ supportsInstantSearch }
+																isSaving={ isSavingEitherOption }
+																isDisabledFromOverLimit={ isOverLimit }
 																updateOptions={ updateOptions }
 															/>
 														</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -121,7 +121,7 @@ body.jetpack_page_jetpack-search .jp-search-dashboard-page {
 	}
 }
 
-.jp-search-reader-chat-card {
+.jp-search-settings-card {
 	margin-block-start: var(--wpds-dimension-padding-3xl);
 	padding: var(--wpds-dimension-padding-2xl);
 	background: var(--wpds-color-bg-surface-neutral-strong);

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -188,6 +188,17 @@ describe( 'DashboardPage', () => {
 		expect( mockSearchSuggestionsControl ).not.toHaveBeenCalled();
 	} );
 
+	test( 'does not render the Search Suggestions card when the plan does not support instant search', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'supportsInstantSearch' ).mockImplementation( () => false );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.queryByTestId( 'search-suggestions-control' ) ).not.toBeInTheDocument();
+		expect( mockSearchSuggestionsControl ).not.toHaveBeenCalled();
+	} );
+
 	test( 'does not render Reader Chat card in the experience selector path when unavailable', () => {
 		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
 		jest.spyOn( mockSelectMethods, 'isReaderChatAvailable' ).mockImplementation( () => false );

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -1,5 +1,6 @@
 const mockModuleControl = jest.fn();
 const mockReaderChatControl = jest.fn();
+const mockSearchSuggestionsControl = jest.fn();
 let mockSelectMethods;
 let mockDispatchMethods;
 
@@ -39,6 +40,10 @@ jest.mock( 'components/experience-selector', () => () => (
 jest.mock( 'components/reader-chat-control', () => props => {
 	mockReaderChatControl( props );
 	return <div data-testid="reader-chat-control" />;
+} );
+jest.mock( 'components/search-suggestions-control', () => props => {
+	mockSearchSuggestionsControl( props );
+	return <div data-testid="search-suggestions-control" />;
 } );
 jest.mock( 'components/record-meter', () => () => <div data-testid="record-meter" /> );
 jest.mock( '../sections/first-run-section', () => () => <div data-testid="first-run-section" /> );
@@ -98,6 +103,7 @@ describe( 'DashboardPage', () => {
 	beforeEach( () => {
 		mockModuleControl.mockClear();
 		mockReaderChatControl.mockClear();
+		mockSearchSuggestionsControl.mockClear();
 		window.history.replaceState( {}, '', DEFAULT_TEST_URL );
 		mockSelectMethods = createSelectMethods();
 		mockDispatchMethods = {
@@ -143,6 +149,43 @@ describe( 'DashboardPage', () => {
 				updateOptions: mockDispatchMethods.updateJetpackSettings,
 			} )
 		);
+	} );
+
+	test( 'renders SearchSuggestionsControl below Reader Chat when search blocks is enabled', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		const blocks = screen.getAllByTestId(
+			/^(experience-selector|reader-chat-control|search-suggestions-control)$/
+		);
+		expect( blocks ).toEqual( [
+			screen.getByTestId( 'experience-selector' ),
+			screen.getByTestId( 'reader-chat-control' ),
+			screen.getByTestId( 'search-suggestions-control' ),
+		] );
+		expect( mockSearchSuggestionsControl ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isEnabled: false,
+				isInstantSearchEnabled: true,
+				supportsInstantSearch: true,
+				isSaving: false,
+				isDisabledFromOverLimit: false,
+				updateOptions: mockDispatchMethods.updateJetpackSettings,
+			} )
+		);
+	} );
+
+	test( 'does not render the Search Suggestions card when instant search is disabled', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isInstantSearchEnabled' ).mockImplementation( () => false );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.queryByTestId( 'search-suggestions-control' ) ).not.toBeInTheDocument();
+		expect( mockSearchSuggestionsControl ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not render Reader Chat card in the experience selector path when unavailable', () => {

--- a/projects/packages/search/src/dashboard/components/search-suggestions-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/search-suggestions-control/index.jsx
@@ -44,7 +44,7 @@ export default function SearchSuggestionsControl( {
 		return null;
 	}
 
-	const isToggleDisabled = isSaving || ! isInstantSearchEnabled || isDisabledFromOverLimit;
+	const isToggleDisabled = isSaving || isDisabledFromOverLimit;
 
 	return (
 		<div className="jp-form-search-settings-group__toggle is-search-suggestions jp-search-dashboard-wrap">

--- a/projects/packages/search/src/dashboard/components/search-suggestions-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/search-suggestions-control/index.jsx
@@ -1,0 +1,70 @@
+import analytics from '@automattic/jetpack-analytics';
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+
+const SEARCH_SUGGESTIONS_DESCRIPTION = __(
+	'Show autocomplete query suggestions as visitors type, instead of updating search results on every keystroke.',
+	'jetpack-search-pkg'
+);
+
+/**
+ * Search suggestions opt-in control. Reads and writes the
+ * search_suggestions_enabled option through the Search dashboard settings
+ * store. Only applies to the instant search experience.
+ *
+ * @param {object}   props                         - Component properties.
+ * @param {boolean}  props.isEnabled               - Whether search suggestions are enabled.
+ * @param {boolean}  props.isInstantSearchEnabled  - Whether Instant Search is enabled.
+ * @param {boolean}  props.supportsInstantSearch   - Whether the plan supports Instant Search.
+ * @param {boolean}  props.isSaving                - Whether settings are being saved.
+ * @param {boolean}  props.isDisabledFromOverLimit - Whether controls are locked due to over-limit usage.
+ * @param {Function} props.updateOptions           - Function to update settings.
+ * @return {import('react').Component} Search suggestions settings component.
+ */
+export default function SearchSuggestionsControl( {
+	isEnabled,
+	isInstantSearchEnabled,
+	supportsInstantSearch,
+	isSaving,
+	isDisabledFromOverLimit,
+	updateOptions,
+} ) {
+	const toggle = useCallback( () => {
+		if ( isDisabledFromOverLimit ) {
+			return;
+		}
+		const newOption = { search_suggestions_enabled: ! isEnabled };
+		updateOptions( newOption );
+		analytics.tracks.recordEvent( 'jetpack_search_suggestions_toggle', newOption );
+	}, [ isEnabled, updateOptions, isDisabledFromOverLimit ] );
+
+	// Search suggestions only apply to the instant search experience.
+	if ( ! supportsInstantSearch || ! isInstantSearchEnabled ) {
+		return null;
+	}
+
+	const isToggleDisabled = isSaving || ! isInstantSearchEnabled || isDisabledFromOverLimit;
+
+	return (
+		<div className="jp-form-search-settings-group__toggle is-search-suggestions jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<ToggleControl
+					checked={ !! isEnabled && ! isDisabledFromOverLimit }
+					disabled={ isToggleDisabled }
+					onChange={ toggle }
+					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
+					label={ __( 'Enable search suggestions', 'jetpack-search-pkg' ) }
+					__nextHasNoMarginBottom={ true }
+				/>
+			</div>
+			<div className="jp-search-dashboard-row">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+					<p className="jp-form-search-settings-group__toggle-explanation">
+						{ SEARCH_SUGGESTIONS_DESCRIPTION }
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/search-suggestions-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/search-suggestions-control/test/index.test.jsx
@@ -1,0 +1,114 @@
+// Mocks must precede module imports so Jest can hoist them above the
+// component file's own dependency chain (which would otherwise drag in
+// the full `@wordpress/components` + admin-ui stack at test time).
+/* eslint-disable testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package; fireEvent is intentional. */
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: ( ...args ) => mockRecordEvent( ...args ) } },
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	ToggleControl: ( { checked, disabled, label, onChange } ) => (
+		<input
+			type="checkbox"
+			checked={ !! checked }
+			disabled={ !! disabled }
+			aria-label={ label }
+			onChange={ event => onChange( event.target.checked ) }
+		/>
+	),
+} ) );
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchSuggestionsControl from '../index.jsx';
+
+const defaultProps = {
+	isEnabled: false,
+	isInstantSearchEnabled: true,
+	supportsInstantSearch: true,
+	isSaving: false,
+	isDisabledFromOverLimit: false,
+	updateOptions: jest.fn(),
+};
+
+const getToggle = () => screen.getByRole( 'checkbox', { name: /Enable search suggestions/i } );
+
+describe( 'SearchSuggestionsControl', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders nothing when the plan does not support instant search', () => {
+		const { container } = render(
+			<SearchSuggestionsControl { ...defaultProps } supportsInstantSearch={ false } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing when instant search is disabled', () => {
+		const { container } = render(
+			<SearchSuggestionsControl { ...defaultProps } isInstantSearchEnabled={ false } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders the toggle reflecting the current stored value', () => {
+		render( <SearchSuggestionsControl { ...defaultProps } isEnabled /> );
+
+		expect( getToggle() ).toBeChecked();
+	} );
+
+	test( 'renders the toggle as off when the stored value is false', () => {
+		render( <SearchSuggestionsControl { ...defaultProps } isEnabled={ false } /> );
+
+		expect( getToggle() ).not.toBeChecked();
+	} );
+
+	test( 'dispatches a settings update and records an event when toggled', () => {
+		const updateOptions = jest.fn();
+		render( <SearchSuggestionsControl { ...defaultProps } updateOptions={ updateOptions } /> );
+
+		fireEvent.click( getToggle() );
+
+		expect( updateOptions ).toHaveBeenCalledWith( { search_suggestions_enabled: true } );
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_search_suggestions_toggle', {
+			search_suggestions_enabled: true,
+		} );
+	} );
+
+	test( 'does not dispatch when over the usage limit', () => {
+		const updateOptions = jest.fn();
+		render(
+			<SearchSuggestionsControl
+				{ ...defaultProps }
+				isEnabled
+				isDisabledFromOverLimit
+				updateOptions={ updateOptions }
+			/>
+		);
+
+		fireEvent.click( getToggle() );
+
+		expect( updateOptions ).not.toHaveBeenCalled();
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+
+	test( 'shows the toggle unchecked while over the usage limit even if stored on', () => {
+		render( <SearchSuggestionsControl { ...defaultProps } isEnabled isDisabledFromOverLimit /> );
+
+		const toggle = getToggle();
+		expect( toggle ).not.toBeChecked();
+		expect( toggle ).toBeDisabled();
+	} );
+
+	test( 'disables the toggle while settings are saving', () => {
+		render( <SearchSuggestionsControl { ...defaultProps } isSaving /> );
+
+		expect( getToggle() ).toBeDisabled();
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-198

## Why

When the new Jetpack Search blocks experience is enabled, site owners on a paid Instant Search plan lost the ability to turn search suggestions (autocomplete) on or off — the toggle simply wasn't there. The old dashboard had it; the new Settings tab dropped it. This restores that control so those sites can manage autocomplete again, right where they manage Reader Chat.

## Proposed changes

* Extract the search suggestions toggle out of `ModuleControl` into a reusable `SearchSuggestionsControl` component (mirroring the existing `ReaderChatControl` extraction).
* Render it on the Settings tab directly below Reader Chat in the search blocks experience, under the experience selector.
* Behaviour, gating (`supportsInstantSearch && isInstantSearchEnabled`), store wiring (`search_suggestions_enabled`), and the `jetpack_search_suggestions_toggle` analytics event are unchanged from the legacy path.
* Card spacing matches the Reader Chat card (shared `jp-search-settings-card` style).
* `ModuleControl` now consumes the same component, so the legacy path is unchanged.

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-198
* Follows the same pattern as RSM-3175 (Reader Chat toggle missing when the search blocks flag is on).

## Does this pull request change what data or activity we track or use?

No. The `jetpack_search_suggestions_toggle` event and `search_suggestions_enabled` option already exist in the legacy path; this only changes where the toggle is rendered.

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/2e17672b-02fe-4cbc-be78-207c973d94d3)

### After
![after](https://github.com/user-attachments/assets/28d5bd17-7ead-4d52-90be-3cc699db6370)

## Testing instructions

Enable the `jetpack_search_blocks_enabled` filter and use a site/plan that supports Instant Search with the Overlay experience active.

* Go to **Jetpack → Search → Settings** tab.
* Confirm the **Enable search suggestions** card renders directly below **Enable Reader Chat**, under the experience selector, with spacing matching the Reader Chat card.
* Toggle **Enable search suggestions** on and off — confirm it persists (the `jetpack_search_suggestions_enabled` option updates) and a `jetpack_search_suggestions_toggle` analytics event fires.
* Switch the experience to **Embedded search** or **Off** (non-Instant-Search) — confirm the search suggestions card disappears (Reader Chat stays).
* Confirm the legacy dashboard (search blocks flag off) still shows the search suggestions toggle below Reader Chat as before.
