### PR TITLE
Blaze: opt-in panel + hidden landing-page CPT (Woo product editor)

### DIFF
--- a/projects/packages/blaze/changelog/add-landing-page-cpt
+++ b/projects/packages/blaze/changelog/add-landing-page-cpt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a hidden `blaze_landing_page` custom post type with random-slug public URLs and a server-to-server REST endpoint (`POST /jetpack/v4/blaze/landing-pages`) so AI-generated landing pages can be created from WPCOM/DSP without surfacing in any merchant UI.

--- a/projects/packages/blaze/changelog/add-landing-page-dispatcher
+++ b/projects/packages/blaze/changelog/add-landing-page-dispatcher
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forward the `jetpack_blaze_woo_product_promote_requested` event to a WPCOM internal endpoint via `wpcom_json_api_request_as_blog`, so DSP can enqueue a Blaze landing-page job when a merchant publishes a Woo product with the Promote-with-Blaze opt-in checked.

--- a/projects/packages/blaze/changelog/add-woo-product-promote-panel
+++ b/projects/packages/blaze/changelog/add-woo-product-promote-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add an opt-in "Promote it free with Blaze Ads" panel to the WooCommerce product editor, gated on the `blaze-featured-woocommerce-site` site sticker and a Jetpack connection.

--- a/projects/packages/blaze/changelog/update-landing-page-theme-template
+++ b/projects/packages/blaze/changelog/update-landing-page-theme-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Render Blaze landing pages on-brand: load the merchant theme's global styles and real header/footer template parts, show the live WooCommerce price and image gallery, and support AI-generated lifestyle images alongside it.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack;
 use Automattic\Jetpack\Blaze\Dashboard as Blaze_Dashboard;
 use Automattic\Jetpack\Blaze\Dashboard_REST_Controller as Blaze_Dashboard_REST_Controller;
 use Automattic\Jetpack\Blaze\REST_Controller;
