### PR TITLE
Search: gate prepend_search_template() like WooCommerce's ProductSearchResultsTemplate

### DIFF
--- a/projects/packages/search/changelog/RSM-3498-gate-prepend-search-template
+++ b/projects/packages/search/changelog/RSM-3498-gate-prepend-search-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Only prepend the Jetpack Search template to the search template hierarchy on block themes during an actual search request, mirroring WooCommerce's ProductSearchResultsTemplate guard so the slug is never injected where it cannot resolve.

--- a/projects/packages/search/changelog/RSM-3498-gate-prepend-search-template
+++ b/projects/packages/search/changelog/RSM-3498-gate-prepend-search-template
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Search Blocks: Only prepend the Jetpack Search template to the search template hierarchy on block themes during an actual search request, mirroring WooCommerce's ProductSearchResultsTemplate guard so the slug is never injected where it cannot resolve.
+Search Blocks: Only register the Jetpack Search block template and prepend it to the search template hierarchy on block themes, and run the hierarchy filter after WooCommerce's so the Embedded takeover of product searches is deterministic regardless of plugin load order.

--- a/projects/packages/search/changelog/RSM-3498-gate-prepend-search-template
+++ b/projects/packages/search/changelog/RSM-3498-gate-prepend-search-template
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Search Blocks: Only register the Jetpack Search block template and prepend it to the search template hierarchy on block themes, and run the hierarchy filter after WooCommerce's so the Embedded takeover of product searches is deterministic regardless of plugin load order.
+Search Blocks: Only register the Jetpack Search block template and prepend it to the search template hierarchy on block themes during an actual search request, so the slug is never injected where it cannot resolve.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -143,15 +143,7 @@ class Search_Blocks {
 
 		if ( Module_Control::EXPERIENCE_EMBEDDED === ( new Module_Control() )->get_experience() ) {
 			add_action( 'init', array( static::class, 'register_search_template' ) );
-			// Priority 11 so this runs *after* WooCommerce's
-			// `ProductSearchResultsTemplate`, which prepends
-			// `product-search-results` at the default priority 10. Both
-			// callbacks `array_unshift()` onto the same hierarchy, so the
-			// later one ends up first; running last is what makes the
-			// Embedded-experience takeover of product searches (see
-			// `should_take_over_search()`) deterministic instead of
-			// dependent on plugin load order.
-			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ), 11 );
+			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		}
 	}
 
