### PR TITLE
Fix podcast status readiness

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-dashboard-episode-status
+++ b/projects/packages/podcast/changelog/fix-podcast-dashboard-episode-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: use server-derived feed URL and episode status in the dashboard.

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Podcast episode query helpers.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast;
+
+use WP_Post;
+use WP_Query;
+
+/**
+ * Shared helpers for identifying posts that are actual podcast episodes.
+ */
+class Episode_Query {
+
+	/**
+	 * Whether a post carries supported podcast media.
+	 *
+	 * @param WP_Post $post Post being checked.
+	 */
+	public static function post_has_podcast_media( WP_Post $post ): bool {
+		return self::has_podcast_episode_block_media( $post )
+			|| has_block( 'core/audio', $post )
+			|| has_block( 'core/video', $post )
+			|| ! empty( get_attached_media( 'audio', $post->ID ) )
+			|| ! empty( get_attached_media( 'video', $post->ID ) );
+	}
+
+	/**
+	 * Whether a post has a Podcast Episode block with a concrete media URL.
+	 *
+	 * @param WP_Post $post Post being checked.
+	 */
+	private static function has_podcast_episode_block_media( WP_Post $post ): bool {
+		return self::blocks_have_podcast_episode_media( parse_blocks( $post->post_content ) );
+	}
+
+	/**
+	 * Recursively inspect parsed blocks for a Podcast Episode media URL.
+	 *
+	 * @param array $blocks Parsed blocks.
+	 */
+	private static function blocks_have_podcast_episode_media( array $blocks ): bool {
+		foreach ( $blocks as $block ) {
+			if (
+				isset( $block['blockName'], $block['attrs']['mediaUrl'] ) &&
+				'jetpack/podcast-episode' === $block['blockName'] &&
+				is_string( $block['attrs']['mediaUrl'] ) &&
+				'' !== trim( $block['attrs']['mediaUrl'] )
+			) {
+				return true;
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) && self::blocks_have_podcast_episode_media( $block['innerBlocks'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the configured category has at least one published episode.
+	 *
+	 * @param int $category_id     Configured podcast category ID.
+	 * @param int $exclude_post_id Optional post ID to exclude from the scan.
+	 */
+	public static function has_published_episode( int $category_id, int $exclude_post_id = 0 ): bool {
+		if ( $category_id <= 0 ) {
+			return false;
+		}
+
+		$page = 1;
+		do {
+			$query = new WP_Query(
+				array(
+					'post_status'            => 'publish',
+					'post_type'              => 'post',
+					'cat'                    => $category_id,
+					'post__not_in'           => $exclude_post_id > 0 ? array( $exclude_post_id ) : array(),
+					'posts_per_page'         => 50,
+					'paged'                  => $page,
+					'ignore_sticky_posts'    => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				)
+			);
+
+			foreach ( $query->posts as $post ) {
+				if (
+					$post instanceof WP_Post &&
+					in_category( $category_id, $post ) &&
+					self::post_has_podcast_media( $post )
+				) {
+					return true;
+				}
+			}
+
+			$page++;
+		} while ( $page <= (int) $query->max_num_pages );
+
+		return false;
+	}
+}

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -45,8 +45,9 @@ class Episode_Query {
 	private static function blocks_have_podcast_episode_media( array $blocks ): bool {
 		foreach ( $blocks as $block ) {
 			if (
-				isset( $block['blockName'], $block['attrs']['mediaUrl'] ) &&
+				isset( $block['blockName'] ) &&
 				'jetpack/podcast-episode' === $block['blockName'] &&
+				isset( $block['attrs']['mediaUrl'] ) &&
 				is_string( $block['attrs']['mediaUrl'] ) &&
 				'' !== trim( $block['attrs']['mediaUrl'] )
 			) {
@@ -98,7 +99,7 @@ class Episode_Query {
 				}
 			}
 
-			$page++;
+			++$page;
 		} while ( $page <= (int) $query->max_num_pages );
 
 		return false;

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -16,7 +16,11 @@ use WP_Query;
 class Episode_Query {
 
 	/**
-	 * Maximum number of published posts to scan per readiness check.
+	 * Maximum number of published posts to scan per readiness check to keep
+	 * dashboard status calls bounded on large sites while still covering typical
+	 * show catalogs (50 posts/page x 10 pages).
+	 *
+	 * @var int
 	 */
 	private const MAX_POSTS_TO_SCAN = 500;
 
@@ -76,7 +80,7 @@ class Episode_Query {
 			return false;
 		}
 
-		$page         = 1;
+		$page = 1;
 		$scanned_posts = 0;
 		while ( $scanned_posts < self::MAX_POSTS_TO_SCAN ) {
 			$query = new WP_Query(
@@ -101,12 +105,8 @@ class Episode_Query {
 			foreach ( $query->posts as $post ) {
 				++$scanned_posts;
 
-				if ( $post instanceof WP_Post && self::post_has_podcast_media( $post ) ) {
+				if ( self::post_has_podcast_media( $post ) ) {
 					return true;
-				}
-
-				if ( $scanned_posts >= self::MAX_POSTS_TO_SCAN ) {
-					break;
 				}
 			}
 

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -16,6 +16,11 @@ use WP_Query;
 class Episode_Query {
 
 	/**
+	 * Maximum number of published posts to scan per readiness check.
+	 */
+	private const MAX_POSTS_TO_SCAN = 500;
+
+	/**
 	 * Whether a post carries supported podcast media.
 	 *
 	 * @param WP_Post $post Post being checked.
@@ -23,9 +28,7 @@ class Episode_Query {
 	public static function post_has_podcast_media( WP_Post $post ): bool {
 		return self::has_podcast_episode_block_media( $post )
 			|| has_block( 'core/audio', $post )
-			|| has_block( 'core/video', $post )
-			|| ! empty( get_attached_media( 'audio', $post->ID ) )
-			|| ! empty( get_attached_media( 'video', $post->ID ) );
+			|| ! empty( get_attached_media( 'audio', $post->ID ) );
 	}
 
 	/**
@@ -73,8 +76,9 @@ class Episode_Query {
 			return false;
 		}
 
-		$page = 1;
-		do {
+		$page         = 1;
+		$scanned_posts = 0;
+		while ( $scanned_posts < self::MAX_POSTS_TO_SCAN ) {
 			$query = new WP_Query(
 				array(
 					'post_status'            => 'publish',
@@ -84,23 +88,30 @@ class Episode_Query {
 					'posts_per_page'         => 50,
 					'paged'                  => $page,
 					'ignore_sticky_posts'    => true,
+					'no_found_rows'          => true,
 					'update_post_meta_cache' => false,
 					'update_post_term_cache' => false,
 				)
 			);
 
+			if ( empty( $query->posts ) ) {
+				break;
+			}
+
 			foreach ( $query->posts as $post ) {
-				if (
-					$post instanceof WP_Post &&
-					in_category( $category_id, $post ) &&
-					self::post_has_podcast_media( $post )
-				) {
+				++$scanned_posts;
+
+				if ( $post instanceof WP_Post && self::post_has_podcast_media( $post ) ) {
 					return true;
+				}
+
+				if ( $scanned_posts >= self::MAX_POSTS_TO_SCAN ) {
+					break;
 				}
 			}
 
 			++$page;
-		} while ( $page <= (int) $query->max_num_pages );
+		}
 
 		return false;
 	}

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -16,9 +16,16 @@ use WP_Query;
 class Episode_Query {
 
 	/**
+	 * Batch size for each query page during episode scans.
+	 *
+	 * @var int
+	 */
+	private const POSTS_PER_PAGE = 50;
+
+	/**
 	 * Maximum number of published posts to scan per readiness check to keep
 	 * dashboard status calls bounded on large sites while still covering typical
-	 * show catalogs (50 posts/page x 10 pages).
+	 * show catalogs (self::POSTS_PER_PAGE x 10 pages).
 	 *
 	 * @var int
 	 */
@@ -83,13 +90,15 @@ class Episode_Query {
 		$page = 1;
 		$scanned_posts = 0;
 		while ( $scanned_posts < self::MAX_POSTS_TO_SCAN ) {
+			$posts_per_page = min( self::POSTS_PER_PAGE, self::MAX_POSTS_TO_SCAN - $scanned_posts );
+
 			$query = new WP_Query(
 				array(
 					'post_status'            => 'publish',
 					'post_type'              => 'post',
 					'cat'                    => $category_id,
 					'post__not_in'           => $exclude_post_id > 0 ? array( $exclude_post_id ) : array(),
-					'posts_per_page'         => 50,
+					'posts_per_page'         => $posts_per_page,
 					'paged'                  => $page,
 					'ignore_sticky_posts'    => true,
 					'no_found_rows'          => true,

--- a/projects/packages/podcast/src/class-podcast-status-endpoint.php
+++ b/projects/packages/podcast/src/class-podcast-status-endpoint.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Podcast dashboard status endpoint.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast;
+
+use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Provides derived podcast status that is awkward to infer from core REST data.
+ */
+class Podcast_Status_Endpoint extends WP_REST_Controller {
+
+	/**
+	 * Wire the route when the podcast package is enabled.
+	 */
+	public static function init() {
+		$instance = new self();
+		add_action( 'rest_api_init', array( $instance, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the status route.
+	 */
+	public function register_routes() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'podcast/status';
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'read_status' ),
+					'permission_callback' => array( $this, 'permission_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function permission_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to manage podcast settings on this site.', 'jetpack-podcast' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read derived podcast status for the dashboard.
+	 */
+	public function read_status() {
+		$category_id = Customize_Feed::resolve_category_id();
+		$feed_url    = $category_id > 0 ? get_category_feed_link( $category_id, 'rss2' ) : '';
+
+		return rest_ensure_response(
+			array(
+				'categoryId'          => $category_id,
+				'feedUrl'             => $feed_url ? esc_url_raw( $feed_url ) : '',
+				'hasPublishedEpisode' => $category_id > 0 ? Episode_Query::has_published_episode( $category_id ) : false,
+			)
+		);
+	}
+}

--- a/projects/packages/podcast/src/class-podcast-status-endpoint.php
+++ b/projects/packages/podcast/src/class-podcast-status-endpoint.php
@@ -18,6 +18,14 @@ use WP_REST_Server;
 class Podcast_Status_Endpoint extends WP_REST_Controller {
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'podcast/status';
+	}
+
+	/**
 	 * Wire the route when the podcast package is enabled.
 	 */
 	public static function init() {
@@ -29,9 +37,6 @@ class Podcast_Status_Endpoint extends WP_REST_Controller {
 	 * Register the status route.
 	 */
 	public function register_routes() {
-		$this->namespace = 'wpcom/v2';
-		$this->rest_base = 'podcast/status';
-
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base,

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -68,7 +68,10 @@ class Podcast {
 
 		Tracks::init();
 
-		if ( is_admin() || self::is_rest_request() ) {
+		// `class_exists()` guards a mid-deploy window where the loader (this
+		// file) may land before `class-podcast-status-endpoint.php` on
+		// non-atomic deploys.
+		if ( ( is_admin() || self::is_rest_request() ) && class_exists( Podcast_Status_Endpoint::class ) ) {
 			Podcast_Status_Endpoint::init();
 		}
 

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -68,6 +68,10 @@ class Podcast {
 
 		Tracks::init();
 
+		if ( is_admin() || self::is_rest_request() ) {
+			Podcast_Status_Endpoint::init();
+		}
+
 		// Wire the wp-admin entry point. Admin_Page::init() stages the wp-build
 		// dashboard; menu registration itself runs from wpcom-admin-menu.php
 		// via Admin_Page::add_wp_admin_submenu() at admin_menu priority 999999.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -366,14 +366,11 @@ class Tracks {
 
 	/**
 	 * Filters out posts in the podcast category that aren't actually episodes.
-	 * `core/audio` block + classic-editor attached audio cover the supported
-	 * authoring paths.
 	 *
 	 * @param WP_Post $post Post being checked.
 	 */
 	private static function has_podcast_media( WP_Post $post ): bool {
-		return has_block( 'core/audio', $post )
-			|| ! empty( get_attached_media( 'audio', $post->ID ) );
+		return Episode_Query::post_has_podcast_media( $post );
 	}
 
 	/**

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -12,7 +12,6 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
-import { useEntityRecord } from '@wordpress/core-data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
@@ -78,17 +77,9 @@ interface DistributionTabProps {
 
 const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	const { data: settings } = usePodcastSettings();
-	const { issues, isReady, isLoading } = useValidationIssues();
+	const { issues, isReady, isLoading, status } = useValidationIssues();
 	const categoryId = settings?.podcasting_category_id ?? 0;
-	// Pull the configured category record so we can derive the feed URL
-	// (`{category-archive}feed/`) without needing PHP-side script data.
-	const { record: category } = useEntityRecord< { link?: string } >(
-		'taxonomy',
-		'category',
-		categoryId,
-		{ enabled: categoryId > 0 }
-	);
-	const feedUrl = category?.link ? `${ category.link }feed/` : '';
+	const feedUrl = status?.feedUrl ?? '';
 	const isEnabled = categoryId > 0;
 	// Includes isLoading so the buttons don't flash enabled before issues resolve.
 	const isSubmitBlocked = ! isEnabled || ! isReady || isLoading;

--- a/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
@@ -2,7 +2,9 @@
 // draft; hook variant adds cover-media + episode-presence checks for the
 // Distribution Submit gate.
 
-import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import apiFetch from '@wordpress/api-fetch';
+import { useEntityRecord } from '@wordpress/core-data';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { usePodcastSettings } from './use-podcast-settings';
 import type { PodcastSettings } from '../types';
@@ -10,6 +12,12 @@ import type { PodcastSettings } from '../types';
 interface CoverImageRecord {
 	media_details?: { width?: number; height?: number };
 	mime_type?: string;
+}
+
+interface PodcastStatus {
+	categoryId: number;
+	feedUrl: string;
+	hasPublishedEpisode: boolean;
 }
 
 /**
@@ -90,11 +98,60 @@ const getDistributionIssues = (
 	return issues;
 };
 
+function usePodcastStatus( categoryId: number ): {
+	status: PodcastStatus | undefined;
+	hasResolved: boolean;
+} {
+	const [ status, setStatus ] = useState< PodcastStatus | undefined >( undefined );
+	const [ hasResolved, setHasResolved ] = useState( categoryId <= 0 );
+
+	useEffect( () => {
+		if ( categoryId <= 0 ) {
+			setStatus( undefined );
+			setHasResolved( true );
+			return;
+		}
+
+		let cancelled = false;
+		setStatus( undefined );
+		setHasResolved( false );
+		apiFetch( { path: '/wpcom/v2/podcast/status', method: 'GET' } )
+			.then( response => {
+				if ( cancelled ) {
+					return;
+				}
+				const payload = response as Partial< PodcastStatus >;
+				setStatus( {
+					categoryId: Number( payload.categoryId ?? categoryId ) || categoryId,
+					feedUrl: typeof payload.feedUrl === 'string' ? payload.feedUrl : '',
+					hasPublishedEpisode: payload.hasPublishedEpisode === true,
+				} );
+			} )
+			.catch( () => {
+				if ( cancelled ) {
+					return;
+				}
+				setStatus( { categoryId, feedUrl: '', hasPublishedEpisode: false } );
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setHasResolved( true );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ categoryId ] );
+
+	return { status, hasResolved };
+}
+
 /**
- * Distribution Submit gate. Reads cover media + an episode probe alongside
- * saved settings; both subqueries are `enabled`-gated.
+ * Distribution Submit gate. Reads cover media + derived podcast status
+ * alongside saved settings; subqueries are `enabled`-gated.
  *
- * @return `{ issues, isReady, isLoading }` — issues suppressed during load.
+ * @return `{ issues, isReady, isLoading, status }` — issues suppressed during load.
  */
 export function useValidationIssues() {
 	const { data: settings, isLoading: settingsLoading } = usePodcastSettings();
@@ -108,23 +165,14 @@ export function useValidationIssues() {
 	);
 
 	const categoryId = settings?.podcasting_category_id ?? 0;
-	const { records: episodeProbe, hasResolved: episodeProbeResolved } = useEntityRecords< {
-		id: number;
-	} >(
-		'postType',
-		'post',
-		{ categories: categoryId, per_page: 1, status: 'publish', _fields: 'id' },
-		{ enabled: categoryId > 0 }
-	);
+	const { status, hasResolved: statusResolved } = usePodcastStatus( categoryId );
 
 	const hasPublishedEpisode: boolean | undefined =
-		categoryId > 0 && episodeProbeResolved
-			? Array.isArray( episodeProbe ) && episodeProbe.length > 0
-			: undefined;
+		categoryId > 0 && statusResolved ? status?.hasPublishedEpisode === true : undefined;
 
 	const isLoading =
 		settingsLoading ||
-		( categoryId > 0 && ! episodeProbeResolved ) ||
+		( categoryId > 0 && ! statusResolved ) ||
 		( coverImageId > 0 && ! coverResolved );
 
 	const issues = isLoading
@@ -135,5 +183,6 @@ export function useValidationIssues() {
 		issues,
 		isReady: ! isLoading && issues.length === 0,
 		isLoading,
+		status,
 	};
 }

--- a/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
@@ -98,6 +98,12 @@ const getDistributionIssues = (
 	return issues;
 };
 
+/**
+ * Fetch derived podcast status (feed URL + published-episode flag) for a category.
+ *
+ * @param categoryId - Configured podcast category ID; 0 disables the fetch.
+ * @return             `{ status, hasResolved }` — status is undefined while in flight.
+ */
 function usePodcastStatus( categoryId: number ): {
 	status: PodcastStatus | undefined;
 	hasResolved: boolean;

--- a/projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\Episode_Query;
+use Automattic\Jetpack\Podcast\Podcast_Status_Endpoint;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts as WorDBless_Posts;
+use WP_Term;
+
+/**
+ * @covers \Automattic\Jetpack\Podcast\Podcast_Status_Endpoint
+ */
+#[CoversClass( Podcast_Status_Endpoint::class )]
+#[CoversClass( Episode_Query::class )]
+class Podcast_Status_Endpoint_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! taxonomy_exists( 'category' ) ) {
+			register_taxonomy( 'category', 'post', array( 'hierarchical' => true ) );
+		}
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'podcasting_category_id' );
+		remove_all_filters( 'category_feed_link' );
+		remove_all_filters( 'posts_pre_query' );
+		wp_cache_flush();
+		WorDBless_Posts::init()->clear_all_posts();
+		parent::tearDown();
+	}
+
+	private function configure_podcast_category( int $id = 42 ): int {
+		$term = new WP_Term(
+			(object) array(
+				'term_id'          => $id,
+				'name'             => 'Podcast',
+				'slug'             => 'podcast',
+				'taxonomy'         => 'category',
+				'term_taxonomy_id' => $id,
+			)
+		);
+		wp_cache_set( $id, $term, 'terms' );
+		update_option( 'podcasting_category_id', $id );
+		return $id;
+	}
+
+	private function insert_post_in_category( int $category_id, string $content ): \WP_Post {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Episode ' . wp_generate_uuid4(),
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+		wp_cache_set( (int) $post_id, array( $category_id ), 'category_relationships' );
+		$post               = get_post( (int) $post_id );
+		$post->post_content = $content;
+		return $post;
+	}
+
+	public function test_read_status_uses_wordpress_category_feed_link() {
+		$this->configure_podcast_category();
+		add_filter(
+			'category_feed_link',
+			static function () {
+				return 'https://example.org/?cat=42&feed=rss2';
+			}
+		);
+
+		$response = ( new Podcast_Status_Endpoint() )->read_status();
+		$data     = $response->get_data();
+
+		$this->assertSame( 'https://example.org/?cat=42&feed=rss2', $data['feedUrl'] );
+	}
+
+	public function test_read_status_requires_actual_podcast_media_for_published_episode() {
+		$cat_id  = $this->configure_podcast_category();
+		$regular = $this->insert_post_in_category( $cat_id, 'A regular post without podcast media.' );
+
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $regular ) {
+				return 'post' === $query->get( 'post_type' ) ? array( $regular ) : $posts;
+			},
+			10,
+			2
+		);
+		$response = ( new Podcast_Status_Endpoint() )->read_status();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['hasPublishedEpisode'] );
+		remove_all_filters( 'posts_pre_query' );
+
+		$episode = $this->insert_post_in_category(
+			$cat_id,
+			'<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.org/episode.mp3","mediaType":"audio"} /-->'
+		);
+
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $regular, $episode ) {
+				return 'post' === $query->get( 'post_type' ) ? array( $regular, $episode ) : $posts;
+			},
+			10,
+			2
+		);
+		$response = ( new Podcast_Status_Endpoint() )->read_status();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['hasPublishedEpisode'] );
+	}
+}

--- a/projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php
+++ b/projects/packages/podcast/tests/php/Podcast_Status_Endpoint_Test.php
@@ -14,6 +14,7 @@ use WP_Term;
 
 /**
  * @covers \Automattic\Jetpack\Podcast\Podcast_Status_Endpoint
+ * @covers \Automattic\Jetpack\Podcast\Episode_Query
  */
 #[CoversClass( Podcast_Status_Endpoint::class )]
 #[CoversClass( Episode_Query::class )]


### PR DESCRIPTION
## Summary

Fixes a bug where the Submit-to-Apple and Submit-to-Spotify buttons in the Distribution tab unlocked too soon.

The old readiness check counted whether any post existed in your podcast category. Most users put text posts and podcast episodes in the same category, though, so a blog post was enough to tell the buttons you were ready to submit a feed with no episodes in it.

This PR adds a server-side check that opens each post and looks for actual audio before counting it as a published episode. It recognizes a Podcast Episode block, an Audio block, or an attached audio file. The Distribution tab unlocks only when at least one real episode exists.

## What's in here

- A new `Episode_Query` helper that introspects post content for podcast media.
- A new REST endpoint `/wp/v2/podcast/status` that returns the configured feed URL and a `has_published_episode` flag.
- The Distribution tab now uses the new endpoint instead of the old "any post counts" probe.
- Endpoint registration is guarded with `class_exists()` so non-atomic deploys can't fatal if the loader lands before the endpoint file.

## Testing

- Created a podcast category, added a text-only post. Submit buttons stayed locked with "Publish at least one episode."
- Added a post with a Podcast Episode block. Submit buttons unlocked.
- Added a post with only an Audio block. Submit buttons unlocked.
- PHPUnit covers `Episode_Query` and the new endpoint.
- `php -l` on the new and changed PHP files, plus `git diff --check`.

JS lint and type checks weren't run locally because the clean worktree has no `node_modules` and local Node is older than the repo requires. CI covers these.
