### PR TITLE
Block podcast setup close while creating category

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-setup-modal-create-save
+++ b/projects/packages/podcast/changelog/fix-podcast-setup-modal-create-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: prevent setup modal dismissal while inline category creation is saving.

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -22,9 +22,11 @@ interface CategoryPickerProps {
 	onSelect: ( id: number ) => void;
 	disabled?: boolean;
 	// Fires when the inline "create a new category" form opens/closes, so a
-	// containing modal can gate its own Confirm button until the user either
-	// finishes or cancels the inline flow.
+	// containing modal can gate Confirm until the user finishes or cancels.
 	onCreatingChange?: ( isCreating: boolean ) => void;
+	// Fires while the create request is in flight, so a containing modal can
+	// prevent dismissal until the async create settles.
+	onSavingChange?: ( isSaving: boolean ) => void;
 }
 
 const parseErrorMessage = ( error: unknown, fallback: string ): string => {
@@ -47,6 +49,7 @@ const CategoryPicker = ( {
 	onSelect,
 	disabled = false,
 	onCreatingChange,
+	onSavingChange,
 }: CategoryPickerProps ) => {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -66,6 +69,10 @@ const CategoryPicker = ( {
 	useEffect( () => {
 		onCreatingChange?.( isCreating );
 	}, [ isCreating, onCreatingChange ] );
+
+	useEffect( () => {
+		onSavingChange?.( saving );
+	}, [ saving, onSavingChange ] );
 
 	const trimmedName = newName.trim();
 

--- a/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/category-setup-modal.tsx
@@ -49,15 +49,16 @@ const CategorySetupModal = ( {
 	const [ error, setError ] = useState< string | null >( null );
 	const [ saving, setSaving ] = useState( false );
 	const [ pickerCreating, setPickerCreating ] = useState( false );
+	const [ pickerSaving, setPickerSaving ] = useState( false );
 
 	const requestClose = useCallback( () => {
-		// Block dismissal while a save is in flight so the in-flight promise
-		// can't mutate settings after the user thought they cancelled.
-		if ( saving ) {
+		// Block dismissal while a settings save or inline category create is
+		// in flight, so async callbacks can't update a dismissed setup flow.
+		if ( saving || pickerSaving ) {
 			return;
 		}
 		onClose();
-	}, [ saving, onClose ] );
+	}, [ saving, pickerSaving, onClose ] );
 
 	const onConfirm = useCallback( async () => {
 		if ( ! categoryId ) {
@@ -117,9 +118,10 @@ const CategorySetupModal = ( {
 					onSelect={ setCategoryId }
 					disabled={ saving }
 					onCreatingChange={ setPickerCreating }
+					onSavingChange={ setPickerSaving }
 				/>
 				<HStack justify="flex-end" spacing={ 3 }>
-					<Button variant="tertiary" onClick={ requestClose } disabled={ saving }>
+					<Button variant="tertiary" onClick={ requestClose } disabled={ saving || pickerSaving }>
 						{ __( 'Cancel', 'jetpack-podcast' ) }
 					</Button>
 					<Button
@@ -128,7 +130,7 @@ const CategorySetupModal = ( {
 						// Block Confirm while the inline create form is open so
 						// the user can't commit a stale `selectedId` with the
 						// half-filled inline form still mounted.
-						disabled={ ! categoryId || saving || pickerCreating }
+						disabled={ ! categoryId || saving || pickerCreating || pickerSaving }
 						isBusy={ saving }
 					>
 						{ __( 'Confirm', 'jetpack-podcast' ) }


### PR DESCRIPTION
## Summary

Fixes a race in the first-time podcast setup modal.

The modal asks you to pick a category, and lets you create a new one inline by typing a name and clicking Create. That fires a server request that takes around half a second. The old code didn't stop you from dismissing the modal (clicking outside, pressing Escape, or clicking Cancel) during that half second. If you did, the modal closed but the create request kept running. When it finished, it tried to update the now-closed setup state, leaving the flow in a half-done condition.

This PR blocks modal dismissal while the inline category create request is in flight. Once the create finishes, dismissal works normally again.

## Testing

- Opened the setup modal, typed a new category name, clicked Create, then immediately pressed Escape. Modal stayed open until create completed.
- Repeated the same with clicking outside the modal.
- Repeated the same with the Cancel button.
- Once create finished, all three dismissal paths worked as before.

JS lint and type checks weren't run locally because the clean worktree has no `node_modules` and local Node is older than the repo requires. CI covers these.

## Follow-up

The Cancel button blocks dismissal silently during the in-flight window. A tooltip explaining why is tracked in a follow-up PR so this one stays narrow.