@@ -849,8 +841,7 @@ class Search_Blocks {
 	 * on the same hook.
 	 *
 	 * Gated by `should_take_over_search()` (see that method) so the slug is
-	 * only injected when it can actually resolve — mirroring the guard
-	 * WooCommerce's `ProductSearchResultsTemplate` applies to this same hook.
+	 * only injected when it can actually resolve.
 	 *
 	 * @param string[] $templates Template hierarchy slugs.
 	 * @return string[]
@@ -875,21 +866,12 @@ class Search_Blocks {
 	 * Whether the Jetpack Search template should replace the theme's search
 	 * template for the current request.
 	 *
-	 * Mirrors the guard WooCommerce's `ProductSearchResultsTemplate` applies
-	 * to the same `search_template_hierarchy` filter: the slug resolves only
-	 * through the block-template system, so prepending it outside a block
-	 * theme — or outside a search request, should the filter ever run out of
-	 * context — is dead weight that can only mis-shape the hierarchy (and on
-	 * a classic theme it could never resolve to our template anyway).
-	 *
-	 * Unlike WooCommerce we deliberately do *not* additionally scope to
-	 * `is_post_type_archive( 'product' )`. The Embedded experience is a
-	 * site-wide opt-in to Jetpack-owned search results — product searches
-	 * included, which Jetpack Search renders with its own WooCommerce-aware
-	 * filter blocks (`filters-product`, `filter-wc-*`). Carving product
-	 * searches back out to WooCommerce's `product-search-results` template
-	 * would contradict that opt-in, so the takeover stays unconditional
-	 * across search routes and independent of whether WooCommerce is active.
+	 * The slug resolves only through the block-template system, so
+	 * prepending it outside a block theme — or outside a search request,
+	 * should the filter ever run out of context — is dead weight that can
+	 * only mis-shape the hierarchy (and on a classic theme it could never
+	 * resolve to our template anyway). Both conditions are therefore
+	 * required before the takeover applies.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -832,10 +832,17 @@ class Search_Blocks {
 	 * can't accumulate duplicates from a second init pass or another filter
 	 * on the same hook.
 	 *
+	 * Gated by `should_take_over_search()` (see that method) so the slug is
+	 * only injected when it can actually resolve — mirroring the guard
+	 * WooCommerce's `ProductSearchResultsTemplate` applies to this same hook.
+	 *
 	 * @param string[] $templates Template hierarchy slugs.
 	 * @return string[]
 	 */
 	public static function prepend_search_template( $templates ) {
+		if ( ! static::should_take_over_search() ) {
+			return (array) $templates;
+		}
 		$templates = array_values(
 			array_filter(
 				(array) $templates,
@@ -846,6 +853,32 @@ class Search_Blocks {
 		);
 		array_unshift( $templates, self::SEARCH_TEMPLATE_SLUG );
 		return $templates;
+	}
+
+	/**
+	 * Whether the Jetpack Search template should replace the theme's search
+	 * template for the current request.
+	 *
+	 * Mirrors the guard WooCommerce's `ProductSearchResultsTemplate` applies
+	 * to the same `search_template_hierarchy` filter: the slug resolves only
+	 * through the block-template system, so prepending it outside a block
+	 * theme — or outside a search request, should the filter ever run out of
+	 * context — is dead weight that can only mis-shape the hierarchy (and on
+	 * a classic theme it could never resolve to our template anyway).
+	 *
+	 * Unlike WooCommerce we deliberately do *not* additionally scope to
+	 * `is_post_type_archive( 'product' )`. The Embedded experience is a
+	 * site-wide opt-in to Jetpack-owned search results — product searches
+	 * included, which Jetpack Search renders with its own WooCommerce-aware
+	 * filter blocks (`filters-product`, `filter-wc-*`). Carving product
+	 * searches back out to WooCommerce's `product-search-results` template
+	 * would contradict that opt-in, so the takeover stays unconditional
+	 * across search routes and independent of whether WooCommerce is active.
+	 *
+	 * @return bool
+	 */
+	protected static function should_take_over_search(): bool {
+		return is_search() && wp_is_block_theme();
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -758,13 +758,8 @@ class Search_Blocks {
 	 * edits this template in the Site Editor, the `custom` source wins during
 	 * resolution automatically.
 	 *
-	 * Gated on `block_templates_active()` for the same reason
-	 * `prepend_search_template()` is: the registry is only consulted by the
-	 * Site Editor and the block-theme render path, both of which require a
-	 * block theme. Registering on a classic theme is inert and would leave
-	 * registration asymmetric with the (block-theme-only) hierarchy prepend.
-	 * The check is re-evaluated every `init`, so switching to a block theme
-	 * registers the template on the very next request.
+	 * Skipped on classic themes: the registry is only consulted by the Site
+	 * Editor and the block-theme render path. Re-checked every `init`.
 	 */
 	public static function register_search_template() {
 		if ( ! function_exists( 'register_block_template' ) || ! static::block_templates_active() ) {
@@ -840,15 +835,16 @@ class Search_Blocks {
 	 * can't accumulate duplicates from a second init pass or another filter
 	 * on the same hook.
 	 *
-	 * Gated by `should_take_over_search()` (see that method) so the slug is
-	 * only injected when it can actually resolve.
+	 * Only takes effect on a block-theme search request — the slug resolves
+	 * only through the block-template system, so injecting it anywhere else
+	 * just mis-shapes the hierarchy.
 	 *
 	 * @param string[] $templates Template hierarchy slugs.
 	 * @return string[]
 	 */
 	public static function prepend_search_template( $templates ) {
-		if ( ! static::should_take_over_search() ) {
-			return (array) $templates;
+		if ( ! is_search() || ! static::block_templates_active() ) {
+			return $templates;
 		}
 		$templates = array_values(
 			array_filter(
@@ -863,30 +859,9 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Whether the Jetpack Search template should replace the theme's search
-	 * template for the current request.
-	 *
-	 * The slug resolves only through the block-template system, so
-	 * prepending it outside a block theme — or outside a search request,
-	 * should the filter ever run out of context — is dead weight that can
-	 * only mis-shape the hierarchy (and on a classic theme it could never
-	 * resolve to our template anyway). Both conditions are therefore
-	 * required before the takeover applies.
-	 *
-	 * @return bool
-	 */
-	protected static function should_take_over_search(): bool {
-		return is_search() && static::block_templates_active();
-	}
-
-	/**
-	 * Whether the active theme resolves block templates — the precondition
-	 * shared by template registration and the search-hierarchy takeover.
-	 *
-	 * Single-sourced (rather than two `wp_is_block_theme()` calls) so the
-	 * two surfaces can never drift apart and so tests can flip the
-	 * precondition via a subclass without standing up a block theme in the
-	 * dbless environment.
+	 * Whether the active theme resolves block templates. Wraps
+	 * `wp_is_block_theme()` as an overridable seam so tests can exercise the
+	 * block-theme path without standing up a block theme.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -143,7 +143,15 @@ class Search_Blocks {
 
 		if ( Module_Control::EXPERIENCE_EMBEDDED === ( new Module_Control() )->get_experience() ) {
 			add_action( 'init', array( static::class, 'register_search_template' ) );
-			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
+			// Priority 11 so this runs *after* WooCommerce's
+			// `ProductSearchResultsTemplate`, which prepends
+			// `product-search-results` at the default priority 10. Both
+			// callbacks `array_unshift()` onto the same hierarchy, so the
+			// later one ends up first; running last is what makes the
+			// Embedded-experience takeover of product searches (see
+			// `should_take_over_search()`) deterministic instead of
+			// dependent on plugin load order.
+			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ), 11 );
 		}
 	}
 
@@ -757,9 +765,17 @@ class Search_Blocks {
 	 * DB-stored customizations continue to take precedence: if a site owner
 	 * edits this template in the Site Editor, the `custom` source wins during
 	 * resolution automatically.
+	 *
+	 * Gated on `block_templates_active()` for the same reason
+	 * `prepend_search_template()` is: the registry is only consulted by the
+	 * Site Editor and the block-theme render path, both of which require a
+	 * block theme. Registering on a classic theme is inert and would leave
+	 * registration asymmetric with the (block-theme-only) hierarchy prepend.
+	 * The check is re-evaluated every `init`, so switching to a block theme
+	 * registers the template on the very next request.
 	 */
 	public static function register_search_template() {
-		if ( ! function_exists( 'register_block_template' ) ) {
+		if ( ! function_exists( 'register_block_template' ) || ! static::block_templates_active() ) {
 			return;
 		}
 		$content = static::get_search_template_content();
@@ -878,7 +894,22 @@ class Search_Blocks {
 	 * @return bool
 	 */
 	protected static function should_take_over_search(): bool {
-		return is_search() && wp_is_block_theme();
+		return is_search() && static::block_templates_active();
+	}
+
+	/**
+	 * Whether the active theme resolves block templates — the precondition
+	 * shared by template registration and the search-hierarchy takeover.
+	 *
+	 * Single-sourced (rather than two `wp_is_block_theme()` calls) so the
+	 * two surfaces can never drift apart and so tests can flip the
+	 * precondition via a subclass without standing up a block theme in the
+	 * dbless environment.
+	 *
+	 * @return bool
+	 */
+	protected static function block_templates_active(): bool {
+		return wp_is_block_theme();
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -315,12 +315,31 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Subclass that forces `should_take_over_search()` true so the
+	 * array-shaping behavior can be asserted without standing up a block
+	 * theme in the dbless environment. The guard itself is exercised
+	 * separately against real `is_search()` / `wp_is_block_theme()` state.
+	 *
+	 * @return class-string<Search_Blocks>
+	 */
+	private function search_blocks_taking_over(): string {
+		return get_class(
+			new class() extends Search_Blocks {
+				protected static function should_take_over_search(): bool {
+					return true;
+				}
+			}
+		);
+	}
+
+	/**
 	 * The takeover hinges on `search` being replaced by `jetpack-search` at
 	 * the front of the hierarchy: that's what makes core resolve our plugin
 	 * template instead of the theme's `search.html`.
 	 */
 	public function test_prepend_search_template_puts_unique_slug_first() {
-		$result = Search_Blocks::prepend_search_template( array( 'search', 'index' ) );
+		$class  = $this->search_blocks_taking_over();
+		$result = $class::prepend_search_template( array( 'search', 'index' ) );
 		$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $result );
 	}
 
@@ -331,9 +350,68 @@ class Search_Blocks_Test extends TestCase {
 	 * identical registry lookups per search request.
 	 */
 	public function test_prepend_search_template_dedupes_existing_slug() {
-		$result = Search_Blocks::prepend_search_template( array( 'jetpack-search', 'search', 'index' ) );
+		$class  = $this->search_blocks_taking_over();
+		$result = $class::prepend_search_template( array( 'jetpack-search', 'search', 'index' ) );
 		$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $result );
 		$this->assertCount( 1, array_keys( $result, 'jetpack-search', true ) );
+	}
+
+	/**
+	 * `prepend_search_template()` must leave the hierarchy untouched when the
+	 * request isn't a search — the filter is structurally only fired from
+	 * `get_search_template()`, but the guard mirrors WooCommerce's defensive
+	 * `is_search()` check so a stray out-of-context invocation can't shove a
+	 * never-resolving slug to the front.
+	 */
+	public function test_prepend_search_template_skips_when_not_a_search() {
+		$GLOBALS['wp_query'] = new \WP_Query();
+		$this->assertFalse( is_search() );
+		$input  = array( 'search', 'index' );
+		$result = Search_Blocks::prepend_search_template( $input );
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * On a classic (non-block) theme the slug can never resolve through the
+	 * block-template system, so — matching WooCommerce's `wp_is_block_theme()`
+	 * guard — the hierarchy is returned unchanged. The dbless environment's
+	 * default theme is classic, so a search route alone isn't enough.
+	 */
+	public function test_prepend_search_template_skips_on_classic_theme() {
+		$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+		$this->assertTrue( is_search() );
+		$this->assertFalse( wp_is_block_theme(), 'dbless default theme is expected to be classic' );
+		$input  = array( 'search', 'index' );
+		$result = Search_Blocks::prepend_search_template( $input );
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * Documented decision (RSM-3498): the Embedded experience is a site-wide
+	 * opt-in, so Jetpack Search owns product-catalog searches too — it must
+	 * win even when WooCommerce already prepended its `product-search-results`
+	 * slug, and that outcome must not depend on the WooCommerce gate. Asserts
+	 * the full WC-on / WC-off matrix.
+	 *
+	 * @param bool $wc_enabled Forced state of the WooCommerce blocks gate.
+	 * @dataProvider provide_woocommerce_gate
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider( 'provide_woocommerce_gate' )]
+	public function test_prepend_search_template_takes_over_product_search_regardless_of_woocommerce( bool $wc_enabled ) {
+		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( $wc_enabled );
+		$class  = $this->search_blocks_taking_over();
+		$result = $class::prepend_search_template( array( 'product-search-results', 'search', 'index' ) );
+		$this->assertSame( array( 'jetpack-search', 'product-search-results', 'search', 'index' ), $result );
+	}
+
+	/**
+	 * @return array<string, array{0: bool}>
+	 */
+	public static function provide_woocommerce_gate(): array {
+		return array(
+			'woocommerce active'   => array( true ),
+			'woocommerce inactive' => array( false ),
+		);
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -383,11 +383,16 @@ class Search_Blocks_Test extends TestCase {
 	 * never-resolving slug to the front.
 	 */
 	public function test_prepend_search_template_skips_when_not_a_search() {
-		$GLOBALS['wp_query'] = new \WP_Query();
-		$this->assertFalse( is_search() );
-		$input  = array( 'search', 'index' );
-		$result = Search_Blocks::prepend_search_template( $input );
-		$this->assertSame( $input, $result );
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query();
+			$this->assertFalse( is_search() );
+			$input  = array( 'search', 'index' );
+			$result = Search_Blocks::prepend_search_template( $input );
+			$this->assertSame( $input, $result );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
 	}
 
 	/**
@@ -397,12 +402,17 @@ class Search_Blocks_Test extends TestCase {
 	 * default theme is classic, so a search route alone isn't enough.
 	 */
 	public function test_prepend_search_template_skips_on_classic_theme() {
-		$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
-		$this->assertTrue( is_search() );
-		$this->assertFalse( wp_is_block_theme(), 'dbless default theme is expected to be classic' );
-		$input  = array( 'search', 'index' );
-		$result = Search_Blocks::prepend_search_template( $input );
-		$this->assertSame( $input, $result );
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+			$this->assertTrue( is_search() );
+			$this->assertFalse( wp_is_block_theme(), 'dbless default theme is expected to be classic' );
+			$input  = array( 'search', 'index' );
+			$result = Search_Blocks::prepend_search_template( $input );
+			$this->assertSame( $input, $result );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -333,6 +333,25 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Subclass that forces `block_templates_active()` true so
+	 * `register_search_template()` can be exercised without standing up a
+	 * block theme in the dbless environment (whose default theme is
+	 * classic). The block-theme gate itself is covered separately by
+	 * `test_register_search_template_skips_on_classic_theme()`.
+	 *
+	 * @return class-string<Search_Blocks>
+	 */
+	private function search_blocks_with_block_templates(): string {
+		return get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+			}
+		);
+	}
+
+	/**
 	 * The takeover hinges on `search` being replaced by `jetpack-search` at
 	 * the front of the hierarchy: that's what makes core resolve our plugin
 	 * template instead of the theme's `search.html`.
@@ -491,9 +510,10 @@ class Search_Blocks_Test extends TestCase {
 			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
 			'register_search_template must hook into init on embedded'
 		);
-		$this->assertNotFalse(
+		$this->assertSame(
+			11,
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
-			'prepend_search_template must hook into search_template_hierarchy on embedded'
+			'prepend_search_template must hook search_template_hierarchy at priority 11 so it runs after WooCommerce (priority 10) and wins the array_unshift'
 		);
 
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
@@ -538,7 +558,9 @@ class Search_Blocks_Test extends TestCase {
 		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
 		remove_action( 'init', array( Search_Blocks::class, 'register_search_template' ) );
 		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
-		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) );
+		// Priority must match init()'s add_filter (11) — remove_filter()
+		// defaults to 10 and would otherwise leak the hook across tests.
+		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ), 11 );
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
@@ -577,7 +599,8 @@ class Search_Blocks_Test extends TestCase {
 			}
 		}
 
-		Search_Blocks::register_search_template();
+		$class = $this->search_blocks_with_block_templates();
+		$class::register_search_template();
 
 		$namespace = $this->invoke_protected( 'get_parent_plugin_slug' );
 		$expected  = $namespace . '//jetpack-search';
@@ -617,17 +640,49 @@ class Search_Blocks_Test extends TestCase {
 		}
 
 		// Stub empty content by temporarily overriding the method's output
-		// via a mock subclass. Simplest: run register_search_template on a
-		// subclass that returns '' from get_search_template_content().
+		// via a mock subclass. block_templates_active() is also forced true
+		// so the early block-theme guard doesn't short-circuit before the
+		// empty-content check — otherwise this would pass for the wrong
+		// reason in the (classic) dbless default theme.
 		$anon = new class() extends Search_Blocks {
 			protected static function get_search_template_content(): string {
 				return '';
+			}
+			protected static function block_templates_active(): bool {
+				return true;
 			}
 		};
 		$anon::register_search_template();
 
 		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
 			$this->assertFalse( $registry->is_registered( $name ), "Template $name should NOT be registered when content is empty." );
+		}
+	}
+
+	/**
+	 * On a classic (non-block) theme the block-template registry is never
+	 * consulted for rendering and there's no Site Editor to surface the
+	 * template, so registration must be a no-op — keeping it symmetric with
+	 * the (block-theme-only) `prepend_search_template()` guard. The dbless
+	 * default theme is classic, so the real guard is exercised here.
+	 */
+	public function test_register_search_template_skips_on_classic_theme() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$this->assertFalse( wp_is_block_theme(), 'dbless default theme is expected to be classic' );
+
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		Search_Blocks::register_search_template();
+
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			$this->assertFalse( $registry->is_registered( $name ), "Template $name must NOT be registered on a classic theme." );
 		}
 	}
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -416,34 +416,6 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Documented decision (RSM-3498): the Embedded experience is a site-wide
-	 * opt-in, so Jetpack Search owns product-catalog searches too — it must
-	 * win even when WooCommerce already prepended its `product-search-results`
-	 * slug, and that outcome must not depend on the WooCommerce gate. Asserts
-	 * the full WC-on / WC-off matrix.
-	 *
-	 * @param bool $wc_enabled Forced state of the WooCommerce blocks gate.
-	 * @dataProvider provide_woocommerce_gate
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider( 'provide_woocommerce_gate' )]
-	public function test_prepend_search_template_takes_over_product_search_regardless_of_woocommerce( bool $wc_enabled ) {
-		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( $wc_enabled );
-		$class  = $this->search_blocks_taking_over();
-		$result = $class::prepend_search_template( array( 'product-search-results', 'search', 'index' ) );
-		$this->assertSame( array( 'jetpack-search', 'product-search-results', 'search', 'index' ), $result );
-	}
-
-	/**
-	 * @return array<string, array{0: bool}>
-	 */
-	public static function provide_woocommerce_gate(): array {
-		return array(
-			'woocommerce active'   => array( true ),
-			'woocommerce inactive' => array( false ),
-		);
-	}
-
-	/**
 	 * `init()` must always register the block-level hooks AND the IA state
 	 * seeding regardless of which experience the site has saved — admins can
 	 * insert Search blocks anywhere blocks are configurable, and those blocks
@@ -520,10 +492,9 @@ class Search_Blocks_Test extends TestCase {
 			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
 			'register_search_template must hook into init on embedded'
 		);
-		$this->assertSame(
-			11,
+		$this->assertNotFalse(
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
-			'prepend_search_template must hook search_template_hierarchy at priority 11 so it runs after WooCommerce (priority 10) and wins the array_unshift'
+			'prepend_search_template must hook into search_template_hierarchy on embedded'
 		);
 
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
@@ -568,9 +539,7 @@ class Search_Blocks_Test extends TestCase {
 		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
 		remove_action( 'init', array( Search_Blocks::class, 'register_search_template' ) );
 		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
-		// Priority must match init()'s add_filter (11) — remove_filter()
-		// defaults to 10 and would otherwise leak the hook across tests.
-		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ), 11 );
+		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) );
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -315,33 +315,12 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Subclass that forces `should_take_over_search()` true so the
-	 * array-shaping behavior can be asserted without standing up a block
-	 * theme in the dbless environment. The guard itself is exercised
-	 * separately against real `is_search()` / `wp_is_block_theme()` state.
+	 * Subclass forcing `block_templates_active()` so the block-theme path
+	 * runs without a real block theme in the dbless env.
 	 *
 	 * @return class-string<Search_Blocks>
 	 */
-	private function search_blocks_taking_over(): string {
-		return get_class(
-			new class() extends Search_Blocks {
-				protected static function should_take_over_search(): bool {
-					return true;
-				}
-			}
-		);
-	}
-
-	/**
-	 * Subclass that forces `block_templates_active()` true so
-	 * `register_search_template()` can be exercised without standing up a
-	 * block theme in the dbless environment (whose default theme is
-	 * classic). The block-theme gate itself is covered separately by
-	 * `test_register_search_template_skips_on_classic_theme()`.
-	 *
-	 * @return class-string<Search_Blocks>
-	 */
-	private function search_blocks_with_block_templates(): string {
+	private function block_theme_search_blocks(): string {
 		return get_class(
 			new class() extends Search_Blocks {
 				protected static function block_templates_active(): bool {
@@ -352,64 +331,44 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * The takeover hinges on `search` being replaced by `jetpack-search` at
-	 * the front of the hierarchy: that's what makes core resolve our plugin
-	 * template instead of the theme's `search.html`.
+	 * On a block-theme search request the slug is moved to the front of the
+	 * hierarchy, and a pre-existing copy is de-duplicated rather than doubled.
 	 */
-	public function test_prepend_search_template_puts_unique_slug_first() {
-		$class  = $this->search_blocks_taking_over();
-		$result = $class::prepend_search_template( array( 'search', 'index' ) );
-		$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $result );
-	}
-
-	/**
-	 * If the slug is already in the hierarchy (e.g. a second init pass or
-	 * another filter already prepended it), the result must not contain
-	 * duplicate `jetpack-search` entries — core would otherwise do two
-	 * identical registry lookups per search request.
-	 */
-	public function test_prepend_search_template_dedupes_existing_slug() {
-		$class  = $this->search_blocks_taking_over();
-		$result = $class::prepend_search_template( array( 'jetpack-search', 'search', 'index' ) );
-		$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $result );
-		$this->assertCount( 1, array_keys( $result, 'jetpack-search', true ) );
-	}
-
-	/**
-	 * `prepend_search_template()` must leave the hierarchy untouched when the
-	 * request isn't a search — the filter is structurally only fired from
-	 * `get_search_template()`, but the guard mirrors WooCommerce's defensive
-	 * `is_search()` check so a stray out-of-context invocation can't shove a
-	 * never-resolving slug to the front.
-	 */
-	public function test_prepend_search_template_skips_when_not_a_search() {
+	public function test_prepend_search_template_prepends_unique_slug() {
 		$original_query = $GLOBALS['wp_query'] ?? null;
 		try {
-			$GLOBALS['wp_query'] = new \WP_Query();
-			$this->assertFalse( is_search() );
-			$input  = array( 'search', 'index' );
-			$result = Search_Blocks::prepend_search_template( $input );
-			$this->assertSame( $input, $result );
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+			$class               = $this->block_theme_search_blocks();
+
+			$this->assertSame(
+				array( 'jetpack-search', 'search', 'index' ),
+				$class::prepend_search_template( array( 'search', 'index' ) )
+			);
+			$deduped = $class::prepend_search_template( array( 'jetpack-search', 'search', 'index' ) );
+			$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $deduped );
+			$this->assertCount( 1, array_keys( $deduped, 'jetpack-search', true ) );
 		} finally {
 			$GLOBALS['wp_query'] = $original_query;
 		}
 	}
 
 	/**
-	 * On a classic (non-block) theme the slug can never resolve through the
-	 * block-template system, so — matching WooCommerce's `wp_is_block_theme()`
-	 * guard — the hierarchy is returned unchanged. The dbless environment's
-	 * default theme is classic, so a search route alone isn't enough.
+	 * The hierarchy is returned untouched unless the request is a search on a
+	 * block theme — the slug only resolves through the block-template system.
 	 */
-	public function test_prepend_search_template_skips_on_classic_theme() {
+	public function test_prepend_search_template_skips_outside_block_theme_search() {
 		$original_query = $GLOBALS['wp_query'] ?? null;
 		try {
+			$input = array( 'search', 'index' );
+
+			$GLOBALS['wp_query'] = new \WP_Query();
+			$this->assertFalse( is_search() );
+			$this->assertSame( $input, Search_Blocks::prepend_search_template( $input ) );
+
 			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
 			$this->assertTrue( is_search() );
 			$this->assertFalse( wp_is_block_theme(), 'dbless default theme is expected to be classic' );
-			$input  = array( 'search', 'index' );
-			$result = Search_Blocks::prepend_search_template( $input );
-			$this->assertSame( $input, $result );
+			$this->assertSame( $input, Search_Blocks::prepend_search_template( $input ) );
 		} finally {
 			$GLOBALS['wp_query'] = $original_query;
 		}
@@ -578,7 +537,7 @@ class Search_Blocks_Test extends TestCase {
 			}
 		}
 
-		$class = $this->search_blocks_with_block_templates();
+		$class = $this->block_theme_search_blocks();
 		$class::register_search_template();
 
 		$namespace = $this->invoke_protected( 'get_parent_plugin_slug' );
@@ -600,12 +559,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * If the bundled template file can't be read, registration must be a
-	 * no-op — otherwise the slug we prepended to `search_template_hierarchy`
-	 * would resolve to an empty plugin template and take over `/?s=...`
-	 * with a blank page. Simulate the missing-file case with an anonymous
-	 * subclass that overrides `get_search_template_content()` to return ''
-	 * (the actual file is always present in the repo).
+	 * Empty template content must be a no-op — otherwise the prepended slug
+	 * resolves to an empty template and renders a blank `/?s=...` page.
 	 */
 	public function test_register_search_template_skips_when_content_empty() {
 		if ( ! function_exists( 'register_block_template' ) ) {
@@ -618,11 +573,8 @@ class Search_Blocks_Test extends TestCase {
 			}
 		}
 
-		// Stub empty content by temporarily overriding the method's output
-		// via a mock subclass. block_templates_active() is also forced true
-		// so the early block-theme guard doesn't short-circuit before the
-		// empty-content check — otherwise this would pass for the wrong
-		// reason in the (classic) dbless default theme.
+		// block_templates_active() forced true so the block-theme guard
+		// doesn't short-circuit before the empty-content check.
 		$anon = new class() extends Search_Blocks {
 			protected static function get_search_template_content(): string {
 				return '';
@@ -639,11 +591,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * On a classic (non-block) theme the block-template registry is never
-	 * consulted for rendering and there's no Site Editor to surface the
-	 * template, so registration must be a no-op — keeping it symmetric with
-	 * the (block-theme-only) `prepend_search_template()` guard. The dbless
-	 * default theme is classic, so the real guard is exercised here.
+	 * On a classic theme registration must be a no-op. The dbless default
+	 * theme is classic, so the real guard is exercised here.
 	 */
 	public function test_register_search_template_skips_on_classic_theme() {
 		if ( ! function_exists( 'register_block_template' ) ) {


### PR DESCRIPTION
Fixes [RSM-3498](https://linear.app/a8c/issue/RSM-3498/search-gate-prepend-search-template-like-woocommerces)

## Why

When the Embedded search experience is on, Jetpack registered its search template **and** prepended its `jetpack-search` slug to the search template hierarchy **unconditionally** — even on classic themes (where the block-template registry and Site Editor are never consulted) and regardless of request context. The slug only resolves through the block-template system, so injecting it elsewhere is dead weight that can only mis-shape the hierarchy. This scopes both surfaces to where they can actually take effect: a block theme, on a search request.

## Proposed changes

* Add a single `Search_Blocks::block_templates_active()` seam (wraps `wp_is_block_theme()`) so registration and takeover share one block-theme check and tests can exercise the block-theme path without a real block theme.
* Gate `prepend_search_template()` on `is_search() && block_templates_active()` — the slug is only prepended on a block-theme search request.
* Gate `register_search_template()` on `block_templates_active()` too — no point registering a template the Site Editor and block-render path (both block-theme-only) will never consult. Re-evaluated every `init`, so a classic→block theme switch registers it on the next request.
* Tests: block-theme path via one subclass seam; one combined prepend ordering/dedup test, one combined skip test (not-a-search + classic theme), classic-theme registration case. `$GLOBALS['wp_query']` saved/restored via `try/finally`.

WooCommerce search-results interaction is intentionally out of scope for this PR — this is purely about WP search resolving correctly.

## Screenshots

The guard's two outcomes for the same `/?s=hello` request under **identical conditions** — Embedded experience on, Search 3.0 blocks initialized — with the active theme as the only variable. (The local docker env isn't connected to a Search plan, so a dev mu-plugin forced the package past the unrelated connection/plan gate; the code that runs from there — `register_search_template()` / `prepend_search_template()` — is exactly this PR's. The mu-plugin was removed after capture.)

| Block theme (Twenty Twenty-Five) | Classic theme (Twenty Twenty-One) |
|---|---|
| ![block theme](https://github.com/user-attachments/assets/4eaedade-086a-4ef3-82d8-2d4213dca083) | ![classic theme](https://github.com/user-attachments/assets/4310a201-2bab-4859-bd13-e9e32e6a507d) |
| `block_templates_active()` → true: the `jetpack-search` template resolves — faceted filter sidebar (Category / Tag / Post Type), sort control, "Search powered by Jetpack". | `block_templates_active()` → false: `register_search_template()` and `prepend_search_template()` both bail, so the theme's native search renders — no `jetpack-search` slug forced into a hierarchy that can't resolve it. |

## Verification

Backend-only change — no user-visible difference (block-theme behavior is identical before/after; on a classic theme search already fell through to the theme template since block templates can't resolve there). Exercised end-to-end against a live WP env (`twentytwentyfive` block theme, `embedded` experience): the hierarchy filter and `register_search_template()` behave correctly across the full block/classic matrix, and a real `/?s=test` request still renders the Jetpack Search template (`Filter options` heading + `search-results` region) — takeover intact, no regression.

<details>
<summary>Live filter matrix (wp eval-file against the running env)</summary>

```text
=== BLOCK THEME (twentytwentyfive) ===
Active theme: twentytwentyfive | wp_is_block_theme()=true
[search=true ] => jetpack-search,search,index
[search=false] => search,index

=== CLASSIC THEME (twentytwentyone) ===
Active theme: twentytwentyone | wp_is_block_theme()=false
[search=true ] => search,index
[search=false] => search,index
```

</details>

<details>
<summary>Live registration guard (register_search_template via wp eval-file)</summary>

```text
theme=twentytwentyfive wp_is_block_theme=true  => register_search_template registered: YES
theme=twentytwentyone  wp_is_block_theme=false => register_search_template registered: no
```

</details>

<details>
<summary>PHPUnit (jetpack-search package)</summary>

```text
$ composer phpunit -- --filter 'Search_Blocks_Test'
........................................................... 59 / 59 (100%)
OK (59 tests, 202 assertions)

$ composer phpunit            # full package suite
OK (461 tests, 1037 assertions)
```

</details>

## Related product discussion/links

* [RSM-3498](https://linear.app/a8c/issue/RSM-3498/search-gate-prepend-search-template-like-woocommerces)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from RSM-3498 (scoped to WP search):

* [x] `prepend_search_template()` no longer unconditionally overrides the search template hierarchy; it guards on block-theme + search context. `register_search_template()` is gated symmetrically.
* [x] Existing `Search_Blocks_Test.php` assertions updated; added non-block-theme prepend + registration cases and not-a-search coverage.

To verify manually:

* On a **block theme** with the Embedded experience saved, visit `/?s=anything` → the Jetpack Search results template renders (filter sidebar + results region); the `jetpack-search` template is registered (Site Editor → Templates).
* Switch to a **classic theme**, keep Embedded on, visit `/?s=anything` → the theme's own search output renders; `apply_filters( 'search_template_hierarchy', array( 'search', 'index' ) )` returns `['search','index']` (no `jetpack-search`) and the `jetpack-search` template is **not** registered.
