### PR TITLE
Sync: whitelist newly added Jetpack Search options for WPcom

### DIFF
--- a/projects/packages/sync/changelog/add-rsm-3508-sync-search-options
+++ b/projects/packages/sync/changelog/add-rsm-3508-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync: Whitelist the new Jetpack Search ai_answers_enabled, search_suggestions_enabled, override_woocommerce_search_template, and reader_chat options so they propagate to WPcom.

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1775,6 +1775,10 @@ class Search extends Module {
 		'jetpack_search_inf_scroll',
 		'jetpack_search_show_powered_by',
 		'jetpack_search_experience',
+		'jetpack_search_ai_answers_enabled',
+		'jetpack_search_suggestions_enabled',
+		'jetpack_search_override_woocommerce_search_template',
+		'reader_chat',
 		'instant_search_enabled',
 	); // end options.
 

--- a/projects/plugins/jetpack/changelog/add-rsm-3508-sync-search-options
+++ b/projects/plugins/jetpack/changelog/add-rsm-3508-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Add test coverage for the newly synced Jetpack Search options.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -296,6 +296,9 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'jetpack_search_inf_scroll'                    => true,
 			'jetpack_search_show_powered_by'               => true,
 			'jetpack_search_experience'                    => 'pineapple',
+			'jetpack_search_ai_answers_enabled'            => true,
+			'jetpack_search_suggestions_enabled'           => true,
+			'jetpack_search_override_woocommerce_search_template' => true,
 			'instant_search_enabled'                       => true,
 		);
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-3508/sync-whitelist-newly-added-jetpack-search-options-to-wpcom

## Why

Site admins can flip the new Search settings (Reader Chat, AI Answers, Search Suggestions, the WooCommerce search-template override) on a connected site, but server-side Search on WPcom never sees those choices because the options aren't whitelisted for Sync. Whitelisting them lets the values reach WPcom's shadow store the same way `jetpack_search_experience` does after #48540.

## Proposed changes

* Add the four new Search option keys to `$options_to_sync` in `projects/packages/sync/src/modules/class-search.php`, following the `jetpack_search_experience` pattern from #48540:
  * `jetpack_search_ai_answers_enabled` (wire field `ai_answers_enabled`)
  * `jetpack_search_suggestions_enabled` (wire field `search_suggestions_enabled`)
  * `jetpack_search_override_woocommerce_search_template` (wire field `override_woocommerce_search_template`)
  * `reader_chat` (wire field `reader_chat`)
* Extend the `Jetpack_Sync_Options_Test::test_sync_default_options` fixture with the three new keys (`reader_chat` was already covered) so the whitelist↔fixture symmetry assertion keeps passing.
* Changelog entries for `packages/sync` (patch / added) and `plugins/jetpack` (patch / other — test-only).

This is the Jetpack (sending) side only. The matching WPcom shadow-replicastore allowlist + sanitizer change is tracked in RSM-3508 and handled separately, mirroring wpcom #215433 — the two must land together (or WPcom first) or synced values get dropped by the sanitizer.

## Verification

`test_sync_default_options` asserts every whitelisted option also has a test fixture entry (`assertEmpty( $whitelist_and_option_keys_difference )`). The nova docker env only ships PHP 8.2 (PHPUnit needs 8.3), so the invariant was verified statically from source — all four keys are present on both the sync whitelist and the test fixture, so the symmetry assertion holds. `php:lint` and `phpcs` pass via the pre-commit hook. Functional sync behaviour is unchanged code — appending option names to the same array that #48540 already exercised for `jetpack_search_experience`.

<details>
<summary>Output</summary>

```text
$ for k in jetpack_search_ai_answers_enabled jetpack_search_suggestions_enabled jetpack_search_override_woocommerce_search_template reader_chat; do ... done
jetpack_search_ai_answers_enabled -> whitelist:2 testfixture:1
jetpack_search_suggestions_enabled -> whitelist:1 testfixture:1
jetpack_search_override_woocommerce_search_template -> whitelist:1 testfixture:1
reader_chat -> whitelist:1 testfixture:1
(jetpack_search_ai_answers_enabled appears twice in class-search.php: once in the whitelist array, once in the AI-answers filter — array membership is single.)

$ git commit  (pre-commit hook)
No syntax error found  (php:lint, 2 files)
No violations were found  (phpcs)
```

</details>

## Related product discussion/links

* RSM-3508
* Sync pattern reference: #48540 (`jetpack_search_experience`)
* WPcom counterpart: wpcom #215433 (to be mirrored for these four keys)

## Does this pull request change what data or activity we track or use?

This adds four existing site-settings options to the Sync whitelist so they propagate to WPcom (consistent with the other already-synced `jetpack_search_*` options). No new user activity is collected. Adding the "[Status] Needs Privacy Updates" label for confirmation.

## Testing instructions

* On a connected test site, set each option locally:
  * `wp option update reader_chat 1`
  * `wp option update jetpack_search_ai_answers_enabled 1`
  * `wp option update jetpack_search_suggestions_enabled 1`
  * `wp option update jetpack_search_override_woocommerce_search_template 1`
* Trigger a full sync (`wp jetpack sync start` or the Jetpack debug page).
* With the WPcom-side allowlist (RSM-3508 / wpcom #215433) also deployed, confirm each value is present in the WPcom shadow store for the site.
* Run the sync options test: `jetpack docker phpunit jetpack -- --filter=Jetpack_Sync_Options_Test::test_sync_default_options` (PHP 8.3+ env) — it should pass, proving the whitelist↔fixture symmetry.
