### PR TITLE
ADS-1117: Use saved payment eligibility for chat submit

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1117-payment-eligibility
+++ b/projects/packages/blaze/changelog/add-ads-1117-payment-eligibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Prepare campaign: Add saved payment eligibility for chat-native submit.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -464,6 +464,10 @@ class Blaze_Abilities extends Registrar {
 							'type'        => 'string',
 							'description' => __( 'Optional MIME type for main_image_url. Defaults to image/jpeg when omitted.', 'jetpack-blaze' ),
 						),
+						'payment_method_id'    => array(
+							'type'        => 'string',
+							'description' => __( 'Optional existing saved payment method ID to use for chat-native submit. Omit to let Blaze choose the default saved payment method. This does not add a new payment method.', 'jetpack-blaze' ),
+						),
 						'languages'            => array(
 							'type'        => 'array',
 							'description' => __( 'Optional ISO 639-1 language codes supported by Blaze/DSP (e.g. ["en", "es"]). Infer from the user\'s natural language request when clear, but omit when unsure or unsupported. Defaults to all languages when omitted; the merchant can adjust language targeting in the Blaze review UI.', 'jetpack-blaze' ),
@@ -624,7 +628,7 @@ class Blaze_Abilities extends Registrar {
 						'submit_eligibility' => array(
 							'type'        => 'object',
 							'description' => __( 'Hints that tell chat clients whether chat-native submit can proceed or whether the merchant should use fallback_url.', 'jetpack-blaze' ),
-							'required'    => array( 'chat_native_submit', 'payment_method', 'reason', 'fallback_url' ),
+							'required'    => array( 'chat_native_submit', 'payment_method', 'reason', 'fallback_url', 'selected_payment_method', 'available_payment_methods' ),
 							'properties'  => array(
 								'chat_native_submit' => array(
 									'type' => 'boolean',
@@ -638,6 +642,18 @@ class Blaze_Abilities extends Registrar {
 								'fallback_url'       => array(
 									'type'   => 'string',
 									'format' => 'uri',
+								),
+								'selected_payment_method' => array(
+									'type'        => array( 'object', 'null' ),
+									'description' => __( 'Compact safe summary of the saved payment method selected for chat-native submit, or null when unavailable.', 'jetpack-blaze' ),
+								),
+								'available_payment_methods' => array(
+									'type'        => 'array',
+									'description' => __( 'Compact safe summaries of usable existing saved payment methods that can be selected by re-running prepare-campaign with payment_method_id.', 'jetpack-blaze' ),
+								),
+								'supports_payment_method_switching' => array(
+									'type'        => 'boolean',
+									'description' => __( 'Whether more than one usable existing saved payment method is available for selection.', 'jetpack-blaze' ),
 								),
 							),
 						),
@@ -1677,16 +1693,20 @@ class Blaze_Abilities extends Registrar {
 			// Future write-path guardrails (per-session spend ceiling, Picard
 			// moderation gating) plug in here. Tracked separately as ADS-989.
 
-			$adds_saved_payment_hint = self::ABILITY_PREPARE_CAMPAIGN === $ability_name;
-			if ( $adds_saved_payment_hint ) {
-				add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+			$payment_methods_filter = null;
+			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+				$payment_methods        = self::get_prepare_campaign_payment_methods();
+				$payment_methods_filter = static function () use ( $payment_methods ) {
+					return $payment_methods;
+				};
+				add_filter( 'jetpack_blaze_prepare_campaign_payment_methods', $payment_methods_filter );
 			}
 
 			try {
 				$result = call_user_func( $original_callback, $input );
 			} finally {
-				if ( $adds_saved_payment_hint ) {
-					remove_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+				if ( null !== $payment_methods_filter ) {
+					remove_filter( 'jetpack_blaze_prepare_campaign_payment_methods', $payment_methods_filter );
 				}
 			}
 
@@ -1698,6 +1718,66 @@ class Blaze_Abilities extends Registrar {
 		};
 
 		return $args;
+	}
+
+	/**
+	 * Fetch usable saved payment methods through the existing Blaze REST proxy.
+	 *
+	 * @return array|null
+	 */
+	private static function get_prepare_campaign_payment_methods() {
+		$site_id = Jetpack_Connection::get_site_id();
+		if ( is_wp_error( $site_id ) || ! $site_id ) {
+			return null;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/payments/methods', (int) $site_id );
+		$request = new WP_REST_Request( 'GET', $route );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return null;
+		}
+
+		return self::extract_payment_methods_response( $response->get_data() );
+	}
+
+	/**
+	 * Extract a payment-method list from known DSP response shapes.
+	 *
+	 * @param mixed $data REST response data.
+	 * @return array|null
+	 */
+	private static function extract_payment_methods_response( $data ) {
+		if ( ! is_array( $data ) ) {
+			return null;
+		}
+
+		if ( self::is_list_array( $data ) ) {
+			return $data;
+		}
+
+		foreach ( array( 'payment_methods', 'paymentMethods', 'methods', 'data' ) as $key ) {
+			if ( isset( $data[ $key ] ) && is_array( $data[ $key ] ) ) {
+				return $data[ $key ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Polyfill array_is_list() for the package PHP support floor.
+	 *
+	 * @param array $array Array to inspect.
+	 * @return bool
+	 */
+	private static function is_list_array( array $array ): bool {
+		if ( array() === $array ) {
+			return true;
+		}
+
+		return array_keys( $array ) === range( 0, count( $array ) - 1 );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -73,8 +73,9 @@ class Campaign_Preparer {
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 		$forecast        = self::request_forecast( $prefill, $intent );
 		$summary         = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
-		$package         = self::build_prepared_campaign_identity( $prefill, $summary );
-		$eligibility     = self::build_submit_eligibility( $args, $prefill, $prefill_url );
+		$payment_context = self::resolve_payment_context( $args, $prefill );
+		$package         = self::build_prepared_campaign_identity( $prefill, $summary, $payment_context['selected_payment_method'] );
+		$eligibility     = self::build_submit_eligibility( $args, $prefill, $prefill_url, $payment_context );
 
 		$proposal = array(
 			'status'               => 'pending_merchant_review',
@@ -301,15 +302,17 @@ class Campaign_Preparer {
 	/**
 	 * Build the immutable package identity for a prepared campaign.
 	 *
-	 * @param array $prefill Recommended campaign prefill payload.
-	 * @param array $summary Structured campaign summary.
+	 * @param array      $prefill                 Recommended campaign prefill payload.
+	 * @param array      $summary                 Structured campaign summary.
+	 * @param array|null $selected_payment_method Selected saved payment method summary.
 	 * @return array
 	 */
-	private static function build_prepared_campaign_identity( array $prefill, array $summary ): array {
+	private static function build_prepared_campaign_identity( array $prefill, array $summary, $selected_payment_method = null ): array {
 		$identity_payload = array(
-			'contract_version' => 'v1',
-			'prefill'          => $prefill,
-			'campaign_summary' => $summary,
+			'contract_version'        => 'v1',
+			'prefill'                 => $prefill,
+			'campaign_summary'        => $summary,
+			'selected_payment_method' => $selected_payment_method,
 		);
 		$hash             = hash( 'sha256', (string) wp_json_encode( $identity_payload, JSON_UNESCAPED_SLASHES ) );
 
@@ -318,6 +321,259 @@ class Campaign_Preparer {
 			'hash'    => $hash,
 			'version' => 'v1',
 		);
+	}
+
+	/**
+	 * Resolve saved payment methods for chat-native submit.
+	 *
+	 * @param array $args    Preparation input.
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @return array
+	 */
+	private static function resolve_payment_context( array $args, array $prefill ): array {
+		/**
+		 * Filters existing saved payment methods available to the prepared
+		 * campaign.
+		 *
+		 * Return an array of payment methods when known, an empty array when no
+		 * usable methods exist, or null when the caller cannot determine saved
+		 * payment method eligibility.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array|null $payment_methods Existing saved payment methods.
+		 * @param array      $args            Preparation input.
+		 * @param array      $prefill         Recommended campaign prefill payload.
+		 */
+		$payment_methods = apply_filters( 'jetpack_blaze_prepare_campaign_payment_methods', null, $args, $prefill );
+
+		if ( is_array( $payment_methods ) ) {
+			$methods             = self::normalize_payment_methods( $payment_methods );
+			$requested_method_id = isset( $args['payment_method_id'] ) ? (string) $args['payment_method_id'] : '';
+			$selected            = self::select_payment_method( $methods, $requested_method_id );
+
+			return array(
+				'known'                       => true,
+				'available_payment_methods'  => $methods,
+				'selected_payment_method'    => $selected,
+				'requested_payment_method_id' => $requested_method_id,
+			);
+		}
+
+		return array(
+			'known'                       => false,
+			'available_payment_methods'  => array(),
+			'selected_payment_method'    => null,
+			'requested_payment_method_id' => isset( $args['payment_method_id'] ) ? (string) $args['payment_method_id'] : '',
+		);
+	}
+
+	/**
+	 * Normalize saved payment methods into a compact safe display summary.
+	 *
+	 * @param array $payment_methods Raw payment methods.
+	 * @return array
+	 */
+	private static function normalize_payment_methods( array $payment_methods ): array {
+		$normalized = array();
+
+		foreach ( $payment_methods as $payment_method ) {
+			if ( ! is_array( $payment_method ) ) {
+				continue;
+			}
+
+			$method = self::normalize_payment_method( $payment_method );
+			if ( null !== $method ) {
+				$normalized[] = $method;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize one saved payment method.
+	 *
+	 * @param array $payment_method Raw payment method.
+	 * @return array|null
+	 */
+	private static function normalize_payment_method( array $payment_method ) {
+		$id = self::first_non_empty_string( $payment_method, array( 'id', 'payment_method_id', 'paymentMethodId', 'token_id', 'tokenId' ) );
+		if ( '' === $id || ! self::is_usable_payment_method( $payment_method ) ) {
+			return null;
+		}
+
+		$card      = isset( $payment_method['card'] ) && is_array( $payment_method['card'] ) ? $payment_method['card'] : array();
+		$type      = self::first_non_empty_string( $payment_method, array( 'type', 'payment_method_type', 'paymentMethodType', 'method' ) );
+		$brand     = self::first_non_empty_string( $payment_method, array( 'brand', 'card_brand', 'cardBrand' ) );
+		$last4     = self::first_non_empty_string( $payment_method, array( 'last4', 'last_4', 'card_last4', 'cardLast4' ) );
+		$exp_month = self::first_integer( $payment_method, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
+		$exp_year  = self::first_integer( $payment_method, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
+
+		if ( '' === $brand ) {
+			$brand = self::first_non_empty_string( $card, array( 'brand', 'card_brand', 'cardBrand' ) );
+		}
+		if ( '' === $last4 ) {
+			$last4 = self::first_non_empty_string( $card, array( 'last4', 'last_4', 'card_last4', 'cardLast4' ) );
+		}
+		if ( null === $exp_month ) {
+			$exp_month = self::first_integer( $card, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
+		}
+		if ( null === $exp_year ) {
+			$exp_year = self::first_integer( $card, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
+		}
+		if ( '' === $type ) {
+			$type = '' !== $last4 ? 'card' : 'saved_payment_method';
+		}
+
+		$summary = array(
+			'id'         => $id,
+			'type'       => $type,
+			'brand'      => $brand,
+			'last4'      => $last4,
+		);
+
+		if ( null !== $exp_month ) {
+			$summary['exp_month'] = $exp_month;
+		}
+		if ( null !== $exp_year ) {
+			$summary['exp_year'] = $exp_year;
+		}
+
+		$summary['label']      = self::build_payment_method_label( $type, $brand, $last4 );
+		$summary['is_default'] = self::is_default_payment_method( $payment_method );
+
+		return $summary;
+	}
+
+	/**
+	 * Whether a saved payment method is usable for chat-native submit.
+	 *
+	 * @param array $payment_method Raw payment method.
+	 * @return bool
+	 */
+	private static function is_usable_payment_method( array $payment_method ): bool {
+		foreach ( array( 'usable', 'is_usable', 'isUsable', 'eligible', 'enabled' ) as $key ) {
+			if ( array_key_exists( $key, $payment_method ) ) {
+				return (bool) $payment_method[ $key ];
+			}
+		}
+
+		foreach ( array( 'invalid', 'disabled', 'expired' ) as $key ) {
+			if ( ! empty( $payment_method[ $key ] ) ) {
+				return false;
+			}
+		}
+
+		if ( isset( $payment_method['status'] ) ) {
+			$status = strtolower( (string) $payment_method['status'] );
+			return in_array( $status, array( 'active', 'valid', 'usable', 'enabled' ), true );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a saved payment method is the server-owned default.
+	 *
+	 * @param array $payment_method Raw payment method.
+	 * @return bool
+	 */
+	private static function is_default_payment_method( array $payment_method ): bool {
+		foreach ( array( 'is_default', 'isDefault', 'default' ) as $key ) {
+			if ( array_key_exists( $key, $payment_method ) ) {
+				return (bool) $payment_method[ $key ];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Select the requested saved payment method, the default, or the first usable.
+	 *
+	 * @param array  $payment_methods     Normalized payment methods.
+	 * @param string $requested_method_id Requested payment method ID.
+	 * @return array|null
+	 */
+	private static function select_payment_method( array $payment_methods, string $requested_method_id ) {
+		if ( '' !== $requested_method_id ) {
+			foreach ( $payment_methods as $method ) {
+				if ( isset( $method['id'] ) && $requested_method_id === (string) $method['id'] ) {
+					return $method;
+				}
+			}
+
+			return null;
+		}
+
+		foreach ( $payment_methods as $method ) {
+			if ( ! empty( $method['is_default'] ) ) {
+				return $method;
+			}
+		}
+
+		return $payment_methods[0] ?? null;
+	}
+
+	/**
+	 * Build a compact display label for a saved payment method.
+	 *
+	 * @param string $type  Payment method type.
+	 * @param string $brand Payment brand.
+	 * @param string $last4 Last four digits.
+	 * @return string
+	 */
+	private static function build_payment_method_label( string $type, string $brand, string $last4 ): string {
+		if ( '' !== $last4 ) {
+			$display_brand = '' !== $brand ? ucwords( str_replace( array( '_', '-' ), ' ', $brand ) ) : __( 'Card', 'jetpack-blaze' );
+			return sprintf(
+				/* translators: 1: payment card brand, 2: last four digits. */
+				__( '%1$s ending in %2$s', 'jetpack-blaze' ),
+				$display_brand,
+				$last4
+			);
+		}
+
+		if ( '' !== $brand ) {
+			return ucwords( str_replace( array( '_', '-' ), ' ', $brand ) );
+		}
+
+		return ucwords( str_replace( array( '_', '-' ), ' ', $type ) );
+	}
+
+	/**
+	 * Return the first non-empty string field from an array.
+	 *
+	 * @param array $source Source array.
+	 * @param array $keys   Candidate keys.
+	 * @return string
+	 */
+	private static function first_non_empty_string( array $source, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && '' !== (string) $source[ $key ] ) {
+				return (string) $source[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return the first integer field from an array.
+	 *
+	 * @param array $source Source array.
+	 * @param array $keys   Candidate keys.
+	 * @return int|null
+	 */
+	private static function first_integer( array $source, array $keys ) {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && is_numeric( $source[ $key ] ) ) {
+				return (int) $source[ $key ];
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -419,12 +675,44 @@ class Campaign_Preparer {
 	/**
 	 * Build chat-native submit eligibility hints.
 	 *
-	 * @param array  $args         Preparation input.
-	 * @param array  $prefill      Recommended campaign prefill payload.
-	 * @param string $fallback_url Blaze widget/dashboard fallback URL.
+	 * @param array  $args            Preparation input.
+	 * @param array  $prefill         Recommended campaign prefill payload.
+	 * @param string $fallback_url    Blaze widget/dashboard fallback URL.
+	 * @param array  $payment_context Saved payment method context.
 	 * @return array
 	 */
-	private static function build_submit_eligibility( array $args, array $prefill, string $fallback_url ): array {
+	private static function build_submit_eligibility( array $args, array $prefill, string $fallback_url, array $payment_context ): array {
+		if ( $payment_context['known'] ) {
+			$base = array(
+				'fallback_url'                       => $fallback_url,
+				'selected_payment_method'            => $payment_context['selected_payment_method'],
+				'available_payment_methods'          => $payment_context['available_payment_methods'],
+				'supports_payment_method_switching' => count( $payment_context['available_payment_methods'] ) > 1,
+			);
+
+			if ( is_array( $payment_context['selected_payment_method'] ) ) {
+				return array_merge(
+					array(
+						'chat_native_submit' => true,
+						'payment_method'     => 'saved_payment_method',
+						'reason'             => null,
+					),
+					$base
+				);
+			}
+
+			return array_merge(
+				array(
+					'chat_native_submit' => false,
+					'payment_method'     => 'missing_saved_payment_method',
+					'reason'             => '' !== $payment_context['requested_payment_method_id']
+						? 'requested_payment_method_unavailable'
+						: 'saved_payment_method_required',
+				),
+				$base
+			);
+		}
+
 		/**
 		 * Filters whether the prepared campaign can use an existing saved payment
 		 * method for chat-native submit.
@@ -441,24 +729,35 @@ class Campaign_Preparer {
 		 */
 		$has_saved_payment_method = apply_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', null, $args, $prefill );
 
+		$base = array(
+			'fallback_url'                       => $fallback_url,
+			'selected_payment_method'            => null,
+			'available_payment_methods'          => array(),
+			'supports_payment_method_switching' => false,
+		);
+
 		if ( true === $has_saved_payment_method ) {
-			return array(
-				'chat_native_submit' => true,
-				'payment_method'     => 'saved_payment_method',
-				'reason'             => null,
-				'fallback_url'       => $fallback_url,
+			return array_merge(
+				array(
+					'chat_native_submit' => true,
+					'payment_method'     => 'saved_payment_method',
+					'reason'             => null,
+				),
+				$base
 			);
 		}
 
-		return array(
-			'chat_native_submit' => false,
-			'payment_method'     => false === $has_saved_payment_method
-				? 'missing_saved_payment_method'
-				: 'unknown',
-			'reason'             => false === $has_saved_payment_method
-				? 'saved_payment_method_required'
-				: 'payment_eligibility_unknown',
-			'fallback_url'       => $fallback_url,
+		return array_merge(
+			array(
+				'chat_native_submit' => false,
+				'payment_method'     => false === $has_saved_payment_method
+					? 'missing_saved_payment_method'
+					: 'unknown',
+				'reason'             => false === $has_saved_payment_method
+					? 'saved_payment_method_required'
+					: 'payment_eligibility_unknown',
+			),
+			$base
 		);
 	}
 
@@ -496,9 +795,10 @@ class Campaign_Preparer {
 				'cadence',
 				'schedule',
 				'targeting',
+				'payment_method',
 			),
 			'message'            => __(
-				'Changing destination, creative, budget, cadence, schedule, or targeting requires preparing a new Blaze campaign package before approval or submit.',
+				'Changing destination, creative, budget, cadence, schedule, targeting, or payment method requires preparing a new Blaze campaign package before approval or submit.',
 				'jetpack-blaze'
 			),
 		);

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -45,6 +45,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		unset( $GLOBALS['wp_rest_server'] );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
 	}
 
 	/**
@@ -211,6 +212,72 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertContains( 'creative', $result['material_edit_policy']['material_fields'] );
 		$this->assertContains( 'budget', $result['material_edit_policy']['material_fields'] );
 		$this->assertContains( 'targeting', $result['material_edit_policy']['material_fields'] );
+	}
+
+	/**
+	 * Saved payment details are summarized compactly and become part of the
+	 * prepared identity so switching methods requires fresh approval.
+	 */
+	public function test_prepare_selects_saved_payment_method_for_chat_native_submit() {
+		add_filter(
+			'jetpack_blaze_prepare_campaign_payment_methods',
+			static function () {
+				return array(
+					array(
+						'id'         => 'pm_backup',
+						'type'       => 'card',
+						'card_brand' => 'visa',
+						'last4'      => '4242',
+						'is_default' => false,
+					),
+					array(
+						'id'         => 'pm_default',
+						'type'       => 'card',
+						'card_brand' => 'mastercard',
+						'last4'      => '5555',
+						'exp_month'  => 8,
+						'exp_year'   => 2030,
+						'is_default' => true,
+					),
+				);
+			}
+		);
+
+		$ctx = $this->make_test_post();
+
+		$default_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+		$switched_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'         => $ctx['target_urn'],
+				'payment_method_id'  => 'pm_backup',
+			)
+		);
+
+		$this->assertIsArray( $default_result );
+		$this->assertIsArray( $switched_result );
+		$this->assertTrue( $default_result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'saved_payment_method', $default_result['submit_eligibility']['payment_method'] );
+		$this->assertSame(
+			array(
+				'id'         => 'pm_default',
+				'type'       => 'card',
+				'brand'      => 'mastercard',
+				'last4'      => '5555',
+				'exp_month'  => 8,
+				'exp_year'   => 2030,
+				'label'      => 'Mastercard ending in 5555',
+				'is_default' => true,
+			),
+			$default_result['submit_eligibility']['selected_payment_method']
+		);
+		$this->assertCount( 2, $default_result['submit_eligibility']['available_payment_methods'] );
+		$this->assertSame( 'pm_backup', $switched_result['submit_eligibility']['selected_payment_method']['id'] );
+		$this->assertNotSame( $default_result['prepared_campaign']['id'], $switched_result['prepared_campaign']['id'] );
+		$this->assertContains( 'payment_method', $default_result['material_edit_policy']['material_fields'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -67,6 +67,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_tracks_event' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
 		remove_all_actions( 'wp_after_execute_ability' );
 		unset( $GLOBALS['wp_rest_server'] );
 	}
@@ -898,6 +899,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'text_snippet', $properties );
 		$this->assertArrayHasKey( 'cta_text', $properties );
 		$this->assertArrayHasKey( 'main_image_url', $properties );
+		$this->assertArrayHasKey( 'payment_method_id', $properties );
 		$this->assertArrayHasKey( 'languages', $properties );
 		$this->assertArrayHasKey( 'countries', $properties );
 		$this->assertArrayHasKey( 'devices', $properties );
@@ -918,6 +920,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Blaze public page topic IDs', $properties['interests']['description'] );
 		$this->assertContains( 'IAB8_IAB18', $properties['interests']['items']['enum'] );
 		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
+		$this->assertStringContainsString( 'existing saved payment method', $properties['payment_method_id']['description'] );
 
 		$output_properties = $ability['output_schema']['properties'];
 		$this->assertContains( 'message', $ability['output_schema']['required'] );
@@ -945,6 +948,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
 		$this->assertContains( 'destination', $output_properties['campaign_summary']['required'] );
 		$this->assertContains( 'chat_native_submit', $output_properties['submit_eligibility']['required'] );
+		$this->assertContains( 'selected_payment_method', $output_properties['submit_eligibility']['required'] );
+		$this->assertContains( 'available_payment_methods', $output_properties['submit_eligibility']['required'] );
 		$this->assertContains( 'material_fields', $output_properties['material_edit_policy']['required'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
@@ -989,6 +994,23 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', self::TEST_SITE_ID ),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Register a test payment methods route for the preparer's proxied DSP request.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_payment_methods_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/payments/methods', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => $callback,
 				'permission_callback' => '__return_true',
 			)
@@ -1254,6 +1276,21 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 */
 	public function test_wrapped_prepare_campaign_marks_chat_native_submit_eligible() {
 		$ctx = $this->make_test_post();
+		$this->register_payment_methods_route(
+			static function () {
+				return array(
+					'payment_methods' => array(
+						array(
+							'id'         => 'pm_default',
+							'type'       => 'card',
+							'card_brand' => 'visa',
+							'last4'      => '4242',
+							'is_default' => true,
+						),
+					),
+				);
+			}
+		);
 
 		$args = array(
 			'execute_callback' => array( Blaze_Abilities::class, 'prepare_campaign' ),
@@ -1273,9 +1310,52 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
 		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertSame( 'pm_default', $result['submit_eligibility']['selected_payment_method']['id'] );
+		$this->assertSame( 'Visa ending in 4242', $result['submit_eligibility']['selected_payment_method']['label'] );
 		$this->assertArrayHasKey( 'approval_block', $result );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
 		$this->assertSame( 'blaze.approval.confirm_prepared_campaign', $result['approval_block']['confirmation_label_key'] );
+	}
+
+	/**
+	 * Sites without a usable saved payment method still get prepare/preview
+	 * output, but chat-native submit remains blocked in favor of the Blaze UI.
+	 */
+	public function test_wrapped_prepare_campaign_blocks_chat_native_submit_without_saved_payment_method() {
+		$ctx = $this->make_test_post();
+		$this->register_payment_methods_route(
+			static function () {
+				return array(
+					'payment_methods' => array(),
+				);
+			}
+		);
+
+		$args = array(
+			'execute_callback' => array( Blaze_Abilities::class, 'prepare_campaign' ),
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		$result  = call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertNotEmpty( $result['fallback_url'] );
+		$this->assertFalse( $result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'missing_saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertSame( 'saved_payment_method_required', $result['submit_eligibility']['reason'] );
+		$this->assertNull( $result['submit_eligibility']['selected_payment_method'] );
+		$this->assertSame( array(), $result['submit_eligibility']['available_payment_methods'] );
+		$this->assertArrayNotHasKey( 'approval_block', $result );
+		$this->assertStringContainsString( 'Review URL: ' . $result['fallback_url'], $result['message'] );
 	}
 
 	/**


### PR DESCRIPTION
🤖 Draft agent PR for https://linear.app/a8c/issue/ADS-1117/use-saved-payment-eligibility-for-chat-submit.

Sandcastle run log is local at `.agent-runs/jetpack/ADS-1117-2026-05-19T09-30-01-314Z/sandcastle.log`.

This PR was created as draft and must be reviewed by a human before merge.