### PR TITLE
Update changelog for number-formatters 1.1.9

### DIFF
--- a/projects/js-packages/number-formatters/CHANGELOG.md
+++ b/projects/js-packages/number-formatters/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.9] - 2026-05-19
+### Fixed
+- Currency formatting: use ISO 4217 minor-unit exponent for smallest-unit conversion to correctly format IDR and other currencies where browser ICU disagrees with ISO 4217. [#48967]
+
 ## [1.1.8] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -144,6 +148,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial release
 - Basic number formatting functionality
 
+[1.1.9]: https://github.com/Automattic/number-formatters/compare/1.1.8...1.1.9
 [1.1.8]: https://github.com/Automattic/number-formatters/compare/1.1.7...1.1.8
 [1.1.7]: https://github.com/Automattic/number-formatters/compare/1.1.6...1.1.7
 [1.1.6]: https://github.com/Automattic/number-formatters/compare/1.1.5...1.1.6

--- a/projects/js-packages/number-formatters/changelog/fix-format-currency-division-bug
+++ b/projects/js-packages/number-formatters/changelog/fix-format-currency-division-bug
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Currency formatting: use ISO 4217 minor-unit exponent for smallest-unit conversion to correctly format IDR and other currencies where browser ICU disagrees with ISO 4217.

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"description": "Number formatting utilities",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/number-formatters/#readme",
 	"bugs": {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-1761/

## Proposed changes

This bumps `@automattic/number-formatters` from `1.1.8` to `1.1.9`.

## Why are these changes being made?

A CLDR update (shipped via ICU 78.2) changed the smallest unit for `IDR` from `0.01` to `1`, which broke `isSmallestUnit: true` handling in our currency formatter and produced visibly wrong prices in checkout (e.g. HUF Premium showing as Ft 2,700,000/year instead of ~Ft 27,000/year — a 100x inflation across all billing intervals). This also affects `HUF`.

This change appears to only be in Chrome right now. Firefox and Safari still treat `IDR` as having 2 decimal places. Because of this, we need to hard-code the number of decimal places in our rendering package to make sure it is consistent across browsers.

`@automattic/number-formatters` 1.1.9 contains the fixes for this behavior (see https://github.com/Automattic/jetpack/pull/48967). 


