### PR TITLE
Search: surface "Enable search suggestions" and "Enable AI Answers" toggles in the search customizer (SEARCH-211)

### DIFF
--- a/projects/packages/search/changelog/search-211-customberg-suggestions-ai-toggles
+++ b/projects/packages/search/changelog/search-211-customberg-suggestions-ai-toggles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: surface the "Enable search suggestions" and "Enable AI Answers" toggles in the search customizer's Additional settings panel, alongside their existing home on the search dashboard.

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -53,6 +53,7 @@ class Settings {
 			array( $setting_prefix . 'show_product_price', 'boolean', true ),
 			array( $setting_prefix . 'show_powered_by', 'boolean', true ),
 			array( $setting_prefix . 'ai_answers_enabled', 'boolean', false ),
+			array( $setting_prefix . 'suggestions_enabled', 'boolean', false ),
 		);
 		foreach ( $settings as $value ) {
 			register_setting(

--- a/projects/packages/search/src/customberg/components/app-wrapper/index.jsx
+++ b/projects/packages/search/src/customberg/components/app-wrapper/index.jsx
@@ -30,6 +30,7 @@ const PROPS_FROM_WINDOW = {
  */
 export default function AppWrapper() {
 	const {
+		aiAnswersEnabled,
 		color,
 		excludedPostTypes,
 		infiniteScroll,
@@ -37,6 +38,7 @@ export default function AppWrapper() {
 		postDate,
 		productPrice,
 		resultFormat,
+		searchSuggestionsEnabled,
 		showLogo,
 		sort,
 		sortEnabled,
@@ -64,6 +66,20 @@ export default function AppWrapper() {
 			} ).filter( ( [ , v ] ) => typeof v !== 'undefined' )
 		),
 	};
+
+	// aiAnswersEnabled + searchSuggestionsEnabled live at the top level of the
+	// instant-search options object (not under `overlayOptions`). Override them
+	// here so the preview reacts to the sidebar toggles without a save round-trip.
+	const options = {
+		...window[ SERVER_OBJECT_NAME ],
+		...Object.fromEntries(
+			Object.entries( {
+				aiAnswersEnabled,
+				searchSuggestionsEnabled,
+			} ).filter( ( [ , v ] ) => typeof v !== 'undefined' )
+		),
+	};
+
 	const { isLoading } = useSiteLoadingState();
 
 	return (
@@ -90,6 +106,7 @@ export default function AppWrapper() {
 						initialIsVisible={ true }
 						initialShowResults={ true }
 						isInCustomizer={ false }
+						options={ options }
 						overlayOptions={ overlayOptions }
 						shouldCreatePortal={ false }
 						shouldIntegrateWithDom={ false }

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -214,6 +214,10 @@ export default function SidebarOptions() {
 						checked={ aiAnswersEnabled }
 						disabled={ isDisabled }
 						label={ __( 'Enable AI Answers', 'jetpack-search-pkg' ) }
+						help={ __(
+							'Generate AI-powered answers to visitor queries using your site’s content.',
+							'jetpack-search-pkg'
+						) }
 						onChange={ setAiAnswersEnabled }
 						__nextHasNoMarginBottom={ true }
 					/>

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -50,6 +50,10 @@ export default function SidebarOptions() {
 		setPostDate,
 		productPrice = true,
 		setProductPrice,
+		aiAnswersEnabled = false,
+		setAiAnswersEnabled,
+		searchSuggestionsEnabled = false,
+		setSearchSuggestionsEnabled,
 	} = useSearchOptions();
 
 	const { isSaving } = useEntityRecordState();
@@ -189,6 +193,28 @@ export default function SidebarOptions() {
 						disabled={ isDisabled }
 						label={ __( 'Show "Powered by Jetpack"', 'jetpack-search-pkg' ) }
 						onChange={ setShowLogo }
+						__nextHasNoMarginBottom={ true }
+					/>
+				) }
+				<ToggleControl
+					className="jp-search-configure-search-suggestions-toggle"
+					checked={ searchSuggestionsEnabled }
+					disabled={ isDisabled }
+					label={ __( 'Enable search suggestions', 'jetpack-search-pkg' ) }
+					help={ __(
+						'Show autocomplete query suggestions as visitors type, instead of updating search results on every keystroke.',
+						'jetpack-search-pkg'
+					) }
+					onChange={ setSearchSuggestionsEnabled }
+					__nextHasNoMarginBottom={ true }
+				/>
+				{ ! isFreePlan && (
+					<ToggleControl
+						className="jp-search-configure-ai-answers-toggle"
+						checked={ aiAnswersEnabled }
+						disabled={ isDisabled }
+						label={ __( 'Enable AI Answers', 'jetpack-search-pkg' ) }
+						onChange={ setAiAnswersEnabled }
 						__nextHasNoMarginBottom={ true }
 					/>
 				) }

--- a/projects/packages/search/src/customberg/hooks/use-search-options.js
+++ b/projects/packages/search/src/customberg/hooks/use-search-options.js
@@ -49,6 +49,16 @@ export default function useSearchOptions() {
 		'site',
 		'jetpack_search_show_product_price'
 	);
+	const [ aiAnswersEnabled, setAiAnswersEnabled ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_ai_answers_enabled'
+	);
+	const [ searchSuggestionsEnabled, setSearchSuggestionsEnabled ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_suggestions_enabled'
+	);
 	const [ excludedPostTypesCsv, setExcludedPostTypesCsv ] = useEntityProp(
 		'root',
 		'site',
@@ -100,5 +110,9 @@ export default function useSearchOptions() {
 		setPostDate,
 		productPrice,
 		setProductPrice,
+		aiAnswersEnabled,
+		setAiAnswersEnabled,
+		searchSuggestionsEnabled,
+		setSearchSuggestionsEnabled,
 	};
 }

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -427,10 +427,15 @@ class SearchApp extends Component {
 
 	getAiAnswer = () => {
 		const query = this.props.searchQuery;
-		// Prefer the props options so customberg's live overrides win; falls back
-		// to the page-load snapshot on the public-facing overlay.
-		const options = this.props.options || window[ SERVER_OBJECT_NAME ] || {};
+		const options = window[ SERVER_OBJECT_NAME ] || {};
 		const siteId = options.siteId;
+		// Honour a props-level override of the AI Answers gate when one is
+		// passed (customberg drives the preview from React state); otherwise
+		// fall back to the page-load snapshot used by the public overlay.
+		const aiAnswersEnabled =
+			this.props.options && this.props.options.aiAnswersEnabled !== undefined
+				? this.props.options.aiAnswersEnabled
+				: options.aiAnswersEnabled;
 
 		const idleState = {
 			aiBriefStatus: 'idle',
@@ -452,7 +457,7 @@ class SearchApp extends Component {
 		}
 
 		// Respect the admin's AI Answers toggle.
-		if ( options.aiAnswersEnabled === false ) {
+		if ( aiAnswersEnabled === false ) {
 			this.setState( idleState );
 			return;
 		}

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -427,7 +427,9 @@ class SearchApp extends Component {
 
 	getAiAnswer = () => {
 		const query = this.props.searchQuery;
-		const options = window[ SERVER_OBJECT_NAME ] || {};
+		// Prefer the props options so customberg's live overrides win; falls back
+		// to the page-load snapshot on the public-facing overlay.
+		const options = this.props.options || window[ SERVER_OBJECT_NAME ] || {};
 		const siteId = options.siteId;
 
 		const idleState = {


### PR DESCRIPTION
Fixes [SEARCH-211](https://linear.app/a8c/issue/SEARCH-211/search-surface-enable-search-suggestions-and-enable-ai-answers-toggles)

## Why
Admins styling the instant-search overlay live in the search customizer (`?page=jetpack-search-configure`), but the two toggles that govern what that overlay actually shows visitors — **Enable search suggestions** and **Enable AI Answers** — only existed on the search dashboard, forcing a context-switch out of the page they came to tune. Both options now sit in the customizer's *Additional settings* panel alongside Show-sort / Infinite-scroll / Show-post-date / Powered-by, so configuration of the overlay's behaviour and its appearance happen in one place. The dashboard versions stay put — this is a second access point, not a move.

## Proposed changes
* Add **Enable search suggestions** and **Enable AI Answers** toggles to the *Additional settings* panel in `src/customberg/components/sidebar/sidebar-options.jsx`.
* Both toggles round-trip the same backing site options as the dashboard (`jetpack_search_suggestions_enabled`, `jetpack_search_ai_answers_enabled`), so flipping in either screen stays consistent.
* `jetpack_search_ai_answers_enabled` was already `register_setting`'d. Register `jetpack_search_suggestions_enabled` the same way so the customizer can read/write it through the standard `/wp/v2/settings` flow that drives the rest of the page.
* AI Answers toggle is hidden on free plans, mirroring the existing `! isFreePlan` guard on the Powered-by toggle. Defensive — the customizer is itself only mounted when the plan supports instant search.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/4aa3c179-da40-4bb2-a4de-a9e3022d709e) | ![after](https://github.com/user-attachments/assets/d77365f8-ee00-4ac0-bd5a-40124e26b6de) |

## Related product discussion/links
* [SEARCH-211](https://linear.app/a8c/issue/SEARCH-211/search-surface-enable-search-suggestions-and-enable-ai-answers-toggles)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. On a connected site with a plan that supports Jetpack Search and **Instant Search enabled**, go to `/wp-admin/admin.php?page=jetpack-search-configure`.
2. Scroll the right-rail sidebar to the *Additional settings* panel.
3. Verify two new toggles appear:
   * **Enable search suggestions** (with help text "Show autocomplete query suggestions as visitors type…").
   * **Enable AI Answers** (paid plans only — hidden on the `jetpack_search_free` product).
4. Flip **Enable search suggestions** on, click **Save**. Open `/wp-admin/admin.php?page=jetpack-search&tab=settings` and confirm the dashboard toggle reflects the new state. Flip it off from the dashboard and confirm the customizer reflects the change on reload.
5. Repeat for **Enable AI Answers** using the customizer ↔ the `AI Answers (Preview)` tab on the dashboard.
6. On a free plan (`jetpack_search_free`), reload the customizer and confirm the **Enable AI Answers** toggle is hidden while **Enable search suggestions** remains visible.
