### PR TITLE
Search Blocks: externalize shared store as a Script Module (~9.3 MB → 119 KB build)

### DIFF
--- a/projects/packages/search/.size-limit.js
+++ b/projects/packages/search/.size-limit.js
@@ -7,4 +7,16 @@ module.exports = [
 		path: 'build/instant-search/jp-search.chunk-main-payload.js',
 		limit: '50 KiB',
 	},
+	// The shared search-blocks store ships once as the `jetpack-search/store`
+	// Script Module. `results-list.js` is a pure store importer — if the
+	// externalization regresses and the store gets inlined again, it balloons
+	// from ~1 KB back past 40 KB and trips this limit.
+	{
+		path: 'build/search-blocks/store/index.js',
+		limit: '60 KiB',
+	},
+	{
+		path: 'build/search-blocks/results-list.js',
+		limit: '3 KiB',
+	},
 ];

--- a/projects/packages/search/changelog/search-204-externalize-blocks-store
+++ b/projects/packages/search/changelog/search-204-externalize-blocks-store
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Search blocks no longer inline a full copy of the shared store into every block's view script. The store ships once as the `jetpack-search/store` WordPress Script Module, cutting the search-blocks JS payload from ~14 duplicated bundles to one shared module.

--- a/projects/packages/search/eslint.config.mjs
+++ b/projects/packages/search/eslint.config.mjs
@@ -4,4 +4,10 @@ export default defineConfig( makeBaseConfig( import.meta.url ), {
 	rules: {
 		'react/jsx-no-bind': 'off',
 	},
+	settings: {
+		// `jetpack-search/store` is a WordPress Script Module the blocks build
+		// externalizes (see tools/webpack.blocks.config.js); it has no resolvable
+		// path on disk, so treat it as an external module for import/no-unresolved.
+		'import/core-modules': [ 'jetpack-search/store' ],
+	},
 } );

