### PR TITLE
Podcast: block + settings polish (regression sweep)

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-big-son-of-a
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-big-son-of-a
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast settings + block polish from the regression sweep: decode HTML entities in the episode block title preview, defer Podcast Topics saves until focus leaves the field, persist empty Summary values, and align the block's season/episode number inputs with the feed's positive-integer requirement.

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -23,6 +23,7 @@ import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import metadata from './block.json';
@@ -361,7 +362,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 					<TextControl
 						label={ __( 'Season number', 'jetpack-podcast' ) }
 						type="number"
-						min={ 0 }
+						min={ 1 }
 						value={ seasonNumber ?? '' }
 						onChange={ value =>
 							setAttributes( {
@@ -374,7 +375,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 					<TextControl
 						label={ __( 'Episode number', 'jetpack-podcast' ) }
 						type="number"
-						min={ 0 }
+						min={ 1 }
 						value={ episodeNumber ?? '' }
 						onChange={ value =>
 							setAttributes( {
@@ -672,7 +673,9 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 					) }
 
 					<h3 className="jetpack-podcast-episode__title">
-						{ postTitle || __( 'Untitled episode', 'jetpack-podcast' ) }
+						{ postTitle
+							? decodeEntities( postTitle )
+							: __( 'Untitled episode', 'jetpack-podcast' ) }
 					</h3>
 
 					{ ( postAuthor || postDate || duration ) && (

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -16,7 +16,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import CategoryPicker from '../category-picker';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
@@ -25,6 +25,7 @@ import CoverImageControl from './cover-image-control';
 import './style.scss';
 import { TOPICS } from './topics';
 import type { PodcastSettings, PodcastSettingsUpdate } from '../types';
+import type { FocusEvent } from 'react';
 
 const EXPLICIT_OPTIONS: Array< { label: string; value: string } > = [
 	{ label: __( 'No', 'jetpack-podcast' ), value: 'no' },
@@ -170,34 +171,49 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		[ draft?.podcasting_category_1, draft?.podcasting_category_2, draft?.podcasting_category_3 ]
 	);
 
-	// Calypso renders three native selects, one per slot, so each pick closes
-	// its dropdown and saves discretely. We use a single `FormTokenField` but
-	// match that UX: save on every change, then blur the input so the
-	// suggestions list closes before the save's re-render lands. Without the
-	// blur, the open list visibly flickers when the field receives a fresh
-	// `value` prop reference.
-	//
-	// The `querySelector('input')` below relies on `FormTokenField` rendering
-	// exactly one `<input>` inside the wrapper div. If that internal shape
-	// changes upstream, this becomes a no-op (no thrown error) but the flicker
-	// returns; replace with a forwarded ref API if `@wordpress/components`
-	// gains one.
-	const topicFieldRef = useRef< HTMLDivElement >( null );
+	// Topics save on blur, not on every chip add/remove. Saving per change
+	// caused the suggestions dropdown to close and reopen on each pick: the
+	// `value` prop got a fresh reference after the round-trip, which `FormTokenField`
+	// reads as a reason to reset its internal state. Holding a local draft until
+	// focus leaves the wrapper keeps the dropdown stable while the user picks
+	// multiple topics.
+	const [ draftTopics, setDraftTopics ] = useState< string[] >( topicValue );
 
-	const handleTopicsChange = useCallback(
-		( values: ( string | { value: string } )[] ) => {
-			const stored = values
-				.slice( 0, 3 )
-				.map( v => ( typeof v === 'string' ? v : v.value ) )
-				.map( display => TOPIC_STORAGE_BY_DISPLAY.get( display ) ?? '' );
-			commit( {
+	// Re-sync from server when the saved values change externally (e.g. a
+	// successful save merges new data into `draft`, or a different tab updates
+	// the settings).
+	useEffect( () => {
+		setDraftTopics( topicValue );
+	}, [ topicValue ] );
+
+	const handleTopicsChange = useCallback( ( values: ( string | { value: string } )[] ) => {
+		const next = values.slice( 0, 3 ).map( v => ( typeof v === 'string' ? v : v.value ) );
+		setDraftTopics( next );
+	}, [] );
+
+	const handleTopicsBlur = useCallback(
+		( event: FocusEvent< HTMLDivElement > ) => {
+			// Focus is bouncing between the input and a suggestion inside the
+			// same wrapper — not a real "user is done" signal.
+			if ( event.currentTarget.contains( event.relatedTarget as Node | null ) ) {
+				return;
+			}
+			const stored = draftTopics.map( display => TOPIC_STORAGE_BY_DISPLAY.get( display ) ?? '' );
+			const next = {
 				podcasting_category_1: stored[ 0 ] ?? '',
 				podcasting_category_2: stored[ 1 ] ?? '',
 				podcasting_category_3: stored[ 2 ] ?? '',
-			} );
-			topicFieldRef.current?.querySelector< HTMLInputElement >( 'input' )?.blur();
+			};
+			if (
+				next.podcasting_category_1 === ( draft?.podcasting_category_1 ?? '' ) &&
+				next.podcasting_category_2 === ( draft?.podcasting_category_2 ?? '' ) &&
+				next.podcasting_category_3 === ( draft?.podcasting_category_3 ?? '' )
+			) {
+				return;
+			}
+			commit( next );
 		},
-		[ commit ]
+		[ draftTopics, draft, commit ]
 	);
 
 	const issues = useMemo( () => getValidationIssues( draft ?? settings ), [ draft, settings ] );
@@ -305,13 +321,13 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							) }
 						</Text>
 						<VStack spacing={ 1 }>
-							<div ref={ topicFieldRef }>
+							<div onBlur={ handleTopicsBlur }>
 								<FormTokenField
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									__experimentalExpandOnFocus
 									label={ __( 'Podcast topics', 'jetpack-podcast' ) }
-									value={ topicValue }
+									value={ draftTopics }
 									suggestions={ TOPIC_SUGGESTIONS }
 									onChange={ handleTopicsChange }
 									maxLength={ 3 }


### PR DESCRIPTION
## Proposed changes

Three small fixes from the regression sweep, rebased onto the latest trunk:

- **Block editor**: `decodeEntities()` on the post title in the Podcast Episode block preview so `Test & Verify` renders as written instead of `Test &amp; Verify`. Same encoding fix as core blocks do for `useEntityProp('title')`.
- **Settings UI**: defer the *Podcast topics* save until focus leaves the field wrapper. Holding a local `draftTopics` state and committing on focusout (with `currentTarget.contains(relatedTarget)` to ignore intra-component focus bounces) stops the suggestions dropdown from closing-and-reopening on every chip add.
- **Block editor**: bump `min` on Season number / Episode number inputs from `0` to `1`. Aligns the input UI with `Episode_Block_Tags::emit_episode_number` / `emit_season_number` on trunk, which only emit positive integers — previously the input happily accepted `0` and the feed silently dropped the tag.

The earlier googleplay namespace removal and per-episode `<itunes:explicit>` work that this branch originally carried both landed via trunk in the meantime (see `Episode_Block_Tags::emit_explicit_override`), so the rebase trimmed those parts out — they're now no-ops vs trunk.

The Pass 4 "empty Summary doesn't persist" regression finding turned out to be a test-methodology artifact — no "Settings saved" toast ever fired in that test, meaning the React `onBlur` never ran. Tracing the code (`useFieldEditor` → `saveEntityRecord` → WP REST settings controller → `update_option`) shows nothing that drops empty strings. Worth a manual repro before final ship, but no code change in this PR.

## Testing instructions

1. In a post with a Podcast Episode block, set the title to `Test & Verify` — the block preview should show `&`, not `&amp;`.
2. Open Podcast admin → Settings → *Podcast topics*. Add two or three topics in sequence — the suggestions dropdown should stay open through all picks and close only when you click outside the field.
3. Remove a chip via its X and add another — confirm a single save fires when you click away.
4. In a Podcast Episode block, try to type `0` into Season number or Episode number — the input should reject or step away from 0 (HTML5 number input `min="1"`).

## Test plan

- [x] PHPUnit: 114 tests / 257 assertions pass
- [x] PHPCS clean on changed PHP
- [x] ESLint: no new violations on changed JS
- [ ] Manual: topic field flow + empty Summary repro
