### PR TITLE
Bug: Fix/format currency division bug

### DIFF
--- a/projects/js-packages/number-formatters/changelog/fix-format-currency-division-bug
+++ b/projects/js-packages/number-formatters/changelog/fix-format-currency-division-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Currency formatting: use ISO 4217 minor-unit exponent for smallest-unit conversion to correctly format IDR and other currencies where browser ICU disagrees with ISO 4217.

--- a/projects/js-packages/number-formatters/src/number-format-currency/index.ts
+++ b/projects/js-packages/number-formatters/src/number-format-currency/index.ts
@@ -142,7 +142,7 @@ const ISO_4217_EXPONENTS: Record< string, number > = {
  * Returns the smallest unit exponent from ISO_4217_EXPONENTS given a currency.
  * Falls back to 2 (most currencies).
  * @param currency - The currency code (ISO 4217)
- * @return number  - The smalles unit exponent
+ * @return number  - The smallest unit exponent
  */
 function getSmallestUnitExponent( currency: string ): number {
 	return ISO_4217_EXPONENTS[ currency ] ?? 2;

--- a/projects/js-packages/number-formatters/src/number-format-currency/index.ts
+++ b/projects/js-packages/number-formatters/src/number-format-currency/index.ts
@@ -99,6 +99,56 @@ function getCurrencyFormatter( {
 }
 
 /**
+ * ISO 4217 minor-unit exponents.
+ *
+ * Used ONLY to convert prices given in the smallest unit (e.g. cents) into
+ * major-unit floats when `isSmallestUnit` is set. Display precision (how many
+ * decimal digits to render) is still decided by `Intl.NumberFormat` per locale.
+ *
+ * Browser ICU data and ISO 4217 disagree for some currencies — notably IDR and HUF
+ * which modern Chrome reports as 0-decimal but ISO 4217 defines as exponent 2.
+ * The WordPress.com API encodes smallest-unit integers using the ISO exponent,
+ * so we must use the same value to invert the conversion. Using the browser's
+ * value here produces off-by-100 errors for IDR.
+ */
+const ISO_4217_EXPONENTS: Record< string, number > = {
+	BHD: 3,
+	IQD: 3,
+	JOD: 3,
+	KWD: 3,
+	LYD: 3,
+	OMR: 3,
+	TND: 3,
+	BIF: 0,
+	CLP: 0,
+	DJF: 0,
+	GNF: 0,
+	ISK: 0,
+	JPY: 0,
+	KMF: 0,
+	KRW: 0,
+	MGA: 0,
+	PYG: 0,
+	RWF: 0,
+	UGX: 0,
+	VND: 0,
+	VUV: 0,
+	XAF: 0,
+	XOF: 0,
+	XPF: 0,
+};
+
+/**
+ * Returns the smallest unit exponent from ISO_4217_EXPONENTS given a currency.
+ * Falls back to 2 (most currencies).
+ * @param currency - The currency code (ISO 4217)
+ * @return number  - The smalles unit exponent
+ */
+function getSmallestUnitExponent( currency: string ): number {
+	return ISO_4217_EXPONENTS[ currency ] ?? 2;
+}
+
+/**
  * Returns the precision for a given locale and currency.
  * @param  browserSafeLocale - The browser safe locale.
  * @param  currency          - The currency to get the precision for.
@@ -139,15 +189,15 @@ function scaleNumberForPrecision( number: number, currencyPrecision: number ): n
 /**
  * Prepares a number for formatting.
  * @param  number            - The number to prepare.
- * @param  currencyPrecision - The precision to prepare the number for.
+ * @param  currencyPrecision - The display precision (from the browser) to round the result to.
+ * @param  currency          - The currency code, used to look up the ISO 4217 exponent for smallest-unit conversion.
  * @param  isSmallestUnit    - Whether the number is the smallest unit of a currency.
  * @return {number} The prepared number.
  */
 function prepareNumberForFormatting(
 	number: number,
-	// currencyPrecision here must be the precision of the currency, regardless
-	// of what precision is requested for display!
 	currencyPrecision: number,
+	currency: string,
 	isSmallestUnit?: boolean
 ): number {
 	if ( isNaN( number ) ) {
@@ -162,7 +212,7 @@ function prepareNumberForFormatting(
 				number
 			);
 		}
-		const smallestUnitDivisor = 10 ** currencyPrecision;
+		const smallestUnitDivisor = 10 ** getSmallestUnitExponent( currency );
 		return scaleNumberForPrecision( Math.round( number ) / smallestUnitDivisor, currencyPrecision );
 	}
 
@@ -235,6 +285,7 @@ const numberFormatCurrency = ( {
 	const numberAsFloat = prepareNumberForFormatting(
 		number,
 		currencyPrecision ?? 0,
+		validCurrency,
 		isSmallestUnit
 	);
 	const formatter = getCurrencyFormatter( {
@@ -326,6 +377,7 @@ const getCurrencyObject = ( {
 	const numberAsFloat = prepareNumberForFormatting(
 		number,
 		currencyPrecision ?? 0,
+		validCurrency,
 		isSmallestUnit
 	);
 	const formatter = getCurrencyFormatter( {

--- a/projects/js-packages/number-formatters/src/number-format-currency/index.ts
+++ b/projects/js-packages/number-formatters/src/number-format-currency/index.ts
@@ -99,53 +99,34 @@ function getCurrencyFormatter( {
 }
 
 /**
- * ISO 4217 minor-unit exponents.
+ * Smallest-unit exponent overrides for currencies where browser ICU's
+ * `maximumFractionDigits` disagrees with the API's smallest-unit encoding.
  *
- * Used ONLY to convert prices given in the smallest unit (e.g. cents) into
- * major-unit floats when `isSmallestUnit` is set. Display precision (how many
- * decimal digits to render) is still decided by `Intl.NumberFormat` per locale.
+ * Keep this list minimal — the backend is the source of truth for the API's
+ * smallest-unit encoding, so adding speculative entries here risks silent
+ * drift. Only add a currency once we've verified that browsers report a
+ * value the API does not use.
  *
- * Browser ICU data and ISO 4217 disagree for some currencies — notably IDR and HUF
- * which modern Chrome reports as 0-decimal but ISO 4217 defines as exponent 2.
- * The WordPress.com API encodes smallest-unit integers using the ISO exponent,
- * so we must use the same value to invert the conversion. Using the browser's
- * value here produces off-by-100 errors for IDR.
+ * - IDR: modern Chrome / Node 24+ ICU reports 0; the API encodes with exponent 2.
+ * - HUF: same browser/API divergence as IDR.
  */
-const ISO_4217_EXPONENTS: Record< string, number > = {
-	BHD: 3,
-	IQD: 3,
-	JOD: 3,
-	KWD: 3,
-	LYD: 3,
-	OMR: 3,
-	TND: 3,
-	BIF: 0,
-	CLP: 0,
-	DJF: 0,
-	GNF: 0,
-	ISK: 0,
-	JPY: 0,
-	KMF: 0,
-	KRW: 0,
-	MGA: 0,
-	PYG: 0,
-	RWF: 0,
-	UGX: 0,
-	VND: 0,
-	VUV: 0,
-	XAF: 0,
-	XOF: 0,
-	XPF: 0,
+const SMALLEST_UNIT_EXPONENT_OVERRIDES: Record< string, number > = {
+	IDR: 2,
+	HUF: 2,
 };
 
 /**
- * Returns the smallest unit exponent from ISO_4217_EXPONENTS given a currency.
- * Falls back to 2 (most currencies).
+ * Returns the smallest unit exponent for a currency.
+ *
+ * Falls back to the browser-derived display precision for any currency not in
+ * the override map — i.e. existing behavior is preserved for everything except
+ * the explicitly listed currencies.
  * @param currency - The currency code (ISO 4217)
+ * @param fallback - The browser-derived precision to use when no override applies
  * @return number  - The smallest unit exponent
  */
-function getSmallestUnitExponent( currency: string ): number {
-	return ISO_4217_EXPONENTS[ currency ] ?? 2;
+function getSmallestUnitExponent( currency: string, fallback: number ): number {
+	return SMALLEST_UNIT_EXPONENT_OVERRIDES[ currency ] ?? fallback;
 }
 
 /**
@@ -190,7 +171,7 @@ function scaleNumberForPrecision( number: number, currencyPrecision: number ): n
  * Prepares a number for formatting.
  * @param  number            - The number to prepare.
  * @param  currencyPrecision - The display precision (from the browser) to round the result to.
- * @param  currency          - The currency code, used to look up the ISO 4217 exponent for smallest-unit conversion.
+ * @param  currency          - The currency code, used to look up any smallest-unit exponent override.
  * @param  isSmallestUnit    - Whether the number is the smallest unit of a currency.
  * @return {number} The prepared number.
  */
@@ -212,7 +193,7 @@ function prepareNumberForFormatting(
 				number
 			);
 		}
-		const smallestUnitDivisor = 10 ** getSmallestUnitExponent( currency );
+		const smallestUnitDivisor = 10 ** getSmallestUnitExponent( currency, currencyPrecision );
 		return scaleNumberForPrecision( Math.round( number ) / smallestUnitDivisor, currencyPrecision );
 	}
 

--- a/projects/js-packages/number-formatters/src/test/number-format-currency.test.ts
+++ b/projects/js-packages/number-formatters/src/test/number-format-currency.test.ts
@@ -411,20 +411,26 @@ describe( 'numberFormatCurrency()', () => {
 			} );
 			expect( money ).toBe( 'R$ 9.800.900,32' );
 		} );
-		// Disabled temporarily due to the smallest unit being changed:
-		// https://unicode-org.atlassian.net/browse/CLDR-11586
-		// See also: p1773338482018929-slack-C034JEXD1RD
-		// eslint-disable-next-line jest/no-commented-out-tests
-		// it( 'IDR', () => {
-		// 	const money = numberFormatCurrency( {
-		// 		number: 107280000,
-		// 		currency: 'IDR',
-		// 		browserSafeLocale: 'in-ID',
-		// 		isSmallestUnit: true,
-		// 	} );
-		// eslint-disable-next-line no-irregular-whitespace
-		// 	expect( money ).toBe( 'Rp 1.072.800,00' );
-		// } );
+		it( 'IDR', () => {
+			const money = numberFormatCurrency( {
+				number: 107280000,
+				currency: 'IDR',
+				browserSafeLocale: 'in-ID',
+				isSmallestUnit: true,
+			} );
+
+			expect( money ).toBe( 'Rp 1.072.800' );
+		} );
+		it( 'HUF in smallest unit', () => {
+			const money = numberFormatCurrency( {
+				number: 99900,
+				currency: 'HUF',
+				browserSafeLocale: 'hu-HU',
+				isSmallestUnit: true,
+			} );
+
+			expect( money ).toBe( '999 Ft' );
+		} );
 	} );
 } );
 
@@ -512,6 +518,24 @@ describe( 'getCurrencyObject()', () => {
 			sign: '',
 			hasNonZeroFraction: true,
 			floatValue: 99.32,
+		} );
+	} );
+
+	it( 'handles IDR in smallest unit using ISO 4217 exponent', () => {
+		const money = getCurrencyObject( {
+			number: 24000000,
+			currency: 'IDR',
+			browserSafeLocale: 'in-ID',
+			isSmallestUnit: true,
+		} );
+		expect( money ).toEqual( {
+			symbol: 'Rp',
+			symbolPosition: 'before',
+			integer: '240.000',
+			fraction: '',
+			sign: '',
+			hasNonZeroFraction: false,
+			floatValue: 240000,
 		} );
 	} );
 


### PR DESCRIPTION
Fixes DOTMART-131

## Proposed changes
<!--- Explain what functional changes your PR includes -->
  * Use a static ISO 4217 minor-unit exponent table — not browser-derived `maximumFractionDigits` — as the divisor when `isSmallestUnit: true`. Display precision still flows from `Intl.NumberFormat`, so locale-aware rendering is unchanged.
  * You can compare the latest version(s) of Chrome(ium) vs Firefox in the console.

```js
new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' })
    .resolvedOptions().maximumFractionDigits
// 0 in Chrome
// 2 in Firefox
```

  * I am not familiar with the extent of where this is used, but I put significance patch, as it has no breaking API changes.
  * Re-enable the previously-disabled IDR test. Add HUF and `getCurrencyObject` IDR regression tests.
## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
  * DOTMART-131 
  * Shill-1731 
  * p1773338482018929-slack-C034JEXD1RD
## Does this pull request change what data or activity we track or use?
Nope
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
* `pnpm test` pass, including the re-enabled IDR test and the new HUF / `getCurrencyObject` IDR tests.
* `pnpm typecheck` and `pnpm build` 

Manual:
* In calypso, patch these changes via `yarn patch @automattic/number-formatters`
* In the temp folder it returns in stdout, copy the relevant file from this branch:

```sh
PATCH_DIR=/private/var/folders/.../xfs-XXXXXX/user     # paste from step 2
JETPACK_DIST=~/Developer/a8c/jetpack/projects/js-packages/number-formatters/dist
cp "$JETPACK_DIST/esm/number-format-currency/index.js"  "$PATCH_DIR/dist/esm/number-format-currency/index.js"
cp "$JETPACK_DIST/cjs/number-format-currency/index.cjs" "$PATCH_DIR/dist/cjs/number-format-currency/index.cjs"
yarn patch-commit -s "$PATCH_DIR" 
```
* yarn && yarn start
* Go to localhost:3000/start/ with HUF or IDR as your currency. The correct prices should show.

<img width="3872" height="2632" alt="CleanShot 2026-05-18 at 19 30 57@2x" src="https://github.com/user-attachments/assets/f3dc2554-409d-4adc-bb63-fcefd7f0fb5e" />

Compare to `trunk`, and observe that the number is correct vs 100x too large. Do the same in Firefox (or another browser where the below is still `2` ):

```
new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' })
    .resolvedOptions().maximumFractionDigits
```

And confirm it remains the same (and not 100 times less than it should be)

You can also test with EUR and USD (currencies with no override).