### PR TITLE
Normalize page tabs onto shared minimal variant

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3399,8 +3399,8 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
-        specifier: 0.11.0
-        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.13.0
+        version: 0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.44.0
         version: 4.44.0
@@ -4219,8 +4219,8 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
-        specifier: 0.11.0
-        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.13.0
+        version: 0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.44.0
         version: 4.44.0
@@ -4343,8 +4343,8 @@ importers:
         specifier: 6.20.0
         version: 6.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
-        specifier: 0.12.0
-        version: 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.13.0
+        version: 0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.44.0
         version: 4.44.0
@@ -4652,8 +4652,8 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
-        specifier: 0.11.0
-        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.13.0
+        version: 0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.44.0
         version: 4.44.0
@@ -5971,8 +5971,8 @@ importers:
         specifier: 12.2.0
         version: 12.2.0(react@18.3.1)
       '@wordpress/ui':
-        specifier: 0.11.0
-        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.13.0
+        version: 0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.44.0
         version: 4.44.0
@@ -10835,6 +10835,10 @@ packages:
     resolution: {integrity: sha512-KOgdBsZP34nAi+UfrhIAZDt2I1ZDb3DXAgIeQk7QxTIc9OlQKMNfrYwPG0jidgfKwmjFxh8vV8HbZcBzTD29Rw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/a11y@4.46.0':
+    resolution: {integrity: sha512-9VKhQHB/TQHJciOtxbpJ5JPhxMHCOszcxs4eL27krFXMEp3fl4tzVy13r1LPuXg/yjZ9NpV3NY+Qwx4G0aW3Kw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/admin-ui@1.12.0':
     resolution: {integrity: sha512-CVTvE2jLTP71vBliAhOrvlMoOG1o1TdyoCL5gmw0Uswuj/qhqK3f1Y1adz7hAWiR9o7H9SoPYf+qg6pbZJVyaQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11010,6 +11014,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/compose@7.46.0':
+    resolution: {integrity: sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/core-data@7.44.0':
     resolution: {integrity: sha512-SBT/wiprxlo15QUwxKWH0t9RMvPu1TPgdd7+kPqqg79uUbkebs2P70Q3vBbQ6OdfEC4Mz7MGFeLlAr0uGT6KJQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11072,6 +11082,10 @@ packages:
     resolution: {integrity: sha512-qer/fk/lgmmisb8/hj1xZtsbJbZhCoOblhyxI2k7RRul7rQDdk+fm28LJYV+eIF0ldSVX30f4dmz1pvcVHQEEg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/deprecated@4.46.0':
+    resolution: {integrity: sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom-ready@4.44.0':
     resolution: {integrity: sha512-YSiDpmelYLgFu0/Mki9OogEDO5t8Dr1pZnJU/RYRC7aawWGxidgNr0hael+9jO6pLAd+3LiAEV5cAvLg0V1pZQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11080,12 +11094,20 @@ packages:
     resolution: {integrity: sha512-0lFImpg9DGXcGCDQePdoU8haz7QYsKOFXUMTpRvi/Te38LFXzgZtOUBQbY8fRBlLxrgrj4FsAIc7bzdLn73wNQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/dom-ready@4.46.0':
+    resolution: {integrity: sha512-CQ6KPaCkMzAmbxmR4E4Fu99ngyPpkP9VGaIFu0xUgx0ubkYOzcvEfEEPuyEV3n7PY2Jg/XWzBilgWCa8PmaxWw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom@4.44.0':
     resolution: {integrity: sha512-W8uzlz83q73qO3fxl1Qcm69KvZqiXtcebEiXntO2lAyOtA5k/C3rbSwpGdTlgxFbQvg+SKbux17ZyztcB2p33Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dom@4.45.0':
     resolution: {integrity: sha512-6RObr/KEZS1FnZwpcDAsKlJ3qw2KLF5+A/LsxlM9fSWDGSO05CEaTp+VmWgx9pwjQWbPEa7N73ijEy8cCNSZWA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/dom@4.46.0':
+    resolution: {integrity: sha512-XngkvNJpf0JnpZuOcsbBl/cTprfYQTfSykttIL4laXcFXfZe8rU3bGgv8K7AEoYigDwxfw3g/yMPi4fn195Kpw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/e2e-test-utils-playwright@1.44.0':
@@ -11117,12 +11139,20 @@ packages:
     resolution: {integrity: sha512-WFrGNPEnj8uE+XhFW9NVbxvqraYpConaEokLv9IszFYVfyg8juXSQcHOAfEnxjC08HBPfVcayr2igu/XUgGOAw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/element@6.46.0':
+    resolution: {integrity: sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/escape-html@3.44.0':
     resolution: {integrity: sha512-nAEshSe6IYFr3G8sfY8o9pYNTRKvxocQ3DXs3KUesmdaEtrtJSlDmrMOI3FIgaYfv1PP6d+cDZpsygp6IZGo2w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/escape-html@3.45.0':
     resolution: {integrity: sha512-IW4mnA+65XKhABuBkwrQNAlbq97luC6ZIBfdSq0Tkq+AFPqE1lJTMlLo7iBkTpsHsBLyznViPXultq40fz8L7w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/escape-html@3.46.0':
+    resolution: {integrity: sha512-SzrVQwLQBZdaSStYVpTKeYqp97NABz1w551T8me3msDDsfhWWPhSZiZTNaGZ6iqUNfOX2uKyZsqXedvkqwLHqA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/eslint-plugin@25.1.0':
@@ -11186,6 +11216,10 @@ packages:
     resolution: {integrity: sha512-+gOlu8TdohqL1INQNxS/7CxhM4T4MuYnKietWV9zWDmNQV2ysM0SdamNk5pWERJ4w0yY9XhtMBcwR/piJtePZg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/hooks@4.46.0':
+    resolution: {integrity: sha512-fsKw4dmw4voIRoKc8t0XRREQlFvwj9XS/jTXvkh6mqRYCDpaEnrdB2Ji5jgbRXEMPU0GKVGMeAn5Wwi56gjBMg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/html-entities@4.44.0':
     resolution: {integrity: sha512-Vejleo4VvES7Ec4qX6p74DL8M6P15p0Law9+A8Wp4Vu8wg4TLtTNZE4Hfet1YoXwY9t6czty+KGISZpEG3Y7RA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11204,6 +11238,11 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
+  '@wordpress/i18n@6.19.0':
+    resolution: {integrity: sha512-hRXd2E0SF9OQf22ZZWw7Ny/o+Q9u8jINiF1p0bF+rnSDKQUgoStihak6YiazWVRiIEYwctzotKXlt0HePJelXA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+
   '@wordpress/icons@10.32.0':
     resolution: {integrity: sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11218,6 +11257,12 @@ packages:
 
   '@wordpress/icons@13.0.0':
     resolution: {integrity: sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/icons@13.1.0':
+    resolution: {integrity: sha512-KMZAeYghsLs6e5wKMZ3/Ynrsuu5yZt2gAlMHmZSkWJKQFld++Pz/pEj8nDCJ79z/zx9FO7q4teG49vHHvVosjQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -11252,6 +11297,10 @@ packages:
     resolution: {integrity: sha512-saamGjAuhZOiFOyznsriPGrO8GRDremImMO4q92qjQqmDqssC+FRDQnwr9D8BaedSnVvUDcriGeYBObEEnIJ2A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/is-shallow-equal@5.46.0':
+    resolution: {integrity: sha512-46J36GNPw7q3c5HF0RurUx9yJHvBDYqOFVqbb8Td8bov9pVI6TGtcMKd+/O+Q89ZUVSTVx/NfxKjNwXpeQQCmg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/jest-console@8.44.0':
     resolution: {integrity: sha512-2Dawx6Qh2zr0ZlFByFmvkfCukb6CzCrCFnTnHImdiwlQ7wKcmTaIR3QPomJg6fTxiwgBiWn9yeiO7N97vJ59eg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11270,6 +11319,10 @@ packages:
 
   '@wordpress/keycodes@4.45.0':
     resolution: {integrity: sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/keycodes@4.46.0':
+    resolution: {integrity: sha512-+eW0b4bRrpmiOOfdmz1BtQsbTqWqCkgJyeiR5yMLJ+sGG2He9icVLjt/fSc4xCQ56MhT03Zypb33L6j+zJFEgA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/latex-to-mathml@1.13.0':
@@ -11356,8 +11409,18 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/primitives@4.46.0':
+    resolution: {integrity: sha512-x1IhEVa/aGDe6otGJ4VIqEioQGfIeK5B1VQm32+ycqinJRbtbw9F5bgx4ARIdnm5M1Lg63oV9Bhmg/XMyGSTZA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/priority-queue@3.45.0':
     resolution: {integrity: sha512-0sIX2PRPzo5nk252f60xpPj3/BUZxEOLcabCC7FuvQDYPGZrRyS6Dy0vDDzozZxHGuUYCT65t8ubBwXx37wXCw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/priority-queue@3.46.0':
+    resolution: {integrity: sha512-rjwzO/I7Os16VMJFVdzIeXMmyvwe+DbODrXl3mgW5LZZeIYob94d++pjQxUdWN1/0APnXPQP6zk4yFfSLOVkYg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/private-apis@1.44.0':
@@ -11366,6 +11429,10 @@ packages:
 
   '@wordpress/private-apis@1.45.0':
     resolution: {integrity: sha512-UjhIDpoyKKUghPM0tkqd5Whsuk4kqfAfhb5VYGoEYtunDs0rB8IxgFO7hE0PhimHL74QVgaJOlprRZVRCCoQ6w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/private-apis@1.46.0':
+    resolution: {integrity: sha512-l8dsEuxq6CrtsI7Twfpn6CbPHmGBUQoGN4oLPJG1Bqsr1yXXLU/bEx9KAQN9emxRjXaELPsn7x7TVx0TUoKyJw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/react-i18n@4.45.0':
@@ -11430,6 +11497,10 @@ packages:
     resolution: {integrity: sha512-TQZbdLiDsQL1EATq4HKkmKCn99+l6eK3fmBpwOgXeOscQB9ta/Na64KYLoilZBuXnAelmFOXsWpz0c8ijRRniw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/style-runtime@0.2.0':
+    resolution: {integrity: sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
   '@wordpress/stylelint-config@23.36.0':
     resolution: {integrity: sha512-UJIrrJjdHD28tzjHZLS/KmaJjuaVZ5r5zYHguPSJfa5lxXP6JEqYPN4sQV6Ebjd5YtB4ZPKNVQDJHLQqtgRSdA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11467,6 +11538,17 @@ packages:
       stylelint:
         optional: true
 
+  '@wordpress/theme@0.13.0':
+    resolution: {integrity: sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      stylelint: '>=16.8.2'
+    peerDependenciesMeta:
+      stylelint:
+        optional: true
+
   '@wordpress/token-list@3.44.0':
     resolution: {integrity: sha512-+96NDDOC6vA/DQnRk/fnnmLylnZXEpMctklNOdztgpdwrXSsM+LoPoksaOYrmswPUxayzlHPBBbO/5rZ72g7zQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11489,8 +11571,19 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/ui@0.13.0':
+    resolution: {integrity: sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/undo-manager@1.45.0':
     resolution: {integrity: sha512-BqclZIPjzBYIjLqLZFihs+Ce+w+yBQuj44VYSrRDOj56AbMtwmClIUqgIVBZAe2En/2ncixTTWOZG9KluvEXfA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/undo-manager@1.46.0':
+    resolution: {integrity: sha512-vAchoUrF97IdjqVD30Iz7NI9YvDtgeMNPshgjsrM8MF9nOCMq2tBWb3HS+ue/kQknfAuU73FEnn/UNKt0JPH4Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/upload-media@0.29.0':
@@ -23899,6 +23992,11 @@ snapshots:
       '@wordpress/dom-ready': 4.45.0
       '@wordpress/i18n': 6.18.0
 
+  '@wordpress/a11y@4.46.0':
+    dependencies:
+      '@wordpress/dom-ready': 4.46.0
+      '@wordpress/i18n': 6.19.0
+
   '@wordpress/admin-ui@1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 6.20.0
@@ -25081,6 +25179,21 @@ snapshots:
       react: 18.3.1
       use-memo-one: 1.1.3(react@18.3.1)
 
+  '@wordpress/compose@7.46.0(react@18.3.1)':
+    dependencies:
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.46.0
+      '@wordpress/dom': 4.46.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/is-shallow-equal': 5.46.0
+      '@wordpress/keycodes': 4.46.0
+      '@wordpress/priority-queue': 3.46.0
+      '@wordpress/undo-manager': 1.46.0
+      change-case: 4.1.2
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+
   '@wordpress/core-data@7.44.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/api-fetch': 7.44.0
@@ -25541,9 +25654,15 @@ snapshots:
     dependencies:
       '@wordpress/hooks': 4.45.0
 
+  '@wordpress/deprecated@4.46.0':
+    dependencies:
+      '@wordpress/hooks': 4.46.0
+
   '@wordpress/dom-ready@4.44.0': {}
 
   '@wordpress/dom-ready@4.45.0': {}
+
+  '@wordpress/dom-ready@4.46.0': {}
 
   '@wordpress/dom@4.44.0':
     dependencies:
@@ -25552,6 +25671,10 @@ snapshots:
   '@wordpress/dom@4.45.0':
     dependencies:
       '@wordpress/deprecated': 4.45.0
+
+  '@wordpress/dom@4.46.0':
+    dependencies:
+      '@wordpress/deprecated': 4.46.0
 
   '@wordpress/e2e-test-utils-playwright@1.44.0(@playwright/test@1.58.2)(@types/node@24.12.3)':
     dependencies:
@@ -25920,9 +26043,21 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@wordpress/element@6.46.0':
+    dependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      '@wordpress/escape-html': 3.46.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/escape-html@3.44.0': {}
 
   '@wordpress/escape-html@3.45.0': {}
+
+  '@wordpress/escape-html@3.46.0': {}
 
   '@wordpress/eslint-plugin@25.1.0(@babel/core@7.29.0)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint-plugin-import@2.32.0)(eslint-plugin-jest@29.15.0(eslint@9.39.4)(jest@30.3.0)(typescript@5.9.3))(eslint-plugin-jsdoc@62.8.0(eslint@9.39.4))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4))(eslint-plugin-playwright@2.10.0(eslint@9.39.4))(eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(wp-prettier@3.0.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.4))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0(typescript@5.9.3))(typescript@5.9.3)(wp-prettier@3.0.3)':
     dependencies:
@@ -26211,6 +26346,8 @@ snapshots:
 
   '@wordpress/hooks@4.45.0': {}
 
+  '@wordpress/hooks@4.46.0': {}
+
   '@wordpress/html-entities@4.44.0': {}
 
   '@wordpress/html-entities@4.45.0': {}
@@ -26227,6 +26364,14 @@ snapshots:
     dependencies:
       '@tannin/sprintf': 1.3.3
       '@wordpress/hooks': 4.45.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+
+  '@wordpress/i18n@6.19.0':
+    dependencies:
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.46.0
       gettext-parser: 1.4.0
       memize: 2.1.1
       tannin: 1.2.0
@@ -26249,6 +26394,13 @@ snapshots:
     dependencies:
       '@wordpress/element': 6.45.0
       '@wordpress/primitives': 4.45.0(react@18.3.1)
+      change-case: 4.1.2
+      react: 18.3.1
+
+  '@wordpress/icons@13.1.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.46.0(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
 
@@ -26332,6 +26484,8 @@ snapshots:
 
   '@wordpress/is-shallow-equal@5.45.0': {}
 
+  '@wordpress/is-shallow-equal@5.46.0': {}
+
   '@wordpress/jest-console@8.44.0(jest@30.3.0)':
     dependencies:
       jest: 30.3.0
@@ -26352,6 +26506,10 @@ snapshots:
   '@wordpress/keycodes@4.45.0':
     dependencies:
       '@wordpress/i18n': 6.18.0
+
+  '@wordpress/keycodes@4.46.0':
+    dependencies:
+      '@wordpress/i18n': 6.19.0
 
   '@wordpress/latex-to-mathml@1.13.0':
     dependencies:
@@ -26758,13 +26916,25 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
 
+  '@wordpress/primitives@4.46.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      clsx: 2.1.1
+      react: 18.3.1
+
   '@wordpress/priority-queue@3.45.0':
+    dependencies:
+      requestidlecallback: 0.3.0
+
+  '@wordpress/priority-queue@3.46.0':
     dependencies:
       requestidlecallback: 0.3.0
 
   '@wordpress/private-apis@1.44.0': {}
 
   '@wordpress/private-apis@1.45.0': {}
+
+  '@wordpress/private-apis@1.46.0': {}
 
   '@wordpress/react-i18n@4.45.0':
     dependencies:
@@ -26933,6 +27103,8 @@ snapshots:
     dependencies:
       change-case: 4.1.2
 
+  '@wordpress/style-runtime@0.2.0': {}
+
   '@wordpress/stylelint-config@23.36.0(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@7.0.0(stylelint@17.7.0(typescript@5.9.3)))(stylelint@17.7.0(typescript@5.9.3))':
     dependencies:
       '@stylistic/stylelint-plugin': 5.1.0(stylelint@17.7.0(typescript@5.9.3))
@@ -27009,6 +27181,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       stylelint: 17.7.0(typescript@5.9.3)
+
+  '@wordpress/theme@0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/private-apis': 1.46.0
+      '@wordpress/style-runtime': 0.2.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@wordpress/token-list@3.44.0': {}
 
@@ -27102,9 +27284,59 @@ snapshots:
       - '@types/react'
       - stylelint
 
+  '@wordpress/ui@0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/tz': 1.4.1
+      '@wordpress/a11y': 4.46.0
+      '@wordpress/compose': 7.46.0(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.19.0
+      '@wordpress/icons': 13.1.0(react@18.3.1)
+      '@wordpress/keycodes': 4.46.0
+      '@wordpress/primitives': 4.46.0(react@18.3.1)
+      '@wordpress/private-apis': 1.46.0
+      '@wordpress/style-runtime': 0.2.0
+      '@wordpress/theme': 0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - stylelint
+
+  '@wordpress/ui@0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/tz': 1.4.1
+      '@wordpress/a11y': 4.46.0
+      '@wordpress/compose': 7.46.0(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.19.0
+      '@wordpress/icons': 13.1.0(react@18.3.1)
+      '@wordpress/keycodes': 4.46.0
+      '@wordpress/primitives': 4.46.0(react@18.3.1)
+      '@wordpress/private-apis': 1.46.0
+      '@wordpress/style-runtime': 0.2.0
+      '@wordpress/theme': 0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - stylelint
+
   '@wordpress/undo-manager@1.45.0':
     dependencies:
       '@wordpress/is-shallow-equal': 5.45.0
+
+  '@wordpress/undo-manager@1.46.0':
+    dependencies:
+      '@wordpress/is-shallow-equal': 5.46.0
 
   '@wordpress/upload-media@0.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/projects/packages/newsletter/_inc/components/newsletter-page.scss
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.scss
@@ -57,29 +57,6 @@ body.jetpack_page_jetpack-newsletter {
 		}
 	}
 
-	// Tabs row: sticks at the top of the body wrapper (which itself starts
-	// directly below the sticky page header), so the bar stays in view while
-	// the panel content scrolls underneath. The wrapper carries the
-	// full-width separator + inline padding while the nested `Tabs.List`
-	// keeps its native `width: fit-content` so the animated active-tab
-	// indicator slides smoothly between tabs.
-	// The selector mirrors admin-ui's
-	// `.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer) > *`
-	// rule so the `flex: 0 0 auto` here outweighs the `flex: 1 1 auto`
-	// admin-ui sprays across body-wrapper children. Without that boost the
-	// tabs row collapses to ~24px and the tab buttons clip out of view.
-	.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer) > .jetpack-newsletter-page__tabs-row {
-		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
-		border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
-		box-sizing: border-box;
-		flex: 0 0 auto;
-		padding-inline: $jetpack-newsletter-inset;
-		position: sticky;
-		top: 0;
-		width: 100%;
-		z-index: 9;
-	}
-
 	.jetpack-newsletter-page__content--padded {
 		padding: $jetpack-newsletter-inset;
 	}

--- a/projects/packages/newsletter/_inc/components/newsletter-page.tsx
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.tsx
@@ -123,10 +123,7 @@ export default function NewsletterPage( {
 		>
 			{ subscribersEnabled ? (
 				<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
-					{ /* Wrapper carries the full-width bottom border. The Tabs.List
-					     inside keeps its native `width: fit-content` so the
-					     animated active-tab indicator slides smoothly. */ }
-					<div className="jetpack-newsletter-page__tabs-row">
+					<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 						<Tabs.List variant="minimal">
 							<Tabs.Tab value="subscribers">{ __( 'Subscribers', 'jetpack-newsletter' ) }</Tabs.Tab>
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-newsletter' ) }</Tabs.Tab>

--- a/projects/packages/newsletter/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/newsletter/changelog/normalize-tabs-minimal-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Newsletter: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier; drop bespoke jetpack-newsletter-page__tabs-row class.

--- a/projects/packages/newsletter/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/newsletter/changelog/normalize-tabs-minimal-variant
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Newsletter: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier; drop bespoke jetpack-newsletter-page__tabs-row class.
+Newsletter: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier; drop bespoke jetpack-newsletter-page__tabs-row class. Bump @wordpress/ui to 0.13.0.

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -61,7 +61,7 @@
 		"@wordpress/primitives": "4.44.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0",
 		"debug": "4.4.3"
 	},

--- a/projects/packages/newsletter/routes/dashboard/package.json
+++ b/projects/packages/newsletter/routes/dashboard/package.json
@@ -23,7 +23,7 @@
 		"@wordpress/notices": "5.44.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0"
 	},
 	"route": {

--- a/projects/packages/scan/_inc/components/scan-page.tsx
+++ b/projects/packages/scan/_inc/components/scan-page.tsx
@@ -55,7 +55,7 @@ export default function ScanPage( { activeTab, children }: Props ): JSX.Element 
 			actions={ headerActions }
 		>
 			<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
-				<div className="jp-admin-page-tabs">
+				<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 					<Tabs.List variant="minimal">
 						<Tabs.Tab value="active">{ __( 'Active threats', 'jetpack-scan-page' ) }</Tabs.Tab>
 						<Tabs.Tab value="history">{ __( 'History', 'jetpack-scan-page' ) }</Tabs.Tab>

--- a/projects/packages/scan/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/scan/changelog/normalize-tabs-minimal-variant
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Scan: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier.
+Scan: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier. Bump @wordpress/ui to 0.13.0.

--- a/projects/packages/scan/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/scan/changelog/normalize-tabs-minimal-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scan: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier.

--- a/projects/packages/scan/package.json
+++ b/projects/packages/scan/package.json
@@ -57,7 +57,7 @@
 		"@wordpress/notices": "5.44.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0"
 	},
 	"devDependencies": {

--- a/projects/packages/scan/routes/index/package.json
+++ b/projects/packages/scan/routes/index/package.json
@@ -22,7 +22,7 @@
 		"@wordpress/notices": "5.44.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0"
+		"@wordpress/ui": "0.13.0"
 	},
 	"route": {
 		"path": "/",

--- a/projects/packages/search/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/search/changelog/normalize-tabs-minimal-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier.

--- a/projects/packages/search/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/search/changelog/normalize-tabs-minimal-variant
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier.
+Search: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier. Bump @wordpress/ui to 0.13.0.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -64,7 +64,7 @@
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/interactivity": "6.44.0",
 		"@wordpress/server-side-render": "6.20.0",
-		"@wordpress/ui": "0.12.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0",
 		"@wordpress/viewport": "6.44.0",
 		"clsx": "2.1.1",

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -206,7 +206,7 @@ export default function DashboardPage( { isLoading = false } ) {
 					handleLocalNoticeDismissClick={ handleLocalNoticeDismissClick }
 				/>
 				<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
-					<div className="jp-admin-page-tabs">
+					<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 						<Tabs.List variant="minimal">
 							<Tabs.Tab value="plan-usage">{ __( 'Plan & Usage', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -1,33 +1,6 @@
 @use "scss/variables";
 @use "scss/rna-styles";
 
-// Body-scoped to beat the `body.jetpack_page_jetpack-search`-prefixed rules
-// from `@automattic/jetpack-base-styles/admin-page-layout` on specificity.
-body.jetpack_page_jetpack-search .jp-search-dashboard-page {
-	// Make `<Tabs.Tab>` actually use its design token. `@wordpress/ui` declares
-	// `font-size: var(--wpds-typography-font-size-md)` inside `@layer
-	// wp-ui-components`, but wp-admin core ships an unlayered
-	// `button { font-size: inherit }` reset that wins over any layered rule —
-	// so the tab silently inherits 16px from its surrounding context instead
-	// of the 13px the token specifies. Re-applying the token from an
-	// unlayered selector lets the design system land as intended (tab text
-	// smaller than the 15px page title — visual hierarchy restored).
-	.jp-admin-page-tabs [role="tab"] {
-		font-size: var(--wpds-typography-font-size-md, 13px);
-	}
-
-	// Align the first tab's content edge with the page header's start.
-	// admin-ui's page header sits at padding-inline 2xl (24px). The shared
-	// `.jp-admin-page-tabs` wrapper adds only 8px (designed for the default
-	// <Tabs.Tab> which ships with padding-inline lg = 16px, so 8 + 16 = 24
-	// matches the header). With `variant="minimal"`, <Tabs.Tab> has 0 inline
-	// padding, so the wrapper has to provide the full 2xl itself to keep
-	// the first tab flush with the header content edge across all widths.
-	.jp-admin-page-tabs {
-		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
-	}
-}
-
 #jp-search-dashboard {
 	color: variables.$black;
 	font-size: 16px;

--- a/projects/packages/videopress/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/videopress/changelog/normalize-tabs-minimal-variant
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-VideoPress: Migrate dashboard tabs from default to minimal variant; align via shared jp-admin-page-tabs--minimal wrapper modifier.
+VideoPress: Migrate dashboard tabs from default to minimal variant; align via shared jp-admin-page-tabs--minimal wrapper modifier. Bump @wordpress/ui to 0.13.0.

--- a/projects/packages/videopress/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/videopress/changelog/normalize-tabs-minimal-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Migrate dashboard tabs from default to minimal variant; align via shared jp-admin-page-tabs--minimal wrapper modifier.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -60,7 +60,7 @@
 		"@wordpress/notices": "5.44.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0",
 		"clsx": "2.1.1",
 		"debug": "4.4.3",

--- a/projects/packages/videopress/routes/library/package.json
+++ b/projects/packages/videopress/routes/library/package.json
@@ -10,7 +10,7 @@
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/route": "0.10.0",
-		"@wordpress/ui": "0.11.0"
+		"@wordpress/ui": "0.13.0"
 	},
 	"route": {
 		"path": "/library",

--- a/projects/packages/videopress/routes/overview/package.json
+++ b/projects/packages/videopress/routes/overview/package.json
@@ -14,7 +14,7 @@
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/route": "0.10.0",
 		"@wordpress/theme": "0.11.0",
-		"@wordpress/ui": "0.11.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0"
 	},
 	"route": {

--- a/projects/packages/videopress/routes/settings/package.json
+++ b/projects/packages/videopress/routes/settings/package.json
@@ -9,7 +9,7 @@
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/route": "0.10.0",
-		"@wordpress/ui": "0.11.0"
+		"@wordpress/ui": "0.13.0"
 	},
 	"route": {
 		"path": "/settings",

--- a/projects/packages/videopress/routes/video/package.json
+++ b/projects/packages/videopress/routes/video/package.json
@@ -13,7 +13,7 @@
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/route": "0.10.0",
-		"@wordpress/ui": "0.11.0"
+		"@wordpress/ui": "0.13.0"
 	},
 	"route": {
 		"path": "/video/$id",

--- a/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/DashboardLayout/style.scss
@@ -25,21 +25,4 @@ body.jetpack_page_jetpack-videopress {
 		}
 	}
 
-	// Match the design-system default-variant Tabs (Storybook reference).
-	// We pair `<Tabs.List>` (no variant) with the canonical 16px per-tab inline
-	// padding — `admin-page-layout` would otherwise bump it to 24px to line the
-	// first tab up with the page-title edge. To keep that alignment, offset the
-	// tablist itself by the missing 8px so the first tab's text still starts at
-	// the page-header inline padding (8px tablist + 16px tab = 24px). The
-	// hairline lives on `.jp-admin-page-tabs` and still spans the full width.
-	.jp-admin-page-tabs {
-
-		[role="tablist"] {
-			padding-inline-start: 8px;
-		}
-
-		[role="tab"] {
-			padding-inline: var(--wpds-dimension-padding-lg);
-		}
-	}
 }

--- a/projects/packages/videopress/src/dashboard/components/DashboardTabs/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/DashboardTabs/index.tsx
@@ -22,8 +22,8 @@ export const TAB_PATHS: Record< DashboardTab, string > = {
  */
 export default function DashboardTabs() {
 	return (
-		<div className="jp-admin-page-tabs">
-			<Tabs.List>
+		<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
+			<Tabs.List variant="minimal">
 				<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
 				<Tabs.Tab value="library">{ __( 'Library', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
 				<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-videopress-pkg' ) }</Tabs.Tab>

--- a/projects/plugins/protect/changelog/normalize-tabs-minimal-variant
+++ b/projects/plugins/protect/changelog/normalize-tabs-minimal-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: Migrate page tabs from default to minimal variant; align via shared jp-admin-page-tabs--minimal wrapper modifier.

--- a/projects/plugins/protect/changelog/normalize-tabs-minimal-variant
+++ b/projects/plugins/protect/changelog/normalize-tabs-minimal-variant
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Protect: Migrate page tabs from default to minimal variant; align via shared jp-admin-page-tabs--minimal wrapper modifier.
+Protect: Migrate page tabs from default to minimal variant; align via shared jp-admin-page-tabs--minimal wrapper modifier. Bump @wordpress/ui to 0.13.0.

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
-		"@wordpress/ui": "0.11.0",
+		"@wordpress/ui": "0.13.0",
 		"@wordpress/url": "4.44.0",
 		"camelize": "1.0.1",
 		"clsx": "2.1.1",

--- a/projects/plugins/protect/src/js/components/protect-app/index.jsx
+++ b/projects/plugins/protect/src/js/components/protect-app/index.jsx
@@ -94,8 +94,8 @@ const ProtectApp = () => {
 		>
 			{ notice && <Notice floating={ true } dismissable={ true } { ...notice } /> }
 			<Tabs.Root ref={ tabsRootRef } value={ activeTab } onValueChange={ onValueChange }>
-				<div className="jp-admin-page-tabs">
-					<Tabs.List>
+				<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
+					<Tabs.List variant="minimal">
 						<Tabs.Tab value="scan">{ scanLabel }</Tabs.Tab>
 						<Tabs.Tab value="firewall">{ __( 'Firewall', 'jetpack-protect' ) }</Tabs.Tab>
 						<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-protect' ) }</Tabs.Tab>


### PR DESCRIPTION
Fixes #48160

## Proposed changes

Normalize all page-level `<Tabs.List>` usages in Jetpack admin pages onto `<Tabs.List variant="minimal">` + the shared `.jp-admin-page-tabs--minimal` wrapper modifier shipped in #48908. Delete the local SCSS blocks that were re-implementing what the new shared modifier now provides, plus the legacy default-variant alignment workarounds.

* **Scan / Newsletter / Search**: were already `variant="minimal"` but each had a local SCSS block re-implementing what the new shared modifier does — local blocks deleted.
* **Protect / VideoPress**: migrated from default → minimal variant. VideoPress also had a 16-line workaround in `DashboardLayout/style.scss` specifically to hold default-variant tabs aligned with the page header — deleted, since minimal removes the need entirely.
* **Newsletter** additionally drops its bespoke wrapper class `jetpack-newsletter-page__tabs-row` in favour of the shared `jp-admin-page-tabs jp-admin-page-tabs--minimal`.

Diff stat: **+27 / -77 lines** (13 files, 5 of them changelog entries).

## Related product discussion/links

* Issue: #48160 (Jetpack UI Modernization)
* Shared modifier: #48908 (Rob Pugh, merged 2026-05-18) introduced `.jp-admin-page-tabs--minimal` in `admin-page-layout.scss`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. With this branch built (`pnpm jetpack build packages/search packages/scan packages/newsletter packages/videopress plugins/protect`), open the affected admin pages and confirm the page-level tab strip renders with the minimal variant (text-only labels, no rounded pill, tabs flush with the page title's start edge):
   * **Search** — Plan & Usage / Settings / AI Answers (Preview)
   * **Newsletter** — Subscribers / Settings (gated behind `rsm_jetpack_ui_modernization_newsletter` filter)
   * **Protect** — Scan / Firewall / Settings
   * **VideoPress** — Overview / Library / Settings (gated behind `rsm_jetpack_ui_modernization_videopress` filter)
   * **Scan** (optional) — Active threats / History (gated behind `rsm_jetpack_ui_modernization_scan` filter)
2. Verify the first tab's text content edge lines up with the page header title at all widths.
3. Switch between tabs and confirm the active-tab indicator slides smoothly (Tabs.List keeps `width: fit-content` via the shared wrapper).
4. Confirm there are no console errors related to layout/CSS on any of the pages above.

Biggest visual deltas expected on **Protect** and **VideoPress** (both migrating default → minimal variant).

## Out of scope (intentionally)

The following are *not* migrated in this PR — flagging so reviewers know what's deliberately excluded:

* `projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx` — legacy settings page doesn't use AdminPage / the shared mixin yet. Waiting on PoC #48181.
* 5 sub-strip / modal `variant="minimal"` consumers in Forms + the Newsletter add-subscribers-modal — they don't sit at the page-header edge, so wrapper alignment isn't needed.
* `projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx` — separate slice (double-logo fix), tracked in a parallel [PR](https://github.com/Automattic/jetpack/pull/48962).

## Screenshots

Before/after captures for the 4 visible admin pages (and Scan, captured with the modernization filter toggled locally). All shots at 1440×900.

| Page | Before | After |
| --- | --- | --- |
| **Search** | <img width="600" alt="Search before" src="https://github.com/user-attachments/assets/f2ca7a43-b1a6-4d43-94a9-993d6c7313d3" /> | <img width="600" alt="Search after" src="https://github.com/user-attachments/assets/8c49f9d4-6437-4b5a-8f7e-333d439706be" /> |
| **Newsletter** | <img width="600" alt="Newsletter before" src="https://github.com/user-attachments/assets/ce8feaaa-871d-4da8-9977-0f9ef5557b46" /> | <img width="600" alt="Newsletter after" src="https://github.com/user-attachments/assets/75612a97-7423-4bbe-9c1f-ed0c68696c17" /> |
| **Protect** | <img width="600" alt="Protect before" src="https://github.com/user-attachments/assets/566fcd90-f2b4-4b8e-bbf4-2af45a0aaab7" /> | <img width="600" alt="Protect after" src="https://github.com/user-attachments/assets/ef451204-37e4-4fe2-aae8-5d26f9431e96" /> |
| **VideoPress** | <img width="600" alt="VideoPress before" src="https://github.com/user-attachments/assets/6364014c-1403-4fc9-b2c4-9f1e9f2029e4" /> | <img width="600" alt="VideoPress after" src="https://github.com/user-attachments/assets/d1ba7f99-133e-47c7-9725-8a79334f741e" /> |
| **Scan** | <img width="600" alt="Scan before" src="https://github.com/user-attachments/assets/0d9718b9-50b6-426c-aad1-1c58535c2949" /> | <img width="600" alt="Scan after" src="https://github.com/user-attachments/assets/f48ccb2c-b3e2-4a9c-a4e5-9b8fab281762" /> |
