### PR TITLE
Podcast: show notes field + lean feed

### DIFF
--- a/projects/packages/podcast/changelog/arcangelini-podcast-feed-lean
+++ b/projects/packages/podcast/changelog/arcangelini-podcast-feed-lean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: surface a Show notes textarea in the Podcast Episode block (synced with the post Excerpt) so authors know where the episode description in Apple Podcasts / Spotify / Pocket Casts comes from. Strip non-podcast RSS chrome from the feed: drop content:encoded (full post body + image EXIF), media:content (avatar + post images), per-item categories, and the comments-link cluster.

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -15,6 +15,7 @@ import {
 	PanelBody,
 	Placeholder,
 	SelectControl,
+	TextareaControl,
 	TextControl,
 	ToggleControl,
 	ToolbarGroup,
@@ -202,6 +203,15 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 		'featured_media',
 		postId
 	);
+	// `post_excerpt` is the show notes — feed `<description>` / `<itunes:summary>`
+	// read from here. Bound to the same REST field as the sidebar Excerpt panel
+	// so the two controls stay in sync.
+	const [ postExcerpt, setPostExcerpt ] = useEntityProp< string >(
+		'postType',
+		postType,
+		'excerpt',
+		postId
+	);
 
 	// Source the show-level cover from the same REST surface the dashboard
 	// reads: /wp/v2/settings exposes `podcasting_image` (registered in
@@ -359,6 +369,17 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Episode', 'jetpack-podcast' ) }>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show notes', 'jetpack-podcast' ) }
+						help={ __(
+							'Episode description shown in Apple Podcasts, Spotify, and Pocket Casts. Synced with the post’s Excerpt.',
+							'jetpack-podcast'
+						) }
+						value={ postExcerpt || '' }
+						onChange={ setPostExcerpt }
+						rows={ 4 }
+					/>
 					<TextControl
 						label={ __( 'Season number', 'jetpack-podcast' ) }
 						type="number"

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -74,6 +74,22 @@ class Customize_Feed {
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
 		add_filter( 'the_excerpt_rss', array( __CLASS__, 'filter_excerpt_to_manual_only' ) );
 
+		// Prune RSS chrome that podcatchers don't read. Cuts payload size and
+		// keeps incidental post data (body content, gravatar URLs, image EXIF,
+		// comments metadata) out of a feed whose only job is to deliver
+		// podcast episode metadata + the audio enclosure.
+		//
+		// - option_rss_use_excerpt -> suppresses content:encoded (full post body, incl. EXIF in image attrs).
+		// - comments_open + get_comments_number -> together suppress per-item comments / wfw:commentRss / slash:comments.
+		// - the_category_rss -> suppresses per-item category tags (channel itunes:category is the podcatcher signal).
+		// - removing wpcom mrss.php hooks -> suppresses media:content for author gravatar + post images.
+		add_filter( 'option_rss_use_excerpt', '__return_true' );
+		add_filter( 'comments_open', '__return_false' );
+		add_filter( 'get_comments_number', '__return_zero' );
+		add_filter( 'the_category_rss', '__return_empty_string' );
+		remove_action( 'rss2_item', 'mrss_item', 10 );
+		remove_action( 'rss2_item', 'mrss_news_item' );
+
 		Feed_Detection::detect_and_record();
 	}
 


### PR DESCRIPTION
## Proposed changes

Two related fixes to the podcast feed's signal-to-noise ratio:

### 1. Surface a "Show notes" field in the Podcast Episode block

Authors had no clue that the post Excerpt is what Apple Podcasts / Spotify / Pocket Casts display as the episode description. The sidebar Excerpt panel is hidden by default and labeled generically. Adds a `TextareaControl` at the top of the block's *Episode* inspector panel, bound via `useEntityProp` to the same `excerpt` field — so the block control and the sidebar Excerpt panel stay in sync (they're the same data). Help text spells out the consumer:

> *Episode description shown in Apple Podcasts, Spotify, and Pocket Casts. Synced with the post's Excerpt.*

### 2. Strip non-podcast RSS chrome from the feed

The feed was carrying multiple KB per item of content that no podcatcher reads — full post body via `<content:encoded>` (with embedded image EXIF including GPS coordinates), gravatar URLs and image srcsets via `<media:content>`, plus the `<comments>` / `<wfw:commentRss>` / `<slash:comments>` cluster and per-item `<category>` tags.

Hooks registered alongside the existing podcast feed customization:

| Filter / action | Suppresses |
|---|---|
| `add_filter( 'option_rss_use_excerpt', '__return_true' )` | `<content:encoded>` (post body + image EXIF leak) |
| `add_filter( 'comments_open', '__return_false' )` + `add_filter( 'get_comments_number', '__return_zero' )` | `<comments>`, `<wfw:commentRss>`, `<slash:comments>` |
| `add_filter( 'the_category_rss', '__return_empty_string' )` | Per-item `<category>` (the channel `<itunes:category>` is what podcatchers read) |
| `remove_action( 'rss2_item', 'mrss_item' )` + `remove_action( 'rss2_item', 'mrss_news_item' )` | `<media:content>` (avatar + post images with EXIF / srcset) — wpcom `blog-plugins/mrss.php` |

All registered inside `Customize_Feed::maybe_register_feed_hooks()`, which already gates on `is_feed() && is_category( $podcast_category_id )` — the filters only fire for podcast feed requests, never for regular blog feeds.

`<dc:creator>` and the com-wordpress namespace tags (`<post-id>`, `<site>`) are intentionally left in place — they're hardcoded in the WP core template / wpcom-reader integration, and removing them carries more risk than benefit for marginal noise reduction.

## Why both fixes in one PR

They're two halves of the same problem: the feed is the publishing surface, the block is the authoring surface. Stripping the feed without surfacing the show notes UX would leave authors with empty episode descriptions and no idea why. Adding the UX without stripping the feed would still leak EXIF and body content. Together they make the lean-feed posture coherent.

## Testing instructions

1. **Author flow**: open a published podcast episode in the block editor. The Podcast Episode block's *Episode* inspector panel should now have *Show notes* at the top. Type a description, save. Open the sidebar *Excerpt* panel — same text appears there. Edit it from either side, the other stays in sync.

2. **Feed cleanup** (fetch via the SOCKS5 proxy):
   ```
   curl --socks5 localhost:8080 "https://p00dcasting.blog/category/poo-audio/feed/?nocache=$(date +%s)"
   ```
   Verify each `<item>` no longer contains:
   - `<content:encoded>` (was multi-KB per item)
   - `<media:content>` (was 2 per item — gravatar + image)
   - `<comments>`, `<wfw:commentRss>`, `<slash:comments>`
   - `<category>` (item-level — channel-level `<itunes:category>` is preserved)

3. **Non-podcast feeds unaffected**: fetch a non-podcast category feed on the same site (e.g., `/category/some-other-cat/feed/`) and confirm `<content:encoded>`, `<media:content>`, etc. still emit normally. The filters only register inside `maybe_register_feed_hooks()` which short-circuits on non-podcast category requests.

## Test plan

- [x] PHPUnit: 119 tests / 263 assertions pass
- [x] PHPCS clean on `class-customize-feed.php`
- [x] ESLint: no new violations on `edit.tsx`
- [x] `build:blocks` compiles cleanly
- [ ] Manual: feed before/after diff on the test site
- [ ] Manual: non-podcast category feed on the same site still has the standard chrome
