### PR TITLE
Podcast: stop excerpt leak + chapters URL-only

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-excerpt-and-chapters-url
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-excerpt-and-chapters-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: stop leaking body content into the episode RSS description, and drop the broken chapters JSON upload button in favor of a URL-only field with a soft warning when the URL doesn't look like JSON.

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -12,7 +12,6 @@ import {
 	BaseControl,
 	Button,
 	ExternalLink,
-	Notice,
 	PanelBody,
 	Placeholder,
 	SelectControl,
@@ -515,18 +514,6 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>
-						{ chaptersUrl && ! /\.json(?:\?|#|$)/i.test( chaptersUrl ) && (
-							<Notice
-								status="warning"
-								isDismissible={ false }
-								className="jetpack-podcast-episode__chapters-warning"
-							>
-								{ __(
-									'Chapter files typically end in .json. Players may reject this URL if it doesn’t serve JSON.',
-									'jetpack-podcast'
-								) }
-							</Notice>
-						) }
 						{ chaptersUrl && (
 							<Button
 								variant="link"

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -12,6 +12,7 @@ import {
 	BaseControl,
 	Button,
 	ExternalLink,
+	Notice,
 	PanelBody,
 	Placeholder,
 	SelectControl,
@@ -502,42 +503,30 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 						</BaseControl.VisualLabel>
 						<p className="components-base-control__help">
 							{ __(
-								'Upload a chapters JSON file or link to one. Podcasting 2.0 players fetch the file directly and display chapter markers in their UI.',
+								'Link to a chapters JSON file hosted on a public URL. Podcasting 2.0 players fetch the file directly and display chapter markers in their UI.',
 								'jetpack-podcast'
 							) }
 						</p>
-						<MediaUploadCheck>
-							<MediaUpload
-								onSelect={ ( media: MediaAttachment ) => {
-									if ( ! media?.url ) {
-										return;
-									}
-									// WP's MIME map almost never tags files as application/json+chapters, so
-									// always store the spec-blessed type and let the user override via the
-									// format select below if they really need plain application/json.
-									setAttributes( {
-										chaptersUrl: media.url,
-										chaptersType: 'application/json+chapters',
-									} );
-								} }
-								allowedTypes={ [ 'application/json', 'application/json+chapters' ] }
-								render={ ( { open }: { open: () => void } ) => (
-									<Button variant="secondary" onClick={ open }>
-										{ chaptersUrl
-											? __( 'Replace chapters file', 'jetpack-podcast' )
-											: __( 'Upload chapters file', 'jetpack-podcast' ) }
-									</Button>
-								) }
-							/>
-						</MediaUploadCheck>
 						<TextControl
-							label={ __( 'Or paste a chapters file URL', 'jetpack-podcast' ) }
+							label={ __( 'Chapters file URL', 'jetpack-podcast' ) }
 							type="url"
 							value={ chaptersUrl || '' }
 							onChange={ value => setAttributes( { chaptersUrl: value } ) }
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 						/>
+						{ chaptersUrl && ! /\.json(?:\?|#|$)/i.test( chaptersUrl ) && (
+							<Notice
+								status="warning"
+								isDismissible={ false }
+								className="jetpack-podcast-episode__chapters-warning"
+							>
+								{ __(
+									'Chapter files typically end in .json. Players may reject this URL if it doesn’t serve JSON.',
+									'jetpack-podcast'
+								) }
+							</Notice>
+						) }
 						{ chaptersUrl && (
 							<Button
 								variant="link"
@@ -549,7 +538,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 									} )
 								}
 							>
-								{ __( 'Remove chapters file', 'jetpack-podcast' ) }
+								{ __( 'Remove chapters URL', 'jetpack-podcast' ) }
 							</Button>
 						) }
 						<SelectControl

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
@@ -84,10 +84,3 @@
 	display: flex;
 	gap: 12px;
 }
-
-// Soft hint shown when the chapters URL doesn't end in `.json`. Notice itself
-// already paints the warning color; the margin just keeps it from butting
-// directly against the URL input above and the Remove button below.
-.jetpack-podcast-episode__chapters-warning {
-	margin: 8px 0;
-}

--- a/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/editor.scss
@@ -84,3 +84,10 @@
 	display: flex;
 	gap: 12px;
 }
