### PR TITLE
Search Blocks: experimental opt-in to render the Search blocks template as the overlay (SEARCH-206)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-206-block-template-overlay
+++ b/projects/packages/search/changelog/SEARCH-206-block-template-overlay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: Add experimental opt-in to replace the legacy instant-search overlay with the server-rendered Search blocks template; gated behind the `jetpack_search_overlay_block_template_enabled` filter (default false).

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -147,6 +147,15 @@ class Initializer {
 		// so their callback runs after this default.
 		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' );
 		Search_Blocks::init();
+
+		// When the experimental block-template overlay is on, the legacy
+		// instant-search overlay must not boot — both would otherwise own
+		// `?s=`, popstate, and the overlay-trigger selectors. Skipping at
+		// the init filter is cleaner than dequeuing the preact bundle after
+		// it's been enqueued.
+		if ( Search_Blocks::is_block_template_overlay_enabled() ) {
+			add_filter( 'jetpack_search_init_instant_search', '__return_false' );
+		}
 	}
 
 	/**

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -76,6 +76,17 @@ class Initializer {
 
 		// Initialize search package.
 		if ( ! static::init_search( $blog_id ) ) {
+			// The block-template overlay path provides the search UI via
+			// `Search_Blocks` rather than the legacy instant/classic
+			// experiences, so `init_search()` legitimately returns falsy
+			// (both branches are skipped) without being an abort. Without
+			// this carve-out, the legacy `jetpack_search_abort` action
+			// would fire and `jetpack_search_loaded` would not — which
+			// would silently break anything hooked to the loaded action.
+			if ( Search_Blocks::is_block_template_overlay_enabled() ) {
+				do_action( 'jetpack_search_loaded' );
+				return;
+			}
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
 			do_action( 'jetpack_search_abort', 'jetpack_search_init_search', null );
 			return;

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -15,6 +15,22 @@ use WP_Error;
 class Initializer {
 
 	/**
+	 * Whether the experimental block-template overlay path has been wired
+	 * up this request. Set to `true` at the end of `init_search_blocks()`
+	 * only when BOTH the `jetpack_search_blocks_enabled` gate AND the
+	 * `jetpack_search_overlay_block_template_enabled` gate are on — never
+	 * by the overlay filter alone. `init()` reads this to decide whether
+	 * `init_search()` returning falsy is a real failure or a no-op-by-
+	 * design. Anchoring on the actually-wired-up state (not the filter
+	 * read) prevents the abort carve-out from being bypassed by setting
+	 * the overlay filter on a site that doesn't have Search Blocks
+	 * registered.
+	 *
+	 * @var bool
+	 */
+	private static $block_template_overlay_active = false;
+
+	/**
 	 * Initialize the search package.
 	 *
 	 * The method is called from the `Config` class.
@@ -77,9 +93,13 @@ class Initializer {
 		// Initialize search package. The block-template overlay path
 		// intentionally skips both instant and classic init (Search_Blocks
 		// owns the UI), so a falsy return there is by design — not an
-		// abort. Anything else falsy is a real failure.
+		// abort. Anything else falsy is a real failure. Anchor on the
+		// actually-wired-up flag (set in `init_search_blocks()` only when
+		// both gates passed) rather than the overlay filter alone, so
+		// flipping the overlay filter without the blocks gate can never
+		// bypass the abort.
 		$initialized = static::init_search( $blog_id )
-			|| Search_Blocks::is_block_template_overlay_enabled();
+			|| self::$block_template_overlay_active;
 
 		if ( ! $initialized ) {
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
@@ -158,9 +178,13 @@ class Initializer {
 		// `Search_Blocks::is_block_template_overlay_enabled()`): bypass the
 		// preact `SearchApp` so it doesn't race the block overlay for
 		// `?s=`, popstate, and theme search-trigger selectors. Suppressing
-		// at the init filter is cleaner than dequeuing post-enqueue.
+		// at the init filter is cleaner than dequeuing post-enqueue. The
+		// active flag set here is the single source of truth for the
+		// `init()` carve-out — it is true only when BOTH this branch ran
+		// (blocks gate passed) AND the overlay gate is on.
 		if ( Search_Blocks::is_block_template_overlay_enabled() ) {
 			add_filter( 'jetpack_search_init_instant_search', '__return_false' );
+			self::$block_template_overlay_active = true;
 		}
 	}
 

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -74,19 +74,14 @@ class Initializer {
 			return;
 		}
 
-		// Initialize search package.
-		if ( ! static::init_search( $blog_id ) ) {
-			// The block-template overlay path provides the search UI via
-			// `Search_Blocks` rather than the legacy instant/classic
-			// experiences, so `init_search()` legitimately returns falsy
-			// (both branches are skipped) without being an abort. Without
-			// this carve-out, the legacy `jetpack_search_abort` action
-			// would fire and `jetpack_search_loaded` would not — which
-			// would silently break anything hooked to the loaded action.
-			if ( Search_Blocks::is_block_template_overlay_enabled() ) {
-				do_action( 'jetpack_search_loaded' );
-				return;
-			}
+		// Initialize search package. The block-template overlay path
+		// intentionally skips both instant and classic init (Search_Blocks
+		// owns the UI), so a falsy return there is by design — not an
+		// abort. Anything else falsy is a real failure.
+		$initialized = static::init_search( $blog_id )
+			|| Search_Blocks::is_block_template_overlay_enabled();
+
+		if ( ! $initialized ) {
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
 			do_action( 'jetpack_search_abort', 'jetpack_search_init_search', null );
 			return;
@@ -159,11 +154,11 @@ class Initializer {
 		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' );
 		Search_Blocks::init();
 
-		// When the experimental block-template overlay is on, the legacy
-		// instant-search overlay must not boot — both would otherwise own
-		// `?s=`, popstate, and the overlay-trigger selectors. Skipping at
-		// the init filter is cleaner than dequeuing the preact bundle after
-		// it's been enqueued.
+		// Experimental block-template overlay (off by default; see
+		// `Search_Blocks::is_block_template_overlay_enabled()`): bypass the
+		// preact `SearchApp` so it doesn't race the block overlay for
+		// `?s=`, popstate, and theme search-trigger selectors. Suppressing
+		// at the init filter is cleaner than dequeuing post-enqueue.
 		if ( Search_Blocks::is_block_template_overlay_enabled() ) {
 			add_filter( 'jetpack_search_init_instant_search', '__return_false' );
 		}

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -96,8 +96,10 @@ $context_json = $enable_suggestions
 			class="jetpack-search-input__clear"
 			data-wp-bind--hidden="!state.searchQuery"
 			data-wp-on--click="actions.clearSearch"
-			aria-label="<?php echo esc_attr__( 'Clear search', 'jetpack-search-pkg' ); ?>"
-		>&#10005;</button>
+		><?php
+			/* translators: Button is used to clear the search input query. */
+			echo esc_html__( 'clear', 'jetpack-search-pkg' );
+		?></button>
 		<?php if ( $enable_suggestions ) : ?>
 		<ul
 			id="<?php echo esc_attr( $listbox_id ); ?>"

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -96,10 +96,12 @@ $context_json = $enable_suggestions
 			class="jetpack-search-input__clear"
 			data-wp-bind--hidden="!state.searchQuery"
 			data-wp-on--click="actions.clearSearch"
