### PR TITLE
Search dashboard: full-width toggle description text

### DIFF
--- a/projects/packages/search/changelog/fix-search-toggle-description-width
+++ b/projects/packages/search/changelog/fix-search-toggle-description-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search dashboard: let the toggle description text span the full settings card width instead of wrapping in a narrow 7-column band.

--- a/projects/packages/search/src/dashboard/components/ai-agent-access-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/ai-agent-access-control/index.jsx
@@ -127,7 +127,7 @@ export default function AIAgentAccessControl( {
 				/>
 			</div>
 			<div className="jp-search-dashboard-row">
-				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ AI_AGENT_ACCESS_DESCRIPTION }
 					</p>

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -240,7 +240,7 @@ const InstantSearchToggle = ( {
 				/>
 			</div>
 			<div className="jp-search-dashboard-row">
-				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
 					{ supportsInstantSearch && (
 						<Fragment>
 							<p className="jp-form-search-settings-group__toggle-explanation">
@@ -330,7 +330,7 @@ const SearchToggle = ( {
 				</div>
 			) }
 			<div className="jp-search-dashboard-row">
-				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ SEARCH_DESCRIPTION }
 					</p>

--- a/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
@@ -52,7 +52,7 @@ export default function ReaderChatControl( {
 				/>
 			</div>
 			<div className="jp-search-dashboard-row">
-				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ READER_CHAT_DESCRIPTION }
 					</p>

--- a/projects/packages/search/src/dashboard/components/search-suggestions-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/search-suggestions-control/index.jsx
@@ -59,7 +59,7 @@ export default function SearchSuggestionsControl( {
 				/>
 			</div>
 			<div className="jp-search-dashboard-row">
-				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ SEARCH_SUGGESTIONS_DESCRIPTION }
 					</p>


### PR DESCRIPTION
Fixes # N/A

## Why

On the Search dashboard, each settings toggle's description sat in a 7-of-12-column band, so the explanation text wrapped into an unnecessarily narrow column with empty space to its right. This widens it to the full settings-card width, matching the toggle row.

## Proposed changes

* Change the toggle description container from `lg-col-span-7 md-col-span-5` to `lg-col-span-12 md-col-span-8` (full width, matching the toggle) in the Module, AI Agent Access, Reader Chat, and Search Suggestions controls. Markup-only; no behavior change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open **Jetpack → Search → Settings**.
* For each toggle (Module / AI Agent Access / Reader Chat / Search Suggestions), confirm the description text spans the full card width instead of wrapping early in a narrow column.
* No functional change — toggles behave exactly as before.
