### PR TITLE
Search: add "Additional settings" heading above the search-blocks feature toggles

### DIFF
--- a/projects/packages/search/changelog/SEARCH-203-additional-settings-heading
+++ b/projects/packages/search/changelog/SEARCH-203-additional-settings-heading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Dashboard: add an "Additional settings" heading above the feature toggles in the search-blocks settings view. The heading only renders when at least one of those settings is available, so it never appears orphaned.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -160,7 +160,8 @@ export default function DashboardPage( { isLoading = false } ) {
 	const hasAdditionalSettings =
 		isReaderChatAvailable ||
 		isAIAgentAccessAvailable ||
-		( supportsInstantSearch && isInstantSearchEnabled );
+		( supportsInstantSearch && isInstantSearchEnabled ) ||
+		showWooCommerceProductSearchControl;
 
 	// Record Meter data
 	const tierMaximumRecords = useSelect( select => select( STORE_ID ).getTierMaximumRecords() );

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -272,7 +272,10 @@ export default function DashboardPage( { isLoading = false } ) {
 												<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 													<ExperienceSelector />
 													{ hasAdditionalSettings && (
-														<h2 className="jp-search-additional-settings__heading">
+														<h2
+															id="jp-search-additional-settings-heading"
+															className="jp-search-additional-settings__heading"
+														>
 															{ __( 'Additional settings', 'jetpack-search-pkg' ) }
 														</h2>
 													) }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -157,6 +157,10 @@ export default function DashboardPage( { isLoading = false } ) {
 		! isReaderChatAvailable ||
 		! isReaderChatEnabled ||
 		readerChatGuidelinesUrl !== aiAgentAccessGuidelinesUrl;
+	const hasAdditionalSettings =
+		isReaderChatAvailable ||
+		isAIAgentAccessAvailable ||
+		( supportsInstantSearch && isInstantSearchEnabled );
 
 	// Record Meter data
 	const tierMaximumRecords = useSelect( select => select( STORE_ID ).getTierMaximumRecords() );
@@ -267,6 +271,11 @@ export default function DashboardPage( { isLoading = false } ) {
 											<div className="jp-search-dashboard-row">
 												<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 													<ExperienceSelector />
+													{ hasAdditionalSettings && (
+														<h2 className="jp-search-additional-settings__heading">
+															{ __( 'Additional settings', 'jetpack-search-pkg' ) }
+														</h2>
+													) }
 													{ isReaderChatAvailable && (
 														<div className="jp-search-settings-card">
 															<ReaderChatControl

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -120,6 +120,12 @@ body.jetpack_page_jetpack-search .jp-search-dashboard-page {
 	}
 }
 
+.jp-search-additional-settings__heading {
+	margin: var(--wpds-dimension-padding-3xl) 0 0;
+	font-size: var(--wpds-typography-font-size-xl);
+	line-height: var(--wpds-typography-line-height-md);
+}
+
 .jp-search-settings-card,
 .jp-search-ai-agent-access-card {
 	box-sizing: border-box;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-203

## Why
On the Jetpack Search **Settings** tab (search-blocks UI), the experience selector was followed immediately by a stack of unrelated opt-in feature toggles — Reader Chat, AI Agent Access, Search Suggestions — with nothing introducing them. They read as a loose continuation of the experience selector. This adds an "Additional settings" heading so the toggle group is a clearly labelled section that parallels the experience-selector heading above it.

## Proposed changes
* Add an `<h2>` "Additional settings" between `<ExperienceSelector />` and the first settings card in the search-blocks settings view.
* Gate the heading on `hasAdditionalSettings` (any of Reader Chat available, AI Agent Access available, or Instant Search enabled) so it never renders orphaned when none of the toggles are present.
* Style the heading to mirror the existing `.jp-search-experience-selector__heading` (font size, line height) with a `3xl` top margin for separation.
* String is translatable under the `jetpack-search-pkg` text domain.

## Screenshots
| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/90b87614-201a-443a-8237-5b893b507fab) | ![after](https://github.com/user-attachments/assets/6ad23d3d-8022-415e-b34a-b8fb802f4f9f) |

## Related product discussion/links
* https://linear.app/a8c/issue/SEARCH-203

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Prerequisite: a site with the search-blocks experience UI enabled (the `jetpack_search_blocks_enabled` filter returns true) and the Search module active. Go to **Jetpack → Search → Settings**.

* [ ] "Additional settings" `<h2>` renders directly below the experience selector and above the Reader Chat / AI Agent Access / Search Suggestions toggles, only in the search-blocks experience UI.
* [ ] Heading typography/spacing matches the existing experience-selector heading.
* [ ] String is translatable under the `jetpack-search-pkg` text domain.
* [ ] Before/after screenshots attached to the PR.
* [ ] Edge case: when none of those settings are available (e.g. Embedded experience, no Reader Chat / AI Agent Access, Instant Search off), the heading does not render — no orphaned section header.
