### PR TITLE
Podcast: show Pending/Submitted state badges in the Distribution tab

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-add-podcast-show-state
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-add-podcast-show-state
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Distribution tab: show Pending/Submitted state badges next to each podcast directory.
+Distribution tab: show Pending/Live state badges next to each podcast directory.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-add-podcast-show-state
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-add-podcast-show-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Distribution tab: show Pending/Submitted state badges next to each podcast directory.

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -284,7 +284,9 @@ class Settings {
 
 	/**
 	 * Merge a partial show-states patch into the stored value. Values outside
-	 * SHOW_STATES are dropped; empty string clears.
+	 * SHOW_STATES are dropped; empty string clears. `'active'` → `'pending'` is
+	 * refused so a stale SPA cache can't downgrade a state that `Feed_Detection`
+	 * promoted via real UA evidence (explicit `''` clears still work).
 	 *
 	 * @param mixed $input Incoming patch.
 	 * @return array<string, string>
@@ -306,9 +308,18 @@ class Settings {
 
 			if ( '' === $value ) {
 				unset( $current[ $key ] );
-			} elseif ( in_array( $value, self::SHOW_STATES, true ) ) {
-				$current[ $key ] = $value;
+				continue;
 			}
+
+			if ( ! in_array( $value, self::SHOW_STATES, true ) ) {
+				continue;
+			}
+
+			if ( 'pending' === $value && isset( $current[ $key ] ) && 'active' === $current[ $key ] ) {
+				continue;
+			}
+
+			$current[ $key ] = $value;
 		}
 
 		return $current;

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -38,13 +38,13 @@ const selectOnFocus = ( event: FocusEvent< HTMLInputElement > ) => {
 const COPIED_LABEL = __( 'Copied!', 'jetpack-podcast' );
 const COPY_LINK_LABEL = __( 'Copy link', 'jetpack-podcast' );
 const PENDING_LABEL = __( 'Pending', 'jetpack-podcast' );
-const SUBMITTED_LABEL = __( 'Submitted', 'jetpack-podcast' );
+const LIVE_LABEL = __( 'Live', 'jetpack-podcast' );
 
 const StateBadge = ( { state }: { state: PodcastShowState } ) => {
 	if ( state !== 'pending' && state !== 'active' ) {
 		return null;
 	}
-	const label = state === 'active' ? SUBMITTED_LABEL : PENDING_LABEL;
+	const label = state === 'active' ? LIVE_LABEL : PENDING_LABEL;
 	return (
 		<span className={ `podcast__state-badge podcast__state-badge--${ state }` }>
 			<VisuallyHidden as="span">{ __( 'Status:', 'jetpack-podcast' ) } </VisuallyHidden>

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -22,7 +22,7 @@ import ConfettiAnimation from './confetti';
 import { PODCAST_APPS } from './podcast-apps';
 import './style.scss';
 import SubmitModal from './submit-modal';
-import type { PodcatcherId } from '../types';
+import type { PodcastShowState, PodcatcherId } from '../types';
 import type { FocusEvent } from 'react';
 
 const prefersReducedMotion = (): boolean =>
@@ -36,6 +36,18 @@ const selectOnFocus = ( event: FocusEvent< HTMLInputElement > ) => {
 // validator rejects that shape.
 const COPIED_LABEL = __( 'Copied!', 'jetpack-podcast' );
 const COPY_LINK_LABEL = __( 'Copy link', 'jetpack-podcast' );
+const PENDING_LABEL = __( 'Pending', 'jetpack-podcast' );
+const SUBMITTED_LABEL = __( 'Submitted', 'jetpack-podcast' );
+
+const StateBadge = ( { state }: { state: PodcastShowState } ) => {
+	if ( state !== 'pending' && state !== 'active' ) {
+		return null;
+	}
+	const label = state === 'active' ? SUBMITTED_LABEL : PENDING_LABEL;
+	return (
+		<span className={ `podcast__state-badge podcast__state-badge--${ state }` }>{ label }</span>
+	);
+};
 
 const FeedCopyField = ( { value }: { value: string } ) => {
 	const [ copied, setCopied ] = useState( false );
@@ -170,6 +182,7 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 							<VStack as="ul" spacing={ 0 } className="podcast__directory-list">
 								{ PODCAST_APPS.map( app => {
 									const { Logo } = app;
+									const state = settings?.podcasting_show_states?.[ app.id ] ?? '';
 									return (
 										<HStack
 											as="li"
@@ -178,11 +191,12 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 											justify="space-between"
 											className="podcast__directory-row"
 										>
-											<HStack alignment="center" spacing={ 4 } expanded={ false }>
+											<HStack alignment="center" spacing={ 3 } expanded={ false }>
 												<span aria-hidden="true">
 													<Logo />
 												</span>
 												<Text weight={ 500 }>{ app.name }</Text>
+												<StateBadge state={ state } />
 											</HStack>
 											<Button
 												variant="primary"

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -4,6 +4,7 @@ import {
 	Card,
 	CardBody,
 	Notice,
+	VisuallyHidden,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -45,7 +46,10 @@ const StateBadge = ( { state }: { state: PodcastShowState } ) => {
 	}
 	const label = state === 'active' ? SUBMITTED_LABEL : PENDING_LABEL;
 	return (
-		<span className={ `podcast__state-badge podcast__state-badge--${ state }` }>{ label }</span>
+		<span className={ `podcast__state-badge podcast__state-badge--${ state }` }>
+			<VisuallyHidden as="span">{ __( 'Status:', 'jetpack-podcast' ) } </VisuallyHidden>
+			{ label }
+		</span>
 	);
 };
 

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -26,7 +26,7 @@ import type { PodcastAppModalProps } from '../types';
 const stateLabel = ( state: PodcastShowState ): string => {
 	switch ( state ) {
 		case 'active':
-			return __( 'Submitted', 'jetpack-podcast' );
+			return __( 'Live', 'jetpack-podcast' );
 		case 'pending':
 			return __( 'Pending', 'jetpack-podcast' );
 		default:

--- a/projects/packages/podcast/src/dashboard/distribution/style.scss
+++ b/projects/packages/podcast/src/dashboard/distribution/style.scss
@@ -20,6 +20,27 @@
 	}
 }
 
+.podcast__state-badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: 999px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.4;
+	letter-spacing: 0.02em;
+}
+
+.podcast__state-badge--pending {
+	background: #fcf2c3;
+	color: #674d00;
+}
+
+.podcast__state-badge--active {
+	background: #d3f5d6;
+	color: #00542b;
+}
+
 .podcast__feed-copy {
 	display: flex;
 	align-items: center;

--- a/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
@@ -23,6 +23,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { check, external, link } from '@wordpress/icons';
 import { prependHTTPS } from '@wordpress/url';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
+import type { PodcastSettingsUpdate } from '../types';
 import type { PodcastAppModalProps } from './podcast-apps';
 import type { FormEvent } from 'react';
 
@@ -93,6 +94,8 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 		input?.select();
 	}, [ isEditing ] );
 
+	const storedState = settings?.podcasting_show_states?.[ app.id ] ?? '';
+
 	const copyRef = useCopyToClipboard< HTMLButtonElement >( feedUrl, () => setHasCopied( true ) );
 
 	useEffect( () => {
@@ -149,36 +152,21 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 			const isReplace = !! storedUrl;
 			const isFirstSave = ! storedUrl;
 			const isFirstEverSave = hadAnyStoredUrl === null ? false : ! hadAnyStoredUrl;
-			saveSettings(
-				{ podcasting_show_urls: { [ app.id ]: normalizedDraft } },
-				{
-					onSuccess: result => {
-						// The wpcom endpoint returns 200 even when `wp_http_validate_url`
-						// rejects the value (stored field stays unchanged). Round-trip the
-						// value to catch silent drops.
-						const persisted = result.podcasting_show_urls?.[ app.id ] ?? '';
-						if ( persisted !== normalizedDraft ) {
-							setSaveError(
-								sprintf(
-									/* translators: %s: podcast directory name. */
-									__( 'We couldn’t save your %s URL. Please try again.', 'jetpack-podcast' ),
-									app.name
-								)
-							);
-							return;
-						}
-						jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_show_url_saved', {
-							directory: app.id,
-							is_first_save: isFirstSave,
-							is_replace: isReplace,
-						} );
-						if ( isFirstEverSave ) {
-							onFirstSave?.();
-						}
-						setIsEditing( false );
-						onClose();
-					},
-					onError: () => {
+			// Mark pending unless Feed_Detection has already promoted the directory
+			// to 'active' from a real UA hit — don't downgrade verified state.
+			const patch: PodcastSettingsUpdate = {
+				podcasting_show_urls: { [ app.id ]: normalizedDraft },
+			};
+			if ( storedState !== 'active' ) {
+				patch.podcasting_show_states = { [ app.id ]: 'pending' };
+			}
+			saveSettings( patch, {
+				onSuccess: result => {
+					// The wpcom endpoint returns 200 even when `wp_http_validate_url`
+					// rejects the value (stored field stays unchanged). Round-trip the
+					// value to catch silent drops.
+					const persisted = result.podcasting_show_urls?.[ app.id ] ?? '';
+					if ( persisted !== normalizedDraft ) {
 						setSaveError(
 							sprintf(
 								/* translators: %s: podcast directory name. */
@@ -186,9 +174,29 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 								app.name
 							)
 						);
-					},
-				}
-			);
+						return;
+					}
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_podcast_show_url_saved', {
+						directory: app.id,
+						is_first_save: isFirstSave,
+						is_replace: isReplace,
+					} );
+					if ( isFirstEverSave ) {
+						onFirstSave?.();
+					}
+					setIsEditing( false );
+					onClose();
+				},
+				onError: () => {
+					setSaveError(
+						sprintf(
+							/* translators: %s: podcast directory name. */
+							__( 'We couldn’t save your %s URL. Please try again.', 'jetpack-podcast' ),
+							app.name
+						)
+					);
+				},
+			} );
 		},
 		[
 			normalizedDraft,
@@ -197,6 +205,7 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 			app.name,
 			saveSettings,
 			storedUrl,
+			storedState,
 			hadAnyStoredUrl,
 			onFirstSave,
 			onClose,

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -159,4 +159,12 @@ class Settings_Test extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'spotify', $result );
 		$this->assertArrayNotHasKey( 'apple', $result );
 	}
+
+	public function test_sanitize_show_states_refuses_active_to_pending_downgrade() {
+		update_option( 'podcasting_show_states', array( 'apple' => 'active' ) );
+
+		$result = Settings::sanitize_show_states( array( 'apple' => 'pending' ) );
+
+		$this->assertSame( 'active', $result['apple'] );
+	}
 }


### PR DESCRIPTION
## Description

Add [Pending] and [Live] badges to the podcast app items in distribution tab.

Set to pending when the user saves a show URL. This means they have officially did the work to register their show with the app.

Set to live when we notice the podcast app first crawl their feed.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

TBC...