### PR TITLE
Search dashboard: add Autocomplete to the pricing comparison grid

### DIFF
--- a/projects/packages/search/changelog/SEARCH-199-autocomplete-pricing-grid
+++ b/projects/packages/search/changelog/SEARCH-199-autocomplete-pricing-grid
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: Add "Autocomplete" to the pricing comparison grid, shown as included on both the free and paid plans.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -326,6 +326,7 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
+							<PricingTableItem isIncluded={ true } />
 							{ ( isSearchBlocksEnabled ? searchBlocksPricingItems : [] ).map( item => (
 								<PricingTableItem key={ item.id } isIncluded={ true } />
 							) ) }
@@ -411,6 +412,7 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 								label={ __( 'Shows Jetpack logo', 'jetpack-search-pkg' ) }
 							/>
 							<PricingTableItem isIncluded={ false } />
+							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
 							<PricingTableItem isIncluded={ true } />
@@ -511,6 +513,13 @@ const newPricingArgs = {
 			name: __( 'Spelling correction', 'jetpack-search-pkg' ),
 			tooltipInfo: __(
 				'Quick and accurate spelling correction for when your site visitors mistype their search.',
+				'jetpack-search-pkg'
+			),
+		},
+		{
+			name: __( 'Autocomplete', 'jetpack-search-pkg' ),
+			tooltipInfo: __(
+				'Suggest search queries as your visitors type, so they can find what they need faster and reach results in a single click.',
 				'jetpack-search-pkg'
 			),
 		},


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-199

## Why

When comparing the free and paid Jetpack Search plans, customers couldn't see that autocomplete — search query suggestions as they type — is part of the search experience. Autocomplete shipped recently (#48473) but was missing from the comparison grid, understating the value of both the free and paid offerings. This adds it so customers can make a more informed choice.

## Proposed changes

* Add an **Autocomplete** row to the pricing comparison grid (`NewPricingComponent`), placed after **Spelling correction**, with a tooltip describing the search-suggestions experience.
* The row is marked as included (✓) in the paid **and** free columns — a matching `<PricingTableItem>` was added to each column, keeping the `newPricingArgs.items` ↔ `PricingTableItem` mapping 1:1 (no off-by-one with the existing gated Search-blocks rows).

## Screenshots

Captured at `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1` via local docker at 1440 wide.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/09bf7f52-3bae-4fd9-9f96-27a4f722ecf8) | ![after](https://github.com/user-attachments/assets/69473760-3057-4357-81ec-98e3cbb35a93) |

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-199
* Follows the same pattern as #48891 (Search blocks / Embedded search page rows)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Spin up a WP env with the Jetpack Search plugin active.
* Go to **Jetpack → Search**. To force the new pricing grid on a local/disconnected env, append `&new_pricing_202208=1` to the upsell page URL (`admin.php?page=jetpack-search&new_pricing_202208=1`).
* Scroll to the feature comparison grid and confirm:
  * An **Autocomplete** row renders, with a clear tooltip on its info icon.
  * It is shown as included (✓) in **both** the paid and free columns.
  * It sits directly after **Spelling correction**, and every existing feature row still aligns with the correct paid/free included state (no off-by-one in the grid).
