### PR TITLE
Podcast: narrow grandfather to sites on a paid plan

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-narrow-grandfather-paid
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-narrow-grandfather-paid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: narrow grandfather rule to sites registered before the cutoff that are also on a paid plan.

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -33,11 +33,20 @@ class Podcast_Gate {
 			return false;
 		}
 
-		if ( self::blog_created_before_cutoff( $blog_id ) ) {
+		if ( self::is_grandfathered( $blog_id ) ) {
 			return true;
 		}
 
 		return (bool) Current_Plan::supports( self::FEATURE_SLUG );
+	}
+
+	/**
+	 * Whether the blog is grandfathered: registered before the cutoff AND on a paid plan.
+	 *
+	 * @param int $blog_id Blog ID.
+	 */
+	protected static function is_grandfathered( int $blog_id ): bool {
+		return self::blog_created_before_cutoff( $blog_id ) && self::has_paid_plan();
 	}
 
 	/**
@@ -58,5 +67,13 @@ class Podcast_Gate {
 			return false;
 		}
 		return $registered_ts < strtotime( self::GRANDFATHER_CUTOFF_DATE );
+	}
+
+	/**
+	 * Whether the current blog is on any paid plan.
+	 */
+	protected static function has_paid_plan(): bool {
+		$plan = Current_Plan::get();
+		return ! empty( $plan['class'] ) && 'free' !== $plan['class'];
 	}
 }

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -46,15 +46,6 @@ class Podcast_Gate {
 	 * @param int $blog_id Blog ID.
 	 */
 	protected static function is_grandfathered( int $blog_id ): bool {
-		return self::blog_created_before_cutoff( $blog_id ) && self::has_paid_plan();
-	}
-
-	/**
-	 * Whether the blog predates the grandfather cutoff.
-	 *
-	 * @param int $blog_id Blog ID.
-	 */
-	protected static function blog_created_before_cutoff( int $blog_id ): bool {
 		if ( ! function_exists( 'get_blog_details' ) ) {
 			return false;
 		}
@@ -63,16 +54,10 @@ class Podcast_Gate {
 			return false;
 		}
 		$registered_ts = strtotime( $details->registered );
-		if ( false === $registered_ts ) {
+		if ( false === $registered_ts || $registered_ts >= strtotime( self::GRANDFATHER_CUTOFF_DATE ) ) {
 			return false;
 		}
-		return $registered_ts < strtotime( self::GRANDFATHER_CUTOFF_DATE );
-	}
 
-	/**
-	 * Whether the current blog is on any paid plan.
-	 */
-	protected static function has_paid_plan(): bool {
 		$plan = Current_Plan::get();
 		return ! empty( $plan['class'] ) && 'free' !== $plan['class'];
 	}

--- a/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Gate_Test.php
@@ -60,8 +60,9 @@ class Podcast_Gate_Test extends BaseTestCase {
 		$this->assertFalse( Podcast_Gate::has_product_access() );
 	}
 
-	public function test_blog_registered_before_cutoff_grants_access(): void {
-		$plan                       = Current_Plan::PLAN_DATA['free'];
+	public function test_blog_registered_before_cutoff_on_paid_plan_grants_access(): void {
+		$plan                       = Current_Plan::PLAN_DATA['personal'];
+		$plan['product_slug']       = 'jetpack_personal';
 		$plan['features']['active'] = array();
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
 
@@ -70,6 +71,18 @@ class Podcast_Gate_Test extends BaseTestCase {
 		);
 
 		$this->assertTrue( Podcast_Gate::has_product_access() );
+	}
+
+	public function test_blog_registered_before_cutoff_on_free_plan_denies_access(): void {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
+		$GLOBALS['jetpack_podcast_test_blog_details'][ get_current_blog_id() ] = array(
+			'registered' => '2025-01-01 00:00:00',
+		);
+
+		$this->assertFalse( Podcast_Gate::has_product_access() );
 	}
 
 	public function test_blog_registered_on_cutoff_falls_through_to_plan(): void {


### PR DESCRIPTION
## Proposed changes
* Tighten the Podcast Premium grandfather rule: a site is now grandfathered only if it registered before `GRANDFATHER_CUTOFF_DATE` **and** is currently on a paid plan. Free sites that pre-date the cutoff no longer get free Premium podcast access.
* Add `Podcast_Gate::is_grandfathered()` and `Podcast_Gate::has_paid_plan()` helpers; `has_product_access()` now composes them.
* Update unit tests: replaced the old before-cutoff-grants-access case with paid+before-cutoff (grants) and free+before-cutoff (denies). Existing cutoff-boundary and after-cutoff cases unchanged.

Paid-plan detection uses `Current_Plan::get()` plan class (anything not `free`). The matching WPCOM-side check is being handled separately.

## Testing instructions
* `cd projects/packages/podcast && composer phpunit` — 81/81 should pass.
* Manual:
  1. On a Jetpack site registered **before** 2026-05-18 with a **free** plan, Podcast Premium features should be locked.
  2. Same site on a **paid** plan, should be unlocked (grandfathered).
  3. A site registered **after** the cutoff still gates by plan/feature support as before.
