### PR TITLE
Search: block Embedded search on classic themes with an explanatory modal

### DIFF
--- a/projects/packages/search/changelog/RSM-3501-block-embedded-classic-theme
+++ b/projects/packages/search/changelog/RSM-3501-block-embedded-classic-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search dashboard: block switching to Embedded search on classic themes, with an explanatory modal, since Embedded search is built in the Site Editor which classic themes lack.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -95,6 +95,13 @@ class Initial_State {
 				 * (`?p=/wp_template/<stylesheet>//jetpack-search`).
 				 */
 				'activeThemeStylesheet'      => get_stylesheet(),
+				/**
+				 * Whether the active theme is a block theme. The Embedded search
+				 * experience is built and customized in the Site Editor, which
+				 * classic themes don't have, so the dashboard blocks switching to
+				 * Embedded when this is false.
+				 */
+				'themeSupportsBlocks'        => wp_is_block_theme(),
 			),
 			'userData'        => array(
 				'currentUser' => $this->current_user_data(),

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -16,6 +16,7 @@ import './experience-option.scss';
 
 const SEARCH_CUSTOMIZE_URL = 'admin.php?page=jetpack-search-configure';
 const WIDGETS_EDITOR_URL = 'widgets.php';
+const THEMES_URL = 'themes.php';
 // The Site Editor identifies templates by `<theme-stylesheet>//<template-slug>`
 // even for plugin-registered ones, so the active theme is part of the URL. Built
 // at render time so the link follows theme switches without a re-deploy. Falls
@@ -256,19 +257,25 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 			{ isEmbeddedBlockedByTheme ? (
 				isConfirmOpen && (
 					// Informational only: classic themes can't run Embedded
-					// search, so this modal explains why and offers a single
-					// dismiss action — no confirm path that would commit the
+					// search, so this modal explains why and points to theme
+					// management — no confirm path that would commit the
 					// switch. (ConfirmDialog always renders both a confirm and
 					// a cancel button, so Modal is the right primitive here.)
+					// `size="medium"` constrains the width so the explanation
+					// wraps to a readable measure instead of one long line.
 					<Modal
 						title={ __( 'Embedded search needs a block theme', 'jetpack-search-pkg' ) }
 						onRequestClose={ () => setConfirmOpen( false ) }
 						className="jp-search-experience-option__blocked-modal"
+						size="medium"
 					>
 						<p>
-							{ __(
-								'Embedded search is a search page built and customized in the Site Editor. Your active theme is a classic theme, which has no Site Editor, so this experience can’t be used until you switch to a block theme.',
-								'jetpack-search-pkg'
+							{ createInterpolateElement(
+								__(
+									'Embedded search is a search page built and customized in the Site Editor. Your active theme is a classic theme, which has no Site Editor. <a>Switch to a block theme</a> to use this experience.',
+									'jetpack-search-pkg'
+								),
+								{ a: <a href={ THEMES_URL } /> }
 							) }
 						</p>
 						<div className="jp-search-experience-option__blocked-modal-actions">

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -105,12 +105,12 @@ const getHoverHint = experience => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const { active, isUpdating, activeThemeStylesheet, themeSupportsBlocks } = useSelect(
+	const { active, isUpdating, activeThemeStylesheet, isBlockTheme } = useSelect(
 		select => ( {
 			active: select( STORE_ID ).getActiveExperience(),
 			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
 			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
-			themeSupportsBlocks: select( STORE_ID ).themeSupportsBlocks(),
+			isBlockTheme: select( STORE_ID ).isBlockTheme(),
 		} ),
 		[]
 	);
@@ -125,7 +125,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 	// classic themes don't have. The card stays clickable so the click opens
 	// an explanatory modal instead of silently doing nothing — but the switch
 	// itself is never committed.
-	const isEmbeddedBlockedByTheme = experience === EXPERIENCE.EMBEDDED && ! themeSupportsBlocks;
+	const isEmbeddedBlockedByTheme = experience === EXPERIENCE.EMBEDDED && ! isBlockTheme;
 	const blockedThemeHint = __( 'Embedded search requires a block theme', 'jetpack-search-pkg' );
 
 	const Preview = PREVIEWS[ experience ];

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { Button, Modal, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -104,11 +104,12 @@ const getHoverHint = experience => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const { active, isUpdating, activeThemeStylesheet } = useSelect(
+	const { active, isUpdating, activeThemeStylesheet, themeSupportsBlocks } = useSelect(
 		select => ( {
 			active: select( STORE_ID ).getActiveExperience(),
 			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
 			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
+			themeSupportsBlocks: select( STORE_ID ).themeSupportsBlocks(),
 		} ),
 		[]
 	);
@@ -118,6 +119,13 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 	const isActive = active === experience;
 	const isRecommended = experience === EXPERIENCE.EMBEDDED;
 	const linksDisabled = isUpdating || ! isActive;
+
+	// Embedded search is built and customized in the Site Editor, which
+	// classic themes don't have. The card stays clickable so the click opens
+	// an explanatory modal instead of silently doing nothing — but the switch
+	// itself is never committed.
+	const isEmbeddedBlockedByTheme = experience === EXPERIENCE.EMBEDDED && ! themeSupportsBlocks;
+	const blockedThemeHint = __( 'Embedded search requires a block theme', 'jetpack-search-pkg' );
 
 	const Preview = PREVIEWS[ experience ];
 
@@ -221,7 +229,14 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					type="button"
 					className="jp-search-experience-option__commit-overlay"
 					aria-disabled={ commitButtonDisabled }
-					title={ commitButtonDisabled ? undefined : getHoverHint( experience ) }
+					title={
+						// eslint-disable-next-line no-nested-ternary -- three mutually exclusive hint states; flattening would duplicate the attribute.
+						commitButtonDisabled
+							? undefined
+							: isEmbeddedBlockedByTheme
+							? blockedThemeHint
+							: getHoverHint( experience )
+					}
 					onClick={ () => {
 						if ( commitButtonDisabled ) {
 							return;
@@ -229,27 +244,57 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 						setConfirmOpen( true );
 					} }
 					aria-label={
+						// eslint-disable-next-line no-nested-ternary -- three mutually exclusive label states; flattening would duplicate the attribute.
 						disabled
 							? `${ getCommitLabel( experience ) }. ${ upsellHint }`
+							: isEmbeddedBlockedByTheme
+							? `${ getExperienceLabel( experience ) }. ${ blockedThemeHint }`
 							: getCommitLabel( experience )
 					}
 				/>
 			) }
-			<ConfirmDialog
-				isOpen={ isConfirmOpen }
-				onConfirm={ () => {
-					saveExperience( experience );
-					setConfirmOpen( false );
-				} }
-				onCancel={ () => setConfirmOpen( false ) }
-				confirmButtonText={ getCommitLabel( experience ) }
-			>
-				{ sprintf(
-					/* translators: %s — the human-readable experience name (e.g. "Embedded search"). */
-					__( 'Switch the visitor-facing search experience to %s?', 'jetpack-search-pkg' ),
-					getExperienceLabel( experience )
-				) }
-			</ConfirmDialog>
+			{ isEmbeddedBlockedByTheme ? (
+				isConfirmOpen && (
+					// Informational only: classic themes can't run Embedded
+					// search, so this modal explains why and offers a single
+					// dismiss action — no confirm path that would commit the
+					// switch. (ConfirmDialog always renders both a confirm and
+					// a cancel button, so Modal is the right primitive here.)
+					<Modal
+						title={ __( 'Embedded search needs a block theme', 'jetpack-search-pkg' ) }
+						onRequestClose={ () => setConfirmOpen( false ) }
+						className="jp-search-experience-option__blocked-modal"
+					>
+						<p>
+							{ __(
+								'Embedded search is a search page built and customized in the Site Editor. Your active theme is a classic theme, which has no Site Editor, so this experience can’t be used until you switch to a block theme.',
+								'jetpack-search-pkg'
+							) }
+						</p>
+						<div className="jp-search-experience-option__blocked-modal-actions">
+							<Button variant="primary" onClick={ () => setConfirmOpen( false ) }>
+								{ __( 'Got it', 'jetpack-search-pkg' ) }
+							</Button>
+						</div>
+					</Modal>
+				)
+			) : (
+				<ConfirmDialog
+					isOpen={ isConfirmOpen }
+					onConfirm={ () => {
+						saveExperience( experience );
+						setConfirmOpen( false );
+					} }
+					onCancel={ () => setConfirmOpen( false ) }
+					confirmButtonText={ getCommitLabel( experience ) }
+				>
+					{ sprintf(
+						/* translators: %s — the human-readable experience name (e.g. "Embedded search"). */
+						__( 'Switch the visitor-facing search experience to %s?', 'jetpack-search-pkg' ),
+						getExperienceLabel( experience )
+					) }
+				</ConfirmDialog>
+			) }
 		</Stack>
 	);
 }

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.scss
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.scss
@@ -173,3 +173,9 @@
 		flex-wrap: wrap;
 	}
 }
+
+.jp-search-experience-option__blocked-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: var(--wpds-dimension-padding-lg);
+}

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -17,6 +17,9 @@ const siteDataSelectors = {
 	isPlanJustUpgraded: state => state.siteData?.isPlanJustUpgraded ?? false,
 	isSearchBlocksEnabled: state => state.siteData?.searchBlocksEnabled ?? false,
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
+	// Defaults to true so Embedded is never blocked when the flag is absent
+	// (older initial state) — fail open rather than hide a working option.
+	themeSupportsBlocks: state => state.siteData?.themeSupportsBlocks ?? true,
 };
 
 export default siteDataSelectors;

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -19,7 +19,7 @@ const siteDataSelectors = {
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 	// Defaults to true so Embedded is never blocked when the flag is absent
 	// (older initial state) — fail open rather than hide a working option.
-	themeSupportsBlocks: state => state.siteData?.themeSupportsBlocks ?? true,
+	isBlockTheme: state => state.siteData?.themeSupportsBlocks ?? true,
 };
 
 export default siteDataSelectors;

--- a/projects/packages/search/src/dashboard/store/selectors/test/site-data.test.js
+++ b/projects/packages/search/src/dashboard/store/selectors/test/site-data.test.js
@@ -15,4 +15,18 @@ describe( 'siteDataSelectors', () => {
 	test( 'returns an empty Reader Chat guidelines URL by default', () => {
 		expect( siteDataSelectors.getReaderChatGuidelinesUrl( {} ) ).toBe( '' );
 	} );
+
+	test( 'reports theme block support from siteData', () => {
+		expect(
+			siteDataSelectors.themeSupportsBlocks( { siteData: { themeSupportsBlocks: false } } )
+		).toBe( false );
+		expect(
+			siteDataSelectors.themeSupportsBlocks( { siteData: { themeSupportsBlocks: true } } )
+		).toBe( true );
+	} );
+
+	test( 'fails open to true when theme block support is absent', () => {
+		expect( siteDataSelectors.themeSupportsBlocks( {} ) ).toBe( true );
+		expect( siteDataSelectors.themeSupportsBlocks( { siteData: {} } ) ).toBe( true );
+	} );
 } );

--- a/projects/packages/search/src/dashboard/store/selectors/test/site-data.test.js
+++ b/projects/packages/search/src/dashboard/store/selectors/test/site-data.test.js
@@ -17,16 +17,16 @@ describe( 'siteDataSelectors', () => {
 	} );
 
 	test( 'reports theme block support from siteData', () => {
-		expect(
-			siteDataSelectors.themeSupportsBlocks( { siteData: { themeSupportsBlocks: false } } )
-		).toBe( false );
-		expect(
-			siteDataSelectors.themeSupportsBlocks( { siteData: { themeSupportsBlocks: true } } )
-		).toBe( true );
+		expect( siteDataSelectors.isBlockTheme( { siteData: { themeSupportsBlocks: false } } ) ).toBe(
+			false
+		);
+		expect( siteDataSelectors.isBlockTheme( { siteData: { themeSupportsBlocks: true } } ) ).toBe(
+			true
+		);
 	} );
 
 	test( 'fails open to true when theme block support is absent', () => {
-		expect( siteDataSelectors.themeSupportsBlocks( {} ) ).toBe( true );
-		expect( siteDataSelectors.themeSupportsBlocks( { siteData: {} } ) ).toBe( true );
+		expect( siteDataSelectors.isBlockTheme( {} ) ).toBe( true );
+		expect( siteDataSelectors.isBlockTheme( { siteData: {} } ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes [RSM-3501](https://linear.app/a8c/issue/RSM-3501)

## Why

Embedded search is a search page built and customized in the Site Editor. Classic (non-block) themes have no Site Editor, so Embedded search can't work for them — yet the dashboard let a classic-theme site owner click "Embedded search", confirm, and switch into a search experience that simply won't function. This change stops that: on a classic theme, clicking Embedded now opens a short modal that explains why it isn't available, instead of letting the user break their site search.

## Proposed changes

* Pass `wp_is_block_theme()` to the Search dashboard as `siteData.themeSupportsBlocks`, exposed via a new `themeSupportsBlocks` selector (defaults to `true` when absent, so behaviour is unchanged on older initial state).
* On a non-block theme, the Embedded card stays clickable but the click opens an informational modal ("Embedded search needs a block theme") with a single dismiss action — the switch is never committed.
* All other experiences (Overlay, Theme search, Off) and the existing plan-tier paywall path are untouched and orthogonal to this theme check.
* Added selector unit tests for `themeSupportsBlocks`.

## Screenshots

Classic theme (Twenty Twenty-One), clicking the "Embedded search" card, captured at 1440×900 on local docker.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/d0b17c46-0422-4ee3-91e1-fea5aaffb71f) | ![after](https://github.com/user-attachments/assets/b52d2364-98ba-48dd-acb7-8829d16eda78) |

## Related product discussion/links

* [RSM-3501](https://linear.app/a8c/issue/RSM-3501) (project: Jetpack Search blocks)

## Does this pull request change what data or activity we track or use?

No. This is a client-side gate on an existing dashboard control; no new data is tracked, sent, or stored. `wp_is_block_theme()` is a local capability check already used elsewhere in the package.

## Testing instructions

Prerequisite: a site with the Search dashboard experience selector available (`jetpack_search_blocks_enabled`) and a Search-capable plan.

* Activate a **classic** theme (e.g. Twenty Twenty-One). Go to **Jetpack → Search → Settings**.
* Click the **Embedded search** card → a modal "Embedded search needs a block theme" appears with an explanation and a single **Got it** / close action. Dismiss it → confirm the active experience is **unchanged** (no switch happened).
* Activate a **block** theme (e.g. Twenty Twenty-Five). Click the **Embedded search** card → the normal "Switch the visitor-facing search experience to Embedded search?" confirmation appears and confirming switches (behaviour unchanged from before).
* On the classic theme, click **Overlay search** → the normal confirmation still appears (only Embedded is gated by theme support).
* Confirm the plan-tier paywall behaviour for Embedded/Overlay is unchanged for plans that only support classic search.
