### PR TITLE
Experience Selector: add new blocks-powered Overlay option + rename legacy (SEARCH-213)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-213-overlay-blocks-experience
+++ b/projects/packages/search/changelog/SEARCH-213-overlay-blocks-experience
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Experience Selector: Add a new "Overlay search" card backed by the experimental blocks-powered overlay introduced in #48987; the legacy preact Overlay is renamed to "Overlay search (legacy)" when the new card is visible. Both cards stay opt-in via the `jetpack_search_overlay_block_template_enabled` filter and remain switchable from the dashboard.

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -338,6 +338,23 @@ class Module_Control {
 			);
 		}
 
+		// Defence-in-depth for the experimental blocks-powered overlay: the
+		// dashboard already hides the option when the
+		// `jetpack_search_overlay_block_template_enabled` filter is off, but
+		// a scripted REST POST could otherwise pre-stage `overlay_blocks` on
+		// a site where operators haven't opted in. Reject the value at the
+		// boundary so the runtime gate isn't the only safety net.
+		if (
+			self::EXPERIENCE_OVERLAY_BLOCKS === $experience
+			&& ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false )
+		) {
+			return new WP_Error(
+				'experience_not_available',
+				esc_html__( 'The blocks-powered Overlay search experience is not enabled on this site.', 'jetpack-search-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		switch ( $experience ) {
 			case self::EXPERIENCE_OFF:
 				$this->disable_instant_search();

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -45,11 +45,19 @@ class Module_Control {
 
 	/**
 	 * Valid experience values.
+	 *
+	 * `EXPERIENCE_OVERLAY_BLOCKS` is the experimental blocks-powered overlay
+	 * (server-rendered Search blocks template inside a modal). It is gated
+	 * by the `jetpack_search_overlay_block_template_enabled` filter — the
+	 * dashboard option only appears when the filter is on, and the runtime
+	 * swap from the legacy preact app to the new overlay only kicks in when
+	 * the user has explicitly chosen this experience.
 	 */
-	const EXPERIENCE_OVERLAY  = 'overlay';
-	const EXPERIENCE_EMBEDDED = 'embedded';
-	const EXPERIENCE_INLINE   = 'inline';
-	const EXPERIENCE_OFF      = 'off';
+	const EXPERIENCE_OVERLAY        = 'overlay';
+	const EXPERIENCE_OVERLAY_BLOCKS = 'overlay_blocks';
+	const EXPERIENCE_EMBEDDED       = 'embedded';
+	const EXPERIENCE_INLINE         = 'inline';
+	const EXPERIENCE_OFF            = 'off';
 
 	/**
 	 * Contructor
@@ -111,7 +119,11 @@ class Module_Control {
 		if ( self::EXPERIENCE_OVERLAY === $saved ) {
 			return true;
 		}
-		if ( self::EXPERIENCE_INLINE === $saved || self::EXPERIENCE_EMBEDDED === $saved ) {
+		if (
+			self::EXPERIENCE_INLINE === $saved
+			|| self::EXPERIENCE_EMBEDDED === $saved
+			|| self::EXPERIENCE_OVERLAY_BLOCKS === $saved
+		) {
 			return false;
 		}
 
@@ -249,6 +261,9 @@ class Module_Control {
 		if ( self::EXPERIENCE_OVERLAY === $saved ) {
 			return self::EXPERIENCE_OVERLAY;
 		}
+		if ( self::EXPERIENCE_OVERLAY_BLOCKS === $saved ) {
+			return self::EXPERIENCE_OVERLAY_BLOCKS;
+		}
 
 		// Legacy fallback for sites that have never saved via the new UI: a true
 		// `instant_search_enabled` boolean reads as overlay; otherwise inline.
@@ -308,7 +323,13 @@ class Module_Control {
 	 *                      no-op the REST controller treats as success).
 	 */
 	public function update_experience( string $experience ) {
-		$valid_values = array( self::EXPERIENCE_OVERLAY, self::EXPERIENCE_EMBEDDED, self::EXPERIENCE_INLINE, self::EXPERIENCE_OFF );
+		$valid_values = array(
+			self::EXPERIENCE_OVERLAY,
+			self::EXPERIENCE_OVERLAY_BLOCKS,
+			self::EXPERIENCE_EMBEDDED,
+			self::EXPERIENCE_INLINE,
+			self::EXPERIENCE_OFF,
+		);
 		if ( ! in_array( $experience, $valid_values, true ) ) {
 			return new WP_Error(
 				'invalid_experience',
@@ -353,6 +374,20 @@ class Module_Control {
 					return $result;
 				}
 				update_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, self::EXPERIENCE_OVERLAY );
+				return true;
+
+			case self::EXPERIENCE_OVERLAY_BLOCKS:
+				// The blocks-powered overlay does not boot the legacy preact
+				// `SearchApp`, so we keep `instant_search_enabled` off; the
+				// runtime hookup lives in `Search_Blocks::is_block_template_overlay_enabled()`
+				// which combines the user's experience choice with the
+				// `jetpack_search_overlay_block_template_enabled` server filter.
+				$result = $this->activate();
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+				$this->disable_instant_search();
+				update_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, self::EXPERIENCE_OVERLAY_BLOCKS );
 				return true;
 		}
 	}

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -243,11 +243,12 @@ class Module_Control {
 	 * Get the active search experience.
 	 *
 	 * `'off'` is read from the global Jetpack module-active state (not stored in
-	 * this package's option). `'inline'`, `'embedded'`, and `'overlay'` are each
-	 * written as their literal value to `jetpack_search_experience` whenever the
-	 * experience changes, and read straight back here.
+	 * this package's option). `'inline'`, `'embedded'`, `'overlay'`, and
+	 * `'overlay_blocks'` are each written as their literal value to
+	 * `jetpack_search_experience` whenever the experience changes, and read
+	 * straight back here.
 	 *
-	 * @return string One of 'embedded', 'overlay', 'inline', 'off'.
+	 * @return string One of 'embedded', 'overlay', 'overlay_blocks', 'inline', 'off'.
 	 */
 	public function get_experience() {
 		if ( ! $this->is_active() ) {
@@ -405,6 +406,16 @@ class Module_Control {
 				}
 				$this->disable_instant_search();
 				update_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, self::EXPERIENCE_OVERLAY_BLOCKS );
+				return true;
+
+			default:
+				// Unreachable — the `in_array` guard at the top of this
+				// method already restricts $experience to the cases above.
+				// Returning a typed value (rather than falling through to an
+				// implicit `null`) satisfies the static analyzers that flag
+				// switch statements without a `default` branch, and keeps the
+				// method's `bool|WP_Error` contract honest if a future caller
+				// loosens the validation.
 				return true;
 		}
 	}

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -89,6 +89,16 @@ class Initial_State {
 				 * same flag the back end uses to register the blocks themselves.
 				 */
 				'searchBlocksEnabled'        => (bool) apply_filters( 'jetpack_search_blocks_enabled', false ),
+				/**
+				 * Whether the experimental blocks-powered Overlay search experience
+				 * is available in the Experience Selector. Mirrors the
+				 * `jetpack_search_overlay_block_template_enabled` server-side filter
+				 * so the dashboard React app can gate the new card on the same flag
+				 * the back end uses to enable the runtime swap. Sites that haven't
+				 * opted into the experimental overlay continue to see the four
+				 * original cards unchanged.
+				 */
+				'blockOverlayEnabled'        => (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false ),
 				// Gates the WooCommerce Product Search control to stores.
 				'isWooCommerceActive'        => Search_Blocks::woocommerce_blocks_enabled(),
 				/**

--- a/projects/packages/search/src/dashboard/components/experience-selector/constants.js
+++ b/projects/packages/search/src/dashboard/components/experience-selector/constants.js
@@ -12,16 +12,25 @@ import { __, _x } from '@wordpress/i18n';
  */
 export const EXPERIENCE = Object.freeze( {
 	EMBEDDED: 'embedded',
+	OVERLAY_BLOCKS: 'overlay_blocks',
 	OVERLAY: 'overlay',
 	INLINE: 'inline',
 	OFF: 'off',
 } );
 
 /**
- * Display order on the dashboard. Embedded leads (RECOMMENDED), Off comes last.
+ * Display order on the dashboard. Embedded leads (RECOMMENDED); the new
+ * blocks-powered Overlay sits where the legacy one used to so the card
+ * grid layout stays stable for sites that opt in to the new flag; legacy
+ * Overlay follows immediately after; Off comes last.
+ *
+ * `OVERLAY_BLOCKS` is filtered out at render time on sites where the
+ * `jetpack_search_overlay_block_template_enabled` server flag is false,
+ * so the unflagged dashboard still shows the original four cards.
  */
 export const EXPERIENCE_ORDER = [
 	EXPERIENCE.EMBEDDED,
+	EXPERIENCE.OVERLAY_BLOCKS,
 	EXPERIENCE.OVERLAY,
 	EXPERIENCE.INLINE,
 	EXPERIENCE.OFF,
@@ -33,6 +42,10 @@ export const EXPERIENCE_ORDER = [
  * Wrapped in a function so __() runs at render time (i18n is locale-aware
  * after the dashboard boots, not at module-load time).
  *
+ * The legacy overlay carries a contextual "(legacy)" suffix only when the
+ * blocks-powered overlay is also visible — see `getOverlayLabelSuffix()`.
+ * Unflagged sites continue to see plain "Overlay search".
+ *
  * @param {string} experience - One of the EXPERIENCE values.
  * @return {string} - Translated title.
  */
@@ -40,6 +53,8 @@ export function getExperienceLabel( experience ) {
 	switch ( experience ) {
 		case EXPERIENCE.EMBEDDED:
 			return __( 'Embedded search', 'jetpack-search-pkg' );
+		case EXPERIENCE.OVERLAY_BLOCKS:
+			return __( 'Overlay search', 'jetpack-search-pkg' );
 		case EXPERIENCE.OVERLAY:
 			return __( 'Overlay search', 'jetpack-search-pkg' );
 		case EXPERIENCE.INLINE:
@@ -49,4 +64,24 @@ export function getExperienceLabel( experience ) {
 		default:
 			return '';
 	}
+}
+
+/**
+ * Title displayed on the card.
+ *
+ * Identical to `getExperienceLabel()` except for the legacy overlay: when
+ * the blocks-powered overlay is also on offer the two cards would
+ * otherwise share the same name, so the legacy one picks up a "(legacy)"
+ * suffix to disambiguate. On unflagged sites the suffix is suppressed
+ * and the legacy card keeps its original title.
+ *
+ * @param {string}  experience          - One of the EXPERIENCE values.
+ * @param {boolean} blockOverlayEnabled - True if the new overlay card is visible.
+ * @return {string} - Translated title for the card.
+ */
+export function getCardTitle( experience, blockOverlayEnabled ) {
+	if ( experience === EXPERIENCE.OVERLAY && blockOverlayEnabled ) {
+		return __( 'Overlay search (legacy)', 'jetpack-search-pkg' );
+	}
+	return getExperienceLabel( experience );
 }

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -194,12 +194,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 				</Stack>
 				<CardCopy experience={ experience } blockOverlayEnabled={ blockOverlayEnabled } />
 			</Stack>
-			{ ( experience === EXPERIENCE.EMBEDDED || experience === EXPERIENCE.OVERLAY_BLOCKS ) && (
-				// Embedded and the blocks-powered Overlay both render the same
-				// Search blocks template — the only difference is *where*
-				// (results page vs modal). They share the same customization
-				// surface (Site Editor template + pattern insertion), so the
-				// action links are identical.
+			{ experience === EXPERIENCE.EMBEDDED && (
 				<Stack
 					direction="row"
 					gap="sm"
@@ -218,6 +213,17 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					/>
 				</Stack>
 			) }
+			{ /*
+			   The blocks-powered Overlay intentionally has no action links
+			   during the experimental phase: the FSE `jetpack-search`
+			   template only registers when Embedded is the active
+			   experience, so an "Edit search template" link would 404 from
+			   here, and the overlay actually renders from a separate
+			   bundled template (`templates/jetpack-search-overlay.html`)
+			   that the Site Editor cannot reach anyway. Skipping the
+			   action row keeps the card honest until the two templates
+			   converge — see SEARCH-213 review thread.
+			*/ }
 			{ experience === EXPERIENCE.OVERLAY && (
 				<Stack
 					direction="row"
@@ -355,17 +361,29 @@ const CardCopy = ( { experience, blockOverlayEnabled = false } ) => {
 		// While the blocks-powered Overlay is also visible, the legacy
 		// card explicitly names itself as the older preact-based path so
 		// site owners can tell the two cards apart at a glance.
+		//
+		// Each branch returns its own `<p>` rather than putting the two
+		// `__()` calls in a JSX ternary expression — the production
+		// build's translation-string optimizer folds the latter into a
+		// single `__(t?A:B, domain)` and trips strict-literal validation,
+		// breaking the build. Splitting at the JSX-boundary keeps each
+		// `__()` argument unambiguously a string literal.
+		if ( blockOverlayEnabled ) {
+			return (
+				<p className="jp-search-experience-option__description">
+					{ __(
+						'The original preact-powered Instant Search overlay. Customize via the dedicated search screen and widget sidebar.',
+						'jetpack-search-pkg'
+					) }
+				</p>
+			);
+		}
 		return (
 			<p className="jp-search-experience-option__description">
-				{ blockOverlayEnabled
-					? __(
-							'The original preact-powered Instant Search overlay. Customize via the dedicated search screen and widget sidebar.',
-							'jetpack-search-pkg'
-					  )
-					: __(
-							'A search-as-you-type overlay that opens from any search box on your site (formerly Instant Search).',
-							'jetpack-search-pkg'
-					  ) }
+				{ __(
+					'A search-as-you-type overlay that opens from any search box on your site (formerly Instant Search).',
+					'jetpack-search-pkg'
+				) }
 			</p>
 		);
 	}

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -7,10 +7,11 @@ import { Icon, cancelCircleFilled } from '@wordpress/icons';
 import { Badge, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { STORE_ID } from 'store';
-import { EXPERIENCE, getExperienceLabel } from './constants';
+import { EXPERIENCE, getCardTitle } from './constants';
 import EmbeddedPreview from './previews/embedded-preview';
 import InlinePreview from './previews/inline-preview';
 import OffPreview from './previews/off-preview';
+import OverlayBlocksPreview from './previews/overlay-blocks-preview';
 import OverlayPreview from './previews/overlay-preview';
 import './experience-option.scss';
 
@@ -31,12 +32,13 @@ const PATTERNS_URL = 'site-editor.php?p=%2Fpattern&search=jetpack-search';
 
 const PREVIEWS = {
 	[ EXPERIENCE.EMBEDDED ]: EmbeddedPreview,
+	[ EXPERIENCE.OVERLAY_BLOCKS ]: OverlayBlocksPreview,
 	[ EXPERIENCE.OVERLAY ]: OverlayPreview,
 	[ EXPERIENCE.INLINE ]: InlinePreview,
 	[ EXPERIENCE.OFF ]: OffPreview,
 };
 
-const getCommitLabel = experience => {
+const getCommitLabel = ( experience, blockOverlayEnabled = false ) => {
 	switch ( experience ) {
 		case EXPERIENCE.EMBEDDED:
 			return _x(
@@ -44,12 +46,27 @@ const getCommitLabel = experience => {
 				'Button label that activates the Embedded search experience',
 				'jetpack-search-pkg'
 			);
-		case EXPERIENCE.OVERLAY:
+		case EXPERIENCE.OVERLAY_BLOCKS:
 			return _x(
 				'Use Overlay search',
-				'Button label that activates the Overlay search experience',
+				'Button label that activates the blocks-powered Overlay search experience',
 				'jetpack-search-pkg'
 			);
+		case EXPERIENCE.OVERLAY:
+			// When the new blocks-powered Overlay is on offer alongside the
+			// legacy one, the commit label disambiguates which path the
+			// click activates. Unflagged sites keep the plain wording.
+			return blockOverlayEnabled
+				? _x(
+						'Use Overlay search (legacy)',
+						'Button label that activates the legacy preact Overlay search experience',
+						'jetpack-search-pkg'
+				  )
+				: _x(
+						'Use Overlay search',
+						'Button label that activates the Overlay search experience',
+						'jetpack-search-pkg'
+				  );
 		case EXPERIENCE.INLINE:
 			return _x(
 				'Use Theme search',
@@ -67,7 +84,7 @@ const getCommitLabel = experience => {
 	}
 };
 
-const getHoverHint = experience => {
+const getHoverHint = ( experience, blockOverlayEnabled = false ) => {
 	if ( experience === EXPERIENCE.OFF ) {
 		return _x(
 			'Click to turn off Jetpack Search',
@@ -82,7 +99,7 @@ const getHoverHint = experience => {
 			'Hover hint on a non-active experience card explaining what clicking the card does',
 			'jetpack-search-pkg'
 		),
-		getExperienceLabel( experience )
+		getCardTitle( experience, blockOverlayEnabled )
 	);
 };
 
@@ -105,15 +122,17 @@ const getHoverHint = experience => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const { active, isUpdating, activeThemeStylesheet, isBlockTheme } = useSelect(
-		select => ( {
-			active: select( STORE_ID ).getActiveExperience(),
-			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
-			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
-			isBlockTheme: select( STORE_ID ).isBlockTheme(),
-		} ),
-		[]
-	);
+	const { active, isUpdating, activeThemeStylesheet, isBlockTheme, blockOverlayEnabled } =
+		useSelect(
+			select => ( {
+				active: select( STORE_ID ).getActiveExperience(),
+				isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
+				activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
+				isBlockTheme: select( STORE_ID ).isBlockTheme(),
+				blockOverlayEnabled: select( STORE_ID ).isBlockOverlayEnabled(),
+			} ),
+			[]
+		);
 	const { saveExperience } = useDispatch( STORE_ID );
 	const [ isConfirmOpen, setConfirmOpen ] = useState( false );
 
@@ -167,15 +186,20 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 			<Stack direction="column" gap="lg" className="jp-search-experience-option__content">
 				<Stack direction="row" gap="sm" align="center" wrap="wrap">
 					<h3 id={ titleId } className="jp-search-experience-option__title">
-						{ getExperienceLabel( experience ) }
+						{ getCardTitle( experience, blockOverlayEnabled ) }
 					</h3>
 					{ isRecommended && (
 						<Badge intent="informational">{ __( 'Recommended', 'jetpack-search-pkg' ) }</Badge>
 					) }
 				</Stack>
-				<CardCopy experience={ experience } />
+				<CardCopy experience={ experience } blockOverlayEnabled={ blockOverlayEnabled } />
 			</Stack>
-			{ experience === EXPERIENCE.EMBEDDED && (
+			{ ( experience === EXPERIENCE.EMBEDDED || experience === EXPERIENCE.OVERLAY_BLOCKS ) && (
+				// Embedded and the blocks-powered Overlay both render the same
+				// Search blocks template — the only difference is *where*
+				// (results page vs modal). They share the same customization
+				// surface (Site Editor template + pattern insertion), so the
+				// action links are identical.
 				<Stack
 					direction="row"
 					gap="sm"
@@ -236,7 +260,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 							? undefined
 							: isEmbeddedBlockedByTheme
 							? blockedThemeHint
-							: getHoverHint( experience )
+							: getHoverHint( experience, blockOverlayEnabled )
 					}
 					onClick={ () => {
 						if ( commitButtonDisabled ) {
@@ -247,10 +271,10 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					aria-label={
 						// eslint-disable-next-line no-nested-ternary -- three mutually exclusive label states; flattening would duplicate the attribute.
 						disabled
-							? `${ getCommitLabel( experience ) }. ${ upsellHint }`
+							? `${ getCommitLabel( experience, blockOverlayEnabled ) }. ${ upsellHint }`
 							: isEmbeddedBlockedByTheme
-							? `${ getExperienceLabel( experience ) }. ${ blockedThemeHint }`
-							: getCommitLabel( experience )
+							? `${ getCardTitle( experience, blockOverlayEnabled ) }. ${ blockedThemeHint }`
+							: getCommitLabel( experience, blockOverlayEnabled )
 					}
 				/>
 			) }
@@ -293,12 +317,12 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 						setConfirmOpen( false );
 					} }
 					onCancel={ () => setConfirmOpen( false ) }
-					confirmButtonText={ getCommitLabel( experience ) }
+					confirmButtonText={ getCommitLabel( experience, blockOverlayEnabled ) }
 				>
 					{ sprintf(
 						/* translators: %s — the human-readable experience name (e.g. "Embedded search"). */
 						__( 'Switch the visitor-facing search experience to %s?', 'jetpack-search-pkg' ),
-						getExperienceLabel( experience )
+						getCardTitle( experience, blockOverlayEnabled )
 					) }
 				</ConfirmDialog>
 			) }
@@ -306,7 +330,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 	);
 }
 
-const CardCopy = ( { experience } ) => {
+const CardCopy = ( { experience, blockOverlayEnabled = false } ) => {
 	if ( experience === EXPERIENCE.EMBEDDED ) {
 		return (
 			<p className="jp-search-experience-option__description">
@@ -317,13 +341,31 @@ const CardCopy = ( { experience } ) => {
 			</p>
 		);
 	}
-	if ( experience === EXPERIENCE.OVERLAY ) {
+	if ( experience === EXPERIENCE.OVERLAY_BLOCKS ) {
 		return (
 			<p className="jp-search-experience-option__description">
 				{ __(
-					'A search-as-you-type overlay that opens from any search box on your site (formerly Instant Search).',
+					'A search-as-you-type overlay rendered from your Search blocks — same filters, sorting, and store as Embedded, but opens over your existing pages.',
 					'jetpack-search-pkg'
 				) }
+			</p>
+		);
+	}
+	if ( experience === EXPERIENCE.OVERLAY ) {
+		// While the blocks-powered Overlay is also visible, the legacy
+		// card explicitly names itself as the older preact-based path so
+		// site owners can tell the two cards apart at a glance.
+		return (
+			<p className="jp-search-experience-option__description">
+				{ blockOverlayEnabled
+					? __(
+							'The original preact-powered Instant Search overlay. Customize via the dedicated search screen and widget sidebar.',
+							'jetpack-search-pkg'
+					  )
+					: __(
+							'A search-as-you-type overlay that opens from any search box on your site (formerly Instant Search).',
+							'jetpack-search-pkg'
+					  ) }
 			</p>
 		);
 	}

--- a/projects/packages/search/src/dashboard/components/experience-selector/index.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/index.jsx
@@ -15,25 +15,39 @@ import './style.scss';
  * @return {import('react').Element} - The selector.
  */
 export default function ExperienceSelector() {
-	const { isUpdating, supportsOnlyClassicSearch, isWpcom } = useSelect(
+	const { isUpdating, supportsOnlyClassicSearch, isWpcom, blockOverlayEnabled } = useSelect(
 		select => ( {
 			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
 			supportsOnlyClassicSearch: select( STORE_ID ).supportsOnlyClassicSearch(),
 			isWpcom: select( STORE_ID ).isWpcom(),
+			blockOverlayEnabled: select( STORE_ID ).isBlockOverlayEnabled(),
 		} ),
 		[]
 	);
 
-	// On WordPress.com Simple sites, Off is managed from the .com side, so
-	// hide the row here.
-	const visibleExperiences = isWpcom
-		? EXPERIENCE_ORDER.filter( experience => experience !== EXPERIENCE.OFF )
-		: EXPERIENCE_ORDER;
+	// Two filters compose on top of the canonical EXPERIENCE_ORDER:
+	//   * On WordPress.com Simple sites, Off is managed from the .com side,
+	//     so hide that row here.
+	//   * The blocks-powered Overlay is opt-in via the
+	//     `jetpack_search_overlay_block_template_enabled` server filter;
+	//     while it's off, the dashboard shows the original four cards and
+	//     the legacy Overlay keeps its plain title (no "(legacy)" suffix).
+	const visibleExperiences = EXPERIENCE_ORDER.filter( experience => {
+		if ( experience === EXPERIENCE.OFF && isWpcom ) {
+			return false;
+		}
+		if ( experience === EXPERIENCE.OVERLAY_BLOCKS && ! blockOverlayEnabled ) {
+			return false;
+		}
+		return true;
+	} );
 
 	const isExperienceDisabled = experience =>
 		isUpdating ||
 		( supportsOnlyClassicSearch &&
-			( experience === EXPERIENCE.EMBEDDED || experience === EXPERIENCE.OVERLAY ) );
+			( experience === EXPERIENCE.EMBEDDED ||
+				experience === EXPERIENCE.OVERLAY ||
+				experience === EXPERIENCE.OVERLAY_BLOCKS ) );
 
 	return (
 		<>

--- a/projects/packages/search/src/dashboard/components/experience-selector/previews/overlay-blocks-preview.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/previews/overlay-blocks-preview.jsx
@@ -1,0 +1,85 @@
+import { Icon, search } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
+import TextRowPlaceHolder from '../../mocked-search/placeholder';
+import './overlay-blocks-preview.scss';
+
+/**
+ * Decorative blocks-powered Overlay mockup — `aria-hidden`. Differs from
+ * the legacy OverlayPreview by adding a filter column inside the modal
+ * card, communicating that the new overlay renders the same Search
+ * blocks template (results + filters + sort) the Embedded experience
+ * uses, just inside a modal.
+ *
+ * @return {import('react').Element} - The preview.
+ */
+export default function OverlayBlocksPreview() {
+	return (
+		<Stack className="jp-search-overlay-blocks-preview" aria-hidden="true">
+			<div className="jp-search-overlay-blocks-preview__page">
+				<div className="jp-search-overlay-blocks-preview__page-bar" />
+				<div className="jp-search-overlay-blocks-preview__page-bar is-short" />
+				<div className="jp-search-overlay-blocks-preview__popup">
+					<Stack
+						direction="row"
+						gap="sm"
+						align="center"
+						className="jp-search-overlay-blocks-preview__search"
+					>
+						<Icon
+							className="jp-search-overlay-blocks-preview__search-icon"
+							icon={ search }
+							size={ 16 }
+						/>
+						<TextRowPlaceHolder style={ { height: '8px', width: '60px' } } />
+					</Stack>
+					<Stack direction="row" gap="sm" className="jp-search-overlay-blocks-preview__body">
+						<Stack
+							direction="column"
+							gap="xs"
+							className="jp-search-overlay-blocks-preview__results"
+						>
+							<Result />
+							<Result />
+						</Stack>
+						<Stack
+							direction="column"
+							gap="xs"
+							className="jp-search-overlay-blocks-preview__filters"
+						>
+							<FilterGroup itemCount={ 2 } />
+						</Stack>
+					</Stack>
+				</div>
+			</div>
+		</Stack>
+	);
+}
+
+const Result = () => (
+	<Stack
+		direction="row"
+		gap="sm"
+		align="center"
+		className="jp-search-overlay-blocks-preview__result"
+	>
+		<span className="jp-search-overlay-blocks-preview__thumb" />
+		<div className="jp-search-overlay-blocks-preview__result-content">
+			<TextRowPlaceHolder style={ { height: '8px', width: '80%' } } />
+			<TextRowPlaceHolder style={ { height: '6px', width: '40%', marginTop: '4px' } } />
+		</div>
+	</Stack>
+);
+
+const FilterGroup = ( { itemCount } ) => (
+	<Stack direction="column" gap="xs" className="jp-search-overlay-blocks-preview__filter-group">
+		<TextRowPlaceHolder style={ { height: '6px', width: '60%' } } />
+		<ul className="jp-search-overlay-blocks-preview__filter-list">
+			{ Array.from( { length: itemCount } ).map( ( _, index ) => (
+				<li key={ index } className={ index === 0 ? 'is-checked' : undefined }>
+					<span className="jp-search-overlay-blocks-preview__checkbox" />
+					<TextRowPlaceHolder style={ { height: '6px', width: '70%' } } />
+				</li>
+			) ) }
+		</ul>
+	</Stack>
+);

--- a/projects/packages/search/src/dashboard/components/experience-selector/previews/overlay-blocks-preview.scss
+++ b/projects/packages/search/src/dashboard/components/experience-selector/previews/overlay-blocks-preview.scss
@@ -1,0 +1,117 @@
+.jp-search-overlay-blocks-preview {
+	width: 100%;
+	height: 200px;
+	padding: var(--wpds-dimension-padding-md);
+	background: var(--wpds-color-bg-surface-neutral);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+}
+
+.jp-search-overlay-blocks-preview__page {
+	position: relative;
+	flex: 1 1 auto;
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
+	background: var(--wpds-color-bg-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm);
+}
+
+.jp-search-overlay-blocks-preview__page-bar {
+	width: 80%;
+	height: 4px;
+	margin-block: 6px;
+	background: var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm);
+
+	&.is-short {
+		width: 50%;
+	}
+}
+
+.jp-search-overlay-blocks-preview__popup {
+	position: absolute;
+	inset-block-start: var(--wpds-dimension-padding-xl);
+	inset-inline-start: var(--wpds-dimension-padding-md);
+	inset-inline-end: var(--wpds-dimension-padding-md);
+	padding: var(--wpds-dimension-padding-sm);
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	border-radius: var(--wpds-border-radius-md);
+	box-shadow: var(--wpds-elevation-sm);
+}
+
+.jp-search-overlay-blocks-preview__search {
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	background: var(--wpds-color-bg-surface-neutral-weak);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	margin-block-end: var(--wpds-dimension-gap-sm);
+}
+
+.jp-search-overlay-blocks-preview__search-icon {
+	fill: currentColor;
+	flex: 0 0 auto;
+}
+
+.jp-search-overlay-blocks-preview__results {
+	flex: 2 1 0;
+	min-width: 0;
+}
+
+.jp-search-overlay-blocks-preview__result {
+	padding-block: var(--wpds-dimension-padding-xs);
+
+	&:not(:last-child) {
+		border-block-end:
+			var(--wpds-border-width-xs) solid
+			var(--wpds-color-stroke-surface-neutral);
+	}
+}
+
+.jp-search-overlay-blocks-preview__thumb {
+	flex: 0 0 auto;
+	width: 24px;
+	height: 24px;
+	background: var(--wpds-color-bg-surface-neutral);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-sm);
+}
+
+.jp-search-overlay-blocks-preview__result-content {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.jp-search-overlay-blocks-preview__filters {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+.jp-search-overlay-blocks-preview__filter-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	li {
+		display: flex;
+		align-items: center;
+		gap: var(--wpds-dimension-gap-xs);
+		margin: 0;
+		padding-block: 1px;
+	}
+}
+
+.jp-search-overlay-blocks-preview__checkbox {
+	width: 9px;
+	height: 9px;
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-interactive-neutral);
+	border-radius: var(--wpds-border-radius-sm);
+	background: var(--wpds-color-bg-surface-neutral-weak);
+	flex: 0 0 auto;
+}
+
+.jp-search-overlay-blocks-preview__filter-list
+.is-checked
+.jp-search-overlay-blocks-preview__checkbox {
+	background: var(--wpds-color-bg-interactive-brand-strong);
+	border-color: var(--wpds-color-bg-interactive-brand-strong);
+}

--- a/projects/packages/search/src/dashboard/components/experience-selector/stories/experience-selector.stories.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/stories/experience-selector.stories.jsx
@@ -19,10 +19,16 @@ export default {
 			control: 'boolean',
 			description: 'Seed `sitePlan.supports_only_classic_search` — disables Embedded + Overlay.',
 		},
+		blockOverlayEnabled: {
+			control: 'boolean',
+			description:
+				'Seed `siteData.blockOverlayEnabled` — mirrors the `jetpack_search_overlay_block_template_enabled` server filter; reveals the new blocks-powered Overlay card and tags the legacy one "(legacy)".',
+		},
 	},
 	args: {
 		isWpcom: false,
 		supportsOnlyClassicSearch: false,
+		blockOverlayEnabled: false,
 	},
 };
 
@@ -64,7 +70,10 @@ const createStoreWithSettings = ( jetpackSettings, sitePlan = {}, siteData = {} 
 
 const renderWithStoryArgs = ( settings, args ) => {
 	const sitePlan = { supports_only_classic_search: args.supportsOnlyClassicSearch };
-	const siteData = { isWpcom: args.isWpcom };
+	const siteData = {
+		isWpcom: args.isWpcom,
+		blockOverlayEnabled: args.blockOverlayEnabled,
+	};
 	const registry = createStoreWithSettings( settings, sitePlan, siteData );
 	return (
 		<RegistryProvider value={ registry }>
@@ -194,4 +203,39 @@ export const WpcomSite = args =>
 	);
 WpcomSite.args = {
 	isWpcom: true,
+};
+
+// Blocks-powered Overlay flag on — five cards visible, legacy carries the
+// "(legacy)" suffix. The user has not yet switched, so the legacy card is
+// the active one.
+export const OverlayBlocksAvailable = args =>
+	renderWithStoryArgs(
+		{
+			module_active: true,
+			instant_search_enabled: true,
+			pending_experience: null,
+			experience: EXPERIENCE.OVERLAY,
+			is_updating: false,
+		},
+		args
+	);
+OverlayBlocksAvailable.args = {
+	blockOverlayEnabled: true,
+};
+
+// User has opted into the blocks-powered Overlay — the new card is Active,
+// and the legacy card stays selectable as a fallback.
+export const OverlayBlocksActive = args =>
+	renderWithStoryArgs(
+		{
+			module_active: true,
+			instant_search_enabled: false,
+			pending_experience: null,
+			experience: EXPERIENCE.OVERLAY_BLOCKS,
+			is_updating: false,
+		},
+		args
+	);
+OverlayBlocksActive.args = {
+	blockOverlayEnabled: true,
 };

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -16,6 +16,7 @@ const siteDataSelectors = {
 	isWpcom: state => state.siteData?.isWpcom ?? false,
 	isPlanJustUpgraded: state => state.siteData?.isPlanJustUpgraded ?? false,
 	isSearchBlocksEnabled: state => state.siteData?.searchBlocksEnabled ?? false,
+	isBlockOverlayEnabled: state => state.siteData?.blockOverlayEnabled ?? false,
 	isWooCommerceActive: state => state.siteData?.isWooCommerceActive ?? false,
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 	// Defaults to true so Embedded is never blocked when the flag is absent

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -202,11 +202,21 @@ class Search_Blocks {
 	 * server-rendered Search blocks template
 	 * (`templates/jetpack-search-overlay.html`).
 	 *
-	 * EXPERIMENTAL — off by default; not production-ready. Opt-in requires
-	 * both this filter AND `jetpack_search_blocks_enabled` to be true, since
-	 * the rendered markup needs the Search blocks themselves registered to
-	 * have anything to hydrate. When on, the legacy `SearchApp` is fully
-	 * bypassed via the `jetpack_search_init_instant_search` filter.
+	 * EXPERIMENTAL — off by default; not production-ready. Two conditions
+	 * must hold for the runtime swap to occur:
+	 *
+	 *   1. The `jetpack_search_overlay_block_template_enabled` filter is on.
+	 *      This is the operator-level gate that surfaces the new option in
+	 *      the Experience Selector and registers the overlay assets.
+	 *   2. The site owner has chosen the new overlay experience in the
+	 *      dashboard (`Module_Control::EXPERIENCE_OVERLAY_BLOCKS`).
+	 *
+	 * Both conditions let the legacy and blocks-powered overlays coexist
+	 * on the same site — operators can opt a site into the new path, and
+	 * site owners can still flip back to the legacy experience without
+	 * touching any server-side filter. When both are true the legacy
+	 * `SearchApp` is bypassed via the `jetpack_search_init_instant_search`
+	 * filter (wired in `Initializer::init_search_blocks()`).
 	 *
 	 * @return bool
 	 */
@@ -217,7 +227,10 @@ class Search_Blocks {
 		 *
 		 * @param bool $enabled Default false.
 		 */
-		return (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false );
+		if ( ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false ) ) {
+			return false;
+		}
+		return Module_Control::EXPERIENCE_OVERLAY_BLOCKS === ( new Module_Control() )->get_experience();
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -23,6 +23,7 @@ class Initializer_Test extends Search_TestCase {
 		remove_all_filters( 'jetpack_search_woocommerce_blocks_enabled' );
 		remove_all_filters( 'jetpack_search_overlay_block_template_enabled' );
 		remove_all_filters( 'jetpack_search_init_instant_search' );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 		$this->reset_block_template_overlay_active();
 		$this->remove_search_blocks_hooks();
 		parent::tearDown();
@@ -113,9 +114,16 @@ class Initializer_Test extends Search_TestCase {
 		);
 	}
 
-	public function test_init_search_blocks_activates_overlay_when_both_gates_on() {
+	public function test_init_search_blocks_activates_overlay_when_both_gates_on_and_experience_matches() {
 		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
 		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		// The runtime swap also requires the site owner to have selected the
+		// new overlay experience in the dashboard. Without it, the operator-
+		// level filter is a no-op so the legacy and new overlays can coexist.
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+		// `get_experience()` short-circuits to `off` if the module is not
+		// active, so flip the module on for the duration of this test.
+		( new \Automattic\Jetpack\Modules() )->activate( Module_Control::JETPACK_SEARCH_MODULE_SLUG, false, false );
 
 		$this->invoke_init_search_blocks();
 
@@ -125,13 +133,43 @@ class Initializer_Test extends Search_TestCase {
 		}
 		$this->assertTrue(
 			$property->getValue(),
-			'Overlay must register as active when both gates are on.'
+			'Overlay must register as active when both gates are on AND the user has selected the new overlay experience.'
 		);
 		$this->assertSame(
 			10,
 			has_filter( 'jetpack_search_init_instant_search', '__return_false' ),
-			'The legacy-suppress filter must be added when both gates are on.'
+			'The legacy-suppress filter must be added when both gates are on and the experience matches.'
 		);
+
+		( new \Automattic\Jetpack\Modules() )->deactivate( Module_Control::JETPACK_SEARCH_MODULE_SLUG );
+	}
+
+	public function test_init_search_blocks_does_not_activate_overlay_when_experience_does_not_match() {
+		// Operator opted in via the filter, but the site owner left the
+		// experience selector on the legacy Overlay. The runtime must stay
+		// on the legacy path so the two cards remain switchable without
+		// touching any server-side filter.
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
+		( new \Automattic\Jetpack\Modules() )->activate( Module_Control::JETPACK_SEARCH_MODULE_SLUG, false, false );
+
+		$this->invoke_init_search_blocks();
+
+		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertFalse(
+			$property->getValue(),
+			'Overlay must stay off when the user has chosen the legacy Overlay experience, even with both filters on.'
+		);
+		$this->assertFalse(
+			has_filter( 'jetpack_search_init_instant_search', '__return_false' ),
+			'The legacy-suppress filter must not be added when the user has chosen the legacy Overlay.'
+		);
+
+		( new \Automattic\Jetpack\Modules() )->deactivate( Module_Control::JETPACK_SEARCH_MODULE_SLUG );
 	}
 
 	public function test_init_search_blocks_does_not_activate_overlay_when_overlay_gate_off() {

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -525,6 +525,51 @@ class Module_Control_Test extends Search_TestCase {
 	}
 
 	/**
+	 * The blocks-powered overlay experience is gated at the REST boundary by
+	 * the `jetpack_search_overlay_block_template_enabled` filter. Without
+	 * this gate a scripted POST could pre-stage `overlay_blocks` on a site
+	 * where operators haven't opted in, and the value would silently
+	 * activate the moment the filter flipped on. With the filter off the
+	 * write must be rejected and the option left untouched.
+	 */
+	public function test_update_experience_overlay_blocks_rejected_when_flag_off() {
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		// Filter defaults false — do not register any callback.
+
+		$result = static::$search_module->update_experience( Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'experience_not_available', $result->get_error_code() );
+		$this->assertFalse( get_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY ) );
+	}
+
+	/**
+	 * With both gates on, the blocks-powered overlay activates the module,
+	 * keeps `instant_search_enabled` off (the new path doesn't boot the
+	 * legacy preact `SearchApp`), and writes `overlay_blocks` to the
+	 * experience option.
+	 */
+	public function test_update_experience_overlay_blocks_persists_when_flag_on() {
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		update_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY, true );
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		add_filter( 'jetpack_options', array( $this, 'return_active_modules_array_without_search' ), 10, 2 );
+
+		static::$search_module->update_experience( Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+		$active_modules = get_option( 'jetpack_' . Module_Control::JETPACK_ACTIVE_MODULES_OPTION_KEY, array() );
+
+		remove_filter( 'jetpack_options', array( $this, 'return_active_modules_array_without_search' ) );
+		remove_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+
+		$this->assertContains( Module_Control::JETPACK_SEARCH_MODULE_SLUG, $active_modules );
+		$this->assertFalse( (bool) get_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY ) );
+		$this->assertEquals( Module_Control::EXPERIENCE_OVERLAY_BLOCKS, get_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY ) );
+
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		delete_option( Module_Control::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY );
+	}
+
+	/**
 	 * Each experience that calls activate() must propagate its WP_Error rather than
 	 * fall through and write the experience option in an inconsistent state.
 	 *


### PR DESCRIPTION
Fixes [SEARCH-213](https://linear.app/a8c/issue/SEARCH-213/experience-selector-add-new-overlay-search-blocks-powered-option)

## Why

Right now the new server-rendered Search blocks overlay from #48987 is opt-in via a single binary site filter — flip it and every legacy "Overlay search" user is silently moved off the preact `SearchApp`, with no way back from the dashboard. That's fine for the engineer shipping the experiment, but it's the wrong UX for an early-access feature: site owners can't compare the two paths, can't roll back if the new overlay misbehaves, and the dashboard's "Overlay search" card no longer matches what's actually running on the front end.

This PR turns the flag into a gate for a **new** Experience Selector card. With the flag on, the dashboard surfaces two distinct overlay options — "Overlay search" (new, blocks-powered) and "Overlay search (legacy)" (the existing preact path) — and the user's choice drives the runtime swap. Without the flag, nothing changes.

## Proposed changes

* Add a fifth experience ID — `overlay_blocks` — and surface it as a new Experience Selector card whose preview, copy, and action links describe the blocks-powered overlay.
* Suffix the existing "Overlay search" card with "(legacy)" **only** when the new card is also visible. Unflagged sites continue to see plain "Overlay search" with no change in wording, ordering, or behavior.
* Plumb the `jetpack_search_overlay_block_template_enabled` filter through `Initial_State` → `siteData.blockOverlayEnabled` → a new `isBlockOverlayEnabled` selector → the selector / card components.
* Persist `experience = 'overlay_blocks'` in `Module_Control::update_experience()`; activate the search module, write the option, and keep `instant_search_enabled` off so the legacy preact app does not boot in parallel.
* Re-gate `Search_Blocks::is_block_template_overlay_enabled()` on `flag_on && get_experience() === 'overlay_blocks'`, so both overlays can coexist on the same site and the user can freely flip back to the legacy experience without touching any server-side filter. Updates the matching Initializer tests.
* Add a blocks-overlay preview component (filter column + result list) and reuse Embedded's customization action links (Edit search template / Insert pattern) on the new card, since both render the same Search blocks template.
* Storybook: new `OverlayBlocksAvailable` and `OverlayBlocksActive` stories; new `blockOverlayEnabled` arg.

## Real-screen before / after

Captured via local docker (`https://jp-sage.jurassic.tube`) at 1280×1500, clipped to the selector heading + grid.

| Before (trunk — 4 cards, legacy Overlay Active) | After (this PR + flag on — 5 cards, new Overlay Active, legacy renamed) |
|---|---|
| ![before](https://github.com/user-attachments/assets/6f967879-5862-433b-9f8c-050479394726) | ![after](https://github.com/user-attachments/assets/e14cfbc1-1686-4065-a6f9-21f9e8e3b0be) |

## Related product discussion/links

* Linear issue: [SEARCH-213](https://linear.app/a8c/issue/SEARCH-213/experience-selector-add-new-overlay-search-blocks-powered-option)
* Linear project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586)
* Hard dependency: **must land after #48987** — the runtime hookup modifies `Search_Blocks::is_block_template_overlay_enabled()`, introduced in that PR. This branch is currently stacked on top of #48987's commits and the cross-cutting tests; once #48987 merges the PR diff narrows to just the new commits in this branch.

## Does this pull request change what data or activity we track or use?

No. No new tracking or analytics; re-uses the existing `jetpack_search_experience_save` event already fired by the selector.

## Testing instructions

These mirror the acceptance criteria on [SEARCH-213](https://linear.app/a8c/issue/SEARCH-213/experience-selector-add-new-overlay-search-blocks-powered-option).

* With `jetpack_search_overlay_block_template_enabled` **off** (default): visit *Jetpack → Search → Settings*. The dashboard looks identical to today — four cards, "Overlay search" label unchanged, no "(legacy)" suffix anywhere.
* Enable both gates in a mu-plugin:
  ```php
  add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
  add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
  ```
  Reload the dashboard. Five cards visible, in order: Embedded, **Overlay search** (new), **Overlay search (legacy)**, Theme search, Off.
* Click the new **Overlay search** card → confirm dialog reads *"Switch the visitor-facing search experience to Overlay search?"* with the *"Use Overlay search"* confirm button. Confirm.
* Verify backend persistence:
  ```bash
  wp option get jetpack_search_experience       # → overlay_blocks
  wp option get instant_search_enabled          # → 0
  wp eval 'echo \Automattic\Jetpack\Search\Search_Blocks::is_block_template_overlay_enabled() ? "ON\n" : "OFF\n";'   # → ON
  ```
* Visit any front-end page and view source. `<template id="jetpack-search-block-overlay-template">` and the `<div id="jetpack-search-block-overlay">` shell are present; `JetpackInstantSearchOptions` is **not** defined (the legacy preact app is suppressed).
* Click **Overlay search (legacy)** in the dashboard → confirm dialog reads *"Switch the visitor-facing search experience to Overlay search (legacy)?"* with the *"Use Overlay search (legacy)"* confirm button. Confirm.
* Re-verify: `wp option get jetpack_search_experience` → `overlay`; `instant_search_enabled` → `1`. Front-end source now contains `JetpackInstantSearchOptions` and **no** `jetpack-search-block-overlay-template`. The legacy preact overlay is back.
* Plan paywall: with `supports_only_classic_search` true, both overlay cards (legacy and new) render the upsell hint and are non-selectable.
* Storybook: `Packages/Search/ExperienceSelector` → flip the new `blockOverlayEnabled` arg in the Controls panel to compare the 4-card and 5-card layouts. `OverlayBlocksActive` shows the active state for the new card.

