### PR TITLE
VideoPress modernization: wire all screens to real data (Phases 6+8)

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-modernization-phase-6-8
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-phase-6-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Modernized VideoPress dashboard (gated behind rsm_jetpack_ui_modernization_videopress) now wires Overview, Library, Video Details, and Settings to real REST endpoints. Also corrects the stats proxy's watch-time unit conversion.

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -27,6 +27,8 @@ export declare global {
 					timezoneString: string;
 					locale: string;
 					hasVideoPressAccess: boolean;
+					isVideoPress1TB?: boolean;
+					isVideoPressUnlimited?: boolean;
 				};
 				assets: {
 					buildUrl: string;

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -14,6 +14,7 @@ export declare global {
 				API: {
 					WP_API_root: string;
 					WP_API_nonce: string;
+					contentNonce: string;
 				};
 				jetpackStatus: {
 					calypsoSlug: string;

--- a/projects/packages/videopress/routes/library/package.json
+++ b/projects/packages/videopress/routes/library/package.json
@@ -4,7 +4,9 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
 		"@types/react": "18.3.28",
+		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/dataviews": "14.1.0",
 		"@wordpress/element": "6.44.0",

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -9,8 +9,12 @@ import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
 import { buildLibraryActions } from '../../src/dashboard/components/Library/actions';
 import { libraryFields } from '../../src/dashboard/components/Library/fields';
 import { UploadActionsProvider } from '../../src/dashboard/components/Library/upload-actions-context';
+import QueryClientWrapper from '../../src/dashboard/components/QueryClientWrapper';
+import { useDeleteVideo } from '../../src/dashboard/hooks/use-delete-video';
 import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
-import { useMockLibrary } from '../../src/dashboard/hooks/use-mock-library';
+import { useLibrary } from '../../src/dashboard/hooks/use-library';
+import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
+import { useUpload } from '../../src/dashboard/hooks/use-upload';
 import './style.scss';
 import type { LibraryItemPrivacy, MockLibraryItem } from '../../src/dashboard/types/library';
 import type { View } from '@wordpress/dataviews';
@@ -43,13 +47,15 @@ const defaultLayouts = {
 	table: { density: 'balanced' as const },
 };
 
-const Stage = () => {
-	const { items, isLoading, startUpload, promoteLocal, retryUpload, deleteItems, setPrivacy } =
-		useMockLibrary();
-	const { isAtLimit } = useFreeTier();
-
+const StageInner = () => {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ selection, setSelection ] = useState< string[] >( [] );
+
+	const { items, isLoading, paginationInfo } = useLibrary( view );
+	const { uploadQueue, startUpload, retryUpload } = useUpload();
+	const { mutate: deleteVideo } = useDeleteVideo();
+	const { mutate: updateMeta } = useUpdateVideoMeta();
+	const { isAtLimit } = useFreeTier();
 
 	const onChangeView = useCallback( ( next: View ) => {
 		setView( current => {
@@ -95,97 +101,76 @@ const Stage = () => {
 	const actions = useMemo(
 		() =>
 			buildLibraryActions( {
-				promoteLocal,
+				promoteLocal: () => {
+					// no-op: the real uploader doesn't have a separate "promote local" step
+				},
 				retryUpload,
 				openVideoDetails,
-				deleteItems: ids => {
-					deleteItems( ids );
-					createSuccessNotice(
-						sprintf(
-							/* translators: %d: number of deleted videos. */
-							_n( '%d video deleted.', '%d videos deleted.', ids.length, 'jetpack-videopress-pkg' ),
-							ids.length
-						)
-					);
+				deleteItems: ( ids: string[] ) => {
+					deleteVideo( ids, {
+						onSuccess: () => {
+							createSuccessNotice(
+								sprintf(
+									/* translators: %d: number of deleted videos. */
+									_n(
+										'%d video deleted.',
+										'%d videos deleted.',
+										ids.length,
+										'jetpack-videopress-pkg'
+									),
+									ids.length
+								)
+							);
+						},
+					} );
 				},
-				setPrivacy: ( id, privacy ) => {
-					setPrivacy( id, privacy );
-					createSuccessNotice(
-						sprintf(
-							/* translators: %s: new privacy label, e.g. "Public". */
-							__( 'Privacy updated to %s.', 'jetpack-videopress-pkg' ),
-							PRIVACY_LABELS[ privacy ]
-						)
+				setPrivacy: ( id: string, privacy: LibraryItemPrivacy ) => {
+					updateMeta(
+						{ id, patch: { privacy } },
+						{
+							onSuccess: () => {
+								createSuccessNotice(
+									sprintf(
+										/* translators: %s: new privacy label. */
+										__( 'Privacy updated to %s.', 'jetpack-videopress-pkg' ),
+										PRIVACY_LABELS[ privacy ]
+									)
+								);
+							},
+						}
 					);
 				},
 			} ),
-		[ promoteLocal, retryUpload, deleteItems, setPrivacy, openVideoDetails, createSuccessNotice ]
+		[ retryUpload, deleteVideo, updateMeta, openVideoDetails, createSuccessNotice ]
 	);
 
-	const filteredData = useMemo< MockLibraryItem[] >( () => {
-		let result = items;
-
-		const search = view.search?.trim().toLowerCase();
-		if ( search ) {
-			result = result.filter(
-				item =>
-					item.title.toLowerCase().includes( search ) ||
-					item.filename.toLowerCase().includes( search )
-			);
-		}
-
-		for ( const filter of view.filters ?? [] ) {
-			const { field, value } = filter;
-			if ( value === undefined || value === null || value === 'all' ) {
-				continue;
-			}
-			result = result.filter( item => {
-				switch ( field ) {
-					case 'type':
-						return item.type === value;
-					case 'privacy':
-						return item.privacy === value;
-					default:
-						return true;
-				}
-			} );
-		}
-
-		if ( view.sort ) {
-			const { field, direction } = view.sort;
-			const dir = direction === 'asc' ? 1 : -1;
-			result = [ ...result ].sort( ( a, b ) => {
-				switch ( field ) {
-					case 'title':
-						return a.title.localeCompare( b.title ) * dir;
-					case 'uploadDate':
-						return ( a.uploadDate < b.uploadDate ? -1 : 1 ) * dir;
-					case 'duration':
-						return ( a.durationSeconds - b.durationSeconds ) * dir;
-					case 'fileSize':
-						return ( a.fileSizeBytes - b.fileSizeBytes ) * dir;
-					default:
-						return 0;
-				}
-			} );
-		}
-
-		return result;
-	}, [ items, view.search, view.filters, view.sort ] );
-
-	const perPage = view.perPage ?? 12;
-	const totalItems = filteredData.length;
-	const totalPages = Math.max( 1, Math.ceil( totalItems / perPage ) );
-	const page = Math.min( view.page ?? 1, totalPages );
-	const pagedData = useMemo(
-		() => filteredData.slice( ( page - 1 ) * perPage, page * perPage ),
-		[ filteredData, page, perPage ]
-	);
-
-	const paginationInfo = useMemo(
-		() => ( { totalItems, totalPages } ),
-		[ totalItems, totalPages ]
-	);
+	// Splice in-flight uploads at the top of the listing so the user sees
+	// their upload immediately, before the next server refetch.
+	const renderedItems = useMemo< MockLibraryItem[] >( () => {
+		const inFlight: MockLibraryItem[] = uploadQueue
+			.filter( u => u.status === 'pending' || u.status === 'uploading' || u.status === 'failed' )
+			.map( u => ( {
+				id: u.id,
+				type: 'local' as const,
+				title: u.file.name.replace( /\.[^.]+$/, '' ),
+				filename: u.file.name,
+				thumbnailUrl: null,
+				durationSeconds: 0,
+				uploadDate: new Date().toISOString(),
+				privacy: 'site-default' as LibraryItemPrivacy,
+				fileSizeBytes: u.file.size,
+				upload: {
+					status: u.status === 'failed' ? ( 'failed' as const ) : ( 'uploading' as const ),
+					progress: Math.round( u.progress * 100 ),
+				},
+				description: '',
+				rating: 'G' as MockLibraryItem[ 'rating' ],
+				displayEmbed: false,
+				allowDownloads: false,
+				shortcode: '',
+			} ) );
+		return [ ...inFlight, ...items ];
+	}, [ uploadQueue, items ] );
 
 	const getItemId = useCallback( ( item: MockLibraryItem ) => item.id, [] );
 
@@ -224,10 +209,10 @@ const Stage = () => {
 				</>
 			}
 		>
-			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
+			<UploadActionsProvider value={ { promoteLocal: () => {}, retryUpload } }>
 				<div className={ `vp-library__viewport vp-library__viewport--${ view.type }` }>
 					<DataViews< MockLibraryItem >
-						data={ pagedData }
+						data={ renderedItems }
 						fields={ libraryFields }
 						actions={ actions }
 						view={ view }
@@ -244,5 +229,11 @@ const Stage = () => {
 		</DashboardLayout>
 	);
 };
+
+const Stage = () => (
+	<QueryClientWrapper>
+		<StageInner />
+	</QueryClientWrapper>
+);
 
 export { Stage as stage };

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -96,7 +96,7 @@ const StageInner = () => {
 		[ navigate ]
 	);
 
-	const { createSuccessNotice } = useGlobalNotices();
+	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 
 	const actions = useMemo(
 		() =>
@@ -122,6 +122,16 @@ const StageInner = () => {
 								)
 							);
 						},
+						onError: () => {
+							createErrorNotice(
+								_n(
+									'Failed to delete video.',
+									'Failed to delete videos.',
+									ids.length,
+									'jetpack-videopress-pkg'
+								)
+							);
+						},
 					} );
 				},
 				setPrivacy: ( id: string, privacy: LibraryItemPrivacy ) => {
@@ -137,11 +147,21 @@ const StageInner = () => {
 									)
 								);
 							},
+							onError: () => {
+								createErrorNotice( __( 'Failed to update privacy.', 'jetpack-videopress-pkg' ) );
+							},
 						}
 					);
 				},
 			} ),
-		[ retryUpload, deleteVideo, updateMeta, openVideoDetails, createSuccessNotice ]
+		[
+			retryUpload,
+			deleteVideo,
+			updateMeta,
+			openVideoDetails,
+			createSuccessNotice,
+			createErrorNotice,
+		]
 	);
 
 	// Splice in-flight uploads at the top of the listing so the user sees

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -171,6 +171,7 @@ const StageInner = () => {
 			.filter( u => u.status === 'pending' || u.status === 'uploading' || u.status === 'failed' )
 			.map( u => ( {
 				id: u.id,
+				guid: '',
 				type: 'local' as const,
 				title: u.file.name.replace( /\.[^.]+$/, '' ),
 				filename: u.file.name,
@@ -178,6 +179,7 @@ const StageInner = () => {
 				durationSeconds: 0,
 				uploadDate: new Date().toISOString(),
 				privacy: 'site-default' as LibraryItemPrivacy,
+				isPrivate: false,
 				fileSizeBytes: u.file.size,
 				upload: {
 					status: u.status === 'failed' ? ( 'failed' as const ) : ( 'uploading' as const ),
@@ -188,6 +190,7 @@ const StageInner = () => {
 				displayEmbed: false,
 				allowDownloads: false,
 				shortcode: '',
+				isProcessing: false,
 			} ) );
 		return [ ...inFlight, ...items ];
 	}, [ uploadQueue, items ] );

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -27,7 +27,11 @@ const PRIVACY_LABELS: Record< LibraryItemPrivacy, string > = {
 };
 
 const GRID_VISIBLE_FIELDS = [ 'filename' ];
-const TABLE_VISIBLE_FIELDS = [ 'filename', 'duration', 'fileSize', 'uploadDate', 'privacy' ];
+// `fileSize` is intentionally omitted: it's only populated for local
+// (non-VideoPress) uploads today, so it's blank for most rows. Users
+// who want the column can still toggle it on via the DataViews column-
+// visibility control.
+const TABLE_VISIBLE_FIELDS = [ 'filename', 'duration', 'uploadDate', 'privacy' ];
 
 const DEFAULT_VIEW: View = {
 	type: 'grid',

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -15,6 +15,7 @@ import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
 import { useLibrary } from '../../src/dashboard/hooks/use-library';
 import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
+import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-library';
 import './style.scss';
 import type { LibraryItemPrivacy, MockLibraryItem } from '../../src/dashboard/types/library';
 import type { View } from '@wordpress/dataviews';
@@ -54,11 +55,16 @@ const defaultLayouts = {
 const StageInner = () => {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ selection, setSelection ] = useState< string[] >( [] );
+	// Local IDs currently being promoted from local-storage to VideoPress.
+	// The upload-from-library endpoint doesn't report progress, so we just
+	// need to know which rows to overlay with an "Uploading…" state.
+	const [ promotingIds, setPromotingIds ] = useState< Set< string > >( () => new Set() );
 
 	const { items, isLoading, paginationInfo } = useLibrary( view );
 	const { uploadQueue, startUpload, retryUpload } = useUpload();
 	const { mutate: deleteVideo } = useDeleteVideo();
 	const { mutate: updateMeta } = useUpdateVideoMeta();
+	const { mutate: uploadFromLibrary } = useUploadFromLibrary();
 	const { isAtLimit } = useFreeTier();
 
 	const onChangeView = useCallback( ( next: View ) => {
@@ -102,12 +108,48 @@ const StageInner = () => {
 
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 
+	const promoteLocal = useCallback(
+		( id: string ) => {
+			setPromotingIds( prev => {
+				const next = new Set( prev );
+				next.add( id );
+				return next;
+			} );
+			uploadFromLibrary( id, {
+				onSuccess: () => {
+					createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
+				},
+				onError: ( error: Error ) => {
+					const reason = error?.message?.trim();
+					createErrorNotice(
+						reason
+							? sprintf(
+									/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
+									__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
+									reason
+							  )
+							: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
+					);
+				},
+				onSettled: () => {
+					setPromotingIds( prev => {
+						if ( ! prev.has( id ) ) {
+							return prev;
+						}
+						const next = new Set( prev );
+						next.delete( id );
+						return next;
+					} );
+				},
+			} );
+		},
+		[ uploadFromLibrary, createSuccessNotice, createErrorNotice ]
+	);
+
 	const actions = useMemo(
 		() =>
 			buildLibraryActions( {
-				promoteLocal: () => {
-					// no-op: the real uploader doesn't have a separate "promote local" step
-				},
+				promoteLocal,
 				retryUpload,
 				openVideoDetails,
 				deleteItems: ( ids: string[] ) => {
@@ -159,6 +201,7 @@ const StageInner = () => {
 				},
 			} ),
 		[
+			promoteLocal,
 			retryUpload,
 			deleteVideo,
 			updateMeta,
@@ -196,8 +239,19 @@ const StageInner = () => {
 				shortcode: '',
 				isProcessing: false,
 			} ) );
-		return [ ...inFlight, ...items ];
-	}, [ uploadQueue, items ] );
+		// Overlay an "uploading"-style state on items currently being
+		// promoted from local-storage to VideoPress, so the title-cell
+		// pill and the thumbnail overlay reflect the in-flight state
+		// without needing a parallel signal at every render site.
+		const overlaid = promotingIds.size
+			? items.map( item =>
+					promotingIds.has( item.id )
+						? { ...item, upload: { status: 'promoting' as const, progress: 0 } }
+						: item
+			  )
+			: items;
+		return [ ...inFlight, ...overlaid ];
+	}, [ uploadQueue, items, promotingIds ] );
 
 	const getItemId = useCallback( ( item: MockLibraryItem ) => item.id, [] );
 
@@ -236,7 +290,7 @@ const StageInner = () => {
 				</>
 			}
 		>
-			<UploadActionsProvider value={ { promoteLocal: () => {}, retryUpload } }>
+			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
 				<div className={ `vp-library__viewport vp-library__viewport--${ view.type }` }>
 					<DataViews< MockLibraryItem >
 						data={ renderedItems }

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -76,6 +76,21 @@
 		color: #1e1e1e;
 	}
 
+	// "Processing" overlay shown while the VideoPress backend is still
+	// transcoding a freshly uploaded video. Sits above the (absent) image
+	// and below the duration badge. Hidden in narrow table-mode cells —
+	// the "Processing" pill in the title cell carries the state there.
+	&__processing {
+		position: absolute;
+		inset: 0;
+		background: #f0f0f0;
+		color: #1e1e1e;
+
+		@container (max-width: 120px) {
+			display: none;
+		}
+	}
+
 	&__hover-action {
 		position: absolute;
 		inset: 0;

--- a/projects/packages/videopress/routes/overview/stage.tsx
+++ b/projects/packages/videopress/routes/overview/stage.tsx
@@ -6,8 +6,9 @@ import MostViewedCard from '../../src/dashboard/components/Overview/most-viewed-
 import StorageMeterCard from '../../src/dashboard/components/Overview/storage-meter-card';
 import TopByWatchTimeCard from '../../src/dashboard/components/Overview/top-by-watch-time-card';
 import ViewsTrendsCard from '../../src/dashboard/components/Overview/views-trends-card';
+import QueryClientWrapper from '../../src/dashboard/components/QueryClientWrapper';
 import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
-import { useMockStats } from '../../src/dashboard/hooks/use-mock-stats';
+import { useStats } from '../../src/dashboard/hooks/use-stats';
 import './style.scss';
 import type { ActiveMetric } from '../../src/dashboard/types/stats';
 
@@ -20,7 +21,7 @@ const KPI_TAB_IDS: Record< ActiveMetric, string > = {
 	watch_time: 'vp-overview-kpi-tab-watch-time',
 };
 
-const Stage = () => {
+const StageInner = () => {
 	const {
 		stats,
 		isLoading,
@@ -32,7 +33,7 @@ const Stage = () => {
 		setActiveMetric,
 		compare,
 		setCompare,
-	} = useMockStats();
+	} = useStats();
 	const { isFree, isAtomic, isUnlimited, videoCount } = useFreeTier();
 
 	const showStorageMeter = ! isFree && videoCount > 0 && ! isUnlimited && ! isAtomic;
@@ -74,5 +75,11 @@ const Stage = () => {
 		</DashboardLayout>
 	);
 };
+
+const Stage = () => (
+	<QueryClientWrapper>
+		<StageInner />
+	</QueryClientWrapper>
+);
 
 export { Stage as stage };

--- a/projects/packages/videopress/routes/overview/stage.tsx
+++ b/projects/packages/videopress/routes/overview/stage.tsx
@@ -65,7 +65,7 @@ const Stage = () => {
 					panelId={ TRENDS_PANEL_ID }
 					activeTabId={ KPI_TAB_IDS[ activeMetric ] }
 				/>
-				{ showStorageMeter && <StorageMeterCard usedBytes={ stats.storageUsedBytes } /> }
+				{ showStorageMeter && <StorageMeterCard /> }
 				<div className="vp-overview__row--bottom">
 					<MostViewedCard videos={ stats.topVideos } isLoading={ isLoading } />
 					<TopByWatchTimeCard videos={ stats.topVideosByWatchTime } isLoading={ isLoading } />

--- a/projects/packages/videopress/routes/settings/package.json
+++ b/projects/packages/videopress/routes/settings/package.json
@@ -4,7 +4,9 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
 		"@types/react": "18.3.28",
+		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",

--- a/projects/packages/videopress/routes/settings/stage.tsx
+++ b/projects/packages/videopress/routes/settings/stage.tsx
@@ -1,33 +1,42 @@
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Card } from '@wordpress/ui';
-import { useState } from 'react';
 import DashboardLayout from '../../src/dashboard/components/DashboardLayout';
+import QueryClientWrapper from '../../src/dashboard/components/QueryClientWrapper';
+import { useSettings, useUpdateSettings } from '../../src/dashboard/hooks/use-settings';
 import './style.scss';
 
-const Stage = () => {
-	// Local-only state for Phase 1; wires to videopress/v1/settings in Phase 6.
-	const [ restrict, setRestrict ] = useState( false );
+const SettingsForm = () => {
+	const settings = useSettings();
+	const update = useUpdateSettings();
+	const checked = settings.data?.videoPressVideosPrivateForSite ?? false;
 
 	return (
-		<DashboardLayout activeTab="settings">
-			<div className="jp-videopress-settings">
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>{ __( 'Restrict video access', 'jetpack-videopress-pkg' ) }</Card.Title>
-					</Card.Header>
-					<Card.Content>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Only logged-in users can play your videos', 'jetpack-videopress-pkg' ) }
-							checked={ restrict }
-							onChange={ setRestrict }
-						/>
-					</Card.Content>
-				</Card.Root>
-			</div>
-		</DashboardLayout>
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>{ __( 'Restrict video access', 'jetpack-videopress-pkg' ) }</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Only logged-in users can play your videos', 'jetpack-videopress-pkg' ) }
+					checked={ checked }
+					disabled={ settings.isLoading || update.isPending }
+					onChange={ next => update.mutate( { videoPressVideosPrivateForSite: next } ) }
+				/>
+			</Card.Content>
+		</Card.Root>
 	);
 };
+
+const Stage = () => (
+	<QueryClientWrapper>
+		<DashboardLayout activeTab="settings">
+			<div className="jp-videopress-settings">
+				<SettingsForm />
+			</div>
+		</DashboardLayout>
+	</QueryClientWrapper>
+);
 
 export { Stage as stage };

--- a/projects/packages/videopress/routes/video/package.json
+++ b/projects/packages/videopress/routes/video/package.json
@@ -4,8 +4,10 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "2.0.0",
+		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/compose": "7.44.0",
 		"@wordpress/date": "5.44.0",

--- a/projects/packages/videopress/routes/video/package.json
+++ b/projects/packages/videopress/routes/video/package.json
@@ -15,7 +15,8 @@
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/route": "0.10.0",
-		"@wordpress/ui": "0.13.0"
+		"@wordpress/ui": "0.13.0",
+		"@wordpress/url": "4.44.0"
 	},
 	"route": {
 		"path": "/video/$id",

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -121,7 +121,7 @@ const Editor = ( {
 				/>
 				<PrivacySharingCard
 					privacy={ values.privacy }
-					allowSharing={ values.allowSharing }
+					displayEmbed={ values.displayEmbed }
 					allowDownloads={ values.allowDownloads }
 					onChange={ update }
 				/>

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -135,7 +135,7 @@ const StageReady = ( { video }: StageReadyProps ) => {
 	const navigate = useNavigate();
 	const { mutate: updateMeta, isPending: isSaving } = useUpdateVideoMeta();
 	const { mutate: deleteVideo } = useDeleteVideo();
-	const { createSuccessNotice } = useGlobalNotices();
+	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 	const [ chaptersOpen, setChaptersOpen ] = useState( false );
 
 	return (
@@ -150,6 +150,9 @@ const StageReady = ( { video }: StageReadyProps ) => {
 							createSuccessNotice( __( 'Video details saved.', 'jetpack-videopress-pkg' ) );
 							reset( values );
 						},
+						onError: () => {
+							createErrorNotice( __( 'Failed to save video details.', 'jetpack-videopress-pkg' ) );
+						},
 					}
 				);
 			} }
@@ -158,6 +161,9 @@ const StageReady = ( { video }: StageReadyProps ) => {
 					onSuccess: () => {
 						createSuccessNotice( __( 'Video deleted.', 'jetpack-videopress-pkg' ) );
 						navigate( { href: '/library' } );
+					},
+					onError: () => {
+						createErrorNotice( __( 'Failed to delete video.', 'jetpack-videopress-pkg' ) );
 					},
 				} );
 			} }

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link, useNavigate, useParams } from '@wordpress/route';
 import { Stack, Text } from '@wordpress/ui';
+import { addQueryArgs } from '@wordpress/url';
 import QueryClientWrapper from '../../src/dashboard/components/QueryClientWrapper';
 import ChaptersHelpModal from '../../src/dashboard/components/VideoDetails/chapters-help-modal';
 import HeaderActions from '../../src/dashboard/components/VideoDetails/header-actions';
@@ -124,11 +125,6 @@ const Editor = ( {
 	);
 };
 
-const guidFromShortcode = ( shortcode?: string ): string | undefined => {
-	const match = shortcode?.match( /\[videopress ([^\]]+)\]/ );
-	return match?.[ 1 ];
-};
-
 type StageReadyProps = { video: MockLibraryItem };
 
 const StageReady = ( { video }: StageReadyProps ) => {
@@ -173,10 +169,18 @@ const StageReady = ( { video }: StageReadyProps ) => {
 				}
 			} }
 			onAddToNewPost={ () => {
-				const guid = guidFromShortcode( video.shortcode );
-				if ( guid ) {
-					window.location.href = `post-new.php?videopress=${ guid }`;
+				const nonce =
+					typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+						? JPVIDEOPRESS_INITIAL_STATE?.API?.contentNonce
+						: undefined;
+				if ( ! video.guid || ! nonce ) {
+					return;
 				}
+				const url = addQueryArgs( 'post-new.php', {
+					videopress_guid: video.guid,
+					_wpnonce: nonce,
+				} );
+				window.open( url, '_blank' );
 			} }
 			chaptersOpen={ chaptersOpen }
 			setChaptersOpen={ setChaptersOpen }

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link, useNavigate, useParams } from '@wordpress/route';
 import { Stack, Text } from '@wordpress/ui';
