### PR TITLE
Episode stats: dispatch premium-required on error code, not HTTP 402

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-stats-gate-premium-error-code
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-stats-gate-premium-error-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Episode stats: dispatch the premium-required state on the `podcast_premium_required` error code instead of HTTP 402.

--- a/projects/packages/podcast/src/dashboard/episodes/use-episode-stats-query.ts
+++ b/projects/packages/podcast/src/dashboard/episodes/use-episode-stats-query.ts
@@ -9,10 +9,10 @@ import type { EpisodeStats } from '../types';
  * (no core-data entity), so a thin `apiFetch` + `useState` wrapper. Server
  * caches 5 minutes; refetching on remount is cheap.
  *
- * `premiumRequired` is `true` when the endpoint responds 402
- * (`podcast_premium_required`). The dashboard tab gate normally hides the
- * stats UI before any request fires, so this is a defense-in-depth state for
- * stale gate snapshots and grandfather-edge races.
+ * `premiumRequired` is `true` when the endpoint responds with a
+ * `podcast_premium_required` error code. The dashboard tab gate normally
+ * hides the stats UI before any request fires, so this is a defense-in-depth
+ * state for stale gate snapshots and grandfather-edge races.
  *
  * @param postIds - Episode post IDs (from the visible page of the table).
  * @return         `{ data, premiumRequired }`.
@@ -59,9 +59,8 @@ export function useEpisodeStatsQuery( postIds: number[] ): {
 						out.push( ...result.episodes );
 					}
 				} catch ( error ) {
-					const err = error as { data?: { status?: number }; status?: number };
-					const status = err?.data?.status ?? err?.status;
-					if ( status === 402 ) {
+					const err = error as { code?: string };
+					if ( err?.code === 'podcast_premium_required' ) {
 						if ( ! cancelled ) {
 							setData( [] );
 							setPremiumRequired( true );


### PR DESCRIPTION
## Proposed changes

- Switch `use-episode-stats-query.ts` to detect the premium-required state from the `podcast_premium_required` error code (`err.code`) instead of HTTP 402 status. Aligns with the standard WordPress REST convention of returning `WP_Error( 'podcast_premium_required', $msg, [ 'status' => 403 ] )` from the server.
- Update the docblock to match.

Stacked on #48885 (locked-preview component + dashboard tab gating, which already covers the Stats tab as of the most recent commit on that branch). Pairs with a wpcom-side change that switches the stats endpoint from emitting 402 to emitting the 403 / `podcast_premium_required` WP_Error.

Defense-in-depth only: the dashboard tab gate normally prevents the request from firing for non-Premium users; this hook-level handling covers stale-script-data races.

## Testing instructions

- Search the podcast package for any remaining `402` references; should be zero after this PR + #48885.
- After the paired wpcom change deploys, on a non-grandfathered Free site:
  - Force-flip `window.JetpackScriptData.podcast.has_product_access` to `true` in DevTools to bypass the tab gate, then navigate to the Episodes tab.
  - Confirm the per-episode stats column renders the premium-required state (empty + flagged), not a thrown error.

## Does this pull request change what data or activity we track or use?

No.
