### PR TITLE
wpcomsh: flip jetpack_podcast_untangle globally on Atomic

### DIFF
--- a/projects/packages/podcast/changelog/podcast-default-untangle-true
+++ b/projects/packages/podcast/changelog/podcast-default-untangle-true
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: default jetpack_podcast_untangle to true. The new package now owns the experience on every Simple and Atomic site by default; the filter stays as an escape hatch for forcing the legacy stack back on.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -114,24 +114,19 @@ class Podcast {
 	/**
 	 * Whether the Podcast untangle is enabled for the current request.
 	 *
-	 * Defaults to true for A8C-proxied requests so Automatticians dogfood
-	 * the new package; everyone else stays on the legacy stack until the
-	 * `jetpack_podcast_untangle` filter is flipped globally.
+	 * Defaults to true — the new package owns the experience on Simple
+	 * and Atomic. The filter remains as an escape hatch for forcing the
+	 * legacy stack back on (rollback, test fixtures, per-site overrides).
 	 */
 	public static function is_enabled() {
 		/**
 		 * Master switch for the Podcast untangle.
 		 *
-		 * While the legacy podcasting code is still the source of truth on
-		 * Simple and Atomic sites, this filter stays false for non-proxied
-		 * requests. Subsequent PRs layer the new wp-admin SPA, REST
-		 * integration, and feed customization on top of this gate.
-		 *
 		 * @since 0.1.0
 		 *
 		 * @param bool $enabled Whether to enable the new Podcast package.
 		 */
-		return (bool) apply_filters( 'jetpack_podcast_untangle', self::is_proxied_request() );
+		return (bool) apply_filters( 'jetpack_podcast_untangle', true );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/wpcomsh-podcast-untangle-global-flip
+++ b/projects/plugins/wpcomsh/changelog/wpcomsh-podcast-untangle-global-flip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcasting: flip jetpack_podcast_untangle globally on Atomic so every WoA site moves to the new jetpack-podcast package (parallel to the wpcom-side flip already live on Simple).

--- a/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
@@ -20,9 +20,13 @@ class WpcomshLoadedTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that any composer dependencies are loaded.
+	 *
+	 * The legacy at-pressable-podcasting vendor is intentionally gated by
+	 * `jetpack_podcast_untangle` and no longer loads when the gate is on
+	 * (which is now the default). The vendor still ships in vendor/ until
+	 * the Phase D cleanup; only the boot path is gated.
 	 */
 	public function test_composer_dependencies_loaded() {
-		$this->assertTrue( function_exists( 'automattic_podcasting_init' ), 'vendor/automattic/at-pressable-podcasting not loaded' );
 		$this->assertTrue( class_exists( 'Jetpack_Fonts' ), 'vendor/automattic/custom-fonts not loaded' );
 		$this->assertTrue( class_exists( 'Jetpack_Fonts_Typekit' ), 'vendor/automattic/custom-fonts-typekit not loaded' );
 		$this->assertTrue( function_exists( 'wpcom_media_video_styles' ), 'vendor/automattic/text-media-widget-styles not loaded' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -123,10 +123,10 @@ if ( is_readable( $jetpack_autoloader ) ) {
 	return;
 }
 /**
- * Atomic-side parallel of the wpcom-default-filters.php flip. Hands the
- * new automattic/jetpack-podcast package the experience on every WoA site
- * regardless of proxy state. The legacy at-pressable-podcasting stack
- * stands down via the gate below.
+ * Atomic-side safety net for the Podcast untangle. The package now defaults
+ * the gate to true on its own, so this filter is redundant in steady state —
+ * keep it as a belt-and-suspenders pin until the legacy
+ * at-pressable-podcasting vendor is removed in the Phase D cleanup.
  */
 add_filter( 'jetpack_podcast_untangle', '__return_true' );
 

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -122,6 +122,14 @@ if ( is_readable( $jetpack_autoloader ) ) {
 
 	return;
 }
+/**
+ * Atomic-side parallel of the wpcom-default-filters.php flip. Hands the
+ * new automattic/jetpack-podcast package the experience on every WoA site
+ * regardless of proxy state. The legacy at-pressable-podcasting stack
+ * stands down via the gate below.
+ */
+add_filter( 'jetpack_podcast_untangle', '__return_true' );
+
 if (
 	! class_exists( '\Automattic\Jetpack\Podcast\Podcast' )
 	|| ! \Automattic\Jetpack\Podcast\Podcast::is_enabled()


### PR DESCRIPTION
## Summary

Adds `add_filter('jetpack_podcast_untangle', '__return_true')` at wpcomsh bootstrap so every WoA site hands the experience to the new `@automattic/jetpack-podcast` package regardless of proxy state.

## Why a separate flip

The wpcom-side filter lives in `wp-content/mu-plugins/wpcom-default-filters.php`, which only loads on Simple sites. Atomic runs wpcomsh as the bootstrap and never sees that filter. Until this lands, `Podcast::is_enabled()` on Atomic defaults to `is_proxied_request()` — Automatticians on proxy see the new stack, every real visitor (and the site owner browsing wp-admin directly) still gets the legacy `at-pressable-podcasting` plugin.

## What changes when this deploys to Atomic

- wp-admin sidebar: 'Jetpack > Podcasting' (Calypso link) → 'Jetpack > Podcast' (new in-admin SPA).
- RSS feeds: produced by the new `Customize_Feed` (channel-tag cleanup already in trunk via #48968).
- Settings: same options, now read/written through the new `Settings::register()` + `/wp/v2/settings` exposure (Atomic-side; v1.x exposure remains via the wpcom-side filter for any cross-platform consumers).
- Tracks: continues with full parity.

## Rollback

Single-line revert restores the legacy stack atomically. The legacy `at-pressable-podcasting` plugin still ships with the wpcomsh vendor, so the only thing changing is which stack the gate routes to.

## Test plan

- [ ] On a Pressable/Atomic sandbox with this wpcomsh build deployed: `Jetpack > Podcast` opens the new SPA at `admin.php?page=jetpack-podcast`.
- [ ] Anonymous `curl` of the podcast RSS feed: `<itunes:*>` tags present, no `<image>` / `<cloud …/>` channel tags.
- [ ] As the site owner (non-proxied browse to wp-admin): confirm the new menu shows up (this is the case that was broken before this PR).