### PR TITLE
Blaze: hidden landing-page CPT, REST endpoints, and dispatcher

### DIFF
--- a/projects/packages/blaze/changelog/add-landing-page-cpt
+++ b/projects/packages/blaze/changelog/add-landing-page-cpt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a hidden `blaze_landing_page` custom post type with random-slug public URLs and a server-to-server REST endpoint (`POST /jetpack/v4/blaze/landing-pages`) so AI-generated landing pages can be created from WPCOM/DSP without surfacing in any merchant UI.

--- a/projects/packages/blaze/changelog/add-landing-page-dispatcher
+++ b/projects/packages/blaze/changelog/add-landing-page-dispatcher
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forward the `jetpack_blaze_woo_product_promote_requested` event to a WPCOM internal endpoint via `wpcom_json_api_request_as_blog`, so DSP can enqueue a Blaze landing-page job when a merchant publishes a Woo product with the Promote-with-Blaze opt-in checked.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Blaze\Dashboard as Blaze_Dashboard;
 use Automattic\Jetpack\Blaze\Dashboard_REST_Controller as Blaze_Dashboard_REST_Controller;
+use Automattic\Jetpack\Blaze\Landing_Page_CPT;
+use Automattic\Jetpack\Blaze\Landing_Page_Dispatcher;
 use Automattic\Jetpack\Blaze\REST_Controller;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
