### PR TITLE
[RSM] Hide AI Agent Access toggle on private sites

### DIFF
--- a/projects/packages/search/changelog/fix-ai-agent-access-private-toggle
+++ b/projects/packages/search/changelog/fix-ai-agent-access-private-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: Hide the AI Agent Access toggle for private sites and improve related settings spacing.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -173,7 +173,20 @@ class Initial_State {
 	 * @return bool
 	 */
 	protected function is_ai_agent_access_available() {
-		return $this->is_automattic_proxied_request();
+		return $this->is_automattic_proxied_request() && ! $this->is_private_site();
+	}
+
+	/**
+	 * Check whether the current site is private.
+	 *
+	 * @return bool
+	 */
+	protected function is_private_site() {
+		if ( function_exists( 'is_private_blog' ) ) {
+			return (bool) \is_private_blog();
+		}
+
+		return -1 === (int) get_option( 'blog_public', 1 );
 	}
 
 	/**

--- a/projects/packages/search/src/dashboard/components/ai-agent-access-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/ai-agent-access-control/index.jsx
@@ -51,6 +51,11 @@ export default function AIAgentAccessControl( {
 
 		apiFetch( { path: settingsPath } )
 			.then( settings => {
+				if ( isWpcom && settings?.available === false ) {
+					setIsSettingAvailable( false );
+					return;
+				}
+
 				if ( settings && Object.prototype.hasOwnProperty.call( settings, settingsKey ) ) {
 					setIsEnabled( Boolean( settings[ settingsKey ] ) );
 					setIsSettingAvailable( true );
@@ -65,7 +70,7 @@ export default function AIAgentAccessControl( {
 			.finally( () => {
 				setIsLoading( false );
 			} );
-	}, [ isAvailable, settingsKey, settingsPath ] );
+	}, [ isAvailable, isWpcom, settingsKey, settingsPath ] );
 
 	const toggle = useCallback(
 		next => {

--- a/projects/packages/search/src/dashboard/components/ai-agent-access-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/ai-agent-access-control/test/index.test.jsx
@@ -223,6 +223,16 @@ describe( 'AIAgentAccessControl', () => {
 		expect( apiFetch ).toHaveBeenCalledWith( { path: '/wpcom/v2/ai-agents-settings' } );
 	} );
 
+	test( 'renders nothing when the wpcom ai-agents settings endpoint marks the setting unavailable', async () => {
+		mockIsWpcom( true );
+		apiFetch.mockResolvedValueOnce( { enabled: false, available: false } );
+
+		const { container } = render( <AIAgentAccessControl /> );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
 	test( 'posts enabled to the wpcom ai-agents settings endpoint', async () => {
 		mockIsWpcom( true );
 		apiFetch.mockResolvedValueOnce( { enabled: false } ).mockResolvedValueOnce( { enabled: true } );

--- a/projects/packages/search/src/dashboard/components/module-control/style.scss
+++ b/projects/packages/search/src/dashboard/components/module-control/style.scss
@@ -32,6 +32,11 @@
 		margin-top: 4em;
 	}
 
+	&.is-reader-chat + &.is-search-suggestions,
+	&.is-ai-agent-access + &.is-search-suggestions {
+		margin-top: 4em;
+	}
+
 	.jp-form-search-settings-group__toggle-container {
 		display: flex;
 

--- a/projects/packages/search/tests/php/Initial_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_State_Test.php
@@ -18,10 +18,18 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class Initial_State_Test extends Search_TestCase {
 
 	/**
+	 * Original blog_public option value.
+	 *
+	 * @var mixed
+	 */
+	private $original_blog_public;
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->original_blog_public = get_option( 'blog_public', 1 );
 		$this->unregister_guidelines_page();
 	}
 
@@ -34,6 +42,7 @@ class Initial_State_Test extends Search_TestCase {
 		Constants::clear_single_constant( 'A8C_PROXIED_REQUEST' );
 		Constants::clear_single_constant( 'AT_PROXIED_REQUEST' );
 		Constants::clear_single_constant( 'ATOMIC_CLIENT_ID' );
+		update_option( 'blog_public', $this->original_blog_public );
 		$this->unregister_guidelines_page();
 		parent::tearDown();
 	}
@@ -130,6 +139,18 @@ class Initial_State_Test extends Search_TestCase {
 		$state = ( new Initial_State() )->get_initial_state();
 
 		$this->assertTrue( $state['siteData']['aiAgentAccessAvailable'] );
+	}
+
+	/**
+	 * Test that the AI Agent Access toggle is unavailable on private sites.
+	 */
+	public function test_ai_agent_access_available_is_false_for_private_sites() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		update_option( 'blog_public', -1 );
+
+		$state = ( new Initial_State() )->get_initial_state();
+
+		$this->assertFalse( $state['siteData']['aiAgentAccessAvailable'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Hide the AI Agent Access toggle in the Jetpack Search dashboard when the current site is private.
* Keep the existing proxied rollout gate and add a private-site check to the initial dashboard state.
* On WPCOM, also hide the control when `/wpcom/v2/ai-agents-settings` returns `available: false`. This covers private simple sites where the dashboard learns availability from the WPCOM settings endpoint after load.
* Add spacing between the AI Agent Access and Search Suggestions controls in the legacy/Atomic Search settings layout.
* Add PHP coverage for proxied private sites returning `aiAgentAccessAvailable: false`.
* Add JS coverage for the WPCOM settings endpoint returning `{ enabled: false, available: false }`.

## Does this pull request change what data or activity we track or use?
No.

## Steps to test
* See WPCOM PR 218192 