### PR TITLE
Search: fall back to Theme search on non-block themes (Embedded experience)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"3388d88a-0f0a-4771-9d9c-e980cfc3ac73","pid":59378,"procStart":"Mon May 18 22:33:04 2026","acquiredAt":1779144613095}

--- a/projects/packages/search/changelog/SEARCH-202-theme-search-fallback
+++ b/projects/packages/search/changelog/SEARCH-202-theme-search-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: fall back to Theme search when the Embedded experience is configured on a non-block theme, so the search page keeps working instead of resolving to a missing FSE template. The saved Embedded preference is preserved and resumes automatically when the site switches back to a block theme.

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -282,7 +282,7 @@ class Module_Control {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param bool $is_block_theme Whether the active theme is a block theme.
+		 * @param bool $supported Whether the active theme can render Embedded search (defaults to whether it is a block theme).
 		 */
 		return (bool) apply_filters( 'jetpack_search_theme_supports_embedded_experience', $is_block_theme );
 	}

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -244,7 +244,7 @@ class Module_Control {
 
 		$saved = get_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, false );
 		if ( self::EXPERIENCE_EMBEDDED === $saved ) {
-			return self::EXPERIENCE_EMBEDDED;
+			return $this->theme_supports_embedded_experience() ? self::EXPERIENCE_EMBEDDED : self::EXPERIENCE_INLINE;
 		}
 		if ( self::EXPERIENCE_OVERLAY === $saved ) {
 			return self::EXPERIENCE_OVERLAY;
@@ -257,6 +257,34 @@ class Module_Control {
 		}
 
 		return self::EXPERIENCE_INLINE;
+	}
+
+	/**
+	 * Whether the active theme can render the Embedded search experience.
+	 *
+	 * Embedded takes over the theme's search results through an FSE block
+	 * template, which only exists on block themes. On a classic theme
+	 * `get_experience()` falls back to Theme search (inline) so the search
+	 * page keeps working instead of resolving to a missing template; the
+	 * saved `embedded` option is left untouched so the experience resumes
+	 * automatically once the site switches back to a block theme.
+	 *
+	 * @return bool
+	 */
+	protected function theme_supports_embedded_experience(): bool {
+		$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+
+		/**
+		 * Filter whether the active theme can render the Embedded search experience.
+		 *
+		 * Defaults to `wp_is_block_theme()`. Sites whose classic theme provides
+		 * block-template support through other means can force this true.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $is_block_theme Whether the active theme is a block theme.
+		 */
+		return (bool) apply_filters( 'jetpack_search_theme_supports_embedded_experience', $is_block_theme );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -278,9 +278,14 @@ class Module_Control_Test extends Search_TestCase {
 
 	/**
 	 * Saved 'embedded' / 'overlay' values are returned when the module is active.
+	 *
+	 * 'embedded' only renders on a block theme, so the assertion forces the
+	 * block-theme seam true to isolate the saved-value behaviour from the
+	 * non-block-theme fallback covered separately below.
 	 */
 	public function test_get_experience_returns_saved_value() {
 		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 		$this->assertEquals( Module_Control::EXPERIENCE_EMBEDDED, static::$search_module->get_experience() );
@@ -288,6 +293,51 @@ class Module_Control_Test extends Search_TestCase {
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
 		$this->assertEquals( Module_Control::EXPERIENCE_OVERLAY, static::$search_module->get_experience() );
 
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * Saved 'embedded' falls back to 'inline' (Theme search) on a non-block
+	 * theme so the search page keeps working instead of resolving to a missing
+	 * FSE template. The saved option must stay 'embedded' so the experience
+	 * resumes once the site switches back to a block theme.
+	 */
+	public function test_get_experience_embedded_falls_back_to_inline_on_non_block_theme() {
+		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		$this->assertEquals( Module_Control::EXPERIENCE_INLINE, static::$search_module->get_experience() );
+		$this->assertEquals(
+			Module_Control::EXPERIENCE_EMBEDDED,
+			get_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY ),
+			'The saved experience option must be preserved across the fallback.'
+		);
+
+		// Switching back to a block theme restores the embedded experience without a re-save.
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		$this->assertEquals( Module_Control::EXPERIENCE_EMBEDDED, static::$search_module->get_experience() );
+
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * The non-block-theme fallback only affects 'embedded' — 'overlay' is
+	 * theme-agnostic (modal overlay) and must be unaffected.
+	 */
+	public function test_get_experience_overlay_unaffected_by_non_block_theme() {
+		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
+
+		$this->assertEquals( Module_Control::EXPERIENCE_OVERLAY, static::$search_module->get_experience() );
+
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
 		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -467,6 +467,9 @@ class REST_Controller_Test extends Search_TestCase {
 	 */
 	public function test_update_settings_experience_embedded() {
 		wp_set_current_user( $this->admin_id );
+		// Embedded only reports back as 'embedded' on a block theme; force the
+		// seam true so this exercises persistence, not the non-block fallback.
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$request->set_header( 'content-type', 'application/json' );
@@ -477,6 +480,8 @@ class REST_Controller_Test extends Search_TestCase {
 		$this->assertTrue( $data['module_active'] );
 		$this->assertFalse( $data['instant_search_enabled'] );
 		$this->assertEquals( 'embedded', $data['experience'] );
+
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 	}
 
 	/**
@@ -580,6 +585,7 @@ class REST_Controller_Test extends Search_TestCase {
 	 */
 	public function test_get_settings_returns_persisted_experience() {
 		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 
 		// Save experience=embedded.
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -593,6 +599,8 @@ class REST_Controller_Test extends Search_TestCase {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'embedded', $response->get_data()['experience'] );
+
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -405,6 +405,7 @@ class Search_Blocks_Test extends TestCase {
 	public function test_init_registers_template_hooks_when_embedded() {
 		$this->reset_search_blocks_hooks();
 		$this->set_module_active( true );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 
 		Search_Blocks::init();
@@ -418,6 +419,33 @@ class Search_Blocks_Test extends TestCase {
 			'prepend_search_template must hook into search_template_hierarchy on embedded'
 		);
 
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * Saved Embedded but on a non-block theme: the experience resolves to Theme
+	 * search (inline), so the FSE template-takeover hooks must NOT register —
+	 * otherwise `/?s=…` would resolve to a template the theme can't render.
+	 */
+	public function test_init_does_not_register_template_hooks_when_embedded_on_non_block_theme() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		Search_Blocks::init();
+
+		$this->assertFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
+			'register_search_template must not hook into init when the theme cannot render Embedded'
+		);
+		$this->assertFalse(
+			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
+			'prepend_search_template must not hook into search_template_hierarchy on a non-block theme'
+		);
+
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-202](https://linear.app/a8c/issue/SEARCH-202/search-fall-back-to-theme-search-on-non-block-themes-embedded)

## Why
A site that picks the **Embedded search** experience and then switches to a classic (non-block) theme — or runs the embedded path under one — currently ends up with a broken search page: Embedded takes over `/?s=…` with an FSE block template that only exists on block themes. After this change the search page keeps working: it transparently falls back to **Theme search**, and the user's Embedded choice is remembered so it comes back automatically if they return to a block theme.

## Proposed changes
* `Module_Control::get_experience()` now resolves a saved `embedded` value to `inline` (Theme search) when the active theme is not a block theme, instead of returning `embedded` unconditionally.
* Added `Module_Control::theme_supports_embedded_experience()` — a single, filterable seam (`jetpack_search_theme_supports_embedded_experience`, defaults to `wp_is_block_theme()`) so the determination lives in one place and sites with unusual setups can override it.
* The saved `jetpack_search_experience` option is left untouched on fallback, so Embedded resumes automatically when a block theme is active again (no re-save needed).
* No new theme-switch hook is needed: every consumer (REST controller, dashboard initial state, `Search_Blocks` template takeover) already reads `get_experience()`, so resolving per-request at that single source of truth makes theme switches inherently safe in both directions.

## Related product discussion/links
* [SEARCH-202](https://linear.app/a8c/issue/SEARCH-202/search-fall-back-to-theme-search-on-non-block-themes-embedded)
* Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586/overview)

## Does this pull request change what data or activity we track or use?
No.

## Verification
Behavioral, feature-flag-gated logic with deterministic coverage at both the resolution layer (`Module_Control::get_experience()`) and the integration layer (`Search_Blocks::init()` FSE template takeover). The embedded path is not reachable in a browser without a WPCOM connection, a Search plan, and the `jetpack_search_blocks_enabled` flag, so the change is exercised via the test suite — no user-visible change on any reachable default configuration.

<details>
<summary>Output — targeted tests (5/5)</summary>

```text
Module_Control_
 ✔ Get experience returns saved value
 ✔ Get experience embedded falls back to inline on non block theme
 ✔ Get experience overlay unaffected by non block theme
Search_Blocks_
 ✔ Init registers template hooks when embedded
 ✔ Init does not register template hooks when embedded on non block theme
OK (5 tests, 10 assertions)
```

</details>

<details>
<summary>Output — full jetpack-search suite</summary>

```text
OK (463 tests, 1035 assertions)
```

</details>

## Testing instructions
Acceptance criteria (from SEARCH-202):

* [ ] On a classic (non-block) theme, the effective experience is never `embedded`; it falls back to Theme search and no FSE search-template registration occurs.
* [ ] Switching from a block theme (Embedded configured) to a classic theme degrades gracefully with no fatals / broken search; switching back restores Embedded without re-saving.
* [ ] Unit tests cover `get_experience()` block vs. non-block theme resolution.

To verify locally:
* On a connected site with a Search plan and `jetpack_search_blocks_enabled` filtered on, set the experience to **Embedded** while a block theme is active and confirm `/?s=test` resolves to the Jetpack Search template.
* Switch to a classic theme (e.g. Twenty Twenty-One). Confirm `/?s=test` now renders the theme's own search results (Theme search) with no fatal, and the Search dashboard reflects Theme search.
* Switch back to the block theme and confirm Embedded is active again without re-saving.
* `cd projects/packages/search && composer phpunit` — full suite green.