--- a/projects/packages/search/jest.config.js
+++ b/projects/packages/search/jest.config.js
@@ -20,6 +20,10 @@ module.exports = {
 	},
 	moduleNameMapper: {
 		...baseConfig.moduleNameMapper,
+		// The blocks build externalizes this bare specifier to the
+		// `jetpack-search/store` Script Module; Jest has no such resolver,
+		// so point it at the real store source.
+		'^jetpack-search/store$': '<rootDir>/src/search-blocks/store/index.js',
 		'tiny-lru/lib/tiny-lru.esm$': '<rootDir>/src/instant-search/lib/test-helpers/tiny-lru.mock.js',
 		'instant-search/components/gridicon':
 			'<rootDir>/src/instant-search/components/gridicon/index.jsx',

--- a/projects/packages/search/jest.url-tests.config.js
+++ b/projects/packages/search/jest.url-tests.config.js
@@ -18,6 +18,10 @@ module.exports = {
 	},
 	moduleNameMapper: {
 		...baseConfig.moduleNameMapper,
+		// The blocks build externalizes this bare specifier to the
+		// `jetpack-search/store` Script Module; Jest has no such resolver,
+		// so point it at the real store source.
+		'^jetpack-search/store$': '<rootDir>/src/search-blocks/store/index.js',
 		'tiny-lru/lib/tiny-lru.esm$': '<rootDir>/src/instant-search/lib/test-helpers/tiny-lru.mock.js',
 		'instant-search/components/gridicon':
 			'<rootDir>/src/instant-search/components/gridicon/index.jsx',

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -31,7 +31,7 @@
 		"test": "concurrently 'pnpm:test-scripts' 'pnpm:test-url-tests' 'pnpm:test-size'",
 		"test-coverage": "pnpm:test-scripts --coverage && pnpm:test-url-tests --coverage",
 		"test-scripts": "jest --passWithNoTests",
-		"test-size": "NODE_ENV=production BABEL_ENV=production pnpm run build-instant && size-limit",
+		"test-size": "NODE_ENV=production BABEL_ENV=production pnpm run build-instant && NODE_ENV=production BABEL_ENV=production pnpm run build-blocks && size-limit",
 		"test-url-tests": "jest --config=jest.url-tests.config.js --passWithNoTests",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "concurrently 'pnpm:build-instant --watch' 'pnpm:build-customberg --watch' 'pnpm:build-dashboard --watch' 'pnpm:build-inline --watch' 'pnpm:build-blocks --watch' 'pnpm:build-blocks-editor --watch'"

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -15,6 +15,29 @@ Current slug shapes — match one if it fits, but new shapes are fine when nothi
 
 Titles aim to read naturally in the inserter, not mirror the slug shape — "Sort By" not "Results Sort", "Collapsible Filters" not "Filters Popover".
 
+## Shared store / bundles
+
+`store/` is a single shared module, not per-block code. A block `view.js` that
+needs store actions/state imports the bare specifier:
+
+```js
+import 'jetpack-search/store';
+```
+
+**Never** `import '../../store'` (relative) — that inlines the whole ~1,250-line
+store into the block's view bundle, and with ~14 interactive blocks that's the
+store shipped ~14 times. The blocks build (`tools/webpack.blocks.config.js`)
+externalizes `jetpack-search/store` via `DependencyExtractionPlugin`'s
+`requestToExternalModule`, so the bare specifier compiles to a dependency on the
+`jetpack-search/store` WordPress Script Module (registered in
+`Search_Blocks::register_store_script_module()`), shipped once and cached.
+
+The same specifier is mapped back to `store/index.js` for Jest
+(`jest*.config.js` `moduleNameMapper`) and for `import/no-unresolved`
+(`eslint.config.mjs` `import/core-modules`). A pure store importer compiles to
+~1 KB; `.size-limit.js` guards `results-list.js` so a regression that re-inlines
+the store trips CI.
+
 ## CSS classes
 
 WordPress derives `.wp-block-jetpack-search-{bare-slug}` from the full block name. For blocks whose bare slug already starts with `search-` the segment repeats (`.wp-block-jetpack-search-search-input`); that's harmless and only used internally.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
@@ -1,5 +1,5 @@
 import { store, getContext } from '@wordpress/interactivity';
-import '../../store';
+import 'jetpack-search/store';
 import { buildActivePills } from './lib';
 import './style.scss';
 

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/view.js
@@ -4,5 +4,5 @@
 // picks up the shared module so `data-wp-on--click` and `data-wp-bind--hidden`
 // resolve when the block is hydrated in isolation (e.g. dropped onto a
 // page outside the parent wrapper).
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/view.js
@@ -1,5 +1,5 @@
 // Runtime behavior lives on the shared store in `store/index.js`. Per-block
 // re-registration would clobber sibling filter blocks (Interactivity API
 // merges later `store()` patches).
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/view.js
@@ -1,4 +1,4 @@
 // Runtime behavior lives on the shared store in `store/index.js`,
 // type-dispatching on `filterConfigs[filterKey].filterType === 'date'`.
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/view.js
@@ -3,5 +3,5 @@
 // `state.hasFilterBuckets` / `actions.onFilterChange` bindings. This file
 // exists so the block has its own webpack entry (and its own style.scss
 // hook); all behavior lives in `../../store`.
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/view.js
@@ -1,5 +1,5 @@
 import { store, getElement } from '@wordpress/interactivity';
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
@@ -1,5 +1,5 @@
 import { store, getContext } from '@wordpress/interactivity';
-import '../../store';
+import 'jetpack-search/store';
 import { bucketsToStarCountMap } from './bucket-projection';
 import './style.scss';
 

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
@@ -1,5 +1,5 @@
 import { store, getContext, getElement } from '@wordpress/interactivity';
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/view.js
@@ -1,2 +1,2 @@
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/results-count/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/view.js
@@ -1,4 +1,4 @@
 // Display-only block. View module pulls in the style + shared store so
 // state.resultsCountText is defined and updates re-render the node.
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/results-list/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/view.js
@@ -1,4 +1,4 @@
 // Intentionally empty: this block is fully declarative.
 // Importing the store registers the shared actions/state on pages with this block.
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/view.js
@@ -1,3 +1,3 @@
 // loadMore action is defined in store/index.js. Import the store + styles.
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/view.js
@@ -1,5 +1,5 @@
 import { store, getContext, getElement } from '@wordpress/interactivity';
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -1,5 +1,5 @@
 import { store } from '@wordpress/interactivity';
-import '../../store';
+import 'jetpack-search/store';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -562,6 +562,8 @@ class Search_Blocks {
 			);
 		}
 
+		self::register_store_script_module();
+
 		$blocks_dir = __DIR__ . '/blocks';
 		$block_dirs = glob( $blocks_dir . '/*', GLOB_ONLYDIR );
 
@@ -582,6 +584,35 @@ class Search_Blocks {
 
 		add_filter( 'get_block_type_variations', array( static::class, 'inject_filter_checkbox_variations' ), 10, 2 );
 		static::register_patterns();
+	}
+
+	/**
+	 * Register the shared store as the `jetpack-search/store` Script Module.
+	 *
+	 * Every interactive block's `view.js` imports this bare specifier instead
+	 * of inlining the ~1,250-line store; the build externalizes it (see
+	 * `tools/webpack.blocks.config.js`) and writes the dependency into each
+	 * block's generated `.asset.php`, so WordPress resolves it to this single
+	 * module and ships the store once instead of ~14 duplicated copies.
+	 */
+	public static function register_store_script_module() {
+		if ( ! function_exists( 'wp_register_script_module' ) ) {
+			return;
+		}
+
+		$base_path  = Package::get_installed_path() . 'build/search-blocks/store/';
+		$asset_file = $base_path . 'index.asset.php';
+		if ( ! file_exists( $asset_file ) ) {
+			return;
+		}
+		$asset = require $asset_file;
+
+		wp_register_script_module(
+			'jetpack-search/store',
+			plugins_url( 'index.js', $base_path . 'index.js' ),
+			$asset['dependencies'] ?? array(),
+			$asset['version'] ?? false
+		);
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -600,7 +600,12 @@ class Search_Blocks_Test extends TestCase {
 	private function registered_script_modules(): array {
 		$modules  = wp_script_modules();
 		$property = new \ReflectionProperty( $modules, 'registered' );
-		$property->setAccessible( true );
+		// PHP 7.2–8.0 require setAccessible(true) to read a private prop via
+		// Reflection; 8.1 made it a no-op and 8.5 deprecates the call. Gate
+		// on the version so the package's PHP 7.2–8.5 matrix stays green.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		return $property->getValue( $modules );
 	}
 
@@ -614,7 +619,9 @@ class Search_Blocks_Test extends TestCase {
 	private function unregister_script_module( string $id ): void {
 		$modules  = wp_script_modules();
 		$property = new \ReflectionProperty( $modules, 'registered' );
-		$property->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$registered = $property->getValue( $modules );
 		unset( $registered[ $id ] );
 		$property->setValue( $modules, $registered );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -593,6 +593,135 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Read the private `registered` map off the WP_Script_Modules singleton.
+	 *
+	 * @return array<string,array> Registered script modules keyed by id.
+	 */
+	private function registered_script_modules(): array {
+		$modules  = wp_script_modules();
+		$property = new \ReflectionProperty( $modules, 'registered' );
+		$property->setAccessible( true );
+		return $property->getValue( $modules );
+	}
+
+	/**
+	 * Drop a script module from the WP_Script_Modules singleton. The class
+	 * exposes no public unregister, and the registry persists for the whole
+	 * PHPUnit process, so reach into the private map to keep tests isolated.
+	 *
+	 * @param string $id Script module id.
+	 */
+	private function unregister_script_module( string $id ): void {
+		$modules  = wp_script_modules();
+		$property = new \ReflectionProperty( $modules, 'registered' );
+		$property->setAccessible( true );
+		$registered = $property->getValue( $modules );
+		unset( $registered[ $id ] );
+		$property->setValue( $modules, $registered );
+	}
+
+	/**
+	 * Place a fixture `store/index.asset.php` at the path
+	 * `register_store_script_module()` reads, without clobbering a real
+	 * build. Returns a cleanup callback that restores the prior state
+	 * (original contents, or removal of anything this created).
+	 *
+	 * @param array $asset Asset array to write.
+	 * @return callable Cleanup callback.
+	 */
+	private function stub_store_asset_file( array $asset ): callable {
+		$dir  = Package::get_installed_path() . 'build/search-blocks/store';
+		$file = $dir . '/index.asset.php';
+
+		$created_dirs = array();
+		foreach ( array( Package::get_installed_path() . 'build', Package::get_installed_path() . 'build/search-blocks', $dir ) as $d ) {
+			if ( ! is_dir( $d ) ) {
+				mkdir( $d );
+				$created_dirs[] = $d;
+			}
+		}
+
+		$had_file = file_exists( $file );
+		$original = $had_file ? file_get_contents( $file ) : null;
+		$export   = var_export( $asset, true );
+		file_put_contents( $file, "<?php return $export;\n" );
+
+		return static function () use ( $file, $had_file, $original, $created_dirs ) {
+			if ( $had_file ) {
+				file_put_contents( $file, $original );
+			} elseif ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+			foreach ( array_reverse( $created_dirs ) as $d ) {
+				// Only directories this fixture created, and only while
+				// empty — scandir() returns just '.' and '..' for an empty
+				// dir, so guard on that instead of silencing rmdir().
+				if ( is_dir( $d ) && 2 === count( scandir( $d ) ) ) {
+					rmdir( $d );
+				}
+			}
+		};
+	}
+
+	/**
+	 * The shared store must register as the `jetpack-search/store` Script
+	 * Module, sourced from the built `store/index.js` with the deps/version
+	 * declared in its generated asset file — that's what lets WordPress
+	 * resolve the dependency each block's view module declares instead of
+	 * shipping the store inlined per block.
+	 */
+	public function test_register_store_script_module_registers_shared_module() {
+		$cleanup = $this->stub_store_asset_file(
+			array(
+				'dependencies' => array( '@wordpress/interactivity' ),
+				'version'      => 'test-store-version',
+			)
+		);
+
+		try {
+			Search_Blocks::register_store_script_module();
+
+			$registered = $this->registered_script_modules();
+			$this->assertArrayHasKey( 'jetpack-search/store', $registered, 'Shared store must be registered as a script module.' );
+
+			$module = $registered['jetpack-search/store'];
+			$this->assertStringContainsString( 'build/search-blocks/store/index.js', $module['src'] );
+			$this->assertSame( 'test-store-version', $module['version'] );
+			$this->assertContains(
+				'@wordpress/interactivity',
+				array_column( $module['dependencies'], 'id' ),
+				'Store module must carry the dependencies from its asset file.'
+			);
+		} finally {
+			$this->unregister_script_module( 'jetpack-search/store' );
+			$cleanup();
+		}
+	}
+
+	/**
+	 * No build present (the common case in a fresh checkout / CI unit job):
+	 * the method must bail without registering anything or erroring, so
+	 * block registration is unaffected.
+	 */
+	public function test_register_store_script_module_noop_without_asset_file() {
+		$base = Package::get_installed_path() . 'build/search-blocks/store/index.asset.php';
+		if ( file_exists( $base ) ) {
+			$this->markTestSkipped( 'A real build asset file is present; the missing-file path cannot be exercised here.' );
+		}
+
+		// A prior test may have registered it in the process-wide singleton.
+		$this->unregister_script_module( 'jetpack-search/store' );
+
+		Search_Blocks::register_store_script_module();
+
+		$this->assertArrayNotHasKey(
+			'jetpack-search/store',
+			$this->registered_script_modules(),
+			'Without an asset file the store module must not be registered.'
+		);
+	}
+
+	/**
 	 * Off the Embedded experience, the template-override hooks
 	 * (`register_search_template` / `prepend_search_template`) must NOT be
 	 * registered — `/?s=…` should resolve to the theme's `search.html`, not

--- a/projects/packages/search/tools/webpack.blocks.config.js
+++ b/projects/packages/search/tools/webpack.blocks.config.js
@@ -98,14 +98,18 @@ module.exports = {
 		...jetpackWebpackConfig.StandardPlugins( {
 			DependencyExtractionPlugin: {
 				injectPolyfill: false,
-				// Keep the shared store out of every view bundle: emit a bare
-				// `import 'jetpack-search/store'` and let WordPress resolve it
-				// to the registered Script Module. Returning undefined for
-				// everything else preserves the default `@wordpress/*`
-				// externalization (useDefaults stays on).
+				// Keep the shared store out of every view bundle: emit a
+				// static `import 'jetpack-search/store'` and let WordPress
+				// resolve it to the registered Script Module. The `module `
+				// prefix forces webpack's ESM external type for this request
+				// (DEWP otherwise defaults externals to `import`, which turns
+				// a binding-less side-effect import into an async `import()`
+				// and a forbidden top-level await — `validate-es` rejects it).
+				// Returning undefined for everything else preserves the
+				// default `@wordpress/*` externalization (useDefaults stays on).
 				requestToExternalModule( request ) {
 					if ( request === STORE_MODULE_ID ) {
-						return STORE_MODULE_ID;
+						return `module ${ STORE_MODULE_ID }`;
 					}
 				},
 			},

--- a/projects/packages/search/tools/webpack.blocks.config.js
+++ b/projects/packages/search/tools/webpack.blocks.config.js
@@ -27,7 +27,12 @@ function readBlockViewEntries() {
 
 const blockViewEntries = readBlockViewEntries();
 
-// Also include the shared store module so it can be imported by view.js files.
+// The shared store is emitted as its own ESM bundle and registered as the
+// `jetpack-search/store` WordPress Script Module. Every block `view.js`
+// imports that bare specifier; DependencyExtractionPlugin externalizes it
+// (see `requestToExternalModule` below) so the store ships once instead of
+// being inlined into all ~14 view bundles.
+const STORE_MODULE_ID = 'jetpack-search/store';
 const storeIndexPath = path.join( __dirname, '../src/search-blocks/store/index.js' );
 const storeEntries = fs.existsSync( storeIndexPath ) ? { 'store/index': storeIndexPath } : {};
 
@@ -55,6 +60,14 @@ module.exports = {
 	},
 	resolve: {
 		...jetpackWebpackConfig.resolve,
+		alias: {
+			...jetpackWebpackConfig.resolve.alias,
+			// Lets the `store/index` entry (and Jest, via moduleNameMapper)
+			// resolve the same bare specifier the view bundles import.
+			// In the view bundles DependencyExtractionPlugin intercepts it
+			// first and externalizes it, so this alias never inlines it there.
+			[ STORE_MODULE_ID ]: storeIndexPath,
+		},
 		modules: [
 			path.resolve( __dirname, '../src/search-blocks' ),
 			'node_modules',
@@ -83,7 +96,19 @@ module.exports = {
 	},
 	plugins: [
 		...jetpackWebpackConfig.StandardPlugins( {
-			DependencyExtractionPlugin: { injectPolyfill: false },
+			DependencyExtractionPlugin: {
+				injectPolyfill: false,
+				// Keep the shared store out of every view bundle: emit a bare
+				// `import 'jetpack-search/store'` and let WordPress resolve it
+				// to the registered Script Module. Returning undefined for
+				// everything else preserves the default `@wordpress/*`
+				// externalization (useDefaults stays on).
+				requestToExternalModule( request ) {
+					if ( request === STORE_MODULE_ID ) {
+						return STORE_MODULE_ID;
+					}
+				},
+			},
 			// I18nLoaderPlugin tries to inject @wordpress/jp-i18n-loader as an
 			// import, which isn't supported by the DependencyExtractionPlugin
 			// in ESM/module output mode. Disable for this build.


### PR DESCRIPTION
Fixes SEARCH-204

## Proposed changes

The Search blocks build (`tools/webpack.blocks.config.js`) compiles one ESM `view.js` bundle per block. 14 of the ~17 blocks did `import '../../store'` to register the shared Interactivity store (`src/search-blocks/store/`, ~1,250 LOC + `api.js`/`url-state.js`/`result-utils.js`). Each `view.js` is a **separate webpack entry with no code-splitting and no externalization**, so the entire shared store was **inlined into every block bundle** — with ~14 interactive blocks the store shipped ~14 times.

This registers the store once as the **`jetpack-search/store` WordPress Script Module** and externalizes it from the per-block bundles, the canonical WP-native pattern (Script Modules API + `@wordpress/dependency-extraction-webpack-plugin`):

* `tools/webpack.blocks.config.js` — `DependencyExtractionPlugin.requestToExternalModule()` externalizes `jetpack-search/store`; `resolve.alias` lets the store entry / tooling resolve the bare specifier; the `store/index` entry still emits the shared module.
* 14 `blocks/*/view.js` — `import '../../store'` → `import 'jetpack-search/store'`.
* `class-search-blocks.php` — `Search_Blocks::register_store_script_module()` calls `wp_register_script_module( 'jetpack-search/store', … )`, reading deps/version from the generated `build/search-blocks/store/index.asset.php`. DEWP writes `jetpack-search/store` into each block's `.asset.php`, so WP core resolves the dependency to this single module automatically — no per-`block.json` edits.
* `jest.config.js` / `jest.url-tests.config.js` — `moduleNameMapper` maps the bare specifier back to the store source.
* `eslint.config.mjs` — `import/core-modules` so `import/no-unresolved` accepts the externalized specifier.
* `.size-limit.js` + `test-size` — guards the shared store (≤60 KiB) and `results-list.js` (≤3 KiB); a regression that re-inlines the store trips CI.
* `src/search-blocks/AGENTS.md` — documents the shared-store contract for future block authors.

### Impact (production build)

| | Before | After |
|---|---|---|
| Shipped search-blocks JS | ~14 × ~305 KB duplicated | one shared store + tiny view stubs |
| Total `.js` emitted | ~9.3 MB | **119 KB** (store 46 KB / **14.6 KB brotli**) |
| Pure store-importer view (e.g. `results-list.js`) | ~305 KB | **~1.2 KB / 621 B brotli** |

Requires WP 6.5+ Script Modules / DEWP v5+ — Jetpack already requires WP 6.8+.

Researched and rejected: Interactivity-namespace auto-merge (dedupes only IA *state*, not the shared JS helpers — webpack still inlines per entry); webpack `splitChunks`/`runtimeChunk` under `outputModule` (extra chunks aren't auto-enqueued by the Script Modules API and fail to load — WP core recommends register-once + externalize).

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-204

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/search && pnpm run test-size` — builds instant-search + blocks and runs size-limit; the new `build/search-blocks/store/index.js` and `build/search-blocks/results-list.js` limits pass.
* `pnpm run test-scripts && pnpm run test-url-tests` — 1409 JS tests pass.
* Verify the externalization: after a blocks build, `build/search-blocks/results-list.asset.php` should read `'dependencies' => array('jetpack-search/store')` and `results-list.js` should be ~1 KB (the store is no longer inlined).
* Runtime smoke test: on a site running the Embedded search experience with block-built search (e.g. a page containing the Results List + a filter block), confirm the page enqueues the `jetpack-search/store` module once, filtering/sort/load-more still work, and there are no console errors. The shared store now loads as a single `<script type="module">` referenced by every search block's view module.
