### PR TITLE
Search: add an AI Answer block for the embedded search template (RSM-3591)

### DIFF
--- a/projects/packages/search/.size-limit.js
+++ b/projects/packages/search/.size-limit.js
@@ -19,4 +19,10 @@ module.exports = [
 		path: 'build/search-blocks/results-list.js',
 		limit: '3 KiB',
 	},
+	// `ai-answer.js` is also a pure store importer; the SSE + markdown logic
+	// lives in the shared store module, so the view bundle should stay tiny.
+	{
+		path: 'build/search-blocks/ai-answer.js',
+		limit: '3 KiB',
+	},
 ];

--- a/projects/packages/search/changelog/add-RSM-3591-ai-answer-block
+++ b/projects/packages/search/changelog/add-RSM-3591-ai-answer-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add an AI Answer block (`jetpack-search/ai-answer`) so authors can surface the AI Answers panel inside the embedded search template — previously only the instant-search overlay could render it.

--- a/projects/packages/search/src/instant-search/components/answers-panel.jsx
+++ b/projects/packages/search/src/instant-search/components/answers-panel.jsx
@@ -166,7 +166,7 @@ export default function AnswersPanel( {
 			) }
 			{ onShowMore === null && loadingHint && (
 				<p className="jp-search-answers-panel__loading-hint">
-					{ loadingHint.endsWith( '…' ) ? loadingHint.slice( 0, -1 ) : loadingHint }
+					{ loadingHint }
 					<AnimatedEllipsis />
 				</p>
 			) }

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -483,22 +483,28 @@ class SearchApp extends Component {
 		const options = window[ SERVER_OBJECT_NAME ] || {};
 		const siteId = options.siteId;
 
+		// Source strings deliberately omit a trailing `…` — answers-panel.jsx
+		// appends an animated three-dot ellipsis right after the label, so a
+		// static one would render as a doubled "Searching harder… …".
+		// Mirrors `Search_Blocks::build_ai_extended_loading_hints()` so the
+		// overlay and the embedded `jetpack-search/ai-answer` block share
+		// translation keys.
 		const loadingMessages = [
-			__( 'Searching harder…', 'jetpack-search-pkg' ),
-			__( 'Looking deeper into this…', 'jetpack-search-pkg' ),
-			__( 'Finding a more complete answer…', 'jetpack-search-pkg' ),
-			__( 'Analyzing additional sources…', 'jetpack-search-pkg' ),
-			__( 'Gathering more details…', 'jetpack-search-pkg' ),
-			__( 'Pulling in more context…', 'jetpack-search-pkg' ),
-			__( 'Expanding the search…', 'jetpack-search-pkg' ),
-			__( 'Rolling up my virtual sleeves…', 'jetpack-search-pkg' ),
-			__( 'Digging through the archives…', 'jetpack-search-pkg' ),
-			__( 'Putting on my reading glasses…', 'jetpack-search-pkg' ),
-			__( 'Checking under the digital couch cushions…', 'jetpack-search-pkg' ),
-			__( 'Consulting the oracle…', 'jetpack-search-pkg' ),
-			__( 'Asking a smarter algorithm…', 'jetpack-search-pkg' ),
-			__( 'Brewing a fresh batch of insights…', 'jetpack-search-pkg' ),
-			__( 'Unleashing the full power of search…', 'jetpack-search-pkg' ),
+			__( 'Searching harder', 'jetpack-search-pkg' ),
+			__( 'Looking deeper into this', 'jetpack-search-pkg' ),
+			__( 'Finding a more complete answer', 'jetpack-search-pkg' ),
+			__( 'Analyzing additional sources', 'jetpack-search-pkg' ),
+			__( 'Gathering more details', 'jetpack-search-pkg' ),
+			__( 'Pulling in more context', 'jetpack-search-pkg' ),
+			__( 'Expanding the search', 'jetpack-search-pkg' ),
+			__( 'Rolling up my virtual sleeves', 'jetpack-search-pkg' ),
+			__( 'Digging through the archives', 'jetpack-search-pkg' ),
+			__( 'Putting on my reading glasses', 'jetpack-search-pkg' ),
+			__( 'Checking under the digital couch cushions', 'jetpack-search-pkg' ),
+			__( 'Consulting the oracle', 'jetpack-search-pkg' ),
+			__( 'Asking a smarter algorithm', 'jetpack-search-pkg' ),
+			__( 'Brewing a fresh batch of insights', 'jetpack-search-pkg' ),
+			__( 'Unleashing the full power of search', 'jetpack-search-pkg' ),
 		];
 		const aiExtendedLoadingText =
 			loadingMessages[ Math.floor( Math.random() * loadingMessages.length ) ];

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/block.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/ai-answer",
+	"version": "0.1.0",
+	"title": "AI Answer",
+	"category": "jetpack-search",
+	"description": "Show an AI-generated answer above the search results, with citations and an optional Show more / extended answer flow. Powered by Jetpack Search.",
+	"attributes": {
+		"heading": { "type": "string", "default": "" },
+		"showCitations": { "type": "boolean", "default": true },
+		"enableShowMore": { "type": "boolean", "default": true }
+	},
+	"supports": {
+		"html": false,
+		"interactivity": true
+	},
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/ai-answer.js",
+	"style": "file:../../../../build/search-blocks/ai-answer.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/edit.js
@@ -1,0 +1,105 @@
+/**
+ * Editor preview for jetpack-search/ai-answer.
+ *
+ * The block has no editor-side state — render.php drives the front end via
+ * the Interactivity store. The preview here is static markup mirroring the
+ * `done` state with a sample answer + citations so authors can see what
+ * they're placing without an SSE connection in the editor.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const SAMPLE_CITATIONS = [
+	{ title: 'Getting started with WordPress', url: 'https://example.com/getting-started' },
+	{ title: 'Customizing your theme', url: 'https://example.com/customizing' },
+];
+
+/**
+ * Editor preview component.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function AiAnswerEdit( { attributes, setAttributes } ) {
+	const heading = attributes?.heading?.trim() || __( 'AI answer', 'jetpack-search-pkg' );
+	const showCitations = attributes?.showCitations !== false;
+	const enableShowMore = attributes?.enableShowMore !== false;
+	const blockProps = useBlockProps();
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Heading', 'jetpack-search-pkg' ) }
+						value={ attributes?.heading || '' }
+						placeholder={ __( 'AI answer', 'jetpack-search-pkg' ) }
+						onChange={ value => setAttributes( { heading: value } ) }
+						help={ __(
+							'Label shown above the answer. Leave empty for the default.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show citations', 'jetpack-search-pkg' ) }
+						checked={ showCitations }
+						onChange={ value => setAttributes( { showCitations: value } ) }
+						help={ __(
+							'Display the sources used by the AI under the answer.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Allow "Show more" for a longer answer', 'jetpack-search-pkg' ) }
+						checked={ enableShowMore }
+						onChange={ value => setAttributes( { enableShowMore: value } ) }
+						help={ __(
+							'After the brief answer arrives, offer a button that loads a longer, more detailed response.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<h2 className="jp-search-answers-panel__heading">{ heading }</h2>
+				<div className="jp-search-answers-panel__content">
+					<div className="jp-search-answers-panel__text">
+						<p>
+							{ __(
+								'Once a visitor searches, an AI-generated answer will appear here with citations drawn from your site.',
+								'jetpack-search-pkg'
+							) }
+						</p>
+					</div>
+					{ showCitations && (
+						<ul className="jp-search-answers-panel__citations">
+							{ SAMPLE_CITATIONS.map( ( { title, url } ) => (
+								<li key={ url }>
+									<a href={ url } onClick={ e => e.preventDefault() }>
+										{ title }
+									</a>
+								</li>
+							) ) }
+						</ul>
+					) }
+				</div>
+				{ enableShowMore && (
+					<button
+						type="button"
+						className="jp-search-answers-panel__toggle"
+						onClick={ e => e.preventDefault() }
+					>
+						{ __( 'Show more', 'jetpack-search-pkg' ) }
+						<span className="jp-search-answers-panel__toggle-icon" aria-hidden="true" />
+					</button>
+				) }
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * AI Answer block render.
+ *
+ * Renders the panel scaffold that the Interactivity store hydrates with the
+ * streaming brief / extended AI answer. Server-side bails to an empty string
+ * when AI Answers is disabled site-wide so the block disappears without the
+ * author touching saved post content.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! AI_Answers::is_enabled() ) {
+	return '';
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$attrs           = (array) $attributes;
+$heading_raw     = trim( (string) ( $attrs['heading'] ?? '' ) );
+$heading         = '' === $heading_raw ? __( 'AI answer', 'jetpack-search-pkg' ) : $heading_raw;
+$show_citations  = ! isset( $attrs['showCitations'] ) || $attrs['showCitations'];
+$enable_extended = ! isset( $attrs['enableShowMore'] ) || $attrs['enableShowMore'];
+$wrapper_attrs   = get_block_wrapper_attributes(
+	array( 'class' => 'jp-search-answers-panel' )
+);
+?>
+<div
+	<?php echo wp_kses_data( $wrapper_attrs ); ?>
+	data-wp-interactive="jetpack-search"
+	data-wp-init="callbacks.initializeAiAnswer"
+	data-wp-bind--hidden="state.aiPanelHidden"
+	aria-live="polite"
+	hidden
+>
+	<h2 class="jp-search-answers-panel__heading"><?php echo esc_html( $heading ); ?></h2>
+
+	<div
+		class="jp-search-answers-panel__loading"
+		data-wp-bind--hidden="!state.aiIsLoading"
+		hidden
+	>
+		<?php esc_html_e( 'Finding an answer', 'jetpack-search-pkg' ); ?>
+		<span class="jp-search-animated-ellipsis" aria-hidden="true">
+			<span></span><span></span><span></span>
+		</span>
+	</div>
+
+	<div
+		class="jp-search-answers-panel__error"
+		role="alert"
+		data-wp-bind--hidden="!state.aiIsError"
+		hidden
+	>
+		<p
+			class="jp-search-answers-panel__error-message"
+			data-wp-text="state.aiErrorPrimary"
+		></p>
+		<p
+			class="jp-search-answers-panel__error-detail"
+			data-wp-bind--hidden="!state.aiHasErrorDetail"
+		>
+			<span data-wp-text="state.aiErrorDetail"></span>
+			<span data-wp-bind--hidden="!state.aiHasErrorCode">
+				<br />
+				<span data-wp-text="state.aiErrorCodeText"></span>
+			</span>
+		</p>
+	</div>
+
+	<div
+		class="jp-search-answers-panel__content"
+		data-wp-bind--hidden="!state.aiHasContent"
+		hidden
+	>
+		<div
+			class="jp-search-answers-panel__text"
+			data-wp-watch="callbacks.renderAiAnswerHtml"
+		></div>
+
+		<?php if ( $show_citations ) : ?>
+		<ul
+			class="jp-search-answers-panel__citations"
+			data-wp-bind--hidden="!state.aiHasCitations"
+			hidden
+		>
+			<template
+				data-wp-each--citation="state.aiVisibleCitations"
+				data-wp-key="context.citation.url"
+			>
+				<li>
+					<a
+						data-wp-bind--href="context.citation.href"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<span data-wp-text="context.citation.title"></span>
+						<svg
+							width="10"
+							height="10"
+							viewBox="0 0 10 10"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+							aria-hidden="true"
+							class="jp-search-answers-panel__citation-icon"
+						>
+							<path d="M1 9L9 1M9 1H5M9 1V5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+						</svg>
+					</a>
+				</li>
+			</template>
+		</ul>
+		<?php endif; ?>
+	</div>
+
+	<p
+		class="jp-search-answers-panel__loading-hint"
+		data-wp-bind--hidden="!state.aiExtendedLoadingHintShown"
+		hidden
+	>
+		<span data-wp-text="state.aiExtendedLoadingText"></span>
+		<span class="jp-search-animated-ellipsis" aria-hidden="true">
+			<span></span><span></span><span></span>
+		</span>
+	</p>
+
+	<?php if ( $enable_extended ) : ?>
+	<button
+		type="button"
+		class="jp-search-answers-panel__toggle"
+		data-wp-bind--hidden="!state.aiShowExtendedButton"
+		data-wp-on--click="actions.showExtendedAiAnswer"
+		hidden
+	>
+		<?php esc_html_e( 'Show more', 'jetpack-search-pkg' ); ?>
+		<span class="jp-search-answers-panel__toggle-icon" aria-hidden="true"></span>
+	</button>
+	<?php endif; ?>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -12,14 +12,15 @@
 
 namespace Automattic\Jetpack\Search;
 
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-
 if ( ! AI_Answers::is_enabled() ) {
 	return '';
 }
 
+// $attributes is injected by WordPress at block-render time via the
+// `render_callback` include scope; static analysis can't see the binding,
+// so both phpcs and Phan need a one-line suppression on the next statement.
 // @phan-suppress-next-line PhanUndeclaredGlobalVariable
-$attrs           = (array) $attributes;
+$attrs           = (array) $attributes; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $heading_raw     = trim( (string) ( $attrs['heading'] ?? '' ) );
 $heading         = '' === $heading_raw ? __( 'AI answer', 'jetpack-search-pkg' ) : $heading_raw;
 $show_citations  = ! isset( $attrs['showCitations'] ) || $attrs['showCitations'];
@@ -89,7 +90,7 @@ $wrapper_attrs   = get_block_wrapper_attributes(
 		>
 			<template
 				data-wp-each--citation="state.aiVisibleCitations"
-				data-wp-key="context.citation.url"
+				data-wp-key="context.citation.key"
 			>
 				<li>
 					<a

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
@@ -1,0 +1,189 @@
+.wp-block-jetpack-search-ai-answer {
+	background: #fff;
+	border: 1px solid #ddd;
+	border-radius: 6px;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+	margin: 0 0 1rem;
+	overflow: hidden;
+
+	&[hidden] {
+		display: none;
+	}
+}
+
+.jp-search-answers-panel__heading {
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	margin: 0;
+	padding: 14px 18px 8px;
+	text-transform: uppercase;
+}
+
+.jp-search-answers-panel__loading,
+.jp-search-answers-panel__loading-hint {
+	align-items: center;
+	color: #50575e;
+	display: flex;
+	font-size: 13px;
+	gap: 8px;
+	margin: 0;
+	padding: 0 18px 14px;
+}
+
+.jp-search-answers-panel__loading-hint {
+	font-style: italic;
+}
+
+.jp-search-answers-panel__error {
+	padding: 0 18px 14px;
+}
+
+.jp-search-answers-panel__error-message {
+	color: #b32d2e;
+	font-size: 13px;
+	margin: 0 0 4px;
+}
+
+.jp-search-answers-panel__error-detail {
+	color: #50575e;
+	font-size: 12px;
+	margin: 0;
+}
+
+.jp-search-answers-panel__content {
+	padding: 0 18px 14px;
+}
+
+.jp-search-answers-panel__text {
+	font-size: 13px;
+	line-height: 1.6;
+
+	h2,
+	h3,
+	h4 {
+		font-size: 1em;
+		font-weight: 700;
+		margin: 0.8em 0 0.3em;
+	}
+
+	p {
+		margin: 0 0 0.6em;
+	}
+
+	ul {
+		list-style: disc;
+		margin: 0 0 0.6em 1.2em;
+		padding: 0;
+	}
+
+	li {
+		margin-bottom: 0.2em;
+	}
+
+	strong {
+		font-weight: 700;
+	}
+
+	em {
+		font-style: italic;
+	}
+
+	a {
+		color: #2271b1;
+		text-decoration: underline;
+	}
+}
+
+.jp-search-answers-panel__toggle {
+	align-items: center;
+	background: none;
+	border: none;
+	border-top: 1px solid #f0f0f0;
+	color: #2271b1;
+	cursor: pointer;
+	display: flex;
+	font-size: 12px;
+	font-weight: 500;
+	gap: 6px;
+	justify-content: center;
+	padding: 9px 0;
+	width: 100%;
+
+	&:hover {
+		background: #f6f7f7;
+	}
+}
+
+.jp-search-answers-panel__toggle-icon {
+	border-bottom: 1.5px solid currentColor;
+	border-right: 1.5px solid currentColor;
+	display: inline-block;
+	height: 6px;
+	transform: rotate(45deg);
+	width: 6px;
+}
+
+.jp-search-answers-panel__citations {
+	border-top: 1px solid #f0f0f0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 12px;
+	justify-content: flex-end;
+	list-style: none;
+	margin: 6px 0 0;
+	padding: 10px 0 0;
+
+	li {
+		font-size: 12px;
+		line-height: 1.5;
+	}
+
+	a {
+		align-items: center;
+		color: #2271b1;
+		display: inline-flex;
+		gap: 4px;
+		text-decoration: underline;
+	}
+}
+
+.jp-search-answers-panel__citation-icon {
+	flex-shrink: 0;
+}
+
+@keyframes jp-search-animated-ellipsis-bounce {
+
+	0%,
+	80%,
+	100% {
+		opacity: 0.2;
+	}
+
+	40% {
+		opacity: 1;
+	}
+}
+
+.jp-search-animated-ellipsis {
+	display: inline-flex;
+	gap: 2px;
+
+	span {
+		animation: jp-search-animated-ellipsis-bounce 1.4s infinite both;
+		background: currentColor;
+		border-radius: 50%;
+		display: inline-block;
+		height: 3px;
+		width: 3px;
+
+		&:nth-child(2) {
+			animation-delay: 0.16s;
+		}
+
+		&:nth-child(3) {
+			animation-delay: 0.32s;
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
@@ -39,6 +39,7 @@
 	align-items: center;
 	color: inherit;
 	display: flex;
+	font-size: 0.875em;
 	gap: 0.5em;
 	margin: 0.5em 0 0;
 	opacity: 0.7;
@@ -76,6 +77,7 @@
 }
 
 .jp-search-answers-panel__text {
+	font-size: 0.875em;
 	line-height: 1.6;
 
 	// Headings stay in-flow rather than mimicking the theme's body

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
@@ -42,6 +42,15 @@
 	gap: 0.5em;
 	margin: 0.5em 0 0;
 	opacity: 0.7;
+
+	// Author `display: flex` wins over UA `[hidden] { display: none }`, so
+	// every `data-wp-bind--hidden`-gated row needs its own override —
+	// without it the row stays on screen with `hidden` attached but no
+	// visual effect. Same idiom the other Search blocks use (e.g.
+	// `results-list/style.scss`'s skeleton-item `[hidden]` rule).
+	&[hidden] {
+		display: none;
+	}
 }
 
 .jp-search-answers-panel__loading-hint {
@@ -121,6 +130,10 @@
 	padding: 0;
 	text-decoration: underline;
 
+	&[hidden] {
+		display: none;
+	}
+
 	&:hover {
 		opacity: 0.7;
 	}
@@ -143,6 +156,10 @@
 	list-style: none;
 	margin: 0.75em 0 0;
 	padding: 0;
+
+	&[hidden] {
+		display: none;
+	}
 
 	li {
 		margin: 0;

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
@@ -39,7 +39,7 @@
 	align-items: center;
 	color: inherit;
 	display: flex;
-	font-size: 0.875em;
+	font-size: 0.75em;
 	gap: 0.5em;
 	margin: 0.5em 0 0;
 	opacity: 0.7;
@@ -126,7 +126,7 @@
 	cursor: pointer;
 	display: inline-flex;
 	font: inherit;
-	font-size: 0.875em;
+	font-size: 0.75em;
 	gap: 0.4em;
 	margin-top: 0.5em;
 	padding: 0;
@@ -153,7 +153,7 @@
 .jp-search-answers-panel__citations {
 	display: flex;
 	flex-wrap: wrap;
-	font-size: 0.875em;
+	font-size: 0.75em;
 	gap: 0.5em 1em;
 	list-style: none;
 	margin: 0.75em 0 0;

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/style.scss
@@ -1,10 +1,24 @@
+// The AI Answer block intentionally ships no card chrome (background,
+// border, shadow) and no hardcoded brand colours. It inherits typography,
+// foreground colour, link colour, and link-hover treatment from the theme
+// so the panel reads as a first-class section of the page rather than a
+// floating widget. Subtle separation comes from `color-mix(currentColor)`
+// — the same idiom the filter blocks use for their pill backgrounds —
+// which adapts to a dark theme by sampling whatever the theme already
+// chose for body text.
+// All spacing uses theme preset tokens (`--wp--preset--spacing--*`) when
+// available, with `em` fallbacks tied to local font-size so a classic
+// theme without preset spacing still renders sensibly.
+
 .wp-block-jetpack-search-ai-answer {
-	background: #fff;
-	border: 1px solid #ddd;
-	border-radius: 6px;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-	margin: 0 0 1rem;
-	overflow: hidden;
+	margin-block: 0 var(--wp--preset--spacing--40, 1.5rem);
+	padding-block: var(--wp--preset--spacing--30, 0.75rem);
+	// A subtle inline-start accent rule reads as "callout" without
+	// imposing a background. Border colour is sampled from the theme via
+	// `currentColor` at 30% so it always has contrast against the page
+	// surface without picking a specific palette colour.
+	border-inline-start: 3px solid color-mix(in sRGB, currentColor 30%, transparent);
+	padding-inline-start: var(--wp--preset--spacing--30, 1rem);
 
 	&[hidden] {
 		display: none;
@@ -12,24 +26,22 @@
 }
 
 .jp-search-answers-panel__heading {
-	color: #50575e;
-	font-size: 11px;
+	font-size: 0.75em;
 	font-weight: 600;
-	letter-spacing: 0.08em;
-	margin: 0;
-	padding: 14px 18px 8px;
+	letter-spacing: 0.06em;
+	margin: 0 0 0.5em;
+	opacity: 0.7;
 	text-transform: uppercase;
 }
 
 .jp-search-answers-panel__loading,
 .jp-search-answers-panel__loading-hint {
 	align-items: center;
-	color: #50575e;
+	color: inherit;
 	display: flex;
-	font-size: 13px;
-	gap: 8px;
-	margin: 0;
-	padding: 0 18px 14px;
+	gap: 0.5em;
+	margin: 0.5em 0 0;
+	opacity: 0.7;
 }
 
 .jp-search-answers-panel__loading-hint {
@@ -37,29 +49,30 @@
 }
 
 .jp-search-answers-panel__error {
-	padding: 0 18px 14px;
-}
-
-.jp-search-answers-panel__error-message {
-	color: #b32d2e;
-	font-size: 13px;
-	margin: 0 0 4px;
-}
-
-.jp-search-answers-panel__error-detail {
-	color: #50575e;
-	font-size: 12px;
 	margin: 0;
 }
 
+.jp-search-answers-panel__error-message {
+	margin: 0 0 0.25em;
+}
+
+.jp-search-answers-panel__error-detail {
+	font-size: 0.875em;
+	margin: 0;
+	opacity: 0.7;
+}
+
 .jp-search-answers-panel__content {
-	padding: 0 18px 14px;
+	margin: 0;
 }
 
 .jp-search-answers-panel__text {
-	font-size: 13px;
 	line-height: 1.6;
 
+	// Headings stay in-flow rather than mimicking the theme's body
+	// heading scale — the answer is one block of prose, so internal
+	// headings need to be visually subordinate to the panel's own
+	// heading ("AI ANSWER") and to any surrounding page headings.
 	h2,
 	h3,
 	h4 {
@@ -90,29 +103,26 @@
 		font-style: italic;
 	}
 
-	a {
-		color: #2271b1;
-		text-decoration: underline;
-	}
+	// Links inherit the theme's link colour cascade entirely — no
+	// `color:` override here. The same applies to `:hover` / `:focus-visible`.
 }
 
 .jp-search-answers-panel__toggle {
 	align-items: center;
 	background: none;
-	border: none;
-	border-top: 1px solid #f0f0f0;
-	color: #2271b1;
+	border: 0;
+	color: inherit;
 	cursor: pointer;
-	display: flex;
-	font-size: 12px;
-	font-weight: 500;
-	gap: 6px;
-	justify-content: center;
-	padding: 9px 0;
-	width: 100%;
+	display: inline-flex;
+	font: inherit;
+	font-size: 0.875em;
+	gap: 0.4em;
+	margin-top: 0.5em;
+	padding: 0;
+	text-decoration: underline;
 
 	&:hover {
-		background: #f6f7f7;
+		opacity: 0.7;
 	}
 }
 
@@ -120,32 +130,30 @@
 	border-bottom: 1.5px solid currentColor;
 	border-right: 1.5px solid currentColor;
 	display: inline-block;
-	height: 6px;
+	height: 0.4em;
 	transform: rotate(45deg);
-	width: 6px;
+	width: 0.4em;
 }
 
 .jp-search-answers-panel__citations {
-	border-top: 1px solid #f0f0f0;
 	display: flex;
 	flex-wrap: wrap;
-	gap: 6px 12px;
-	justify-content: flex-end;
+	font-size: 0.875em;
+	gap: 0.5em 1em;
 	list-style: none;
-	margin: 6px 0 0;
-	padding: 10px 0 0;
+	margin: 0.75em 0 0;
+	padding: 0;
 
 	li {
-		font-size: 12px;
-		line-height: 1.5;
+		margin: 0;
 	}
 
+	// Anchor colour inherits from the theme's link cascade. The `inline-flex`
+	// is purely to align the external-link icon vertically with the title.
 	a {
 		align-items: center;
-		color: #2271b1;
 		display: inline-flex;
-		gap: 4px;
-		text-decoration: underline;
+		gap: 0.25em;
 	}
 }
 
@@ -153,6 +161,8 @@
 	flex-shrink: 0;
 }
 
+// Inline three-dot loading ellipsis. Reuses `currentColor` so it tints to
+// the inherited foreground rather than picking its own brand colour.
 @keyframes jp-search-animated-ellipsis-bounce {
 
 	0%,

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/view.js
@@ -1,0 +1,7 @@
+// Intentionally empty: this block is fully declarative.
+// Importing the store registers the shared AI Answers state, actions, and
+// fetch-on-search callbacks on pages with this block. The SSE call itself
+// lives in the store so the AI Answer block shares one source of truth with
+// any future surface that wants to reuse the same panel.
+import 'jetpack-search/store';
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1625,41 +1625,47 @@ class Search_Blocks {
 	 * @return array<int, string>
 	 */
 	protected static function build_ai_extended_loading_hints(): array {
+		// Source strings deliberately omit a trailing `…`. The block's
+		// render.php emits an animated three-dot ellipsis right after the
+		// label, so a static one in the source would read as a doubled
+		// "Searching harder… …". The overlay strips the trailing `…` for
+		// the same reason — keeping the source clean here means the two
+		// surfaces share the same translation keys.
 		if ( ! function_exists( '__' ) ) {
 			return array(
-				'Searching harder…',
-				'Looking deeper into this…',
-				'Finding a more complete answer…',
-				'Analyzing additional sources…',
-				'Gathering more details…',
-				'Pulling in more context…',
-				'Expanding the search…',
-				'Rolling up my virtual sleeves…',
-				'Digging through the archives…',
-				'Putting on my reading glasses…',
-				'Checking under the digital couch cushions…',
-				'Consulting the oracle…',
-				'Asking a smarter algorithm…',
-				'Brewing a fresh batch of insights…',
-				'Unleashing the full power of search…',
+				'Searching harder',
+				'Looking deeper into this',
+				'Finding a more complete answer',
+				'Analyzing additional sources',
+				'Gathering more details',
+				'Pulling in more context',
+				'Expanding the search',
+				'Rolling up my virtual sleeves',
+				'Digging through the archives',
+				'Putting on my reading glasses',
+				'Checking under the digital couch cushions',
+				'Consulting the oracle',
+				'Asking a smarter algorithm',
+				'Brewing a fresh batch of insights',
+				'Unleashing the full power of search',
 			);
 		}
 		return array(
-			__( 'Searching harder…', 'jetpack-search-pkg' ),
-			__( 'Looking deeper into this…', 'jetpack-search-pkg' ),
-			__( 'Finding a more complete answer…', 'jetpack-search-pkg' ),
-			__( 'Analyzing additional sources…', 'jetpack-search-pkg' ),
-			__( 'Gathering more details…', 'jetpack-search-pkg' ),
-			__( 'Pulling in more context…', 'jetpack-search-pkg' ),
-			__( 'Expanding the search…', 'jetpack-search-pkg' ),
-			__( 'Rolling up my virtual sleeves…', 'jetpack-search-pkg' ),
-			__( 'Digging through the archives…', 'jetpack-search-pkg' ),
-			__( 'Putting on my reading glasses…', 'jetpack-search-pkg' ),
-			__( 'Checking under the digital couch cushions…', 'jetpack-search-pkg' ),
-			__( 'Consulting the oracle…', 'jetpack-search-pkg' ),
-			__( 'Asking a smarter algorithm…', 'jetpack-search-pkg' ),
-			__( 'Brewing a fresh batch of insights…', 'jetpack-search-pkg' ),
-			__( 'Unleashing the full power of search…', 'jetpack-search-pkg' ),
+			__( 'Searching harder', 'jetpack-search-pkg' ),
+			__( 'Looking deeper into this', 'jetpack-search-pkg' ),
+			__( 'Finding a more complete answer', 'jetpack-search-pkg' ),
+			__( 'Analyzing additional sources', 'jetpack-search-pkg' ),
+			__( 'Gathering more details', 'jetpack-search-pkg' ),
+			__( 'Pulling in more context', 'jetpack-search-pkg' ),
+			__( 'Expanding the search', 'jetpack-search-pkg' ),
+			__( 'Rolling up my virtual sleeves', 'jetpack-search-pkg' ),
+			__( 'Digging through the archives', 'jetpack-search-pkg' ),
+			__( 'Putting on my reading glasses', 'jetpack-search-pkg' ),
+			__( 'Checking under the digital couch cushions', 'jetpack-search-pkg' ),
+			__( 'Consulting the oracle', 'jetpack-search-pkg' ),
+			__( 'Asking a smarter algorithm', 'jetpack-search-pkg' ),
+			__( 'Brewing a fresh batch of insights', 'jetpack-search-pkg' ),
+			__( 'Unleashing the full power of search', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1640,6 +1640,8 @@ class Search_Blocks {
 				'Checking under the digital couch cushions…',
 				'Consulting the oracle…',
 				'Asking a smarter algorithm…',
+				'Brewing a fresh batch of insights…',
+				'Unleashing the full power of search…',
 			);
 		}
 		return array(
@@ -1656,6 +1658,8 @@ class Search_Blocks {
 			__( 'Checking under the digital couch cushions…', 'jetpack-search-pkg' ),
 			__( 'Consulting the oracle…', 'jetpack-search-pkg' ),
 			__( 'Asking a smarter algorithm…', 'jetpack-search-pkg' ),
+			__( 'Brewing a fresh batch of insights…', 'jetpack-search-pkg' ),
+			__( 'Unleashing the full power of search…', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1308,6 +1308,14 @@ class Search_Blocks {
 			// locale-agnostic — only the display string carries the symbol.
 			'priceCurrencySymbol'        => '$',
 
+			// AI Answers — whether the agent endpoint should be called at all.
+			// Render.php for `jetpack-search/ai-answer` also short-circuits to
+			// an empty string when this is false, so the panel disappears at
+			// SSR time even for a saved post that still has the block in its
+			// content. The JS gate here covers the edge case where the flag
+			// flips off between SSR and hydration.
+			'aiAnswersEnabled'           => AI_Answers::is_enabled(),
+
 			// Display labels for `wc_stock_status` selections, keyed by slug.
 			// Seeded from the status block's static option list so an active-
 			// filters chip for "instock" reads "In stock" rather than the raw
@@ -1546,6 +1554,7 @@ class Search_Blocks {
 	 * @return array<string, string>
 	 */
 	protected static function build_initial_strings(): array {
+		$ai_extended_loading_hints = static::build_ai_extended_loading_hints();
 		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
 			return array(
 				'searching'               => 'Searching…',
@@ -1562,6 +1571,9 @@ class Search_Blocks {
 				'suggestionLabelQuery'    => 'Suggestions',
 				'suggestionLabelTaxonomy' => 'Popular Filters',
 				'suggestionLabelPost'     => 'Articles',
+				'aiErrorMessage'          => 'Sorry, an error occurred while generating an answer.',
+				'aiErrorCode'             => 'Error code: %s',
+				'aiExtendedLoadingHints'  => $ai_extended_loading_hints,
 			);
 		}
 		return array(
@@ -1592,6 +1604,53 @@ class Search_Blocks {
 			'suggestionLabelTaxonomy' => __( 'Popular Filters', 'jetpack-search-pkg' ),
 			/* translators: Group label for the post-title section of the Search Input autocomplete dropdown. */
 			'suggestionLabelPost'     => __( 'Articles', 'jetpack-search-pkg' ),
+			/* translators: Heading shown on the AI Answer panel when the agent endpoint returns an error. The technical message + HTTP/JSON-RPC code render below this string. */
+			'aiErrorMessage'          => __( 'Sorry, an error occurred while generating an answer.', 'jetpack-search-pkg' ),
+			/* translators: %s: numeric error code. Surfaces the HTTP / JSON-RPC code that came back with the AI Answer failure, under the technical message. */
+			'aiErrorCode'             => __( 'Error code: %s', 'jetpack-search-pkg' ),
+			'aiExtendedLoadingHints'  => $ai_extended_loading_hints,
+		);
+	}
+
+	/**
+	 * Localized rotating loading hints shown while the "Show more" extended
+	 * AI answer streams. Mirrors the overlay's copy verbatim so the two
+	 * surfaces read the same to a visitor switching between them.
+	 *
+	 * @return array<int, string>
+	 */
+	protected static function build_ai_extended_loading_hints(): array {
+		if ( ! function_exists( '__' ) ) {
+			return array(
+				'Searching harder…',
+				'Looking deeper into this…',
+				'Finding a more complete answer…',
+				'Analyzing additional sources…',
+				'Gathering more details…',
+				'Pulling in more context…',
+				'Expanding the search…',
+				'Rolling up my virtual sleeves…',
+				'Digging through the archives…',
+				'Putting on my reading glasses…',
+				'Checking under the digital couch cushions…',
+				'Consulting the oracle…',
+				'Asking a smarter algorithm…',
+			);
+		}
+		return array(
+			__( 'Searching harder…', 'jetpack-search-pkg' ),
+			__( 'Looking deeper into this…', 'jetpack-search-pkg' ),
+			__( 'Finding a more complete answer…', 'jetpack-search-pkg' ),
+			__( 'Analyzing additional sources…', 'jetpack-search-pkg' ),
+			__( 'Gathering more details…', 'jetpack-search-pkg' ),
+			__( 'Pulling in more context…', 'jetpack-search-pkg' ),
+			__( 'Expanding the search…', 'jetpack-search-pkg' ),
+			__( 'Rolling up my virtual sleeves…', 'jetpack-search-pkg' ),
+			__( 'Digging through the archives…', 'jetpack-search-pkg' ),
+			__( 'Putting on my reading glasses…', 'jetpack-search-pkg' ),
+			__( 'Checking under the digital couch cushions…', 'jetpack-search-pkg' ),
+			__( 'Consulting the oracle…', 'jetpack-search-pkg' ),
+			__( 'Asking a smarter algorithm…', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1316,6 +1316,14 @@ class Search_Blocks {
 			// flips off between SSR and hydration.
 			'aiAnswersEnabled'           => AI_Answers::is_enabled(),
 
+			// Localized rotating loading hints shown while the "Show more"
+			// extended AI answer streams. Lives on the top-level seed (not
+			// under `strings`) because the `strings` map is typed
+			// `array<string,string>` for Phan, and an `array<int,string>`
+			// value would break that contract — splitting it out keeps both
+			// surfaces strictly typed.
+			'aiExtendedLoadingHints'     => static::build_ai_extended_loading_hints(),
+
 			// Display labels for `wc_stock_status` selections, keyed by slug.
 			// Seeded from the status block's static option list so an active-
 			// filters chip for "instock" reads "In stock" rather than the raw
@@ -1554,7 +1562,6 @@ class Search_Blocks {
 	 * @return array<string, string>
 	 */
 	protected static function build_initial_strings(): array {
-		$ai_extended_loading_hints = static::build_ai_extended_loading_hints();
 		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
 			return array(
 				'searching'               => 'Searching…',
@@ -1573,7 +1580,6 @@ class Search_Blocks {
 				'suggestionLabelPost'     => 'Articles',
 				'aiErrorMessage'          => 'Sorry, an error occurred while generating an answer.',
 				'aiErrorCode'             => 'Error code: %s',
-				'aiExtendedLoadingHints'  => $ai_extended_loading_hints,
 			);
 		}
 		return array(
@@ -1608,7 +1614,6 @@ class Search_Blocks {
 			'aiErrorMessage'          => __( 'Sorry, an error occurred while generating an answer.', 'jetpack-search-pkg' ),
 			/* translators: %s: numeric error code. Surfaces the HTTP / JSON-RPC code that came back with the AI Answer failure, under the technical message. */
 			'aiErrorCode'             => __( 'Error code: %s', 'jetpack-search-pkg' ),
-			'aiExtendedLoadingHints'  => $ai_extended_loading_hints,
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -26,6 +26,7 @@ import {
 	cart,
 	category,
 	chevronUpDown,
+	commentContent,
 	currencyDollar,
 	customPostType,
 	filter,
@@ -54,6 +55,7 @@ const BRAND_FOREGROUND = '#069e08';
 const greened = src => ( { src, foreground: BRAND_FOREGROUND } );
 
 const BLOCK_ICONS = {
+	'jetpack-search/ai-answer': greened( commentContent ),
 	'jetpack-search/search-input': greened( search ),
 	'jetpack-search/search-results': greened( listView ),
 	'jetpack-search/results-list': greened( grid ),

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -20,6 +20,7 @@ import { getCategories, registerBlockType, setCategories } from '@wordpress/bloc
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import ActiveFiltersEdit from '../blocks/active-filters/edit';
+import AiAnswerEdit from '../blocks/ai-answer/edit';
 import ClearFiltersEdit from '../blocks/clear-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
@@ -48,6 +49,7 @@ import BLOCK_ICONS, { FILTER_CHECKBOX_VARIATION_ICONS } from './icons';
 const save = () => null;
 
 const BLOCKS = [
+	[ 'jetpack-search/ai-answer', AiAnswerEdit ],
 	[ 'jetpack-search/search-input', SearchInputEdit ],
 	[ 'jetpack-search/results-list', ResultsListEdit ],
 	[ 'jetpack-search/filter-checkbox', FilterCheckboxEdit ],

--- a/projects/packages/search/src/search-blocks/store/ai-stream.js
+++ b/projects/packages/search/src/search-blocks/store/ai-stream.js
@@ -1,0 +1,156 @@
+/**
+ * Server-Sent-Events streaming for the AI Answers endpoint.
+ *
+ * Wraps `fetchEventSource` against the WPCOM AI Agent's search summariser so
+ * the Interactivity store can drive the brief / extended response flow
+ * without inlining the SSE protocol details into every consumer. Mirrors the
+ * shape used by the instant-search overlay's `streamAiAnswer` so a single
+ * answer endpoint serves both surfaces.
+ */
+import { fetchEventSource } from '@microsoft/fetch-event-source';
+
+const ENDPOINT_URL =
+	'https://public-api.wordpress.com/wpcom/v2/ai/agent/jetpack-workflow-search_summarizer';
+
+const HTTP_STATUS_NAMES = {
+	400: 'Bad Request',
+	401: 'Unauthorized',
+	403: 'Forbidden',
+	404: 'Not Found',
+	429: 'Too Many Requests',
+	500: 'Internal Server Error',
+	502: 'Bad Gateway',
+	503: 'Service Unavailable',
+	504: 'Gateway Timeout',
+};
+
+/**
+ * Open a streaming AI answer request and route incoming events through the
+ * supplied callbacks. Returns nothing; callers manage the AbortController.
+ *
+ * The handlers are split rather than passing a single onEvent function so
+ * each store action stays a thin dispatcher over its own state keys without
+ * embedding SSE-protocol parsing in two places. Errors come through a single
+ * `onError({ message, code, source })` shape so the panel can render the same
+ * message regardless of whether the failure came from HTTP, the API payload,
+ * or the network.
+ *
+ * @param {object}             args               - Request args.
+ * @param {AbortController}    args.controller    - Caller-owned abort handle.
+ * @param {string}             args.query         - Search query text.
+ * @param {number|string}      args.siteId        - WPCOM site ID for the answer agent.
+ * @param {object}             args.filters       - Active filters payload passed through to the agent.
+ * @param {string}             args.locale        - BCP47 locale.
+ * @param {string}             args.homeUrl       - Public URL of the site.
+ * @param {'brief'|'extended'} args.format        - Which answer length to request.
+ * @param {string|null}        [args.sessionId]   - Session ID returned by an earlier brief call (so the extended
+ *                                                response can reuse context).
+ * @param {Function}           args.onDelta       - Called with each streamed token: `(textChunk)`.
+ * @param {Function}           args.onDone        - Called with the final citations array on completion.
+ * @param {Function}           args.onError       - Called once on any failure: `({ message, code, source })`.
+ * @param {Function}           [args.onSessionId] - Called with the session ID when the server emits it.
+ */
+export function streamAiAnswer( {
+	controller,
+	query,
+	siteId,
+	filters,
+	locale,
+	homeUrl,
+	format,
+	sessionId = null,
+	onDelta,
+	onDone,
+	onError,
+	onSessionId = null,
+} ) {
+	let httpError = null;
+
+	fetchEventSource( ENDPOINT_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify( {
+			jsonrpc: '2.0',
+			id: `req-${ format }`,
+			method: 'message/stream',
+			constructor_arguments: {},
+			params: {
+				...( sessionId ? { sessionId } : {} ),
+				message: {
+					role: 'user',
+					parts: [
+						{ type: 'text', text: query },
+						{
+							type: 'data',
+							data: {
+								clientContext: {
+									selectedSiteId: siteId,
+									site_url: homeUrl || '',
+									filters: filters || {},
+									locale: locale || 'en',
+									aiAnswersFormat: format,
+								},
+							},
+							metadata: {},
+						},
+					],
+					kind: 'message',
+					messageId: `msg-${ format }`,
+				},
+			},
+			tokenStreaming: true,
+		} ),
+		signal: controller.signal,
+		onopen: async response => {
+			if ( ! response.ok ) {
+				httpError = {
+					message: HTTP_STATUS_NAMES[ response.status ] || `HTTP ${ response.status }`,
+					code: response.status,
+					source: 'http',
+				};
+				throw new Error( `HTTP ${ response.status }` );
+			}
+		},
+		onmessage: event => {
+			try {
+				const data = JSON.parse( event.data );
+				if ( data.result?.sessionId && onSessionId ) {
+					onSessionId( data.result.sessionId );
+				}
+				if ( data.method === 'message/delta' && data.params?.delta?.deltaType === 'content' ) {
+					onDelta( data.params.delta.content ?? '' );
+				} else if (
+					data.result?.type === 'TaskStatusUpdateEvent' &&
+					data.result?.status?.state === 'completed'
+				) {
+					const parts = data.result.status.message?.parts || [];
+					const dataPart = parts.find( p => p.type === 'data' );
+					const citations = dataPart?.data?.sources || dataPart?.data?.strict_sources || [];
+					onDone( citations );
+				} else if ( data.result?.status?.state === 'failed' || data.error ) {
+					const textPart = data.result?.status?.message?.parts?.find( p => p.type === 'text' );
+					const message = data.error?.message || textPart?.text || 'Request failed';
+					const code = data.error?.code ?? null;
+					onError( { message, code, source: 'api' } );
+				}
+			} catch {
+				// Ignore unparseable events.
+			}
+		},
+		onerror: () => {
+			// `.catch()` below owns terminal error state so the httpError captured
+			// in onopen isn't overwritten between callbacks.
+			throw new Error( 'onerror' );
+		},
+	} ).catch( () => {
+		if ( ! controller.signal.aborted ) {
+			onError(
+				httpError ?? {
+					message: 'Network request error',
+					code: null,
+					source: 'network',
+				}
+			);
+		}
+	} );
+}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -66,8 +66,16 @@ const AI_EXTENDED_LOADING_HINTS = [
  * `state.aiExtendedLoadingHints` so a site that ships translated copy via
  * the PHP seed wins over the English defaults baked into the bundle.
  *
+ * Strips a trailing `…` (single character or three dots) before returning —
+ * the source strings end with one for the standalone overlay surface, but
+ * the embedded block already renders an animated three-dot ellipsis right
+ * after the hint, so a static ellipsis baked into the text reads as a
+ * doubled "Searching harder… ●●●". The source strings stay unchanged so
+ * the overlay (which doesn't render the animated dots adjacent to the
+ * label) keeps the existing translations.
+ *
  * @param {object} liveState - The IA store state.
- * @return {string} Loading hint.
+ * @return {string} Loading hint, with any trailing ellipsis stripped.
  */
 function pickExtendedLoadingHint( liveState ) {
 	const hints = Array.isArray( liveState.aiExtendedLoadingHints )
@@ -76,7 +84,8 @@ function pickExtendedLoadingHint( liveState ) {
 	if ( hints.length === 0 ) {
 		return '';
 	}
-	return hints[ Math.floor( Math.random() * hints.length ) ];
+	const raw = hints[ Math.floor( Math.random() * hints.length ) ];
+	return raw.replace( /(?:…|\.{3})\s*$/u, '' ).trimEnd();
 }
 
 /**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1,8 +1,11 @@
 import {
 	store,
 	getContext,
+	getElement,
 	withSyncEvent as originalWithSyncEvent,
 } from '@wordpress/interactivity';
+import { markdownToHtml } from '../../instant-search/lib/markdown';
+import { streamAiAnswer } from './ai-stream';
 import { buildSearchUrl, formatDateBucketLabel } from './api';
 import { bucketLabel, bucketValue } from './bucket-key';
 import { isEventInsidePopoverRoot } from './popover-events';
@@ -16,6 +19,77 @@ import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
 let initialized = false;
+
+// Abort handles for in-flight AI Answer requests. Module-scope so a
+// re-trigger from `actions.search()` can cancel the previous stream — the
+// fetch action would otherwise have no way to reach across action calls to
+// abort.
+let aiBriefController = null;
+let aiExtendedController = null;
+// Last query whose AI answer we kicked off, so re-runs of `actions.search()`
+// triggered by filter/sort changes don't re-spam the agent endpoint for the
+// same text. Mirrors the overlay's `prevProps.searchQuery` comparison.
+let aiLastQuery = null;
+// True when an `ai-answer` block has mounted on the page. Pages without one
+// shouldn't pay for an SSE round-trip on every search — the fetch is a no-op
+// for them. Flipped from the block's `data-wp-init` callback.
+let aiBlockPresent = false;
+
+// Playful rotating loading hints shown under the panel while the extended
+// answer is in flight. Mirrors the overlay copy verbatim so the two surfaces
+// read the same to a user who toggles between them.
+const AI_EXTENDED_LOADING_HINTS = [
+	'Searching harder…',
+	'Looking deeper into this…',
+	'Finding a more complete answer…',
+	'Analyzing additional sources…',
+	'Gathering more details…',
+	'Pulling in more context…',
+	'Expanding the search…',
+	'Rolling up my virtual sleeves…',
+	'Digging through the archives…',
+	'Putting on my reading glasses…',
+	'Checking under the digital couch cushions…',
+	'Consulting the oracle…',
+	'Asking a smarter algorithm…',
+];
+
+/**
+ * Pick a random extended-answer loading hint. Reads `state.strings.ai*` so a
+ * site that ships translated copy via the PHP seed wins over the English
+ * defaults baked into the bundle.
+ *
+ * @param {object} liveState - The IA store state.
+ * @return {string} Loading hint.
+ */
+function pickExtendedLoadingHint( liveState ) {
+	const hints = Array.isArray( liveState.strings?.aiExtendedLoadingHints )
+		? liveState.strings.aiExtendedLoadingHints
+		: AI_EXTENDED_LOADING_HINTS;
+	if ( hints.length === 0 ) {
+		return '';
+	}
+	return hints[ Math.floor( Math.random() * hints.length ) ];
+}
+
+/**
+ * Reset the brief/extended answer state slice. Pulled out so every entry
+ * point that clears the panel (new query, disabled flag flips, etc.) writes
+ * the same shape.
+ */
+function resetAiAnswerState() {
+	state.aiBriefStatus = 'idle';
+	state.aiBriefText = '';
+	state.aiBriefCitations = [];
+	state.aiBriefError = null;
+	state.aiExtendedStatus = 'idle';
+	state.aiExtendedText = '';
+	state.aiExtendedCitations = [];
+	state.aiExtendedError = null;
+	state.aiExtendedLoadingText = '';
+	state.aiShowExtended = false;
+	state.aiSessionId = null;
+}
 
 // `withSyncEvent` opts an action into reading synchronous event APIs
 // (`event.currentTarget`, `event.preventDefault()`) without the
@@ -489,6 +563,31 @@ const { state, actions } = store( NAMESPACE, {
 		// the currently checked option becomes the implicit default.
 		sortMenuFocusedKey: null,
 
+		// AI Answers state. The `jetpack-search/ai-answer` block renders a
+		// panel that streams a brief answer first and (optionally) a longer
+		// "Show more" follow-up. State is split into brief/extended slices so
+		// the show-more flow can run a second SSE request alongside the first
+		// without overwriting its body, then `aiShowExtended` flips reads to
+		// the longer slice. Mirrors the React class state in the overlay's
+		// `search-app.jsx` so a future single-source refactor can merge them.
+		aiBriefStatus: 'idle',
+		aiBriefText: '',
+		aiBriefCitations: [],
+		aiBriefError: null,
+		aiExtendedStatus: 'idle',
+		aiExtendedText: '',
+		aiExtendedCitations: [],
+		aiExtendedError: null,
+		aiExtendedLoadingText: '',
+		aiShowExtended: false,
+		aiSessionId: null,
+		// `aiAnswersEnabled` is intentionally NOT declared here — declaring a
+		// JS default for a PHP-seeded key would overwrite the seeded value at
+		// hydration time (the IA runtime treats the JS-side `state` object as
+		// a defaults bag whose keys win over the seed). The seed is the
+		// source of truth; consumers read `state.aiAnswersEnabled` and the
+		// proxy resolves it through to the hydrated value.
+
 		// `resultsCountText` lives on the seeded state (PHP-side), not as a
 		// getter, so the IA SSR pass can resolve `data-wp-text="state.resultsCountText"`
 		// to the right initial string on a deep-link load. See
@@ -711,6 +810,95 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			return checkboxFilterItems( state, filterKey, config );
 		},
+
+		// AI Answers — derived state for the `ai-answer` block bindings. All
+		// of these flip on `aiShowExtended`: while it's false the panel reads
+		// the brief slice, true (after the user clicks Show more) and it
+		// reads the extended slice. Defining the visible-* getters once here
+		// keeps the render.php template free of brief/extended branching.
+		get aiVisibleStatus() {
+			return state.aiShowExtended ? state.aiExtendedStatus : state.aiBriefStatus;
+		},
+		get aiVisibleText() {
+			return state.aiShowExtended ? state.aiExtendedText : state.aiBriefText;
+		},
+		get aiVisibleCitations() {
+			const list = state.aiShowExtended ? state.aiExtendedCitations : state.aiBriefCitations;
+			return list.map( ( { title, url } ) => ( {
+				title,
+				url,
+				// Pre-resolve href on the seeded list so a `data-wp-bind--href`
+				// directive can read a plain string instead of running the
+				// regex check inline (`data-wp-bind` evaluates simple property
+				// paths only, not expressions).
+				href: /^https?:\/\//i.test( url ) ? url : '#',
+			} ) );
+		},
+		get aiVisibleError() {
+			return state.aiShowExtended ? state.aiExtendedError : state.aiBriefError;
+		},
+
+		// Panel-level visibility. `aiPanelHidden` collapses the whole block
+		// to `hidden` until something interesting happens — idle, no answers
+		// enabled, or no query yet — so an empty page or a search-less /
+		// disabled site doesn't reserve a wrapper of padding/border.
+		get aiPanelHidden() {
+			return ! state.aiAnswersEnabled || state.aiVisibleStatus === 'idle';
+		},
+		get aiIsLoading() {
+			return state.aiVisibleStatus === 'loading';
+		},
+		get aiIsError() {
+			return state.aiVisibleStatus === 'error';
+		},
+		// True when the panel has a streaming or final answer to render —
+		// the content region (text + citations) is gated on this so an early
+		// `streaming` event doesn't blink the placeholder loading row off
+		// before the first token paints.
+		get aiHasContent() {
+			return state.aiVisibleStatus === 'streaming' || state.aiVisibleStatus === 'done';
+		},
+		get aiHasCitations() {
+			return state.aiVisibleStatus === 'done' && state.aiVisibleCitations.length > 0;
+		},
+		get aiShowExtendedButton() {
+			return state.aiBriefStatus === 'done' && ! state.aiShowExtended;
+		},
+		get aiExtendedLoadingHintShown() {
+			return (
+				state.aiShowExtended &&
+				( state.aiExtendedStatus === 'loading' || state.aiExtendedStatus === 'streaming' ) &&
+				!! state.aiExtendedLoadingText
+			);
+		},
+
+		// Error sub-fields. The panel surfaces a primary localized message
+		// plus the API/network detail and (when present) the HTTP/JSON-RPC
+		// error code. Splitting them here lets `data-wp-text` bind to plain
+		// strings instead of computing them in the template, and matches the
+		// React overlay's `error.message` + `error.code` shape.
+		get aiErrorPrimary() {
+			return (
+				state.strings?.aiErrorMessage ?? 'Sorry, an error occurred while generating an answer.'
+			);
+		},
+		get aiHasErrorDetail() {
+			return !! state.aiVisibleError?.message;
+		},
+		get aiErrorDetail() {
+			return state.aiVisibleError?.message ?? '';
+		},
+		get aiHasErrorCode() {
+			return state.aiVisibleError?.code != null;
+		},
+		get aiErrorCodeText() {
+			const code = state.aiVisibleError?.code;
+			if ( code == null ) {
+				return '';
+			}
+			const template = state.strings?.aiErrorCode ?? 'Error code: %s';
+			return template.replace( '%s', String( code ) );
+		},
 	},
 
 	actions: {
@@ -746,6 +934,15 @@ const { state, actions } = store( NAMESPACE, {
 			state.isLoadingMore = false;
 			state.hasError = false;
 			state.resultsCountText = computeResultsCountText( state );
+			// Kick the AI answer off alongside the results fetch, but only
+			// when an `ai-answer` block has mounted on the page — pages with
+			// just search-input + results-list shouldn't pay for an SSE
+			// round-trip whose output nothing on the page renders. The
+			// action also gates on enable-flag + query length + a same-query
+			// memo, so filter/sort-only re-calls don't re-spam the agent.
+			if ( aiBlockPresent ) {
+				actions.fetchAiAnswer();
+			}
 			try {
 				const data = yield* fetchResults( null );
 				// A newer `search()` started while this one was in-flight — its
@@ -1180,6 +1377,139 @@ const { state, actions } = store( NAMESPACE, {
 				state.sortMenuFocusedKey = null;
 			}
 		},
+
+		/**
+		 * Start a brief AI answer for the current `state.searchQuery`. Called
+		 * from inside `actions.search()`, so the answer always tracks the
+		 * results fetch.
+		 *
+		 * Bails when: `aiAnswersEnabled` is false (admin toggle disables the
+		 * feature); the query is shorter than 3 chars (matching the overlay
+		 * heuristic); or the query is the same one we already kicked off
+		 * (filter/sort re-triggers `search()` without changing the text, and
+		 * the agent response would be identical).
+		 *
+		 * Aborts any in-flight brief / extended stream from the previous
+		 * query before starting the new one so a slow earlier response can't
+		 * land on top of fresh state.
+		 */
+		fetchAiAnswer() {
+			if ( ! state.aiAnswersEnabled ) {
+				return;
+			}
+			const query = state.searchQuery;
+			if ( ! query || query.length < 3 ) {
+				// Tear down whatever's on screen — a query that dropped below
+				// the threshold (cleared input, deletion) should hide the
+				// panel, not freeze the last answer in place.
+				if ( aiBriefController ) {
+					aiBriefController.abort();
+					aiBriefController = null;
+				}
+				if ( aiExtendedController ) {
+					aiExtendedController.abort();
+					aiExtendedController = null;
+				}
+				resetAiAnswerState();
+				aiLastQuery = null;
+				return;
+			}
+			if ( query === aiLastQuery ) {
+				return;
+			}
+			aiLastQuery = query;
+
+			if ( aiBriefController ) {
+				aiBriefController.abort();
+			}
+			if ( aiExtendedController ) {
+				aiExtendedController.abort();
+				aiExtendedController = null;
+			}
+			aiBriefController = new AbortController();
+
+			resetAiAnswerState();
+			state.aiBriefStatus = 'loading';
+
+			streamAiAnswer( {
+				controller: aiBriefController,
+				query,
+				siteId: state.siteId,
+				filters: state.activeFilters,
+				locale: state.locale,
+				homeUrl: state.homeUrl,
+				format: 'brief',
+				onDelta: chunk => {
+					state.aiBriefStatus = 'streaming';
+					state.aiBriefText += chunk;
+				},
+				onDone: citations => {
+					state.aiBriefStatus = 'done';
+					state.aiBriefCitations = Array.isArray( citations ) ? citations : [];
+				},
+				onError: error => {
+					state.aiBriefStatus = 'error';
+					state.aiBriefError = error;
+				},
+				onSessionId: id => {
+					state.aiSessionId = id;
+				},
+			} );
+		},
+
+		/**
+		 * Trigger the longer "Show more" follow-up. Reuses the session ID the
+		 * brief response handed back so the agent can keep its earlier
+		 * context. No-ops if the brief answer hasn't finished — the brief
+		 * Show-more button is only rendered when `aiBriefStatus === 'done'`,
+		 * but a slow click after a re-fetch could still race the brief.
+		 */
+		showExtendedAiAnswer() {
+			if ( ! state.aiAnswersEnabled ) {
+				return;
+			}
+			if ( state.aiBriefStatus !== 'done' ) {
+				return;
+			}
+			const query = state.searchQuery;
+			if ( ! query || query.length < 3 ) {
+				return;
+			}
+			if ( aiExtendedController ) {
+				aiExtendedController.abort();
+			}
+			aiExtendedController = new AbortController();
+
+			state.aiShowExtended = true;
+			state.aiExtendedStatus = 'loading';
+			state.aiExtendedText = '';
+			state.aiExtendedCitations = [];
+			state.aiExtendedError = null;
+			state.aiExtendedLoadingText = pickExtendedLoadingHint( state );
+
+			streamAiAnswer( {
+				controller: aiExtendedController,
+				query,
+				siteId: state.siteId,
+				filters: state.activeFilters,
+				locale: state.locale,
+				homeUrl: state.homeUrl,
+				format: 'extended',
+				sessionId: state.aiSessionId,
+				onDelta: chunk => {
+					state.aiExtendedStatus = 'streaming';
+					state.aiExtendedText += chunk;
+				},
+				onDone: citations => {
+					state.aiExtendedStatus = 'done';
+					state.aiExtendedCitations = Array.isArray( citations ) ? citations : [];
+				},
+				onError: error => {
+					state.aiExtendedStatus = 'error';
+					state.aiExtendedError = error;
+				},
+			} );
+		},
 	},
 
 	callbacks: {
@@ -1234,6 +1564,45 @@ const { state, actions } = store( NAMESPACE, {
 				// spinner and also drop the skeleton, since no fetch is coming.
 				state.isLoading = false;
 				state.skeletonHidden = true;
+			}
+		},
+
+		/**
+		 * Fires when the `ai-answer` block mounts. Flips the module-scope
+		 * `aiBlockPresent` flag so `actions.search()` knows to dispatch the
+		 * AI fetch alongside the results fetch, and kicks off a first fetch
+		 * for the URL-seeded query so a deep-link load gets an answer
+		 * without the user re-submitting the search input.
+		 */
+		initializeAiAnswer() {
+			aiBlockPresent = true;
+			if ( state.searchQuery && state.searchQuery.length >= 3 ) {
+				actions.fetchAiAnswer();
+			}
+		},
+
+		/**
+		 * Render the AI answer markdown into the panel's content element via
+		 * `innerHTML`. The Interactivity API has no `data-wp-html` directive
+		 * (reactively setting innerHTML is intentionally not built in), so
+		 * the AI Answer block binds `data-wp-watch` to this callback and
+		 * lets the markdown→HTML render run imperatively. The reactive read
+		 * of `state.aiVisibleText` inside `markdownToHtml()` is what wires
+		 * the dependency tracking, so subsequent token writes re-fire it.
+		 *
+		 * Safe because `markdownToHtml()` escapes every text segment before
+		 * stitching in its own tag set — see the inline-format pass in
+		 * `instant-search/lib/markdown.js`.
+		 */
+		renderAiAnswerHtml() {
+			const element = getElement?.();
+			const ref = element?.ref;
+			if ( ! ref ) {
+				return;
+			}
+			const html = markdownToHtml( state.aiVisibleText );
+			if ( ref.innerHTML !== html ) {
+				ref.innerHTML = html;
 			}
 		},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -59,6 +59,8 @@ const AI_EXTENDED_LOADING_HINTS = [
 	'Checking under the digital couch cushions…',
 	'Consulting the oracle…',
 	'Asking a smarter algorithm…',
+	'Brewing a fresh batch of insights…',
+	'Unleashing the full power of search…',
 ];
 
 /**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -818,19 +818,46 @@ const { state, actions } = store( NAMESPACE, {
 			return checkboxFilterItems( state, filterKey, config );
 		},
 
-		// AI Answers — derived state for the `ai-answer` block bindings. All
-		// of these flip on `aiShowExtended`: while it's false the panel reads
-		// the brief slice, true (after the user clicks Show more) and it
-		// reads the extended slice. Defining the visible-* getters once here
-		// keeps the render.php template free of brief/extended branching.
+		// AI Answers — derived state for the `ai-answer` block bindings. The
+		// visible slice flips on `aiShowExtended` *and* on whether the
+		// extended response has actually finished: while extended is still
+		// `loading` or `streaming`, keep showing the brief content so the
+		// panel doesn't collapse to a "Finding an answer" placeholder for
+		// the few seconds it takes to come back. The extended-loading hint
+		// at the bottom of the panel provides the in-flight signal during
+		// that window; the content swap happens in one move when extended
+		// reaches `done`. Without this we get a visible "reset" on click
+		// (RSM-3591 in-review feedback).
 		get aiVisibleStatus() {
-			return state.aiShowExtended ? state.aiExtendedStatus : state.aiBriefStatus;
+			if ( ! state.aiShowExtended ) {
+				return state.aiBriefStatus;
+			}
+			// Extended error surfaces immediately — failures aren't worth
+			// hiding behind the brief content.
+			if ( state.aiExtendedStatus === 'error' ) {
+				return 'error';
+			}
+			// Once extended is done, fully swap to it.
+			if ( state.aiExtendedStatus === 'done' ) {
+				return 'done';
+			}
+			// Otherwise (extended is loading or streaming) hold the brief
+			// content visible — its status is already `done` at this point
+			// because `aiShowExtendedButton` only renders the trigger after
+			// the brief finishes.
+			return state.aiBriefStatus;
 		},
 		get aiVisibleText() {
-			return state.aiShowExtended ? state.aiExtendedText : state.aiBriefText;
+			if ( state.aiShowExtended && state.aiExtendedStatus === 'done' ) {
+				return state.aiExtendedText;
+			}
+			return state.aiBriefText;
 		},
 		get aiVisibleCitations() {
-			const list = state.aiShowExtended ? state.aiExtendedCitations : state.aiBriefCitations;
+			const list =
+				state.aiShowExtended && state.aiExtendedStatus === 'done'
+					? state.aiExtendedCitations
+					: state.aiBriefCitations;
 			return list.map( ( { title, url }, index ) => ( {
 				title,
 				url,
@@ -847,7 +874,13 @@ const { state, actions } = store( NAMESPACE, {
 			} ) );
 		},
 		get aiVisibleError() {
-			return state.aiShowExtended ? state.aiExtendedError : state.aiBriefError;
+			// Only surface the extended error once it actually failed, so a
+			// brief-stage error doesn't get masked by an extended slice
+			// that hasn't started yet.
+			if ( state.aiShowExtended && state.aiExtendedError ) {
+				return state.aiExtendedError;
+			}
+			return state.aiBriefError;
 		},
 
 		// Panel-level visibility. `aiPanelHidden` collapses the whole block

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -45,22 +45,27 @@ let aiBlockPresent = false;
 // Playful rotating loading hints shown under the panel while the extended
 // answer is in flight. Mirrors the overlay copy verbatim so the two surfaces
 // read the same to a user who toggles between them.
+// Source strings deliberately omit a trailing `…` — the block's render.php
+// emits an animated three-dot ellipsis right after the label so a static
+// one would read as a doubled "Searching harder… …". Mirrors the PHP-side
+// `Search_Blocks::build_ai_extended_loading_hints()` exactly so the two
+// surfaces share translation keys.
 const AI_EXTENDED_LOADING_HINTS = [
-	'Searching harder…',
-	'Looking deeper into this…',
-	'Finding a more complete answer…',
-	'Analyzing additional sources…',
-	'Gathering more details…',
-	'Pulling in more context…',
-	'Expanding the search…',
-	'Rolling up my virtual sleeves…',
-	'Digging through the archives…',
-	'Putting on my reading glasses…',
-	'Checking under the digital couch cushions…',
-	'Consulting the oracle…',
-	'Asking a smarter algorithm…',
-	'Brewing a fresh batch of insights…',
-	'Unleashing the full power of search…',
+	'Searching harder',
+	'Looking deeper into this',
+	'Finding a more complete answer',
+	'Analyzing additional sources',
+	'Gathering more details',
+	'Pulling in more context',
+	'Expanding the search',
+	'Rolling up my virtual sleeves',
+	'Digging through the archives',
+	'Putting on my reading glasses',
+	'Checking under the digital couch cushions',
+	'Consulting the oracle',
+	'Asking a smarter algorithm',
+	'Brewing a fresh batch of insights',
+	'Unleashing the full power of search',
 ];
 
 /**
@@ -68,16 +73,8 @@ const AI_EXTENDED_LOADING_HINTS = [
  * `state.aiExtendedLoadingHints` so a site that ships translated copy via
  * the PHP seed wins over the English defaults baked into the bundle.
  *
- * Strips a trailing `…` (single character or three dots) before returning —
- * the source strings end with one for the standalone overlay surface, but
- * the embedded block already renders an animated three-dot ellipsis right
- * after the hint, so a static ellipsis baked into the text reads as a
- * doubled "Searching harder… ●●●". The source strings stay unchanged so
- * the overlay (which doesn't render the animated dots adjacent to the
- * label) keeps the existing translations.
- *
  * @param {object} liveState - The IA store state.
- * @return {string} Loading hint, with any trailing ellipsis stripped.
+ * @return {string} Loading hint.
  */
 function pickExtendedLoadingHint( liveState ) {
 	const hints = Array.isArray( liveState.aiExtendedLoadingHints )
@@ -86,8 +83,7 @@ function pickExtendedLoadingHint( liveState ) {
 	if ( hints.length === 0 ) {
 		return '';
 	}
-	const raw = hints[ Math.floor( Math.random() * hints.length ) ];
-	return raw.replace( /(?:…|\.{3})\s*$/u, '' ).trimEnd();
+	return hints[ Math.floor( Math.random() * hints.length ) ];
 }
 
 /**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -33,6 +33,13 @@ let aiLastQuery = null;
 // True when an `ai-answer` block has mounted on the page. Pages without one
 // shouldn't pay for an SSE round-trip on every search — the fetch is a no-op
 // for them. Flipped from the block's `data-wp-init` callback.
+//
+// Intentionally never flipped back to `false`. The flag is per-page-load,
+// not per-mount: once an AI Answer block has been on screen during this
+// page, treat AI fetches as in-scope until the next full document load.
+// WordPress's Interactivity runtime isn't a SPA, so a virtual unmount that
+// keeps the document alive isn't a scenario today; if that changes, a
+// matching `cleanup` callback would need to clear this flag.
 let aiBlockPresent = false;
 
 // Playful rotating loading hints shown under the panel while the extended
@@ -55,16 +62,16 @@ const AI_EXTENDED_LOADING_HINTS = [
 ];
 
 /**
- * Pick a random extended-answer loading hint. Reads `state.strings.ai*` so a
- * site that ships translated copy via the PHP seed wins over the English
- * defaults baked into the bundle.
+ * Pick a random extended-answer loading hint. Reads
+ * `state.aiExtendedLoadingHints` so a site that ships translated copy via
+ * the PHP seed wins over the English defaults baked into the bundle.
  *
  * @param {object} liveState - The IA store state.
  * @return {string} Loading hint.
  */
 function pickExtendedLoadingHint( liveState ) {
-	const hints = Array.isArray( liveState.strings?.aiExtendedLoadingHints )
-		? liveState.strings.aiExtendedLoadingHints
+	const hints = Array.isArray( liveState.aiExtendedLoadingHints )
+		? liveState.aiExtendedLoadingHints
 		: AI_EXTENDED_LOADING_HINTS;
 	if ( hints.length === 0 ) {
 		return '';
@@ -824,7 +831,7 @@ const { state, actions } = store( NAMESPACE, {
 		},
 		get aiVisibleCitations() {
 			const list = state.aiShowExtended ? state.aiExtendedCitations : state.aiBriefCitations;
-			return list.map( ( { title, url } ) => ( {
+			return list.map( ( { title, url }, index ) => ( {
 				title,
 				url,
 				// Pre-resolve href on the seeded list so a `data-wp-bind--href`
@@ -832,6 +839,11 @@ const { state, actions } = store( NAMESPACE, {
 				// regex check inline (`data-wp-bind` evaluates simple property
 				// paths only, not expressions).
 				href: /^https?:\/\//i.test( url ) ? url : '#',
+				// `index`-prefixed key so a duplicate URL in the agent's
+				// citation list doesn't collide on the IA `data-wp-each --key`
+				// dedupe pass — the runtime would silently drop a duplicate
+				// without it.
+				key: `${ index }-${ url }`,
 			} ) );
 		},
 		get aiVisibleError() {

--- a/projects/packages/search/tests/js/search-blocks/ai-answer-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/ai-answer-edit.test.jsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import AiAnswerEdit from '../../../src/search-blocks/blocks/ai-answer/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: props => ( { ...props, className: props?.className } ),
+	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { title, children } ) => (
+		<section data-testid="panel" aria-label={ title }>
+			{ children }
+		</section>
+	),
+	ToggleControl: ( { label, checked, onChange } ) => {
+		const id = `toggle-${ String( label ).toLowerCase().replace( /\s+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="checkbox"
+					checked={ !! checked }
+					onChange={ event => onChange( event.target.checked ) }
+				/>
+			</>
+		);
+	},
+	TextControl: ( { label, value, onChange, placeholder } ) => {
+		const id = `text-${ String( label ).toLowerCase().replace( /\s+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="text"
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ event => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
+} ) );
+
+describe( 'AiAnswerEdit', () => {
+	it( 'renders the default heading when none is set', () => {
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+		expect( screen.getByText( 'AI answer' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a custom heading when set', () => {
+		render( <AiAnswerEdit attributes={ { heading: 'Summary' } } setAttributes={ () => {} } /> );
+		expect( screen.getByText( 'Summary' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows sample citations by default', () => {
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+		// First sample citation's title — its presence stands in for the
+		// whole citations list since the preview owns the fixture data.
+		expect( screen.getByText( 'Getting started with WordPress' ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits citations when showCitations is false', () => {
+		render( <AiAnswerEdit attributes={ { showCitations: false } } setAttributes={ () => {} } /> );
+		expect( screen.queryByText( 'Getting started with WordPress' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the Show more button by default', () => {
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+		expect( screen.getByText( 'Show more' ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits the Show more button when enableShowMore is false', () => {
+		render( <AiAnswerEdit attributes={ { enableShowMore: false } } setAttributes={ () => {} } /> );
+		expect( screen.queryByText( 'Show more' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls setAttributes when the heading input changes', () => {
+		const setAttributes = jest.fn();
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ setAttributes } /> );
+		// `fireEvent.change` over `userEvent.type` here because the mocked
+		// `TextControl` fires `onChange` once with the full value (matching
+		// how Gutenberg's real component behaves), whereas `userEvent.type`
+		// would fire one event per character and the assertion would only
+		// see the last character.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.change( screen.getByLabelText( 'Heading' ), {
+			target: { value: 'Quick reply' },
+		} );
+		expect( setAttributes ).toHaveBeenCalledWith( { heading: 'Quick reply' } );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
@@ -1,0 +1,250 @@
+/**
+ * Tests for the AI Answers slice of the shared Search blocks store: state
+ * derivation, the brief-fetch action's same-query memo, the abort-on-clear
+ * path, and the brief → extended hand-off.
+ */
+
+// Capture the store config the way the existing store.test.js does so we can
+// drive its actions / read its state from the test runtime.
+const captured = {
+	state: {},
+	actions: {},
+	callbacks: {},
+	context: {},
+};
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const descriptors = Object.getOwnPropertyDescriptors( config.state || {} );
+				for ( const key of Object.keys( descriptors ) ) {
+					Object.defineProperty( captured.state, key, descriptors[ key ] );
+				}
+				Object.assign( captured.actions, config.actions || {} );
+				Object.assign( captured.callbacks, config.callbacks || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+		getContext: () => captured.context,
+		getElement: () => ( { ref: null } ),
+	} ),
+	{ virtual: true }
+);
+
+// Mock the SSE module so no real network calls are made — capture every
+// invocation so the test can inspect arguments and fire fake events back
+// through the callbacks.
+const mockStreamAiAnswer = jest.fn();
+jest.mock( '../../../src/search-blocks/store/ai-stream', () => ( {
+	streamAiAnswer: ( ...args ) => mockStreamAiAnswer( ...args ),
+} ) );
+
+import { actions, state } from '../../../src/search-blocks/store';
+
+/**
+ * Pull the args object the store handed to the most recent SSE call so the
+ * test can fire fake events back through the callbacks it captured.
+ *
+ * @return {object} Args of the most recent `streamAiAnswer` invocation.
+ */
+function lastStreamCall() {
+	return mockStreamAiAnswer.mock.calls.at( -1 )[ 0 ];
+}
+
+describe( 'AI Answers store slice', () => {
+	beforeEach( () => {
+		mockStreamAiAnswer.mockReset();
+		state.aiAnswersEnabled = true;
+		state.searchQuery = '';
+		state.siteId = 42;
+		state.locale = 'en-US';
+		state.homeUrl = 'https://example.com';
+		state.activeFilters = {};
+		actions.fetchAiAnswer();
+		mockStreamAiAnswer.mockReset();
+		// Reset slice manually after the bail-on-short-query reset above.
+		state.aiBriefStatus = 'idle';
+		state.aiBriefText = '';
+		state.aiBriefCitations = [];
+		state.aiBriefError = null;
+		state.aiExtendedStatus = 'idle';
+		state.aiExtendedText = '';
+		state.aiExtendedCitations = [];
+		state.aiExtendedError = null;
+		state.aiExtendedLoadingText = '';
+		state.aiShowExtended = false;
+		state.aiSessionId = null;
+	} );
+
+	it( 'aiPanelHidden is true when aiAnswersEnabled is false', () => {
+		state.aiAnswersEnabled = false;
+		state.aiBriefStatus = 'streaming';
+		expect( state.aiPanelHidden ).toBe( true );
+	} );
+
+	it( 'aiPanelHidden is true when status is idle', () => {
+		state.aiAnswersEnabled = true;
+		state.aiBriefStatus = 'idle';
+		expect( state.aiPanelHidden ).toBe( true );
+	} );
+
+	it( 'aiPanelHidden is false once a fetch is in flight', () => {
+		state.aiBriefStatus = 'loading';
+		expect( state.aiPanelHidden ).toBe( false );
+	} );
+
+	it( 'visible-* getters flip from brief to extended on aiShowExtended', () => {
+		state.aiBriefText = 'short';
+		state.aiBriefCitations = [ { title: 'A', url: 'https://a' } ];
+		state.aiBriefStatus = 'done';
+		state.aiExtendedText = 'long';
+		state.aiExtendedCitations = [ { title: 'B', url: 'https://b' } ];
+		state.aiExtendedStatus = 'streaming';
+
+		expect( state.aiVisibleText ).toBe( 'short' );
+		expect( state.aiVisibleCitations ).toHaveLength( 1 );
+		expect( state.aiVisibleCitations[ 0 ].title ).toBe( 'A' );
+
+		state.aiShowExtended = true;
+
+		expect( state.aiVisibleText ).toBe( 'long' );
+		expect( state.aiVisibleStatus ).toBe( 'streaming' );
+		expect( state.aiVisibleCitations[ 0 ].title ).toBe( 'B' );
+	} );
+
+	it( 'aiVisibleCitations marks non-http hrefs as `#` so a bad URL never lands on a `data-wp-bind--href`', () => {
+		state.aiBriefCitations = [
+			{ title: 'Safe', url: 'https://example.com/safe' },
+			{ title: 'Sketchy', url: 'javascript:alert(1)' },
+		];
+		state.aiBriefStatus = 'done';
+		const list = state.aiVisibleCitations;
+		expect( list[ 0 ].href ).toBe( 'https://example.com/safe' );
+		expect( list[ 1 ].href ).toBe( '#' );
+	} );
+
+	it( 'fetchAiAnswer bails when aiAnswersEnabled is false', () => {
+		state.aiAnswersEnabled = false;
+		state.searchQuery = 'something long enough';
+		actions.fetchAiAnswer();
+		expect( mockStreamAiAnswer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetchAiAnswer bails when query is shorter than 3 characters', () => {
+		state.searchQuery = 'ai';
+		actions.fetchAiAnswer();
+		expect( mockStreamAiAnswer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetchAiAnswer dedups when called twice for the same query', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		actions.fetchAiAnswer();
+		expect( mockStreamAiAnswer ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'fetchAiAnswer streams updates state.aiBriefStatus and aiBriefText', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		const call = lastStreamCall();
+		expect( call.format ).toBe( 'brief' );
+		expect( state.aiBriefStatus ).toBe( 'loading' );
+
+		call.onDelta( 'Hello ' );
+		expect( state.aiBriefStatus ).toBe( 'streaming' );
+		expect( state.aiBriefText ).toBe( 'Hello ' );
+
+		call.onDelta( 'world.' );
+		expect( state.aiBriefText ).toBe( 'Hello world.' );
+
+		call.onDone( [ { title: 'Source A', url: 'https://example.com/a' } ] );
+		expect( state.aiBriefStatus ).toBe( 'done' );
+		expect( state.aiBriefCitations ).toHaveLength( 1 );
+	} );
+
+	it( 'fetchAiAnswer routes errors to state.aiBriefError', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		const call = lastStreamCall();
+		call.onError( { message: 'Bad Gateway', code: 502, source: 'http' } );
+		expect( state.aiBriefStatus ).toBe( 'error' );
+		expect( state.aiBriefError ).toEqual( {
+			message: 'Bad Gateway',
+			code: 502,
+			source: 'http',
+		} );
+	} );
+
+	it( 'fetchAiAnswer captures the session ID for the extended follow-up', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		lastStreamCall().onSessionId( 'sess-123' );
+		expect( state.aiSessionId ).toBe( 'sess-123' );
+	} );
+
+	it( 'showExtendedAiAnswer kicks off a second stream with the captured sessionId', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		const briefCall = lastStreamCall();
+		briefCall.onSessionId( 'sess-xyz' );
+		briefCall.onDone( [] );
+		expect( state.aiBriefStatus ).toBe( 'done' );
+
+		actions.showExtendedAiAnswer();
+		const extendedCall = lastStreamCall();
+		expect( extendedCall.format ).toBe( 'extended' );
+		expect( extendedCall.sessionId ).toBe( 'sess-xyz' );
+		expect( state.aiShowExtended ).toBe( true );
+		expect( state.aiExtendedStatus ).toBe( 'loading' );
+		expect( typeof state.aiExtendedLoadingText ).toBe( 'string' );
+		expect( state.aiExtendedLoadingText.length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'showExtendedAiAnswer is a no-op until the brief response has finished', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		mockStreamAiAnswer.mockReset();
+		actions.showExtendedAiAnswer();
+		expect( mockStreamAiAnswer ).not.toHaveBeenCalled();
+		expect( state.aiShowExtended ).toBe( false );
+	} );
+
+	it( 'aiShowExtendedButton is true only when brief is done and extended has not started', () => {
+		state.aiBriefStatus = 'streaming';
+		expect( state.aiShowExtendedButton ).toBe( false );
+		state.aiBriefStatus = 'done';
+		expect( state.aiShowExtendedButton ).toBe( true );
+		state.aiShowExtended = true;
+		expect( state.aiShowExtendedButton ).toBe( false );
+	} );
+
+	it( 'aiErrorCodeText formats the code with the localized template', () => {
+		state.strings = { aiErrorCode: 'Error code: %s' };
+		state.aiBriefStatus = 'error';
+		state.aiBriefError = { message: 'Bad Gateway', code: 502, source: 'http' };
+		expect( state.aiErrorCodeText ).toBe( 'Error code: 502' );
+		expect( state.aiHasErrorCode ).toBe( true );
+	} );
+
+	it( 'aiHasErrorCode is false when the agent returns no numeric code', () => {
+		state.aiBriefStatus = 'error';
+		state.aiBriefError = { message: 'Network request error', code: null, source: 'network' };
+		expect( state.aiHasErrorCode ).toBe( false );
+		expect( state.aiHasErrorDetail ).toBe( true );
+	} );
+
+	it( 'clearing the query mid-stream resets the panel state', () => {
+		state.searchQuery = 'tabby cats';
+		actions.fetchAiAnswer();
+		lastStreamCall().onDelta( 'partial' );
+		expect( state.aiBriefStatus ).toBe( 'streaming' );
+
+		state.searchQuery = '';
+		actions.fetchAiAnswer();
+
+		expect( state.aiBriefStatus ).toBe( 'idle' );
+		expect( state.aiBriefText ).toBe( '' );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
@@ -224,6 +224,24 @@ describe( 'AI Answers store slice', () => {
 		expect( state.aiExtendedStatus ).toBe( 'loading' );
 		expect( typeof state.aiExtendedLoadingText ).toBe( 'string' );
 		expect( state.aiExtendedLoadingText.length ).toBeGreaterThan( 0 );
+		// Strip the trailing ellipsis — the animated dots after the text
+		// already signal "in progress".
+		expect( state.aiExtendedLoadingText ).not.toMatch( /…\s*$/ );
+		expect( state.aiExtendedLoadingText ).not.toMatch( /\.{3}\s*$/ );
+	} );
+
+	it( 'showExtendedAiAnswer falls back to a curated hint set when the seed is missing', () => {
+		state.searchQuery = 'tabby cats';
+		state.aiExtendedLoadingHints = undefined;
+		actions.fetchAiAnswer();
+		const briefCall = lastStreamCall();
+		briefCall.onDone( [] );
+		actions.showExtendedAiAnswer();
+		// Even with the JS-side fallback (which keeps the ellipsis in the
+		// source string for the overlay's separate use), the picked hint
+		// must be trimmed.
+		expect( state.aiExtendedLoadingText.length ).toBeGreaterThan( 0 );
+		expect( state.aiExtendedLoadingText ).not.toMatch( /…\s*$/ );
 	} );
 
 	it( 'showExtendedAiAnswer is a no-op until the brief response has finished', () => {

--- a/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
@@ -95,23 +95,47 @@ describe( 'AI Answers store slice', () => {
 		expect( state.aiPanelHidden ).toBe( false );
 	} );
 
-	it( 'visible-* getters flip from brief to extended on aiShowExtended', () => {
+	it( 'visible-* getters hold the brief while extended is still loading/streaming, then swap on done', () => {
 		state.aiBriefText = 'short';
 		state.aiBriefCitations = [ { title: 'A', url: 'https://a' } ];
 		state.aiBriefStatus = 'done';
 		state.aiExtendedText = 'long';
 		state.aiExtendedCitations = [ { title: 'B', url: 'https://b' } ];
-		state.aiExtendedStatus = 'streaming';
+		state.aiExtendedStatus = 'loading';
 
+		// Pre-click: brief drives the visible slice.
 		expect( state.aiVisibleText ).toBe( 'short' );
-		expect( state.aiVisibleCitations ).toHaveLength( 1 );
+		expect( state.aiVisibleStatus ).toBe( 'done' );
 		expect( state.aiVisibleCitations[ 0 ].title ).toBe( 'A' );
 
+		// User clicks Show more → extended is loading, but the panel must
+		// keep showing the brief so it doesn't collapse to a "Finding an
+		// answer" placeholder (the bug that prompted this test).
 		state.aiShowExtended = true;
+		expect( state.aiVisibleText ).toBe( 'short' );
+		expect( state.aiVisibleStatus ).toBe( 'done' );
+		expect( state.aiVisibleCitations[ 0 ].title ).toBe( 'A' );
 
+		// Extended now streaming — still brief content, status still done.
+		state.aiExtendedStatus = 'streaming';
+		expect( state.aiVisibleText ).toBe( 'short' );
+		expect( state.aiVisibleStatus ).toBe( 'done' );
+
+		// Extended finishes — one clean swap to the longer answer.
+		state.aiExtendedStatus = 'done';
 		expect( state.aiVisibleText ).toBe( 'long' );
-		expect( state.aiVisibleStatus ).toBe( 'streaming' );
+		expect( state.aiVisibleStatus ).toBe( 'done' );
 		expect( state.aiVisibleCitations[ 0 ].title ).toBe( 'B' );
+	} );
+
+	it( 'aiVisibleStatus surfaces an extended error immediately rather than masking it with the brief', () => {
+		state.aiBriefText = 'short';
+		state.aiBriefStatus = 'done';
+		state.aiShowExtended = true;
+		state.aiExtendedError = { message: 'Bad Gateway', code: 502, source: 'http' };
+		state.aiExtendedStatus = 'error';
+		expect( state.aiVisibleStatus ).toBe( 'error' );
+		expect( state.aiVisibleError.code ).toBe( 502 );
 	} );
 
 	it( 'aiVisibleCitations marks non-http hrefs as `#` so a bad URL never lands on a `data-wp-bind--href`', () => {

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -128,10 +128,15 @@ class Ai_Answer_Render_Test extends TestCase {
 		$markup = $this->render();
 		// The panel binds to `state.aiPanelHidden` and also carries the bare
 		// `hidden` attribute so server-rendered visitors never see the
-		// scaffold before hydration. Use a regex so whitespace around the
-		// attribute (tabs / newlines between `aria-live=` and `hidden`) is
-		// allowed to vary without breaking the assertion.
+		// scaffold before hydration. `preg_match` rather than
+		// `assertMatchesRegularExpression` because the latter was added in
+		// PHPUnit 9.1, and the PHP 7.2 CI matrix still runs an older
+		// PHPUnit that doesn't ship the method.
 		$this->assertStringContainsString( 'data-wp-bind--hidden="state.aiPanelHidden"', $markup );
-		$this->assertMatchesRegularExpression( '/aria-live="polite"\s+hidden\s*>/', $markup );
+		$this->assertSame(
+			1,
+			preg_match( '/aria-live="polite"\s+hidden\s*>/', $markup ),
+			'Expected the rendered wrapper to carry a bare `hidden` attribute right after `aria-live="polite"`.'
+		);
 	}
 }

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * AI Answer block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the ai-answer block's render template.
+ *
+ * Asserts that render output is gated by `AI_Answers::is_enabled()`, and that
+ * the attribute-driven affordances (heading, citations region, Show-more
+ * button) appear / disappear in the markup the way the front-end consumer
+ * expects.
+ */
+class Ai_Answer_Render_Test extends TestCase {
+
+	/**
+	 * Register the ai-answer block inline so `do_blocks()` can resolve it
+	 * without depending on `build/` artifacts referenced by block.json.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			'jetpack-search/ai-answer',
+			array(
+				'attributes'      => array(
+					'heading'        => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'showCitations'  => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'enableShowMore' => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+				),
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/ai-answer/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack-search/ai-answer' );
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+	}
+
+	protected function tearDown(): void {
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Render the ai-answer block via `do_blocks()`.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack-search/ai-answer ' . $json . ' /-->' );
+	}
+
+	public function test_disabled_renders_nothing() {
+		update_option( 'jetpack_search_ai_answers_enabled', false );
+		$markup = $this->render();
+		$this->assertSame( '', trim( $markup ) );
+	}
+
+	public function test_enabled_renders_panel_wrapper() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+	}
+
+	public function test_default_heading_is_ai_answer() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'AI answer', $markup );
+	}
+
+	public function test_custom_heading_overrides_default() {
+		$markup = $this->render( array( 'heading' => 'Quick summary' ) );
+		$this->assertStringContainsString( 'Quick summary', $markup );
+		$this->assertStringNotContainsString( '>AI answer<', $markup );
+	}
+
+	public function test_show_citations_true_renders_citations_list() {
+		$markup = $this->render( array( 'showCitations' => true ) );
+		$this->assertStringContainsString( 'jp-search-answers-panel__citations', $markup );
+	}
+
+	public function test_show_citations_false_omits_citations_list() {
+		$markup = $this->render( array( 'showCitations' => false ) );
+		$this->assertStringNotContainsString( 'jp-search-answers-panel__citations', $markup );
+	}
+
+	public function test_enable_show_more_true_renders_button() {
+		$markup = $this->render( array( 'enableShowMore' => true ) );
+		$this->assertStringContainsString( 'jp-search-answers-panel__toggle', $markup );
+		$this->assertStringContainsString( 'actions.showExtendedAiAnswer', $markup );
+	}
+
+	public function test_enable_show_more_false_omits_button() {
+		$markup = $this->render( array( 'enableShowMore' => false ) );
+		$this->assertStringNotContainsString( 'jp-search-answers-panel__toggle', $markup );
+		$this->assertStringNotContainsString( 'showExtendedAiAnswer', $markup );
+	}
+
+	public function test_panel_is_hidden_until_status_changes() {
+		$markup = $this->render();
+		// The panel binds to `state.aiPanelHidden` and also carries the bare
+		// `hidden` attribute so server-rendered visitors never see the
+		// scaffold before hydration. Use a regex so whitespace around the
+		// attribute (tabs / newlines between `aria-live=` and `hidden`) is
+		// allowed to vary without breaking the assertion.
+		$this->assertStringContainsString( 'data-wp-bind--hidden="state.aiPanelHidden"', $markup );
+		$this->assertMatchesRegularExpression( '/aria-live="polite"\s+hidden\s*>/', $markup );
+	}
+}


### PR DESCRIPTION
Fixes [RSM-3591](https://linear.app/a8c/issue/RSM-3591/search-30-ai-answer-block-for-embedded-search-template).

## Why

Before this PR the Jetpack Search AI Answers panel only rendered inside the instant-search overlay. Authors using the Search 3.0 embedded template (the block-rendered results page) had no way to surface it.

This adds a new `jetpack-search/ai-answer` block authors can insert anywhere — above results, inside a sidebar column, in a custom landing pattern — and get the same loading → streaming → citations → "Show more" → extended-answer experience as the overlay.

## Proposed changes

* New `jetpack-search/ai-answer` block under `projects/packages/search/src/search-blocks/blocks/ai-answer/` (`block.json`, `edit.js`, `render.php`, `view.js`, `style.scss`), registered automatically by the existing block-discovery walker and listed in the inserter under the **Search** category.
* Shared `jetpack-search/store` (`search-blocks/store/index.js`) gains the AI Answers state slice (`aiBriefStatus / aiBriefText / aiBriefCitations / aiBriefError`, plus the matching `aiExtended*` slice and `aiShowExtended / aiSessionId / aiExtendedLoadingText`), derived getters (`aiPanelHidden`, `aiVisibleStatus`, `aiVisibleText`, `aiVisibleCitations`, `aiShowExtendedButton`, `aiExtendedLoadingHintShown`, `aiError*`), and the `fetchAiAnswer` / `showExtendedAiAnswer` actions.
* SSE call extracted into `search-blocks/store/ai-stream.js` so a future AI surface only needs a new caller — the protocol details aren't redeclared at each site.
* Server-side gate via `AI_Answers::is_enabled()`: render.php returns an empty string when the option is off, so the panel disappears at SSR even for saved posts that still carry the block.
* `aiAnswersEnabled` seeded into the Interactivity state by `Search_Blocks::build_initial_state()`; the JS store reads it directly without redeclaring a default that would clobber the seed at hydration time.
* AI fetches only fire when the AI Answer block has actually mounted — `data-wp-init="callbacks.initializeAiAnswer"` flips a module flag the `search()` action consults, so pages without the block don't pay for an SSE round-trip.
* `markdownToHtml` (reused from `instant-search/lib/markdown.js`) renders the streaming markdown body via a `data-wp-watch` callback that imperatively sets `innerHTML` — there's no built-in `data-wp-html` directive.
* Editor preview mirrors the front-end shape (heading + sample answer + citations + Show-more button) with Inspector controls for heading, citations toggle, and extended-answer toggle.
* Tests: PHP render gating + attribute affordances (9 tests, `Ai_Answer_Render_Test.php`); JS unit tests for the store slice — status transitions, error / session-ID hand-off, query memo, cleared-query reset (17 tests, `ai-answers-store.test.js`); editor preview (7 tests, `ai-answer-edit.test.jsx`).
* Size-limit entry for `ai-answer.js` so a regression that re-inlines the shared store trips CI.

## Related product discussion/links

* Linear: [RSM-3591](https://linear.app/a8c/issue/RSM-3591/search-30-ai-answer-block-for-embedded-search-template) (project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586))

## Does this pull request change what data or activity we track or use?

No. The block reuses the existing `POST https://public-api.wordpress.com/wpcom/v2/ai/agent/jetpack-workflow-search_summarizer` SSE endpoint that the instant-search overlay already calls — same request shape (jsonrpc 2.0, `clientContext` carrying site ID + filters + locale + format), same site/query/filter payload. No new endpoint, no new tracking event, no new option key (reuses `jetpack_search_ai_answers_enabled`).

## Screenshots

Captured at `/rsm-3591-ai-answer-block-fixture/?q=wordpress` against the local raven docker env (`https://jp-raven.jurassic.tube/`) at 1440×900.

| Before (trunk — block not registered, renders nothing) | After (this PR — panel streams above results) |
|---|---|
| ![before](https://github.com/user-attachments/assets/aba9c2d8-4ca7-410a-8fee-b8255ef72f58) | ![after](https://github.com/user-attachments/assets/8cfd3c25-bfc5-4f86-884c-9e5451143917) |

## Testing instructions

1. Build the matrix: `pnpm jetpack build packages/my-jetpack && pnpm jetpack build plugins/jetpack && pnpm jetpack build packages/search && pnpm jetpack build plugins/search`.
2. Bring up any docker / Jurassic Ninja env with this branch installed.
3. Enable AI Answers on the site: `wp option update jetpack_search_ai_answers_enabled 1`.
4. Create a page with the embedded-search template plus the new block. Quickest path: paste the block markup below into a new page and publish.
   ```
   <!-- wp:jetpack-search/search-input /-->
   <!-- wp:jetpack-search/ai-answer /-->
   <!-- wp:jetpack-search/search-results -->
   <!-- wp:jetpack-search/results-list /-->
   <!-- /wp:jetpack-search/search-results -->
   ```
5. Visit the page with a search query, e.g. `/<your-page-slug>/?q=wordpress` (Jetpack Search uses `?q=` on non-search pages; the WP search route uses `?s=`).

Verify each of the issue's acceptance criteria:

- [ ] `jetpack-search/ai-answer` appears in the inserter under the Search category with the speech-bubble icon, sample editor preview, and Inspector controls for heading / citations / Show more.
- [ ] On the published page, the panel renders: "Finding an answer" loading row → streaming markdown body → "done" state with a citations list (if the agent returned sources).
- [ ] Clicking **Show more** loads the extended answer, swaps the visible body, and the rotating loading hint ("Searching harder…", "Looking deeper into this…", …) shows during the second stream. The session ID from the brief call is reused (inspect a `params.sessionId` on the second SSE request to confirm).
- [ ] Toggle `jetpack_search_ai_answers_enabled` off (`wp option update jetpack_search_ai_answers_enabled 0`) and reload — the block disappears entirely from the rendered page (`curl -s '<url>' | grep wp-block-jetpack-search-ai-answer` should return no matches).
- [ ] Network errors / HTTP failures from the agent endpoint surface in the panel's error state with the right code/message (simulate by blocking `public-api.wordpress.com` in DevTools or via `dnsmasq`).
- [ ] Run `pnpm --filter @automattic/jetpack-search test-size`. The `build/search-blocks/ai-answer.js` bundle should be ~240 B (a regression that re-inlines the shared store would push it past the 3 KiB limit).
- [ ] Existing instant-search overlay AI Answers panel still works on a search page that does not have the new block.
- [ ] `composer phpunit -- --filter Ai_Answer_Render_Test` passes (9 tests).
- [ ] `npx jest tests/js/search-blocks/ai-answer-edit.test.jsx tests/js/search-blocks/ai-answers-store.test.js` passes (24 tests).
