### PR TITLE
Search: exclude search-blocks source .js from production build

### DIFF
--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -14,13 +14,5 @@
 /src/**/*.ts                                             production-exclude
 /src/**/*.tsx                                            production-exclude
 /src/**/*.jsx                                            production-exclude
+/src/**/*.js                                             production-exclude
 /src/**/*.scss                                           production-exclude
-
-# @todo Are there any .js files we actually want to keep, or is everything built and we can do `/src/**/*.js` like above?
-/src/customberg/**/*.js                                  production-exclude
-/src/customizer/**/*.js                                  production-exclude
-/src/dashboard/**/*.js                                   production-exclude
-/src/inline-search/**/*.js                               production-exclude
-/src/instant-search/**/*.js                              production-exclude
-/src/search-blocks/**/*.js                               production-exclude
-/src/widgets/**/*.js                                     production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -21,4 +21,5 @@
 /src/dashboard/**/*.js                                   production-exclude
 /src/inline-search/**/*.js                               production-exclude
 /src/instant-search/**/*.js                              production-exclude
+/src/search-blocks/**/*.js                               production-exclude
 /src/widgets/**/*.js                                     production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -14,5 +14,15 @@
 /src/**/*.ts                                             production-exclude
 /src/**/*.tsx                                            production-exclude
 /src/**/*.jsx                                            production-exclude
-/src/**/*.js                                             production-exclude
 /src/**/*.scss                                           production-exclude
+
+# Source .js is excluded per-directory, not via `/src/**/*.js`, because
+# `src/widgets/js/` has no build step — `class-search-widget.php` enqueues
+# those files straight from source, so they must ship. Every other src
+# subdirectory below is bundled into `/build/**` and its source is dev-only.
+/src/customberg/**/*.js                                  production-exclude
+/src/customizer/**/*.js                                  production-exclude
+/src/dashboard/**/*.js                                   production-exclude
+/src/inline-search/**/*.js                               production-exclude
+/src/instant-search/**/*.js                              production-exclude
+/src/search-blocks/**/*.js                               production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -8,6 +8,7 @@
 /.size-limit.js                                          production-exclude
 /jest.url-tests.config.js                                production-exclude
 /postcss.config.js                                       production-exclude
+/docs/**                                                 production-exclude
 /tools/**                                                production-exclude
 /src/**/test/**                                          production-exclude
 /src/**/*.ts                                             production-exclude

--- a/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
+++ b/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
@@ -1,3 +1,3 @@
 Significance: patch
 Type: changed
-Comment: Consolidate the per-directory source `.js` exclusions into a single `/src/**/*.js` rule and exclude the `docs/` planning directory from the production build, reducing the distributed package size.
+Comment: Exclude search-blocks source `.js` and the `docs/` planning directory from the production build, and stop excluding `src/widgets/js/` (it has no build step and is enqueued from source at runtime), reducing the distributed package size without dropping runtime assets.

--- a/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
+++ b/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
@@ -1,3 +1,3 @@
 Significance: patch
 Type: changed
-Comment: Exclude search-blocks source `.js` files and the `docs/` planning directory from the production build to reduce the distributed package size.
+Comment: Consolidate the per-directory source `.js` exclusions into a single `/src/**/*.js` rule and exclude the `docs/` planning directory from the production build, reducing the distributed package size.

--- a/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
+++ b/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
@@ -1,3 +1,3 @@
 Significance: patch
 Type: changed
-Comment: Exclude search-blocks source `.js` files from the production build to reduce the distributed package size.
+Comment: Exclude search-blocks source `.js` files and the `docs/` planning directory from the production build to reduce the distributed package size.

--- a/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
+++ b/projects/packages/search/changelog/rsm-3495-search-blocks-gitattributes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Exclude search-blocks source `.js` files from the production build to reduce the distributed package size.


