### PR TITLE
Search: add optional autocomplete dropdown to the Search Input block

### DIFF
--- a/projects/packages/search/changelog/search-205-search-input-autocomplete
+++ b/projects/packages/search/changelog/search-205-search-input-autocomplete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add optional autocomplete suggestions dropdown to the Search Input block — query, taxonomy, and post suggestions powered by the WPCOM search-suggestions endpoint. Authors opt in per block via the new "Show search suggestions" inspector toggle. Taxonomy picks apply as an inline filter when a matching filter block is on the page, otherwise navigate to the archive URL.

--- a/projects/packages/search/src/instant-search/hooks/use-search-suggestions.js
+++ b/projects/packages/search/src/instant-search/hooks/use-search-suggestions.js
@@ -22,6 +22,11 @@ export default function useSearchSuggestions( { query, siteId, enabled } ) {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const abortRef = useRef( null );
 
+	// `debounce(fn, 0)` defers to the next event loop tick rather than
+	// coalescing keystrokes — the calling `SearchForm` component owns the
+	// real (150 ms) debounce via its own blur timeout. Don't add a non-zero
+	// delay here without also revisiting the form-side timing or both
+	// debounces will compound.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const run = useCallback(
 		debounce( async ( q, sId ) => {

--- a/projects/packages/search/src/instant-search/hooks/use-search-suggestions.js
+++ b/projects/packages/search/src/instant-search/hooks/use-search-suggestions.js
@@ -1,119 +1,21 @@
 import debounce from 'debounce';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchSuggestions } from '../../search-blocks/store/suggestions-api';
 import { SERVER_OBJECT_NAME } from '../lib/constants';
 
 /**
- * Attempts to extract a taxonomy name and term slug from a WordPress archive URL.
- * Works for default permalink structures (/category/slug/, /tag/slug/, ?tag=slug).
- *
- * @param {string} url - Archive URL.
- * @return {{taxonomy: string, slug: string}|null} Parsed result or null.
- */
-function parseTaxonomyFromUrl( url ) {
-	try {
-		const u = new URL( url );
-		// WPCOM suggestions API format: ?taxonomy=category&term=slug
-		const taxonomyParam = u.searchParams.get( 'taxonomy' );
-		const termParam = u.searchParams.get( 'term' );
-		if ( taxonomyParam && termParam ) {
-			return { taxonomy: taxonomyParam, slug: termParam };
-		}
-		// Pretty permalink format: /tag/slug/ or /category/slug/
-		const tagSlug = u.searchParams.get( 'tag' );
-		if ( tagSlug ) {
-			return { taxonomy: 'post_tag', slug: tagSlug };
-		}
-		const parts = u.pathname.replace( /\/$/, '' ).split( '/' ).filter( Boolean );
-		if ( parts.length >= 2 ) {
-			const base = parts[ parts.length - 2 ];
-			const slug = parts[ parts.length - 1 ];
-			if ( base === 'category' ) return { taxonomy: 'category', slug };
-			if ( base === 'tag' ) return { taxonomy: 'post_tag', slug };
-		}
-	} catch {
-		// ignore malformed URLs
-	}
-	return null;
-}
-
-/**
- * @typedef {object} SuggestionItem
- * @property {'query'|'post'|'taxonomy'} type       - The kind of suggestion.
- * @property {string}                    text       - Display text.
- * @property {string}                    [url]      - Navigation URL (post and taxonomy types).
- * @property {string}                    [taxonomy] - Taxonomy name for taxonomy items (e.g. 'category', 'post_tag').
- * @property {string}                    [slug]     - Term slug for taxonomy items.
- */
-
-/**
- * Fetches all suggestion types from the WPCOM suggestions API in a single request.
- *
- * @param {string}      q       - Search query.
- * @param {string}      sId     - Site ID.
- * @param {object}      options - Server options (apiNonce, homeUrl, isPrivateSite, isWpcom).
- * @param {AbortSignal} signal  - Abort signal.
- * @return {Promise<SuggestionItem[]>} Resolved suggestion items.
- */
-async function fetchSuggestionsFromApi( q, sId, options, signal ) {
-	const { apiNonce, homeUrl, isPrivateSite, isWpcom } = options;
-	const path = `/${ encodeURIComponent( sId ) }/search-suggestions?query=${ encodeURIComponent(
-		q
-	) }&size=5`;
-	const url =
-		isPrivateSite && isWpcom
-			? `${ homeUrl }/wp-json/wpcom-origin/wpcom/v2/sites${ path }`
-			: `https://public-api.wordpress.com/wpcom/v2/sites${ path }`;
-	const fetchOptions = {
-		signal,
-		...( isPrivateSite && {
-			headers: { 'X-WP-Nonce': apiNonce },
-			credentials: 'include',
-		} ),
-	};
-	const response = await fetch( url, fetchOptions );
-	if ( ! response.ok ) {
-		return [];
-	}
-	const data = await response.json();
-
-	const toItems = ( items, type ) =>
-		( items ?? [] )
-			.map( item => {
-				const text = item.text ?? '';
-				if ( ! text ) {
-					return null;
-				}
-				if ( type === 'post' || type === 'taxonomy' ) {
-					const itemUrl = item.url ?? null;
-					if ( ! itemUrl ) {
-						return null;
-					}
-					if ( type === 'taxonomy' ) {
-						const taxonomy = item.taxonomy ?? parseTaxonomyFromUrl( itemUrl )?.taxonomy ?? null;
-						const slug = item.slug ?? parseTaxonomyFromUrl( itemUrl )?.slug ?? null;
-						return { type, text, url: itemUrl, taxonomy, slug };
-					}
-					return { type, text, url: itemUrl };
-				}
-				return { type: 'query', text };
-			} )
-			.filter( Boolean );
-
-	return [
-		...toItems( data.query_suggestions, 'query' ),
-		...toItems( data.taxonomy_suggestions, 'taxonomy' ),
-		...toItems( data.title_suggestions, 'post' ),
-	];
-}
-
-/**
  * Fetches search query suggestions from the WPCOM suggestions API.
+ *
+ * Reads the per-request config (apiNonce, homeUrl, isPrivateSite, isWpcom)
+ * from the legacy server-seeded global. The actual fetch + URL building +
+ * response normalization lives in the shared `suggestions-api` module so
+ * the Interactivity-API search-input block can call the same code path.
  *
  * @param {object}  args         - Arguments.
  * @param {string}  args.query   - Current input value.
  * @param {string}  args.siteId  - The site ID used in the API URL.
  * @param {boolean} args.enabled - Whether suggestions are enabled.
- * @return {{ suggestions: SuggestionItem[], isLoading: boolean }} Suggestions state.
+ * @return {{ suggestions: import('../../search-blocks/store/suggestions-api').SuggestionItem[], isLoading: boolean }} Suggestions state.
  */
 export default function useSearchSuggestions( { query, siteId, enabled } ) {
 	const [ suggestions, setSuggestions ] = useState( [] );
@@ -121,7 +23,7 @@ export default function useSearchSuggestions( { query, siteId, enabled } ) {
 	const abortRef = useRef( null );
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const fetchSuggestions = useCallback(
+	const run = useCallback(
 		debounce( async ( q, sId ) => {
 			if ( ! q || ! sId ) {
 				setSuggestions( [] );
@@ -135,8 +37,16 @@ export default function useSearchSuggestions( { query, siteId, enabled } ) {
 			setIsLoading( true );
 
 			try {
-				const options = window[ SERVER_OBJECT_NAME ] ?? {};
-				const results = await fetchSuggestionsFromApi( q, sId, options, abortRef.current.signal );
+				const { apiNonce, homeUrl, isPrivateSite, isWpcom } = window[ SERVER_OBJECT_NAME ] ?? {};
+				const results = await fetchSuggestions( {
+					query: q,
+					siteId: sId,
+					isPrivateSite,
+					isWpcom,
+					homeUrl,
+					nonce: apiNonce,
+					signal: abortRef.current.signal,
+				} );
 				setSuggestions( results );
 			} catch ( err ) {
 				if ( err.name !== 'AbortError' ) {
@@ -154,17 +64,17 @@ export default function useSearchSuggestions( { query, siteId, enabled } ) {
 			setSuggestions( [] );
 			return;
 		}
-		fetchSuggestions( query, siteId );
-	}, [ query, siteId, enabled, fetchSuggestions ] );
+		run( query, siteId );
+	}, [ query, siteId, enabled, run ] );
 
 	useEffect( () => {
 		return () => {
-			fetchSuggestions.clear?.();
+			run.clear?.();
 			if ( abortRef.current ) {
 				abortRef.current.abort();
 			}
 		};
-	}, [ fetchSuggestions ] );
+	}, [ run ] );
 
 	return { suggestions, isLoading };
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -13,7 +13,8 @@
 	"attributes": {
 		"placeholder": { "type": "string", "default": "" },
 		"showIcon": { "type": "boolean", "default": true },
-		"submitOnly": { "type": "boolean", "default": false }
+		"submitOnly": { "type": "boolean", "default": false },
+		"enableSuggestions": { "type": "boolean", "default": false }
 	},
 	"textdomain": "jetpack-search-pkg",
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -53,6 +53,7 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const placeholder = ( attributes?.placeholder || '' ).trim() || defaultPlaceholder;
 	const showIcon = attributes?.showIcon !== false;
 	const submitOnly = !! attributes?.submitOnly;
+	const enableSuggestions = !! attributes?.enableSuggestions;
 	return (
 		<>
 			<InspectorControls>
@@ -82,6 +83,16 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 						onChange={ value => setAttributes( { submitOnly: value } ) }
 						help={ __(
 							'When enabled, queries fire on Enter or when clearing the field, instead of on every keystroke.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show search suggestions', 'jetpack-search-pkg' ) }
+						checked={ enableSuggestions }
+						onChange={ value => setAttributes( { enableSuggestions: value } ) }
+						help={ __(
+							'Display an autocomplete dropdown with query, category, and post suggestions as the visitor types. Requires a configured Jetpack Search site ID.',
 							'jetpack-search-pkg'
 						) }
 					/>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -19,18 +19,45 @@ $placeholder = trim( (string) ( $attributes['placeholder'] ?? '' ) );
 if ( '' === $placeholder ) {
 	$placeholder = __( 'Search…', 'jetpack-search-pkg' );
 }
-$show_icon   = (bool) ( $attributes['showIcon'] ?? true );
-$submit_only = ! empty( $attributes['submitOnly'] );
+$show_icon          = (bool) ( $attributes['showIcon'] ?? true );
+$submit_only        = ! empty( $attributes['submitOnly'] );
+$enable_suggestions = ! empty( $attributes['enableSuggestions'] );
 // Read the URL-derived query through the shared helper so the SSR
 // `value=` matches the Interactivity store's seeded `searchQuery`.
 // The helper picks `s` vs `q` based on `is_search()` and applies the
 // same sanitize_text_field + trim WP would have applied to `s`.
 $initial_query = Search_Blocks::parse_url_search_query();
 $input_id      = wp_unique_id( 'jetpack-search-input-' );
+// A separate id pair is generated for the listbox + status region so the
+// input's `aria-controls` / `aria-activedescendant` can resolve to stable
+// DOM ids. Only generated (and only emitted) when suggestions are on, to
+// keep the default DOM untouched for authors who haven't opted in.
+$listbox_id = $enable_suggestions ? wp_unique_id( 'jetpack-search-suggestions-' ) : '';
+// `data-wp-context` seeds the per-instance Interactivity state. Keeping it
+// per-block (rather than on the shared `jetpack-search` store) means a
+// header + sidebar Search Input on the same page never share a dropdown's
+// `showSuggestions` / `activeIndex` — each instance owns its own UI state
+// while still pulling the query from the shared `state.searchQuery`.
+$context_json = $enable_suggestions
+	? wp_json_encode(
+		array(
+			'showSuggestions' => false,
+			'activeIndex'     => -1,
+			'activeOptionId'  => '',
+			'rows'            => array(),
+			'isLoading'       => false,
+			'listboxId'       => $listbox_id,
+		),
+		JSON_HEX_AMP | JSON_UNESCAPED_SLASHES
+	)
+	: '';
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
+	<?php if ( $enable_suggestions ) : ?>
+	data-wp-context='<?php echo esc_attr( $context_json ); ?>'
+	<?php endif; ?>
 >
 	<label class="jetpack-search-input__label screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>">
 		<?php esc_html_e( 'Search', 'jetpack-search-pkg' ); ?>
@@ -47,10 +74,19 @@ $input_id      = wp_unique_id( 'jetpack-search-input-' );
 			class="jetpack-search-input__field"
 			placeholder="<?php echo esc_attr( $placeholder ); ?>"
 			value="<?php echo esc_attr( $initial_query ); ?>"
-			<?php
-			if ( $submit_only ) :
-				?>
-				data-submit-only="true"<?php endif; ?>
+			<?php if ( $submit_only ) : ?>
+			data-submit-only="true"
+			<?php endif; ?>
+			<?php if ( $enable_suggestions ) : ?>
+			role="combobox"
+			aria-autocomplete="list"
+			aria-controls="<?php echo esc_attr( $listbox_id ); ?>"
+			data-suggestions-enabled="true"
+			data-wp-bind--aria-expanded="context.showSuggestions"
+			data-wp-bind--aria-activedescendant="context.activeOptionId"
+			data-wp-on--focus="actions.onSearchFocus"
+			data-wp-on--blur="actions.onSearchBlur"
+			<?php endif; ?>
 			data-wp-bind--value="state.searchQuery"
 			data-wp-on--input="actions.onSearchInput"
 			data-wp-on--keydown="actions.onSearchKeydown"
@@ -62,5 +98,40 @@ $input_id      = wp_unique_id( 'jetpack-search-input-' );
 			data-wp-on--click="actions.clearSearch"
 			aria-label="<?php echo esc_attr__( 'Clear search', 'jetpack-search-pkg' ); ?>"
 		>&#10005;</button>
+		<?php if ( $enable_suggestions ) : ?>
+		<ul
+			id="<?php echo esc_attr( $listbox_id ); ?>"
+			class="jetpack-search-input__suggestions"
+			role="listbox"
+			aria-label="<?php echo esc_attr__( 'Search suggestions', 'jetpack-search-pkg' ); ?>"
+			data-wp-bind--hidden="!context.showSuggestions"
+			hidden
+		>
+			<template
+				data-wp-each--row="context.rows"
+				data-wp-each-key="context.row.key"
+			>
+				<li
+					class="jetpack-search-input__suggestions-label"
+					role="presentation"
+					data-wp-bind--hidden="!context.row.isHeader"
+					data-wp-text="context.row.label"
+				></li>
+				<li
+					class="jetpack-search-input__suggestions-option"
+					role="option"
+					data-wp-bind--hidden="context.row.isHeader"
+					data-wp-bind--id="context.row.optionId"
+					data-wp-bind--aria-selected="state.isRowActive"
+					data-wp-class--is-active="state.isRowActive"
+					data-wp-on--mousedown="actions.onSuggestionMousedown"
+					data-wp-on--click="actions.onSuggestionClick"
+					tabindex="-1"
+				>
+					<span data-wp-text="context.row.text"></span>
+				</li>
+			</template>
+		</ul>
+		<?php endif; ?>
 	</div>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -79,6 +79,7 @@ $context_json = $enable_suggestions
 			<?php if ( $enable_suggestions ) : ?>
 			role="combobox"
 			aria-autocomplete="list"
+			aria-haspopup="listbox"
 			aria-controls="<?php echo esc_attr( $listbox_id ); ?>"
 			data-suggestions-enabled="true"
 			data-wp-bind--aria-expanded="context.showSuggestions"

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -45,7 +45,6 @@ $context_json = $enable_suggestions
 			'activeIndex'     => -1,
 			'activeOptionId'  => '',
 			'rows'            => array(),
-			'isLoading'       => false,
 			'listboxId'       => $listbox_id,
 		),
 		JSON_HEX_AMP | JSON_UNESCAPED_SLASHES

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -70,4 +70,64 @@
 			opacity: 1;
 		}
 	}
+
+	// Autocomplete dropdown — only present when the block author enabled
+	// `enableSuggestions`. Positioned absolutely against `.__inside-wrapper`
+	// (which is already `position: relative`) so the dropdown overlays the
+	// page below the input without disrupting layout. Visual tokens are
+	// lifted from instant-search/components/search-suggestions.scss so the
+	// two surfaces stay recognizably the same UI.
+	.jetpack-search-input__suggestions {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		margin: 0;
+		padding: 4px 0 8px;
+		max-height: 60vh;
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		background: #fff;
+		border: 1px solid #dcdcde;
+		border-top: none;
+		border-radius: 0 0 4px 4px;
+		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+		list-style: none;
+
+		&[hidden] {
+			display: none;
+		}
+
+		@media (max-width: 480px) {
+			max-height: 50vh;
+		}
+	}
+
+	.jetpack-search-input__suggestions-label {
+		color: #787c82;
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.06em;
+		padding: 8px 16px 4px;
+		text-transform: uppercase;
+	}
+
+	.jetpack-search-input__suggestions-option {
+		cursor: pointer;
+		font-size: 14px;
+		line-height: 1.4;
+		color: #1e1e1e;
+		padding: 10px 20px;
+
+		@media (max-width: 480px) {
+			padding: 13px 20px;
+		}
+
+		&:hover,
+		&.is-active {
+			background: #f0f6fc;
+			color: #0675c4;
+		}
+	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -74,25 +74,37 @@
 	// Autocomplete dropdown — only present when the block author enabled
 	// `enableSuggestions`. Positioned absolutely against `.__inside-wrapper`
 	// (which is already `position: relative`) so the dropdown overlays the
-	// page below the input without disrupting layout. Visual tokens are
-	// lifted from instant-search/components/search-suggestions.scss so the
-	// two surfaces stay recognizably the same UI.
+	// page below the input without disrupting layout. The visual treatment
+	// matches the `filters-popover` / `results-sort` menus: `base`/`contrast`
+	// theme tokens for the surface (so it inverts cleanly on dark themes
+	// instead of flashing as a white rectangle) and `color-mix` against
+	// `currentColor` for borders, hover, and the active highlight. Sharing
+	// the popover family's vocabulary makes the dropdown read as part of
+	// the same block set rather than a one-off WP-admin-styled panel.
 	.jetpack-search-input__suggestions {
 		position: absolute;
-		top: 100%;
+		top: calc(100% + 4px);
 		left: 0;
 		right: 0;
-		z-index: 100;
+		z-index: 20;
 		margin: 0;
-		padding: 4px 0 8px;
+		padding: 4px 0;
 		max-height: 60vh;
 		overflow-y: auto;
 		overscroll-behavior: contain;
-		background: #fff;
-		border: 1px solid #dcdcde;
-		border-top: none;
-		border-radius: 0 0 4px 4px;
-		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+		background: var(--wp--preset--color--base);
+		// The dropdown owns its surface, so pin the ink color too — otherwise
+		// the option text inherits a low-contrast theme accent from the
+		// surrounding page (e.g. a muted header link color).
+		color: var(--wp--preset--color--contrast);
+		// Reset the inherited theme base size so option text tracks the
+		// other block surfaces (sort menu, filters popover) at 1rem instead
+		// of the host theme's oversized default.
+		font-size: 1rem;
+		border: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 15%, transparent);
+		border-radius: 4px;
+		box-shadow: 0 4px 16px color-mix(in sRGB, currentColor 12%, transparent);
 		list-style: none;
 
 		&[hidden] {
@@ -105,29 +117,40 @@
 	}
 
 	.jetpack-search-input__suggestions-label {
-		color: #787c82;
-		font-size: 11px;
+		// Muted relative to the inherited ink so the group label reads as a
+		// section heading without being a hard-coded grey. ~55% alpha against
+		// the surface color is the same level used by the active-filters
+		// heading and the results-sort label.
+		color: color-mix(in sRGB, currentColor 55%, transparent);
+		font-size: 0.75rem;
 		font-weight: 600;
 		letter-spacing: 0.06em;
-		padding: 8px 16px 4px;
+		padding: 8px 12px 4px;
 		text-transform: uppercase;
 	}
 
 	.jetpack-search-input__suggestions-option {
 		cursor: pointer;
-		font-size: 14px;
+		font: inherit;
 		line-height: 1.4;
-		color: #1e1e1e;
-		padding: 10px 20px;
+		color: inherit;
+		padding: 8px 12px;
+		border-radius: 2px;
 
 		@media (max-width: 480px) {
-			padding: 13px 20px;
+			padding: 12px 12px;
 		}
 
-		&:hover,
+		// Hover and keyboard-active states use the same currentColor mix the
+		// sort menu uses for its items, just at a slightly stronger ratio
+		// for the keyboard-highlighted row so the active row is unambiguous
+		// even when the pointer is also hovering a different one.
+		&:hover {
+			background: color-mix(in sRGB, currentColor 8%, transparent);
+		}
+
 		&.is-active {
-			background: #f0f6fc;
-			color: #0675c4;
+			background: color-mix(in sRGB, currentColor 14%, transparent);
 		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/suggestion-rows.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/suggestion-rows.js
@@ -1,0 +1,120 @@
+/**
+ * Ordered list of suggestion types — drives both the group ordering in the
+ * rendered dropdown and the source order of the API response after the
+ * shared `fetchSuggestions` has flattened it.
+ */
+const TYPE_ORDER = [ 'query', 'taxonomy', 'post' ];
+
+/**
+ * Flatten grouped suggestions into a single row stream for `data-wp-each`.
+ *
+ * The Interactivity API's list-rendering directive only iterates over a
+ * single array, so the group headers and the option rows need to live in
+ * the same list — discriminated by `isHeader`. Two `<li>` siblings inside
+ * the same `<template>`, each gated by `data-wp-bind--hidden` against the
+ * row's `isHeader` flag, render the correct one. The pattern mirrors how
+ * `active-filters/render.php` walks a flat `state.activePills` list.
+ *
+ * Each option row also receives `optionIndex` (its 0-based position among
+ * option rows only — headers do not consume an index, so ArrowDown / ArrowUp
+ * move through the dropdown linearly without skipping over labels), `optionId`
+ * (`${ listboxId }-option-${ optionIndex }` — used as the `<li id>` for
+ * `aria-activedescendant`), and `key` (a stable, collision-proof key for
+ * `data-wp-each-key`: `hdr:<type>` for headers, `opt:<type>:<originalIndex>`
+ * for options).
+ *
+ * The `labels` argument carries the translated group titles. They come from
+ * PHP via `state.strings` because `@wordpress/i18n` isn't yet available as
+ * a Script Module (the blocks build target), so client-side translation
+ * isn't an option in this view bundle.
+ *
+ * @param {Array<{type: 'query'|'post'|'taxonomy', text: string, url?: string, taxonomy?: string, slug?: string}>} suggestions
+ *                                                                                                                             Flat list returned by `fetchSuggestions`.
+ * @param {string}                                                                                                 listboxId   - DOM id of the parent `<ul role="listbox">`. Used to
+ *                                                                                                                             bake `optionId` so the input's `aria-activedescendant` can target it.
+ * @param {{query: string, taxonomy: string, post: string}}                                                        labels
+ *                                                                                                                             Translated group titles. Missing keys render as the bare type string.
+ * @return {Array<object>} Rows ready for `data-wp-each`.
+ */
+export function buildSuggestionRows( suggestions, listboxId, labels ) {
+	if ( ! Array.isArray( suggestions ) || suggestions.length === 0 ) {
+		return [];
+	}
+
+	const safeLabels = labels ?? {};
+	const rows = [];
+	let optionIndex = 0;
+
+	for ( const type of TYPE_ORDER ) {
+		const indexed = suggestions
+			.map( ( item, originalIndex ) => ( { item, originalIndex } ) )
+			.filter( ( { item } ) => item.type === type );
+
+		if ( indexed.length === 0 ) {
+			continue;
+		}
+
+		rows.push( {
+			key: `hdr:${ type }`,
+			isHeader: true,
+			type,
+			label: safeLabels[ type ] ?? type,
+		} );
+
+		for ( const { item, originalIndex } of indexed ) {
+			rows.push( {
+				key: `opt:${ type }:${ originalIndex }`,
+				isHeader: false,
+				type,
+				text: item.text,
+				url: item.url ?? '',
+				taxonomy: item.taxonomy ?? '',
+				slug: item.slug ?? '',
+				optionIndex,
+				optionId: `${ listboxId }-option-${ optionIndex }`,
+			} );
+			optionIndex += 1;
+		}
+	}
+
+	return rows;
+}
+
+/**
+ * Count of selectable rows (excludes headers). Hoisted into its own helper
+ * because the view bundle needs it for arrow-key clamping and it would be
+ * fragile to filter rows again inside the keydown handler.
+ *
+ * @param {Array<object>} rows - Output of `buildSuggestionRows`.
+ * @return {number} Number of option rows.
+ */
+export function countOptions( rows ) {
+	let n = 0;
+	for ( const row of rows ) {
+		if ( ! row.isHeader ) {
+			n += 1;
+		}
+	}
+	return n;
+}
+
+/**
+ * Find a row's index in the flat list by its `optionIndex`. Arrow-key
+ * navigation tracks the option index (so headers don't consume key strokes),
+ * but selection lookups need the underlying row — this bridges the two.
+ *
+ * @param {Array<object>} rows        - Output of `buildSuggestionRows`.
+ * @param {number}        optionIndex - Target option index.
+ * @return {object|null} Matching row, or null when out of range.
+ */
+export function rowAtOptionIndex( rows, optionIndex ) {
+	if ( optionIndex < 0 ) {
+		return null;
+	}
+	for ( const row of rows ) {
+		if ( ! row.isHeader && row.optionIndex === optionIndex ) {
+			return row;
+		}
+	}
+	return null;
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-input/suggestions.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/suggestions.js
@@ -1,0 +1,385 @@
+/**
+ * Autocomplete-suggestions surface for the Search Input block.
+ *
+ * Everything that's specific to the suggestions dropdown — the per-input
+ * debounce / abort WeakMaps, the focus / blur / click handlers, the
+ * `data-wp-each` row-active getter, the WPCOM fetch generator action, and
+ * the `acceptSuggestion` dispatcher — lives here. The block's own
+ * `view.js` only knows about typing and clearing; it delegates the
+ * suggestion-specific work to the three helpers exported below.
+ *
+ * The actions registered by the side-effect `store()` call at the bottom of
+ * the file are merged into the shared `jetpack-search` Interactivity store
+ * alongside the actions registered from `view.js`. Interactivity composes
+ * `store()` calls on the same namespace by key, so as long as the two files
+ * register disjoint keys (this file owns the suggestions-only ones; view.js
+ * owns the input-only ones) there's no cross-file mutable state.
+ */
+
+import { getContext, store } from '@wordpress/interactivity';
+import { fetchSuggestions } from '../../store/suggestions-api';
+import { buildSuggestionRows, countOptions, rowAtOptionIndex } from './suggestion-rows';
+
+const NAMESPACE = 'jetpack-search';
+const SUGGESTIONS_DEBOUNCE_MS = 120;
+const SUGGESTIONS_BLUR_CLOSE_MS = 150;
+
+// Per-input timer / abort state. WeakMaps keyed by the input element itself
+// so two `search-input` blocks on the same page (header + sidebar) don't
+// reset each other's timers or abort each other's suggestions request, and
+// so GC can reclaim the entries automatically when an input leaves the DOM.
+const suggestionTimers = new WeakMap();
+const suggestionAborts = new WeakMap();
+const blurTimers = new WeakMap();
+
+/**
+ * Whether a particular search input opted into suggestions. The block
+ * author's `enableSuggestions` attribute renders the `data-suggestions-enabled`
+ * attribute server-side; this is the single source of truth the suggestions
+ * layer consults at every entry point so non-opted-in inputs cost nothing.
+ *
+ * @param {HTMLInputElement} input - The input to check.
+ * @return {boolean} True when this input is suggestions-enabled.
+ */
+function isSuggestionsInput( input ) {
+	return input?.dataset?.suggestionsEnabled === 'true';
+}
+
+/**
+ * Schedule (or restart) the debounced suggestions fetch for a single
+ * input. Faster than the search debounce so the dropdown feels responsive —
+ * 120 ms is short enough to keep up with quick typing but long enough to
+ * coalesce held keys into one request. The caller passes the per-instance
+ * Interactivity context proxy so the deferred action can mutate it
+ * directly — `getContext()` from inside a `setTimeout` would return null
+ * because context tracking is only live inside the originating handler.
+ *
+ * @param {HTMLInputElement} input - The input whose timer should be reset.
+ * @param {object}           ctx   - The per-instance context to mutate when the fetch lands.
+ */
+function scheduleSuggestions( input, ctx ) {
+	clearTimeout( suggestionTimers.get( input ) );
+	const timer = setTimeout( () => {
+		suggestionTimers.delete( input );
+		store( NAMESPACE ).actions.fetchSuggestionsFor( input, ctx );
+	}, SUGGESTIONS_DEBOUNCE_MS );
+	suggestionTimers.set( input, timer );
+}
+
+/**
+ * Cancel a pending suggestions debounce and abort any in-flight request.
+ *
+ * @param {HTMLInputElement} input - The input being reset.
+ */
+function cancelPendingSuggestions( input ) {
+	clearTimeout( suggestionTimers.get( input ) );
+	suggestionTimers.delete( input );
+	const controller = suggestionAborts.get( input );
+	if ( controller ) {
+		controller.abort();
+		suggestionAborts.delete( input );
+	}
+}
+
+/**
+ * Schedule a suggestions fetch on a fresh keystroke. No-op when the input
+ * isn't suggestions-enabled, so `view.js`'s `onSearchInput` can call it
+ * unconditionally without branching on the attribute.
+ *
+ * @param {HTMLInputElement} input - The input that received the keystroke.
+ */
+export function handleInputForSuggestions( input ) {
+	if ( ! isSuggestionsInput( input ) ) {
+		return;
+	}
+	scheduleSuggestions( input, getContext() );
+}
+
+/**
+ * Route ArrowUp / ArrowDown / Escape / Enter for suggestions-enabled
+ * inputs. Returns `true` when the keystroke was consumed by the
+ * suggestions layer (caller should NOT run the default search action),
+ * `false` otherwise (caller proceeds with its usual Enter-fires-search
+ * behavior). Non-suggestions inputs always get `false` so the keyboard
+ * path in `view.js`'s `onSearchKeydown` is uniform.
+ *
+ * @param {KeyboardEvent}    event - The keydown event from `view.js`.
+ * @param {HTMLInputElement} input - `event.target`, threaded through so callers don't repeat the lookup.
+ * @return {boolean} True if the suggestions layer claimed the keystroke.
+ */
+export function handleKeydownForSuggestions( event, input ) {
+	if ( ! isSuggestionsInput( input ) ) {
+		return false;
+	}
+	const ctx = getContext();
+	const rows = ctx?.rows ?? [];
+	const optionCount = countOptions( rows );
+
+	switch ( event.key ) {
+		case 'ArrowDown':
+			event.preventDefault();
+			if ( optionCount === 0 ) {
+				return true;
+			}
+			ctx.showSuggestions = true;
+			ctx.activeIndex = ctx.activeIndex < optionCount - 1 ? ctx.activeIndex + 1 : ctx.activeIndex;
+			ctx.activeOptionId = rowAtOptionIndex( rows, ctx.activeIndex )?.optionId ?? '';
+			return true;
+		case 'ArrowUp':
+			event.preventDefault();
+			if ( optionCount === 0 ) {
+				return true;
+			}
+			ctx.activeIndex = ctx.activeIndex > 0 ? ctx.activeIndex - 1 : -1;
+			ctx.activeOptionId = rowAtOptionIndex( rows, ctx.activeIndex )?.optionId ?? '';
+			return true;
+		case 'Escape':
+			ctx.showSuggestions = false;
+			ctx.activeIndex = -1;
+			ctx.activeOptionId = '';
+			return true;
+		case 'Enter': {
+			if ( ctx.showSuggestions && ctx.activeIndex >= 0 ) {
+				const row = rowAtOptionIndex( rows, ctx.activeIndex );
+				if ( row ) {
+					event.preventDefault();
+					cancelPendingSuggestions( input );
+					store( NAMESPACE ).actions.acceptSuggestion( row );
+					return true;
+				}
+			}
+			// No row was highlighted — close the dropdown but let `view.js`
+			// fire the actual search via its own Enter path.
+			ctx.showSuggestions = false;
+			ctx.activeIndex = -1;
+			ctx.activeOptionId = '';
+			cancelPendingSuggestions( input );
+			return false;
+		}
+		default:
+			return false;
+	}
+}
+
+/**
+ * Reset the suggestion-side per-instance state. Called from `view.js`'s
+ * `clearSearch` so a cleared input also empties any open dropdown. Safe
+ * for non-suggestions blocks: when no `data-wp-context` is in scope the
+ * proxy resolves to an empty object and the writes are no-ops.
+ */
+export function clearSuggestionsContext() {
+	const ctx = getContext();
+	if ( ! ctx ) {
+		return;
+	}
+	ctx.rows = [];
+	ctx.showSuggestions = false;
+	ctx.activeIndex = -1;
+	ctx.activeOptionId = '';
+}
+
+// Side-effect: register the suggestions-only slice on the shared
+// `jetpack-search` Interactivity store. Interactivity composes slices
+// across `store()` calls on the same namespace by key, so this co-exists
+// with the slice registered by `view.js` without sharing mutable state.
+store( NAMESPACE, {
+	state: {
+		/**
+		 * Whether the row currently being rendered by `data-wp-each` is the
+		 * keyboard-highlighted option. The Interactivity API only evaluates
+		 * simple property paths on `data-wp-bind`, so this getter encapsulates
+		 * the `row.optionIndex === context.activeIndex` comparison both the
+		 * `aria-selected` binding and the `is-active` class binding need.
+		 *
+		 * @return {boolean} True when the current row should look active.
+		 */
+		get isRowActive() {
+			const ctx = getContext();
+			const row = ctx?.row;
+			if ( ! row || row.isHeader ) {
+				return false;
+			}
+			return row.optionIndex === ctx.activeIndex;
+		},
+	},
+
+	actions: {
+		onSearchFocus( event ) {
+			// Re-opening the dropdown on focus only matters when there are
+			// suggestions to show — otherwise we'd flash an empty `<ul>`.
+			const ctx = getContext();
+			const input = event.target;
+			clearTimeout( blurTimers.get( input ) );
+			blurTimers.delete( input );
+			if ( ctx?.rows?.length > 0 ) {
+				ctx.showSuggestions = true;
+			}
+		},
+
+		onSearchBlur( event ) {
+			// 150 ms grace period before closing — matches the instant-search
+			// overlay's behavior and lets a click on a suggestion `<li>`
+			// fire its `click` handler before the dropdown disappears.
+			const ctx = getContext();
+			const input = event.target;
+			clearTimeout( blurTimers.get( input ) );
+			const timer = setTimeout( () => {
+				blurTimers.delete( input );
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+			}, SUGGESTIONS_BLUR_CLOSE_MS );
+			blurTimers.set( input, timer );
+		},
+
+		onSuggestionMousedown( event ) {
+			// Stop the input from blurring before the click fires, otherwise
+			// the blur handler would close the dropdown and cancel the click.
+			event.preventDefault();
+		},
+
+		onSuggestionClick() {
+			const ctx = getContext();
+			const row = ctx?.row;
+			if ( ! row || row.isHeader ) {
+				return;
+			}
+			store( NAMESPACE ).actions.acceptSuggestion( row );
+		},
+
+		/**
+		 * Apply a selected suggestion. Dispatches one of three behaviors:
+		 * `query` fills the input, closes the dropdown, and fires a search;
+		 * `taxonomy` applies as a filter on the current page when a matching
+		 * taxonomy filter is registered (so the result list refreshes inline),
+		 * otherwise navigates to the archive URL; `post` navigates to the
+		 * post URL.
+		 *
+		 * The `row` argument is whatever `buildSuggestionRows` produced
+		 * (not the raw API item), so `taxonomy` and `slug` are already
+		 * URL-recovered when the API omitted them.
+		 *
+		 * @param {object} row - Selected suggestion row.
+		 */
+		acceptSuggestion( row ) {
+			const { state, actions } = store( NAMESPACE );
+
+			// Close the dropdown on the originating input. The action is
+			// dispatched from either the input's keydown handler (wrapper
+			// scope) or the suggestion `<li>`'s click handler (row scope
+			// nested under the same wrapper). The Interactivity API merges
+			// the `data-wp-each` row entries onto the wrapper's context, and
+			// writes to keys that exist on the wrapper proxy (`showSuggestions`,
+			// `activeIndex`, `activeOptionId`, `rows`) propagate up through
+			// the same reactive signal — verified empirically by clicking a
+			// suggestion row and watching the dropdown close. Only writes to
+			// `ctx.row` itself would be absorbed by the each scope.
+			const ctx = getContext();
+			if ( ctx ) {
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+				ctx.rows = [];
+			}
+
+			if ( row.type === 'query' ) {
+				state.searchQuery = row.text;
+				actions.search();
+				return;
+			}
+
+			if ( row.type === 'taxonomy' ) {
+				const filterConfig = state.filterConfigs?.[ row.taxonomy ];
+				if ( row.taxonomy && row.slug && filterConfig?.filterType === 'taxonomy' ) {
+					actions.setFilter( row.taxonomy, row.slug );
+					return;
+				}
+			}
+
+			if ( row.url ) {
+				window.location.href = row.url;
+			}
+		},
+
+		/**
+		 * Fetch suggestions for a specific input. Generator action so the
+		 * Interactivity API can `await` the fetch; aborts any prior request
+		 * for the same input before starting a new one.
+		 *
+		 * The context proxy is passed in (rather than read via `getContext()`)
+		 * because this action is dispatched from a `setTimeout` callback,
+		 * where Interactivity's context tracking is no longer live.
+		 *
+		 * @param {HTMLInputElement} input - The input whose query to fetch for.
+		 * @param {object}           ctx   - The per-instance context proxy to mutate.
+		 * @yield {Promise<Array>} Suggestions fetch promise.
+		 */
+		*fetchSuggestionsFor( input, ctx ) {
+			if ( ! ctx ) {
+				return;
+			}
+			const { state } = store( NAMESPACE );
+			const query = state.searchQuery;
+			const siteId = state.siteId;
+			// The block can be rendered on a site that doesn't have a
+			// configured Jetpack Search site id — gracefully degrade to
+			// "no suggestions" rather than firing a doomed request.
+			if ( ! query || ! siteId ) {
+				ctx.rows = [];
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+				return;
+			}
+
+			const prior = suggestionAborts.get( input );
+			if ( prior ) {
+				prior.abort();
+			}
+			const controller = new AbortController();
+			suggestionAborts.set( input, controller );
+
+			let suggestions = [];
+			try {
+				suggestions = yield fetchSuggestions( {
+					query,
+					siteId,
+					isPrivateSite: !! state.isPrivateSite,
+					isWpcom: !! state.isWpcom,
+					homeUrl: state.homeUrl ?? '',
+					nonce: state.nonce ?? '',
+					signal: controller.signal,
+				} );
+			} catch ( err ) {
+				// AbortError is the expected outcome when typing fast — every
+				// keystroke aborts the prior fetch — so we don't surface it
+				// as an error. Any other failure also degrades silently:
+				// suggestions are an enhancement, not a critical path.
+				if ( err?.name !== 'AbortError' ) {
+					suggestions = [];
+				} else {
+					return;
+				}
+			} finally {
+				// Only clear the abort slot if it's still pointing at this
+				// controller — a newer keystroke may have replaced it.
+				if ( suggestionAborts.get( input ) === controller ) {
+					suggestionAborts.delete( input );
+				}
+			}
+
+			const rows = buildSuggestionRows( suggestions, ctx.listboxId, {
+				query: state.strings?.suggestionLabelQuery ?? '',
+				taxonomy: state.strings?.suggestionLabelTaxonomy ?? '',
+				post: state.strings?.suggestionLabelPost ?? '',
+			} );
+			ctx.rows = rows;
+			ctx.activeIndex = -1;
+			ctx.activeOptionId = '';
+			// Only auto-open if the input is still focused; otherwise let
+			// the next focus event reveal the dropdown to avoid flashing it
+			// after the user has already tabbed away.
+			ctx.showSuggestions = rows.length > 0 && input.ownerDocument.activeElement === input;
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/blocks/search-input/test/suggestion-rows.test.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/test/suggestion-rows.test.js
@@ -1,0 +1,154 @@
+import { buildSuggestionRows, countOptions, rowAtOptionIndex } from '../suggestion-rows';
+
+const LISTBOX_ID = 'lb-1';
+const LABELS = { query: 'Suggestions', taxonomy: 'Popular Filters', post: 'Articles' };
+
+describe( 'buildSuggestionRows', () => {
+	it( 'returns an empty array for non-array or empty input', () => {
+		expect( buildSuggestionRows( null, LISTBOX_ID, LABELS ) ).toEqual( [] );
+		expect( buildSuggestionRows( undefined, LISTBOX_ID, LABELS ) ).toEqual( [] );
+		expect( buildSuggestionRows( [], LISTBOX_ID, LABELS ) ).toEqual( [] );
+	} );
+
+	it( 'emits groups in the canonical query → taxonomy → post order', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'post', text: 'A post', url: '/a' },
+				{ type: 'taxonomy', text: 'News', url: '/c/news', taxonomy: 'category', slug: 'news' },
+				{ type: 'query', text: 'react hooks' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		const types = rows.filter( r => r.isHeader ).map( r => r.type );
+		expect( types ).toEqual( [ 'query', 'taxonomy', 'post' ] );
+	} );
+
+	it( 'uses the provided labels for header rows', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'q' },
+				{ type: 'taxonomy', text: 't', url: '/c/t', taxonomy: 'category', slug: 't' },
+				{ type: 'post', text: 'p', url: '/p' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		const headers = rows.filter( r => r.isHeader );
+		expect( headers.map( r => r.label ) ).toEqual( [
+			'Suggestions',
+			'Popular Filters',
+			'Articles',
+		] );
+	} );
+
+	it( 'falls back to the bare type string when a label is missing', () => {
+		const rows = buildSuggestionRows( [ { type: 'query', text: 'q' } ], LISTBOX_ID, {} );
+		expect( rows[ 0 ].label ).toBe( 'query' );
+	} );
+
+	it( 'skips empty groups instead of emitting an orphan header', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'a' },
+				{ type: 'post', text: 'b', url: '/b' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		const types = rows.filter( r => r.isHeader ).map( r => r.type );
+		expect( types ).toEqual( [ 'query', 'post' ] );
+		expect( types ).not.toContain( 'taxonomy' );
+	} );
+
+	it( 'assigns a contiguous optionIndex across groups, skipping headers', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'q1' },
+				{ type: 'query', text: 'q2' },
+				{ type: 'taxonomy', text: 't1', url: '/c/t1', taxonomy: 'category', slug: 't1' },
+				{ type: 'post', text: 'p1', url: '/p/p1' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		const options = rows.filter( r => ! r.isHeader );
+		expect( options.map( r => r.optionIndex ) ).toEqual( [ 0, 1, 2, 3 ] );
+	} );
+
+	it( 'bakes optionId as `<listboxId>-option-<optionIndex>` for aria-activedescendant', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'q' },
+				{ type: 'post', text: 'p', url: '/p' },
+			],
+			'my-listbox',
+			LABELS
+		);
+		const options = rows.filter( r => ! r.isHeader );
+		expect( options[ 0 ].optionId ).toBe( 'my-listbox-option-0' );
+		expect( options[ 1 ].optionId ).toBe( 'my-listbox-option-1' );
+	} );
+
+	it( 'produces stable, collision-proof keys for headers and options', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'q1' },
+				{ type: 'post', text: 'q1', url: '/q1' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		const keys = rows.map( r => r.key );
+		expect( new Set( keys ).size ).toBe( keys.length );
+		expect( keys ).toEqual( [ 'hdr:query', 'opt:query:0', 'hdr:post', 'opt:post:1' ] );
+	} );
+
+	it( 'normalizes missing url, taxonomy, and slug to empty strings on option rows', () => {
+		const rows = buildSuggestionRows( [ { type: 'query', text: 'q' } ], LISTBOX_ID, LABELS );
+		const option = rows.find( r => ! r.isHeader );
+		expect( option.url ).toBe( '' );
+		expect( option.taxonomy ).toBe( '' );
+		expect( option.slug ).toBe( '' );
+	} );
+} );
+
+describe( 'countOptions', () => {
+	it( 'counts option rows and excludes headers', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'a' },
+				{ type: 'query', text: 'b' },
+				{ type: 'post', text: 'c', url: '/c' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		expect( countOptions( rows ) ).toBe( 3 );
+	} );
+
+	it( 'returns 0 for an empty input', () => {
+		expect( countOptions( [] ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'rowAtOptionIndex', () => {
+	it( 'returns the option row matching the given optionIndex', () => {
+		const rows = buildSuggestionRows(
+			[
+				{ type: 'query', text: 'a' },
+				{ type: 'post', text: 'b', url: '/b' },
+			],
+			LISTBOX_ID,
+			LABELS
+		);
+		expect( rowAtOptionIndex( rows, 0 )?.text ).toBe( 'a' );
+		expect( rowAtOptionIndex( rows, 1 )?.text ).toBe( 'b' );
+	} );
+
+	it( 'returns null for negative or out-of-range indexes', () => {
+		const rows = buildSuggestionRows( [ { type: 'query', text: 'a' } ], LISTBOX_ID, LABELS );
+		expect( rowAtOptionIndex( rows, -1 ) ).toBeNull();
+		expect( rowAtOptionIndex( rows, 99 ) ).toBeNull();
+	} );
+} );

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -1,15 +1,22 @@
-import { store } from '@wordpress/interactivity';
+import { getContext, store } from '@wordpress/interactivity';
+import { fetchSuggestions } from '../../store/suggestions-api';
 import 'jetpack-search/store';
+import { buildSuggestionRows, countOptions, rowAtOptionIndex } from './suggestion-rows';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';
-const DEBOUNCE_MS = 300;
+const SEARCH_DEBOUNCE_MS = 300;
+const SUGGESTIONS_DEBOUNCE_MS = 120;
+const SUGGESTIONS_BLUR_CLOSE_MS = 150;
 
-// Per-input debounce state. Keyed by the input element itself so two
-// search-input blocks on the same page (e.g. header + sidebar) don't
-// reset each other's typing timer. WeakMap lets GC reclaim entries
-// when an input is removed from the DOM.
+// Per-input timer / abort state. WeakMaps keyed by the input element itself
+// so two `search-input` blocks on the same page (header + sidebar) don't
+// reset each other's timers or abort each other's suggestions request, and
+// so GC can reclaim the entries automatically when an input leaves the DOM.
 const debounceTimers = new WeakMap();
+const suggestionTimers = new WeakMap();
+const blurTimers = new WeakMap();
+const suggestionAborts = new WeakMap();
 
 /**
  * Start (or restart) the debounced search for a single input.
@@ -22,13 +29,13 @@ function scheduleSearch( input ) {
 		debounceTimers.delete( input );
 		const { actions } = store( NAMESPACE );
 		actions.search();
-	}, DEBOUNCE_MS );
+	}, SEARCH_DEBOUNCE_MS );
 	debounceTimers.set( input, timer );
 }
 
 /**
- * Cancel any in-flight debounce for a single input — used when a keystroke
- * should fire a search immediately (e.g. Enter).
+ * Cancel any in-flight search debounce for a single input — used when a
+ * keystroke should fire a search immediately (e.g. Enter).
  *
  * @param {HTMLInputElement} input - The input whose timer should be cleared.
  */
@@ -37,7 +44,64 @@ function cancelPendingSearch( input ) {
 	debounceTimers.delete( input );
 }
 
+/**
+ * Start (or restart) the debounced suggestions fetch for a single input.
+ * Runs faster than the search debounce so the dropdown feels responsive —
+ * 120 ms is short enough to keep up with quick typing but long enough to
+ * coalesce held keys into one request. The caller passes the per-instance
+ * Interactivity context proxy so the deferred action can mutate it
+ * directly — `getContext()` from inside a `setTimeout` would return null
+ * because context tracking is only live inside the originating handler.
+ *
+ * @param {HTMLInputElement} input - The input whose timer should be reset.
+ * @param {object}           ctx   - The per-instance context to mutate when the fetch lands.
+ */
+function scheduleSuggestions( input, ctx ) {
+	clearTimeout( suggestionTimers.get( input ) );
+	const timer = setTimeout( () => {
+		suggestionTimers.delete( input );
+		const { actions } = store( NAMESPACE );
+		actions.fetchSuggestionsFor( input, ctx );
+	}, SUGGESTIONS_DEBOUNCE_MS );
+	suggestionTimers.set( input, timer );
+}
+
+/**
+ * Cancel a pending suggestions debounce and abort any in-flight request.
+ *
+ * @param {HTMLInputElement} input - The input being reset.
+ */
+function cancelPendingSuggestions( input ) {
+	clearTimeout( suggestionTimers.get( input ) );
+	suggestionTimers.delete( input );
+	const controller = suggestionAborts.get( input );
+	if ( controller ) {
+		controller.abort();
+		suggestionAborts.delete( input );
+	}
+}
+
 store( NAMESPACE, {
+	state: {
+		/**
+		 * Whether the row currently being rendered by `data-wp-each` is the
+		 * keyboard-highlighted option. The Interactivity API only evaluates
+		 * simple property paths on `data-wp-bind`, so this getter encapsulates
+		 * the `row.optionIndex === context.activeIndex` comparison both the
+		 * `aria-selected` binding and the `is-active` class binding need.
+		 *
+		 * @return {boolean} True when the current row should look active.
+		 */
+		get isRowActive() {
+			const ctx = getContext();
+			const row = ctx?.row;
+			if ( ! row || row.isHeader ) {
+				return false;
+			}
+			return row.optionIndex === ctx.activeIndex;
+		},
+	},
+
 	actions: {
 		onSearchInput( event ) {
 			const { state } = store( NAMESPACE );
@@ -48,17 +112,253 @@ store( NAMESPACE, {
 			// fewer requests than the default live-search debounce produces.
 			if ( event.target.dataset.submitOnly === 'true' ) {
 				cancelPendingSearch( event.target );
-				return;
+			} else {
+				scheduleSearch( event.target );
 			}
-			scheduleSearch( event.target );
+
+			// Suggestions debounce runs alongside the search debounce when
+			// the block opted in. A separate timer (and a shorter window)
+			// keeps the dropdown feeling responsive even on `submitOnly`
+			// blocks where the main search waits for Enter. The context
+			// proxy is captured here and threaded into the deferred action
+			// because `getContext()` won't resolve inside the setTimeout.
+			if ( event.target.dataset.suggestionsEnabled === 'true' ) {
+				scheduleSuggestions( event.target, getContext() );
+			}
 		},
 
 		onSearchKeydown( event ) {
-			if ( event.key === 'Enter' ) {
-				cancelPendingSearch( event.target );
-				const { actions } = store( NAMESPACE );
-				actions.search();
+			const input = event.target;
+			const suggestionsEnabled = input.dataset.suggestionsEnabled === 'true';
+			const ctx = suggestionsEnabled ? getContext() : null;
+			const rows = ctx?.rows ?? [];
+			const optionCount = countOptions( rows );
+
+			switch ( event.key ) {
+				case 'ArrowDown':
+					if ( ! suggestionsEnabled || optionCount === 0 ) {
+						return;
+					}
+					event.preventDefault();
+					ctx.showSuggestions = true;
+					ctx.activeIndex =
+						ctx.activeIndex < optionCount - 1 ? ctx.activeIndex + 1 : ctx.activeIndex;
+					ctx.activeOptionId = rowAtOptionIndex( rows, ctx.activeIndex )?.optionId ?? '';
+					return;
+				case 'ArrowUp':
+					if ( ! suggestionsEnabled || optionCount === 0 ) {
+						return;
+					}
+					event.preventDefault();
+					ctx.activeIndex = ctx.activeIndex > 0 ? ctx.activeIndex - 1 : -1;
+					ctx.activeOptionId = rowAtOptionIndex( rows, ctx.activeIndex )?.optionId ?? '';
+					return;
+				case 'Escape':
+					if ( ! suggestionsEnabled ) {
+						return;
+					}
+					ctx.showSuggestions = false;
+					ctx.activeIndex = -1;
+					ctx.activeOptionId = '';
+					return;
+				case 'Enter': {
+					if ( suggestionsEnabled && ctx.showSuggestions && ctx.activeIndex >= 0 ) {
+						const row = rowAtOptionIndex( rows, ctx.activeIndex );
+						if ( row ) {
+							event.preventDefault();
+							cancelPendingSearch( input );
+							cancelPendingSuggestions( input );
+							const { actions } = store( NAMESPACE );
+							actions.acceptSuggestion( row );
+							return;
+						}
+					}
+					if ( suggestionsEnabled ) {
+						ctx.showSuggestions = false;
+						ctx.activeIndex = -1;
+						ctx.activeOptionId = '';
+					}
+					cancelPendingSearch( input );
+					cancelPendingSuggestions( input );
+					const { actions } = store( NAMESPACE );
+					actions.search();
+					break;
+				}
+				default:
+					break;
 			}
+		},
+
+		onSearchFocus( event ) {
+			// Re-opening the dropdown on focus only matters when there are
+			// suggestions to show — otherwise we'd flash an empty `<ul>`.
+			const ctx = getContext();
+			const input = event.target;
+			clearTimeout( blurTimers.get( input ) );
+			blurTimers.delete( input );
+			if ( ctx?.rows?.length > 0 ) {
+				ctx.showSuggestions = true;
+			}
+		},
+
+		onSearchBlur( event ) {
+			// 150 ms grace period before closing — matches the instant-search
+			// overlay's behavior and lets a click on a suggestion `<li>`
+			// fire its `click` handler before the dropdown disappears.
+			const ctx = getContext();
+			const input = event.target;
+			clearTimeout( blurTimers.get( input ) );
+			const timer = setTimeout( () => {
+				blurTimers.delete( input );
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+			}, SUGGESTIONS_BLUR_CLOSE_MS );
+			blurTimers.set( input, timer );
+		},
+
+		onSuggestionMousedown( event ) {
+			// Stop the input from blurring before the click fires, otherwise
+			// the blur handler would close the dropdown and cancel the click.
+			event.preventDefault();
+		},
+
+		onSuggestionClick() {
+			const ctx = getContext();
+			const row = ctx?.row;
+			if ( ! row || row.isHeader ) {
+				return;
+			}
+			const { actions } = store( NAMESPACE );
+			actions.acceptSuggestion( row );
+		},
+
+		/**
+		 * Apply a selected suggestion. Dispatches one of three behaviors:
+		 * `query` fills the input, closes the dropdown, and fires a search;
+		 * `taxonomy` applies as a filter on the current page when a matching
+		 * taxonomy filter is registered (so the result list refreshes inline),
+		 * otherwise navigates to the archive URL; `post` navigates to the
+		 * post URL.
+		 *
+		 * The `row` argument is whatever `buildSuggestionRows` produced
+		 * (not the raw API item), so `taxonomy` and `slug` are already
+		 * URL-recovered when the API omitted them.
+		 *
+		 * @param {object} row - Selected suggestion row.
+		 */
+		acceptSuggestion( row ) {
+			const { state, actions } = store( NAMESPACE );
+
+			// Close the dropdown on the originating input. The action is
+			// dispatched from the suggestion `<li>` so getContext() resolves
+			// to the wrapper's context — same instance the input lives in.
+			const ctx = getContext();
+			if ( ctx ) {
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+				ctx.rows = [];
+			}
+
+			if ( row.type === 'query' ) {
+				state.searchQuery = row.text;
+				actions.search();
+				return;
+			}
+
+			if ( row.type === 'taxonomy' ) {
+				const filterConfig = state.filterConfigs?.[ row.taxonomy ];
+				if ( row.taxonomy && row.slug && filterConfig?.filterType === 'taxonomy' ) {
+					actions.setFilter( row.taxonomy, row.slug );
+					return;
+				}
+			}
+
+			if ( row.url ) {
+				window.location.href = row.url;
+			}
+		},
+
+		/**
+		 * Fetch suggestions for a specific input. Generator action so the
+		 * Interactivity API can `await` the fetch; aborts any prior request
+		 * for the same input before starting a new one.
+		 *
+		 * The context proxy is passed in (rather than read via `getContext()`)
+		 * because this action is dispatched from a `setTimeout` callback,
+		 * where Interactivity's context tracking is no longer live.
+		 *
+		 * @param {HTMLInputElement} input - The input whose query to fetch for.
+		 * @param {object}           ctx   - The per-instance context proxy to mutate.
+		 * @yield {Promise<Array>} Suggestions fetch promise.
+		 */
+		*fetchSuggestionsFor( input, ctx ) {
+			if ( ! ctx ) {
+				return;
+			}
+			const { state } = store( NAMESPACE );
+			const query = state.searchQuery;
+			const siteId = state.siteId;
+			// The block can be rendered on a site that doesn't have a
+			// configured Jetpack Search site id — gracefully degrade to
+			// "no suggestions" rather than firing a doomed request.
+			if ( ! query || ! siteId ) {
+				ctx.rows = [];
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+				return;
+			}
+
+			const prior = suggestionAborts.get( input );
+			if ( prior ) {
+				prior.abort();
+			}
+			const controller = new AbortController();
+			suggestionAborts.set( input, controller );
+
+			let suggestions = [];
+			try {
+				suggestions = yield fetchSuggestions( {
+					query,
+					siteId,
+					isPrivateSite: !! state.isPrivateSite,
+					isWpcom: !! state.isWpcom,
+					homeUrl: state.homeUrl ?? '',
+					nonce: state.nonce ?? '',
+					signal: controller.signal,
+				} );
+			} catch ( err ) {
+				// AbortError is the expected outcome when typing fast — every
+				// keystroke aborts the prior fetch — so we don't surface it
+				// as an error. Any other failure also degrades silently:
+				// suggestions are an enhancement, not a critical path.
+				if ( err?.name !== 'AbortError' ) {
+					suggestions = [];
+				} else {
+					return;
+				}
+			} finally {
+				// Only clear the abort slot if it's still pointing at this
+				// controller — a newer keystroke may have replaced it.
+				if ( suggestionAborts.get( input ) === controller ) {
+					suggestionAborts.delete( input );
+				}
+			}
+
+			const rows = buildSuggestionRows( suggestions, ctx.listboxId, {
+				query: state.strings?.suggestionLabelQuery ?? '',
+				taxonomy: state.strings?.suggestionLabelTaxonomy ?? '',
+				post: state.strings?.suggestionLabelPost ?? '',
+			} );
+			ctx.rows = rows;
+			ctx.activeIndex = -1;
+			ctx.activeOptionId = '';
+			// Only auto-open if the input is still focused; otherwise let
+			// the next focus event reveal the dropdown to avoid flashing it
+			// after the user has already tabbed away.
+			ctx.showSuggestions = rows.length > 0 && input.ownerDocument.activeElement === input;
 		},
 
 		/**
@@ -69,6 +369,15 @@ store( NAMESPACE, {
 		*clearSearch() {
 			const { state, actions } = store( NAMESPACE );
 			state.searchQuery = '';
+			// Closing the dropdown on the originating wrapper. `getContext()`
+			// resolves to the wrapper that owns the clicked clear button.
+			const ctx = getContext();
+			if ( ctx ) {
+				ctx.rows = [];
+				ctx.showSuggestions = false;
+				ctx.activeIndex = -1;
+				ctx.activeOptionId = '';
+			}
 			yield actions.search();
 		},
 	},

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -162,13 +162,13 @@ store( NAMESPACE, {
 					ctx.activeOptionId = '';
 					return;
 				case 'Enter': {
+					const { actions } = store( NAMESPACE );
 					if ( suggestionsEnabled && ctx.showSuggestions && ctx.activeIndex >= 0 ) {
 						const row = rowAtOptionIndex( rows, ctx.activeIndex );
 						if ( row ) {
 							event.preventDefault();
 							cancelPendingSearch( input );
 							cancelPendingSuggestions( input );
-							const { actions } = store( NAMESPACE );
 							actions.acceptSuggestion( row );
 							return;
 						}
@@ -180,7 +180,6 @@ store( NAMESPACE, {
 					}
 					cancelPendingSearch( input );
 					cancelPendingSuggestions( input );
-					const { actions } = store( NAMESPACE );
 					actions.search();
 					break;
 				}
@@ -251,8 +250,15 @@ store( NAMESPACE, {
 			const { state, actions } = store( NAMESPACE );
 
 			// Close the dropdown on the originating input. The action is
-			// dispatched from the suggestion `<li>` so getContext() resolves
-			// to the wrapper's context — same instance the input lives in.
+			// dispatched from either the input's keydown handler (wrapper
+			// scope) or the suggestion `<li>`'s click handler (row scope
+			// nested under the same wrapper). The Interactivity API merges
+			// the `data-wp-each` row entries onto the wrapper's context, and
+			// writes to keys that exist on the wrapper proxy (`showSuggestions`,
+			// `activeIndex`, `activeOptionId`, `rows`) propagate up through
+			// the same reactive signal — verified empirically by clicking a
+			// suggestion row and watching the dropdown close. Only writes to
+			// `ctx.row` itself would be absorbed by the each scope.
 			const ctx = getContext();
 			if ( ctx ) {
 				ctx.showSuggestions = false;

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -1,22 +1,20 @@
-import { getContext, store } from '@wordpress/interactivity';
-import { fetchSuggestions } from '../../store/suggestions-api';
+import { store } from '@wordpress/interactivity';
 import 'jetpack-search/store';
-import { buildSuggestionRows, countOptions, rowAtOptionIndex } from './suggestion-rows';
+import {
+	clearSuggestionsContext,
+	handleInputForSuggestions,
+	handleKeydownForSuggestions,
+} from './suggestions';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';
 const SEARCH_DEBOUNCE_MS = 300;
-const SUGGESTIONS_DEBOUNCE_MS = 120;
-const SUGGESTIONS_BLUR_CLOSE_MS = 150;
 
-// Per-input timer / abort state. WeakMaps keyed by the input element itself
-// so two `search-input` blocks on the same page (header + sidebar) don't
-// reset each other's timers or abort each other's suggestions request, and
-// so GC can reclaim the entries automatically when an input leaves the DOM.
+// Per-input debounce state. Keyed by the input element itself so two
+// search-input blocks on the same page (e.g. header + sidebar) don't
+// reset each other's typing timer. WeakMap lets GC reclaim entries
+// when an input is removed from the DOM.
 const debounceTimers = new WeakMap();
-const suggestionTimers = new WeakMap();
-const blurTimers = new WeakMap();
-const suggestionAborts = new WeakMap();
 
 /**
  * Start (or restart) the debounced search for a single input.
@@ -27,8 +25,7 @@ function scheduleSearch( input ) {
 	clearTimeout( debounceTimers.get( input ) );
 	const timer = setTimeout( () => {
 		debounceTimers.delete( input );
-		const { actions } = store( NAMESPACE );
-		actions.search();
+		store( NAMESPACE ).actions.search();
 	}, SEARCH_DEBOUNCE_MS );
 	debounceTimers.set( input, timer );
 }
@@ -44,64 +41,7 @@ function cancelPendingSearch( input ) {
 	debounceTimers.delete( input );
 }
 
-/**
- * Start (or restart) the debounced suggestions fetch for a single input.
- * Runs faster than the search debounce so the dropdown feels responsive —
- * 120 ms is short enough to keep up with quick typing but long enough to
- * coalesce held keys into one request. The caller passes the per-instance
- * Interactivity context proxy so the deferred action can mutate it
- * directly — `getContext()` from inside a `setTimeout` would return null
- * because context tracking is only live inside the originating handler.
- *
- * @param {HTMLInputElement} input - The input whose timer should be reset.
- * @param {object}           ctx   - The per-instance context to mutate when the fetch lands.
- */
-function scheduleSuggestions( input, ctx ) {
-	clearTimeout( suggestionTimers.get( input ) );
-	const timer = setTimeout( () => {
-		suggestionTimers.delete( input );
-		const { actions } = store( NAMESPACE );
-		actions.fetchSuggestionsFor( input, ctx );
-	}, SUGGESTIONS_DEBOUNCE_MS );
-	suggestionTimers.set( input, timer );
-}
-
-/**
- * Cancel a pending suggestions debounce and abort any in-flight request.
- *
- * @param {HTMLInputElement} input - The input being reset.
- */
-function cancelPendingSuggestions( input ) {
-	clearTimeout( suggestionTimers.get( input ) );
-	suggestionTimers.delete( input );
-	const controller = suggestionAborts.get( input );
-	if ( controller ) {
-		controller.abort();
-		suggestionAborts.delete( input );
-	}
-}
-
 store( NAMESPACE, {
-	state: {
-		/**
-		 * Whether the row currently being rendered by `data-wp-each` is the
-		 * keyboard-highlighted option. The Interactivity API only evaluates
-		 * simple property paths on `data-wp-bind`, so this getter encapsulates
-		 * the `row.optionIndex === context.activeIndex` comparison both the
-		 * `aria-selected` binding and the `is-active` class binding need.
-		 *
-		 * @return {boolean} True when the current row should look active.
-		 */
-		get isRowActive() {
-			const ctx = getContext();
-			const row = ctx?.row;
-			if ( ! row || row.isHeader ) {
-				return false;
-			}
-			return row.optionIndex === ctx.activeIndex;
-		},
-	},
-
 	actions: {
 		onSearchInput( event ) {
 			const { state } = store( NAMESPACE );
@@ -115,256 +55,23 @@ store( NAMESPACE, {
 			} else {
 				scheduleSearch( event.target );
 			}
-
-			// Suggestions debounce runs alongside the search debounce when
-			// the block opted in. A separate timer (and a shorter window)
-			// keeps the dropdown feeling responsive even on `submitOnly`
-			// blocks where the main search waits for Enter. The context
-			// proxy is captured here and threaded into the deferred action
-			// because `getContext()` won't resolve inside the setTimeout.
-			if ( event.target.dataset.suggestionsEnabled === 'true' ) {
-				scheduleSuggestions( event.target, getContext() );
-			}
+			// Delegated to ./suggestions.js — short-circuits on non-suggestions
+			// inputs, so this stays a single unconditional call.
+			handleInputForSuggestions( event.target );
 		},
 
 		onSearchKeydown( event ) {
-			const input = event.target;
-			const suggestionsEnabled = input.dataset.suggestionsEnabled === 'true';
-			const ctx = suggestionsEnabled ? getContext() : null;
-			const rows = ctx?.rows ?? [];
-			const optionCount = countOptions( rows );
-
-			switch ( event.key ) {
-				case 'ArrowDown':
-					if ( ! suggestionsEnabled || optionCount === 0 ) {
-						return;
-					}
-					event.preventDefault();
-					ctx.showSuggestions = true;
-					ctx.activeIndex =
-						ctx.activeIndex < optionCount - 1 ? ctx.activeIndex + 1 : ctx.activeIndex;
-					ctx.activeOptionId = rowAtOptionIndex( rows, ctx.activeIndex )?.optionId ?? '';
-					return;
-				case 'ArrowUp':
-					if ( ! suggestionsEnabled || optionCount === 0 ) {
-						return;
-					}
-					event.preventDefault();
-					ctx.activeIndex = ctx.activeIndex > 0 ? ctx.activeIndex - 1 : -1;
-					ctx.activeOptionId = rowAtOptionIndex( rows, ctx.activeIndex )?.optionId ?? '';
-					return;
-				case 'Escape':
-					if ( ! suggestionsEnabled ) {
-						return;
-					}
-					ctx.showSuggestions = false;
-					ctx.activeIndex = -1;
-					ctx.activeOptionId = '';
-					return;
-				case 'Enter': {
-					const { actions } = store( NAMESPACE );
-					if ( suggestionsEnabled && ctx.showSuggestions && ctx.activeIndex >= 0 ) {
-						const row = rowAtOptionIndex( rows, ctx.activeIndex );
-						if ( row ) {
-							event.preventDefault();
-							cancelPendingSearch( input );
-							cancelPendingSuggestions( input );
-							actions.acceptSuggestion( row );
-							return;
-						}
-					}
-					if ( suggestionsEnabled ) {
-						ctx.showSuggestions = false;
-						ctx.activeIndex = -1;
-						ctx.activeOptionId = '';
-					}
-					cancelPendingSearch( input );
-					cancelPendingSuggestions( input );
-					actions.search();
-					break;
-				}
-				default:
-					break;
-			}
-		},
-
-		onSearchFocus( event ) {
-			// Re-opening the dropdown on focus only matters when there are
-			// suggestions to show — otherwise we'd flash an empty `<ul>`.
-			const ctx = getContext();
-			const input = event.target;
-			clearTimeout( blurTimers.get( input ) );
-			blurTimers.delete( input );
-			if ( ctx?.rows?.length > 0 ) {
-				ctx.showSuggestions = true;
-			}
-		},
-
-		onSearchBlur( event ) {
-			// 150 ms grace period before closing — matches the instant-search
-			// overlay's behavior and lets a click on a suggestion `<li>`
-			// fire its `click` handler before the dropdown disappears.
-			const ctx = getContext();
-			const input = event.target;
-			clearTimeout( blurTimers.get( input ) );
-			const timer = setTimeout( () => {
-				blurTimers.delete( input );
-				ctx.showSuggestions = false;
-				ctx.activeIndex = -1;
-				ctx.activeOptionId = '';
-			}, SUGGESTIONS_BLUR_CLOSE_MS );
-			blurTimers.set( input, timer );
-		},
-
-		onSuggestionMousedown( event ) {
-			// Stop the input from blurring before the click fires, otherwise
-			// the blur handler would close the dropdown and cancel the click.
-			event.preventDefault();
-		},
-
-		onSuggestionClick() {
-			const ctx = getContext();
-			const row = ctx?.row;
-			if ( ! row || row.isHeader ) {
+			// The suggestions layer claims ArrowUp / ArrowDown / Escape
+			// outright, and `Enter` only when a row is highlighted. Any
+			// other keystroke — including an unclaimed Enter — falls
+			// through to the default search dispatch below.
+			if ( handleKeydownForSuggestions( event, event.target ) ) {
 				return;
 			}
-			const { actions } = store( NAMESPACE );
-			actions.acceptSuggestion( row );
-		},
-
-		/**
-		 * Apply a selected suggestion. Dispatches one of three behaviors:
-		 * `query` fills the input, closes the dropdown, and fires a search;
-		 * `taxonomy` applies as a filter on the current page when a matching
-		 * taxonomy filter is registered (so the result list refreshes inline),
-		 * otherwise navigates to the archive URL; `post` navigates to the
-		 * post URL.
-		 *
-		 * The `row` argument is whatever `buildSuggestionRows` produced
-		 * (not the raw API item), so `taxonomy` and `slug` are already
-		 * URL-recovered when the API omitted them.
-		 *
-		 * @param {object} row - Selected suggestion row.
-		 */
-		acceptSuggestion( row ) {
-			const { state, actions } = store( NAMESPACE );
-
-			// Close the dropdown on the originating input. The action is
-			// dispatched from either the input's keydown handler (wrapper
-			// scope) or the suggestion `<li>`'s click handler (row scope
-			// nested under the same wrapper). The Interactivity API merges
-			// the `data-wp-each` row entries onto the wrapper's context, and
-			// writes to keys that exist on the wrapper proxy (`showSuggestions`,
-			// `activeIndex`, `activeOptionId`, `rows`) propagate up through
-			// the same reactive signal — verified empirically by clicking a
-			// suggestion row and watching the dropdown close. Only writes to
-			// `ctx.row` itself would be absorbed by the each scope.
-			const ctx = getContext();
-			if ( ctx ) {
-				ctx.showSuggestions = false;
-				ctx.activeIndex = -1;
-				ctx.activeOptionId = '';
-				ctx.rows = [];
+			if ( event.key === 'Enter' ) {
+				cancelPendingSearch( event.target );
+				store( NAMESPACE ).actions.search();
 			}
-
-			if ( row.type === 'query' ) {
-				state.searchQuery = row.text;
-				actions.search();
-				return;
-			}
-
-			if ( row.type === 'taxonomy' ) {
-				const filterConfig = state.filterConfigs?.[ row.taxonomy ];
-				if ( row.taxonomy && row.slug && filterConfig?.filterType === 'taxonomy' ) {
-					actions.setFilter( row.taxonomy, row.slug );
-					return;
-				}
-			}
-
-			if ( row.url ) {
-				window.location.href = row.url;
-			}
-		},
-
-		/**
-		 * Fetch suggestions for a specific input. Generator action so the
-		 * Interactivity API can `await` the fetch; aborts any prior request
-		 * for the same input before starting a new one.
-		 *
-		 * The context proxy is passed in (rather than read via `getContext()`)
-		 * because this action is dispatched from a `setTimeout` callback,
-		 * where Interactivity's context tracking is no longer live.
-		 *
-		 * @param {HTMLInputElement} input - The input whose query to fetch for.
-		 * @param {object}           ctx   - The per-instance context proxy to mutate.
-		 * @yield {Promise<Array>} Suggestions fetch promise.
-		 */
-		*fetchSuggestionsFor( input, ctx ) {
-			if ( ! ctx ) {
-				return;
-			}
-			const { state } = store( NAMESPACE );
-			const query = state.searchQuery;
-			const siteId = state.siteId;
-			// The block can be rendered on a site that doesn't have a
-			// configured Jetpack Search site id — gracefully degrade to
-			// "no suggestions" rather than firing a doomed request.
-			if ( ! query || ! siteId ) {
-				ctx.rows = [];
-				ctx.showSuggestions = false;
-				ctx.activeIndex = -1;
-				ctx.activeOptionId = '';
-				return;
-			}
-
-			const prior = suggestionAborts.get( input );
-			if ( prior ) {
-				prior.abort();
-			}
-			const controller = new AbortController();
-			suggestionAborts.set( input, controller );
-
-			let suggestions = [];
-			try {
-				suggestions = yield fetchSuggestions( {
-					query,
-					siteId,
-					isPrivateSite: !! state.isPrivateSite,
-					isWpcom: !! state.isWpcom,
-					homeUrl: state.homeUrl ?? '',
-					nonce: state.nonce ?? '',
-					signal: controller.signal,
-				} );
-			} catch ( err ) {
-				// AbortError is the expected outcome when typing fast — every
-				// keystroke aborts the prior fetch — so we don't surface it
-				// as an error. Any other failure also degrades silently:
-				// suggestions are an enhancement, not a critical path.
-				if ( err?.name !== 'AbortError' ) {
-					suggestions = [];
-				} else {
-					return;
-				}
-			} finally {
-				// Only clear the abort slot if it's still pointing at this
-				// controller — a newer keystroke may have replaced it.
-				if ( suggestionAborts.get( input ) === controller ) {
-					suggestionAborts.delete( input );
-				}
-			}
-
-			const rows = buildSuggestionRows( suggestions, ctx.listboxId, {
-				query: state.strings?.suggestionLabelQuery ?? '',
-				taxonomy: state.strings?.suggestionLabelTaxonomy ?? '',
-				post: state.strings?.suggestionLabelPost ?? '',
-			} );
-			ctx.rows = rows;
-			ctx.activeIndex = -1;
-			ctx.activeOptionId = '';
-			// Only auto-open if the input is still focused; otherwise let
-			// the next focus event reveal the dropdown to avoid flashing it
-			// after the user has already tabbed away.
-			ctx.showSuggestions = rows.length > 0 && input.ownerDocument.activeElement === input;
 		},
 
 		/**
@@ -375,15 +82,7 @@ store( NAMESPACE, {
 		*clearSearch() {
 			const { state, actions } = store( NAMESPACE );
 			state.searchQuery = '';
-			// Closing the dropdown on the originating wrapper. `getContext()`
-			// resolves to the wrapper that owns the clicked clear button.
-			const ctx = getContext();
-			if ( ctx ) {
-				ctx.rows = [];
-				ctx.showSuggestions = false;
-				ctx.activeIndex = -1;
-				ctx.activeOptionId = '';
-			}
+			clearSuggestionsContext();
 			yield actions.search();
 		},
 	},

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1548,41 +1548,50 @@ class Search_Blocks {
 	protected static function build_initial_strings(): array {
 		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
 			return array(
-				'searching'              => 'Searching…',
-				'resultsCountSingle'     => 'Found %d result',
-				'resultsCountPlural'     => 'Found %d results',
-				'removeFilter'           => 'Remove %s',
-				'ratingStarsTop'         => '5 stars',
-				'ratingStarsAndUpSingle' => '%d star and up',
-				'ratingStarsAndUpPlural' => '%d stars and up',
-				'priceRangeFromTo'       => '%1$s – %2$s',
-				'priceRangeFrom'         => '%s+',
-				'priceRangeUpTo'         => 'Under %s',
-				'priceLabel'             => 'Price',
+				'searching'               => 'Searching…',
+				'resultsCountSingle'      => 'Found %d result',
+				'resultsCountPlural'      => 'Found %d results',
+				'removeFilter'            => 'Remove %s',
+				'ratingStarsTop'          => '5 stars',
+				'ratingStarsAndUpSingle'  => '%d star and up',
+				'ratingStarsAndUpPlural'  => '%d stars and up',
+				'priceRangeFromTo'        => '%1$s – %2$s',
+				'priceRangeFrom'          => '%s+',
+				'priceRangeUpTo'          => 'Under %s',
+				'priceLabel'              => 'Price',
+				'suggestionLabelQuery'    => 'Suggestions',
+				'suggestionLabelTaxonomy' => 'Popular Filters',
+				'suggestionLabelPost'     => 'Articles',
 			);
 		}
 		return array(
-			'searching'              => __( 'Searching…', 'jetpack-search-pkg' ),
+			'searching'               => __( 'Searching…', 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
-			'resultsCountSingle'     => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
+			'resultsCountSingle'      => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
-			'resultsCountPlural'     => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
+			'resultsCountPlural'      => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
 			/* translators: %s: filter label (e.g. "Category: News"). Announced by screen readers when focus lands on a filter pill's remove button. */
-			'removeFilter'           => __( 'Remove %s', 'jetpack-search-pkg' ),
+			'removeFilter'            => __( 'Remove %s', 'jetpack-search-pkg' ),
 			/* translators: Active-filter chip label for the 5-star row. The 5-star row is "exactly 5 stars" — no "& up" affordance — because there is no higher rating. Mirrors the row's aria-label in filter-wc-rating/render.php. */
-			'ratingStarsTop'         => __( '5 stars', 'jetpack-search-pkg' ),
+			'ratingStarsTop'          => __( '5 stars', 'jetpack-search-pkg' ),
 			/* translators: %d: rating threshold (singular form, i.e. 1). Active-filter chip label for the "1 star and up" threshold row. Mirrors the row's aria-label in filter-wc-rating/render.php. */
-			'ratingStarsAndUpSingle' => _n( '%d star and up', '%d stars and up', 1, 'jetpack-search-pkg' ),
+			'ratingStarsAndUpSingle'  => _n( '%d star and up', '%d stars and up', 1, 'jetpack-search-pkg' ),
 			/* translators: %d: rating threshold (plural form, i.e. 2-4). Active-filter chip label for the "X stars and up" threshold rows. Mirrors the row's aria-label in filter-wc-rating/render.php. */
-			'ratingStarsAndUpPlural' => _n( '%d star and up', '%d stars and up', 2, 'jetpack-search-pkg' ),
+			'ratingStarsAndUpPlural'  => _n( '%d star and up', '%d stars and up', 2, 'jetpack-search-pkg' ),
 			/* translators: 1: minimum price (already includes the currency symbol). 2: maximum price (already includes the currency symbol). Renders an active "Price: $10 – $50" filter pill. */
-			'priceRangeFromTo'       => __( '%1$s – %2$s', 'jetpack-search-pkg' ),
+			'priceRangeFromTo'        => __( '%1$s – %2$s', 'jetpack-search-pkg' ),
 			/* translators: %s: minimum price (already includes the currency symbol). Renders an active "Price: $10+" filter pill (no upper bound) — compact "and above" form aligned with mainstream e-commerce filter chips. */
-			'priceRangeFrom'         => __( '%s+', 'jetpack-search-pkg' ),
+			'priceRangeFrom'          => __( '%s+', 'jetpack-search-pkg' ),
 			/* translators: %s: maximum price (already includes the currency symbol). Renders an active "Price: Under $50" filter pill (no lower bound) — mirrors Amazon/eBay/Walmart's "Under $X" convention. */
-			'priceRangeUpTo'         => __( 'Under %s', 'jetpack-search-pkg' ),
+			'priceRangeUpTo'          => __( 'Under %s', 'jetpack-search-pkg' ),
 			/* translators: Group label for the price filter pill ("Price: $10 – $50"). Mirrors the price block's default heading; falls back to this when no price block is on the page. */
-			'priceLabel'             => __( 'Price', 'jetpack-search-pkg' ),
+			'priceLabel'              => __( 'Price', 'jetpack-search-pkg' ),
+			/* translators: Group label for the typed-query suggestions section of the Search Input autocomplete dropdown. */
+			'suggestionLabelQuery'    => __( 'Suggestions', 'jetpack-search-pkg' ),
+			/* translators: Group label for the taxonomy (category / tag) section of the Search Input autocomplete dropdown. */
+			'suggestionLabelTaxonomy' => __( 'Popular Filters', 'jetpack-search-pkg' ),
+			/* translators: Group label for the post-title section of the Search Input autocomplete dropdown. */
+			'suggestionLabelPost'     => __( 'Articles', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/store/suggestions-api.js
+++ b/projects/packages/search/src/search-blocks/store/suggestions-api.js
@@ -1,0 +1,190 @@
+/**
+ * Shared client for the WPCOM `/search-suggestions` endpoint.
+ *
+ * Two consumers depend on this contract: the React `useSearchSuggestions`
+ * hook used by the instant-search overlay, and the Interactivity-API view
+ * bundle for the `jetpack-search/search-input` block (no React on that side —
+ * the generator action calls `fetchSuggestions` directly with its own
+ * `AbortController`).
+ *
+ * Keeping URL construction, the fetch wiring, and the response-shape
+ * normalization in one module means both surfaces stay in lock-step when
+ * the API or auth path evolves. The module is pure — every config field
+ * (siteId, isPrivateSite, isWpcom, homeUrl, nonce) is passed in, so it
+ * has no implicit dependency on a window global.
+ */
+
+/**
+ * Best-effort taxonomy/term recovery from a WordPress archive URL.
+ *
+ * The suggestions API normally returns `taxonomy` and `slug` directly, but
+ * older response bodies omit them — in that case we fall back to parsing
+ * the archive URL the API also returns. Three URL shapes are covered:
+ * WPCOM `?taxonomy=…&term=…` (canonical), legacy `?tag=…` (defaults to the
+ * built-in `post_tag` taxonomy), and pretty permalinks `/category/<slug>/`
+ * and `/tag/<slug>/`.
+ *
+ * @param {string} url - Archive URL from a `taxonomy_suggestions[]` item.
+ * @return {{taxonomy: string, slug: string}|null} Parsed pair, or null when the URL doesn't match any known shape.
+ */
+export function parseTaxonomyFromUrl( url ) {
+	try {
+		const u = new URL( url );
+		const taxonomyParam = u.searchParams.get( 'taxonomy' );
+		const termParam = u.searchParams.get( 'term' );
+		if ( taxonomyParam && termParam ) {
+			return { taxonomy: taxonomyParam, slug: termParam };
+		}
+		const tagSlug = u.searchParams.get( 'tag' );
+		if ( tagSlug ) {
+			return { taxonomy: 'post_tag', slug: tagSlug };
+		}
+		const parts = u.pathname.replace( /\/$/, '' ).split( '/' ).filter( Boolean );
+		if ( parts.length >= 2 ) {
+			const base = parts[ parts.length - 2 ];
+			const slug = parts[ parts.length - 1 ];
+			if ( base === 'category' ) {
+				return { taxonomy: 'category', slug };
+			}
+			if ( base === 'tag' ) {
+				return { taxonomy: 'post_tag', slug };
+			}
+		}
+	} catch {
+		// Malformed URL — caller falls back to navigating to `item.url` as-is.
+	}
+	return null;
+}
+
+/**
+ * Build the WPCOM `/search-suggestions` request URL.
+ *
+ * Private WPCOM sites talk to the local `wpcom-origin` proxy so cookies are
+ * sent and the nonce check passes; public sites hit the public API directly.
+ * The two URL shapes are otherwise identical, so the caller can swap freely
+ * between them by flipping `isPrivateSite`.
+ *
+ * @param {object}  args               - Arguments.
+ * @param {string}  args.siteId        - Numeric WPCOM site id (URL-encoded).
+ * @param {string}  args.query         - Raw search query (URL-encoded).
+ * @param {boolean} args.isPrivateSite - True when the site is private/atomic.
+ * @param {boolean} args.isWpcom       - True when running on WPCOM infra.
+ * @param {string}  args.homeUrl       - Site home URL (used for private proxy).
+ * @param {number}  [args.size]        - Suggestions per group; defaults to 5.
+ * @return {string} The fully-qualified request URL.
+ */
+export function buildSuggestionsUrl( {
+	siteId,
+	query,
+	isPrivateSite,
+	isWpcom,
+	homeUrl,
+	size = 5,
+} ) {
+	const path = `/${ encodeURIComponent( siteId ) }/search-suggestions?query=${ encodeURIComponent(
+		query
+	) }&size=${ encodeURIComponent( size ) }`;
+	if ( isPrivateSite && isWpcom ) {
+		return `${ homeUrl }/wp-json/wpcom-origin/wpcom/v2/sites${ path }`;
+	}
+	return `https://public-api.wordpress.com/wpcom/v2/sites${ path }`;
+}
+
+/**
+ * @typedef {object} SuggestionItem
+ * @property {'query'|'post'|'taxonomy'} type       - The kind of suggestion.
+ * @property {string}                    text       - Display text.
+ * @property {string}                    [url]      - Navigation URL (post and taxonomy types).
+ * @property {string}                    [taxonomy] - Taxonomy name for taxonomy items (e.g. 'category', 'post_tag').
+ * @property {string}                    [slug]     - Term slug for taxonomy items.
+ */
+
+/**
+ * Normalize one API response array into a flat list of `SuggestionItem`s.
+ *
+ * Items without display text are dropped. `post` / `taxonomy` items without
+ * a `url` are dropped too, since both rely on `url` to navigate or to recover
+ * taxonomy/slug pairs. `query` items can't be dropped on a missing url because
+ * they don't carry one in the first place — they just fill the input.
+ *
+ * @param {Array<object>}             items - Raw API items.
+ * @param {'query'|'post'|'taxonomy'} type  - Discriminator for the group.
+ * @return {SuggestionItem[]} Normalized items.
+ */
+function toItems( items, type ) {
+	return ( items ?? [] )
+		.map( item => {
+			const text = item?.text ?? '';
+			if ( ! text ) {
+				return null;
+			}
+			if ( type === 'post' || type === 'taxonomy' ) {
+				const itemUrl = item.url ?? null;
+				if ( ! itemUrl ) {
+					return null;
+				}
+				if ( type === 'taxonomy' ) {
+					const fallback = parseTaxonomyFromUrl( itemUrl );
+					return {
+						type,
+						text,
+						url: itemUrl,
+						taxonomy: item.taxonomy ?? fallback?.taxonomy ?? null,
+						slug: item.slug ?? fallback?.slug ?? null,
+					};
+				}
+				return { type, text, url: itemUrl };
+			}
+			return { type: 'query', text };
+		} )
+		.filter( Boolean );
+}
+
+/**
+ * Fetch and normalize suggestions for a single query.
+ *
+ * Returns an empty array on any non-OK HTTP status — suggestions are a
+ * non-critical surface, so 4xx/5xx silently degrades to "no suggestions"
+ * rather than throwing into the caller. Aborts are propagated to the caller
+ * via the original `AbortError`, which both consumers swallow.
+ *
+ * @param {object}      args               - Arguments.
+ * @param {string}      args.query         - Search query.
+ * @param {string}      args.siteId        - WPCOM site id.
+ * @param {boolean}     args.isPrivateSite - True for private/atomic sites.
+ * @param {boolean}     args.isWpcom       - True when running on WPCOM infra.
+ * @param {string}      args.homeUrl       - Site home URL.
+ * @param {string}      [args.nonce]       - REST nonce; sent as `X-WP-Nonce` on private sites.
+ * @param {AbortSignal} [args.signal]      - Abort signal for caller-driven cancellation.
+ * @param {number}      [args.size]        - Suggestions per group.
+ * @return {Promise<SuggestionItem[]>} Resolved suggestions, ordered query → taxonomy → post.
+ */
+export async function fetchSuggestions( {
+	query,
+	siteId,
+	isPrivateSite,
+	isWpcom,
+	homeUrl,
+	nonce,
+	signal,
+	size,
+} ) {
+	const url = buildSuggestionsUrl( { siteId, query, isPrivateSite, isWpcom, homeUrl, size } );
+	const fetchOptions = {
+		signal,
+		...( isPrivateSite && {
+			headers: { 'X-WP-Nonce': nonce ?? '' },
+			credentials: 'include',
+		} ),
+	};
+	const response = await fetch( url, fetchOptions );
+	if ( ! response.ok ) {
+		return [];
+	}
+	const data = await response.json();
+	return [
+		...toItems( data.query_suggestions, 'query' ),
+		...toItems( data.taxonomy_suggestions, 'taxonomy' ),
+		...toItems( data.title_suggestions, 'post' ),
+	];
+}

--- a/projects/packages/search/src/search-blocks/store/test/suggestions-api.test.js
+++ b/projects/packages/search/src/search-blocks/store/test/suggestions-api.test.js
@@ -1,0 +1,247 @@
+import { buildSuggestionsUrl, fetchSuggestions, parseTaxonomyFromUrl } from '../suggestions-api';
+
+const SITE_ID = '12345';
+
+/**
+ * Build a resolved mock fetch response.
+ *
+ * @param {object}  data - Response body to resolve with.
+ * @param {boolean} ok   - Response `ok` flag; defaults true.
+ * @return {Promise} Fetch-shaped response promise.
+ */
+function makeResponse( data, ok = true ) {
+	return Promise.resolve( {
+		ok,
+		json: () => Promise.resolve( data ),
+	} );
+}
+
+beforeEach( () => {
+	// eslint-disable-next-line jest/prefer-spy-on
+	global.fetch = jest.fn();
+} );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'buildSuggestionsUrl', () => {
+	it( 'targets the public API on non-private sites', () => {
+		const url = buildSuggestionsUrl( {
+			siteId: SITE_ID,
+			query: 'hello',
+			isPrivateSite: false,
+			isWpcom: false,
+			homeUrl: 'https://example.com',
+		} );
+		expect( url ).toMatch( /^https:\/\/public-api\.wordpress\.com\/wpcom\/v2\/sites\// );
+		expect( url ).toContain( encodeURIComponent( SITE_ID ) );
+		expect( url ).toContain( 'query=hello' );
+		expect( url ).toContain( 'size=5' );
+	} );
+
+	it( 'targets the homeUrl wpcom-origin proxy on private WPCOM sites', () => {
+		const url = buildSuggestionsUrl( {
+			siteId: SITE_ID,
+			query: 'hello',
+			isPrivateSite: true,
+			isWpcom: true,
+			homeUrl: 'https://my.private.site',
+		} );
+		expect( url ).toMatch(
+			/^https:\/\/my\.private\.site\/wp-json\/wpcom-origin\/wpcom\/v2\/sites\//
+		);
+	} );
+
+	it( 'falls back to the public API when the site is private but not WPCOM', () => {
+		const url = buildSuggestionsUrl( {
+			siteId: SITE_ID,
+			query: 'hello',
+			isPrivateSite: true,
+			isWpcom: false,
+			homeUrl: 'https://my.private.site',
+		} );
+		expect( url ).toMatch( /^https:\/\/public-api\.wordpress\.com\// );
+	} );
+
+	it( 'URL-encodes the query string and site id', () => {
+		const url = buildSuggestionsUrl( {
+			siteId: 'a b',
+			query: 'hello world & more',
+			isPrivateSite: false,
+			isWpcom: false,
+			homeUrl: '',
+		} );
+		expect( url ).toContain( 'sites/a%20b/' );
+		expect( url ).toContain( 'query=hello%20world%20%26%20more' );
+	} );
+
+	it( 'honors a custom size argument', () => {
+		const url = buildSuggestionsUrl( {
+			siteId: SITE_ID,
+			query: 'q',
+			isPrivateSite: false,
+			isWpcom: false,
+			homeUrl: '',
+			size: 10,
+		} );
+		expect( url ).toContain( 'size=10' );
+	} );
+} );
+
+describe( 'parseTaxonomyFromUrl', () => {
+	it( 'recovers WPCOM-style ?taxonomy=…&term=…', () => {
+		expect( parseTaxonomyFromUrl( 'https://example.com/?taxonomy=category&term=news' ) ).toEqual( {
+			taxonomy: 'category',
+			slug: 'news',
+		} );
+	} );
+
+	it( 'recovers /category/<slug>/ pretty permalinks', () => {
+		expect( parseTaxonomyFromUrl( 'https://example.com/category/news/' ) ).toEqual( {
+			taxonomy: 'category',
+			slug: 'news',
+		} );
+	} );
+
+	it( 'recovers /tag/<slug>/ pretty permalinks as post_tag', () => {
+		expect( parseTaxonomyFromUrl( 'https://example.com/tag/wp/' ) ).toEqual( {
+			taxonomy: 'post_tag',
+			slug: 'wp',
+		} );
+	} );
+
+	it( 'recovers legacy ?tag=<slug>', () => {
+		expect( parseTaxonomyFromUrl( 'https://example.com/?tag=open-source' ) ).toEqual( {
+			taxonomy: 'post_tag',
+			slug: 'open-source',
+		} );
+	} );
+
+	it( 'returns null when the URL shape is unrecognized', () => {
+		expect( parseTaxonomyFromUrl( 'https://example.com/about/' ) ).toBeNull();
+	} );
+
+	it( 'returns null on malformed URLs without throwing', () => {
+		expect( parseTaxonomyFromUrl( 'not-a-url' ) ).toBeNull();
+	} );
+} );
+
+describe( 'fetchSuggestions', () => {
+	const baseArgs = {
+		query: 'react',
+		siteId: SITE_ID,
+		isPrivateSite: false,
+		isWpcom: false,
+		homeUrl: '',
+		nonce: '',
+	};
+
+	it( 'returns query, taxonomy, and post items in canonical order', async () => {
+		global.fetch.mockReturnValue(
+			makeResponse( {
+				query_suggestions: [ { text: 'react hooks' } ],
+				taxonomy_suggestions: [
+					{ text: 'News', url: '/category/news/', taxonomy: 'category', slug: 'news' },
+				],
+				title_suggestions: [ { text: 'Getting Started', url: '/getting-started/' } ],
+			} )
+		);
+
+		const items = await fetchSuggestions( baseArgs );
+
+		expect( items ).toHaveLength( 3 );
+		expect( items[ 0 ] ).toEqual( { type: 'query', text: 'react hooks' } );
+		expect( items[ 1 ] ).toMatchObject( { type: 'taxonomy', text: 'News' } );
+		expect( items[ 2 ] ).toEqual( {
+			type: 'post',
+			text: 'Getting Started',
+			url: '/getting-started/',
+		} );
+	} );
+
+	it( 'drops items without display text', async () => {
+		global.fetch.mockReturnValue(
+			makeResponse( {
+				query_suggestions: [ { text: '' }, { text: 'kept' } ],
+				taxonomy_suggestions: [],
+				title_suggestions: [],
+			} )
+		);
+		const items = await fetchSuggestions( baseArgs );
+		expect( items ).toHaveLength( 1 );
+		expect( items[ 0 ].text ).toBe( 'kept' );
+	} );
+
+	it( 'drops post / taxonomy items without a url', async () => {
+		global.fetch.mockReturnValue(
+			makeResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [ { text: 'No URL' } ],
+				title_suggestions: [ { text: 'No URL post' } ],
+			} )
+		);
+		const items = await fetchSuggestions( baseArgs );
+		expect( items ).toEqual( [] );
+	} );
+
+	it( 'recovers taxonomy + slug from the archive URL when the API omits them', async () => {
+		global.fetch.mockReturnValue(
+			makeResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [ { text: 'News', url: 'https://example.com/category/news/' } ],
+				title_suggestions: [],
+			} )
+		);
+		const items = await fetchSuggestions( baseArgs );
+		expect( items[ 0 ] ).toMatchObject( { taxonomy: 'category', slug: 'news' } );
+	} );
+
+	it( 'returns an empty array on a non-ok HTTP response', async () => {
+		global.fetch.mockReturnValue( makeResponse( {}, false ) );
+		const items = await fetchSuggestions( baseArgs );
+		expect( items ).toEqual( [] );
+	} );
+
+	it( 'sets X-WP-Nonce + credentials only for private sites', async () => {
+		global.fetch.mockReturnValue(
+			makeResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [],
+				title_suggestions: [],
+			} )
+		);
+
+		await fetchSuggestions( {
+			...baseArgs,
+			isPrivateSite: true,
+			isWpcom: true,
+			homeUrl: 'https://my.private.site',
+			nonce: 'abc',
+		} );
+		const [ , privateOpts ] = global.fetch.mock.calls[ 0 ];
+		expect( privateOpts.headers ).toEqual( { 'X-WP-Nonce': 'abc' } );
+		expect( privateOpts.credentials ).toBe( 'include' );
+
+		global.fetch.mockClear();
+		global.fetch.mockReturnValue(
+			makeResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [],
+				title_suggestions: [],
+			} )
+		);
+
+		await fetchSuggestions( baseArgs );
+		const [ , publicOpts ] = global.fetch.mock.calls[ 0 ];
+		expect( publicOpts.headers ).toBeUndefined();
+		expect( publicOpts.credentials ).toBeUndefined();
+	} );
+
+	it( 'propagates AbortError so callers can distinguish it from network failure', async () => {
+		const abort = new Error( 'Aborted' );
+		abort.name = 'AbortError';
+		global.fetch.mockRejectedValue( abort );
+		await expect( fetchSuggestions( baseArgs ) ).rejects.toMatchObject( { name: 'AbortError' } );
+	} );
+} );


### PR DESCRIPTION
Fixes [SEARCH-205](https://linear.app/a8c/issue/SEARCH-205/search-blocks-add-autocomplete-suggestions-dropdown-to-the-search-input-block)

## Why

A visitor typing into the Jetpack Search Input block today sees a bare input — no inline guidance, no popular categories, no "did you mean this article?" jump-offs. The legacy instant-search overlay already ships that autocomplete UX, and as more sites migrate to the new Gutenberg block-based search experience, the gap is conspicuous: people abandon empty-feeling search boxes. This PR puts the autocomplete dropdown back into a visitor's typing path on block-based search pages.

Authors enable it per-block via a new "Show search suggestions" inspector toggle (default off, so existing posts are unchanged). When on, typing reveals suggestions in three groups — query completions, popular categories/tags, and matching post titles. Selecting a category applies it as a filter on the current page and refreshes the result list without a page reload; selecting a post or unfiltered tag navigates to it.

## Proposed changes

- New `enableSuggestions` block attribute on `jetpack-search/search-input` (default `false`).
- Inspector "Show search suggestions" toggle in the block editor.
- Conditional combobox markup in `render.php`: `role="combobox"`, `aria-autocomplete="list"`, `aria-controls`, `aria-expanded`, `aria-activedescendant`, plus a sibling `<ul role="listbox">` rendered via `data-wp-each`.
- View-bundle store actions: debounced fetch with per-input `AbortController`, ArrowUp/ArrowDown/Enter/Escape keyboard handling, 150 ms blur grace period, click handling on suggestion `<li>`s.
- Suggestion selection routes to one of three behaviors — query (fill + search), taxonomy (`actions.setFilter(...)` when a matching filter block is registered, else navigate), post (navigate).
- New shared module `search-blocks/store/suggestions-api.js` extracts the WPCOM `/search-suggestions` URL + fetch + normalization logic out of `instant-search/hooks/use-search-suggestions.js` so both surfaces share one contract. The React hook now imports from it.
- New pure helper `search-input/suggestion-rows.js` flattens grouped suggestions into a single `data-wp-each` stream with stable keys and a contiguous `optionIndex` for keyboard navigation.
- Three new translated `state.strings` keys (`suggestionLabelQuery` / `suggestionLabelTaxonomy` / `suggestionLabelPost`) seeded by PHP, because `@wordpress/i18n` isn't yet available as a Script Module in the blocks build target.
- Unit tests for both new modules (29 assertions).

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-205

## Does this pull request change what data or activity we track or use?

No. Suggestions are fetched from the existing public WPCOM `/wpcom/v2/sites/<id>/search-suggestions` endpoint that the instant-search overlay already uses today. No new data is collected and no new telemetry is added. Default-off opt-in means no new network calls fire until an author enables the toggle on a specific block.

## Screenshots

### Before (suggestions off — default; matches `trunk`)

![before](https://github.com/user-attachments/assets/b9a6fa11-020d-47ba-b1c8-48ef0d7fde0d)

### After (suggestions on, dropdown open with second item keyboard-highlighted)

![after](https://github.com/user-attachments/assets/563290ac-2131-4e81-92cc-801a4369dcd9)

## Testing instructions

1. Insert a **Search Input** block on a page. In the inspector, toggle **Show search suggestions** on. Add a **Filter Checkbox** (configured as `category` taxonomy) and a **Results List** to the same page. Save and view the page on the front-end.
2. **Suggestions render.** Focus the input and type a query that has indexed content (e.g. `wordpress`). Within ~120 ms the dropdown should open with up to three sections: `Suggestions` (query completions), `Popular Filters` (categories/tags), `Articles` (post titles).
3. **Keyboard navigation.** Press `ArrowDown` repeatedly — focus should move through the option rows linearly, skipping group headers. The highlighted row should turn blue (`is-active`) and the input's `aria-activedescendant` should match the highlighted `<li id>`.
4. **Press Enter on a `Suggestions` row.** Input fills with that text, dropdown closes, the result list refreshes.
5. **Press Enter (or click) on a `Popular Filters` row.** The filter applies inline — the URL gains `?<filterKey>[]=<slug>` and the result list refreshes without a page reload. Clicking the active-filter chip removes the filter.
6. **Press Enter (or click) on an `Articles` row.** The browser navigates to that post.
7. **Press `Escape`.** Dropdown closes; `aria-expanded` flips to `false`; `aria-activedescendant` clears.
8. **Click outside the input.** Dropdown closes after a ~150 ms grace period.
9. **Clear the input.** Dropdown disappears; no `<ul>` rows remain in the DOM.
10. **Multi-instance.** Add a second Search Input block (e.g. in the page header) with suggestions also on. Type in one — the other's dropdown stays closed.
11. **Control case.** Toggle **Show search suggestions** off and view the page. No `role="combobox"`, no `aria-*` attributes, no `<ul role="listbox">` in the DOM, no network calls to `/search-suggestions`.
12. **Unit tests.** `pnpm --filter jetpack-search test src/search-blocks src/instant-search/hooks` — all 44 tests pass.

