### PR TITLE
ci: Set `maintenance.auto = false` for git 2.54.0

### DIFF
--- a/.github/actions/deepen-to-merge-base/action.yml
+++ b/.github/actions/deepen-to-merge-base/action.yml
@@ -27,6 +27,9 @@ runs:
         HEAD: ${{ inputs.head }}
         BRANCH: ${{ inputs.branch }}
       run: |
+        # See https://github.com/actions/checkout/issues/2437
+        git config --local maintenance.auto false
+
         depth=$DEPTH
         echo "::group::Initial fetch to $depth"
         echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth origin $HEAD $BRANCH"

--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -145,7 +145,7 @@ while IFS=$'\t' read -r SRC MIRROR SLUG; do
 
 	echo "::group::Initializing $SLUG"
 	git init -b "tmp" .
-	git config --local gc.auto 0
+	git config --local maintenance.auto false
 	git remote add origin "${GITHUB_SERVER_URL}/${MIRROR}"
 	if ! UPSTREAM_SHA=$( get_upstream_sha ); then
 		echo "::endgroup::"

--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-ci-git-garbage-collection
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-ci-git-garbage-collection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set `maintenance.auto` (instead of `gc.auto`) for compatibility with git 2.54.0. If for some reason you're still on git <2.30, you should upgrade that.

--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -24,7 +24,7 @@ function init_repo {
 	echo "::group::Initializing repo"
 	git init -q .
 	git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
-	git config --local gc.auto 0
+	git config --local maintenance.auto false
 	echo "::endgroup::"
 
 	echo "::group::Fetching tags"

--- a/projects/github-actions/push-to-mirrors/changelog/fix-ci-git-garbage-collection
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-ci-git-garbage-collection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set `maintenance.auto` (instead of `gc.auto`) for compatibility with git 2.54.0. If for some reason you're still on git <2.30, you should upgrade that.

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -157,7 +157,7 @@ while read -r GIT_SLUG; do
 
 	# Initialize the directory as a git repo, and set the remote
 	git init -b "$BRANCH" .
-	git config --local gc.auto 0
+	git config --local maintenance.auto false
 	git remote add origin "${GITHUB_SERVER_URL}/${GIT_SLUG}"
 	if [[ -n "$API_TOKEN_GITHUB" ]]; then
 		git config --local "http.${GITHUB_SERVER_URL}/.extraheader" "AUTHORIZATION: basic $(printf "x-access-token:%s" "$API_TOKEN_GITHUB" | base64 -w 0)"


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Git 2.54.0 changed the default garbage collection strategy from "gc" to "geometric", which has the side effect that setting `gc.auto = 0` to disable garbage collection in CI has no effect.

This updates three places that deal with checkouts to set `maintenance.auto` to `false` instead. We also temporarily do this in our deepen-to-merge-base action until actions/checkout fixes this upstream for its checkouts.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1779147785161169-slack-CDLH4C1UZ
https://github.com/actions/checkout/issues/2437

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* I suppose you could re-run something that uses deepen-to-merge-base several times and see if the error can no longer be reproduced.