### PR TITLE
Refine post-publish podcast promo modal

### DIFF
--- a/projects/packages/podcast/changelog/refine-post-publish-podcast-promo-modal
+++ b/projects/packages/podcast/changelog/refine-post-publish-podcast-promo-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post-publish podcast promo: Refine modal text and layout styles.

--- a/projects/packages/podcast/src/editor/post-publish-podcast-promo/index.tsx
+++ b/projects/packages/podcast/src/editor/post-publish-podcast-promo/index.tsx
@@ -5,7 +5,9 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
+import { Stack, Text } from '@wordpress/ui';
 
 import './style.scss';
 
@@ -101,13 +103,14 @@ const PostPublishPodcastPromo = () => {
 		return null;
 	}
 
+	const title = __( 'Your post is live. Ready for the podcast version?', 'jetpack-podcast' );
+
 	return (
 		<Modal
 			className="jetpack-post-publish-podcast-promo-modal"
-			title=""
-			aria={ {
-				labelledby: 'jetpack-post-publish-podcast-promo-modal-title',
-			} }
+			size="small"
+			contentLabel={ title }
+			isDismissible={ false }
 			onRequestClose={ handleRequestClose }
 		>
 			<div className="jetpack-post-publish-podcast-promo-modal__hero">
@@ -159,21 +162,26 @@ const PostPublishPodcastPromo = () => {
 						/>
 					</svg>
 				</div>
+				<Button
+					className="jetpack-post-publish-podcast-promo-modal__close"
+					icon={ close }
+					label={ __( 'Close', 'jetpack-podcast' ) }
+					onClick={ handleRequestClose }
+				/>
 			</div>
-			<div className="jetpack-post-publish-podcast-promo-modal__body">
-				<h1
-					id="jetpack-post-publish-podcast-promo-modal-title"
-					className="jetpack-post-publish-podcast-promo-modal__title"
-				>
-					{ __( 'Your post is live. Ready for the podcast version?', 'jetpack-podcast' ) }
-				</h1>
-				<p className="jetpack-post-publish-podcast-promo-modal__description">
-					{ __(
-						'Give your audience another way to enjoy your content. Pick a date range or a few posts, and we’ll turn them into a two-host podcast episode.',
-						'jetpack-podcast'
-					) }
-				</p>
-				<div className="jetpack-post-publish-podcast-promo-modal__actions">
+			<Stack className="jetpack-post-publish-podcast-promo-modal__body" direction="column" gap="lg">
+				<Stack direction="column" gap="sm">
+					<Text className="jetpack-post-publish-podcast-promo-modal__title" render={ <h1 /> }>
+						{ title }
+					</Text>
+					<Text className="jetpack-post-publish-podcast-promo-modal__description" render={ <p /> }>
+						{ __(
+							'Give your audience another way to enjoy your content. Pick a date range or a few posts, and we’ll turn them into a two-host podcast episode.',
+							'jetpack-podcast'
+						) }
+					</Text>
+				</Stack>
+				<div>
 					<Button
 						className="jetpack-post-publish-podcast-promo-modal__primary-action"
 						variant="primary"
@@ -182,7 +190,7 @@ const PostPublishPodcastPromo = () => {
 						{ __( 'Create podcast episode', 'jetpack-podcast' ) }
 					</Button>
 				</div>
-			</div>
+			</Stack>
 		</Modal>
 	);
 };

--- a/projects/packages/podcast/src/editor/post-publish-podcast-promo/style.scss
+++ b/projects/packages/podcast/src/editor/post-publish-podcast-promo/style.scss
@@ -1,35 +1,13 @@
 .jetpack-post-publish-podcast-promo-modal {
-	max-width: 409px;
-	border-radius: 8px;
 	overflow: hidden;
 
 	.components-modal__header {
-		position: absolute;
-		z-index: 1;
-		inset-inline-start: 0;
-		inset-inline-end: 0;
-		height: auto;
-		margin: 0;
-		padding: 8px;
-		border-bottom: 0;
-		background-color: transparent;
-
-		button {
-			inset-inline-start: unset;
-
-			svg {
-				fill: #fff;
-			}
-		}
+		display: none;
 	}
 
 	.components-modal__content {
-		padding: 0;
 		margin-block-start: 0;
-
-		&::before {
-			margin: 0;
-		}
+		padding-block-start: 24px;
 	}
 }
 
@@ -38,6 +16,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	margin: -24px -24px 0;
 	padding: 44px 32px 36px;
 	background:
 		radial-gradient(circle at 0% 0%, rgba(255, 255, 255, 0.2), transparent 55%),
@@ -100,47 +79,50 @@
 	backdrop-filter: blur(4px);
 }
 
+.jetpack-post-publish-podcast-promo-modal__close.components-button {
+	position: absolute;
+	z-index: 3;
+	inset-block-start: 8px;
+	inset-inline-end: 8px;
+	color: #fff;
+
+	&:hover,
+	&:focus {
+		color: #fff;
+	}
+}
+
 .jetpack-post-publish-podcast-promo-modal__body {
-	padding: 24px 32px 32px;
+	padding: 24px 8px 8px;
 }
 
 .jetpack-post-publish-podcast-promo-modal__title {
 	margin: 0;
-	color: #1e1e1e;
+	font-family:
+		-apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		Roboto,
+		Oxygen-Sans,
+		Ubuntu,
+		Cantarell,
+		"Helvetica Neue",
+		sans-serif;
 	font-size: 20px;
 	font-weight: 600;
 	line-height: 1.3;
+	color: #1e1e1e;
+	text-transform: none;
 }
 
 .jetpack-post-publish-podcast-promo-modal__description {
-	color: #1e1e1e;
-	font-size: 13px;
+	margin: 0;
+	font-size: 16px;
 	line-height: 1.6;
-	margin: 12px 0 0;
-}
-
-.jetpack-post-publish-podcast-promo-modal__actions {
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-	gap: 12px;
-	margin-block-start: 24px;
+	color: #1e1e1e;
 }
 
 .jetpack-post-publish-podcast-promo-modal__primary-action.components-button {
+	width: 100%;
 	justify-content: center;
-	height: auto;
-	padding: 12px 24px;
-	border-radius: 4px;
-	background-color: #3858e9;
-	font-size: 14px;
-	font-weight: 500;
-
-	&:hover {
-		background-color: #2c48c7;
-	}
-
-	&:focus {
-		box-shadow: 0 0 0 2px #3858e9;
-	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Refine the Posts to Podcast post-publish promo modal to use WordPress `Text` and `VStack` component primitives for its copy/layout.
* Remove redundant custom typography and action layout styles while preserving the custom hero artwork.
* Keep the visible modal heading as the accessible label without passing an empty modal title.

## Related product discussion/links
* Follow-up to #48902.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Apply these changes to your WP.com site
* If your site doesn't meet the eligibility criteria for the modal to be visible (5 posts published in the last month, 50 visitors in the last week), modify the criteria with these filters:

```
add_filter( 'jetpack_posts_to_podcast_post_publish_promo_min_published_posts', function () {
	return 1;
} );

add_filter( 'jetpack_posts_to_podcast_post_publish_promo_min_visitors', function () {
	return 1;
} );
```

* Go to Posts > Add New
* Publish the post
* Confirm the Posts to Podcast promo modal appears.
* Confirm the modal body text is readable at normal paragraph size.
* Confirm the primary action spans the modal body width and opens `/wp-admin/upload.php?page=create-ai-podcast`.
