### PR TITLE
Search: lighter Clear Filters button + Compact block style (RSM-3507)

### DIFF
--- a/projects/packages/search/changelog/RSM-3507-clear-filters-button-customization
+++ b/projects/packages/search/changelog/RSM-3507-clear-filters-button-customization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Add a "Compact" block style to the Clear Filters block and stop it inheriting the core Button block styling that rendered oversized on some themes — the default now uses the theme's lighter button baseline.

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/block.json
@@ -14,6 +14,10 @@
 			"padding": true
 		}
 	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "compact", "label": "Compact" }
+	],
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {
 		"label": { "type": "string", "default": "" },

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
@@ -1,6 +1,12 @@
 /**
  * Editor preview for jetpack-search/clear-filters.
  *
+ * A neutral wrapper `<div>` is the block root (so it follows theme block
+ * layout); the inner button takes the theme's `wp-element-button` baseline
+ * rather than the core Button block's heavier `wp-block-button__link`
+ * styling, which renders oversized on some themes. The "Compact" block style
+ * trims it further for themes whose button baseline is still too large.
+ *
  * Always renders the button at full opacity in the editor — the live block
  * hides itself when no filter is active, but a hidden affordance is hard to
  * style or position. The "hide when inactive" toggle in the inspector is
@@ -53,11 +59,13 @@ export default function ClearFiltersEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<div className="wp-block-button is-style-outline has-custom-font-size has-small-font-size">
-					<button type="button" className="wp-block-button__link wp-element-button" disabled>
-						{ previewLabel }
-					</button>
-				</div>
+				<button
+					type="button"
+					className="jetpack-search-clear-filters__button wp-element-button"
+					disabled
+				>
+					{ previewLabel }
+				</button>
 			</div>
 		</>
 	);

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
@@ -2,10 +2,12 @@
  * Editor preview for jetpack-search/clear-filters.
  *
  * A neutral wrapper `<div>` is the block root (so it follows theme block
- * layout); the inner button takes the theme's `wp-element-button` baseline
- * rather than the core Button block's heavier `wp-block-button__link`
- * styling, which renders oversized on some themes. The "Compact" block style
- * trims it further for themes whose button baseline is still too large.
+ * layout); the inner button carries `wp-block-button__link` + `wp-element-button`
+ * so it picks up the theme's full core/button styling (border-radius, hover,
+ * etc.) — but the `.wp-block-button` parent and `is-style-outline` are
+ * deliberately omitted, since *those* were the source of the oversized
+ * rendering on some themes. The "Compact" block style trims padding/font
+ * for themes whose button baseline is still too large.
  *
  * Always renders the button at full opacity in the editor — the live block
  * hides itself when no filter is active, but a hidden affordance is hard to
@@ -61,7 +63,7 @@ export default function ClearFiltersEdit( { attributes, setAttributes } ) {
 			<div { ...blockProps }>
 				<button
 					type="button"
-					className="jetpack-search-clear-filters__button wp-element-button"
+					className="jetpack-search-clear-filters__button wp-block-button__link wp-element-button"
 					disabled
 				>
 					{ previewLabel }

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
@@ -59,7 +59,7 @@ if ( ! $has_any_active && is_array( $seeded_price ) ) {
 >
 	<button
 		type="button"
-		class="jetpack-search-clear-filters__button wp-element-button"
+		class="jetpack-search-clear-filters__button wp-block-button__link wp-element-button"
 		data-wp-on--click="actions.clearFilters"
 	>
 		<?php echo esc_html( $label ); ?>

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
@@ -57,13 +57,11 @@ if ( ! $has_any_active && is_array( $seeded_price ) ) {
 		data-wp-bind--hidden="!state.hasActiveFilters"<?php endif; ?>
 	<?php echo $hide_when_inactive && ! $has_any_active ? 'hidden' : ''; ?>
 >
-	<div class="wp-block-button is-style-outline has-custom-font-size has-small-font-size">
-		<button
-			type="button"
-			class="wp-block-button__link wp-element-button"
-			data-wp-on--click="actions.clearFilters"
-		>
-			<?php echo esc_html( $label ); ?>
-		</button>
-	</div>
+	<button
+		type="button"
+		class="jetpack-search-clear-filters__button wp-element-button"
+		data-wp-on--click="actions.clearFilters"
+	>
+		<?php echo esc_html( $label ); ?>
+	</button>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
@@ -29,6 +29,13 @@ if ( '' === $label ) {
 	$label = __( 'Clear filters', 'jetpack-search-pkg' );
 }
 
+// The button below carries `wp-block-button__link` so it inherits the
+// theme's full core/button look (border-radius, hover, etc.). That class is
+// only styled when the core Button block's stylesheet is on the page —
+// without a core/button on the page, the handle isn't auto-enqueued and the
+// class is inert. Pull it in explicitly so this block stands alone.
+wp_enqueue_style( 'wp-block-button' );
+
 // Mirror `state.hasActiveFilters` on the server so the button paints
 // pre-hidden on a fresh URL — otherwise a flash of the button appears
 // before JS hydrates and applies the data-wp-bind--hidden binding.

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
@@ -1,7 +1,27 @@
 .jetpack-search-clear-filters {
-	display: flex;
-
+	// The block root is a neutral wrapper `<div>` so it inherits the active
+	// theme's block-layout alignment (a bare `<button>` root gets
+	// `wp-element-button`'s `margin:0` and breaks out of the content column —
+	// the same reason core/button wraps its button in `.wp-block-button`).
 	&[hidden] {
 		display: none;
+	}
+
+	// The button takes the theme's `wp-element-button` baseline instead of
+	// the core Button block's heavier `wp-block-button__link` styling, which
+	// renders oversized on some themes.
+	&__button {
+		cursor: pointer;
+	}
+
+	// `is-style-compact` lands on the block root (wrapper); the slim metrics
+	// target the inner button. Two-class specificity beats theme.json's
+	// single-class `.wp-element-button` rules so it wins without `!important`.
+	&.is-style-compact &__button {
+		padding: 0.25em 0.75em;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		min-width: 0;
+		width: auto;
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
@@ -7,9 +7,11 @@
 		display: none;
 	}
 
-	// The button takes the theme's `wp-element-button` baseline instead of
-	// the core Button block's heavier `wp-block-button__link` styling, which
-	// renders oversized on some themes.
+	// The button carries `wp-block-button__link` + `wp-element-button` so it
+	// inherits the theme's full core/button look (border-radius, hover) and
+	// renders pixel-identical to a regular core/button on the same theme —
+	// without the `.wp-block-button` parent wrapper that was the actual
+	// source of the oversized rendering on some themes.
 	&__button {
 		cursor: pointer;
 	}


### PR DESCRIPTION
Fixes [RSM-3507](https://linear.app/a8c/issue/RSM-3507/search-30-clear-filters-button-renders-theme-massive-add-author)

## Why

On some themes the standalone **Clear Filters** block rendered as an oversized button with no way for an author to right-size it — it was hardcoded to the core Button block's heavy `.wp-block-button` wrapper + `is-style-outline` variation. Authors can now pick a **Compact** style for a slim button, while the Default keeps the theme's regular `core/button` look (pill on TT5, rounded on TT4, etc.) — pixel-identical to a vanilla `core/button` placed on the same page.

## Proposed changes

* Drop the `.wp-block-button` wrapper and `is-style-outline` style variation — *those* were the source of the oversized rendering. Keep `wp-block-button__link` on the button so it still inherits the theme's full core/button look (border-radius, hover, etc.).
* Use a neutral `<div>` as the block root so the block follows theme block-layout alignment (a bare `<button>` root inherits `wp-element-button`'s `margin:0` and breaks out of the content column — the same reason core wraps its button in `.wp-block-button`).
* Explicitly enqueue the core Button block stylesheet (`wp_enqueue_style( 'wp-block-button' )`) from `render.php`. That stylesheet is normally only auto-enqueued when a `core/button` is on the page; without it, our `wp-block-button__link` class would be inert.
* Register two block styles — **Default** (theme's regular core/button look) and **Compact** (slim padding/font, keeps the theme's radius/colors/typography) — so authors can right-size the button without custom CSS.
* Behavior unchanged: the `label` and "Hide when no filter is active" controls, the hide-when-inactive server seeding, and the `actions.clearFilters` interactivity binding all work as before.

Note: full typography/color/border block supports were evaluated but intentionally not shipped — for a server-rendered block they don't reliably reach the inner button without the heavy core/search render-time style plumbing, and fine-grained color/border controls are over-engineering for a utility "clear" button. The Default/Compact styles plus the pre-existing spacing (margin/padding) support cover the real need.

## Screenshots

Real-screen before / after, captured at `/clear-filters-test/` via local docker (Twenty Twenty-Five) at 1440×900.

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/f422b810-8de1-4aa5-998c-380e8a1111c5) | ![after](https://github.com/user-attachments/assets/b831e177-14af-4a7d-9b55-0c967a3f516c) |

Before: both buttons forced to the core Button outline variation (oversized, no theme polish). After: themed pill **Default** that matches the theme's regular `core/button` exactly, plus a visibly slim pill **Compact** — both correctly aligned with the content column.

## Related product discussion/links

* [RSM-3507](https://linear.app/a8c/issue/RSM-3507/search-30-clear-filters-button-renders-theme-massive-add-author)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Add the **Clear Filters** block to a page (or use the `jetpack-search/clear-filters` block inside a Filters group). Set "Hide when no filter is active" off so it's always visible for testing.
* On a theme with large default buttons, confirm the block no longer renders the oversized core Button outline style.
* Confirm the **Default** style renders pixel-identical to a regular `core/button` placed on the same page (same border-radius, colors, padding, typography).
* In the block toolbar/inspector **Styles**, switch to **Compact**; confirm it renders a visibly slimmer button (smaller padding/font) while keeping the theme's border-radius, colors, and typography.
* Confirm the button stays aligned with the surrounding content column (not flush to the viewport edge).
* Try a theme that defines `styles.elements.button.border.radius` in `theme.json` (e.g. Twenty Twenty-Four = `.33rem`) and confirm both Default and Compact pick up that radius. Try a theme without it (e.g. Twenty Twenty-Five) and confirm both pick up core's default (pill / `9999px`) so the button still looks like a regular `core/button` on that theme.
* Confirm unchanged behavior: the **Label** field and **Hide when no filter is active** toggle still work; with a filter active the button appears and clicking it clears all active filters and the price range.
