### PR TITLE
Podcast feed: strip channel-level tags that conflict with iTunes feed spec

### DIFF
--- a/projects/packages/podcast/changelog/podcast-preflight-feed-cleanup
+++ b/projects/packages/podcast/changelog/podcast-preflight-feed-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast feed: strip the blavatar, site-icon, and rss-cloud channel tags from the podcast RSS feed so the output stays iTunes-compliant once the untangle filter is flipped globally.

--- a/projects/packages/podcast/src/class-podcast-gate.php
+++ b/projects/packages/podcast/src/class-podcast-gate.php
@@ -20,6 +20,11 @@ class Podcast_Gate {
 
 	const FEATURE_SLUG = 'podcasting';
 
+	/**
+	 * Launch-day cutoff for the paying-blog grandfather rule. Paid blogs
+	 * registered before this date keep Premium podcast features without
+	 * needing the `podcasting` plan feature.
+	 */
 	const GRANDFATHER_CUTOFF_DATE = '2026-05-18';
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -54,6 +54,13 @@ class Customize_Feed {
 			return;
 		}
 
+		// Strip channel-level tags that conflict with the iTunes-compliant
+		// header: blavatar / site-icon `<image>` duplicates `<itunes:image>`,
+		// and `<cloud …/>` from rsscloud isn't part of the podcast spec.
+		remove_action( 'rss2_head', 'rss2_blavatar' );
+		remove_action( 'rss2_head', 'rss2_site_icon' );
+		remove_action( 'rss2_head', 'rsscloud_add_rss_cloud_element' );
+
 		add_action( 'rss2_ns', array( __CLASS__, 'output_namespaces' ) );
 		add_filter( 'wp_title_rss', array( __CLASS__, 'feed_title' ) );
 		add_filter( 'bloginfo_rss', array( __CLASS__, 'feed_description' ), 10, 2 );


### PR DESCRIPTION
## Summary

Pre-flight cleanup ahead of the global `jetpack_podcast_untangle` rollout:

- **Customize_Feed**: remove the three `rss2_head` callbacks (`rss2_blavatar`, `rss2_site_icon`, `rsscloud_add_rss_cloud_element`) that the legacy `Automattic_Podcasting` did at construct time. Without these, podcast feeds re-acquire the site-icon `<image>` (duplicates `<itunes:image>`) and the `<cloud …/>` element (not part of the podcast spec) once the legacy plugin stands down.
- **Podcast_Gate**: add a doc comment naming `GRANDFATHER_CUTOFF_DATE` as the launch-day cutoff for the paying-blog grandfather rule.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- [ ] On a proxied site with `jetpack_podcast_untangle` on, fetch the podcast category RSS feed and confirm the `<image>`, site-icon, and `<cloud …/>` channel tags are absent.
- [ ] On the same site, fetch a non-podcast feed (regular site RSS) and confirm those tags are still present (the removes are scoped to the podcast-feed branch in `maybe_register_feed_hooks`).