### PR TITLE
Search: auto-switch Results List to Product view for product-scoped searches

### DIFF
--- a/projects/packages/search/changelog/SEARCH-201-auto-product-view
+++ b/projects/packages/search/changelog/SEARCH-201-auto-product-view
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search Blocks: Results List auto-switches to the Product layout when the search is scoped to exactly the `product` post type via the `?post_types[]=product` URL parameter. Opt-out per block via the new "Auto-switch to Product view" toggle in the editor.
+Search Blocks: Results List auto-switches to the Product layout when the search is scoped to exactly the `product` post type via the `?post_types[]=product` URL parameter. On WooCommerce sites this takes effect for existing Results List blocks immediately after the update (no author action needed); opt out per block via the new "Auto-switch to Product view" toggle in the editor.

--- a/projects/packages/search/changelog/SEARCH-201-auto-product-view
+++ b/projects/packages/search/changelog/SEARCH-201-auto-product-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: Results List auto-switches to the Product layout when the search is scoped to exactly the `product` post type via the `?post_types[]=product` URL parameter. Opt-out per block via the new "Auto-switch to Product view" toggle in the editor.

--- a/projects/packages/search/src/search-blocks/blocks/results-list/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/block.json
@@ -12,6 +12,7 @@
 			"enum": [ "compact", "expanded", "product" ],
 			"default": "expanded"
 		},
+		"autoProductView": { "type": "boolean", "default": true },
 		"noResultsMessage": { "type": "string", "default": "" },
 		"errorMessage": { "type": "string", "default": "" }
 	},

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
@@ -150,7 +150,7 @@ export default function ResultsListEdit( { attributes, setAttributes } ) {
 							checked={ attributes?.autoProductView ?? true }
 							onChange={ value => setAttributes( { autoProductView: value } ) }
 							help={ __(
-								'When the search is scoped to products (a ?post_type=product link), show results as a product grid regardless of the format above. Turn off to always use the format above.',
+								'When the search is scoped to products (a ?post_types[]=product link), show results as a product grid regardless of the format above. Turn off to always use the format above.',
 								'jetpack-search-pkg'
 							) }
 						/>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
@@ -15,7 +15,7 @@
  * names.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, RadioControl, TextControl } from '@wordpress/components';
+import { PanelBody, RadioControl, TextControl, ToggleControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 // `product` is WC-only. On non-Woo sites it's pruned from the picker and a
@@ -140,6 +140,21 @@ export default function ResultsListEdit( { attributes, setAttributes } ) {
 						options={ LAYOUT_OPTIONS() }
 						onChange={ value => setAttributes( { layout: value } ) }
 					/>
+					{ isWooCommerceBlocksEnabled() && (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Auto-switch to Product view for product searches',
+								'jetpack-search-pkg'
+							) }
+							checked={ attributes?.autoProductView ?? true }
+							onChange={ value => setAttributes( { autoProductView: value } ) }
+							help={ __(
+								'When the search is scoped to products (a ?post_type=product link), show results as a product grid regardless of the format above. Turn off to always use the format above.',
+								'jetpack-search-pkg'
+							) }
+						/>
+					) }
 					<TextControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -76,12 +76,15 @@ if ( 'card' === $layout ) {
 	$layout = 'expanded';
 }
 // Auto-switch to the product layout when the request is scoped to exactly