+
+// Soft hint shown when the chapters URL doesn't end in `.json`. Notice itself
+// already paints the warning color; the margin just keeps it from butting
+// directly against the URL input above and the Remove button below.
+.jetpack-podcast-episode__chapters-warning {
+	margin: 8px 0;
+}

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -72,8 +72,26 @@ class Customize_Feed {
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
+		add_filter( 'the_excerpt_rss', array( __CLASS__, 'filter_excerpt_to_manual_only' ) );
 
 		Feed_Detection::detect_and_record();
+	}
+
+	/**
+	 * Restrict per-item `<description>` (and the `<itunes:summary>` we mirror
+	 * from it) to the post's manual excerpt — never the auto-generated one.
+	 *
+	 * Default WP behavior pipes the post body through `wp_trim_excerpt()` when
+	 * the post has no manual excerpt, which leaks paragraph + heading text from
+	 * below the Podcast Episode block into the description that Apple Podcasts
+	 * and Spotify present to listeners. Authors with no excerpt set should see
+	 * an empty description, not a flattened body.
+	 *
+	 * @return string Manual excerpt, or empty string when none is set.
+	 */
+	public static function filter_excerpt_to_manual_only(): string {
+		global $post;
+		return $post instanceof WP_Post ? (string) $post->post_excerpt : '';
 	}
 
 	/**
@@ -179,10 +197,9 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// Re-applying `the_excerpt_rss` so `<itunes:summary>` matches whatever
-		// the item's `<description>` ends up emitting — `get_the_excerpt()`
-		// doesn't run the filter chain itself.
-		$excerpt = (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+		// Mirror what the `<description>` emits (manual excerpt, never the
+		// auto-generated body trim — see `filter_excerpt_to_manual_only()`).
+		$excerpt = self::filter_excerpt_to_manual_only();
 		if ( '' !== $excerpt ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
 		}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -433,4 +433,82 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( 'type="application/json+chapters"', $output );
 	}
+
+	public function test_filter_excerpt_to_manual_only_returns_manual_excerpt() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'           => 101,
+				'post_excerpt' => 'A manually written episode summary.',
+				'post_content' => '<p>Body content that should be ignored.</p>',
+			)
+		);
+
+		$this->assertSame(
+			'A manually written episode summary.',
+			Customize_Feed::filter_excerpt_to_manual_only()
+		);
+	}
+
+	public function test_filter_excerpt_to_manual_only_returns_empty_when_no_manual_excerpt() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'           => 102,
+				'post_excerpt' => '',
+				'post_content' => '<p>Body paragraph that should NOT leak into description.</p><h2>A heading</h2>',
+			)
+		);
+
+		$this->assertSame( '', Customize_Feed::filter_excerpt_to_manual_only() );
+	}
+
+	public function test_filter_excerpt_to_manual_only_handles_missing_post() {
+		global $post;
+		$post = null;
+
+		$this->assertSame( '', Customize_Feed::filter_excerpt_to_manual_only() );
+	}
+
+	public function test_output_item_tags_uses_manual_excerpt_for_itunes_summary() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'           => 103,
+				'post_type'    => 'post',
+				'post_title'   => 'Episode with Excerpt',
+				'post_excerpt' => 'Authored summary for this episode.',
+				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /-->',
+			)
+		);
+
+		ob_start();
+		Customize_Feed::output_item_tags();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString(
+			'<itunes:summary>Authored summary for this episode.</itunes:summary>',
+			$output
+		);
+	}
+
+	public function test_output_item_tags_omits_itunes_summary_when_no_manual_excerpt() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'           => 104,
+				'post_type'    => 'post',
+				'post_title'   => 'Episode without Excerpt',
+				'post_excerpt' => '',
+				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /--><p>Body content.</p>',
+			)
+		);
+
+		ob_start();
+		Customize_Feed::output_item_tags();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString( '<itunes:summary>', $output );
+		$this->assertStringNotContainsString( 'Body content', $output );
+	}
 }


### PR DESCRIPTION
## Proposed changes

Two follow-up fixes from the regression sweep:

- **Stop the body content leak into `<description>` / `<itunes:summary>`.** When a podcast episode post has no manual excerpt, WordPress's default `wp_trim_excerpt()` flattens the post body (every paragraph + heading + linked text below the Podcast Episode block) into the episode description Apple Podcasts / Spotify show to listeners. New `Customize_Feed::filter_excerpt_to_manual_only()` hooks `the_excerpt_rss` to return only the manual `post_excerpt` — empty when none is set. The matching `<itunes:summary>` emission in `output_item_tags()` is rewired to the same helper so they stay in lockstep.
- **Drop the chapters JSON upload button; URL-only field.** WP's allowed-upload-mimes list excludes `.json`, so the block's *Upload chapters file* button opened a Media Library that filtered out every JSON file the user might have. Removed `<MediaUploadCheck>`/`<MediaUpload>` from the chapters control. The URL field is now the only input. No client-side URL validation — verifying it actually serves JSON requires a cross-origin fetch + content-type check that the editor can't safely do. Storage schema (`chaptersUrl` / `chaptersType` attrs) is unchanged — no deprecation needed since the block hasn't shipped.

## Testing instructions

**Excerpt leak fix**
1. Publish a podcast episode (post in the Poo Audio category with a Podcast Episode block) and add body content below the block (a paragraph, a heading, a link).
2. Leave the post excerpt blank.
3. Fetch the feed via the SOCKS5 proxy: `curl --socks5 localhost:8080 "https://p00dcasting.blog/category/poo-audio/feed/?nocache=$(date +%s)"`.
4. Confirm `<description />` is empty (self-closing) and `<itunes:summary>` is absent from that `<item>`.
5. Set a manual excerpt on the post via the sidebar Excerpt panel and republish.
6. Re-fetch — `<description>` and `<itunes:summary>` should now both contain the manual excerpt exactly, with no body content mixed in.

**Chapters URL-only**
1. Open a published episode in the block editor; select the Podcast Episode block.
2. Scroll to the *Chapters* section. Confirm only the URL field is present (no Upload button).
3. Paste a chapters JSON URL and save.
4. Fetch the feed — `<podcast:chapters url="…" type="application/json+chapters" />` should emit on the item.
5. Clear the URL — feed should no longer contain `<podcast:chapters>` for that item.

## Test plan

- [x] PHPUnit: 119 tests / 263 assertions pass (5 new tests covering the excerpt filter + integration)
- [x] PHPCS clean on changed PHP
- [x] ESLint: no new violations on changed JS
- [x] `build:blocks` compiles cleanly
- [ ] Manual: chapters URL field + excerpt fix end-to-end on the test site
