### PR TITLE
Podcast: collapse setup-modal Create + Confirm into one click

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-setup-create-confirm
+++ b/projects/packages/podcast/changelog/fix-podcast-setup-create-confirm
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: collapse the setup modal's Create + Confirm into a single click when inline-creating a category, and block dismissal while that create is in flight.
+Reduce podcast setup to a single click when you create a new category from the setup modal.

--- a/projects/packages/podcast/changelog/fix-podcast-setup-create-confirm
+++ b/projects/packages/podcast/changelog/fix-podcast-setup-create-confirm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: collapse the setup modal's Create + Confirm into a single click when inline-creating a category, and block dismissal while that create is in flight.

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -120,11 +120,20 @@ const CategoryPicker = ( {
 					__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
 				);
 			}
-			setIsCreating( false );
-			setNewName( '' );
 			const newId = Number( result.id );
 			onSelect( newId );
-			onCreateSuccess?.( newId );
+			if ( onCreateSuccess ) {
+				// Parent will commit the save and unmount the picker. Leave the
+				// inline form mounted and the Create button in its busy state
+				// until that happens — collapsing back to the dropdown for the
+				// frame between picker resolve and modal close is visible as
+				// a flash.
+				onCreateSuccess( newId );
+				return;
+			}
+			setIsCreating( false );
+			setNewName( '' );
+			setSaving( false );
 		} catch ( err ) {
 			setCreateError(
 				parseErrorMessage(
@@ -132,7 +141,6 @@ const CategoryPicker = ( {
 					__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
 				)
 			);
-		} finally {
 			setSaving( false );
 		}
 	}, [ trimmedName, saveEntityRecord, onSelect, onCreateSuccess ] );

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -13,6 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCategoriesQuery } from './hooks/use-categories-query';
+import { parseErrorMessage } from './parse-error-message';
 
 // Sentinel for the "create new category" option in the select.
 const CREATE_NEW = '__create_new__';
@@ -34,21 +35,6 @@ interface CategoryPickerProps {
 	// confirm a second time.
 	onCreateSuccess?: ( id: number ) => void;
 }
