### PR TITLE
Search Blocks: cap filter-checkbox list at Maximum items after session retention (SEARCH-208)

### DIFF
--- a/projects/packages/search/changelog/search-208-filter-checkbox-cap-maxitems
+++ b/projects/packages/search/changelog/search-208-filter-checkbox-cap-maxitems
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: cap the filter-checkbox list at its configured "Maximum items" even after the session has retained options across multiple searches.

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -219,6 +219,9 @@ function dateBucketSlug( bucket ) {
  * the visible label as a tiebreaker so two buckets with the same count don't
  * swap positions across re-renders — ES bucket order is unstable on ties.
  *
+ * Sliced to `maxItems` after sorting so retained options and URL-seeded
+ * selections can't push the list past the configured cap.
+ *
  * @param {object} sharedState - Live store state.
  * @param {string} filterKey   - Filter key.
  * @param {object} config      - filterConfigs entry.
@@ -259,7 +262,11 @@ function checkboxFilterItems( sharedState, filterKey, config ) {
 		add( value, bucketLabel( value, valueLabels ), 0 );
 	}
 
-	return sortFilterItems( items, config, sharedState.locale );
+	// Slice after sort so retained options and URL-seeded selections can't
+	// push the list past `maxItems`; the sort already sinks unchecked count=0
+	// items to the bottom so retained-but-now-empty entries drop first.
+	const limit = Math.max( 1, config.maxItems ?? 10 );
+	return sortFilterItems( items, config, sharedState.locale ).slice( 0, limit );
 }
 
 /**

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -257,6 +257,62 @@ describe( 'filter-checkbox view store — filterItems', () => {
 		] );
 	} );
 
+	it( 'caps the rendered list at maxItems when retained options push it past the limit', () => {
+		// Repro of SEARCH-208: the ES request is bounded at `size: maxItems`,
+		// but retained options accumulated from earlier searches are appended
+		// on the client. Once the merged set exceeds the cap the list must
+		// still slice to `maxItems`. Sort by count, so the live (non-zero)
+		// buckets win their slots and the retained-but-now-empty entries
+		// drop off the bottom first.
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'news/News', doc_count: 9 },
+					{ key: 'reviews/Reviews', doc_count: 4 },
+				],
+			},
+		};
+		captured.state.retainedFilterOptions = {
+			category: [
+				{ value: 'news', label: 'News' },
+				{ value: 'reviews', label: 'Reviews' },
+				{ value: 'archive', label: 'Archive' },
+				{ value: 'opinion', label: 'Opinion' },
+				{ value: 'sports', label: 'Sports' },
+			],
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {}, maxItems: 3 },
+		};
+		const items = captured.state.filterItems;
+		expect( items.map( i => i.value ) ).toEqual( [ 'news', 'reviews', 'archive' ] );
+	} );
+
+	it( 'falls back to a maxItems default of 10 when the config omits it', () => {
+		contextRef.current = { filterKey: 'category' };
+		const buckets = Array.from( { length: 12 }, ( _, i ) => ( {
+			key: `cat-${ i }/Cat ${ i }`,
+			doc_count: 12 - i,
+		} ) );
+		captured.state.aggregations = { category: { buckets } };
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
+		};
+		expect( captured.state.filterItems ).toHaveLength( 10 );
+	} );
+
+	it( 'coerces a maxItems below 1 up to 1 so the slice never empties the list', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: { buckets: [ { key: 'news/News', doc_count: 9 } ] },
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {}, maxItems: 0 },
+		};
+		expect( captured.state.filterItems.map( i => i.value ) ).toEqual( [ 'news' ] );
+	} );
+
 	it( 'renders selected values that are not in any aggregation yet (URL-seeded deep link)', () => {
 		contextRef.current = { filterKey: 'post_types' };
 		captured.state.activeFilters = { post_types: [ 'post' ] };


### PR DESCRIPTION
Fixes [SEARCH-208](https://linear.app/a8c/issue/SEARCH-208/search-blocks-filter-checkbox-renders-more-items-than-maxitems-once)

## Why

A Filter by Category / Tag / custom-taxonomy block has a "Maximum items" setting. Today, once a visitor narrows their search, the rendered checkbox list grows past that maximum — every search appends new categories to a session-retained map, and on the next render those retained entries stack on top of the live aggregation buckets. After the fix, the list is capped at the configured number, with live (non-zero count) entries preferred and retained-but-now-empty entries dropping off the bottom first.

## Proposed changes

* `projects/packages/search/src/search-blocks/store/index.js` — slice the merged item list in `checkboxFilterItems()` to `Math.max( 1, config.maxItems ?? 10 )` after the existing sort. The sort already sinks unchecked count=0 items to the bottom, so retained-but-now-empty entries drop first; selections beyond the cap still surface via the active-filters pill list.
* Three new tests in `projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js` covering the cap, the default-of-10 fallback, and the floor-at-1 coercion.

Date filter unaffected — `mergeRetainedFilterOptions()` already skips `filterType === 'date'` and `dateFilterItems()` slices in-loop.

## Screenshots

Captured against the local docker env (`https://jp-sage.jurassic.tube`) on the `SEARCH-208 Repro` page with a `jetpack-search/filter-checkbox` block configured at `maxItems = 5`. Repro driven via `page.evaluate()` injecting a session that retained 7 distinct categories and a follow-up narrowed query whose live aggregation returns only 2 of them.

| Before (bug) | After (fix) |
|---|---|
| ![before](https://github.com/user-attachments/assets/a3c89fe5-e525-411e-93eb-760a8db0a211) | ![after](https://github.com/user-attachments/assets/d931eae8-5337-487a-b791-b9d8f012c103) |
| 7 items rendered (News 4, Reviews 2, Food 0, Guides 0, Opinion 0, Sports 0, Travel 0) — exceeds the configured maximum. | 5 items rendered (News 4, Reviews 2, Food 0, Guides 0, Opinion 0) — capped at `maxItems`; the two extra retained-at-zero entries drop off. |

## Verification

In addition to the visual capture above, the new Jest tests in `projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js` drive the same `checkboxFilterItems()` code path and assert the cap deterministically — no live ES backend needed.

<details>
<summary>Test output</summary>

```text
$ pnpm jest tests/js/search-blocks/filter-checkbox-view.test.js

Test Suites: 1 passed, 1 total
Tests:       26 passed, 26 total
```

New tests:
* caps the rendered list at maxItems when retained options push it past the limit
* falls back to a maxItems default of 10 when the config omits it
* coerces a maxItems below 1 up to 1 so the slice never empties the list

Full search-blocks suite (no regressions):
```text
Test Suites: 21 passed, 21 total
Tests:       494 passed, 494 total
```

</details>

## Related product discussion/links

* [SEARCH-208](https://linear.app/a8c/issue/SEARCH-208/search-blocks-filter-checkbox-renders-more-items-than-maxitems-once) — Linear issue
* [#48593](https://github.com/Automattic/jetpack/pull/48593) (SEARCH-178) — introduced session-retained options that this change caps

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-208, as a reviewer checklist (requires a Jetpack-Search-connected site with indexed content):

* [ ] Add a Filter by Category block to a search-results page and set **Maximum items = 5**.
* [ ] Run a broad search query so the category aggregation returns 5 categories.
* [ ] Refine the query so the live aggregation returns only 2 of those categories.
* [ ] Confirm the checkbox list still shows at most 5 items (not 7).
* [ ] Confirm the 2 live (non-zero count) categories appear in the list, with retained-but-now-empty entries filling remaining slots and dropping off first.
* [ ] Confirm selecting a category beyond the cap still surfaces via the active-filters pill row.
* [ ] Confirm the date filter is unchanged.

For local-env review (no Jetpack-Search index needed), the new Jest tests in `tests/js/search-blocks/filter-checkbox-view.test.js` drive the same code path and assert the cap deterministically:

```
pnpm --filter @automattic/jetpack-search jest tests/js/search-blocks/filter-checkbox-view.test.js
```
