### PR TITLE
Forms: fix unread counter badge colors in WP 7.0

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-sidebar-unread-badge-colors
+++ b/projects/packages/forms/changelog/fix-forms-sidebar-unread-badge-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix unread submissions counter badge colors in the admin sidebar.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1539,7 +1539,7 @@ class Contact_Form_Plugin {
 			$unread = self::get_unread_count();
 
 			if ( isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
-				$forms_unread_count_tag = " <span class='jp-feedback-unread-counter count-{$unread} awaiting-mod'><span class='feedback-unread-counter'>" . number_format_i18n( $unread ) . '</span></span>';
+				$forms_unread_count_tag = $this->get_unread_count_badge_markup( $unread );
 				$jetpack_badge_count    = $unread;
 
 				// Main menu entries
@@ -1557,7 +1557,10 @@ class Contact_Form_Plugin {
 						}
 
 						if ( $unread > 0 ) {
-							$jetpack_unread_tag = " <span data-unread-diff='" . ( $jetpack_badge_count - $unread ) . "' class='jp-feedback-unread-counter count-{$jetpack_badge_count} awaiting-mod'><span class='feedback-unread-counter'>" . number_format_i18n( $jetpack_badge_count ) . '</span></span>';
+							$jetpack_unread_tag = $this->get_unread_count_badge_markup(
+								$jetpack_badge_count,
+								$jetpack_badge_count - $unread
+							);
 
 							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 							$menu[ $index ][0] = $jetpack_menu_item['title'] . ' ' . $jetpack_unread_tag;
@@ -1579,6 +1582,28 @@ class Contact_Form_Plugin {
 			}
 			return;
 		}
+	}
+
+	/**
+	 * Build the admin menu unread count badge markup.
+	 *
+	 * Uses the `menu-counter` markup expected by admin color schemes so bubble
+	 * colors render correctly in the sidebar.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int      $count         Badge count to display.
+	 * @param int|null $unread_diff   Optional diff for combined Jetpack menu badges.
+	 * @return string Badge HTML.
+	 */
+	private function get_unread_count_badge_markup( $count, $unread_diff = null ) {
+		$attributes = "class='menu-counter jp-feedback-unread-counter count-" . (int) $count . "'";
+
+		if ( null !== $unread_diff ) {
+			$attributes = "data-unread-diff='" . (int) $unread_diff . "' " . $attributes;
+		}
+
+		return " <span {$attributes}><span class='count'>" . number_format_i18n( $count ) . '</span></span>';
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -25,7 +25,13 @@ function updateBadge( element, count ) {
 	}
 
 	element.ariaHidden = count > 0 ? 'false' : 'true';
-	element.textContent = formatNumber( count );
+
+	const countElement = element.querySelector( '.count' );
+	if ( countElement ) {
+		countElement.textContent = formatNumber( count );
+	} else {
+		element.textContent = formatNumber( count );
+	}
 }
 
 /**

--- a/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
@@ -12,7 +12,8 @@ import {
 
 describe( 'Menu counter updates', () => {
 	beforeEach( () => {
-		document.body.innerHTML = '<span class="jp-feedback-unread-counter count-5">5</span>';
+		document.body.innerHTML =
+			'<span class="menu-counter jp-feedback-unread-counter count-5"><span class="count">5</span></span>';
 	} );
 
 	it( 'updates counter from server', () => {

--- a/projects/packages/forms/tests/js/dashboard/inbox/optimistically-update-unread-count.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/optimistically-update-unread-count.test.js
@@ -9,7 +9,8 @@ import { optimisticallyUpdateUnreadCount } from '../../../../src/dashboard/inbox
 
 describe( 'optimisticallyUpdateUnreadCount', () => {
 	beforeEach( () => {
-		document.body.innerHTML = '<span class="jp-feedback-unread-counter count-5">5</span>';
+		document.body.innerHTML =
+			'<span class="menu-counter jp-feedback-unread-counter count-5"><span class="count">5</span></span>';
 	} );
 
 	it( 'does not change counter for read items', () => {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1241,6 +1241,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		global $menu;
 
+		$this->assertStringContainsString( 'menu-counter', $menu[ $indices['menu_index'] ][0], 'Should use menu-counter badge markup.' );
 		$this->assertStringContainsString( 'jp-feedback-unread-counter', $menu[ $indices['menu_index'] ][0], 'Should contain Forms badge class.' );
 		$this->assertStringContainsString( 'count-3', $menu[ $indices['menu_index'] ][0], 'Should show count of 3.' );
 		$this->assertStringContainsString( "data-unread-diff='0'", $menu[ $indices['menu_index'] ][0], 'Diff should be 0 when no other badges exist.' );
@@ -1278,6 +1279,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		global $submenu;
 
+		$this->assertStringContainsString( 'menu-counter', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu should use menu-counter badge markup.' );
 		$this->assertStringContainsString( 'jp-feedback-unread-counter', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu should contain Forms badge.' );
 		$this->assertStringContainsString( 'count-5', $submenu['jetpack'][ $indices['submenu_index'] ][0], 'Submenu badge should show count of 5.' );
 	}


### PR DESCRIPTION
Part of JETPACK-1572

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fixes compatibility issues in unread badges with WP 7.0 for Forms menu
* Boost seems to work well already before.

There might have been issues with some colour schemes already before WP 7.0 started highlighting the issues more visibly.

Before
<img width="174" height="398" alt="image" src="https://github.com/user-attachments/assets/cce87cdb-fab8-4053-9307-6af7b50d66f2" />

After
<img width="174" height="407" alt="Screenshot 2026-05-18 at 22 56 47" src="https://github.com/user-attachments/assets/8a77129a-8d11-4512-b8d3-ba7d607a7651" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Have unread messages under Forms, notices in Boost, and note no issues with badge colors on hover, on selected menu, unselected menu, etc. Try different combos.