### PR TITLE
Preserve podcast Apple category values

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-preserve-apple-categories
+++ b/projects/packages/podcast/changelog/fix-podcast-preserve-apple-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: preserve legacy Apple category values when saving settings.

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -169,6 +169,10 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 				.filter( ( v ): v is string => !! v ),
 		[ draft?.podcasting_category_1, draft?.podcasting_category_2, draft?.podcasting_category_3 ]
 	);
+	const preservedUnknownTopics = useMemo(
+		() => new Set( topicValue.filter( display => ! TOPIC_STORAGE_BY_DISPLAY.has( display ) ) ),
+		[ topicValue ]
+	);
 
 	// Calypso renders three native selects, one per slot, so each pick closes
 	// its dropdown and saves discretely. We use a single `FormTokenField` but
@@ -189,7 +193,11 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 			const stored = values
 				.slice( 0, 3 )
 				.map( v => ( typeof v === 'string' ? v : v.value ) )
-				.map( display => TOPIC_STORAGE_BY_DISPLAY.get( display ) ?? '' );
+				.map(
+					display =>
+						TOPIC_STORAGE_BY_DISPLAY.get( display ) ??
+						( preservedUnknownTopics.has( display ) ? display : '' )
+				);
 			commit( {
 				podcasting_category_1: stored[ 0 ] ?? '',
 				podcasting_category_2: stored[ 1 ] ?? '',
@@ -197,7 +205,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 			} );
 			topicFieldRef.current?.querySelector< HTMLInputElement >( 'input' )?.blur();
 		},
-		[ commit ]
+		[ commit, preservedUnknownTopics ]
 	);
 
 	const issues = useMemo( () => getValidationIssues( draft ?? settings ), [ draft, settings ] );


### PR DESCRIPTION
## Summary

Fixes a data-loss bug in podcast Settings.

Apple Podcasts changes its category list every few years, renaming, splitting, and merging entries. If your saved category value came from an older version of Apple's list, it won't match anything in the current list. The Settings UI handled the display side correctly, since it showed the legacy value as-is so you could see what was there. But on save, the code looked up each displayed category in the current Apple list, didn't find the legacy values, and wrote empty strings. The result: opening Settings and clicking Save without changing anything wiped your legacy categories.

This PR remembers which displayed values came from legacy data (values the user didn't just type in this session) and preserves them on save. Freshly typed unknown tokens still get dropped, matching the existing intent.

## Testing

- Set `podcasting_category_1` directly to a legacy value in the DB.
- Opened Settings, confirmed the legacy value displayed.
- Clicked Save without changing anything. Legacy value preserved.
- Typed a fresh nonsense token, clicked Save. Token dropped, real values intact.

JS lint and type checks weren't run locally because the clean worktree has no `node_modules` and local Node is older than the repo requires. CI covers these.
