### PR TITLE
Connection: signal secondary user connections to Calypso

### DIFF
--- a/projects/packages/connection/changelog/add-connection-secondary-user-authorize-signal
+++ b/projects/packages/connection/changelog/add-connection-secondary-user-authorize-signal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: Signal to Calypso that the site already has a connection owner so the authorize page can show appropriate content for secondary user connections.

--- a/projects/packages/connection/changelog/update-connector-card-secondary-prompt
+++ b/projects/packages/connection/changelog/update-connector-card-secondary-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connectors: Show shorter, role-appropriate connect prompt for secondary user connections when the site already has a connection owner.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2134,7 +2134,7 @@ class Manager {
 		// Signal to Calypso that the site already has a connection owner so the
 		// authorize page can show secondary-connection content where appropriate.
 		if ( $this->has_connected_owner() ) {
-			$body_args['already_authorized'] = true;
+			$body_args['has_connected_owner'] = true;
 		}
 
 		/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2131,6 +2131,12 @@ class Manager {
 			$body_args['plugins'] = implode( ',', array_keys( $active_plugins ) );
 		}
 
+		// Signal to Calypso that the site already has a connection owner so the
+		// authorize page can show secondary-connection content where appropriate.
+		if ( $this->has_connected_owner() ) {
+			$body_args['already_authorized'] = true;
+		}
+
 		/**
 		 * Filters the user connection request data for additional property addition.
 		 *

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -368,20 +368,26 @@ function ConnectedPluginsSection() {
  * @return {object} React element.
  */
 function ConnectPrompt( { onConnect, isConnecting, isDisconnecting } ) {
+	// When a connection owner is already linked, the viewing admin is
+	// connecting as a secondary user — the site-registration framing no
+	// longer applies, so use shorter copy focused on the user benefit.
+	const promptText = connectionOwner
+		? __(
+				'Connect your user account to unlock more functionalities and use SSO.',
+				'jetpack-connection'
+		  )
+		: __(
+				'Your site is registered with WordPress.com. Connect your user account to unlock full functionality.',
+				'jetpack-connection'
+		  );
+
 	return createElement(
 		HStack,
 		{ spacing: 3, className: 'jetpack-connector__section' },
 		createElement(
 			'div',
 			{ className: 'jetpack-connector__connect-prompt-text' },
-			createElement(
-				Text,
-				{ size: 13 },
-				__(
-					'Your site is registered with WordPress.com. Connect your user account to unlock full functionality.',
-					'jetpack-connection'
-				)
-			)
+			createElement( Text, { size: 13 }, promptText )
 		),
 		createElement(
 			Button,

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -373,7 +373,7 @@ function ConnectPrompt( { onConnect, isConnecting, isDisconnecting } ) {
 	// longer applies, so use shorter copy focused on the user benefit.
 	const promptText = connectionOwner
 		? __(
-				'Connect your user account to unlock more functionalities and use SSO.',
+				'Connect your user account to unlock more features and sign in via WordPress.com (SSO).',
 				'jetpack-connection'
 		  )
 		: __(

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -1130,6 +1130,60 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * `Manager::get_authorization_url()` should include `already_authorized=1`
+	 * in the URL when the site already has a connection owner, and omit the
+	 * parameter entirely when it does not. Calypso uses this signal in the
+	 * `from=jetpack-connector` flow to render secondary-connection content
+	 * instead of blocking the user.
+	 */
+	public function test_get_authorization_url_includes_already_authorized_when_owner_connected() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'secondary_conn_test_user',
+				'user_pass'  => 'pass',
+				'user_email' => 'secondary-conn@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		Jetpack_Options::update_option( 'id', 1 );
+		Jetpack_Options::update_option( 'blog_token', 'fake.blogtoken' );
+
+		$tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
+			->onlyMethods( array( 'get_access_token', 'sign_role' ) )
+			->getMock();
+		$tokens->method( 'get_access_token' )->willReturn( (object) array( 'secret' => 'fake.secret' ) );
+		$tokens->method( 'sign_role' )->willReturn( 'administrator:signed' );
+
+		$this->reset_plugin_storage();
+
+		// Owner connected -> already_authorized=1 should be present.
+		$manager_with_owner = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->onlyMethods( array( 'get_tokens', 'has_connected_owner', 'get_assumed_site_creation_date' ) )
+			->getMock();
+		$manager_with_owner->method( 'get_tokens' )->willReturn( $tokens );
+		$manager_with_owner->method( 'has_connected_owner' )->willReturn( true );
+		$manager_with_owner->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
+
+		$url = $manager_with_owner->get_authorization_url();
+		$this->assertStringContainsString( 'already_authorized=1', $url );
+
+		// No owner connected -> parameter should be omitted entirely.
+		$manager_without_owner = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->onlyMethods( array( 'get_tokens', 'has_connected_owner', 'get_assumed_site_creation_date' ) )
+			->getMock();
+		$manager_without_owner->method( 'get_tokens' )->willReturn( $tokens );
+		$manager_without_owner->method( 'has_connected_owner' )->willReturn( false );
+		$manager_without_owner->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
+
+		$url = $manager_without_owner->get_authorization_url();
+		$this->assertStringNotContainsString( 'already_authorized=', $url );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
 	 * Reset `Plugin_Storage` to a clean, "post-`plugins_loaded`" state for
 	 * tests: `configured = true`, no cached plugins. Setting `configured`
 	 * to `false` here would make `Plugin_Storage::get_all()` hand back a

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -1130,13 +1130,13 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * `Manager::get_authorization_url()` should include `already_authorized=1`
+	 * `Manager::get_authorization_url()` should include `has_connected_owner=1`
 	 * in the URL when the site already has a connection owner, and omit the
 	 * parameter entirely when it does not. Calypso uses this signal in the
 	 * `from=jetpack-connector` flow to render secondary-connection content
 	 * instead of blocking the user.
 	 */
-	public function test_get_authorization_url_includes_already_authorized_when_owner_connected() {
+	public function test_get_authorization_url_includes_has_connected_owner_when_owner_connected() {
 		$user_id = wp_insert_user(
 			array(
 				'user_login' => 'secondary_conn_test_user',
@@ -1158,7 +1158,7 @@ class ManagerTest extends TestCase {
 
 		$this->reset_plugin_storage();
 
-		// Owner connected -> already_authorized=1 should be present.
+		// Owner connected -> has_connected_owner=1 should be present.
 		$manager_with_owner = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
 			->onlyMethods( array( 'get_tokens', 'has_connected_owner', 'get_assumed_site_creation_date' ) )
 			->getMock();
@@ -1167,7 +1167,7 @@ class ManagerTest extends TestCase {
 		$manager_with_owner->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
 
 		$url = $manager_with_owner->get_authorization_url();
-		$this->assertStringContainsString( 'already_authorized=1', $url );
+		$this->assertStringContainsString( 'has_connected_owner=1', $url );
 
 		// No owner connected -> parameter should be omitted entirely.
 		$manager_without_owner = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
@@ -1178,7 +1178,7 @@ class ManagerTest extends TestCase {
 		$manager_without_owner->method( 'get_assumed_site_creation_date' )->willReturn( '2020-01-01 00:00:00' );
 
 		$url = $manager_without_owner->get_authorization_url();
-		$this->assertStringNotContainsString( 'already_authorized=', $url );
+		$this->assertStringNotContainsString( 'has_connected_owner=', $url );
 
 		wp_delete_user( $user_id );
 	}


### PR DESCRIPTION
## Proposed changes

* Add a `has_connected_owner=1` parameter to the authorize URL built by `Manager::get_authorization_url()` whenever the site already has a connection owner. Calypso (via [wp-calypso#110763](https://github.com/Automattic/wp-calypso/pull/110763)) uses this signal in the `from=jetpack-connector` flow to render secondary-connection content instead of blocking the user.
* Tailor the local Jetpack connector card's connect prompt: when a connection owner already exists, show shorter, role-appropriate copy ("Connect your user account to unlock more features and sign in via WordPress.com (SSO).") instead of the first-connection framing.
* Add a PHPUnit test covering both branches of the new URL parameter (owner present → param added; no owner → param omitted).

## Related product discussion/links

* CONNECT-186
* Calypso PR: [Automattic/wp-calypso#110763](https://github.com/Automattic/wp-calypso/pull/110763) — depends on this change

## Does this pull request change what data or activity we track or use?

No. A new boolean signal (`has_connected_owner`) is sent on the authorize URL. It carries the same information already exposed via the existing `is_active` body arg (which mirrors `Manager::has_connected_owner()`); the new name is added so Calypso can read it under a clearer name distinct from the legacy `already_authorized` re-authorization signal in `Webhooks::handle_connect_url_redirect()`.

## Testing instructions

This change is consumed by [wp-calypso#110763](https://github.com/Automattic/wp-calypso/pull/110763), which has full UI testing steps. To verify the plugin side alone:

1. Install the Jetpack plugin from this branch on a self-hosted WordPress site.
2. Connect the site as User A (this becomes the connection owner).
3. Log out and log in as User B (a different admin on the same site).
4. Trigger the connect flow (for example, from Settings → Connectors, or from My Jetpack).
5. Before being redirected, inspect the resulting Calypso authorize URL.
6. Confirm `has_connected_owner=1` is present as a query parameter.
7. Disconnect the site entirely, then start a fresh connection as the first user.
8. Confirm `has_connected_owner=1` is **absent** from the authorize URL (it's only sent when an owner already exists).
9. In Settings → Connectors, as User B (with User A still the owner), confirm the connect prompt reads "Connect your user account to unlock more features and sign in via WordPress.com (SSO)." instead of the longer "Your site is registered with WordPress.com…" copy.

Automated coverage:

* `jp test php packages/connection` — the new `ManagerTest::test_get_authorization_url_includes_has_connected_owner_when_owner_connected` covers both branches.
