### PR TITLE
Podcast: release 1.0.1

### DIFF
--- a/projects/packages/podcast/CHANGELOG.md
+++ b/projects/packages/podcast/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-05-20
+### Added
+- Podcast feed: surface per-episode metadata (transcript, location, license, people, soundbites, alternate enclosures, episode/season numbers) from the Podcast Episode block.
+
+### Changed
+- Podcast: rename the Distribution "Live" state badge to "Submitted" — the underlying signal is a crawler hit, not directory publication.
+- Podcast Episode: swap inline chapters editor for a chapters JSON file uploader; feed now emits podcast:chapters.
+
+### Fixed
+- Podcast: proxy stats and Pocket Casts submit through Jetpack REST routes so the dashboard works on Atomic.
+- Podcast: stop leaking body content into the episode RSS description, and drop the broken chapters JSON upload button in favor of a URL-only field with a soft warning when the URL doesn't look like JSON.
+- Podcast feed: skip items without an enclosure and restore episode descriptions.
+- Podcast feed: strip the blavatar, site-icon, and rss-cloud channel tags from the podcast RSS feed so the output stays iTunes-compliant once the untangle filter is flipped globally.
+- Podcast settings + block polish from the regression sweep: decode HTML entities in the episode block title preview, defer Podcast Topics saves until focus leaves the field, persist empty Summary values, and align the block's season/episode number inputs with the feed's positive-integer requirement.
+- Reduce podcast setup to a single click when you create a new category from the setup modal.
+
 ## [1.0.0] - 2026-05-19
 ### Security
 - Podcast: escape title overrides, descriptions, and iTunes category attribute values for the RSS feed to prevent malformed XML. [#48876]
@@ -72,4 +88,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard: Replace the wp-build placeholder with page chrome and tab navigation. [#48559]
 - Dashboard: Slim down wp-build wiring to the Backup pattern. [#48600]
 
+[1.0.1]: https://github.com/Automattic/jetpack-podcast/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Automattic/jetpack-podcast/compare/v0.1.0...v1.0.0

--- a/projects/packages/podcast/changelog/arcangelini-podcast-big-son-of-a
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-big-son-of-a
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast settings + block polish from the regression sweep: decode HTML entities in the episode block title preview, defer Podcast Topics saves until focus leaves the field, persist empty Summary values, and align the block's season/episode number inputs with the feed's positive-integer requirement.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-chapter-fix
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-chapter-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast Episode: swap inline chapters editor for a chapters JSON file uploader; feed now emits podcast:chapters.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-excerpt-and-chapters-url
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-excerpt-and-chapters-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: stop leaking body content into the episode RSS description, and drop the broken chapters JSON upload button in favor of a URL-only field with a soft warning when the URL doesn't look like JSON.

--- a/projects/packages/podcast/changelog/arcangelini-podcast-feed-skip-enclosureless
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-feed-skip-enclosureless
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast feed: skip items without an enclosure and restore episode descriptions.

--- a/projects/packages/podcast/changelog/fix-podcast-setup-create-confirm
+++ b/projects/packages/podcast/changelog/fix-podcast-setup-create-confirm
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Reduce podcast setup to a single click when you create a new category from the setup modal.

--- a/projects/packages/podcast/changelog/podcast-distribution-rename-live-to-submitted
+++ b/projects/packages/podcast/changelog/podcast-distribution-rename-live-to-submitted
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: rename the Distribution "Live" state badge to "Submitted" — the underlying signal is a crawler hit, not directory publication.

--- a/projects/packages/podcast/changelog/podcast-feed-episode-metadata
+++ b/projects/packages/podcast/changelog/podcast-feed-episode-metadata
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Podcast feed: surface per-episode metadata (transcript, location, license, people, soundbites, alternate enclosures, episode/season numbers) from the Podcast Episode block.

--- a/projects/packages/podcast/changelog/podcast-fix-atomic-fetches
+++ b/projects/packages/podcast/changelog/podcast-fix-atomic-fetches
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: proxy stats and Pocket Casts submit through Jetpack REST routes so the dashboard works on Atomic.

--- a/projects/packages/podcast/changelog/podcast-preflight-feed-cleanup
+++ b/projects/packages/podcast/changelog/podcast-preflight-feed-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast feed: strip the blavatar, site-icon, and rss-cloud channel tags from the podcast RSS feed so the output stays iTunes-compliant once the untangle filter is flipped globally.

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-podcast",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"private": true,
 	"description": "Jetpack Podcast functionality (Simple and Atomic only).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/podcast/#readme",

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -21,7 +21,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Podcast {
 
-	const PACKAGE_VERSION = '1.0.0';
+	const PACKAGE_VERSION = '1.0.1';
 
 	/**
 	 * Whether the class has been initialized.


### PR DESCRIPTION
## Proposed changes

Cuts the `automattic/jetpack-podcast` package release to **1.0.1**.

Rolls the 9 unreleased changelog entries into `CHANGELOG.md` and bumps `package.json` + `PACKAGE_VERSION` accordingly. Cut now so the upcoming `jetpack_podcast_untangle` filter flip lands on a known, taggable package version instead of "current trunk plus N unreleased changes."

### What's in 1.0.1

**Added**
- Podcast feed: surface per-episode metadata (transcript, location, license, people, soundbites, alternate enclosures, episode/season numbers) from the Podcast Episode block.

**Changed**
- Podcast: rename the Distribution "Live" state badge to "Submitted" — the underlying signal is a crawler hit, not directory publication.
- Podcast Episode: swap inline chapters editor for a chapters JSON file uploader; feed now emits `podcast:chapters`.

**Fixed**
- Podcast: proxy stats and Pocket Casts submit through Jetpack REST routes so the dashboard works on Atomic.
- Podcast: stop leaking body content into the episode RSS description, and drop the broken chapters JSON upload button in favor of a URL-only field.
- Podcast feed: skip items without an enclosure and restore episode descriptions.
- Podcast feed: strip the blavatar, site-icon, and rss-cloud channel tags from the podcast RSS feed so the output stays iTunes-compliant once the untangle filter is flipped globally.
- Podcast settings + block polish from the regression sweep: decode HTML entities in the episode block title preview, defer Podcast Topics saves until focus leaves the field, and align the block's season/episode number inputs with the feed's positive-integer requirement.
- Reduce podcast setup to a single click when you create a new category from the setup modal.

## Testing instructions

1. Confirm `projects/packages/podcast/CHANGELOG.md` has a new `## [1.0.1]` section with the 9 entries above.
2. Confirm `projects/packages/podcast/package.json` shows `"version": "1.0.1"` and `projects/packages/podcast/src/class-podcast.php` shows `const PACKAGE_VERSION = '1.0.1';`.
3. Confirm `projects/packages/podcast/composer.json` `branch-alias.dev-trunk` still says `1.0.x-dev` (no change needed for a patch bump).
4. Run `pnpm jetpack test php packages/podcast` — 119 tests / 263 assertions pass.

## Test plan

- [x] PHPUnit: 119 tests / 263 assertions pass
- [x] Version constants synchronized (`package.json` + `PACKAGE_VERSION` constant in `class-podcast.php`)
- [x] Changelog rollup includes all 9 pending entries
- [ ] Manual: confirm CI green before merging

## Notes

- Committed with `--no-verify` to bypass an `eslint-plugin-package-json/valid-repository-directory` false-positive that fires when committing a `package.json` change from a git worktree. The plugin walks up looking for a `.git/` directory but worktrees use a `.git` file → resolves the "repo root" to the main checkout and computes the package directory as `../.worktrees/...`. Running `eslint` directly on the same file exits 0; CI doesn't use worktrees so this won't affect lint there.
