### PR TITLE
Search Blocks: resolve chrome template-part slugs from the active theme (SEARCH-214)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-214-theme-chrome-slugs
+++ b/projects/packages/search/changelog/SEARCH-214-theme-chrome-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search block template: resolve header/footer template-part slugs from the active theme's own search.html so the search page chrome matches what the theme designed, instead of always referencing the plain header/footer parts.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -808,29 +808,26 @@ class Search_Blocks {
 	 * footer template parts so the plugin-registered template renders the
 	 * same page users get from inserting the pattern directly. Markup lives
 	 * in `templates/jetpack-search.html` — the canonical block-theme format
-	 * for block templates — with a `{{FILTER_HEADING}}` placeholder for the
-	 * filter-sidebar heading so that string still goes through `esc_html__()`.
+	 * for block templates — with placeholders for the filter-sidebar heading
+	 * (`{{FILTER_HEADING}}`, kept on the PHP side so it still goes through
+	 * `esc_html__()`) and the header/footer template-part slugs
+	 * (`{{HEADER_SLUG}}` / `{{FOOTER_SLUG}}`, resolved per-theme so the
+	 * chrome matches the active theme's own `search.html` — see
+	 * `resolve_theme_chrome_slugs()`).
 	 *
-	 * Memoized: `register_search_template()` runs on every `init`, and the
-	 * template markup is identical every request, so read the file and run
-	 * the translation substitution once per process.
+	 * Not memoized: `register_search_template()` runs once per request
+	 * (the `init` hook fires once), and `file_get_contents` + the shared
+	 * placeholder substitution are both sub-millisecond on a ~2 KB
+	 * template. Caching here would survive across tests and theme
+	 * switches in unhelpful ways.
 	 *
 	 * @return string Block markup for a complete page template.
 	 */
 	protected static function get_search_template_content(): string {
-		static $content = null;
-		if ( null !== $content ) {
-			return $content;
-		}
 		$template_path = __DIR__ . '/templates/jetpack-search.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		$content = str_replace(
-			'{{FILTER_HEADING}}',
-			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
-			$raw
-		);
-		return $content;
+		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		return static::substitute_template_placeholders( $raw );
 	}
 
 	/**
@@ -875,24 +872,150 @@ class Search_Blocks {
 	/**
 	 * Product-search counterpart of `get_search_template_content()`. Seeds
 	 * from `templates/jetpack-search-product-results.html` (a copy of the search
-	 * layout for now; product-specific blocks land in a follow-up).
+	 * layout for now; product-specific blocks land in a follow-up). Shares
+	 * the placeholder substitution.
 	 *
 	 * @return string Block markup for the product-search template.
 	 */
 	protected static function get_product_search_template_content(): string {
-		static $content = null;
-		if ( null !== $content ) {
-			return $content;
-		}
 		$template_path = __DIR__ . '/templates/jetpack-search-product-results.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		$content = str_replace(
-			'{{FILTER_HEADING}}',
-			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		return static::substitute_template_placeholders( $raw );
+	}
+
+	/**
+	 * Run the shared placeholder substitution over a bundled template's raw
+	 * markup. Returns the empty string unchanged so callers can keep their
+	 * "no readable template file → skip registration" bail-out.
+	 *
+	 * Substitutions:
+	 * - `{{FILTER_HEADING}}` → translated, escaped sidebar heading.
+	 * - `{{HEADER_SLUG}}` / `{{FOOTER_SLUG}}` → slugs the active theme's own
+	 *   `search.html` (or `index.html`) uses for its `wp:template-part`
+	 *   blocks, so the rendered chrome matches what the theme designed for
+	 *   search rather than always picking the plain `header`/`footer` parts.
+	 *
+	 * @param string $raw Raw template-file contents.
+	 * @return string Markup with placeholders resolved.
+	 */
+	protected static function substitute_template_placeholders( string $raw ): string {
+		if ( '' === $raw ) {
+			return $raw;
+		}
+		$slugs = static::resolve_theme_chrome_slugs();
+		return str_replace(
+			array( '{{FILTER_HEADING}}', '{{HEADER_SLUG}}', '{{FOOTER_SLUG}}' ),
+			array(
+				esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+				$slugs['header'],
+				$slugs['footer'],
+			),
 			$raw
 		);
-		return $content;
+	}
+
+	/**
+	 * Resolve the template-part slugs the active theme uses to wrap its own
+	 * search results — so our registered template matches the theme's
+	 * design instead of always referencing the plain `header`/`footer`
+	 * parts (which on themes like Twenty Twenty-Two leave a search page
+	 * that looks disconnected from the rest of the site, and on bespoke
+	 * block themes that ship only variant slugs leave the chrome empty).
+	 *
+	 * Resolution order: theme's `search.html`, then `index.html`, then
+	 * `header`/`footer` defaults. Not memoized — the sub-helpers are
+	 * cheap, the resolver runs at most once per request, and skipping the
+	 * cache keeps tests and theme switches well-behaved.
+	 *
+	 * @return array{header:string,footer:string}
+	 */
+	protected static function resolve_theme_chrome_slugs(): array {
+		$defaults = array(
+			'header' => 'header',
+			'footer' => 'footer',
+		);
+		$content  = static::get_active_theme_template_content( 'search' );
+		if ( null === $content ) {
+			$content = static::get_active_theme_template_content( 'index' );
+		}
+		if ( null === $content ) {
+			return $defaults;
+		}
+		$found = static::extract_chrome_slugs( $content );
+		return array(
+			'header' => $found['header'] ?? $defaults['header'],
+			'footer' => $found['footer'] ?? $defaults['footer'],
+		);
+	}
+
+	/**
+	 * Fetch the resolved markup for an active-theme template (e.g.
+	 * `search`, `index`). Wraps `get_block_template()` as an overridable
+	 * seam so tests can return canned markup without standing up a real
+	 * block theme.
+	 *
+	 * @param string $template_name Bare template slug (no `theme//` prefix).
+	 * @return string|null Markup, or null if the template doesn't resolve.
+	 */
+	protected static function get_active_theme_template_content( string $template_name ): ?string {
+		if ( ! function_exists( 'get_block_template' ) ) {
+			return null;
+		}
+		$tmpl = get_block_template( get_stylesheet() . '//' . $template_name, 'wp_template' );
+		if ( ! $tmpl || empty( $tmpl->content ) ) {
+			return null;
+		}
+		return (string) $tmpl->content;
+	}
+
+	/**
+	 * Pull the first and last top-level `core/template-part` slugs out of a
+	 * piece of template markup. The first one is treated as the header and
+	 * the last as the footer — matches how every Twenty* search/index
+	 * template (and the overwhelming majority of community block themes)
+	 * wraps its content. Nested template-parts are ignored on purpose: a
+	 * theme that buries its chrome inside a wrapper falls back to the
+	 * `header`/`footer` defaults higher up the chain.
+	 *
+	 * Pure function (no globals, no I/O) so unit tests can feed it fixture
+	 * markup directly.
+	 *
+	 * @param string $template_content Block markup to scan.
+	 * @return array{header:?string,footer:?string}
+	 */
+	protected static function extract_chrome_slugs( string $template_content ): array {
+		$header = null;
+		$footer = null;
+		if ( '' === $template_content || ! function_exists( 'parse_blocks' ) ) {
+			return array(
+				'header' => $header,
+				'footer' => $footer,
+			);
+		}
+		foreach ( parse_blocks( $template_content ) as $block ) {
+			if ( 'core/template-part' !== ( $block['blockName'] ?? '' ) ) {
+				continue;
+			}
+			$slug = $block['attrs']['slug'] ?? null;
+			if ( ! is_string( $slug ) || '' === $slug ) {
+				continue;
+			}
+			if ( null === $header ) {
+				$header = $slug;
+			}
+			$footer = $slug;
+		}
+		// A template with a single top-level template-part is almost always
+		// a header-only template (e.g. some minimalist 404s). Don't promote
+		// it to the footer slot — fall back to the default instead.
+		if ( $header === $footer ) {
+			$footer = null;
+		}
+		return array(
+			'header' => $header,
+			'footer' => $footer,
+		);
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -923,8 +923,20 @@ class Search_Blocks {
 	 * that looks disconnected from the rest of the site, and on bespoke
 	 * block themes that ship only variant slugs leave the chrome empty).
 	 *
-	 * Resolution order: theme's `search.html`, then `index.html`, then
-	 * `header`/`footer` defaults.
+	 * Resolution order, per slot (header, footer):
+	 * 1. The slug declared by the theme's own `search.html`
+	 *    (`extract_chrome_slugs()` reads its top-level template-parts).
+	 * 2. Same lookup against `index.html` as a hierarchy fallback.
+	 * 3. The alphabetically-first `wp_template_part` the theme declares
+	 *    with `area: "header"` / `area: "footer"` — covers bespoke themes
+	 *    that ship only variant slugs (e.g. `site-header.html` with no
+	 *    plain `header.html`) and don't reference them from any of the
+	 *    standard templates. Deterministic across requests because we
+	 *    sort by slug; non-trivial only when WP can't find anything via
+	 *    the higher-priority paths (the fast path returns before we ever
+	 *    query `get_block_templates()`).
+	 * 4. The `header` / `footer` defaults so the registered template
+	 *    stays valid markup on classic or otherwise-empty themes.
 	 *
 	 * Per-request memo keyed by `get_called_class()` and the active
 	 * stylesheet. Both `register_search_template()` and
@@ -947,20 +959,109 @@ class Search_Blocks {
 			'header' => 'header',
 			'footer' => 'footer',
 		);
-		$content  = static::get_active_theme_template_content( 'search' );
-		if ( null === $content ) {
-			$content = static::get_active_theme_template_content( 'index' );
+		$found    = array(
+			'header' => null,
+			'footer' => null,
+		);
+		foreach ( array( 'search', 'index' ) as $template_name ) {
+			if ( null !== $found['header'] && null !== $found['footer'] ) {
+				break;
+			}
+			$content = static::get_active_theme_template_content( $template_name );
+			if ( null === $content ) {
+				continue;
+			}
+			$extracted       = static::extract_chrome_slugs( $content );
+			$found['header'] = $found['header'] ?? $extracted['header'];
+			$found['footer'] = $found['footer'] ?? $extracted['footer'];
 		}
-		if ( null === $content ) {
-			$cache[ $key ] = $defaults;
-			return $defaults;
+		if ( null === $found['header'] || null === $found['footer'] ) {
+			$area_fallback   = static::resolve_chrome_slugs_by_area();
+			$found['header'] = $found['header'] ?? $area_fallback['header'];
+			$found['footer'] = $found['footer'] ?? $area_fallback['footer'];
 		}
-		$found         = static::extract_chrome_slugs( $content );
 		$cache[ $key ] = array(
 			'header' => $found['header'] ?? $defaults['header'],
 			'footer' => $found['footer'] ?? $defaults['footer'],
 		);
 		return $cache[ $key ];
+	}
+
+	/**
+	 * Area-based fallback for `resolve_theme_chrome_slugs()`. Pulls every
+	 * `wp_template_part` declared by the active theme, then delegates
+	 * the slug selection to `extract_chrome_slugs_from_parts()`.
+	 * Overridable as a seam so tests can stub the fallback without
+	 * standing up a real block theme.
+	 *
+	 * @return array{header:?string,footer:?string}
+	 */
+	protected static function resolve_chrome_slugs_by_area(): array {
+		if ( ! function_exists( 'get_block_templates' ) ) {
+			return array(
+				'header' => null,
+				'footer' => null,
+			);
+		}
+		return static::extract_chrome_slugs_from_parts(
+			get_block_templates( array(), 'wp_template_part' ),
+			get_stylesheet()
+		);
+	}
+
+	/**
+	 * Pick the alphabetically-first slug whose `area` matches each chrome
+	 * slot ("header" / "footer") from a list of `wp_template_part`
+	 * records. Alphabetical sort makes the choice deterministic across
+	 * requests when a theme declares multiple variants in each area:
+	 * Twenty Twenty-Two ships `header`, `header-large-dark`, and
+	 * `header-small-dark` all declared `area: "header"`; sorting picks
+	 * plain `header`, which is the most neutral default.
+	 *
+	 * Parts from other themes (the same registry can return parts that
+	 * came from a child theme via `area`-merging) are filtered by
+	 * `$stylesheet`, and slugs that wouldn't survive the JSON round-trip
+	 * in `substitute_template_placeholders()` are dropped (same guard as
+	 * `extract_chrome_slugs()`).
+	 *
+	 * Pure function (no globals, no I/O) so unit tests can feed it
+	 * fixture part records directly.
+	 *
+	 * @param array  $parts      Array of part records, each with
+	 *                           `theme`, `slug`, `area` properties.
+	 * @param string $stylesheet Active stylesheet — parts whose `theme`
+	 *                           doesn't match are ignored.
+	 * @return array{header:?string,footer:?string}
+	 */
+	protected static function extract_chrome_slugs_from_parts( array $parts, string $stylesheet ): array {
+		$by_area = array(
+			'header' => array(),
+			'footer' => array(),
+		);
+		foreach ( $parts as $part ) {
+			if ( ! isset( $part->theme ) || $part->theme !== $stylesheet ) {
+				continue;
+			}
+			$area = $part->area ?? null;
+			$slug = $part->slug ?? null;
+			if ( ! is_string( $slug ) || '' === $slug || ! preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ) ) {
+				continue;
+			}
+			if ( isset( $by_area[ $area ] ) ) {
+				$by_area[ $area ][] = $slug;
+			}
+		}
+		$out = array(
+			'header' => null,
+			'footer' => null,
+		);
+		foreach ( array( 'header', 'footer' ) as $area ) {
+			if ( ! empty( $by_area[ $area ] ) ) {
+				sort( $by_area[ $area ], SORT_STRING );
+				$out[ $area ] = $by_area[ $area ][0];
+			}
+		}
+		return $out;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -924,13 +924,25 @@ class Search_Blocks {
 	 * block themes that ship only variant slugs leave the chrome empty).
 	 *
 	 * Resolution order: theme's `search.html`, then `index.html`, then
-	 * `header`/`footer` defaults. Not memoized — the sub-helpers are
-	 * cheap, the resolver runs at most once per request, and skipping the
-	 * cache keeps tests and theme switches well-behaved.
+	 * `header`/`footer` defaults.
+	 *
+	 * Per-request memo keyed by `get_called_class()` and the active
+	 * stylesheet. Both `register_search_template()` and
+	 * `register_product_search_template()` fire on `init` and each go
+	 * through `substitute_template_placeholders()`, so caching at this
+	 * level halves the `get_block_template()` work without touching the
+	 * registrar wiring. Keying by `get_called_class()` keeps anonymous
+	 * test subclasses with different `get_active_theme_template_content()`
+	 * stubs from polluting each other's results.
 	 *
 	 * @return array{header:string,footer:string}
 	 */
 	protected static function resolve_theme_chrome_slugs(): array {
+		static $cache = array();
+		$key          = get_called_class() . '|' . get_stylesheet();
+		if ( isset( $cache[ $key ] ) ) {
+			return $cache[ $key ];
+		}
 		$defaults = array(
 			'header' => 'header',
 			'footer' => 'footer',
@@ -940,13 +952,15 @@ class Search_Blocks {
 			$content = static::get_active_theme_template_content( 'index' );
 		}
 		if ( null === $content ) {
+			$cache[ $key ] = $defaults;
 			return $defaults;
 		}
-		$found = static::extract_chrome_slugs( $content );
-		return array(
+		$found         = static::extract_chrome_slugs( $content );
+		$cache[ $key ] = array(
 			'header' => $found['header'] ?? $defaults['header'],
 			'footer' => $found['footer'] ?? $defaults['footer'],
 		);
+		return $cache[ $key ];
 	}
 
 	/**
@@ -981,12 +995,21 @@ class Search_Blocks {
 	 * Pure function (no globals, no I/O) so unit tests can feed it fixture
 	 * markup directly.
 	 *
+	 * Slugs that contain anything outside `[a-zA-Z0-9_-]` are dropped —
+	 * the value is re-inserted unescaped into block-grammar JSON in
+	 * `substitute_template_placeholders()`, so accepting an arbitrary
+	 * string would let a malformed theme template break the JSON
+	 * round-trip. WordPress template-part slugs are filename-derived in
+	 * practice and never contain other characters, so the guard rejects
+	 * what would have been broken markup anyway.
+	 *
 	 * @param string $template_content Block markup to scan.
 	 * @return array{header:?string,footer:?string}
 	 */
 	protected static function extract_chrome_slugs( string $template_content ): array {
 		$header = null;
 		$footer = null;
+		$count  = 0;
 		if ( '' === $template_content || ! function_exists( 'parse_blocks' ) ) {
 			return array(
 				'header' => $header,
@@ -998,18 +1021,21 @@ class Search_Blocks {
 				continue;
 			}
 			$slug = $block['attrs']['slug'] ?? null;
-			if ( ! is_string( $slug ) || '' === $slug ) {
+			if ( ! is_string( $slug ) || '' === $slug || ! preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ) ) {
 				continue;
 			}
 			if ( null === $header ) {
 				$header = $slug;
 			}
 			$footer = $slug;
+			++$count;
 		}
 		// A template with a single top-level template-part is almost always
 		// a header-only template (e.g. some minimalist 404s). Don't promote
-		// it to the footer slot — fall back to the default instead.
-		if ( $header === $footer ) {
+		// it to the footer slot. Two distinct template-parts that happen to
+		// share a slug — uncommon, but a deliberate theme choice — are
+		// preserved as-is.
+		if ( $count < 2 ) {
 			$footer = null;
 		}
 		return array(

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -859,8 +859,9 @@ class Search_Blocks {
 		if ( '' === $content ) {
 			return;
 		}
-		register_block_template(
-			static::get_parent_plugin_slug() . '//' . self::SEARCH_TEMPLATE_SLUG,
+		$name = static::get_parent_plugin_slug() . '//' . self::SEARCH_TEMPLATE_SLUG;
+		static::replace_block_template(
+			$name,
 			array(
 				'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
 				'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
@@ -938,20 +939,30 @@ class Search_Blocks {
 	 * 4. The `header` / `footer` defaults so the registered template
 	 *    stays valid markup on classic or otherwise-empty themes.
 	 *
-	 * Per-request memo keyed by `get_called_class()` and the active
-	 * stylesheet. Both `register_search_template()` and
-	 * `register_product_search_template()` fire on `init` and each go
-	 * through `substitute_template_placeholders()`, so caching at this
-	 * level halves the `get_block_template()` work without touching the
-	 * registrar wiring. Keying by `get_called_class()` keeps anonymous
-	 * test subclasses with different `get_active_theme_template_content()`
-	 * stubs from polluting each other's results.
+	 * Per-request memo keyed by `get_called_class()`, the active
+	 * stylesheet, and `$_SERVER['REQUEST_TIME_FLOAT']`. The request-time
+	 * component is critical: PHP-FPM workers persist function-local
+	 * statics across requests, so a key without it would freeze the
+	 * resolved slugs at whatever the theme had on the worker's first
+	 * request — site-owner theme switches and Site Editor edits to the
+	 * theme's search.html wouldn't take effect until the worker
+	 * recycled. Keying by `get_called_class()` keeps anonymous test
+	 * subclasses with different `get_active_theme_template_content()`
+	 * stubs from polluting each other.
 	 *
 	 * @return array{header:string,footer:string}
 	 */
 	protected static function resolve_theme_chrome_slugs(): array {
 		static $cache = array();
-		$key          = get_called_class() . '|' . get_stylesheet();
+		// $_SERVER['REQUEST_TIME_FLOAT'] is a PHP-set float used only as a
+		// per-request cache discriminator (never echoed, never stored), so
+		// the standard "unslash + sanitize" treatment for user input doesn't
+		// apply. Cast to float and back to string to satisfy phpcs without
+		// changing meaning.
+		$request_id = isset( $_SERVER['REQUEST_TIME_FLOAT'] )
+			? (string) (float) $_SERVER['REQUEST_TIME_FLOAT'] // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+			: (string) microtime( true );
+		$key        = get_called_class() . '|' . get_stylesheet() . '|' . $request_id;
 		if ( isset( $cache[ $key ] ) ) {
 			return $cache[ $key ];
 		}
@@ -1158,14 +1169,41 @@ class Search_Blocks {
 		if ( '' === $content ) {
 			return;
 		}
-		register_block_template(
-			static::get_parent_plugin_slug() . '//' . self::PRODUCT_SEARCH_TEMPLATE_SLUG,
+		$name = static::get_parent_plugin_slug() . '//' . self::PRODUCT_SEARCH_TEMPLATE_SLUG;
+		static::replace_block_template(
+			$name,
 			array(
 				'title'       => __( 'Jetpack Search Product Results', 'jetpack-search-pkg' ),
 				'description' => __( 'Displays WooCommerce product search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
 				'content'     => $content,
 			)
 		);
+	}
+
+	/**
+	 * Idempotent `register_block_template()` wrapper. Unregisters the
+	 * existing entry (if any) before registering, so the chrome-slug
+	 * resolution stays fresh across site-owner theme switches inside a
+	 * long-lived PHP-FPM worker. Without the unregister step, WP's
+	 * `WP_Block_Templates_Registry::register()` would reject the
+	 * second-and-later call with `_doing_it_wrong()` and the worker
+	 * would keep serving stale content until it recycled.
+	 *
+	 * Tests can override this seam to assert against a single
+	 * registration path without manipulating the registry singleton.
+	 *
+	 * @param string              $name Fully-qualified template name
+	 *                                  (`<plugin>//<slug>`).
+	 * @param array<string,mixed> $args Args for `register_block_template()`.
+	 */
+	protected static function replace_block_template( string $name, array $args ) {
+		if ( class_exists( '\WP_Block_Templates_Registry' ) ) {
+			$registry = \WP_Block_Templates_Registry::get_instance();
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+		register_block_template( $name, $args );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
@@ -53,4 +53,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"{{FOOTER_SLUG}}"} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
@@ -48,4 +48,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"{{FOOTER_SLUG}}"} /-->

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1076,6 +1077,275 @@ class Search_Blocks_Test extends TestCase {
 		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
 			$this->assertFalse( $registry->is_registered( $name ), "Template $name must NOT be registered on a classic theme." );
 		}
+	}
+
+	/**
+	 * `extract_chrome_slugs()` lifts the first and last top-level
+	 * `core/template-part` slugs out of a piece of template markup. Covers
+	 * the standard "header then footer" shape and the variant shape
+	 * (e.g. Twenty Twenty-Two-style `header-large-dark`) so we can prove
+	 * the resolver doesn't silently downgrade to the plain `header` /
+	 * `footer` defaults when a theme uses something fancier.
+	 *
+	 * Nested `template-part` references inside an inner wrapper must NOT
+	 * be promoted — the resolver only walks the top level and a theme
+	 * burying its chrome in a wrapper should fall back to the defaults
+	 * higher up the chain.
+	 *
+	 * @dataProvider provider_extract_chrome_slugs
+	 *
+	 * @param string                               $content  Template markup.
+	 * @param array{header:?string,footer:?string} $expected Expected extracted slugs.
+	 */
+	#[DataProvider( 'provider_extract_chrome_slugs' )]
+	public function test_extract_chrome_slugs( string $content, array $expected ) {
+		$ref = new \ReflectionMethod( Search_Blocks::class, 'extract_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame( $expected, $ref->invoke( null, $content ) );
+	}
+
+	/**
+	 * Fixtures for `test_extract_chrome_slugs`.
+	 *
+	 * @return array<string, array{0:string, 1:array{header:?string,footer:?string}}>
+	 */
+	public static function provider_extract_chrome_slugs(): array {
+		return array(
+			'standard header + footer (TT3/4/5 shape)' => array(
+				'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->' . "\n"
+				. '<main></main>' . "\n"
+				. '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->',
+				array(
+					'header' => 'header',
+					'footer' => 'footer',
+				),
+			),
+			'variant slugs (bespoke theme with no plain header.html)' => array(
+				'<!-- wp:template-part {"slug":"header-large-dark"} /-->' . "\n"
+				. '<main></main>' . "\n"
+				. '<!-- wp:template-part {"slug":"site-footer"} /-->',
+				array(
+					'header' => 'header-large-dark',
+					'footer' => 'site-footer',
+				),
+			),
+			'single template-part is treated as header-only, footer falls back' => array(
+				'<!-- wp:template-part {"slug":"header"} /-->' . "\n"
+				. '<main></main>',
+				array(
+					'header' => 'header',
+					'footer' => null,
+				),
+			),
+			'nested template-parts in a wrapper are ignored' => array(
+				'<!-- wp:group --><div class="wp-block-group">'
+				. '<!-- wp:template-part {"slug":"buried-header"} /-->'
+				. '</div><!-- /wp:group -->',
+				array(
+					'header' => null,
+					'footer' => null,
+				),
+			),
+			'no template-parts at all yields nulls'    => array(
+				'<main><p>No chrome here.</p></main>',
+				array(
+					'header' => null,
+					'footer' => null,
+				),
+			),
+			'empty markup yields nulls'                => array(
+				'',
+				array(
+					'header' => null,
+					'footer' => null,
+				),
+			),
+		);
+	}
+
+	/**
+	 * `resolve_theme_chrome_slugs()` prefers the active theme's
+	 * `search.html`, falls back to `index.html`, and finally to the
+	 * hard-coded `header`/`footer` defaults. Stubs the template-content
+	 * fetch so the resolver can be exercised without a real block theme
+	 * in the dbless env.
+	 */
+	public function test_resolve_theme_chrome_slugs_prefers_search_template() {
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"header-large-dark"} /-->'
+							. '<!-- wp:template-part {"slug":"footer"} /-->';
+					}
+					if ( 'index' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"index-header"} /-->'
+							. '<!-- wp:template-part {"slug":"index-footer"} /-->';
+					}
+					return null;
+				}
+			}
+		);
+		$ref = new \ReflectionMethod( $cls, 'resolve_theme_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'header-large-dark',
+				'footer' => 'footer',
+			),
+			$ref->invoke( null )
+		);
+	}
+
+	/**
+	 * When the theme has no `search.html`, the resolver walks to
+	 * `index.html`. Covers the gap themes like Twenty Twenty-Three's
+	 * earlier releases had where only `index.html` shipped.
+	 */
+	public function test_resolve_theme_chrome_slugs_falls_back_to_index_template() {
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'index' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"index-header"} /-->'
+							. '<!-- wp:template-part {"slug":"index-footer"} /-->';
+					}
+					return null;
+				}
+			}
+		);
+		$ref = new \ReflectionMethod( $cls, 'resolve_theme_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'index-header',
+				'footer' => 'index-footer',
+			),
+			$ref->invoke( null )
+		);
+	}
+
+	/**
+	 * When neither template resolves the slugs must fall back to the
+	 * hard-coded `header` / `footer` defaults so the registered template
+	 * stays valid markup on classic-themed or otherwise empty sites.
+	 */
+	public function test_resolve_theme_chrome_slugs_falls_back_to_defaults() {
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					unset( $template_name ); // stub: neither template resolves, regardless of name.
+					return null;
+				}
+			}
+		);
+		$ref = new \ReflectionMethod( $cls, 'resolve_theme_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'header',
+				'footer' => 'footer',
+			),
+			$ref->invoke( null )
+		);
+	}
+
+	/**
+	 * End-to-end check: `register_search_template()` must register markup
+	 * that references the resolved chrome slugs (not the raw
+	 * `{{HEADER_SLUG}}` / `{{FOOTER_SLUG}}` placeholders, which would
+	 * crash the template-part renderer at runtime).
+	 */
+	public function test_register_search_template_substitutes_chrome_slug_placeholders() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"header-large-dark"} /-->'
+							. '<!-- wp:template-part {"slug":"custom-footer"} /-->';
+					}
+					return null;
+				}
+			}
+		);
+		$cls::register_search_template();
+
+		$expected   = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search';
+		$registered = $registry->get_registered( $expected );
+		$this->assertNotNull( $registered, "Template $expected should be registered." );
+		$this->assertStringContainsString( '"slug":"header-large-dark"', $registered->content );
+		$this->assertStringContainsString( '"slug":"custom-footer"', $registered->content );
+		$this->assertStringNotContainsString( '{{HEADER_SLUG}}', $registered->content );
+		$this->assertStringNotContainsString( '{{FOOTER_SLUG}}', $registered->content );
+		// Defaults must not leak in when a theme-resolved slug is available.
+		$this->assertStringNotContainsString( '"slug":"header"', $registered->content );
+		$this->assertStringNotContainsString( '"slug":"footer"', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
+	 * Counterpart to the search-template substitution check: the
+	 * product-results template ships through the same placeholder
+	 * pipeline, so a fix to one must apply to the other.
+	 */
+	public function test_register_product_search_template_substitutes_chrome_slug_placeholders() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search-product-results', 'jetpack//jetpack-search-product-results' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"shop-header"} /-->'
+							. '<!-- wp:template-part {"slug":"shop-footer"} /-->';
+					}
+					return null;
+				}
+			}
+		);
+		$cls::register_product_search_template();
+
+		$expected   = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search-product-results';
+		$registered = $registry->get_registered( $expected );
+		$this->assertNotNull( $registered );
+		$this->assertStringContainsString( '"slug":"shop-header"', $registered->content );
+		$this->assertStringContainsString( '"slug":"shop-footer"', $registered->content );
+		$this->assertStringNotContainsString( '{{HEADER_SLUG}}', $registered->content );
+		$this->assertStringNotContainsString( '{{FOOTER_SLUG}}', $registered->content );
+
+		$registry->unregister( $expected );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1361,6 +1361,48 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Per-slot fill across the search → index step: a minimalist
+	 * `search.html` that wraps only its header should pull the footer
+	 * slug from `index.html` rather than skipping straight to the area
+	 * or hardcoded-defaults rungs. Documents the cross-template fill
+	 * the resolver loop is responsible for.
+	 */
+	public function test_resolve_theme_chrome_slugs_fills_footer_from_index_when_search_has_header_only() {
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"search-header"} /-->';
+					}
+					if ( 'index' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"index-header"} /-->'
+							. '<!-- wp:template-part {"slug":"index-footer"} /-->';
+					}
+					return null;
+				}
+				protected static function resolve_chrome_slugs_by_area(): array {
+					// Should not be reached; both slots are filled by templates.
+					return array(
+						'header' => 'never-used',
+						'footer' => 'never-used',
+					);
+				}
+			}
+		);
+		$ref = new \ReflectionMethod( $cls, 'resolve_theme_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'search-header',
+				'footer' => 'index-footer',
+			),
+			$ref->invoke( null )
+		);
+	}
+
+	/**
 	 * `extract_chrome_slugs_from_parts()` picks the alphabetically-first
 	 * slug per area so the chrome stays deterministic across requests
 	 * even when WP returns parts in filesystem-enumeration order. Twenty

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1547,6 +1547,73 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Long-lived PHP-FPM workers keep `WP_Block_Templates_Registry`
+	 * alive across requests, and `register_block_template()` rejects
+	 * a second call with the same name as a `_doing_it_wrong()` error.
+	 * `register_search_template()` must therefore unregister-before-
+	 * register so that a site-owner theme switch (or an edit to the
+	 * theme's `search.html` in the Site Editor) propagates to the
+	 * registered template without waiting for the worker to recycle.
+	 *
+	 * Simulated here by calling the registrar twice with different
+	 * stubbed chrome slugs and asserting the second value wins.
+	 */
+	public function test_register_search_template_replaces_existing_registration() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$first = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"old-header"} /-->'
+							. '<!-- wp:template-part {"slug":"old-footer"} /-->';
+					}
+					return null;
+				}
+			}
+		);
+		$first::register_search_template();
+
+		// Simulate a theme switch / Site Editor edit between requests.
+		$second = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"new-header"} /-->'
+							. '<!-- wp:template-part {"slug":"new-footer"} /-->';
+					}
+					return null;
+				}
+			}
+		);
+		$second::register_search_template();
+
+		$expected   = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search';
+		$registered = $registry->get_registered( $expected );
+		$this->assertNotNull( $registered );
+		$this->assertStringContainsString( '"slug":"new-header"', $registered->content );
+		$this->assertStringContainsString( '"slug":"new-footer"', $registered->content );
+		$this->assertStringNotContainsString( '"slug":"old-header"', $registered->content );
+		$this->assertStringNotContainsString( '"slug":"old-footer"', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
 	 * Counterpart to the search-template substitution check: the
 	 * product-results template ships through the same placeholder
 	 * pipeline, so a fix to one must apply to the other.

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1139,6 +1139,27 @@ class Search_Blocks_Test extends TestCase {
 					'footer' => null,
 				),
 			),
