### PR TITLE
Base styles: Fix admin-page-layout header selector for admin-ui 2.1

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -206,8 +206,14 @@ $jp-breakpoint-mobile: 782px;
 	// admin-ui 2.0.0 moved internals to CSS Modules (no `.admin-ui-page*`
 	// class hooks anymore). We pass `className="jp-admin-page__page"` from
 	// <AdminPage>; admin-ui forwards it onto the page's outer node. The
-	// header is a stable `<header>` element directly inside that node, so
-	// we anchor to `> header` instead of a class.
+	// page's <Header> is always rendered as the first child of that node, so
+	// we anchor structurally to `> :first-child` instead of a class. We used
+	// to target `> header`, but @wordpress/admin-ui 2.1.0 (Gutenberg PR
+	// WordPress/gutenberg#78001, "Fix nested landmark in header") removed
+	// `render={ <header /> }` from the page header's Stack so the rendered
+	// element changed from `<header>` to `<div>`. `:first-child` matches
+	// regardless of element type, keeping us forward-compatible with 2.1+
+	// AND backward-compatible with 2.0's `<header>`.
 	.jp-admin-page__page {
 		flex: 1 1 auto;
 		min-height: 0;
@@ -216,7 +222,7 @@ $jp-breakpoint-mobile: 782px;
 		flex-direction: column;
 	}
 
-	.jp-admin-page__page > header {
+	.jp-admin-page__page > :first-child {
 		flex-shrink: 0;              // pinned at top of the flex column.
 	}
 
@@ -225,7 +231,7 @@ $jp-breakpoint-mobile: 782px;
 	// strip's own hairline becomes the only divider between header and tab
 	// content. Same `:has()` pattern used elsewhere in this mixin to react
 	// to the page's content shape.
-	.jp-admin-page__page:has(.jp-admin-page-tabs) > header {
+	.jp-admin-page__page:has(.jp-admin-page-tabs) > :first-child {
 		border-bottom: none;
 		padding-bottom: 0;
 	}

--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -259,7 +259,7 @@ $jp-breakpoint-mobile: 782px;
 	// fill their bounded slot. Form-style pages keep working: their
 	// children stay content-sized (default `flex: 0 1 auto`) and any
 	// overflow still falls back to Container's `overflow: auto`.
-	.jp-admin-page__page > :not(header):not(.jetpack-footer) {
+	.jp-admin-page__page > :not(:first-child):not(.jetpack-footer) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;

--- a/projects/js-packages/base-styles/changelog/fix-admin-page-layout-header-selector
+++ b/projects/js-packages/base-styles/changelog/fix-admin-page-layout-header-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Base styles: Update admin-page-layout mixin's header selector from `> header` to `> :first-child` so it keeps matching after @wordpress/admin-ui 2.1 changed the page header element from `<header>` to `<div>`.


### PR DESCRIPTION
Fixes header growing to fill the flex column on dashboards that adopted the shared `jetpack-admin-page-layout` mixin once `@wordpress/admin-ui` bumps to 2.1.x.

## Proposed changes

* Update `admin-page-layout.scss`'s two header-anchoring selectors from `.jp-admin-page__page > header` to `.jp-admin-page__page > :first-child`.
* Update the inline comment to document the new anchor and the upstream change it adapts to.

### Why

`@wordpress/admin-ui` 2.0.x rendered the `<Page>`'s header as a `<header>` element (via `render={ <header /> }` on the Stack). 2.1.0 removed that render prop — see Gutenberg PR [WordPress/gutenberg#78001 ("Fix nested landmark in header")](https://github.com/WordPress/gutenberg/pull/78001) — so the header is now a plain `<div>`. Verified locally against both versions resolved under `node_modules/.pnpm/`:

* `@wordpress/admin-ui@2.0.0` — `src/page/header.tsx` line 36: `render={ <header /> }`
* `@wordpress/admin-ui@2.1.0` — `src/page/header.tsx` line 58: no header `render` prop on the outer Stack

With the element change, our `> header` selector silently stops matching: the header loses `flex-shrink: 0` and grows to fill the flex column, and the tabs-strip flush-fit rule stops firing too.

### Why `:first-child`

admin-ui's `<Page>` always renders `<Header>` as the first child of the page wrapper (`src/page/index.tsx`). `> :first-child` is therefore stable across element changes inside `<Header>`'s render tree and works for both 2.0 (`<header>`) and 2.1+ (`<div>`). The CSS-Modules class hash on the new wrapper is not selector-stable, so structural selection is the only forward-compatible option.

### Context

This surfaced via Renovate PR #48404 (bundled `@wordpress/*` bump to 2.1.x). Without this change, dashboards using `<AdminPage>` (VideoPress, Search, Newsletter, Protect, etc.) show a header that grows to fill the flex column once they pull admin-ui 2.1+.

## Related product discussion/links

* Upstream cause: https://github.com/WordPress/gutenberg/pull/78001
* Trigger: Renovate PR #48404 (bundled `@wordpress/*` monorepo bump to 2.1.x).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is an SCSS-only change in a shared mixin. To verify functionally:

1. On a Jetpack environment with `@wordpress/admin-ui@2.1.x` installed, build a consumer of the mixin — for example:
   ```
   pnpm jetpack build packages/videopress packages/search
   ```
2. Open a dashboard that uses `<AdminPage>` (e.g. VideoPress, Search, Newsletter, Protect).
3. Before this change: the page header grows to fill the available flex column height. After this change: the header is pinned at its natural height at the top of the column, and the scrollable middle takes the remaining space (matching admin-ui 2.0 behaviour).
4. Repeat the check on a Jetpack environment still on `@wordpress/admin-ui@2.0.x` (e.g. trunk pre-Renovate) — the layout should be identical to before (`> :first-child` matches the `<header>` element just like `> header` did).
5. On a dashboard with a tabs strip (e.g. VideoPress), confirm the tabs strip still sits flush against the page header (the `:has(.jp-admin-page-tabs) > :first-child` rule still applies its `border-bottom: none; padding-bottom: 0`).
