### PR TITLE
Podcast: keep Pocket Casts show URL visible after modal reopen

### DIFF
--- a/projects/packages/podcast/changelog/podcast-pocketcasts-persist-show-url
+++ b/projects/packages/podcast/changelog/podcast-pocketcasts-persist-show-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: surface the Pocket Casts show URL in the submit modal after a reload, not just immediately after submission.

--- a/projects/packages/podcast/changelog/podcast-pocketcasts-persist-show-url
+++ b/projects/packages/podcast/changelog/podcast-pocketcasts-persist-show-url
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: surface the Pocket Casts show URL in the submit modal after a reload, not just immediately after submission.
+Podcast: Surface the Pocket Casts show URL in the submit modal after a reload, not just immediately after submission.

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -67,6 +67,12 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 	const liveState = result ? liveStateFromResult( result.state ) : null;
 	const effectiveState: PodcastShowState = liveState ?? storedState;
 
+	// Relay persists `share_link` to `podcasting_show_urls.pocketcasts` on
+	// active responses, so reopening the modal still has a URL even though
+	// `result` is null until the next submit.
+	const storedShareLink = settings?.podcasting_show_urls?.pocketcasts ?? '';
+	const effectiveShareLink = result?.share_link ?? storedShareLink;
+
 	const rejectionReasons = useMemo(
 		() => ( result?.state === 'rejected' ? extractRejectionReasons( result.pcc ) : [] ),
 		[ result ]
@@ -126,9 +132,9 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 					</Text>
 				) }
 
-				{ result?.state === 'active' && result.share_link && (
+				{ effectiveState === 'active' && effectiveShareLink && (
 					<Text as="p" variant="muted">
-						<ExternalLink href={ result.share_link }>
+						<ExternalLink href={ effectiveShareLink }>
 							{ __( 'View on Pocket Casts', 'jetpack-podcast' ) }
 						</ExternalLink>
 					</Text>


### PR DESCRIPTION
## Summary

The Pocket Casts submit modal renders the **View on Pocket Casts** link from the live submission response (`result.share_link`). The relay persists `podcasting_show_states.pocketcasts = 'active'`, so the button still reads **Submitted** after a reload. But `result` is `null` until the next submit, so the link disappears even though the feed is live.

This change falls back to `settings.podcasting_show_urls.pocketcasts` so the link stays visible whenever the effective state is `active`.

The paired wpcom relay change persists the `share_link` Pocket Casts returns into `podcasting_show_urls.pocketcasts` alongside the state save. Without that, the fallback is empty for current sites.

## Test plan

- [ ] Submit a fresh feed in the Pocket Casts modal. **View on Pocket Casts** still appears immediately (no regression of the live-result path).
- [ ] Reload the page (or close and reopen the modal) on a site whose Pocket Casts state is `active`. Link now persists.
- [ ] State is `pending`: no link rendered (PCC hasn't issued a `share_link` yet).
- [ ] State is `rejected` or `unreachable`: no link rendered, rejection notice still shows.

Generated with [Claude Code](https://claude.com/claude-code)
