### PR TITLE
Podcast: loose-ends

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/podcast-loose-ends-align-menu-gate
+++ b/projects/packages/jetpack-mu-wpcom/changelog/podcast-loose-ends-align-menu-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com admin menu: delegate the Podcast untangle gate to Podcast::is_enabled() so the menu honors the same default as the rest of the package.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -405,10 +405,6 @@ function wpcom_add_jetpack_submenu() {
 		$subscribers_dashboard->add_wp_admin_submenu();
 	}
 
-	// When the new jetpack-podcast package is active, register the in-admin
-	// "Jetpack > Podcast" page; otherwise keep the legacy
-	// "Jetpack > Podcasting" Calypso link unchanged. Gate delegates to
-	// {@see Podcast::is_enabled()} for a single source of truth.
 	if ( Podcast::is_enabled() ) {
 		Podcast_Admin_Page::add_wp_admin_submenu();
 	} else {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -10,6 +10,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Podcast\Admin_Page as Podcast_Admin_Page;
+use Automattic\Jetpack\Podcast\Podcast;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 
@@ -404,10 +405,11 @@ function wpcom_add_jetpack_submenu() {
 		$subscribers_dashboard->add_wp_admin_submenu();
 	}
 
-	// When the `jetpack_podcast_untangle` filter is on, register the new
-	// "Jetpack > Podcast" in-admin page from the jetpack-podcast package.
-	// Otherwise keep the legacy "Jetpack > Podcasting" Calypso link unchanged.
-	if ( apply_filters( 'jetpack_podcast_untangle', false ) ) {
+	// When the new jetpack-podcast package is active, register the in-admin
+	// "Jetpack > Podcast" page; otherwise keep the legacy
+	// "Jetpack > Podcasting" Calypso link unchanged. Gate delegates to
+	// {@see Podcast::is_enabled()} for a single source of truth.
+	if ( Podcast::is_enabled() ) {
 		Podcast_Admin_Page::add_wp_admin_submenu();
 	} else {
 		add_submenu_page(

--- a/projects/packages/podcast/changelog/podcast-loose-ends-align-block-gate
+++ b/projects/packages/podcast/changelog/podcast-loose-ends-align-block-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast Episode block: delegate the untangle gate to Podcast::is_enabled() so the block honors the same default as the rest of the package.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -50,10 +50,12 @@ class Podcast_Episode_Block {
 
 	/**
 	 * Whether the new podcast experience is enabled.
+	 *
+	 * Delegates to {@see Podcast::is_enabled()} so the block honors the
+	 * same default (proxied A8C requests) as the rest of the package.
 	 */
 	private static function is_enabled(): bool {
-		/** This filter is documented in projects/packages/podcast/src/class-podcast.php */
-		return (bool) apply_filters( 'jetpack_podcast_untangle', false );
+		return Podcast::is_enabled();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/podcast-loose-ends-drop-podcast-dep
+++ b/projects/plugins/jetpack/changelog/podcast-loose-ends-drop-podcast-dep
@@ -1,4 +1,4 @@
 Significance: patch
-Type: removed
+Type: other
 
 Composer: drop the automattic/jetpack-podcast dependency. The package is only consumed via jetpack-mu-wpcom and was never initialized from the Jetpack plugin.

--- a/projects/plugins/jetpack/changelog/podcast-loose-ends-drop-podcast-dep
+++ b/projects/plugins/jetpack/changelog/podcast-loose-ends-drop-podcast-dep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Composer: drop the automattic/jetpack-podcast dependency. The package is only consumed via jetpack-mu-wpcom and was never initialized from the Jetpack plugin.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -44,7 +44,6 @@
 		"automattic/jetpack-newsletter": "@dev",
 		"automattic/jetpack-paypal-payments": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
-		"automattic/jetpack-podcast": "@dev",
 		"automattic/jetpack-post-list": "@dev",
 		"automattic/jetpack-post-media": "@dev",
 		"automattic/jetpack-publicize": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd56c7a169c5b040c1ca00923d60e8db",
+    "content-hash": "a173a2dbd72bc84909485ad57af10e43",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -2565,78 +2565,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Handle installation of plugins from WP.org",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-podcast",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/podcast",
-                "reference": "165176b0f879970e605cf1219a0c286a0f3fcb0d"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-blocks": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-plans": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "automattic/jetpack-wp-build-polyfills": "@dev",
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-podcast",
-                "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
-                },
-                "textdomain": "jetpack-podcast",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-podcast.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-podcast/compare/v${old}...v${new}"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "watch": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run watch"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Podcast functionality (Simple and Atomic only).",
             "transport-options": {
                 "relative": true
             }
@@ -5923,7 +5851,6 @@
         "automattic/jetpack-newsletter": 20,
         "automattic/jetpack-paypal-payments": 20,
         "automattic/jetpack-plugins-installer": 20,
-        "automattic/jetpack-podcast": 20,
         "automattic/jetpack-post-list": 20,
         "automattic/jetpack-post-media": 20,
         "automattic/jetpack-publicize": 20,

--- a/projects/plugins/wpcomsh/changelog/podcast-loose-ends-gate-legacy-load
+++ b/projects/plugins/wpcomsh/changelog/podcast-loose-ends-gate-legacy-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcasting: only load the legacy at-pressable-podcasting plugin when the new jetpack-podcast package is not taking over the feature.

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -122,7 +122,15 @@ if ( is_readable( $jetpack_autoloader ) ) {
 
 	return;
 }
-require_once __DIR__ . '/vendor/automattic/at-pressable-podcasting/podcasting.php';
+// Load the legacy at-pressable-podcasting plugin only when the new
+// jetpack-podcast package is not taking over the feature. See
+// Automattic\Jetpack\Podcast\Podcast::is_enabled() for the gate.
+if (
+	! class_exists( Automattic\Jetpack\Podcast\Podcast::class )
+	|| ! Automattic\Jetpack\Podcast\Podcast::is_enabled()
+) {
+	require_once __DIR__ . '/vendor/automattic/at-pressable-podcasting/podcasting.php';
+}
 require_once __DIR__ . '/vendor/automattic/custom-fonts/custom-fonts.php';
 require_once __DIR__ . '/vendor/automattic/custom-fonts-typekit/custom-fonts-typekit.php';
 require_once __DIR__ . '/vendor/automattic/text-media-widget-styles/text-media-widget-styles.php';

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -122,18 +122,12 @@ if ( is_readable( $jetpack_autoloader ) ) {
 
 	return;
 }
-// Mirrors Automattic\Jetpack\Podcast\Podcast::is_enabled()'s
-// proxied-request default without depending on the Podcast class being
-// resolvable through the autoloader at this point in bootstrap.
-$wpcomsh_podcast_untangle_default = (
-	( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() )
-	|| ! empty( $_SERVER['A8C_PROXIED_REQUEST'] )
-	|| ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST )
-);
-if ( ! apply_filters( 'jetpack_podcast_untangle', $wpcomsh_podcast_untangle_default ) ) {
+if (
+	! class_exists( '\Automattic\Jetpack\Podcast\Podcast' )
+	|| ! \Automattic\Jetpack\Podcast\Podcast::is_enabled()
+) {
 	require_once __DIR__ . '/vendor/automattic/at-pressable-podcasting/podcasting.php';
 }
-unset( $wpcomsh_podcast_untangle_default );
 require_once __DIR__ . '/vendor/automattic/custom-fonts/custom-fonts.php';
 require_once __DIR__ . '/vendor/automattic/custom-fonts-typekit/custom-fonts-typekit.php';
 require_once __DIR__ . '/vendor/automattic/text-media-widget-styles/text-media-widget-styles.php';

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -122,15 +122,18 @@ if ( is_readable( $jetpack_autoloader ) ) {
 
 	return;
 }
-// Load the legacy at-pressable-podcasting plugin only when the new
-// jetpack-podcast package is not taking over the feature. See
-// Automattic\Jetpack\Podcast\Podcast::is_enabled() for the gate.
-if (
-	! class_exists( Automattic\Jetpack\Podcast\Podcast::class )
-	|| ! Automattic\Jetpack\Podcast\Podcast::is_enabled()
-) {
+// Mirrors Automattic\Jetpack\Podcast\Podcast::is_enabled()'s
+// proxied-request default without depending on the Podcast class being
+// resolvable through the autoloader at this point in bootstrap.
+$wpcomsh_podcast_untangle_default = (
+	( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() )
+	|| ! empty( $_SERVER['A8C_PROXIED_REQUEST'] )
+	|| ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST )
+);
+if ( ! apply_filters( 'jetpack_podcast_untangle', $wpcomsh_podcast_untangle_default ) ) {
 	require_once __DIR__ . '/vendor/automattic/at-pressable-podcasting/podcasting.php';
 }
+unset( $wpcomsh_podcast_untangle_default );
 require_once __DIR__ . '/vendor/automattic/custom-fonts/custom-fonts.php';
 require_once __DIR__ . '/vendor/automattic/custom-fonts-typekit/custom-fonts-typekit.php';
 require_once __DIR__ . '/vendor/automattic/text-media-widget-styles/text-media-widget-styles.php';


### PR DESCRIPTION
## Description

Close the loose ends in the Podcast untangle:

- wpcomsh: stop unconditionally loading the legacy at-pressable-podcasting plugin; gate it on `Podcast::is_enabled()`.
- Block + admin-menu gates: delegate to `Podcast::is_enabled()` so all three sites share a single default.
- Drop the unused `automattic/jetpack-podcast` composer dep from the Jetpack plugin.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Smoke test