### PR TITLE
forms: Set `uniqueName` in webpack blocks build

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-webpack-uniqueName
+++ b/projects/packages/forms/changelog/fix-forms-webpack-uniqueName
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a JavaScript error in the editor.

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -31,6 +31,8 @@ const sharedWebpackConfig = {
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '../dist/blocks' ),
+		// We need a more unique uniqueName here so ai-form-plugin's `dependOn` doesn't get confused with modules from other builds in the package.
+		uniqueName: jetpackWebpackConfig.output.uniqueName + '/blocks',
 	},
 	optimization: {
 		...jetpackWebpackConfig.optimization,

--- a/projects/plugins/jetpack/changelog/fix-forms-webpack-uniqueName
+++ b/projects/plugins/jetpack/changelog/fix-forms-webpack-uniqueName
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix a JavaScript error in the editor.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The ai-form-plugin block uses `dependOn`, and it seems that that can get confused if the `uniqueName` isn't actually unique (which it's not, since Forms has several separate webpack builds).

So, let's set a unique value for the relevant build.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1779200869756149-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Open the editor. Forms should still work, and there should be no `Uncaught TypeError: n[e] is not a function` error in the console.