+import QueryClientWrapper from '../../src/dashboard/components/QueryClientWrapper';
 import ChaptersHelpModal from '../../src/dashboard/components/VideoDetails/chapters-help-modal';
 import HeaderActions from '../../src/dashboard/components/VideoDetails/header-actions';
 import PrivacySharingCard from '../../src/dashboard/components/VideoDetails/privacy-sharing-card';
@@ -12,7 +13,9 @@ import RatingCard from '../../src/dashboard/components/VideoDetails/rating-card'
 import ThumbnailCard from '../../src/dashboard/components/VideoDetails/thumbnail-card';
 import { useVideoDetailsForm } from '../../src/dashboard/components/VideoDetails/use-video-details-form';
 import VideoDetailsCard from '../../src/dashboard/components/VideoDetails/video-details-card';
-import { useMockLibrary } from '../../src/dashboard/hooks/use-mock-library';
+import { useDeleteVideo } from '../../src/dashboard/hooks/use-delete-video';
+import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
+import { useVideo } from '../../src/dashboard/hooks/use-video';
 import './style.scss';
 import type { MockLibraryItem, VideoRating } from '../../src/dashboard/types/library';
 
@@ -41,20 +44,25 @@ const NotFound = () => (
 
 type EditorProps = {
 	video: MockLibraryItem;
-	updateVideoDetails: ReturnType< typeof useMockLibrary >[ 'updateVideoDetails' ];
-	deleteItems: ReturnType< typeof useMockLibrary >[ 'deleteItems' ];
-	createSuccessNotice: ReturnType< typeof useGlobalNotices >[ 'createSuccessNotice' ];
-	navigate: ReturnType< typeof useNavigate >;
+	onSave: (
+		values: ReturnType< typeof useVideoDetailsForm >[ 'values' ],
+		reset: ReturnType< typeof useVideoDetailsForm >[ 'reset' ]
+	) => void;
+	isSaving: boolean;
+	onDelete: () => void;
+	onDownload: () => void;
+	onAddToNewPost: () => void;
 	chaptersOpen: boolean;
 	setChaptersOpen: ( open: boolean ) => void;
 };
 
 const Editor = ( {
 	video,
-	updateVideoDetails,
-	deleteItems,
-	createSuccessNotice,
-	navigate,
+	onSave,
+	isSaving,
+	onDelete,
+	onDownload,
+	onAddToNewPost,
 	chaptersOpen,
 	setChaptersOpen,
 }: EditorProps ) => {
@@ -75,25 +83,9 @@ const Editor = ( {
 		[ update ]
 	);
 
-	const onSave = useCallback( () => {
-		updateVideoDetails( video.id, values );
-		createSuccessNotice( __( 'Video details saved.', 'jetpack-videopress-pkg' ) );
-		reset( values );
-	}, [ updateVideoDetails, video.id, values, createSuccessNotice, reset ] );
-
-	const onDelete = useCallback( () => {
-		deleteItems( [ video.id ] );
-		createSuccessNotice( __( 'Video deleted.', 'jetpack-videopress-pkg' ) );
-		navigate( { href: '/library' } );
-	}, [ deleteItems, video.id, createSuccessNotice, navigate ] );
-
-	const onDownload = useCallback( () => {
-		// Phase 6 wires this to the real file URL.
-	}, [] );
-
-	const onAddToNewPost = useCallback( () => {
-		// Phase 6 wires this to the real newPostURL.
-	}, [] );
+	const handleSave = useCallback( () => {
+		onSave( values, reset );
+	}, [ onSave, values, reset ] );
 
 	return (
 		<AdminPage
@@ -104,8 +96,8 @@ const Editor = ( {
 			}
 			actions={
 				<HeaderActions
-					canSave={ isDirty }
-					onSave={ onSave }
+					canSave={ isDirty && ! isSaving }
+					onSave={ handleSave }
 					onDownload={ onDownload }
 					onDelete={ onDelete }
 				/>
@@ -132,30 +124,79 @@ const Editor = ( {
 	);
 };
 
-const Stage = () => {
-	const { id } = useParams( { from: '/video/$id' } );
+const guidFromShortcode = ( shortcode?: string ): string | undefined => {
+	const match = shortcode?.match( /\[videopress ([^\]]+)\]/ );
+	return match?.[ 1 ];
+};
+
+type StageReadyProps = { video: MockLibraryItem };
+
+const StageReady = ( { video }: StageReadyProps ) => {
 	const navigate = useNavigate();
-	const { items, updateVideoDetails, deleteItems } = useMockLibrary();
+	const { mutate: updateMeta, isPending: isSaving } = useUpdateVideoMeta();
+	const { mutate: deleteVideo } = useDeleteVideo();
 	const { createSuccessNotice } = useGlobalNotices();
 	const [ chaptersOpen, setChaptersOpen ] = useState( false );
-
-	const video = items.find( item => item.id === id );
-
-	if ( ! video || ! isEditable( video ) ) {
-		return <NotFound />;
-	}
 
 	return (
 		<Editor
 			video={ video }
-			updateVideoDetails={ updateVideoDetails }
-			deleteItems={ deleteItems }
-			createSuccessNotice={ createSuccessNotice }
-			navigate={ navigate }
+			isSaving={ isSaving }
+			onSave={ ( values, reset ) => {
+				updateMeta(
+					{ id: video.id, patch: values },
+					{
+						onSuccess: () => {
+							createSuccessNotice( __( 'Video details saved.', 'jetpack-videopress-pkg' ) );
+							reset( values );
+						},
+					}
+				);
+			} }
+			onDelete={ () => {
+				deleteVideo( Number( video.id ), {
+					onSuccess: () => {
+						createSuccessNotice( __( 'Video deleted.', 'jetpack-videopress-pkg' ) );
+						navigate( { href: '/library' } );
+					},
+				} );
+			} }
+			onDownload={ () => {
+				if ( video.sourceUrl ) {
+					window.open( video.sourceUrl, '_blank' );
+				}
+			} }
+			onAddToNewPost={ () => {
+				const guid = guidFromShortcode( video.shortcode );
+				if ( guid ) {
+					window.location.href = `post-new.php?videopress=${ guid }`;
+				}
+			} }
 			chaptersOpen={ chaptersOpen }
 			setChaptersOpen={ setChaptersOpen }
 		/>
 	);
 };
+
+const StageInner = () => {
+	const { id } = useParams( { from: '/video/$id' } );
+	const { video, isLoading } = useVideo( id );
+
+	if ( isLoading ) {
+		return null;
+	}
+
+	if ( ! video || ! isEditable( video ) ) {
+		return <NotFound />;
+	}
+
+	return <StageReady video={ video } />;
+};
+
+const Stage = () => (
+	<QueryClientWrapper>
+		<StageInner />
+	</QueryClientWrapper>
+);
 
 export { Stage as stage };

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -43,6 +43,24 @@ const NotFound = () => (
 	</AdminPage>
 );
 
+// Placeholder shown while /wp/v2/media/{id} is in flight. Mirrors NotFound's
+// AdminPage + breadcrumbs shell so the page chrome stays present rather than
+// blanking out the viewport for the duration of the fetch.
+const Loading = () => (
+	<AdminPage
+		breadcrumbs={
+			<Breadcrumbs
+				items={ [
+					{ label: 'VideoPress', to: '/library' },
+					{ label: __( 'Loading…', 'jetpack-videopress-pkg' ) },
+				] }
+			/>
+		}
+	>
+		<div className="vp-video-details vp-video-details__loading" aria-busy="true" />
+	</AdminPage>
+);
+
 type EditorProps = {
 	video: MockLibraryItem;
 	onSave: (
@@ -193,7 +211,7 @@ const StageInner = () => {
 	const { video, isLoading } = useVideo( id );
 
 	if ( isLoading ) {
-		return null;
+		return <Loading />;
 	}
 
 	if ( ! video || ! isEditable( video ) ) {

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -18,6 +18,13 @@
 	text-align: center;
 }
 
+// Empty placeholder shown while the /wp/v2/media/{id} fetch is in flight.
+// Sized to roughly match the editor body height so the layout doesn't
+// jump when the real content arrives.
+.vp-video-details__loading {
+	min-height: 320px;
+}
+
 .vp-video-details__thumbnail {
 	width: 240px;
 	height: 135px;

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -26,6 +26,18 @@
 	flex-shrink: 0;
 }
 
+// "Processing" placeholder shown in place of the poster <img> while
+// the VideoPress backend is still transcoding the upload. Shares the
+// .vp-video-details__thumbnail class for size and border-radius, plus
+// this modifier for the centered text + neutral background.
+.vp-video-details__thumbnail-processing {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #f0f0f0;
+	color: #1e1e1e;
+}
+
 .vp-video-details__thumbnail-meta {
 	flex: 1;
 	min-width: 0;

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -83,6 +83,7 @@ class Initial_State {
 			'API'           => array(
 				'WP_API_root'  => esc_url_raw( rest_url() ),
 				'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
+				'contentNonce' => wp_create_nonce( 'videopress-content-nonce' ),
 			),
 			'jetpackStatus' => array(
 				'calypsoSlug' => ( new Status() )->get_site_suffix(),

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -88,21 +88,22 @@ class Initial_State {
 				'calypsoSlug' => ( new Status() )->get_site_suffix(),
 			),
 			'siteData'      => array(
-				'id'                  => Jetpack_Options::get_option( 'id' ),
-				'title'               => get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url(),
-				'adminUrl'            => esc_url_raw( admin_url() ),
-				'slug'                => is_string( $home_host ) ? $home_host : '',
-				'gmtOffset'           => is_numeric( $gmt_offset ) ? (float) $gmt_offset : 0.0,
-				'timezoneString'      => is_string( $timezone_string ) ? $timezone_string : '',
-				'locale'              => str_replace( '_', '-', (string) get_locale() ),
-				// Paid-tier capability check. Drives the free-tier UX
-				// (callout / DataViews configuration) once designer input
-				// lands. Backed by `Product::get_site_features_from_wpcom()`,
-				// which caches the WPCOM `/sites/%d/features` response in a
-				// 15-second site transient. On a cache miss this issues a
-				// synchronous WPCOM request that blocks page rendering until
-				// it returns.
-				'hasVideoPressAccess' => self::has_videopress_access(),
+				'id'                    => Jetpack_Options::get_option( 'id' ),
+				'title'                 => get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url(),
+				'adminUrl'              => esc_url_raw( admin_url() ),
+				'slug'                  => is_string( $home_host ) ? $home_host : '',
+				'gmtOffset'             => is_numeric( $gmt_offset ) ? (float) $gmt_offset : 0.0,
+				'timezoneString'        => is_string( $timezone_string ) ? $timezone_string : '',
+				'locale'                => str_replace( '_', '-', (string) get_locale() ),
+				// Paid-tier capability check. Drives the free-tier UX (callout /
+				// DataViews configuration) once designer input lands. Backed by
+				// `Product::get_site_features_from_wpcom()`, which caches the WPCOM
+				// `/sites/%d/features` response in a 15-second site transient. On a
+				// cache miss this issues a synchronous WPCOM request that blocks
+				// page rendering until it returns.
+				'hasVideoPressAccess'   => self::has_videopress_access(),
+				'isVideoPress1TB'       => self::has_videopress_feature( 'videopress-1tb-storage' ),
+				'isVideoPressUnlimited' => self::has_videopress_feature( 'videopress-unlimited-storage' ),
 			),
 			'assets'        => array(
 				'buildUrl' => plugins_url( '../build/', __FILE__ ),
@@ -111,7 +112,7 @@ class Initial_State {
 	}
 
 	/**
-	 * Whether the site has a paid VideoPress plan.
+	 * Whether the site has any paid VideoPress feature flag active.
 	 *
 	 * Matches the active-features check used by the existing
 	 * `videopress/v1/features` REST endpoint: any of the storage tiers
@@ -121,6 +122,18 @@ class Initial_State {
 	 * @return bool
 	 */
 	public static function has_videopress_access() {
+		return self::has_videopress_feature( 'videopress-1tb-storage' )
+			|| self::has_videopress_feature( 'videopress-unlimited-storage' )
+			|| ( ( new Host() )->is_wpcom_platform() && self::has_videopress_feature( 'videopress' ) );
+	}
+
+	/**
+	 * Whether the named feature appears in the WPCOM active-features list.
+	 *
+	 * @param string $feature_slug Feature slug as returned by WPCOM (e.g. `videopress-1tb-storage`).
+	 * @return bool
+	 */
+	private static function has_videopress_feature( $feature_slug ) {
 		$features = Product::get_site_features_from_wpcom();
 
 		if ( is_wp_error( $features ) ) {
@@ -129,9 +142,7 @@ class Initial_State {
 
 		$active = $features['active'] ?? array();
 
-		return in_array( 'videopress-1tb-storage', $active, true )
-			|| in_array( 'videopress-unlimited-storage', $active, true )
-			|| ( ( new Host() )->is_wpcom_platform() && in_array( 'videopress', $active, true ) );
+		return in_array( $feature_slug, $active, true );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-rest-controller.php
+++ b/projects/packages/videopress/src/class-rest-controller.php
@@ -108,9 +108,11 @@ class Rest_Controller {
 	 *
 	 * Forwards the whitelisted query params to WPCOM (REST v1.1, blog-signed
 	 * — matching the existing `Stats::fetch_video_plays` path) and forces
-	 * `complete_stats=true` so each day entry carries `total.views`,
-	 * `total.impressions`, and `total.watch_time` alongside the per-video
-	 * `plays[]` list the Overview's top-N cards consume.
+	 * `complete_stats=true`. In complete-stats mode, each day entry carries
+	 * `total.views`, `total.impressions`, and `total.watch_time` (in hours)
+	 * plus a per-video `data[]` array whose entries have `post_id`, `title`,
+	 * `views`, `impressions`, `watch_time` (hours), and `retention_rate`.
+	 * The `plays` field is NOT returned in complete-stats mode.
 	 *
 	 * @param WP_REST_Request $request Incoming request.
 	 * @return mixed Decoded JSON response from WPCOM, or WP_Error on failure.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -110,6 +110,19 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			);
 		}
 
+		/*
+		 * Hide local attachments that have already been uploaded to VideoPress.
+		 * Such "zombie" locals carry a `_videopress_uploaded_id` meta pointing
+		 * at their VideoPress sibling attachment; the sibling is the row the
+		 * dashboard should surface.
+		 */
+		if ( isset( $request['videopress_hide_already_uploaded'] ) ) {
+			$args['meta_query'][] = array(
+				'key'     => Uploader::UPLOADED_KEY,
+				'compare' => 'NOT EXISTS',
+			);
+		}
+
 		/* Filter using privacy setting meta key */
 		if ( isset( $request['videopress_privacy_setting'] ) ) {
 			$videopress_privacy_setting = sanitize_text_field( $request['videopress_privacy_setting'] );

--- a/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
@@ -83,6 +83,19 @@ export default function ThumbnailField( { item }: Props ) {
 				</Stack>
 			) : null }
 
+			{ upload.status === 'promoting' ? (
+				<Stack
+					direction="column"
+					gap="sm"
+					align="center"
+					justify="center"
+					className="vp-library__progress"
+				>
+					<Text>{ __( 'Uploading…', 'jetpack-videopress-pkg' ) }</Text>
+					<ProgressBar className="vp-library__progress-bar" />
+				</Stack>
+			) : null }
+
 			{ upload.status === 'failed' ? (
 				<Stack
 					direction="column"

--- a/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
@@ -21,7 +21,7 @@ type Props = { item: MockLibraryItem };
  */
 export default function ThumbnailField( { item }: Props ) {
 	const { promoteLocal, retryUpload } = useUploadActions();
-	const { type, upload, durationSeconds, id, title } = item;
+	const { type, upload, durationSeconds, id, title, isProcessing } = item;
 	const posterUrl = usePosterUrl( item );
 
 	return (
@@ -30,7 +30,18 @@ export default function ThumbnailField( { item }: Props ) {
 				<img className="vp-library__thumbnail-image" src={ posterUrl } alt={ title } />
 			) : null }
 
-			{ type === 'videopress' && upload.status === 'idle' ? (
+			{ type === 'videopress' && upload.status === 'idle' && isProcessing ? (
+				<Stack
+					direction="column"
+					align="center"
+					justify="center"
+					className="vp-library__processing"
+				>
+					<Text>{ __( 'Processing', 'jetpack-videopress-pkg' ) }</Text>
+				</Stack>
+			) : null }
+
+			{ type === 'videopress' && upload.status === 'idle' && durationSeconds > 0 ? (
 				<span className="vp-library__thumbnail-duration-badge">
 					{ formatDuration( durationSeconds ) }
 				</span>

--- a/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/ThumbnailField.tsx
@@ -1,6 +1,7 @@
 import { ProgressBar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
+import { usePosterUrl } from '../../hooks/use-poster-url';
 import { formatDuration } from '../../utils/format';
 import { useUploadActions } from './upload-actions-context';
 import type { MockLibraryItem } from '../../types/library';
@@ -20,12 +21,13 @@ type Props = { item: MockLibraryItem };
  */
 export default function ThumbnailField( { item }: Props ) {
 	const { promoteLocal, retryUpload } = useUploadActions();
-	const { type, upload, thumbnailUrl, durationSeconds, id, title } = item;
+	const { type, upload, durationSeconds, id, title } = item;
+	const posterUrl = usePosterUrl( item );
 
 	return (
 		<div className="vp-library__thumbnail">
-			{ thumbnailUrl ? (
-				<img className="vp-library__thumbnail-image" src={ thumbnailUrl } alt={ title } />
+			{ posterUrl ? (
+				<img className="vp-library__thumbnail-image" src={ posterUrl } alt={ title } />
 			) : null }
 
 			{ type === 'videopress' && upload.status === 'idle' ? (

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -22,7 +22,7 @@ const privacyLabel = ( privacy: MockLibraryItem[ 'privacy' ] ): string => {
 };
 
 const TitleCell = ( { item }: { item: MockLibraryItem } ) => {
-	const { upload, type, title } = item;
+	const { upload, type, title, isProcessing } = item;
 	let pill: { intent: BadgeIntent; label: string } | null = null;
 	if ( upload.status === 'uploading' ) {
 		pill = {
@@ -37,6 +37,11 @@ const TitleCell = ( { item }: { item: MockLibraryItem } ) => {
 		pill = {
 			intent: 'high',
 			label: __( 'Upload failed', 'jetpack-videopress-pkg' ),
+		};
+	} else if ( isProcessing ) {
+		pill = {
+			intent: 'informational',
+			label: __( 'Processing', 'jetpack-videopress-pkg' ),
 		};
 	} else if ( type === 'local' ) {
 		pill = {

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -86,7 +86,7 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 				{ item.filename }
 			</Text>
 		),
-		enableSorting: false,
+		enableSorting: true,
 	},
 	{
 		id: 'type',
@@ -114,7 +114,7 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		label: __( 'Duration', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.durationSeconds,
 		render: ( { item } ) => formatDuration( item.durationSeconds ),
-		enableSorting: true,
+		enableSorting: false,
 	},
 	{
 		id: 'privacy',
@@ -134,6 +134,6 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		label: __( 'File size', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.fileSizeBytes,
 		render: ( { item } ) => formatBytes( item.fileSizeBytes ),
-		enableSorting: true,
+		enableSorting: false,
 	},
 ];

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -33,6 +33,11 @@ const TitleCell = ( { item }: { item: MockLibraryItem } ) => {
 				Math.round( upload.progress )
 			),
 		};
+	} else if ( upload.status === 'promoting' ) {
+		pill = {
+			intent: 'informational',
+			label: __( 'Uploading…', 'jetpack-videopress-pkg' ),
+		};
 	} else if ( upload.status === 'failed' ) {
 		pill = {
 			intent: 'high',

--- a/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Library/fields.tsx
@@ -107,6 +107,11 @@ export const libraryFields: Field< MockLibraryItem >[] = [
 		type: 'datetime',
 		getValue: ( { item } ) => item.uploadDate,
 		format: { datetime: dateSettings.formats.date },
+		// /wp/v2/media exposes only `before` and `after` for date filtering;
+		// surface only the operators we can actually honour so the UI
+		// doesn't offer choices that silently no-op (on / notOn / inclusive
+		// variants / inThePast / over).
+		filterBy: { operators: [ 'before', 'after' ] as Operator[] },
 		enableSorting: true,
 	},
 	{

--- a/projects/packages/videopress/src/dashboard/components/Overview/storage-meter-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/Overview/storage-meter-card.tsx
@@ -1,37 +1,33 @@
 import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { filesize } from 'filesize';
+import { getStorageUsedBytes, useSite } from '../../hooks/use-site';
 import type { ReactElement } from 'react';
 
-const TOTAL_BYTES = 1_000_000_000_000; // 1 TB — same as legacy VideoStorageMeter.
-
-type Props = {
-	usedBytes: number;
-};
+const ONE_TB_BYTES = 1_000_000_000_000; // 1 TB — same as legacy VideoStorageMeter.
 
 /**
  * Storage meter strip rendered below the Overview's trends chart and
  * above the bottom row. Ported from the legacy `VideoStorageMeter`:
- * same string, same denominator, same percentage-of-1-TB display. The
- * caller is responsible for the hide rules (free / atomic / unlimited /
- * no uploads) — keeping that logic at the call site keeps this
- * component pure.
+ * same string, same denominator, same percentage-of-1-TB display.
  *
- * Falls back to a no-op `null` render when `usedBytes` is non-positive,
- * which gracefully handles the loading state and any future "API
- * returned 0 bytes" case.
+ * Sources storage usage internally from `useSite()` so callers no
+ * longer need to thread a `usedBytes` prop through the stats shape.
  *
- * @param props           - Component props.
- * @param props.usedBytes - Cumulative bytes used across the site's VideoPress library.
+ * Returns `null` while the site info is loading or when storage
+ * usage is zero (mirrors legacy hide logic).
+ *
  * @return The meter strip, or `null` when there's nothing to render.
  */
-export default function StorageMeterCard( { usedBytes }: Props ): ReactElement | null {
-	if ( usedBytes <= 0 ) {
+export default function StorageMeterCard(): ReactElement | null {
+	const site = useSite();
+	const usedBytes = getStorageUsedBytes( site.data );
+	if ( site.isLoading || ! usedBytes ) {
 		return null;
 	}
-	const progress = usedBytes / TOTAL_BYTES;
+	const progress = usedBytes / ONE_TB_BYTES;
 	const progressLabel = `${ ( progress * 100 ).toFixed() }%`;
-	const totalLabel = filesize( TOTAL_BYTES, { base: 10 } );
+	const totalLabel = filesize( ONE_TB_BYTES, { base: 10 } );
 	return (
 		<div className="vp-overview__storage-meter">
 			<span className="vp-overview__storage-meter-label">

--- a/projects/packages/videopress/src/dashboard/components/QueryClientWrapper/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/QueryClientWrapper/index.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const STORE_KEY = '__jetpackVideopressQueryClient' as const;
+
+declare global {
+	interface Window {
+		[ STORE_KEY ]?: QueryClient;
+	}
+}
+
+/**
+ * Returns the singleton QueryClient for the VideoPress dashboard.
+ *
+ * The client is attached to `window` so that all lazy-loaded wp-build route
+ * bundles share one cache instance across navigations.
+ *
+ * @return {QueryClient} The shared QueryClient instance.
+ */
+function getClient(): QueryClient {
+	if ( ! window[ STORE_KEY ] ) {
+		window[ STORE_KEY ] = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					staleTime: 30_000,
+					retry: 1,
+					refetchOnWindowFocus: false,
+				},
+			},
+		} );
+	}
+	return window[ STORE_KEY ];
+}
+
+const QueryClientWrapper = ( { children }: { children: ReactNode } ) => (
+	<QueryClientProvider client={ getClient() }>{ children }</QueryClientProvider>
+);
+
+export default QueryClientWrapper;
+export { getClient as getVideopressQueryClient };

--- a/projects/packages/videopress/src/dashboard/components/VideoDetails/privacy-sharing-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/VideoDetails/privacy-sharing-card.tsx
@@ -6,11 +6,11 @@ import type { ReactElement } from 'react';
 
 type Props = {
 	privacy: LibraryItemPrivacy;
-	allowSharing: boolean;
+	displayEmbed: boolean;
 	allowDownloads: boolean;
 	onChange: ( partial: {
 		privacy?: LibraryItemPrivacy;
-		allowSharing?: boolean;
+		displayEmbed?: boolean;
 		allowDownloads?: boolean;
 	} ) => void;
 };
@@ -27,14 +27,14 @@ const PRIVACY_OPTIONS: { label: string; value: LibraryItemPrivacy }[] = [
  *
  * @param props                - Component props.
  * @param props.privacy        - Current privacy value.
- * @param props.allowSharing   - Whether sharing is allowed.
+ * @param props.displayEmbed   - Whether the share menu is displayed.
  * @param props.allowDownloads - Whether downloads are allowed.
  * @param props.onChange       - Partial-update handler from the form hook.
  * @return The card element.
  */
 export default function PrivacySharingCard( {
 	privacy,
-	allowSharing,
+	displayEmbed,
 	allowDownloads,
 	onChange,
 }: Props ): ReactElement {
@@ -54,10 +54,13 @@ export default function PrivacySharingCard( {
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Allow sharing', 'jetpack-videopress-pkg' ) }
-						help={ __( 'Let viewers copy a link or embed this video.', 'jetpack-videopress-pkg' ) }
-						checked={ allowSharing }
-						onChange={ next => onChange( { allowSharing: next } ) }
+						label={ __( 'Share', 'jetpack-videopress-pkg' ) }
+						help={ __(
+							'Display share menu and allow viewers to copy a link or embed this video',
+							'jetpack-videopress-pkg'
+						) }
+						checked={ displayEmbed }
+						onChange={ next => onChange( { displayEmbed: next } ) }
 					/>
 					<ToggleControl
 						__nextHasNoMarginBottom

--- a/projects/packages/videopress/src/dashboard/components/VideoDetails/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/VideoDetails/thumbnail-card.tsx
@@ -4,6 +4,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { copy } from '@wordpress/icons';
 import { Button, Card, IconButton, InputControl, Stack, Text } from '@wordpress/ui';
+import { usePosterUrl } from '../../hooks/use-poster-url';
 import type { MockLibraryItem } from '../../types/library';
 import type { ReactElement } from 'react';
 
@@ -73,14 +74,15 @@ const CopyIconButton = ( {
  */
 export default function ThumbnailCard( { video, onAddToNewPost }: Props ): ReactElement {
 	const link = linkForVideo( video );
+	const posterUrl = usePosterUrl( video );
 
 	return (
 		<Card.Root>
 			<Card.Content>
 				<Stack direction="row" gap="md" align="start" className="vp-video-details__thumbnail-row">
-					{ video.thumbnailUrl && (
+					{ posterUrl && (
 						<img
-							src={ video.thumbnailUrl }
+							src={ posterUrl }
 							alt=""
 							width={ 240 }
 							height={ 135 }

--- a/projects/packages/videopress/src/dashboard/components/VideoDetails/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/VideoDetails/thumbnail-card.tsx
@@ -14,7 +14,10 @@ type Props = {
 
 const dateSettings = getDateSettings();
 
-const linkForVideo = ( video: MockLibraryItem ): string => `https://videopress.com/v/${ video.id }`;
+const linkForVideo = ( video: MockLibraryItem ): string => {
+	const host = video.isPrivate ? 'video.wordpress.com' : 'videopress.com';
+	return `https://${ host }/v/${ video.guid || video.id }`;
+};
 
 /**
  * Icon-only button that copies its `text` prop to the clipboard. Uses

--- a/projects/packages/videopress/src/dashboard/components/VideoDetails/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/VideoDetails/thumbnail-card.tsx
@@ -76,19 +76,30 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 	const link = linkForVideo( video );
 	const posterUrl = usePosterUrl( video );
 
+	let thumbnail: ReactElement | null = null;
+	if ( posterUrl ) {
+		thumbnail = (
+			<img
+				src={ posterUrl }
+				alt=""
+				width={ 240 }
+				height={ 135 }
+				className="vp-video-details__thumbnail"
+			/>
+		);
+	} else if ( video.isProcessing ) {
+		thumbnail = (
+			<div className="vp-video-details__thumbnail vp-video-details__thumbnail-processing">
+				<Text>{ __( 'Processing', 'jetpack-videopress-pkg' ) }</Text>
+			</div>
+		);
+	}
+
 	return (
 		<Card.Root>
 			<Card.Content>
 				<Stack direction="row" gap="md" align="start" className="vp-video-details__thumbnail-row">
-					{ posterUrl && (
-						<img
-							src={ posterUrl }
-							alt=""
-							width={ 240 }
-							height={ 135 }
-							className="vp-video-details__thumbnail"
-						/>
-					) }
+					{ thumbnail }
 					<Stack direction="column" gap="md" className="vp-video-details__thumbnail-meta">
 						<Button
 							variant="outline"

--- a/projects/packages/videopress/src/dashboard/components/VideoDetails/use-video-details-form.ts
+++ b/projects/packages/videopress/src/dashboard/components/VideoDetails/use-video-details-form.ts
@@ -7,7 +7,7 @@ const baseline = ( video: MockLibraryItem ): VideoDetailsFormValues => ( {
 	title: video.title,
 	description: video.description,
 	privacy: video.privacy,
-	allowSharing: video.allowSharing,
+	displayEmbed: video.displayEmbed,
 	allowDownloads: video.allowDownloads,
 	rating: video.rating,
 } );
@@ -16,7 +16,7 @@ const shallowEqual = ( a: VideoDetailsFormValues, b: VideoDetailsFormValues ): b
 	a.title === b.title &&
 	a.description === b.description &&
 	a.privacy === b.privacy &&
-	a.allowSharing === b.allowSharing &&
+	a.displayEmbed === b.displayEmbed &&
 	a.allowDownloads === b.allowDownloads &&
 	a.rating === b.rating;
 

--- a/projects/packages/videopress/src/dashboard/fixtures/library.ts
+++ b/projects/packages/videopress/src/dashboard/fixtures/library.ts
@@ -105,6 +105,7 @@ export function generateMockLibrary( count = 50 ): MockLibraryItem[] {
 			displayEmbed: i % 2 === 0,
 			allowDownloads: i % 3 === 0,
 			shortcode: `[videopress mock-${ i + 1 }]`,
+			isProcessing: false,
 		};
 	} );
 }

--- a/projects/packages/videopress/src/dashboard/fixtures/library.ts
+++ b/projects/packages/videopress/src/dashboard/fixtures/library.ts
@@ -89,6 +89,7 @@ export function generateMockLibrary( count = 50 ): MockLibraryItem[] {
 
 		return {
 			id: `mock-${ i + 1 }`,
+			guid: type === 'videopress' ? `mock${ i + 1 }` : '',
 			type,
 			title,
 			filename,
@@ -96,6 +97,7 @@ export function generateMockLibrary( count = 50 ): MockLibraryItem[] {
 			durationSeconds,
 			uploadDate,
 			privacy,
+			isPrivate: privacy === 'private',
 			fileSizeBytes,
 			upload: { status: 'idle', progress: 0 },
 			description: DESCRIPTIONS[ i % DESCRIPTIONS.length ],

--- a/projects/packages/videopress/src/dashboard/fixtures/library.ts
+++ b/projects/packages/videopress/src/dashboard/fixtures/library.ts
@@ -100,7 +100,7 @@ export function generateMockLibrary( count = 50 ): MockLibraryItem[] {
 			upload: { status: 'idle', progress: 0 },
 			description: DESCRIPTIONS[ i % DESCRIPTIONS.length ],
 			rating: RATINGS[ i % RATINGS.length ],
-			allowSharing: i % 2 === 0,
+			displayEmbed: i % 2 === 0,
 			allowDownloads: i % 3 === 0,
 			shortcode: `[videopress mock-${ i + 1 }]`,
 		};

--- a/projects/packages/videopress/src/dashboard/fixtures/stats.ts
+++ b/projects/packages/videopress/src/dashboard/fixtures/stats.ts
@@ -268,9 +268,5 @@ export function generateMockStats( dateRange: DateRange, granularity: Granularit
 		topVideosByWatchTime: [ ...scaledVideos ].sort(
 			( a, b ) => b.watchTimeSeconds - a.watchTimeSeconds
 		),
-		// ~42% of 1 TB — enough that the meter is visually meaningful and
-		// not so high that it implies the user is at capacity. Storage is
-		// a snapshot, so it does not vary with `dateRange` / `granularity`.
-		storageUsedBytes: 420_000_000_000,
 	};
 }

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-delete-video.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-delete-video.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useDeleteVideo } from '../use-delete-video';
+
+describe( 'useDeleteVideo', () => {
+	it( 'sends DELETE for each id', async () => {
+		const paths: string[] = [];
+		mockApiFetch( async ( { path, method } ) => {
+			if ( method === 'DELETE' ) {
+				paths.push( path ?? '' );
+				return { deleted: true };
+			}
+			throw new Error( 'unexpected' );
+		} );
+
+		const wrapper = createTestWrapper( createTestQueryClient() );
+		const { result } = renderHook( () => useDeleteVideo(), { wrapper } );
+		await act( async () => {
+			await result.current.mutateAsync( [ 1, 2, 3 ] );
+		} );
+
+		expect( paths ).toEqual( [
+			'/wp/v2/media/1?force=true',
+			'/wp/v2/media/2?force=true',
+			'/wp/v2/media/3?force=true',
+		] );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-features.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-features.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useFeatures } from '../use-features';
+
+describe( 'useFeatures', () => {
+	it( 'fetches videopress/v1/features and returns the feature flags', async () => {
+		mockApiFetch( async ( { path } ) => {
+			if ( path === '/videopress/v1/features' ) {
+				return {
+					isVideoPressSupported: true,
+					isVideoPress1TBSupported: true,
+					isVideoPressUnlimitedSupported: false,
+				};
+			}
+			throw new Error( `unexpected path: ${ path }` );
+		} );
+
+		const { result } = renderHook( () => useFeatures(), { wrapper: createTestWrapper() } );
+
+		await waitFor( () => expect( result.current.data ).toBeDefined() );
+		expect( result.current.data ).toEqual( {
+			isVideoPressSupported: true,
+			isVideoPress1TBSupported: true,
+			isVideoPressUnlimitedSupported: false,
+		} );
+	} );
+
+	it( 'surfaces errors via the error state', async () => {
+		mockApiFetch( async () => {
+			throw new Error( 'forbidden' );
+		} );
+
+		const { result } = renderHook( () => useFeatures(), { wrapper: createTestWrapper() } );
+
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier-integration.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier-integration.test.ts
@@ -1,0 +1,99 @@
+// Integration test that exercises useFreeTier *together with* a real
+// useUpload instance — not the mocked one used by use-free-tier.test.ts.
+//
+// This is the regression test for the bug where useFreeTier called
+// useUpload() in isolation and never saw the uploads kicked off by a
+// separate useUpload() instance in Library Stage. The fix moves the
+// queue to a shared window-attached store so any consumer sees the
+// same items.
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useFreeTier } from '../use-free-tier';
+import { useUpload } from '../use-upload';
+
+/**
+ * Reset the upload store between tests by clearing the window-attached
+ * queue directly, rather than going through use-upload.ts's exported
+ * helper. This keeps the test loadable against the pre-fix version of
+ * use-upload.ts so the failure mode (videoCount stuck at 0) is provably
+ * the original bug rather than a missing test helper.
+ */
+function resetUploadStore() {
+	const STORE_KEY = '__jetpackVideopressUploadStore';
+	if ( ( window as unknown as Record< string, unknown > )[ STORE_KEY ] ) {
+		( window as unknown as Record< string, { queue: unknown[] } > )[ STORE_KEY ].queue = [];
+	}
+}
+
+const mockUploadHandler = jest.fn();
+
+jest.mock( '../../../client/hooks/use-resumable-uploader', () => ( {
+	__esModule: true,
+	default: jest.fn( () => ( {
+		onUploadHandler: jest.fn(),
+		uploadHandler: mockUploadHandler,
+		resumeHandler: undefined,
+		uploadingData: { bytesSent: 0, bytesTotal: 0, percent: 0, status: 'idle' },
+		media: undefined,
+		error: null,
+	} ) ),
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWoASite: jest.fn( () => false ),
+} ) );
+
+beforeAll( () => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE = {
+		siteData: { hasVideoPressAccess: false, isVideoPressUnlimited: false },
+	};
+} );
+
+beforeEach( () => {
+	mockUploadHandler.mockClear();
+	resetUploadStore();
+} );
+
+describe( 'useFreeTier + useUpload integration', () => {
+	it( 'observes an in-flight upload kicked off by a separate useUpload instance', async () => {
+		mockApiFetch( async ( { parse } ) => {
+			if ( parse === false ) {
+				return {
+					headers: {
+						get: ( key: string ) => ( key === 'X-WP-Total' ? '0' : '0' ),
+					},
+					json: async () => [],
+				};
+			}
+			return {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: false,
+				isVideoPressUnlimitedSupported: false,
+			};
+		} );
+
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+
+		// Mount the observer first to mirror the real wiring (Overview or
+		// Library Stage renders useFreeTier alongside useUpload).
+		const { result: freeTier } = renderHook( () => useFreeTier(), { wrapper } );
+		const { result: uploader } = renderHook( () => useUpload(), { wrapper } );
+
+		// Wait until the free-tier query has settled with 0 server videos.
+		await waitFor( () => expect( freeTier.current.videoCount ).toBe( 0 ) );
+		expect( freeTier.current.isAtLimit ).toBe( false );
+
+		act( () => {
+			uploader.current.startUpload( new File( [ 'x' ], 'a.mp4', { type: 'video/mp4' } ) );
+		} );
+
+		// 0 completed (server) + 1 in-flight (shared queue) = 1; free tier
+		// limit = 1 → at limit. The observer instance sees the upload via
+		// the shared window store.
+		await waitFor( () => expect( freeTier.current.videoCount ).toBe( 1 ) );
+		expect( freeTier.current.isAtLimit ).toBe( true );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useFreeTier } from '../use-free-tier';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWoASite: jest.fn( () => false ),
+} ) );
+
+jest.mock( '../use-upload', () => ( {
+	useUpload: () => ( {
+		uploadQueue: [ { id: 'a', status: 'uploading', progress: 0.5, file: new File( [], 'a' ) } ],
+		startUpload: jest.fn(),
+		retryUpload: jest.fn(),
+	} ),
+} ) );
+
+describe( 'useFreeTier', () => {
+	beforeAll( () => {
+		( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE = {
+			siteData: { hasVideoPressAccess: false, isVideoPressUnlimited: false },
+		};
+	} );
+
+	it( 'counts completed (from totalItems) + in-flight uploads', async () => {
+		mockApiFetch( async ( { parse } ) => {
+			if ( parse === false ) {
+				return {
+					headers: {
+						get: ( key: string ) => ( key === 'X-WP-Total' ? '0' : '0' ),
+					},
+					json: async () => [],
+				};
+			}
+			// /videopress/v1/features default response
+			return {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: false,
+				isVideoPressUnlimitedSupported: false,
+			};
+		} );
+
+		const { result } = renderHook( () => useFreeTier(), { wrapper: createTestWrapper() } );
+		await waitFor( () => expect( result.current.videoCount ).toBeGreaterThanOrEqual( 1 ) );
+		// 0 completed (server total) + 1 in-flight = 1; free tier limit = 1 → at limit
+		expect( result.current.videoCount ).toBe( 1 );
+		expect( result.current.isAtLimit ).toBe( true );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
@@ -1,0 +1,105 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useLibrary, viewToQueryArgs, privacyStringToInt } from '../use-library';
+import type { View } from '@wordpress/dataviews';
+
+const DEFAULT_VIEW: View = {
+	type: 'grid',
+	page: 1,
+	perPage: 12,
+	fields: [],
+	sort: { field: 'uploadDate', direction: 'desc' },
+	filters: [],
+	search: '',
+};
+
+describe( 'privacyStringToInt', () => {
+	it( 'maps UI privacy strings to WPCOM integer codes', () => {
+		expect( privacyStringToInt( 'public' ) ).toBe( 0 );
+		expect( privacyStringToInt( 'private' ) ).toBe( 1 );
+		expect( privacyStringToInt( 'site-default' ) ).toBe( 2 );
+	} );
+} );
+
+describe( 'viewToQueryArgs', () => {
+	it( 'maps the default view to core media query args', () => {
+		expect( viewToQueryArgs( DEFAULT_VIEW ) ).toEqual( {
+			media_type: 'video',
+			mime_type: 'video/*',
+			page: 1,
+			per_page: 12,
+			orderby: 'date',
+			order: 'desc',
+		} );
+	} );
+
+	it( 'maps title sort to orderby=title', () => {
+		expect(
+			viewToQueryArgs( { ...DEFAULT_VIEW, sort: { field: 'title', direction: 'asc' } } )
+		).toMatchObject( { orderby: 'title', order: 'asc' } );
+	} );
+
+	it( 'drops unsupported sort fields (duration, fileSize) so WPCOM uses its default', () => {
+		expect(
+			viewToQueryArgs( { ...DEFAULT_VIEW, sort: { field: 'duration', direction: 'asc' } } )
+		).not.toHaveProperty( 'orderby' );
+		expect(
+			viewToQueryArgs( { ...DEFAULT_VIEW, sort: { field: 'fileSize', direction: 'asc' } } )
+		).not.toHaveProperty( 'orderby' );
+	} );
+
+	it( 'maps privacy filter to videopress_privacy_setting integer', () => {
+		expect(
+			viewToQueryArgs( {
+				...DEFAULT_VIEW,
+				filters: [ { field: 'privacy', operator: 'is', value: 'private' } ],
+			} )
+		).toMatchObject( { videopress_privacy_setting: '1' } );
+	} );
+
+	it( 'maps search to the search param', () => {
+		expect( viewToQueryArgs( { ...DEFAULT_VIEW, search: 'foo' } ) ).toMatchObject( {
+			search: 'foo',
+		} );
+	} );
+} );
+
+describe( 'useLibrary', () => {
+	it( 'returns items and paginationInfo derived from response headers', async () => {
+		const body = JSON.stringify( [
+			{
+				id: 42,
+				title: { rendered: 'Test video' },
+				source_url: 'https://example.com/v.mp4',
+				media_details: { length: 120, filesize: 12_345_678 },
+				date: '2026-05-15T10:00:00',
+				jetpack_videopress: {
+					guid: 'abc',
+					rating: 'G',
+					display_embed: 1,
+					allow_download: 0,
+					privacy_setting: 0,
+				},
+			},
+		] );
+		const responseHeaders: Record< string, string > = {
+			'X-WP-Total': '1',
+			'X-WP-TotalPages': '1',
+			'Content-Type': 'application/json',
+		};
+		mockApiFetch( async () => ( {
+			headers: { get: ( name: string ) => responseHeaders[ name ] ?? null },
+			json: async () => JSON.parse( body ),
+		} ) );
+
+		const { result } = renderHook( () => useLibrary( DEFAULT_VIEW ), {
+			wrapper: createTestWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current.items.length ).toBeGreaterThan( 0 ) );
+		expect( result.current.items[ 0 ].title ).toBe( 'Test video' );
+		expect( result.current.paginationInfo.totalItems ).toBe( 1 );
+		expect( result.current.paginationInfo.totalPages ).toBe( 1 );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
@@ -31,6 +31,7 @@ describe( 'viewToQueryArgs', () => {
 			per_page: 12,
 			orderby: 'date',
 			order: 'desc',
+			videopress_hide_already_uploaded: 1,
 		} );
 	} );
 

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-settings.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-settings.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useSettings, useUpdateSettings } from '../use-settings';
+
+describe( 'useSettings', () => {
+	it( 'fetches videopress/v1/settings', async () => {
+		mockApiFetch( async ( { path } ) => {
+			if ( path === '/videopress/v1/settings' ) {
+				return {
+					videopress_videos_private_for_site: true,
+					site_is_private: false,
+					site_type: 'jetpack',
+				};
+			}
+			throw new Error( `unexpected path: ${ path }` );
+		} );
+
+		const { result } = renderHook( () => useSettings(), { wrapper: createTestWrapper() } );
+		await waitFor( () => expect( result.current.data ).toBeDefined() );
+		expect( result.current.data?.videoPressVideosPrivateForSite ).toBe( true );
+		expect( result.current.data?.siteIsPrivate ).toBe( false );
+	} );
+} );
+
+describe( 'useUpdateSettings', () => {
+	it( 'POSTs videopress_videos_private_for_site and optimistically updates the cache', async () => {
+		const calls: { path?: string; method?: string; data?: unknown }[] = [];
+		// Track server state so the refetch after onSettled returns the updated value.
+		let serverValue = false;
+		mockApiFetch( async ( { path, method, data } ) => {
+			calls.push( { path, method, data } );
+			if ( method === 'POST' ) {
+				serverValue = ( data as Record< string, unknown > )
+					?.videopress_videos_private_for_site as boolean;
+				return { code: 'success', message: 'ok', data: 200 };
+			}
+			return {
+				videopress_videos_private_for_site: serverValue,
+				site_is_private: false,
+				site_type: 'jetpack',
+			};
+		} );
+
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+		const { result: settingsResult } = renderHook( () => useSettings(), { wrapper } );
+		await waitFor( () => expect( settingsResult.current.data ).toBeDefined() );
+
+		const { result: mutationResult } = renderHook( () => useUpdateSettings(), { wrapper } );
+		await act( async () => {
+			await mutationResult.current.mutateAsync( { videoPressVideosPrivateForSite: true } );
+		} );
+
+		const postCall = calls.find( c => c.method === 'POST' );
+		expect( postCall?.data ).toEqual( { videopress_videos_private_for_site: true } );
+		await waitFor( () =>
+			expect( settingsResult.current.data?.videoPressVideosPrivateForSite ).toBe( true )
+		);
+	} );
+
+	it( 'rolls back on error', async () => {
+		mockApiFetch( async ( { method } ) => {
+			if ( method === 'POST' ) {
+				throw new Error( 'fail' );
+			}
+			return {
+				videopress_videos_private_for_site: false,
+				site_is_private: false,
+				site_type: 'jetpack',
+			};
+		} );
+
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+		const { result: settingsResult } = renderHook( () => useSettings(), { wrapper } );
+		await waitFor( () => expect( settingsResult.current.data ).toBeDefined() );
+
+		const { result: mutationResult } = renderHook( () => useUpdateSettings(), { wrapper } );
+		await act( async () => {
+			try {
+				await mutationResult.current.mutateAsync( { videoPressVideosPrivateForSite: true } );
+			} catch {
+				// expected — POST throws to simulate a server error
+			}
+		} );
+
+		await waitFor( () =>
+			expect( settingsResult.current.data?.videoPressVideosPrivateForSite ).toBe( false )
+		);
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-site.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-site.test.ts
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useSite, getStorageUsedBytes } from '../use-site';
+
+describe( 'useSite', () => {
+	it( 'fetches videopress/v1/site', async () => {
+		mockApiFetch( async ( { path } ) => {
+			if ( path === '/videopress/v1/site' ) {
+				return { options: { videopress_storage_used: 250, is_wpcom_atomic: false } };
+			}
+			throw new Error( `unexpected path: ${ path }` );
+		} );
+
+		const { result } = renderHook( () => useSite(), { wrapper: createTestWrapper() } );
+
+		await waitFor( () => expect( result.current.data ).toBeDefined() );
+		expect( result.current.data?.options?.videopress_storage_used ).toBe( 250 );
+	} );
+} );
+
+describe( 'getStorageUsedBytes', () => {
+	it( 'converts decimal megabytes to bytes (× 1_000_000)', () => {
+		expect( getStorageUsedBytes( { options: { videopress_storage_used: 250 } } ) ).toBe(
+			250_000_000
+		);
+	} );
+
+	it( 'returns 0 when the field is missing', () => {
+		expect( getStorageUsedBytes( undefined ) ).toBe( 0 );
+		expect( getStorageUsedBytes( { options: {} } ) ).toBe( 0 );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-stats.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-stats.test.ts
@@ -1,0 +1,51 @@
+import { transformVideoPlays } from '../use-stats';
+
+describe( 'transformVideoPlays', () => {
+	it( 'converts watch_time from hours (WPCOM unit) to seconds in totals', () => {
+		const current = {
+			days: {
+				'2026-05-15': { total: { views: 10, impressions: 20, watch_time: 2 } },
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.watchTimeSeconds.current ).toBe( 2 * 3600 );
+	} );
+
+	it( 'converts per-video watch_time from hours to seconds in top lists', () => {
+		const current = {
+			days: {
+				'2026-05-15': {
+					data: [ { post_id: 1, title: 'A', views: 5, watch_time: 0.5 } ],
+				},
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideosByWatchTime[ 0 ].watchTimeSeconds ).toBe( 1800 );
+	} );
+
+	it( 'does not surface a plays field on top videos', () => {
+		const current = {
+			days: {
+				'2026-05-15': {
+					data: [ { post_id: 1, title: 'A', views: 7, watch_time: 1 } ],
+				},
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideos[ 0 ] ).not.toHaveProperty( 'plays' );
+		expect( result.topVideos[ 0 ].views ).toBe( 7 );
+	} );
+
+	it( 'treats missing per-video fields as zero (no plays fallback)', () => {
+		const current = {
+			days: {
+				'2026-05-15': {
+					data: [ { post_id: 1, title: 'A' } ],
+				},
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideos[ 0 ].views ).toBe( 0 );
+		expect( result.topVideosByWatchTime[ 0 ].watchTimeSeconds ).toBe( 0 );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-meta.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-meta.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useUpdateVideoMeta, patchToApi } from '../use-update-video-meta';
+
+describe( 'patchToApi', () => {
+	it( 'maps UI fields to wpcom/v2/videopress/meta shape', () => {
+		expect(
+			patchToApi( {
+				title: 'New',
+				description: 'd',
+				rating: 'PG-13',
+				privacy: 'private',
+				displayEmbed: true,
+				allowDownloads: false,
+			} )
+		).toEqual( {
+			title: 'New',
+			description: 'd',
+			rating: 'PG-13',
+			privacy_setting: 1,
+			display_embed: true,
+			allow_download: false,
+		} );
+	} );
+
+	it( 'omits keys not in the patch', () => {
+		expect( patchToApi( { title: 'Only' } ) ).toEqual( { title: 'Only' } );
+	} );
+} );
+
+describe( 'useUpdateVideoMeta', () => {
+	it( 'POSTs to wpcom/v2/videopress/meta with id and the converted patch', async () => {
+		let capturedData: unknown;
+		mockApiFetch( async ( { path, method, data } ) => {
+			if ( path === '/wpcom/v2/videopress/meta' && method === 'POST' ) {
+				capturedData = data;
+				return { code: 'success', message: 'ok', data: 200 };
+			}
+			throw new Error( `unexpected: ${ path } ${ method }` );
+		} );
+
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+		const { result } = renderHook( () => useUpdateVideoMeta(), { wrapper } );
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: 42,
+				patch: { title: 'X', displayEmbed: true },
+			} );
+		} );
+
+		expect( capturedData ).toEqual( { id: 42, title: 'X', display_embed: true } );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -1,0 +1,93 @@
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { uploadFromLibrary } from '../use-upload-from-library';
+
+describe( 'uploadFromLibrary', () => {
+	it( 'returns guid + mediaId immediately when the first response is complete', async () => {
+		mockApiFetch( async () => ( {
+			status: 'complete',
+			uploaded_details: { guid: 'g', media_id: 42 },
+		} ) );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).resolves.toEqual( {
+			guid: 'g',
+			mediaId: 42,
+		} );
+	} );
+
+	it( 'recognises the "uploaded" terminal status (zombie row safety net)', async () => {
+		mockApiFetch( async () => ( {
+			status: 'uploaded',
+			uploaded_video_guid: 'zg',
+			uploaded_post_id: 7,
+		} ) );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).resolves.toEqual( {
+			guid: 'zg',
+			mediaId: 7,
+		} );
+	} );
+
+	it( 'polls through new/uploading until complete', async () => {
+		const responses = [
+			{ status: 'new' as const },
+			{ status: 'uploading' as const },
+			{
+				status: 'complete' as const,
+				uploaded_details: { guid: 'g', media_id: 9 },
+			},
+		];
+		let i = 0;
+		mockApiFetch( async () => responses[ i++ ] );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).resolves.toEqual( {
+			guid: 'g',
+			mediaId: 9,
+		} );
+		expect( i ).toBe( 3 );
+	} );
+
+	it( 'throws after exceeding the max poll attempts', async () => {
+		mockApiFetch( async () => ( { status: 'uploading' } ) );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0, maxAttempts: 3 } ) ).rejects.toThrow(
+			/timed out/i
+		);
+	} );
+
+	it( 'tolerates a transient apiFetch failure and keeps polling', async () => {
+		let calls = 0;
+		mockApiFetch( async () => {
+			calls += 1;
+			if ( calls === 1 ) {
+				throw new Error( 'network blip' );
+			}
+			return {
+				status: 'complete',
+				uploaded_details: { guid: 'g', media_id: 1 },
+			};
+		} );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).resolves.toEqual( {
+			guid: 'g',
+			mediaId: 1,
+		} );
+		expect( calls ).toBe( 2 );
+	} );
+
+	it( 'gives up after consecutive transient failures exceed maxAttempts', async () => {
+		mockApiFetch( async () => {
+			throw new Error( 'down' );
+		} );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0, maxAttempts: 3 } ) ).rejects.toThrow();
+	} );
+
+	it( 'rethrows the explicit error status from the endpoint', async () => {
+		mockApiFetch( async () => ( {
+			status: 'error',
+			error: '403: Invalid Mime',
+		} ) );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).rejects.toThrow( '403: Invalid Mime' );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload.test.ts
@@ -2,29 +2,41 @@
 // { onUploadHandler, uploadHandler, resumeHandler, uploadingData, media, error }
 //
 // We only expose uploadHandler (and a minimal resumeHandler stub) because
-// those are the only members used by the adapter.
+// those are the only members used by the adapter. The most recent set of
+// callbacks passed to useResumableUploader is captured in `lastCallbacks`
+// so individual tests can simulate progress / success / error.
 
 import { renderHook, act } from '@testing-library/react';
-import { createTestWrapper } from '../../test-utils/query-client-wrapper';
-import { useUpload } from '../use-upload';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useUpload, __resetUploadStoreForTests } from '../use-upload';
 
 const mockUploadHandler = jest.fn();
+let lastCallbacks: {
+	onProgress?: ( bytesSent: number, bytesTotal: number ) => void;
+	onSuccess?: ( data?: unknown ) => void;
+	onError?: ( err: unknown ) => void;
+};
 
 jest.mock( '../../../client/hooks/use-resumable-uploader', () => ( {
 	__esModule: true,
-	default: jest.fn( () => ( {
-		onUploadHandler: jest.fn(),
-		uploadHandler: mockUploadHandler,
-		resumeHandler: undefined,
-		uploadingData: { bytesSent: 0, bytesTotal: 0, percent: 0, status: 'idle' },
-		media: undefined,
-		error: null,
-	} ) ),
+	default: jest.fn( options => {
+		lastCallbacks = options;
+		return {
+			onUploadHandler: jest.fn(),
+			uploadHandler: mockUploadHandler,
+			resumeHandler: undefined,
+			uploadingData: { bytesSent: 0, bytesTotal: 0, percent: 0, status: 'idle' },
+			media: undefined,
+			error: null,
+		};
+	} ),
 } ) );
 
 describe( 'useUpload', () => {
 	beforeEach( () => {
 		mockUploadHandler.mockClear();
+		lastCallbacks = {};
+		__resetUploadStoreForTests();
 	} );
 
 	it( 'exposes an empty queue initially', () => {
@@ -60,12 +72,15 @@ describe( 'useUpload', () => {
 		expect( mockUploadHandler ).toHaveBeenCalledWith( file );
 	} );
 
-	it( 'retryUpload re-delegates to the legacy uploadHandler', () => {
+	it( 'retryUpload re-delegates to the legacy uploadHandler after a failure', () => {
 		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
 		const file = new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } );
 		let id: string | undefined;
 		act( () => {
 			id = result.current.startUpload( file );
+		} );
+		act( () => {
+			lastCallbacks.onError?.( new Error( 'boom' ) );
 		} );
 		mockUploadHandler.mockClear();
 		act( () => {
@@ -82,5 +97,94 @@ describe( 'useUpload', () => {
 			result.current.retryUpload( 'upload-does-not-exist' );
 		} );
 		expect( mockUploadHandler ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shares the upload queue across separate useUpload instances backed by the same QueryClient', () => {
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+		const { result: producer } = renderHook( () => useUpload(), { wrapper } );
+		const { result: observer } = renderHook( () => useUpload(), { wrapper } );
+
+		expect( observer.current.uploadQueue ).toEqual( [] );
+
+		act( () => {
+			producer.current.startUpload( new File( [ 'x' ], 'shared.mp4', { type: 'video/mp4' } ) );
+		} );
+
+		expect( producer.current.uploadQueue ).toHaveLength( 1 );
+		expect( observer.current.uploadQueue ).toHaveLength( 1 );
+		expect( observer.current.uploadQueue[ 0 ].file.name ).toBe( 'shared.mp4' );
+	} );
+
+	it( 'queues a second startUpload behind the active one instead of overwriting it', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		const file1 = new File( [ 'x' ], 'a.mp4', { type: 'video/mp4' } );
+		const file2 = new File( [ 'y' ], 'b.mp4', { type: 'video/mp4' } );
+
+		act( () => {
+			result.current.startUpload( file1 );
+			result.current.startUpload( file2 );
+		} );
+
+		// Only the first dispatches to the legacy uploader; the second waits its turn.
+		expect( mockUploadHandler ).toHaveBeenCalledTimes( 1 );
+		expect( mockUploadHandler ).toHaveBeenLastCalledWith( file1 );
+		expect( result.current.uploadQueue.map( u => u.file.name ) ).toEqual( [ 'a.mp4', 'b.mp4' ] );
+	} );
+
+	it( 'dispatches the next queued upload after the active one succeeds', () => {
+		jest.useFakeTimers();
+		try {
+			const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+			const file1 = new File( [ 'x' ], 'a.mp4', { type: 'video/mp4' } );
+			const file2 = new File( [ 'y' ], 'b.mp4', { type: 'video/mp4' } );
+
+			act( () => {
+				result.current.startUpload( file1 );
+				result.current.startUpload( file2 );
+			} );
+
+			// Before success fires, only file1 has been handed to the legacy uploader.
+			expect( mockUploadHandler ).toHaveBeenCalledTimes( 1 );
+			expect( mockUploadHandler ).toHaveBeenLastCalledWith( file1 );
+
+			// Simulate the legacy uploader finishing the first upload.
+			act( () => {
+				lastCallbacks.onSuccess?.();
+			} );
+
+			// Removing the success'd item is debounced by 2s; flush timers
+			// so the success-removal + next-dispatch both run.
+			act( () => {
+				jest.runOnlyPendingTimers();
+			} );
+
+			expect( mockUploadHandler ).toHaveBeenCalledTimes( 2 );
+			expect( mockUploadHandler ).toHaveBeenLastCalledWith( file2 );
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'dispatches the next queued upload after the active one fails', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		const file1 = new File( [ 'x' ], 'a.mp4', { type: 'video/mp4' } );
+		const file2 = new File( [ 'y' ], 'b.mp4', { type: 'video/mp4' } );
+
+		act( () => {
+			result.current.startUpload( file1 );
+			result.current.startUpload( file2 );
+		} );
+		expect( mockUploadHandler ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			lastCallbacks.onError?.( new Error( 'boom' ) );
+		} );
+
+		// A failed upload stays in the queue (so the user can retry it),
+		// but the next pending upload should be picked up immediately.
+		expect( mockUploadHandler ).toHaveBeenCalledTimes( 2 );
+		expect( mockUploadHandler ).toHaveBeenLastCalledWith( file2 );
+		expect( result.current.uploadQueue[ 0 ].status ).toBe( 'failed' );
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload.test.ts
@@ -1,0 +1,86 @@
+// The mock shape mirrors the actual useResumableUploader return value:
+// { onUploadHandler, uploadHandler, resumeHandler, uploadingData, media, error }
+//
+// We only expose uploadHandler (and a minimal resumeHandler stub) because
+// those are the only members used by the adapter.
+
+import { renderHook, act } from '@testing-library/react';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useUpload } from '../use-upload';
+
+const mockUploadHandler = jest.fn();
+
+jest.mock( '../../../client/hooks/use-resumable-uploader', () => ( {
+	__esModule: true,
+	default: jest.fn( () => ( {
+		onUploadHandler: jest.fn(),
+		uploadHandler: mockUploadHandler,
+		resumeHandler: undefined,
+		uploadingData: { bytesSent: 0, bytesTotal: 0, percent: 0, status: 'idle' },
+		media: undefined,
+		error: null,
+	} ) ),
+} ) );
+
+describe( 'useUpload', () => {
+	beforeEach( () => {
+		mockUploadHandler.mockClear();
+	} );
+
+	it( 'exposes an empty queue initially', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		expect( result.current.uploadQueue ).toEqual( [] );
+	} );
+
+	it( 'adds an item to the queue when startUpload is called', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		act( () => {
+			result.current.startUpload( new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } ) );
+		} );
+		expect( result.current.uploadQueue ).toHaveLength( 1 );
+		expect( result.current.uploadQueue[ 0 ].status ).toBe( 'pending' );
+	} );
+
+	it( 'returns a string id from startUpload', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		let id: string | undefined;
+		act( () => {
+			id = result.current.startUpload( new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } ) );
+		} );
+		expect( typeof id ).toBe( 'string' );
+		expect( id ).toMatch( /^upload-/ );
+	} );
+
+	it( 'delegates to the legacy uploadHandler with the file', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		const file = new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } );
+		act( () => {
+			result.current.startUpload( file );
+		} );
+		expect( mockUploadHandler ).toHaveBeenCalledWith( file );
+	} );
+
+	it( 'retryUpload re-delegates to the legacy uploadHandler', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		const file = new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } );
+		let id: string | undefined;
+		act( () => {
+			id = result.current.startUpload( file );
+		} );
+		mockUploadHandler.mockClear();
+		act( () => {
+			result.current.retryUpload( id! );
+		} );
+		expect( mockUploadHandler ).toHaveBeenCalledWith( file );
+		expect( result.current.uploadQueue[ 0 ].status ).toBe( 'pending' );
+		expect( result.current.uploadQueue[ 0 ].progress ).toBe( 0 );
+	} );
+
+	it( 'retryUpload is a no-op for an unknown id', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		act( () => {
+			result.current.retryUpload( 'upload-does-not-exist' );
+		} );
+		expect( mockUploadHandler ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-video.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-video.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useVideo } from '../use-video';
+
+describe( 'useVideo', () => {
+	it( 'fetches /wp/v2/media/{id} and maps to LibraryItem', async () => {
+		mockApiFetch( async ( { path } ) => {
+			if ( path === '/wp/v2/media/42' ) {
+				return {
+					id: 42,
+					title: { rendered: 'V' },
+					source_url: 'https://example.com/v.mp4',
+					media_details: { length: 60, filesize: 1000 },
+					jetpack_videopress: {
+						guid: 'g',
+						rating: 'G',
+						display_embed: 1,
+						allow_download: 0,
+						privacy_setting: 1,
+					},
+				};
+			}
+			throw new Error( `unexpected path: ${ path }` );
+		} );
+
+		const { result } = renderHook( () => useVideo( 42 ), { wrapper: createTestWrapper() } );
+
+		await waitFor( () => expect( result.current.video ).toBeDefined() );
+		expect( result.current.video?.title ).toBe( 'V' );
+		expect( result.current.video?.privacy ).toBe( 'private' );
+		expect( result.current.video?.displayEmbed ).toBe( true );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/use-delete-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-delete-video.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { LIBRARY_QUERY_KEY } from './use-library';
+
+type Id = number | string;
+
+/**
+ * Return a mutation that permanently deletes one or more videos via DELETE /wp/v2/media/{id}?force=true
+ * and invalidates the library cache on success.
+ *
+ * @return A TanStack Query mutation object whose mutateAsync accepts a single id or an array of ids.
+ */
+export function useDeleteVideo() {
+	const client = useQueryClient();
+	return useMutation< void, Error, Id | Id[] >( {
+		mutationFn: async input => {
+			const ids = Array.isArray( input ) ? input : [ input ];
+			for ( const id of ids ) {
+				await apiFetch( {
+					path: `/wp/v2/media/${ id }?force=true`,
+					method: 'DELETE',
+				} );
+			}
+		},
+		onSuccess: () => {
+			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+		},
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-features.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-features.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+
+export type Features = {
+	isVideoPressSupported: boolean;
+	isVideoPress1TBSupported: boolean;
+	isVideoPressUnlimitedSupported: boolean;
+};
+
+const QUERY_KEY = [ 'jetpack-videopress-features' ] as const;
+
+/**
+ * Fetch the VideoPress feature flags from the REST API.
+ *
+ * @return TanStack Query result containing the Features payload.
+ */
+export function useFeatures() {
+	return useQuery< Features >( {
+		queryKey: QUERY_KEY,
+		queryFn: () => apiFetch< Features >( { path: '/videopress/v1/features' } ),
+		staleTime: 5 * 60_000,
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -1,4 +1,8 @@
-import { useMockLibrary } from './use-mock-library';
+import { isWoASite } from '@automattic/jetpack-script-data';
+import { useFeatures } from './use-features';
+import { useLibrary } from './use-library';
+import { useUpload } from './use-upload';
+import type { View } from '@wordpress/dataviews';
 
 export type FreeTierState = {
 	isFree: boolean;
@@ -11,6 +15,18 @@ export type FreeTierState = {
 
 const FREE_TIER_UPLOAD_LIMIT = 1;
 
+// Minimal View used only to read totalItems from the listing query.
+// `perPage: 1` keeps the payload tiny.
+const COUNT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 1,
+	fields: [],
+	filters: [],
+	search: '',
+	sort: { field: 'date', direction: 'desc' },
+};
+
 type Override = boolean | null;
 
 /**
@@ -20,8 +36,7 @@ type Override = boolean | null;
  *
  * Designer/QA toggles are read once on first call and frozen. They are
  * deliberately non-reactive because they require a full page reload to
- * change in practice; this keeps the swap to a TanStack Query hook
- * (Phase 6/8) a no-op at the call sites.
+ * change in practice.
  *
  * @param search - The query string (with or without leading `?`).
  * @param key    - Param name to read.
@@ -45,47 +60,41 @@ const FREE_OVERRIDE: Override = parseOverride( SEARCH, 'vp_free' );
 const AT_LIMIT_OVERRIDE: Override = parseOverride( SEARCH, 'vp_at_limit' );
 
 /**
- * Read `hasVideoPressAccess` from the inlined initial state. Returns
- * `false` (i.e., free tier) when the global is missing — matches the
- * legacy dashboard's behavior of treating unknown plan state as "no
- * paid access".
+ * Free-tier state derived from real data sources: server-side library
+ * count via useLibrary, in-flight uploads via useUpload, plan-tier flags
+ * via useFeatures + Initial State, and atomic via script-data.
  *
- * @return Whether the site has a paid VideoPress plan.
- */
-function readHasAccess(): boolean {
-	if ( typeof JPVIDEOPRESS_INITIAL_STATE === 'undefined' ) {
-		return false;
-	}
-	return Boolean( JPVIDEOPRESS_INITIAL_STATE?.siteData?.hasVideoPressAccess );
-}
-
-/**
- * Single source of truth for free-tier state across the modernized
- * VideoPress dashboard. Returns the same shape Phase 6/8 will return
- * from a TanStack Query hook — call sites swap mock for real with no
- * structural change.
- *
- * The legacy `VideoStorageMeter` hides on Atomic and unlimited plans;
- * those signals aren't wired through the modernized initial-state
- * payload yet, so this PR hard-codes them to `false`. Phase 6 replaces
- * those hard-codes with the corresponding settings/features hooks.
- *
- * @return Free-tier state for the page session.
+ * @return Free-tier state.
  */
 export function useFreeTier(): FreeTierState {
-	const { items } = useMockLibrary();
-	const isFree = FREE_OVERRIDE !== null ? FREE_OVERRIDE : ! readHasAccess();
-	// Mock-library items are all "completed", so `items.length` matches
-	// the legacy `uploadedVideoCount` semantics here. The Phase 6/8 swap
-	// must filter the real query result to completed uploads (exclude
-	// in-progress and failed) before assigning to `videoCount`.
-	const realVideoCount = items.length;
+	const { paginationInfo } = useLibrary( COUNT_VIEW );
+	const { uploadQueue } = useUpload();
+	const features = useFeatures();
+	const siteData =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+			? JPVIDEOPRESS_INITIAL_STATE?.siteData
+			: undefined;
+
+	const isFree = FREE_OVERRIDE !== null ? FREE_OVERRIDE : ! siteData?.hasVideoPressAccess;
+
+	const completed = paginationInfo?.totalItems ?? 0;
+	const inFlight = uploadQueue.filter(
+		u => u.status === 'uploading' || u.status === 'pending'
+	).length;
+	const realVideoCount = completed + inFlight;
 	const videoCount = AT_LIMIT_OVERRIDE === true ? FREE_TIER_UPLOAD_LIMIT : realVideoCount;
+
+	const isAtomic = isWoASite();
+	const isUnlimited = Boolean(
+		siteData?.isVideoPressUnlimited || features.data?.isVideoPressUnlimitedSupported
+	);
+
 	const isAtLimit = isFree && videoCount >= FREE_TIER_UPLOAD_LIMIT;
+
 	return {
 		isFree,
-		isAtomic: false,
-		isUnlimited: false,
+		isAtomic,
+		isUnlimited,
 		videoCount,
 		limit: FREE_TIER_UPLOAD_LIMIT,
 		isAtLimit,

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -19,7 +19,7 @@ type ApiMediaItem = {
 		filesize?: number;
 		width?: number;
 		height?: number;
-		videopress?: { duration?: number; poster?: string };
+		videopress?: { duration?: number; poster?: string; finished?: boolean };
 	};
 	jetpack_videopress?: {
 		guid?: string;
@@ -124,13 +124,16 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 	const vpDurationMs = raw.media_details?.videopress?.duration;
 	const durationSeconds =
 		vpDurationMs !== undefined ? Math.floor( vpDurationMs / 1000 ) : raw.media_details?.length ?? 0;
+	const poster = raw.media_details?.videopress?.poster;
+	const finished = raw.media_details?.videopress?.finished;
+	const isProcessing = isVideoPress && ( ! poster || finished === false );
 	return {
 		id: String( raw.id ),
 		guid: vp?.guid ?? '',
 		type: isVideoPress ? 'videopress' : 'local',
 		title: raw.title?.rendered ?? raw.slug ?? '',
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
-		thumbnailUrl: raw.media_details?.videopress?.poster ?? null,
+		thumbnailUrl: poster ?? null,
 		durationSeconds,
 		uploadDate: raw.date ?? '',
 		privacy: privacyIntToString( vp?.privacy_setting ),
@@ -143,6 +146,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		allowDownloads: Boolean( vp?.allow_download ),
 		shortcode: buildShortcode( vp?.guid, raw.media_details?.width, raw.media_details?.height ),
 		sourceUrl: raw.source_url,
+		isProcessing,
 	};
 }
 
@@ -180,6 +184,12 @@ export function useLibrary( view: View ) {
 		queryKey: [ 'jetpack-videopress-library', viewToQueryArgs( view ) ],
 		queryFn: () => fetchLibrary( view ),
 		placeholderData: keepPreviousData,
+		// While any item on the current page is still being processed
+		// by the VideoPress backend (no poster yet / finished=false),
+		// re-fetch every 2s so the placeholder is replaced as soon as
+		// the data is ready. React-query pauses this when the tab is
+		// hidden, so it's cheap.
+		refetchInterval: q => ( q.state.data?.items.some( item => item.isProcessing ) ? 2000 : false ),
 	} );
 
 	return {

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -35,7 +35,16 @@ type ApiMediaItem = {
 
 type PaginationInfo = { totalItems: number; totalPages: number };
 
-const SUPPORTED_ORDERBY = new Set( [ 'title', 'date' ] );
+const SUPPORTED_ORDERBY = new Set( [ 'title', 'date', 'slug' ] );
+
+// DataViews field id → /wp/v2/media `orderby` value. Fields not in
+// this map are forwarded as-is and filtered by SUPPORTED_ORDERBY.
+// Attachment slugs are auto-generated from the upload filename, so
+// orderby=slug approximates a filename sort.
+const SORT_FIELD_MAP: Record< string, string > = {
+	uploadDate: 'date',
+	filename: 'slug',
+};
 
 const PRIVACY_TO_INT: Record< LibraryItemPrivacy, 0 | 1 | 2 > = {
 	public: 0,
@@ -86,7 +95,8 @@ export function viewToQueryArgs( view: View ): Record< string, string | number >
 		per_page: view.perPage ?? 12,
 	};
 
-	const sortField = view.sort?.field === 'uploadDate' ? 'date' : view.sort?.field;
+	const rawSortField = view.sort?.field;
+	const sortField = rawSortField ? SORT_FIELD_MAP[ rawSortField ] ?? rawSortField : undefined;
 	if ( sortField && SUPPORTED_ORDERBY.has( sortField ) ) {
 		args.orderby = sortField;
 		args.order = view.sort?.direction ?? 'desc';

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -1,6 +1,7 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { buildShortcode } from '../utils/format';
 import type { LibraryItemPrivacy, MockLibraryItem } from '../types/library';
 import type { View } from '@wordpress/dataviews';
 
@@ -13,13 +14,20 @@ type ApiMediaItem = {
 	source_url?: string;
 	date?: string;
 	mime_type?: string;
-	media_details?: { length?: number; filesize?: number };
+	media_details?: {
+		length?: number;
+		filesize?: number;
+		width?: number;
+		height?: number;
+		videopress?: { duration?: number };
+	};
 	jetpack_videopress?: {
 		guid?: string;
 		rating?: string;
 		display_embed?: 0 | 1 | boolean;
 		allow_download?: 0 | 1 | boolean;
 		privacy_setting?: 0 | 1 | 2;
+		is_private?: boolean;
 		description?: string;
 		caption?: string;
 		poster?: string;
@@ -114,22 +122,27 @@ export function viewToQueryArgs( view: View ): Record< string, string | number >
 function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 	const vp = raw.jetpack_videopress;
 	const isVideoPress = Boolean( vp?.guid );
+	const vpDurationMs = raw.media_details?.videopress?.duration;
+	const durationSeconds =
+		vpDurationMs !== undefined ? Math.floor( vpDurationMs / 1000 ) : raw.media_details?.length ?? 0;
 	return {
 		id: String( raw.id ),
+		guid: vp?.guid ?? '',
 		type: isVideoPress ? 'videopress' : 'local',
 		title: raw.title?.rendered ?? raw.slug ?? '',
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
 		thumbnailUrl: vp?.poster ?? null,
-		durationSeconds: raw.media_details?.length ?? 0,
+		durationSeconds,
 		uploadDate: raw.date ?? '',
 		privacy: privacyIntToString( vp?.privacy_setting ),
+		isPrivate: Boolean( vp?.is_private ),
 		fileSizeBytes: raw.media_details?.filesize ?? 0,
 		upload: { status: 'idle', progress: 0 },
 		description: vp?.description ?? '',
 		rating: ( vp?.rating ?? 'G' ) as MockLibraryItem[ 'rating' ],
 		displayEmbed: Boolean( vp?.display_embed ),
 		allowDownloads: Boolean( vp?.allow_download ),
-		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
+		shortcode: buildShortcode( vp?.guid, raw.media_details?.width, raw.media_details?.height ),
 		sourceUrl: raw.source_url,
 	};
 }

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -93,6 +93,11 @@ export function viewToQueryArgs( view: View ): Record< string, string | number >
 		mime_type: 'video/*',
 		page: view.page ?? 1,
 		per_page: view.perPage ?? 12,
+		// Always hide local attachments that already have a VideoPress
+		// sibling (they carry the `_videopress_uploaded_id` post-meta).
+		// The sibling is the row we want to surface; the original local
+		// is a leftover that would let users try to re-upload it.
+		videopress_hide_already_uploaded: 1,
 	};
 
 	const rawSortField = view.sort?.field;

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -19,7 +19,7 @@ type ApiMediaItem = {
 		filesize?: number;
 		width?: number;
 		height?: number;
-		videopress?: { duration?: number };
+		videopress?: { duration?: number; poster?: string };
 	};
 	jetpack_videopress?: {
 		guid?: string;
@@ -30,7 +30,6 @@ type ApiMediaItem = {
 		is_private?: boolean;
 		description?: string;
 		caption?: string;
-		poster?: string;
 	};
 };
 
@@ -131,7 +130,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		type: isVideoPress ? 'videopress' : 'local',
 		title: raw.title?.rendered ?? raw.slug ?? '',
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
-		thumbnailUrl: vp?.poster ?? null,
+		thumbnailUrl: raw.media_details?.videopress?.poster ?? null,
 		durationSeconds,
 		uploadDate: raw.date ?? '',
 		privacy: privacyIntToString( vp?.privacy_setting ),

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -127,7 +127,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		upload: { status: 'idle', progress: 0 },
 		description: vp?.description ?? '',
 		rating: ( vp?.rating ?? 'G' ) as MockLibraryItem[ 'rating' ],
-		allowSharing: Boolean( vp?.display_embed ),
+		displayEmbed: Boolean( vp?.display_embed ),
 		allowDownloads: Boolean( vp?.allow_download ),
 		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
 	};

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -130,6 +130,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		displayEmbed: Boolean( vp?.display_embed ),
 		allowDownloads: Boolean( vp?.allow_download ),
 		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
+		sourceUrl: raw.source_url,
 	};
 }
 

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -1,0 +1,182 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import type { LibraryItemPrivacy, MockLibraryItem } from '../types/library';
+import type { View } from '@wordpress/dataviews';
+
+const REST_PATH = '/wp/v2/media';
+
+type ApiMediaItem = {
+	id: number;
+	title?: { rendered?: string };
+	slug?: string;
+	source_url?: string;
+	date?: string;
+	mime_type?: string;
+	media_details?: { length?: number; filesize?: number };
+	jetpack_videopress?: {
+		guid?: string;
+		rating?: string;
+		display_embed?: 0 | 1 | boolean;
+		allow_download?: 0 | 1 | boolean;
+		privacy_setting?: 0 | 1 | 2;
+		description?: string;
+		caption?: string;
+		poster?: string;
+	};
+};
+
+type PaginationInfo = { totalItems: number; totalPages: number };
+
+const SUPPORTED_ORDERBY = new Set( [ 'title', 'date' ] );
+
+const PRIVACY_TO_INT: Record< LibraryItemPrivacy, 0 | 1 | 2 > = {
+	public: 0,
+	private: 1,
+	'site-default': 2,
+};
+
+const PRIVACY_FROM_INT: Record< 0 | 1 | 2, LibraryItemPrivacy > = {
+	0: 'public',
+	1: 'private',
+	2: 'site-default',
+};
+
+/**
+ * Map a UI privacy string to its WPCOM integer code.
+ *
+ * @param value - The UI privacy string ('public' | 'private' | 'site-default').
+ * @return The corresponding WPCOM integer (0 | 1 | 2).
+ */
+export function privacyStringToInt( value: LibraryItemPrivacy ): 0 | 1 | 2 {
+	return PRIVACY_TO_INT[ value ];
+}
+
+/**
+ * Map a WPCOM privacy integer to its UI string representation.
+ *
+ * @param value - The WPCOM integer code (0 | 1 | 2 | undefined).
+ * @return The corresponding UI privacy string.
+ */
+export function privacyIntToString( value: 0 | 1 | 2 | undefined ): LibraryItemPrivacy {
+	if ( value === undefined ) {
+		return 'site-default';
+	}
+	return PRIVACY_FROM_INT[ value ] ?? 'site-default';
+}
+
+/**
+ * Convert a DataViews View into REST API query arguments for /wp/v2/media.
+ *
+ * @param view - The current DataViews view state (sort, filters, pagination, search).
+ * @return A plain object of query args suitable for addQueryArgs.
+ */
+export function viewToQueryArgs( view: View ): Record< string, string | number > {
+	const args: Record< string, string | number > = {
+		media_type: 'video',
+		mime_type: 'video/*',
+		page: view.page ?? 1,
+		per_page: view.perPage ?? 12,
+	};
+
+	const sortField = view.sort?.field === 'uploadDate' ? 'date' : view.sort?.field;
+	if ( sortField && SUPPORTED_ORDERBY.has( sortField ) ) {
+		args.orderby = sortField;
+		args.order = view.sort?.direction ?? 'desc';
+	}
+
+	const search = view.search?.trim();
+	if ( search ) {
+		args.search = search;
+	}
+
+	for ( const filter of view.filters ?? [] ) {
+		if ( filter.value === undefined || filter.value === null || filter.value === 'all' ) {
+			continue;
+		}
+		if ( filter.field === 'privacy' ) {
+			args.videopress_privacy_setting = String(
+				privacyStringToInt( filter.value as LibraryItemPrivacy )
+			);
+		}
+		// `type` filter (local vs videopress) is a client-side partition.
+	}
+
+	return args;
+}
+
+/**
+ * Transform a raw /wp/v2/media API item into a MockLibraryItem.
+ *
+ * @param raw - The raw media item from the REST API response.
+ * @return A normalized MockLibraryItem for the VideoPress library UI.
+ */
+function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
+	const vp = raw.jetpack_videopress;
+	const isVideoPress = Boolean( vp?.guid );
+	return {
+		id: String( raw.id ),
+		type: isVideoPress ? 'videopress' : 'local',
+		title: raw.title?.rendered ?? raw.slug ?? '',
+		filename: raw.source_url?.split( '/' ).pop() ?? '',
+		thumbnailUrl: vp?.poster ?? null,
+		durationSeconds: raw.media_details?.length ?? 0,
+		uploadDate: raw.date ?? '',
+		privacy: privacyIntToString( vp?.privacy_setting ),
+		fileSizeBytes: raw.media_details?.filesize ?? 0,
+		upload: { status: 'idle', progress: 0 },
+		description: vp?.description ?? '',
+		rating: ( vp?.rating ?? 'G' ) as MockLibraryItem[ 'rating' ],
+		allowSharing: Boolean( vp?.display_embed ),
+		allowDownloads: Boolean( vp?.allow_download ),
+		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
+	};
+}
+
+/**
+ * Fetch a page of VideoPress media items from the REST API.
+ *
+ * @param view - The current DataViews view (sort, filters, search, pagination).
+ * @return Items array and pagination metadata derived from response headers.
+ */
+async function fetchLibrary(
+	view: View
+): Promise< { items: MockLibraryItem[]; paginationInfo: PaginationInfo } > {
+	const args = viewToQueryArgs( view );
+	const response = ( await apiFetch( {
+		path: addQueryArgs( REST_PATH, args ),
+		parse: false,
+	} ) ) as Response;
+	const totalItems = Number( response.headers.get( 'X-WP-Total' ) ?? 0 );
+	const totalPages = Number( response.headers.get( 'X-WP-TotalPages' ) ?? 0 );
+	const raw = ( await response.json() ) as ApiMediaItem[];
+	return {
+		items: raw.map( toLibraryItem ),
+		paginationInfo: { totalItems, totalPages },
+	};
+}
+
+/**
+ * Fetch and cache the VideoPress media library from /wp/v2/media.
+ *
+ * @param view - The current DataViews view (sort, filters, search, pagination).
+ * @return Items, loading/error state, pagination info, and a refetch callback.
+ */
+export function useLibrary( view: View ) {
+	const query = useQuery( {
+		queryKey: [ 'jetpack-videopress-library', viewToQueryArgs( view ) ],
+		queryFn: () => fetchLibrary( view ),
+		placeholderData: keepPreviousData,
+	} );
+
+	return {
+		items: query.data?.items ?? [],
+		isLoading: query.isLoading,
+		paginationInfo: query.data?.paginationInfo ?? { totalItems: 0, totalPages: 0 },
+		isError: query.isError,
+		error: query.error,
+		refetch: query.refetch,
+	};
+}
+
+export const LIBRARY_QUERY_KEY = 'jetpack-videopress-library' as const;

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -115,8 +115,34 @@ export function viewToQueryArgs( view: View ): Record< string, string | number >
 			args.videopress_privacy_setting = String(
 				privacyStringToInt( filter.value as LibraryItemPrivacy )
 			);
+		} else if ( filter.field === 'type' ) {
+			// `videopress`: narrow the mime filter to video/videopress and
+			// drop media_type — empirically, setting both broadens the
+			// query and returns non-videopress items too.
+			// `local`: keep the default video filter and add the
+			// no_videopress flag handled by the package's PHP
+			// rest_attachment_query filter.
+			if ( filter.value === 'videopress' ) {
+				delete args.media_type;
+				args.mime_type = 'video/videopress';
+			} else if ( filter.value === 'local' ) {
+				args.no_videopress = 1;
+			}
+		} else if ( filter.field === 'uploadDate' ) {
+			// DataViews emits the value from <input type=datetime-local>
+			// as a local-time string; convert to UTC ISO8601 for the WP
+			// REST API. Only `before` and `after` are supported here
+			// (matching the field's filterBy.operators allowlist).
+			const parsed = new Date( filter.value as string );
+			if ( ! Number.isNaN( parsed.getTime() ) ) {
+				const iso = parsed.toISOString();
+				if ( filter.operator === 'before' ) {
+					args.before = iso;
+				} else if ( filter.operator === 'after' ) {
+					args.after = iso;
+				}
+			}
 		}
-		// `type` filter (local vs videopress) is a client-side partition.
 	}
 
 	return args;

--- a/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
@@ -231,6 +231,7 @@ const startUpload = ( file: StartUploadInput ): void => {
 	const id = `upload-${ Date.now() }-${ Math.random().toString( 36 ).slice( 2, 7 ) }`;
 	const item: MockLibraryItem = {
 		id,
+		guid: '',
 		type: 'local',
 		title: name.replace( /\.[^.]+$/, '' ) || 'Untitled',
 		filename: name,
@@ -238,6 +239,7 @@ const startUpload = ( file: StartUploadInput ): void => {
 		durationSeconds: 0,
 		uploadDate: new Date().toISOString(),
 		privacy: 'site-default',
+		isPrivate: false,
 		fileSizeBytes: sizeBytes,
 		upload: { status: 'uploading', progress: 0 },
 		description: '',

--- a/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
@@ -242,7 +242,7 @@ const startUpload = ( file: StartUploadInput ): void => {
 		upload: { status: 'uploading', progress: 0 },
 		description: '',
 		rating: 'G',
-		allowSharing: false,
+		displayEmbed: false,
 		allowDownloads: false,
 		shortcode: `[videopress ${ id }]`,
 	};

--- a/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-mock-library.ts
@@ -247,6 +247,7 @@ const startUpload = ( file: StartUploadInput ): void => {
 		displayEmbed: false,
 		allowDownloads: false,
 		shortcode: `[videopress ${ id }]`,
+		isProcessing: false,
 	};
 	dispatch( { type: 'prepend', item } );
 	runUpload( id, true );

--- a/projects/packages/videopress/src/dashboard/hooks/use-poster-url.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-poster-url.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import type { MockLibraryItem } from '../types/library';
+
+const PLAYBACK_JWT_PATH = '/wpcom/v2/videopress/playback-jwt';
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+
+type PlaybackJwtResponse = { playback_token?: string };
+
+/**
+ * Fetch a short-lived playback JWT for a VideoPress GUID. The token is
+ * required to access poster (and stream) URLs of private videos and is
+ * appended as `?metadata_token=<jwt>` to those URLs.
+ *
+ * The query is keyed by guid alone so concurrent renders of the same
+ * private video (e.g. multiple rows of the same library) share one
+ * request, and the token is cached for ~24h to match the JWT lifetime.
+ *
+ * @param guid    - VideoPress GUID, or '' for non-VideoPress items.
+ * @param enabled - Skip the request when false (e.g. for public videos).
+ * @return The token (or undefined while loading / disabled).
+ */
+export function usePlaybackToken( guid: string, enabled: boolean ): string | undefined {
+	const query = useQuery( {
+		queryKey: [ 'videopress-playback-token', guid ],
+		queryFn: async () => {
+			const res = await apiFetch< PlaybackJwtResponse >( {
+				path: `${ PLAYBACK_JWT_PATH }/${ guid }`,
+				method: 'POST',
+			} );
+			return res.playback_token ?? '';
+		},
+		enabled: enabled && Boolean( guid ),
+		staleTime: ONE_DAY_MS,
+		gcTime: ONE_DAY_MS,
+	} );
+	return query.data;
+}
+
+/**
+ * Resolve a video's poster URL, signing it with a playback JWT when the
+ * video is private. Returns null while the token is still in flight so
+ * the caller can render nothing rather than a broken image.
+ *
+ * @param video - The library item whose poster URL is needed.
+ * @return The poster URL ready to use as an <img> src, or null.
+ */
+export function usePosterUrl( video: MockLibraryItem ): string | null {
+	const { thumbnailUrl, isPrivate, guid } = video;
+	const token = usePlaybackToken( guid, isPrivate );
+
+	if ( ! thumbnailUrl || ( isPrivate && ! token ) ) {
+		return null;
+	}
+	return isPrivate ? `${ thumbnailUrl }?metadata_token=${ token }` : thumbnailUrl;
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-settings.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-settings.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+
+type ApiSettings = {
+	videopress_videos_private_for_site: boolean;
+	site_is_private: boolean;
+	site_type: string;
+};
+
+export type Settings = {
+	videoPressVideosPrivateForSite: boolean;
+	siteIsPrivate: boolean;
+	siteType: string;
+};
+
+export type SettingsPatch = Partial< Pick< Settings, 'videoPressVideosPrivateForSite' > >;
+
+const QUERY_KEY = [ 'jetpack-videopress-settings' ] as const;
+
+/**
+ * Convert a raw REST API settings object to the camelCase shape used in JS.
+ *
+ * @param raw - The snake_case settings object returned by the REST API.
+ * @return The camelCase Settings object used throughout the dashboard.
+ */
+function fromApi( raw: ApiSettings ): Settings {
+	return {
+		videoPressVideosPrivateForSite: raw.videopress_videos_private_for_site,
+		siteIsPrivate: raw.site_is_private,
+		siteType: raw.site_type,
+	};
+}
+
+/**
+ * Fetch the VideoPress site settings from the REST API.
+ *
+ * @return TanStack Query result containing the Settings object.
+ */
+export function useSettings() {
+	return useQuery< Settings >( {
+		queryKey: QUERY_KEY,
+		queryFn: async () => {
+			const raw = await apiFetch< ApiSettings >( { path: '/videopress/v1/settings' } );
+			return fromApi( raw );
+		},
+		staleTime: 5 * 60_000,
+	} );
+}
+
+/**
+ * Return a mutation for updating VideoPress site settings with optimistic updates.
+ * On success the cache is updated immediately; on error the previous value is restored.
+ *
+ * @return TanStack Mutation object for updating Settings.
+ */
+export function useUpdateSettings() {
+	const client = useQueryClient();
+	return useMutation< void, Error, SettingsPatch, { previous?: Settings } >( {
+		mutationFn: async patch => {
+			if ( patch.videoPressVideosPrivateForSite === undefined ) {
+				return;
+			}
+			await apiFetch( {
+				path: '/videopress/v1/settings',
+				method: 'POST',
+				data: { videopress_videos_private_for_site: patch.videoPressVideosPrivateForSite },
+			} );
+		},
+		onMutate: async patch => {
+			await client.cancelQueries( { queryKey: QUERY_KEY } );
+			const previous = client.getQueryData< Settings >( QUERY_KEY );
+			if ( previous ) {
+				client.setQueryData< Settings >( QUERY_KEY, { ...previous, ...patch } );
+			}
+			return { previous };
+		},
+		onError: ( _err, _patch, context ) => {
+			if ( context?.previous ) {
+				client.setQueryData( QUERY_KEY, context.previous );
+			}
+		},
+		onSettled: () => {
+			client.invalidateQueries( { queryKey: QUERY_KEY } );
+		},
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-site.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-site.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+
+export type SiteInfo = {
+	options?: {
+		videopress_storage_used?: number; // decimal megabytes
+		is_wpcom_atomic?: boolean;
+		[ key: string ]: unknown;
+	};
+	[ key: string ]: unknown;
+};
+
+const QUERY_KEY = [ 'jetpack-videopress-site' ] as const;
+
+/**
+ * Fetch the VideoPress site info from the REST API.
+ *
+ * @return TanStack Query result containing the SiteInfo payload.
+ */
+export function useSite() {
+	return useQuery< SiteInfo >( {
+		queryKey: QUERY_KEY,
+		queryFn: () => apiFetch< SiteInfo >( { path: '/videopress/v1/site' } ),
+		staleTime: 5 * 60_000,
+	} );
+}
+
+/**
+ * Extract storage usage in bytes from the site payload. WPCOM reports
+ * `options.videopress_storage_used` in decimal megabytes (matches legacy
+ * conversion at `src/client/state/resolvers.js:273`).
+ *
+ * @param site - The site info payload, or undefined when still loading.
+ * @return Storage used in bytes (0 when the field is missing).
+ */
+export function getStorageUsedBytes( site: SiteInfo | undefined ): number {
+	const mb = site?.options?.videopress_storage_used;
+	if ( typeof mb !== 'number' ) {
+		return 0;
+	}
+	return Math.round( mb * 1_000_000 );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
@@ -16,16 +16,17 @@ import type {
 
 // Raw WPCOM `sites/{id}/stats/video-plays?complete_stats=true` shape.
 // Each day carries a per-period `total` ({ views, impressions,
-// watch_time }) and a per-video `data[]` array. Per-video watch_time
-// / views fields are best-effort: confirmed empty for sites with no
-// traffic but undocumented for sites with plays — the transformer
-// falls back to the per-video plays count when they're absent.
+// watch_time in hours }) and a per-video `data[]` array. Per-video
+// entries have `post_id`, `title`, `views`, `impressions`,
+// `watch_time` (hours), and `retention_rate`. `plays` is NOT
+// returned in complete-stats mode.
 type VideoPlayEntry = {
 	post_id?: number | string;
 	title?: string;
-	plays?: number;
 	views?: number;
+	impressions?: number;
 	watch_time?: number;
+	retention_rate?: number;
 };
 
 type DayEntry = {
@@ -116,8 +117,8 @@ function computeWindows( rangeDays: number ): {
 /**
  * TanStack Query options for one `stats/video-plays` window. Server-side
  * forces `complete_stats=true`, so each day entry carries
- * `total.{views,impressions,watch_time}` and a per-video `plays[]`
- * list.
+ * `total.{views,impressions,watch_time}` (watch_time in hours) and a
+ * per-video `data[]` array. The `plays` field is not present.
  *
  * @param params - Window parameters.
  * @return queryOptions ready to pass to `useQuery` / `useQueries`.
@@ -179,13 +180,9 @@ function sumTotal(
 
 /**
  * Aggregate per-video metrics across every day in the response, keyed
- * by `post_id` (falling back to `title` when WPCOM omits the id).
- *
- * Per-video `views` / `watch_time` are not consistently documented for
- * `stats/video-plays?complete_stats=true`; when they're absent we fall
- * back to using the per-video `plays` count for both. That keeps the
- * Top-by-watch-time card from breaking before Phase 8 confirms the
- * shape against a real paid site.
+ * by `post_id` (falling back to `title` when WPCOM omits the id). Hours
+ * → seconds conversion happens at the boundary so consumers see
+ * `watchTimeSeconds` accurately.
  *
  * @param response - One `stats/video-plays` response, or undefined.
  * @return Map keyed by stable per-video key → cumulative metrics.
@@ -204,9 +201,10 @@ function aggregateTopVideos( response: VideoPlaysResponse | undefined ): Map< st
 			if ( ! id ) {
 				continue;
 			}
-			const plays = entry.plays ?? 0;
-			const views = entry.views ?? plays;
-			const watch = entry.watch_time ?? plays;
+			const views = entry.views ?? 0;
+			// WPCOM returns watch_time in hours; convert at boundary so the
+			// downstream `watchTimeSeconds` name stays accurate.
+			const watch = ( entry.watch_time ?? 0 ) * 3600;
 			const existing = acc.get( id );
 			if ( existing ) {
 				existing.views += views;
@@ -288,7 +286,7 @@ function bucketDays(
 		const existing = buckets.get( key );
 		const views = day.total?.views ?? 0;
 		const impressions = day.total?.impressions ?? 0;
-		const watchTime = day.total?.watch_time ?? 0;
+		const watchTime = ( day.total?.watch_time ?? 0 ) * 3600;
 		if ( existing ) {
 			existing.views += views;
 			existing.impressions += impressions;
@@ -332,8 +330,8 @@ export function transformVideoPlays(
 			previousPeriod: sumTotal( previous, 'impressions' ),
 		},
 		watchTimeSeconds: {
-			current: sumTotal( current, 'watch_time' ),
-			previousPeriod: sumTotal( previous, 'watch_time' ),
+			current: sumTotal( current, 'watch_time' ) * 3600,
+			previousPeriod: sumTotal( previous, 'watch_time' ) * 3600,
 		},
 		series: buildSeries( current, previous, granularity ),
 		topVideos: [ ...topVideos ].sort( ( a, b ) => b.views - a.views ).slice( 0, TOP_VIDEOS_LIMIT ),

--- a/projects/packages/videopress/src/dashboard/hooks/use-update-video-meta.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-update-video-meta.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { privacyStringToInt, LIBRARY_QUERY_KEY } from './use-library';
+import type { VideoDetailsPatch } from '../types/library';
+
+type ApiPatch = {
+	title?: string;
+	description?: string;
+	caption?: string;
+	rating?: string;
+	display_embed?: boolean;
+	allow_download?: boolean;
+	privacy_setting?: 0 | 1 | 2;
+};
+
+/**
+ * Convert a UI VideoDetailsPatch to the shape expected by the wpcom/v2/videopress/meta endpoint.
+ *
+ * @param patch - The partial UI-layer patch object with camelCase field names.
+ * @return A plain object with snake_case API field names, omitting undefined keys.
+ */
+export function patchToApi( patch: Partial< VideoDetailsPatch > ): ApiPatch {
+	const out: ApiPatch = {};
+	if ( patch.title !== undefined ) {
+		out.title = patch.title;
+	}
+	if ( patch.description !== undefined ) {
+		out.description = patch.description;
+	}
+	if ( patch.rating !== undefined ) {
+		out.rating = patch.rating;
+	}
+	if ( patch.privacy !== undefined ) {
+		out.privacy_setting = privacyStringToInt( patch.privacy );
+	}
+	if ( patch.displayEmbed !== undefined ) {
+		out.display_embed = patch.displayEmbed;
+	}
+	if ( patch.allowDownloads !== undefined ) {
+		out.allow_download = patch.allowDownloads;
+	}
+	return out;
+}
+
+/**
+ * Return a mutation that POSTs video meta updates to wpcom/v2/videopress/meta and
+ * invalidates the library cache on success.
+ *
+ * @return A TanStack Query mutation object with a mutateAsync method.
+ */
+export function useUpdateVideoMeta() {
+	const client = useQueryClient();
+	return useMutation< void, Error, { id: number | string; patch: Partial< VideoDetailsPatch > } >( {
+		mutationFn: async ( { id, patch } ) => {
+			await apiFetch( {
+				path: '/wpcom/v2/videopress/meta',
+				method: 'POST',
+				data: { id: Number( id ), ...patchToApi( patch ) },
+			} );
+		},
+		onSuccess: ( _data, { id } ) => {
+			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+			client.invalidateQueries( {
+				queryKey: [ LIBRARY_QUERY_KEY, 'item', String( id ) ],
+			} );
+		},
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { LIBRARY_QUERY_KEY } from './use-library';
+
+type UploadStatusResponse = {
+	status: 'new' | 'resume' | 'uploading' | 'complete' | 'uploaded' | 'error';
+	error?: string;
+	uploaded_details?: {
+		guid: string;
+		media_id: number;
+		upload_src?: string;
+	};
+	// Returned for the `uploaded` (already-on-VideoPress) terminal status.
+	uploaded_post_id?: number | string;
+	uploaded_video_guid?: string;
+};
+
+export type UploadFromLibraryResult = {
+	guid: string;
+	mediaId: number;
+};
+
+/**
+ * Recursively POST to `/videopress/v1/upload/{id}` until the endpoint
+ * settles on `complete` or `error`. Each call is the pacing mechanism
+ * — the server uploads one chunk per request and returns immediately
+ * with an in-progress status when more work remains. Matches the
+ * legacy `uploadFromLibrary()` semantics exactly.
+ *
+ * @param attachmentId - The numeric or string WordPress attachment ID.
+ * @return The new VideoPress GUID and media post ID.
+ */
+async function uploadFromLibrary(
+	attachmentId: string | number
+): Promise< UploadFromLibraryResult > {
+	const result = await apiFetch< UploadStatusResponse >( {
+		path: `/videopress/v1/upload/${ attachmentId }`,
+		method: 'POST',
+	} );
+	if ( result.status === 'complete' && result.uploaded_details ) {
+		return {
+			guid: result.uploaded_details.guid,
+			mediaId: result.uploaded_details.media_id,
+		};
+	}
+	// `uploaded` means the attachment had already been promoted to
+	// VideoPress in a prior session. The library filter
+	// (`videopress_hide_already_uploaded`) normally hides those rows;
+	// this branch is a safety net for any zombie that slips through.
+	if ( result.status === 'uploaded' && result.uploaded_video_guid ) {
+		return {
+			guid: result.uploaded_video_guid,
+			mediaId: Number( result.uploaded_post_id ),
+		};
+	}
+	if ( result.status === 'new' || result.status === 'resume' || result.status === 'uploading' ) {
+		return uploadFromLibrary( attachmentId );
+	}
+	throw new Error( result.error ?? 'Unexpected upload status.' );
+}
+
+/**
+ * Promote an existing local WordPress media attachment to a
+ * VideoPress-hosted video by walking the chunked upload endpoint.
+ * On success the library query is invalidated so the new VideoPress
+ * item appears (in processing state, which the library's existing
+ * 2s polling then resolves once the backend finishes transcoding).
+ *
+ * @return A react-query mutation.
+ */
+export function useUploadFromLibrary() {
+	const client = useQueryClient();
+	return useMutation< UploadFromLibraryResult, Error, string | number >( {
+		mutationFn: uploadFromLibrary,
+		onSuccess: () => {
+			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+		},
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
@@ -20,43 +20,91 @@ export type UploadFromLibraryResult = {
 	mediaId: number;
 };
 
+export type UploadFromLibraryOptions = {
+	/** Delay (ms) between polls and between transient-error retries. */
+	delayMs?: number;
+	/** Maximum total attempts before giving up. */
+	maxAttempts?: number;
+};
+
+const DEFAULT_DELAY_MS = 500;
+const DEFAULT_MAX_ATTEMPTS = 120; // ~1 minute at 500ms cadence.
+
+const sleep = ( ms: number ): Promise< void > =>
+	new Promise( resolve => {
+		if ( ms <= 0 ) {
+			resolve();
+			return;
+		}
+		setTimeout( resolve, ms );
+	} );
+
 /**
- * Recursively POST to `/videopress/v1/upload/{id}` until the endpoint
- * settles on `complete` or `error`. Each call is the pacing mechanism
- * — the server uploads one chunk per request and returns immediately
- * with an in-progress status when more work remains. Matches the
- * legacy `uploadFromLibrary()` semantics exactly.
+ * Walk the `/videopress/v1/upload/{id}` endpoint until it settles on a
+ * terminal status (`complete`, `uploaded`, `error`) or `maxAttempts` is
+ * reached. Each in-progress response (`new` / `resume` / `uploading`)
+ * triggers another POST after `delayMs`. Transient apiFetch failures are
+ * also retried, counting against the same attempt budget. Matches the
+ * legacy `uploadFromLibrary()` semantics but adds a cap so a stuck
+ * backend can't lock the client in a tight loop.
  *
  * @param attachmentId - The numeric or string WordPress attachment ID.
+ * @param options      - Optional polling cadence and retry cap.
  * @return The new VideoPress GUID and media post ID.
  */
-async function uploadFromLibrary(
-	attachmentId: string | number
+export async function uploadFromLibrary(
+	attachmentId: string | number,
+	options: UploadFromLibraryOptions = {}
 ): Promise< UploadFromLibraryResult > {
-	const result = await apiFetch< UploadStatusResponse >( {
-		path: `/videopress/v1/upload/${ attachmentId }`,
-		method: 'POST',
-	} );
-	if ( result.status === 'complete' && result.uploaded_details ) {
-		return {
-			guid: result.uploaded_details.guid,
-			mediaId: result.uploaded_details.media_id,
-		};
+	const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+	const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+	const path = `/videopress/v1/upload/${ attachmentId }`;
+
+	let lastError: unknown;
+
+	for ( let attempt = 0; attempt < maxAttempts; attempt += 1 ) {
+		if ( attempt > 0 ) {
+			await sleep( delayMs );
+		}
+
+		let result: UploadStatusResponse;
+		try {
+			result = await apiFetch< UploadStatusResponse >( { path, method: 'POST' } );
+		} catch ( err ) {
+			// Transient apiFetch failure — count against the attempt
+			// budget and try again on the next iteration.
+			lastError = err;
+			continue;
+		}
+
+		if ( result.status === 'complete' && result.uploaded_details ) {
+			return {
+				guid: result.uploaded_details.guid,
+				mediaId: result.uploaded_details.media_id,
+			};
+		}
+		// `uploaded` means the attachment had already been promoted to
+		// VideoPress in a prior session. The library filter
+		// (`videopress_hide_already_uploaded`) normally hides those rows;
+		// this branch is a safety net for any zombie that slips through.
+		if ( result.status === 'uploaded' && result.uploaded_video_guid ) {
+			return {
+				guid: result.uploaded_video_guid,
+				mediaId: Number( result.uploaded_post_id ),
+			};
+		}
+		if ( result.status === 'new' || result.status === 'resume' || result.status === 'uploading' ) {
+			// Keep polling.
+			continue;
+		}
+
+		throw new Error( result.error ?? 'Unexpected upload status.' );
 	}
-	// `uploaded` means the attachment had already been promoted to
-	// VideoPress in a prior session. The library filter
-	// (`videopress_hide_already_uploaded`) normally hides those rows;
-	// this branch is a safety net for any zombie that slips through.
-	if ( result.status === 'uploaded' && result.uploaded_video_guid ) {
-		return {
-			guid: result.uploaded_video_guid,
-			mediaId: Number( result.uploaded_post_id ),
-		};
+
+	if ( lastError instanceof Error ) {
+		throw lastError;
 	}
-	if ( result.status === 'new' || result.status === 'resume' || result.status === 'uploading' ) {
-		return uploadFromLibrary( attachmentId );
-	}
-	throw new Error( result.error ?? 'Unexpected upload status.' );
+	throw new Error( 'Upload from library timed out.' );
 }
 
 /**
@@ -71,7 +119,7 @@ async function uploadFromLibrary(
 export function useUploadFromLibrary() {
 	const client = useQueryClient();
 	return useMutation< UploadFromLibraryResult, Error, string | number >( {
-		mutationFn: uploadFromLibrary,
+		mutationFn: id => uploadFromLibrary( id ),
 		onSuccess: () => {
 			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
 		},

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload.ts
@@ -1,0 +1,151 @@
+// Adapter: wraps the legacy single-file resumable (tus) uploader from
+// `../../client/hooks/use-resumable-uploader` and exposes a multi-item queue
+// suitable for the modernised VideoPress dashboard.
+//
+// Legacy hook shape (as of reading use-resumable-uploader/index.ts):
+//   useResumableUploader({ onProgress, onSuccess, onError })
+//     onProgress( bytesSent: number, bytesTotal: number ) — raw bytes, no id
+//     onSuccess( data: VideoMediaProps )                  — media object, no id
+//     onError( err )                                      — error value, no id
+//   returns { uploadHandler( file ), resumeHandler: { start, abort } | undefined, … }
+//
+// The legacy hook is designed around one active upload at a time.  It manages
+// its own internal state (uploadingData, media, error) and exposes a tus
+// `resumeHandler` that is set asynchronously after the first uploadHandler call.
+//
+// Adapter strategy:
+//   - We call useResumableUploader once per useUpload instance.
+//   - A `currentIdRef` ref tracks which queue item is "active" so the
+//     callback bodies can route progress / success / error updates correctly.
+//   - `startUpload` sets currentIdRef then calls uploadHandler(file).
+//   - `retryUpload` resets the item's status and calls uploadHandler again;
+//     tus automatically resumes from its stored fingerprint when available.
+//     (The legacy resumeHandler.start() path is not used here because it
+//     operates on the *same* upload object created in the previous call, which
+//     may be gone after a page interaction — calling uploadHandler afresh is
+//     safer and still benefits from tus fingerprint resumption.)
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef, useState } from '@wordpress/element';
+import useResumableUploader from '../../client/hooks/use-resumable-uploader';
+import { LIBRARY_QUERY_KEY } from './use-library';
+
+export type UploadStatus = 'pending' | 'uploading' | 'success' | 'failed';
+
+export type UploadItem = {
+	id: string;
+	file: File;
+	progress: number; // 0..1
+	status: UploadStatus;
+	error?: string;
+};
+
+/**
+ * Generate a unique id for a new upload queue item.
+ *
+ * @param file - The file being uploaded.
+ * @return A unique string id prefixed with "upload-".
+ */
+function makeId( file: File ): string {
+	return `upload-${ Date.now() }-${ Math.random().toString( 36 ).slice( 2, 7 ) }-${ file.name }`;
+}
+
+/**
+ * Wrap the legacy resumable (tus) uploader in a multi-item upload queue.
+ *
+ * @return An object with the current upload queue and handlers to start or retry uploads.
+ */
+export function useUpload() {
+	const client = useQueryClient();
+	const [ queue, setQueue ] = useState< UploadItem[] >( [] );
+
+	// Tracks which queue item is currently active inside the legacy hook's
+	// single-upload state machine.  Using a ref avoids stale-closure issues
+	// inside the callbacks passed to useResumableUploader.
+	const currentIdRef = useRef< string | null >( null );
+
+	const patch = useCallback( ( id: string, next: Partial< UploadItem > ) => {
+		setQueue( prev => prev.map( item => ( item.id === id ? { ...item, ...next } : item ) ) );
+	}, [] );
+
+	const remove = useCallback( ( id: string ) => {
+		setQueue( prev => prev.filter( item => item.id !== id ) );
+	}, [] );
+
+	// Adapter callbacks — translate the legacy (bytesSent, bytesTotal) /
+	// (data: VideoMediaProps) / (err) signatures to our queue-item updates.
+	const { uploadHandler } = useResumableUploader( {
+		onProgress: ( bytesSent: number, bytesTotal: number ) => {
+			const id = currentIdRef.current;
+			if ( ! id ) {
+				return;
+			}
+			const progress = bytesTotal > 0 ? bytesSent / bytesTotal : 0;
+			patch( id, { progress, status: 'uploading' } );
+		},
+		onSuccess: () => {
+			const id = currentIdRef.current;
+			if ( ! id ) {
+				return;
+			}
+			patch( id, { progress: 1, status: 'success' } );
+			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+			window.setTimeout( () => {
+				remove( id );
+				// Clear the ref only after the removal timeout so that any
+				// late-arriving callbacks still resolve to the right item.
+				if ( currentIdRef.current === id ) {
+					currentIdRef.current = null;
+				}
+			}, 2_000 );
+		},
+		onError: ( err: unknown ) => {
+			const id = currentIdRef.current;
+			if ( ! id ) {
+				return;
+			}
+			let message = 'Upload failed';
+			if ( err instanceof Error ) {
+				message = err.message;
+			} else if ( typeof err === 'string' ) {
+				message = err;
+			}
+			patch( id, { status: 'failed', error: message } );
+			currentIdRef.current = null;
+		},
+	} );
+
+	const startUpload = useCallback(
+		( file: File ): string => {
+			const id = makeId( file );
+			currentIdRef.current = id;
+			setQueue( prev => [ ...prev, { id, file, progress: 0, status: 'pending' } ] );
+			// uploadHandler is async (fetches a JWT before starting tus) but we
+			// don't await it here — progress flows via the callbacks above.
+			uploadHandler( file );
+			return id;
+		},
+		[ uploadHandler ]
+	);
+
+	const retryUpload = useCallback(
+		( id: string ) => {
+			const item = queue.find( q => q.id === id );
+			if ( ! item ) {
+				return;
+			}
+			currentIdRef.current = id;
+			patch( id, { status: 'pending', progress: 0, error: undefined } );
+			// Re-invoke uploadHandler; tus will find the stored fingerprint and
+			// resume from where the previous attempt left off.
+			uploadHandler( item.file );
+		},
+		[ queue, patch, uploadHandler ]
+	);
+
+	return {
+		uploadQueue: queue,
+		startUpload,
+		retryUpload,
+	};
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload.ts
@@ -9,24 +9,26 @@
 //     onError( err )                                      — error value, no id
 //   returns { uploadHandler( file ), resumeHandler: { start, abort } | undefined, … }
 //
-// The legacy hook is designed around one active upload at a time.  It manages
+// The legacy hook is designed around one active upload at a time. It manages
 // its own internal state (uploadingData, media, error) and exposes a tus
 // `resumeHandler` that is set asynchronously after the first uploadHandler call.
 //
 // Adapter strategy:
 //   - We call useResumableUploader once per useUpload instance.
-//   - A `currentIdRef` ref tracks which queue item is "active" so the
-//     callback bodies can route progress / success / error updates correctly.
-//   - `startUpload` sets currentIdRef then calls uploadHandler(file).
-//   - `retryUpload` resets the item's status and calls uploadHandler again;
-//     tus automatically resumes from its stored fingerprint when available.
-//     (The legacy resumeHandler.start() path is not used here because it
-//     operates on the *same* upload object created in the previous call, which
-//     may be gone after a page interaction — calling uploadHandler afresh is
-//     safer and still benefits from tus fingerprint resumption.)
+//   - The upload *queue* lives in a window-attached singleton store (mirrors
+//     the QueryClientWrapper pattern) so multiple useUpload() consumers —
+//     Library Stage that produces uploads and useFreeTier() that only
+//     observes them — see the same items even when they sit in separately
+//     code-split route bundles. Subscribers re-render via useSyncExternalStore.
+//   - A per-instance `currentIdRef` ref tracks which queue item is being
+//     handled by *this* instance's legacy uploader. Only the instance that
+//     called startUpload owns the active upload; observer instances stay idle.
+//   - startUpload appends to the queue; if the local instance is idle it
+//     dispatches immediately, otherwise the item waits and is picked up
+//     when the current upload settles (in onSuccess / onError).
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useCallback, useRef, useSyncExternalStore } from '@wordpress/element';
 import useResumableUploader from '../../client/hooks/use-resumable-uploader';
 import { LIBRARY_QUERY_KEY } from './use-library';
 
@@ -40,6 +42,78 @@ export type UploadItem = {
 	error?: string;
 };
 
+const STORE_KEY = '__jetpackVideopressUploadStore' as const;
+const SUCCESS_REMOVAL_DELAY_MS = 2_000;
+
+type UploadStore = {
+	queue: UploadItem[];
+	subscribers: Set< () => void >;
+};
+
+declare global {
+	interface Window {
+		[ STORE_KEY ]?: UploadStore;
+	}
+}
+
+/**
+ * Return the singleton upload store, creating it on first access. The store
+ * lives on `window` so separately-built route bundles share one queue.
+ *
+ * @return The shared upload store.
+ */
+function getStore(): UploadStore {
+	if ( ! window[ STORE_KEY ] ) {
+		window[ STORE_KEY ] = { queue: [], subscribers: new Set() };
+	}
+	return window[ STORE_KEY ];
+}
+
+/**
+ * Subscribe to upload-store changes. Returns an unsubscribe callback.
+ *
+ * @param notify - Called when the queue changes.
+ * @return Unsubscribe.
+ */
+function subscribeStore( notify: () => void ): () => void {
+	const store = getStore();
+	store.subscribers.add( notify );
+	return () => {
+		store.subscribers.delete( notify );
+	};
+}
+
+/**
+ * Read the current queue snapshot. Must return a stable reference between
+ * mutations so useSyncExternalStore can short-circuit unchanged renders.
+ *
+ * @return The current upload queue.
+ */
+function readQueue(): UploadItem[] {
+	return getStore().queue;
+}
+
+/**
+ * Apply a synchronous updater to the queue and notify subscribers.
+ *
+ * @param updater - Pure function producing the next queue.
+ */
+function mutateQueue( updater: ( prev: UploadItem[] ) => UploadItem[] ): void {
+	const store = getStore();
+	store.queue = updater( store.queue );
+	store.subscribers.forEach( cb => cb() );
+}
+
+/**
+ * Reset the shared upload store. Intended for tests; production code should
+ * not call this.
+ */
+export function __resetUploadStoreForTests(): void {
+	if ( window[ STORE_KEY ] ) {
+		window[ STORE_KEY ].queue = [];
+	}
+}
+
 /**
  * Generate a unique id for a new upload queue item.
  *
@@ -51,29 +125,48 @@ function makeId( file: File ): string {
 }
 
 /**
- * Wrap the legacy resumable (tus) uploader in a multi-item upload queue.
+ * Subscribe to the shared upload queue via useSyncExternalStore so the
+ * queue is a single source of truth across every useUpload() instance.
+ *
+ * @return The current upload queue.
+ */
+function useUploadQueue(): UploadItem[] {
+	return useSyncExternalStore( subscribeStore, readQueue, readQueue );
+}
+
+/**
+ * Wrap the legacy resumable (tus) uploader in a multi-item upload queue
+ * backed by a window-attached singleton store.
  *
  * @return An object with the current upload queue and handlers to start or retry uploads.
  */
 export function useUpload() {
 	const client = useQueryClient();
-	const [ queue, setQueue ] = useState< UploadItem[] >( [] );
+	const queue = useUploadQueue();
 
-	// Tracks which queue item is currently active inside the legacy hook's
-	// single-upload state machine.  Using a ref avoids stale-closure issues
-	// inside the callbacks passed to useResumableUploader.
+	// Tracks which queue item is being handled by *this* instance's
+	// legacy uploader. Only the instance that called startUpload (and
+	// thus invoked uploadHandler) sets this; observer instances leave it
+	// null because their legacy uploader is idle.
 	const currentIdRef = useRef< string | null >( null );
 
-	const patch = useCallback( ( id: string, next: Partial< UploadItem > ) => {
-		setQueue( prev => prev.map( item => ( item.id === id ? { ...item, ...next } : item ) ) );
-	}, [] );
+	// uploadHandler is captured in a ref so callbacks can dispatch the
+	// next pending upload without depending on the render-by-render
+	// identity of `useResumableUploader`'s return value.
+	const uploadHandlerRef = useRef< ( ( file: File ) => void ) | null >( null );
 
-	const remove = useCallback( ( id: string ) => {
-		setQueue( prev => prev.filter( item => item.id !== id ) );
+	const startNextPending = useCallback( () => {
+		const next = readQueue().find( item => item.status === 'pending' );
+		if ( next && uploadHandlerRef.current ) {
+			currentIdRef.current = next.id;
+			uploadHandlerRef.current( next.file );
+		} else {
+			currentIdRef.current = null;
+		}
 	}, [] );
 
 	// Adapter callbacks — translate the legacy (bytesSent, bytesTotal) /
-	// (data: VideoMediaProps) / (err) signatures to our queue-item updates.
+	// (data: VideoMediaProps) / (err) signatures to queue-item updates.
 	const { uploadHandler } = useResumableUploader( {
 		onProgress: ( bytesSent: number, bytesTotal: number ) => {
 			const id = currentIdRef.current;
@@ -81,23 +174,25 @@ export function useUpload() {
 				return;
 			}
 			const progress = bytesTotal > 0 ? bytesSent / bytesTotal : 0;
-			patch( id, { progress, status: 'uploading' } );
+			mutateQueue( prev =>
+				prev.map( item => ( item.id === id ? { ...item, progress, status: 'uploading' } : item ) )
+			);
 		},
 		onSuccess: () => {
 			const id = currentIdRef.current;
 			if ( ! id ) {
 				return;
 			}
-			patch( id, { progress: 1, status: 'success' } );
+			mutateQueue( prev =>
+				prev.map( item => ( item.id === id ? { ...item, progress: 1, status: 'success' } : item ) )
+			);
 			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+			// Kick off the next pending upload right away so the user
+			// doesn't have to wait out the 2s success-removal grace.
+			startNextPending();
 			window.setTimeout( () => {
-				remove( id );
-				// Clear the ref only after the removal timeout so that any
-				// late-arriving callbacks still resolve to the right item.
-				if ( currentIdRef.current === id ) {
-					currentIdRef.current = null;
-				}
-			}, 2_000 );
+				mutateQueue( prev => prev.filter( item => item.id !== id ) );
+			}, SUCCESS_REMOVAL_DELAY_MS );
 		},
 		onError: ( err: unknown ) => {
 			const id = currentIdRef.current;
@@ -110,19 +205,31 @@ export function useUpload() {
 			} else if ( typeof err === 'string' ) {
 				message = err;
 			}
-			patch( id, { status: 'failed', error: message } );
-			currentIdRef.current = null;
+			mutateQueue( prev =>
+				prev.map( item =>
+					item.id === id ? { ...item, status: 'failed', error: message } : item
+				)
+			);
+			// Failed items stay in the queue so the user can retry. Move
+			// on to the next pending item rather than blocking the queue.
+			startNextPending();
 		},
 	} );
+
+	uploadHandlerRef.current = uploadHandler;
 
 	const startUpload = useCallback(
 		( file: File ): string => {
 			const id = makeId( file );
-			currentIdRef.current = id;
-			setQueue( prev => [ ...prev, { id, file, progress: 0, status: 'pending' } ] );
-			// uploadHandler is async (fetches a JWT before starting tus) but we
-			// don't await it here — progress flows via the callbacks above.
-			uploadHandler( file );
+			mutateQueue( prev => [ ...prev, { id, file, progress: 0, status: 'pending' } ] );
+			// Only dispatch immediately when this instance's legacy
+			// uploader is idle. Otherwise the item waits in the queue
+			// and is picked up by startNextPending when the active
+			// upload settles.
+			if ( ! currentIdRef.current ) {
+				currentIdRef.current = id;
+				uploadHandler( file );
+			}
 			return id;
 		},
 		[ uploadHandler ]
@@ -130,17 +237,24 @@ export function useUpload() {
 
 	const retryUpload = useCallback(
 		( id: string ) => {
-			const item = queue.find( q => q.id === id );
+			const item = readQueue().find( q => q.id === id );
 			if ( ! item ) {
 				return;
 			}
-			currentIdRef.current = id;
-			patch( id, { status: 'pending', progress: 0, error: undefined } );
-			// Re-invoke uploadHandler; tus will find the stored fingerprint and
-			// resume from where the previous attempt left off.
-			uploadHandler( item.file );
+			mutateQueue( prev =>
+				prev.map( q =>
+					q.id === id ? { ...q, status: 'pending', progress: 0, error: undefined } : q
+				)
+			);
+			// Dispatch immediately if idle; otherwise wait for the
+			// active upload to settle and startNextPending to pick this
+			// up.
+			if ( ! currentIdRef.current ) {
+				currentIdRef.current = id;
+				uploadHandler( item.file );
+			}
 		},
-		[ queue, patch, uploadHandler ]
+		[ uploadHandler ]
 	);
 
 	return {

--- a/projects/packages/videopress/src/dashboard/hooks/use-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-video.ts
@@ -14,7 +14,7 @@ type ApiMediaItem = {
 		filesize?: number;
 		width?: number;
 		height?: number;
-		videopress?: { poster?: string };
+		videopress?: { poster?: string; duration?: number; finished?: boolean };
 	};
 	jetpack_videopress?: {
 		guid?: string;
@@ -35,14 +35,21 @@ type ApiMediaItem = {
  */
 function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 	const vp = raw.jetpack_videopress;
+	const isVideoPress = Boolean( vp?.guid );
+	const vpDurationMs = raw.media_details?.videopress?.duration;
+	const durationSeconds =
+		vpDurationMs !== undefined ? Math.floor( vpDurationMs / 1000 ) : raw.media_details?.length ?? 0;
+	const poster = raw.media_details?.videopress?.poster;
+	const finished = raw.media_details?.videopress?.finished;
+	const isProcessing = isVideoPress && ( ! poster || finished === false );
 	return {
 		id: String( raw.id ),
 		guid: vp?.guid ?? '',
-		type: vp?.guid ? 'videopress' : 'local',
+		type: isVideoPress ? 'videopress' : 'local',
 		title: raw.title?.rendered ?? '',
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
-		thumbnailUrl: raw.media_details?.videopress?.poster ?? null,
-		durationSeconds: raw.media_details?.length ?? 0,
+		thumbnailUrl: poster ?? null,
+		durationSeconds,
 		uploadDate: raw.date ?? '',
 		privacy: privacyIntToString( vp?.privacy_setting ),
 		isPrivate: Boolean( vp?.is_private ),
@@ -54,6 +61,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		allowDownloads: Boolean( vp?.allow_download ),
 		shortcode: buildShortcode( vp?.guid, raw.media_details?.width, raw.media_details?.height ),
 		sourceUrl: raw.source_url,
+		isProcessing,
 	};
 }
 
@@ -71,6 +79,9 @@ export function useVideo( id: number | string ) {
 			return toLibraryItem( raw );
 		},
 		enabled: Boolean( id ),
+		// Re-fetch every 2s while the backend is still processing this
+		// video so the poster / duration appear without a manual reload.
+		refetchInterval: q => ( q.state.data?.isProcessing ? 2000 : false ),
 	} );
 
 	return {

--- a/projects/packages/videopress/src/dashboard/hooks/use-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-video.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
+import { buildShortcode } from '../utils/format';
 import { privacyIntToString } from './use-library';
 import type { MockLibraryItem } from '../types/library';
 
@@ -8,13 +9,19 @@ type ApiMediaItem = {
 	title?: { rendered?: string };
 	source_url?: string;
 	date?: string;
-	media_details?: { length?: number; filesize?: number };
+	media_details?: {
+		length?: number;
+		filesize?: number;
+		width?: number;
+		height?: number;
+	};
 	jetpack_videopress?: {
 		guid?: string;
 		rating?: string;
 		display_embed?: 0 | 1 | boolean;
 		allow_download?: 0 | 1 | boolean;
 		privacy_setting?: 0 | 1 | 2;
+		is_private?: boolean;
 		description?: string;
 		poster?: string;
 	};
@@ -30,6 +37,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 	const vp = raw.jetpack_videopress;
 	return {
 		id: String( raw.id ),
+		guid: vp?.guid ?? '',
 		type: vp?.guid ? 'videopress' : 'local',
 		title: raw.title?.rendered ?? '',
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
@@ -37,13 +45,14 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		durationSeconds: raw.media_details?.length ?? 0,
 		uploadDate: raw.date ?? '',
 		privacy: privacyIntToString( vp?.privacy_setting ),
+		isPrivate: Boolean( vp?.is_private ),
 		fileSizeBytes: raw.media_details?.filesize ?? 0,
 		upload: { status: 'idle', progress: 0 },
 		description: vp?.description ?? '',
 		rating: ( vp?.rating ?? 'G' ) as MockLibraryItem[ 'rating' ],
 		displayEmbed: Boolean( vp?.display_embed ),
 		allowDownloads: Boolean( vp?.allow_download ),
-		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
+		shortcode: buildShortcode( vp?.guid, raw.media_details?.width, raw.media_details?.height ),
 		sourceUrl: raw.source_url,
 	};
 }

--- a/projects/packages/videopress/src/dashboard/hooks/use-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-video.ts
@@ -14,6 +14,7 @@ type ApiMediaItem = {
 		filesize?: number;
 		width?: number;
 		height?: number;
+		videopress?: { poster?: string };
 	};
 	jetpack_videopress?: {
 		guid?: string;
@@ -23,7 +24,6 @@ type ApiMediaItem = {
 		privacy_setting?: 0 | 1 | 2;
 		is_private?: boolean;
 		description?: string;
-		poster?: string;
 	};
 };
 
@@ -41,7 +41,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		type: vp?.guid ? 'videopress' : 'local',
 		title: raw.title?.rendered ?? '',
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
-		thumbnailUrl: vp?.poster ?? null,
+		thumbnailUrl: raw.media_details?.videopress?.poster ?? null,
 		durationSeconds: raw.media_details?.length ?? 0,
 		uploadDate: raw.date ?? '',
 		privacy: privacyIntToString( vp?.privacy_setting ),

--- a/projects/packages/videopress/src/dashboard/hooks/use-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-video.ts
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { privacyIntToString } from './use-library';
+import type { MockLibraryItem } from '../types/library';
+
+type ApiMediaItem = {
+	id: number;
+	title?: { rendered?: string };
+	source_url?: string;
+	date?: string;
+	media_details?: { length?: number; filesize?: number };
+	jetpack_videopress?: {
+		guid?: string;
+		rating?: string;
+		display_embed?: 0 | 1 | boolean;
+		allow_download?: 0 | 1 | boolean;
+		privacy_setting?: 0 | 1 | 2;
+		description?: string;
+		poster?: string;
+	};
+};
+
+/**
+ * Transform a raw /wp/v2/media API item into a MockLibraryItem.
+ *
+ * @param raw - The raw media item from the REST API response.
+ * @return A normalized MockLibraryItem for the VideoPress UI.
+ */
+function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
+	const vp = raw.jetpack_videopress;
+	return {
+		id: String( raw.id ),
+		type: vp?.guid ? 'videopress' : 'local',
+		title: raw.title?.rendered ?? '',
+		filename: raw.source_url?.split( '/' ).pop() ?? '',
+		thumbnailUrl: vp?.poster ?? null,
+		durationSeconds: raw.media_details?.length ?? 0,
+		uploadDate: raw.date ?? '',
+		privacy: privacyIntToString( vp?.privacy_setting ),
+		fileSizeBytes: raw.media_details?.filesize ?? 0,
+		upload: { status: 'idle', progress: 0 },
+		description: vp?.description ?? '',
+		rating: ( vp?.rating ?? 'G' ) as MockLibraryItem[ 'rating' ],
+		displayEmbed: Boolean( vp?.display_embed ),
+		allowDownloads: Boolean( vp?.allow_download ),
+		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
+	};
+}
+
+/**
+ * Fetch and cache a single VideoPress media item from /wp/v2/media/{id}.
+ *
+ * @param id - The numeric or string media post ID to fetch.
+ * @return An object with the video item, loading/error state, and the raw error.
+ */
+export function useVideo( id: number | string ) {
+	const query = useQuery< MockLibraryItem >( {
+		queryKey: [ 'jetpack-videopress-library', 'item', String( id ) ],
+		queryFn: async () => {
+			const raw = await apiFetch< ApiMediaItem >( { path: `/wp/v2/media/${ id }` } );
+			return toLibraryItem( raw );
+		},
+		enabled: Boolean( id ),
+	} );
+
+	return {
+		video: query.data,
+		isLoading: query.isLoading,
+		isError: query.isError,
+		error: query.error,
+	};
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-video.ts
@@ -44,6 +44,7 @@ function toLibraryItem( raw: ApiMediaItem ): MockLibraryItem {
 		displayEmbed: Boolean( vp?.display_embed ),
 		allowDownloads: Boolean( vp?.allow_download ),
 		shortcode: vp?.guid ? `[videopress ${ vp.guid }]` : '',
+		sourceUrl: raw.source_url,
 	};
 }
 

--- a/projects/packages/videopress/src/dashboard/test-utils/mock-api-fetch.ts
+++ b/projects/packages/videopress/src/dashboard/test-utils/mock-api-fetch.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+type FetchHandler = ( options: {
+	path?: string;
+	method?: string;
+	data?: unknown;
+	parse?: boolean;
+	headers?: Record< string, string >;
+} ) => Promise< unknown > | unknown;
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mocked = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+/**
+ * Reset the apiFetch mock and install a new handler for the current test.
+ *
+ * @param handler - A function that receives the apiFetch options object and
+ *                returns the desired response (or throws to simulate errors).
+ * @return The jest mock function for further assertions.
+ */
+export function mockApiFetch( handler: FetchHandler ): jest.MockedFunction< typeof apiFetch > {
+	mocked.mockReset();
+	mocked.mockImplementation( handler as never );
+	return mocked;
+}
+
+/**
+ * Return the jest mock function for `@wordpress/api-fetch` so tests can
+ * inspect calls without installing a new handler.
+ *
+ * @return The current jest mock for apiFetch.
+ */
+export function getApiFetchMock(): jest.MockedFunction< typeof apiFetch > {
+	return mocked;
+}

--- a/projects/packages/videopress/src/dashboard/test-utils/query-client-wrapper.tsx
+++ b/projects/packages/videopress/src/dashboard/test-utils/query-client-wrapper.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+/**
+ * Create a QueryClient configured for test environments: no retries, no
+ * cache, and zero stale time so each test starts from a clean state.
+ *
+ * @return A fresh QueryClient instance suitable for use in tests.
+ */
+export function createTestQueryClient(): QueryClient {
+	return new QueryClient( {
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: 0 },
+			mutations: { retry: false },
+		},
+	} );
+}
+
+/**
+ * Return a wrapper component that provides a QueryClientProvider. Pass a
+ * pre-created client to share state across multiple hooks in one test; omit
+ * it to get a fresh isolated client.
+ *
+ * @param client - Optional QueryClient; defaults to a new test client.
+ * @return A React component that wraps its children in QueryClientProvider.
+ */
+export function createTestWrapper( client: QueryClient = createTestQueryClient() ) {
+	return ( { children }: { children: ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -21,7 +21,7 @@ export interface MockLibraryItem {
 	upload: UploadState;
 	description: string;
 	rating: VideoRating;
-	allowSharing: boolean;
+	displayEmbed: boolean;
 	allowDownloads: boolean;
 	shortcode: string;
 }
@@ -29,6 +29,6 @@ export interface MockLibraryItem {
 export type VideoDetailsPatch = Partial<
 	Pick<
 		MockLibraryItem,
-		'title' | 'description' | 'privacy' | 'allowSharing' | 'allowDownloads' | 'rating'
+		'title' | 'description' | 'privacy' | 'displayEmbed' | 'allowDownloads' | 'rating'
 	>
 >;

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -1,6 +1,6 @@
 export type LibraryItemType = 'videopress' | 'local';
 export type LibraryItemPrivacy = 'public' | 'private' | 'site-default';
-export type UploadStatus = 'idle' | 'uploading' | 'failed';
+export type UploadStatus = 'idle' | 'uploading' | 'promoting' | 'failed';
 export type VideoRating = 'G' | 'PG-13' | 'R';
 
 export interface UploadState {

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -10,6 +10,7 @@ export interface UploadState {
 
 export interface MockLibraryItem {
 	id: string;
+	guid: string;
 	type: LibraryItemType;
 	title: string;
 	filename: string;
@@ -17,6 +18,7 @@ export interface MockLibraryItem {
 	durationSeconds: number;
 	uploadDate: string;
 	privacy: LibraryItemPrivacy;
+	isPrivate: boolean;
 	fileSizeBytes: number;
 	upload: UploadState;
 	description: string;

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -24,6 +24,7 @@ export interface MockLibraryItem {
 	displayEmbed: boolean;
 	allowDownloads: boolean;
 	shortcode: string;
+	sourceUrl?: string;
 }
 
 export type VideoDetailsPatch = Partial<

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -27,6 +27,7 @@ export interface MockLibraryItem {
 	allowDownloads: boolean;
 	shortcode: string;
 	sourceUrl?: string;
+	isProcessing: boolean;
 }
 
 export type VideoDetailsPatch = Partial<

--- a/projects/packages/videopress/src/dashboard/types/stats.ts
+++ b/projects/packages/videopress/src/dashboard/types/stats.ts
@@ -37,7 +37,6 @@ export interface OverviewStats {
 	series: StatsSeriesPoint[];
 	topVideos: TopVideo[];
 	topVideosByWatchTime: TopVideo[];
-	storageUsedBytes: number;
 }
 
 export const DATE_RANGE_DAYS: Record< DateRange, number > = {

--- a/projects/packages/videopress/src/dashboard/utils/format.ts
+++ b/projects/packages/videopress/src/dashboard/utils/format.ts
@@ -1,4 +1,28 @@
 /**
+ * Build the `[videopress …]` shortcode string. Returns empty if the GUID
+ * is missing (non-VideoPress items). Matches the legacy admin format:
+ * `[videopress GUID w=W h=H]` with `w=`/`h=` only included when present
+ * and values rendered bare (no quotes).
+ *
+ * @param guid   - VideoPress GUID, or undefined for non-VideoPress items.
+ * @param width  - Video width in pixels, if known.
+ * @param height - Video height in pixels, if known.
+ * @return The shortcode string, or '' when no GUID is available.
+ */
+export function buildShortcode(
+	guid: string | undefined,
+	width: number | undefined,
+	height: number | undefined
+): string {
+	if ( ! guid ) {
+		return '';
+	}
+	const w = width ? ` w=${ width }` : '';
+	const h = height ? ` h=${ height }` : '';
+	return `[videopress ${ guid }${ w }${ h }]`;
+}
+
+/**
  * Format a duration in seconds as `mm:ss` or `hh:mm:ss`.
  *
  * @param seconds - Total seconds.


### PR DESCRIPTION
Part of #48506 (Phases 6 + 8).

## Proposed changes

Wires all four modernized VideoPress dashboard screens (Overview, Library, Video Details, Settings) from fixture data to real REST endpoints, plus the surrounding parity work to keep the modernized UI behavior-equivalent to the legacy admin. Combines Phases 6 and 8 of the tracking issue into a single PR since Phase 8 reduces to a one-line hook swap once Phase 5+7's `useStats` is consumed. All work remains hidden behind the `rsm_jetpack_ui_modernization_videopress` filter (default off). Phase 9 cutover is a separate PR.

* **New TanStack Query hooks** under `src/dashboard/hooks/`:
  - `use-library.ts` — `/wp/v2/media?media_type=video&mime_type=video/*` with server-side filter/sort/pagination, `keepPreviousData` for smooth transitions, pagination headers (`X-WP-Total` / `X-WP-TotalPages`). Type filter switches between `mime_type=video/videopress` and `media_type=video` + `no_videopress=1`; Uploaded filter converts local-time to UTC ISO8601 and forwards as `before` / `after`.
  - `use-video.ts` — `/wp/v2/media/{id}` single-item fetch, mapped to `LibraryItem`.
  - `use-update-video-meta.ts` — POST `/wpcom/v2/videopress/meta` with field mapping (privacy int↔string, `displayEmbed` ↔ `display_embed`).
  - `use-delete-video.ts` — sequenced DELETE `/wp/v2/media/{id}?force=true`.
  - `use-settings.ts` / `useUpdateSettings` — GET/POST `videopress/v1/settings` with optimistic update + rollback.
  - `use-features.ts` — `videopress/v1/features` for `isVideoPress1TBSupported` / `isVideoPressUnlimitedSupported`.
  - `use-site.ts` + `getStorageUsedBytes` helper — `videopress/v1/site` for storage meter (decimal MB → bytes conversion at the boundary).
  - `use-upload.ts` — wraps the legacy `useResumableUploader` (tus) with an upload-queue surface backed by a window-attached singleton read via `useSyncExternalStore`, so every `useUpload()` consumer shares one queue; bridges the legacy `(bytesSent, bytesTotal)` callbacks to a normalized 0..1 progress. Guards `startUpload` against concurrent dispatch (the legacy uploader is single-active).
  - `use-upload-from-library.ts` — bounded poll of `/videopress/v1/upload/{id}` (120 attempts × 500ms by default; tolerates transient apiFetch failures against the same budget) until the endpoint settles on `complete` / `uploaded` / `error`. Powers the Library card's "Upload to VideoPress" action and bulk action for local attachments.
  - `use-playback-token.ts` / `use-poster-url.ts` — signs poster URLs for private VideoPress items with `?metadata_token=<jwt>`. 24h react-query cache keyed by guid dedupes multiple rows of the same private video to a single token request.
* **`use-free-tier.ts`** — counts `paginationInfo.totalItems` (server count) + in-flight uploads, reads `isAtomic` from `isWoASite()` (`@automattic/jetpack-script-data`), and `isUnlimited` from `useFeatures` with Initial State fallback. The in-flight count comes from the shared upload-queue singleton, so uploads kicked off in the Library Stage are visible to `useFreeTier` (an earlier non-singleton implementation left the concurrent-upload race open until the next library refetch landed).
* **`QueryClientWrapper`** — new component with a window-attached singleton `QueryClient` so all four lazy-loaded wp-build route bundles share one cache. Each Stage wraps itself.
* **Stage call-site rewrites:**
  - Overview swaps `useMockStats` → `useStats` and drops the `usedBytes` prop (StorageMeterCard now reads `useSite()` directly).
  - Library replaces the entire client-side filter/sort/paginate block (now server-driven), splices in-flight uploads at the top of the list, and wires "Upload to VideoPress" (single + bulk) through `useUploadFromLibrary`. Type and Uploaded filters round-trip through the server; sort affordances on Duration / File size are disabled (not indexed for ordering on `/wp/v2/media`); Filename sort is enabled (`orderby=slug` — slug is auto-generated from the upload filename); File size is hidden from the default columns (only populated for local uploads). Library cards derive `isProcessing` from `media_details.videopress.poster` + `finished`; the list query refetches every 2s while any row is processing, and rows show a "Processing" overlay on the thumbnail and a pill in the title cell.
  - Video Details replaces mock-library lookup with `useVideo(id)`; save/delete wired through mutations with success + error notices. Loading state mirrors the NotFound shell (AdminPage + breadcrumbs + aria-busy placeholder) instead of returning `null`. Processing state renders a "Processing" placeholder until the poster is ready; the duration badge stays hidden until the backend reports a duration so it doesn't flash "00:00". "Link to video" uses `jetpack_videopress.guid` (host switches to `video.wordpress.com` when `is_private`); the shortcode includes `w=`/`h=` from `media_details`. "Add to new post" opens `post-new.php?videopress_guid=<guid>&_wpnonce=<nonce>` (matches what the package's `class-block-editor-content.php` expects — the prior arg name + missing nonce caused the server-side block-injection filter to skip).
  - Settings replaces local `useState` with `useSettings` / `useUpdateSettings`.
* **Initial_State extension (`class-initial-state.php`)** — adds `isVideoPress1TB` and `isVideoPressUnlimited` to the synchronous payload (via a new `has_videopress_feature($slug)` helper), and adds `contentNonce` (action `videopress-content-nonce`) so the modernized dashboard has the same nonce the legacy admin reads from `jetpackVideoPressInitialState.contentNonce`. Avoids one round-trip on every page load.
* **PHP backend extensions** — new `videopress_hide_already_uploaded` request param on `/wp/v2/media` (handled by the package's `rest_attachment_query` filter) adds a `_videopress_uploaded_id NOT EXISTS` meta_query clause. The dashboard library query always sends it so "zombie" local rows (locals that already have a VideoPress sibling attachment) don't appear and can't be re-promoted.
* **Library item mapping parity** — `duration` reads `media_details.videopress.duration` (ms → s, floored), falling back to `media_details.length` for non-VideoPress items; poster reads `media_details.videopress.poster` (the `jetpack_videopress.poster` field is undefined on `/wp/v2/media`). Both mappers populate `sourceUrl`.
* **`use-stats.ts` bug fixes** (caught during WPCOM-endpoint verification):
  - Drops the dead `entry.plays ?? 0` fallback. `complete_stats=true` mode never returns `plays` per-video; it returns `views`, `impressions`, `watch_time`, and `retention_rate`.
  - Converts WPCOM's `watch_time` (which is in hours, not seconds) to seconds at the three transform boundaries. Previously the Watch time KPI would be displayed at 1/3600 of its correct value.
* **`class-rest-controller.php` docblock fix** for the same shape misunderstanding.
* **`allowSharing` → `displayEmbed`** rename across `MockLibraryItem`, video-details form, and the privacy/sharing card. Adopts the legacy verbatim copy: label "Share", help "Display share menu and allow viewers to copy a link or embed this video."
* **Test infrastructure** — `src/dashboard/test-utils/` with a `QueryClientProvider` test wrapper and an `apiFetch` mock helper. Each new hook ships with a co-located `test/<name>.test.ts`, all passing with > 80% line coverage on every new hook.

## Related product discussion/links

* Tracking issue: #48506 (see "Plan" section for the phasing).
* Phase 5 + 7 PR: #48817 (stats proxy + Initial State scaffolding this PR consumes).
* Free-tier UX (now merged): #48843.
* Reference architecture: `projects/packages/activity-log/`.

WPCOM-side investigation surfaced two endpoint gaps worth tracking (neither blocks this PR):

1. **Server-side sort on `videopress_duration` / `videopress_file_size` meta** on `/wp/v2/media` — would unblock real sort on the Library's Duration/Size columns (currently disabled in the UI).
2. **`videopress_privacy_setting` / `videopress_rating` filters on simple-WPCOM** — currently `! IS_WPCOM`-gated in the attachment-data filter; the modernization filter is Jetpack-side so this only matters if the modernized UI later ships on simple-WPCOM.

## Does this pull request change what data or activity we track or use?

No new tracking, no new data collection. Every endpoint this PR consumes is already in use by the legacy dashboard. The `Initial_State` additions (`isVideoPress1TB`, `isVideoPressUnlimited`, `contentNonce`) read from data already used by the legacy admin: the features data already exposed by `videopress/v1/features`, and the same `videopress-content-nonce` action the legacy admin uses.

## Testing instructions

This PR is behind the `rsm_jetpack_ui_modernization_videopress` filter (default off). Enable it on a connected Jetpack site with `manage_options`:

```php
add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );
```

Build the package:

```bash
jp build packages/videopress
```

Visit `/wp-admin/admin.php?page=jetpack-videopress`.

### Library tab

* Listing populates from the server (not a hardcoded fixture).
* Search filters server-side (a search with many results doesn't jitter on each keystroke — DataViews holds the previous page until the next refetch lands).
* Sort by Title / Upload date / Filename works server-side; Filename uses `orderby=slug`. Sort headers on Duration / File size are deliberately disabled (WPCOM follow-up).
* File size is hidden from the default columns (toggleable via the column-visibility menu).
* Pagination next/prev triggers a network call; the previous page stays visible during the transition.
* Privacy filter (Public / Private / Site default) round-trips through `videopress_privacy_setting` integer codes (0 / 1 / 2).
* Type filter — "VideoPress" returns only VideoPress items; "Local" returns only local video attachments (no zombies).
* Uploaded filter — pick a date with the `before` or `after` operator; the listing narrows accordingly (UTC conversion happens at the boundary).
* Bulk delete fires sequenced DELETEs and shows a success notice (or an error notice on failure).
* Privacy change from a row action shows a success / error notice.
* Upload button: clicking opens the file picker; the selected file appears at the top of the list with progress; on success the listing refreshes. After completion, the row shows a "Processing" pill + overlay until the backend reports a poster and `finished`; the list refetches every 2s during this window.
* "Upload to VideoPress" on a local-attachment row (and the matching bulk action) promotes the local file to VideoPress; the row shows an "Uploading…" pill with an indeterminate progress bar while the recursive endpoint runs, then disappears from the listing (filtered out by `videopress_hide_already_uploaded`). Errors surface the server reason in the notice (e.g. "403: Invalid Mime").
* Private video thumbnails render (JWT-signed poster). Multiple rows of the same private video share a single token request.
* Free-tier (`?vp_free=1`): Upload button disables after the first in-flight or completed upload (the count closes the concurrent-upload race even when the upload was kicked off elsewhere on the page).
* At-limit toggle (`?vp_at_limit=1`): Upload button stays disabled.

### Video Details (`/video/<id>`)

* Initial load shows a placeholder (AdminPage shell with aria-busy body) — no blank viewport.
* When loaded: real title / description / rating / privacy / Share toggle / Allow downloads from the server.
* Thumbnail renders correctly for both public and private videos (private uses the JWT-signed poster); while the backend is still processing the upload, a "Processing" placeholder renders and the duration badge stays hidden.
* Edit + Save → success notice fires; reloading the page preserves the change. Failed save shows an error notice.
* Delete → confirmation, success notice, navigates back to `/library`. Failed delete shows an error notice.
* Download opens the source file URL in a new tab.
* "Link to video" — `https://videopress.com/v/<guid>` (or `https://video.wordpress.com/v/<guid>` when private); the shortcode includes `w=`/`h=` from media_details.
* "Add to new post" — opens `post-new.php?videopress_guid=<guid>&_wpnonce=<nonce>` and the block editor opens with the video block already inserted.
* Verify the Share toggle label reads exactly **"Share"** with help text **"Display share menu and allow viewers to copy a link or embed this video"** (matches the legacy dashboard verbatim).

### Settings (`/settings`)

* Toggle for "Restrict video access" loads from `videopress/v1/settings`.
* Toggling fires `useUpdateSettings` (optimistic update + invalidate-on-settle); reload preserves the new state.
* Toggle disables briefly while the mutation is in flight.

### Overview (`/overview`)

* KPI cards (Views / Impressions / Watch time) populate from `/jetpack/v4/videopress/stats/video-plays?complete_stats=true`. Zero values on a site without traffic are valid, not a bug.
* **Watch time renders in correct units** — e.g., a video with 10 minutes of watch time shows "10m", not "0m" or "10h". (Pre-fix: the field was displayed as if seconds, but WPCOM returns hours — a 10-minute total would render as ~17 hours.)
* Trends chart renders with the active metric (Views / Impressions / Watch time) and the comparison series.
* Most viewed / Top by watch time cards render the per-video lists (populated by `data[*].views` / `data[*].watch_time`, not the absent `plays` field).
* Date range selector changes the data window. Granularity selector changes bucketing.
* Storage meter renders only when: not free, has at least one video, not Unlimited, not Atomic. Shows realistic percentage. Reads `videopress/v1/site` → `options.videopress_storage_used` × 1,000,000.
* Free-tier callout (`?vp_free=1`): shows the FreeTierNotice; hides the storage meter.

### Verify cache and network behavior (DevTools)

* On the Library tab, paginate forward; the previous page's items stay visible (no flash of empty state). The next page is fetched in a single `/wp/v2/media?...&page=N` request.
* On the Video Details page, save → the per-item query is invalidated and refetches; navigating back to /library, the listing has the updated record.
* Across tabs (Overview → Library → Settings → Overview), each tab's first visit triggers its initial fetches; subsequent visits within 30 s of the first fetch reuse the cached data (TanStack `staleTime: 30_000` default).
* When a row is processing, the list query polls every 2s; the polling pauses when the tab is hidden.
* When a local attachment is being promoted with "Upload to VideoPress", the mutation polls `/videopress/v1/upload/{id}` at the bounded rate (120 attempts × 500ms by default) and stops as soon as the endpoint settles.

### Bug-fix verifications

1. **Watch time unit.** On a paid site with real traffic, the Watch time KPI should show realistic minute/hour values — not 3600× too high or too low. Verify against a known-good source if available.
2. **Per-video metrics populate.** Most viewed and Top by watch time cards should show non-zero values for active videos. Pre-fix, the fallback to a missing `plays` field would have left them at zero.
3. **Stats proxy docblock.** `class-rest-controller.php` no longer claims a per-video `plays[]` field exists.

### Tests + build

```bash
pnpm --filter @automattic/jetpack-videopress test
pnpm --filter @automattic/jetpack-videopress build      # clean
jp phan packages/videopress                              # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
