### PR TITLE
Write: normalize inline formatting tags before block serialization

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-normalize-formatting-tags
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-normalize-formatting-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: normalize inline formatting tags (b, i, u, strike) so posts opened in the block editor don't show unknown-formatting warnings

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -531,6 +531,40 @@ function normalizeColorMarkup( container ) {
 }
 
 /**
+ * Normalize inline formatting tags before block serialization.
+ *
+ * document.execCommand produces legacy tags (<b>, <i>, <u>, <strike>) that
+ * Gutenberg's rich text system flags as unknown formatting. Convert them to
+ * the tags Gutenberg's default formats use: <strong>, <em>, <s>, and a span
+ * with text-decoration:underline for <u>.
+ *
+ * @param {HTMLElement} container - The container to normalize in place.
+ */
+function normalizeFormattingTags( container ) {
+	const replacements = [
+		[ 'b', 'strong' ],
+		[ 'i', 'em' ],
+		[ 'strike', 's' ],
+	];
+	for ( const [ from, to ] of replacements ) {
+		container.querySelectorAll( from ).forEach( oldEl => {
+			const newEl = document.createElement( to );
+			newEl.innerHTML = oldEl.innerHTML;
+			oldEl.replaceWith( newEl );
+		} );
+	}
+
+	// <u> has no dedicated tag in Gutenberg's core formats; the core/underline
+	// format uses <span style="text-decoration:underline"> instead.
+	container.querySelectorAll( 'u' ).forEach( u => {
+		const span = document.createElement( 'span' );
+		span.style.textDecoration = 'underline';
+		span.innerHTML = u.innerHTML;
+		u.replaceWith( span );
+	} );
+}
+
+/**
  * Convert contentEditable HTML into WordPress block markup.
  *
  * @param {string} html - The innerHTML from the contenteditable area.
@@ -542,6 +576,10 @@ function convertToBlocks( html ) {
 
 	// Normalize color markup before serialization.
 	normalizeColorMarkup( tmp );
+
+	// Normalize inline formatting tags (<b>/<i>/<u>/<strike>) to the tags
+	// Gutenberg's rich text system expects.
+	normalizeFormattingTags( tmp );
 
 	const blocks = [];
 


### PR DESCRIPTION
Fixes [RSM-3352](https://linear.app/a8c/issue/RSM-3352/bolditalicunderlinestrikethrough-saved-as-non-standard-html-tags).

## Proposed changes
* `document.execCommand` in the Write editor produces legacy `<b>`, `<i>`, `<u>`, and `<strike>` tags. Gutenberg's rich text system expects `<strong>`, `<em>`, `<s>`, and (for underline) a `<span style="text-decoration:underline">`, so posts created in Write showed "unknown formatting" warnings when opened in the block editor.
* Add a small `normalizeFormattingTags( container )` helper in `view.js` (mirrors the existing `normalizeColorMarkup` pass) and call it from `convertToBlocks` before serialization.

## Related product discussion/links
* [RSM-3352](https://linear.app/a8c/issue/RSM-3352/bolditalicunderlinestrikethrough-saved-as-non-standard-html-tags)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open the Write editor (`wp-admin/admin.php?page=write`).
* Type a few words and apply Bold, Italic, Underline, and Strikethrough from the toolbar to different words.
* Save the draft.
* Open the same post in the block editor (`post.php?post=<id>&action=edit`).
* **Before this PR:** the paragraph shows "unknown formatting" markers / invalid-block warnings.
* **After this PR:** the paragraph opens cleanly; all four formats render correctly and the saved HTML uses `<strong>`, `<em>`, `<s>`, and `<span style="text-decoration:underline">`.