### PR TITLE
Write: skip last-editor meta update for posts with unsupported content

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write_last_editor_meta
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write_last_editor_meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Don't update last-editor post meta when the post contains unsupported content

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -482,9 +482,13 @@ function wpcom_write_render_admin_page() {
 			$edit_featured_id   = (int) get_post_thumbnail_id( $edit_post_id );
 			$unsupported_type   = wpcom_write_detect_unsupported_content( $edit_post->post_content );
 
-			// Track that this post was last edited in the Write editor,
-			// matching the pattern used by the block and classic editors.
-			\Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\EditorType\remember_editor( $edit_post_id, 'write-editor' );
+			// Only track the last editor when the post is actually editable
+			// in Write. Posts with unsupported content show a warning modal
+			// and are never editable, so recording Write as the last editor
+			// would be misleading.
+			if ( ! $unsupported_type ) {
+				\Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\EditorType\remember_editor( $edit_post_id, 'write-editor' );
+			}
 		} else {
 			$edit_post_id = 0;
 		}


### PR DESCRIPTION
Fixes RSM-3572

## Proposed changes

* Skip updating the `last_editor` post meta when opening a post in the Write editor that contains unsupported blocks or classic-editor content.
* Previously, `remember_editor()` was called unconditionally — even when the post couldn't actually be edited in Write (the editor area is made inert and a warning modal is shown). This could mislead editor-routing logic into thinking the post was last edited in Write.
* Now the meta is only updated when `wpcom_write_detect_unsupported_content()` returns no warning.

## Related product discussion/links

* RSM-3572

## Does this pull request change what data or activity we track or use?

No. This narrows when existing metadata is written — it doesn't add new tracking.

## Testing instructions

* Open a post in the Write editor that **can** be edited (only supported blocks). Verify the `last_editor` post meta is set to `write-editor`.
* Open a post that contains unsupported block-editor features (e.g. a Columns block). Verify the unsupported-content warning modal appears and the `last_editor` post meta is **not** updated to `write-editor`.
* Open a classic-editor post. Verify the classic-editor warning modal appears and the `last_editor` post meta is **not** updated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
