### PR TITLE
Write: disable scroll restoration so editor starts at top on refresh

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-05-18-22-06-01-552045
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-05-18-22-06-01-552045
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: disable browser scroll restoration so the editor always starts at the top on refresh

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3802,6 +3802,13 @@ async function savePost( postStatus, isAutosave = false ) {
 
 // --- Autosave timer and recovery ---
 
+// Disable browser scroll restoration so the editor always starts at the top.
+// Without this, refreshing while scrolled down restores the old scroll offset.
+if ( 'scrollRestoration' in history ) {
+	history.scrollRestoration = 'manual';
+}
+window.scrollTo( 0, 0 );
+
 // Start the autosave interval once the content area is ready.
 const autosaveReady = setInterval( () => {
 	const contentEl = document.querySelector( '.bw-content' );


### PR DESCRIPTION
Fixes RSM-2177

## Proposed changes
* Disable browser scroll restoration in the Write editor so the page always starts at the top on refresh, rather than preserving the previous scroll offset.

## Related product discussion/links
* RSM-2177

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open the Write editor (`/wp-admin/admin.php?page=write`)
* Scroll down in the editor
* Refresh the page
* **Expected:** The editor starts at the top (title visible below the header)
* **Before this fix:** The editor stayed scrolled to the previous position

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
