### PR TITLE
Podcast: episode block byline uses show host from settings

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-byline-use-talent-name
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-byline-use-talent-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: Episode block byline uses the show host from Podcasting settings, falling back to the post author.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -255,10 +255,22 @@ class Podcast_Episode_Block {
 			$transcript_url = '';
 		}
 
-		$author_id        = (int) $post->post_author;
-		$title            = get_the_title( $post );
-		$author_name      = get_the_author_meta( 'display_name', $author_id );
-		$author_url       = esc_url_raw( (string) get_the_author_meta( 'url', $author_id ) );
+		$author_id = (int) $post->post_author;
+		$title     = get_the_title( $post );
+
+		// Byline prefers the show-level host (Podcasting settings → talent
+		// name) so episodes attribute to the show, not whoever happened to
+		// publish the post. Falls back to post author when the setting is
+		// empty. The settings field has no URL, so the link wrapper is only
+		// kept on the author fallback.
+		$talent_name = trim( (string) get_option( 'podcasting_talent_name', '' ) );
+		if ( '' !== $talent_name ) {
+			$author_name = $talent_name;
+			$author_url  = '';
+		} else {
+			$author_name = get_the_author_meta( 'display_name', $author_id );
+			$author_url  = esc_url_raw( (string) get_the_author_meta( 'url', $author_id ) );
+		}
 		$publish_date_iso = get_the_date( 'c', $post );
 		$publish_date     = get_the_date( '', $post );
 		$episode_url      = get_permalink( $post );

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -291,6 +291,8 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 	const [ siteShowCover ] = useEntityProp< string >( 'root', 'site', 'podcasting_image' );
 	const showCoverUrl = siteShowCover || '';
 
+	const [ siteTalentName ] = useEntityProp< string >( 'root', 'site', 'podcasting_talent_name' );
+
 	const postAuthor = useSelect(
 		select => {
 			const author = authorId
@@ -302,6 +304,11 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 		},
 		[ authorId ]
 	);
