### PR TITLE
Search: collapse per-directory production-exclude rules in search-package .gitattributes

### DIFF
--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -16,13 +16,8 @@
 /src/**/*.jsx                                            production-exclude
 /src/**/*.scss                                           production-exclude
 
-# Source .js is excluded per-directory, not via `/src/**/*.js`, because
 # `src/widgets/js/` has no build step — `class-search-widget.php` enqueues
 # those files straight from source, so they must ship. Every other src
-# subdirectory below is bundled into `/build/**` and its source is dev-only.
-/src/customberg/**/*.js                                  production-exclude
-/src/customizer/**/*.js                                  production-exclude
-/src/dashboard/**/*.js                                   production-exclude
-/src/inline-search/**/*.js                               production-exclude
-/src/instant-search/**/*.js                              production-exclude
-/src/search-blocks/**/*.js                               production-exclude
+# subdirectory is bundled into `/build/**` and its source is dev-only.
+/src/**/*.js                                             production-exclude
+/src/widgets/**/*.js                                     !production-exclude

--- a/projects/packages/search/changelog/fix-search-gitattributes-negation
+++ b/projects/packages/search/changelog/fix-search-gitattributes-negation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: collapse the per-directory `production-exclude` rules for `src/**/*.js` into a single broad exclude with an explicit carve-out for `src/widgets/**/*.js` (which has no build step and must ship).


### PR DESCRIPTION
Follow-up to #48933 — addresses [@anomiex's suggestion](https://github.com/Automattic/jetpack/pull/48933#discussion_r3269562260) to simplify the rule using a negation pattern.

## Proposed changes
* Collapse the six per-directory `production-exclude` rules for `src/**/*.js` into a single broad exclude plus an explicit carve-out for `src/widgets/**/*.js`:
  ```
  /src/**/*.js                production-exclude
  /src/widgets/**/*.js        !production-exclude
  ```
  The `!production-exclude` pattern is already used in the monorepo root `.gitattributes` (e.g. `projects/js-packages/*/package.json`), so it's an established convention.
* Future `src/` subdirectories with bundled JS now inherit the exclusion automatically — the rule no longer needs editing each time a new directory is added (which was the motivation for #48933 in the first place).
* Updated the comment block to reflect the new rule shape.

## Related product discussion/links
* Original PR: #48933
* Review comment: https://github.com/Automattic/jetpack/pull/48933#discussion_r3269562260

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Check out the branch.
* From the monorepo root, run `git check-attr production-exclude` against a representative set of files and confirm widgets resolve to `unspecified` (ship) while everything else under `src/**/*.js` resolves to `set` (excluded):
  ```
  git check-attr production-exclude \
    projects/packages/search/src/widgets/js/search-widget.js \
    projects/packages/search/src/widgets/js/search-widget-admin.js \
    projects/packages/search/src/search-blocks/index.js \
    projects/packages/search/src/dashboard/index.js \
    projects/packages/search/src/customberg/components/customberg.js \
    projects/packages/search/src/customizer/customize-controls.js \
    projects/packages/search/src/inline-search/index.js \
    projects/packages/search/src/instant-search/event-handlers/track-input.js
  ```
  Expected:
  * `src/widgets/js/*.js` → `production-exclude: unspecified`
  * Everything else → `production-exclude: set`
* Optionally run `jetpack rsync` (or whichever production-mirror tool the package uses) and confirm the resulting tree mirrors the behavior of #48933 — `src/widgets/js/` is present, every other `src/*/` source directory is absent.