### PR DESCRIPTION
Fixes [RSM-3495](https://linear.app/a8c/issue/RSM-3495/search-30-add-gitattributes-production-exclude-rules-for-search-blocks)

Follow-up to [#48198 review feedback](https://github.com/Automattic/jetpack/pull/48198#issuecomment-4481713402).

## Why

The Search 3.0 block work added a `src/search-blocks/` tree, but the package's `.gitattributes` listed `production-exclude` `.js` rules per-directory and had no entry for it — so the block source (`view.js` / `edit.js` / `lib.js`, `store/*.js`, the editor bundle) ships in the distributed package even though only the built copies under `build/` load at runtime. Confirmed live in the published mirror: [`Automattic/jetpack-search/src/search-blocks`](https://github.com/Automattic/jetpack-search/tree/trunk/src/search-blocks) currently carries the full unbuilt source. This excludes it, matching #47365's pattern, and trims the `docs/` planning notes too.

While verifying, found and fixed a regression introduced by #47365: its `/src/widgets/**/*.js production-exclude` rule strips the Search widget's runtime JS from the published package. `src/widgets/` has **no build step** and `class-search-widget.php` enqueues `js/search-widget.js` / `js/search-widget-admin.js` straight from source. The effect is already live — [`Automattic/jetpack-search/src/widgets`](https://github.com/Automattic/jetpack-search/tree/trunk/src/widgets) is missing its `js/` directory, so the standalone package enqueues two scripts that don't exist in it (broken legacy-widget frontend + widget Customizer UI). Flagged on #47365.

## Proposed changes

* Add `/src/search-blocks/**/*.js production-exclude`, alongside the existing per-directory `.js` exclusions for the other bundled directories (`customberg`, `customizer`, `dashboard`, `inline-search`, `instant-search`).
* Add `/docs/** production-exclude` so the `docs/plans/` planning notes stop shipping (same pattern #47365 applied to `forms`).
* Remove the `/src/widgets/**/*.js production-exclude` rule introduced by #47365 — `src/widgets/js/` is runtime, unbuilt, and enqueued from source. Add a comment documenting why exclusions stay per-directory rather than a blanket `/src/**/*.js` (widgets is the one unbuilt source dir), so this can't regress.
* Add a changelog entry.

Runtime files are untouched: blocks register from `__DIR__/blocks` via `register_block_type()`, so `render.php`, `block.json`, the PHP classes, `patterns/*.php`, and `templates/*.html` stay included. `build/**` is `production-include`, so the built runtime bundles ship.

## Verification

`git check-attr production-exclude` against trunk (#47365 rules) vs this branch, run through the same filter `tools/cli/helpers/list-project-files.js` uses for mirror builds (keeps `unspecified`/`unset`, drops `set`):

<details>
<summary>Output</summary>

```text
File                                    Trunk/#47365   This branch
src/widgets/js/search-widget.js         set (dropped)  unspecified (ships)
src/widgets/js/search-widget-admin.js   set (dropped)  unspecified (ships)
src/search-blocks/store/index.js        unspecified    set (excluded)
src/instant-search/lib/api.js           set            set
src/widgets/class-search-widget.php     unspecified    unspecified
docs/plans/local-testing-setup.md       unspecified    set (excluded)

Published mirror today (Automattic/jetpack-search, includes #47365):
  src/widgets/js/                -> 404 (directory gone)
  src/widgets/                   -> class-search-widget.php, css/ only
  src/search-blocks/             -> full unbuilt source present (the RSM-3495 leak)
```

</details>

## Related product discussion/links

* [RSM-3495](https://linear.app/a8c/issue/RSM-3495/search-30-add-gitattributes-production-exclude-rules-for-search-blocks)
* Follow-up to #48198 (Search 3.0 Phase 1), per the pattern in #47365 (MONOREP-371); widgets regression flagged on #47365

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/search`
* Confirm bundled-directory source `.js` and docs are excluded from the production mirror:
  `git check-attr production-exclude -- src/search-blocks/store/index.js src/dashboard/index.js src/instant-search/lib/api.js docs/plans/local-testing-setup.md` → all `set`
* Confirm widget runtime JS, runtime files, and built bundles still ship:
  `git check-attr production-exclude -- src/widgets/js/search-widget.js src/widgets/js/search-widget-admin.js src/search-blocks/blocks/search-input/render.php src/search-blocks/class-search-blocks.php build/search-blocks/search-input.js` → all `unspecified`
* Optionally run `jp build --for-mirrors` for a search-consuming plugin and confirm the built `vendor/automattic/jetpack-search/src/` contains `widgets/js/*.js`, the `block.json`/`render.php`/PHP/templates, no bundled-dir source `.js`, no `docs/`, and the built `build/search-blocks/*.js` runtime bundles.
