### PR TITLE
Fix podcast dashboard episode readiness

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-dashboard-episode-status
+++ b/projects/packages/podcast/changelog/fix-podcast-dashboard-episode-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: use server-derived feed URL and episode status in the dashboard, and recognize Podcast Episode block media in publish tracking.

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Podcast episode query helpers.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast;
+
+use WP_Post;
+use WP_Query;
+
+/**
+ * Shared helpers for identifying posts that are actual podcast episodes.
+ */
+class Episode_Query {
+
+	/**
+	 * Whether a post carries supported podcast media.
+	 *
+	 * @param WP_Post $post Post being checked.
+	 */
+	public static function post_has_podcast_media( WP_Post $post ): bool {
+		return self::has_podcast_episode_block_media( $post )
+			|| has_block( 'core/audio', $post )
+			|| has_block( 'core/video', $post )
+			|| ! empty( get_attached_media( 'audio', $post->ID ) )
+			|| ! empty( get_attached_media( 'video', $post->ID ) );
+	}
+
+	/**
+	 * Whether a post has a Podcast Episode block with a concrete media URL.
+	 *
+	 * @param WP_Post $post Post being checked.
+	 */
+	private static function has_podcast_episode_block_media( WP_Post $post ): bool {
+		return self::blocks_have_podcast_episode_media( parse_blocks( $post->post_content ) );
+	}
+
+	/**
+	 * Recursively inspect parsed blocks for a Podcast Episode media URL.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 */
+	private static function blocks_have_podcast_episode_media( array $blocks ): bool {
+		foreach ( $blocks as $block ) {
+			if (
+				isset( $block['blockName'], $block['attrs']['mediaUrl'] ) &&
+				'jetpack/podcast-episode' === $block['blockName'] &&
+				is_string( $block['attrs']['mediaUrl'] ) &&
+				'' !== trim( $block['attrs']['mediaUrl'] )
+			) {
+				return true;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) && self::blocks_have_podcast_episode_media( $block['innerBlocks'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the configured category has at least one published episode.
+	 *
+	 * @param int $category_id     Configured podcast category ID.
+	 * @param int $exclude_post_id Optional post ID to exclude from the scan.
+	 */
+	public static function has_published_episode( int $category_id, int $exclude_post_id = 0 ): bool {
+		if ( $category_id <= 0 ) {
+			return false;
+		}
+
+		$page = 1;
+		do {
+			$query = new WP_Query(
+				array(
+					'post_status'            => 'publish',
+					'post_type'              => 'post',
+					'cat'                    => $category_id,
+					'post__not_in'           => $exclude_post_id > 0 ? array( $exclude_post_id ) : array(),
+					'posts_per_page'         => 50,
+					'paged'                  => $page,
+					'ignore_sticky_posts'    => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
+
+			foreach ( $query->posts as $post ) {
+				if (
+					$post instanceof WP_Post &&
+					in_category( $category_id, $post ) &&
+					self::post_has_podcast_media( $post )
+				) {
+					return true;
+				}
+			}
+
+			$page++;
+		} while ( $page <= (int) $query->max_num_pages );
+
+		return false;
+	}
+}

--- a/projects/packages/podcast/src/class-podcast-status-endpoint.php
+++ b/projects/packages/podcast/src/class-podcast-status-endpoint.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Podcast dashboard status endpoint.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast;
+
+use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Provides derived podcast status that is awkward to infer from core REST data.
+ */
+class Podcast_Status_Endpoint extends WP_REST_Controller {
+
+	/**
+	 * Wire the route when the podcast package is enabled.
+	 */
+	public static function init() {
+		$instance = new self();
+		add_action( 'rest_api_init', array( $instance, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the status route.
+	 */
+	public function register_routes() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'podcast/status';
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'read_status' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function permission_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to manage podcast settings on this site.', 'jetpack-podcast' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read derived podcast status for the dashboard.
+	 */
+	public function read_status() {
+		$category_id = Customize_Feed::resolve_category_id();
+		$feed_url    = $category_id > 0 ? get_category_feed_link( $category_id, 'rss2' ) : '';
+
+		return rest_ensure_response(
+			array(
+				'categoryId'          => $category_id,
+				'feedUrl'             => $feed_url ? esc_url_raw( $feed_url ) : '',
+				'hasPublishedEpisode' => $category_id > 0 ? Episode_Query::has_published_episode( $category_id ) : false,
+			)
+		);
+	}
+}

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -68,6 +68,10 @@ class Podcast {
 
 		Tracks::init();
 
+		if ( is_admin() || self::is_rest_request() ) {
+			Podcast_Status_Endpoint::init();
+		}
+
 		// Wire the wp-admin entry point. Admin_Page::init() stages the wp-build
 		// dashboard; menu registration itself runs from wpcom-admin-menu.php
 		// via Admin_Page::add_wp_admin_submenu() at admin_menu priority 999999.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -12,7 +12,6 @@ namespace Automattic\Jetpack\Podcast;
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Throwable;
 use WP_Post;
-use WP_Query;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_User;
@@ -93,8 +92,8 @@ class Tracks {
 			}
 
 			// Match the RSS feed's definition of an episode — must carry
-			// audio, not just sit in the podcast category.
-			if ( ! self::has_podcast_media( $post ) ) {
+			// podcast media, not just sit in the podcast category.
+			if ( ! Episode_Query::post_has_podcast_media( $post ) ) {
 				return;
 			}
 
@@ -365,38 +364,13 @@ class Tracks {
 	}
 
 	/**
-	 * Filters out posts in the podcast category that aren't actually episodes.
-	 * `core/audio` block + classic-editor attached audio cover the supported
-	 * authoring paths.
-	 *
-	 * @param WP_Post $post Post being checked.
-	 */
-	private static function has_podcast_media( WP_Post $post ): bool {
-		return has_block( 'core/audio', $post )
-			|| ! empty( get_attached_media( 'audio', $post->ID ) );
-	}
-
-	/**
 	 * True when no other published post exists in the podcast category.
 	 *
 	 * @param int $category_id     Configured podcast category ID.
 	 * @param int $current_post_id Post being published (excluded from the check).
 	 */
 	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {
-		$existing = new WP_Query(
-			array(
-				'post_status'      => 'publish',
-				'post_type'        => 'post',
-				'cat'              => $category_id,
-				'post__not_in'     => array( $current_post_id ),
-				'posts_per_page'   => 1,
-				'fields'           => 'ids',
-				'no_found_rows'    => true,
-				'suppress_filters' => true,
-			)
-		);
-
-		return empty( $existing->posts );
+		return ! Episode_Query::has_published_episode( $category_id, $current_post_id );
 	}
 
 	/**

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -22,9 +22,11 @@ interface CategoryPickerProps {
 	onSelect: ( id: number ) => void;
 	disabled?: boolean;
 	// Fires when the inline "create a new category" form opens/closes, so a
-	// containing modal can gate its own Confirm button until the user either
-	// finishes or cancels the inline flow.
+	// containing modal can gate Confirm until the user finishes or cancels.
 	onCreatingChange?: ( isCreating: boolean ) => void;
+	// Fires while the create request is in flight, so a containing modal can
+	// prevent dismissal until the async create settles.
+	onSavingChange?: ( isSaving: boolean ) => void;
 }
 
 const parseErrorMessage = ( error: unknown, fallback: string ): string => {
@@ -47,6 +49,7 @@ const CategoryPicker = ( {
 	onSelect,
 	disabled = false,
 	onCreatingChange,
+	onSavingChange,
 }: CategoryPickerProps ) => {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -66,6 +69,10 @@ const CategoryPicker = ( {
 	useEffect( () => {
 		onCreatingChange?.( isCreating );
 	}, [ isCreating, onCreatingChange ] );
+
+	useEffect( () => {
+		onSavingChange?.( saving );
+	}, [ saving, onSavingChange ] );
 
 	const trimmedName = newName.trim();
 

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -12,7 +12,6 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
-import { useEntityRecord } from '@wordpress/core-data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
@@ -78,17 +77,9 @@ interface DistributionTabProps {
 
 const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	const { data: settings } = usePodcastSettings();
-	const { issues, isReady, isLoading } = useValidationIssues();
+	const { issues, isReady, isLoading, status } = useValidationIssues();
 	const categoryId = settings?.podcasting_category_id ?? 0;
-	// Pull the configured category record so we can derive the feed URL
-	// (`{category-archive}feed/`) without needing PHP-side script data.
-	const { record: category } = useEntityRecord< { link?: string } >(
-		'taxonomy',
-		'category',
-		categoryId,
-		{ enabled: categoryId > 0 }
-	);
-	const feedUrl = category?.link ? `${ category.link }feed/` : '';
+	const feedUrl = status?.feedUrl ?? '';
 	const isEnabled = categoryId > 0;
 	// Includes isLoading so the buttons don't flash enabled before issues resolve.
 	const isSubmitBlocked = ! isEnabled || ! isReady || isLoading;

--- a/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
@@ -2,7 +2,9 @@
 // draft; hook variant adds cover-media + episode-presence checks for the
 // Distribution Submit gate.
 
-import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import apiFetch from '@wordpress/api-fetch';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { usePodcastSettings } from './use-podcast-settings';
 import type { PodcastSettings } from '../types';
@@ -10,6 +12,12 @@ import type { PodcastSettings } from '../types';
 interface CoverImageRecord {
 	media_details?: { width?: number; height?: number };
 	mime_type?: string;
+}
+
+interface PodcastStatus {
+	categoryId: number;
+	feedUrl: string;
+	hasPublishedEpisode: boolean;
 }
 
 /**
@@ -90,11 +98,60 @@ const getDistributionIssues = (
 	return issues;
 };
 
+function usePodcastStatus( categoryId: number ): {
+	status: PodcastStatus | undefined;
+	hasResolved: boolean;
+} {
+	const [ status, setStatus ] = useState< PodcastStatus | undefined >( undefined );
+	const [ hasResolved, setHasResolved ] = useState( categoryId <= 0 );
+
+	useEffect( () => {
+		if ( categoryId <= 0 ) {
+			setStatus( undefined );
+			setHasResolved( true );
+			return;
+		}
+
+		let cancelled = false;
+		setStatus( undefined );
+		setHasResolved( false );
+		apiFetch( { path: '/wpcom/v2/podcast/status', method: 'GET' } )
+			.then( response => {
+				if ( cancelled ) {
+					return;
+				}
+				const payload = response as Partial< PodcastStatus >;
+				setStatus( {
+					categoryId: Number( payload.categoryId ?? categoryId ) || categoryId,
+					feedUrl: typeof payload.feedUrl === 'string' ? payload.feedUrl : '',
+					hasPublishedEpisode: payload.hasPublishedEpisode === true,
+				} );
+			} )
+			.catch( () => {
+				if ( cancelled ) {
+					return;
+				}
+				setStatus( { categoryId, feedUrl: '', hasPublishedEpisode: false } );
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setHasResolved( true );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ categoryId ] );
+
+	return { status, hasResolved };
+}
+
 /**
- * Distribution Submit gate. Reads cover media + an episode probe alongside
- * saved settings; both subqueries are `enabled`-gated.
+ * Distribution Submit gate. Reads cover media + derived podcast status
+ * alongside saved settings; subqueries are `enabled`-gated.
  *
- * @return `{ issues, isReady, isLoading }` — issues suppressed during load.
+ * @return `{ issues, isReady, isLoading, status }` — issues suppressed during load.
  */
 export function useValidationIssues() {
 	const { data: settings, isLoading: settingsLoading } = usePodcastSettings();
@@ -108,23 +165,14 @@ export function useValidationIssues() {
 	);
 
 	const categoryId = settings?.podcasting_category_id ?? 0;
-	const { records: episodeProbe, hasResolved: episodeProbeResolved } = useEntityRecords< {
-		id: number;
-	} >(
-		'postType',
-		'post',
-		{ categories: categoryId, per_page: 1, status: 'publish', _fields: 'id' },
-		{ enabled: categoryId > 0 }
-	);
+	const { status, hasResolved: statusResolved } = usePodcastStatus( categoryId );
 
 	const hasPublishedEpisode: boolean | undefined =
-		categoryId > 0 && episodeProbeResolved
-			? Array.isArray( episodeProbe ) && episodeProbe.length > 0
-			: undefined;
+		categoryId > 0 && statusResolved ? status?.hasPublishedEpisode === true : undefined;
 
 	const isLoading =
 		settingsLoading ||
-		( categoryId > 0 && ! episodeProbeResolved ) ||
+		( categoryId > 0 && ! statusResolved ) ||
 		( coverImageId > 0 && ! coverResolved );
 
 	const issues = isLoading
@@ -135,5 +183,6 @@ export function useValidationIssues() {
 		issues,
 		isReady: ! isLoading && issues.length === 0,
 		isLoading,
+		status,
 	};
 }

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -169,6 +169,10 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 				.filter( ( v ): v is string => !! v ),
 		[ draft?.podcasting_category_1, draft?.podcasting_category_2, draft?.podcasting_category_3 ]
 	);
+	const preservedUnknownTopics = useMemo(
+		() => new Set( topicValue.filter( display => ! TOPIC_STORAGE_BY_DISPLAY.has( display ) ) ),
+		[ topicValue ]
+	);
 
 	// Calypso renders three native selects, one per slot, so each pick closes
 	// its dropdown and saves discretely. We use a single `FormTokenField` but
@@ -189,7 +193,11 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 			const stored = values
 				.slice( 0, 3 )
 				.map( v => ( typeof v === 'string' ? v : v.value ) )
-				.map( display => TOPIC_STORAGE_BY_DISPLAY.get( display ) ?? '' );
+				.map(
+					display =>
+						TOPIC_STORAGE_BY_DISPLAY.get( display ) ??
+						( preservedUnknownTopics.has( display ) ? display : '' )
+				);
 			commit( {
 				podcasting_category_1: stored[ 0 ] ?? '',
 				podcasting_category_2: stored[ 1 ] ?? '',
@@ -197,7 +205,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 			} );
 			topicFieldRef.current?.querySelector< HTMLInputElement >( 'input' )?.blur();
 		},
-		[ commit ]
+		[ commit, preservedUnknownTopics ]
 	);
 
 	const issues = useMemo( () => getValidationIssues( draft ?? settings ), [ draft, settings ] );

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -49,15 +49,16 @@ const CategorySetupModal = ( {
 	const [ error, setError ] = useState< string | null >( null );
 	const [ saving, setSaving ] = useState( false );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
+	const [ pickerSaving, setPickerSaving ] = useState( false );
 
 	const requestClose = useCallback( () => {
-		// Block dismissal while a save is in flight so the in-flight promise
-		// can't mutate settings after the user thought they cancelled.
-		if ( saving ) {
+		// Block dismissal while a settings save or inline category create is
+		// in flight, so async callbacks can't update a dismissed setup flow.
+		if ( saving || pickerSaving ) {
 			return;
 		}
 		onClose();
-	}, [ saving, onClose ] );
+	}, [ saving, pickerSaving, onClose ] );
 
 	const onConfirm = useCallback( async () => {
 		if ( ! categoryId ) {
@@ -117,9 +118,10 @@ const CategorySetupModal = ( {
 					onSelect={ setCategoryId }
 					disabled={ saving }
 					onCreatingChange={ setPickerCreating }
+					onSavingChange={ setPickerSaving }
 				/>
 				<HStack justify="flex-end" spacing={ 3 }>
-					<Button variant="tertiary" onClick={ requestClose } disabled={ saving }>
+					<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
 						{ __( 'Cancel', 'jetpack-podcast' ) }
 					</Button>
 					<Button
@@ -128,7 +130,7 @@ const CategorySetupModal = ( {
 						// Block Confirm while the inline create form is open so
 						// the user can't commit a stale `selectedId` with the
 						// half-filled inline form still mounted.
-						disabled={ ! categoryId || saving || pickerCreating }
+						disabled={ ! categoryId || saving || pickerCreating || pickerSaving }
 						isBusy={ saving }
 					>
 						{ __( 'Confirm', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\Episode_Query;
+use Automattic\Jetpack\Podcast\Podcast_Status_Endpoint;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts as WorDBless_Posts;
+use WP_Term;
+
+/**
+ * @covers \Automattic\Jetpack\Podcast\Podcast_Status_Endpoint
+ */
+#[CoversClass( Podcast_Status_Endpoint::class )]
+#[CoversClass( Episode_Query::class )]
+class Podcast_Status_Endpoint_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! taxonomy_exists( 'category' ) ) {
+			register_taxonomy( 'category', 'post', array( 'hierarchical' => true ) );
+		}
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'podcasting_category_id' );
+		remove_all_filters( 'category_feed_link' );
+		remove_all_filters( 'posts_pre_query' );
+		wp_cache_flush();
+		WorDBless_Posts::init()->clear_all_posts();
+		parent::tearDown();
+	}
+
+	private function configure_podcast_category( int $id = 42 ): int {
+		$term = new WP_Term(
+			(object) array(
+				'term_id'          => $id,
+				'name'             => 'Podcast',
+				'slug'             => 'podcast',
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => $id,
+			)
+		);
+		wp_cache_set( $id, $term, 'terms' );
+		update_option( 'podcasting_category_id', $id );
+		return $id;
+	}
+
+	private function insert_post_in_category( int $category_id, string $content ): \WP_Post {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Episode ' . wp_generate_uuid4(),
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		wp_cache_set( (int) $post_id, array( $category_id ), 'category_relationships' );
+		$post               = get_post( (int) $post_id );
+		$post->post_content = $content;
+		return $post;
+	}
+
+	public function test_read_status_uses_wordpress_category_feed_link() {
+		$this->configure_podcast_category();
+		add_filter(
+			'category_feed_link',
+			static function () {
+				return 'https://example.org/?cat=42&feed=rss2';
+			}
+		);
+
+		$response = ( new Podcast_Status_Endpoint() )->read_status();
+		$data     = $response->get_data();
+
+		$this->assertSame( 'https://example.org/?cat=42&feed=rss2', $data['feedUrl'] );
+	}
+
+	public function test_read_status_requires_actual_podcast_media_for_published_episode() {
+		$cat_id  = $this->configure_podcast_category();
+		$regular = $this->insert_post_in_category( $cat_id, 'A regular post without podcast media.' );
+
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $regular ) {
+				return 'post' === $query->get( 'post_type' ) ? array( $regular ) : $posts;
+			},
+			10,
+			2
+		);
+		$response = ( new Podcast_Status_Endpoint() )->read_status();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['hasPublishedEpisode'] );
+		remove_all_filters( 'posts_pre_query' );
+
+		$episode = $this->insert_post_in_category(
+			$cat_id,
+			'<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.org/episode.mp3","mediaType":"audio"} /-->'
+		);
+
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $regular, $episode ) {
+				return 'post' === $query->get( 'post_type' ) ? array( $regular, $episode ) : $posts;
+			},
+			10,
+			2
+		);
+		$response = ( new Podcast_Status_Endpoint() )->read_status();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['hasPublishedEpisode'] );
+	}
+}

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Podcast\Episode_Query;
 use Automattic\Jetpack\Podcast\Tracks;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -22,6 +23,7 @@ use WP_Term;
  * @covers \Automattic\Jetpack\Podcast\Tracks
  */
 #[CoversClass( Tracks::class )]
+#[CoversClass( Episode_Query::class )]
 class Tracks_Test extends BaseTestCase {
 
 	protected function setUp(): void {
@@ -44,6 +46,7 @@ class Tracks_Test extends BaseTestCase {
 		delete_option( 'podcasting_email' );
 		delete_option( 'podcasting_talent_name' );
 		delete_option( 'podcast_show_launched_tracked' );
+		remove_all_filters( 'posts_pre_query' );
 		wp_cache_flush();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
@@ -101,7 +104,9 @@ class Tracks_Test extends BaseTestCase {
 			)
 		);
 		wp_cache_set( (int) $post_id, array( $category_id ), 'category_relationships' );
-		return get_post( (int) $post_id );
+		$post               = get_post( (int) $post_id );
+		$post->post_content = $content;
+		return $post;
 	}
 
 	public function test_episode_published_emits_for_first_published_post_in_category() {
@@ -181,6 +186,70 @@ class Tracks_Test extends BaseTestCase {
 		Tracks::record_episode_published( $post->ID, $post, false, null );
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_emits_for_podcast_episode_block() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category(
+			$cat_id,
+			'publish',
+			'<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.org/episode.mp3","mediaType":"audio"} /-->'
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( $post->ID, $events[0]['properties']['post_id'] );
+	}
+
+	public function test_episode_published_skips_empty_podcast_episode_block() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category(
+			$cat_id,
+			'publish',
+			'<!-- wp:jetpack/podcast-episode /-->'
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_emits_for_video_episode_block() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category(
+			$cat_id,
+			'publish',
+			'<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.org/episode.mp4","mediaType":"video"} /-->'
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( $post->ID, $events[0]['properties']['post_id'] );
+	}
+
+	public function test_first_episode_ignores_prior_non_episode_posts_in_category() {
+		$cat_id  = $this->configure_podcast_category();
+		$regular = $this->insert_post_in_category( $cat_id, 'publish', 'A regular post without podcast media.' );
+
+		$post = $this->insert_post_in_category( $cat_id );
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $regular ) {
+				return 'post' === $query->get( 'post_type' ) ? array( $regular ) : $posts;
+			},
+			10,
+			2
+		);
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertTrue( $events[0]['properties']['is_first_episode_for_site'] );
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_show_launched' ) );
 	}
 
 	public function test_media_uploaded_emits_for_audio_when_podcasting_enabled() {


### PR DESCRIPTION
## Summary

- Add a podcast status endpoint that returns the WordPress-derived category RSS feed URL and whether the configured category has a real published episode.
- Use that status in the dashboard Distribution tab so readiness and the copied RSS URL come from server-side podcast state.
- Share episode media detection with Tracks, including Podcast Episode blocks, core audio/video blocks, and attached audio/video media.
- Preserve legacy Apple category values on settings save and block setup modal dismissal while inline category creation is still saving.

## Testing

- `php -l projects/packages/podcast/src/class-episode-query.php`
- `php -l projects/packages/podcast/src/class-podcast-status-endpoint.php`
- `php -l projects/packages/podcast/src/class-podcast.php`
- `php -l projects/packages/podcast/src/class-tracks.php`
- `php -l projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php`
- `php -l projects/packages/podcast/tests/php/Tracks_Test.php`
- `vendor/bin/phpunit --configuration phpunit.12.xml.dist --filter Podcast_Status_Endpoint_Test`
- `vendor/bin/phpunit --configuration phpunit.12.xml.dist --filter Tracks_Test`
- `git diff --check`

Full package PHP suite:

- `composer test-php` fails in this isolated test setup with the existing Settings `pca.st` normalization failures and Podcast Episode block render-output failures.

Not run:

- JS lint/type checks; this clean worktree has no `node_modules`, and local Node is `v22.17.0` while the repo requires `^24.14.0`.
