### PR TITLE
Podcast: clarify setup save + blocked Submit buttons

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-setup-and-distribution-clarity
+++ b/projects/packages/podcast/changelog/add-podcast-setup-and-distribution-clarity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: collapse the setup modal's Create + Confirm into a single click, and make Distribution submit buttons explain why they are disabled.

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -25,6 +25,10 @@ interface CategoryPickerProps {
 	// containing modal can gate its own Confirm button until the user either
 	// finishes or cancels the inline flow.
 	onCreatingChange?: ( isCreating: boolean ) => void;
+	// Fires while a category-create request is in flight, so a containing
+	// modal can block its own dismissal — otherwise the user can Cancel and
+	// the create resolves into a `onCreateSuccess` after the modal is gone.
+	onSavingChange?: ( saving: boolean ) => void;
 	// Fires once the inline create has saved a new category. The parent can
 	// commit its own save in the same click rather than asking the user to
 	// confirm a second time.
@@ -51,6 +55,7 @@ const CategoryPicker = ( {
 	onSelect,
 	disabled = false,
 	onCreatingChange,
+	onSavingChange,
 	onCreateSuccess,
 }: CategoryPickerProps ) => {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
@@ -71,6 +76,10 @@ const CategoryPicker = ( {
 	useEffect( () => {
 		onCreatingChange?.( isCreating );
 	}, [ isCreating, onCreatingChange ] );
+
+	useEffect( () => {
+		onSavingChange?.( saving );
+	}, [ saving, onSavingChange ] );
 
 	const trimmedName = newName.trim();
 

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -25,6 +25,10 @@ interface CategoryPickerProps {
 	// containing modal can gate its own Confirm button until the user either
 	// finishes or cancels the inline flow.
 	onCreatingChange?: ( isCreating: boolean ) => void;
+	// Fires once the inline create has saved a new category. The parent can
+	// commit its own save in the same click rather than asking the user to
+	// confirm a second time.
+	onCreateSuccess?: ( id: number ) => void;
 }
 
 const parseErrorMessage = ( error: unknown, fallback: string ): string => {
@@ -47,6 +51,7 @@ const CategoryPicker = ( {
 	onSelect,
 	disabled = false,
 	onCreatingChange,
+	onCreateSuccess,
 }: CategoryPickerProps ) => {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -120,7 +125,9 @@ const CategoryPicker = ( {
 			}
 			setIsCreating( false );
 			setNewName( '' );
-			onSelect( Number( result.id ) );
+			const newId = Number( result.id );
+			onSelect( newId );
+			onCreateSuccess?.( newId );
 		} catch ( err ) {
 			setCreateError(
 				parseErrorMessage(
@@ -131,7 +138,7 @@ const CategoryPicker = ( {
 		} finally {
 			setSaving( false );
 		}
-	}, [ trimmedName, saveEntityRecord, onSelect ] );
+	}, [ trimmedName, saveEntityRecord, onSelect, onCreateSuccess ] );
 
 	const options: Array< { label: string; value: string } > = [
 		{ label: __( '— Select a category —', 'jetpack-podcast' ), value: '' },

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -116,10 +116,14 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	// While validation probes are in flight, `issues.length === 0` and
 	// `stepsLeftLabel` is empty — fall back to a loading message so the
 	// disabled Submit buttons still explain themselves on hover/focus.
+	// Note: gating only on `isLoading`, NOT `! isReady`. `isReady` is
+	// derived as `! isLoading && issues.length === 0`, so once loading
+	// finishes with issues outstanding, `! isReady` stays true and would
+	// keep the tooltip stuck on "Checking…" instead of showing the count.
 	let blockedTooltip = '';
 	if ( ! isEnabled ) {
 		blockedTooltip = __( 'Set a podcast category in Settings first.', 'jetpack-podcast' );
-	} else if ( isLoading || ! isReady ) {
+	} else if ( isLoading ) {
 		blockedTooltip = __( 'Checking your podcast setup…', 'jetpack-podcast' );
 	} else {
 		blockedTooltip = stepsLeftLabel;

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -4,6 +4,7 @@ import {
 	Card,
 	CardBody,
 	Notice,
+	Tooltip,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -14,7 +15,7 @@ import {
 import { useCopyToClipboard } from '@wordpress/compose';
 import { useEntityRecord } from '@wordpress/core-data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
 import { usePodcastSettings } from '../hooks/use-podcast-settings';
 import { useValidationIssues } from '../hooks/use-validation-issues';
@@ -97,6 +98,25 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	const [ showConfetti, setShowConfetti ] = useState( false );
 	const activeApp = PODCAST_APPS.find( a => a.id === activeId ) ?? null;
 
+	// Single source of truth for "what's blocking submission", so the Notice
+	// header, Submit aria-labels, and Submit tooltips all stay in sync.
+	const stepsLeftLabel =
+		issues.length > 0
+			? sprintf(
+					/* translators: %d: number of remaining setup steps before podcast directory submission is unlocked. */
+					_n(
+						'%d step left before you can submit',
+						'%d steps left before you can submit',
+						issues.length,
+						'jetpack-podcast'
+					),
+					issues.length
+			  )
+			: '';
+	const blockedTooltip = ! isEnabled
+		? __( 'Set a podcast category in Settings first.', 'jetpack-podcast' )
+		: stepsLeftLabel;
+
 	const handleSubmitClick = useCallback( ( id: PodcatcherId ) => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_submit_modal_opened', {
 			directory: id,
@@ -118,7 +138,7 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 		<>
 			{ issues.length > 0 && (
 				<Notice status="warning" isDismissible={ false }>
-					<strong>{ __( 'Almost ready to submit', 'jetpack-podcast' ) }</strong>
+					<strong>{ stepsLeftLabel }</strong>
 					<ul className="podcast__settings-issues">
 						{ issues.map( issue => (
 							<li key={ issue }>{ issue }</li>
@@ -184,28 +204,27 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 												</span>
 												<Text weight={ 500 }>{ app.name }</Text>
 											</HStack>
-											<Button
-												variant="primary"
-												size="compact"
-												// eslint-disable-next-line react/jsx-no-bind
-												onClick={ () => handleSubmitClick( app.id ) }
-												disabled={ isSubmitBlocked }
-												accessibleWhenDisabled
-												aria-label={
-													isSubmitBlocked
-														? sprintf(
-																/* translators: %s is the directory name (Apple Podcasts, Spotify, etc.). */
-																__(
-																	'Submit to %s (finish setting up your podcast first).',
-																	'jetpack-podcast'
-																),
-																app.name
-														  )
-														: undefined
-												}
-											>
-												{ __( 'Submit', 'jetpack-podcast' ) }
-											</Button>
+											<Tooltip text={ isSubmitBlocked ? blockedTooltip : '' }>
+												<Button
+													variant="primary"
+													size="compact"
+													// eslint-disable-next-line react/jsx-no-bind
+													onClick={ () => handleSubmitClick( app.id ) }
+													disabled={ isSubmitBlocked }
+													accessibleWhenDisabled
+													aria-label={
+														isSubmitBlocked
+															? sprintf(
+																	/* translators: %s is the directory name (Apple Podcasts, Spotify, etc.). */
+																	__( 'Submit to %s', 'jetpack-podcast' ),
+																	app.name
+															  )
+															: undefined
+													}
+												>
+													{ __( 'Submit', 'jetpack-podcast' ) }
+												</Button>
+											</Tooltip>
 										</HStack>
 									);
 								} ) }

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -113,9 +113,17 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 					issues.length
 			  )
 			: '';
-	const blockedTooltip = ! isEnabled
-		? __( 'Set a podcast category in Settings first.', 'jetpack-podcast' )
-		: stepsLeftLabel;
+	// While validation probes are in flight, `issues.length === 0` and
+	// `stepsLeftLabel` is empty — fall back to a loading message so the
+	// disabled Submit buttons still explain themselves on hover/focus.
+	let blockedTooltip = '';
+	if ( ! isEnabled ) {
+		blockedTooltip = __( 'Set a podcast category in Settings first.', 'jetpack-podcast' );
+	} else if ( isLoading || ! isReady ) {
+		blockedTooltip = __( 'Checking your podcast setup…', 'jetpack-podcast' );
+	} else {
+		blockedTooltip = stepsLeftLabel;
+	}
 
 	const handleSubmitClick = useCallback( ( id: PodcatcherId ) => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_submit_modal_opened', {

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -227,9 +227,10 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 													aria-label={
 														isSubmitBlocked
 															? sprintf(
-																	/* translators: %s is the directory name (Apple Podcasts, Spotify, etc.). */
-																	__( 'Submit to %s', 'jetpack-podcast' ),
-																	app.name
+																	/* translators: 1: directory name (Apple Podcasts, Spotify, etc.). 2: reason the Submit button is disabled. */
+																	__( 'Submit to %1$s. %2$s', 'jetpack-podcast' ),
+																	app.name,
+																	blockedTooltip
 															  )
 															: undefined
 													}

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -49,15 +49,18 @@ const CategorySetupModal = ( {
 	const [ error, setError ] = useState< string | null >( null );
 	const [ saving, setSaving ] = useState( false );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
+	const [ pickerSaving, setPickerSaving ] = useState( false );
 
 	const requestClose = useCallback( () => {
 		// Block dismissal while a save is in flight so the in-flight promise
-		// can't mutate settings after the user thought they cancelled.
-		if ( saving ) {
+		// can't mutate settings after the user thought they cancelled. The
+		// picker's own save needs the same gate, because its success callback
+		// reaches back here to commit settings.
+		if ( saving || pickerSaving ) {
 			return;
 		}
 		onClose();
-	}, [ saving, onClose ] );
+	}, [ saving, pickerSaving, onClose ] );
 
 	const onConfirm = useCallback(
 		// `idArg` lets the inline-create path commit the save in the same click,
@@ -134,10 +137,11 @@ const CategorySetupModal = ( {
 					onSelect={ setCategoryId }
 					disabled={ saving }
 					onCreatingChange={ setPickerCreating }
+					onSavingChange={ setPickerSaving }
 					onCreateSuccess={ handleCreateSuccess }
 				/>
 				<HStack justify="flex-end" spacing={ 3 }>
-					<Button variant="tertiary" onClick={ requestClose } disabled={ saving }>
+					<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
 						{ __( 'Cancel', 'jetpack-podcast' ) }
 					</Button>
 					<Button

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -59,41 +59,58 @@ const CategorySetupModal = ( {
 		onClose();
 	}, [ saving, onClose ] );
 
-	const onConfirm = useCallback( async () => {
-		if ( ! categoryId ) {
-			return;
-		}
-		setError( null );
-		setSaving( true );
-		try {
-			// Only prefill the title from the site name when the user hasn't
-			// already set one — preserves a custom title from a partial setup.
-			const updates: PodcastSettingsUpdate = { podcasting_category_id: categoryId };
-			if ( ! existingTitle && siteName.trim() ) {
-				updates.podcasting_title = siteName.trim();
+	const onConfirm = useCallback(
+		// `idArg` lets the inline-create path commit the save in the same click,
+		// without waiting for the async `setCategoryId` to flush.
+		async ( idArg?: number ) => {
+			const id = idArg ?? categoryId;
+			if ( ! id ) {
+				return;
 			}
-			await new Promise< void >( ( resolve, reject ) => {
-				saveSettings( updates, {
-					onSuccess: () => resolve(),
-					onError: reject,
-					// Inline Notice below covers the error UX; suppress the hook's
-					// duplicate snackbar. Success is implicit (modal closes and
-					// lands the user on a populated Settings tab).
-					silent: true,
+			setError( null );
+			setSaving( true );
+			try {
+				// Only prefill the title from the site name when the user hasn't
+				// already set one — preserves a custom title from a partial setup.
+				const updates: PodcastSettingsUpdate = { podcasting_category_id: id };
+				if ( ! existingTitle && siteName.trim() ) {
+					updates.podcasting_title = siteName.trim();
+				}
+				await new Promise< void >( ( resolve, reject ) => {
+					saveSettings( updates, {
+						onSuccess: () => resolve(),
+						onError: reject,
+						// Inline Notice below covers the error UX; suppress the hook's
+						// duplicate snackbar. Success is implicit (modal closes and
+						// lands the user on a populated Settings tab).
+						silent: true,
+					} );
 				} );
-			} );
-			onSuccess();
-		} catch ( err ) {
-			setError(
-				parseErrorMessage(
-					err,
-					__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
-				)
-			);
-		} finally {
-			setSaving( false );
-		}
-	}, [ categoryId, existingTitle, siteName, saveSettings, onSuccess ] );
+				onSuccess();
+			} catch ( err ) {
+				setError(
+					parseErrorMessage(
+						err,
+						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
+					)
+				);
+			} finally {
+				setSaving( false );
+			}
+		},
+		[ categoryId, existingTitle, siteName, saveSettings, onSuccess ]
+	);
+
+	const handleCreateSuccess = useCallback(
+		( id: number ) => {
+			onConfirm( id );
+		},
+		[ onConfirm ]
+	);
+
+	const handleExistingCategoryConfirm = useCallback( () => {
+		onConfirm();
+	}, [ onConfirm ] );
 
 	return (
 		<Modal title={ __( 'Set up your podcast', 'jetpack-podcast' ) } onRequestClose={ requestClose }>
@@ -117,6 +134,7 @@ const CategorySetupModal = ( {
 					onSelect={ setCategoryId }
 					disabled={ saving }
 					onCreatingChange={ setPickerCreating }
+					onCreateSuccess={ handleCreateSuccess }
 				/>
 				<HStack justify="flex-end" spacing={ 3 }>
 					<Button variant="tertiary" onClick={ requestClose } disabled={ saving }>
@@ -124,7 +142,9 @@ const CategorySetupModal = ( {
 					</Button>
 					<Button
 						variant="primary"
-						onClick={ onConfirm }
+						// The inline-create path commits via `handleCreateSuccess`, so
+						// Confirm is only used when the user picks an existing category.
+						onClick={ handleExistingCategoryConfirm }
 						// Block Confirm while the inline create form is open so
 						// the user can't commit a stale `selectedId` with the
 						// half-filled inline form still mounted.


### PR DESCRIPTION
Fixes #

## Proposed changes

Two clarity fixes surfaced in internal call-for-testing feedback.

1. **Setup modal: Create + Confirm collapse to one click.** When the user inline-creates a category, the new id flows back to the parent and commits the settings save in the same click. The user no longer has to press Confirm a second time.
2. **Distribution tab: disabled Submit buttons explain themselves.** Each Submit is wrapped in a `Tooltip` that says what is blocking: missing category, outstanding validation issues, or a loading state during the validation probes. The warning Notice header uses the same pluralized `%d steps left` string for consistency.

Also folded in: modal dismissal is now blocked while the inline category-create is in flight, so a Cancel mid-save cannot resolve into a settings save the user already walked away from.

## Related product discussion/links

* Internal call-for-testing feedback on the `/podcast` UI.

## Does this pull request change what data or activity we track or use?

No. The existing `jetpack_podcast_submit_modal_opened` event is unchanged.

## Testing instructions

1. Enable the package: `add_filter( 'jetpack_podcast_untangle', '__return_true' );`
2. On a site with no podcast configured, open `/podcast`. The setup modal opens. Pick "Create new category…", type a name, click Create. You should land on Settings with the category already saved (one click, not two).
3. Reopen the modal. Pick Create new category, type a name, click Create, then immediately hit Escape. Cancel and the Modal close should be blocked until the create resolves, and settings should not commit if you do escape after that.
4. With the category set and validation probes still in flight, hover a Distribution Submit button. Tooltip should read "Checking your podcast setup…".
5. With one or more validation issues outstanding, hover Submit. Tooltip should match the Notice header text.
6. With no category set at all, hover Submit. Tooltip should read "Set a podcast category in Settings first."

Notes for reviewer:

- I am an automation and cannot drive a browser, so I have not captured before/after screenshots. Visual verification still needs a sandbox check at review time.
- A second PR adding per-directory `requires` (so Pocket Casts only blocks on category) will follow.