+
+	// Byline prefers the show-level host (Podcasting settings → talent name)
+	// so episodes attribute to the show, not whoever happened to publish the
+	// post. Falls back to post author when the setting is empty.
+	const bylineName = ( siteTalentName || '' ).trim() || postAuthor;
 
 	const featuredImageUrl = useSelect(
 		select => {
@@ -690,10 +697,10 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 						{ postTitle || __( 'Untitled episode', 'jetpack-podcast' ) }
 					</h3>
 
-					{ ( postAuthor || postDate || duration ) && (
+					{ ( bylineName || postDate || duration ) && (
 						<p className="jetpack-podcast-episode__byline">
-							{ postAuthor && (
-								<span className="jetpack-podcast-episode__author">{ postAuthor }</span>
+							{ bylineName && (
+								<span className="jetpack-podcast-episode__author">{ bylineName }</span>
 							) }
 							{ postDate && (
 								<time className="jetpack-podcast-episode__date">

--- a/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
+++ b/projects/packages/podcast/tests/php/blocks/Podcast_Episode_Block_Test.php
@@ -43,6 +43,7 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 	public function tear_down() {
 		remove_filter( 'jetpack_is_frontend', '__return_true' );
 		delete_option( 'podcasting_image' );
+		delete_option( 'podcasting_talent_name' );
 		delete_option( 'date_format' );
 		WP_Block_Supports::$block_to_render = null;
 		parent::tear_down();
@@ -323,6 +324,98 @@ class Podcast_Episode_Block_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Spanish dub (es, 128 kbps, audio/mpeg)', $result );
 		$this->assertStringContainsString( 'hreflang="es"', $result );
 		$this->assertStringNotContainsString( 'not-a-url', $result );
+	}
+
+	public function test_byline_uses_talent_name_when_set() {
+		update_option( 'podcasting_talent_name', 'The Show Host' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'byline_post_author',
+				'user_pass'    => 'pass',
+				'user_email'   => 'byline_pa@example.com',
+				'display_name' => 'Post Author Name',
+			)
+		);
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Byline Episode',
+				'post_status' => 'publish',
+				'post_author' => $user_id,
+			)
+		);
+
+		$result = Podcast_Episode_Block::render_block( $this->default_attrs, '', $this->block_ctx( $post_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString( 'The Show Host', $result );
+		$this->assertStringNotContainsString( 'Post Author Name', $result );
+	}
+
+	public function test_byline_talent_name_has_no_author_url_link() {
+		update_option( 'podcasting_talent_name', 'The Show Host' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'byline_url_author',
+				'user_pass'    => 'pass',
+				'user_email'   => 'byline_url@example.com',
+				'user_url'     => 'https://example.com/author-profile',
+				'display_name' => 'Linked Author',
+			)
+		);
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Byline Episode',
+				'post_status' => 'publish',
+				'post_author' => $user_id,
+			)
+		);
+
+		$result = Podcast_Episode_Block::render_block( $this->default_attrs, '', $this->block_ctx( $post_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_user( $user_id );
+
+		// Schema.org Person markup must still be present.
+		$this->assertStringContainsString( 'itemprop="author" itemscope itemtype="https://schema.org/Person"', $result );
+		// The talent name itself must appear.
+		$this->assertStringContainsString( 'The Show Host', $result );
+		// No link to the post author URL must appear (no other <a> elements in a
+		// basic render without people / alternate-enclosures / transcript / license).
+		$this->assertStringNotContainsString( '<a href=', $result );
+	}
+
+	public function test_byline_post_author_fallback_links_when_author_has_url() {
+		// Ensure the talent-name option is absent so the post-author path is taken.
+		delete_option( 'podcasting_talent_name' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'byline_fallback_author',
+				'user_pass'    => 'pass',
+				'user_email'   => 'byline_fb@example.com',
+				'user_url'     => 'https://example.com/fallback-author',
+				'display_name' => 'Fallback Author',
+			)
+		);
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Byline Episode',
+				'post_status' => 'publish',
+				'post_author' => $user_id,
+			)
+		);
+
+		$result = Podcast_Episode_Block::render_block( $this->default_attrs, '', $this->block_ctx( $post_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString( 'Fallback Author', $result );
+		$this->assertStringContainsString( '<a href="https://example.com/fallback-author" itemprop="url">', $result );
 	}
 
 	public function test_filter_editor_script_src_rewrites_scheme_for_editor_handle() {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Episode block byline reads `podcasting_talent_name` from Podcasting settings, falling back to the post author display name when the setting is empty.
* The change covers both the editor preview (`edit.tsx`) and the rendered front end (`class-podcast-episode-block.php`).
* The RSS feed already prefers `podcasting_talent_name` via `class-customize-feed.php`, so the block was the outlier. After this PR the editor, the front-end render, and the feed all agree.
* Schema.org Person `itemprop` survives in both branches. The author-URL link wrapper now only appears on the post-author fallback, since the talent-name setting has no matching URL field.

## Related product discussion/links
* I spotted this on a fresh-site walkthrough: the byline displayed the site owner instead of the show host configured in podcast settings.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Any environment with the podcast Premium feature enabled works (wp-env or sandbox rsync).

1. Open a podcast post that contains the Podcast Episode block, and set the host (talent name) in Podcasting settings to something distinct from the post author display name.
2. Reload the editor and confirm the byline under the episode title now reads the talent name. View the post on the front end and confirm it matches.
3. Clear the talent-name field in settings, save, then reload the editor and front end. The byline falls back to the post author display name, and the author-URL link wraps it again if the post author has a profile URL set.

Test coverage: none added. The change is pure render code, exercised by the path above.

How this PR came about: Claude drafted the diff after a walkthrough I ran, since the byline showing site owner instead of show host was one of several small bugs in the new podcast flow.