-// the `product` post type via the URL (`?post_type=product` or
-// `?post_types[]=product`), so a product search renders as a shop grid
-// without the author hand-picking the layout. Opt-out per block via the
-// `autoProductView` attribute (default on). The non-Woo collapse below is
-// still the final gate, so this can never force `product` on a non-Woo
-// site even if the URL asks for it.
+// the `product` post type via the Jetpack Search `?post_types[]=product`
+// URL parameter, so a product search renders as a shop grid without the
+// author hand-picking the layout. (`request_is_product_only()` also
+// accepts the scalar `?post_type=product`, but that is a WP core query
+// var that reroutes to the WC shop archive before this block renders —
+// see its docblock.) Opt-out per block via the `autoProductView`
+// attribute (default on). The non-Woo collapse below is still the final
+// gate, so this can never force `product` on a non-Woo site even if the
+// URL asks for it.
 $auto_product_view = $attrs['autoProductView'] ?? true;
 if ( $auto_product_view && Search_Blocks::woocommerce_blocks_enabled() && Search_Blocks::request_is_product_only() ) {
 	$layout = 'product';

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -75,6 +75,17 @@ $layout = $attrs['layout'] ?? 'expanded';
 if ( 'card' === $layout ) {
 	$layout = 'expanded';
 }
+// Auto-switch to the product layout when the request is scoped to exactly
+// the `product` post type via the URL (`?post_type=product` or
+// `?post_types[]=product`), so a product search renders as a shop grid
+// without the author hand-picking the layout. Opt-out per block via the
+// `autoProductView` attribute (default on). The non-Woo collapse below is
+// still the final gate, so this can never force `product` on a non-Woo
+// site even if the URL asks for it.
+$auto_product_view = $attrs['autoProductView'] ?? true;
+if ( $auto_product_view && Search_Blocks::woocommerce_blocks_enabled() && Search_Blocks::request_is_product_only() ) {
+	$layout = 'product';
+}
 // The product layout reads WC-shaped fields (price, sale price, rating)
 // off each result. On a non-Woo site those fields don't exist, so
 // rendering would emit empty price/rating regions. Collapse to the

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1240,6 +1240,12 @@ class Search_Blocks {
 	 * not a registered visitor-facing filter — it never lands in
 	 * `activeFilters`.
 	 *
+	 * Deliberately not memoized (unlike `is_initial_loading()`): the only
+	 * caller is results-list/render.php, and a page carries one such block,
+	 * so this runs at most once per request. Mirrors `parse_url_filters()`,
+	 * which is likewise uncached. Skipping the static-cache + test-reset
+	 * plumbing keeps the no-shared-state contract the tests rely on.
+	 *
 	 * @return bool
 	 */
 	public static function request_is_product_only(): bool {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1220,6 +1220,56 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Whether the current request is scoped to exactly the `product` post
+	 * type via the URL. In practice this is driven by the Jetpack Search
+	 * array shape `?post_types[]=product` — the shape store/url-state.js
+	 * writes and round-trips. The scalar `?post_type=product` is also
+	 * accepted for completeness, but a top-level `?post_type=product` is a
+	 * WordPress core query var that reroutes the request to the product
+	 * post-type archive (the WooCommerce shop template) before any Jetpack
+	 * Search block renders, so it does not reach this code on a normal
+	 * search page; it only matters for a custom search context that carries
+	 * the scalar param within the Search template.
+	 *
+	 * Used by results-list/render.php to auto-switch to the product layout
+	 * for a product search without the author hand-picking it. "Exactly
+	 * product" is deliberate: a mixed request (e.g.
+	 * `?post_types[]=product&post_types[]=post`) keeps the saved layout so
+	 * non-product results never render as product cards. Reads `$_GET`
+	 * directly rather than `parse_url_filters()` because post-type scope is
+	 * not a registered visitor-facing filter — it never lands in
+	 * `activeFilters`.
+	 *
+	 * @return bool
+	 */
+	public static function request_is_product_only(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only URL state; sanitized per-value below.
+		$raw = wp_unslash( $_GET );
+		if ( ! is_array( $raw ) ) {
+			return false;
+		}
+
+		$requested = array();
+		foreach ( array( 'post_type', 'post_types' ) as $param ) {
+			if ( ! isset( $raw[ $param ] ) ) {
+				continue;
+			}
+			$values = is_array( $raw[ $param ] ) ? $raw[ $param ] : array( $raw[ $param ] );
+			foreach ( $values as $value ) {
+				if ( ! is_scalar( $value ) ) {
+					continue;
+				}
+				$slug = sanitize_key( (string) $value );
+				if ( '' !== $slug ) {
+					$requested[ $slug ] = true;
+				}
+			}
+		}
+
+		return array( 'product' ) === array_keys( $requested );
+	}
+
+	/**
 	 * Pre-hydration view state for a filter block's wrapper. Centralizes the
 	 * seeded-state read shared by filter-checkbox and filter-date so each
 	 * render.php branches on a single struct rather than re-deriving the

--- a/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
@@ -32,6 +32,20 @@ jest.mock( '@wordpress/components', () => ( {
 			} ) }
 		</fieldset>
 	),
+	ToggleControl: ( { label, checked, onChange } ) => {
+		const id = `toggle-${ String( label ).toLowerCase().replace( /\s+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="checkbox"
+					checked={ !! checked }
+					onChange={ event => onChange( event.target.checked ) }
+				/>
+			</>
+		);
+	},
 	TextControl: ( { label, value, onChange, placeholder } ) => {
 		const id = `text-${ String( label ).toLowerCase().replace( /\s+/g, '-' ) }`;
 		return (
@@ -111,6 +125,41 @@ describe( 'ResultsListEdit', () => {
 		expect( screen.getByText( '$19.99' ) ).toBeInTheDocument();
 	} );
 
+	it( 'shows the auto-product-view toggle, defaulting on when the attribute is unset', () => {
+		render( <ResultsListEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Auto-switch to Product view for product searches',
+			} )
+		).toBeChecked();
+	} );
+
+	it( 'reflects autoProductView=false as an unchecked toggle', () => {
+		render(
+			<ResultsListEdit attributes={ { autoProductView: false } } setAttributes={ jest.fn() } />
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Auto-switch to Product view for product searches',
+			} )
+		).not.toBeChecked();
+	} );
+
+	it( 'updates the autoProductView attribute when the toggle changes', () => {
+		const setAttributes = jest.fn();
+		render( <ResultsListEdit attributes={ {} } setAttributes={ setAttributes } /> );
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- @testing-library/user-event isn't a dep of the search package; results-sort-edit.test.jsx uses fireEvent for the same reason.
+		fireEvent.click(
+			screen.getByRole( 'checkbox', {
+				name: 'Auto-switch to Product view for product searches',
+			} )
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { autoProductView: false } );
+	} );
+
 	it( 'exposes message controls for the empty and error states in the inspector', () => {
 		render( <ResultsListEdit attributes={ {} } setAttributes={ jest.fn() } /> );
 
@@ -179,6 +228,16 @@ describe( 'ResultsListEdit on non-WooCommerce sites (RSM-2805)', () => {
 		expect( screen.getByRole( 'radio', { name: 'Expanded' } ) ).toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'radio', { name: 'Product (for WooCommerce stores)' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'omits the auto-product-view toggle (the product layout it controls is WC-only)', () => {
+		render( <ResultsListEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'Auto-switch to Product view for product searches',
+			} )
 		).not.toBeInTheDocument();
 	} );
 

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -28,6 +28,10 @@ class Results_List_Render_Test extends TestCase {
 						'type'    => 'string',
 						'default' => 'expanded',
 					),
+					'autoProductView'  => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
 					'noResultsMessage' => array(
 						'type'    => 'string',
 						'default' => '',
@@ -442,5 +446,180 @@ class Results_List_Render_Test extends TestCase {
 			$this->assertStringNotContainsString( 'jetpack-search-skeleton--rating', $markup, "Layout '{$layout}': rating skeleton must be absent." );
 			$this->assertStringNotContainsString( 'jetpack-search-skeleton--title-secondary', $markup, "Layout '{$layout}': title-secondary skeleton must be absent." );
 		}
+	}
+
+	/**
+	 * Render the block with the given post-type request params seeded into
+	 * `$_GET`. Resets the `is_initial_loading()` memo around the render and
+	 * clears the params after so the auto-product-view cases stay isolated
+	 * from one another (the PHPUnit harness reuses one process).
+	 *
+	 * @param array $get        Params to merge into `$_GET` for the render.
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render_with_request( array $get, array $attributes = array() ): string {
+		Search_Blocks::reset_initial_loading_cache();
+		foreach ( $get as $key => $value ) {
+			$_GET[ $key ] = $value;
+		}
+		$markup = $this->render( $attributes );
+		foreach ( array_keys( $get ) as $key ) {
+			unset( $_GET[ $key ] );
+		}
+		Search_Blocks::reset_initial_loading_cache();
+		return $markup;
+	}
+
+	/**
+	 * `request_is_product_only()` is true only when the combined post-type
+	 * request resolves to exactly `product` — across the scalar
+	 * `?post_type=` shape, the array `?post_types[]=` shape, or both.
+	 */
+	public function test_request_is_product_only_recognizes_exact_product_scope() {
+		$cases = array(
+			array(
+				'get'      => array( 'post_type' => 'product' ),
+				'expected' => true,
+			),
+			array(
+				'get'      => array( 'post_types' => array( 'product' ) ),
+				'expected' => true,
+			),
+			array(
+				'get'      => array(
+					'post_type'  => 'product',
+					'post_types' => array( 'product' ),
+				),
+				'expected' => true,
+			),
+			array(
+				'get'      => array( 'post_types' => array( 'product', 'post' ) ),
+				'expected' => false,
+			),
+			array(
+				'get'      => array(
+					'post_type'  => 'product',
+					'post_types' => array( 'post' ),
+				),
+				'expected' => false,
+			),
+			array(
+				'get'      => array( 'post_type' => 'post' ),
+				'expected' => false,
+			),
+			array(
+				'get'      => array( 'post_type' => '' ),
+				'expected' => false,
+			),
+			array(
+				'get'      => array( 'post_types' => 'product' ),
+				'expected' => true,
+			),
+			array(
+				'get'      => array(),
+				'expected' => false,
+			),
+		);
+		foreach ( $cases as $case ) {
+			$get = $case['get'];
+			foreach ( $get as $k => $v ) {
+				$_GET[ $k ] = $v;
+			}
+			$this->assertSame(
+				$case['expected'],
+				Search_Blocks::request_is_product_only(),
+				'Unexpected result for ' . wp_json_encode( $get, JSON_UNESCAPED_SLASHES )
+			);
+			foreach ( array_keys( $get ) as $k ) {
+				unset( $_GET[ $k ] );
+			}
+		}
+	}
+
+	/**
+	 * A `?post_type=product` request auto-switches the Results List to the
+	 * product layout on a Woo site even though the saved layout is the
+	 * default `expanded` and the author never picked `product`.
+	 */
+	public function test_scalar_post_type_product_auto_switches_to_product_layout() {
+		$markup = $this->render_with_request( array( 'post_type' => 'product' ) );
+		$this->assertStringContainsString( 'jetpack-search-results--product', $markup );
+		$this->assertStringContainsString( 'jetpack-search-results__price', $markup );
+		$this->assertStringContainsString( 'jetpack-search-results__rating', $markup );
+	}
+
+	/**
+	 * The array `?post_types[]=product` shape behaves identically to the
+	 * scalar shape.
+	 */
+	public function test_array_post_types_product_auto_switches_to_product_layout() {
+		$markup = $this->render_with_request( array( 'post_types' => array( 'product' ) ) );
+		$this->assertStringContainsString( 'jetpack-search-results--product', $markup );
+	}
+
+	/**
+	 * The auto-switch overrides the saved layout — a block saved as
+	 * `compact` still renders as a product grid for a product search.
+	 */
+	public function test_auto_switch_overrides_saved_layout() {
+		$markup = $this->render_with_request(
+			array( 'post_type' => 'product' ),
+			array( 'layout' => 'compact' )
+		);
+		$this->assertStringContainsString( 'jetpack-search-results--product', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results--compact', $markup );
+	}
+
+	/**
+	 * A mixed post-type request keeps the saved layout — product cards must
+	 * not render for non-product results.
+	 */
+	public function test_mixed_post_types_keep_saved_layout() {
+		$markup = $this->render_with_request(
+			array( 'post_types' => array( 'product', 'post' ) ),
+			array( 'layout' => 'expanded' )
+		);
+		$this->assertStringContainsString( 'jetpack-search-results--expanded', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results--product', $markup );
+	}
+
+	/**
+	 * With no post-type request param the saved layout is respected.
+	 */
+	public function test_no_post_type_param_keeps_saved_layout() {
+		$markup = $this->render( array( 'layout' => 'compact' ) );
+		$this->assertStringContainsString( 'jetpack-search-results--compact', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results--product', $markup );
+	}
+
+	/**
+	 * `autoProductView` off pins the saved layout even for an exact
+	 * `?post_type=product` request.
+	 */
+	public function test_auto_product_view_off_pins_saved_layout() {
+		$markup = $this->render_with_request(
+			array( 'post_type' => 'product' ),
+			array(
+				'layout'          => 'compact',
+				'autoProductView' => false,
+			)
+		);
+		$this->assertStringContainsString( 'jetpack-search-results--compact', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results--product', $markup );
+	}
+
+	/**
+	 * On a non-Woo site a `?post_type=product` request must never produce
+	 * the product layout — the existing non-Woo collapse stays the final
+	 * gate, so the auto-switch can't force WC-shaped markup onto a site
+	 * whose index has no price/rating fields.
+	 */
+	public function test_non_woo_site_never_auto_switches_to_product() {
+		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( false );
+		$markup = $this->render_with_request( array( 'post_type' => 'product' ) );
+		$this->assertStringContainsString( 'jetpack-search-results--expanded', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results--product', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results__price', $markup );
 	}
 }


### PR DESCRIPTION
Fixes [SEARCH-201](https://linear.app/a8c/issue/SEARCH-201/search-blocks-auto-switch-results-list-to-product-view-when-the-search)

## Why

When a shopper follows a product-scoped search link (`?post_types[]=product`), the Results List previously rendered in the saved editorial format — title, breadcrumb path, excerpt, author/date — which looks wrong for a store. It now automatically switches to the Product grid (image cards with price and rating) for product-only searches, so a shop search looks like a shop without the author having to hand-pick the layout. Authors who don't want this can turn it off per block.

## Proposed changes

* New `autoProductView` attribute on `jetpack-search/results-list` (boolean, default **on**).
* `render.php` auto-switches the resolved layout to `product` when the request is scoped to exactly the `product` post type via the URL — gated by `autoProductView` and the existing `Search_Blocks::woocommerce_blocks_enabled()` check, with the non-Woo collapse still the final gate (never forces WC-shaped markup on a non-Woo site).
* New `Search_Blocks::request_is_product_only()` helper — true only when the combined post-type request resolves to exactly `product` (mixed requests keep the saved layout so non-product results never render as product cards).
* WooCommerce-only inspector toggle ("Auto-switch to Product view for product searches") to opt out per block.
* PHP + JS test matrices; changelog entry.

**Scope note:** the trigger is the Jetpack Search array shape `?post_types[]=product` — the shape `store/url-state.js` writes and round-trips. The scalar `?post_type=product` is a WordPress core query var that reroutes the request to the WooCommerce shop archive *before* any Jetpack Search block renders, so it never reaches this block and is intentionally a non-goal (handling it would require overriding standard shop-archive routing site-wide).

## Screenshots

Same `?s=hat&post_types[]=product` URL, captured at 1440×900 via local docker.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/ee8e4afd-0a60-48f1-a7d1-a6ec4b66256c) | ![after](https://github.com/user-attachments/assets/03417083-a86e-40bc-8755-bdef2a1daf27) |

## Related product discussion/links

* [SEARCH-201](https://linear.app/a8c/issue/SEARCH-201/search-blocks-auto-switch-results-list-to-product-view-when-the-search)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a WooCommerce site with the Search 3.0 blocks experience and the WC search blocks enabled (`add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_true', 20 )`), with a Search Results template containing a `results-list` block whose saved format is **not** Product. Acceptance criteria:

* [ ] `?s=<term>&post_types[]=product` renders the Results List as a product grid (image cards, price, rating) with `autoProductView` on (default).
* [ ] Without the param, the same search keeps the saved (e.g. Expanded) format.
* [ ] `?post_types[]=product&post_types[]=post` (mixed) keeps the saved format.
* [ ] Turning off the editor toggle "Auto-switch to Product view" pins the saved format even with `?post_types[]=product`.
* [ ] On a non-Woo site, `?post_types[]=product` never produces the product layout (collapses to Expanded).
* [ ] The inspector toggle appears only when WooCommerce is enabled and defaults to on.
* [ ] `jp test php packages/search` and `jp test js packages/search` are green.