+use Automattic\Jetpack\Blaze\Woo_Product_Panel;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
@@ -59,6 +60,8 @@ class Blaze {
 		add_action( 'rest_api_init', array( new Blaze_Dashboard_REST_Controller(), 'register_rest_routes' ) );
 		// Add general Blaze REST API endpoints.
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+		// Promote-with-Blaze opt-in panel on the WooCommerce product editor.
+		Woo_Product_Panel::init();
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Blaze\Dashboard as Blaze_Dashboard;
 use Automattic\Jetpack\Blaze\Dashboard_REST_Controller as Blaze_Dashboard_REST_Controller;
+use Automattic\Jetpack\Blaze\Landing_Page_CPT;
+use Automattic\Jetpack\Blaze\Landing_Page_Dispatcher;
 use Automattic\Jetpack\Blaze\REST_Controller;
 use Automattic\Jetpack\Blaze\Woo_Product_Panel;
 use Automattic\Jetpack\Connection\Client;
@@ -62,6 +64,10 @@ class Blaze {
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		// Promote-with-Blaze opt-in panel on the WooCommerce product editor.
 		Woo_Product_Panel::init();
+		// Hidden CPT used to host AI-generated landing pages for promoted products.
+		Landing_Page_CPT::init();
+		// Forward Woo product promote-requested events to WPCOM (DSP enqueue).
+		Landing_Page_Dispatcher::init();
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Hidden CPT used to host AI-generated Blaze landing pages.
+ * Hidden CPT for Blaze AI landing pages.
+ *
+ * A landing page is defined by STRUCTURED fields — headline, subheadline,
+ * highlights, CTA, plus product and brand data — stored in sanitized post
+ * meta. It is NOT arbitrary HTML: the AI generates copy, not markup. On the
+ * public URL the theme is bypassed and a fixed, package-owned template renders
+ * those fields, styled by the package's own stylesheet. Because nothing
+ * untrusted is stored as markup or CSS, this never fights the platform's
+ * content sanitization (KSES / WPCOM filters).
  *
  * The CPT is:
  *  - not public (no archive, not in search, not in nav menus, no admin UI),
  *  - publicly queryable (the random-slug URL works), and
- *  - REST-enabled so DSP can create/update entries via the WPCOM proxy.
- *
- * Each landing page is a self-contained HTML document stored in
- * `post_content`. When the public URL is hit, the theme is bypassed and
- * the document is served inside a sandboxed iframe, so its (AI-generated,
- * attacker-influenceable) markup cannot run scripts or reach the merchant's
- * origin, cookies, or parent DOM.
+ *  - REST-enabled so the WPCOM proxy can create/update entries.
  *
  * @package automattic/jetpack-blaze
  */
@@ -30,21 +32,40 @@ class Landing_Page_CPT {
 	const SLUG_BYTES = 16;
 
 	/**
-	 * Meta keys for landing-page metadata. Stored as post meta so the
-	 * post_content stays a clean HTML document.
+	 * Prefix for all landing-page field meta keys (protected meta).
 	 */
+	const META_PREFIX = '_blaze_landing_';
+
 	const META_PRODUCT_ID = '_blaze_landing_product_id';
 	const META_MODE       = '_blaze_landing_mode';
 	const META_CAMPAIGN   = '_blaze_landing_campaign_id';
+	const META_HIGHLIGHTS = '_blaze_landing_highlights';
+
+	const ASSET_VERSION  = '1.0.0';
+	const MAX_HIGHLIGHTS = 6;
 
 	/**
-	 * The landing-page HTML document is stored base64-encoded in this protected
-	 * meta key, NOT in post_content. WPCOM/Atomic run content sanitization on
-	 * post_content (KSES + platform filters) that strips `<style>`/`<head>`,
-	 * which would break the page even with KSES disabled. Base64 in meta is
-	 * opaque to every sanitizer and round-trips intact on Simple/Atomic/JN.
+	 * Scalar landing-page fields and the WordPress sanitizer registered for
+	 * each. The sanitizer runs automatically on save (via register_post_meta)
+	 * and the values are escaped again at render — no raw markup is ever stored.
+	 *
+	 * @return array<string,string> Field name => sanitize callback.
 	 */
-	const META_HTML = '_blaze_landing_html';
+	private static function fields() {
+		return array(
+			'headline'     => 'sanitize_text_field',
+			'subheadline'  => 'sanitize_text_field',
+			'cta_text'     => 'sanitize_text_field',
+			'cta_url'      => 'esc_url_raw',
+			'product_name' => 'sanitize_text_field',
+			'price'        => 'sanitize_text_field',
+			'currency'     => 'sanitize_text_field',
+			'image_url'    => 'esc_url_raw',
+			'brand_name'   => 'sanitize_text_field',
+			'logo_url'     => 'esc_url_raw',
+			'accent_color' => 'sanitize_hex_color',
+		);
+	}
 
 	/**
 	 * Wire hooks.
@@ -53,11 +74,11 @@ class Landing_Page_CPT {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register' ) );
-		add_filter( 'template_include', array( __CLASS__, 'render_raw_document' ), PHP_INT_MAX );
+		add_filter( 'template_include', array( __CLASS__, 'render' ), PHP_INT_MAX );
 	}
 
 	/**
-	 * Register the CPT.
+	 * Register the CPT and its field meta.
 	 *
 	 * @return void
 	 */
@@ -76,9 +97,7 @@ class Landing_Page_CPT {
 				'show_in_menu'        => false,
 				'show_in_nav_menus'   => false,
 				'show_in_admin_bar'   => false,
-				'show_in_rest'        => true,
-				'rest_base'           => 'blaze-landing-pages',
-				'rest_namespace'      => 'jetpack/v4',
+				'show_in_rest'        => false,
 				'rewrite'             => array(
 					'slug'       => self::URL_PREFIX,
 					'with_front' => false,
@@ -86,53 +105,65 @@ class Landing_Page_CPT {
 					'pages'      => false,
 				),
 				'has_archive'         => false,
-				'supports'            => array( 'title', 'editor', 'custom-fields' ),
+				'supports'            => array( 'title' ),
 				'capability_type'     => 'post',
 				'map_meta_cap'        => true,
 				'delete_with_user'    => false,
 			)
 		);
 
-		register_post_meta(
-			self::POST_TYPE,
-			self::META_PRODUCT_ID,
-			array(
-				'type'         => 'integer',
-				'single'       => true,
-				'show_in_rest' => true,
-			)
-		);
+		foreach ( self::fields() as $field => $sanitizer ) {
+			register_post_meta(
+				self::POST_TYPE,
+				self::META_PREFIX . $field,
+				array(
+					'type'              => 'string',
+					'single'            => true,
+					'show_in_rest'      => false,
+					'sanitize_callback' => $sanitizer,
+				)
+			);
+		}
+
 		register_post_meta(
 			self::POST_TYPE,
 			self::META_MODE,
 			array(
-				'type'         => 'string',
-				'single'       => true,
-				'show_in_rest' => true,
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => false,
+				'sanitize_callback' => 'sanitize_key',
+			)
+		);
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_PRODUCT_ID,
+			array(
+				'type'              => 'integer',
+				'single'            => true,
+				'show_in_rest'      => false,
+				'sanitize_callback' => 'absint',
 			)
 		);
 		register_post_meta(
 			self::POST_TYPE,
 			self::META_CAMPAIGN,
 			array(
-				'type'         => 'integer',
-				'single'       => true,
-				'show_in_rest' => true,
+				'type'              => 'integer',
+				'single'            => true,
+				'show_in_rest'      => false,
+				'sanitize_callback' => 'absint',
 			)
 		);
 	}
 
 	/**
-	 * Bypass the theme on landing-page requests and emit the stored HTML.
-	 *
-	 * The stored `post_content` is a complete HTML document (or HTML
-	 * fragment). We send a minimal header/body wrapper only when the
-	 * content does not already include `<html>`.
+	 * Bypass the theme on landing-page requests and render the template.
 	 *
 	 * @param string $template Theme template that would otherwise load.
 	 * @return string|void
 	 */
-	public static function render_raw_document( $template ) {
+	public static function render( $template ) {
 		if ( ! is_singular( self::POST_TYPE ) ) {
 			return $template;
 		}
@@ -145,123 +176,105 @@ class Landing_Page_CPT {
 		nocache_headers();
 		header( 'Content-Type: text/html; charset=utf-8' );
 		header( 'X-Robots-Tag: noindex, nofollow, noarchive', true );
-		// Outer-frame hardening (clickjacking + base-tag hijack). The untrusted
-		// document itself is isolated in the sandboxed iframe built below.
 		header( "Content-Security-Policy: frame-ancestors 'none'; base-uri 'none'", true );
 		header( 'X-Content-Type-Options: nosniff', true );
 		header( 'Referrer-Policy: no-referrer', true );
 
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper is built from escaped values; the untrusted document is escaped into the iframe srcdoc and isolated by the sandbox.
-		echo self::render_sandboxed( $post->post_title, self::get_stored_html( $post ) );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_template() escapes every dynamic value with esc_html/esc_url/esc_attr.
+		echo self::render_template( $post );
 		exit;
 	}
 
 	/**
-	 * Read the stored landing-page HTML for a post.
+	 * Read the stored landing-page fields for a post.
 	 *
-	 * Primary storage is the base64-encoded META_HTML meta. Falls back to
-	 * post_content for any legacy entries written before the meta switch.
+	 * @param int $post_id Post ID.
+	 * @return array<string,mixed> Field values; `highlights` is a string array.
+	 */
+	private static function get_fields( $post_id ) {
+		$out = array();
+		foreach ( array_keys( self::fields() ) as $field ) {
+			$out[ $field ] = (string) get_post_meta( $post_id, self::META_PREFIX . $field, true );
+		}
+		$highlights        = get_post_meta( $post_id, self::META_HIGHLIGHTS, true );
+		$out['highlights'] = is_array( $highlights ) ? $highlights : array();
+		return $out;
+	}
+
+	/**
+	 * Render the landing page from its structured fields.
 	 *
 	 * @param WP_Post $post Landing-page post.
-	 * @return string HTML document.
+	 * @return string Full HTML document.
 	 */
-	private static function get_stored_html( $post ) {
-		$encoded = (string) get_post_meta( $post->ID, self::META_HTML, true );
-		if ( '' !== $encoded ) {
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Benign: decoding our own stored HTML document, not obfuscation.
-			$decoded = base64_decode( $encoded, true );
-			if ( false !== $decoded && '' !== $decoded ) {
-				return $decoded;
-			}
-		}
-		return (string) $post->post_content;
-	}
+	private static function render_template( $post ) {
+		$f       = self::get_fields( $post->ID );
+		$lang    = get_bloginfo( 'language' );
+		$css_url = plugins_url( 'css/landing-page.css', __FILE__ );
+		$cta     = '' !== $f['cta_text'] ? $f['cta_text'] : __( 'Shop now', 'jetpack-blaze' );
+		$price   = trim( $f['price'] . ( '' !== $f['currency'] ? ' ' . $f['currency'] : '' ) );
+		$brand   = '' !== $f['brand_name'] ? $f['brand_name'] : get_bloginfo( 'name' );
 
-	/**
-	 * Render the stored landing-page HTML inside a sandboxed iframe.
-	 *
-	 * The AI-generated document is attacker-influenceable (product data feeds
-	 * the prompt) and is served on the merchant's own origin, so it is a
-	 * stored-XSS surface. We isolate it in an iframe whose `sandbox` lacks
-	 * `allow-scripts` and `allow-same-origin`: JavaScript cannot execute and
-	 * the content runs in a unique opaque origin with no access to the
-	 * merchant's cookies, storage, or parent DOM. CSS still renders.
-	 *
-	 * The default sandbox keeps the conversion link working (popups +
-	 * user-activated top navigation). The policy is filterable for stricter
-	 * variants.
-	 *
-	 * @param string $title   Document title for the outer frame.
-	 * @param string $content Stored landing-page HTML (full document or fragment).
-	 * @return string Outer HTML document embedding the sandboxed iframe.
-	 */
-	private static function render_sandboxed( $title, $content ) {
-		$lang = get_bloginfo( 'language' );
-
-		/**
-		 * Filter the iframe `sandbox` policy for rendered landing pages.
-		 *
-		 * Never add `allow-scripts` together with `allow-same-origin`: that
-		 * combination lets the framed document remove its own sandbox.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param string $sandbox Space-separated sandbox tokens.
-		 */
-		$sandbox = (string) apply_filters(
-			'jetpack_blaze_landing_page_iframe_sandbox',
-			'allow-popups allow-top-navigation-by-user-activation'
-		);
-
-		return sprintf(
-			'<!doctype html><html lang="%1$s"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>%2$s</title><style>html,body{margin:0;padding:0;height:100%%}.blaze-lp-frame{border:0;display:block;width:100%%;height:100vh}</style></head><body><iframe class="blaze-lp-frame" sandbox="%3$s" referrerpolicy="no-referrer" title="%2$s" srcdoc="%4$s"></iframe></body></html>',
-			esc_attr( $lang ),
-			esc_html( $title ),
-			esc_attr( $sandbox ),
-			esc_attr( $content )
-		);
-	}
-
-	/**
-	 * Sanitize an AI-generated HTML document before storing it.
-	 *
-	 * Default policy is "HTML + CSS, no JS". `<script>` blocks and `on*`
-	 * event attributes are removed. CSS in `<style>` and `style=""` is kept.
-	 *
-	 * The policy can be relaxed (e.g. for a sandboxed iframe variant) via
-	 * the `jetpack_blaze_landing_page_allow_js` filter.
-	 *
-	 * @param string $html Raw HTML.
-	 * @return string Sanitized HTML.
-	 */
-	public static function sanitize_html( $html ) {
-		$html = (string) $html;
-
-		/**
-		 * Whether to allow JavaScript in landing-page HTML.
-		 *
-		 * Default false. Flip to true once a sandboxed render path is in place.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param bool $allow_js Whether to keep <script> and on* attributes.
-		 */
-		$allow_js = (bool) apply_filters( 'jetpack_blaze_landing_page_allow_js', false );
-		if ( $allow_js ) {
-			return $html;
-		}
-
-		// Strip script blocks entirely.
-		$html = preg_replace( '#<script\b[^>]*>.*?</script\s*>#is', '', $html );
-		$html = preg_replace( '#<script\b[^>]*/?>#is', '', (string) $html );
-		// Strip inline event handlers (on*="…" or on*='…' or on*=value).
-		$html = preg_replace( '#\son[a-z]+\s*=\s*"[^"]*"#i', '', (string) $html );
-		$html = preg_replace( "#\son[a-z]+\s*=\s*'[^']*'#i", '', (string) $html );
-		$html = preg_replace( '#\son[a-z]+\s*=\s*[^\s>]+#i', '', (string) $html );
-		// Strip javascript: URLs in href/src.
-		$html = preg_replace( '#(href|src)\s*=\s*(["\'])\s*javascript:[^"\']*\2#i', '$1=$2#$2', (string) $html );
-
-		return (string) $html;
+		ob_start();
+		?>
+<!doctype html>
+<html lang="<?php echo esc_attr( $lang ); ?>">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title><?php echo esc_html( $post->post_title ); ?></title>
+		<?php
+		wp_enqueue_style( 'jetpack-blaze-landing', $css_url, array(), self::ASSET_VERSION );
+		wp_print_styles( 'jetpack-blaze-landing' );
+		?>
+		<?php if ( '' !== $f['accent_color'] ) : ?>
+<style>:root{--blaze-accent:<?php echo esc_html( $f['accent_color'] ); ?>}</style>
+		<?php endif; ?>
+</head>
+<body class="blaze-lp">
+<header class="blaze-lp-header">
+		<?php if ( '' !== $f['logo_url'] ) : ?>
+	<img class="blaze-lp-logo" src="<?php echo esc_url( $f['logo_url'] ); ?>" alt="<?php echo esc_attr( $brand ); ?>">
+		<?php else : ?>
+	<span class="blaze-lp-brand"><?php echo esc_html( $brand ); ?></span>
+		<?php endif; ?>
+</header>
+<main class="blaze-lp-main">
+	<section class="blaze-lp-hero">
+		<?php if ( '' !== $f['image_url'] ) : ?>
+		<div class="blaze-lp-media">
+			<img src="<?php echo esc_url( $f['image_url'] ); ?>" alt="<?php echo esc_attr( '' !== $f['product_name'] ? $f['product_name'] : $f['headline'] ); ?>">
+		</div>
+		<?php endif; ?>
+		<div class="blaze-lp-copy">
+		<?php if ( '' !== $f['headline'] ) : ?>
+			<h1 class="blaze-lp-headline"><?php echo esc_html( $f['headline'] ); ?></h1>
+		<?php endif; ?>
+		<?php if ( '' !== $f['subheadline'] ) : ?>
+			<p class="blaze-lp-sub"><?php echo esc_html( $f['subheadline'] ); ?></p>
+		<?php endif; ?>
+		<?php if ( '' !== $price ) : ?>
+			<p class="blaze-lp-price"><?php echo esc_html( $price ); ?></p>
+		<?php endif; ?>
+		<?php if ( '' !== $f['cta_url'] ) : ?>
+			<a class="blaze-lp-cta" href="<?php echo esc_url( $f['cta_url'] ); ?>"><?php echo esc_html( $cta ); ?></a>
+		<?php endif; ?>
+		</div>
+	</section>
+		<?php if ( ! empty( $f['highlights'] ) ) : ?>
+	<ul class="blaze-lp-highlights">
+			<?php foreach ( $f['highlights'] as $highlight ) : ?>
+		<li><?php echo esc_html( (string) $highlight ); ?></li>
+			<?php endforeach; ?>
+	</ul>
+		<?php endif; ?>
+</main>
+<footer class="blaze-lp-footer"><?php echo esc_html( $brand ); ?></footer>
+</body>
+</html>
+		<?php
+		return (string) ob_get_clean();
 	}
 
 	/**
@@ -271,40 +284,44 @@ class Landing_Page_CPT {
 	 */
 	public static function generate_slug() {
 		$bytes = random_bytes( self::SLUG_BYTES );
-		// Base64-url, no padding.
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Benign: URL-safe encoding of random bytes for a slug, not obfuscation.
 		return rtrim( strtr( base64_encode( $bytes ), '+/', '-_' ), '=' );
 	}
 
 	/**
-	 * Upsert a landing page.
+	 * Create or update a landing page from structured fields.
 	 *
-	 * If `$slug` is provided and matches an existing landing-page post,
-	 * the post is updated. Otherwise a new one is created with a fresh
-	 * random slug.
+	 * Scalar fields are sanitized by their registered meta sanitize_callback;
+	 * highlights are sanitized item by item here.
 	 *
-	 * @param array $args Upsert arguments: `html` (required AI-generated HTML),
-	 *                    `title` (defaults to product name), `mode` (required,
-	 *                    e.g. 'woocommerce'), `product_id` (required),
-	 *                    `campaign_id`, and `slug` (optional existing slug to
-	 *                    upsert in place).
-	 * @return array|\WP_Error { id, slug, url } or WP_Error.
+	 * @param array $args Landing-page fields: `mode` (required, e.g.
+	 *                    'woocommerce'), `product_id` (required), `headline`,
+	 *                    `subheadline`, `cta_text`, `cta_url`, `product_name`,
+	 *                    `price`, `currency`, `image_url`, `brand_name`,
+	 *                    `logo_url`, `accent_color`, `highlights` (string[]),
+	 *                    `campaign_id`, `slug` (optional, upsert in place).
+	 * @return array|\WP_Error Array with id, slug, url; or WP_Error.
 	 */
 	public static function upsert( array $args ) {
-		$html = isset( $args['html'] ) ? (string) $args['html'] : '';
-		if ( '' === $html ) {
-			return new \WP_Error( 'jetpack_blaze_landing_missing_html', __( 'Missing HTML payload.', 'jetpack-blaze' ) );
-		}
 		$mode       = isset( $args['mode'] ) ? sanitize_key( $args['mode'] ) : '';
 		$product_id = isset( $args['product_id'] ) ? (int) $args['product_id'] : 0;
 		if ( '' === $mode || 0 === $product_id ) {
 			return new \WP_Error( 'jetpack_blaze_landing_missing_meta', __( 'mode and product_id are required.', 'jetpack-blaze' ) );
 		}
 
-		$sanitized_html = self::sanitize_html( $html );
-		$title          = isset( $args['title'] ) && is_string( $args['title'] )
-			? sanitize_text_field( $args['title'] )
-			: sprintf( 'Blaze landing — product %d', $product_id );
+		$headline     = isset( $args['headline'] ) ? sanitize_text_field( (string) $args['headline'] ) : '';
+		$product_name = isset( $args['product_name'] ) ? sanitize_text_field( (string) $args['product_name'] ) : '';
+		if ( '' === $headline && '' === $product_name ) {
+			return new \WP_Error( 'jetpack_blaze_landing_missing_content', __( 'A headline or product name is required.', 'jetpack-blaze' ) );
+		}
+
+		if ( '' !== $product_name ) {
+			$title = $product_name;
+		} elseif ( isset( $args['title'] ) && is_string( $args['title'] ) ) {
+			$title = sanitize_text_field( $args['title'] );
+		} else {
+			$title = $headline;
+		}
 
 		$slug        = isset( $args['slug'] ) ? sanitize_title( $args['slug'] ) : '';
 		$existing_id = 0;
@@ -314,14 +331,12 @@ class Landing_Page_CPT {
 				$existing_id = (int) $existing->ID;
 			}
 		}
-
 		if ( '' === $slug ) {
 			$slug = self::generate_slug();
 		}
 
-		// The HTML document lives in META_HTML (base64), not post_content —
-		// see that constant's note. post_content is left empty so platform
-		// content sanitizers have nothing to mangle.
+		// post_content stays empty: the page is rendered from structured meta by
+		// our template, so there is no markup for content sanitizers to touch.
 		$postarr = array(
 			'post_type'    => self::POST_TYPE,
 			'post_status'  => 'publish',
@@ -340,10 +355,26 @@ class Landing_Page_CPT {
 			return $post_id;
 		}
 
-		// Store the document base64-encoded so no content/meta sanitizer can
-		// strip its <style>/<head>; render_raw_document decodes it.
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Benign: opaque-storing our own HTML to survive platform sanitizers, not obfuscation.
-		update_post_meta( $post_id, self::META_HTML, base64_encode( $sanitized_html ) );
+		// Scalar fields: stored raw, sanitized by their registered meta callback.
+		foreach ( array_keys( self::fields() ) as $field ) {
+			if ( array_key_exists( $field, $args ) ) {
+				update_post_meta( $post_id, self::META_PREFIX . $field, (string) $args[ $field ] );
+			}
+		}
+
+		// Highlights: a short list of plain-text bullets.
+		if ( isset( $args['highlights'] ) && is_array( $args['highlights'] ) ) {
+			$highlights = array();
+			foreach ( $args['highlights'] as $highlight ) {
+				$clean = sanitize_text_field( (string) $highlight );
+				if ( '' !== $clean ) {
+					$highlights[] = $clean;
+				}
+			}
+			$highlights = array_slice( $highlights, 0, self::MAX_HIGHLIGHTS );
+			update_post_meta( $post_id, self::META_HIGHLIGHTS, $highlights );
+		}
+
 		update_post_meta( $post_id, self::META_MODE, $mode );
 		update_post_meta( $post_id, self::META_PRODUCT_ID, $product_id );
 		if ( ! empty( $args['campaign_id'] ) ) {

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -38,6 +38,15 @@ class Landing_Page_CPT {
 	const META_CAMPAIGN   = '_blaze_landing_campaign_id';
 
 	/**
+	 * The landing-page HTML document is stored base64-encoded in this protected
+	 * meta key, NOT in post_content. WPCOM/Atomic run content sanitization on
+	 * post_content (KSES + platform filters) that strips `<style>`/`<head>`,
+	 * which would break the page even with KSES disabled. Base64 in meta is
+	 * opaque to every sanitizer and round-trips intact on Simple/Atomic/JN.
+	 */
+	const META_HTML = '_blaze_landing_html';
+
+	/**
 	 * Wire hooks.
 	 *
 	 * @return void
@@ -143,8 +152,29 @@ class Landing_Page_CPT {
 		header( 'Referrer-Policy: no-referrer', true );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper is built from escaped values; the untrusted document is escaped into the iframe srcdoc and isolated by the sandbox.
-		echo self::render_sandboxed( $post->post_title, (string) $post->post_content );
+		echo self::render_sandboxed( $post->post_title, self::get_stored_html( $post ) );
 		exit;
+	}
+
+	/**
+	 * Read the stored landing-page HTML for a post.
+	 *
+	 * Primary storage is the base64-encoded META_HTML meta. Falls back to
+	 * post_content for any legacy entries written before the meta switch.
+	 *
+	 * @param WP_Post $post Landing-page post.
+	 * @return string HTML document.
+	 */
+	private static function get_stored_html( $post ) {
+		$encoded = (string) get_post_meta( $post->ID, self::META_HTML, true );
+		if ( '' !== $encoded ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Benign: decoding our own stored HTML document, not obfuscation.
+			$decoded = base64_decode( $encoded, true );
+			if ( false !== $decoded && '' !== $decoded ) {
+				return $decoded;
+			}
+		}
+		return (string) $post->post_content;
 	}
 
 	/**
@@ -289,35 +319,31 @@ class Landing_Page_CPT {
 			$slug = self::generate_slug();
 		}
 
+		// The HTML document lives in META_HTML (base64), not post_content —
+		// see that constant's note. post_content is left empty so platform
+		// content sanitizers have nothing to mangle.
 		$postarr = array(
 			'post_type'    => self::POST_TYPE,
 			'post_status'  => 'publish',
 			'post_title'   => $title,
 			'post_name'    => $slug,
-			'post_content' => wp_slash( $sanitized_html ),
+			'post_content' => '',
 		);
 
-		// The HTML is a complete, self-contained document that we already
-		// sanitized (scripts/JS stripped) in self::sanitize_html(). Blog-token
-		// REST requests run as a user without `unfiltered_html`, so KSES would
-		// strip `<!doctype>`, `<html>`, `<head>` and `<style>` tags on save —
-		// keeping the CSS as visible text and breaking the page. Disable the
-		// KSES content filters around the write and restore them right after.
-		kses_remove_filters();
-		try {
-			if ( $existing_id > 0 ) {
-				$postarr['ID'] = $existing_id;
-				$post_id       = wp_update_post( $postarr, true );
-			} else {
-				$post_id = wp_insert_post( $postarr, true );
-			}
-		} finally {
-			kses_init_filters();
+		if ( $existing_id > 0 ) {
+			$postarr['ID'] = $existing_id;
+			$post_id       = wp_update_post( $postarr, true );
+		} else {
+			$post_id = wp_insert_post( $postarr, true );
 		}
 		if ( is_wp_error( $post_id ) ) {
 			return $post_id;
 		}
 
+		// Store the document base64-encoded so no content/meta sanitizer can
+		// strip its <style>/<head>; render_raw_document decodes it.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Benign: opaque-storing our own HTML to survive platform sanitizers, not obfuscation.
+		update_post_meta( $post_id, self::META_HTML, base64_encode( $sanitized_html ) );
 		update_post_meta( $post_id, self::META_MODE, $mode );
 		update_post_meta( $post_id, self::META_PRODUCT_ID, $product_id );
 		if ( ! empty( $args['campaign_id'] ) ) {

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -259,8 +259,13 @@ class Landing_Page_CPT {
 
 	/**
 	 * Pick an accent color from the active theme's palette so the landing's own
-	 * accents (CTA, dividers) match the store. Skips the usual neutral slugs and
-	 * returns the first "brand" color, or '' when none can be determined.
+	 * accents (CTA, dividers) match the store.
+	 *
+	 * The earlier "first non-neutral slug" approach grabbed pale secondary tints.
+	 * Instead we drop obvious neutrals, prefer well-known brand slugs
+	 * (primary/accent/brand), and otherwise choose the most saturated color at a
+	 * usable lightness — that reliably lands on the brand color (e.g. a gold)
+	 * rather than a near-white cream.
 	 *
 	 * @return string Hex color or ''.
 	 */
@@ -275,11 +280,14 @@ class Landing_Page_CPT {
 		} elseif ( is_array( $palette ) ) {
 			$colors = $palette;
 		}
-		$skip = array( 'base', 'background', 'foreground', 'contrast', 'text', 'white', 'black', 'light', 'dark' );
+
+		$skip       = array( 'base', 'background', 'foreground', 'contrast', 'text', 'white', 'black', 'light', 'dark', 'neutral' );
+		$prefer     = array( 'primary', 'accent', 'brand' );
+		$candidates = array();
 		foreach ( $colors as $color ) {
 			$slug = isset( $color['slug'] ) ? strtolower( (string) $color['slug'] ) : '';
-			$hex  = isset( $color['color'] ) ? (string) $color['color'] : '';
-			if ( '' === $slug || '' === $hex ) {
+			$hex  = isset( $color['color'] ) ? sanitize_hex_color( (string) $color['color'] ) : null;
+			if ( '' === $slug || ! $hex ) {
 				continue;
 			}
 			$is_neutral = false;
@@ -290,13 +298,57 @@ class Landing_Page_CPT {
 				}
 			}
 			if ( ! $is_neutral ) {
-				$clean = sanitize_hex_color( $hex );
-				if ( $clean ) {
-					return $clean;
+				$candidates[ $slug ] = $hex;
+			}
+		}
+		if ( empty( $candidates ) ) {
+			return '';
+		}
+
+		foreach ( $prefer as $needle ) {
+			foreach ( $candidates as $slug => $hex ) {
+				if ( false !== strpos( $slug, $needle ) ) {
+					return $hex;
 				}
 			}
 		}
-		return '';
+
+		$best     = '';
+		$best_sat = -1.0;
+		foreach ( $candidates as $hex ) {
+			list( $sat, $light ) = self::hex_saturation_lightness( $hex );
+			if ( $light < 0.15 || $light > 0.82 ) {
+				continue;
+			}
+			if ( $sat > $best_sat ) {
+				$best_sat = $sat;
+				$best     = $hex;
+			}
+		}
+		// If everything was too light/dark, fall back to the first candidate.
+		return '' !== $best ? $best : reset( $candidates );
+	}
+
+	/**
+	 * Compute the HSL saturation and lightness (0..1) of a hex color.
+	 *
+	 * @param string $hex A sanitized hex color (#rgb or #rrggbb).
+	 * @return array{0:float,1:float} [ saturation, lightness ].
+	 */
+	private static function hex_saturation_lightness( $hex ) {
+		$hex = ltrim( $hex, '#' );
+		if ( 3 === strlen( $hex ) ) {
+			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+		}
+		$r   = hexdec( substr( $hex, 0, 2 ) ) / 255;
+		$g   = hexdec( substr( $hex, 2, 2 ) ) / 255;
+		$b   = hexdec( substr( $hex, 4, 2 ) ) / 255;
+		$max = max( $r, $g, $b );
+		$min = min( $r, $g, $b );
+		$l   = ( $max + $min ) / 2;
+		$d   = $max - $min;
+		$s   = $d > 0.0 ? $d / ( 1 - abs( 2 * $l - 1 ) ) : 0.0;
+		return array( $s, $l );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -9,7 +9,9 @@
  *
  * Each landing page is a self-contained HTML document stored in
  * `post_content`. When the public URL is hit, the theme is bypassed and
- * the raw document is served verbatim.
+ * the document is served inside a sandboxed iframe, so its (AI-generated,
+ * attacker-influenceable) markup cannot run scripts or reach the merchant's
+ * origin, cookies, or parent DOM.
  *
  * @package automattic/jetpack-blaze
  */
@@ -134,31 +136,59 @@ class Landing_Page_CPT {
 		nocache_headers();
 		header( 'Content-Type: text/html; charset=utf-8' );
 		header( 'X-Robots-Tag: noindex, nofollow, noarchive', true );
+		// Outer-frame hardening (clickjacking + base-tag hijack). The untrusted
+		// document itself is isolated in the sandboxed iframe built below.
+		header( "Content-Security-Policy: frame-ancestors 'none'; base-uri 'none'", true );
+		header( 'X-Content-Type-Options: nosniff', true );
+		header( 'Referrer-Policy: no-referrer', true );
 
-		$content = (string) $post->post_content;
-		if ( stripos( $content, '<html' ) === false ) {
-			$content = self::wrap_fragment( $post->post_title, $content );
-		}
-
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content was sanitized at write time.
-		echo $content;
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Wrapper is built from escaped values; the untrusted document is escaped into the iframe srcdoc and isolated by the sandbox.
+		echo self::render_sandboxed( $post->post_title, (string) $post->post_content );
 		exit;
 	}
 
 	/**
-	 * Minimal HTML5 wrapper for HTML fragments (no theme, no admin bar).
+	 * Render the stored landing-page HTML inside a sandboxed iframe.
 	 *
-	 * @param string $title   Document title.
-	 * @param string $content HTML fragment.
-	 * @return string Full HTML document.
+	 * The AI-generated document is attacker-influenceable (product data feeds
+	 * the prompt) and is served on the merchant's own origin, so it is a
+	 * stored-XSS surface. We isolate it in an iframe whose `sandbox` lacks
+	 * `allow-scripts` and `allow-same-origin`: JavaScript cannot execute and
+	 * the content runs in a unique opaque origin with no access to the
+	 * merchant's cookies, storage, or parent DOM. CSS still renders.
+	 *
+	 * The default sandbox keeps the conversion link working (popups +
+	 * user-activated top navigation). The policy is filterable for stricter
+	 * variants.
+	 *
+	 * @param string $title   Document title for the outer frame.
+	 * @param string $content Stored landing-page HTML (full document or fragment).
+	 * @return string Outer HTML document embedding the sandboxed iframe.
 	 */
-	private static function wrap_fragment( $title, $content ) {
+	private static function render_sandboxed( $title, $content ) {
 		$lang = get_bloginfo( 'language' );
+
+		/**
+		 * Filter the iframe `sandbox` policy for rendered landing pages.
+		 *
+		 * Never add `allow-scripts` together with `allow-same-origin`: that
+		 * combination lets the framed document remove its own sandbox.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $sandbox Space-separated sandbox tokens.
+		 */
+		$sandbox = (string) apply_filters(
+			'jetpack_blaze_landing_page_iframe_sandbox',
+			'allow-popups allow-top-navigation-by-user-activation'
+		);
+
 		return sprintf(
-			'<!doctype html><html lang="%1$s"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>%2$s</title></head><body>%3$s</body></html>',
+			'<!doctype html><html lang="%1$s"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>%2$s</title><style>html,body{margin:0;padding:0;height:100%%}.blaze-lp-frame{border:0;display:block;width:100%%;height:100vh}</style></head><body><iframe class="blaze-lp-frame" sandbox="%3$s" referrerpolicy="no-referrer" title="%2$s" srcdoc="%4$s"></iframe></body></html>',
 			esc_attr( $lang ),
 			esc_html( $title ),
-			$content
+			esc_attr( $sandbox ),
+			esc_attr( $content )
 		);
 	}
 
@@ -212,6 +242,7 @@ class Landing_Page_CPT {
 	public static function generate_slug() {
 		$bytes = random_bytes( self::SLUG_BYTES );
 		// Base64-url, no padding.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Benign: URL-safe encoding of random bytes for a slug, not obfuscation.
 		return rtrim( strtr( base64_encode( $bytes ), '+/', '-_' ), '=' );
 	}
 
@@ -222,14 +253,11 @@ class Landing_Page_CPT {
 	 * the post is updated. Otherwise a new one is created with a fresh
 	 * random slug.
 	 *
-	 * @param array $args {
-	 *     @type string $html        Required. AI-generated HTML.
-	 *     @type string $title       Optional. Defaults to product name.
-	 *     @type string $mode        Required. e.g. 'woocommerce'.
-	 *     @type int    $product_id  Required.
-	 *     @type int    $campaign_id Optional.
-	 *     @type string $slug        Optional. Existing slug to upsert.
-	 * }
+	 * @param array $args Upsert arguments: `html` (required AI-generated HTML),
+	 *                    `title` (defaults to product name), `mode` (required,
+	 *                    e.g. 'woocommerce'), `product_id` (required),
+	 *                    `campaign_id`, and `slug` (optional existing slug to
+	 *                    upsert in place).
 	 * @return array|\WP_Error { id, slug, url } or WP_Error.
 	 */
 	public static function upsert( array $args ) {
@@ -248,8 +276,8 @@ class Landing_Page_CPT {
 			? sanitize_text_field( $args['title'] )
 			: sprintf( 'Blaze landing — product %d', $product_id );
 
-		$slug         = isset( $args['slug'] ) ? sanitize_title( $args['slug'] ) : '';
-		$existing_id  = 0;
+		$slug        = isset( $args['slug'] ) ? sanitize_title( $args['slug'] ) : '';
+		$existing_id = 0;
 		if ( '' !== $slug ) {
 			$existing = get_page_by_path( $slug, OBJECT, self::POST_TYPE );
 			if ( $existing instanceof WP_Post ) {
@@ -269,11 +297,22 @@ class Landing_Page_CPT {
 			'post_content' => wp_slash( $sanitized_html ),
 		);
 
-		if ( $existing_id > 0 ) {
-			$postarr['ID'] = $existing_id;
-			$post_id       = wp_update_post( $postarr, true );
-		} else {
-			$post_id = wp_insert_post( $postarr, true );
+		// The HTML is a complete, self-contained document that we already
+		// sanitized (scripts/JS stripped) in self::sanitize_html(). Blog-token
+		// REST requests run as a user without `unfiltered_html`, so KSES would
+		// strip `<!doctype>`, `<html>`, `<head>` and `<style>` tags on save —
+		// keeping the CSS as visible text and breaking the page. Disable the
+		// KSES content filters around the write and restore them right after.
+		kses_remove_filters();
+		try {
+			if ( $existing_id > 0 ) {
+				$postarr['ID'] = $existing_id;
+				$post_id       = wp_update_post( $postarr, true );
+			} else {
+				$post_id = wp_insert_post( $postarr, true );
+			}
+		} finally {
+			kses_init_filters();
 		}
 		if ( is_wp_error( $post_id ) ) {
 			return $post_id;

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Hidden CPT used to host AI-generated Blaze landing pages.
+ *
+ * The CPT is:
+ *  - not public (no archive, not in search, not in nav menus, no admin UI),
+ *  - publicly queryable (the random-slug URL works), and
+ *  - REST-enabled so DSP can create/update entries via the WPCOM proxy.
+ *
+ * Each landing page is a self-contained HTML document stored in
+ * `post_content`. When the public URL is hit, the theme is bypassed and
+ * the raw document is served verbatim.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use WP_Post;
+
+/**
+ * Blaze landing-page CPT.
+ */
+class Landing_Page_CPT {
+
+	const POST_TYPE  = 'blaze_landing_page';
+	const URL_PREFIX = 'blaze-lp';
+	const SLUG_BYTES = 16;
+
+	/**
+	 * Meta keys for landing-page metadata. Stored as post meta so the
+	 * post_content stays a clean HTML document.
+	 */
+	const META_PRODUCT_ID = '_blaze_landing_product_id';
+	const META_MODE       = '_blaze_landing_mode';
+	const META_CAMPAIGN   = '_blaze_landing_campaign_id';
+
+	/**
+	 * Wire hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'register' ) );
+		add_filter( 'template_include', array( __CLASS__, 'render_raw_document' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Register the CPT.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'              => array(
+					'name'          => __( 'Blaze Landing Pages', 'jetpack-blaze' ),
+					'singular_name' => __( 'Blaze Landing Page', 'jetpack-blaze' ),
+				),
+				'public'              => false,
+				'publicly_queryable'  => true,
+				'exclude_from_search' => true,
+				'show_ui'             => false,
+				'show_in_menu'        => false,
+				'show_in_nav_menus'   => false,
+				'show_in_admin_bar'   => false,
+				'show_in_rest'        => true,
+				'rest_base'           => 'blaze-landing-pages',
+				'rest_namespace'      => 'jetpack/v4',
+				'rewrite'             => array(
+					'slug'       => self::URL_PREFIX,
+					'with_front' => false,
+					'feeds'      => false,
+					'pages'      => false,
+				),
+				'has_archive'         => false,
+				'supports'            => array( 'title', 'editor', 'custom-fields' ),
+				'capability_type'     => 'post',
+				'map_meta_cap'        => true,
+				'delete_with_user'    => false,
+			)
+		);
+
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_PRODUCT_ID,
+			array(
+				'type'         => 'integer',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_MODE,
+			array(
+				'type'         => 'string',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_CAMPAIGN,
+			array(
+				'type'         => 'integer',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+	}
+
+	/**
+	 * Bypass the theme on landing-page requests and emit the stored HTML.
+	 *
+	 * The stored `post_content` is a complete HTML document (or HTML
+	 * fragment). We send a minimal header/body wrapper only when the
+	 * content does not already include `<html>`.
+	 *
+	 * @param string $template Theme template that would otherwise load.
+	 * @return string|void
+	 */
+	public static function render_raw_document( $template ) {
+		if ( ! is_singular( self::POST_TYPE ) ) {
+			return $template;
+		}
+
+		$post = get_post();
+		if ( ! $post instanceof WP_Post || self::POST_TYPE !== $post->post_type ) {
+			return $template;
+		}
+
+		nocache_headers();
+		header( 'Content-Type: text/html; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex, nofollow, noarchive', true );
+
+		$content = (string) $post->post_content;
+		if ( stripos( $content, '<html' ) === false ) {
+			$content = self::wrap_fragment( $post->post_title, $content );
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content was sanitized at write time.
+		echo $content;
+		exit;
+	}
+
+	/**
+	 * Minimal HTML5 wrapper for HTML fragments (no theme, no admin bar).
+	 *
+	 * @param string $title   Document title.
+	 * @param string $content HTML fragment.
+	 * @return string Full HTML document.
+	 */
+	private static function wrap_fragment( $title, $content ) {
+		$lang = get_bloginfo( 'language' );
+		return sprintf(
+			'<!doctype html><html lang="%1$s"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>%2$s</title></head><body>%3$s</body></html>',
+			esc_attr( $lang ),
+			esc_html( $title ),
+			$content
+		);
+	}
+
+	/**
+	 * Sanitize an AI-generated HTML document before storing it.
+	 *
+	 * Default policy is "HTML + CSS, no JS". `<script>` blocks and `on*`
+	 * event attributes are removed. CSS in `<style>` and `style=""` is kept.
+	 *
+	 * The policy can be relaxed (e.g. for a sandboxed iframe variant) via
+	 * the `jetpack_blaze_landing_page_allow_js` filter.
+	 *
+	 * @param string $html Raw HTML.
+	 * @return string Sanitized HTML.
+	 */
+	public static function sanitize_html( $html ) {
+		$html = (string) $html;
+
+		/**
+		 * Whether to allow JavaScript in landing-page HTML.
+		 *
+		 * Default false. Flip to true once a sandboxed render path is in place.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $allow_js Whether to keep <script> and on* attributes.
+		 */
+		$allow_js = (bool) apply_filters( 'jetpack_blaze_landing_page_allow_js', false );
+		if ( $allow_js ) {
+			return $html;
+		}
+
+		// Strip script blocks entirely.
+		$html = preg_replace( '#<script\b[^>]*>.*?</script\s*>#is', '', $html );
+		$html = preg_replace( '#<script\b[^>]*/?>#is', '', (string) $html );
+		// Strip inline event handlers (on*="…" or on*='…' or on*=value).
+		$html = preg_replace( '#\son[a-z]+\s*=\s*"[^"]*"#i', '', (string) $html );
+		$html = preg_replace( "#\son[a-z]+\s*=\s*'[^']*'#i", '', (string) $html );
+		$html = preg_replace( '#\son[a-z]+\s*=\s*[^\s>]+#i', '', (string) $html );
+		// Strip javascript: URLs in href/src.
+		$html = preg_replace( '#(href|src)\s*=\s*(["\'])\s*javascript:[^"\']*\2#i', '$1=$2#$2', (string) $html );
+
+		return (string) $html;
+	}
+
+	/**
+	 * Generate a random URL-safe slug.
+	 *
+	 * @return string
+	 */
+	public static function generate_slug() {
+		$bytes = random_bytes( self::SLUG_BYTES );
+		// Base64-url, no padding.
+		return rtrim( strtr( base64_encode( $bytes ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Upsert a landing page.
+	 *
+	 * If `$slug` is provided and matches an existing landing-page post,
+	 * the post is updated. Otherwise a new one is created with a fresh
+	 * random slug.
+	 *
+	 * @param array $args {
+	 *     @type string $html        Required. AI-generated HTML.
+	 *     @type string $title       Optional. Defaults to product name.
+	 *     @type string $mode        Required. e.g. 'woocommerce'.
+	 *     @type int    $product_id  Required.
+	 *     @type int    $campaign_id Optional.
+	 *     @type string $slug        Optional. Existing slug to upsert.
+	 * }
+	 * @return array|\WP_Error { id, slug, url } or WP_Error.
+	 */
+	public static function upsert( array $args ) {
+		$html = isset( $args['html'] ) ? (string) $args['html'] : '';
+		if ( '' === $html ) {
+			return new \WP_Error( 'jetpack_blaze_landing_missing_html', __( 'Missing HTML payload.', 'jetpack-blaze' ) );
+		}
+		$mode       = isset( $args['mode'] ) ? sanitize_key( $args['mode'] ) : '';
+		$product_id = isset( $args['product_id'] ) ? (int) $args['product_id'] : 0;
+		if ( '' === $mode || 0 === $product_id ) {
+			return new \WP_Error( 'jetpack_blaze_landing_missing_meta', __( 'mode and product_id are required.', 'jetpack-blaze' ) );
+		}
+
+		$sanitized_html = self::sanitize_html( $html );
+		$title          = isset( $args['title'] ) && is_string( $args['title'] )
+			? sanitize_text_field( $args['title'] )
+			: sprintf( 'Blaze landing — product %d', $product_id );
+
+		$slug         = isset( $args['slug'] ) ? sanitize_title( $args['slug'] ) : '';
+		$existing_id  = 0;
+		if ( '' !== $slug ) {
+			$existing = get_page_by_path( $slug, OBJECT, self::POST_TYPE );
+			if ( $existing instanceof WP_Post ) {
+				$existing_id = (int) $existing->ID;
+			}
+		}
+
+		if ( '' === $slug ) {
+			$slug = self::generate_slug();
+		}
+
+		$postarr = array(
+			'post_type'    => self::POST_TYPE,
+			'post_status'  => 'publish',
+			'post_title'   => $title,
+			'post_name'    => $slug,
+			'post_content' => wp_slash( $sanitized_html ),
+		);
+
+		if ( $existing_id > 0 ) {
+			$postarr['ID'] = $existing_id;
+			$post_id       = wp_update_post( $postarr, true );
+		} else {
+			$post_id = wp_insert_post( $postarr, true );
+		}
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		update_post_meta( $post_id, self::META_MODE, $mode );
+		update_post_meta( $post_id, self::META_PRODUCT_ID, $product_id );
+		if ( ! empty( $args['campaign_id'] ) ) {
+			update_post_meta( $post_id, self::META_CAMPAIGN, (int) $args['campaign_id'] );
+		}
+
+		return array(
+			'id'   => (int) $post_id,
+			'slug' => $slug,
+			'url'  => get_permalink( $post_id ),
+		);
+	}
+
+	/**
+	 * Look up a landing page by its slug.
+	 *
+	 * @param string $slug Slug.
+	 * @return WP_Post|null
+	 */
+	public static function get_by_slug( $slug ) {
+		$slug = sanitize_title( (string) $slug );
+		if ( '' === $slug ) {
+			return null;
+		}
+		$post = get_page_by_path( $slug, OBJECT, self::POST_TYPE );
+		return $post instanceof WP_Post ? $post : null;
+	}
+
+	/**
+	 * Delete a landing page by slug.
+	 *
+	 * @param string $slug Slug.
+	 * @return bool
+	 */
+	public static function delete_by_slug( $slug ) {
+		$post = self::get_by_slug( $slug );
+		if ( null === $post ) {
+			return false;
+		}
+		return (bool) wp_delete_post( (int) $post->ID, true );
+	}
+}

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -42,7 +42,7 @@ class Landing_Page_CPT {
 	const META_HIGHLIGHTS = '_blaze_landing_highlights';
 	const META_GEN_IMAGES = '_blaze_landing_gen_images';
 
-	const ASSET_VERSION  = '1.1.0';
+	const ASSET_VERSION  = '1.2.0';
 	const MAX_HIGHLIGHTS = 6;
 	const MAX_GEN_IMAGES = 8;
 
@@ -227,37 +227,6 @@ class Landing_Page_CPT {
 	}
 
 	/**
-	 * Build the ordered list of image URLs to show: the product's featured image,
-	 * its WooCommerce gallery, then any AI-generated lifestyle images. Falls back
-	 * to the stored image_url when there is no live product.
-	 *
-	 * @param array            $f       Stored fields.
-	 * @param \WC_Product|null $product Live product, if any.
-	 * @return string[] De-duplicated image URLs.
-	 */
-	private static function get_images( $f, $product ) {
-		$urls = array();
-		if ( $product instanceof \WC_Product ) {
-			$ids = array_merge( array( $product->get_image_id() ), $product->get_gallery_image_ids() );
-			foreach ( $ids as $id ) {
-				$url = $id ? wp_get_attachment_image_url( (int) $id, 'large' ) : '';
-				if ( $url ) {
-					$urls[] = $url;
-				}
-			}
-		} elseif ( '' !== $f['image_url'] ) {
-			$urls[] = $f['image_url'];
-		}
-		foreach ( $f['gen_images'] as $gen ) {
-			$gen = esc_url_raw( (string) $gen );
-			if ( '' !== $gen ) {
-				$urls[] = $gen;
-			}
-		}
-		return array_values( array_unique( $urls ) );
-	}
-
-	/**
 	 * Pick an accent color from the active theme's palette so the landing's own
 	 * accents (CTA, dividers) match the store.
 	 *
@@ -360,7 +329,6 @@ class Landing_Page_CPT {
 	private static function render_template( $post ) {
 		$f       = self::get_fields( $post->ID );
 		$product = self::get_wc_product( $f );
-		$images  = self::get_images( $f, $product );
 		$accent  = self::theme_accent_color();
 
 		$headline = '' !== $f['headline'] ? $f['headline'] : ( $product ? $product->get_name() : $post->post_title );
@@ -375,7 +343,27 @@ class Landing_Page_CPT {
 			$price_html = esc_html( trim( $f['price'] . ( '' !== $f['currency'] ? ' ' . $f['currency'] : '' ) ) );
 		}
 
-		$main_image = array_shift( $images );
+		// Split images by source so each plays its proper role on the page:
+		// - The product photo (first WC image) anchors the full-viewport hero.
+		// - The AI-generated lifestyle images (`gen_images`) each get their own
+		// scroll-revealed feature section.
+		$product_images = array();
+		if ( $product instanceof \WC_Product ) {
+			$ids = array_merge( array( $product->get_image_id() ), $product->get_gallery_image_ids() );
+			foreach ( $ids as $id ) {
+				$url = $id ? wp_get_attachment_image_url( (int) $id, 'large' ) : '';
+				if ( $url ) {
+					$product_images[] = $url;
+				}
+			}
+		} elseif ( '' !== $f['image_url'] ) {
+			$product_images[] = $f['image_url'];
+		}
+		$gen_images   = array_values( array_filter( $f['gen_images'], 'strlen' ) );
+		$hero_image   = $product_images[0] ?? ( $gen_images[0] ?? '' );
+		$feature_imgs = array_slice( $gen_images, 0, 3 );
+
+		$highlights = array_values( array_filter( $f['highlights'], 'strlen' ) );
 
 		ob_start();
 		?>
@@ -400,22 +388,14 @@ class Landing_Page_CPT {
 <body <?php body_class( 'blaze-lp' ); ?>>
 		<?php self::render_site_chrome( 'header' ); ?>
 <main class="blaze-lp-main">
-	<section class="blaze-lp-hero">
-		<div class="blaze-lp-gallery">
-		<?php if ( $main_image ) : ?>
-			<figure class="blaze-lp-gallery-main">
-				<img src="<?php echo esc_url( $main_image ); ?>" alt="<?php echo esc_attr( $headline ); ?>">
-			</figure>
-			<?php if ( ! empty( $images ) ) : ?>
-			<ul class="blaze-lp-gallery-thumbs">
-				<?php foreach ( $images as $img ) : ?>
-				<li><img src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $headline ); ?>" loading="lazy"></li>
-				<?php endforeach; ?>
-			</ul>
-			<?php endif; ?>
-		<?php endif; ?>
-		</div>
-		<div class="blaze-lp-copy">
+	<!-- HERO: full-viewport with the product photo as full-bleed background. -->
+	<section class="blaze-lp-hero"
+		<?php
+		if ( '' !== $hero_image ) :
+			?>
+		style="background-image: url('<?php echo esc_url( $hero_image ); ?>');"<?php endif; ?>>
+		<div class="blaze-lp-hero-scrim" aria-hidden="true"></div>
+		<div class="blaze-lp-hero-content">
 			<h1 class="blaze-lp-headline"><?php echo esc_html( $headline ); ?></h1>
 		<?php if ( '' !== $f['subheadline'] ) : ?>
 			<p class="blaze-lp-sub"><?php echo esc_html( $f['subheadline'] ); ?></p>
@@ -427,19 +407,84 @@ class Landing_Page_CPT {
 		<?php endif; ?>
 		<?php if ( '' !== $cta_url ) : ?>
 			<p class="blaze-lp-cta-wrap">
-				<a class="blaze-lp-cta" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta ); ?></a>
+				<a class="blaze-lp-cta blaze-lp-cta--hero" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta ); ?></a>
 			</p>
 		<?php endif; ?>
 		</div>
+		<a class="blaze-lp-scroll-hint" href="#blaze-lp-features" aria-label="<?php esc_attr_e( 'Scroll for more', 'jetpack-blaze' ); ?>"></a>
 	</section>
-		<?php if ( ! empty( $f['highlights'] ) ) : ?>
-	<ul class="blaze-lp-highlights">
-			<?php foreach ( $f['highlights'] as $highlight ) : ?>
-		<li><?php echo esc_html( (string) $highlight ); ?></li>
+
+	<!-- LIFESTYLE FEATURE SECTIONS: one per AI-generated image, alternating sides. -->
+		<?php if ( ! empty( $feature_imgs ) ) : ?>
+	<div id="blaze-lp-features" class="blaze-lp-features">
+			<?php foreach ( $feature_imgs as $i => $img ) : ?>
+		<section class="blaze-lp-feature blaze-lp-feature--<?php echo 0 === $i % 2 ? 'left' : 'right'; ?> blaze-lp-reveal">
+			<div class="blaze-lp-feature-img">
+				<img src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $headline ); ?>" loading="lazy">
+			</div>
+			<div class="blaze-lp-feature-copy">
+				<?php if ( isset( $highlights[ $i ] ) ) : ?>
+				<h2 class="blaze-lp-feature-title"><?php echo esc_html( (string) $highlights[ $i ] ); ?></h2>
+				<?php endif; ?>
+				<?php if ( '' !== $cta_url ) : ?>
+				<p class="blaze-lp-cta-wrap">
+					<a class="blaze-lp-cta" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta ); ?></a>
+				</p>
+				<?php endif; ?>
+			</div>
+		</section>
 			<?php endforeach; ?>
-	</ul>
+	</div>
+		<?php endif; ?>
+
+	<!-- Any remaining highlights (beyond the 3 used as feature titles) as a feature grid. -->
+		<?php $extra_highlights = array_slice( $highlights, count( $feature_imgs ) ); ?>
+		<?php if ( ! empty( $extra_highlights ) ) : ?>
+	<section class="blaze-lp-extras blaze-lp-reveal">
+		<ul class="blaze-lp-highlights">
+			<?php foreach ( $extra_highlights as $highlight ) : ?>
+			<li><?php echo esc_html( (string) $highlight ); ?></li>
+			<?php endforeach; ?>
+		</ul>
+	</section>
+		<?php endif; ?>
+
+	<!-- FINAL closing CTA so the buy moment is one tap away from the bottom. -->
+		<?php if ( '' !== $cta_url ) : ?>
+	<section class="blaze-lp-final blaze-lp-reveal">
+		<h2 class="blaze-lp-final-title"><?php echo esc_html( $headline ); ?></h2>
+			<?php if ( '' !== $f['subheadline'] ) : ?>
+		<p class="blaze-lp-final-sub"><?php echo esc_html( $f['subheadline'] ); ?></p>
+		<?php endif; ?>
+			<?php if ( '' !== $price_html ) : ?>
+		<div class="blaze-lp-price">
+				<?php echo wp_kses_post( $price_html ); ?>
+		</div>
+		<?php endif; ?>
+		<p class="blaze-lp-cta-wrap">
+			<a class="blaze-lp-cta blaze-lp-cta--big" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta ); ?></a>
+		</p>
+	</section>
 		<?php endif; ?>
 </main>
+<script>
+/* Reveal each .blaze-lp-reveal section as it scrolls into view. Progressive
+	enhancement: if IntersectionObserver is missing, sections are visible by
+	default (no class added → CSS treats them as already revealed). */
+(function () {
+	if (!('IntersectionObserver' in window)) { return; }
+	document.body.classList.add('blaze-lp-js');
+	var io = new IntersectionObserver(function (entries) {
+		entries.forEach(function (e) {
+			if (e.isIntersecting) {
+				e.target.classList.add('is-revealed');
+				io.unobserve(e.target);
+			}
+		});
+	}, { threshold: 0.15, rootMargin: '0px 0px -10% 0px' });
+	document.querySelectorAll('.blaze-lp-reveal').forEach(function (el) { io.observe(el); });
+})();
+</script>
 		<?php
 		self::render_site_chrome( 'footer' );
 		wp_footer();

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -40,9 +40,11 @@ class Landing_Page_CPT {
 	const META_MODE       = '_blaze_landing_mode';
 	const META_CAMPAIGN   = '_blaze_landing_campaign_id';
 	const META_HIGHLIGHTS = '_blaze_landing_highlights';
+	const META_GEN_IMAGES = '_blaze_landing_gen_images';
 
-	const ASSET_VERSION  = '1.0.0';
+	const ASSET_VERSION  = '1.1.0';
 	const MAX_HIGHLIGHTS = 6;
+	const MAX_GEN_IMAGES = 8;
 
 	/**
 	 * Scalar landing-page fields and the WordPress sanitizer registered for
@@ -198,7 +200,103 @@ class Landing_Page_CPT {
 		}
 		$highlights        = get_post_meta( $post_id, self::META_HIGHLIGHTS, true );
 		$out['highlights'] = is_array( $highlights ) ? $highlights : array();
+		$gen_images        = get_post_meta( $post_id, self::META_GEN_IMAGES, true );
+		$out['gen_images'] = is_array( $gen_images ) ? $gen_images : array();
+		$out['product_id'] = (int) get_post_meta( $post_id, self::META_PRODUCT_ID, true );
+		$out['mode']       = (string) get_post_meta( $post_id, self::META_MODE, true );
 		return $out;
+	}
+
+	/**
+	 * Load the live WooCommerce product behind a landing page, when available.
+	 *
+	 * The landing renders on the merchant site, so the product (price, gallery,
+	 * permalink) is read live from WooCommerce rather than copied at creation
+	 * time. Returns null when WooCommerce or the product is unavailable, so the
+	 * template can fall back to stored meta.
+	 *
+	 * @param array $f Stored fields (see get_fields()).
+	 * @return \WC_Product|null
+	 */
+	private static function get_wc_product( $f ) {
+		if ( 'woocommerce' !== $f['mode'] || $f['product_id'] <= 0 || ! function_exists( 'wc_get_product' ) ) {
+			return null;
+		}
+		$product = wc_get_product( $f['product_id'] );
+		return $product instanceof \WC_Product ? $product : null;
+	}
+
+	/**
+	 * Build the ordered list of image URLs to show: the product's featured image,
+	 * its WooCommerce gallery, then any AI-generated lifestyle images. Falls back
+	 * to the stored image_url when there is no live product.
+	 *
+	 * @param array            $f       Stored fields.
+	 * @param \WC_Product|null $product Live product, if any.
+	 * @return string[] De-duplicated image URLs.
+	 */
+	private static function get_images( $f, $product ) {
+		$urls = array();
+		if ( $product instanceof \WC_Product ) {
+			$ids = array_merge( array( $product->get_image_id() ), $product->get_gallery_image_ids() );
+			foreach ( $ids as $id ) {
+				$url = $id ? wp_get_attachment_image_url( (int) $id, 'large' ) : '';
+				if ( $url ) {
+					$urls[] = $url;
+				}
+			}
+		} elseif ( '' !== $f['image_url'] ) {
+			$urls[] = $f['image_url'];
+		}
+		foreach ( $f['gen_images'] as $gen ) {
+			$gen = esc_url_raw( (string) $gen );
+			if ( '' !== $gen ) {
+				$urls[] = $gen;
+			}
+		}
+		return array_values( array_unique( $urls ) );
+	}
+
+	/**
+	 * Pick an accent color from the active theme's palette so the landing's own
+	 * accents (CTA, dividers) match the store. Skips the usual neutral slugs and
+	 * returns the first "brand" color, or '' when none can be determined.
+	 *
+	 * @return string Hex color or ''.
+	 */
+	private static function theme_accent_color() {
+		if ( ! function_exists( 'wp_get_global_settings' ) ) {
+			return '';
+		}
+		$palette = wp_get_global_settings( array( 'color', 'palette' ) );
+		$colors  = array();
+		if ( isset( $palette['theme'] ) && is_array( $palette['theme'] ) ) {
+			$colors = $palette['theme'];
+		} elseif ( is_array( $palette ) ) {
+			$colors = $palette;
+		}
+		$skip = array( 'base', 'background', 'foreground', 'contrast', 'text', 'white', 'black', 'light', 'dark' );
+		foreach ( $colors as $color ) {
+			$slug = isset( $color['slug'] ) ? strtolower( (string) $color['slug'] ) : '';
+			$hex  = isset( $color['color'] ) ? (string) $color['color'] : '';
+			if ( '' === $slug || '' === $hex ) {
+				continue;
+			}
+			$is_neutral = false;
+			foreach ( $skip as $needle ) {
+				if ( false !== strpos( $slug, $needle ) ) {
+					$is_neutral = true;
+					break;
+				}
+			}
+			if ( ! $is_neutral ) {
+				$clean = sanitize_hex_color( $hex );
+				if ( $clean ) {
+					return $clean;
+				}
+			}
+		}
+		return '';
 	}
 
 	/**
@@ -209,56 +307,76 @@ class Landing_Page_CPT {
 	 */
 	private static function render_template( $post ) {
 		$f       = self::get_fields( $post->ID );
-		$lang    = get_bloginfo( 'language' );
-		$css_url = plugins_url( 'css/landing-page.css', __FILE__ );
-		$cta     = '' !== $f['cta_text'] ? $f['cta_text'] : __( 'Shop now', 'jetpack-blaze' );
-		$price   = trim( $f['price'] . ( '' !== $f['currency'] ? ' ' . $f['currency'] : '' ) );
-		$brand   = '' !== $f['brand_name'] ? $f['brand_name'] : get_bloginfo( 'name' );
+		$product = self::get_wc_product( $f );
+		$images  = self::get_images( $f, $product );
+		$accent  = self::theme_accent_color();
+
+		$headline = '' !== $f['headline'] ? $f['headline'] : ( $product ? $product->get_name() : $post->post_title );
+		$cta      = '' !== $f['cta_text'] ? $f['cta_text'] : __( 'Shop now', 'jetpack-blaze' );
+		$cta_url  = $f['cta_url'];
+		if ( '' === $cta_url && $product ) {
+			$cta_url = $product->add_to_cart_url();
+		}
+
+		$price_html = $product ? $product->get_price_html() : '';
+		if ( '' === $price_html && '' !== $f['price'] ) {
+			$price_html = esc_html( trim( $f['price'] . ( '' !== $f['currency'] ? ' ' . $f['currency'] : '' ) ) );
+		}
+
+		$main_image = array_shift( $images );
 
 		ob_start();
 		?>
 <!doctype html>
-<html lang="<?php echo esc_attr( $lang ); ?>">
+<html <?php language_attributes(); ?>>
 <head>
-<meta charset="utf-8">
+<meta charset="<?php echo esc_attr( get_bloginfo( 'charset' ) ); ?>">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="robots" content="noindex,nofollow">
-<title><?php echo esc_html( $post->post_title ); ?></title>
+<title><?php echo esc_html( $headline ); ?></title>
 		<?php
-		wp_enqueue_style( 'jetpack-blaze-landing', $css_url, array(), self::ASSET_VERSION );
-		wp_print_styles( 'jetpack-blaze-landing' );
+		// Enqueue our stylesheet, then let wp_head() print it together with the
+		// theme's global styles (theme.json palette + typography) and block CSS,
+		// so the page inherits the store's look.
+		wp_enqueue_style( 'jetpack-blaze-landing', plugins_url( 'css/landing-page.css', __FILE__ ), array(), self::ASSET_VERSION );
+		wp_head();
 		?>
-		<?php if ( '' !== $f['accent_color'] ) : ?>
-<style>:root{--blaze-accent:<?php echo esc_html( $f['accent_color'] ); ?>}</style>
+		<?php if ( '' !== $accent ) : ?>
+<style>:root{--blaze-accent:<?php echo esc_html( $accent ); ?>}</style>
 		<?php endif; ?>
 </head>
-<body class="blaze-lp">
-<header class="blaze-lp-header">
-		<?php if ( '' !== $f['logo_url'] ) : ?>
-	<img class="blaze-lp-logo" src="<?php echo esc_url( $f['logo_url'] ); ?>" alt="<?php echo esc_attr( $brand ); ?>">
-		<?php else : ?>
-	<span class="blaze-lp-brand"><?php echo esc_html( $brand ); ?></span>
-		<?php endif; ?>
-</header>
+<body <?php body_class( 'blaze-lp' ); ?>>
+		<?php self::render_site_chrome( 'header' ); ?>
 <main class="blaze-lp-main">
 	<section class="blaze-lp-hero">
-		<?php if ( '' !== $f['image_url'] ) : ?>
-		<div class="blaze-lp-media">
-			<img src="<?php echo esc_url( $f['image_url'] ); ?>" alt="<?php echo esc_attr( '' !== $f['product_name'] ? $f['product_name'] : $f['headline'] ); ?>">
+		<div class="blaze-lp-gallery">
+		<?php if ( $main_image ) : ?>
+			<figure class="blaze-lp-gallery-main">
+				<img src="<?php echo esc_url( $main_image ); ?>" alt="<?php echo esc_attr( $headline ); ?>">
+			</figure>
+			<?php if ( ! empty( $images ) ) : ?>
+			<ul class="blaze-lp-gallery-thumbs">
+				<?php foreach ( $images as $img ) : ?>
+				<li><img src="<?php echo esc_url( $img ); ?>" alt="<?php echo esc_attr( $headline ); ?>" loading="lazy"></li>
+				<?php endforeach; ?>
+			</ul>
+			<?php endif; ?>
+		<?php endif; ?>
 		</div>
-		<?php endif; ?>
 		<div class="blaze-lp-copy">
-		<?php if ( '' !== $f['headline'] ) : ?>
-			<h1 class="blaze-lp-headline"><?php echo esc_html( $f['headline'] ); ?></h1>
-		<?php endif; ?>
+			<h1 class="blaze-lp-headline"><?php echo esc_html( $headline ); ?></h1>
 		<?php if ( '' !== $f['subheadline'] ) : ?>
 			<p class="blaze-lp-sub"><?php echo esc_html( $f['subheadline'] ); ?></p>
 		<?php endif; ?>
-		<?php if ( '' !== $price ) : ?>
-			<p class="blaze-lp-price"><?php echo esc_html( $price ); ?></p>
+		<?php if ( '' !== $price_html ) : ?>
+			<div class="blaze-lp-price">
+				<?php echo wp_kses_post( $price_html ); ?>
+			</div>
 		<?php endif; ?>
-		<?php if ( '' !== $f['cta_url'] ) : ?>
-			<a class="blaze-lp-cta" href="<?php echo esc_url( $f['cta_url'] ); ?>"><?php echo esc_html( $cta ); ?></a>
+		<?php if ( '' !== $cta_url ) : ?>
+			<p class="blaze-lp-cta-wrap">
+				<a class="blaze-lp-cta" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta ); ?></a>
+			</p>
 		<?php endif; ?>
 		</div>
 	</section>
@@ -270,11 +388,45 @@ class Landing_Page_CPT {
 	</ul>
 		<?php endif; ?>
 </main>
-<footer class="blaze-lp-footer"><?php echo esc_html( $brand ); ?></footer>
+		<?php
+		self::render_site_chrome( 'footer' );
+		wp_footer();
+		?>
 </body>
 </html>
 		<?php
 		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Render the store's real header or footer so the landing matches the site.
+	 *
+	 * Block themes expose header/footer as template parts; classic themes get a
+	 * minimal branded fallback (logo or site name) so the page still looks owned.
+	 *
+	 * @param string $part 'header' or 'footer'.
+	 * @return void
+	 */
+	private static function render_site_chrome( $part ) {
+		if (
+			function_exists( 'wp_is_block_theme' ) && wp_is_block_theme()
+			&& function_exists( 'block_template_part' )
+		) {
+			block_template_part( $part );
+			return;
+		}
+
+		if ( 'header' === $part ) {
+			echo '<header class="blaze-lp-fallback-header">';
+			if ( function_exists( 'has_custom_logo' ) && has_custom_logo() ) {
+				echo get_custom_logo(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core markup.
+			} else {
+				echo '<span class="blaze-lp-brand">' . esc_html( get_bloginfo( 'name' ) ) . '</span>';
+			}
+			echo '</header>';
+		} else {
+			echo '<footer class="blaze-lp-fallback-footer">' . esc_html( get_bloginfo( 'name' ) ) . '</footer>';
+		}
 	}
 
 	/**
@@ -299,6 +451,7 @@ class Landing_Page_CPT {
 	 *                    `subheadline`, `cta_text`, `cta_url`, `product_name`,
 	 *                    `price`, `currency`, `image_url`, `brand_name`,
 	 *                    `logo_url`, `accent_color`, `highlights` (string[]),
+	 *                    `gen_images` (string[] of AI image URLs),
 	 *                    `campaign_id`, `slug` (optional, upsert in place).
 	 * @return array|\WP_Error Array with id, slug, url; or WP_Error.
 	 */
@@ -373,6 +526,20 @@ class Landing_Page_CPT {
 			}
 			$highlights = array_slice( $highlights, 0, self::MAX_HIGHLIGHTS );
 			update_post_meta( $post_id, self::META_HIGHLIGHTS, $highlights );
+		}
+
+		// AI-generated lifestyle images: a short list of absolute URLs (hosted by
+		// DSP). Shown in the gallery alongside the live WooCommerce images.
+		if ( isset( $args['gen_images'] ) && is_array( $args['gen_images'] ) ) {
+			$gen_images = array();
+			foreach ( $args['gen_images'] as $gen_image ) {
+				$clean = esc_url_raw( (string) $gen_image );
+				if ( '' !== $clean ) {
+					$gen_images[] = $clean;
+				}
+			}
+			$gen_images = array_slice( $gen_images, 0, self::MAX_GEN_IMAGES );
+			update_post_meta( $post_id, self::META_GEN_IMAGES, $gen_images );
 		}
 
 		update_post_meta( $post_id, self::META_MODE, $mode );

--- a/projects/packages/blaze/src/class-landing-page-dispatcher.php
+++ b/projects/packages/blaze/src/class-landing-page-dispatcher.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Bridges the Woo opt-in hook to WPCOM, which in turn enqueues the
+ * landing-page creation job in DSP.
+ *
+ * Listens for `jetpack_blaze_woo_product_promote_requested` and POSTs
+ * a minimal payload to a WPCOM internal endpoint via the canonical
+ * `wpcom_json_api_request_as_blog` signed channel.
+ *
+ * The WPCOM endpoint itself ships separately (Phase 2 — see PR roadmap).
+ * Until that endpoint lands the call will 404; the dispatcher logs and
+ * swallows the error so it doesn't break the merchant publish flow.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
+use WP_Post;
+
+/**
+ * Dispatcher for Blaze landing-page jobs.
+ */
+class Landing_Page_Dispatcher {
+
+	const ENDPOINT_PATH = '/blaze/landing-pages/enqueue';
+	const API_VERSION   = '2';
+
+	/**
+	 * Wire hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action(
+			'jetpack_blaze_woo_product_promote_requested',
+			array( __CLASS__, 'dispatch' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Enqueue a landing-page job for the given product.
+	 *
+	 * @param int     $product_id Product ID.
+	 * @param WP_Post $product    Product post.
+	 * @return void
+	 */
+	public static function dispatch( $product_id, $product ) {
+		$payload = array(
+			'mode'       => 'woocommerce',
+			'product_id' => (int) $product_id,
+			'title'      => $product instanceof WP_Post ? (string) $product->post_title : '',
+		);
+
+		/**
+		 * Filter the payload sent to WPCOM when enqueueing a Blaze
+		 * landing-page job.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $payload    Payload that will be JSON-encoded.
+		 * @param int   $product_id Product ID.
+		 */
+		$payload = (array) apply_filters( 'jetpack_blaze_landing_dispatch_payload', $payload, (int) $product_id );
+
+		$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+			self::ENDPOINT_PATH,
+			self::API_VERSION,
+			array(
+				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json' ),
+			),
+			wp_json_encode( $payload ),
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			self::log( 'wp_error', $response->get_error_message(), $product_id );
+			return;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $code >= 200 && $code < 300 ) {
+			return;
+		}
+
+		self::log(
+			'http_' . $code,
+			(string) wp_remote_retrieve_body( $response ),
+			$product_id
+		);
+	}
+
+	/**
+	 * Log a dispatch failure. Uses error_log because Jetpack-blaze does
+	 * not currently ship a structured logger, and we want this visible in
+	 * `WP_DEBUG_LOG` without crashing the publish request.
+	 *
+	 * @param string $reason     Short reason code.
+	 * @param string $detail     Detail string.
+	 * @param int    $product_id Product ID.
+	 * @return void
+	 */
+	private static function log( $reason, $detail, $product_id ) {
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Best-effort debug logging guarded by WP_DEBUG.
+		error_log(
+			sprintf(
+				'[jetpack-blaze] landing-page dispatch failed (%s) for product %d: %s',
+				$reason,
+				(int) $product_id,
+				$detail
+			)
+		);
+	}
+}

--- a/projects/packages/blaze/src/class-landing-page-dispatcher.php
+++ b/projects/packages/blaze/src/class-landing-page-dispatcher.php
@@ -17,6 +17,7 @@
 namespace Automattic\Jetpack\Blaze;
 
 use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use WP_Post;
 
 /**
@@ -24,8 +25,14 @@ use WP_Post;
  */
 class Landing_Page_Dispatcher {
 
-	const ENDPOINT_PATH = '/blaze/landing-pages/enqueue';
-	const API_VERSION   = '2';
+	/**
+	 * Path suffix appended to `/sites/{blog_id}/` when calling WPCOM.
+	 * The WPCOM endpoint is site-specific, so the blog id segment is required.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT_PATH_SUFFIX = '/blaze/landing-pages/enqueue';
+	const API_VERSION          = '2';
 
 	/**
 	 * Wire hooks.
@@ -66,14 +73,25 @@ class Landing_Page_Dispatcher {
 		 */
 		$payload = (array) apply_filters( 'jetpack_blaze_landing_dispatch_payload', $payload, (int) $product_id );
 
+		$blog_id = Jetpack_Connection::get_site_id();
+		if ( is_wp_error( $blog_id ) || ! is_numeric( $blog_id ) ) {
+			self::log(
+				'no_blog_id',
+				is_wp_error( $blog_id ) ? $blog_id->get_error_message() : 'not numeric',
+				$product_id
+			);
+			return;
+		}
+		$path = '/sites/' . (int) $blog_id . self::ENDPOINT_PATH_SUFFIX;
+
 		$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
-			self::ENDPOINT_PATH,
+			$path,
 			self::API_VERSION,
 			array(
 				'method'  => 'POST',
 				'headers' => array( 'Content-Type' => 'application/json' ),
 			),
-			wp_json_encode( $payload ),
+			wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ),
 			'wpcom'
 		);
 
@@ -87,9 +105,10 @@ class Landing_Page_Dispatcher {
 			return;
 		}
 
+		$body = (string) wp_remote_retrieve_body( $response );
 		self::log(
 			'http_' . $code,
-			(string) wp_remote_retrieve_body( $response ),
+			'' === $body ? '(empty body)' : $body,
 			$product_id
 		);
 	}

--- a/projects/packages/blaze/src/class-rest-controller.php
+++ b/projects/packages/blaze/src/class-rest-controller.php
@@ -9,7 +9,6 @@
 namespace Automattic\Jetpack\Blaze;
 
 use Automattic\Jetpack\Blaze;
-use Automattic\Jetpack\Blaze\Landing_Page_CPT;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Status\Host;
@@ -97,23 +96,59 @@ class REST_Controller {
 	 */
 	private static function landing_page_args() {
 		return array(
-			'html'        => array(
-				'type'     => 'string',
-				'required' => true,
-			),
-			'title'       => array(
-				'type' => 'string',
-			),
-			'mode'        => array(
+			'mode'         => array(
 				'type'     => 'string',
 				'enum'     => array( 'woocommerce' ),
 				'required' => true,
 			),
-			'product_id'  => array(
+			'product_id'   => array(
 				'type'     => 'integer',
 				'required' => true,
 			),
-			'campaign_id' => array(
+			'title'        => array(
+				'type' => 'string',
+			),
+			'headline'     => array(
+				'type' => 'string',
+			),
+			'subheadline'  => array(
+				'type' => 'string',
+			),
+			'cta_text'     => array(
+				'type' => 'string',
+			),
+			'cta_url'      => array(
+				'type'   => 'string',
+				'format' => 'uri',
+			),
+			'product_name' => array(
+				'type' => 'string',
+			),
+			'price'        => array(
+				'type' => 'string',
+			),
+			'currency'     => array(
+				'type' => 'string',
+			),
+			'image_url'    => array(
+				'type'   => 'string',
+				'format' => 'uri',
+			),
+			'brand_name'   => array(
+				'type' => 'string',
+			),
+			'logo_url'     => array(
+				'type'   => 'string',
+				'format' => 'uri',
+			),
+			'accent_color' => array(
+				'type' => 'string',
+			),
+			'highlights'   => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
+			'campaign_id'  => array(
 				'type' => 'integer',
 			),
 		);
@@ -141,14 +176,26 @@ class REST_Controller {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function upsert_landing_page( WP_REST_Request $request ) {
-		$slug_from_url = $request->get_param( 'slug' );
-		$args          = array(
-			'html'        => (string) $request->get_param( 'html' ),
-			'title'       => (string) $request->get_param( 'title' ),
-			'mode'        => (string) $request->get_param( 'mode' ),
-			'product_id'  => (int) $request->get_param( 'product_id' ),
-			'campaign_id' => (int) $request->get_param( 'campaign_id' ),
+		$args = array(
+			'mode'         => (string) $request->get_param( 'mode' ),
+			'product_id'   => (int) $request->get_param( 'product_id' ),
+			'title'        => (string) $request->get_param( 'title' ),
+			'headline'     => (string) $request->get_param( 'headline' ),
+			'subheadline'  => (string) $request->get_param( 'subheadline' ),
+			'cta_text'     => (string) $request->get_param( 'cta_text' ),
+			'cta_url'      => (string) $request->get_param( 'cta_url' ),
+			'product_name' => (string) $request->get_param( 'product_name' ),
+			'price'        => (string) $request->get_param( 'price' ),
+			'currency'     => (string) $request->get_param( 'currency' ),
+			'image_url'    => (string) $request->get_param( 'image_url' ),
+			'brand_name'   => (string) $request->get_param( 'brand_name' ),
+			'logo_url'     => (string) $request->get_param( 'logo_url' ),
+			'accent_color' => (string) $request->get_param( 'accent_color' ),
+			'highlights'   => (array) $request->get_param( 'highlights' ),
+			'campaign_id'  => (int) $request->get_param( 'campaign_id' ),
 		);
+
+		$slug_from_url = $request->get_param( 'slug' );
 		if ( ! empty( $slug_from_url ) ) {
 			$args['slug'] = (string) $slug_from_url;
 		}

--- a/projects/packages/blaze/src/class-rest-controller.php
+++ b/projects/packages/blaze/src/class-rest-controller.php
@@ -148,6 +148,10 @@ class REST_Controller {
 				'type'  => 'array',
 				'items' => array( 'type' => 'string' ),
 			),
+			'gen_images'   => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 			'campaign_id'  => array(
 				'type' => 'integer',
 			),
@@ -192,6 +196,7 @@ class REST_Controller {
 			'logo_url'     => (string) $request->get_param( 'logo_url' ),
 			'accent_color' => (string) $request->get_param( 'accent_color' ),
 			'highlights'   => (array) $request->get_param( 'highlights' ),
+			'gen_images'   => (array) $request->get_param( 'gen_images' ),
 			'campaign_id'  => (int) $request->get_param( 'campaign_id' ),
 		);
 

--- a/projects/packages/blaze/src/class-rest-controller.php
+++ b/projects/packages/blaze/src/class-rest-controller.php
@@ -9,9 +9,12 @@
 namespace Automattic\Jetpack\Blaze;
 
 use Automattic\Jetpack\Blaze;
+use Automattic\Jetpack\Blaze\Landing_Page_CPT;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Status\Host;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**
@@ -56,6 +59,124 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'can_user_view_blaze_settings' ),
 			)
 		);
+
+		// Landing pages — server-to-server only, signed by WPCOM as blog.
+		register_rest_route(
+			static::$namespace,
+			'landing-pages',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'upsert_landing_page' ),
+				'permission_callback' => array( $this, 'can_wpcom_manage_landing_pages' ),
+				'args'                => self::landing_page_args(),
+			)
+		);
+		register_rest_route(
+			static::$namespace,
+			'landing-pages/(?P<slug>[A-Za-z0-9\-_]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'upsert_landing_page' ),
+					'permission_callback' => array( $this, 'can_wpcom_manage_landing_pages' ),
+					'args'                => self::landing_page_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_landing_page' ),
+					'permission_callback' => array( $this, 'can_wpcom_manage_landing_pages' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Argument schema for the landing-page upsert endpoints.
+	 *
+	 * @return array
+	 */
+	private static function landing_page_args() {
+		return array(
+			'html'        => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+			'title'       => array(
+				'type' => 'string',
+			),
+			'mode'        => array(
+				'type'     => 'string',
+				'enum'     => array( 'woocommerce' ),
+				'required' => true,
+			),
+			'product_id'  => array(
+				'type'     => 'integer',
+				'required' => true,
+			),
+			'campaign_id' => array(
+				'type' => 'integer',
+			),
+		);
+	}
+
+	/**
+	 * Permission check for landing-page mutations.
+	 *
+	 * The merchant site never grants UI access; only requests signed by
+	 * WPCOM as the blog (via `wpcom_json_api_request_as_blog`) are allowed.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function can_wpcom_manage_landing_pages() {
+		if ( Rest_Authentication::is_signed_with_blog_token() ) {
+			return true;
+		}
+		return $this->get_forbidden_error();
+	}
+
+	/**
+	 * Create or update a landing page.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function upsert_landing_page( WP_REST_Request $request ) {
+		$slug_from_url = $request->get_param( 'slug' );
+		$args          = array(
+			'html'        => (string) $request->get_param( 'html' ),
+			'title'       => (string) $request->get_param( 'title' ),
+			'mode'        => (string) $request->get_param( 'mode' ),
+			'product_id'  => (int) $request->get_param( 'product_id' ),
+			'campaign_id' => (int) $request->get_param( 'campaign_id' ),
+		);
+		if ( ! empty( $slug_from_url ) ) {
+			$args['slug'] = (string) $slug_from_url;
+		}
+
+		$result = Landing_Page_CPT::upsert( $args );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Delete a landing page by slug.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function delete_landing_page( WP_REST_Request $request ) {
+		$slug    = (string) $request->get_param( 'slug' );
+		$deleted = Landing_Page_CPT::delete_by_slug( $slug );
+		if ( ! $deleted ) {
+			return new WP_Error(
+				'jetpack_blaze_landing_not_found',
+				__( 'Landing page not found.', 'jetpack-blaze' ),
+				array( 'status' => 404 )
+			);
+		}
+		return rest_ensure_response( array( 'deleted' => true ) );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-woo-product-panel.php
+++ b/projects/packages/blaze/src/class-woo-product-panel.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Promote-with-Blaze opt-in panel on the WooCommerce product editor.
+ *
+ * Renders a sidebar metabox on the classic editor for `product`
+ * post type. Gated on:
+ *  - the `blaze-featured-woocommerce-site` WPCOM site sticker, and
+ *  - the standard Blaze initialization checks (Jetpack-connected,
+ *    user connected, sync enabled, site eligible).
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use Automattic\Jetpack\Blaze;
+use WP_Post;
+
+/**
+ * Woo product promote panel.
+ */
+class Woo_Product_Panel {
+
+	const META_KEY            = '_jetpack_blaze_promote';
+	const NONCE_ACTION        = 'jetpack_blaze_woo_product_promote';
+	const NONCE_FIELD         = 'jetpack_blaze_woo_product_promote_nonce';
+	const STICKER             = 'blaze-featured-woocommerce-site';
+	const METABOX_ID          = 'jetpack_blaze_woo_product_promote';
+	const PROMOTE_HOOK        = 'jetpack_blaze_woo_product_promote_requested';
+	const PROMOTION_PROCESSED = '_jetpack_blaze_promote_dispatched';
+
+	/**
+	 * Wire WordPress hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'register_meta' ) );
+		add_action( 'add_meta_boxes_product', array( __CLASS__, 'register_metabox' ) );
+		add_action( 'save_post_product', array( __CLASS__, 'save_meta' ), 10, 2 );
+		// Run after save_meta so the checkbox value is persisted before we
+		// decide whether to dispatch.
+		add_action( 'save_post_product', array( __CLASS__, 'maybe_dispatch_promote' ), 20, 2 );
+		// Woo seeds a fixed `meta-box-order_product` user meta that places our
+		// metabox after Woo's own boxes. Splice ours in right after Publish.
+		add_filter( 'get_user_option_meta-box-order_product', array( __CLASS__, 'filter_metabox_order' ) );
+	}
+
+	/**
+	 * Splice our metabox into the saved side-column order so it lands between
+	 * `submitdiv` (Publish) and `postimagediv` (Product image).
+	 *
+	 * @param mixed $order Saved meta box order. Array keyed by context, or empty.
+	 * @return mixed
+	 */
+	public static function filter_metabox_order( $order ) {
+		if ( ! is_array( $order ) || empty( $order['side'] ) || ! is_string( $order['side'] ) ) {
+			return $order;
+		}
+		$boxes = array_values( array_filter( array_map( 'trim', explode( ',', $order['side'] ) ) ) );
+		// Drop any existing entry so we end up with at most one.
+		$boxes = array_values( array_filter( $boxes, static fn ( $b ) => $b !== self::METABOX_ID ) );
+
+		$insert_at = array_search( 'submitdiv', $boxes, true );
+		$insert_at = false === $insert_at ? 0 : $insert_at + 1;
+		array_splice( $boxes, $insert_at, 0, array( self::METABOX_ID ) );
+
+		$order['side'] = implode( ',', $boxes );
+		return $order;
+	}
+
+	/**
+	 * Whether the panel should render on the current site/screen.
+	 *
+	 * Combines the sticker check with the standard Blaze init checks.
+	 *
+	 * @return bool
+	 */
+	public static function should_render() {
+		if ( ! self::is_featured_woocommerce_site() ) {
+			return false;
+		}
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return false;
+		}
+		$can = Blaze::should_initialize();
+		return ! empty( $can['can_init'] );
+	}
+
+	/**
+	 * Check the `blaze-featured-woocommerce-site` WPCOM site sticker.
+	 *
+	 * Uses the canonical wrapper when available (Simple + Atomic), and
+	 * exposes a filter so the check can be forced in tests / mu-plugins.
+	 *
+	 * @return bool
+	 */
+	public static function is_featured_woocommerce_site() {
+		$has_sticker = false;
+
+		if ( function_exists( 'wpcom_has_blog_sticker' ) ) {
+			$blog_id     = method_exists( '\Automattic\Jetpack\Connection\Manager', 'get_site_id' )
+				? \Automattic\Jetpack\Connection\Manager::get_site_id()
+				: 0;
+			$blog_id     = is_numeric( $blog_id ) ? (int) $blog_id : 0;
+			$has_sticker = wpcom_has_blog_sticker( self::STICKER, $blog_id );
+		} elseif ( function_exists( 'has_blog_sticker' ) ) {
+			$has_sticker = (bool) has_blog_sticker( self::STICKER );
+		} elseif ( function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
+			$has_sticker = (bool) wpcomsh_is_site_sticker_active( self::STICKER );
+		}
+
+		/**
+		 * Override the `blaze-featured-woocommerce-site` sticker lookup.
+		 *
+		 * Lets self-hosted sites opt in (or force-disable) the WooCommerce
+		 * product promote panel without a WPCOM sticker.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $has_sticker Whether the site has the sticker.
+		 */
+		return (bool) apply_filters( 'jetpack_blaze_featured_woocommerce_site', $has_sticker );
+	}
+
+	/**
+	 * Register the `_jetpack_blaze_promote` product meta.
+	 *
+	 * Default is `true` — the checkbox starts checked.
+	 *
+	 * @return void
+	 */
+	public static function register_meta() {
+		register_post_meta(
+			'product',
+			self::META_KEY,
+			array(
+				'type'              => 'boolean',
+				'single'            => true,
+				'default'           => true,
+				'show_in_rest'      => true,
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'sanitize_callback' => static function ( $value ) {
+					return (bool) $value;
+				},
+			)
+		);
+	}
+
+	/**
+	 * Register the sidebar metabox on the product edit screen.
+	 *
+	 * Priority `default` keeps the panel between the Publish box (priority
+	 * `core`) and the Product image box (priority `low`).
+	 *
+	 * @param WP_Post $post The product being edited.
+	 * @return void
+	 */
+	public static function register_metabox( $post ) {
+		if ( ! self::should_render() ) {
+			return;
+		}
+		add_meta_box(
+			self::METABOX_ID,
+			__( 'Blaze Ads', 'jetpack-blaze' ),
+			array( __CLASS__, 'render_metabox' ),
+			'product',
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the metabox.
+	 *
+	 * @param WP_Post $post The product being edited.
+	 * @return void
+	 */
+	public static function render_metabox( $post ) {
+		$stored = get_post_meta( $post->ID, self::META_KEY, true );
+		// Default to checked when the meta has never been written.
+		$checked = ( '' === $stored ) ? true : (bool) $stored;
+
+		wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD );
+		?>
+		<p class="jetpack-blaze-woo-product-promote">
+			<label>
+				<input
+					type="checkbox"
+					name="<?php echo esc_attr( self::META_KEY ); ?>"
+					value="1"
+					<?php checked( $checked, true ); ?>
+				/>
+				<?php esc_html_e( 'Promote it free with Blaze Ads', 'jetpack-blaze' ); ?>
+			</label>
+			<a
+				href="#"
+				class="jetpack-blaze-woo-product-promote-info"
+				aria-expanded="false"
+				aria-controls="jetpack-blaze-woo-product-promote-help"
+			>
+				<?php esc_html_e( 'more info', 'jetpack-blaze' ); ?>
+			</a>
+		</p>
+		<div id="jetpack-blaze-woo-product-promote-help" class="jetpack-blaze-woo-product-promote-help" hidden>
+			<p>
+				<?php
+				esc_html_e(
+					'When checked, this product is eligible for a free Blaze Ads promotion when you publish it. Conditions: TBD.',
+					'jetpack-blaze'
+				);
+				?>
+			</p>
+		</div>
+		<style>
+			.jetpack-blaze-woo-product-promote-info { margin-left: 6px; }
+			.jetpack-blaze-woo-product-promote-help {
+				margin-top: 8px;
+				padding: 8px 10px;
+				background: #f6f7f7;
+				border-left: 3px solid #2271b1;
+			}
+		</style>
+		<script>
+		( function () {
+			var link = document.querySelector( '.jetpack-blaze-woo-product-promote-info' );
+			var help = document.getElementById( 'jetpack-blaze-woo-product-promote-help' );
+			if ( ! link || ! help ) { return; }
+			link.addEventListener( 'click', function ( ev ) {
+				ev.preventDefault();
+				var open = help.hasAttribute( 'hidden' );
+				if ( open ) {
+					help.removeAttribute( 'hidden' );
+					link.setAttribute( 'aria-expanded', 'true' );
+				} else {
+					help.setAttribute( 'hidden', '' );
+					link.setAttribute( 'aria-expanded', 'false' );
+				}
+			} );
+		} )();
+		</script>
+		<?php
+	}
+
+	/**
+	 * Persist the checkbox value when the product is saved.
+	 *
+	 * @param int     $post_id Product ID.
+	 * @param WP_Post $post    The product object.
+	 * @return void
+	 */
+	public static function save_meta( $post_id, $post ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( ! isset( $_POST[ self::NONCE_FIELD ] ) ) {
+			return;
+		}
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ self::NONCE_FIELD ] ) ), self::NONCE_ACTION ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$checked = ! empty( $_POST[ self::META_KEY ] );
+		update_post_meta( $post_id, self::META_KEY, $checked );
+
+		// Allow re-dispatch on the next publish if the product is being unpublished.
+		if ( 'publish' !== $post->post_status ) {
+			delete_post_meta( $post_id, self::PROMOTION_PROCESSED );
+		}
+	}
+
+	/**
+	 * Fire the promote-requested hook the first time the product is published
+	 * with the opt-in meta set to true.
+	 *
+	 * Runs on `save_post_product` (priority 20) — after `save_meta` has
+	 * persisted the checkbox value for this request.
+	 *
+	 * @param int     $post_id Product ID.
+	 * @param WP_Post $post    Product post object.
+	 * @return void
+	 */
+	public static function maybe_dispatch_promote( $post_id, $post ) {
+		if ( ! $post instanceof WP_Post || 'product' !== $post->post_type ) {
+			return;
+		}
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+		if ( ! (bool) get_post_meta( $post_id, self::META_KEY, true ) ) {
+			return;
+		}
+		if ( (bool) get_post_meta( $post_id, self::PROMOTION_PROCESSED, true ) ) {
+			return;
+		}
+
+		update_post_meta( $post_id, self::PROMOTION_PROCESSED, 1 );
+
+		/**
+		 * Fires when a WooCommerce product is published with the
+		 * Promote-with-Blaze opt-in checked.
+		 *
+		 * Consumers can hook here to kick off a Blaze campaign creation
+		 * flow for the product.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int     $product_id The product post ID.
+		 * @param WP_Post $product    The product post object.
+		 */
+		do_action( self::PROMOTE_HOOK, $post_id, $post );
+	}
+}

--- a/projects/packages/blaze/src/class-woo-product-panel.php
+++ b/projects/packages/blaze/src/class-woo-product-panel.php
@@ -37,7 +37,7 @@ class Woo_Product_Panel {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_meta' ) );
 		add_action( 'add_meta_boxes_product', array( __CLASS__, 'register_metabox' ) );
-		add_action( 'save_post_product', array( __CLASS__, 'save_meta' ), 10, 2 );
+		add_action( 'save_post_product', array( __CLASS__, 'save_meta' ), 10, 1 );
 		// Run after save_meta so the checkbox value is persisted before we
 		// decide whether to dispatch.
 		add_action( 'save_post_product', array( __CLASS__, 'maybe_dispatch_promote' ), 20, 2 );
@@ -155,10 +155,9 @@ class Woo_Product_Panel {
 	 * Priority `default` keeps the panel between the Publish box (priority
 	 * `core`) and the Product image box (priority `low`).
 	 *
-	 * @param WP_Post $post The product being edited.
 	 * @return void
 	 */
-	public static function register_metabox( $post ) {
+	public static function register_metabox() {
 		if ( ! self::should_render() ) {
 			return;
 		}
@@ -247,11 +246,10 @@ class Woo_Product_Panel {
 	/**
 	 * Persist the checkbox value when the product is saved.
 	 *
-	 * @param int     $post_id Product ID.
-	 * @param WP_Post $post    The product object.
+	 * @param int $post_id Product ID.
 	 * @return void
 	 */
-	public static function save_meta( $post_id, $post ) {
+	public static function save_meta( $post_id ) {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
@@ -267,11 +265,6 @@ class Woo_Product_Panel {
 
 		$checked = ! empty( $_POST[ self::META_KEY ] );
 		update_post_meta( $post_id, self::META_KEY, $checked );
-
-		// Allow re-dispatch on the next publish if the product is being unpublished.
-		if ( 'publish' !== $post->post_status ) {
-			delete_post_meta( $post_id, self::PROMOTION_PROCESSED );
-		}
 	}
 
 	/**
@@ -280,6 +273,12 @@ class Woo_Product_Panel {
 	 *
 	 * Runs on `save_post_product` (priority 20) — after `save_meta` has
 	 * persisted the checkbox value for this request.
+	 *
+	 * Dedup is intentionally NOT done here: every publish/update of a
+	 * product with the opt-in checked re-fires the action. Downstream
+	 * consumers are expected to skip if a campaign already exists for
+	 * the product. The `_jetpack_blaze_promote_dispatched` post meta is
+	 * still written as a breadcrumb so the dispatch history is visible.
 	 *
 	 * @param int     $post_id Product ID.
 	 * @param WP_Post $post    Product post object.
@@ -301,11 +300,8 @@ class Woo_Product_Panel {
 		if ( ! (bool) get_post_meta( $post_id, self::META_KEY, true ) ) {
 			return;
 		}
-		if ( (bool) get_post_meta( $post_id, self::PROMOTION_PROCESSED, true ) ) {
-			return;
-		}
 
-		update_post_meta( $post_id, self::PROMOTION_PROCESSED, 1 );
+		update_post_meta( $post_id, self::PROMOTION_PROCESSED, time() );
 
 		/**
 		 * Fires when a WooCommerce product is published with the

--- a/projects/packages/blaze/src/css/landing-page.css
+++ b/projects/packages/blaze/src/css/landing-page.css
@@ -75,7 +75,6 @@
 }
 
 .blaze-lp-headline {
-	font-family: inherit;
 	font-size: clamp(2rem, 4.2vw, 3.25rem);
 	line-height: 1.1;
 	margin: 0 0 0.75rem;

--- a/projects/packages/blaze/src/css/landing-page.css
+++ b/projects/packages/blaze/src/css/landing-page.css
@@ -12,102 +12,239 @@
 
 :root {
 	--blaze-accent: #1e6fff;
-	--blaze-radius: 12px;
+	--blaze-radius: 14px;
+	--blaze-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+	--blaze-section-pad: clamp(3rem, 8vw, 6rem);
 }
 
 .blaze-lp .blaze-lp-main {
-	max-width: 1200px;
-	margin: 0 auto;
-	padding: clamp(2rem, 5vw, 4.5rem) 1.5rem;
+	max-width: none;
+	margin: 0;
+	padding: 0;
 	box-sizing: border-box;
 }
 
-/* Hero: gallery on the left, copy on the right. */
-.blaze-lp-hero {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: clamp(1.5rem, 4vw, 3.5rem);
-	align-items: start;
-}
+/* ──────────────────────────────────────────────────────────────────────────
+ * HERO — full-viewport, product photo as full-bleed background.
+ * ────────────────────────────────────────────────────────────────────────── */
 
-/* Gallery */
-.blaze-lp-gallery {
+.blaze-lp-hero {
+	position: relative;
+	min-height: 100vh;
+	min-height: 100svh;
 	display: flex;
 	flex-direction: column;
-	gap: 0.85rem;
+	justify-content: center;
+	align-items: center;
+	text-align: center;
+	padding: 6rem 1.5rem 3rem;
+	color: #fff;
+	background-color: #111;
+	background-position: center;
+	background-size: cover;
+	background-repeat: no-repeat;
+	overflow: hidden;
+	isolation: isolate;
 }
 
-.blaze-lp-gallery-main {
+/* Dark scrim so the headline reads regardless of the underlying image. */
+.blaze-lp-hero-scrim {
+	position: absolute;
+	inset: 0;
+	background:
+ linear-gradient(to bottom, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0.35) 45%, rgba(0, 0, 0, 0.7) 100%);
+	z-index: 0;
+}
+
+.blaze-lp-hero-content {
+	position: relative;
+	z-index: 1;
+	max-width: 760px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1.25rem;
+}
+
+.blaze-lp-hero .blaze-lp-headline {
+	color: #fff;
+	font-size: clamp(2.4rem, 6vw, 4.6rem);
+	line-height: 1.05;
 	margin: 0;
+	letter-spacing: -0.01em;
+	text-shadow: 0 2px 24px rgba(0, 0, 0, 0.35);
 }
 
-.blaze-lp-gallery-main img {
-	width: 100%;
-	height: auto;
-	display: block;
-	border-radius: var(--blaze-radius);
-	box-shadow: 0 18px 50px rgba(0, 0, 0, 0.12);
-	aspect-ratio: 1 / 1;
-	object-fit: cover;
-}
-
-.blaze-lp-gallery-thumbs {
-	list-style: none;
+.blaze-lp-hero .blaze-lp-sub {
+	color: rgba(255, 255, 255, 0.9);
+	font-size: clamp(1.1rem, 1.8vw, 1.4rem);
 	margin: 0;
-	padding: 0;
-	display: grid;
-	grid-template-columns: repeat(4, 1fr);
-	gap: 0.6rem;
+	max-width: 56ch;
+	text-shadow: 0 1px 18px rgba(0, 0, 0, 0.35);
 }
 
-.blaze-lp-gallery-thumbs img {
-	width: 100%;
-	height: auto;
-	display: block;
-	border-radius: 8px;
-	aspect-ratio: 1 / 1;
-	object-fit: cover;
-}
-
-/* Copy column */
-.blaze-lp-copy {
-	align-self: center;
-}
-
-.blaze-lp-headline {
-	font-size: clamp(2rem, 4.2vw, 3.25rem);
-	line-height: 1.1;
-	margin: 0 0 0.75rem;
-}
-
-.blaze-lp-sub {
-	font-size: clamp(1.05rem, 1.6vw, 1.25rem);
-	opacity: 0.8;
-	margin: 0 0 1.5rem;
-	max-width: 46ch;
-}
-
-.blaze-lp-price {
-	font-size: 1.6rem;
+.blaze-lp-hero .blaze-lp-price {
+	color: #fff;
+	font-size: clamp(1.4rem, 2.6vw, 2rem);
 	font-weight: 700;
-	margin: 0 0 1.6rem;
+	margin: 0.25rem 0 0;
+	text-shadow: 0 1px 18px rgba(0, 0, 0, 0.4);
 }
 
-.blaze-lp-price del {
-	opacity: 0.5;
+.blaze-lp-hero .blaze-lp-price del {
+	opacity: 0.55;
 	font-weight: 400;
 	margin-right: 0.5rem;
 }
 
-.blaze-lp-price ins {
+.blaze-lp-hero .blaze-lp-price ins {
 	text-decoration: none;
 }
 
-.blaze-lp-price .woocommerce-Price-amount {
+.blaze-lp-hero .blaze-lp-price .woocommerce-Price-amount {
 	white-space: nowrap;
 }
 
-/* CTA — styled with the theme's brand accent so it matches the store. */
+.blaze-lp-scroll-hint {
+	position: absolute;
+	left: 50%;
+	bottom: 2rem;
+	width: 32px;
+	height: 32px;
+	transform: translateX(-50%);
+	border-right: 2px solid rgba(255, 255, 255, 0.85);
+	border-bottom: 2px solid rgba(255, 255, 255, 0.85);
+	transform-origin: center;
+	z-index: 1;
+	animation: blaze-lp-bounce 2.4s ease-in-out infinite;
+	text-decoration: none;
+	rotate: 45deg;
+}
+
+@keyframes blaze-lp-bounce {
+
+	0%,
+ 100% {
+		transform: translate(-50%, 0) rotate(0);
+	}
+
+	50% {
+		transform: translate(-50%, 12px) rotate(0);
+	}
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * FEATURE SECTIONS — one per AI image, alternating image/copy sides.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+.blaze-lp-features {
+	background: #fff;
+}
+
+.blaze-lp-feature {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	align-items: center;
+	gap: clamp(2rem, 5vw, 5rem);
+	max-width: 1240px;
+	margin: 0 auto;
+	padding: var(--blaze-section-pad) 1.5rem;
+	box-sizing: border-box;
+}
+
+.blaze-lp-feature--right .blaze-lp-feature-img {
+	order: 2;
+}
+
+.blaze-lp-feature--right .blaze-lp-feature-copy {
+	order: 1;
+}
+
+.blaze-lp-feature-img img {
+	display: block;
+	width: 100%;
+	height: auto;
+	border-radius: var(--blaze-radius);
+	box-shadow: var(--blaze-shadow);
+	aspect-ratio: 1 / 1;
+	object-fit: cover;
+}
+
+.blaze-lp-feature-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+}
+
+.blaze-lp-feature-title {
+	font-size: clamp(1.6rem, 3vw, 2.4rem);
+	line-height: 1.18;
+	margin: 0;
+	letter-spacing: -0.005em;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * EXTRAS — remaining highlights as a tidy card grid.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+.blaze-lp-extras {
+	background: #fafafa;
+	padding: var(--blaze-section-pad) 1.5rem;
+}
+
+.blaze-lp-highlights {
+	list-style: none;
+	margin: 0 auto;
+	padding: 0;
+	max-width: 1100px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: 1rem;
+}
+
+.blaze-lp-highlights li {
+	border: 1px solid rgba(0, 0, 0, 0.08);
+	border-top: 3px solid var(--blaze-accent);
+	border-radius: 10px;
+	padding: 1.25rem 1.4rem;
+	background: #fff;
+	font-size: 1rem;
+	line-height: 1.4;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * FINAL CTA — closing pitch + big button.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+.blaze-lp-final {
+	background: linear-gradient(180deg, #fff 0%, #f3f3f3 100%);
+	text-align: center;
+	padding: var(--blaze-section-pad) 1.5rem;
+}
+
+.blaze-lp-final-title {
+	font-size: clamp(2rem, 4vw, 3rem);
+	margin: 0 0 0.5rem;
+	line-height: 1.1;
+}
+
+.blaze-lp-final-sub {
+	font-size: clamp(1rem, 1.6vw, 1.2rem);
+	opacity: 0.75;
+	margin: 0 auto 1.5rem;
+	max-width: 56ch;
+}
+
+.blaze-lp-final .blaze-lp-price {
+	font-size: clamp(1.4rem, 2.4vw, 1.8rem);
+	font-weight: 700;
+	margin: 0 0 1.5rem;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * CTA BUTTON — themed with the store's brand accent.
+ * ────────────────────────────────────────────────────────────────────────── */
+
 .blaze-lp-cta-wrap {
 	margin: 0;
 }
@@ -122,33 +259,58 @@
 	text-transform: uppercase;
 	font-size: 0.95rem;
 	padding: 1rem 2.2rem;
-	border-radius: 6px;
-	transition: transform 0.15s ease, opacity 0.15s ease;
+	border-radius: 8px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+	transition: transform 0.18s ease, box-shadow 0.18s ease, opacity 0.18s ease;
 }
 
-.blaze-lp-cta:hover {
-	opacity: 0.92;
-	transform: translateY(-1px);
+.blaze-lp-cta:hover,
+.blaze-lp-cta:focus-visible {
 	color: #fff;
+	transform: translateY(-2px);
+	box-shadow: 0 14px 32px rgba(0, 0, 0, 0.18);
 }
 
-/* Highlights */
-.blaze-lp-highlights {
-	list-style: none;
-	margin: clamp(2.5rem, 5vw, 4rem) 0 0;
-	padding: 0;
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-	gap: 1rem;
-}
-
-.blaze-lp-highlights li {
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	border-top: 3px solid var(--blaze-accent);
-	border-radius: 10px;
-	padding: 1.15rem 1.25rem;
-	background: rgba(0, 0, 0, 0.015);
+.blaze-lp-cta--hero {
 	font-size: 1rem;
+	padding: 1.15rem 2.6rem;
+	margin-top: 0.5rem;
+}
+
+.blaze-lp-cta--big {
+	font-size: 1.1rem;
+	padding: 1.3rem 3rem;
+	border-radius: 10px;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * REVEAL-ON-SCROLL — only when the JS hook ran. Without JS, sections show
+ * normally (no flash-of-empty content for users with scripts disabled).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+.blaze-lp-js .blaze-lp-reveal {
+	opacity: 0;
+	transform: translateY(28px);
+	transition: opacity 0.7s ease, transform 0.7s ease;
+	will-change: opacity, transform;
+}
+
+.blaze-lp-js .blaze-lp-reveal.is-revealed {
+	opacity: 1;
+	transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.blaze-lp-js .blaze-lp-reveal {
+		opacity: 1;
+		transform: none;
+		transition: none;
+	}
+
+	.blaze-lp-scroll-hint {
+		animation: none;
+	}
 }
 
 /* Fallback chrome for classic (non-block) themes. */
@@ -176,16 +338,30 @@
 	opacity: 0.7;
 	padding: 2.5rem 1.5rem;
 	border-top: 1px solid rgba(0, 0, 0, 0.1);
-	margin-top: 3.5rem;
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * MOBILE — stack feature sections, tighten hero.
+ * ────────────────────────────────────────────────────────────────────────── */
 
 @media (max-width: 781px) {
 
 	.blaze-lp-hero {
-		grid-template-columns: 1fr;
+		padding: 5rem 1.25rem 4rem;
 	}
 
-	.blaze-lp-gallery-thumbs {
-		grid-template-columns: repeat(5, 1fr);
+	.blaze-lp-feature {
+		grid-template-columns: 1fr;
+		gap: 1.5rem;
+		padding: clamp(2.5rem, 8vw, 4rem) 1.25rem;
+	}
+
+	/* On mobile every section reads top-to-bottom: image first, copy second. */
+	.blaze-lp-feature--right .blaze-lp-feature-img {
+		order: 1;
+	}
+
+	.blaze-lp-feature--right .blaze-lp-feature-copy {
+		order: 2;
 	}
 }

--- a/projects/packages/blaze/src/css/landing-page.css
+++ b/projects/packages/blaze/src/css/landing-page.css
@@ -2,97 +2,115 @@
  * Styles for Blaze AI landing pages.
  *
  * Owned by the jetpack-blaze package and linked by Landing_Page_CPT::render().
- * The per-page brand accent is injected as the --blaze-accent custom property.
+ * The page renders inside the merchant site, so the theme's global styles
+ * (theme.json palette + typography) load via wp_head() and the header and
+ * footer are the theme's real template parts. This stylesheet is therefore
+ * LAYOUT-FIRST: it inherits the theme's fonts and colors and only adds the
+ * landing structure. The per-page brand accent is injected as the
+ * --blaze-accent custom property, derived from the theme's color palette.
  */
 
 :root {
 	--blaze-accent: #1e6fff;
-	--blaze-fg: #1a1a1a;
-	--blaze-muted: #5b6470;
-	--blaze-bg: #fff;
-	--blaze-surface: #f6f7f9;
-	--blaze-border: #e6e8eb;
 	--blaze-radius: 12px;
 }
 
-*,
-*::before,
-*::after {
+.blaze-lp .blaze-lp-main {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: clamp(2rem, 5vw, 4.5rem) 1.5rem;
 	box-sizing: border-box;
 }
 
-html,
-body {
-	margin: 0;
-	padding: 0;
-}
-
-body.blaze-lp {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-	color: var(--blaze-fg);
-	background: var(--blaze-bg);
-	line-height: 1.6;
-	-webkit-font-smoothing: antialiased;
-}
-
-.blaze-lp-header {
-	display: flex;
-	align-items: center;
-	gap: 0.75rem;
-	padding: 1.1rem 1.5rem;
-	border-bottom: 1px solid var(--blaze-border);
-}
-
-.blaze-lp-logo {
-	height: 36px;
-	width: auto;
-	display: block;
-}
-
-.blaze-lp-brand {
-	font-weight: 700;
-	font-size: 1.15rem;
-	letter-spacing: 0.01em;
-}
-
-.blaze-lp-main {
-	max-width: 1040px;
-	margin: 0 auto;
-	padding: 3rem 1.5rem;
-}
-
+/* Hero: gallery on the left, copy on the right. */
 .blaze-lp-hero {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
-	gap: 3rem;
-	align-items: center;
+	gap: clamp(1.5rem, 4vw, 3.5rem);
+	align-items: start;
 }
 
-.blaze-lp-media img {
+/* Gallery */
+.blaze-lp-gallery {
+	display: flex;
+	flex-direction: column;
+	gap: 0.85rem;
+}
+
+.blaze-lp-gallery-main {
+	margin: 0;
+}
+
+.blaze-lp-gallery-main img {
 	width: 100%;
 	height: auto;
 	display: block;
 	border-radius: var(--blaze-radius);
 	box-shadow: 0 18px 50px rgba(0, 0, 0, 0.12);
+	aspect-ratio: 1 / 1;
+	object-fit: cover;
+}
+
+.blaze-lp-gallery-thumbs {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 0.6rem;
+}
+
+.blaze-lp-gallery-thumbs img {
+	width: 100%;
+	height: auto;
+	display: block;
+	border-radius: 8px;
+	aspect-ratio: 1 / 1;
+	object-fit: cover;
+}
+
+/* Copy column */
+.blaze-lp-copy {
+	align-self: center;
 }
 
 .blaze-lp-headline {
-	font-size: clamp(1.9rem, 4vw, 3rem);
-	line-height: 1.12;
+	font-family: inherit;
+	font-size: clamp(2rem, 4.2vw, 3.25rem);
+	line-height: 1.1;
 	margin: 0 0 0.75rem;
-	letter-spacing: -0.01em;
 }
 
 .blaze-lp-sub {
-	font-size: 1.2rem;
-	color: var(--blaze-muted);
+	font-size: clamp(1.05rem, 1.6vw, 1.25rem);
+	opacity: 0.8;
 	margin: 0 0 1.5rem;
+	max-width: 46ch;
 }
 
 .blaze-lp-price {
-	font-size: 1.4rem;
+	font-size: 1.6rem;
 	font-weight: 700;
-	margin: 0 0 1.5rem;
+	margin: 0 0 1.6rem;
+}
+
+.blaze-lp-price del {
+	opacity: 0.5;
+	font-weight: 400;
+	margin-right: 0.5rem;
+}
+
+.blaze-lp-price ins {
+	text-decoration: none;
+}
+
+.blaze-lp-price .woocommerce-Price-amount {
+	white-space: nowrap;
+}
+
+/* CTA — styled with the theme's brand accent so it matches the store. */
+.blaze-lp-cta-wrap {
+	margin: 0;
 }
 
 .blaze-lp-cta {
@@ -100,21 +118,25 @@ body.blaze-lp {
 	background: var(--blaze-accent);
 	color: #fff;
 	text-decoration: none;
-	font-weight: 600;
-	font-size: 1.05rem;
-	padding: 0.9rem 1.8rem;
-	border-radius: 8px;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	font-size: 0.95rem;
+	padding: 1rem 2.2rem;
+	border-radius: 6px;
 	transition: transform 0.15s ease, opacity 0.15s ease;
 }
 
 .blaze-lp-cta:hover {
 	opacity: 0.92;
 	transform: translateY(-1px);
+	color: #fff;
 }
 
+/* Highlights */
 .blaze-lp-highlights {
 	list-style: none;
-	margin: 3.5rem 0 0;
+	margin: clamp(2.5rem, 5vw, 4rem) 0 0;
 	padding: 0;
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -122,30 +144,49 @@ body.blaze-lp {
 }
 
 .blaze-lp-highlights li {
-	background: var(--blaze-surface);
-	border: 1px solid var(--blaze-border);
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-top: 3px solid var(--blaze-accent);
 	border-radius: 10px;
-	padding: 1.1rem 1.25rem;
+	padding: 1.15rem 1.25rem;
+	background: rgba(0, 0, 0, 0.015);
 	font-size: 1rem;
 }
 
-.blaze-lp-footer {
+/* Fallback chrome for classic (non-block) themes. */
+.blaze-lp-fallback-header {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 1.1rem 1.5rem;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.blaze-lp-fallback-header .blaze-lp-brand {
+	font-weight: 700;
+	font-size: 1.2rem;
+}
+
+.blaze-lp-fallback-header img,
+.blaze-lp-fallback-header .custom-logo {
+	max-height: 40px;
+	width: auto;
+}
+
+.blaze-lp-fallback-footer {
 	text-align: center;
-	color: var(--blaze-muted);
-	font-size: 0.9rem;
+	opacity: 0.7;
 	padding: 2.5rem 1.5rem;
-	border-top: 1px solid var(--blaze-border);
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
 	margin-top: 3.5rem;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 781px) {
 
 	.blaze-lp-hero {
 		grid-template-columns: 1fr;
-		gap: 1.75rem;
 	}
 
-	.blaze-lp-main {
-		padding: 2rem 1.25rem;
+	.blaze-lp-gallery-thumbs {
+		grid-template-columns: repeat(5, 1fr);
 	}
 }

--- a/projects/packages/blaze/src/css/landing-page.css
+++ b/projects/packages/blaze/src/css/landing-page.css
@@ -1,0 +1,151 @@
+/**
+ * Styles for Blaze AI landing pages.
+ *
+ * Owned by the jetpack-blaze package and linked by Landing_Page_CPT::render().
+ * The per-page brand accent is injected as the --blaze-accent custom property.
+ */
+
+:root {
+	--blaze-accent: #1e6fff;
+	--blaze-fg: #1a1a1a;
+	--blaze-muted: #5b6470;
+	--blaze-bg: #fff;
+	--blaze-surface: #f6f7f9;
+	--blaze-border: #e6e8eb;
+	--blaze-radius: 12px;
+}
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	margin: 0;
+	padding: 0;
+}
+
+body.blaze-lp {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	color: var(--blaze-fg);
+	background: var(--blaze-bg);
+	line-height: 1.6;
+	-webkit-font-smoothing: antialiased;
+}
+
+.blaze-lp-header {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 1.1rem 1.5rem;
+	border-bottom: 1px solid var(--blaze-border);
+}
+
+.blaze-lp-logo {
+	height: 36px;
+	width: auto;
+	display: block;
+}
+
+.blaze-lp-brand {
+	font-weight: 700;
+	font-size: 1.15rem;
+	letter-spacing: 0.01em;
+}
+
+.blaze-lp-main {
+	max-width: 1040px;
+	margin: 0 auto;
+	padding: 3rem 1.5rem;
+}
+
+.blaze-lp-hero {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 3rem;
+	align-items: center;
+}
+
+.blaze-lp-media img {
+	width: 100%;
+	height: auto;
+	display: block;
+	border-radius: var(--blaze-radius);
+	box-shadow: 0 18px 50px rgba(0, 0, 0, 0.12);
+}
+
+.blaze-lp-headline {
+	font-size: clamp(1.9rem, 4vw, 3rem);
+	line-height: 1.12;
+	margin: 0 0 0.75rem;
+	letter-spacing: -0.01em;
+}
+
+.blaze-lp-sub {
+	font-size: 1.2rem;
+	color: var(--blaze-muted);
+	margin: 0 0 1.5rem;
+}
+
+.blaze-lp-price {
+	font-size: 1.4rem;
+	font-weight: 700;
+	margin: 0 0 1.5rem;
+}
+
+.blaze-lp-cta {
+	display: inline-block;
+	background: var(--blaze-accent);
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.05rem;
+	padding: 0.9rem 1.8rem;
+	border-radius: 8px;
+	transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.blaze-lp-cta:hover {
+	opacity: 0.92;
+	transform: translateY(-1px);
+}
+
+.blaze-lp-highlights {
+	list-style: none;
+	margin: 3.5rem 0 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: 1rem;
+}
+
+.blaze-lp-highlights li {
+	background: var(--blaze-surface);
+	border: 1px solid var(--blaze-border);
+	border-radius: 10px;
+	padding: 1.1rem 1.25rem;
+	font-size: 1rem;
+}
+
+.blaze-lp-footer {
+	text-align: center;
+	color: var(--blaze-muted);
+	font-size: 0.9rem;
+	padding: 2.5rem 1.5rem;
+	border-top: 1px solid var(--blaze-border);
+	margin-top: 3.5rem;
+}
+
+@media (max-width: 720px) {
+
+	.blaze-lp-hero {
+		grid-template-columns: 1fr;
+		gap: 1.75rem;
+	}
+
+	.blaze-lp-main {
+		padding: 2rem 1.25rem;
+	}
+}

--- a/projects/packages/blaze/src/css/landing-page.css
+++ b/projects/packages/blaze/src/css/landing-page.css
@@ -51,8 +51,7 @@
 .blaze-lp-hero-scrim {
 	position: absolute;
 	inset: 0;
-	background:
- linear-gradient(to bottom, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0.35) 45%, rgba(0, 0, 0, 0.7) 100%);
+	background: linear-gradient(to bottom, rgb(0 0 0 / 55%) 0%, rgb(0 0 0 / 35%) 45%, rgb(0 0 0 / 70%) 100%);
 	z-index: 0;
 }
 


### PR DESCRIPTION
## Proposed changes

Two coupled changes that together make the **Promote-with-Blaze** opt-in actionable end-to-end on the merchant side:

### 1. Opt-in panel on the WooCommerce product editor

Adds an opt-in "Promote it free with Blaze Ads" panel to the WooCommerce product editor, on the right sidebar between **Publish** and **Product image**. The checkbox is checked by default. On the first publish with the opt-in checked, fires a new `jetpack_blaze_woo_product_promote_requested` action.

- `Automattic\Jetpack\Blaze\Woo_Product_Panel` registers the sidebar metabox, registers `_jetpack_blaze_promote` post meta, persists the checkbox with a nonce check, and emits the action.
- Slices into WooCommerce's seeded `meta-box-order_product` so the panel lands between Publish and Product image regardless of metabox priority.

### 2. Hidden landing-page CPT, REST endpoints, and dispatcher

Adds a hidden `blaze_landing_page` custom post type used to host landing pages generated elsewhere, plus the wiring to receive them.

- `Automattic\Jetpack\Blaze\Landing_Page_CPT` registers the CPT with `public=false`, `publicly_queryable=true`, `exclude_from_search=true`, `show_ui=false`. Stored HTML is served via a `template_include` filter that bypasses the theme entirely and emits a `noindex,nofollow` header.
- The stored HTML is sanitized at write time: `<script>` blocks and `on*` event attributes are stripped by default. A `jetpack_blaze_landing_page_allow_js` filter lets that policy be relaxed once a sandboxed render path is in place.
- New REST routes (signed-with-blog-token only): `POST /jetpack/v4/blaze/landing-pages`, `PUT /jetpack/v4/blaze/landing-pages/{slug}`, `DELETE /jetpack/v4/blaze/landing-pages/{slug}`.
- `Automattic\Jetpack\Blaze\Landing_Page_Dispatcher` listens for `jetpack_blaze_woo_product_promote_requested` and forwards a minimal payload via `wpcom_json_api_request_as_blog`.

### Gating (opt-in panel)

Renders only when **all** of these are true:

1. Site has the `blaze-featured-woocommerce-site` WPCOM site sticker. The `jetpack_blaze_featured_woocommerce_site` filter is exposed so self-hosted sites and tests can override.
2. WooCommerce is active.
3. `Blaze::should_initialize()['can_init']` returns true (Jetpack-connected, user connected, sync enabled, site eligible).

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No new tracking. One new post meta (`_jetpack_blaze_promote`) on `product` posts (written only when an authenticated admin saves the editor form). New CPT entries store HTML and three small post meta values (`_blaze_landing_product_id`, `_blaze_landing_mode`, `_blaze_landing_campaign_id`). The CPT is not surfaced in any merchant UI.

## Testing instructions

Requires a Jetpack-connected site with WooCommerce active.

### Opt-in panel

1. Force the sticker check on for local testing: `add_filter( 'jetpack_blaze_featured_woocommerce_site', '__return_true' );`
2. Go to **Products → Add new product**.
3. Verify the **Blaze Ads** panel appears between **Publish** and **Product image**. The checkbox is checked by default. The "more info" link toggles a help block.
4. Publish the product with the checkbox **checked** → the action fires once. Hook a listener to verify: `add_action( 'jetpack_blaze_woo_product_promote_requested', function ( $id, $post ) { error_log( "promote: $id" ); }, 10, 2 );`
5. Create another product, **uncheck** the checkbox, publish → the action must **not** fire. Meta `_jetpack_blaze_promote` should be falsy.
6. Re-saving a published opt-in product does **not** re-fire the action.

### Hidden landing-page CPT

1. Trigger an upsert through the new REST endpoint (the request must be signed as the blog):

   ```php
   $result = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
     '/sites/' . \Jetpack_Options::get_option( 'id' ) . '/blaze-landing-pages',
     '2',
     array( 'method' => 'POST' ),
     wp_json_encode( array(
       'mode'       => 'woocommerce',
       'product_id' => 123,
       'html'       => '<!doctype html><html><body><h1>hi</h1></body></html>',
     ) ),
     'wpcom'
   );
   ```

2. Confirm the response carries an `id`, `slug`, and `url`. Open the `url` in a browser and verify the raw HTML is served with no theme chrome and a `X-Robots-Tag: noindex, nofollow, noarchive` header.
3. POST again with the same `slug` → in-place update.
4. DELETE `/jetpack/v4/blaze/landing-pages/{slug}` → returns `{ "deleted": true }`.
5. Visit `/wp-admin` as the merchant: confirm the CPT does not appear in any menu, in `Posts → All Posts`, or in search.