### PR TITLE
Write: Add topbar three-dot menu for block editor and preview

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-block-editor-preview-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-block-editor-preview-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Add a topbar three-dot menu with "Open in block editor" and "Preview" actions when editing an existing post.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-empty-publish-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-empty-publish-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Show "Please write something" instead of the server-side excerpt error when publishing or saving an empty post.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -196,6 +196,75 @@
 	background: #1a5f99;
 }
 
+/* "More options" dropdown to the right of Publish/Update */
+.bw-more-wrap {
+	position: relative;
+}
+
+.bw-more-toggle {
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	border: 1px solid transparent;
+	background: transparent;
+	color: #666;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	transition: all 0.15s ease;
+	font-family: inherit;
+}
+
+.bw-more-toggle:hover,
+.bw-more-toggle[aria-expanded="true"] {
+	background: #f5f5f5;
+	color: #333;
+}
+
+.bw-more-dots {
+	font-size: 22px;
+	line-height: 1;
+}
+
+.bw-more-menu {
+	position: absolute;
+	top: calc(100% + 6px);
+	right: 0;
+	z-index: 100002;
+	background: #fff;
+	border-radius: 8px;
+	min-width: 200px;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+	padding: 4px;
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-more-menu[hidden] {
+	display: none;
+}
+
+.bw-more-menu-item {
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: transparent;
+	border: none;
+	padding: 8px 12px;
+	border-radius: 4px;
+	font-size: 14px;
+	color: #1a1a1a;
+	cursor: pointer;
+	font-family: inherit;
+}
+
+.bw-more-menu-item:hover,
+.bw-more-menu-item:focus {
+	background: #f5f5f5;
+	outline: none;
+}
+
 /* ===== Recovery banner ===== */
 .bw-recovery-banner {
 	position: fixed;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3800,8 +3800,11 @@ const { state } = store( 'wpcom-write', {
  */
 async function savePost( postStatus, isAutosave = false ) {
 	if ( ! isAutosave ) {
-		const content = getContent();
-		if ( ! state.title.trim() && ( ! content || ! content.innerHTML.trim() ) ) {
+		// Use textContent rather than innerHTML so structural-only markup
+		// (e.g. <p><br></p> left over from clearing the editor) doesn't
+		// pass the client-side guard and reach the server, which would
+		// return a confusing "title, content, or excerpt is empty" error.
+		if ( ! hasWritableContent() ) {
 			state.message = i18n.pleaseWriteSomething || 'Please write something';
 			setTimeout( () => {
 				state.message = '';

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -320,18 +320,29 @@ function getContent() {
 }
 
 /**
- * Whether the editor has anything worth saving — non-empty title or
- * non-empty content. Used by actions that need a real post to navigate
- * to before they can do their job.
+ * Whether the editor has anything worth saving — non-empty title, any
+ * text content, or a media/separator block. Used by actions that need a
+ * real post to navigate to before they can do their job, and by the
+ * client-side empty-save guard.
  *
- * @return {boolean} True when there's title or content text.
+ * textContent rather than innerHTML so structural-only markup like
+ * <p><br></p> doesn't count as content. Figures and separators have no
+ * textContent but are still valid content, so check for them too.
+ *
+ * @return {boolean} True when there's title, text, or a media/separator block.
  */
 function hasWritableContent() {
 	if ( state.title && state.title.trim() ) {
 		return true;
 	}
 	const content = getContent();
-	return !! ( content && content.textContent.trim() );
+	if ( ! content ) {
+		return false;
+	}
+	if ( content.textContent.trim() ) {
+		return true;
+	}
+	return !! content.querySelector( 'figure, hr' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -320,6 +320,21 @@ function getContent() {
 }
 
 /**
+ * Whether the editor has anything worth saving — non-empty title or
+ * non-empty content. Used by actions that need a real post to navigate
+ * to before they can do their job.
+ *
+ * @return {boolean} True when there's title or content text.
+ */
+function hasWritableContent() {
+	if ( state.title && state.title.trim() ) {
+		return true;
+	}
+	const content = getContent();
+	return !! ( content && content.textContent.trim() );
+}
+
+/**
  * Deselect the currently-selected figure, if any, and optionally
  * restore the cursor position saved before the figure was selected.
  *
@@ -3467,6 +3482,144 @@ const { state } = store( 'wpcom-write', {
 			if ( ! wrap.contains( event.relatedTarget ) ) {
 				state.showHelp = false;
 			}
+		},
+
+		// --- Topbar "more" menu (Open in block editor / Preview) ---
+
+		toggleMoreMenu() {
+			state.showMoreMenu = ! state.showMoreMenu;
+			if ( state.showMoreMenu ) {
+				const close = e => {
+					if ( e.target.closest( '.bw-more-wrap' ) ) return;
+					state.showMoreMenu = false;
+					document.removeEventListener( 'click', close );
+				};
+				setTimeout( () => document.addEventListener( 'click', close ), 0 );
+			}
+		},
+
+		handleMoreMenuKeyDown( event ) {
+			const wrap = event.currentTarget;
+			const menu = wrap.querySelector( '.bw-more-menu' );
+			const items = menu ? [ ...menu.querySelectorAll( '.bw-more-menu-item' ) ] : [];
+			const onToggle = !! event.target.closest( '.bw-more-toggle' );
+
+			if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				state.showMoreMenu = false;
+				// Defer so the focus-restoration happens after the Interactivity
+				// state update; otherwise focus can land on <body>.
+				const toggle = wrap.querySelector( '.bw-more-toggle' );
+				requestAnimationFrame( () => toggle?.focus() );
+				return;
+			}
+
+			// Open the menu from the toggle with ArrowDown/ArrowUp and move focus
+			// to the first/last item respectively.
+			if ( onToggle && ( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) ) {
+				event.preventDefault();
+				state.showMoreMenu = true;
+				const target = event.key === 'ArrowUp' ? items[ items.length - 1 ] : items[ 0 ];
+				requestAnimationFrame( () => target?.focus() );
+				return;
+			}
+
+			if ( ! state.showMoreMenu || ! items.length ) {
+				return;
+			}
+
+			const focused = wrap.ownerDocument.activeElement;
+			const idx = items.indexOf( focused );
+
+			if ( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) {
+				event.preventDefault();
+				const delta = event.key === 'ArrowDown' ? 1 : -1;
+				let next;
+				if ( idx < 0 ) {
+					next = delta > 0 ? 0 : items.length - 1;
+				} else {
+					next = ( idx + delta + items.length ) % items.length;
+				}
+				items[ next ]?.focus();
+			} else if ( event.key === 'Home' ) {
+				event.preventDefault();
+				items[ 0 ]?.focus();
+			} else if ( event.key === 'End' ) {
+				event.preventDefault();
+				items[ items.length - 1 ]?.focus();
+			}
+		},
+
+		handleMoreMenuFocusOut( event ) {
+			const wrap = event.currentTarget;
+			if ( ! wrap.contains( event.relatedTarget ) ) {
+				state.showMoreMenu = false;
+			}
+		},
+
+		async openInBlockEditor() {
+			state.showMoreMenu = false;
+
+			// New posts need a save to create the underlying post before we
+			// have a URL to navigate to. Surface the same "Please write
+			// something" hint the publish flow shows so the menu doesn't
+			// appear unresponsive on an empty page.
+			if ( ! state.editPostId && ! hasWritableContent() ) {
+				state.message = i18n.pleaseWriteSomething || 'Please write something';
+				setTimeout( () => {
+					state.message = '';
+				}, 2500 );
+				return;
+			}
+
+			// Save first to preserve unsaved changes (and to create the post
+			// if this is a new draft). Silent autosave so we don't trigger
+			// the publish flow's auto-redirect.
+			if ( isDirty() || ! state.editPostId ) {
+				const status = state.postStatus === 'publish' ? 'publish' : 'draft';
+				await savePost( status, true );
+			}
+			if ( ! state.editPostId ) {
+				// Save failed for some other reason — abort.
+				return;
+			}
+
+			const url =
+				state.adminUrl +
+				'post.php?post=' +
+				state.editPostId +
+				'&action=edit&classic-editor__forget';
+			allowLeave = true;
+			window.location.href = url;
+		},
+
+		async previewPost() {
+			state.showMoreMenu = false;
+
+			if ( ! state.editPostId && ! hasWritableContent() ) {
+				state.message = i18n.pleaseWriteSomething || 'Please write something';
+				setTimeout( () => {
+					state.message = '';
+				}, 2500 );
+				return;
+			}
+
+			// For unpublished posts, silently save the draft first so preview
+			// reflects current edits (and creates the post if it's new).
+			// For published posts, open the live URL without auto-saving to
+			// avoid silently pushing unsaved edits live.
+			if ( state.postStatus !== 'publish' && ( isDirty() || ! state.editPostId ) ) {
+				await savePost( 'draft', true );
+			}
+			if ( ! state.editPostId ) {
+				return;
+			}
+
+			// Use the SSR-seeded preview URL when available — it includes any
+			// nonce returned by get_preview_post_link(). For posts created in
+			// this session, build the draft preview URL from state.homeUrl.
+			const url = state.previewUrl || state.homeUrl + '?p=' + state.editPostId + '&preview=true';
+			window.open( url, '_blank', 'noopener,noreferrer' );
 		},
 
 		// --- Inline category meta ---

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -325,9 +325,10 @@ function getContent() {
  * real post to navigate to before they can do their job, and by the
  * client-side empty-save guard.
  *
- * textContent rather than innerHTML so structural-only markup like
- * <p><br></p> doesn't count as content. Figures and separators have no
- * textContent but are still valid content, so check for them too.
+ * Checks textContent rather than innerHTML so structural-only markup
+ * like <p><br></p> doesn't count as content. Figures and separators
+ * have no textContent but are still valid content, so check for them
+ * too.
  *
  * @return {boolean} True when there's title, text, or a media/separator block.
  */
@@ -3583,23 +3584,27 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
-			// Save first to preserve unsaved changes (and to create the post
-			// if this is a new draft). Silent autosave so we don't trigger
-			// the publish flow's auto-redirect.
-			if ( isDirty() || ! state.editPostId ) {
-				const status = state.postStatus === 'publish' ? 'publish' : 'draft';
-				await savePost( status, true );
+			// For unpublished posts, silently save the draft first so the
+			// block editor opens with current edits (and to create the post
+			// if it's new). For published posts, hand off to the block
+			// editor without auto-saving — we don't want to silently push
+			// unsaved Write edits live.
+			if ( state.postStatus !== 'publish' && ( isDirty() || ! state.editPostId ) ) {
+				await savePost( 'draft', true );
 			}
 			if ( ! state.editPostId ) {
 				// Save failed for some other reason — abort.
 				return;
 			}
 
+			// Prefer the SSR-seeded URL; fall back to building it for posts
+			// created in this session (no SSR-seeded URL yet).
 			const url =
+				state.blockEditorUrl ||
 				state.adminUrl +
-				'post.php?post=' +
-				state.editPostId +
-				'&action=edit&classic-editor__forget';
+					'post.php?post=' +
+					state.editPostId +
+					'&action=edit&classic-editor__forget';
 			allowLeave = true;
 			window.location.href = url;
 		},

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -498,6 +498,19 @@ function wpcom_write_render_admin_page() {
 		$editor_url = '';
 	}
 
+	// URLs for the topbar "more" menu (Open in block editor / Preview).
+	// Always available when editing an existing post — independent of the
+	// unsupported-content warning's $editor_url which only triggers on load.
+	$block_editor_url = $edit_post_id
+		? admin_url( 'post.php?post=' . $edit_post_id . '&action=edit&classic-editor__forget' )
+		: '';
+	$preview_url      = '';
+	if ( $edit_post_id ) {
+		$preview_url = 'publish' === $post_status
+			? (string) get_permalink( $edit_post_id )
+			: (string) get_preview_post_link( $edit_post_id );
+	}
+
 	// Determine how the user arrived at the Write editor.
 	// 1. Explicit query param (highest priority).
 	// 2. Infer from HTTP referer.
@@ -629,6 +642,9 @@ function wpcom_write_render_admin_page() {
 			'showRecoveryBanner'  => false,
 			'unsupportedWarning'  => $unsupported_type,
 			'editorUrl'           => $editor_url,
+			'blockEditorUrl'      => $block_editor_url,
+			'previewUrl'          => $preview_url,
+			'showMoreMenu'        => false,
 		)
 	);
 
@@ -685,6 +701,31 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--click="actions.publish"
 				data-wp-bind--disabled="state.isSaving"
 			><?php echo 'publish' === $post_status ? esc_html__( 'Update', 'jetpack-mu-wpcom' ) : esc_html__( 'Publish', 'jetpack-mu-wpcom' ); ?></button>
+			<div class="bw-more-wrap" data-wp-on--keydown="actions.handleMoreMenuKeyDown" data-wp-on--focusout="actions.handleMoreMenuFocusOut">
+				<button
+					class="bw-more-toggle"
+					aria-haspopup="menu"
+					aria-expanded="false"
+					data-wp-bind--aria-expanded="state.showMoreMenu"
+					data-wp-on--click="actions.toggleMoreMenu"
+					title="<?php echo esc_attr__( 'More options', 'jetpack-mu-wpcom' ); ?>"
+					aria-label="<?php echo esc_attr__( 'More options', 'jetpack-mu-wpcom' ); ?>"
+				><span class="bw-more-dots" aria-hidden="true">&#x22EE;</span></button>
+				<div class="bw-more-menu" role="menu" aria-label="<?php echo esc_attr__( 'More options', 'jetpack-mu-wpcom' ); ?>" hidden data-wp-bind--hidden="!state.showMoreMenu">
+					<button
+						class="bw-more-menu-item"
+						role="menuitem"
+						tabindex="-1"
+						data-wp-on--click="actions.openInBlockEditor"
+					><?php echo esc_html__( 'Open in block editor', 'jetpack-mu-wpcom' ); ?></button>
+					<button
+						class="bw-more-menu-item"
+						role="menuitem"
+						tabindex="-1"
+						data-wp-on--click="actions.previewPost"
+					><?php echo esc_html__( 'Preview', 'jetpack-mu-wpcom' ); ?></button>
+				</div>
+			</div>
 		</div>
 	</header>
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -360,6 +360,97 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the topbar "more" menu is rendered when editing an existing post.
+	 */
+	public function test_more_menu_rendered_when_editing() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Draft',
+				'post_status' => 'draft',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		$output = $this->render_template( 'Draft', '<p>Hi</p>', $post_id, array(), 'draft' );
+
+		$this->assertStringContainsString( 'class="bw-more-wrap"', $output );
+		$this->assertStringContainsString( 'actions.toggleMoreMenu', $output );
+		$this->assertStringContainsString( 'actions.openInBlockEditor', $output );
+		$this->assertStringContainsString( 'actions.previewPost', $output );
+		$this->assertStringContainsString( 'Open in block editor', $output );
+		$this->assertStringContainsString( '>Preview<', $output );
+	}
+
+	/**
+	 * Test that the topbar "more" menu is also rendered for new posts.
+	 * The actions save first to create the post before navigating.
+	 */
+	public function test_more_menu_rendered_for_new_post() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'class="bw-more-wrap"', $output );
+		$this->assertStringContainsString( 'actions.openInBlockEditor', $output );
+		$this->assertStringContainsString( 'actions.previewPost', $output );
+	}
+
+	/**
+	 * Test that blockEditorUrl and previewUrl are seeded in state when editing.
+	 */
+	public function test_more_menu_urls_in_state_when_editing() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Draft',
+				'post_status' => 'draft',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		$_GET['post'] = $post_id;
+
+		ob_start();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
+
+		unset( $_GET['post'] );
+
+		$state = wp_interactivity_state( 'wpcom-write' );
+
+		$this->assertArrayHasKey( 'blockEditorUrl', $state );
+		$this->assertArrayHasKey( 'previewUrl', $state );
+		$this->assertArrayHasKey( 'showMoreMenu', $state );
+		$this->assertFalse( $state['showMoreMenu'] );
+
+		// Block editor URL uses the existing classic-editor__forget pattern.
+		$this->assertStringContainsString( 'post.php?post=' . $post_id, $state['blockEditorUrl'] );
+		$this->assertStringContainsString( 'classic-editor__forget', $state['blockEditorUrl'] );
+
+		// Preview URL for a draft should be non-empty.
+		$this->assertNotEmpty( $state['previewUrl'] );
+	}
+
+	/**
+	 * Test that blockEditorUrl and previewUrl are empty for new posts.
+	 */
+	public function test_more_menu_urls_empty_for_new_post() {
+		wp_set_current_user( $this->admin_id );
+
+		ob_start();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
+
+		$state = wp_interactivity_state( 'wpcom-write' );
+
+		$this->assertSame( '', $state['blockEditorUrl'] );
+		$this->assertSame( '', $state['previewUrl'] );
+	}
+
+	/**
 	 * Test that the help modal contains the #tag tip.
 	 */
 	public function test_help_modal_contains_hashtag_tip() {


### PR DESCRIPTION
Fixes RSM-3471 / https://linear.app/a8c/issue/RSM-3471
Also fixes RSM-2833 / https://linear.app/a8c/issue/RSM-2833

## Proposed changes
* Add a kebab-menu (⋮) button to the right of the Publish/Update button in the Write editor topbar.
* The menu exposes two clear escalation paths:
  * **Open in block editor** — silently saves any pending edits (or creates a draft on first save) and navigates to the existing `classic-editor__forget` URL so the post opens in the block editor.
  * **Preview** — opens the preview URL in a new tab. Drafts are autosaved first so the preview reflects current edits; published posts open the live URL without auto-saving (so unsaved Write edits aren't silently pushed live).
* The menu surfaces on new posts too: with content present it saves a draft first then proceeds; empty editors show the same "Please write something" hint as the Publish button.
* Keyboard navigation mirrors the existing category dropdown — ArrowDown from the toggle opens and focuses the first item, ArrowUp/Down wrap, Home/End jump to ends, Escape returns focus to the toggle.
* **Bonus fix (RSM-2833):** the new `hasWritableContent()` helper is reused in `savePost`'s empty-content guard. The previous guard checked `innerHTML.trim()`, which let structural-only markup like `<p><br></p>` through to the server, producing a confusing "title, content, or excerpt is empty" REST API error. The friendly "Please write something" message now fires for all empty-save attempts.

<img width="326" height="147" alt="Screenshot 2026-05-19 at 3 16 32 PM" src="https://github.com/user-attachments/assets/aaf7e1c3-6dd0-4416-a01a-3d1d6c8d1063" />


## Related product discussion/links
* https://linear.app/a8c/issue/RSM-3471
* https://linear.app/a8c/issue/RSM-2833

## Does this pull request change what data or activity we track or use?
No new tracking. Reuses the existing save flow (which already fires `wpcom_write_editor_draft_saved`).

## Testing instructions
**Three-dot menu (RSM-3471):**
1. Enable the Write editor and open it with no post selected (`/wp-admin/admin.php?page=write`).
2. Click the three-dot button to the right of Publish — menu appears with "Open in block editor" and "Preview".
3. With an empty editor, click either menu item — status bar shows "Please write something" briefly.
4. Type a title and some content, click "Open in block editor" — Write autosaves a draft and navigates to it in the block editor (verify the title matches).
5. Reopen the new draft in Write (`?page=write&post=<id>`) and click Preview — the preview URL opens in a new tab and reflects unsaved edits when the post is a draft.
6. For a published post (`?page=write&post=<published-id>`), Preview opens the live permalink in a new tab without auto-saving.
7. Keyboard test: Tab to the three-dot toggle, ArrowDown opens the menu and focuses the first item; ArrowDown/ArrowUp wrap; Home/End jump; Escape closes and returns focus to the toggle.

**Empty-publish error (RSM-2833):**
1. Open the Write editor with no post selected, leave title and content empty.
2. Click Publish — status bar shows "Please write something", never the server-side "title, content, or excerpt is empty" error.
3. Same behavior holds when the content area contains only structural HTML like `<p><br></p>`.