### PR TITLE
Search: take over WooCommerce Product Search Results template (opt-in)

### DIFF
--- a/projects/packages/search/changelog/RSM-3497-woocommerce-product-search-takeover
+++ b/projects/packages/search/changelog/RSM-3497-woocommerce-product-search-takeover
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search dashboard: add a "WooCommerce Product Search" control that, when enabled, serves product searches from a dedicated Site-Editor-editable Jetpack Search template instead of WooCommerce's default product search template.

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -257,7 +257,9 @@ class REST_Controller {
 
 		$search_suggestions_enabled = isset( $request_body['search_suggestions_enabled'] ) ? (bool) $request_body['search_suggestions_enabled'] : null;
 
-		$error = $this->validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience, $reader_chat, $ai_answers_enabled, $search_suggestions_enabled );
+		$override_woocommerce_search_template = isset( $request_body['override_woocommerce_search_template'] ) ? (bool) $request_body['override_woocommerce_search_template'] : null;
+
+		$error = $this->validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience, $reader_chat, $ai_answers_enabled, $search_suggestions_enabled, $override_woocommerce_search_template );
 
 		if ( is_wp_error( $error ) ) {
 			return $error;
@@ -308,6 +310,9 @@ class REST_Controller {
 		if ( $search_suggestions_enabled !== null ) {
 			update_option( 'jetpack_search_suggestions_enabled', $search_suggestions_enabled );
 		}
+		if ( $override_woocommerce_search_template !== null ) {
+			update_option( 'jetpack_search_override_woocommerce_search_template', $override_woocommerce_search_template );
+		}
 
 		if ( ! empty( $errors ) ) {
 			return new WP_Error(
@@ -337,8 +342,9 @@ class REST_Controller {
 	 * @param bool|null   $reader_chat - Reader Chat status.
 	 * @param bool|null   $ai_answers_enabled - Whether Jetpack Search AI answers is enabled.
 	 * @param boolean     $search_suggestions_enabled - New search suggestions status.
+	 * @param boolean     $override_woocommerce_search_template - New WooCommerce search-template override status.
 	 */
-	protected function validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience = null, $reader_chat = null, $ai_answers_enabled = null, $search_suggestions_enabled = null ) {
+	protected function validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience = null, $reader_chat = null, $ai_answers_enabled = null, $search_suggestions_enabled = null, $override_woocommerce_search_template = null ) {
 		if ( $reader_chat !== null && ! $this->is_reader_chat_setting_registered() ) {
 			return new WP_Error(
 				'rest_invalid_arguments',
@@ -352,10 +358,10 @@ class REST_Controller {
 		// lose those fields — the `experience` branch in update_settings() early-returns and
 		// would otherwise drop them.
 		if ( $experience !== null ) {
-			if ( $module_active !== null || $instant_search_enabled !== null || $swap_classic_to_inline_search !== null || $reader_chat !== null ) {
+			if ( $module_active !== null || $instant_search_enabled !== null || $swap_classic_to_inline_search !== null || $reader_chat !== null || $override_woocommerce_search_template !== null ) {
 				return new WP_Error(
 					'rest_invalid_arguments',
-					esc_html__( 'The `experience` field cannot be combined with `module_active`, `instant_search_enabled`, `swap_classic_to_inline_search`, or `reader_chat`.', 'jetpack-search-pkg' ),
+					esc_html__( 'The `experience` field cannot be combined with `module_active`, `instant_search_enabled`, `swap_classic_to_inline_search`, `reader_chat`, or `override_woocommerce_search_template`.', 'jetpack-search-pkg' ),
 					array( 'status' => 400 )
 				);
 			}
@@ -377,6 +383,10 @@ class REST_Controller {
 			// allow updating 'search_suggestions_enabled' without updating/validating other settings.
 			return true;
 		}
+		if ( $module_active === null && $instant_search_enabled === null && $swap_classic_to_inline_search === null && $override_woocommerce_search_template !== null ) {
+			// allow updating 'override_woocommerce_search_template' without updating/validating other settings.
+			return true;
+		}
 		if ( ( true === $instant_search_enabled && false === $module_active ) || ( $module_active === null && $instant_search_enabled === null ) ) {
 			return new WP_Error(
 				'rest_invalid_arguments',
@@ -392,12 +402,13 @@ class REST_Controller {
 		 */
 	public function get_settings() {
 		$settings = array(
-			'module_active'                 => $this->search_module->is_active(),
-			'instant_search_enabled'        => $this->search_module->is_instant_search_enabled(),
-			'swap_classic_to_inline_search' => $this->search_module->is_swap_classic_to_inline_search(),
-			'experience'                    => $this->search_module->get_experience(),
-			'ai_answers_enabled'            => AI_Answers::is_enabled(),
-			'search_suggestions_enabled'    => (bool) get_option( 'jetpack_search_suggestions_enabled', false ),
+			'module_active'                        => $this->search_module->is_active(),
+			'instant_search_enabled'               => $this->search_module->is_instant_search_enabled(),
+			'swap_classic_to_inline_search'        => $this->search_module->is_swap_classic_to_inline_search(),
+			'experience'                           => $this->search_module->get_experience(),
+			'ai_answers_enabled'                   => AI_Answers::is_enabled(),
+			'search_suggestions_enabled'           => (bool) get_option( 'jetpack_search_suggestions_enabled', false ),
+			'override_woocommerce_search_template' => Search_Blocks::woocommerce_search_template_override_enabled(),
 		);
 
 		if ( $this->is_reader_chat_setting_registered() ) {

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -89,6 +89,8 @@ class Initial_State {
 				 * same flag the back end uses to register the blocks themselves.
 				 */
 				'searchBlocksEnabled'        => (bool) apply_filters( 'jetpack_search_blocks_enabled', false ),
+				// Gates the WooCommerce Product Search control to stores.
+				'isWooCommerceActive'        => Search_Blocks::woocommerce_blocks_enabled(),
 				/**
 				 * Active theme stylesheet — used by the experience-selector to deep-link
 				 * the "Edit search template" action to the right Site Editor entry

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -14,7 +14,9 @@ import ModuleControl from 'components/module-control';
 import ReaderChatControl from 'components/reader-chat-control';
 import RecordMeter from 'components/record-meter';
 import SearchSuggestionsControl from 'components/search-suggestions-control';
+import WooCommerceProductSearchControl from 'components/woocommerce-product-search-control';
 import { STORE_ID } from 'store';
+import { EXPERIENCE } from '../experience-selector/constants';
 import FirstRunSection from './sections/first-run-section';
 import PlanUsageSection from './sections/plan-usage-section';
 import './dashboard-page.scss';
@@ -131,6 +133,26 @@ export default function DashboardPage( { isLoading = false } ) {
 	const isSearchSuggestionsEnabled = useSelect( select =>
 		select( STORE_ID ).isSearchSuggestionsEnabled()
 	);
+	const isWooCommerceActive = useSelect( select => select( STORE_ID ).isWooCommerceActive() );
+	const isWooCommerceSearchTemplateOverrideEnabled = useSelect( select =>
+		select( STORE_ID ).isWooCommerceSearchTemplateOverrideEnabled()
+	);
+	const activeExperience = useSelect( select => select( STORE_ID ).getActiveExperience() );
+	const activeThemeStylesheet = useSelect( select =>
+		select( STORE_ID ).getActiveThemeStylesheet()
+	);
+	// Only meaningful for server-rendered templates; Overlay intercepts
+	// client-side so the override would be a no-op there.
+	const showWooCommerceProductSearchControl =
+		isWooCommerceActive &&
+		( activeExperience === EXPERIENCE.EMBEDDED || activeExperience === EXPERIENCE.INLINE );
+	// Site Editor identifies plugin templates as `<stylesheet>//<slug>`;
+	// fall back to the Templates list when the stylesheet is unavailable.
+	const wooProductSearchEditUrl = activeThemeStylesheet
+		? `${ siteAdminUrl }site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
+				activeThemeStylesheet
+		  ) }%2F%2Fjetpack-search-product-results&canvas=edit`
+		: `${ siteAdminUrl }site-editor.php?p=%2Ftemplate`;
 	const showAIAgentAccessGuidelinesLink =
 		! isReaderChatAvailable ||
 		! isReaderChatEnabled ||
@@ -271,6 +293,16 @@ export default function DashboardPage( { isLoading = false } ) {
 																isSaving={ isSavingEitherOption }
 																isDisabledFromOverLimit={ isOverLimit }
 																updateOptions={ updateOptions }
+															/>
+														</div>
+													) }
+													{ showWooCommerceProductSearchControl && (
+														<div className="jp-search-settings-card">
+															<WooCommerceProductSearchControl
+																isEnabled={ isWooCommerceSearchTemplateOverrideEnabled }
+																isSaving={ isSavingEitherOption }
+																updateOptions={ updateOptions }
+																editTemplateUrl={ wooProductSearchEditUrl }
 															/>
 														</div>
 													) }

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -2,6 +2,7 @@ const mockModuleControl = jest.fn();
 const mockReaderChatControl = jest.fn();
 const mockSearchSuggestionsControl = jest.fn();
 const mockAIAgentAccessControl = jest.fn();
+const mockWooCommerceProductSearchControl = jest.fn();
 let mockSelectMethods;
 let mockDispatchMethods;
 
@@ -50,6 +51,10 @@ jest.mock( 'components/ai-agent-access-control', () => props => {
 	mockAIAgentAccessControl( props );
 	return <div data-testid="ai-agent-access-control" />;
 } );
+jest.mock( 'components/woocommerce-product-search-control', () => props => {
+	mockWooCommerceProductSearchControl( props );
+	return <div data-testid="woocommerce-product-search-control" />;
+} );
 jest.mock( 'components/record-meter', () => () => <div data-testid="record-meter" /> );
 jest.mock( '../sections/first-run-section', () => () => <div data-testid="first-run-section" /> );
 jest.mock( '../sections/plan-usage-section', () => () => <div data-testid="plan-usage-section" /> );
@@ -84,6 +89,7 @@ const createSelectMethods = () => ( {
 	getSearchPlanInfo: jest.fn(),
 	getSearchStats: jest.fn(),
 	getSiteAdminUrl: jest.fn( () => 'https://example.com/wp-admin/' ),
+	getActiveThemeStylesheet: jest.fn( () => 'twentytwentyfive' ),
 	getSiteTitle: jest.fn( () => 'Example Site' ),
 	getTierMaximumRecords: jest.fn( () => 100 ),
 	hasStartedResolution: jest.fn( () => true ),
@@ -100,6 +106,9 @@ const createSelectMethods = () => ( {
 	isResolving: jest.fn( () => false ),
 	isSearchBlocksEnabled: jest.fn( () => false ),
 	isSearchSuggestionsEnabled: jest.fn( () => false ),
+	isWooCommerceActive: jest.fn( () => false ),
+	isWooCommerceSearchTemplateOverrideEnabled: jest.fn( () => false ),
+	getActiveExperience: jest.fn( () => 'embedded' ),
 	isTogglingInstantSearch: jest.fn( () => false ),
 	isTogglingModule: jest.fn( () => false ),
 	isUpdatingJetpackSettings: jest.fn( () => false ),
@@ -114,6 +123,7 @@ describe( 'DashboardPage', () => {
 		mockReaderChatControl.mockClear();
 		mockSearchSuggestionsControl.mockClear();
 		mockAIAgentAccessControl.mockClear();
+		mockWooCommerceProductSearchControl.mockClear();
 		window.history.replaceState( {}, '', DEFAULT_TEST_URL );
 		mockSelectMethods = createSelectMethods();
 		mockDispatchMethods = {
@@ -221,6 +231,61 @@ describe( 'DashboardPage', () => {
 
 		expect( screen.queryByTestId( 'search-suggestions-control' ) ).not.toBeInTheDocument();
 		expect( mockSearchSuggestionsControl ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders WooCommerceProductSearchControl when WooCommerce is active and the experience is Embedded', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'getActiveExperience' ).mockImplementation( () => 'embedded' );
+		jest
+			.spyOn( mockSelectMethods, 'isWooCommerceSearchTemplateOverrideEnabled' )
+			.mockImplementation( () => true );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.getByTestId( 'woocommerce-product-search-control' ) ).toBeInTheDocument();
+		expect( mockWooCommerceProductSearchControl ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isEnabled: true,
+				isSaving: false,
+				updateOptions: mockDispatchMethods.updateJetpackSettings,
+			} )
+		);
+	} );
+
+	test( 'renders WooCommerceProductSearchControl for the Theme search (inline) experience', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'getActiveExperience' ).mockImplementation( () => 'inline' );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.getByTestId( 'woocommerce-product-search-control' ) ).toBeInTheDocument();
+	} );
+
+	test( 'hides WooCommerceProductSearchControl on non-WooCommerce sites', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => false );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.queryByTestId( 'woocommerce-product-search-control' ) ).not.toBeInTheDocument();
+		expect( mockWooCommerceProductSearchControl ).not.toHaveBeenCalled();
+	} );
+
+	test( 'hides WooCommerceProductSearchControl under the Overlay experience (moot — instant search intercepts)', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'getActiveExperience' ).mockImplementation( () => 'overlay' );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( screen.queryByTestId( 'woocommerce-product-search-control' ) ).not.toBeInTheDocument();
+		expect( mockWooCommerceProductSearchControl ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not render Reader Chat card in the experience selector path when unavailable', () => {

--- a/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/index.jsx
@@ -1,0 +1,64 @@
+import analytics from '@automattic/jetpack-analytics';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+
+const WOOCOMMERCE_PRODUCT_SEARCH_DESCRIPTION = __(
+	"Render product searches through Jetpack Search's filtered results page instead of WooCommerce's default product search template.",
+	'jetpack-search-pkg'
+);
+
+/**
+ * Opt-in toggle for the `override_woocommerce_search_template` setting.
+ *
+ * @param {object}   props                 - Component properties.
+ * @param {boolean}  props.isEnabled       - Whether the override is enabled.
+ * @param {boolean}  props.isSaving        - Whether settings are being saved.
+ * @param {Function} props.updateOptions   - Function to update settings.
+ * @param {string}   props.editTemplateUrl - Site Editor URL for the product-search template.
+ * @return {import('react').Component} WooCommerce product search settings component.
+ */
+export default function WooCommerceProductSearchControl( {
+	isEnabled,
+	isSaving,
+	updateOptions,
+	editTemplateUrl,
+} ) {
+	const toggle = useCallback( () => {
+		const newOption = { override_woocommerce_search_template: ! isEnabled };
+		updateOptions( newOption );
+		analytics.tracks.recordEvent(
+			'jetpack_search_woocommerce_search_template_override_toggle',
+			newOption
+		);
+	}, [ isEnabled, updateOptions ] );
+
+	return (
+		<div className="jp-form-search-settings-group__toggle is-woocommerce-product-search jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<ToggleControl
+					checked={ !! isEnabled }
+					disabled={ isSaving }
+					onChange={ toggle }
+					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
+					label={ __( 'Use Jetpack Search for product search results', 'jetpack-search-pkg' ) }
+					__nextHasNoMarginBottom={ true }
+				/>
+			</div>
+			<div className="jp-search-dashboard-row">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
+					<p className="jp-form-search-settings-group__toggle-explanation">
+						{ WOOCOMMERCE_PRODUCT_SEARCH_DESCRIPTION }
+					</p>
+					{ isEnabled && editTemplateUrl && (
+						<p className="jp-form-search-settings-group__toggle-explanation">
+							<ExternalLink href={ editTemplateUrl }>
+								{ __( 'Edit the product search template', 'jetpack-search-pkg' ) }
+							</ExternalLink>
+						</p>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/test/index.test.jsx
@@ -1,0 +1,111 @@
+// Mocks must precede module imports so Jest can hoist them above the
+// component file's own dependency chain (which would otherwise drag in
+// the full `@wordpress/components` + admin-ui stack at test time).
+/* eslint-disable testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package; fireEvent is intentional. */
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: ( ...args ) => mockRecordEvent( ...args ) } },
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	ToggleControl: ( { checked, disabled, label, onChange } ) => (
+		<input
+			type="checkbox"
+			checked={ !! checked }
+			disabled={ !! disabled }
+			aria-label={ label }
+			onChange={ event => onChange( event.target.checked ) }
+		/>
+	),
+	ExternalLink: ( { href, children } ) => <a href={ href }>{ children }</a>,
+} ) );
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import WooCommerceProductSearchControl from '../index.jsx';
+
+const defaultProps = {
+	isEnabled: false,
+	isSaving: false,
+	updateOptions: jest.fn(),
+};
+
+const getToggle = () =>
+	screen.getByRole( 'checkbox', { name: /Use Jetpack Search for product search results/i } );
+
+describe( 'WooCommerceProductSearchControl', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the toggle reflecting the current stored value', () => {
+		render( <WooCommerceProductSearchControl { ...defaultProps } isEnabled /> );
+
+		expect( getToggle() ).toBeChecked();
+	} );
+
+	test( 'renders the toggle as off when the stored value is false', () => {
+		render( <WooCommerceProductSearchControl { ...defaultProps } isEnabled={ false } /> );
+
+		expect( getToggle() ).not.toBeChecked();
+	} );
+
+	test( 'dispatches a settings update and records an event when toggled on', () => {
+		const updateOptions = jest.fn();
+		render(
+			<WooCommerceProductSearchControl { ...defaultProps } updateOptions={ updateOptions } />
+		);
+
+		fireEvent.click( getToggle() );
+
+		expect( updateOptions ).toHaveBeenCalledWith( {
+			override_woocommerce_search_template: true,
+		} );
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_search_woocommerce_search_template_override_toggle',
+			{ override_woocommerce_search_template: true }
+		);
+	} );
+
+	test( 'dispatches the inverse value when toggled off', () => {
+		const updateOptions = jest.fn();
+		render(
+			<WooCommerceProductSearchControl
+				{ ...defaultProps }
+				isEnabled
+				updateOptions={ updateOptions }
+			/>
+		);
+
+		fireEvent.click( getToggle() );
+
+		expect( updateOptions ).toHaveBeenCalledWith( {
+			override_woocommerce_search_template: false,
+		} );
+	} );
+
+	test( 'disables the toggle while saving', () => {
+		render( <WooCommerceProductSearchControl { ...defaultProps } isSaving /> );
+
+		expect( getToggle() ).toBeDisabled();
+	} );
+
+	test( 'shows the edit-template link only when enabled', () => {
+		const url = 'https://example.com/wp-admin/site-editor.php?p=x';
+		const { rerender } = render(
+			<WooCommerceProductSearchControl { ...defaultProps } editTemplateUrl={ url } />
+		);
+		expect(
+			screen.queryByRole( 'link', { name: /edit the product search template/i } )
+		).not.toBeInTheDocument();
+
+		rerender(
+			<WooCommerceProductSearchControl { ...defaultProps } isEnabled editTemplateUrl={ url } />
+		);
+		expect(
+			screen.getByRole( 'link', { name: /edit the product search template/i } )
+		).toHaveAttribute( 'href', url );
+	} );
+} );

--- a/projects/packages/search/src/dashboard/store/actions/jetpack-settings.js
+++ b/projects/packages/search/src/dashboard/store/actions/jetpack-settings.js
@@ -28,7 +28,8 @@ const getRollbackSettings = settings =>
 				k === 'experience' ||
 				k === 'reader_chat' ||
 				k === 'ai_answers_enabled' ||
-				k === 'search_suggestions_enabled'
+				k === 'search_suggestions_enabled' ||
+				k === 'override_woocommerce_search_template'
 		)
 	);
 

--- a/projects/packages/search/src/dashboard/store/selectors/jetpack-settings.js
+++ b/projects/packages/search/src/dashboard/store/selectors/jetpack-settings.js
@@ -23,6 +23,8 @@ const jetpackSettingSelectors = {
 	isReaderChatEnabled: state => state.jetpackSettings.reader_chat,
 	isAiAnswersEnabled: state => !! state.jetpackSettings.ai_answers_enabled,
 	isSearchSuggestionsEnabled: state => !! state.jetpackSettings.search_suggestions_enabled,
+	isWooCommerceSearchTemplateOverrideEnabled: state =>
+		!! state.jetpackSettings.override_woocommerce_search_template,
 	isUpdatingJetpackSettings: state => state.jetpackSettings.is_updating,
 	isTogglingModule: state => state.jetpackSettings.is_toggling_module,
 	isTogglingInstantSearch: state => state.jetpackSettings.is_toggling_instant_search,

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -16,6 +16,7 @@ const siteDataSelectors = {
 	isWpcom: state => state.siteData?.isWpcom ?? false,
 	isPlanJustUpgraded: state => state.siteData?.isPlanJustUpgraded ?? false,
 	isSearchBlocksEnabled: state => state.siteData?.searchBlocksEnabled ?? false,
+	isWooCommerceActive: state => state.siteData?.isWooCommerceActive ?? false,
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 	// Defaults to true so Embedded is never blocked when the flag is absent
 	// (older initial state) — fail open rather than hide a working option.

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
@@ -19,10 +19,19 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const TEMPLATE = [
 	[ 'jetpack-search/filter-post-type', { mode: 'include', postTypes: [ 'product' ] } ],
+	[ 'jetpack-search/active-filters' ],
 	[ 'jetpack-search/clear-filters' ],
-	[ 'jetpack-search/filter-wc-stock-status' ],
-	[ 'jetpack-search/filter-wc-rating' ],
+	[
+		'jetpack-search/filter-checkbox',
+		{ filterType: 'taxonomy', taxonomy: 'product_cat', displayStyle: 'chips' },
+	],
+	[
+		'jetpack-search/filter-checkbox',
+		{ filterType: 'taxonomy', taxonomy: 'product_brand', displayStyle: 'chips' },
+	],
+	[ 'jetpack-search/filter-wc-rating', { enabledStars: [ 4 ] } ],
 	[ 'jetpack-search/filter-wc-price' ],
+	[ 'jetpack-search/filter-wc-stock-status' ],
 ];
 
 const ALLOWED = [

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -49,6 +49,19 @@ class Search_Blocks {
 	const SEARCH_TEMPLATE_SLUG = 'jetpack-search';
 
 	/**
+	 * Slug for the dedicated Jetpack product-search template, registered and
+	 * fronted (in place of WooCommerce's) when the override is on. Separate
+	 * from `SEARCH_TEMPLATE_SLUG` so it's its own Site Editor entry.
+	 */
+	const PRODUCT_SEARCH_TEMPLATE_SLUG = 'jetpack-search-product-results';
+
+	/**
+	 * Mirror of `ProductSearchResultsTemplate::SLUG`, copied to avoid a hard
+	 * dependency on the WooCommerce class.
+	 */
+	const WC_PRODUCT_SEARCH_TEMPLATE_SLUG = 'product-search-results';
+
+	/**
 	 * Per-request memo backing `is_initial_loading()`. Lifted out of the
 	 * method's local `static` so tests can clear it between cases via
 	 * `reset_initial_loading_cache()` — function-local statics aren't
@@ -144,6 +157,16 @@ class Search_Blocks {
 		if ( Module_Control::EXPERIENCE_EMBEDDED === ( new Module_Control() )->get_experience() ) {
 			add_action( 'init', array( static::class, 'register_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
+		}
+
+		// Priority 20: after WooCommerce's priority-10 prepend (so the
+		// result is load-order independent), leaving 11-19 free for other
+		// integrations. The WC/product-search guard lives in the callback,
+		// which runs late enough to satisfy woocommerce_blocks_enabled()'s
+		// load-order contract.
+		if ( static::woocommerce_search_template_override_enabled() ) {
+			add_action( 'init', array( static::class, 'register_product_search_template' ) );
+			add_filter( 'search_template_hierarchy', array( static::class, 'route_woocommerce_product_search_template' ), 20 );
 		}
 	}
 
@@ -244,6 +267,29 @@ class Search_Blocks {
 	 */
 	public static function reset_woocommerce_blocks_enabled_cache(): void {
 		self::$woocommerce_blocks_enabled_cache = null;
+	}
+
+	/**
+	 * The `jetpack_search_override_woocommerce_search_template` opt-in
+	 * (default off), set from the Search dashboard.
+	 *
+	 * @return bool
+	 */
+	public static function woocommerce_search_template_override_enabled(): bool {
+		return (bool) get_option( 'jetpack_search_override_woocommerce_search_template', false );
+	}
+
+	/**
+	 * Mirrors WooCommerce's own `ProductSearchResultsTemplate` guard so the
+	 * override only touches requests WooCommerce would itself reroute.
+	 *
+	 * @return bool
+	 */
+	protected static function is_woocommerce_product_search(): bool {
+		return self::woocommerce_blocks_enabled()
+			&& is_search()
+			&& is_post_type_archive( 'product' )
+			&& static::block_templates_active();
 	}
 
 	/**
@@ -785,6 +831,52 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Product-search counterpart of `get_search_template_content()`. Seeds
+	 * from `templates/jetpack-search-product-results.html` (a copy of the search
+	 * layout for now; product-specific blocks land in a follow-up).
+	 *
+	 * @return string Block markup for the product-search template.
+	 */
+	protected static function get_product_search_template_content(): string {
+		static $content = null;
+		if ( null !== $content ) {
+			return $content;
+		}
+		$template_path = __DIR__ . '/templates/jetpack-search-product-results.html';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
+		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		$content = str_replace(
+			'{{FILTER_HEADING}}',
+			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+			$raw
+		);
+		return $content;
+	}
+
+	/**
+	 * Register the dedicated Jetpack product-search template. Counterpart of
+	 * `register_search_template()`; same Site Editor / DB-customization
+	 * semantics and empty-content / classic-theme bail-outs.
+	 */
+	public static function register_product_search_template() {
+		if ( ! function_exists( 'register_block_template' ) || ! static::block_templates_active() ) {
+			return;
+		}
+		$content = static::get_product_search_template_content();
+		if ( '' === $content ) {
+			return;
+		}
+		register_block_template(
+			static::get_parent_plugin_slug() . '//' . self::PRODUCT_SEARCH_TEMPLATE_SLUG,
+			array(
+				'title'       => __( 'Jetpack Search Product Results', 'jetpack-search-pkg' ),
+				'description' => __( 'Displays WooCommerce product search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
+				'content'     => $content,
+			)
+		);
+	}
+
+	/**
 	 * Directory slug of the plugin that should own the template in the
 	 * Site Editor UI.
 	 *
@@ -839,11 +931,19 @@ class Search_Blocks {
 	 * only through the block-template system, so injecting it anywhere else
 	 * just mis-shapes the hierarchy.
 	 *
+	 * WooCommerce product-search carve-out: override off → leave the
+	 * hierarchy to WooCommerce's prepend; override on → fall through here,
+	 * then `route_woocommerce_product_search_template()` swaps WooCommerce's
+	 * slug for `jetpack-search-product-results`.
+	 *
 	 * @param string[] $templates Template hierarchy slugs.
 	 * @return string[]
 	 */
 	public static function prepend_search_template( $templates ) {
 		if ( ! is_search() || ! static::block_templates_active() ) {
+			return $templates;
+		}
+		if ( ! static::woocommerce_search_template_override_enabled() && static::is_woocommerce_product_search() ) {
 			return $templates;
 		}
 		$templates = array_values(
@@ -867,6 +967,34 @@ class Search_Blocks {
 	 */
 	protected static function block_templates_active(): bool {
 		return wp_is_block_theme();
+	}
+
+	/**
+	 * Front the dedicated `jetpack-search-product-results` template for a WooCommerce
+	 * product search: drop WooCommerce's `product-search-results` slug and
+	 * unshift ours so it resolves first (ahead of any `jetpack-search`
+	 * prepended for the generic search route). Registered at priority 20
+	 * only when the override is on; no-op outside a WooCommerce product
+	 * search.
+	 *
+	 * @param string[] $templates Template hierarchy slugs.
+	 * @return string[]
+	 */
+	public static function route_woocommerce_product_search_template( $templates ) {
+		if ( ! static::is_woocommerce_product_search() ) {
+			return $templates;
+		}
+		$templates = array_values(
+			array_filter(
+				(array) $templates,
+				static function ( $slug ) {
+					return self::WC_PRODUCT_SEARCH_TEMPLATE_SLUG !== $slug
+						&& self::PRODUCT_SEARCH_TEMPLATE_SLUG !== $slug;
+				}
+			)
+		);
+		array_unshift( $templates, self::PRODUCT_SEARCH_TEMPLATE_SLUG );
+		return $templates;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -1,0 +1,56 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
+<div class="wp-block-group alignwide">
+<!-- wp:jetpack-search/search-input /-->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
+<div class="wp-block-columns">
+
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:jetpack-search/search-results -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack-search/results-count /-->
+<!-- wp:jetpack-search/results-sort /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:jetpack-search/results-list {"layout":"product"} /-->
+<!-- wp:jetpack-search/results-load-more /-->
+<!-- wp:jetpack-search/powered-by /-->
+<!-- /wp:jetpack-search/search-results -->
+</div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"260px","fontSize":"small","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column has-small-font-size" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
+<!-- /wp:heading -->
+<!-- wp:jetpack-search/filters-product -->
+<!-- wp:jetpack-search/filter-post-type {"mode":"include","postTypes":["product"]} /-->
+<!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/clear-filters /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
+<!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->
+<!-- wp:jetpack-search/filter-wc-price /-->
+<!-- wp:jetpack-search/filter-wc-stock-status /-->
+<!-- /wp:jetpack-search/filters-product -->
+</div>
+<!-- /wp:column -->
+
+</div>
+<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -143,8 +143,9 @@ class REST_Controller_Test extends Search_TestCase {
 		$expected     = array_merge(
 			$new_settings,
 			array(
-				'experience'                 => 'overlay',
-				'search_suggestions_enabled' => false,
+				'experience'                           => 'overlay',
+				'search_suggestions_enabled'           => false,
+				'override_woocommerce_search_template' => false,
 			)
 		);
 
@@ -202,8 +203,9 @@ class REST_Controller_Test extends Search_TestCase {
 		$expected     = array_merge(
 			$new_settings,
 			array(
-				'experience'                 => 'off',
-				'search_suggestions_enabled' => false,
+				'experience'                           => 'off',
+				'search_suggestions_enabled'           => false,
+				'override_woocommerce_search_template' => false,
 			)
 		);
 
@@ -224,12 +226,13 @@ class REST_Controller_Test extends Search_TestCase {
 			'module_active' => false,
 		);
 		$expected     = array(
-			'module_active'                 => false,
-			'instant_search_enabled'        => false,
-			'swap_classic_to_inline_search' => false,
-			'experience'                    => 'off',
-			'ai_answers_enabled'            => false,
-			'search_suggestions_enabled'    => false,
+			'module_active'                        => false,
+			'instant_search_enabled'               => false,
+			'swap_classic_to_inline_search'        => false,
+			'experience'                           => 'off',
+			'ai_answers_enabled'                   => false,
+			'search_suggestions_enabled'           => false,
+			'override_woocommerce_search_template' => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -249,12 +252,13 @@ class REST_Controller_Test extends Search_TestCase {
 			'instant_search_enabled' => true,
 		);
 		$expected     = array(
-			'module_active'                 => true,
-			'instant_search_enabled'        => true,
-			'swap_classic_to_inline_search' => false,
-			'experience'                    => 'overlay',
-			'ai_answers_enabled'            => false,
-			'search_suggestions_enabled'    => false,
+			'module_active'                        => true,
+			'instant_search_enabled'               => true,
+			'swap_classic_to_inline_search'        => false,
+			'experience'                           => 'overlay',
+			'ai_answers_enabled'                   => false,
+			'search_suggestions_enabled'           => false,
+			'override_woocommerce_search_template' => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -274,12 +278,13 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => true,
 		);
 		$expected     = array(
-			'module_active'                 => false,
-			'instant_search_enabled'        => false,
-			'swap_classic_to_inline_search' => true,
-			'experience'                    => 'off',
-			'ai_answers_enabled'            => false,
-			'search_suggestions_enabled'    => false,
+			'module_active'                        => false,
+			'instant_search_enabled'               => false,
+			'swap_classic_to_inline_search'        => true,
+			'experience'                           => 'off',
+			'ai_answers_enabled'                   => false,
+			'search_suggestions_enabled'           => false,
+			'override_woocommerce_search_template' => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -299,12 +304,13 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => false,
 		);
 		$expected     = array(
-			'module_active'                 => false,
-			'instant_search_enabled'        => false,
-			'swap_classic_to_inline_search' => false,
-			'experience'                    => 'off',
-			'ai_answers_enabled'            => false,
-			'search_suggestions_enabled'    => false,
+			'module_active'                        => false,
+			'instant_search_enabled'               => false,
+			'swap_classic_to_inline_search'        => false,
+			'experience'                           => 'off',
+			'ai_answers_enabled'                   => false,
+			'search_suggestions_enabled'           => false,
+			'override_woocommerce_search_template' => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -569,6 +575,10 @@ class REST_Controller_Test extends Search_TestCase {
 					'experience'                    => 'inline',
 					'swap_classic_to_inline_search' => true,
 				),
+				array(
+					'experience'                           => 'embedded',
+					'override_woocommerce_search_template' => true,
+				),
 			) as $body
 		) {
 			$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -634,6 +644,34 @@ class REST_Controller_Test extends Search_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertFalse( $data['ai_answers_enabled'] );
+	}
+
+	/**
+	 * The override option round-trips through the settings endpoint on
+	 * its own and persists to its backing option.
+	 */
+	public function test_update_settings_override_woocommerce_search_template_toggles() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode( array( 'override_woocommerce_search_template' => true ), JSON_UNESCAPED_SLASHES )
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['override_woocommerce_search_template'] );
+		$this->assertTrue( (bool) get_option( 'jetpack_search_override_woocommerce_search_template' ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode( array( 'override_woocommerce_search_template' => false ), JSON_UNESCAPED_SLASHES )
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $response->get_data()['override_woocommerce_search_template'] );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_override_woocommerce_search_template' ) );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -25,6 +25,8 @@ class Search_Blocks_Test extends TestCase {
 		Search_Blocks::reset_initial_loading_cache();
 		Search_Blocks::reset_woocommerce_blocks_enabled_cache();
 		Search_Blocks::reset_custom_taxonomy_map_cache();
+		// Guards against a failed assertion leaking the option across tests.
+		delete_option( 'jetpack_search_override_woocommerce_search_template' );
 		parent::tearDown();
 	}
 
@@ -375,6 +377,185 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * WC-off arm: with WooCommerce inactive it is never a product search.
+	 */
+	public function test_is_woocommerce_product_search_false_when_woocommerce_inactive() {
+		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( false );
+		try {
+			$this->assertFalse( $this->invoke_protected( 'is_woocommerce_product_search' ) );
+		} finally {
+			Search_Blocks::set_woocommerce_blocks_enabled_for_testing( null );
+		}
+	}
+
+	/**
+	 * WC-on arm: a plain (non-product) request is still not a product search.
+	 */
+	public function test_is_woocommerce_product_search_false_on_plain_request_when_woocommerce_active() {
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( true );
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query();
+			$this->assertFalse( $this->invoke_protected( 'is_woocommerce_product_search' ) );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+			Search_Blocks::set_woocommerce_blocks_enabled_for_testing( null );
+		}
+	}
+
+	/**
+	 * With the override option OFF, a WooCommerce product search must leave
+	 * the hierarchy untouched so WooCommerce's own priority-10 prepend of
+	 * `product-search-results` wins — that's the no-regression default for
+	 * stores that haven't opted in.
+	 */
+	public function test_prepend_search_template_defers_to_woocommerce_when_override_off() {
+		delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		// Force the block-theme search context so we exercise the WooCommerce
+		// carve-out rather than the upstream `is_search()`/block-theme guard.
+		$anon           = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function is_woocommerce_product_search(): bool {
+					return true;
+				}
+			}
+		);
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$input  = array( 'product-search-results', 'search', 'index' );
+			$result = $anon::prepend_search_template( $input );
+
+			$this->assertSame( $input, $result, 'Hierarchy must be returned unchanged so WooCommerce wins.' );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * With the override option ON, a WooCommerce product search falls
+	 * through the prepend carve-out (the priority-20 router then swaps
+	 * WooCommerce's slug for `jetpack-search-product-results`).
+	 */
+	public function test_prepend_search_template_fronts_jetpack_when_override_on() {
+		update_option( 'jetpack_search_override_woocommerce_search_template', true );
+		$anon           = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function is_woocommerce_product_search(): bool {
+					return true;
+				}
+			}
+		);
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$result = $anon::prepend_search_template( array( 'product-search-results', 'search', 'index' ) );
+
+			$this->assertSame( 'jetpack-search', $result[0] );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		}
+	}
+
+	/**
+	 * On a WooCommerce product search, WooCommerce's slug is dropped and
+	 * `jetpack-search-product-results` is fronted ahead of any `jetpack-search`.
+	 */
+	public function test_route_woocommerce_product_search_template_fronts_product_slug() {
+		$anon = new class() extends Search_Blocks {
+			protected static function is_woocommerce_product_search(): bool {
+				return true;
+			}
+		};
+
+		$result = $anon::route_woocommerce_product_search_template(
+			array( 'jetpack-search', 'product-search-results', 'search', 'index' )
+		);
+
+		$this->assertSame( array( 'jetpack-search-product-results', 'jetpack-search', 'search', 'index' ), $result );
+		$this->assertNotContains( Search_Blocks::WC_PRODUCT_SEARCH_TEMPLATE_SLUG, $result );
+	}
+
+	/**
+	 * Outside a WooCommerce product search the router is a strict no-op.
+	 */
+	public function test_route_woocommerce_product_search_template_noop_off_product_search() {
+		$anon = new class() extends Search_Blocks {
+			protected static function is_woocommerce_product_search(): bool {
+				return false;
+			}
+		};
+
+		$input  = array( 'product-search-results', 'search', 'index' );
+		$result = $anon::route_woocommerce_product_search_template( $input );
+
+		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * With the override on, `init()` registers both the product-search
+	 * template and the priority-20 routing filter.
+	 */
+	public function test_init_registers_product_search_hooks_when_override_on() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		update_option( 'jetpack_search_override_woocommerce_search_template', true );
+
+		try {
+			Search_Blocks::init();
+
+			$this->assertNotFalse(
+				has_action( 'init', array( Search_Blocks::class, 'register_product_search_template' ) ),
+				'register_product_search_template must hook into init when the override is on'
+			);
+			$this->assertSame(
+				20,
+				has_filter(
+					'search_template_hierarchy',
+					array( Search_Blocks::class, 'route_woocommerce_product_search_template' )
+				),
+				'route_woocommerce_product_search_template must hook at priority 20 when the override is on'
+			);
+		} finally {
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		}
+	}
+
+	/**
+	 * The product-search hooks are absent when the override is off.
+	 */
+	public function test_init_does_not_register_product_search_hooks_when_override_off() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		delete_option( 'jetpack_search_override_woocommerce_search_template' );
+
+		Search_Blocks::init();
+
+		$this->assertFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_product_search_template' ) ),
+			'register_product_search_template must not hook when the override is off'
+		);
+		$this->assertFalse(
+			has_filter(
+				'search_template_hierarchy',
+				array( Search_Blocks::class, 'route_woocommerce_product_search_template' )
+			),
+			'route_woocommerce_product_search_template must not hook when the override is off'
+		);
+	}
+
+	/**
 	 * `init()` must always register the block-level hooks AND the IA state
 	 * seeding regardless of which experience the site has saved — admins can
 	 * insert Search blocks anywhere blocks are configurable, and those blocks
@@ -412,7 +593,7 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Off the Embedded experience, the template-takeover hooks
+	 * Off the Embedded experience, the template-override hooks
 	 * (`register_search_template` / `prepend_search_template`) must NOT be
 	 * registered — `/?s=…` should resolve to the theme's `search.html`, not
 	 * the Jetpack Search template.
@@ -436,7 +617,7 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * On the Embedded experience, the template-takeover hooks must be
+	 * On the Embedded experience, the template-override hooks must be
 	 * registered so `/?s=…` resolves to the Jetpack Search template instead
 	 * of the theme's `search.html`.
 	 */
@@ -489,7 +670,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * If the module isn't active, the experience is `'off'` regardless of any
-	 * stale value in the experience option, so the template-takeover hooks
+	 * stale value in the experience option, so the template-override hooks
 	 * must not register. Guards against a leftover `'embedded'` value on a
 	 * site that's been deactivated. The block-level and seed hooks still
 	 * register so any post-content Search block continues to hydrate.
@@ -525,8 +706,10 @@ class Search_Blocks_Test extends TestCase {
 	private function reset_search_blocks_hooks(): void {
 		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
 		remove_action( 'init', array( Search_Blocks::class, 'register_search_template' ) );
+		remove_action( 'init', array( Search_Blocks::class, 'register_product_search_template' ) );
 		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
 		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) );
+		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'route_woocommerce_product_search_template' ), 20 );
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
@@ -581,6 +764,50 @@ class Search_Blocks_Test extends TestCase {
 		// The `{{FILTER_HEADING}}` placeholder must have been substituted —
 		// if it leaks into the registry, the heading renders as `{{FILTER_HEADING}}`
 		// on the front end.
+		$this->assertStringNotContainsString( '{{FILTER_HEADING}}', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
+	 * `register_product_search_template()` registers the dedicated
+	 * `jetpack-search-product-results` template (its own Site Editor entry) seeded
+	 * from the product-search layout.
+	 */
+	public function test_register_product_search_template_registers_via_block_template_api() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search-product-results', 'jetpack//jetpack-search-product-results' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$class = $this->block_theme_search_blocks();
+		$class::register_product_search_template();
+
+		$expected = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search-product-results';
+		$this->assertTrue( $registry->is_registered( $expected ), "Template $expected should be registered." );
+
+		$registered = $registry->get_registered( $expected );
+		$this->assertSame( 'Jetpack Search Product Results', $registered->title );
+		// Product-specific layout: product result list + the product filters block.
+		$this->assertStringContainsString(
+			'<!-- wp:jetpack-search/results-list {"layout":"product"} /-->',
+			$registered->content
+		);
+		// filters-product serialized with its children (it's an InnerBlocks
+		// container — a self-closing tag would render an empty sidebar).
+		$this->assertStringContainsString(
+			'<!-- wp:jetpack-search/filters-product -->',
+			$registered->content
+		);
+		$this->assertStringContainsString(
+			'"taxonomy":"product_cat","displayStyle":"chips"',
+			$registered->content
+		);
 		$this->assertStringNotContainsString( '{{FILTER_HEADING}}', $registered->content );
 
 		$registry->unregister( $expected );


### PR DESCRIPTION
Fixes [RSM-3497](https://linear.app/a8c/issue/RSM-3497/jetpack-search-take-over-woocommerce-product-search-results-template)

## Why

On a WooCommerce store, a product search (`/?s=…&post_type=product`) is served by WooCommerce's own *Product Search Results* template, so it never benefits from Jetpack Search's faceted results page even when the store has chosen the Embedded experience. Store owners now get a single opt-in toggle — **WooCommerce Product Search** — that routes product searches through Jetpack Search's filtered results page instead. It's off by default, so existing stores keep WooCommerce's behavior unchanged.

## Proposed changes

* Add a `jetpack_search_override_woocommerce_search_template` option (default off) and a "WooCommerce Product Search" control on the Search dashboard Settings tab, shown only on WooCommerce sites and only for the Embedded / Theme-search experiences (the Overlay/Instant experience intercepts searches client-side, so WooCommerce's template never renders there).
* When the option is **on**, a priority-20 `search_template_hierarchy` filter drops WooCommerce's `product-search-results` slug and fronts a dedicated, Site-Editor-editable **`jetpack-search-product-results`** block template (title "Jetpack Search Product Results"; registered separately from `jetpack-search`). Priority 20 (after WooCommerce's 10) makes the result deterministic regardless of plugin load order, leaving the 11–19 band free for other integrations and 21+ to run after us.
* The product template is a two-column layout: a **product-format result list** on the left, and a small-font **product filters sidebar** (`filters-product` — product category & brand as chips, rating "4★ & up", price, stock status). The control surfaces an **"Edit the product search template"** link to its Site Editor entry.
* When the option is **off**, `prepend_search_template()` defers WooCommerce product searches to WooCommerce's own priority-10 prepend — a true no-op for stores that haven't opted in, with no effect on non-product or non-Woo searches.
* Wire the option through the settings REST endpoint, the dashboard store (selector + optimistic rollback), and a new `isWooCommerceActive` siteData flag (reuses `Search_Blocks`' single memoized WooCommerce probe).

## Screenshots

Real before/after of a product search (`/?s=Hat&post_type=product`) on a connected WooCommerce store — Twenty Twenty-Five block theme, Embedded experience — toggling only the new option:

| Before — option off (WooCommerce's Product Search Results template) | After — option on (Jetpack Search takes over) |
|---|---|
| ![before](https://github.com/user-attachments/assets/6c6179ce-7c2e-4600-b6ed-e05b94bebcd2) | ![after](https://github.com/user-attachments/assets/bb970524-6538-45be-ab97-329510a86726) |

The *After* shot is the dedicated `jetpack-search-product-results` template: WooCommerce’s default product grid is replaced by the Jetpack Search results page — search input, **product-format result list** (cards with price), and a small-font product filters sidebar (**Product Category & Brand as chips, Rating "4★ & up", Price, Stock Status**).

The control itself, on the Search dashboard **Settings** tab (WooCommerce site, Embedded/Theme-search experience):

![WooCommerce Product Search toggle](https://github.com/user-attachments/assets/f9d740fc-9142-4bdd-bb55-2cc6b05a7748)

## API changes

`GET`/`POST /jetpack/v4/search/settings` now includes a boolean `override_woocommerce_search_template` (default `false`), updatable on its own.

<details>
<summary>Live REST round-trip (echo dev env)</summary>

```text
GET  before: override_woocommerce_search_template=false
POST {true}: status=200 value=true
option stored: true
POST {false}: status=200 value=false
```

</details>

## Verification

Exercised the actual `search_template_hierarchy` resolution against a live WooCommerce store (30 products, Twenty Twenty-Five block theme, WooCommerce active) under simulated product-search conditions:

<details>
<summary>search_template_hierarchy outcomes</summary>

```text
conditions: is_search=1  is_post_type_archive(product)=1  wp_is_block_theme=1  wc_filter_present=1

OFF, product search      -> product-search-results, …                  (WooCommerce wins — no regression)
ON,  product search      -> jetpack-search-product-results, jetpack-search, …  (dedicated template wins)
ON,  non-product search  -> jetpack-search, …                          (unaffected)
OFF, non-product / non-Woo -> unchanged                                (no effect)
```

</details>

> Note: the matrix slugs above reflect the original suppress-only design; the current design fronts the dedicated `jetpack-search-product-results` template (see Proposed changes). The routing, the dedicated-template registration, and the control gating are covered by the PHP suite (482 tests) and JS unit tests; gating stays behind `jetpack_search_woocommerce_blocks_enabled` (the WooCommerce Search-blocks rollout flag).

## Does this pull request change what data or activity we track or use?

Adds one Tracks event, `jetpack_search_woocommerce_search_template_override_toggle`, recording the new boolean value when the toggle is flipped — same shape and surface as the existing `jetpack_search_suggestions_toggle` / `jetpack_search_ai_agent_access_toggle` events. No new personal data.

## Related product discussion/links

* [RSM-3497](https://linear.app/a8c/issue/RSM-3497/jetpack-search-take-over-woocommerce-product-search-results-template)

## Testing instructions

Acceptance criteria (from RSM-3497):

* [ ] On a WooCommerce site with the Search dashboard, the **WooCommerce Product Search** control appears in the Settings tab (Embedded or Theme-search experience); it is hidden on non-WooCommerce sites and under the Overlay experience.
* [ ] The toggle persists via `GET`/`POST /jetpack/v4/search/settings` (`override_woocommerce_search_template`); default is off. See the API changes round-trip above.
* [ ] Option **on**: a product search (`/?s=shirt&post_type=product`) resolves to the dedicated `jetpack-search-product-results` template (visible/editable in the Site Editor as its own entry, separate from `jetpack-search`).
* [ ] Option **off**: product searches resolve to WooCommerce's `product-search-results`; non-product and non-Woo searches are unaffected.
* [ ] `pnpm jetpack test php packages/search` (PHP WC-on/off matrix + REST round-trip) and the JS control test pass.
* [ ] Changelog entry present (`projects/packages/search/changelog/RSM-3497-woocommerce-product-search-takeover`).







