### PR TITLE
Sync guideline source meta

### DIFF
--- a/projects/packages/sync/changelog/sync-guideline-source-meta
+++ b/projects/packages/sync/changelog/sync-guideline-source-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Guidelines: Sync source metadata for guideline posts.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -786,6 +786,7 @@ class Defaults {
 		'custom_css_add',
 		'custom_css_preprocessor',
 		'enclosure',
+		'guideline_source',
 		'imagedata',
 		'nova_price',
 		'publicize_results',


### PR DESCRIPTION
## Proposed changes

Add `guideline_source` to Jetpack Sync's default post meta whitelist.
This is needed for the wpcom agents to keep track of installed skills.

## Related product discussion/links

peGwbA-5ey-p2 

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

Not necessary