### PR TITLE
Podcast: release 1.0.0

### DIFF
--- a/projects/packages/podcast/CHANGELOG.md
+++ b/projects/packages/podcast/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-05-19
+### Security
+- Podcast: escape title overrides, descriptions, and iTunes category attribute values for the RSS feed to prevent malformed XML. [#48876]
+
+### Added
+- Add a Free and Premium plan card to the podcast welcome screen so users can see what podcasting includes per plan before they enable. [#48800]
+- Add the Podcast Episode block. Embeds a single podcast episode from an audio or video file with Podcasting 2.0 metadata. Registration is gated behind the `jetpack_podcast_untangle` filter (default off). [#48546]
+- Create AI Podcast: emit client-side tracks events for page view, generation request, episode plays, draft opens, pagination, and the quota banner / upgrade CTAs. [#48900]
+- Dashboard: gate the Episodes tab on Premium product access, with a blurred locked-preview overlay for free users. [#48885]
+- Default the untangle gate to enabled for A8C-proxied requests so Automatticians dogfood the new package on Simple and Atomic. [#48699]
+- Distribution tab: show Pending/Live state badges next to each podcast directory. [#48915]
+- Pocket Casts: replace the 3-step submit modal with a one-click Relay API flow that reflects pending/submitted state on the button and surfaces rejection reasons inline. [#48732]
+- Podcast: add product-access gate (Podcast_Gate::has_product_access) and grandfather sticker constant. [#48702]
+- Podcast Welcome: require a category when enabling podcasting. [#48825]
+- Posts to Podcast: Add an editor modal inviting eligible sites to create a podcast episode after publishing a post. [#48902]
+- Posts to Podcast: new Media > Create AI Podcast wp-admin page for generating podcast episode drafts from posts via the wpcom-side pipeline. Pick posts to include or use a recent-posts window, steer the output with a free-form prompt, watch a remaining-credits indicator backed by the quota-snapshot endpoint, and resume polling across page reloads. The page is plain PHP plus a vanilla-JS island — no React or wp-build chassis for this surface. Feature is wpcom-only; self-hosted Jetpack sites don't see the menu. [#48774]
+- Stats tab: render show- and episode-level podcast download stats. [#48614]
+
+### Changed
+- Build: Run webpack and wp-build scripts concurrently. [#48794]
+- Create AI Podcast: map 429 responses (including non-JSON edge rate-limit pages) to "Out of credits" and other non-JSON failures to "An unexpected error occurred." instead of "The response is not a valid JSON response."; decode HTML entities in the posts-picker titles so values like "&nbsp;" no longer render literally; add an "Experimental" badge to the intro banner; instrument the generation poller and post-publish promo with Tracks events for funnel analysis. [#48949]
+- Create AI Podcast: visual polish, floating toast notices, dismissible notices, generated episodes list, server-side bootstrap, and credits panel with reset messaging. [#48900]
+- Distribution: refresh Apple Podcasts, Spotify, YouTube Music, Amazon Music, and Podcast Index logos with current brand marks. Rename the YouTube directory to YouTube Music. Map matching slugs in the Stats "By app" and "Top app" labels. [#48879]
+- Episodes stats: detect 402 responses from the episode stats endpoint as a Premium-required state. [#48703]
+- Episode stats: dispatch the premium-required state on the `podcast_premium_required` error code instead of HTTP 402. [#48885]
+- Exclude development files from production builds. [#47365]
+- Podcast: grandfather Premium access by site registration date; drop the sticker-based grandfathering path. [#48894]
+- Podcast: narrow grandfather rule to sites registered before the cutoff that are also on a paid plan. [#48905]
+- Podcast: serve square cover art in the feed by center-cropping via Photon, regardless of source aspect ratio. [#48938]
+- Podcast: visual polish on the Stats tab — keep horizontal padding at narrow widths, lighter card headers, and integer-only axis ticks on the Downloads chart. [#48722]
+- Podcast dashboard: opt into the shared `jp-admin-page-tabs--minimal` modifier so the tab strip aligns with the page header and labels use the design-system font size. [#48908]
+- Podcast dashboard: reorder tabs so Stats appears first, followed by Episodes, Distribution, and Settings. [#48789]
+- Podcast Episode: enrich front-end schema.org markup and make chapter / soundbite list items click-to-seek in the audio player. [#48793]
+- Podcast Episode block: delegate the untangle gate to Podcast::is_enabled() so the block honors the same default as the rest of the package. [#48907]
+- Podcast Episodes: fall back to the show cover image when an episode has no featured image. [#48790]
+- Podcast Episodes: open the episode stats drilldown from a play-count click in the Episodes tab. [#48792]
+- Podcast Settings: create new categories inline without leaving the podcast dashboard. [#48791]
+- Podcast stats: rebuild summary tiles and bar list rows on @wordpress/components primitives. [#48742]
+- Podcast stats dashboard: replace period dropdown with Calypso Stats date range picker (presets, calendar, custom from/to). [#48742]
+- Polish the podcast setup flow: pin the post-setup destination to Settings, add a lead-in to the category picker modal, and surface a "+ Create episode" CTA on the empty Episodes state. [#48882]
+- Settings: Add a "Cover image" subheading above the cover image control and rename the "Podcast category" section to "Post category". [#48880]
+- Stats: Use Studio Blue (#3858e9) for bar colors on every surface, matching Calypso defaults. [#48888]
+- Stats tab: Align Top episodes, By app, and Locations cards with the WordPress.com Stats card module look (real border, larger header, and 24px padding). [#48761]
+- Update welcome screen copy to lead with the blog and newsletter story, and refresh the feature boxes and how-it-works steps. [#48796]
+
+### Fixed
+- Always show the Disable podcasting card on the settings tab, and return the user to the welcome screen after disabling, so the back-out flow works before a category has been chosen. [#48797]
+- Create AI Podcast: Clarify that free trial credits do not reset. [#48957]
+- Create AI Podcast: serve the generated-episodes list directly from the site database so it works on Atomic installs. [#48900]
+- Distribution: revert Podcast Index logo to previous version. [#48922]
+- Podcast: enqueue WP media library so the cover image selector loads. [#48720]
+- Podcast: skip rewriting the RSS enclosure URL through the stats endpoint when the URL does not resolve to a local attachment, so externally hosted enclosures stay playable. [#48878]
+- Polish Podcast dashboard styles: match placeholder thumbnail size to populated thumbnails, and space out the Distribution tab's warning notice. [#48920]
+
 ## 0.1.0 - 2026-05-11
 ### Added
 - Add initial package gated behind the `jetpack_podcast_untangle` filter. [#48556]
@@ -17,3 +71,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Dashboard: Replace the wp-build placeholder with page chrome and tab navigation. [#48559]
 - Dashboard: Slim down wp-build wiring to the Backup pattern. [#48600]
+
+[1.0.0]: https://github.com/Automattic/jetpack-podcast/compare/v0.1.0...v1.0.0

--- a/projects/packages/podcast/changelog/add-podcast-episode-block
+++ b/projects/packages/podcast/changelog/add-podcast-episode-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the Podcast Episode block. Embeds a single podcast episode from an audio or video file with Podcasting 2.0 metadata. Registration is gated behind the `jetpack_podcast_untangle` filter (default off).

--- a/projects/packages/podcast/changelog/add-podcast-welcome-category-modal
+++ b/projects/packages/podcast/changelog/add-podcast-welcome-category-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Podcast Welcome: require a category when enabling podcasting.

--- a/projects/packages/podcast/changelog/add-podcast-welcome-pricing-card
+++ b/projects/packages/podcast/changelog/add-podcast-welcome-pricing-card
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a Free and Premium plan card to the podcast welcome screen so users can see what podcasting includes per plan before they enable.

--- a/projects/packages/podcast/changelog/add-post-publish-podcast-promo
+++ b/projects/packages/podcast/changelog/add-post-publish-podcast-promo
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Posts to Podcast: Add an editor modal inviting eligible sites to create a podcast episode after publishing a post.

--- a/projects/packages/podcast/changelog/add-posts-to-podcast-section
+++ b/projects/packages/podcast/changelog/add-posts-to-podcast-section
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Posts to Podcast: new Media > Create AI Podcast wp-admin page for generating podcast episode drafts from posts via the wpcom-side pipeline. Pick posts to include or use a recent-posts window, steer the output with a free-form prompt, watch a remaining-credits indicator backed by the quota-snapshot endpoint, and resume polling across page reloads. The page is plain PHP plus a vanilla-JS island — no React or wp-build chassis for this surface. Feature is wpcom-only; self-hosted Jetpack sites don't see the menu.

--- a/projects/packages/podcast/changelog/add-posts-to-podcast-tracks-events
+++ b/projects/packages/podcast/changelog/add-posts-to-podcast-tracks-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Create AI Podcast: emit client-side tracks events for page view, generation request, episode plays, draft opens, pagination, and the quota banner / upgrade CTAs.

--- a/projects/packages/podcast/changelog/add-stats-ui
+++ b/projects/packages/podcast/changelog/add-stats-ui
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats tab: render show- and episode-level podcast download stats.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-add-pocket-cast
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-add-pocket-cast
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Pocket Casts: replace the 3-step submit modal with a one-click Relay API flow that reflects pending/submitted state on the button and surfaces rejection reasons inline.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-add-podcast-show-state
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-add-podcast-show-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Distribution tab: show Pending/Live state badges next to each podcast directory.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-cover-image-refinement
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-cover-image-refinement
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: serve square cover art in the feed by center-cropping via Photon, regardless of source aspect ratio.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-fix-image-selector
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-fix-image-selector
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: enqueue WP media library so the cover image selector loads.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-grandfather-cutoff
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-grandfather-cutoff
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: grandfather Premium access by site registration date; drop the sticker-based grandfathering path.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-narrow-grandfather-paid
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-narrow-grandfather-paid
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: narrow grandfather rule to sites registered before the cutoff that are also on a paid plan.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-proxy-default
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-proxy-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Default the untangle gate to enabled for A8C-proxied requests so Automatticians dogfood the new package on Simple and Atomic.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-stats-gate-premium-error-code
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-stats-gate-premium-error-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Episode stats: dispatch the premium-required state on the `podcast_premium_required` error code instead of HTTP 402.

--- a/projects/packages/podcast/changelog/exclude-dev-vendor-files
+++ b/projects/packages/podcast/changelog/exclude-dev-vendor-files
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Exclude development files from production builds.

--- a/projects/packages/podcast/changelog/fix-create-ai-podcast-free-credit-reset-copy
+++ b/projects/packages/podcast/changelog/fix-create-ai-podcast-free-credit-reset-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create AI Podcast: Clarify that free trial credits do not reset.

--- a/projects/packages/podcast/changelog/fix-jetpack-adjust_wp-build_builds
+++ b/projects/packages/podcast/changelog/fix-jetpack-adjust_wp-build_builds
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: Run webpack and wp-build scripts concurrently.

--- a/projects/packages/podcast/changelog/fix-podcast-disable-always-visible
+++ b/projects/packages/podcast/changelog/fix-podcast-disable-always-visible
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Always show the Disable podcasting card on the settings tab, and return the user to the welcome screen after disabling, so the back-out flow works before a category has been chosen.

--- a/projects/packages/podcast/changelog/fix-podcast-episode-thumb-placeholder-size
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-thumb-placeholder-size
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Polish Podcast dashboard styles: match placeholder thumbnail size to populated thumbnails, and space out the Distribution tab's warning notice.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-skip-untrusted-enclosure-rewrite
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-skip-untrusted-enclosure-rewrite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: skip rewriting the RSS enclosure URL through the stats endpoint when the URL does not resolve to a local attachment, so externally hosted enclosures stay playable.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-xml-escaping
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-xml-escaping
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Podcast: escape title overrides, descriptions, and iTunes category attribute values for the RSS feed to prevent malformed XML.

--- a/projects/packages/podcast/changelog/fix-podcast-index-logo
+++ b/projects/packages/podcast/changelog/fix-podcast-index-logo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Distribution: revert Podcast Index logo to previous version.

--- a/projects/packages/podcast/changelog/fix-posts-to-podcast-atomic-episodes
+++ b/projects/packages/podcast/changelog/fix-posts-to-podcast-atomic-episodes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create AI Podcast: serve the generated-episodes list directly from the site database so it works on Atomic installs.

--- a/projects/packages/podcast/changelog/fix-posts-to-podcast-non-json-errors
+++ b/projects/packages/podcast/changelog/fix-posts-to-podcast-non-json-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Create AI Podcast: map 429 responses (including non-JSON edge rate-limit pages) to "Out of credits" and other non-JSON failures to "An unexpected error occurred." instead of "The response is not a valid JSON response."; decode HTML entities in the posts-picker titles so values like "&nbsp;" no longer render literally; add an "Experimental" badge to the intro banner; instrument the generation poller and post-publish promo with Tracks events for funnel analysis.

--- a/projects/packages/podcast/changelog/podcast-loose-ends-align-block-gate
+++ b/projects/packages/podcast/changelog/podcast-loose-ends-align-block-gate
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast Episode block: delegate the untangle gate to Podcast::is_enabled() so the block honors the same default as the rest of the package.

--- a/projects/packages/podcast/changelog/pods-141-add-gate
+++ b/projects/packages/podcast/changelog/pods-141-add-gate
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Podcast: add product-access gate (Podcast_Gate::has_product_access) and grandfather sticker constant.

--- a/projects/packages/podcast/changelog/pods-146-client-gate-stats-on-premium
+++ b/projects/packages/podcast/changelog/pods-146-client-gate-stats-on-premium
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Episodes stats: detect 402 responses from the episode stats endpoint as a Premium-required state.

--- a/projects/packages/podcast/changelog/pods-amazon-music-logo
+++ b/projects/packages/podcast/changelog/pods-amazon-music-logo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Distribution: refresh Apple Podcasts, Spotify, YouTube Music, Amazon Music, and Podcast Index logos with current brand marks. Rename the YouTube directory to YouTube Music. Map matching slugs in the Stats "By app" and "Top app" labels.

--- a/projects/packages/podcast/changelog/pods-locked-preview
+++ b/projects/packages/podcast/changelog/pods-locked-preview
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Dashboard: gate the Episodes tab on Premium product access, with a blurred locked-preview overlay for free users.

--- a/projects/packages/podcast/changelog/pods-setup-flow-polish
+++ b/projects/packages/podcast/changelog/pods-setup-flow-polish
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Polish the podcast setup flow: pin the post-setup destination to Settings, add a lead-in to the category picker modal, and surface a "+ Create episode" CTA on the empty Episodes state.

--- a/projects/packages/podcast/changelog/pods-show-details-labels
+++ b/projects/packages/podcast/changelog/pods-show-details-labels
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Settings: Add a "Cover image" subheading above the cover image control and rename the "Podcast category" section to "Post category".

--- a/projects/packages/podcast/changelog/strip-unminified-from-production-build
+++ b/projects/packages/podcast/changelog/strip-unminified-from-production-build
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Production builds no longer ship the unminified `.js`/`.css` wp-build outputs. SCRIPT_DEBUG-driven loads now always resolve to the minified bundle.

--- a/projects/packages/podcast/changelog/update-podcast-dashboard-tab-order
+++ b/projects/packages/podcast/changelog/update-podcast-dashboard-tab-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast dashboard: reorder tabs so Stats appears first, followed by Episodes, Distribution, and Settings.

--- a/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
+++ b/projects/packages/podcast/changelog/update-podcast-episode-schema-markup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast Episode: enrich front-end schema.org markup and make chapter / soundbite list items click-to-seek in the audio player.

--- a/projects/packages/podcast/changelog/update-podcast-episodes-image-fallback
+++ b/projects/packages/podcast/changelog/update-podcast-episodes-image-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast Episodes: fall back to the show cover image when an episode has no featured image.

--- a/projects/packages/podcast/changelog/update-podcast-episodes-plays-drilldown
+++ b/projects/packages/podcast/changelog/update-podcast-episodes-plays-drilldown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast Episodes: open the episode stats drilldown from a play-count click in the Episodes tab.

--- a/projects/packages/podcast/changelog/update-podcast-settings-category-modal
+++ b/projects/packages/podcast/changelog/update-podcast-settings-category-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast Settings: create new categories inline without leaving the podcast dashboard.

--- a/projects/packages/podcast/changelog/update-podcast-stats-bar-colors
+++ b/projects/packages/podcast/changelog/update-podcast-stats-bar-colors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Stats: Use Studio Blue (#3858e9) for bar colors on every surface, matching Calypso defaults.

--- a/projects/packages/podcast/changelog/update-podcast-stats-bottom-cards-wpcom-styling
+++ b/projects/packages/podcast/changelog/update-podcast-stats-bottom-cards-wpcom-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Stats tab: Align Top episodes, By app, and Locations cards with the WordPress.com Stats card module look (real border, larger header, and 24px padding).

--- a/projects/packages/podcast/changelog/update-podcast-stats-components-refactor
+++ b/projects/packages/podcast/changelog/update-podcast-stats-components-refactor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast stats: rebuild summary tiles and bar list rows on @wordpress/components primitives.

--- a/projects/packages/podcast/changelog/update-podcast-stats-date-range-picker
+++ b/projects/packages/podcast/changelog/update-podcast-stats-date-range-picker
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast stats dashboard: replace period dropdown with Calypso Stats date range picker (presets, calendar, custom from/to).

--- a/projects/packages/podcast/changelog/update-podcast-stats-visual-polish
+++ b/projects/packages/podcast/changelog/update-podcast-stats-visual-polish
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: visual polish on the Stats tab — keep horizontal padding at narrow widths, lighter card headers, and integer-only axis ticks on the Downloads chart.

--- a/projects/packages/podcast/changelog/update-podcast-tabs-padding-and-font-size
+++ b/projects/packages/podcast/changelog/update-podcast-tabs-padding-and-font-size
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast dashboard: opt into the shared `jp-admin-page-tabs--minimal` modifier so the tab strip aligns with the page header and labels use the design-system font size.

--- a/projects/packages/podcast/changelog/update-podcast-welcome-copy
+++ b/projects/packages/podcast/changelog/update-podcast-welcome-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update welcome screen copy to lead with the blog and newsletter story, and refresh the feature boxes and how-it-works steps.

--- a/projects/packages/podcast/changelog/update-posts-to-podcast-create-page-polish
+++ b/projects/packages/podcast/changelog/update-posts-to-podcast-create-page-polish
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Create AI Podcast: visual polish, floating toast notices, dismissible notices, generated episodes list, server-side bootstrap, and credits panel with reset messaging.

--- a/projects/packages/podcast/changelog/update-production-exclude-boilerplate
+++ b/projects/packages/podcast/changelog/update-production-exclude-boilerplate
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Clean up `.gitattributes`, moved a lot of boilerplate to the monorepo root.
-
-

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -55,7 +55,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-podcast",
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "1.0.x-dev"
 		},
 		"textdomain": "jetpack-podcast",
 		"version-constants": {

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-podcast",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"private": true,
 	"description": "Jetpack Podcast functionality (Simple and Atomic only).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/podcast/#readme",

--- a/projects/packages/podcast/src/class-create-ai-podcast-page.php
+++ b/projects/packages/podcast/src/class-create-ai-podcast-page.php
@@ -195,7 +195,7 @@ class Create_AI_Podcast_Page {
 		/**
 		 * Filters the minimum posts published in the last month needed for the Posts to Podcast post-publish promo.
 		 *
-		 * @since $$next-version$$
+		 * @since 1.0.0
 		 *
 		 * @param int $minimum Minimum number of published posts.
 		 */
@@ -240,7 +240,7 @@ class Create_AI_Podcast_Page {
 		/**
 		 * Filters the minimum visitors in the last week needed for the Posts to Podcast post-publish promo.
 		 *
-		 * @since $$next-version$$
+		 * @since 1.0.0
 		 *
 		 * @param int $minimum Minimum number of visitors.
 		 */

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -21,7 +21,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Podcast {
 
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '1.0.0';
 
 	/**
 	 * Whether the class has been initialized.

--- a/projects/plugins/mu-wpcom-plugin/changelog/podcast-release-1.0-composer-lock
+++ b/projects/plugins/mu-wpcom-plugin/changelog/podcast-release-1.0-composer-lock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock for podcast 1.0.0 release.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1431,7 +1431,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "165176b0f879970e605cf1219a0c286a0f3fcb0d"
+                "reference": "7689dce6984ad7d23f76f02c1138b01cc6d3629f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1456,7 +1456,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "1.0.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/podcast-release-1.0-composer-lock
+++ b/projects/plugins/wpcomsh/changelog/podcast-release-1.0-composer-lock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock for podcast 1.0.0 release.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1638,7 +1638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "165176b0f879970e605cf1219a0c286a0f3fcb0d"
+                "reference": "7689dce6984ad7d23f76f02c1138b01cc6d3629f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1663,7 +1663,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "1.0.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {


### PR DESCRIPTION
## Summary
- Cuts the first non-scaffold release of the `jetpack-podcast` package: `0.1.0` -> `1.0.0`.
- Major bump is intentional: the package has accumulated 45 pending changelog entries since the initial scaffold (wp-admin SPA, REST/feed integration, untangle gate, Stats/Distribution tabs, AI Posts-to-Podcast, security fixes, etc.) and consumers need a non-default-`0.1.0` version to win the Jetpack autoloader tie-break against stale plugin copies.
- Specifically unblocks the wpcomsh fatal where `Automattic\Jetpack\Podcast\Podcast::is_enabled()` exists in source but a stale Jetpack mu-plugin copy on Atomic shadows it. Once this lands, consumers picking up `1.0.x-dev` will autoload the copy that has the method.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- [ ] CI passes (lint, unit, intra-monorepo deps).
- [ ] `composer install` in a consumer (e.g. `projects/packages/jetpack-mu-wpcom`) resolves `automattic/jetpack-podcast` to `1.0.x-dev`.
- [ ] `\Automattic\Jetpack\Podcast\Podcast::PACKAGE_VERSION === '1.0.0'`.
- [ ] CHANGELOG.md renders the consolidated 1.0.0 entry cleanly.