-		><?php
+		>
+			<?php
 			/* translators: Button is used to clear the search input query. */
 			echo esc_html__( 'clear', 'jetpack-search-pkg' );
-		?></button>
+			?>
+		</button>
 		<?php if ( $enable_suggestions ) : ?>
 		<ul
 			id="<?php echo esc_attr( $listbox_id ); ?>"

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1157,7 +1157,7 @@ class Search_Blocks {
 	width: 60px;
 	height: 60px;
 	padding: 0;
-	font-size: 1em;
+	font-size: 0.875rem;
 	font-weight: 400;
 	line-height: 1;
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1107,24 +1107,74 @@ class Search_Blocks {
 	height: 24px;
 }
 /*
- * The first IA-interactive child of the rendered template is the search
- * input. Promote it to a 60px header strip flush with the close button so
- * the two read as a single top bar — matching the legacy header.
+ * The first child of the rendered template is the search-input block.
+ * Promote it to a 60px header strip flush with the close button so the
+ * two read as a single top bar — matching the legacy `__box` header:
+ * 60px magnifying-glass column on the left, full-width input in the
+ * middle, ×-clear column on the right (before the overlay's own X).
+ * The block's default `border-bottom: 1px solid currentColor` on
+ * `.jetpack-search-input__inside-wrapper` is intentionally suppressed
+ * inside the overlay — the header strip's own border-bottom handles
+ * the visual separation from the results area.
  */
-.jetpack-search-block-overlay__content > .wp-block-group:first-child > .wp-block-jetpack-search-search-input:first-child {
+.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input {
 	position: absolute;
 	top: 0;
 	left: 0;
 	right: 60px;
 	height: 60px;
 	margin: 0;
-	display: flex;
-	align-items: center;
-	padding: 0 1em;
+	padding: 0;
 	border-bottom: 1px solid #e0e0e0;
+}
+.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__inside-wrapper {
+	height: 100%;
+	display: flex;
+	align-items: stretch;
+	gap: 0;
+	padding: 0;
+	border-bottom: 0;
+}
+.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__icon {
+	flex: 0 0 60px;
+	width: 60px;
+	height: 60px;
+	padding: 18px;
+	box-sizing: border-box;
+	opacity: 0.5;
+}
+.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__field {
+	flex: 1 1 auto;
+	min-width: 0;
+	height: 100%;
+	font-size: 18px;
+	line-height: 1;
+	padding: 0;
+	background: transparent;
+}
+.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__clear {
+	flex: 0 0 60px;
+	width: 60px;
+	height: 60px;
+	padding: 0;
+	font-size: 1.25rem;
 }
 .jetpack-search-block-overlay__content > .wp-block-group:first-child {
 	padding: 0 2em 2em;
+}
+/*
+ * The "Found N results" + sort dropdown row sits inside the rendered
+ * `search-results` block. The wp:group inline layout
+ * (`justifyContent: space-between`) does not always emit the matching
+ * core flex-layout class in this context, so we force the row layout
+ * explicitly. Results count anchors left, sort anchors right — matching
+ * the legacy `__search-results-controls` row.
+ */
+.jetpack-search-block-overlay__results-header {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	align-items: center;
 }
 @media (max-width: 781px) {
 	.jetpack-search-block-overlay {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -199,19 +199,21 @@ class Search_Blocks {
 
 	/**
 	 * Whether the legacy instant-search overlay should be replaced by the
-	 * server-rendered Search blocks template (jetpack-search.html).
+	 * server-rendered Search blocks template
+	 * (`templates/jetpack-search-overlay.html`).
 	 *
-	 * Opt-in only — the legacy overlay (`Instant_Search` + `SearchApp`) is the
-	 * default and is fully bypassed when this returns true. Callers must also
-	 * make sure the Search blocks themselves are registered (the package's
-	 * `jetpack_search_blocks_enabled` filter); without them the rendered
-	 * markup would have no hydration counterparts on the page.
+	 * EXPERIMENTAL — off by default; not production-ready. Opt-in requires
+	 * both this filter AND `jetpack_search_blocks_enabled` to be true, since
+	 * the rendered markup needs the Search blocks themselves registered to
+	 * have anything to hydrate. When on, the legacy `SearchApp` is fully
+	 * bypassed via the `jetpack_search_init_instant_search` filter.
 	 *
 	 * @return bool
 	 */
 	public static function is_block_template_overlay_enabled(): bool {
 		/**
-		 * Opt into the experimental Search blocks overlay.
+		 * Opt into the experimental Search blocks overlay. Off by default.
+		 * Do not enable in production until this feature graduates.
 		 *
 		 * @param bool $enabled Default false.
 		 */

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1157,7 +1157,9 @@ class Search_Blocks {
 	width: 60px;
 	height: 60px;
 	padding: 0;
-	font-size: 1.25rem;
+	font-size: 1em;
+	font-weight: 400;
+	line-height: 1;
 }
 .jetpack-search-block-overlay__content > .wp-block-group:first-child {
 	padding: 0 2em 2em;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -108,6 +108,17 @@ class Search_Blocks {
 	private static $supported_custom_taxonomies_cache = null;
 
 	/**
+	 * Cached rendered HTML for the overlay template. Filled during
+	 * `wp_enqueue_scripts` so the embedded blocks' view-module enqueues
+	 * land before `wp_print_import_map()` runs (footer priority 1) — that
+	 * walk is what puts `jetpack-search/store` into the importmap, and
+	 * deferring the render to footer priority 10 misses it.
+	 *
+	 * @var string|null
+	 */
+	private static $block_template_overlay_rendered_html = null;
+
+	/**
 	 * Register block types and hook into WordPress.
 	 *
 	 * Two gates apply:
@@ -179,6 +190,32 @@ class Search_Blocks {
 			add_action( 'init', array( static::class, 'register_product_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'route_woocommerce_product_search_template' ), 20 );
 		}
+
+		if ( static::is_block_template_overlay_enabled() ) {
+			add_action( 'wp_enqueue_scripts', array( static::class, 'enqueue_block_template_overlay_assets' ) );
+			add_action( 'wp_footer', array( static::class, 'print_block_template_overlay' ) );
+		}
+	}
+
+	/**
+	 * Whether the legacy instant-search overlay should be replaced by the
+	 * server-rendered Search blocks template (jetpack-search.html).
+	 *
+	 * Opt-in only — the legacy overlay (`Instant_Search` + `SearchApp`) is the
+	 * default and is fully bypassed when this returns true. Callers must also
+	 * make sure the Search blocks themselves are registered (the package's
+	 * `jetpack_search_blocks_enabled` filter); without them the rendered
+	 * markup would have no hydration counterparts on the page.
+	 *
+	 * @return bool
+	 */
+	public static function is_block_template_overlay_enabled(): bool {
+		/**
+		 * Opt into the experimental Search blocks overlay.
+		 *
+		 * @param bool $enabled Default false.
+		 */
+		return (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false );
 	}
 
 	/**
@@ -870,6 +907,172 @@ class Search_Blocks {
 				'content'     => $content,
 			)
 		);
+	}
+
+	/**
+	 * Read the dedicated overlay-template markup (`jetpack-search-overlay.html`).
+	 *
+	 * Distinct from `get_search_template_content()`: that one wraps the
+	 * search blocks inside `header` / `main` / `footer` template-parts so
+	 * the result renders as a full page. The overlay needs only the main
+	 * region — a modal isn't a page — so it ships as its own file rather
+	 * than runtime-stripping the page template's wrappers.
+	 *
+	 * Memoized like the page template: the markup is identical every
+	 * request, so the file read + placeholder substitution happen once
+	 * per process.
+	 *
+	 * @return string Block markup for the overlay body.
+	 */
+	protected static function get_overlay_template_content(): string {
+		static $content = null;
+		if ( null !== $content ) {
+			return $content;
+		}
+		$template_path = __DIR__ . '/templates/jetpack-search-overlay.html';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
+		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		$content = str_replace(
+			'{{FILTER_HEADING}}',
+			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+			$raw
+		);
+		return $content;
+	}
+
+	/**
+	 * Echo the Search-blocks overlay shell into `wp_footer`.
+	 *
+	 * Server-renders `jetpack-search.html` once per request (template-part
+	 * comments stripped), wraps it in a hidden modal container, and prints
+	 * the result. Block markup carries `data-wp-interactive` directives, so
+	 * the Interactivity API's standard `DOMContentLoaded` hydration picks it
+	 * up — no client-side fetch and no private-API re-hydration needed.
+	 *
+	 * Caller (`init()`) gates this on `is_block_template_overlay_enabled()`,
+	 * so the action isn't even registered when the legacy overlay is in use.
+	 */
+	public static function print_block_template_overlay() {
+		$rendered = self::$block_template_overlay_rendered_html;
+		if ( null === $rendered || '' === $rendered ) {
+			return;
+		}
+		$config = wp_json_encode(
+			array(
+				'searchInputSelector'    => 'input[name="s"]:not(.jetpack-search-input__field), #searchform input.search-field, .search-form input.search-field, .searchform input.search-field',
+				'overlayTriggerSelector' => '.jetpack-search-block-overlay-trigger, .jetpack-instant-search__open-overlay-button, header#site-header .search-toggle[data-toggle-target]',
+			),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
+		?>
+		<script id="jetpack-search-block-overlay-config">window.JetpackSearchBlockOverlay=<?php echo $config; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode + JSON_HEX_* flags. ?>;</script>
+		<?php
+		// `<template>` keeps `data-wp-interactive` regions out of
+		// `document.querySelectorAll`, so the IA runtime's one-shot
+		// DOMContentLoaded hydration walk skips them; the bootstrap
+		// clones the content into the shell on first open and hydrates
+		// there.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks output.
+		printf( '<template id="jetpack-search-block-overlay-template">%s</template>', $rendered );
+		?>
+		<div
+			id="jetpack-search-block-overlay"
+			class="jetpack-search-block-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-label="<?php echo esc_attr__( 'Search', 'jetpack-search-pkg' ); ?>"
+			hidden
+		>
+			<button
+				type="button"
+				class="jetpack-search-block-overlay__close"
+				aria-label="<?php echo esc_attr__( 'Close search', 'jetpack-search-pkg' ); ?>"
+			>&times;</button>
+			<div class="jetpack-search-block-overlay__content"></div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Register + enqueue the overlay-bootstrap Script Module that wires
+	 * theme-defined search triggers (input, form, button) to the rendered
+	 * overlay shell, plus a minimal inline stylesheet for the modal chrome.
+	 * Config (trigger selectors) is emitted alongside the overlay HTML in
+	 * `print_block_template_overlay()` so it's guaranteed to land in the
+	 * page before the deferred module imports it.
+	 */
+	public static function enqueue_block_template_overlay_assets() {
+		if ( ! function_exists( 'wp_register_script_module' ) ) {
+			return;
+		}
+		$base_path  = Package::get_installed_path() . 'build/search-blocks/overlay-bootstrap/';
+		$asset_file = $base_path . 'index.asset.php';
+		if ( ! file_exists( $asset_file ) ) {
+			return;
+		}
+		$asset = require $asset_file;
+		wp_register_script_module(
+			'jetpack-search/overlay-bootstrap',
+			plugins_url( 'index.js', $base_path . 'index.js' ),
+			$asset['dependencies'] ?? array(),
+			$asset['version'] ?? false
+		);
+		wp_enqueue_script_module( 'jetpack-search/overlay-bootstrap' );
+
+		wp_register_style( 'jetpack-search-block-overlay', false, array(), $asset['version'] ?? false );
+		wp_enqueue_style( 'jetpack-search-block-overlay' );
+		wp_add_inline_style( 'jetpack-search-block-overlay', static::block_template_overlay_inline_css() );
+
+		// Render the template content now (during `wp_enqueue_scripts`) so
+		// the view-module enqueues triggered by `do_blocks()` are in place
+		// before the importmap is printed in `wp_footer` priority 1.
+		// `wp_footer` priority 10 (where `print_block_template_overlay`
+		// runs) is too late — the importmap walk has already happened and
+		// `jetpack-search/store` would be missing from it.
+		self::$block_template_overlay_rendered_html = trim(
+			do_blocks( static::get_overlay_template_content() )
+		);
+	}
+
+	/**
+	 * Minimal CSS for the overlay shell. Block-rendered content brings its
+	 * own styling; this only handles the modal chrome (positioning, scrim,
+	 * close button) and the hidden/visible toggle.
+	 *
+	 * @return string
+	 */
+	protected static function block_template_overlay_inline_css(): string {
+		return <<<'CSS'
+.jetpack-search-block-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 100000;
+	background: #fff;
+	overflow-y: auto;
+	padding: 2rem 1.5rem;
+}
+.jetpack-search-block-overlay[hidden] {
+	display: none;
+}
+.jetpack-search-block-overlay__close {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	font-size: 1.75rem;
+	line-height: 1;
+	background: transparent;
+	border: 0;
+	cursor: pointer;
+	padding: 0.25rem 0.5rem;
+}
+.jetpack-search-block-overlay__content {
+	max-width: 1200px;
+	margin: 0 auto;
+}
+body.jetpack-search-block-overlay-open {
+	overflow: hidden;
+}
+CSS;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -919,8 +919,11 @@ class Search_Blocks {
 	 * than runtime-stripping the page template's wrappers.
 	 *
 	 * Memoized like the page template: the markup is identical every
-	 * request, so the file read + placeholder substitution happen once
-	 * per process.
+	 * request, so the file read happens once per process. Unlike the
+	 * page-template variant, this template has no `{{FILTER_HEADING}}`
+	 * placeholder — the per-filter labels on each filter block render
+	 * the headings directly, matching the legacy overlay's per-filter
+	 * subheading layout.
 	 *
 	 * @return string Block markup for the overlay body.
 	 */
@@ -931,12 +934,7 @@ class Search_Blocks {
 		}
 		$template_path = __DIR__ . '/templates/jetpack-search-overlay.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		$content = str_replace(
-			'{{FILTER_HEADING}}',
-			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
-			$raw
-		);
+		$content = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
 		return $content;
 	}
 
@@ -983,12 +981,18 @@ class Search_Blocks {
 			aria-label="<?php echo esc_attr__( 'Search', 'jetpack-search-pkg' ); ?>"
 			hidden
 		>
-			<button
-				type="button"
-				class="jetpack-search-block-overlay__close"
-				aria-label="<?php echo esc_attr__( 'Close search', 'jetpack-search-pkg' ); ?>"
-			>&times;</button>
-			<div class="jetpack-search-block-overlay__content"></div>
+			<div class="jetpack-search-block-overlay__card">
+				<button
+					type="button"
+					class="jetpack-search-block-overlay__close"
+					aria-label="<?php echo esc_attr__( 'Close search', 'jetpack-search-pkg' ); ?>"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+						<path d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7A1 1 0 0 0 5.7 7.11L10.59 12 5.7 16.89a1 1 0 1 0 1.41 1.41L12 13.41l4.89 4.89a1 1 0 0 0 1.41-1.41L13.41 12l4.89-4.89a1 1 0 0 0 0-1.4z" fill="currentColor" />
+					</svg>
+				</button>
+				<div class="jetpack-search-block-overlay__content"></div>
+			</div>
 		</div>
 		<?php
 	}
@@ -1043,33 +1047,108 @@ class Search_Blocks {
 	 */
 	protected static function block_template_overlay_inline_css(): string {
 		return <<<'CSS'
+/*
+ * Modal chrome only. The rendered Search blocks bring their own styling
+ * from the active theme; this stylesheet handles only the overlay scrim,
+ * the centered card, the header strip (search input + close button),
+ * open/close animation, and the body-scroll-lock helper. Mirrors the
+ * visual idiom of the legacy `instant-search/components/overlay.scss`.
+ */
 .jetpack-search-block-overlay {
 	position: fixed;
 	inset: 0;
 	z-index: 100000;
-	background: #fff;
+	display: flex;
+	justify-content: center;
+	align-items: flex-start;
+	background: rgba(31, 31, 31, 0.7);
 	overflow-y: auto;
-	padding: 2rem 1.5rem;
+	padding: 3em 1em;
+	transition: opacity 0.1s ease-in;
 }
 .jetpack-search-block-overlay[hidden] {
 	display: none;
 }
+@media (prefers-reduced-motion: reduce) {
+	.jetpack-search-block-overlay {
+		transition: none;
+	}
+}
+.jetpack-search-block-overlay__card {
+	position: relative;
+	width: 100%;
+	max-width: 1080px;
+	background: #fff;
+	border-radius: 4px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+	padding-top: 60px;
+}
 .jetpack-search-block-overlay__close {
 	position: absolute;
-	top: 1rem;
-	right: 1rem;
-	font-size: 1.75rem;
-	line-height: 1;
+	top: 0;
+	right: 0;
+	width: 60px;
+	height: 60px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	background: transparent;
 	border: 0;
+	border-bottom: 1px solid #e0e0e0;
 	cursor: pointer;
-	padding: 0.25rem 0.5rem;
+	color: inherit;
 }
-.jetpack-search-block-overlay__content {
-	max-width: 1200px;
-	margin: 0 auto;
+.jetpack-search-block-overlay__close:hover,
+.jetpack-search-block-overlay__close:focus-visible {
+	background: #f6f7f7;
 }
+.jetpack-search-block-overlay__close svg {
+	width: 24px;
+	height: 24px;
+}
+/*
+ * The first IA-interactive child of the rendered template is the search
+ * input. Promote it to a 60px header strip flush with the close button so
+ * the two read as a single top bar — matching the legacy header.
+ */
+.jetpack-search-block-overlay__content > .wp-block-group:first-child > .wp-block-jetpack-search-search-input:first-child {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 60px;
+	height: 60px;
+	margin: 0;
+	display: flex;
+	align-items: center;
+	padding: 0 1em;
+	border-bottom: 1px solid #e0e0e0;
+}
+.jetpack-search-block-overlay__content > .wp-block-group:first-child {
+	padding: 0 2em 2em;
+}
+@media (max-width: 781px) {
+	.jetpack-search-block-overlay {
+		padding: 0;
+	}
+	.jetpack-search-block-overlay__card {
+		min-height: 100vh;
+		border-radius: 0;
+		box-shadow: none;
+	}
+	.jetpack-search-block-overlay__content > .wp-block-group:first-child {
+		padding: 0 1em 1em;
+	}
+}
+/*
+ * Body-scroll lock — set `position: fixed` while the overlay is open so
+ * the page underneath doesn't scroll, with the JS side stashing and
+ * restoring scrollY around the toggle to keep the visible position stable.
+ */
 body.jetpack-search-block-overlay-open {
+	position: fixed;
+	left: 0;
+	right: 0;
+	width: 100%;
 	overflow: hidden;
 }
 CSS;

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -22,7 +22,11 @@ const triggerSelector = config.overlayTriggerSelector || '';
 const searchInputSelector = config.searchInputSelector || '';
 
 let lastFocusedTrigger = null;
-let hydrated = false;
+// Holds the in-flight hydration promise. Storing the promise (rather than a
+// boolean flag) means concurrent `openOverlay()` calls all `await` the same
+// hydration job instead of one racing past it while the import is still
+// resolving.
+let hydrationPromise = null;
 
 /**
  * Look up the overlay root element by id.
@@ -45,43 +49,54 @@ function isOpen( overlay ) {
 
 /**
  * Move the rendered template content into the overlay shell and hydrate
- * its Interactivity API regions. Idempotent — runs once, then bails.
+ * its Interactivity API regions. Idempotent and concurrency-safe — the
+ * first call kicks off the work and stores the promise; subsequent calls
+ * (including those racing in while the dynamic import is still resolving)
+ * await the same job.
+ *
+ * @return {Promise<void>} Resolves when hydration is complete (or no-ops if there is nothing to hydrate).
  */
-async function ensureHydrated() {
-	if ( hydrated ) {
-		return;
+function ensureHydrated() {
+	if ( hydrationPromise ) {
+		return hydrationPromise;
 	}
-	hydrated = true;
-	const overlay = getOverlay();
-	const template = document.getElementById( TEMPLATE_ID );
-	const content = overlay?.querySelector( '.jetpack-search-block-overlay__content' );
-	if ( ! overlay || ! template || ! content ) {
-		return;
-	}
-	content.appendChild( template.content.cloneNode( true ) );
+	hydrationPromise = ( async () => {
+		const overlay = getOverlay();
+		const template = document.getElementById( TEMPLATE_ID );
+		const content = overlay?.querySelector( '.jetpack-search-block-overlay__content' );
+		if ( ! overlay || ! template || ! content ) {
+			return;
+		}
+		content.appendChild( template.content.cloneNode( true ) );
 
-	// Hydration uses the WP Interactivity API's private surface. There is
-	// no public API for hydrating content inserted after DOMContentLoaded.
-	// If the privateApis contract changes, the catch leaves the overlay
-	// rendered-but-inert rather than crashing the page; the IA store
-	// reading from a static seed already covers initial display.
-	try {
-		const ia = await import( '@wordpress/interactivity' );
-		if ( typeof ia.privateApis !== 'function' ) {
-			return;
+		// Hydration uses the WP Interactivity API's private surface. There is
+		// no public API for hydrating content inserted after DOMContentLoaded.
+		// If the privateApis contract changes, the catch leaves the overlay
+		// rendered-but-inert rather than crashing the page; the IA store
+		// reading from a static seed already covers initial display.
+		try {
+			const ia = await import( '@wordpress/interactivity' );
+			if ( typeof ia.privateApis !== 'function' ) {
+				return;
+			}
+			const apis = ia.privateApis( PRIVATE_API_CONSENT );
+			if (
+				typeof apis.render !== 'function' ||
+				typeof apis.toVdom !== 'function' ||
+				typeof apis.getRegionRootFragment !== 'function'
+			) {
+				return;
+			}
+			const regions = content.querySelectorAll( '[data-wp-interactive]' );
+			for ( const region of regions ) {
+				apis.render( apis.toVdom( region ), apis.getRegionRootFragment( region ) );
+			}
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.warn( '[jetpack-search] overlay hydration failed', e );
 		}
-		const apis = ia.privateApis( PRIVATE_API_CONSENT );
-		if ( typeof apis.render !== 'function' || typeof apis.toVdom !== 'function' ) {
-			return;
-		}
-		const regions = content.querySelectorAll( '[data-wp-interactive]' );
-		for ( const region of regions ) {
-			apis.render( apis.toVdom( region ), apis.getRegionRootFragment( region ) );
-		}
-	} catch ( e ) {
-		// eslint-disable-next-line no-console
-		console.warn( '[jetpack-search] overlay hydration failed', e );
-	}
+	} )();
+	return hydrationPromise;
 }
 
 /**
@@ -171,19 +186,52 @@ async function handleFormSubmit( event ) {
 	}
 }
 
+const FOCUSABLE_SELECTOR = [
+	'a[href]',
+	'button:not([disabled])',
+	'input:not([disabled]):not([type="hidden"])',
+	'select:not([disabled])',
+	'textarea:not([disabled])',
+	'[tabindex]:not([tabindex="-1"])',
+].join( ',' );
+
 /**
- * Document-level keydown handler: closes the overlay on Escape.
+ * Document-level keydown handler: closes on Escape and traps Tab inside the
+ * open overlay so keyboard users can't fall out into the inert background
+ * content. The overlay's PHP shell declares `role="dialog" aria-modal="true"`,
+ * which assistive tech treats as a modal — without a trap that contract is
+ * violated for keyboard navigation.
  *
  * @param {KeyboardEvent} event - The keydown event.
  */
 function handleKeydown( event ) {
-	if ( event.key !== 'Escape' ) {
+	const overlay = getOverlay();
+	if ( ! isOpen( overlay ) ) {
 		return;
 	}
-	const overlay = getOverlay();
-	if ( isOpen( overlay ) ) {
+	if ( event.key === 'Escape' ) {
 		event.preventDefault();
 		closeOverlay();
+		return;
+	}
+	if ( event.key !== 'Tab' ) {
+		return;
+	}
+	const activeEl = overlay.ownerDocument?.activeElement;
+	const focusable = Array.from( overlay.querySelectorAll( FOCUSABLE_SELECTOR ) ).filter(
+		el => el.offsetParent !== null || el === activeEl
+	);
+	if ( focusable.length === 0 ) {
+		return;
+	}
+	const first = focusable[ 0 ];
+	const last = focusable[ focusable.length - 1 ];
+	if ( event.shiftKey && activeEl === first ) {
+		event.preventDefault();
+		last.focus();
+	} else if ( ! event.shiftKey && activeEl === last ) {
+		event.preventDefault();
+		first.focus();
 	}
 }
 

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -1,0 +1,217 @@
+/**
+ * Bootstraps the Search blocks overlay.
+ *
+ * Perf shape: the rendered template lives inside a `<template>` element, whose
+ * `[data-wp-interactive]` regions are invisible to `document.querySelectorAll`
+ * and so are skipped by the IA runtime's DOMContentLoaded hydration walk. On
+ * first open the bootstrap clones the template content into the visible shell
+ * and hydrates the freshly-added regions via `@wordpress/interactivity`'s
+ * `privateApis`. Subsequent opens just toggle the `hidden` attribute.
+ */
+
+const PRIVATE_API_CONSENT =
+	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
+
+const OVERLAY_ID = 'jetpack-search-block-overlay';
+const TEMPLATE_ID = 'jetpack-search-block-overlay-template';
+const BODY_OPEN_CLASS = 'jetpack-search-block-overlay-open';
+const CONFIG_GLOBAL = 'JetpackSearchBlockOverlay';
+
+const config = ( typeof window !== 'undefined' && window[ CONFIG_GLOBAL ] ) || {};
+const triggerSelector = config.overlayTriggerSelector || '';
+const searchInputSelector = config.searchInputSelector || '';
+
+let lastFocusedTrigger = null;
+let hydrated = false;
+
+/**
+ * Look up the overlay root element by id.
+ *
+ * @return {HTMLElement|null} The overlay root element, if rendered.
+ */
+function getOverlay() {
+	return document.getElementById( OVERLAY_ID );
+}
+
+/**
+ * Whether the overlay is currently visible.
+ *
+ * @param {HTMLElement|null} overlay - The overlay root.
+ * @return {boolean} True if the overlay is rendered and not hidden.
+ */
+function isOpen( overlay ) {
+	return overlay && ! overlay.hasAttribute( 'hidden' );
+}
+
+/**
+ * Move the rendered template content into the overlay shell and hydrate
+ * its Interactivity API regions. Idempotent — runs once, then bails.
+ */
+async function ensureHydrated() {
+	if ( hydrated ) {
+		return;
+	}
+	hydrated = true;
+	const overlay = getOverlay();
+	const template = document.getElementById( TEMPLATE_ID );
+	const content = overlay?.querySelector( '.jetpack-search-block-overlay__content' );
+	if ( ! overlay || ! template || ! content ) {
+		return;
+	}
+	content.appendChild( template.content.cloneNode( true ) );
+
+	// Hydration uses the WP Interactivity API's private surface. There is
+	// no public API for hydrating content inserted after DOMContentLoaded.
+	// If the privateApis contract changes, the catch leaves the overlay
+	// rendered-but-inert rather than crashing the page; the IA store
+	// reading from a static seed already covers initial display.
+	try {
+		const ia = await import( '@wordpress/interactivity' );
+		if ( typeof ia.privateApis !== 'function' ) {
+			return;
+		}
+		const apis = ia.privateApis( PRIVATE_API_CONSENT );
+		if ( typeof apis.render !== 'function' || typeof apis.toVdom !== 'function' ) {
+			return;
+		}
+		const regions = content.querySelectorAll( '[data-wp-interactive]' );
+		for ( const region of regions ) {
+			apis.render( apis.toVdom( region ), apis.getRegionRootFragment( region ) );
+		}
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.warn( '[jetpack-search] overlay hydration failed', e );
+	}
+}
+
+/**
+ * Show the overlay and move focus into it.
+ *
+ * @param {HTMLElement|null} [triggerEl] - Element that opened the overlay; receives focus on close.
+ */
+async function openOverlay( triggerEl ) {
+	const overlay = getOverlay();
+	if ( ! overlay || isOpen( overlay ) ) {
+		return;
+	}
+	lastFocusedTrigger = triggerEl || overlay.ownerDocument?.activeElement || null;
+	await ensureHydrated();
+	overlay.removeAttribute( 'hidden' );
+	document.body.classList.add( BODY_OPEN_CLASS );
+	const input = overlay.querySelector( 'input[type="search"]' );
+	if ( input ) {
+		input.focus();
+	}
+}
+
+/**
+ * Hide the overlay and restore focus to the element that opened it.
+ */
+function closeOverlay() {
+	const overlay = getOverlay();
+	if ( ! overlay || ! isOpen( overlay ) ) {
+		return;
+	}
+	overlay.setAttribute( 'hidden', '' );
+	document.body.classList.remove( BODY_OPEN_CLASS );
+	if ( lastFocusedTrigger && typeof lastFocusedTrigger.focus === 'function' ) {
+		lastFocusedTrigger.focus();
+	}
+	lastFocusedTrigger = null;
+}
+
+/**
+ * Document-level click handler: opens the overlay when a configured trigger is clicked.
+ *
+ * @param {MouseEvent} event - The click event.
+ */
+function handleTriggerClick( event ) {
+	if ( ! triggerSelector ) {
+		return;
+	}
+	const trigger = event.target.closest( triggerSelector );
+	if ( ! trigger ) {
+		return;
+	}
+	const overlay = getOverlay();
+	if ( ! overlay || overlay.contains( trigger ) ) {
+		return;
+	}
+	event.preventDefault();
+	openOverlay( trigger );
+}
+
+/**
+ * Document-level submit handler: intercepts theme search forms and routes them into the overlay.
+ *
+ * @param {SubmitEvent} event - The submit event.
+ */
+async function handleFormSubmit( event ) {
+	if ( ! searchInputSelector ) {
+		return;
+	}
+	const form = event.target;
+	if ( ! ( form instanceof HTMLFormElement ) ) {
+		return;
+	}
+	const overlay = getOverlay();
+	if ( ! overlay || overlay.contains( form ) ) {
+		return;
+	}
+	const sourceInput = form.querySelector( searchInputSelector );
+	if ( ! sourceInput ) {
+		return;
+	}
+	event.preventDefault();
+	await openOverlay( sourceInput );
+	const overlayInput = overlay.querySelector( 'input[type="search"]' );
+	if ( overlayInput ) {
+		overlayInput.value = sourceInput.value || '';
+		overlayInput.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+	}
+}
+
+/**
+ * Document-level keydown handler: closes the overlay on Escape.
+ *
+ * @param {KeyboardEvent} event - The keydown event.
+ */
+function handleKeydown( event ) {
+	if ( event.key !== 'Escape' ) {
+		return;
+	}
+	const overlay = getOverlay();
+	if ( isOpen( overlay ) ) {
+		event.preventDefault();
+		closeOverlay();
+	}
+}
+
+/**
+ * Overlay-scoped click handler: close button + scrim-click dismissal.
+ *
+ * @param {MouseEvent} event - The click event.
+ */
+function handleOverlayClick( event ) {
+	const overlay = getOverlay();
+	if ( ! isOpen( overlay ) ) {
+		return;
+	}
+	if ( event.target.closest( '.jetpack-search-block-overlay__close' ) ) {
+		event.preventDefault();
+		closeOverlay();
+		return;
+	}
+	// Click on the scrim (the overlay root itself, not its inner content) closes.
+	if ( event.target === overlay ) {
+		closeOverlay();
+	}
+}
+
+document.addEventListener( 'click', handleTriggerClick, true );
+document.addEventListener( 'submit', handleFormSubmit, true );
+document.addEventListener( 'keydown', handleKeydown );
+const overlayEl = getOverlay();
+if ( overlayEl ) {
+	overlayEl.addEventListener( 'click', handleOverlayClick );
+}

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -22,6 +22,7 @@ const triggerSelector = config.overlayTriggerSelector || '';
 const searchInputSelector = config.searchInputSelector || '';
 
 let lastFocusedTrigger = null;
+let savedScrollY = 0;
 // Holds the in-flight hydration promise. Storing the promise (rather than a
 // boolean flag) means concurrent `openOverlay()` calls all `await` the same
 // hydration job instead of one racing past it while the import is still
@@ -112,6 +113,12 @@ async function openOverlay( triggerEl ) {
 	lastFocusedTrigger = triggerEl || overlay.ownerDocument?.activeElement || null;
 	await ensureHydrated();
 	overlay.removeAttribute( 'hidden' );
+	// Body-scroll lock: stash the current scroll position so the underlying
+	// page doesn't snap to 0 when `position: fixed` is applied (and so we
+	// can restore the same position on close). Matches the legacy
+	// `preventBodyScroll()` pattern.
+	savedScrollY = window.scrollY || window.pageYOffset || 0;
+	document.body.style.top = `-${ savedScrollY }px`;
 	document.body.classList.add( BODY_OPEN_CLASS );
 	const input = overlay.querySelector( 'input[type="search"]' );
 	if ( input ) {
@@ -129,6 +136,8 @@ function closeOverlay() {
 	}
 	overlay.setAttribute( 'hidden', '' );
 	document.body.classList.remove( BODY_OPEN_CLASS );
+	document.body.style.top = '';
+	window.scrollTo( 0, savedScrollY );
 	if ( lastFocusedTrigger && typeof lastFocusedTrigger.focus === 'function' ) {
 		lastFocusedTrigger.focus();
 	}
@@ -237,6 +246,8 @@ function handleKeydown( event ) {
 
 /**
  * Overlay-scoped click handler: close button + scrim-click dismissal.
+ * Mirrors the legacy overlay's pattern of dismissing on any click outside
+ * the centered card.
  *
  * @param {MouseEvent} event - The click event.
  */
@@ -250,8 +261,31 @@ function handleOverlayClick( event ) {
 		closeOverlay();
 		return;
 	}
-	// Click on the scrim (the overlay root itself, not its inner content) closes.
-	if ( event.target === overlay ) {
+	// Click on the scrim — anywhere outside the card — closes.
+	if ( ! event.target.closest( '.jetpack-search-block-overlay__card' ) ) {
+		closeOverlay();
+	}
+}
+
+/**
+ * `popstate` handler: keep the overlay's visibility in sync with the URL so
+ * the browser's back/forward navigation behaves like the legacy overlay.
+ * The IA store owns the URL → state mapping; this only owns the
+ * shell's visibility.
+ *
+ * - URL gains `?q=` or `?s=` while the overlay is closed → open it.
+ * - URL drops both while the overlay is open → close it.
+ */
+function handlePopState() {
+	const params = new URLSearchParams( window.location.search );
+	const hasQuery = params.has( 'q' ) || params.has( 's' );
+	const overlay = getOverlay();
+	if ( ! overlay ) {
+		return;
+	}
+	if ( hasQuery && ! isOpen( overlay ) ) {
+		openOverlay( null );
+	} else if ( ! hasQuery && isOpen( overlay ) ) {
 		closeOverlay();
 	}
 }
@@ -259,6 +293,7 @@ function handleOverlayClick( event ) {
 document.addEventListener( 'click', handleTriggerClick, true );
 document.addEventListener( 'submit', handleFormSubmit, true );
 document.addEventListener( 'keydown', handleKeydown );
+window.addEventListener( 'popstate', handlePopState );
 const overlayEl = getOverlay();
 if ( overlayEl ) {
 	overlayEl.addEventListener( 'click', handleOverlayClick );

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -1,0 +1,41 @@
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
+<div class="wp-block-group alignwide">
+<!-- wp:jetpack-search/search-input /-->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
+<div class="wp-block-columns">
+
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:jetpack-search/search-results -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack-search/results-count /-->
+<!-- wp:jetpack-search/results-sort /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:jetpack-search/results-list /-->
+<!-- wp:jetpack-search/results-load-more /-->
+<!-- wp:jetpack-search/powered-by /-->
+<!-- /wp:jetpack-search/search-results -->
+</div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
+<!-- /wp:heading -->
+<!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/clear-filters /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
+</div>
+<!-- /wp:column -->
+
+</div>
+<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -8,8 +8,8 @@
 <!-- wp:column -->
 <div class="wp-block-column">
 <!-- wp:jetpack-search/search-results -->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"className":"jetpack-search-block-overlay__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group jetpack-search-block-overlay__results-header">
 <!-- wp:jetpack-search/results-count /-->
 <!-- wp:jetpack-search/results-sort /-->
 </div>

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -24,9 +24,6 @@
 
 <!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
 <div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
-<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
-<!-- /wp:heading -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -21,6 +21,9 @@ class Initializer_Test extends Search_TestCase {
 	public function tearDown(): void {
 		remove_all_filters( 'jetpack_search_blocks_enabled' );
 		remove_all_filters( 'jetpack_search_woocommerce_blocks_enabled' );
+		remove_all_filters( 'jetpack_search_overlay_block_template_enabled' );
+		remove_all_filters( 'jetpack_search_init_instant_search' );
+		$this->reset_block_template_overlay_active();
 		$this->remove_search_blocks_hooks();
 		parent::tearDown();
 	}
@@ -84,6 +87,73 @@ class Initializer_Test extends Search_TestCase {
 		);
 	}
 
+	public function test_init_search_blocks_does_not_activate_overlay_when_blocks_gate_off() {
+		// The overlay carve-out in `init()` must read the actually-wired-up
+		// flag, not just the overlay filter — otherwise flipping the
+		// overlay filter on a site without the blocks gate would bypass
+		// the abort path. Confirms `$block_template_overlay_active` stays
+		// false when the blocks gate is off, regardless of the overlay
+		// filter.
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		// `jetpack_search_blocks_enabled` defaults false — not registered.
+
+		$this->invoke_init_search_blocks();
+
+		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertFalse(
+			$property->getValue(),
+			'Overlay must not register as active when the blocks gate is off, even if the overlay filter is on.'
+		);
+		$this->assertFalse(
+			has_filter( 'jetpack_search_init_instant_search', '__return_false' ),
+			'The legacy-suppress filter must not be added when the overlay gate is bypassed by the blocks gate.'
+		);
+	}
+
+	public function test_init_search_blocks_activates_overlay_when_both_gates_on() {
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+
+		$this->invoke_init_search_blocks();
+
+		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertTrue(
+			$property->getValue(),
+			'Overlay must register as active when both gates are on.'
+		);
+		$this->assertSame(
+			10,
+			has_filter( 'jetpack_search_init_instant_search', '__return_false' ),
+			'The legacy-suppress filter must be added when both gates are on.'
+		);
+	}
+
+	public function test_init_search_blocks_does_not_activate_overlay_when_overlay_gate_off() {
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+		// `jetpack_search_overlay_block_template_enabled` defaults false.
+
+		$this->invoke_init_search_blocks();
+
+		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertFalse(
+			$property->getValue(),
+			'Overlay must not register as active when only the blocks gate is on.'
+		);
+		$this->assertFalse(
+			has_filter( 'jetpack_search_init_instant_search', '__return_false' ),
+			'The legacy-suppress filter must not be added when the overlay gate is off.'
+		);
+	}
+
 	public function test_init_search_blocks_sets_woocommerce_blocks_gate_off_by_default_when_enabled() {
 		// Verifies the Phase 1 default — opt-in sites get the non-WC subset
 		// unless they re-enable WC blocks at a later priority.
@@ -112,6 +182,20 @@ class Initializer_Test extends Search_TestCase {
 			$method->setAccessible( true );
 		}
 		$method->invoke( null );
+	}
+
+	/**
+	 * Reset the private `$block_template_overlay_active` flag between
+	 * tests so the overlay carve-out can be exercised cleanly across
+	 * cases. Uses reflection because the property is package-private —
+	 * intentionally not part of the public surface, but tests own it.
+	 */
+	private function reset_block_template_overlay_active(): void {
+		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, false );
 	}
 
 	/**

--- a/projects/packages/search/tools/webpack.blocks.config.js
+++ b/projects/packages/search/tools/webpack.blocks.config.js
@@ -36,11 +36,22 @@ const STORE_MODULE_ID = 'jetpack-search/store';
 const storeIndexPath = path.join( __dirname, '../src/search-blocks/store/index.js' );
 const storeEntries = fs.existsSync( storeIndexPath ) ? { 'store/index': storeIndexPath } : {};
 
+// Standalone overlay-bootstrap entry. Wires theme search triggers to the
+// server-rendered Search blocks overlay; opt-in feature, not part of any block.
+const overlayBootstrapPath = path.join(
+	__dirname,
+	'../src/search-blocks/overlay-bootstrap/index.js'
+);
+const overlayBootstrapEntries = fs.existsSync( overlayBootstrapPath )
+	? { 'overlay-bootstrap/index': overlayBootstrapPath }
+	: {};
+
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		...storeEntries,
+		...overlayBootstrapEntries,
 		...blockViewEntries,
 	},
 	output: {


### PR DESCRIPTION
Fixes [SEARCH-206](https://linear.app/a8c/issue/SEARCH-206/spike-server-render-the-search-blocks-template-as-the-entire-instant)

## Why

Sites that have adopted the Search 3.0 block experience still ship the legacy preact instant-search overlay (`SearchApp`) whenever `?s=…` is used in a non-embedded context. This PR explores a way to swap that overlay for a server-rendered version of the same Search blocks the site already uses inline — same blocks, same store, same hydration story — so the overlay UI evolves through the block editor instead of through a parallel React app. It ships as an opt-in filter so the legacy path stays 100% intact and uncontaminated.

## Demo

![demo](https://github.com/user-attachments/assets/b0f748c7-c541-4d38-b914-fde65cb2c6c0)

Visitor submits the theme's search form → the bootstrap intercepts the submit and opens the rendered Search blocks template inside the overlay. Inside, the input is bound to `state.searchQuery`; refining the query re-fetches via the shared IA store (note the filter counts update); the Clear button drops the query and shows all results; Esc closes.

## Proposed changes

* Add a new filter `jetpack_search_overlay_block_template_enabled` (default false). When on, `Search_Blocks` server-renders a new dedicated overlay template (`templates/jetpack-search-overlay.html`) and emits the markup inside a `<template>` element in `wp_footer`. The IA runtime's `document.querySelectorAll('[data-wp-interactive]')` scan skips template content, so the DOMContentLoaded hydration walk costs nothing for the overlay on every page load.
* New vanilla-JS Script Module `jetpack-search/overlay-bootstrap` (~1.2 KB gzipped, no preact / no React). On first open it clones the template content into the visible shell and hydrates the freshly-added IA regions via `privateApis(consent).render(toVdom(region), getRegionRootFragment(region))` from `@wordpress/interactivity`. Subsequent opens just toggle `hidden`. Theme-defined search triggers (the same `overlayTriggerSelector` / `searchInputSelector` defaults as the legacy `getThemeOptions`) drive open; Esc / scrim-click / close-button drive close.
* When the filter is on, the Initializer filters `jetpack_search_init_instant_search` → false so the legacy preact `SearchApp` does not boot. With the gate off, the legacy overlay path is completely untouched.
* Implementation note baked into the code (and worth surfacing in review): `do_blocks()` for the overlay template runs during `wp_enqueue_scripts` — not in `wp_footer` priority 10 — because `WP_Script_Modules::print_import_map()` runs at `wp_footer` priority 1 and bare-specifier imports like `jetpack-search/store` only end up in that importmap if their referring view modules are enqueued before then. Rendering in `wp_footer` priority 10 silently broke action registration (state binding worked, action handlers didn't); the rendered HTML is cached in a class static and echoed from the footer.

## Related product discussion/links

* Linear project: https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586
* Issue: [SEARCH-206](https://linear.app/a8c/issue/SEARCH-206/spike-server-render-the-search-blocks-template-as-the-entire-instant)

## Does this pull request change what data or activity we track or use?

No. No new tracking or analytics; the new path uses the same shared IA store the existing search blocks use.

## Screenshots

### Homepage (overlay closed — zero hydration cost, no visible change)

![homepage closed](https://github.com/user-attachments/assets/8db63523-33ff-42ff-ba2b-96101c9765f0)

### Overlay open with the rendered block template

![overlay open](https://github.com/user-attachments/assets/a4e31661-dad8-48d6-8047-0c7ea6e97be4)

## Testing instructions

1. On an env with the Search 3.0 block experience enabled (`jetpack_search_blocks_enabled` → true), enable the new gate:
   ```php
   add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
   ```
2. Load any front-end page. View source and confirm:
   * `<template id="jetpack-search-block-overlay-template">` is present in the footer.
   * A `<div id="jetpack-search-block-overlay" … hidden>` shell sits next to it.
   * The page's `<script type="importmap" id="wp-importmap">` contains a `jetpack-search/store` entry.
   * The legacy `jp-search.js` (instant-search) bundle is **not** enqueued, and `window.JetpackInstantSearchOptions` is not defined.
3. Click the theme's search-toggle button (or submit any theme search form matching `input[name="s"]`). The overlay should open with the rendered Search blocks template inside.
4. Inside the overlay: type in the input → `state.searchQuery` (`window.wp` interactivity store) should update; the URL should sync to `?q=…`. Click a filter checkbox → it should appear in `state.activeFilters`. Press Esc → overlay closes; focus restores to the trigger element.
5. Disable the filter (comment out the `add_filter` line). Reload. Confirm the legacy preact `SearchApp` boots, `window.JetpackInstantSearchOptions` is defined, and the new overlay shell is **not** in the page.
6. Perf check: on a page with the gate **on** but before the user opens the overlay, `document.querySelectorAll('#jetpack-search-block-overlay [data-wp-interactive]').length` should be 0 (the rendered template lives inside `<template>`, invisible to the IA scan). After first open it should be 10.

## Acceptance criteria (from SEARCH-206)

* [ ] Block-template overlay reachable via an opt-in filter; legacy SearchApp is suppressed when the filter is on.
* [ ] Pre-open cost: zero IA islands hydrated for the overlay; bootstrap script under ~2 KB gz.
* [ ] First open hydrates the cloned content; all view-module actions register; input typing updates store state.
* [ ] Filter off → legacy overlay path is fully intact.
