### PR TITLE
Podcast: locked-preview upgrade lands on Settings after checkout

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-locked-preview-redirect-to-settings
+++ b/projects/packages/podcast/changelog/fix-podcast-locked-preview-redirect-to-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: Upgrading from a locked Stats or Episodes preview now lands on the Settings tab so the new podcaster can pick a category, matching the Welcome flow.

--- a/projects/packages/podcast/changelog/fix-podcast-locked-preview-redirect-to-settings
+++ b/projects/packages/podcast/changelog/fix-podcast-locked-preview-redirect-to-settings
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: Upgrading from a locked Stats or Episodes preview now lands on the Settings tab so the new podcaster can pick a category, matching the Welcome flow.
+Podcast: Fix post-upgrade redirect from locked Stats or Episodes preview to land on the Settings tab instead of the originating locked page.

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -32,7 +32,7 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 		// the user to where they were.
 		const settingsUrl = adminUrl
 			? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
-			: '';
+			: cancelTo;
 		const url = new URL( getProductCheckoutUrl( 'premium', siteSuffix, settingsUrl, true ) );
 		url.searchParams.set( 'cancel_to', cancelTo );
 		return url.toString();

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -17,16 +17,24 @@ interface LockedPreviewProps {
 const Skeleton = () => <span className="podcast-locked-preview__cell-skeleton" />;
 
 const LockedPreview = ( { variant }: LockedPreviewProps ) => {
-	const siteSuffix = getSiteData()?.suffix ?? '';
-	const returnUrl = window.location.href;
+	const data = getSiteData();
+	const siteSuffix = data?.suffix ?? '';
+	const adminUrl = data?.admin_url ?? '';
+	const cancelTo = window.location.href;
 	const checkoutUrl = ( () => {
 		if ( ! siteSuffix ) {
 			return 'https://wordpress.com/pricing';
 		}
-		// `getProductCheckoutUrl` sets `redirect_to`; the cart's close button
-		// reads `cancel_to`, so both need to point back to the dashboard.
-		const url = new URL( getProductCheckoutUrl( 'premium', siteSuffix, returnUrl, true ) );
-		url.searchParams.set( 'cancel_to', returnUrl );
+		// `redirect_to` lands on the Settings tab so the new podcaster picks
+		// a category before anything else (the rest of the dashboard is empty
+		// until that's done, and `?tab=settings` also bypasses the Welcome
+		// gate). `cancel_to` keeps the original page so a cart close returns
+		// the user to where they were.
+		const settingsUrl = adminUrl
+			? `${ adminUrl.replace( /\/$/, '' ) }/admin.php?page=jetpack-podcast&tab=settings`
+			: '';
+		const url = new URL( getProductCheckoutUrl( 'premium', siteSuffix, settingsUrl, true ) );
+		url.searchParams.set( 'cancel_to', cancelTo );
 		return url.toString();
 	} )();
 


### PR DESCRIPTION
Fixes #

## Proposed changes

The "Upgrade to Premium" CTA on the locked Stats and Episodes previews was sending the buyer back to the same locked-preview page after checkout. The page is now unlocked but empty: no episodes yet, no stats yet, and the rest of the dashboard is gated on a podcasting category the user hasn't picked.

The Welcome page's upgrade CTA already redirects to `admin.php?page=jetpack-podcast&tab=settings` after checkout (see `projects/packages/podcast/src/dashboard/welcome/index.tsx:48-50`). That URL both bypasses the Welcome gate (`?tab=` deep link, per `dashboard/index.tsx:52-53`) and lands the buyer on Settings so they can configure the show.

This change mirrors that behavior in `locked-preview/index.tsx`. `redirect_to` now points at the Settings tab, while `cancel_to` keeps the original page so a cart close returns the user to where they were.

## Related product discussion/links

* Walkthrough surfaced this when a brand-new buyer hit "Upgrade to Premium" from the locked Stats preview, completed checkout, and landed back on the same blank Stats panel with nothing to do.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Any WordPress.com test site on a Free plan with the podcast Premium feature gated.

1. On a Free-plan site, open the Podcasting dashboard (`/wp-admin/admin.php?page=jetpack-podcast`). Enable podcasting by picking a category, then open the Episodes or Stats tab. You should see the locked preview with the "Upgrade to Premium" card.
2. Inspect the upgrade CTA's `href`. The `redirect_to=` query parameter should point at `/wp-admin/admin.php?page=jetpack-podcast&tab=settings`. The `cancel_to=` should point at the current Episodes or Stats URL.
3. Click "Upgrade to Premium" and complete checkout. After payment, the user should land on the Settings tab of the Podcasting dashboard, not the original locked preview.
4. Open the cart, click close (cancel_to path). The user should land back on the Episodes/Stats page they started from.
5. Sanity check: the Welcome flow (free site with no category picked) should be unchanged. Welcome's "Start your premium podcast" still redirects to Settings.

Test coverage: none added. The change matches an existing pattern in `welcome/index.tsx` and is exercised by the walkthrough above.

How this PR came about: Claude drafted the diff after a walkthrough I ran. The buyer journey was leaving people stranded on the same locked preview they had just paid to unlock.
