### PR TITLE
Search: prevent Instant Search modal from triggering on third-party form submissions

### DIFF
--- a/projects/packages/search/changelog/fix-search-modal-third-party-forms
+++ b/projects/packages/search/changelog/fix-search-modal-third-party-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: prevent the search modal from triggering on third-party form submissions. Forms embedding an input named "s" (e.g. ActiveCampaign sign-up widgets) would incorrectly open the search overlay and block the submission. The fix checks that the form's action URL shares the same origin as the site before intercepting.

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -163,6 +163,17 @@ export default class DomEventHandler extends Component {
 	};
 
 	handleSubmit = event => {
+		// Don't intercept submissions targeting third-party domains. A form can
+		// contain an input named "s" without being a WordPress search form (e.g.
+		// ActiveCampaign sign-up embeds), so only intercept same-origin forms.
+		try {
+			if ( new URL( event.target.action ).origin !== window.location.origin ) {
+				return;
+			}
+		} catch {
+			return;
+		}
+
 		event.preventDefault();
 		this.handleInput.flush();
 

--- a/projects/packages/search/src/instant-search/components/test/dom-event-handler.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/dom-event-handler.test.jsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import DomEventHandler from '../dom-event-handler';
+
+const noop = () => {};
+
+const defaultProps = {
+	themeOptions: {
+		searchInputSelector: 'input[name="s"]',
+		overlayTriggerSelector: '',
+		filterInputSelector: '',
+	},
+	overlayOptions: { overlayTrigger: 'immediate' },
+	isVisible: false,
+	initializeQueryValues: noop,
+	setSearchQuery: noop,
+	setFilter: noop,
+	showResults: noop,
+};
+
+describe( 'DomEventHandler.handleSubmit', () => {
+	let setSearchQuery;
+	let showResults;
+	let preventDefault;
+
+	beforeEach( () => {
+		setSearchQuery = jest.fn();
+		showResults = jest.fn();
+		preventDefault = jest.fn();
+	} );
+
+	function makeSubmitEvent( action ) {
+		const input = document.createElement( 'input' );
+		input.name = 's';
+		input.value = 'test';
+		const form = document.createElement( 'form' );
+		form.action = action;
+		form.appendChild( input );
+		return {
+			target: form,
+			preventDefault,
+		};
+	}
+
+	function renderHandler( extraProps = {} ) {
+		return render(
+			<DomEventHandler
+				{ ...defaultProps }
+				setSearchQuery={ setSearchQuery }
+				showResults={ showResults }
+				{ ...extraProps }
+			/>
+		);
+	}
+
+	it( 'intercepts same-origin form submissions', () => {
+		const { instance } = renderHandler();
+		// Access the class instance via the rendered component ref is not straightforward with RTL;
+		// call handleSubmit directly on a new instance.
+		const handler = new DomEventHandler( defaultProps );
+		handler.props = { ...defaultProps, setSearchQuery, showResults };
+
+		const event = makeSubmitEvent( window.location.origin + '/search' );
+		handler.handleSubmit( event );
+
+		expect( preventDefault ).toHaveBeenCalled();
+	} );
+
+	it( 'does not intercept third-party form submissions', () => {
+		const handler = new DomEventHandler( defaultProps );
+		handler.props = { ...defaultProps, setSearchQuery, showResults };
+
+		const event = makeSubmitEvent( 'https://third-party.example.com/subscribe' );
+		handler.handleSubmit( event );
+
+		expect( preventDefault ).not.toHaveBeenCalled();
+		expect( showResults ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not intercept form submissions with a different subdomain', () => {
+		const handler = new DomEventHandler( defaultProps );
+		handler.props = { ...defaultProps, setSearchQuery, showResults };
+
+		const event = makeSubmitEvent( 'https://other.example.com/form' );
+		handler.handleSubmit( event );
+
+		expect( preventDefault ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/search/src/instant-search/components/test/dom-event-handler.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/dom-event-handler.test.jsx
@@ -1,4 +1,3 @@
-import { render } from '@testing-library/react';
 import * as React from 'react';
 import DomEventHandler from '../dom-event-handler';
 
@@ -29,6 +28,12 @@ describe( 'DomEventHandler.handleSubmit', () => {
 		preventDefault = jest.fn();
 	} );
 
+	/**
+	 * Creates a mock submit event targeting a form with the given action URL.
+	 *
+	 * @param {string} action - The form action URL.
+	 * @return {object} A mock submit event with `target` and `preventDefault`.
+	 */
 	function makeSubmitEvent( action ) {
 		const input = document.createElement( 'input' );
 		input.name = 's';
@@ -42,24 +47,20 @@ describe( 'DomEventHandler.handleSubmit', () => {
 		};
 	}
 
-	function renderHandler( extraProps = {} ) {
-		return render(
-			<DomEventHandler
-				{ ...defaultProps }
-				setSearchQuery={ setSearchQuery }
-				showResults={ showResults }
-				{ ...extraProps }
-			/>
-		);
+	/**
+	 * Creates a DomEventHandler instance with test props injected.
+	 *
+	 * @param {object} extraProps - Additional props to merge.
+	 * @return {DomEventHandler} The handler instance.
+	 */
+	function makeHandler( extraProps = {} ) {
+		const handler = new DomEventHandler( defaultProps );
+		handler.props = { ...defaultProps, setSearchQuery, showResults, ...extraProps };
+		return handler;
 	}
 
 	it( 'intercepts same-origin form submissions', () => {
-		const { instance } = renderHandler();
-		// Access the class instance via the rendered component ref is not straightforward with RTL;
-		// call handleSubmit directly on a new instance.
-		const handler = new DomEventHandler( defaultProps );
-		handler.props = { ...defaultProps, setSearchQuery, showResults };
-
+		const handler = makeHandler();
 		const event = makeSubmitEvent( window.location.origin + '/search' );
 		handler.handleSubmit( event );
 
@@ -67,9 +68,7 @@ describe( 'DomEventHandler.handleSubmit', () => {
 	} );
 
 	it( 'does not intercept third-party form submissions', () => {
-		const handler = new DomEventHandler( defaultProps );
-		handler.props = { ...defaultProps, setSearchQuery, showResults };
-
+		const handler = makeHandler();
 		const event = makeSubmitEvent( 'https://third-party.example.com/subscribe' );
 		handler.handleSubmit( event );
 
@@ -78,9 +77,7 @@ describe( 'DomEventHandler.handleSubmit', () => {
 	} );
 
 	it( 'does not intercept form submissions with a different subdomain', () => {
-		const handler = new DomEventHandler( defaultProps );
-		handler.props = { ...defaultProps, setSearchQuery, showResults };
-
+		const handler = makeHandler();
 		const event = makeSubmitEvent( 'https://other.example.com/form' );
 		handler.handleSubmit( event );
 

--- a/projects/packages/search/src/instant-search/components/test/dom-event-handler.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/dom-event-handler.test.jsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import DomEventHandler from '../dom-event-handler';
 
 const noop = () => {};


### PR DESCRIPTION
Fixes #47553

## Proposed changes

* Add an origin check in `DomEventHandler.handleSubmit` so the Instant Search modal only intercepts same-origin form submissions. Previously, any form containing an input named `s` would trigger the overlay and block the submission, including embedded third-party forms (e.g. ActiveCampaign sign-up widgets) that the user cannot modify.

The fix resolves the form's `action` attribute with `new URL()` and compares its `origin` against `window.location.origin`. If they don't match, `handleSubmit` returns early and the browser processes the form normally.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/47553

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a post or page, add a Custom HTML block with a form that targets a third-party URL and includes an input named `s`:
   ```html
   <form action="https://example.com" method="POST">
     <input type="hidden" name="s" value=""/>
     <button type="submit">Test</button>
   </form>
   ```
2. With Instant Search active, click the submit button on the frontend.
3. **Before this fix:** the search modal opens and the form is never submitted.
4. **After this fix:** the search modal does not open and the browser submits the form to `https://example.com` normally.
5. Verify that a standard WordPress search form (action pointing to the site itself) still opens the Instant Search overlay as expected.

## Use of AI Tools

This PR was developed with Claude Code (Anthropic). The fix logic, test cases, and changelog entry were AI-assisted and reviewed by the author.