### PR TITLE
VideoPress: remove duplicate Jetpack logo from edit video header

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-edit-video-double-logo
+++ b/projects/packages/videopress/changelog/fix-videopress-edit-video-double-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate Jetpack logo rendering in the Edit Video page header.

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -4,7 +4,6 @@ import {
 	AdminSection,
 	Container,
 	Col,
-	JetpackLogo,
 	LoadingPlaceholder,
 } from '@automattic/jetpack-components';
 import {
@@ -227,7 +226,6 @@ const EditVideoDetails = () => {
 			>
 				<li>
 					<a href={ backUrl } className={ styles[ 'breadcrumb-link' ] }>
-						<JetpackLogo showText={ false } height={ 20 } />
 						{ 'VideoPress' /** "VideoPress" is a product name, do not translate. */ }
 					</a>
 				</li>


### PR DESCRIPTION
Related context: #48160

## Proposed changes
* VideoPress: Remove the duplicate `<JetpackLogo />` rendered inside the custom breadcrumbs of the Edit Video Details page. The `<AdminPage>` wrapper already provides the Jetpack brand mark in the page header, so the in-breadcrumb logo was rendering a second one right next to it.
* Drop the now-unused `JetpackLogo` import from the same file.

The breadcrumb keeps the "VideoPress" text label, which is the section marker users actually act on.

## Related product discussion/links
* Reference issue: #48160 (related context; this is a small bug fix, not a migration).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Visit the VideoPress admin (`/wp-admin/admin.php?page=jetpack-videopress`).
* Pick any uploaded video → click **Edit details**.
* The page header should show **one** Jetpack logo (from AdminPage) on the left, then the "VideoPress / Edit" breadcrumb. Before this fix, two Jetpack logos rendered side by side at the start of the breadcrumb.
* Confirm the "VideoPress" breadcrumb link still navigates back to the library.
* Before/after screenshots: I wasn't able to capture them in the parallel worktree (no live container bound to it). I'll attach the two states inline as a follow-up comment.

## Notes for reviewers

* This PR was authored alongside a parallel slice that touches `src/dashboard/**` (tabs unification). On trunk and on this branch, `pnpm jetpack build packages/videopress` currently fails because `src/dashboard/**` references `@automattic/charts`, `@automattic/number-formatters`, `social-logos`, and the not-yet-built subpath exports of `@automattic/jetpack-components` — all preexisting on trunk, none related to this change. The touched file is in `src/client/admin/**` and is a clean two-line deletion.
* `npx eslint` against the touched file is clean from the package root (the one `import/no-unresolved` warning is preexisting on trunk and resolves once the components package is built locally).
* Pre-commit hooks (prettier, eslint --fix) ran clean on the committed file.
