### PR TITLE
Recognize podcast block media in Tracks

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-tracks-episode-media
+++ b/projects/packages/podcast/changelog/fix-podcast-tracks-episode-media
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: recognize Podcast Episode block and video media in publish tracking.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -12,7 +12,6 @@ namespace Automattic\Jetpack\Podcast;
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Throwable;
 use WP_Post;
-use WP_Query;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_User;
@@ -93,8 +92,8 @@ class Tracks {
 			}
 
 			// Match the RSS feed's definition of an episode — must carry
-			// audio, not just sit in the podcast category.
-			if ( ! self::has_podcast_media( $post ) ) {
+			// podcast media, not just sit in the podcast category.
+			if ( ! Episode_Query::post_has_podcast_media( $post ) ) {
 				return;
 			}
 
@@ -365,38 +364,13 @@ class Tracks {
 	}
 
 	/**
-	 * Filters out posts in the podcast category that aren't actually episodes.
-	 * `core/audio` block + classic-editor attached audio cover the supported
-	 * authoring paths.
-	 *
-	 * @param WP_Post $post Post being checked.
-	 */
-	private static function has_podcast_media( WP_Post $post ): bool {
-		return has_block( 'core/audio', $post )
-			|| ! empty( get_attached_media( 'audio', $post->ID ) );
-	}
-
-	/**
 	 * True when no other published post exists in the podcast category.
 	 *
 	 * @param int $category_id     Configured podcast category ID.
 	 * @param int $current_post_id Post being published (excluded from the check).
 	 */
 	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {
-		$existing = new WP_Query(
-			array(
-				'post_status'      => 'publish',
-				'post_type'        => 'post',
-				'cat'              => $category_id,
-				'post__not_in'     => array( $current_post_id ),
-				'posts_per_page'   => 1,
-				'fields'           => 'ids',
-				'no_found_rows'    => true,
-				'suppress_filters' => true,
-			)
-		);
-
-		return empty( $existing->posts );
+		return ! Episode_Query::has_published_episode( $category_id, $current_post_id );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -370,6 +370,10 @@ class Tracks {
 	 * @param int $current_post_id Post being published (excluded from the check).
 	 */
 	private static function is_first_episode_for_site( int $category_id, int $current_post_id ): bool {
+		if ( get_option( 'podcast_show_launched_tracked', false ) ) {
+			return false;
+		}
+
 		return ! Episode_Query::has_published_episode( $category_id, $current_post_id );
 	}
 

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -253,6 +253,34 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_show_launched' ) );
 	}
 
+	public function test_first_episode_is_false_when_show_launch_already_tracked() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category( $cat_id );
+
+		update_option( 'podcast_show_launched_tracked', time(), false );
+
+		$query_ran = false;
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( &$query_ran ) {
+				if ( 'post' === $query->get( 'post_type' ) ) {
+					$query_ran = true;
+				}
+				return $posts;
+			},
+			10,
+			2
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertFalse( $events[0]['properties']['is_first_episode_for_site'] );
+		$this->assertFalse( $query_ran );
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_show_launched' ) );
+	}
+
 	public function test_media_uploaded_emits_for_audio_when_podcasting_enabled() {
 		$this->configure_podcast_category();
 

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\Jetpack\Podcast\Tests;
 
+use Automattic\Jetpack\Podcast\Episode_Query;
 use Automattic\Jetpack\Podcast\Tracks;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -22,6 +23,7 @@ use WP_Term;
  * @covers \Automattic\Jetpack\Podcast\Tracks
  */
 #[CoversClass( Tracks::class )]
+#[CoversClass( Episode_Query::class )]
 class Tracks_Test extends BaseTestCase {
 
 	protected function setUp(): void {
@@ -44,6 +46,7 @@ class Tracks_Test extends BaseTestCase {
 		delete_option( 'podcasting_email' );
 		delete_option( 'podcasting_talent_name' );
 		delete_option( 'podcast_show_launched_tracked' );
+		remove_all_filters( 'posts_pre_query' );
 		wp_cache_flush();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
@@ -101,7 +104,9 @@ class Tracks_Test extends BaseTestCase {
 			)
 		);
 		wp_cache_set( (int) $post_id, array( $category_id ), 'category_relationships' );
-		return get_post( (int) $post_id );
+		$post               = get_post( (int) $post_id );
+		$post->post_content = $content;
+		return $post;
 	}
 
 	public function test_episode_published_emits_for_first_published_post_in_category() {
@@ -181,6 +186,70 @@ class Tracks_Test extends BaseTestCase {
 		Tracks::record_episode_published( $post->ID, $post, false, null );
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_emits_for_podcast_episode_block() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category(
+			$cat_id,
+			'publish',
+			'<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.org/episode.mp3","mediaType":"audio"} /-->'
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( $post->ID, $events[0]['properties']['post_id'] );
+	}
+
+	public function test_episode_published_skips_empty_podcast_episode_block() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category(
+			$cat_id,
+			'publish',
+			'<!-- wp:jetpack/podcast-episode /-->'
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_emits_for_video_episode_block() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category(
+			$cat_id,
+			'publish',
+			'<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.org/episode.mp4","mediaType":"video"} /-->'
+		);
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertSame( $post->ID, $events[0]['properties']['post_id'] );
+	}
+
+	public function test_first_episode_ignores_prior_non_episode_posts_in_category() {
+		$cat_id  = $this->configure_podcast_category();
+		$regular = $this->insert_post_in_category( $cat_id, 'publish', 'A regular post without podcast media.' );
+
+		$post = $this->insert_post_in_category( $cat_id );
+		add_filter(
+			'posts_pre_query',
+			static function ( $posts, $query ) use ( $regular ) {
+				return 'post' === $query->get( 'post_type' ) ? array( $regular ) : $posts;
+			},
+			10,
+			2
+		);
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$events = $this->events_named( 'wpcom_podcast_episode_published' );
+		$this->assertCount( 1, $events );
+		$this->assertTrue( $events[0]['properties']['is_first_episode_for_site'] );
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_show_launched' ) );
 	}
 
 	public function test_media_uploaded_emits_for_audio_when_podcasting_enabled() {

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -21,6 +21,7 @@ use WP_Term;
  * events are read out of the bootstrap shim's global buffer.
  *
  * @covers \Automattic\Jetpack\Podcast\Tracks
+ * @covers \Automattic\Jetpack\Podcast\Episode_Query
  */
 #[CoversClass( Tracks::class )]
 #[CoversClass( Episode_Query::class )]


### PR DESCRIPTION
## Summary

Fixes inflated podcast analytics. We fire a `wpcom_podcast_episode_published` Tracks event when someone publishes a post in their podcast category. The old code fired it for every post in the category, including text-only blog posts. Anyone using the same category for blog posts and podcast episodes was inflating our internal "episodes published" and "podcasts launched" counts.

This PR uses the new `Episode_Query` helper from #48929 to check whether the post actually has audio before firing the event. The first-episode-ever event (`wpcom_podcast_show_launched`) follows the same gate, so prior text posts in the category no longer block it.

## Testing

- Published a text post in the podcast category. No `wpcom_podcast_episode_published` event fired.
- Published a post with a Podcast Episode block. Event fired with the right `post_id`.
- First episode case also fired `wpcom_podcast_show_launched`.
- PHPUnit covers each branch above, plus `php -l` and `git diff --check`.

## Why this is stacked on #48929

It uses the `Episode_Query` helper introduced there. Splitting them would duplicate the helper, which would make both PRs harder to review and create merge conflicts.
