### PR TITLE
Release Smart Dictation to 50% of English-locale users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-smart-dictation-paid-rollout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-smart-dictation-paid-rollout
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Smart Dictation: Make the feature available to a rollout of paid simple-site users.
+Smart Dictation: Make the feature available to a rollout of paid English-language simple-site users.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -115,7 +115,7 @@ class WPCOM_Smart_Dictation {
 			return;
 		}
 
-		if ( self::is_block_editor() && ( self::is_proxied() || self::current_user_is_in_paid_rollout() ) ) {
+		if ( self::is_block_editor() && 'en' === self::determine_iso_639_locale() && ( self::is_proxied() || self::current_user_is_in_paid_rollout() ) ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/wpcom-smart-dictation/wpcom-smart-dictation.asset.json' );
 			$is_a11n    = function_exists( '\is_automattician' ) && \is_automattician();
 			$version    = ( is_array( $asset_file ) && isset( $asset_file['version'] ) )


### PR DESCRIPTION
Fixes #

## Proposed changes
* Limit Smart Dictation asset enqueueing to users whose normalized locale is English.
* Increase the paid-user rollout from 20% to 50%.
* Update the Smart Dictation rollout changelog entry to note the English-language restriction.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `php -l projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php`.
* Run `php -d error_reporting=24575 vendor/bin/phpcs --standard=projects/packages/jetpack-mu-wpcom/.phpcs.dir.xml projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php`.
* Confirm the Smart Dictation assets only enqueue for block editor requests on simple sites when `determine_iso_639_locale()` returns `en`.
* Confirm paid-user rollout eligibility now uses `user_id % 100 < 50`.
* Note: `composer -d projects/packages/jetpack-mu-wpcom phpunit` currently fails locally in `A8C\FSE\Agents_Manager_Test::test_css_enqueued_only_for_wp_admin_variants`, outside this change.
