### PR TITLE
Podcast: settings save on Enter, email prefilled on activation

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-settings-enter-to-save-and-email-prefill
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-enter-to-save-and-email-prefill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: Settings text fields save on Enter, and the email field prefills with the site admin email on first activation.

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -93,12 +93,69 @@ class Settings {
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
 		add_action( 'rest_api_init', array( __CLASS__, 'register_settings' ) );
 
+		add_action( 'add_option_podcasting_category_id', array( __CLASS__, 'prefill_email_on_activate_added' ), 10, 2 );
+		add_action( 'update_option_podcasting_category_id', array( __CLASS__, 'prefill_email_on_activate_updated' ), 10, 3 );
+
 		add_filter(
 			'jetpack_sync_options_whitelist',
 			static function ( $options ) {
 				return array_merge( $options, self::OPTION_NAMES );
 			}
 		);
+	}
+
+	/**
+	 * `add_option_podcasting_category_id` callback. Fires the one-time email
+	 * prefill on first-ever category assignment.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Newly stored value.
+	 */
+	public static function prefill_email_on_activate_added( $option, $value ): void {
+		unset( $option );
+		self::maybe_prefill_email( 0, (int) $value );
+	}
+
+	/**
+	 * `update_option_podcasting_category_id` callback. Fires the prefill on
+	 * the 0 → non-zero transition. Re-activation is a no-op if the user has
+	 * already saved or cleared the email since.
+	 *
+	 * @param mixed  $old_value Previous stored value.
+	 * @param mixed  $value     Newly stored value.
+	 * @param string $option    Option name.
+	 */
+	public static function prefill_email_on_activate_updated( $old_value, $value, $option ): void {
+		unset( $option );
+		self::maybe_prefill_email( (int) $old_value, (int) $value );
+	}
+
+	/**
+	 * Prefill `podcasting_email` with the site admin email on first
+	 * activation, but only if the user has never written the option. Once the
+	 * option exists (even as `''`), this is a no-op: a user-cleared blank
+	 * stays blank.
+	 *
+	 * @param int $old_value Previous category id.
+	 * @param int $value     New category id.
+	 */
+	private static function maybe_prefill_email( int $old_value, int $value ): void {
+		if ( 0 !== $old_value || 0 === $value ) {
+			return;
+		}
+
+		// `null` default distinguishes "option doesn't exist" from "option
+		// stored as empty string". Only the former triggers the prefill.
+		if ( null !== get_option( 'podcasting_email', null ) ) {
+			return;
+		}
+
+		$admin_email = get_option( 'admin_email' );
+		if ( ! is_string( $admin_email ) || '' === $admin_email ) {
+			return;
+		}
+
+		update_option( 'podcasting_email', $admin_email );
 	}
 
 	/**

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -25,6 +25,7 @@ import CoverImageControl from './cover-image-control';
 import './style.scss';
 import { TOPICS } from './topics';
 import type { PodcastSettings, PodcastSettingsUpdate } from '../types';
+import type { KeyboardEvent } from 'react';
 
 const EXPLICIT_OPTIONS: Array< { label: string; value: string } > = [
 	{ label: __( 'No', 'jetpack-podcast' ), value: 'no' },
@@ -63,21 +64,41 @@ type StringFieldKey =
 // Per-field editor used by every text/textarea/email control. Holds local
 // state per keystroke, then commits on blur if the value differs from what's
 // saved. Re-syncs from `stored` when the saved value changes externally.
-// Spread directly onto `<TextControl>` etc. for `value` / `onChange` / `onBlur`.
+//
+// Spread `fieldProps` onto `<TextControl>` / `<TextareaControl>` for
+// `value` / `onChange` / `onBlur`. Single-line text inputs should also bind
+// `onKeyDownSaveOnEnter` as `onKeyDown`, which commits without waiting for
+// blur. Textareas don't, because Enter is a newline there.
 const useFieldEditor = (
 	stored: string,
 	onCommit: ( value: string ) => void
-): { value: string; onChange: ( v: string ) => void; onBlur: () => void } => {
+): {
+	fieldProps: {
+		value: string;
+		onChange: ( v: string ) => void;
+		onBlur: () => void;
+	};
+	onKeyDownSaveOnEnter: ( event: KeyboardEvent< HTMLInputElement > ) => void;
+} => {
 	const [ local, setLocal ] = useState( stored );
 	useEffect( () => {
 		setLocal( stored );
 	}, [ stored ] );
+	const commit = () => {
+		if ( local !== stored ) {
+			onCommit( local );
+		}
+	};
 	return {
-		value: local,
-		onChange: setLocal,
-		onBlur: () => {
-			if ( local !== stored ) {
-				onCommit( local );
+		fieldProps: {
+			value: local,
+			onChange: setLocal,
+			onBlur: commit,
+		},
+		onKeyDownSaveOnEnter: event => {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				commit();
 			}
 		},
 	};
@@ -268,25 +289,28 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Title', 'jetpack-podcast' ) }
-							{ ...titleField }
+							{ ...titleField.fieldProps }
+							onKeyDown={ titleField.onKeyDownSaveOnEnter }
 						/>
 						<TextareaControl
 							__nextHasNoMarginBottom
 							label={ __( 'Summary/Description', 'jetpack-podcast' ) }
 							rows={ 4 }
-							{ ...summaryField }
+							{ ...summaryField.fieldProps }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Hosts/Artist/Producer', 'jetpack-podcast' ) }
-							{ ...talentNameField }
+							{ ...talentNameField.fieldProps }
+							onKeyDown={ talentNameField.onKeyDownSaveOnEnter }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Copyright', 'jetpack-podcast' ) }
-							{ ...copyrightField }
+							{ ...copyrightField.fieldProps }
+							onKeyDown={ copyrightField.onKeyDownSaveOnEnter }
 						/>
 					</VStack>
 				</CardBody>
@@ -341,7 +365,8 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 								'Included in your feed so podcast directories can verify ownership. Most require it for submission.',
 								'jetpack-podcast'
 							) }
-							{ ...emailField }
+							{ ...emailField.fieldProps }
+							onKeyDown={ emailField.onKeyDownSaveOnEnter }
 						/>
 					</VStack>
 				</CardBody>


### PR DESCRIPTION
Fixes #

## Proposed changes

This bundles two podcasting settings fixes that surfaced in the same walkthrough.

### 1. Settings text fields save on Enter

The four single-line `TextControl`s in Podcasting settings (Title, Hosts/Artist/Producer, Copyright, RSS Email) previously only committed on blur. Hitting Enter felt like nothing happened. They now commit on Enter and on blur, whichever comes first.

Implementation: `useFieldEditor` returns `{ fieldProps, onKeyDownSaveOnEnter }`. Single-line `TextControl`s spread `fieldProps` and bind `onKeyDownSaveOnEnter` as `onKeyDown`. The Summary/Description `TextareaControl` only spreads `fieldProps`, since Enter is a newline in a textarea and we shouldn't hijack it. Commit-on-Enter calls `event.preventDefault()` so the keypress doesn't bubble up to a form submit.

### 2. RSS Email prefills with site admin email on first activation

When a podcast is activated for the first time (a category transitions from "none" to a real category ID), the `podcasting_email` option is prefilled with the site's `admin_email`. The user can edit or clear it at any time, and if they clear it, it stays blank.

Implementation lives in `class-settings.php` and is fully server-side, so it works regardless of which surface the user activated from:

- Two hooks: `add_option_podcasting_category_id` and `update_option_podcasting_category_id`. Both call a shared `maybe_prefill_email( int $old, int $new )`.
- Prefill fires only on the `0` to non-zero transition.
- The "leave blank if cleared" rule comes from a `null`-default `get_option` check: `null !== get_option( 'podcasting_email', null )` means the option row exists, even if its value is `''`. Once the user has saved or cleared the email even once, the row exists and we never prefill again.
- If `admin_email` is missing or empty, we no-op rather than writing an empty string.

## Related product discussion/links

* Walkthrough: both papercuts surfaced in the same session. Save-on-Enter is a muscle-memory expectation for text inputs in WP-admin. The email prefill removes a step from podcast onboarding; the admin email is the right default for most sites, and asking the user to retype it is friction without value.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Any environment with the podcast Premium feature enabled works. Two behaviors to verify.

**Save on Enter**

1. Open Podcasting settings.
2. In the Title field, type a new value and press Enter. The field should save (network request fires, value persists across refresh).
3. Repeat for Hosts/Artist/Producer, Copyright, and the RSS Email field.
4. In the Summary/Description textarea, press Enter. It should insert a newline, NOT trigger a save (save still happens on blur).
5. Blur behavior is unchanged: edit a field, tab away, save fires.

**Email prefill on first activation**

1. On a site that has never set a podcast category before (or where `delete_option('podcasting_category_id')` and `delete_option('podcasting_email')` have been run), go to Podcasting settings.
2. The RSS Email field should be empty.
3. Pick any category in the Podcasting Category picker and save.
4. Reload the settings page. The RSS Email should now be prefilled with the site admin email.
5. Clear the email field and save (empty). Reload. The email stays blank.
6. Change the podcast category to something else and save. The email should still be blank, since re-activation does not re-prefill once the user has cleared it.

Test coverage: none added. Both behaviors are exercised by the path above. The hook signatures for `add_option_*` and `update_option_*` are stable WP-core contracts.

How this PR came about: Claude drafted the diff after a walkthrough I ran. Both papercuts came out of the same session. Save-on-Enter felt broken, and the email field was annoying to fill in when the answer was the site admin email.