-
-const parseErrorMessage = ( error: unknown, fallback: string ): string => {
-	if ( error instanceof Error ) {
-		return error.message;
-	}
-	if (
-		error &&
-		typeof error === 'object' &&
-		'message' in error &&
-		typeof ( error as { message: unknown } ).message === 'string'
-	) {
-		return ( error as { message: string } ).message;
-	}
-	return fallback;
-};
 
 const CategoryPicker = ( {
 	selectedId,

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -25,6 +25,14 @@ interface CategoryPickerProps {
 	// containing modal can gate its own Confirm button until the user either
 	// finishes or cancels the inline flow.
 	onCreatingChange?: ( isCreating: boolean ) => void;
+	// Fires while a category-create request is in flight, so a containing
+	// modal can block its own dismissal — otherwise the user can Cancel and
+	// the create resolves into a `onCreateSuccess` after the modal is gone.
+	onSavingChange?: ( saving: boolean ) => void;
+	// Fires once the inline create has saved a new category. The parent can
+	// commit its own save in the same click rather than asking the user to
+	// confirm a second time.
+	onCreateSuccess?: ( id: number ) => void;
 }
 
 const parseErrorMessage = ( error: unknown, fallback: string ): string => {
@@ -47,6 +55,8 @@ const CategoryPicker = ( {
 	onSelect,
 	disabled = false,
 	onCreatingChange,
+	onSavingChange,
+	onCreateSuccess,
 }: CategoryPickerProps ) => {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -66,6 +76,10 @@ const CategoryPicker = ( {
 	useEffect( () => {
 		onCreatingChange?.( isCreating );
 	}, [ isCreating, onCreatingChange ] );
+
+	useEffect( () => {
+		onSavingChange?.( saving );
+	}, [ saving, onSavingChange ] );
 
 	const trimmedName = newName.trim();
 
@@ -120,7 +134,9 @@ const CategoryPicker = ( {
 			}
 			setIsCreating( false );
 			setNewName( '' );
-			onSelect( Number( result.id ) );
+			const newId = Number( result.id );
+			onSelect( newId );
+			onCreateSuccess?.( newId );
 		} catch ( err ) {
 			setCreateError(
 				parseErrorMessage(
@@ -131,7 +147,7 @@ const CategoryPicker = ( {
 		} finally {
 			setSaving( false );
 		}
-	}, [ trimmedName, saveEntityRecord, onSelect ] );
+	}, [ trimmedName, saveEntityRecord, onSelect, onCreateSuccess ] );
 
 	const options: Array< { label: string; value: string } > = [
 		{ label: __( '— Select a category —', 'jetpack-podcast' ), value: '' },

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -26,16 +26,12 @@ interface CategoryPickerProps {
 	// containing modal can gate its own Confirm button until the user either
 	// finishes or cancels the inline flow.
 	onCreatingChange?: ( isCreating: boolean ) => void;
-	// Fires while a category-create request is in flight, so a containing
-	// modal can block its own dismissal — otherwise the user can Cancel and
-	// the create resolves into a `onCreateSuccess` after the modal is gone.
+	// Lets the parent block its own dismissal while the create is in flight;
+	// otherwise a late `onCreateSuccess` could land after the user cancelled.
 	onSavingChange?: ( saving: boolean ) => void;
-	// Fires once the inline create has saved a new category. The parent can
-	// commit its own save in the same click rather than asking the user to
-	// confirm a second time. Returning a Promise lets the picker hold its
-	// busy state through the parent's commit and only reset on a rejection —
-	// on success the parent unmounts the picker, so leaving state intact
-	// avoids a one-frame flash back to the dropdown.
+	// Returning a Promise lets the picker hold its busy state through the
+	// parent's commit and reset only on rejection — on success the parent
+	// unmounts the picker, avoiding a flash back to the dropdown.
 	onCreateSuccess?: ( id: number ) => void | Promise< void >;
 }
 
@@ -126,10 +122,6 @@ const CategoryPicker = ( {
 			const newId = Number( result.id );
 			onSelect( newId );
 			if ( onCreateSuccess ) {
-				// Parent will commit the save and unmount the picker on success,
-				// so leaving state intact through the commit avoids a one-frame
-				// flash. If the parent's commit rejects, reset so the user isn't
-				// stuck with a busy form and a non-dismissible modal.
 				try {
 					await onCreateSuccess( newId );
 				} catch {

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -32,8 +32,11 @@ interface CategoryPickerProps {
 	onSavingChange?: ( saving: boolean ) => void;
 	// Fires once the inline create has saved a new category. The parent can
 	// commit its own save in the same click rather than asking the user to
-	// confirm a second time.
-	onCreateSuccess?: ( id: number ) => void;
+	// confirm a second time. Returning a Promise lets the picker hold its
+	// busy state through the parent's commit and only reset on a rejection —
+	// on success the parent unmounts the picker, so leaving state intact
+	// avoids a one-frame flash back to the dropdown.
+	onCreateSuccess?: ( id: number ) => void | Promise< void >;
 }
 
 const CategoryPicker = ( {
@@ -123,12 +126,17 @@ const CategoryPicker = ( {
 			const newId = Number( result.id );
 			onSelect( newId );
 			if ( onCreateSuccess ) {
-				// Parent will commit the save and unmount the picker. Leave the
-				// inline form mounted and the Create button in its busy state
-				// until that happens — collapsing back to the dropdown for the
-				// frame between picker resolve and modal close is visible as
-				// a flash.
-				onCreateSuccess( newId );
+				// Parent will commit the save and unmount the picker on success,
+				// so leaving state intact through the commit avoids a one-frame
+				// flash. If the parent's commit rejects, reset so the user isn't
+				// stuck with a busy form and a non-dismissible modal.
+				try {
+					await onCreateSuccess( newId );
+				} catch {
+					setIsCreating( false );
+					setNewName( '' );
+					setSaving( false );
+				}
 				return;
 			}
 			setIsCreating( false );

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -69,6 +69,12 @@ const CategoryPicker = ( {
 
 	const trimmedName = newName.trim();
 
+	const resetCreate = useCallback( () => {
+		setIsCreating( false );
+		setNewName( '' );
+		setCreateError( null );
+	}, [] );
+
 	const handleSelectChange = useCallback(
 		( value: string ) => {
 			if ( value === CREATE_NEW ) {
@@ -80,22 +86,18 @@ const CategoryPicker = ( {
 			// Picking a regular option from the dropdown while the inline
 			// create form is open should dismiss it; otherwise the select
 			// snaps back to CREATE_NEW on the next render.
-			setIsCreating( false );
-			setNewName( '' );
-			setCreateError( null );
+			resetCreate();
 			onSelect( Number( value ) || 0 );
 		},
-		[ onSelect ]
+		[ onSelect, resetCreate ]
 	);
 
 	const cancelCreate = useCallback( () => {
 		if ( saving ) {
 			return;
 		}
-		setIsCreating( false );
-		setNewName( '' );
-		setCreateError( null );
-	}, [ saving ] );
+		resetCreate();
+	}, [ saving, resetCreate ] );
 
 	const createCategory = useCallback( async () => {
 		if ( ! trimmedName ) {

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -135,12 +135,19 @@ const CategoryPicker = ( {
 			setNewName( '' );
 			setSaving( false );
 		} catch ( err ) {
-			setCreateError(
-				parseErrorMessage(
-					err,
-					__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
-				)
-			);
+			// WordPress core surfaces `term_exists` with a long parent-aware
+			// message ("A term with the name provided already exists with
+			// this parent."). The picker isn't exposing parent categories,
+			// so substitute a shorter, plain-language message.
+			const code = ( err as { code?: string } )?.code;
+			const message =
+				code === 'term_exists'
+					? __( 'This category already exists.', 'jetpack-podcast' )
+					: parseErrorMessage(
+							err,
+							__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
+					  );
+			setCreateError( message );
 			setSaving( false );
 		}
 	}, [ trimmedName, saveEntityRecord, onSelect, onCreateSuccess ] );

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -194,9 +194,7 @@ export function useUpdatePodcastSettings(): {
 			updates: PodcastSettingsUpdate,
 			{ onSuccess, onError, silent = false }: MutateCallbacks = {}
 		) => {
-			// Snackbar already covers the failure path when `silent` is false;
-			// swallow so callers without `onError` don't surface "Uncaught (in
-			// promise)" on rejection.
+			// Default no-op keeps the rejection from going uncaught when no `onError` is passed.
 			mutateAsync( updates, { silent } ).then( onSuccess, onError ?? ( () => {} ) );
 		},
 		[ mutateAsync ]

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -139,10 +139,14 @@ export function usePodcastSettings(): { data: PodcastSettings | undefined; isLoa
  * record, which core-data uses to refresh the cache. Snackbars are dispatched
  * here so callers don't have to wire them up.
  *
- * @return `{ mutate, isPending }` matching the prior TanStack-shaped contract.
+ * @return `{ mutate, mutateAsync, isPending }` matching the prior TanStack-shaped contract.
  */
 export function useUpdatePodcastSettings(): {
 	mutate: ( updates: PodcastSettingsUpdate, callbacks?: MutateCallbacks ) => void;
+	mutateAsync: (
+		updates: PodcastSettingsUpdate,
+		options?: { silent?: boolean }
+	) => Promise< PodcastSettings >;
 	isPending: boolean;
 } {
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -152,42 +156,51 @@ export function useUpdatePodcastSettings(): {
 		[]
 	);
 
+	const mutateAsync = useCallback(
+		async (
+			updates: PodcastSettingsUpdate,
+			{ silent = false }: { silent?: boolean } = {}
+		): Promise< PodcastSettings > => {
+			try {
+				const record = await saveEntityRecord(
+					'root',
+					'site',
+					updates as Record< string, unknown >
+				);
+				if ( ! record ) {
+					throw new Error( 'save returned no record' );
+				}
+				if ( ! silent ) {
+					createSuccessNotice( __( 'Settings saved.', 'jetpack-podcast' ), {
+						type: 'snackbar',
+					} );
+				}
+				return pickPodcastFields( record as Record< string, unknown > );
+			} catch ( error ) {
+				if ( ! silent ) {
+					createErrorNotice(
+						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' ),
+						{ type: 'snackbar' }
+					);
+				}
+				throw error;
+			}
+		},
+		[ saveEntityRecord, createSuccessNotice, createErrorNotice ]
+	);
+
 	const mutate = useCallback(
 		(
 			updates: PodcastSettingsUpdate,
 			{ onSuccess, onError, silent = false }: MutateCallbacks = {}
 		) => {
-			saveEntityRecord( 'root', 'site', updates as Record< string, unknown > )
-				.then( record => {
-					if ( ! record ) {
-						onError?.( new Error( 'save returned no record' ) );
-						if ( ! silent ) {
-							createErrorNotice(
-								__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' ),
-								{ type: 'snackbar' }
-							);
-						}
-						return;
-					}
-					onSuccess?.( pickPodcastFields( record as Record< string, unknown > ) );
-					if ( ! silent ) {
-						createSuccessNotice( __( 'Settings saved.', 'jetpack-podcast' ), {
-							type: 'snackbar',
-						} );
-					}
-				} )
-				.catch( error => {
-					onError?.( error );
-					if ( ! silent ) {
-						createErrorNotice(
-							__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' ),
-							{ type: 'snackbar' }
-						);
-					}
-				} );
+			// Snackbar already covers the failure path when `silent` is false;
+			// swallow so callers without `onError` don't surface "Uncaught (in
+			// promise)" on rejection.
+			mutateAsync( updates, { silent } ).then( onSuccess, onError ?? ( () => {} ) );
 		},
-		[ saveEntityRecord, createSuccessNotice, createErrorNotice ]
+		[ mutateAsync ]
 	);
 
-	return { mutate, isPending };
+	return { mutate, mutateAsync, isPending };
 }

--- a/projects/packages/podcast/src/dashboard/parse-error-message.ts
+++ b/projects/packages/podcast/src/dashboard/parse-error-message.ts
@@ -1,0 +1,22 @@
+/**
+ * Extracts a user-facing message from a thrown value, with a safe fallback for
+ * shapes that don't carry a string `message`.
+ *
+ * @param error    - The thrown value (Error, REST error object, or unknown).
+ * @param fallback - Translated message to use when no string message is found.
+ * @return           A string suitable for rendering in a Notice or aria-label.
+ */
+export const parseErrorMessage = ( error: unknown, fallback: string ): string => {
+	if ( error instanceof Error ) {
+		return error.message;
+	}
+	if (
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		typeof ( error as { message: unknown } ).message === 'string'
+	) {
+		return ( error as { message: string } ).message;
+	}
+	return fallback;
+};

--- a/projects/packages/podcast/src/dashboard/parse-error-message.ts
+++ b/projects/packages/podcast/src/dashboard/parse-error-message.ts
@@ -7,16 +7,6 @@
  * @return           A string suitable for rendering in a Notice or aria-label.
  */
 export const parseErrorMessage = ( error: unknown, fallback: string ): string => {
-	if ( error instanceof Error ) {
-		return error.message;
-	}
-	if (
-		error &&
-		typeof error === 'object' &&
-		'message' in error &&
-		typeof ( error as { message: unknown } ).message === 'string'
-	) {
-		return ( error as { message: string } ).message;
-	}
-	return fallback;
+	const message = ( error as { message?: unknown } )?.message;
+	return typeof message === 'string' ? message : fallback;
 };

--- a/projects/packages/podcast/src/dashboard/parse-error-message.ts
+++ b/projects/packages/podcast/src/dashboard/parse-error-message.ts
@@ -1,11 +1,3 @@
-/**
- * Extracts a user-facing message from a thrown value, with a safe fallback for
- * shapes that don't carry a string `message`.
- *
- * @param error    - The thrown value (Error, REST error object, or unknown).
- * @param fallback - Translated message to use when no string message is found.
- * @return           A string suitable for rendering in a Notice or aria-label.
- */
 export const parseErrorMessage = ( error: unknown, fallback: string ): string => {
 	const message = ( error as { message?: unknown } )?.message;
 	return typeof message === 'string' ? message : fallback;

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -49,51 +49,71 @@ const CategorySetupModal = ( {
 	const [ error, setError ] = useState< string | null >( null );
 	const [ saving, setSaving ] = useState( false );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
+	const [ pickerSaving, setPickerSaving ] = useState( false );
 
 	const requestClose = useCallback( () => {
 		// Block dismissal while a save is in flight so the in-flight promise
-		// can't mutate settings after the user thought they cancelled.
-		if ( saving ) {
+		// can't mutate settings after the user thought they cancelled. The
+		// picker's own save needs the same gate, because its success callback
+		// reaches back here to commit settings.
+		if ( saving || pickerSaving ) {
 			return;
 		}
 		onClose();
-	}, [ saving, onClose ] );
+	}, [ saving, pickerSaving, onClose ] );
 
-	const onConfirm = useCallback( async () => {
-		if ( ! categoryId ) {
-			return;
-		}
-		setError( null );
-		setSaving( true );
-		try {
-			// Only prefill the title from the site name when the user hasn't
-			// already set one — preserves a custom title from a partial setup.
-			const updates: PodcastSettingsUpdate = { podcasting_category_id: categoryId };
-			if ( ! existingTitle && siteName.trim() ) {
-				updates.podcasting_title = siteName.trim();
+	const onConfirm = useCallback(
+		// `idArg` lets the inline-create path commit the save in the same click,
+		// without waiting for the async `setCategoryId` to flush.
+		async ( idArg?: number ) => {
+			const id = idArg ?? categoryId;
+			if ( ! id ) {
+				return;
 			}
-			await new Promise< void >( ( resolve, reject ) => {
-				saveSettings( updates, {
-					onSuccess: () => resolve(),
-					onError: reject,
-					// Inline Notice below covers the error UX; suppress the hook's
-					// duplicate snackbar. Success is implicit (modal closes and
-					// lands the user on a populated Settings tab).
-					silent: true,
+			setError( null );
+			setSaving( true );
+			try {
+				// Only prefill the title from the site name when the user hasn't
+				// already set one — preserves a custom title from a partial setup.
+				const updates: PodcastSettingsUpdate = { podcasting_category_id: id };
+				if ( ! existingTitle && siteName.trim() ) {
+					updates.podcasting_title = siteName.trim();
+				}
+				await new Promise< void >( ( resolve, reject ) => {
+					saveSettings( updates, {
+						onSuccess: () => resolve(),
+						onError: reject,
+						// Inline Notice below covers the error UX; suppress the hook's
+						// duplicate snackbar. Success is implicit (modal closes and
+						// lands the user on a populated Settings tab).
+						silent: true,
+					} );
 				} );
-			} );
-			onSuccess();
-		} catch ( err ) {
-			setError(
-				parseErrorMessage(
-					err,
-					__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
-				)
-			);
-		} finally {
-			setSaving( false );
-		}
-	}, [ categoryId, existingTitle, siteName, saveSettings, onSuccess ] );
+				onSuccess();
+			} catch ( err ) {
+				setError(
+					parseErrorMessage(
+						err,
+						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
+					)
+				);
+			} finally {
+				setSaving( false );
+			}
+		},
+		[ categoryId, existingTitle, siteName, saveSettings, onSuccess ]
+	);
+
+	const handleCreateSuccess = useCallback(
+		( id: number ) => {
+			onConfirm( id );
+		},
+		[ onConfirm ]
+	);
+
+	const handleExistingCategoryConfirm = useCallback( () => {
+		onConfirm();
+	}, [ onConfirm ] );
 
 	return (
 		<Modal title={ __( 'Set up your podcast', 'jetpack-podcast' ) } onRequestClose={ requestClose }>
@@ -117,14 +137,18 @@ const CategorySetupModal = ( {
 					onSelect={ setCategoryId }
 					disabled={ saving }
 					onCreatingChange={ setPickerCreating }
+					onSavingChange={ setPickerSaving }
+					onCreateSuccess={ handleCreateSuccess }
 				/>
 				<HStack justify="flex-end" spacing={ 3 }>
-					<Button variant="tertiary" onClick={ requestClose } disabled={ saving }>
+					<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
 						{ __( 'Cancel', 'jetpack-podcast' ) }
 					</Button>
 					<Button
 						variant="primary"
-						onClick={ onConfirm }
+						// The inline-create path commits via `handleCreateSuccess`, so
+						// Confirm is only used when the user picks an existing category.
+						onClick={ handleExistingCategoryConfirm }
 						// Block Confirm while the inline create form is open so
 						// the user can't commit a stale `selectedId` with the
 						// half-filled inline form still mounted.

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -35,20 +35,16 @@ const CategorySetupModal = ( {
 	const [ error, setError ] = useState< string | null >( null );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
 	const [ pickerSaving, setPickerSaving ] = useState( false );
-	// Tracks the inline-create commit flow from the moment the picker finishes
-	// creating the category until the modal unmounts. The picker flips
-	// `pickerCreating` false before our `onConfirm` runs, so without this gate
-	// the outer Cancel/Confirm row briefly remounts (with `isBusy`) in the
-	// window between picker resolve and modal close — visible as a flash.
+	// The picker flips `pickerCreating` false before our `onConfirm` runs,
+	// so without this gate the outer button row briefly remounts in the gap
+	// before the modal unmounts — visible as a flash.
 	const [ committingFromCreate, setCommittingFromCreate ] = useState( false );
 
 	const isSaving = saving || pickerSaving;
 
 	const requestClose = useCallback( () => {
-		// Block dismissal while a save is in flight so the in-flight promise
-		// can't mutate settings after the user thought they cancelled. The
-		// picker's own save needs the same gate, because its success callback
-		// reaches back here to commit settings.
+		// Otherwise an in-flight save can mutate settings after the user
+		// thought they cancelled.
 		if ( isSaving ) {
 			return;
 		}
@@ -71,9 +67,7 @@ const CategorySetupModal = ( {
 				if ( ! existingTitle && siteName.trim() ) {
 					updates.podcasting_title = siteName.trim();
 				}
-				// Inline Notice below covers the error UX; suppress the hook's
-				// duplicate snackbar. Success is implicit (modal closes and
-				// lands the user on a populated Settings tab).
+				// Inline Notice handles errors; suppress the hook's snackbar.
 				await saveSettings( updates, { silent: true } );
 				onSuccess();
 			} catch ( err ) {
@@ -83,8 +77,7 @@ const CategorySetupModal = ( {
 						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
 					)
 				);
-				// Re-throw so the inline-create path can reset the picker; the
-				// existing-category caller catches and discards.
+				// Lets the inline-create path reset the picker.
 				throw err;
 			}
 		},
@@ -97,9 +90,8 @@ const CategorySetupModal = ( {
 			try {
 				await onConfirm( id );
 			} catch ( err ) {
-				// Restore the outer Cancel/Confirm row so the user can retry or
-				// dismiss; re-throw so the picker resets its own busy state.
 				setCommittingFromCreate( false );
+				// Lets the picker reset its busy state.
 				throw err;
 			}
 		},
@@ -107,7 +99,7 @@ const CategorySetupModal = ( {
 	);
 
 	const handleExistingCategoryConfirm = useCallback( () => {
-		// onConfirm's inline Notice owns the error UX; swallow the rejection.
+		// onConfirm's inline Notice handles the error UX.
 		onConfirm().catch( () => {} );
 	}, [ onConfirm ] );
 
@@ -115,9 +107,7 @@ const CategorySetupModal = ( {
 		<Modal
 			title={ __( 'Set up your podcast', 'jetpack-podcast' ) }
 			onRequestClose={ requestClose }
-			// Belt-and-suspenders: some Modal force-close paths skip
-			// `onRequestClose`, so disable Esc/backdrop dismissal directly
-			// while a save is in flight.
+			// `onRequestClose` doesn't catch every dismissal path; belt-and-suspenders.
 			shouldCloseOnEsc={ ! isSaving }
 			shouldCloseOnClickOutside={ ! isSaving }
 		>
@@ -144,12 +134,6 @@ const CategorySetupModal = ( {
 					onSavingChange={ setPickerSaving }
 					onCreateSuccess={ handleCreateSuccess }
 				/>
-				{ /* Hide the outer Cancel/Confirm row while the inline create
-				     form is open. The inline form has its own Cancel/Create row
-				     and the create flow commits settings on success, so showing
-				     both rows looks like two competing actions. Keep it hidden
-				     through the create-driven commit so the row doesn't flash
-				     in for one render as the picker collapses. */ }
 				{ ! pickerCreating && ! committingFromCreate && (
 					<HStack justify="flex-end" spacing={ 3 }>
 						<Button variant="tertiary" onClick={ requestClose } disabled={ isSaving }>
@@ -157,8 +141,6 @@ const CategorySetupModal = ( {
 						</Button>
 						<Button
 							variant="primary"
-							// The inline-create path commits via `handleCreateSuccess`, so
-							// Confirm is only used when the user picks an existing category.
 							onClick={ handleExistingCategoryConfirm }
 							disabled={ ! categoryId || saving }
 							isBusy={ saving }

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -42,16 +42,18 @@ const CategorySetupModal = ( {
 	// window between picker resolve and modal close — visible as a flash.
 	const [ committingFromCreate, setCommittingFromCreate ] = useState( false );
 
+	const isSaving = saving || pickerSaving;
+
 	const requestClose = useCallback( () => {
 		// Block dismissal while a save is in flight so the in-flight promise
 		// can't mutate settings after the user thought they cancelled. The
 		// picker's own save needs the same gate, because its success callback
 		// reaches back here to commit settings.
-		if ( saving || pickerSaving ) {
+		if ( isSaving ) {
 			return;
 		}
 		onClose();
-	}, [ saving, pickerSaving, onClose ] );
+	}, [ isSaving, onClose ] );
 
 	const onConfirm = useCallback(
 		// `idArg` lets the inline-create path commit the save in the same click,
@@ -122,8 +124,8 @@ const CategorySetupModal = ( {
 			// Belt-and-suspenders: some Modal force-close paths skip
 			// `onRequestClose`, so disable Esc/backdrop dismissal directly
 			// while a save is in flight.
-			shouldCloseOnEsc={ ! ( saving || pickerSaving ) }
-			shouldCloseOnClickOutside={ ! ( saving || pickerSaving ) }
+			shouldCloseOnEsc={ ! isSaving }
+			shouldCloseOnClickOutside={ ! isSaving }
 		>
 			<VStack spacing={ 4 }>
 				<Text weight={ 600 }>
@@ -156,7 +158,7 @@ const CategorySetupModal = ( {
 				     in for one render as the picker collapses. */ }
 				{ ! pickerCreating && ! committingFromCreate && (
 					<HStack justify="flex-end" spacing={ 3 }>
-						<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
+						<Button variant="tertiary" onClick={ requestClose } disabled={ isSaving }>
 							{ __( 'Cancel', 'jetpack-podcast' ) }
 						</Button>
 						<Button

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -130,24 +130,27 @@ const CategorySetupModal = ( {
 					onSavingChange={ setPickerSaving }
 					onCreateSuccess={ handleCreateSuccess }
 				/>
-				<HStack justify="flex-end" spacing={ 3 }>
-					<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
-						{ __( 'Cancel', 'jetpack-podcast' ) }
-					</Button>
-					<Button
-						variant="primary"
-						// The inline-create path commits via `handleCreateSuccess`, so
-						// Confirm is only used when the user picks an existing category.
-						onClick={ handleExistingCategoryConfirm }
-						// Block Confirm while the inline create form is open so
-						// the user can't commit a stale `selectedId` with the
-						// half-filled inline form still mounted.
-						disabled={ ! categoryId || saving || pickerCreating }
-						isBusy={ saving }
-					>
-						{ __( 'Confirm', 'jetpack-podcast' ) }
-					</Button>
-				</HStack>
+				{ /* Hide the outer Cancel/Confirm row while the inline create
+				     form is open. The inline form has its own Cancel/Create row
+				     and the create flow commits settings on success, so showing
+				     both rows looks like two competing actions. */ }
+				{ ! pickerCreating && (
+					<HStack justify="flex-end" spacing={ 3 }>
+						<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
+							{ __( 'Cancel', 'jetpack-podcast' ) }
+						</Button>
+						<Button
+							variant="primary"
+							// The inline-create path commits via `handleCreateSuccess`, so
+							// Confirm is only used when the user picks an existing category.
+							onClick={ handleExistingCategoryConfirm }
+							disabled={ ! categoryId || saving }
+							isBusy={ saving }
+						>
+							{ __( 'Confirm', 'jetpack-podcast' ) }
+						</Button>
+					</HStack>
+				) }
 			</VStack>
 		</Modal>
 	);

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -13,6 +13,7 @@ import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import CategoryPicker from '../category-picker';
 import { useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
+import { parseErrorMessage } from '../parse-error-message';
 import type { PodcastSettingsUpdate } from '../types';
 
 interface CategorySetupModalProps {
@@ -21,21 +22,6 @@ interface CategorySetupModalProps {
 	onClose: () => void;
 	onSuccess: () => void;
 }
-
-const parseErrorMessage = ( error: unknown, fallback: string ): string => {
-	if ( error instanceof Error ) {
-		return error.message;
-	}
-	if (
-		error &&
-		typeof error === 'object' &&
-		'message' in error &&
-		typeof ( error as { message: unknown } ).message === 'string'
-	) {
-		return ( error as { message: string } ).message;
-	}
-	return fallback;
-};
 
 const CategorySetupModal = ( {
 	siteName,
@@ -112,7 +98,15 @@ const CategorySetupModal = ( {
 	}, [ onConfirm ] );
 
 	return (
-		<Modal title={ __( 'Set up your podcast', 'jetpack-podcast' ) } onRequestClose={ requestClose }>
+		<Modal
+			title={ __( 'Set up your podcast', 'jetpack-podcast' ) }
+			onRequestClose={ requestClose }
+			// Belt-and-suspenders: some Modal force-close paths skip
+			// `onRequestClose`, so disable Esc/backdrop dismissal directly
+			// while a save is in flight.
+			shouldCloseOnEsc={ ! ( saving || pickerSaving ) }
+			shouldCloseOnClickOutside={ ! ( saving || pickerSaving ) }
+		>
 			<VStack spacing={ 4 }>
 				<Text weight={ 600 }>
 					{ __( 'Select a post category for your podcast', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -29,7 +29,7 @@ const CategorySetupModal = ( {
 	onClose,
 	onSuccess,
 }: CategorySetupModalProps ) => {
-	const { mutate: saveSettings, isPending: saving } = useUpdatePodcastSettings();
+	const { mutateAsync: saveSettings, isPending: saving } = useUpdatePodcastSettings();
 
 	const [ categoryId, setCategoryId ] = useState( 0 );
 	const [ error, setError ] = useState< string | null >( null );
@@ -71,16 +71,10 @@ const CategorySetupModal = ( {
 				if ( ! existingTitle && siteName.trim() ) {
 					updates.podcasting_title = siteName.trim();
 				}
-				await new Promise< void >( ( resolve, reject ) => {
-					saveSettings( updates, {
-						onSuccess: () => resolve(),
-						onError: reject,
-						// Inline Notice below covers the error UX; suppress the hook's
-						// duplicate snackbar. Success is implicit (modal closes and
-						// lands the user on a populated Settings tab).
-						silent: true,
-					} );
-				} );
+				// Inline Notice below covers the error UX; suppress the hook's
+				// duplicate snackbar. Success is implicit (modal closes and
+				// lands the user on a populated Settings tab).
+				await saveSettings( updates, { silent: true } );
 				onSuccess();
 			} catch ( err ) {
 				setError(

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -87,21 +87,32 @@ const CategorySetupModal = ( {
 						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
 					)
 				);
+				// Re-throw so the inline-create path can reset the picker; the
+				// existing-category caller catches and discards.
+				throw err;
 			}
 		},
 		[ categoryId, existingTitle, siteName, saveSettings, onSuccess ]
 	);
 
 	const handleCreateSuccess = useCallback(
-		( id: number ) => {
+		async ( id: number ) => {
 			setCommittingFromCreate( true );
-			onConfirm( id );
+			try {
+				await onConfirm( id );
+			} catch ( err ) {
+				// Restore the outer Cancel/Confirm row so the user can retry or
+				// dismiss; re-throw so the picker resets its own busy state.
+				setCommittingFromCreate( false );
+				throw err;
+			}
 		},
 		[ onConfirm ]
 	);
 
 	const handleExistingCategoryConfirm = useCallback( () => {
-		onConfirm();
+		// onConfirm's inline Notice owns the error UX; swallow the rejection.
+		onConfirm().catch( () => {} );
 	}, [ onConfirm ] );
 
 	return (

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -43,11 +43,10 @@ const CategorySetupModal = ( {
 	onClose,
 	onSuccess,
 }: CategorySetupModalProps ) => {
-	const { mutate: saveSettings } = useUpdatePodcastSettings();
+	const { mutate: saveSettings, isPending: saving } = useUpdatePodcastSettings();
 
 	const [ categoryId, setCategoryId ] = useState( 0 );
 	const [ error, setError ] = useState< string | null >( null );
-	const [ saving, setSaving ] = useState( false );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
 	const [ pickerSaving, setPickerSaving ] = useState( false );
 
@@ -71,7 +70,6 @@ const CategorySetupModal = ( {
 				return;
 			}
 			setError( null );
-			setSaving( true );
 			try {
 				// Only prefill the title from the site name when the user hasn't
 				// already set one — preserves a custom title from a partial setup.
@@ -97,8 +95,6 @@ const CategorySetupModal = ( {
 						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' )
 					)
 				);
-			} finally {
-				setSaving( false );
 			}
 		},
 		[ categoryId, existingTitle, siteName, saveSettings, onSuccess ]

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -35,6 +35,12 @@ const CategorySetupModal = ( {
 	const [ error, setError ] = useState< string | null >( null );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
 	const [ pickerSaving, setPickerSaving ] = useState( false );
+	// Tracks the inline-create commit flow from the moment the picker finishes
+	// creating the category until the modal unmounts. The picker flips
+	// `pickerCreating` false before our `onConfirm` runs, so without this gate
+	// the outer Cancel/Confirm row briefly remounts (with `isBusy`) in the
+	// window between picker resolve and modal close — visible as a flash.
+	const [ committingFromCreate, setCommittingFromCreate ] = useState( false );
 
 	const requestClose = useCallback( () => {
 		// Block dismissal while a save is in flight so the in-flight promise
@@ -88,6 +94,7 @@ const CategorySetupModal = ( {
 
 	const handleCreateSuccess = useCallback(
 		( id: number ) => {
+			setCommittingFromCreate( true );
 			onConfirm( id );
 		},
 		[ onConfirm ]
@@ -133,8 +140,10 @@ const CategorySetupModal = ( {
 				{ /* Hide the outer Cancel/Confirm row while the inline create
 				     form is open. The inline form has its own Cancel/Create row
 				     and the create flow commits settings on success, so showing
-				     both rows looks like two competing actions. */ }
-				{ ! pickerCreating && (
+				     both rows looks like two competing actions. Keep it hidden
+				     through the create-driven commit so the row doesn't flash
+				     in for one render as the picker collapses. */ }
+				{ ! pickerCreating && ! committingFromCreate && (
 					<HStack justify="flex-end" spacing={ 3 }>
 						<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
 							{ __( 'Cancel', 'jetpack-podcast' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Creating a new category from the podcast setup modal used to take two clicks: **Create**, then **Confirm**. This PR commits the save on **Create** so the modal closes in one click.

`CategoryPicker` reports the new id back via `onCreateSuccess`, and `CategorySetupModal`'s `onConfirm` accepts that id directly so it does not have to wait for `setCategoryId` to flush.

Polish fixes that fell out of closing the gap:

- **No mid-save flash.** The inline form stays mounted and the outer button row stays hidden while the parent commits, so the dropdown does not visibly snap back to its empty state.
- **No save-after-cancel race.** The picker reports its own saving state via `onSavingChange`, and the modal refuses to dismiss while a category-create is in flight. Without this, the picker's promise could resolve after the user escaped the modal and still save settings they had backed out of.
- **Friendly duplicate-name error.** WordPress core returns "A term with the name provided already exists with this parent." for `term_exists`. The picker does not expose parents, so this swaps in "This category already exists."
- **Recovery if the settings save fails after create.** If the inline-create succeeded but the modal's settings save then rejected, the picker stayed busy and the modal stayed non-dismissible. The picker now awaits `onCreateSuccess` and resets its own state on rejection; the modal restores its Cancel/Confirm row so the user can retry or dismiss.

<img width="1388" height="706" alt="CleanShot 2026-05-18 at 15 54 21@2x" src="https://github.com/user-attachments/assets/d442ee71-a280-4d7f-b4de-3dccbc982854" />


Companion PR for the Distribution tab Submit-button explanations: [#48917](https://github.com/Automattic/jetpack/pull/48917).

## Does this pull request change what data or activity we track or use?

No.

### Other information

- [x] Have you checked for similar feature implementations? Yes; sibling `submit-modal.tsx` already uses `useUpdatePodcastSettings().isPending` the same way.
- [x] Has the [Code style](https://github.com/Automattic/jetpack/blob/HEAD/docs/coding-standards-and-style.md) been adhered to?
- [x] Are there any [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) errors? No
- [x] Have you added developer documentation, if appropriate?
- [x] Have you added the appropriate Testing Instructions?
- [x] If adding a new feature, have you considered an [experiment](https://github.com/Automattic/jetpack/blob/trunk/docs/experiments.md) to validate it? Gated behind the `jetpack_podcast_untangle` filter.
- [x] If adding a new feature, has the new feature been added to the [Features Comparison Reference](https://github.com/Automattic/jetpack/blob/trunk/docs/feature-comparison.md)? Bug fix on the existing untangled dashboard.

#### Testing instructions

Tested on jk95home.wordpress.com (Atomic) with the untangled dashboard filter enabled.

1. Enable the dashboard with `add_filter( 'jetpack_podcast_untangle', '__return_true' );`.
2. Open the podcast dashboard on a site with no podcast category set.
3. In the setup modal, pick "Create a new category...", type a name, press **Create**. The modal should close in one click; the new category is selected and saved.
4. Repeat step 3 with the name of a category that already exists. The inline error reads "This category already exists." instead of the core message about parents.
5. Repeat step 3 once more, then press **Cancel** while the create request is in flight. The modal should refuse to close until the create resolves, then close cleanly with no settings save.
6. Force a settings-save failure after a successful inline-create (e.g. throw in `useUpdatePodcastSettings`). The picker's busy state clears, the outer Cancel/Confirm row reappears, and the inline error explains the save failure.
7. Sanity check: pick an existing category from the dropdown, press **Confirm**. The two-click path for existing categories is unchanged.
