### PR TITLE
Podcast: init for anonymous requests so feed hooks register for crawlers

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/podcast-init-for-anonymous-requests
+++ b/projects/packages/jetpack-mu-wpcom/changelog/podcast-init-for-anonymous-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: initialize the package for anonymous requests too so feed-customization hooks register for podcatcher crawlers (Apple Podcasts, Spotify, etc.) once the untangle filter is flipped on.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -401,12 +401,6 @@ class Jetpack_Mu_Wpcom {
 			\Automattic\Jetpack\Newsletter\Settings::init();
 		}
 
-		// Initialize the Podcast package on Simple sites (where late_initialization
-		// in class.jetpack.php doesn't run). Gated by `jetpack_podcast_untangle`
-		// inside Podcast::init() so the legacy podcasting code keeps running
-		// until the flag flips.
-		\Automattic\Jetpack\Podcast\Podcast::init();
-
 		// Only load the Masterbar features on WoA sites.
 		if ( class_exists( '\Automattic\Jetpack\Status\Host' ) && ( new \Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
 			// This is temporary. After we cleanup Masterbar on WPCOM we should load Masterbar for Simple sites too.
@@ -424,6 +418,14 @@ class Jetpack_Mu_Wpcom {
 
 		require_once __DIR__ . '/features/gutenberg-rtc/gutenberg-rtc.php';
 		require_once __DIR__ . '/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php';
+
+		// Initialize the Podcast package here (rather than in
+		// load_wpcom_user_features) so feed-customization hooks register
+		// for anonymous requests too — Apple Podcasts / Spotify crawlers
+		// aren't logged in. Podcast::init() gates itself on host
+		// (Simple/WoA) and `jetpack_podcast_untangle`, so the legacy
+		// podcasting code keeps running until the flag flips.
+		\Automattic\Jetpack\Podcast\Podcast::init();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Move `Podcast::init()` from `load_wpcom_user_features()` (which bails for non-wpcom users) to `load_wpcom_sites_features()` (which runs for all users on wpcom sites). This closes the anonymous-feed-crawler gap flagged in the post-#48907 audit.

## Why

Today `Podcast::init()` only runs for wpcom users, so the `Customize_Feed` hooks never register for anonymous traffic. That's fine right now because the filter still resolves to `false` for anonymous requests, leaving the legacy `Automattic_Podcasting` mu-plugin (or `at-pressable-podcasting` on WoA) in charge.

But the moment `jetpack_podcast_untangle` flips globally, the legacy plugins stand down and anonymous crawlers (Apple Podcasts, Spotify, Pocket Casts, etc.) hit a plain WP RSS feed with no `<itunes:*>` / `<googleplay:*>` tags. This PR plugs that gap.

## Safety

`Podcast::init()` already self-gates:
- Bails if not Simple/WoA host
- Bails if `Podcast::is_enabled()` returns false
- Registers block hooks unconditionally (block callbacks re-check the filter)
- `Tracks::init()` only hooks admin/save events — won't misfire for anonymous traffic
- `Posts_To_Podcast_Endpoint` defers to `rest_api_init`
- `Admin_Page::init()` only runs in `is_admin()` context

No test depends on the old `load_wpcom_user_features` call path.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- [ ] On a proxied sandbox Simple site with `jetpack_podcast_untangle` on: verify `<itunes:*>` tags still appear in the podcast feed (regression check for logged-in case)
- [ ] On the same site, hit the feed anonymously (curl/incognito with no session): verify `<itunes:*>` tags now appear (the bug fix)
- [ ] On a non-proxied site (filter off): verify nothing changes — legacy stack still owns the feed