### PR TITLE
Search: fix two follow-up bugs from the WooCommerce product-search takeover (RSM-3545)

### DIFF
--- a/projects/packages/search/changelog/fix-rsm-3545-wc-product-search-followup
+++ b/projects/packages/search/changelog/fix-rsm-3545-wc-product-search-followup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: reject experience requests combined with ai_answers_enabled or search_suggestions_enabled instead of silently dropping them, and gate the WooCommerce product-search template override on the active experience so a stale option can't keep rerouting after a switch away from a server-rendered experience.

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -341,8 +341,8 @@ class REST_Controller {
 	 * @param string|null $experience - Experience value.
 	 * @param bool|null   $reader_chat - Reader Chat status.
 	 * @param bool|null   $ai_answers_enabled - Whether Jetpack Search AI answers is enabled.
-	 * @param boolean     $search_suggestions_enabled - New search suggestions status.
-	 * @param boolean     $override_woocommerce_search_template - New WooCommerce search-template override status.
+	 * @param bool|null   $search_suggestions_enabled - New search suggestions status.
+	 * @param bool|null   $override_woocommerce_search_template - New WooCommerce search-template override status.
 	 */
 	protected function validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience = null, $reader_chat = null, $ai_answers_enabled = null, $search_suggestions_enabled = null, $override_woocommerce_search_template = null ) {
 		if ( $reader_chat !== null && ! $this->is_reader_chat_setting_registered() ) {
@@ -358,10 +358,10 @@ class REST_Controller {
 		// lose those fields — the `experience` branch in update_settings() early-returns and
 		// would otherwise drop them.
 		if ( $experience !== null ) {
-			if ( $module_active !== null || $instant_search_enabled !== null || $swap_classic_to_inline_search !== null || $reader_chat !== null || $override_woocommerce_search_template !== null ) {
+			if ( $module_active !== null || $instant_search_enabled !== null || $swap_classic_to_inline_search !== null || $reader_chat !== null || $ai_answers_enabled !== null || $search_suggestions_enabled !== null || $override_woocommerce_search_template !== null ) {
 				return new WP_Error(
 					'rest_invalid_arguments',
-					esc_html__( 'The `experience` field cannot be combined with `module_active`, `instant_search_enabled`, `swap_classic_to_inline_search`, `reader_chat`, or `override_woocommerce_search_template`.', 'jetpack-search-pkg' ),
+					esc_html__( 'The `experience` field cannot be combined with `module_active`, `instant_search_enabled`, `swap_classic_to_inline_search`, `reader_chat`, `ai_answers_enabled`, `search_suggestions_enabled`, or `override_woocommerce_search_template`.', 'jetpack-search-pkg' ),
 					array( 'status' => 400 )
 				);
 			}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -154,7 +154,9 @@ class Search_Blocks {
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 
-		if ( Module_Control::EXPERIENCE_EMBEDDED === ( new Module_Control() )->get_experience() ) {
+		$experience = ( new Module_Control() )->get_experience();
+
+		if ( Module_Control::EXPERIENCE_EMBEDDED === $experience ) {
 			add_action( 'init', array( static::class, 'register_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		}
@@ -164,7 +166,16 @@ class Search_Blocks {
 		// integrations. The WC/product-search guard lives in the callback,
 		// which runs late enough to satisfy woocommerce_blocks_enabled()'s
 		// load-order contract.
-		if ( static::woocommerce_search_template_override_enabled() ) {
+		//
+		// Gated to the server-rendered experiences (Embedded / Theme search):
+		// Overlay intercepts client-side so the override is a no-op there, and
+		// the dashboard hides the toggle in that state — mirror it server-side
+		// so a stale option from a since-switched experience can't keep
+		// rerouting the template hierarchy.
+		if (
+			static::woocommerce_search_template_override_enabled()
+			&& in_array( $experience, array( Module_Control::EXPERIENCE_EMBEDDED, Module_Control::EXPERIENCE_INLINE ), true )
+		) {
 			add_action( 'init', array( static::class, 'register_product_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'route_woocommerce_product_search_template' ), 20 );
 		}

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -579,6 +579,14 @@ class REST_Controller_Test extends Search_TestCase {
 					'experience'                           => 'embedded',
 					'override_woocommerce_search_template' => true,
 				),
+				array(
+					'experience'                 => 'embedded',
+					'search_suggestions_enabled' => true,
+				),
+				array(
+					'experience'         => 'embedded',
+					'ai_answers_enabled' => true,
+				),
 			) as $body
 		) {
 			$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -556,15 +556,36 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * The override only applies to the server-rendered experiences. With the
-	 * option still on after the site switches to Overlay (client-side) or Off,
-	 * `init()` must NOT register the product-search hooks — a stale option
-	 * from a since-switched experience can't keep rerouting the hierarchy.
-	 * Mirrors the dashboard's Embedded|Inline visibility gate.
+	 * The override only applies to the server-rendered experiences, mirroring
+	 * the dashboard's Embedded|Inline visibility gate. With the option on it
+	 * registers under Inline (server-rendered theme search); with the option
+	 * still on after the site switches to Overlay (client-side) or Off it must
+	 * NOT register — a stale option from a since-switched experience can't keep
+	 * rerouting the hierarchy.
 	 */
-	public function test_init_does_not_register_product_search_hooks_when_experience_not_server_rendered() {
+	public function test_init_gates_product_search_hooks_on_server_rendered_experience() {
 		try {
 			update_option( 'jetpack_search_override_woocommerce_search_template', true );
+
+			// Inline (allowed): module active, no experience opt-in saved, so
+			// get_experience() resolves to 'inline' — the override applies.
+			$this->reset_search_blocks_hooks();
+			$this->set_module_active( true );
+			delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+			Search_Blocks::init();
+
+			$this->assertNotFalse(
+				has_action( 'init', array( Search_Blocks::class, 'register_product_search_template' ) ),
+				'register_product_search_template must hook when experience is Inline'
+			);
+			$this->assertSame(
+				20,
+				has_filter(
+					'search_template_hierarchy',
+					array( Search_Blocks::class, 'route_woocommerce_product_search_template' )
+				),
+				'route_woocommerce_product_search_template must hook at priority 20 when experience is Inline'
+			);
 
 			// Overlay: module active, experience explicitly saved as overlay.
 			$this->reset_search_blocks_hooks();

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -556,6 +556,58 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * The override only applies to the server-rendered experiences. With the
+	 * option still on after the site switches to Overlay (client-side) or Off,
+	 * `init()` must NOT register the product-search hooks — a stale option
+	 * from a since-switched experience can't keep rerouting the hierarchy.
+	 * Mirrors the dashboard's Embedded|Inline visibility gate.
+	 */
+	public function test_init_does_not_register_product_search_hooks_when_experience_not_server_rendered() {
+		try {
+			update_option( 'jetpack_search_override_woocommerce_search_template', true );
+
+			// Overlay: module active, experience explicitly saved as overlay.
+			$this->reset_search_blocks_hooks();
+			$this->set_module_active( true );
+			update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
+			Search_Blocks::init();
+
+			$this->assertFalse(
+				has_action( 'init', array( Search_Blocks::class, 'register_product_search_template' ) ),
+				'register_product_search_template must not hook when experience is Overlay'
+			);
+			$this->assertFalse(
+				has_filter(
+					'search_template_hierarchy',
+					array( Search_Blocks::class, 'route_woocommerce_product_search_template' )
+				),
+				'route_woocommerce_product_search_template must not hook when experience is Overlay'
+			);
+
+			// Off: module inactive, get_experience() resolves to 'off'.
+			$this->reset_search_blocks_hooks();
+			delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+			$this->set_module_active( false );
+			Search_Blocks::init();
+
+			$this->assertFalse(
+				has_action( 'init', array( Search_Blocks::class, 'register_product_search_template' ) ),
+				'register_product_search_template must not hook when the module is off'
+			);
+			$this->assertFalse(
+				has_filter(
+					'search_template_hierarchy',
+					array( Search_Blocks::class, 'route_woocommerce_product_search_template' )
+				),
+				'route_woocommerce_product_search_template must not hook when the module is off'
+			);
+		} finally {
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+			delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		}
+	}
+
+	/**
 	 * `init()` must always register the block-level hooks AND the IA state
 	 * seeding regardless of which experience the site has saved — admins can
 	 * insert Search blocks anywhere blocks are configurable, and those blocks


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-3545/search-two-follow-up-bugs-from-the-woocommerce-product-search-takeover

## Why

Two follow-up bugs from the WooCommerce product-search takeover (RSM-3497 / merged #48936):

1. Saving a Search *experience* together with the AI-answers or search-suggestions toggle accepted the request but silently discarded those two toggles — the dashboard's experience save would appear to succeed while the companion setting was lost.
2. Turning on the WooCommerce product-search override and later switching to Overlay left the server still rerouting the product-search template, with no UI to turn it back off — behaviour drifted from what the dashboard showed.

## Proposed changes

* **`class-rest-controller.php`** — `validate_search_settings()` now rejects (`400`) an `experience` request combined with `ai_answers_enabled` or `search_suggestions_enabled`, matching how `reader_chat` / `override_woocommerce_search_template` are already handled. The `experience` branch early-returns before the auxiliary `update_option()` calls, so without this the fields were silently dropped. Error message and `@param` types (`bool|null`) updated to match.
* **`class-search-blocks.php`** — `init()` now hoists `get_experience()` into a local and gates the product-search override hooks on the active experience being `EXPERIENCE_EMBEDDED` or `EXPERIENCE_INLINE`, mirroring the dashboard's `showWooCommerceProductSearchControl` (Embedded|Inline) gate. The stored option is **not** deleted on an experience switch — the preference is preserved; only its effect is gated, so an Embedded→Overlay→Embedded round-trip restores it.
* Tests: `REST_Controller_Test` gains the two newly-guarded `experience + …` rejection cases; `Search_Blocks_Test` gains a case asserting the product-search hooks are absent on Overlay and Off while the option is still set.

## API changes

`POST /jetpack/v4/search/settings` now returns `400 rest_invalid_arguments` (instead of `200` with a silent drop) when `experience` is combined with `ai_answers_enabled` or `search_suggestions_enabled`. No change to valid requests or to the `GET` response shape.

<details>
<summary>Behaviour (asserted by REST_Controller_Test::test_update_settings_experience_rejects_mixed_legacy_fields)</summary>

```http
POST /jetpack/v4/search/settings
Content-Type: application/json

{ "experience": "embedded", "search_suggestions_enabled": true }
```
```json
{ "code": "rest_invalid_arguments", "data": { "status": 400 } }
```
```http
POST /jetpack/v4/search/settings
Content-Type: application/json

{ "experience": "embedded", "ai_answers_enabled": true }
```
```json
{ "code": "rest_invalid_arguments", "data": { "status": 400 } }
```

</details>

## Verification

Full `packages/search` PHP suite green, including the new/modified REST and Search_Blocks cases.

<details>
<summary>Output</summary>

```text
$ jetpack test php packages/search
OK (483 tests, 1100 assertions)
```

Pre-commit: `composer php:lint` + `phpcs` — 4 files, no syntax errors, no violations.

</details>

## Related product discussion/links

* RSM-3545 (related to RSM-3497)
* Source of findings: claude[bot] review on #48945

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `POST /jetpack/v4/search/settings` with `{ "experience": "embedded", "search_suggestions_enabled": true }` → expect `400` `rest_invalid_arguments` (previously `200`, field silently dropped).
* Same with `{ "experience": "embedded", "ai_answers_enabled": true }` → expect `400`.
* Confirm a plain `{ "experience": "embedded" }` and a plain `{ "search_suggestions_enabled": true }` still succeed (`200`).
* On a WooCommerce site: enable the "override WooCommerce product search template" toggle on the Embedded experience, then switch the experience to Overlay. Confirm `route_woocommerce_product_search_template` is no longer hooked (product searches resolve through WooCommerce/theme, not the Jetpack product template). Switch back to Embedded → the override takes effect again (option preserved).
* `jetpack test php packages/search` → all green.
