### PR TITLE
Connection: show JP logo at users list

### DIFF
--- a/projects/packages/connection/changelog/add-users-list-connected-jetpack-logo
+++ b/projects/packages/connection/changelog/add-users-list-connected-jetpack-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: Show the Jetpack icon beside the Connected label in the WordPress.com account column on the Users screen.

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -75,9 +75,12 @@ class Users_Connection_Admin {
 		}
 
 		if ( ( new Manager() )->is_user_connected( $user_id ) ) {
+			$logo_url = plugins_url( 'connectors/images/jetpack-icon.svg', __FILE__ );
+
 			return sprintf(
-				'<span title="%1$s" class="jetpack-connection-status">%2$s</span>',
+				'<span title="%1$s" class="jetpack-connection-status"><img src="%2$s" alt="" class="jetpack-connection-status__logo" width="16" height="16" decoding="async" loading="lazy" />%3$s</span>',
 				esc_attr__( 'This user has connected their WordPress.com account.', 'jetpack-connection' ),
+				esc_url( $logo_url ),
 				esc_html__( 'Connected', 'jetpack-connection' )
 			);
 		}
@@ -154,6 +157,15 @@ class Users_Connection_Admin {
 			}
 			.column-user_jetpack {
 				width: 140px;
+			}
+			.jetpack-connection-status {
+				display: inline-flex;
+				align-items: center;
+				column-gap: 6px;
+			}
+			.jetpack-connection-status__logo {
+				flex-shrink: 0;
+				display: block;
 			}
 			/* Show tooltip on hover and focus */
 			.jetpack-connection-tooltip-icon:hover .jetpack-connection-tooltip,


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Show the Jetpack icon beside the Connected label in the WordPress.com account column on the Users screen. Just adds a bit of clarity what/which plugin connection we're talking about here.

#### Before

<img width="1448" height="704" alt="Screenshot 2026-05-19 at 11 57 03" src="https://github.com/user-attachments/assets/beec7f62-d4b6-493d-a2c8-63cca3d7d14c" />


#### After
<img width="1392" height="707" alt="Screenshot 2026-05-19 at 12 19 52" src="https://github.com/user-attachments/assets/ed250ee6-f28c-496e-bcfc-372a01c6ddff" />

Tooltips just for reference (no changes in this PR):

<img width="358" height="173" alt="image" src="https://github.com/user-attachments/assets/974d8b1a-ef22-44a5-8a63-fcd17f97b248" />
<img width="383" height="183" alt="image" src="https://github.com/user-attachments/assets/cc7716df-5ae7-4cc5-af6f-07ce727a4941" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to 'Users'
* See Jetpack connecter user now with logo