@@ -59,6 +61,10 @@ class Blaze {
 		add_action( 'rest_api_init', array( new Blaze_Dashboard_REST_Controller(), 'register_rest_routes' ) );
 		// Add general Blaze REST API endpoints.
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+		// Hidden CPT used to host AI-generated landing pages for promoted products.
+		Landing_Page_CPT::init();
+		// Forward Woo product promote-requested events to WPCOM (DSP enqueue).
+		Landing_Page_Dispatcher::init();
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-landing-page-cpt.php
+++ b/projects/packages/blaze/src/class-landing-page-cpt.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Hidden CPT used to host AI-generated Blaze landing pages.
+ *
+ * The CPT is:
+ *  - not public (no archive, not in search, not in nav menus, no admin UI),
+ *  - publicly queryable (the random-slug URL works), and
+ *  - REST-enabled so DSP can create/update entries via the WPCOM proxy.
+ *
+ * Each landing page is a self-contained HTML document stored in
+ * `post_content`. When the public URL is hit, the theme is bypassed and
+ * the raw document is served verbatim.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use WP_Post;
+
+/**
+ * Blaze landing-page CPT.
+ */
+class Landing_Page_CPT {
+
+	const POST_TYPE  = 'blaze_landing_page';
+	const URL_PREFIX = 'blaze-lp';
+	const SLUG_BYTES = 16;
+
+	/**
+	 * Meta keys for landing-page metadata. Stored as post meta so the
+	 * post_content stays a clean HTML document.
+	 */
+	const META_PRODUCT_ID = '_blaze_landing_product_id';
+	const META_MODE       = '_blaze_landing_mode';
+	const META_CAMPAIGN   = '_blaze_landing_campaign_id';
+
+	/**
+	 * Wire hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'register' ) );
+		add_filter( 'template_include', array( __CLASS__, 'render_raw_document' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Register the CPT.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'              => array(
+					'name'          => __( 'Blaze Landing Pages', 'jetpack-blaze' ),
+					'singular_name' => __( 'Blaze Landing Page', 'jetpack-blaze' ),
+				),
+				'public'              => false,
+				'publicly_queryable'  => true,
+				'exclude_from_search' => true,
+				'show_ui'             => false,
+				'show_in_menu'        => false,
+				'show_in_nav_menus'   => false,
+				'show_in_admin_bar'   => false,
+				'show_in_rest'        => true,
+				'rest_base'           => 'blaze-landing-pages',
+				'rest_namespace'      => 'jetpack/v4',
+				'rewrite'             => array(
+					'slug'       => self::URL_PREFIX,
+					'with_front' => false,
+					'feeds'      => false,
+					'pages'      => false,
+				),
+				'has_archive'         => false,
+				'supports'            => array( 'title', 'editor', 'custom-fields' ),
+				'capability_type'     => 'post',
+				'map_meta_cap'        => true,
+				'delete_with_user'    => false,
+			)
+		);
+
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_PRODUCT_ID,
+			array(
+				'type'         => 'integer',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_MODE,
+			array(
+				'type'         => 'string',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_post_meta(
+			self::POST_TYPE,
+			self::META_CAMPAIGN,
+			array(
+				'type'         => 'integer',
+				'single'       => true,
+				'show_in_rest' => true,
+			)
+		);
+	}
+
+	/**
+	 * Bypass the theme on landing-page requests and emit the stored HTML.
+	 *
+	 * The stored `post_content` is a complete HTML document (or HTML
+	 * fragment). We send a minimal header/body wrapper only when the
+	 * content does not already include `<html>`.
+	 *
+	 * @param string $template Theme template that would otherwise load.
+	 * @return string|void
+	 */
+	public static function render_raw_document( $template ) {
+		if ( ! is_singular( self::POST_TYPE ) ) {
+			return $template;
+		}
+
+		$post = get_post();
+		if ( ! $post instanceof WP_Post || self::POST_TYPE !== $post->post_type ) {
+			return $template;
+		}
+
+		nocache_headers();
+		header( 'Content-Type: text/html; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex, nofollow, noarchive', true );
+
+		$content = (string) $post->post_content;
+		if ( stripos( $content, '<html' ) === false ) {
+			$content = self::wrap_fragment( $post->post_title, $content );
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content was sanitized at write time.
+		echo $content;
+		exit;
+	}
+
+	/**
+	 * Minimal HTML5 wrapper for HTML fragments (no theme, no admin bar).
+	 *
+	 * @param string $title   Document title.
+	 * @param string $content HTML fragment.
+	 * @return string Full HTML document.
+	 */
+	private static function wrap_fragment( $title, $content ) {
+		$lang = get_bloginfo( 'language' );
+		return sprintf(
+			'<!doctype html><html lang="%1$s"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>%2$s</title></head><body>%3$s</body></html>',
+			esc_attr( $lang ),
+			esc_html( $title ),
+			$content
+		);
+	}
+
+	/**
+	 * Sanitize an AI-generated HTML document before storing it.
+	 *
+	 * Default policy is "HTML + CSS, no JS". `<script>` blocks and `on*`
+	 * event attributes are removed. CSS in `<style>` and `style=""` is kept.
+	 *
+	 * The policy can be relaxed (e.g. for a sandboxed iframe variant) via
+	 * the `jetpack_blaze_landing_page_allow_js` filter.
+	 *
+	 * @param string $html Raw HTML.
+	 * @return string Sanitized HTML.
+	 */
+	public static function sanitize_html( $html ) {
+		$html = (string) $html;
+
+		/**
+		 * Whether to allow JavaScript in landing-page HTML.
+		 *
+		 * Default false. Flip to true once a sandboxed render path is in place.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $allow_js Whether to keep <script> and on* attributes.
+		 */
+		$allow_js = (bool) apply_filters( 'jetpack_blaze_landing_page_allow_js', false );
+		if ( $allow_js ) {
+			return $html;
+		}
+
+		// Strip script blocks entirely.
+		$html = preg_replace( '#<script\b[^>]*>.*?</script\s*>#is', '', $html );
+		$html = preg_replace( '#<script\b[^>]*/?>#is', '', (string) $html );
+		// Strip inline event handlers (on*="…" or on*='…' or on*=value).
+		$html = preg_replace( '#\son[a-z]+\s*=\s*"[^"]*"#i', '', (string) $html );
+		$html = preg_replace( "#\son[a-z]+\s*=\s*'[^']*'#i", '', (string) $html );
+		$html = preg_replace( '#\son[a-z]+\s*=\s*[^\s>]+#i', '', (string) $html );
+		// Strip javascript: URLs in href/src.
+		$html = preg_replace( '#(href|src)\s*=\s*(["\'])\s*javascript:[^"\']*\2#i', '$1=$2#$2', (string) $html );
+
+		return (string) $html;
+	}
+
+	/**
+	 * Generate a random URL-safe slug.
+	 *
+	 * @return string
+	 */
+	public static function generate_slug() {
+		$bytes = random_bytes( self::SLUG_BYTES );
+		// Base64-url, no padding.
+		return rtrim( strtr( base64_encode( $bytes ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Upsert a landing page.
+	 *
+	 * If `$slug` is provided and matches an existing landing-page post,
+	 * the post is updated. Otherwise a new one is created with a fresh
+	 * random slug.
+	 *
+	 * @param array $args {
+	 *     @type string $html        Required. AI-generated HTML.
+	 *     @type string $title       Optional. Defaults to product name.
+	 *     @type string $mode        Required. e.g. 'woocommerce'.
+	 *     @type int    $product_id  Required.
+	 *     @type int    $campaign_id Optional.
+	 *     @type string $slug        Optional. Existing slug to upsert.
+	 * }
+	 * @return array|\WP_Error { id, slug, url } or WP_Error.
+	 */
+	public static function upsert( array $args ) {
+		$html = isset( $args['html'] ) ? (string) $args['html'] : '';
+		if ( '' === $html ) {
+			return new \WP_Error( 'jetpack_blaze_landing_missing_html', __( 'Missing HTML payload.', 'jetpack-blaze' ) );
+		}
+		$mode       = isset( $args['mode'] ) ? sanitize_key( $args['mode'] ) : '';
+		$product_id = isset( $args['product_id'] ) ? (int) $args['product_id'] : 0;
+		if ( '' === $mode || 0 === $product_id ) {
+			return new \WP_Error( 'jetpack_blaze_landing_missing_meta', __( 'mode and product_id are required.', 'jetpack-blaze' ) );
+		}
+
+		$sanitized_html = self::sanitize_html( $html );
+		$title          = isset( $args['title'] ) && is_string( $args['title'] )
+			? sanitize_text_field( $args['title'] )
+			: sprintf( 'Blaze landing — product %d', $product_id );
+
+		$slug         = isset( $args['slug'] ) ? sanitize_title( $args['slug'] ) : '';
+		$existing_id  = 0;
+		if ( '' !== $slug ) {
+			$existing = get_page_by_path( $slug, OBJECT, self::POST_TYPE );
+			if ( $existing instanceof WP_Post ) {
+				$existing_id = (int) $existing->ID;
+			}
+		}
+
+		if ( '' === $slug ) {
+			$slug = self::generate_slug();
+		}
+
+		$postarr = array(
+			'post_type'    => self::POST_TYPE,
+			'post_status'  => 'publish',
+			'post_title'   => $title,
+			'post_name'    => $slug,
+			'post_content' => wp_slash( $sanitized_html ),
+		);
+
+		if ( $existing_id > 0 ) {
+			$postarr['ID'] = $existing_id;
+			$post_id       = wp_update_post( $postarr, true );
+		} else {
+			$post_id = wp_insert_post( $postarr, true );
+		}
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		update_post_meta( $post_id, self::META_MODE, $mode );
+		update_post_meta( $post_id, self::META_PRODUCT_ID, $product_id );
+		if ( ! empty( $args['campaign_id'] ) ) {
+			update_post_meta( $post_id, self::META_CAMPAIGN, (int) $args['campaign_id'] );
+		}
+
+		return array(
+			'id'   => (int) $post_id,
+			'slug' => $slug,
+			'url'  => get_permalink( $post_id ),
+		);
+	}
+
+	/**
+	 * Look up a landing page by its slug.
+	 *
+	 * @param string $slug Slug.
+	 * @return WP_Post|null
+	 */
+	public static function get_by_slug( $slug ) {
+		$slug = sanitize_title( (string) $slug );
+		if ( '' === $slug ) {
+			return null;
+		}
+		$post = get_page_by_path( $slug, OBJECT, self::POST_TYPE );
+		return $post instanceof WP_Post ? $post : null;
+	}
+
+	/**
+	 * Delete a landing page by slug.
+	 *
+	 * @param string $slug Slug.
+	 * @return bool
+	 */
+	public static function delete_by_slug( $slug ) {
+		$post = self::get_by_slug( $slug );
+		if ( null === $post ) {
+			return false;
+		}
+		return (bool) wp_delete_post( (int) $post->ID, true );
+	}
+}

--- a/projects/packages/blaze/src/class-landing-page-dispatcher.php
+++ b/projects/packages/blaze/src/class-landing-page-dispatcher.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Bridges the Woo opt-in hook to WPCOM, which in turn enqueues the
+ * landing-page creation job in DSP.
+ *
+ * Listens for `jetpack_blaze_woo_product_promote_requested` and POSTs
+ * a minimal payload to a WPCOM internal endpoint via the canonical
+ * `wpcom_json_api_request_as_blog` signed channel.
+ *
+ * The WPCOM endpoint itself ships separately (Phase 2 — see PR roadmap).
+ * Until that endpoint lands the call will 404; the dispatcher logs and
+ * swallows the error so it doesn't break the merchant publish flow.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
+use WP_Post;
+
+/**
+ * Dispatcher for Blaze landing-page jobs.
+ */
+class Landing_Page_Dispatcher {
+
+	const ENDPOINT_PATH = '/blaze/landing-pages/enqueue';
+	const API_VERSION   = '2';
+
+	/**
+	 * Wire hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action(
+			'jetpack_blaze_woo_product_promote_requested',
+			array( __CLASS__, 'dispatch' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Enqueue a landing-page job for the given product.
+	 *
+	 * @param int     $product_id Product ID.
+	 * @param WP_Post $product    Product post.
+	 * @return void
+	 */
+	public static function dispatch( $product_id, $product ) {
+		$payload = array(
+			'mode'       => 'woocommerce',
+			'product_id' => (int) $product_id,
+			'title'      => $product instanceof WP_Post ? (string) $product->post_title : '',
+		);
+
+		/**
+		 * Filter the payload sent to WPCOM when enqueueing a Blaze
+		 * landing-page job.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $payload    Payload that will be JSON-encoded.
+		 * @param int   $product_id Product ID.
+		 */
+		$payload = (array) apply_filters( 'jetpack_blaze_landing_dispatch_payload', $payload, (int) $product_id );
+
+		$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+			self::ENDPOINT_PATH,
+			self::API_VERSION,
+			array(
+				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json' ),
+			),
+			wp_json_encode( $payload ),
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			self::log( 'wp_error', $response->get_error_message(), $product_id );
+			return;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $code >= 200 && $code < 300 ) {
+			return;
+		}
+
+		self::log(
+			'http_' . $code,
+			(string) wp_remote_retrieve_body( $response ),
+			$product_id
+		);
+	}
+
+	/**
+	 * Log a dispatch failure. Uses error_log because Jetpack-blaze does
+	 * not currently ship a structured logger, and we want this visible in
+	 * `WP_DEBUG_LOG` without crashing the publish request.
+	 *
+	 * @param string $reason     Short reason code.
+	 * @param string $detail     Detail string.
+	 * @param int    $product_id Product ID.
+	 * @return void
+	 */
+	private static function log( $reason, $detail, $product_id ) {
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Best-effort debug logging guarded by WP_DEBUG.
+		error_log(
+			sprintf(
+				'[jetpack-blaze] landing-page dispatch failed (%s) for product %d: %s',
+				$reason,
+				(int) $product_id,
+				$detail
+			)
+		);
+	}
+}

--- a/projects/packages/blaze/src/class-rest-controller.php
+++ b/projects/packages/blaze/src/class-rest-controller.php
@@ -9,9 +9,12 @@
 namespace Automattic\Jetpack\Blaze;
 
 use Automattic\Jetpack\Blaze;
+use Automattic\Jetpack\Blaze\Landing_Page_CPT;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Status\Host;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**
@@ -56,6 +59,124 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'can_user_view_blaze_settings' ),
 			)
 		);
+
+		// Landing pages — server-to-server only, signed by WPCOM as blog.
+		register_rest_route(
+			static::$namespace,
+			'landing-pages',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'upsert_landing_page' ),
+				'permission_callback' => array( $this, 'can_wpcom_manage_landing_pages' ),
+				'args'                => self::landing_page_args(),
+			)
+		);
+		register_rest_route(
+			static::$namespace,
+			'landing-pages/(?P<slug>[A-Za-z0-9\-_]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'upsert_landing_page' ),
+					'permission_callback' => array( $this, 'can_wpcom_manage_landing_pages' ),
+					'args'                => self::landing_page_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_landing_page' ),
+					'permission_callback' => array( $this, 'can_wpcom_manage_landing_pages' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Argument schema for the landing-page upsert endpoints.
+	 *
+	 * @return array
+	 */
+	private static function landing_page_args() {
+		return array(
+			'html'        => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+			'title'       => array(
+				'type' => 'string',
+			),
+			'mode'        => array(
+				'type'     => 'string',
+				'enum'     => array( 'woocommerce' ),
+				'required' => true,
+			),
+			'product_id'  => array(
+				'type'     => 'integer',
+				'required' => true,
+			),
+			'campaign_id' => array(
+				'type' => 'integer',
+			),
+		);
+	}
+
+	/**
+	 * Permission check for landing-page mutations.
+	 *
+	 * The merchant site never grants UI access; only requests signed by
+	 * WPCOM as the blog (via `wpcom_json_api_request_as_blog`) are allowed.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function can_wpcom_manage_landing_pages() {
+		if ( Rest_Authentication::is_signed_with_blog_token() ) {
+			return true;
+		}
+		return $this->get_forbidden_error();
+	}
+
+	/**
+	 * Create or update a landing page.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function upsert_landing_page( WP_REST_Request $request ) {
+		$slug_from_url = $request->get_param( 'slug' );
+		$args          = array(
+			'html'        => (string) $request->get_param( 'html' ),
+			'title'       => (string) $request->get_param( 'title' ),
+			'mode'        => (string) $request->get_param( 'mode' ),
+			'product_id'  => (int) $request->get_param( 'product_id' ),
+			'campaign_id' => (int) $request->get_param( 'campaign_id' ),
+		);
+		if ( ! empty( $slug_from_url ) ) {
+			$args['slug'] = (string) $slug_from_url;
+		}
+
+		$result = Landing_Page_CPT::upsert( $args );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Delete a landing page by slug.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function delete_landing_page( WP_REST_Request $request ) {
+		$slug    = (string) $request->get_param( 'slug' );
+		$deleted = Landing_Page_CPT::delete_by_slug( $slug );
+		if ( ! $deleted ) {
+			return new WP_Error(
+				'jetpack_blaze_landing_not_found',
+				__( 'Landing page not found.', 'jetpack-blaze' ),
+				array( 'status' => 404 )
+			);
+		}
+		return rest_ensure_response( array( 'deleted' => true ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Adds a hidden `blaze_landing_page` custom post type used to host landing pages generated elsewhere, plus server-to-server REST endpoints so the generator can write the HTML back to the site.

- `Automattic\Jetpack\Blaze\Landing_Page_CPT` registers the CPT with `public=false`, `publicly_queryable=true`, `exclude_from_search=true`, `show_ui=false`. It serves the stored HTML via a `template_include` filter that bypasses the theme entirely and emits a `noindex,nofollow` header.
- The stored HTML is sanitized at write time: `<script>` blocks and `on*` event attributes are stripped by default. A `jetpack_blaze_landing_page_allow_js` filter lets that policy be relaxed once a sandboxed render path is in place.
- New REST routes (signed-with-blog-token only): `POST /jetpack/v4/blaze/landing-pages`, `PUT /jetpack/v4/blaze/landing-pages/{slug}`, `DELETE /jetpack/v4/blaze/landing-pages/{slug}`.
- `Automattic\Jetpack\Blaze\Landing_Page_Dispatcher` listens for `jetpack_blaze_woo_product_promote_requested` and forwards a minimal payload via `wpcom_json_api_request_as_blog` so generation can be enqueued elsewhere.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No new tracking. New CPT entries store HTML and three small post meta values (`_blaze_landing_product_id`, `_blaze_landing_mode`, `_blaze_landing_campaign_id`). The CPT is not surfaced in any merchant UI.

## Testing instructions

1. Trigger an upsert through the new REST endpoint (the request must be signed as the blog):

   ```php
   $result = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
     '/sites/' . \Jetpack_Options::get_option( 'id' ) . '/blaze-landing-pages',
     '2',
     array( 'method' => 'POST' ),
     wp_json_encode( array(
       'mode'       => 'woocommerce',
       'product_id' => 123,
       'html'       => '<!doctype html><html><body><h1>hi</h1></body></html>',
     ) ),
     'wpcom'
   );
   ```

2. Confirm the response carries an `id`, `slug`, and `url`. Open the `url` in a browser and verify the raw HTML is served with no theme chrome and a `X-Robots-Tag: noindex, nofollow, noarchive` header.
3. POST again with the same `slug` → in-place update.
4. DELETE `/jetpack/v4/blaze/landing-pages/{slug}` → returns `{ "deleted": true }`.
5. Visit `/wp-admin` as the merchant: confirm the CPT does not appear in any menu, in `Posts → All Posts`, or in search.
