### PR TITLE
Podcast: rename Distribution Live badge to Submitted

### DIFF
--- a/projects/packages/podcast/changelog/podcast-distribution-rename-live-to-submitted
+++ b/projects/packages/podcast/changelog/podcast-distribution-rename-live-to-submitted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: rename the Distribution "Live" state badge to "Submitted" — the underlying signal is a crawler hit, not directory publication.

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -38,13 +38,16 @@ const selectOnFocus = ( event: FocusEvent< HTMLInputElement > ) => {
 const COPIED_LABEL = __( 'Copied!', 'jetpack-podcast' );
 const COPY_LINK_LABEL = __( 'Copy link', 'jetpack-podcast' );
 const PENDING_LABEL = __( 'Pending', 'jetpack-podcast' );
-const LIVE_LABEL = __( 'Live', 'jetpack-podcast' );
+// `active` means the feed has been crawled by the directory's bot — not that
+// the show has actually been published in the directory's catalog. "Submitted"
+// reflects what we know; "Live" overpromises.
+const SUBMITTED_LABEL = __( 'Submitted', 'jetpack-podcast' );
 
 const StateBadge = ( { state }: { state: PodcastShowState } ) => {
 	if ( state !== 'pending' && state !== 'active' ) {
 		return null;
 	}
-	const label = state === 'active' ? LIVE_LABEL : PENDING_LABEL;
+	const label = state === 'active' ? SUBMITTED_LABEL : PENDING_LABEL;
 	return (
 		<span className={ `podcast__state-badge podcast__state-badge--${ state }` }>
 			<VisuallyHidden as="span">{ __( 'Status:', 'jetpack-podcast' ) } </VisuallyHidden>

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -26,7 +26,7 @@ import type { PodcastAppModalProps } from '../types';
 const stateLabel = ( state: PodcastShowState ): string => {
 	switch ( state ) {
 		case 'active':
-			return __( 'Live', 'jetpack-podcast' );
+			return __( 'Submitted', 'jetpack-podcast' );
 		case 'pending':
 			return __( 'Pending', 'jetpack-podcast' );
 		default:


### PR DESCRIPTION
## Summary
- The `active` state only means a podcatcher crawler has fetched the feed — not that the show is actually published in the directory. Rename the badge label so we do not overpromise. Stored state value stays `active`.

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- [ ] Distribution tab: directories with `podcasting_show_states.<id> === 'active'` show a "Submitted" badge (green) instead of "Live".
- [ ] Pocket Casts modal button reads "Submitted" instead of "Live" once PCC returns 200.
- [ ] "Pending" badge and yellow styling unchanged.
