### PR TITLE
Write: add full-justification alignment for paragraphs

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-justify-alignment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-justify-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: add full-justification alignment for paragraphs.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1101,6 +1101,15 @@
 	margin: 0 0 1.25em;
 }
 
+/* Editor-preview only: native browser hyphenation for justified paragraphs.
+   Reader-facing rendering of .has-text-align-justify comes from core
+   block-library CSS; reader-facing hyphenation is upstream/theme work. */
+.bw-content p[style*="text-align: justify"],
+.bw-content p[style*="text-align:justify"] {
+	hyphens: auto;
+	-webkit-hyphens: auto;
+}
+
 .bw-content h1,
 .bw-content h2,
 .bw-content h3 {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -568,25 +568,42 @@ function convertToBlocks( html ) {
 		)
 			continue;
 
-		// Check for text alignment.
+		// Check for text alignment. Justify is paragraph-only — headings and
+		// quotes stay L/C/R because browser justification on display type and
+		// narrow quote columns produces large word-spacing gaps.
+		// Justify uses the canonical wpcom form (className + style.typography.textAlign);
+		// L/C/R uses the legacy `align` attribute + inline style.
 		const align = node.style && node.style.textAlign;
-		const alignAttr =
-			align && [ 'left', 'center', 'right' ].includes( align )
-				? ` style="text-align:${ align }"`
-				: '';
-		const alignJson =
-			align && [ 'left', 'center', 'right' ].includes( align ) ? `,"align":"${ align }"` : '';
+		const isLcrAlign = align && [ 'left', 'center', 'right' ].includes( align );
+		const isJustify = align === 'justify';
+		const isHeadingAlign = isLcrAlign;
+		let paragraphAlignJson = '';
+		let paragraphStyleAttr = '';
+		let paragraphClassAttr = '';
+		if ( isLcrAlign ) {
+			paragraphAlignJson = `,"align":"${ align }"`;
+			paragraphStyleAttr = ` style="text-align:${ align }"`;
+		} else if ( isJustify ) {
+			paragraphAlignJson =
+				',"align":"justify","className":"has-text-align-justify","style":{"typography":{"textAlign":"justify"}}';
+			paragraphClassAttr = ' class="has-text-align-justify"';
+			// Inline style fallback for consumers that don't ship the
+			// .has-text-align-justify rule (theme exports, RSS, etc.).
+			paragraphStyleAttr = ' style="text-align:justify"';
+		}
+		const headingAlignAttr = isHeadingAlign ? ` style="text-align:${ align }"` : '';
+		const headingAlignJson = isHeadingAlign ? `,"align":"${ align }"` : '';
 
 		if ( tag === 'p' || tag === 'div' ) {
 			blocks.push(
 				`<!-- wp:paragraph${
-					alignJson ? ` {${ alignJson.slice( 1 ) }}` : ''
-				} -->\n<p${ alignAttr }>${ inner }</p>\n<!-- /wp:paragraph -->`
+					paragraphAlignJson ? ` {${ paragraphAlignJson.slice( 1 ) }}` : ''
+				} -->\n<p${ paragraphClassAttr }${ paragraphStyleAttr }>${ inner }</p>\n<!-- /wp:paragraph -->`
 			);
 		} else if ( /^h[1-6]$/.test( tag ) ) {
 			const level = parseInt( tag.charAt( 1 ), 10 );
 			blocks.push(
-				`<!-- wp:heading {"level":${ level }${ alignJson }} -->\n<${ tag } class="wp-block-heading"${ alignAttr }>${ inner }</${ tag }>\n<!-- /wp:heading -->`
+				`<!-- wp:heading {"level":${ level }${ headingAlignJson }} -->\n<${ tag } class="wp-block-heading"${ headingAlignAttr }>${ inner }</${ tag }>\n<!-- /wp:heading -->`
 			);
 		} else if ( tag === 'figure' && node.querySelector( 'iframe' ) ) {
 			const iframe = node.querySelector( 'iframe' );
@@ -1469,6 +1486,7 @@ function updateFormattingState() {
 	state.formatAlignLeft = true;
 	state.formatAlignCenter = false;
 	state.formatAlignRight = false;
+	state.formatAlignJustify = false;
 
 	if ( sel.rangeCount ) {
 		let node = sel.anchorNode;
@@ -1492,11 +1510,16 @@ function updateFormattingState() {
 					state.formatAlignLeft = align === 'left' || align === 'start' || align === '';
 					state.formatAlignCenter = align === 'center';
 					state.formatAlignRight = align === 'right';
+					state.formatAlignJustify = align === 'justify';
 				}
 			}
 			node = node.parentNode;
 		}
 	}
+
+	// Justify is paragraph-only; disable the toolbar button inside lists,
+	// headings, and quotes where browser justification would look poor.
+	state.cannotJustify = state.insideList || state.formatHeading || state.formatQuote;
 }
 
 /**
@@ -2856,6 +2879,7 @@ const { state } = store( 'wpcom-write', {
 			state.formatAlignLeft = true;
 			state.formatAlignCenter = false;
 			state.formatAlignRight = false;
+			state.formatAlignJustify = false;
 		},
 
 		alignCenter() {
@@ -2864,6 +2888,7 @@ const { state } = store( 'wpcom-write', {
 			state.formatAlignLeft = false;
 			state.formatAlignCenter = true;
 			state.formatAlignRight = false;
+			state.formatAlignJustify = false;
 		},
 
 		alignRight() {
@@ -2872,6 +2897,17 @@ const { state } = store( 'wpcom-write', {
 			state.formatAlignLeft = false;
 			state.formatAlignCenter = false;
 			state.formatAlignRight = true;
+			state.formatAlignJustify = false;
+		},
+
+		alignJustify() {
+			if ( state.cannotJustify ) return;
+			document.execCommand( 'justifyFull' );
+			cleanupAlignmentDivs();
+			state.formatAlignLeft = false;
+			state.formatAlignCenter = false;
+			state.formatAlignRight = false;
+			state.formatAlignJustify = true;
 		},
 
 		// --- Lists ---

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -349,14 +349,24 @@ function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
 		// Both are converted to inline styles on load, so they round-trip.
 		// Strip the style attr if it only contains typography.textAlign
 		// with a supported value, so it doesn't trigger the extra-attrs check.
-		$style_align = $attrs['style']['typography']['textAlign'] ?? '';
+		// Justify is paragraph-only.
+		$supported_text_aligns = 'paragraph' === $name
+			? array( 'left', 'center', 'right', 'justify' )
+			: array( 'left', 'center', 'right' );
+		$style_align           = $attrs['style']['typography']['textAlign'] ?? '';
 		if (
 			isset( $attrs['style'] ) &&
 			$style_align &&
-			in_array( $style_align, array( 'left', 'center', 'right' ), true ) &&
+			in_array( $style_align, $supported_text_aligns, true ) &&
 			array( 'typography' => array( 'textAlign' => $style_align ) ) === $attrs['style']
 		) {
 			unset( $attrs['style'] );
+		}
+
+		// Justify uses the canonical class "has-text-align-justify" on paragraph.
+		// Strip it before the extra-attrs check so the paragraph round-trips.
+		if ( 'paragraph' === $name && ( $attrs['className'] ?? '' ) === 'has-text-align-justify' ) {
+			unset( $attrs['className'] );
 		}
 
 		$extra = array_diff( array_keys( $attrs ), $allowed_attrs[ $name ] );
@@ -367,8 +377,9 @@ function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
 		// Alignment: convertToBlocks() only preserves center and right
 		// (read from style.textAlign). Block-level values like wide/full
 		// are CSS-class-based and silently lost. Left is the default and
-		// renders identically to no alignment, so allow it too.
-		if ( isset( $attrs['align'] ) && ! in_array( $attrs['align'], array( 'left', 'center', 'right' ), true ) ) {
+		// renders identically to no alignment, so allow it too. Justify
+		// is paragraph-only (display type and narrow quotes look poor).
+		if ( isset( $attrs['align'] ) && ! in_array( $attrs['align'], $supported_text_aligns, true ) ) {
 			return true;
 		}
 
@@ -405,7 +416,7 @@ function wpcom_write_has_unsupported_blocks( $blocks, $allowed_attrs ) {
  */
 function wpcom_write_alignment_classes_to_inline( $html ) {
 	return preg_replace_callback(
-		'/(<(?:p|h[1-6]|blockquote)\b[^>]*?)class="([^"]*has-text-align-(left|center|right)[^"]*)"([^>]*?>)/',
+		'/(<(?:p|h[1-6]|blockquote)\b[^>]*?)class="([^"]*has-text-align-(left|center|right|justify)[^"]*)"([^>]*?>)/',
 		function ( $m ) {
 			$before  = $m[1];
 			$classes = $m[2];
@@ -413,7 +424,7 @@ function wpcom_write_alignment_classes_to_inline( $html ) {
 			$after   = $m[4];
 
 			// Remove the has-text-align-* class.
-			$classes = trim( preg_replace( '/\bhas-text-align-(?:left|center|right)\b/', '', $classes ) );
+			$classes = trim( preg_replace( '/\bhas-text-align-(?:left|center|right|justify)\b/', '', $classes ) );
 			$classes = preg_replace( '/  +/', ' ', $classes );
 
 			// Build the new tag, merging alignment into any existing style
@@ -421,8 +432,13 @@ function wpcom_write_alignment_classes_to_inline( $html ) {
 			$class_attr = $classes ? ' class="' . $classes . '"' : '';
 			$tag        = rtrim( $before ) . $class_attr . $after;
 
-			if ( preg_match( '/style="[^"]*"/', $tag ) ) {
-				$tag = preg_replace( '/style="/', 'style="text-align:' . $align . ';', $tag, 1 );
+			if ( preg_match( '/style="([^"]*)"/', $tag, $sm ) ) {
+				// Skip prepending if the existing style attr already declares
+				// the same text-align (avoids duplicate text-align declarations
+				// when the saved HTML carries both class and inline style).
+				if ( strpos( $sm[1], 'text-align:' . $align ) === false ) {
+					$tag = preg_replace( '/style="/', 'style="text-align:' . $align . ';', $tag, 1 );
+				}
 			} else {
 				$tag = preg_replace( '/>$/', ' style="text-align:' . $align . '">', $tag );
 			}
@@ -601,6 +617,8 @@ function wpcom_write_render_admin_page() {
 			'formatAlignLeft'     => true,
 			'formatAlignCenter'   => false,
 			'formatAlignRight'    => false,
+			'formatAlignJustify'  => false,
+			'cannotJustify'       => false,
 			'formatOList'         => false,
 			'formatUList'         => false,
 			'insideList'          => false,
@@ -727,6 +745,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Align left', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.alignLeft" data-wp-class--bw-tool-active="state.formatAlignLeft" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Align left', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-alignleft"></span></button>
 			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Align center', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.alignCenter" data-wp-class--bw-tool-active="state.formatAlignCenter" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Align center', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-aligncenter"></span></button>
 			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Align right', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.alignRight" data-wp-class--bw-tool-active="state.formatAlignRight" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Align right', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-alignright"></span></button>
+			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Justify', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.alignJustify" data-wp-class--bw-tool-active="state.formatAlignJustify" data-wp-bind--disabled="state.cannotJustify" title="<?php echo esc_attr__( 'Justify', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-justify"></span></button>
 			<span class="bw-tool-divider"></span>
 			<!-- Lists -->
 			<button class="bw-tool" aria-label="<?php echo esc_attr__( 'Bulleted list', 'jetpack-mu-wpcom' ); ?>" tabindex="-1" data-wp-on--click="actions.formatUList" data-wp-class--bw-tool-active="state.formatUList" title="<?php echo esc_attr__( 'Bulleted list', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-ul"></span></button>


### PR DESCRIPTION
Fixes RSM-3388.

## Proposed changes

* Add a Justify button to the Write toolbar, scoped to paragraphs only. Disabled inside headings, quotes, and lists, where browser justification on display type or narrow columns produces large word-spacing gaps.
* Serializer emits the canonical wpcom block-attrs form (`{"align":"justify","className":"has-text-align-justify","style":{"typography":{"textAlign":"justify"}}}`) with an inline-style fallback on the rendered `<p>` for robust front-end rendering across environments.
* Extend the unsupported-blocks gate and the class-to-inline load translator so paragraphs authored as canonical justify (e.g. in the Block Editor) round-trip cleanly through Write.
* Editor-only `hyphens: auto` rule scoped to justified paragraphs so the writer sees realistic line breaks while composing. Reader-facing hyphenation is out of scope (theme / upstream block-library concern).

## Screenshots

### Editor view (Justify active in toolbar, hyphenation visible at line breaks)
<img width="1429" height="750" alt="write-justify-editor" src="https://github.com/user-attachments/assets/d1a06e99-ad41-4521-8291-b25a9ac58f0b" />


### Front-end render (justified, no hyphenation — editor-preview only)
<img width="1429" height="750" alt="write-justify-frontend" src="https://github.com/user-attachments/assets/4d8559b4-c416-4cb6-a5ee-9b7b5e6e785e" />

## Sample paragraph

Use this in step 2 below to reproduce the screenshots — it's long enough to wrap to 5+ lines at the editor's default width:

> Justified text spreads each line to the full column width by widening the spaces between words. In a roomy column with good typography this can look polished and book-like, but in narrow columns or on mobile the gaps become rivers of whitespace that hurt readability — which is why the toolbar enables justification only for paragraphs, and pairs it with browser auto-hyphenation while you write so line breaks stay tight.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/RSM-3388/add-full-justification — originally requested in a comment on the Reader Council launch post (linked from Linear). A follow-up question about auto-hyphenation in the same thread is addressed only as an editor preview here; broader (reader-facing) hyphenation is left for a separate Gutenberg / theme conversation.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open Write on a wpcom Simple or Atomic site.
2. Paste the sample paragraph above (or any paragraph long enough to wrap several lines). Click the new Justify button in the toolbar (between Align Right and Bulleted List).
3. Verify the paragraph becomes justified in the editor with visible hyphenation at line breaks.
4. Click Save Draft, then check the saved `post_content` (via wp-cli or REST). It should look like:
   ```
   <!-- wp:paragraph {"align":"justify","className":"has-text-align-justify","style":{"typography":{"textAlign":"justify"}}} -->
   <p class="has-text-align-justify" style="text-align:justify">…</p>
   <!-- /wp:paragraph -->
   ```
5. Publish and view the post on the front-end — text should render justified (no hyphenation on the rendered post is expected; that's editor-preview only).
6. Reopen the post in Write — the unsupported-content warning should NOT appear, and the Justify toolbar button should show as active when the cursor is in the justified paragraph.
7. Click into a heading (created via the Text style dropdown), a blockquote, or a list — the Justify button should be disabled.
8. As a regression check: existing left / center / right alignment should still work as before (legacy `{"align":"<value>"}` + inline-style form, unchanged).
9. Optional: create a paragraph in the regular Block Editor with `text-align: justify` via the typography panel; open the post in Write — it should load cleanly with the alignment preserved.