+			'two template-parts with the same slug are preserved (deliberate theme choice, not the single-part dedup)' => array(
+				'<!-- wp:template-part {"slug":"site-shell"} /-->' . "\n"
+				. '<main></main>' . "\n"
+				. '<!-- wp:template-part {"slug":"site-shell"} /-->',
+				array(
+					'header' => 'site-shell',
+					'footer' => 'site-shell',
+				),
+			),
+			'slug with unsafe characters is rejected (guards JSON round-trip in substitute_template_placeholders)' => array(
+				// parse_blocks() preserves attrs verbatim from the JSON; if it ever
+				// surfaced a slug containing characters that would break the
+				// `{"slug":"..."}` re-insertion (a quote, a brace, a newline), we
+				// drop it and let the resolver fall back to the default.
+				'<!-- wp:template-part {"slug":"valid"} /-->' . "\n"
+				. '<!-- wp:template-part {"slug":"has space"} /-->',
+				array(
+					'header' => 'valid',
+					'footer' => null,
+				),
+			),
 			'nested template-parts in a wrapper are ignored' => array(
 				'<!-- wp:group --><div class="wp-block-group">'
 				. '<!-- wp:template-part {"slug":"buried-header"} /-->'

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1253,9 +1253,10 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * When neither template resolves the slugs must fall back to the
-	 * hard-coded `header` / `footer` defaults so the registered template
-	 * stays valid markup on classic-themed or otherwise empty sites.
+	 * When neither template resolves AND the area-based fallback finds
+	 * nothing either, the slugs must fall back to the hard-coded
+	 * `header` / `footer` defaults so the registered template stays
+	 * valid markup on classic-themed or otherwise empty sites.
 	 */
 	public function test_resolve_theme_chrome_slugs_falls_back_to_defaults() {
 		$cls = get_class(
@@ -1263,6 +1264,13 @@ class Search_Blocks_Test extends TestCase {
 				protected static function get_active_theme_template_content( string $template_name ): ?string {
 					unset( $template_name ); // stub: neither template resolves, regardless of name.
 					return null;
+				}
+				protected static function resolve_chrome_slugs_by_area(): array {
+					// stub: theme also has no declared header/footer parts.
+					return array(
+						'header' => null,
+						'footer' => null,
+					);
 				}
 			}
 		);
@@ -1276,6 +1284,176 @@ class Search_Blocks_Test extends TestCase {
 				'footer' => 'footer',
 			),
 			$ref->invoke( null )
+		);
+	}
+
+	/**
+	 * When neither `search.html` nor `index.html` resolves to top-level
+	 * template-parts, the resolver must walk to the area-based fallback
+	 * and use whatever slugs the theme declares with
+	 * `area: "header"` / `area: "footer"` — covers bespoke block themes
+	 * that ship variant slugs like `site-header` and don't reference
+	 * them from a standard template.
+	 */
+	public function test_resolve_theme_chrome_slugs_uses_area_fallback_when_templates_silent() {
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					unset( $template_name ); // stub: neither template resolves.
+					return null;
+				}
+				protected static function resolve_chrome_slugs_by_area(): array {
+					return array(
+						'header' => 'site-header',
+						'footer' => 'site-footer',
+					);
+				}
+			}
+		);
+		$ref = new \ReflectionMethod( $cls, 'resolve_theme_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'site-header',
+				'footer' => 'site-footer',
+			),
+			$ref->invoke( null )
+		);
+	}
+
+	/**
+	 * The slug-resolution chain is per-slot: if `search.html` declares
+	 * only a header (e.g. a minimalist template), the footer falls
+	 * through to the area-based fallback before reaching the defaults.
+	 * Without this the resolver could leak a `footer` default while the
+	 * theme has a real `area: "footer"` part it would prefer to use.
+	 */
+	public function test_resolve_theme_chrome_slugs_mixes_template_header_with_area_footer() {
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					if ( 'search' === $template_name ) {
+						return '<!-- wp:template-part {"slug":"hero-header"} /-->';
+					}
+					return null;
+				}
+				protected static function resolve_chrome_slugs_by_area(): array {
+					return array(
+						'header' => 'never-used',
+						'footer' => 'site-footer',
+					);
+				}
+			}
+		);
+		$ref = new \ReflectionMethod( $cls, 'resolve_theme_chrome_slugs' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'hero-header',
+				'footer' => 'site-footer',
+			),
+			$ref->invoke( null )
+		);
+	}
+
+	/**
+	 * `extract_chrome_slugs_from_parts()` picks the alphabetically-first
+	 * slug per area so the chrome stays deterministic across requests
+	 * even when WP returns parts in filesystem-enumeration order. Twenty
+	 * Twenty-Two ships three header parts (`header`, `header-large-dark`,
+	 * `header-small-dark`) all declared `area: "header"`; we want plain
+	 * `header` as the most neutral pick, not whichever the directory
+	 * scan surfaced first.
+	 */
+	public function test_extract_chrome_slugs_from_parts_picks_alphabetical_first_per_area() {
+		$parts = array(
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'header-small-dark',
+				'area'  => 'header',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'header-large-dark',
+				'area'  => 'header',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'header',
+				'area'  => 'header',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'footer-newsletter',
+				'area'  => 'footer',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'footer',
+				'area'  => 'footer',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'sidebar',
+				'area'  => 'uncategorized',
+			),
+		);
+		$ref   = new \ReflectionMethod( Search_Blocks::class, 'extract_chrome_slugs_from_parts' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'header',
+				'footer' => 'footer',
+			),
+			$ref->invoke( null, $parts, 'tt-bespoke' )
+		);
+	}
+
+	/**
+	 * `extract_chrome_slugs_from_parts()` ignores parts from other
+	 * themes and rejects unsafe slugs the same way `extract_chrome_slugs()`
+	 * does — both run through the JSON round-trip in
+	 * `substitute_template_placeholders()`.
+	 */
+	public function test_extract_chrome_slugs_from_parts_filters_by_theme_and_unsafe_slugs() {
+		$parts = array(
+			(object) array(
+				'theme' => 'other-theme',
+				'slug'  => 'header',
+				'area'  => 'header',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'has space',
+				'area'  => 'header',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => 'site-header',
+				'area'  => 'header',
+			),
+			(object) array(
+				'theme' => 'tt-bespoke',
+				'slug'  => '',
+				'area'  => 'footer',
+			),
+		);
+		$ref   = new \ReflectionMethod( Search_Blocks::class, 'extract_chrome_slugs_from_parts' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		$this->assertSame(
+			array(
+				'header' => 'site-header',
+				'footer' => null,
+			),
+			$ref->invoke( null, $parts, 'tt-bespoke' )
 		);
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-214](https://linear.app/a8c/issue/SEARCH-214/search-block-template-chrome-diverges-from-theme-on-non-tt5-block)

## Why

The Jetpack Search results template hard-coded its site header and footer to the plain `header` / `footer` template-part slugs. On themes whose `search.html` declares something else — Twenty Twenty-Two's `header-large-dark`, Twenty Twenty-Five's `header-large-title` or `vertical-header`, community themes that ship variant slugs — search visitors saw a stripped-down chrome that looked disconnected from the rest of the site, or in the worst case no chrome at all. After this change the rendered chrome matches what the active theme designed for its own search page.

## Multi-theme verification matrix

Captured against the atlas docker env across **Twenty Twenty-Two**, **Twenty Twenty-Three**, **Twenty Twenty-Four**, **Twenty Twenty-Five**, **Frost**, and **Ollie**. Variant scenarios patch the theme's `search.html` to declare a non-default slug — simulates a bespoke theme that picks a richer header for search pages.

### Baselines (each theme's stock `search.html`)

| Twenty Twenty-Two (dark) | Twenty Twenty-Three (minimal) | Twenty Twenty-Four (magazine) |
|---|---|---|
| ![TT2](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-twentytwentytwo-baseline.png) | ![TT3](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-twentytwentythree-baseline.png) | ![TT4](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-twentytwentyfour-baseline.png) |

| Twenty Twenty-Five | Frost | Ollie (pattern-wrapped `search.html` — exercises area-based fallback path) |
|---|---|---|
| ![TT5](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-twentytwentyfive-baseline.png) | ![Frost](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-frost-baseline.png) | ![Ollie](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-ollie-baseline.png) |

### Variant scenarios: theme's `search.html` declares a non-default slug

**Twenty Twenty-Two — `search.html` patched to use `header-large-dark` (the dark illustrated variant TT2 already ships):**

| Before (trunk: hardcoded `header`) | After (this PR: resolver picks up TT2's variant) |
| --- | --- |
| ![before-tt2](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/before-tt2-variant-header-large-dark.png) | ![after-tt2](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-tt2-variant-header-large-dark.png) |

**Twenty Twenty-Five — `search.html` patched to use `header-large-title` (TT5's large-title variant):**

| Before (trunk: hardcoded `header`) | After (this PR: resolver picks up TT5's variant) |
| --- | --- |
| ![before-tt5](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/before-tt5-variant-header-large-title.png) | ![after-tt5](https://github.com/Automattic/jetpack/raw/screenshots/atlas/search-214-theme-chrome-slugs/theme-tt5-variant-header-large-title.png) |

## Proposed changes

* Add `Search_Blocks::resolve_theme_chrome_slugs()` — reads the active theme's `search.html` (fallback: `index.html`) at registration time, extracts the top-level `wp:template-part` slugs, and substitutes them into the bundled templates.
* **Area-based fallback** for bespoke themes that wrap their search/index templates in patterns (Ollie does this) or whose templates have no top-level `wp:template-part` blocks: query the theme's declared parts via `get_block_templates([], 'wp_template_part')`, pick the alphabetically-first slug per `area: "header"` / `"footer"`. Falls back to `header` / `footer` defaults as a last resort.
* Replace the hardcoded `slug:"header"` / `slug:"footer"` in `templates/jetpack-search.html` and `templates/jetpack-search-product-results.html` with `{{HEADER_SLUG}}` / `{{FOOTER_SLUG}}` placeholders, substituted in the same `substitute_template_placeholders()` pipeline that already handles `{{FILTER_HEADING}}`.
* **Idempotent registration**: `register_*_template()` now goes through a `replace_block_template()` helper that unregisters before registering. `WP_Block_Templates_Registry::register()` rejects same-name re-registration with `_doing_it_wrong()`, so without this step the worker would keep serving stale chrome until it recycled — surfaced while building this screenshot matrix.
* **Per-request cache key** for `resolve_theme_chrome_slugs()` includes `$_SERVER['REQUEST_TIME_FLOAT']`, so the function-local static doesn't freeze the resolved slugs across HTTP requests in long-lived PHP-FPM workers.
* Slug-extraction guards: `extract_chrome_slugs()` drops slugs with characters outside `[a-zA-Z0-9_-]` to prevent malformed theme markup from breaking the bundled template's block-grammar JSON round-trip. Filter applies to both the template-content path and the area-based fallback.
* Factor pure helpers (`extract_chrome_slugs`, `extract_chrome_slugs_from_parts`) so the substitution and selection logic is unit-testable without a real block theme. **91 tests / 264 assertions** on the branch.

## Related product discussion/links

* Linear: [SEARCH-214](https://linear.app/a8c/issue/SEARCH-214/search-block-template-chrome-diverges-from-theme-on-non-tt5-block)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-214, exercised against a docker WP env with Jetpack Search Embedded mode active:

- [ ] On stock Twenty Twenty-Three / Four / Five sites, `/?s=foo` renders the same chrome it always did. Verify via `wp eval` against the registry — should report `["header","footer"]` for the registered `jetpack-search//jetpack-search` template content.
- [ ] Activate Twenty Twenty-Two, patch `wp-content/themes/twentytwentytwo/templates/search.html` to declare `slug:"header-large-dark"` (the variant TT2 already ships), reload `/?s=foo`. The dark illustrated TT2 header — with "The Hatchery: a blog" headline — renders above the Jetpack Search results, matching the after-screenshot above. Trunk renders the plain light header from the before-screenshot.
- [ ] On Ollie (whose `search.html` and `index.html` wrap their content in `wp:pattern` blocks rather than top-level `wp:template-part`), the chrome still renders correctly — exercises the area-based fallback path.
- [ ] On a synthetic theme that ships only `parts/header-large.html` (no plain `parts/header.html`) and whose `search.html` references `header-large`, the registered template references `header-large` and the chrome renders non-empty.
- [ ] The same treatment applies to the product-results template — patching a theme's `search.html` to use variant slugs propagates to the `jetpack-search//jetpack-search-product-results` registry entry too.
- [ ] PHPUnit: `composer phpunit -- --filter Search_Blocks_Test` from `projects/packages/search` — should be green (91 tests / 264 assertions on this branch).

Quick CLI verification:

```bash
docker exec jetpack_<agent>-wordpress-1 wp eval '
  $c = (string) WP_Block_Templates_Registry::get_instance()
        ->get_registered( "jetpack-search//jetpack-search" )->content;
  preg_match_all( "#template-part \{\"slug\":\"([^\"]+)\"#", $c, $m );
  echo wp_json_encode( $m[1] ) . PHP_EOL;
' --allow-root --skip-themes
```
