### PR TITLE
Podcast: match the placeholder thumbnail size to populated thumbnails

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-thumb-placeholder-size
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-thumb-placeholder-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Match the placeholder thumbnail size to populated thumbnails in the Episodes list.

--- a/projects/packages/podcast/changelog/fix-podcast-episode-thumb-placeholder-size
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-thumb-placeholder-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Match the placeholder thumbnail size to populated thumbnails in the Episodes list.
+Polish Podcast dashboard styles: match placeholder thumbnail size to populated thumbnails, and space out the Distribution tab's warning notice.

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -133,11 +133,7 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	return (
 		<>
 			{ issues.length > 0 && (
-				<Notice
-					status="warning"
-					isDismissible={ false }
-					className="podcast__distribution-notice"
-				>
+				<Notice status="warning" isDismissible={ false } className="podcast__distribution-notice">
 					<strong>{ __( 'Almost ready to submit', 'jetpack-podcast' ) }</strong>
 					<ul className="podcast__settings-issues">
 						{ issues.map( issue => (

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -133,7 +133,11 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	return (
 		<>
 			{ issues.length > 0 && (
-				<Notice status="warning" isDismissible={ false }>
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="podcast__distribution-notice"
+				>
 					<strong>{ __( 'Almost ready to submit', 'jetpack-podcast' ) }</strong>
 					<ul className="podcast__settings-issues">
 						{ issues.map( issue => (

--- a/projects/packages/podcast/src/dashboard/distribution/style.scss
+++ b/projects/packages/podcast/src/dashboard/distribution/style.scss
@@ -5,6 +5,10 @@
 	color: #1e1e1e;
 }
 
+.podcast__distribution-notice.components-notice.is-warning {
+	margin-block: 16px;
+}
+
 .podcast__directory-list {
 	list-style: none;
 	margin: 0;

--- a/projects/packages/podcast/src/dashboard/episodes/style.scss
+++ b/projects/packages/podcast/src/dashboard/episodes/style.scss
@@ -1,11 +1,12 @@
 .podcast__episode-thumb {
-	width: 56px;
-	height: 56px;
+	// DataViews ships `.dataviews-column-primary__media img { width: 32px;
+	// height: 32px }` and wins on specificity for the populated <img>, so the
+	// placeholder <div> has to match 32×32 to avoid a visible size mismatch.
+	// box-sizing keeps the 1px dashed border inside the 32px box.
+	width: 32px;
+	height: 32px;
 	object-fit: cover;
 	border-radius: 4px;
-	// Without this the 1px placeholder border below pushes the empty-state
-	// square to 58x58 (content-box default), so blank rows render visibly
-	// larger than rows with thumbnails.
 	box-sizing: border-box;
 }
 

--- a/projects/packages/podcast/src/dashboard/episodes/style.scss
+++ b/projects/packages/podcast/src/dashboard/episodes/style.scss
@@ -3,6 +3,10 @@
 	height: 56px;
 	object-fit: cover;
 	border-radius: 4px;
+	// Without this the 1px placeholder border below pushes the empty-state
+	// square to 58x58 (content-box default), so blank rows render visibly
+	// larger than rows with thumbnails.
+	box-sizing: border-box;
 }
 
 .podcast__episode-thumb--placeholder {

--- a/projects/packages/podcast/src/dashboard/episodes/style.scss
+++ b/projects/packages/podcast/src/dashboard/episodes/style.scss
@@ -1,8 +1,4 @@
 .podcast__episode-thumb {
-	// DataViews ships `.dataviews-column-primary__media img { width: 32px;
-	// height: 32px }` and wins on specificity for the populated <img>, so the
-	// placeholder <div> has to match 32×32 to avoid a visible size mismatch.
-	// box-sizing keeps the 1px dashed border inside the 32px box.
 	width: 32px;
 	height: 32px;
 	object-fit: cover;


### PR DESCRIPTION
## Summary

All image thumbnails should be the same size regardless of content or if they're empty. Not like this.

<img width="530" height="450" alt="CleanShot 2026-05-18 at 16 01 55@2x" src="https://github.com/user-attachments/assets/257f9c88-c125-4d64-836d-85726c065b97" />

more like

<img width="834" height="302" alt="CleanShot 2026-05-18 at 16 35 40@2x" src="https://github.com/user-attachments/assets/0301f370-cf9d-4790-bcf7-08198d9ce467" />


On the Podcast > Episodes list, rows whose post has no featured image (and where the podcast cover image is empty) render a placeholder square instead of an `<img>`. That placeholder was visibly larger than the populated thumbnails — the `1px dashed` border was pushed outside the 56x56 content box (default `content-box`), giving the placeholder a 58x58 footprint while real thumbnails stayed at 56x56.

Fix: add `box-sizing: border-box` to `.podcast__episode-thumb` so the border draws inside the 56x56 box.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- [ ] Episodes list with at least one episode that has no per-episode featured image and no podcast cover set: placeholder square is now the same size as populated thumbnails.
- [ ] Episodes with per-episode featured image render unchanged.
- [ ] Setting a podcast cover image: episodes without their own featured image fall back to the cover, also unchanged.

Reviewer: arcangelini.