### PR TITLE
Fix Create AI Podcast free credit copy

### DIFF
--- a/projects/packages/podcast/changelog/fix-create-ai-podcast-free-credit-reset-copy
+++ b/projects/packages/podcast/changelog/fix-create-ai-podcast-free-credit-reset-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Create AI Podcast: Clarify that free trial credits do not reset.

--- a/projects/packages/podcast/src/admin-pages/create-ai-podcast/index.js
+++ b/projects/packages/podcast/src/admin-pages/create-ai-podcast/index.js
@@ -311,7 +311,8 @@
 		bar.appendChild( fill );
 		creditsEl.appendChild( bar );
 
-		const reset = formatResetPhrase( quota?.resetsAt );
+		const resetsNever = quota?.resetsAt === 'never';
+		const reset = resetsNever ? null : formatResetPhrase( quota?.resetsAt );
 
 		const meta = document.createElement( 'div' );
 		meta.className = 'jetpack-create-ai-podcast__credits-meta';
@@ -324,14 +325,20 @@
 		sep.className = 'jetpack-create-ai-podcast__credits-meta-sep';
 		sep.setAttribute( 'aria-hidden', 'true' );
 		sep.textContent = '·';
-		meta.appendChild( sep );
 
 		const resetEl = document.createElement( 'span' );
 		resetEl.className = 'jetpack-create-ai-podcast__credits-meta-reset';
-		resetEl.textContent = reset
-			? sprintf( data.i18n.creditsResetSummary, reset.inline )
-			: data.i18n.creditsResetMonthly;
-		meta.appendChild( resetEl );
+		let resetText = '';
+		if ( reset ) {
+			resetText = sprintf( data.i18n.creditsResetSummary, reset.inline );
+		} else if ( ! resetsNever ) {
+			resetText = data.i18n.creditsResetMonthly;
+		}
+		if ( resetText ) {
+			meta.appendChild( sep );
+			resetEl.textContent = resetText;
+			meta.appendChild( resetEl );
+		}
 
 		creditsEl.appendChild( meta );
 
@@ -345,12 +352,25 @@
 				outMessage = upgradeUrl
 					? sprintf( data.i18n.outOfCreditsUpgrade, reset.inline )
 					: sprintf( data.i18n.outOfCreditsWait, reset.inline );
+			} else if ( resetsNever ) {
+				outMessage = data.i18n.outOfTrialCredits;
 			}
 			creditsEl.appendChild(
 				buildBanner( {
 					state: 'out',
 					title: data.i18n.outOfCreditsTitle,
 					message: outMessage,
+					upgradeUrl,
+					quota: quotaSummary,
+					reset,
+				} )
+			);
+		} else if ( resetsNever ) {
+			creditsEl.appendChild(
+				buildBanner( {
+					state: 'low',
+					title: data.i18n.trialBannerTitle,
+					message: data.i18n.trialBannerMessage,
 					upgradeUrl,
 					quota: quotaSummary,
 					reset,
@@ -374,8 +394,7 @@
 	 * Translate quota.resetsAt into a relative phrase that works both inside
 	 * a sentence (e.g. "your credits refresh {inline}") and as a stand-alone
 	 * summary line (e.g. "Resets {inline}"). Returns null when the timestamp
-	 * is missing or malformed so callers fall back to a generic "monthly"
-	 * blurb.
+	 * is missing or malformed so callers can use generic monthly copy.
 	 *
 	 * @param  resetsAt - ISO-8601 reset timestamp.
 	 * @return {{ inline: string, days: number, date: Date } | null} Phrase, days until reset, and parsed Date — or null when input is missing.

--- a/projects/packages/podcast/src/class-create-ai-podcast-page.php
+++ b/projects/packages/podcast/src/class-create-ai-podcast-page.php
@@ -390,6 +390,8 @@ class Create_AI_Podcast_Page {
 				'relativeDays'        => __( 'in %d days', 'jetpack-podcast' ),
 				// translators: %s: formatted date, e.g. "May 20, 2026".
 				'relativeOn'          => __( 'on %s', 'jetpack-podcast' ),
+				'trialBannerTitle'    => __( 'Try before you buy', 'jetpack-podcast' ),
+				'trialBannerMessage'  => __( 'Generate a podcast from your posts and see how it sounds on your site. Free trial is limited to one podcast episode.', 'jetpack-podcast' ),
 				'runningLowTitle'     => __( 'Running low', 'jetpack-podcast' ),
 				'runningLowMessage'   => __( 'Upgrade your plan to keep generating without waiting for the monthly refresh.', 'jetpack-podcast' ),
 				'outOfCreditsTitle'   => __( 'Out of credits', 'jetpack-podcast' ),
@@ -397,6 +399,7 @@ class Create_AI_Podcast_Page {
 				'outOfCreditsWait'    => __( 'Your credits will refresh %s.', 'jetpack-podcast' ),
 				// translators: %s: relative time, e.g. "in 12 days" or "tomorrow".
 				'outOfCreditsUpgrade' => __( 'Upgrade your plan for more credits, or wait until they refresh %s.', 'jetpack-podcast' ),
+				'outOfTrialCredits'   => __( 'You have used your one-time trial credit. Upgrade your plan for more credits.', 'jetpack-podcast' ),
 				'noPostsFound'        => __( 'No posts match.', 'jetpack-podcast' ),
 				'loadingPosts'        => __( 'Loading posts…', 'jetpack-podcast' ),
 				'pickPosts'           => __( 'Select at least one post to continue.', 'jetpack-podcast' ),


### PR DESCRIPTION
Fixes #

## Proposed changes
* Update the Create AI Podcast credits UI to treat `resetsAt: "never"` as a one-time free trial credit.
* Stop showing reset/trial text next to the remaining-credit count when credits never reset.
* Show an upgrade banner that explains the free trial is limited to one generated podcast.

## Related product discussion/links
* Follow-up to #48950 testing flow.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Apply these changes to your WP.com site.
* Use a free site where the Posts to Podcast quota endpoint returns `resetsAt: "never"`.
* Go to Media > Create AI Podcast.
* Confirm the credits card says `1 remaining` without any reset or trial text next to it.
* Confirm an upgrade banner appears below the credits meter with copy explaining that the free trial is limited to one podcast.
* Generate one podcast, or use a free site where the trial credit has already been used.
* Reload Media > Create AI Podcast.
* Confirm the out-of-credits banner says the one-time trial credit has been used and prompts the user to upgrade for more credits.
* Confirm paid plans with a real `resetsAt` timestamp still show the relative reset copy, for example `Resets in 12 days`.
