### PR TITLE
Write: Add blockquote citation support

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_citation_support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_citation_support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Add blockquote citation support

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1204,6 +1204,21 @@
 	font-style: italic;
 }
 
+.bw-content blockquote cite {
+	display: block;
+	font-style: normal;
+	font-size: 0.9em;
+	color: #777;
+	margin-top: 0.5em;
+	outline: none;
+}
+
+.bw-content blockquote cite:empty::before {
+	content: attr(data-placeholder);
+	color: #aaa;
+	pointer-events: none;
+}
+
 .bw-content hr {
 	border: none;
 	height: 1px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -15,6 +15,9 @@ import { createUndoHistory } from 'wpcom-write/undo-history';
 // Translated strings passed from PHP via wp_print_inline_script_tag.
 const i18n = window.wpcomWriteStrings || {};
 
+// Tracks the blockquote currently containing the cursor, for citation placeholder lifecycle.
+let activeBlockquote = null;
+
 // Autosave configuration.
 const AUTOSAVE_INTERVAL_MS = 30000; // 30 seconds.
 const AUTOSAVE_MESSAGE_DURATION_MS = 2000;
@@ -700,13 +703,45 @@ function convertToBlocks( html ) {
 				) }" alt="${ escapeAttr( alt ) }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`
 			);
 		} else if ( tag === 'blockquote' ) {
-			// inner may already contain <p> tags from contentEditable.
-			const quoteInner = inner.startsWith( '<p' ) ? inner : `<p>${ inner }</p>`;
+			// Extract citation from <cite> if present.
+			// Strip lone <br> tags that contentEditable inserts into empty elements.
+			const citeEl = node.querySelector( 'cite' );
+			const rawCitation = citeEl ? citeEl.innerHTML.trim().replace( /^<br\s*\/?>$/, '' ) : '';
+			const citationHtml = rawCitation;
+
+			// Remove <cite> and any trailing <br> from the DOM so they don't
+			// end up inside the serialized <p> tags.
+			if ( citeEl ) {
+				citeEl.remove();
+			}
+			// Strip trailing <br> elements left between quote text and removed <cite>.
+			while (
+				node.lastChild &&
+				node.lastChild.nodeType === Node.ELEMENT_NODE &&
+				node.lastChild.tagName === 'BR'
+			) {
+				node.lastChild.remove();
+			}
+			const bodyInner = node.innerHTML.trim().replace( /^<br\s*\/?>$/, '' );
+			const quoteInner = bodyInner.startsWith( '<p' ) ? bodyInner : `<p>${ bodyInner }</p>`;
+
 			const hasQuoteAlign = align && [ 'center', 'right' ].includes( align );
 			const quoteAlignAttr = hasQuoteAlign ? ` style="text-align:${ align }"` : '';
-			const quoteAlignJson = hasQuoteAlign ? ` {"align":"${ align }"}` : '';
+
+			// Build JSON attrs.
+			const attrs = {};
+			if ( hasQuoteAlign ) {
+				attrs.align = align;
+			}
+			if ( citationHtml ) {
+				attrs.citation = citationHtml;
+			}
+			const jsonAttr = Object.keys( attrs ).length ? ` ${ JSON.stringify( attrs ) }` : '';
+
+			const citeHtml = citationHtml ? `<cite>${ citationHtml }</cite>` : '';
+
 			blocks.push(
-				`<!-- wp:quote${ quoteAlignJson } -->\n<blockquote class="wp-block-quote"${ quoteAlignAttr }>${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
+				`<!-- wp:quote${ jsonAttr } -->\n<blockquote class="wp-block-quote"${ quoteAlignAttr }>${ quoteInner }${ citeHtml }</blockquote>\n<!-- /wp:quote -->`
 			);
 		} else if ( tag === 'ul' || tag === 'ol' ) {
 			// Wrap each <li> in wp:list-item block comments.
@@ -1296,6 +1331,15 @@ const contentReady2 = setInterval( () => {
 	// Run the block-structure audit immediately so gap paragraphs are
 	// inserted and the user can start editing right away.
 	ensureBlockStructure();
+
+	// Wire up existing <cite> elements in blockquotes with the placeholder
+	// attribute so the CSS placeholder appears if the user clears the text.
+	contentEl.querySelectorAll( 'blockquote cite' ).forEach( cite => {
+		if ( ! cite.hasAttribute( 'data-placeholder' ) ) {
+			cite.setAttribute( 'data-placeholder', i18n.addCitation || 'Add citation\u2026' );
+		}
+	} );
+
 	if ( ! contentEl.textContent.trim() && ! contentEl.querySelector( 'img, video, figure' ) ) {
 		// bw-is-empty drives the CSS ::before placeholder on the outer .bw-content.
 		// Input events from the inner contenteditable bubble up to the outer,
@@ -1531,6 +1575,66 @@ function insertNewList( listTag ) {
 }
 
 /**
+ * Find the blockquote element containing the current cursor, if any.
+ *
+ * @return {HTMLElement|null} The blockquote element or null.
+ */
+function getActiveBlockquote() {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return null;
+	let node = sel.anchorNode;
+	while ( node && ! node.classList?.contains( 'bw-content' ) ) {
+		if ( node.nodeType === Node.ELEMENT_NODE && node.tagName === 'BLOCKQUOTE' ) {
+			return node;
+		}
+		node = node.parentNode;
+	}
+	return null;
+}
+
+/**
+ * Check if the current cursor is inside a <cite> element within a blockquote.
+ *
+ * @return {HTMLElement|null} The <cite> element, or null.
+ */
+function getActiveCite() {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return null;
+	let node = sel.anchorNode;
+	while ( node && ! node.classList?.contains( 'bw-content' ) ) {
+		if ( node.nodeType === Node.ELEMENT_NODE && node.tagName === 'CITE' ) {
+			return node;
+		}
+		node = node.parentNode;
+	}
+	return null;
+}
+
+/**
+ * Ensure a blockquote has a <cite> placeholder for attribution.
+ *
+ * @param {HTMLElement} blockquote - The blockquote to add the placeholder to.
+ */
+function ensureCitePlaceholder( blockquote ) {
+	if ( blockquote.querySelector( 'cite' ) ) return;
+	const cite = document.createElement( 'cite' );
+	cite.setAttribute( 'data-placeholder', i18n.addCitation || 'Add citation\u2026' );
+	blockquote.appendChild( cite );
+}
+
+/**
+ * Remove an empty <cite> placeholder from a blockquote.
+ *
+ * @param {HTMLElement} blockquote - The blockquote to clean up.
+ */
+function removeEmptyCite( blockquote ) {
+	const cite = blockquote.querySelector( 'cite' );
+	if ( cite && ! cite.textContent.trim() ) {
+		cite.remove();
+	}
+}
+
+/**
  * Detect the current formatting state at the cursor position.
  * Updates all toolbar button states.
  */
@@ -1585,6 +1689,30 @@ function updateFormattingState() {
 	// Justify is paragraph-only; disable the toolbar button inside lists,
 	// headings, and quotes where browser justification would look poor.
 	state.cannotJustify = state.insideList || state.formatHeading || state.formatQuote;
+
+	// Citation placeholder lifecycle.
+	const currentBlockquote = getActiveBlockquote();
+	if ( currentBlockquote !== activeBlockquote ) {
+		// Capture dirty state before modifying the DOM, so we can re-sync
+		// the snapshot only when the placeholder is the sole difference.
+		const wasDirty = isDirty();
+
+		// Leaving a blockquote — clean up empty placeholder.
+		if ( activeBlockquote ) {
+			removeEmptyCite( activeBlockquote );
+		}
+		// Entering a blockquote — ensure placeholder exists.
+		if ( currentBlockquote ) {
+			ensureCitePlaceholder( currentBlockquote );
+		}
+		activeBlockquote = currentBlockquote;
+
+		// Re-sync the snapshot only when the editor was clean before the
+		// placeholder DOM change, so real edits stay dirty.
+		if ( ! wasDirty ) {
+			updateSavedSnapshot();
+		}
+	}
 }
 
 /**
@@ -2571,6 +2699,39 @@ const { state } = store( 'wpcom-write', {
 				}
 			}
 
+			// Backspace in an empty <cite>: remove it and move cursor to quote body.
+			if ( event.key === 'Backspace' ) {
+				const cite = getActiveCite();
+				if ( cite && ! cite.textContent.trim() ) {
+					event.preventDefault();
+					const bq = cite.closest( 'blockquote' );
+					cite.remove();
+					if ( bq ) {
+						const lastP = bq.querySelector( 'p:last-of-type' );
+						if ( lastP ) {
+							placeCursorAtEnd( lastP );
+						}
+					}
+					return;
+				}
+			}
+
+			// Enter inside a blockquote <cite>: break out to a new paragraph.
+			if ( event.key === 'Enter' && ! event.shiftKey ) {
+				const cite = getActiveCite();
+				if ( cite ) {
+					const bq = cite.closest( 'blockquote' );
+					if ( bq ) {
+						event.preventDefault();
+						const p = document.createElement( 'p' );
+						p.innerHTML = '<br>';
+						bq.after( p );
+						placeCursorAt( p );
+						return;
+					}
+				}
+			}
+
 			// Enter key: break out of blockquotes/headings and ensure paragraphs.
 			if ( event.key === 'Enter' && ! event.shiftKey ) {
 				const sel = window.getSelection();
@@ -2595,7 +2756,15 @@ const { state } = store( 'wpcom-write', {
 						const textAfterCursor = range.cloneRange();
 						textAfterCursor.selectNodeContents( block );
 						textAfterCursor.setStart( range.endContainer, range.endOffset );
-						const remaining = textAfterCursor.toString().trim();
+
+						// Exclude <cite> text from the "remaining" check so Enter at the
+						// end of quote body text breaks out even when a citation follows.
+						const tmpFrag = textAfterCursor.cloneContents();
+						const citeFrag = tmpFrag.querySelector( 'cite' );
+						if ( citeFrag ) {
+							citeFrag.remove();
+						}
+						const remaining = tmpFrag.textContent.trim();
 
 						if ( ! remaining ) {
 							event.preventDefault();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3122,8 +3122,20 @@ const { state } = store( 'wpcom-write', {
 		// --- Alignment ---
 
 		alignLeft() {
-			document.execCommand( 'justifyLeft' );
-			cleanupAlignmentDivs();
+			const bq = getActiveBlockquote();
+			if ( bq ) {
+				// Left is the default — remove explicit alignment from
+				// the blockquote and any inner paragraphs.
+				flushUndoDebounce();
+				bq.style.removeProperty( 'text-align' );
+				bq.querySelectorAll( ':scope > p, :scope > div' ).forEach( el => {
+					el.style.removeProperty( 'text-align' );
+				} );
+				pushToUndoHistory();
+			} else {
+				document.execCommand( 'justifyLeft' );
+				cleanupAlignmentDivs();
+			}
 			state.formatAlignLeft = true;
 			state.formatAlignCenter = false;
 			state.formatAlignRight = false;
@@ -3131,8 +3143,20 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		alignCenter() {
-			document.execCommand( 'justifyCenter' );
-			cleanupAlignmentDivs();
+			const bq = getActiveBlockquote();
+			if ( bq ) {
+				// Apply alignment to the blockquote itself so
+				// convertToBlocks reads it from node.style.textAlign.
+				flushUndoDebounce();
+				bq.style.textAlign = 'center';
+				bq.querySelectorAll( ':scope > p, :scope > div' ).forEach( el => {
+					el.style.removeProperty( 'text-align' );
+				} );
+				pushToUndoHistory();
+			} else {
+				document.execCommand( 'justifyCenter' );
+				cleanupAlignmentDivs();
+			}
 			state.formatAlignLeft = false;
 			state.formatAlignCenter = true;
 			state.formatAlignRight = false;
@@ -3140,8 +3164,18 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		alignRight() {
-			document.execCommand( 'justifyRight' );
-			cleanupAlignmentDivs();
+			const bq = getActiveBlockquote();
+			if ( bq ) {
+				flushUndoDebounce();
+				bq.style.textAlign = 'right';
+				bq.querySelectorAll( ':scope > p, :scope > div' ).forEach( el => {
+					el.style.removeProperty( 'text-align' );
+				} );
+				pushToUndoHistory();
+			} else {
+				document.execCommand( 'justifyRight' );
+				cleanupAlignmentDivs();
+			}
 			state.formatAlignLeft = false;
 			state.formatAlignCenter = false;
 			state.formatAlignRight = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -706,8 +706,7 @@ function convertToBlocks( html ) {
 			// Extract citation from <cite> if present.
 			// Strip lone <br> tags that contentEditable inserts into empty elements.
 			const citeEl = node.querySelector( 'cite' );
-			const rawCitation = citeEl ? citeEl.innerHTML.trim().replace( /^<br\s*\/?>$/, '' ) : '';
-			const citationHtml = rawCitation;
+			const citationHtml = citeEl ? citeEl.innerHTML.trim().replace( /^<br\s*\/?>$/, '' ) : '';
 
 			// Remove <cite> and any trailing <br> from the DOM so they don't
 			// end up inside the serialized <p> tags.
@@ -736,7 +735,18 @@ function convertToBlocks( html ) {
 			if ( citationHtml ) {
 				attrs.citation = citationHtml;
 			}
-			const jsonAttr = Object.keys( attrs ).length ? ` ${ JSON.stringify( attrs ) }` : '';
+			// Escape characters that WordPress core escapes inside block
+			// comment attributes (see serializeAttributes in @wordpress/blocks).
+			const jsonAttr = Object.keys( attrs ).length
+				? ' ' +
+				  JSON.stringify( attrs )
+						.replaceAll( '\\\\', '\\u005c' )
+						.replaceAll( '--', '\\u002d\\u002d' )
+						.replaceAll( '<', '\\u003c' )
+						.replaceAll( '>', '\\u003e' )
+						.replaceAll( '&', '\\u0026' )
+						.replaceAll( '\\"', '\\u0022' )
+				: '';
 
 			const citeHtml = citationHtml ? `<cite>${ citationHtml }</cite>` : '';
 
@@ -2716,8 +2726,9 @@ const { state } = store( 'wpcom-write', {
 				}
 			}
 
-			// Enter inside a blockquote <cite>: break out to a new paragraph.
+			// Enter key: handle cite break-out and blockquote/heading break-out.
 			if ( event.key === 'Enter' && ! event.shiftKey ) {
+				// Inside a blockquote <cite>: break out to a new paragraph.
 				const cite = getActiveCite();
 				if ( cite ) {
 					const bq = cite.closest( 'blockquote' );
@@ -2730,10 +2741,8 @@ const { state } = store( 'wpcom-write', {
 						return;
 					}
 				}
-			}
 
-			// Enter key: break out of blockquotes/headings and ensure paragraphs.
-			if ( event.key === 'Enter' && ! event.shiftKey ) {
+				// Break out of blockquotes/headings and ensure paragraphs.
 				const sel = window.getSelection();
 				if ( sel.rangeCount ) {
 					let node = sel.anchorNode;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1348,6 +1348,9 @@ const contentReady2 = setInterval( () => {
 		if ( ! cite.hasAttribute( 'data-placeholder' ) ) {
 			cite.setAttribute( 'data-placeholder', i18n.addCitation || 'Add citation\u2026' );
 		}
+		if ( ! cite.hasAttribute( 'aria-label' ) ) {
+			cite.setAttribute( 'aria-label', i18n.citation || 'Citation' );
+		}
 	} );
 
 	if ( ! contentEl.textContent.trim() && ! contentEl.querySelector( 'img, video, figure' ) ) {
@@ -1629,6 +1632,7 @@ function ensureCitePlaceholder( blockquote ) {
 	if ( blockquote.querySelector( 'cite' ) ) return;
 	const cite = document.createElement( 'cite' );
 	cite.setAttribute( 'data-placeholder', i18n.addCitation || 'Add citation\u2026' );
+	cite.setAttribute( 'aria-label', i18n.citation || 'Citation' );
 	blockquote.appendChild( cite );
 }
 
@@ -4055,6 +4059,10 @@ async function savePost( postStatus, isAutosave = false ) {
 	// runtime attribute that shouldn't be persisted.
 	clone.querySelectorAll( 'figure[contenteditable]' ).forEach( el => {
 		el.removeAttribute( 'contenteditable' );
+	} );
+	clone.querySelectorAll( 'blockquote cite' ).forEach( el => {
+		el.removeAttribute( 'data-placeholder' );
+		el.removeAttribute( 'aria-label' );
 	} );
 	stripRuntimeFigureControls( clone );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -149,6 +149,7 @@ add_action(
 			// translators: %s is a comma-separated list of category names, e.g. "Travel, Food".
 			'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
 			'untitled'             => __( 'Untitled', 'jetpack-mu-wpcom' ),
+			'addCitation'          => __( 'Add citation…', 'jetpack-mu-wpcom' ),
 		);
 		wp_print_inline_script_tag(
 			'window.wpcomWriteStrings = ' . wp_json_encode( $write_strings, JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
@@ -260,7 +261,7 @@ function wpcom_write_allowed_block_attrs() {
 		// alt: preserved via HTML element, not block JSON.
 		'image'     => array( 'id', 'sizeSlug', 'alt' ),
 		'embed'     => array( 'url', 'type', 'providerNameSlug', 'responsive' ),
-		'quote'     => array( 'align' ),
+		'quote'     => array( 'align', 'citation' ),
 		'list'      => array( 'ordered' ),
 		'list-item' => array(),
 		'separator' => array(),

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -150,6 +150,7 @@ add_action(
 			'writingIn'            => __( 'Writing in %s', 'jetpack-mu-wpcom' ),
 			'untitled'             => __( 'Untitled', 'jetpack-mu-wpcom' ),
 			'addCitation'          => __( 'Add citation…', 'jetpack-mu-wpcom' ),
+			'citation'             => __( 'Citation', 'jetpack-mu-wpcom' ),
 		);
 		wp_print_inline_script_tag(
 			'window.wpcomWriteStrings = ' . wp_json_encode( $write_strings, JSON_HEX_TAG | JSON_HEX_AMP ) . ';'

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1080,7 +1080,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		// Read enough of the function body to capture all block types.
 		// If convertToBlocks() grows past this, the assertion below will
 		// catch missing types. Increase as needed.
-		$fn_body = substr( $view_js, $fn_start, 6000 );
+		$fn_body = substr( $view_js, $fn_start, 10000 );
 
 		// Match opening block comments only (negative lookbehind skips closing <!-- /wp:... -->).
 		preg_match_all( '/<!-- (?!\/)wp:([a-z][a-z0-9-]*)/', $fn_body, $matches );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -777,6 +777,14 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that a quote block with a citation attribute returns false (supported).
+	 */
+	public function test_detect_unsupported_quote_block_with_citation() {
+		$content = '<!-- wp:quote {"citation":"Author Name"} --><blockquote class="wp-block-quote"><p>A quote</p><cite>Author Name</cite></blockquote><!-- /wp:quote -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
 	 * Test that a YouTube video embed returns false (supported).
 	 */
 	public function test_detect_unsupported_youtube_embed() {
@@ -1105,7 +1113,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			'list'      => array( 'ordered' ),
 			'list-item' => array(),
 			'paragraph' => array( 'align' ),
-			'quote'     => array( 'align' ),
+			'quote'     => array( 'align', 'citation' ),
 			'separator' => array(),
 		);
 


### PR DESCRIPTION
Fixes RSM-593

## Proposed changes

* Add blockquote citation support to the Write editor, allowing users to add, edit, and remove citations on quotes
* Citations are edited inline via a `<cite>` element inside the blockquote, matching WordPress core's `wp:quote` block format
* A focus-triggered "Add citation…" placeholder appears below the quote body when the cursor enters a blockquote without a citation; it is removed on blur if still empty
* Keyboard handling: Enter in `<cite>` breaks out of the blockquote; Backspace in an empty `<cite>` removes it and returns cursor to the quote body; Enter at end of quote body correctly breaks out even when a citation follows
* Posts with existing citations (created in the block editor) now open in Write instead of being flagged as unsupported
* Existing citations are wired up with placeholder attributes on page load so the CSS placeholder appears if the user clears the text

## Related product discussion/links

* https://linear.app/a8c/issue/RSM-593/add-blockquote-citation-support

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to `/wp-admin/admin.php?page=write` on a test site with the Write editor enabled

**Creating a new citation:**
1. Type `/quote` to insert a blockquote, then type some quote text
2. Click inside the blockquote — verify the "Add citation…" placeholder appears below the quote text
3. Click the placeholder and type an author name
4. Click outside the blockquote — the citation stays, placeholder disappears
5. Save the post, then open it in the block editor — verify the quote block has the citation populated

**Editing an existing citation:**
1. In the block editor, create a post with a quote block that has a citation
2. Open the post in `/wp-admin/admin.php?page=write&post=<ID>`
3. Verify the citation text appears below the quote, styled distinctly (non-italic, smaller, gray)
4. Edit the citation text, save, and re-open in the block editor — verify the edit round-tripped

**Removing a citation:**
1. Open a post with a citation in Write
2. Select all citation text and delete it
3. Click outside the blockquote — verify the empty `<cite>` is removed
4. Save and open in the block editor — verify no citation is present

**Keyboard behavior:**
1. Cursor in quote body, press Enter at end — should break out to new paragraph (not into citation)
2. Cursor in citation, press Enter — should break out of the blockquote
3. Cursor in empty citation, press Backspace — should remove citation and return cursor to quote body

**Quote without citation (no regression):**
1. Create a blockquote without adding a citation
2. Save and verify it round-trips cleanly with no extra whitespace in the block editor

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
