### PR TITLE
Search: decouple AI Answer block from jetpack_search_ai_answers_enabled (RSM-3608)

### DIFF
--- a/projects/packages/search/changelog/update-RSM-3608-ai-answer-block-decoupled-from-option
+++ b/projects/packages/search/changelog/update-RSM-3608-ai-answer-block-decoupled-from-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: the AI Answer block (`jetpack-search/ai-answer`) no longer gates on the site-wide `jetpack_search_ai_answers_enabled` option — block presence in post content is the only switch. The option still governs the instant-search overlay.

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -3,18 +3,16 @@
  * AI Answer block render.
  *
  * Renders the panel scaffold that the Interactivity store hydrates with the
- * streaming brief / extended AI answer. Server-side bails to an empty string
- * when AI Answers is disabled site-wide so the block disappears without the
- * author touching saved post content.
+ * streaming brief / extended AI answer. The author's decision to insert the
+ * block in their post content is the only switch — there's no site-wide
+ * option gate here. The `jetpack_search_ai_answers_enabled` option still
+ * governs the instant-search overlay's AI Answers, which is the default UX
+ * on any search page; the embedded block is an explicit opt-in surface.
  *
  * @package automattic/jetpack-search
  */
 
 namespace Automattic\Jetpack\Search;
-
-if ( ! AI_Answers::is_enabled() ) {
-	return '';
-}
 
 // $attributes is injected by WordPress at block-render time via the
 // `render_callback` include scope; static analysis can't see the binding,

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1308,14 +1308,6 @@ class Search_Blocks {
 			// locale-agnostic — only the display string carries the symbol.
 			'priceCurrencySymbol'        => '$',
 
-			// AI Answers — whether the agent endpoint should be called at all.
-			// Render.php for `jetpack-search/ai-answer` also short-circuits to
-			// an empty string when this is false, so the panel disappears at
-			// SSR time even for a saved post that still has the block in its
-			// content. The JS gate here covers the edge case where the flag
-			// flips off between SSR and hydration.
-			'aiAnswersEnabled'           => AI_Answers::is_enabled(),
-
 			// Localized rotating loading hints shown while the "Show more"
 			// extended AI answer streams. Lives on the top-level seed (not
 			// under `strings`) because the `strings` map is typed

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -595,12 +595,6 @@ const { state, actions } = store( NAMESPACE, {
 		aiExtendedLoadingText: '',
 		aiShowExtended: false,
 		aiSessionId: null,
-		// `aiAnswersEnabled` is intentionally NOT declared here — declaring a
-		// JS default for a PHP-seeded key would overwrite the seeded value at
-		// hydration time (the IA runtime treats the JS-side `state` object as
-		// a defaults bag whose keys win over the seed). The seed is the
-		// source of truth; consumers read `state.aiAnswersEnabled` and the
-		// proxy resolves it through to the hydrated value.
 
 		// `resultsCountText` lives on the seeded state (PHP-side), not as a
 		// getter, so the IA SSR pass can resolve `data-wp-text="state.resultsCountText"`
@@ -891,11 +885,11 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		// Panel-level visibility. `aiPanelHidden` collapses the whole block
-		// to `hidden` until something interesting happens — idle, no answers
-		// enabled, or no query yet — so an empty page or a search-less /
-		// disabled site doesn't reserve a wrapper of padding/border.
+		// to `hidden` until something interesting happens — idle status,
+		// or no query yet — so an empty / search-less page doesn't reserve
+		// a wrapper of padding/border.
 		get aiPanelHidden() {
-			return ! state.aiAnswersEnabled || state.aiVisibleStatus === 'idle';
+			return state.aiVisibleStatus === 'idle';
 		},
 		get aiIsLoading() {
 			return state.aiVisibleStatus === 'loading';
@@ -1435,20 +1429,16 @@ const { state, actions } = store( NAMESPACE, {
 		 * from inside `actions.search()`, so the answer always tracks the
 		 * results fetch.
 		 *
-		 * Bails when: `aiAnswersEnabled` is false (admin toggle disables the
-		 * feature); the query is shorter than 3 chars (matching the overlay
-		 * heuristic); or the query is the same one we already kicked off
-		 * (filter/sort re-triggers `search()` without changing the text, and
-		 * the agent response would be identical).
+		 * Bails when the query is shorter than 3 chars (matching the
+		 * overlay heuristic) or when the query is the same one we already
+		 * kicked off (filter/sort re-triggers `search()` without changing
+		 * the text, and the agent response would be identical).
 		 *
 		 * Aborts any in-flight brief / extended stream from the previous
 		 * query before starting the new one so a slow earlier response can't
 		 * land on top of fresh state.
 		 */
 		fetchAiAnswer() {
-			if ( ! state.aiAnswersEnabled ) {
-				return;
-			}
 			const query = state.searchQuery;
 			if ( ! query || query.length < 3 ) {
 				// Tear down whatever's on screen — a query that dropped below
@@ -1517,9 +1507,6 @@ const { state, actions } = store( NAMESPACE, {
 		 * but a slow click after a re-fetch could still race the brief.
 		 */
 		showExtendedAiAnswer() {
-			if ( ! state.aiAnswersEnabled ) {
-				return;
-			}
 			if ( state.aiBriefStatus !== 'done' ) {
 				return;
 			}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -984,7 +984,7 @@ const { state, actions } = store( NAMESPACE, {
 			// when an `ai-answer` block has mounted on the page — pages with
 			// just search-input + results-list shouldn't pay for an SSE
 			// round-trip whose output nothing on the page renders. The
-			// action also gates on enable-flag + query length + a same-query
+			// action also gates on query length (≥ 3 chars) and a same-query
 			// memo, so filter/sort-only re-calls don't re-spam the agent.
 			if ( aiBlockPresent ) {
 				actions.fetchAiAnswer();

--- a/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/ai-answers-store.test.js
@@ -56,7 +56,6 @@ function lastStreamCall() {
 describe( 'AI Answers store slice', () => {
 	beforeEach( () => {
 		mockStreamAiAnswer.mockReset();
-		state.aiAnswersEnabled = true;
 		state.searchQuery = '';
 		state.siteId = 42;
 		state.locale = 'en-US';
@@ -78,14 +77,7 @@ describe( 'AI Answers store slice', () => {
 		state.aiSessionId = null;
 	} );
 
-	it( 'aiPanelHidden is true when aiAnswersEnabled is false', () => {
-		state.aiAnswersEnabled = false;
-		state.aiBriefStatus = 'streaming';
-		expect( state.aiPanelHidden ).toBe( true );
-	} );
-
 	it( 'aiPanelHidden is true when status is idle', () => {
-		state.aiAnswersEnabled = true;
 		state.aiBriefStatus = 'idle';
 		expect( state.aiPanelHidden ).toBe( true );
 	} );
@@ -147,13 +139,6 @@ describe( 'AI Answers store slice', () => {
 		const list = state.aiVisibleCitations;
 		expect( list[ 0 ].href ).toBe( 'https://example.com/safe' );
 		expect( list[ 1 ].href ).toBe( '#' );
-	} );
-
-	it( 'fetchAiAnswer bails when aiAnswersEnabled is false', () => {
-		state.aiAnswersEnabled = false;
-		state.searchQuery = 'something long enough';
-		actions.fetchAiAnswer();
-		expect( mockStreamAiAnswer ).not.toHaveBeenCalled();
 	} );
 
 	it( 'fetchAiAnswer bails when query is shorter than 3 characters', () => {

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -12,10 +12,12 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for the ai-answer block's render template.
  *
- * Asserts that render output is gated by `AI_Answers::is_enabled()`, and that
- * the attribute-driven affordances (heading, citations region, Show-more
- * button) appear / disappear in the markup the way the front-end consumer
- * expects.
+ * Asserts that render output is independent of the site-wide
+ * `jetpack_search_ai_answers_enabled` option (block presence in post
+ * content is the opt-in signal — the option only governs the overlay),
+ * and that the attribute-driven affordances (heading, citations region,
+ * Show-more button) appear / disappear in the markup the way the
+ * front-end consumer expects.
  */
 class Ai_Answer_Render_Test extends TestCase {
 
@@ -56,16 +58,6 @@ class Ai_Answer_Render_Test extends TestCase {
 		\unregister_block_type( 'jetpack-search/ai-answer' );
 	}
 
-	protected function setUp(): void {
-		parent::setUp();
-		update_option( 'jetpack_search_ai_answers_enabled', true );
-	}
-
-	protected function tearDown(): void {
-		delete_option( 'jetpack_search_ai_answers_enabled' );
-		parent::tearDown();
-	}
-
 	/**
 	 * Render the ai-answer block via `do_blocks()`.
 	 *
@@ -79,16 +71,37 @@ class Ai_Answer_Render_Test extends TestCase {
 		return do_blocks( '<!-- wp:jetpack-search/ai-answer ' . $json . ' /-->' );
 	}
 
-	public function test_disabled_renders_nothing() {
+	public function test_renders_panel_wrapper_independent_of_site_option() {
+		// The block is its own opt-in surface: presence of the block in
+		// post content is the only switch. The site-wide AI Answers option
+		// only governs the instant-search overlay; flipping it must not
+		// affect the embedded block's render.
 		update_option( 'jetpack_search_ai_answers_enabled', false );
-		$markup = $this->render();
-		$this->assertSame( '', trim( $markup ) );
-	}
+		$markup_with_option_off = $this->render();
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+		$markup_with_option_unset = $this->render();
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$markup_with_option_on = $this->render();
+		delete_option( 'jetpack_search_ai_answers_enabled' );
 
-	public function test_enabled_renders_panel_wrapper() {
-		$markup = $this->render();
-		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
-		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+		foreach (
+			array(
+				'option off'   => $markup_with_option_off,
+				'option unset' => $markup_with_option_unset,
+				'option on'    => $markup_with_option_on,
+			) as $label => $markup
+		) {
+			$this->assertStringContainsString(
+				'jp-search-answers-panel',
+				$markup,
+				"Block wrapper should render with the site option $label."
+			);
+			$this->assertStringContainsString(
+				'data-wp-interactive="jetpack-search"',
+				$markup,
+				"Interactivity directive should render with the site option $label."
+			);
+		}
 	}
 
 	public function test_default_heading_is_ai_answer() {


### PR DESCRIPTION
Fixes [RSM-3608](https://linear.app/a8c/issue/RSM-3608/ai-answer-block-decouple-from-the-jetpack-search-ai-answers-enabled). Follow-up to #48986 (this PR is stacked on top of `raven/rsm-3591-ai-answer-block` and targets it as base — once #48986 lands on trunk, this branch can be rebased onto trunk).

## Why

When the [AI Answer block](https://github.com/Automattic/jetpack/pull/48986) ships, the site-wide `jetpack_search_ai_answers_enabled` option will simultaneously control two unrelated decisions: whether the instant-search overlay fires AI Answers (where the option is the right gate — the overlay is the default UX on any search page), and whether an embedded `jetpack-search/ai-answer` block that an author *explicitly* inserted should render (where the block's presence in saved post content already *is* the opt-in signal). That coupling was flagged in [#48986 (review)](https://github.com/Automattic/jetpack/pull/48986#discussion_r3271245120).

This PR keeps the option's role for the overlay and removes it from the block path. To opt out of AI Answers for an embedded surface, an author removes the block — not flips a global flag.

## Proposed changes

* `projects/packages/search/src/search-blocks/blocks/ai-answer/render.php` — drop the `AI_Answers::is_enabled()` early return. The block renders whenever it's present in post content.
* `projects/packages/search/src/search-blocks/class-search-blocks.php` `build_initial_state()` — drop the `aiAnswersEnabled` seed key; no block-side consumer reads it anymore.
* `projects/packages/search/src/search-blocks/store/index.js`:
  * Remove the `aiAnswersEnabled` guards in `actions.fetchAiAnswer()` and `actions.showExtendedAiAnswer()`. The fetch is still gated by the `aiBlockPresent` module flag (set when the block mounts) plus the standard query-length + same-query memo.
  * Remove the `aiAnswersEnabled` clause from the `aiPanelHidden` getter — visible status alone determines panel visibility.
* Tests: drop the option-related setup and the `test_disabled_renders_nothing` PHP case; add `test_renders_panel_wrapper_independent_of_site_option` that exercises render with the option off / unset / on. Drop the matching JS tests; the rest stop setting `state.aiAnswersEnabled` since it no longer exists.

Overlay behaviour is unchanged — `class-helper.php` still localizes `aiAnswersEnabled` for the overlay, and `search-app.jsx::getAiAnswer` still consults it.

## Related product discussion/links

* Linear: [RSM-3608](https://linear.app/a8c/issue/RSM-3608/ai-answer-block-decouple-from-the-jetpack-search-ai-answers-enabled) — Jetpack Search blocks project
* Parent issue: [RSM-3591](https://linear.app/a8c/issue/RSM-3591/search-30-ai-answer-block-for-embedded-search-template)
* Source of the follow-up: https://github.com/Automattic/jetpack/pull/48986#discussion_r3271245120

## Does this pull request change what data or activity we track or use?

No. Same `POST https://public-api.wordpress.com/wpcom/v2/ai/agent/jetpack-workflow-search_summarizer` endpoint, same request shape, same site/query/filter payload. The only change is *when* the block's view bundle decides to call it — block presence on a page now suffices, the site option no longer overrides it.

## Verification

The change is functional (a removed gate) rather than visual. Verified live on the raven docker env (`https://jp-raven.jurassic.tube/`):

<details>
<summary>Server-side render is independent of the option</summary>

```text
# Option off:
$ wp option update jetpack_search_ai_answers_enabled 0
Success: Updated 'jetpack_search_ai_answers_enabled' option.

$ curl -s "http://localhost:18120/rsm-3591-ai-answer-block-fixture/?q=wordpress" \
    | grep -c "wp-block-jetpack-search-ai-answer\|jp-search-answers-panel"
43

# Option on:
$ wp option update jetpack_search_ai_answers_enabled 1
Success: Updated 'jetpack_search_ai_answers_enabled' option.
```

(On `trunk` + parent PR #48986, the same `curl` against an option-off site returns `0` — the gate was emitting nothing.)
</details>

<details>
<summary>Client-side: AI fetch fires + panel renders with the option off</summary>

```js
// After visiting /rsm-3591-ai-answer-block-fixture/?q=wordpress
// with `jetpack_search_ai_answers_enabled = 0`:
{
  "aiAnswersEnabled": undefined,                              // ← no longer seeded
  "aiBriefStatus": "done",                                    // ← SSE fetch ran to completion
  "aiBriefTextPreview": "The results show two WordPress…",    // ← actual streamed content
  "panelHidden": false,                                       // ← panel visible
  "contentHidden": false                                      // ← content section visible
}
```

</details>

<details>
<summary>Unit tests</summary>

```text
$ composer phpunit -- --filter Ai_Answer_Render_Test
OK (8 tests, 17 assertions)

$ npx jest tests/js/search-blocks/ai-answer-edit.test.jsx tests/js/search-blocks/ai-answers-store.test.js
Test Suites: 2 passed, 2 total
Tests:       24 passed, 24 total
```

</details>

## Testing instructions

1. Build the matrix: `pnpm jetpack build packages/my-jetpack && pnpm jetpack build plugins/jetpack && pnpm jetpack build packages/search && pnpm jetpack build plugins/search`.
2. Bring up a docker / Jurassic Ninja env with this branch installed.
3. Create a page containing the embedded AI Answer block:
   ```
   <!-- wp:jetpack-search/search-input /-->
   <!-- wp:jetpack-search/ai-answer /-->
   <!-- wp:jetpack-search/search-results -->
   <!-- wp:jetpack-search/results-list /-->
   <!-- /wp:jetpack-search/search-results -->
   ```

Verify each acceptance criterion from the issue:

- [ ] With `wp option update jetpack_search_ai_answers_enabled 0`, visiting the page with `?q=wordpress` still renders the AI Answer panel and the SSE fetch still fires.
- [ ] With `wp option update jetpack_search_ai_answers_enabled 0`, the instant-search overlay (on the default `/?s=wordpress` route) still does NOT fire its AI Answers. (Unchanged behaviour — the overlay still reads `window.SERVER_OBJECT_NAME.aiAnswersEnabled` from `class-helper.php`.)
- [ ] All existing PHP + JS tests for the block still pass. None were added that re-introduce the option gate.
- [ ] No regressions in the overlay's AI Answers panel (toggle the option, refresh the overlay-backed search page).
