### PR TITLE
Forms: restore full-width submit button on mobile for horizontal inline forms

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-submit-button-full-width-mobile
+++ b/projects/packages/forms/changelog/fix-forms-submit-button-full-width-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: restore full-width submit button on small screens for horizontal inline forms. The existing mobile media query set `flex-basis: 100%` on the button but had no effect when the parent form used the `is-layout-flex` class (horizontal orientation) because that layout lacks `flex-wrap: wrap`. Adding it at the 480px breakpoint allows the field and button to each stack to a full row on mobile.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -712,6 +712,13 @@
 
 @media only screen and ( max-width: 480px ) {
 
+	// Horizontal flex-layout forms need to wrap on small screens so that the
+	// field and button each get their own row. Non-flex-layout forms already
+	// have flex-wrap: wrap from the rule above.
+	.wp-block-jetpack-contact-form.is-layout-flex {
+		flex-wrap: wrap;
+	}
+
 	.wp-block-jetpack-contact-form .grunion-field-wrap {
 		flex-basis: 100%;
 		max-width: none;


### PR DESCRIPTION
Fixes #48075

## Proposed changes

* Add `flex-wrap: wrap` to `.wp-block-jetpack-contact-form.is-layout-flex` inside the existing `max-width: 480px` media query in `grunion.scss`.

The existing mobile breakpoint already set `flex-basis: 100%` on `.wp-block-button` and `.wp-block-jetpack-button`, which should make the submit button fill the row when the form stacks on small screens. However, this had no effect for forms using the `is-layout-flex` class (set when the block layout is configured as horizontal orientation), because that layout type does not carry `flex-wrap: wrap` on the parent container. Without it, `flex-basis: 100%` is ignored and the button stays at its natural width.

Adding `flex-wrap: wrap` to `is-layout-flex` forms at the 480px breakpoint restores the expected stacking behaviour. Non-flex-layout forms are unaffected as they already have `flex-wrap: wrap` from the static rule at line 580.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/48075

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Add a **Contact Form** block to a page.
2. In the block settings, set the **layout** to **Row** (horizontal) and **vertical alignment** to **Bottom**.
3. Set the input field width to **Auto**.
4. Publish the page and view it on the frontend.
5. Resize the browser to below 480px (or use DevTools responsive mode).
6. **Before this fix:** the submit button stays at its natural width even when the form stacks vertically.
7. **After this fix:** the submit button expands to full width when the viewport is below 480px.
8. Verify that at desktop widths the form stays horizontal and the button is not affected.

## Use of AI Tools

This PR was developed with Claude Code (Anthropic). The fix, changelog entry, and PR description were AI-assisted and reviewed by the author.