### PR TITLE
Search Input: let authors pick which suggestion sections appear

### DIFF
--- a/projects/packages/search/changelog/search-212-suggestion-types-per-block
+++ b/projects/packages/search/changelog/search-212-suggestion-types-per-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: let authors pick which suggestion sections appear in the Search Input dropdown (query completions, categories & tags, post titles) via a new per-block suggestionTypes attribute. Existing blocks default to all three.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -14,7 +14,12 @@
 		"placeholder": { "type": "string", "default": "" },
 		"showIcon": { "type": "boolean", "default": true },
 		"submitOnly": { "type": "boolean", "default": false },
-		"enableSuggestions": { "type": "boolean", "default": false }
+		"enableSuggestions": { "type": "boolean", "default": false },
+		"suggestionTypes": {
+			"type": "array",
+			"default": [ "query", "taxonomy", "post" ],
+			"items": { "type": "string", "enum": [ "query", "taxonomy", "post" ] }
+		}
 	},
 	"textdomain": "jetpack-search-pkg",
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -8,9 +8,27 @@
  * and whether queries fire live or only on submit.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	CheckboxControl,
+	Notice,
+	PanelBody,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+// Mirrors the enum on `block.json::attributes.suggestionTypes.items.enum`
+// and the canonical order rendered by `suggestion-rows.js::TYPE_ORDER`.
+// Keep these three in lockstep — a new type means an entry in each plus a
+// matching label in `Search_Blocks::build_initial_strings()`.
+const SUGGESTION_TYPES = [
+	{ value: 'query', label: __( 'Query completions', 'jetpack-search-pkg' ) },
+	{ value: 'taxonomy', label: __( 'Categories & tags', 'jetpack-search-pkg' ) },
+	{ value: 'post', label: __( 'Post titles', 'jetpack-search-pkg' ) },
+];
+const DEFAULT_SUGGESTION_TYPES = SUGGESTION_TYPES.map( t => t.value );
 
 /**
  * Render the magnifying-glass glyph used by the search input, matching the
@@ -54,6 +72,35 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const showIcon = attributes?.showIcon !== false;
 	const submitOnly = !! attributes?.submitOnly;
 	const enableSuggestions = !! attributes?.enableSuggestions;
+	const typesId = useId();
+	// Defensive copy so toggling a checkbox always produces a fresh array —
+	// React-style setAttributes shallow-compares arrays by reference, and a
+	// mutation in-place would skip the save. Falls back to the canonical
+	// default list when the attribute is missing on freshly-inserted blocks
+	// (block.json's default applies on next save, not first render).
+	const suggestionTypes = Array.isArray( attributes?.suggestionTypes )
+		? attributes.suggestionTypes
+		: DEFAULT_SUGGESTION_TYPES;
+	/**
+	 * Toggle a single suggestion type on or off. Preserves the canonical
+	 * `query → taxonomy → post` order in the saved array regardless of the
+	 * click order so two blocks that ended up with the same selection
+	 * serialize identically.
+	 *
+	 * @param {string}  type  - Suggestion type value to toggle.
+	 * @param {boolean} value - True to enable, false to disable.
+	 */
+	const setSuggestionType = ( type, value ) => {
+		const set = new Set( suggestionTypes );
+		if ( value ) {
+			set.add( type );
+		} else {
+			set.delete( type );
+		}
+		setAttributes( {
+			suggestionTypes: DEFAULT_SUGGESTION_TYPES.filter( t => set.has( t ) ),
+		} );
+	};
 	return (
 		<>
 			<InspectorControls>
@@ -92,10 +139,36 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 						checked={ enableSuggestions }
 						onChange={ value => setAttributes( { enableSuggestions: value } ) }
 						help={ __(
-							'Display an autocomplete dropdown with query, category, and post suggestions as the visitor types. Requires a configured Jetpack Search site ID.',
+							'Display an autocomplete dropdown as the visitor types. Requires a configured Jetpack Search site ID.',
 							'jetpack-search-pkg'
 						) }
 					/>
+					{ enableSuggestions && (
+						<BaseControl
+							__nextHasNoMarginBottom
+							id={ typesId }
+							label={ __( 'Suggestion types', 'jetpack-search-pkg' ) }
+							help={ __( 'Pick which sections appear in the dropdown.', 'jetpack-search-pkg' ) }
+						>
+							{ SUGGESTION_TYPES.map( ( { value, label } ) => (
+								<CheckboxControl
+									__nextHasNoMarginBottom
+									key={ value }
+									label={ label }
+									checked={ suggestionTypes.includes( value ) }
+									onChange={ checked => setSuggestionType( value, checked ) }
+								/>
+							) ) }
+							{ suggestionTypes.length === 0 && (
+								<Notice status="info" isDismissible={ false }>
+									{ __(
+										'No types selected — the dropdown won’t appear until at least one is enabled.',
+										'jetpack-search-pkg'
+									) }
+								</Notice>
+							) }
+						</BaseControl>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -29,6 +29,40 @@ const SUGGESTION_TYPES = [
 ];
 const DEFAULT_SUGGESTION_TYPES = SUGGESTION_TYPES.map( t => t.value );
 
+// `<fieldset>` carries the right group semantics but browsers apply default
+// border, padding, and inline-size constraints that wreck the inspector's
+// layout, and the WP component classes don't fully override them when applied
+// to a `<legend>` (legend has its own browser typography). Lock the look in
+// with inline-style resets so it matches the surrounding `components-base-control`
+// blocks. Scoped to this one group rather than added to style.scss because the
+// rest of the inspector renders fine with WP's defaults.
+const FIELDSET_STYLE = {
+	border: 0,
+	padding: 0,
+	margin: 0,
+	marginTop: 16,
+	minInlineSize: 'auto',
+};
+const LEGEND_STYLE = {
+	display: 'block',
+	width: '100%',
+	margin: 0,
+	marginBottom: 12,
+	padding: 0,
+	fontSize: 11,
+	fontWeight: 500,
+	lineHeight: 1.4,
+	textTransform: 'uppercase',
+	color: 'inherit',
+};
+const HELP_STYLE = {
+	marginTop: 8,
+	marginBottom: 0,
+	fontSize: 12,
+	fontStyle: 'normal',
+	color: 'rgb(117, 117, 117)',
+};
+
 /**
  * Render the magnifying-glass glyph used by the search input, matching the
  * inline SVG emitted by render.php so the editor preview looks identical.
@@ -140,8 +174,8 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 						// assistive tech announces the checkbox group correctly. BaseControl
 						// only associates one focusable child with its label — a group of
 						// three checkboxes needs the native group semantics.
-						<fieldset className="components-base-control">
-							<legend className="components-base-control__label">
+						<fieldset className="components-base-control" style={ FIELDSET_STYLE }>
+							<legend className="components-base-control__label" style={ LEGEND_STYLE }>
 								{ __( 'Suggestion types', 'jetpack-search-pkg' ) }
 							</legend>
 							{ SUGGESTION_TYPES.map( ( { value, label } ) => (
@@ -161,7 +195,7 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 									) }
 								</Notice>
 							) }
-							<p className="components-base-control__help">
+							<p className="components-base-control__help" style={ HELP_STYLE }>
 								{ __( 'Pick which sections appear in the dropdown.', 'jetpack-search-pkg' ) }
 							</p>
 						</fieldset>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -9,7 +9,6 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
-	BaseControl,
 	CheckboxControl,
 	Notice,
 	PanelBody,
@@ -72,7 +71,6 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const showIcon = attributes?.showIcon !== false;
 	const submitOnly = !! attributes?.submitOnly;
 	const enableSuggestions = !! attributes?.enableSuggestions;
-	const typesId = useId();
 	// Defensive copy so toggling a checkbox always produces a fresh array —
 	// React-style setAttributes shallow-compares arrays by reference, and a
 	// mutation in-place would skip the save. Falls back to the canonical
@@ -81,15 +79,9 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const suggestionTypes = Array.isArray( attributes?.suggestionTypes )
 		? attributes.suggestionTypes
 		: DEFAULT_SUGGESTION_TYPES;
-	/**
-	 * Toggle a single suggestion type on or off. Preserves the canonical
-	 * `query → taxonomy → post` order in the saved array regardless of the
-	 * click order so two blocks that ended up with the same selection
-	 * serialize identically.
-	 *
-	 * @param {string}  type  - Suggestion type value to toggle.
-	 * @param {boolean} value - True to enable, false to disable.
-	 */
+	// Filter against DEFAULT_SUGGESTION_TYPES on every save so two blocks
+	// that ended up with the same selection serialize identically regardless
+	// of click order.
 	const setSuggestionType = ( type, value ) => {
 		const set = new Set( suggestionTypes );
 		if ( value ) {
@@ -144,12 +136,14 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 						) }
 					/>
 					{ enableSuggestions && (
-						<BaseControl
-							__nextHasNoMarginBottom
-							id={ typesId }
-							label={ __( 'Suggestion types', 'jetpack-search-pkg' ) }
-							help={ __( 'Pick which sections appear in the dropdown.', 'jetpack-search-pkg' ) }
-						>
+						// `<fieldset>` + `<legend>` instead of `BaseControl`'s label/id pair so
+						// assistive tech announces the checkbox group correctly. BaseControl
+						// only associates one focusable child with its label — a group of
+						// three checkboxes needs the native group semantics.
+						<fieldset className="components-base-control">
+							<legend className="components-base-control__label">
+								{ __( 'Suggestion types', 'jetpack-search-pkg' ) }
+							</legend>
 							{ SUGGESTION_TYPES.map( ( { value, label } ) => (
 								<CheckboxControl
 									__nextHasNoMarginBottom
@@ -167,7 +161,10 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 									) }
 								</Notice>
 							) }
-						</BaseControl>
+							<p className="components-base-control__help">
+								{ __( 'Pick which sections appear in the dropdown.', 'jetpack-search-pkg' ) }
+							</p>
+						</fieldset>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -19,9 +19,27 @@ $placeholder = trim( (string) ( $attributes['placeholder'] ?? '' ) );
 if ( '' === $placeholder ) {
 	$placeholder = __( 'Search…', 'jetpack-search-pkg' );
 }
-$show_icon          = (bool) ( $attributes['showIcon'] ?? true );
-$submit_only        = ! empty( $attributes['submitOnly'] );
-$enable_suggestions = ! empty( $attributes['enableSuggestions'] );
+$show_icon   = (bool) ( $attributes['showIcon'] ?? true );
+$submit_only = ! empty( $attributes['submitOnly'] );
+// Sanitize the saved `suggestionTypes` array down to a known-good subset of
+// the enum, in the canonical render order, deduplicated. Mirrors the
+// enum in `block.json::attributes.suggestionTypes.items.enum` and the
+// `TYPE_ORDER` constant in `suggestion-rows.js`. Authors can save anything
+// the editor lets them — and a future block-version migration could leave
+// stale strings here — so the front end stays defensive.
+$allowed_suggestion_types = array( 'query', 'taxonomy', 'post' );
+$raw_suggestion_types     = $attributes['suggestionTypes'] ?? $allowed_suggestion_types;
+if ( ! is_array( $raw_suggestion_types ) ) {
+	$raw_suggestion_types = $allowed_suggestion_types;
+}
+$suggestion_types = array_values(
+	array_intersect( $allowed_suggestion_types, array_map( 'strval', $raw_suggestion_types ) )
+);
+// `enableSuggestions` is the author's master kill switch; an empty
+// `suggestionTypes` array collapses to the same outcome (no dropdown). The
+// combined gate keeps the rest of the render path branch-free — no listbox,
+// no combobox attributes, no `data-wp-context` seeded when either says off.
+$enable_suggestions = ! empty( $attributes['enableSuggestions'] ) && ! empty( $suggestion_types );
 // Read the URL-derived query through the shared helper so the SSR
 // `value=` matches the Interactivity store's seeded `searchQuery`.
 // The helper picks `s` vs `q` based on `is_search()` and applies the
@@ -46,6 +64,11 @@ $context_json = $enable_suggestions
 			'activeOptionId'  => '',
 			'rows'            => array(),
 			'listboxId'       => $listbox_id,
+			// `suggestionTypes` is seeded so the view bundle can filter
+			// rows client-side without re-reading the block attribute via
+			// a roundtrip. Per-instance because two Search Input blocks
+			// on the same page could pick different shapes.
+			'suggestionTypes' => $suggestion_types,
 		),
 		JSON_HEX_AMP | JSON_UNESCAPED_SLASHES
 	)

--- a/projects/packages/search/src/search-blocks/blocks/search-input/suggestion-rows.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/suggestion-rows.js
@@ -28,24 +28,42 @@ const TYPE_ORDER = [ 'query', 'taxonomy', 'post' ];
  * a Script Module (the blocks build target), so client-side translation
  * isn't an option in this view bundle.
  *
+ * The `enabledTypes` argument is the per-block author selection of which
+ * suggestion sections to render. The canonical render order is preserved
+ * regardless of the order `enabledTypes` was saved in; unknown strings are
+ * dropped silently. Passing `undefined` (or any non-array) means "all
+ * three" so older callers stay backward-compatible.
+ *
  * @param {Array<{type: 'query'|'post'|'taxonomy', text: string, url?: string, taxonomy?: string, slug?: string}>} suggestions
- *                                                                                                                             Flat list returned by `fetchSuggestions`.
- * @param {string}                                                                                                 listboxId   - DOM id of the parent `<ul role="listbox">`. Used to
- *                                                                                                                             bake `optionId` so the input's `aria-activedescendant` can target it.
+ *                                                                                                                                Flat list returned by `fetchSuggestions`.
+ * @param {string}                                                                                                 listboxId      - DOM id of the parent `<ul role="listbox">`. Used to
+ *                                                                                                                                bake `optionId` so the input's `aria-activedescendant` can target it.
  * @param {{query: string, taxonomy: string, post: string}}                                                        labels
- *                                                                                                                             Translated group titles. Missing keys render as the bare type string.
+ *                                                                                                                                Translated group titles. Missing keys render as the bare type string.
+ * @param {Array<string>}                                                                                          [enabledTypes]
+ *                                                                                                                                Subset of TYPE_ORDER the block author enabled. Omit / pass non-array for "all".
  * @return {Array<object>} Rows ready for `data-wp-each`.
  */
-export function buildSuggestionRows( suggestions, listboxId, labels ) {
+export function buildSuggestionRows( suggestions, listboxId, labels, enabledTypes ) {
 	if ( ! Array.isArray( suggestions ) || suggestions.length === 0 ) {
 		return [];
 	}
 
 	const safeLabels = labels ?? {};
+	// Filter TYPE_ORDER to the author's selection while preserving the
+	// canonical render order. `null` / `undefined` / non-array short-circuits
+	// to "all enabled" so older callers (and tests) keep working.
+	const types = Array.isArray( enabledTypes )
+		? TYPE_ORDER.filter( t => enabledTypes.includes( t ) )
+		: TYPE_ORDER;
+	if ( types.length === 0 ) {
+		return [];
+	}
+
 	const rows = [];
 	let optionIndex = 0;
 
-	for ( const type of TYPE_ORDER ) {
+	for ( const type of types ) {
 		const indexed = suggestions
 			.map( ( item, originalIndex ) => ( { item, originalIndex } ) )
 			.filter( ( { item } ) => item.type === type );

--- a/projects/packages/search/src/search-blocks/blocks/search-input/suggestions.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/suggestions.js
@@ -368,11 +368,19 @@ store( NAMESPACE, {
 				}
 			}
 
-			const rows = buildSuggestionRows( suggestions, ctx.listboxId, {
-				query: state.strings?.suggestionLabelQuery ?? '',
-				taxonomy: state.strings?.suggestionLabelTaxonomy ?? '',
-				post: state.strings?.suggestionLabelPost ?? '',
-			} );
+			const rows = buildSuggestionRows(
+				suggestions,
+				ctx.listboxId,
+				{
+					query: state.strings?.suggestionLabelQuery ?? '',
+					taxonomy: state.strings?.suggestionLabelTaxonomy ?? '',
+					post: state.strings?.suggestionLabelPost ?? '',
+				},
+				// Per-instance type selection seeded by render.php. Falls
+				// through to "all enabled" when missing — the helper handles
+				// the non-array shape — so older saved blocks keep working.
+				ctx.suggestionTypes
+			);
 			ctx.rows = rows;
 			ctx.activeIndex = -1;
 			ctx.activeOptionId = '';

--- a/projects/packages/search/src/search-blocks/blocks/search-input/test/suggestion-rows.test.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/test/suggestion-rows.test.js
@@ -132,6 +132,74 @@ describe( 'countOptions', () => {
 	} );
 } );
 
+describe( 'buildSuggestionRows enabledTypes filter', () => {
+	const FIXTURE = [
+		{ type: 'query', text: 'q1' },
+		{ type: 'query', text: 'q2' },
+		{ type: 'taxonomy', text: 't1', url: '/c/t1', taxonomy: 'category', slug: 't1' },
+		{ type: 'post', text: 'p1', url: '/p/p1' },
+	];
+
+	it( 'renders only the requested type when enabledTypes is a single-element array', () => {
+		const rows = buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, [ 'query' ] );
+		const headerTypes = rows.filter( r => r.isHeader ).map( r => r.type );
+		const optionTexts = rows.filter( r => ! r.isHeader ).map( r => r.text );
+		expect( headerTypes ).toEqual( [ 'query' ] );
+		expect( optionTexts ).toEqual( [ 'q1', 'q2' ] );
+	} );
+
+	it( 'renders the requested subset in canonical order regardless of input order', () => {
+		const rows = buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, [ 'post', 'query' ] );
+		const headerTypes = rows.filter( r => r.isHeader ).map( r => r.type );
+		expect( headerTypes ).toEqual( [ 'query', 'post' ] );
+	} );
+
+	it( 'returns an empty array when enabledTypes is an empty array', () => {
+		expect( buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, [] ) ).toEqual( [] );
+	} );
+
+	it( 'silently drops unknown strings in enabledTypes', () => {
+		const rows = buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, [
+			'query',
+			'not-a-real-type',
+			'post',
+		] );
+		const headerTypes = rows.filter( r => r.isHeader ).map( r => r.type );
+		expect( headerTypes ).toEqual( [ 'query', 'post' ] );
+	} );
+
+	it( 'falls back to all-enabled when enabledTypes is omitted (backward-compat)', () => {
+		const rows = buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS );
+		const headerTypes = rows.filter( r => r.isHeader ).map( r => r.type );
+		expect( headerTypes ).toEqual( [ 'query', 'taxonomy', 'post' ] );
+	} );
+
+	it( 'falls back to all-enabled when enabledTypes is non-array (null / object)', () => {
+		const all = [ 'query', 'taxonomy', 'post' ];
+		expect(
+			buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, null )
+				.filter( r => r.isHeader )
+				.map( r => r.type )
+		).toEqual( all );
+		expect(
+			buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, { query: true } )
+				.filter( r => r.isHeader )
+				.map( r => r.type )
+		).toEqual( all );
+	} );
+
+	it( 'keeps a contiguous optionIndex sequence after filtering', () => {
+		const rows = buildSuggestionRows( FIXTURE, LISTBOX_ID, LABELS, [ 'query', 'post' ] );
+		const options = rows.filter( r => ! r.isHeader );
+		expect( options.map( r => r.optionIndex ) ).toEqual( [ 0, 1, 2 ] );
+		expect( options.map( r => r.optionId ) ).toEqual( [
+			`${ LISTBOX_ID }-option-0`,
+			`${ LISTBOX_ID }-option-1`,
+			`${ LISTBOX_ID }-option-2`,
+		] );
+	} );
+} );
+
 describe( 'rowAtOptionIndex', () => {
 	it( 'returns the option row matching the given optionIndex', () => {
 		const rows = buildSuggestionRows(


### PR DESCRIPTION
Fixes [SEARCH-212](https://linear.app/a8c/issue/SEARCH-212/search-blocks-let-authors-choose-which-suggestion-types-appear-query)

## Why

The autocomplete dropdown that shipped with [#48985](https://github.com/Automattic/jetpack/pull/48985) was all-or-nothing — toggling **Show search suggestions** always showed all three sections (query completions, popular categories/tags, matching post titles). Different surfaces want different shapes: a header search probably only wants compact query completions; a shop search wants categories + posts; a doc site might want posts only. This PR lets authors pick per block.

## Proposed changes

- New `suggestionTypes` block attribute on `jetpack-search/search-input` — array, items typed via an enum (`query` | `taxonomy` | `post`), default `["query","taxonomy","post"]`.
- Inspector renders a nested `CheckboxControl` group ("Query completions" / "Categories & tags" / "Post titles") under the existing "Show search suggestions" toggle. An inline notice appears when the author unchecks every box explaining the dropdown won't render until at least one is enabled.
- `render.php` sanitizes the saved array down to a known-good subset in canonical order, dedupes, and seeds it into the per-instance `data-wp-context`. When `enableSuggestions` is off OR the sanitized array is empty, the front-end DOM collapses to the same "no dropdown" shape as before — no `role="combobox"`, no `aria-*` plumbing, no `<ul role="listbox">`.
- `buildSuggestionRows` takes a new optional fourth argument `enabledTypes` that intersects `TYPE_ORDER` with the saved selection while preserving canonical order. `null` / `undefined` / non-array short-circuits to "all enabled" so older callers stay backward-compatible.
- The WPCOM `/search-suggestions` endpoint call is unchanged — we still fetch every section and drop the unwanted ones on the client. The endpoint doesn't expose a per-section knob and the bandwidth save isn't worth a server-side dance.
- Existing saved blocks (`enableSuggestions: true` without a `suggestionTypes` field) take the default `["query","taxonomy","post"]` and render identically to before.

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-212
* Follow-up to https://github.com/Automattic/jetpack/pull/48985

## Does this pull request change what data or activity we track or use?

No. Same `/wpcom/v2/sites/<id>/search-suggestions` endpoint, same request shape, same response. Filtering happens client-side after the response lands.

## Screenshots

### Before — all three sections always visible

![before](https://github.com/user-attachments/assets/e6f2279b-575e-40ff-a8d3-81a29e3bc23c)

### After — author opts into "Query completions" only

![after](https://github.com/user-attachments/assets/02beba02-1fa4-4108-8520-9297b8bf57c5)

### New inspector control

![inspector](https://github.com/user-attachments/assets/e32ef443-0a5f-4c5b-8544-6868771ca5d8)

## Testing instructions

1. **Setup.** Insert a Search Input block on a page. Save and visit the front end. Confirm the existing default-off behavior is unchanged (no dropdown, no `role="combobox"` on the input).
2. **Toggle master on, default types.** In the inspector, flip **Show search suggestions** on. The new "Suggestion types" section appears with all three checkboxes pre-checked. Save, visit the front end, type a query — confirm the dropdown shows all three groups (`Suggestions` / `Popular Filters` / `Articles`), matching the prior behavior.
3. **Query completions only.** Uncheck "Categories & tags" and "Post titles". Save, visit the front end, type — confirm only the `Suggestions` group renders. No other groups.
4. **Categories & tags only.** Re-check Categories, uncheck Query completions. Save, visit, type — confirm only `Popular Filters` renders.
5. **Post titles only.** Same flow with just "Post titles" checked — confirm only `Articles` renders.
6. **All sections.** All three boxes checked — same as step 2.
7. **Empty selection.** Uncheck every box while the master toggle is still on. Inspector shows the inline notice "No types selected — the dropdown won't appear until at least one is enabled." Save, visit the front end — confirm the input has **no** `role="combobox"`, **no** `aria-*` plumbing, **no** `<ul role="listbox">` in the DOM (identical to master-toggle-off).
8. **Backward-compat.** Insert a Search Input via `wp post create` with `<!-- wp:jetpack-search/search-input {"enableSuggestions":true} /-->` (no `suggestionTypes` field). Confirm the front end behaves exactly like step 2 — the default `["query","taxonomy","post"]` applies.
9. **Order independence.** Save with `suggestionTypes: ["post","query"]` (out of order, no taxonomy). Confirm the front end renders `Suggestions` first, `Articles` second — canonical TYPE_ORDER is preserved regardless of save order.
10. **Unknown enum strings.** Edit a saved block's JSON to include an unknown string in `suggestionTypes` (e.g. `["query","banana","post"]`). Confirm the front end drops it silently and renders `Suggestions` + `Articles`.
11. **Unit tests.** `pnpm --filter jetpack-search test src/search-blocks src/instant-search/hooks` — all 51 tests pass (including 7 new `enabledTypes` cases).

