### PR TITLE
Search: theme button styling + Compact style for Load More (RSM-3588)

### DIFF
--- a/projects/packages/search/changelog/RSM-3588-load-more-default-compact
+++ b/projects/packages/search/changelog/RSM-3588-load-more-default-compact
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Make the Load More block match the theme's regular core/button look and add a "Compact" block style so authors can right-size it without custom CSS.

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
@@ -7,6 +7,10 @@
 	"category": "jetpack-search",
 	"description": "Loads the next page of results. Powered by Jetpack Search.",
 	"supports": { "html": false, "interactivity": true },
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "compact", "label": "Compact" }
+	],
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {
 		"buttonLabel": { "type": "string", "default": "" }

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/edit.js
@@ -1,11 +1,14 @@
 /**
  * Editor preview for jetpack-search/results-load-more.
  *
- * Includes the (hidden) loading-spinner span render.php emits so the
- * `.jetpack-search-load-more__spinner` CSS hook is available to style. The
- * Inspector exposes a text input for the `buttonLabel` attribute; the saved
- * value (or the translated default) is what render.php prints on the front
- * end.
+ * The inner button carries `wp-block-button__link` + `wp-element-button` so
+ * it picks up the theme's full core/button look (border-radius, hover, etc.)
+ * — and a "Compact" block style trims padding/font for themes whose button
+ * baseline is too large. Includes the (hidden) loading-spinner span
+ * render.php emits so the `.jetpack-search-load-more__spinner` CSS hook is
+ * available to style. The Inspector exposes a text input for the
+ * `buttonLabel` attribute; the saved value (or the translated default) is
+ * what render.php prints on the front end.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
@@ -44,7 +47,7 @@ export default function LoadMoreEdit( { attributes, setAttributes } ) {
 			<div { ...blockProps }>
 				<button
 					type="button"
-					className="wp-element-button jetpack-search-load-more__button"
+					className="jetpack-search-load-more__button wp-block-button__link wp-element-button"
 					disabled
 				>
 					{ buttonLabel }

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/render.php
@@ -16,6 +16,13 @@ $button_label = trim( (string) ( $attributes['buttonLabel'] ?? '' ) );
 if ( '' === $button_label ) {
 	$button_label = __( 'Load more results', 'jetpack-search-pkg' );
 }
+
+// The button below carries `wp-block-button__link` so it inherits the
+// theme's full core/button look (border-radius, hover, etc.). That class is
+// only styled when the core Button block's stylesheet is on the page —
+// without a core/button on the page, the handle isn't auto-enqueued and the
+// class is inert. Pull it in explicitly so this block stands alone.
+wp_enqueue_style( 'wp-block-button' );
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
@@ -25,7 +32,7 @@ if ( '' === $button_label ) {
 >
 	<button
 		type="button"
-		class="wp-element-button jetpack-search-load-more__button"
+		class="jetpack-search-load-more__button wp-block-button__link wp-element-button"
 		data-wp-on--click="actions.loadMore"
 		data-wp-bind--hidden="state.isLoadingMore"
 	>

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/style.scss
@@ -6,9 +6,10 @@
 		display: none;
 	}
 
-	// The button itself relies on the active theme's `wp-element-button`
-	// styles (theme.json → styles.elements.button) — we only own the
-	// disabled visual since theme.json doesn't define one.
+	// The button carries `wp-block-button__link` + `wp-element-button` so it
+	// inherits the theme's full core/button look (border-radius, hover) and
+	// renders pixel-identical to a regular core/button on the same theme.
+	// We only own the disabled visual since theme.json doesn't define one.
 	.jetpack-search-load-more__button {
 		cursor: pointer;
 
@@ -16,6 +17,17 @@
 			opacity: 0.5;
 			cursor: not-allowed;
 		}
+	}
+
+	// `is-style-compact` lands on the block root (wrapper); the slim metrics
+	// target the inner button. Two-class specificity beats theme.json's
+	// single-class `.wp-element-button` rules so it wins without `!important`.
+	&.is-style-compact .jetpack-search-load-more__button {
+		padding: 0.25em 0.75em;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		min-width: 0;
+		width: auto;
 	}
 
 	.jetpack-search-load-more__spinner {


### PR DESCRIPTION
Fixes [RSM-3588](https://linear.app/a8c/issue/RSM-3588/search-30-apply-defaultcompact-theme-button-styling-to-load-more)

## Why

The **Load More** button looked unstyled next to a regular `core/button` on the same page — it picked up the theme's `wp-element-button` baseline (colors, padding, font) but missed the border-radius and polish themes attach to `.wp-block-button__link`. There was also no way to right-size it without custom CSS on themes whose button baseline is oversized.

After this PR: the Default Load More button matches the theme's regular `core/button` pixel-for-pixel, and a new **Compact** block style gives authors a slim variant in one click. This is the same approach RSM-3507 ships for Clear Filters.

## Proposed changes

* Add `wp-block-button__link` to the button class so it inherits the theme's full core/button look (border-radius, hover, etc.).
* Explicitly enqueue the core Button block stylesheet (`wp_enqueue_style( 'wp-block-button' )`) from `render.php`. That stylesheet is normally only auto-enqueued when a `core/button` is on the page; without it, our class would be inert.
* Register two block styles — **Default** (theme's regular core/button look) and **Compact** (slim padding/font, keeps theme's radius/colors/typography).
* `buttonLabel`, the spinner, the hide-when-no-next-page behavior, and `actions.loadMore` are unchanged.

## Screenshots

Real-screen before / after, captured at `/load-more-test/` via local docker (Twenty Twenty-Five) at 1440×900. The page contains two `jetpack-search/results-load-more` blocks (Default + Compact) and the `hidden` wrappers are force-shown in the capture so the buttons paint without a live search context.

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/7f47e58f-2a66-4526-8b4d-2d2b10d62b0d) | ![after](https://github.com/user-attachments/assets/21828cd9-0959-4f95-a891-a61614abc672) |

Before: both buttons render the same bare element-button rectangle. After: themed pill **Default** that matches the theme's regular `core/button`, plus a visibly slim pill **Compact**.

## Related product discussion/links

* [RSM-3588](https://linear.app/a8c/issue/RSM-3588/search-30-apply-defaultcompact-theme-button-styling-to-load-more)
* Mirrors approach from [RSM-3507](https://linear.app/a8c/issue/RSM-3507/search-30-clear-filters-button-renders-theme-massive-add-author) / #48946

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On Twenty Twenty-Five, drop the Load More block on a page and confirm the Default style now renders as a pill, pixel-identical to a regular `core/button` placed on the same page (same border-radius, colors, padding, typography).
* On Twenty Twenty-Four, confirm the Default Load More button picks up `theme.json`'s `.33rem` radius (no regression).
* In the block toolbar/inspector **Styles**, switch to **Compact**; confirm it renders a visibly slimmer button while preserving the theme's radius, colors, and typography.
* Confirm unchanged behavior: the **Button label** field still works; with paginated search results the button still appears, the spinner replaces it during load, and `actions.loadMore` still advances the page.
* Confirm the editor preview matches the front end.
