### PR TITLE
Podcast: auto-assign show category on episode block insert

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-auto-assign-category
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-auto-assign-category
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: Inserting a Podcast Episode block now auto-assigns the configured podcast category if the post doesn't already have it.

--- a/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
@@ -11,10 +11,20 @@ const PODCAST_BLOCK = 'jetpack/podcast-episode';
  * episodes. Users were inserting the block and publishing without realizing
  * the category was the gate, leaving the post invisible to the feed.
  */
+declare global {
+	interface Window {
+		jetpackPodcastEpisodeBlock?: {
+			podcastingCategoryId?: number;
+		};
+	}
+}
+
 export function registerAutoAssignCategory(): void {
 	const editorStore = select( 'core/editor' ) as
 		| {
 				getCurrentPost: () => {
+					id?: number;
+					status?: string;
 					content?: string | { raw?: string };
 				} | null;
 				getEditedPostAttribute: ( name: string ) => unknown;
@@ -45,9 +55,15 @@ export function registerAutoAssignCategory(): void {
 				return;
 			}
 			const isNew = editorStore.isCleanNewPost?.() ?? false;
+			// Auto-drafts and unsaved new posts have no saved content by
+			// definition, so resolve immediately rather than waiting for
+			// hydration. Without this, the first edit (typing a title,
+			// inserting the block) flips isCleanNewPost to false while
+			// content stays empty, and we'd loop forever.
+			const isFreshDraft = isNew || ! post.id || post.status === 'auto-draft';
 			const content = post.content;
 			const rawContent = typeof content === 'string' ? content : content?.raw ?? '';
-			if ( ! isNew && ! rawContent ) {
+			if ( ! isFreshDraft && ! rawContent ) {
 				// Existing post still hydrating; try again on the next tick.
 				return;
 			}
@@ -67,17 +83,25 @@ export function registerAutoAssignCategory(): void {
 			return;
 		}
 
-		const coreStore = select( 'core' ) as
-			| {
-					getEditedEntityRecord: (
-						kind: string,
-						name: string,
-						key?: number | string
-					) => { podcasting_category_id?: number } | null;
-			  }
-			| undefined;
-		const site = coreStore?.getEditedEntityRecord( 'root', 'site' );
-		const podcastingCategoryId = Number( site?.podcasting_category_id ) || 0;
+		// Prefer the inline-localized category id (readable for any user who
+		// can load the editor). `getEditedEntityRecord('root','site')` hits
+		// `/wp/v2/settings`, which requires `manage_options`, so authors and
+		// editors without that cap would otherwise silently skip the nudge.
+		const localized = Number( window.jetpackPodcastEpisodeBlock?.podcastingCategoryId ) || 0;
+		let podcastingCategoryId = localized;
+		if ( ! podcastingCategoryId ) {
+			const coreStore = select( 'core' ) as
+				| {
+						getEditedEntityRecord: (
+							kind: string,
+							name: string,
+							key?: number | string
+						) => { podcasting_category_id?: number } | null;
+				  }
+				| undefined;
+			const site = coreStore?.getEditedEntityRecord( 'root', 'site' );
+			podcastingCategoryId = Number( site?.podcasting_category_id ) || 0;
+		}
 		if ( ! podcastingCategoryId ) {
 			return;
 		}

--- a/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
@@ -1,0 +1,98 @@
+import { dispatch, select, subscribe } from '@wordpress/data';
+
+const PODCAST_BLOCK = 'jetpack/podcast-episode';
+
+/**
+ * Watches the post editor for a freshly-inserted Podcast Episode block and
+ * assigns the configured podcasting category to the post if it doesn't already
+ * have it. Fires once per editor session.
+ *
+ * Why: the podcasting feed and dashboard rely on the show category to scope
+ * episodes. Users were inserting the block and publishing without realizing
+ * the category was the gate, leaving the post invisible to the feed.
+ */
+export function registerAutoAssignCategory(): void {
+	const editorStore = select( 'core/editor' ) as
+		| {
+				getCurrentPost: () => {
+					content?: string | { raw?: string };
+				} | null;
+				getEditedPostAttribute: ( name: string ) => unknown;
+				isCleanNewPost?: () => boolean;
+		  }
+		| undefined;
+
+	// Contexts without `core/editor` (site editor, widgets, etc.) are out of
+	// scope — the block can only bind to a post's categories.
+	if ( ! editorStore ) {
+		return;
+	}
+
+	let alreadyAssigned = false;
+	// `null` = haven't resolved the saved post content yet. Once resolved, the
+	// value tells us whether the block was already present in the saved
+	// version (so we shouldn't re-touch the user's category choice).
+	let savedHadBlock: boolean | null = null;
+
+	subscribe( () => {
+		if ( alreadyAssigned || savedHadBlock === true ) {
+			return;
+		}
+
+		if ( savedHadBlock === null ) {
+			const post = editorStore.getCurrentPost();
+			if ( ! post ) {
+				return;
+			}
+			const isNew = editorStore.isCleanNewPost?.() ?? false;
+			const content = post.content;
+			const rawContent = typeof content === 'string' ? content : content?.raw ?? '';
+			if ( ! isNew && ! rawContent ) {
+				// Existing post still hydrating; try again on the next tick.
+				return;
+			}
+			savedHadBlock = rawContent.includes( '<!-- wp:' + PODCAST_BLOCK );
+			if ( savedHadBlock ) {
+				return;
+			}
+		}
+
+		const blockEditor = select( 'core/block-editor' ) as
+			| { getBlocksByName: ( name: string ) => string[] }
+			| undefined;
+		if ( ! blockEditor ) {
+			return;
+		}
+		if ( blockEditor.getBlocksByName( PODCAST_BLOCK ).length === 0 ) {
+			return;
+		}
+
+		const coreStore = select( 'core' ) as
+			| {
+					getEditedEntityRecord: (
+						kind: string,
+						name: string,
+						key?: number | string
+					) => { podcasting_category_id?: number } | null;
+			  }
+			| undefined;
+		const site = coreStore?.getEditedEntityRecord( 'root', 'site' );
+		const podcastingCategoryId = Number( site?.podcasting_category_id ) || 0;
+		if ( ! podcastingCategoryId ) {
+			return;
+		}
+
+		const currentCategories = editorStore.getEditedPostAttribute( 'categories' );
+		if ( ! Array.isArray( currentCategories ) ) {
+			return;
+		}
+		if ( currentCategories.includes( podcastingCategoryId ) ) {
+			return;
+		}
+
+		alreadyAssigned = true;
+		( dispatch( 'core/editor' ) as { editPost: ( patch: object ) => void } ).editPost( {
+			categories: [ ...currentCategories, podcastingCategoryId ],
+		} );
+	} );
+}

--- a/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
@@ -38,14 +38,15 @@ export function registerAutoAssignCategory(): void {
 		return;
 	}
 
-	let alreadyAssigned = false;
 	// `null` = haven't resolved the saved post content yet. Once resolved, the
 	// value tells us whether the block was already present in the saved
 	// version (so we shouldn't re-touch the user's category choice).
 	let savedHadBlock: boolean | null = null;
 
-	subscribe( () => {
-		if ( alreadyAssigned || savedHadBlock === true ) {
+	// Capture the unsubscribe so we can stop watching once the listener is done.
+	const unsubscribe = subscribe( () => {
+		if ( savedHadBlock === true ) {
+			unsubscribe();
 			return;
 		}
 
@@ -69,12 +70,13 @@ export function registerAutoAssignCategory(): void {
 			const rawContent = typeof content === 'string' ? content : content?.raw ?? '';
 			savedHadBlock = rawContent.includes( '<!-- wp:' + PODCAST_BLOCK );
 			if ( savedHadBlock ) {
+				unsubscribe();
 				return;
 			}
 		}
 
 		const blockEditor = select( 'core/block-editor' ) as
-			| { getBlocksByName: ( name: string ) => string[] }
+			| { getBlocksByName: ( name: string ) => unknown[] }
 			| undefined;
 		if ( ! blockEditor ) {
 			return;
@@ -87,9 +89,13 @@ export function registerAutoAssignCategory(): void {
 		// can load the editor). `getEditedEntityRecord('root','site')` hits
 		// `/wp/v2/settings`, which requires `manage_options`, so authors and
 		// editors without that cap would otherwise silently skip the nudge.
-		const localized = Number( window.jetpackPodcastEpisodeBlock?.podcastingCategoryId ) || 0;
-		let podcastingCategoryId = localized;
-		if ( ! podcastingCategoryId ) {
+		// Check window object presence explicitly: a localized value of 0 means
+		// "no category configured" and should NOT fall through to the core-data
+		// path (which would trigger an unnecessary /wp/v2/settings request).
+		let podcastingCategoryId: number;
+		if ( window.jetpackPodcastEpisodeBlock !== undefined ) {
+			podcastingCategoryId = window.jetpackPodcastEpisodeBlock.podcastingCategoryId ?? 0;
+		} else {
 			const coreStore = select( 'core' ) as
 				| {
 						getEditedEntityRecord: (
@@ -110,11 +116,16 @@ export function registerAutoAssignCategory(): void {
 		if ( ! Array.isArray( currentCategories ) ) {
 			return;
 		}
+
+		// We've detected the block for the first time this session — unsubscribe
+		// regardless of whether we need to assign the category, so we don't
+		// re-add it later if the user explicitly removes it.
+		unsubscribe();
+
 		if ( currentCategories.includes( podcastingCategoryId ) ) {
 			return;
 		}
 
-		alreadyAssigned = true;
 		( dispatch( 'core/editor' ) as { editPost: ( patch: object ) => void } ).editPost( {
 			categories: [ ...currentCategories, podcastingCategoryId ],
 		} );

--- a/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
@@ -51,22 +51,15 @@ export function registerAutoAssignCategory(): void {
 
 		if ( savedHadBlock === null ) {
 			const post = editorStore.getCurrentPost();
+			// `getCurrentPost()` returns null only before the initial post
+			// payload lands. Once it resolves to an object, the saved content
+			// is whatever was on the server — empty is a valid value (auto
+			// drafts, blank existing posts) and shouldn't keep us waiting.
 			if ( ! post ) {
 				return;
 			}
-			const isNew = editorStore.isCleanNewPost?.() ?? false;
-			// Auto-drafts and unsaved new posts have no saved content by
-			// definition, so resolve immediately rather than waiting for
-			// hydration. Without this, the first edit (typing a title,
-			// inserting the block) flips isCleanNewPost to false while
-			// content stays empty, and we'd loop forever.
-			const isFreshDraft = isNew || ! post.id || post.status === 'auto-draft';
 			const content = post.content;
 			const rawContent = typeof content === 'string' ? content : content?.raw ?? '';
-			if ( ! isFreshDraft && ! rawContent ) {
-				// Existing post still hydrating; try again on the next tick.
-				return;
-			}
 			savedHadBlock = rawContent.includes( '<!-- wp:' + PODCAST_BLOCK );
 			if ( savedHadBlock ) {
 				return;

--- a/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/auto-assign-category.ts
@@ -51,11 +51,18 @@ export function registerAutoAssignCategory(): void {
 
 		if ( savedHadBlock === null ) {
 			const post = editorStore.getCurrentPost();
-			// `getCurrentPost()` returns null only before the initial post
-			// payload lands. Once it resolves to an object, the saved content
-			// is whatever was on the server — empty is a valid value (auto
-			// drafts, blank existing posts) and shouldn't keep us waiting.
 			if ( ! post ) {
+				return;
+			}
+			// `getCurrentPost()` returns `{}` while the post entity is still
+			// resolving, which would look identical to an empty saved post.
+			// Wait for either a real id (existing post) or a confirmed
+			// fresh-draft signal before reading content; without this guard
+			// an existing post that already has the block could be flagged
+			// as "fresh insert" and get re-categorized on load.
+			const isFreshDraft =
+				( editorStore.isCleanNewPost?.() ?? false ) || post.status === 'auto-draft';
+			if ( ! post.id && ! isFreshDraft ) {
 				return;
 			}
 			const content = post.content;

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -137,11 +137,14 @@ class Podcast_Episode_Block {
 		// `manage_options`-only, so authors/editors without that cap couldn't
 		// read it client-side. Anyone with the editor loaded is already cleared
 		// to assign categories to a post, so exposing the integer here is fine.
+		// Route through Customize_Feed::resolve_category_id() so legacy sites
+		// that only have the `podcasting_archive` slug get the same fallback
+		// the feed uses, instead of a 0.
 		wp_add_inline_script(
 			self::EDITOR_HANDLE,
 			'window.jetpackPodcastEpisodeBlock = ' . wp_json_encode(
 				array(
-					'podcastingCategoryId' => (int) get_option( 'podcasting_category_id', 0 ),
+					'podcastingCategoryId' => \Automattic\Jetpack\Podcast\Feed\Customize_Feed::resolve_category_id(),
 				),
 				JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 			) . ';',

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -132,6 +132,22 @@ class Podcast_Episode_Block {
 			)
 		);
 
+		// Surface the podcasting category id to the editor for the auto-assign
+		// nudge. core-data's `root/site` entity hits `/wp/v2/settings`, which is
+		// `manage_options`-only, so authors/editors without that cap couldn't
+		// read it client-side. Anyone with the editor loaded is already cleared
+		// to assign categories to a post, so exposing the integer here is fine.
+		wp_add_inline_script(
+			self::EDITOR_HANDLE,
+			'window.jetpackPodcastEpisodeBlock = ' . wp_json_encode(
+				array(
+					'podcastingCategoryId' => (int) get_option( 'podcasting_category_id', 0 ),
+				),
+				JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+			) . ';',
+			'before'
+		);
+
 		// Add the script_loader_src rewrite only while the editor script is
 		// in flight, so the filter doesn't run on every front-end script load.
 		add_filter( 'script_loader_src', array( __CLASS__, 'filter_editor_script_src' ), 10, 2 );

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.ts
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.ts
@@ -1,3 +1,4 @@
+import { registerAutoAssignCategory } from './auto-assign-category';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
@@ -9,3 +10,5 @@ registerJetpackBlockFromMetadata( metadata, {
 	edit,
 	save,
 } );
+
+registerAutoAssignCategory();


### PR DESCRIPTION
Fixes #

## Proposed changes
* When a user inserts the Podcast Episode block into a post that didn't already have it, the configured `podcasting_category_id` is added to the post's categories if it isn't already present.
* The listener is wired in `editor.ts` and lives in a new `auto-assign-category.ts` module. It uses `select('core/block-editor').getBlocksByName('jetpack/podcast-episode')` (same selector the subscriptions paywall command palette uses) to detect presence.
* Decides "freshly inserted" vs "already saved" by reading `getCurrentPost().content.raw` once and checking for the block comment marker. If the saved post already had the block, we never touch categories. This avoids re-adding the category if the user explicitly removed it.
* One-shot per editor session. After the category is assigned (or we determine the block was already saved), the listener no-ops for the rest of the session.
* Site editor and other contexts without `core/editor` are skipped.

## Related product discussion/links
* Walkthrough surfaced episodes silently missing from the feed because users were publishing without applying the show category. This is the nudge that closes that gap from the editor side, without a modal or a notice.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Any environment with the podcast Premium feature enabled works.

1. In Podcasting settings, set a category as the podcasting category. Note the category ID.
2. Create a new post (no categories set, or only non-podcasting categories). Insert the Podcast Episode block from the inserter. The configured podcast category should appear in the Post → Categories sidebar.
3. Remove the block, then re-insert it within the same editor session. The category should NOT be re-added (one-shot per session). Refreshing the editor resets this.
4. Open an existing post that already has the Podcast Episode block. Remove the category if it's set, then refresh the editor. The category should NOT be re-added on load, because the saved post already had the block.
5. Open a post that previously had no podcast block, where the saved categories already include the podcasting category. Insert the block. The category list should stay as-is (no duplicate).
6. Open the Site Editor / template editor and confirm no console errors — the listener should no-op there.

Test coverage: none added. The change is editor-side and exercised by the path above. The selector usage mirrors `projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js`.

How this PR came about: Claude drafted the diff after a walkthrough I ran. Episodes were being published without the show category, which the feed scopes by, so they silently dropped out of the feed.
