### PR TITLE
[RSM] Enable AI Editorial Review sidebar flag by default

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-sidebar-filter-bigsky-provider
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-sidebar-filter-bigsky-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI Sidebar: Fix block editing when another agent provider is present.

--- a/projects/plugins/jetpack/changelog/lift-ai-editorial-review-gate
+++ b/projects/plugins/jetpack/changelog/lift-ai-editorial-review-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Sidebar: Enable AI Editorial Review by default while preserving the feature-specific kill switch.

--- a/projects/plugins/jetpack/changelog/lift-ai-editorial-review-gate
+++ b/projects/plugins/jetpack/changelog/lift-ai-editorial-review-gate
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Sidebar: Enable AI Editorial Review by default while preserving the feature-specific kill switch.
+Jetpack AI Sidebar: Allow AI Editorial Review through the sidebar preview.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -43,12 +43,12 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to false (opt-in). Use this filter to enable the feature
-		 * in specific environments while the feature is under development.
+		 * Defaults to the AI Editorial Review feature flag. Use this filter
+		 * as a host-level kill switch for the whole sidebar entrypoint.
 		 *
 		 * @param bool $enabled Whether the AI sidebar is enabled.
 		 */
-		if ( ! apply_filters( 'jetpack_ai_sidebar_enabled', false ) ) {
+		if ( ! apply_filters( 'jetpack_ai_sidebar_enabled', self::is_review_mediator_enabled() ) ) {
 			return;
 		}
 
@@ -58,6 +58,10 @@ class Jetpack_AI_Sidebar {
 		add_filter( 'agents_manager_agent_providers', array( __CLASS__, 'register_provider' ), 20 );
 
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
+
+		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the
+		// post editor on WordPress.com and Atomic sites.
+		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
 
 		// Load AM from CDN if not already present.
 		// Priority 200: runs AFTER the AM class in jetpack-mu-wpcom (priority 101),
@@ -86,7 +90,7 @@ class Jetpack_AI_Sidebar {
 	 * @return void
 	 */
 	public static function maybe_enqueue_am(): void {
-		if ( ! self::is_block_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -122,7 +126,7 @@ class Jetpack_AI_Sidebar {
 	 * @return void
 	 */
 	public static function maybe_enqueue_abilities_script(): void {
-		if ( ! self::is_block_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -499,6 +503,20 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * Enable Agents Manager in the post editor when AI Editorial Review is available.
+	 *
+	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
+	 * @return bool
+	 */
+	public static function enable_agents_manager_in_post_editor( $enabled ): bool {
+		if ( $enabled ) {
+			return true;
+		}
+
+		return self::is_review_mediator_enabled() && self::is_post_editor();
+	}
+
+	/**
 	 * Inject reviewMediatorEnabled into an externally enqueued AM bundle.
 	 *
 	 * The design-intended hook is jetpack_ai_sidebar_agents_manager_data, applied
@@ -519,7 +537,7 @@ class Jetpack_AI_Sidebar {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
-		if ( ! self::is_block_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 		// 'registered' rather than 'enqueued': wp_add_inline_script attaches to any
@@ -555,6 +573,22 @@ class Jetpack_AI_Sidebar {
 
 		$screen = get_current_screen();
 		return $screen && $screen->is_block_editor();
+	}
+
+	/**
+	 * Check if the current screen is the post block editor.
+	 *
+	 * @return bool
+	 */
+	private static function is_post_editor(): bool {
+		if ( ! self::is_block_editor() ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return $screen instanceof \WP_Screen
+			&& 'post' === $screen->base
+			&& 'post' === $screen->post_type;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -27,6 +27,7 @@ const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai
 const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
 const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
 const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
 
 /**
  * Handles loading the Agents Manager from CDN and registering the
@@ -272,6 +273,7 @@ class Jetpack_AI_Sidebar {
 
 		// Direct CDN-loader fallback. Jetpack owns these defaults; hosts can
 		// override via the AI Editorial Review and preview filters.
+		$am_data['agentId']                  = AI_SIDEBAR_AGENT_ID;
 		$am_data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$am_data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $am_data;
@@ -555,6 +557,7 @@ class Jetpack_AI_Sidebar {
 
 		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
 		// intentional overrides should use the AI Editorial Review and preview filters.
+		$data['agentId']                  = AI_SIDEBAR_AGENT_ID;
 		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
@@ -613,10 +616,15 @@ class Jetpack_AI_Sidebar {
 			self::get_jetpack_ai_sidebar_preview_config(),
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
+		$agent_id_payload            = wp_json_encode(
+			AI_SIDEBAR_AGENT_ID,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
 
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
+				. ' agentsManagerData.agentId = ' . $agent_id_payload . ';'
 				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
 				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'
 				. ' }',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -466,17 +466,18 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * UI feature flag for Review Mediator. Server still gates execution.
-	 * Reuses the existing dev-mode predicate (proxied requests + known
-	 * dev hosts) — same precedent as Image Studio.
+	 * UI feature flag for AI Editorial Review.
+	 *
+	 * Server-side permission checks still gate execution. This site-side flag
+	 * controls whether the sidebar suggestion is exposed, while keeping a
+	 * feature-specific filter available as a kill switch.
 	 *
 	 * @return bool
 	 */
 	private static function is_review_mediator_enabled(): bool {
 		return (bool) apply_filters(
 			'jetpack_ai_review_mediator_enabled',
-			// Intentionally site-side: wpcom uses A8C user/proxy context for backend execution.
-			self::is_dev_mode()
+			true
 		);
 	}
 
@@ -510,7 +511,7 @@ class Jetpack_AI_Sidebar {
 	 * redeploy.
 	 *
 	 * Skipped on WordPress.com Simple — wpcom's data extension owns the predicate
-	 * there with stricter A8C+proxied checks.
+	 * there, including any wpcom_review_mediator_enabled kill-switch override.
 	 *
 	 * @return void
 	 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -19,15 +19,16 @@ use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 require_once __DIR__ . '/../../../shared/cdn-locale.php';
 
-const AM_ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
-const AM_ASSET_TRANSIENT         = 'jetpack_am_gutenberg_asset';
-const AM_ASSET_DC_TRANSIENT      = 'jetpack_am_gutenberg_dc_asset';
-const AI_SIDEBAR_ASSET_TRANSIENT = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
+const AM_ASSET_BASE_PATH          = 'widgets.wp.com/agents-manager/';
+const AM_ASSET_TRANSIENT          = 'jetpack_am_gutenberg_asset';
+const AM_ASSET_DC_TRANSIENT       = 'jetpack_am_gutenberg_dc_asset';
+const AI_SIDEBAR_ASSET_TRANSIENT  = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL           = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL      = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID         = 'wp-orchestrator';
+const BIG_SKY_AGENT_PROVIDER_PATH = '/big-sky-plugin/build/calypso-agent-provider/';
 
 /**
  * Handles loading the Agents Manager from CDN and registering the
@@ -557,10 +558,30 @@ class Jetpack_AI_Sidebar {
 
 		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
 		// intentional overrides should use the AI Editorial Review and preview filters.
+		if ( isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] ) ) {
+			$data['agentProviders'] = self::filter_agent_providers_for_jetpack_ai_sidebar( $data['agentProviders'] );
+		}
 		$data['agentId']                  = AI_SIDEBAR_AGENT_ID;
 		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
+	}
+
+	/**
+	 * Remove providers that should not participate in the Jetpack AI Sidebar surface.
+	 *
+	 * @param array $providers Provider URLs.
+	 * @return array Filtered provider URLs.
+	 */
+	private static function filter_agent_providers_for_jetpack_ai_sidebar( array $providers ): array {
+		return array_values(
+			array_filter(
+				$providers,
+				static function ( $provider ): bool {
+					return ! is_string( $provider ) || ! str_contains( $provider, BIG_SKY_AGENT_PROVIDER_PATH );
+				}
+			)
+		);
 	}
 
 	/**
@@ -620,10 +641,15 @@ class Jetpack_AI_Sidebar {
 			AI_SIDEBAR_AGENT_ID,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
+		$big_sky_provider_payload    = wp_json_encode(
+			BIG_SKY_AGENT_PROVIDER_PATH,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
 
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
+				. ' if ( Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter( function( provider ) { return typeof provider !== "string" || provider.indexOf( ' . $big_sky_provider_payload . ' ) === -1; } ); }'
 				. ' agentsManagerData.agentId = ' . $agent_id_payload . ';'
 				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
 				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -4,7 +4,7 @@
  *
  * Loads the Agents Manager gutenberg variant from the widgets.wp.com CDN
  * (following the Image Studio pattern) and registers the Jetpack AI
- * provider for title optimization.
+ * provider for Jetpack AI tools.
  *
  * @package automattic/jetpack
  */
@@ -43,12 +43,12 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to the AI Editorial Review feature flag. Use this filter
-		 * as a host-level kill switch for the whole sidebar entrypoint.
+		 * Defaults to the Jetpack AI Sidebar Preview gate. Use this filter as
+		 * a host-level kill switch for the whole sidebar entrypoint.
 		 *
 		 * @param bool $enabled Whether the AI sidebar is enabled.
 		 */
-		if ( ! apply_filters( 'jetpack_ai_sidebar_enabled', self::is_review_mediator_enabled() ) ) {
+		if ( ! apply_filters( 'jetpack_ai_sidebar_enabled', self::is_jetpack_ai_sidebar_preview_enabled() ) ) {
 			return;
 		}
 
@@ -68,16 +68,16 @@ class Jetpack_AI_Sidebar {
 		// so wp_script_is('agents-manager') correctly detects if AM is already loaded.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_am' ), 200 );
 
-		// Always enqueue the IIFE bundle in the block editor — it registers
+		// Enqueue the IIFE bundle in the preview post editor — it registers
 		// Jetpack AI abilities via @wordpress/abilities, which Big Sky or AM
 		// can discover regardless of which provider system is active.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_abilities_script' ), 201 );
 
-		// Patch reviewMediatorEnabled into agentsManagerData when AM was
-		// enqueued by an external host (Big Sky on Atomic, etc.) and the
+		// Patch Jetpack AI Sidebar Preview data into agentsManagerData when AM
+		// was enqueued by an external host (Big Sky on Atomic, etc.) and the
 		// jetpack_ai_sidebar_agents_manager_data filter never fired. Priority
 		// 250 runs after both mu-wpcom (101) and the CDN loader above (200).
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_patch_review_mediator_flag' ), 250 );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -85,12 +85,12 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Load AM from CDN if not already present and we're in the block editor.
+	 * Load AM from CDN if not already present and we're in the preview post editor.
 	 *
 	 * @return void
 	 */
 	public static function maybe_enqueue_am(): void {
-		if ( ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -120,13 +120,13 @@ class Jetpack_AI_Sidebar {
 	/**
 	 * Enqueue the IIFE bundle that registers Jetpack AI abilities.
 	 *
-	 * This runs independently of AM/provider registration so abilities
+	 * This runs independently of AM/provider registration so preview abilities
 	 * are available even when Big Sky standalone is the active UI.
 	 *
 	 * @return void
 	 */
 	public static function maybe_enqueue_abilities_script(): void {
-		if ( ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -270,8 +270,10 @@ class Jetpack_AI_Sidebar {
 		$filtered = apply_filters( 'jetpack_ai_sidebar_agents_manager_data', $am_data );
 		$am_data  = is_array( $filtered ) ? $filtered : $am_data;
 
-		// Direct CDN-loader fallback. Jetpack owns this flag; hosts can override via jetpack_ai_review_mediator_enabled.
-		$am_data['reviewMediatorEnabled'] = self::is_review_mediator_enabled();
+		// Direct CDN-loader fallback. Jetpack owns these defaults; hosts can
+		// override via the AI Editorial Review and preview filters.
+		$am_data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
+		$am_data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $am_data;
 	}
 
@@ -402,6 +404,13 @@ class Jetpack_AI_Sidebar {
 			return $providers;
 		}
 
+		// The provider IIFE is only enqueued in the post editor. Avoid registering
+		// the ESM wrapper on other block-editor surfaces, where AM may import it
+		// before window.__JetpackAIProvider exists.
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+			return $providers;
+		}
+
 		// Don't register if the IIFE bundle cannot be loaded. The ESM wrapper
 		// re-exports from window.__JetpackAIProvider at import time; if the
 		// IIFE never ran, toolProvider is still a truthy Proxy and AM would
@@ -478,10 +487,54 @@ class Jetpack_AI_Sidebar {
 	 *
 	 * @return bool
 	 */
-	private static function is_review_mediator_enabled(): bool {
+	private static function is_ai_editorial_review_enabled(): bool {
 		return (bool) apply_filters(
-			'jetpack_ai_review_mediator_enabled',
+			'jetpack_ai_editorial_review_enabled',
 			true
+		);
+	}
+
+	/**
+	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
+	 *
+	 * AI Editorial Review remains a feature inside the preview. Hosts can open
+	 * the preview independently in the future while keeping AI Editorial Review
+	 * behind its own feature-specific gate.
+	 *
+	 * @return bool
+	 */
+	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
+		return (bool) apply_filters(
+			'jetpack_ai_sidebar_preview_enabled',
+			self::is_ai_editorial_review_enabled()
+		);
+	}
+
+	/**
+	 * Preview configuration consumed by the Agents Manager and Jetpack AI provider bundles.
+	 *
+	 * @return array Preview mode and feature availability.
+	 */
+	private static function get_jetpack_ai_sidebar_preview_config(): array {
+		$features = array(
+			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
+			'blockTransformations'    => true,
+			'optimizeTitleSuggestion' => false,
+			'chatHistory'             => false,
+			'supportGuides'           => false,
+		);
+
+		/**
+		 * Filter the feature set exposed in Jetpack AI Sidebar Preview.
+		 *
+		 * @param array $features Associative array of preview feature flags.
+		 */
+		$filtered_features = apply_filters( 'jetpack_ai_sidebar_preview_features', $features );
+		$features          = is_array( $filtered_features ) ? array_merge( $features, $filtered_features ) : $features;
+
+		return array(
+			'enabled'  => self::is_jetpack_ai_sidebar_preview_enabled(),
+			'features' => $features,
 		);
 	}
 
@@ -496,14 +549,19 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		// Set Jetpack's default for externally emitted payloads. Hosts that need
-		// an intentional review-mediator override should use jetpack_ai_review_mediator_enabled.
-		$data['reviewMediatorEnabled'] = self::is_review_mediator_enabled();
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+			return $data;
+		}
+
+		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
+		// intentional overrides should use the AI Editorial Review and preview filters.
+		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
+		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
 	}
 
 	/**
-	 * Enable Agents Manager in the post editor when AI Editorial Review is available.
+	 * Enable Agents Manager in the post editor when Jetpack AI Sidebar Preview is available.
 	 *
 	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
 	 * @return bool
@@ -513,31 +571,31 @@ class Jetpack_AI_Sidebar {
 			return true;
 		}
 
-		return self::is_review_mediator_enabled() && self::is_post_editor();
+		return self::is_jetpack_ai_sidebar_preview_enabled() && self::is_post_editor() && self::has_ai_features();
 	}
 
 	/**
-	 * Inject reviewMediatorEnabled into an externally enqueued AM bundle.
+	 * Inject Jetpack AI Sidebar Preview data into an externally enqueued AM bundle.
 	 *
 	 * The design-intended hook is jetpack_ai_sidebar_agents_manager_data, applied
 	 * by jetpack-mu-wpcom Agents_Manager::enqueue_scripts(). On Atomic the bundled
 	 * mu-wpcom (via wpcomsh) lags this PR, so the filter never fires and the
-	 * client gets agentsManagerData without our flag. This `before` script runs
+	 * client gets agentsManagerData without our fields. This `before` script runs
 	 * after the upstream `before` that declares the const (added earlier) but
 	 * before the AM bundle reads it, so the field is set when AM initialises.
 	 * Gives Atomic parity with Jurassic Ninja without depending on a wpcomsh
 	 * redeploy.
 	 *
 	 * Skipped on WordPress.com Simple — wpcom's data extension owns the predicate
-	 * there, including any wpcom_review_mediator_enabled kill-switch override.
+	 * there, including any WordPress.com-specific kill-switch override.
 	 *
 	 * @return void
 	 */
-	public static function maybe_patch_review_mediator_flag(): void {
+	public static function maybe_patch_jetpack_ai_sidebar_preview_data(): void {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
-		if ( ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 		// 'registered' rather than 'enqueued': wp_add_inline_script attaches to any
@@ -547,15 +605,20 @@ class Jetpack_AI_Sidebar {
 			return;
 		}
 
-		$payload = wp_json_encode(
-			self::is_review_mediator_enabled(),
+		$ai_editorial_review_payload = wp_json_encode(
+			self::is_ai_editorial_review_enabled(),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
+		$preview_payload             = wp_json_encode(
+			self::get_jetpack_ai_sidebar_preview_config(),
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
 
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
-				. ' agentsManagerData.reviewMediatorEnabled = ' . $payload . ';'
+				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
+				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'
 				. ' }',
 			'before'
 		);

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -552,6 +552,32 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Big Sky's provider should not participate in the Jetpack AI Sidebar surface.
+	 */
+	public function test_add_agents_manager_data_filters_big_sky_provider() {
+		$this->set_block_editor_screen();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName'    => 'gutenberg',
+				'agentProviders' => array(
+					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+					'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+					array( 'provider' => 'metadata' ),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+				array( 'provider' => 'metadata' ),
+			),
+			$data['agentProviders']
+		);
+	}
+
+	/**
 	 * Preview and AI Editorial Review have separate gates.
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
@@ -711,13 +737,25 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		// Simulate external host (mu-wpcom / Big Sky) having enqueued AM and
-		// declared the upstream const.
+		// Simulate an external host having enqueued AM and declared upstream
+		// data with both Jetpack AI Sidebar and Big Sky providers.
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
-		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+		wp_add_inline_script(
+			'agents-manager',
+			'const agentsManagerData = { sectionName: "gutenberg", agentProviders: [ "https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123", "https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs" ] };',
+			'before'
+		);
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'/big-sky-plugin/build/calypso-agent-provider/',
+			$this->get_agents_manager_inline_script()
+		);
 		$this->assertStringContainsString(
 			'agentsManagerData.agentId = "wp-orchestrator"',
 			$this->get_agents_manager_inline_script()

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -304,15 +304,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Default off when no dev-mode signal is present and no filter override.
+	 * Default on when no dev-mode signal is present and no filter override.
 	 */
-	public function test_maybe_enqueue_am_hides_review_mediator_by_default() {
+	public function test_maybe_enqueue_am_exposes_review_mediator_by_default() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"reviewMediatorEnabled":true', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -404,6 +404,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_maybe_enqueue_am_prevents_data_filter_from_enabling_review_mediator() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
+		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
 		add_filter(
 			'jetpack_ai_sidebar_agents_manager_data',
 			function ( $data ) {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -50,6 +50,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		$this->reset_sidebar_hooks();
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 		update_option( 'jetpack_offline_mode', '0' );
 		Status_Cache::clear();
@@ -75,11 +76,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		delete_transient( AiAssistantPlugin\AM_ASSET_TRANSIENT );
 		delete_transient( AiAssistantPlugin\AM_ASSET_DC_TRANSIENT );
 		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
-		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		remove_all_filters( 'agents_manager_agent_providers' );
-		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
-		remove_all_filters( 'jetpack_ai_review_mediator_enabled' );
-		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
+		$this->reset_sidebar_hooks();
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_ai_enabled' );
 		remove_all_filters( 'jetpack_offline_mode' );
@@ -93,6 +90,20 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$GLOBALS['wp_scripts']     = $this->saved_wp_scripts;
 		$GLOBALS['wp_styles']      = $this->saved_wp_styles;
 		parent::tear_down();
+	}
+
+	/**
+	 * Reset sidebar hooks that may be registered by plugin bootstrap or earlier tests.
+	 */
+	private function reset_sidebar_hooks() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		remove_all_filters( 'agents_manager_agent_providers' );
+		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
+		remove_all_filters( 'jetpack_ai_review_mediator_enabled' );
+		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
+		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_am' ), 200 );
+		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ), 201 );
+		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_review_mediator_flag' ), 250 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -99,11 +99,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
-		remove_all_filters( 'jetpack_ai_review_mediator_enabled' );
+		remove_all_filters( 'jetpack_ai_editorial_review_enabled' );
+		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
+		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_am' ), 200 );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ), 201 );
-		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_review_mediator_flag' ), 250 );
+		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
 	}
 
 	/**
@@ -271,6 +273,41 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that init() does nothing when the preview gate is disabled.
+	 */
+	public function test_init_does_nothing_when_preview_gate_is_false() {
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_false' );
+		Jetpack_AI_Sidebar::init();
+
+		$this->assertFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should not be hooked when the preview gate is false.'
+		);
+		$this->assertFalse(
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
+			'enable_agents_manager_in_post_editor should not be hooked when the preview gate is false.'
+		);
+	}
+
+	/**
+	 * Test that the preview surface can initialize without AI Editorial Review.
+	 */
+	public function test_init_registers_hooks_when_preview_is_enabled_without_ai_editorial_review() {
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
+		Jetpack_AI_Sidebar::init();
+
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should be hooked when the preview gate is true.'
+		);
+		$this->assertNotFalse(
+			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_am' ) ),
+			'maybe_enqueue_am should be hooked when the preview gate is true.'
+		);
+	}
+
+	/**
 	 * Test that init() registers hooks when the feature filter is true.
 	 */
 	public function test_init_registers_hooks_when_enabled() {
@@ -325,17 +362,38 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that the Agents Manager block-editor gate preserves existing true values.
 	 */
 	public function test_enable_agents_manager_in_post_editor_preserves_existing_true() {
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_page_block_editor_screen();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( true ) );
 	}
 
 	/**
-	 * Test that the review mediator kill switch closes this Agents Manager entrypoint.
+	 * Test that the AI Editorial Review kill switch closes this Agents Manager entrypoint.
 	 */
-	public function test_enable_agents_manager_in_post_editor_respects_review_mediator_filter() {
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
+	public function test_enable_agents_manager_in_post_editor_respects_ai_editorial_review_filter() {
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		$this->set_block_editor_screen();
+
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the preview surface can open independently of AI Editorial Review.
+	 */
+	public function test_enable_agents_manager_in_post_editor_respects_preview_filter() {
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
+		$this->set_block_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate does not open when AI features are disabled.
+	 */
+	public function test_enable_agents_manager_in_post_editor_skips_when_ai_disabled() {
+		add_filter( 'jetpack_ai_enabled', '__return_false' );
 		$this->set_block_editor_screen();
 
 		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
@@ -370,6 +428,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that maybe_enqueue_am does nothing when the preview gate is disabled.
+	 */
+	public function test_maybe_enqueue_am_skips_when_preview_disabled() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_false' );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
+	}
+
+	/**
 	 * Test that maybe_enqueue_am enqueues scripts in the block editor.
 	 */
 	public function test_maybe_enqueue_am_enqueues_in_block_editor() {
@@ -396,66 +467,113 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Filter override flips the flag on regardless of dev-mode signals.
+	 * The AI Editorial Review-specific filter controls the feature flag.
 	 */
-	public function test_maybe_enqueue_am_exposes_review_mediator_enabled_via_filter() {
+	public function test_maybe_enqueue_am_respects_ai_editorial_review_filter() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_true' );
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
-	 * Default on when no dev-mode signal is present and no filter override.
+	 * AI Editorial Review is on by default when no filter override is present.
 	 */
-	public function test_maybe_enqueue_am_exposes_review_mediator_by_default() {
+	public function test_maybe_enqueue_am_exposes_ai_editorial_review_by_default() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"blockTransformations":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"optimizeTitleSuggestion":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"chatHistory":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"supportGuides":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
-	 * Dev-mode signals enable the review mediator flag by default.
+	 * Dev-mode signals keep AI Editorial Review enabled by default.
 	 */
-	public function test_maybe_enqueue_am_exposes_review_mediator_enabled_in_dev_mode() {
-		$this->set_block_editor_screen();
-		$this->cache_am_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-
-		Jetpack_AI_Sidebar::maybe_enqueue_am();
-
-		$this->assertStringContainsString( '"reviewMediatorEnabled":true', $this->get_agents_manager_inline_script() );
-	}
-
-	/**
-	 * The review mediator-specific filter can suppress the flag even in dev mode.
-	 */
-	public function test_maybe_enqueue_am_allows_review_mediator_filter_to_disable_dev_mode() {
+	public function test_maybe_enqueue_am_exposes_ai_editorial_review_enabled_in_dev_mode() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
-	 * Platform-emitted Agents Manager data gets the review mediator flag.
+	 * The AI Editorial Review-specific filter can suppress the flag even in dev mode.
 	 */
-	public function test_add_agents_manager_data_exposes_review_mediator_enabled() {
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_true' );
+	public function test_maybe_enqueue_am_allows_ai_editorial_review_filter_to_disable_dev_mode() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
+	}
+
+	/**
+	 * Platform-emitted Agents Manager data gets the AI Editorial Review flag.
+	 */
+	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
+		$this->set_block_editor_screen();
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		$this->assertSame( true, $data['reviewMediatorEnabled'] );
+		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['chatHistory'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['supportGuides'] );
+	}
+
+	/**
+	 * Preview and AI Editorial Review have separate gates.
+	 */
+	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
+		$this->set_block_editor_screen();
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		$this->assertSame( false, $data['aiEditorialReviewEnabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
+	}
+
+	/**
+	 * Platform-emitted preview data is scoped to the post editor.
+	 */
+	public function test_add_agents_manager_data_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
+		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
 	}
 
 	/**
@@ -475,24 +593,28 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		// Original payload (with reviewMediatorEnabled) is still emitted.
+		// Original payload with Jetpack's authoritative flags is still emitted.
 		$this->assertStringContainsString(
-			'"reviewMediatorEnabled":',
+			'"aiEditorialReviewEnabled":',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'"jetpackAiSidebarPreview":',
 			$this->get_agents_manager_inline_script()
 		);
 	}
 
 	/**
-	 * Generic Agents Manager data filters should not override the Jetpack-owned review mediator flag.
+	 * Generic Agents Manager data filters should not override Jetpack's AI Editorial Review flag.
 	 */
-	public function test_maybe_enqueue_am_keeps_review_mediator_flag_authoritative_after_data_filter() {
+	public function test_maybe_enqueue_am_keeps_ai_editorial_review_flag_authoritative_after_data_filter() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_true' );
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 		add_filter(
 			'jetpack_ai_sidebar_agents_manager_data',
 			function ( $data ) {
-				$data['reviewMediatorEnabled'] = false;
+				$data['aiEditorialReviewEnabled'] = false;
 				return $data;
 			},
 			20
@@ -500,20 +622,22 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
-	 * The generic data filter should not bypass the review mediator-specific gate.
+	 * The generic data filter should not bypass the AI Editorial Review-specific gate.
 	 */
-	public function test_maybe_enqueue_am_prevents_data_filter_from_enabling_review_mediator() {
+	public function test_maybe_enqueue_am_prevents_data_filter_from_enabling_ai_editorial_review() {
 		$this->set_block_editor_screen();
 		$this->cache_am_asset_data();
-		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
 		add_filter(
 			'jetpack_ai_sidebar_agents_manager_data',
 			function ( $data ) {
-				$data['reviewMediatorEnabled'] = true;
+				$data['aiEditorialReviewEnabled'] = true;
 				return $data;
 			},
 			20
@@ -521,7 +645,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
+		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
 	}
 
 	/**
@@ -566,15 +691,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	// ──────────────────────────────────────────────────
-	// maybe_patch_review_mediator_flag() tests
+	// maybe_patch_jetpack_ai_sidebar_preview_data() tests
 	// ──────────────────────────────────────────────────
 
 	/**
 	 * When AM is enqueued by an external host (e.g. Big Sky on Atomic) and our
-	 * data filter never fires, the patch script sets reviewMediatorEnabled so
-	 * the client gating still works.
+	 * data filter never fires, the patch script sets Jetpack AI Sidebar Preview
+	 * data so the client gating still works.
 	 */
-	public function test_patch_review_mediator_flag_sets_field_when_am_enqueued_externally() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Simulate external host (mu-wpcom / Big Sky) having enqueued AM and
@@ -582,10 +707,14 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 
-		Jetpack_AI_Sidebar::maybe_patch_review_mediator_flag();
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertStringContainsString(
-			'agentsManagerData.reviewMediatorEnabled = true',
+			'agentsManagerData.aiEditorialReviewEnabled = true',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'agentsManagerData.jetpackAiSidebarPreview = {"enabled":true',
 			$this->get_agents_manager_inline_script()
 		);
 	}
@@ -593,11 +722,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	/**
 	 * When AM was not enqueued by anyone, the patch is a no-op.
 	 */
-	public function test_patch_review_mediator_flag_noop_when_am_not_enqueued() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_noop_when_am_not_enqueued() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
-		Jetpack_AI_Sidebar::maybe_patch_review_mediator_flag();
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
 	}
@@ -605,16 +734,41 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	/**
 	 * The external AM payload patch is limited to the post editor.
 	 */
-	public function test_patch_review_mediator_flag_skips_page_editor() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_skips_page_editor() {
 		$this->set_page_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 
-		Jetpack_AI_Sidebar::maybe_patch_review_mediator_flag();
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertStringNotContainsString(
-			'agentsManagerData.reviewMediatorEnabled',
+			'agentsManagerData.aiEditorialReviewEnabled',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringNotContainsString(
+			'agentsManagerData.jetpackAiSidebarPreview',
+			$this->get_agents_manager_inline_script()
+		);
+	}
+
+	/**
+	 * The external AM payload patch is gated by the preview surface.
+	 */
+	public function test_patch_jetpack_ai_sidebar_preview_data_skips_when_preview_disabled() {
+		$this->set_block_editor_screen();
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_false' );
+		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
+		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
+
+		$this->assertStringNotContainsString(
+			'agentsManagerData.aiEditorialReviewEnabled',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringNotContainsString(
+			'agentsManagerData.jetpackAiSidebarPreview',
 			$this->get_agents_manager_inline_script()
 		);
 	}
@@ -641,6 +795,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_abilities_script_skips_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+
+		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
+
+		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that abilities script is not enqueued when the preview gate is disabled.
+	 */
+	public function test_abilities_script_skips_when_preview_disabled() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_false' );
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
@@ -680,6 +847,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that register_provider adds provider URL (does not enqueue assets).
 	 */
 	public function test_register_provider_adds_url() {
+		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		$providers = Jetpack_AI_Sidebar::register_provider( array() );
@@ -695,6 +863,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that register_provider returns existing providers unchanged when asset data fails.
 	 */
 	public function test_register_provider_returns_unchanged_when_no_asset_data() {
+		$this->set_block_editor_screen();
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
@@ -717,6 +886,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that register_provider preserves existing providers.
 	 */
 	public function test_register_provider_preserves_existing_providers() {
+		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		$existing  = array( 'https://example.com/provider-a.mjs', 'https://example.com/provider-b.mjs' );
@@ -726,6 +896,33 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
 		$this->assertSame( 'https://example.com/provider-b.mjs', $providers[1] );
 		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[2] );
+	}
+
+	/**
+	 * Test that register_provider returns existing providers unchanged outside the post editor.
+	 */
+	public function test_register_provider_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$existing  = array( 'https://example.com/provider-a.mjs' );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertSame( $existing, $providers );
+	}
+
+	/**
+	 * Test that register_provider returns existing providers when the preview gate is disabled.
+	 */
+	public function test_register_provider_skips_when_preview_disabled() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_false' );
+
+		$existing  = array( 'https://example.com/provider-a.mjs' );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertSame( $existing, $providers );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -786,6 +983,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test full flow: init, simulate AM filter, verify provider registered.
 	 */
 	public function test_full_flow_with_default_enabled() {
+		$this->set_block_editor_screen();
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -77,6 +77,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		remove_all_filters( 'agents_manager_agent_providers' );
+		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
 		remove_all_filters( 'jetpack_ai_review_mediator_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
 		remove_all_filters( 'pre_http_request' );
@@ -121,6 +122,16 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	private function set_block_editor_screen() {
 		set_current_screen( 'post' );
 		get_current_screen()->is_block_editor = true;
+	}
+
+	/**
+	 * Set the current screen to the page block editor.
+	 */
+	private function set_page_block_editor_screen() {
+		set_current_screen( 'post' );
+		$screen                  = get_current_screen();
+		$screen->post_type       = 'page';
+		$screen->is_block_editor = true;
 	}
 
 	/**
@@ -212,14 +223,39 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that init() does nothing when the feature filter is false (default).
+	 * Test that init() registers hooks by default for AI Editorial Review.
+	 */
+	public function test_init_registers_hooks_by_default() {
+		Jetpack_AI_Sidebar::init();
+
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should be hooked by default.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
+			'enable_agents_manager_in_post_editor should be hooked by default.'
+		);
+		$this->assertNotFalse(
+			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_am' ) ),
+			'maybe_enqueue_am should be hooked by default.'
+		);
+	}
+
+	/**
+	 * Test that init() does nothing when the sidebar gate is explicitly disabled.
 	 */
 	public function test_init_does_nothing_when_filter_is_false() {
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		Jetpack_AI_Sidebar::init();
 
 		$this->assertFalse(
 			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
 			'register_provider should not be hooked when filter is false.'
+		);
+		$this->assertFalse(
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
+			'enable_agents_manager_in_post_editor should not be hooked when filter is false.'
 		);
 	}
 
@@ -239,6 +275,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'add_agents_manager_data should be hooked when filter is true.'
 		);
 		$this->assertNotFalse(
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
+			'enable_agents_manager_in_post_editor should be hooked when filter is true.'
+		);
+		$this->assertNotFalse(
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_am' ) ),
 			'maybe_enqueue_am should be hooked when filter is true.'
 		);
@@ -246,6 +286,48 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
 			'maybe_enqueue_abilities_script should be hooked when filter is true.'
 		);
+	}
+
+	// ──────────────────────────────────────────────────
+	// agents_manager_enabled_in_block_editor() tests
+	// ──────────────────────────────────────────────────
+
+	/**
+	 * Test that the Agents Manager block-editor gate opens in the post editor.
+	 */
+	public function test_enable_agents_manager_in_post_editor_enables_post_editor() {
+		$this->set_block_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate does not open in the page editor.
+	 */
+	public function test_enable_agents_manager_in_post_editor_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+	}
+
+	/**
+	 * Test that the Agents Manager block-editor gate preserves existing true values.
+	 */
+	public function test_enable_agents_manager_in_post_editor_preserves_existing_true() {
+		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
+		$this->set_page_block_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( true ) );
+	}
+
+	/**
+	 * Test that the review mediator kill switch closes this Agents Manager entrypoint.
+	 */
+	public function test_enable_agents_manager_in_post_editor_respects_review_mediator_filter() {
+		add_filter( 'jetpack_ai_review_mediator_enabled', '__return_false' );
+		$this->set_block_editor_screen();
+
+		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -257,6 +339,18 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_maybe_enqueue_am_skips_non_block_editor() {
 		set_current_screen( 'dashboard' );
+		$this->cache_am_asset_data();
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that maybe_enqueue_am does nothing outside the post editor.
+	 */
+	public function test_maybe_enqueue_am_skips_page_editor() {
+		$this->set_page_block_editor_screen();
 		$this->cache_am_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
@@ -497,6 +591,23 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
 	}
 
+	/**
+	 * The external AM payload patch is limited to the post editor.
+	 */
+	public function test_patch_review_mediator_flag_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
+		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+
+		Jetpack_AI_Sidebar::maybe_patch_review_mediator_flag();
+
+		$this->assertStringNotContainsString(
+			'agentsManagerData.reviewMediatorEnabled',
+			$this->get_agents_manager_inline_script()
+		);
+	}
+
 	// ──────────────────────────────────────────────────
 	// maybe_enqueue_abilities_script() tests
 	// ──────────────────────────────────────────────────
@@ -514,7 +625,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is enqueued in block editor.
+	 * Test that abilities script is not enqueued outside the post editor.
+	 */
+	public function test_abilities_script_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
+
+		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that abilities script is enqueued in the post block editor.
 	 */
 	public function test_abilities_script_enqueues_in_block_editor() {
 		$this->set_block_editor_screen();
@@ -649,10 +772,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test full flow: enable filter, init, simulate AM filter, verify provider registered.
+	 * Test full flow: init, simulate AM filter, verify provider registered.
 	 */
-	public function test_full_flow_with_filter_enabled() {
-		$this->enable_sidebar();
+	public function test_full_flow_with_default_enabled() {
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
 
@@ -663,10 +785,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test full flow: filter disabled (default), init, verify no provider registered.
+	 * Test full flow: filter disabled, init, verify no provider registered.
 	 */
 	public function test_full_flow_with_filter_disabled() {
-		// Don't enable the filter — defaults to false.
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		Jetpack_AI_Sidebar::init();
 
 		$providers = apply_filters( 'agents_manager_agent_providers', array() );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -477,6 +477,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
+		$this->assertStringContainsString( '"agentId":"wp-orchestrator"', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":false', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":false', $this->get_agents_manager_inline_script() );
@@ -491,6 +492,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
+		$this->assertStringContainsString( '"agentId":"wp-orchestrator"', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReviewEnabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"jetpackAiSidebarPreview":{"enabled":true', $this->get_agents_manager_inline_script() );
 		$this->assertStringContainsString( '"aiEditorialReview":true', $this->get_agents_manager_inline_script() );
@@ -539,6 +541,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
@@ -558,6 +561,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 		$this->assertSame( false, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
@@ -572,6 +576,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
+		$this->assertArrayNotHasKey( 'agentId', $data );
 		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
 		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
 	}
@@ -594,6 +599,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
 		// Original payload with Jetpack's authoritative flags is still emitted.
+		$this->assertStringContainsString(
+			'"agentId":"wp-orchestrator"',
+			$this->get_agents_manager_inline_script()
+		);
 		$this->assertStringContainsString(
 			'"aiEditorialReviewEnabled":',
 			$this->get_agents_manager_inline_script()
@@ -710,6 +719,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertStringContainsString(
+			'agentsManagerData.agentId = "wp-orchestrator"',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
 			'agentsManagerData.aiEditorialReviewEnabled = true',
 			$this->get_agents_manager_inline_script()
 		);
@@ -743,6 +756,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertStringNotContainsString(
+			'agentsManagerData.agentId',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringNotContainsString(
 			'agentsManagerData.aiEditorialReviewEnabled',
 			$this->get_agents_manager_inline_script()
 		);
@@ -763,6 +780,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
+		$this->assertStringNotContainsString(
+			'agentsManagerData.agentId',
+			$this->get_agents_manager_inline_script()
+		);
 		$this->assertStringNotContainsString(
 			'agentsManagerData.aiEditorialReviewEnabled',
 			$this->get_agents_manager_inline_script()


### PR DESCRIPTION
## Proposed changes

* Open the Jetpack AI Sidebar through a limited Jetpack AI Sidebar Preview gate.
* Default `jetpack_ai_sidebar_preview_enabled` to the AI Editorial Review gate so the sidebar opens only for the public preview surface.
* Add `jetpack_ai_editorial_review_enabled` as the feature-specific AI Editorial Review gate.
* Register the Jetpack AI Sidebar provider in the post editor when preview is enabled and AI features are available.
* Scope the Agents Manager entrypoint to post editors only, so pages and other block-editor surfaces do not get AI Editorial Review.
* Inject `agentId`, `aiEditorialReviewEnabled`, and `jetpackAiSidebarPreview` data for the Agents Manager / Jetpack AI Sidebar bundles.
* Force Jetpack AI Sidebar Preview to use `wp-orchestrator` on Atomic/self-hosted post editors so editor prompts consume wp-orchestrator route settings instead of the unified workflow path.
* Preserve existing host agent overrides; Jetpack only sets the sidebar agent when no explicit host agent ID is already provided.
* Keep the Atomic inline-patch fallback for cases where the upstream Agents Manager data filter may lag the Jetpack PR.
* Keep Atomic/self-hosted support in Jetpack: Atomic can pick this up through the Jetpack downloader sandbox plugin without sandboxing the site host.
* Update Jetpack AI Sidebar tests for preview behavior, kill-switch behavior, post-vs-page editor gating, feature payloads, agent ID injection, and hook isolation.
* Add a Jetpack changelog entry.

## Why

AI Editorial Review should be available to users who can edit a post without requiring Automattician/dev-mode gates.

The main blocker is that the Jetpack AI Sidebar is not publicly available. This PR opens a limited preview surface for the sidebar while keeping the broader sidebar experience constrained by preview feature flags in the companion Calypso and WordPress.com PRs.

The sidebar preview explicitly uses `wp-orchestrator` because selected-block prompts and AI Editorial Review rely on wp-orchestrator route settings and abilities. The general Unified AI / Help Center experience remains controlled by the existing unified experience gates.

## Behavior after this PR

* Post editors can get the AI FAB/sidebar when Jetpack AI Sidebar Preview is enabled.
* AI Editorial Review can appear when `jetpack_ai_editorial_review_enabled` is enabled.
* Page editors do not get AI Editorial Review through this path.
* Jetpack AI Sidebar Preview uses `wp-orchestrator` for the post editor unless another host has already provided an explicit agent ID.
* Unified AI remains controlled by the existing `agents_manager_use_unified_experience` gate generally, but the Jetpack AI Sidebar Preview path intentionally opts into the orchestrator.
* Preview feature visibility is controlled through `jetpackAiSidebarPreview.features` in the frontend payload.

## Companion PRs

* WordPress.com: Automattic/wpcom#218494
* Calypso: Automattic/wp-calypso#110864

## Does this pull request change what data or activity we track or use?

No new tracking events or properties are added.

This broadens access to AI Editorial Review, so existing AI Editorial Review events may now be emitted by users who can access the feature after rollout.

## Testing instructions

Manual e2e:

1. Install this branch on a Jetpack-connected test site, preferably Atomic via the Jetpack downloader sandbox plugin.
2. Apply the companion WordPress.com and Calypso branches where applicable.
3. Open the post editor for an existing post as a user with edit access.
4. Confirm the AI FAB/sidebar appears without requiring Unified AI.
5. Confirm `typeof agentsManagerData !== 'undefined'`.
6. Confirm `agentsManagerData.agentId === 'wp-orchestrator'`.
7. Confirm `agentsManagerData.jetpackAiSidebarPreview` is present.
8. Confirm AI Editorial Review appears in the sidebar.
9. Run AI Editorial Review and confirm the review result renders successfully.
10. Confirm Optimize Title, Chat History, and Support Guides are hidden when disabled by the preview payload.
11. Select a supported text block and confirm block-level suggestions can be used through the sidebar.
12. Sanity check that a page editor does not show AI Editorial Review.
