### PR TITLE
Write: fix slash menu keyboard Enter on non-English sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_slash_menu_translations
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_slash_menu_translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: fix slash menu keyboard Enter not working on non-English sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2412,20 +2412,21 @@ const { state } = store( 'wpcom-write', {
 					if ( menu ) menu.classList.remove( 'bw-slash-menu--keyboard' );
 					const target = active || document.querySelector( '.bw-slash-item:hover' ) || visible[ 0 ];
 					if ( target ) {
-						// Map menu items to actions by their label text.
-						const label = target.querySelector( 'strong' )?.textContent?.toLowerCase();
+						// Map menu items to actions by their data-action attribute
+						// (not label text, which is translated and would break on non-English sites).
+						const action = target.dataset.action;
 						const { actions: a } = store( 'wpcom-write' );
 						const actionMap = {
 							heading: a.insertHeading,
 							image: a.insertImage,
-							'bulleted list': a.insertBulletedList,
-							'numbered list': a.insertNumberedList,
+							'bulleted-list': a.insertBulletedList,
+							'numbered-list': a.insertNumberedList,
 							video: a.insertVideo,
 							quote: a.insertQuote,
 							divider: a.insertDivider,
 						};
-						if ( actionMap[ label ] ) {
-							actionMap[ label ]();
+						if ( actionMap[ action ] ) {
+							actionMap[ action ]();
 						}
 					}
 					return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -935,31 +935,31 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 
 	<!-- Slash command menu -->
 	<div class="bw-slash-menu" id="bw-slash-menu" role="listbox" aria-label="<?php echo esc_attr__( 'Insert block', 'jetpack-mu-wpcom' ); ?>" hidden data-wp-bind--hidden="!state.showSlashMenu">
-		<div class="bw-slash-item" id="bw-slash-opt-heading" role="option" aria-selected="false" data-wp-on--click="actions.insertHeading" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-heading" role="option" aria-selected="false" data-action="heading" data-wp-on--click="actions.insertHeading" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">H</span>
 			<div><strong><?php echo esc_html__( 'Heading', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'Large section heading', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
-		<div class="bw-slash-item" id="bw-slash-opt-image" role="option" aria-selected="false" data-wp-on--click="actions.insertImage" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-image" role="option" aria-selected="false" data-action="image" data-wp-on--click="actions.insertImage" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">&#9653;</span>
 			<div><strong><?php echo esc_html__( 'Image', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'Upload or embed an image', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
-		<div class="bw-slash-item" id="bw-slash-opt-quote" role="option" aria-selected="false" data-wp-on--click="actions.insertQuote" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-quote" role="option" aria-selected="false" data-action="quote" data-wp-on--click="actions.insertQuote" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">&ldquo;</span>
 			<div><strong><?php echo esc_html__( 'Quote', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'Highlight a quote', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
-		<div class="bw-slash-item" id="bw-slash-opt-bulleted-list" role="option" aria-selected="false" data-wp-on--click="actions.insertBulletedList" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-bulleted-list" role="option" aria-selected="false" data-action="bulleted-list" data-wp-on--click="actions.insertBulletedList" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">&bull;</span>
 			<div><strong><?php echo esc_html__( 'Bulleted list', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'An unordered list', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
-		<div class="bw-slash-item" id="bw-slash-opt-numbered-list" role="option" aria-selected="false" data-wp-on--click="actions.insertNumberedList" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-numbered-list" role="option" aria-selected="false" data-action="numbered-list" data-wp-on--click="actions.insertNumberedList" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">1.</span>
 			<div><strong><?php echo esc_html__( 'Numbered list', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'An ordered list', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
-		<div class="bw-slash-item" id="bw-slash-opt-video" role="option" aria-selected="false" data-wp-on--click="actions.insertVideo" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-video" role="option" aria-selected="false" data-action="video" data-wp-on--click="actions.insertVideo" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">&#9654;</span>
 			<div><strong><?php echo esc_html__( 'Video', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'Embed a YouTube or Vimeo video', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
-		<div class="bw-slash-item" id="bw-slash-opt-divider" role="option" aria-selected="false" data-wp-on--click="actions.insertDivider" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<div class="bw-slash-item" id="bw-slash-opt-divider" role="option" aria-selected="false" data-action="divider" data-wp-on--click="actions.insertDivider" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon" aria-hidden="true">&mdash;</span>
 			<div><strong><?php echo esc_html__( 'Divider', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'A horizontal separator', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>


### PR DESCRIPTION
Fixes RSM-1986

## Proposed changes

* Fix the slash menu (`/`) keyboard Enter key doing nothing on non-English WordPress sites.

**Root cause:** The Enter handler in `view.js` matched slash menu items to actions by reading the `<strong>` label text and comparing it against hardcoded English keys (`'heading'`, `'bulleted list'`, etc.). On translated sites, `esc_html__()` returns localized strings, so the match always failed silently. Click/tap was unaffected because those use `data-wp-on--click` handlers directly.

**Fix:** Add a `data-action` attribute to each `.bw-slash-item` in `write.php` and read `target.dataset.action` in the Enter handler instead of the label text. The slash filter (type-ahead filtering) still correctly matches against the translated label — only the action dispatch was broken.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to a WordPress.com site and switch the language to something non-English (e.g. Settings → General → Language → Español)
2. Navigate to the Write editor (`/wp-admin/admin.php?page=write`)
3. In the content area, type `/` to open the slash menu
4. Use arrow keys or Tab to navigate to any item (e.g. Heading, Quote, Bulleted list)
5. Press Enter
6. **Expected:** The selected action is inserted (heading converts to `<h2>`, quote wraps in `<blockquote>`, etc.)
7. **Previously:** Nothing happened — Enter was silently ignored on non-English sites
8. Also verify that click/tap on slash menu items still works
9. Also verify that type-ahead filtering still works (e.g. typing `/im` filters to "Image" in the translated label)
10. Switch back to English and verify everything still works as before

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
