### PR TITLE
Forms: remove opacity from Required label to fix WCAG 2.2 SC 1.4.3 contrast failure

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-required-label-contrast
+++ b/projects/packages/forms/changelog/fix-contact-form-required-label-contrast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: remove `opacity: 0.6` from the "Required" label so it inherits the full theme text colour. The opacity caused the rendered colour to fall below the WCAG 2.2 SC 1.4.3 minimum contrast ratio of 4.5:1 across multiple widely-used themes (Storefront, Hello Elementor, Astra, OceanWP).

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -381,7 +381,6 @@
 	.required {
 		word-break: normal;
 		color: unset;
-		opacity: 0.6;
 		font-size: 72%;
 		margin-inline-start: 0.25em;
 		font-weight: 400;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -225,7 +225,6 @@
 	font-size: 85%;
 	margin-left: 0.25em;
 	font-weight: 400;
-	opacity: 0.6;
 }
 
 .contact-form-submission {


### PR DESCRIPTION
Fixes #48315

## Proposed changes

* Remove `opacity: 0.6` from `.grunion-label-required` / `label span.required` in `grunion.scss` (frontend styles) and the `.required` selector in `editor.scss` (block editor styles).

The opacity caused the rendered text colour to fall below the WCAG 2.2 SC 1.4.3 minimum contrast ratio of 4.5:1 across multiple widely-used themes:

| Theme | Text colour | Rendered with `opacity: 0.6` | Contrast ratio | Result |
|---|---|---|---|---|
| Storefront | `#6d6d6d` | `#A7A7A7` | 2.4:1 | Fail |
| Hello Elementor | `#333` | `#858585` | 3.69:1 | Fail |
| Astra | `#1E293B` | `#787F89` | 4.04:1 | Fail |
| OceanWP | `#4A4A4A` | `#929292` | 3.11:1 | Fail |

Removing the declaration lets the label inherit the full theme text colour, restoring accessible contrast. This is a regression of #31203 (PR #34237), which raised opacity from `0.45` to `0.6` but still left it short of the required ratio on many themes.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/48315

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Install and activate the **Storefront** theme (or Hello Elementor, Astra, or OceanWP) with default colour settings.
2. Add a **Contact Form** block to a page and publish it.
3. View the page on the frontend and inspect the "Required" label text next to a field.
4. **Before this fix:** the label has `opacity: 0.6` applied, reducing contrast below 4.5:1.
5. **After this fix:** the label is fully opaque and inherits the theme text colour at full contrast.
6. Open the block editor for the same page and verify the "Required" label appears correctly in the editor view as well.

## Use of AI Tools

This PR was developed with Claude Code (Anthropic). The fix, changelog entry, and PR description were AI-assisted and reviewed by the author.