### PR TITLE
Podcast: align Stats tab padding

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -310,6 +310,23 @@ $jp-breakpoint-mobile: 782px;
 		padding-inline: var(--wpds-dimension-padding-sm, 8px);
 	}
 
+	// Opt-in modifier for hosts that render `<Tabs.List variant="minimal">`.
+	// Minimal tabs ship with `padding-inline: 0`, so the wrapper has to
+	// provide the full 2xl itself to keep the first tab flush with the
+	// header start.
+	.jp-admin-page-tabs--minimal {
+		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	}
+
+	// Re-apply `--wpds-typography-font-size-md` from an unlayered selector.
+	// `@wordpress/ui` declares the token inside `@layer wp-ui-components`,
+	// but wp-admin core ships an unlayered `button { font-size: inherit }`
+	// reset that always wins layered rules. Remove once upstream wires
+	// `Tabs.Tab` into `@wordpress/ui`'s `global-css-defense` module.
+	.jp-admin-page-tabs [role="tab"] {
+		font-size: var(--wpds-typography-font-size-md, 13px);
+	}
+
 	// ── Mobile: admin bar grows to 46px; sidebar goes off-canvas ─────
 	// Match `.folded` and `.auto-fold` explicitly: both outrank the bare
 	// `#wpbody-content` selector on specificity, so the media query needs

--- a/projects/js-packages/base-styles/changelog/update-admin-page-tabs-minimal-modifier
+++ b/projects/js-packages/base-styles/changelog/update-admin-page-tabs-minimal-modifier
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin page mixin: add `.jp-admin-page-tabs--minimal` modifier for hosts that render `<Tabs.List variant="minimal">`, and re-apply the tab font-size design token from an unlayered selector to defeat wp-admin's `button { font-size: inherit }` reset.

--- a/projects/packages/podcast/changelog/update-podcast-tabs-padding-and-font-size
+++ b/projects/packages/podcast/changelog/update-podcast-tabs-padding-and-font-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Podcast dashboard: align tab strip with page header padding and apply the design-system tab font size.
+Podcast dashboard: opt into the shared `jp-admin-page-tabs--minimal` modifier so the tab strip aligns with the page header and labels use the design-system font size.

--- a/projects/packages/podcast/changelog/update-podcast-tabs-padding-and-font-size
+++ b/projects/packages/podcast/changelog/update-podcast-tabs-padding-and-font-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast dashboard: align tab strip with page header padding and apply the design-system tab font size.

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -174,7 +174,7 @@ const App = () => {
 	return (
 		<AdminPage title={ PAGE_TITLE } subTitle={ PAGE_SUBTITLE }>
 			<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
-				<div className="jp-admin-page-tabs" ref={ tablistRef }>
+				<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal" ref={ tablistRef }>
 					<Tabs.List variant="minimal">
 						<Tabs.Tab value="stats" disabled={ ! isSetUp }>
 							{ __( 'Stats', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -4,6 +4,25 @@
 body.jetpack_page_jetpack-podcast {
 
 	@include jetpack-admin-page-layout;
+
+	// Align the first tab's content edge with the page header's start.
+	// admin-ui's page header sits at padding-inline 2xl (24px). The shared
+	// `.jp-admin-page-tabs` wrapper adds only 8px (designed for the default
+	// <Tabs.Tab> which ships with padding-inline lg = 16px, so 8 + 16 = 24
+	// matches the header). With `variant="minimal"`, <Tabs.Tab> has 0 inline
+	// padding, so the wrapper has to provide the full 2xl itself.
+	.jp-admin-page-tabs {
+		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	}
+
+	// Re-apply the design token from an unlayered selector. `@wordpress/ui`
+	// declares `font-size: var(--wpds-typography-font-size-md)` inside
+	// `@layer wp-ui-components`, but wp-admin core ships an unlayered
+	// `button { font-size: inherit }` reset that wins, so the tab inherits
+	// 16px instead of the 13px the token specifies.
+	.jp-admin-page-tabs [role="tab"] {
+		font-size: var(--wpds-typography-font-size-md, 13px);
+	}
 }
 
 .podcast__loading {

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -4,25 +4,6 @@
 body.jetpack_page_jetpack-podcast {
 
 	@include jetpack-admin-page-layout;
-
-	// Align the first tab's content edge with the page header's start.
-	// admin-ui's page header sits at padding-inline 2xl (24px). The shared
-	// `.jp-admin-page-tabs` wrapper adds only 8px (designed for the default
-	// <Tabs.Tab> which ships with padding-inline lg = 16px, so 8 + 16 = 24
-	// matches the header). With `variant="minimal"`, <Tabs.Tab> has 0 inline
-	// padding, so the wrapper has to provide the full 2xl itself.
-	.jp-admin-page-tabs {
-		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
-	}
-
-	// Re-apply the design token from an unlayered selector. `@wordpress/ui`
-	// declares `font-size: var(--wpds-typography-font-size-md)` inside
-	// `@layer wp-ui-components`, but wp-admin core ships an unlayered
-	// `button { font-size: inherit }` reset that wins, so the tab inherits
-	// 16px instead of the 13px the token specifies.
-	.jp-admin-page-tabs [role="tab"] {
-		font-size: var(--wpds-typography-font-size-md, 13px);
-	}
 }
 
 .podcast__loading {


### PR DESCRIPTION

<img width="866" height="272" alt="CleanShot 2026-05-18 at 10 06 33@2x" src="https://github.com/user-attachments/assets/2e1e0dad-0868-4307-974e-89086bd316b2" />


## Proposed changes

* Bump `.jp-admin-page-tabs` `padding-inline` from the wrapper default (8px) to `--wpds-dimension-padding-2xl` (24px) on the Podcast dashboard, so the Stats tab's content edge lines up with the page header start.
* Re-apply `--wpds-typography-font-size-md` (13px) from an unlayered selector so the tab labels render at 13px instead of inheriting 16px from wp-admin's `button { font-size: inherit }` reset.

## Why

The Podcast dashboard renders `<Tabs.List variant="minimal">` inside the shared `.jp-admin-page-tabs` wrapper. The wrapper's 8px padding was designed for the default `<Tabs.Tab>` (which ships with 16px self-padding, summing to 24px). With `variant="minimal"` the tab has 0 inline padding, so the strip starts ~16px to the left of the page header. Same root cause that shipped a fix for the Search dashboard in #48846, applied to Podcast.

## Related product discussion/links

* Reported by lessbloat in the Podcast call-for-testing thread (PODS).
* Sister fix for Search: #48846.

## Testing instructions

1. Load the Podcast admin page (Jetpack > Podcast on a site where the package is enabled).
2. Confirm the Stats tab's left edge is flush with the page title "Podcast" content edge (24px from the page-content edge).
3. Confirm the tab labels render at 13px, not 16px.
4. Before/after screenshots welcome from anyone who has a working preview environment.