### PR TITLE
VideoPress modernized dashboard: thumbnail editor on the Video details screen

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-modernized-thumbnail-edit
+++ b/projects/packages/videopress/changelog/add-videopress-modernized-thumbnail-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Modernized VideoPress dashboard: add a thumbnail editor to the Video details screen.

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -108,3 +108,92 @@
 		aspect-ratio: 16 / 9;
 	}
 }
+
+.vp-video-details__thumbnail-wrapper {
+	position: relative;
+	flex-shrink: 0;
+}
+
+.vp-thumbnail-update__trigger {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	background: rgba(0, 0, 0, 0.6);
+	color: #fff;
+	border-radius: 4px;
+
+	&:hover:not([disabled]) {
+		background: rgba(0, 0, 0, 0.8);
+	}
+}
+
+.vp-thumbnail-update__menu {
+	min-width: 200px;
+	padding: 4px;
+}
+
+.vp-video-details__thumbnail-updating {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.55);
+	color: #fff;
+	border-radius: 4px;
+}
+
+.vp-frame-scrubber {
+	position: relative;
+	width: 100%;
+
+	&:hover .vp-frame-scrubber__play {
+		opacity: 0;
+	}
+}
+
+.vp-frame-scrubber__video {
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	object-fit: cover;
+	background: #000;
+	display: block;
+}
+
+.vp-frame-scrubber__spinner {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.vp-frame-scrubber__play {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 80px;
+	height: 80px;
+	transform: translate(-50%, -50%);
+	color: #fff;
+	opacity: 0.85;
+	transition: opacity 0.2s ease-out;
+	pointer-events: none;
+}
+
+.vp-frame-scrubber__error {
+	padding: 32px;
+	text-align: center;
+	color: var(--jp-gray-50, #646970);
+}
+
+.vp-frame-scrubber__range {
+	margin-top: 12px;
+}
+
+@media (max-width: 600px) {
+
+	.vp-video-details__thumbnail-wrapper {
+		width: 100%;
+	}
+}

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -107,6 +107,10 @@
 		height: auto;
 		aspect-ratio: 16 / 9;
 	}
+
+	.vp-video-details__thumbnail-wrapper {
+		width: 100%;
+	}
 }
 
 .vp-video-details__thumbnail-wrapper {
@@ -135,6 +139,7 @@
 .vp-video-details__thumbnail-updating {
 	position: absolute;
 	inset: 0;
+	z-index: 1;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -189,11 +194,4 @@
 
 .vp-frame-scrubber__range {
 	margin-top: 12px;
-}
-
-@media (max-width: 600px) {
-
-	.vp-video-details__thumbnail-wrapper {
-		width: 100%;
-	}
 }

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -45,9 +45,8 @@
 }
 
 .vp-video-details__thumbnail {
-	width: 240px;
-	height: 135px;
-	object-fit: cover;
+	display: block;
+	max-width: 240px;
 	border-radius: 4px;
 	flex-shrink: 0;
 }
@@ -91,25 +90,14 @@
 }
 
 // Mobile: stack the Thumbnail card's two columns vertically. With the
-// thumbnail fixed at 240px and the meta column hosting full-width copy
-// fields + the primary action, anything narrower than ~600px squashes
-// the meta into a barely-readable strip. The thumbnail goes full-width
-// with a 16/9 aspect ratio so it stays the right shape for any column
-// width below the desktop layout.
+// meta column hosting full-width copy fields + the primary action,
+// anything narrower than ~600px squashes the meta into a barely-readable
+// strip. The thumbnail keeps its natural, width-capped size from the base
+// rule so it renders correctly for any aspect ratio.
 @media (max-width: 600px) {
 
 	.vp-video-details__thumbnail-row {
 		flex-direction: column !important;
-	}
-
-	.vp-video-details__thumbnail {
-		width: 100%;
-		height: auto;
-		aspect-ratio: 16 / 9;
-	}
-
-	.vp-video-details__thumbnail-wrapper {
-		width: 100%;
 	}
 }
 
@@ -122,18 +110,18 @@
 	position: absolute;
 	top: 8px;
 	right: 8px;
-	background: rgba(0, 0, 0, 0.6);
-	color: #fff;
-	border-radius: 4px;
-
-	&:hover:not([disabled]) {
-		background: rgba(0, 0, 0, 0.8);
-	}
 }
 
 .vp-thumbnail-update__menu {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 	min-width: 200px;
 	padding: 4px;
+
+	> button {
+		justify-content: flex-start;
+	}
 }
 
 .vp-video-details__thumbnail-updating {
@@ -151,18 +139,16 @@
 .vp-frame-scrubber {
 	position: relative;
 	width: 100%;
-
-	&:hover .vp-frame-scrubber__play {
-		opacity: 0;
-	}
 }
 
 .vp-frame-scrubber__video {
-	width: 100%;
-	aspect-ratio: 16 / 9;
-	object-fit: cover;
-	background: #000;
 	display: block;
+	max-width: 100%;
+	// Cap the height so portrait/vertical videos stay within the dialog
+	// instead of overflowing it. Landscape videos still fill the width.
+	max-height: 60vh;
+	margin-inline: auto;
+	background: #000;
 }
 
 .vp-frame-scrubber__spinner {
@@ -171,19 +157,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-}
-
-.vp-frame-scrubber__play {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	width: 80px;
-	height: 80px;
-	transform: translate(-50%, -50%);
-	color: #fff;
-	opacity: 0.85;
-	transition: opacity 0.2s ease-out;
-	pointer-events: none;
 }
 
 .vp-frame-scrubber__error {

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -106,21 +106,22 @@
 	flex-shrink: 0;
 }
 
+// The trigger is the @wordpress/components DropdownMenu wrapper; position it
+// over the thumbnail's top-right corner. Give the toggle button an opaque
+// surface so the pencil icon stays legible over any poster image (light or
+// dark), matching the solid affordance it had as a @wordpress/ui IconButton.
 .vp-thumbnail-update__trigger {
 	position: absolute;
 	top: 8px;
 	right: 8px;
-}
 
-.vp-thumbnail-update__menu {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	min-width: 200px;
-	padding: 4px;
+	.components-button {
+		background: rgba(255, 255, 255, 0.9);
+		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
 
-	> button {
-		justify-content: flex-start;
+		&:hover:not(:disabled) {
+			background: #fff;
+		}
 	}
 }
 

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -179,9 +179,14 @@ class Admin_UI {
 				wp_enqueue_style( 'jetpack-videopress-dashboard-shell' );
 			}
 
-			// Beyond the shell stylesheet, wp-build manages its own enqueue
-			// pipeline. The legacy script, initial state, tracking, and
-			// media-library bootstrap are all intentionally skipped for the
+			// The Video details screen's thumbnail editor opens the WordPress
+			// media library (via window.wp.media) for the "Upload image"
+			// action, so the media scripts must be present here too.
+			wp_enqueue_media();
+
+			// Beyond the shell stylesheet and the media library, wp-build
+			// manages its own enqueue pipeline. The legacy script, initial
+			// state, and tracking are all intentionally skipped for the
 			// wp-build dashboard.
 			return;
 		}

--- a/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
@@ -4,6 +4,25 @@ import { Icon, video } from '@wordpress/icons';
 import { Button, Dialog } from '@wordpress/ui';
 import { useEffect, useRef, useState, type ReactElement } from 'react';
 
+// Exported for unit testing.
+export const END_GUARD_SECONDS = 0.05;
+
+/**
+ * Convert a scrubbed time (seconds) to the millisecond `at_time` the poster
+ * endpoint expects, clamped into [0, duration - END_GUARD_SECONDS]. The upper
+ * guard mirrors the legacy behaviour: the VideoPress poster generator fails
+ * when the requested frame sits too close to the end of the media.
+ *
+ * @param seconds         - The scrubbed time in seconds.
+ * @param durationSeconds - The video's duration in seconds.
+ * @return The clamped timestamp in whole milliseconds.
+ */
+export function frameTimeToMs( seconds: number, durationSeconds: number ): number {
+	const upper = Math.max( 0, durationSeconds - END_GUARD_SECONDS );
+	const clamped = Math.min( Math.max( seconds, 0 ), upper );
+	return Math.round( clamped * 1000 );
+}
+
 type FrameScrubberProps = {
 	src: string;
 	onChange: ( ms: number | null ) => void;
@@ -45,7 +64,7 @@ function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
 		setMaxDuration( next );
 		const initial = next / 2;
 		setCurrentTime( initial );
-		onChange( Math.round( initial * 1000 ) );
+		onChange( frameTimeToMs( initial, next ) );
 	};
 
 	const handleRangeChange = ( v: number | undefined ) => {
@@ -53,7 +72,7 @@ function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
 			return;
 		}
 		setCurrentTime( v );
-		onChange( Math.round( v * 1000 ) );
+		onChange( frameTimeToMs( v, maxDuration ) );
 	};
 
 	if ( hasError ) {

--- a/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
@@ -1,6 +1,5 @@
 import { RangeControl, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, video } from '@wordpress/icons';
 import { Button, Dialog } from '@wordpress/ui';
 import { useEffect, useRef, useState, type ReactElement } from 'react';
 
@@ -25,7 +24,7 @@ export function frameTimeToMs( seconds: number, durationSeconds: number ): numbe
 
 type FrameScrubberProps = {
 	src: string;
-	onChange: ( ms: number | null ) => void;
+	onChange: ( ms: number ) => void;
 };
 
 /**
@@ -34,7 +33,7 @@ type FrameScrubberProps = {
  *
  * @param props          - Component props.
  * @param props.src      - Source URL of the video to scrub.
- * @param props.onChange - Called with the selected timestamp in milliseconds, or null when unset.
+ * @param props.onChange - Called with the selected timestamp in milliseconds.
  * @return The frame-scrubber element.
  */
 function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
@@ -50,11 +49,12 @@ function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
 		}
 	}, [ src ] );
 
-	useEffect( () => {
-		if ( videoRef.current && Number.isFinite( currentTime ) ) {
-			videoRef.current.currentTime = currentTime as number;
+	const seekTo = ( seconds: number ) => {
+		setCurrentTime( seconds );
+		if ( videoRef.current ) {
+			videoRef.current.currentTime = seconds;
 		}
-	}, [ currentTime ] );
+	};
 
 	const handleDurationChange = ( event: React.SyntheticEvent< HTMLVideoElement > ) => {
 		const next = event.currentTarget.duration;
@@ -62,16 +62,21 @@ function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
 			return;
 		}
 		setMaxDuration( next );
-		const initial = next / 2;
-		setCurrentTime( initial );
-		onChange( frameTimeToMs( initial, next ) );
+		// `durationchange` can fire more than once (adaptive sources update
+		// duration mid-stream). Seed the midpoint only on the first run so a
+		// later event doesn't snap the slider back and discard the user's pick.
+		if ( currentTime === null ) {
+			const initial = next / 2;
+			seekTo( initial );
+			onChange( frameTimeToMs( initial, next ) );
+		}
 	};
 
 	const handleRangeChange = ( v: number | undefined ) => {
 		if ( v === undefined ) {
 			return;
 		}
-		setCurrentTime( v );
+		seekTo( v );
 		onChange( frameTimeToMs( v, maxDuration ) );
 	};
 
@@ -90,7 +95,6 @@ function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
 					<Spinner />
 				</div>
 			) }
-			<Icon className="vp-frame-scrubber__play" icon={ video } />
 			<video
 				ref={ videoRef }
 				muted

--- a/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
@@ -1,0 +1,172 @@
+import { RangeControl, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, video } from '@wordpress/icons';
+import { Button, Dialog } from '@wordpress/ui';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+
+type FrameScrubberProps = {
+	src: string;
+	onChange: ( ms: number | null ) => void;
+};
+
+/**
+ * Internal component that renders a video element and a range slider
+ * so the user can scrub to any frame and pick it as a thumbnail.
+ *
+ * @param props          - Component props.
+ * @param props.src      - Source URL of the video to scrub.
+ * @param props.onChange - Called with the selected timestamp in milliseconds, or null when unset.
+ * @return The frame-scrubber element.
+ */
+function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
+	const videoRef = useRef< HTMLVideoElement >( null );
+	const [ maxDuration, setMaxDuration ] = useState< number >( 0 );
+	const [ currentTime, setCurrentTime ] = useState< number | null >( null );
+	const [ isLoading, setIsLoading ] = useState< boolean >( true );
+	const [ hasError, setHasError ] = useState< boolean >( false );
+
+	useEffect( () => {
+		if ( videoRef.current ) {
+			videoRef.current.src = src;
+		}
+	}, [ src ] );
+
+	useEffect( () => {
+		if ( videoRef.current && Number.isFinite( currentTime ) ) {
+			videoRef.current.currentTime = currentTime as number;
+		}
+	}, [ currentTime ] );
+
+	const handleDurationChange = ( event: React.SyntheticEvent< HTMLVideoElement > ) => {
+		const next = event.currentTarget.duration;
+		if ( ! Number.isFinite( next ) ) {
+			return;
+		}
+		setMaxDuration( next );
+		const initial = next / 2;
+		setCurrentTime( initial );
+		onChange( Math.round( initial * 1000 ) );
+	};
+
+	const handleRangeChange = ( v: number | undefined ) => {
+		if ( v === undefined ) {
+			return;
+		}
+		setCurrentTime( v );
+		onChange( Math.round( v * 1000 ) );
+	};
+
+	if ( hasError ) {
+		return (
+			<div className="vp-frame-scrubber vp-frame-scrubber__error">
+				{ __( "We couldn't load this video.", 'jetpack-videopress-pkg' ) }
+			</div>
+		);
+	}
+
+	return (
+		<div className="vp-frame-scrubber">
+			{ isLoading && (
+				<div className="vp-frame-scrubber__spinner">
+					<Spinner />
+				</div>
+			) }
+			<Icon className="vp-frame-scrubber__play" icon={ video } />
+			<video
+				ref={ videoRef }
+				muted
+				playsInline
+				className="vp-frame-scrubber__video"
+				onLoadedData={ () => setIsLoading( false ) }
+				onDurationChange={ handleDurationChange }
+				onError={ () => {
+					setHasError( true );
+					setIsLoading( false );
+				} }
+			/>
+			<RangeControl
+				className="vp-frame-scrubber__range"
+				min={ 0 }
+				max={ maxDuration }
+				step={ 0.1 }
+				value={ currentTime ?? 0 }
+				onChange={ handleRangeChange }
+				showTooltip={ false }
+				withInputField={ false }
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+			/>
+		</div>
+	);
+}
+
+type Props = {
+	src: string;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: ( atTimeMs: number ) => void;
+};
+
+/**
+ * Dialog that lets the user scrub through a video and pick a frame to use as
+ * the thumbnail. Purely presentational — no data fetching or mutation inside.
+ * The parent is responsible for firing the poster-update mutation via `onConfirm`.
+ *
+ * @param props           - Component props.
+ * @param props.src       - Source URL of the video to scrub.
+ * @param props.isOpen    - Whether the dialog is open.
+ * @param props.onClose   - Called when the user dismisses the dialog without confirming.
+ * @param props.onConfirm - Called with the selected timestamp in milliseconds when the user confirms.
+ * @return The dialog element.
+ */
+export default function SelectFrameDialog( {
+	src,
+	isOpen,
+	onClose,
+	onConfirm,
+}: Props ): ReactElement {
+	const [ selectedMs, setSelectedMs ] = useState< number | null >( null );
+
+	useEffect( () => {
+		if ( ! isOpen ) {
+			setSelectedMs( null );
+		}
+	}, [ isOpen ] );
+
+	return (
+		<Dialog.Root
+			open={ isOpen }
+			onOpenChange={ open => {
+				if ( ! open ) {
+					onClose();
+				}
+			} }
+		>
+			<Dialog.Popup size="large">
+				<Dialog.Header>
+					<Dialog.Title>
+						{ __( 'Select thumbnail from video', 'jetpack-videopress-pkg' ) }
+					</Dialog.Title>
+					<Dialog.CloseIcon label={ __( 'Close', 'jetpack-videopress-pkg' ) } />
+				</Dialog.Header>
+				{ isOpen && <FrameScrubber src={ src } onChange={ setSelectedMs } /> }
+				<Dialog.Footer>
+					<Dialog.Action render={ <Button variant="outline" /> }>
+						{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
+					</Dialog.Action>
+					<Button
+						variant="solid"
+						disabled={ selectedMs == null }
+						onClick={ () => {
+							if ( selectedMs != null ) {
+								onConfirm( selectedMs );
+							}
+						} }
+					>
+						{ __( 'Select this frame', 'jetpack-videopress-pkg' ) }
+					</Button>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/select-frame-dialog.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/select-frame-dialog.test.ts
@@ -1,0 +1,21 @@
+import { frameTimeToMs, END_GUARD_SECONDS } from '../select-frame-dialog';
+
+describe( 'frameTimeToMs', () => {
+	it( 'rounds seconds to whole milliseconds', () => {
+		expect( frameTimeToMs( 4.2, 60 ) ).toBe( 4200 );
+	} );
+
+	it( 'clamps to >= 0', () => {
+		expect( frameTimeToMs( -3, 60 ) ).toBe( 0 );
+	} );
+
+	it( 'clamps away from the very end of the video', () => {
+		// 60s video: max allowed is 60 - 0.05 = 59.95s => 59950ms.
+		expect( frameTimeToMs( 60, 60 ) ).toBe( ( 60 - END_GUARD_SECONDS ) * 1000 );
+		expect( frameTimeToMs( 59.99, 60 ) ).toBe( ( 60 - END_GUARD_SECONDS ) * 1000 );
+	} );
+
+	it( 'handles a zero/empty duration without going negative', () => {
+		expect( frameTimeToMs( 5, 0 ) ).toBe( 0 );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-card.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-card.test.tsx
@@ -84,20 +84,17 @@ function wrapper( { children }: { children: ReactNode } ) {
 	return createElement( QueryClientProvider, { client }, children );
 }
 
-/** Shorthand for accessing window as a plain object in tests. */
-const win = window as Record< string, unknown >;
-
 beforeEach( () => {
 	mockedApiFetch.mockReset();
 	mockedSelectImage.mockReset();
 	mockSuccessNotice.mockReset();
 	mockErrorNotice.mockReset();
 	// Provide window.wp.media so canUploadImage is true for upload-mode tests.
-	win.wp = { media: jest.fn() };
+	( window as unknown as { wp?: { media?: unknown } } ).wp = { media: jest.fn() };
 } );
 
 afterEach( () => {
-	delete win.wp;
+	delete ( window as unknown as { wp?: { media?: unknown } } ).wp;
 } );
 
 describe( 'ThumbnailCard — update flow', () => {

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-card.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-card.test.tsx
@@ -1,0 +1,189 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { selectImageFromMediaLibrary } from '../../../utils/select-image-from-media-library';
+import ThumbnailCard from '../thumbnail-card';
+import type { LibraryItem } from '../../../types/library';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+jest.mock( '../../../utils/select-image-from-media-library', () => ( {
+	selectImageFromMediaLibrary: jest.fn(),
+} ) );
+const mockedSelectImage = selectImageFromMediaLibrary as unknown as jest.Mock;
+
+jest.mock( '../select-frame-dialog', () => ( {
+	__esModule: true,
+	default: ( {
+		isOpen,
+		onClose,
+		onConfirm,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		onConfirm: ( ms: number ) => void;
+	} ) =>
+		isOpen ? (
+			<div data-testid="select-frame-dialog">
+				<button onClick={ () => onConfirm( 1500 ) }>confirm-frame</button>
+				<button onClick={ onClose }>close-frame</button>
+			</div>
+		) : null,
+} ) );
+
+// Variables referenced inside jest.mock() factories must be prefixed with "mock"
+// (case-insensitive) to satisfy Jest's babel-jest hoisting restrictions.
+const mockSuccessNotice = jest.fn();
+const mockErrorNotice = jest.fn();
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( {
+		createSuccessNotice: mockSuccessNotice,
+		createErrorNotice: mockErrorNotice,
+	} ),
+} ) );
+
+const baseVideo: LibraryItem = {
+	id: '42',
+	guid: 'abc123',
+	type: 'videopress',
+	title: 'My video',
+	filename: 'movie.mp4',
+	thumbnailUrl: 'https://example.test/poster.jpg',
+	durationSeconds: 60,
+	uploadDate: '2026-01-01T00:00:00',
+	privacy: 'public',
+	isPrivate: false,
+	fileSizeBytes: 0,
+	upload: { status: 'idle', progress: 0 },
+	description: '',
+	rating: 'G',
+	displayEmbed: true,
+	allowDownloads: false,
+	shortcode: '[videopress abc123]',
+	sourceUrl: 'https://example.test/movie.mp4',
+	isProcessing: false,
+};
+
+/**
+ * Minimal React Query wrapper for tests.
+ *
+ * @param root0          - Component props.
+ * @param root0.children - Child elements to render inside the provider.
+ * @return The QueryClientProvider element.
+ */
+function wrapper( { children }: { children: ReactNode } ) {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return createElement( QueryClientProvider, { client }, children );
+}
+
+/** Shorthand for accessing window as a plain object in tests. */
+const win = window as Record< string, unknown >;
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+	mockedSelectImage.mockReset();
+	mockSuccessNotice.mockReset();
+	mockErrorNotice.mockReset();
+	// Provide window.wp.media so canUploadImage is true for upload-mode tests.
+	win.wp = { media: jest.fn() };
+} );
+
+afterEach( () => {
+	delete win.wp;
+} );
+
+describe( 'ThumbnailCard — update flow', () => {
+	it( 'renders the Update thumbnail button when video is editable', () => {
+		render( <ThumbnailCard video={ baseVideo } onAddToNewPost={ jest.fn() } />, { wrapper } );
+		expect( screen.getByRole( 'button', { name: /update thumbnail/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the Update thumbnail button while the video is processing', () => {
+		render(
+			<ThumbnailCard video={ { ...baseVideo, isProcessing: true } } onAddToNewPost={ jest.fn() } />,
+			{ wrapper }
+		);
+		expect( screen.queryByRole( 'button', { name: /update thumbnail/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the Update thumbnail button for local (non-VideoPress) items', () => {
+		render(
+			<ThumbnailCard
+				video={ { ...baseVideo, type: 'local', guid: '' } }
+				onAddToNewPost={ jest.fn() }
+			/>,
+			{ wrapper }
+		);
+		expect( screen.queryByRole( 'button', { name: /update thumbnail/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'frame mode: fires the mutation with at_time + is_millisec, shows a success toast', async () => {
+		const user = userEvent.setup();
+		mockedApiFetch.mockResolvedValueOnce( {} );
+		render( <ThumbnailCard video={ baseVideo } onAddToNewPost={ jest.fn() } />, { wrapper } );
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: /select from video/i } ) );
+		await user.click( screen.getByText( 'confirm-frame' ) );
+
+		await waitFor( () =>
+			expect( mockedApiFetch ).toHaveBeenCalledWith( {
+				path: '/wpcom/v2/videopress/abc123/poster',
+				method: 'POST',
+				data: { at_time: 1500, is_millisec: true },
+			} )
+		);
+		await waitFor( () => expect( mockSuccessNotice ).toHaveBeenCalledTimes( 1 ) );
+		expect( mockErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'upload mode: fires the mutation with poster_attachment_id, shows a success toast', async () => {
+		const user = userEvent.setup();
+		mockedApiFetch.mockResolvedValueOnce( {} );
+		mockedSelectImage.mockResolvedValueOnce( { id: 17, url: 'x' } );
+		render( <ThumbnailCard video={ baseVideo } onAddToNewPost={ jest.fn() } />, { wrapper } );
+
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: /upload image/i } ) );
+
+		await waitFor( () =>
+			expect( mockedApiFetch ).toHaveBeenCalledWith( {
+				path: '/wpcom/v2/videopress/abc123/poster',
+				method: 'POST',
+				data: { poster_attachment_id: 17 },
+			} )
+		);
+		await waitFor( () => expect( mockSuccessNotice ).toHaveBeenCalledTimes( 1 ) );
+	} );
+
+	it( 'upload mode: no mutation when the user cancels the media library', async () => {
+		const user = userEvent.setup();
+		mockedSelectImage.mockResolvedValueOnce( null );
+		render( <ThumbnailCard video={ baseVideo } onAddToNewPost={ jest.fn() } />, { wrapper } );
+
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: /upload image/i } ) );
+
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
+		expect( mockSuccessNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows an error toast when the mutation fails', async () => {
+		const user = userEvent.setup();
+		mockedApiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
+		render( <ThumbnailCard video={ baseVideo } onAddToNewPost={ jest.fn() } />, { wrapper } );
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: /select from video/i } ) );
+		await user.click( screen.getByText( 'confirm-frame' ) );
+
+		await waitFor( () => expect( mockErrorNotice ).toHaveBeenCalledTimes( 1 ) );
+		expect( mockSuccessNotice ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-update-button.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-update-button.test.tsx
@@ -34,6 +34,9 @@ describe( 'ThumbnailUpdateButton', () => {
 		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
 		await user.click( screen.getByRole( 'menuitem', { name: /select from video/i } ) );
 		expect( onSelectFromVideo ).toHaveBeenCalledTimes( 1 );
+		expect(
+			screen.queryByRole( 'menuitem', { name: /select from video/i } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'fires onUploadImage when the matching item is clicked', async () => {
@@ -51,6 +54,7 @@ describe( 'ThumbnailUpdateButton', () => {
 		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
 		await user.click( screen.getByRole( 'menuitem', { name: /upload image/i } ) );
 		expect( onUploadImage ).toHaveBeenCalledTimes( 1 );
+		expect( screen.queryByRole( 'menuitem', { name: /upload image/i } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'disables Select from video when not allowed', async () => {
@@ -67,6 +71,21 @@ describe( 'ThumbnailUpdateButton', () => {
 		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
 		const item = screen.getByRole( 'menuitem', { name: /select from video/i } );
 		expect( item ).toBeDisabled();
+	} );
+
+	it( 'disables Upload image when not allowed', async () => {
+		const user = userEvent.setup();
+		render(
+			<ThumbnailUpdateButton
+				canSelectFromVideo
+				canUploadImage={ false }
+				isBusy={ false }
+				onSelectFromVideo={ jest.fn() }
+				onUploadImage={ jest.fn() }
+			/>
+		);
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		expect( screen.getByRole( 'menuitem', { name: /upload image/i } ) ).toBeDisabled();
 	} );
 
 	it( 'disables the trigger when busy', () => {

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-update-button.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-update-button.test.tsx
@@ -69,8 +69,10 @@ describe( 'ThumbnailUpdateButton', () => {
 			/>
 		);
 		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		// @wordpress/components MenuItem marks a disabled item with aria-disabled
+		// (keeping it focusable) rather than the native disabled attribute.
 		const item = screen.getByRole( 'menuitem', { name: /select from video/i } );
-		expect( item ).toBeDisabled();
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
 	it( 'disables Upload image when not allowed', async () => {
@@ -85,7 +87,10 @@ describe( 'ThumbnailUpdateButton', () => {
 			/>
 		);
 		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
-		expect( screen.getByRole( 'menuitem', { name: /upload image/i } ) ).toBeDisabled();
+		expect( screen.getByRole( 'menuitem', { name: /upload image/i } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 
 	it( 'disables the trigger when busy', () => {

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-update-button.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-update-button.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ThumbnailUpdateButton from '../thumbnail-update-button';
+
+describe( 'ThumbnailUpdateButton', () => {
+	it( 'opens a popover with both items on click', async () => {
+		const user = userEvent.setup();
+		render(
+			<ThumbnailUpdateButton
+				canSelectFromVideo
+				canUploadImage
+				isBusy={ false }
+				onSelectFromVideo={ jest.fn() }
+				onUploadImage={ jest.fn() }
+			/>
+		);
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		expect( screen.getByRole( 'menuitem', { name: /select from video/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'menuitem', { name: /upload image/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'fires onSelectFromVideo when the matching item is clicked', async () => {
+		const user = userEvent.setup();
+		const onSelectFromVideo = jest.fn();
+		render(
+			<ThumbnailUpdateButton
+				canSelectFromVideo
+				canUploadImage
+				isBusy={ false }
+				onSelectFromVideo={ onSelectFromVideo }
+				onUploadImage={ jest.fn() }
+			/>
+		);
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: /select from video/i } ) );
+		expect( onSelectFromVideo ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'fires onUploadImage when the matching item is clicked', async () => {
+		const user = userEvent.setup();
+		const onUploadImage = jest.fn();
+		render(
+			<ThumbnailUpdateButton
+				canSelectFromVideo
+				canUploadImage
+				isBusy={ false }
+				onSelectFromVideo={ jest.fn() }
+				onUploadImage={ onUploadImage }
+			/>
+		);
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: /upload image/i } ) );
+		expect( onUploadImage ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'disables Select from video when not allowed', async () => {
+		const user = userEvent.setup();
+		render(
+			<ThumbnailUpdateButton
+				canSelectFromVideo={ false }
+				canUploadImage
+				isBusy={ false }
+				onSelectFromVideo={ jest.fn() }
+				onUploadImage={ jest.fn() }
+			/>
+		);
+		await user.click( screen.getByRole( 'button', { name: /update thumbnail/i } ) );
+		const item = screen.getByRole( 'menuitem', { name: /select from video/i } );
+		expect( item ).toBeDisabled();
+	} );
+
+	it( 'disables the trigger when busy', () => {
+		render(
+			<ThumbnailUpdateButton
+				canSelectFromVideo
+				canUploadImage
+				isBusy
+				onSelectFromVideo={ jest.fn() }
+				onUploadImage={ jest.fn() }
+			/>
+		);
+		expect( screen.getByRole( 'button', { name: /update thumbnail/i } ) ).toBeDisabled();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
@@ -4,7 +4,7 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { copy } from '@wordpress/icons';
 import { Button, Card, IconButton, InputControl, Stack, Text } from '@wordpress/ui';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { usePosterUrl } from '../../hooks/use-poster-url';
 import { useUpdateVideoPoster } from '../../hooks/use-update-video-poster';
 import { selectImageFromMediaLibrary } from '../../utils/select-image-from-media-library';
@@ -19,6 +19,12 @@ type Props = {
 };
 
 const dateSettings = getDateSettings();
+
+// Upper bound on how long we keep showing "Updating…" while waiting for the
+// freshly generated poster <img> to load. The onLoad handler normally clears
+// it sooner; this just guarantees the overlay can't get stuck if onLoad never
+// fires (identical URL, cache hit, or a load error).
+const POSTER_CONFIRM_TIMEOUT_MS = 5000;
 
 const linkForVideo = ( video: LibraryItem ): string => {
 	const host = video.isPrivate ? 'video.wordpress.com' : 'videopress.com';
@@ -86,11 +92,47 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 	const updatePoster = useUpdateVideoPoster();
 	const [ dialogOpen, setDialogOpen ] = useState( false );
+	// True between a poster mutation resolving and the new thumbnail <img>
+	// actually loading. Keeps the "Updating…" overlay up and the success
+	// notice held back so the toast lines up with the visible change rather
+	// than firing a beat early (while the browser is still fetching the image).
+	const [ confirmingPoster, setConfirmingPoster ] = useState( false );
+
+	const finishUpdate = useCallback( () => {
+		setConfirmingPoster( false );
+		createSuccessNotice( __( 'Thumbnail updated.', 'jetpack-videopress-pkg' ) );
+	}, [ createSuccessNotice ] );
+
+	// Safety net: if onLoad never reports back (identical URL, cache hit with no
+	// event, or a load error) don't strand the UI in "Updating…".
+	useEffect( () => {
+		if ( ! confirmingPoster ) {
+			return;
+		}
+		const timer = setTimeout( finishUpdate, POSTER_CONFIRM_TIMEOUT_MS );
+		return () => clearTimeout( timer );
+	}, [ confirmingPoster, finishUpdate ] );
 
 	const notifyResult = {
-		onSuccess: () => createSuccessNotice( __( 'Thumbnail updated.', 'jetpack-videopress-pkg' ) ),
+		onSuccess: ( { poster }: { poster?: string } ) => {
+			// The mutation already wrote the new poster into the cache, so the
+			// <img> below is now pointing at it. Wait for that image to load
+			// before clearing the overlay and notifying. With no poster (e.g.
+			// generation polling exhausted) there's nothing to wait for.
+			if ( poster ) {
+				setConfirmingPoster( true );
+			} else {
+				finishUpdate();
+			}
+		},
 		onError: () =>
 			createErrorNotice( __( 'Failed to update thumbnail.', 'jetpack-videopress-pkg' ) ),
+	};
+
+	const confirmPosterLoad = () => {
+		if ( confirmingPoster ) {
+			finishUpdate();
+		}
 	};
 
 	const handleConfirmFrame = ( atTimeMs: number ) => {
@@ -121,6 +163,8 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 				width={ 240 }
 				height={ 135 }
 				className="vp-video-details__thumbnail"
+				onLoad={ confirmPosterLoad }
+				onError={ confirmPosterLoad }
 			/>
 		);
 	} else if ( video.isProcessing ) {
@@ -132,6 +176,7 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 	}
 
 	const showUpdateButton = canEditThumbnail( video );
+	const isUpdating = updatePoster.isPending || confirmingPoster;
 
 	return (
 		<Card.Root>
@@ -143,12 +188,12 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 							<ThumbnailUpdateButton
 								canSelectFromVideo={ Boolean( video.sourceUrl ) }
 								canUploadImage={ Boolean( window.wp?.media ) }
-								isBusy={ updatePoster.isPending }
+								isBusy={ isUpdating }
 								onSelectFromVideo={ () => setDialogOpen( true ) }
 								onUploadImage={ handleUploadImage }
 							/>
 						) }
-						{ updatePoster.isPending && (
+						{ isUpdating && (
 							<div className="vp-video-details__thumbnail-updating">
 								<Text>{ __( 'Updating…', 'jetpack-videopress-pkg' ) }</Text>
 							</div>

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
@@ -73,9 +73,7 @@ const canEditThumbnail = ( video: LibraryItem ): boolean =>
  * Top-of-page card on the Video details screen. Renders the thumbnail,
  * the "Add video to new post" outlined action, two read-only copy fields
  * (Link to video, Shortcode) using InputControl + IconButton suffix, and
- * two metadata rows (File name, Uploaded on). Also renders the
- * ThumbnailUpdateButton overlay and SelectFrameDialog for VideoPress items
- * that are not currently processing.
+ * two metadata rows (File name, Uploaded on).
  *
  * @param props                - Component props.
  * @param props.video          - The current video record.
@@ -144,7 +142,7 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 						{ showUpdateButton && (
 							<ThumbnailUpdateButton
 								canSelectFromVideo={ Boolean( video.sourceUrl ) }
-								canUploadImage={ typeof window !== 'undefined' && Boolean( window.wp?.media ) }
+								canUploadImage={ Boolean( window.wp?.media ) }
 								isBusy={ updatePoster.isPending }
 								onSelectFromVideo={ () => setDialogOpen( true ) }
 								onUploadImage={ handleUploadImage }

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
@@ -4,7 +4,12 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { copy } from '@wordpress/icons';
 import { Button, Card, IconButton, InputControl, Stack, Text } from '@wordpress/ui';
+import { useState } from 'react';
 import { usePosterUrl } from '../../hooks/use-poster-url';
+import { useUpdateVideoPoster } from '../../hooks/use-update-video-poster';
+import { selectImageFromMediaLibrary } from '../../utils/select-image-from-media-library';
+import SelectFrameDialog from './select-frame-dialog';
+import ThumbnailUpdateButton from './thumbnail-update-button';
 import type { LibraryItem } from '../../types/library';
 import type { ReactElement } from 'react';
 
@@ -61,11 +66,16 @@ const CopyIconButton = ( {
 	);
 };
 
+const canEditThumbnail = ( video: LibraryItem ): boolean =>
+	video.type === 'videopress' && ! video.isProcessing && Boolean( video.sourceUrl || video.guid );
+
 /**
  * Top-of-page card on the Video details screen. Renders the thumbnail,
  * the "Add video to new post" outlined action, two read-only copy fields
  * (Link to video, Shortcode) using InputControl + IconButton suffix, and
- * two metadata rows (File name, Uploaded on).
+ * two metadata rows (File name, Uploaded on). Also renders the
+ * ThumbnailUpdateButton overlay and SelectFrameDialog for VideoPress items
+ * that are not currently processing.
  *
  * @param props                - Component props.
  * @param props.video          - The current video record.
@@ -75,6 +85,34 @@ const CopyIconButton = ( {
 export default function ThumbnailCard( { video, onAddToNewPost }: Props ): ReactElement {
 	const link = linkForVideo( video );
 	const posterUrl = usePosterUrl( video );
+	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
+	const updatePoster = useUpdateVideoPoster();
+	const [ dialogOpen, setDialogOpen ] = useState( false );
+
+	const notifyResult = {
+		onSuccess: () => createSuccessNotice( __( 'Thumbnail updated.', 'jetpack-videopress-pkg' ) ),
+		onError: () =>
+			createErrorNotice( __( 'Failed to update thumbnail.', 'jetpack-videopress-pkg' ) ),
+	};
+
+	const handleConfirmFrame = ( atTimeMs: number ) => {
+		setDialogOpen( false );
+		updatePoster.mutate(
+			{ id: video.id, guid: video.guid, source: 'frame', atTimeMs },
+			notifyResult
+		);
+	};
+
+	const handleUploadImage = async () => {
+		const attachment = await selectImageFromMediaLibrary().catch( () => null );
+		if ( ! attachment ) {
+			return;
+		}
+		updatePoster.mutate(
+			{ id: video.id, guid: video.guid, source: 'attachment', attachmentId: attachment.id },
+			notifyResult
+		);
+	};
 
 	let thumbnail: ReactElement | null = null;
 	if ( posterUrl ) {
@@ -95,11 +133,29 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 		);
 	}
 
+	const showUpdateButton = canEditThumbnail( video );
+
 	return (
 		<Card.Root>
 			<Card.Content>
 				<Stack direction="row" gap="md" align="start" className="vp-video-details__thumbnail-row">
-					{ thumbnail }
+					<div className="vp-video-details__thumbnail-wrapper">
+						{ thumbnail }
+						{ showUpdateButton && (
+							<ThumbnailUpdateButton
+								canSelectFromVideo={ Boolean( video.sourceUrl ) }
+								canUploadImage={ typeof window !== 'undefined' && Boolean( window.wp?.media ) }
+								isBusy={ updatePoster.isPending }
+								onSelectFromVideo={ () => setDialogOpen( true ) }
+								onUploadImage={ handleUploadImage }
+							/>
+						) }
+						{ updatePoster.isPending && (
+							<div className="vp-video-details__thumbnail-updating">
+								<Text>{ __( 'Updating…', 'jetpack-videopress-pkg' ) }</Text>
+							</div>
+						) }
+					</div>
 					<Stack direction="column" gap="md" className="vp-video-details__thumbnail-meta">
 						<Button
 							variant="outline"
@@ -149,6 +205,12 @@ export default function ThumbnailCard( { video, onAddToNewPost }: Props ): React
 					</Stack>
 				</Stack>
 			</Card.Content>
+			<SelectFrameDialog
+				src={ video.sourceUrl ?? '' }
+				isOpen={ dialogOpen }
+				onClose={ () => setDialogOpen( false ) }
+				onConfirm={ handleConfirmFrame }
+			/>
 		</Card.Root>
 	);
 }

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
@@ -42,10 +42,13 @@ export default function ThumbnailUpdateButton( {
 			>
 				<Icon icon={ pencil } />
 			</Popover.Trigger>
-			<Popover.Popup className="vp-thumbnail-update__menu">
+			<Popover.Popup role="menu" className="vp-thumbnail-update__menu">
 				<VisuallyHidden>
 					<Popover.Title>{ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }</Popover.Title>
 				</VisuallyHidden>
+				{ /* focusableWhenDisabled={ false } sets the native disabled attribute so a
+				     disabled item leaves the tab order. There's no tooltip explaining the
+				     disabled state, so there's no value in keeping it focusable. */ }
 				<Button
 					role="menuitem"
 					variant="minimal"

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { cloud, Icon, media, pencil } from '@wordpress/icons';
-import { Button, Popover, VisuallyHidden } from '@wordpress/ui';
+import { Button, IconButton, Popover, VisuallyHidden } from '@wordpress/ui';
 import { useState, type ReactElement } from 'react';
 
 type Props = {
@@ -36,13 +36,21 @@ export default function ThumbnailUpdateButton( {
 	return (
 		<Popover.Root open={ open } onOpenChange={ setOpen }>
 			<Popover.Trigger
-				aria-label={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
 				disabled={ isBusy }
 				className="vp-thumbnail-update__trigger"
-			>
-				<Icon icon={ pencil } />
-			</Popover.Trigger>
+				render={
+					<IconButton
+						icon={ pencil }
+						label={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
+						size="compact"
+						tone="neutral"
+						variant="solid"
+						focusableWhenDisabled={ false }
+					/>
+				}
+			/>
 			<Popover.Popup role="menu" className="vp-thumbnail-update__menu">
+				<Popover.Arrow />
 				<VisuallyHidden>
 					<Popover.Title>{ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }</Popover.Title>
 				</VisuallyHidden>

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
@@ -1,7 +1,7 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { cloud, Icon, media, pencil } from '@wordpress/icons';
-import { Button, IconButton, Popover, VisuallyHidden } from '@wordpress/ui';
-import { useState, type ReactElement } from 'react';
+import { cloud, media, pencil } from '@wordpress/icons';
+import type { ReactElement } from 'react';
 
 type Props = {
 	canSelectFromVideo: boolean;
@@ -12,9 +12,12 @@ type Props = {
 };
 
 /**
- * Overlay button that opens a small popover menu with two actions:
- * "Select from video" and "Upload image". Intended to sit on top of the
- * video thumbnail inside ThumbnailCard so the user can update the poster.
+ * Overlay button that opens the thumbnail-update menu with two actions:
+ * "Select from video" and "Upload image". Uses the same `@wordpress/components`
+ * DropdownMenu as the page header's ⋯ menu so both menus share the design
+ * system's look — including MenuItem's default right-aligned icons. Sits on
+ * top of the video thumbnail inside ThumbnailCard via the
+ * `vp-thumbnail-update__trigger` class.
  *
  * @param props                    - Component props.
  * @param props.canSelectFromVideo - Whether the frame-picker action is available.
@@ -31,59 +34,37 @@ export default function ThumbnailUpdateButton( {
 	onSelectFromVideo,
 	onUploadImage,
 }: Props ): ReactElement {
-	const [ open, setOpen ] = useState( false );
-
 	return (
-		<Popover.Root open={ open } onOpenChange={ setOpen }>
-			<Popover.Trigger
-				disabled={ isBusy }
-				className="vp-thumbnail-update__trigger"
-				render={
-					<IconButton
-						icon={ pencil }
-						label={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
-						size="compact"
-						tone="neutral"
-						variant="solid"
-						focusableWhenDisabled={ false }
-					/>
-				}
-			/>
-			<Popover.Popup role="menu" className="vp-thumbnail-update__menu">
-				<Popover.Arrow />
-				<VisuallyHidden>
-					<Popover.Title>{ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }</Popover.Title>
-				</VisuallyHidden>
-				{ /* focusableWhenDisabled={ false } sets the native disabled attribute so a
-				     disabled item leaves the tab order. There's no tooltip explaining the
-				     disabled state, so there's no value in keeping it focusable. */ }
-				<Button
-					role="menuitem"
-					variant="minimal"
-					disabled={ ! canSelectFromVideo }
-					focusableWhenDisabled={ false }
-					onClick={ () => {
-						setOpen( false );
-						onSelectFromVideo();
-					} }
-				>
-					<Icon icon={ media } />
-					{ __( 'Select from video', 'jetpack-videopress-pkg' ) }
-				</Button>
-				<Button
-					role="menuitem"
-					variant="minimal"
-					disabled={ ! canUploadImage }
-					focusableWhenDisabled={ false }
-					onClick={ () => {
-						setOpen( false );
-						onUploadImage();
-					} }
-				>
-					<Icon icon={ cloud } />
-					{ __( 'Upload image', 'jetpack-videopress-pkg' ) }
-				</Button>
-			</Popover.Popup>
-		</Popover.Root>
+		<DropdownMenu
+			icon={ pencil }
+			label={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
+			className="vp-thumbnail-update__trigger"
+			toggleProps={ { size: 'compact', disabled: isBusy } }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					<MenuItem
+						icon={ media }
+						disabled={ ! canSelectFromVideo }
+						onClick={ () => {
+							onSelectFromVideo();
+							onClose();
+						} }
+					>
+						{ __( 'Select from video', 'jetpack-videopress-pkg' ) }
+					</MenuItem>
+					<MenuItem
+						icon={ cloud }
+						disabled={ ! canUploadImage }
+						onClick={ () => {
+							onUploadImage();
+							onClose();
+						} }
+					>
+						{ __( 'Upload image', 'jetpack-videopress-pkg' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
+		</DropdownMenu>
 	);
 }

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
@@ -1,0 +1,78 @@
+import { __ } from '@wordpress/i18n';
+import { cloud, Icon, media, pencil } from '@wordpress/icons';
+import { Button, Popover, VisuallyHidden } from '@wordpress/ui';
+import { useState, type ReactElement } from 'react';
+
+type Props = {
+	canSelectFromVideo: boolean;
+	canUploadImage: boolean;
+	isBusy: boolean;
+	onSelectFromVideo: () => void;
+	onUploadImage: () => void;
+};
+
+/**
+ * Overlay button that opens a small popover menu with two actions:
+ * "Select from video" and "Upload image". Intended to sit on top of the
+ * video thumbnail inside ThumbnailCard so the user can update the poster.
+ *
+ * @param props                    - Component props.
+ * @param props.canSelectFromVideo - Whether the frame-picker action is available.
+ * @param props.canUploadImage     - Whether the media-library upload action is available.
+ * @param props.isBusy             - When true, the trigger button is disabled.
+ * @param props.onSelectFromVideo  - Called when the user chooses "Select from video".
+ * @param props.onUploadImage      - Called when the user chooses "Upload image".
+ * @return The overlay button element.
+ */
+export default function ThumbnailUpdateButton( {
+	canSelectFromVideo,
+	canUploadImage,
+	isBusy,
+	onSelectFromVideo,
+	onUploadImage,
+}: Props ): ReactElement {
+	const [ open, setOpen ] = useState( false );
+
+	return (
+		<Popover.Root open={ open } onOpenChange={ setOpen }>
+			<Popover.Trigger
+				aria-label={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
+				disabled={ isBusy }
+				className="vp-thumbnail-update__trigger"
+			>
+				<Icon icon={ pencil } />
+			</Popover.Trigger>
+			<Popover.Popup className="vp-thumbnail-update__menu">
+				<VisuallyHidden>
+					<Popover.Title>{ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }</Popover.Title>
+				</VisuallyHidden>
+				<Button
+					role="menuitem"
+					variant="minimal"
+					disabled={ ! canSelectFromVideo }
+					focusableWhenDisabled={ false }
+					onClick={ () => {
+						setOpen( false );
+						onSelectFromVideo();
+					} }
+				>
+					<Icon icon={ media } />
+					{ __( 'Select from video', 'jetpack-videopress-pkg' ) }
+				</Button>
+				<Button
+					role="menuitem"
+					variant="minimal"
+					disabled={ ! canUploadImage }
+					focusableWhenDisabled={ false }
+					onClick={ () => {
+						setOpen( false );
+						onUploadImage();
+					} }
+				>
+					<Icon icon={ cloud } />
+					{ __( 'Upload image', 'jetpack-videopress-pkg' ) }
+				</Button>
+			</Popover.Popup>
+		</Popover.Root>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-poster.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-poster.test.ts
@@ -242,7 +242,7 @@ describe( 'useUpdateVideoPoster — setQueryData patches existing cached item on
 		expect( cached?.title ).toBe( 'My video' );
 	} );
 
-	it( 'does not call setQueryData if there is no pre-seeded item in the cache', async () => {
+	it( 'calls setQueryData but leaves the cache absent when no item is pre-seeded', async () => {
 		mockedApiFetch
 			.mockResolvedValueOnce( { data: { generating: false, poster: 'NEW_POSTER' } } )
 			.mockResolvedValueOnce( {} );
@@ -268,6 +268,104 @@ describe( 'useUpdateVideoPoster — setQueryData patches existing cached item on
 		// `old` (undefined), so the key stays absent.
 		const cached = client.getQueryData( [ LIBRARY_QUERY_KEY, 'item', '99' ] );
 		expect( cached ).toBeUndefined();
+	} );
+} );
+
+describe( 'useUpdateVideoPoster — poll exhaustion (max attempts reached)', () => {
+	it( 'does not POST meta or patch the cache when all polls return generating:true, but still invalidates the list', async () => {
+		jest.useFakeTimers();
+
+		// POST returns generating:true; every subsequent GET also returns generating:true.
+		mockedApiFetch.mockResolvedValueOnce( { data: { generating: true } } ); // POST /poster
+		for ( let i = 0; i < POSTER_POLL_MAX_ATTEMPTS; i++ ) {
+			mockedApiFetch.mockResolvedValueOnce( { data: { generating: true } } ); // GET poll
+		}
+
+		const { wrapper, invalidateSpy, setQueryDataSpy } = makeWrapper();
+		setQueryDataSpy.mockClear();
+
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		let mutationPromise: Promise< { poster?: string } >;
+		act( () => {
+			mutationPromise = result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 1000,
+			} );
+		} );
+
+		// Drive all POSTER_POLL_MAX_ATTEMPTS polls.
+		for ( let i = 0; i < POSTER_POLL_MAX_ATTEMPTS; i++ ) {
+			await act( async () => {
+				await jest.advanceTimersByTimeAsync( POSTER_POLL_INTERVAL_MS );
+			} );
+		}
+
+		// Let the mutation finish.
+		await act( async () => {
+			// @ts-expect-error — mutationPromise is assigned inside act above
+			await mutationPromise;
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		// The meta endpoint should never have been called.
+		const metaCalls = mockedApiFetch.mock.calls.filter(
+			( [ opts ] ) => opts?.path === '/wpcom/v2/videopress/meta'
+		);
+		expect( metaCalls ).toHaveLength( 0 );
+
+		// setQueryData should not have patched any thumbnail (no poster URL).
+		expect( setQueryDataSpy ).not.toHaveBeenCalled();
+
+		// The library list key should still be invalidated.
+		expect( invalidateSpy ).toHaveBeenCalledWith( {
+			queryKey: [ LIBRARY_QUERY_KEY ],
+		} );
+	} );
+} );
+
+describe( 'useUpdateVideoPoster — POST returns {} (no data field)', () => {
+	it( 'skips polling, skips meta POST, resolves successfully, and still invalidates the list', async () => {
+		// POST returns a bare {} — no data property at all.
+		mockedApiFetch.mockResolvedValueOnce( {} );
+
+		const { wrapper, invalidateSpy, setQueryDataSpy } = makeWrapper();
+		setQueryDataSpy.mockClear();
+		invalidateSpy.mockClear();
+
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 1000,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		// No GET poll should have occurred.
+		const getCalls = mockedApiFetch.mock.calls.filter( ( [ opts ] ) => opts?.method === 'GET' );
+		expect( getCalls ).toHaveLength( 0 );
+
+		// No meta POST should have occurred.
+		const metaCalls = mockedApiFetch.mock.calls.filter(
+			( [ opts ] ) => opts?.path === '/wpcom/v2/videopress/meta'
+		);
+		expect( metaCalls ).toHaveLength( 0 );
+
+		// setQueryData should not have been called (no poster to persist).
+		expect( setQueryDataSpy ).not.toHaveBeenCalled();
+
+		// The library list key should be invalidated regardless.
+		expect( invalidateSpy ).toHaveBeenCalledWith( {
+			queryKey: [ LIBRARY_QUERY_KEY ],
+		} );
 	} );
 } );
 

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-poster.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-poster.test.ts
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { LIBRARY_QUERY_KEY } from '../use-library';
+import { useUpdateVideoPoster } from '../use-update-video-poster';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * Create an isolated QueryClient, a spy on its invalidateQueries method, and a
+ * React wrapper component for renderHook.
+ *
+ * @return An object containing the wrapper component and the invalidateSpy.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const invalidateSpy = jest.spyOn( client, 'invalidateQueries' );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { wrapper, invalidateSpy };
+}
+
+describe( 'useUpdateVideoPoster', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+	} );
+
+	it( 'sends frame-mode POST body to the guid-scoped poster endpoint', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {} );
+		const { wrapper } = makeWrapper();
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 4200,
+			} );
+		} );
+
+		expect( mockedApiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/videopress/abc123/poster',
+			method: 'POST',
+			data: { at_time: 4200, is_millisec: true },
+		} );
+	} );
+
+	it( 'sends attachment-mode POST body', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {} );
+		const { wrapper } = makeWrapper();
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'attachment',
+				attachmentId: 17,
+			} );
+		} );
+
+		expect( mockedApiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/videopress/abc123/poster',
+			method: 'POST',
+			data: { poster_attachment_id: 17 },
+		} );
+	} );
+
+	it( 'invalidates the library and item query keys on success', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {} );
+		const { wrapper, invalidateSpy } = makeWrapper();
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 1000,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( invalidateSpy ).toHaveBeenCalledWith( {
+			queryKey: [ LIBRARY_QUERY_KEY ],
+		} );
+		expect( invalidateSpy ).toHaveBeenCalledWith( {
+			queryKey: [ LIBRARY_QUERY_KEY, 'item', '42' ],
+		} );
+	} );
+
+	it( 'does not invalidate on API error', async () => {
+		mockedApiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
+		const { wrapper, invalidateSpy } = makeWrapper();
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await expect(
+				result.current.mutateAsync( {
+					id: '42',
+					guid: 'abc123',
+					source: 'frame',
+					atTimeMs: 1000,
+				} )
+			).rejects.toThrow( 'boom' );
+		} );
+
+		expect( invalidateSpy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-poster.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-update-video-poster.test.ts
@@ -3,7 +3,11 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import { createElement, type ReactNode } from 'react';
 import { LIBRARY_QUERY_KEY } from '../use-library';
-import { useUpdateVideoPoster } from '../use-update-video-poster';
+import {
+	useUpdateVideoPoster,
+	POSTER_POLL_INTERVAL_MS,
+	POSTER_POLL_MAX_ATTEMPTS,
+} from '../use-update-video-poster';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
@@ -13,28 +17,39 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 const mockedApiFetch = apiFetch as unknown as jest.Mock;
 
 /**
- * Create an isolated QueryClient, a spy on its invalidateQueries method, and a
- * React wrapper component for renderHook.
+ * Create an isolated QueryClient, spies on its invalidateQueries and setQueryData
+ * methods, and a React wrapper component for renderHook.
  *
- * @return An object containing the wrapper component and the invalidateSpy.
+ * @return An object containing the client, wrapper component, invalidateSpy, and setQueryDataSpy.
  */
 function makeWrapper() {
 	const client = new QueryClient( {
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	} );
 	const invalidateSpy = jest.spyOn( client, 'invalidateQueries' );
+	const setQueryDataSpy = jest.spyOn( client, 'setQueryData' );
 	const wrapper = ( { children }: { children: ReactNode } ) =>
 		createElement( QueryClientProvider, { client }, children );
-	return { wrapper, invalidateSpy };
+	return { client, wrapper, invalidateSpy, setQueryDataSpy };
 }
 
-describe( 'useUpdateVideoPoster', () => {
-	beforeEach( () => {
-		mockedApiFetch.mockReset();
-	} );
+afterEach( () => {
+	jest.useRealTimers();
+	mockedApiFetch.mockReset();
+} );
 
+describe( 'useUpdateVideoPoster — exported constants', () => {
+	it( 'exports POSTER_POLL_INTERVAL_MS and POSTER_POLL_MAX_ATTEMPTS', () => {
+		expect( POSTER_POLL_INTERVAL_MS ).toBe( 2000 );
+		expect( POSTER_POLL_MAX_ATTEMPTS ).toBe( 30 );
+	} );
+} );
+
+describe( 'useUpdateVideoPoster — POST body', () => {
 	it( 'sends frame-mode POST body to the guid-scoped poster endpoint', async () => {
-		mockedApiFetch.mockResolvedValueOnce( {} );
+		mockedApiFetch.mockResolvedValueOnce( {
+			data: { generating: false, poster: 'https://x/scrubthumb-1.jpg' },
+		} );
 		const { wrapper } = makeWrapper();
 		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
 
@@ -55,7 +70,9 @@ describe( 'useUpdateVideoPoster', () => {
 	} );
 
 	it( 'sends attachment-mode POST body', async () => {
-		mockedApiFetch.mockResolvedValueOnce( {} );
+		mockedApiFetch.mockResolvedValueOnce( {
+			data: { generating: false, poster: 'https://x/scrubthumb-1.jpg' },
+		} );
 		const { wrapper } = makeWrapper();
 		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
 
@@ -74,10 +91,16 @@ describe( 'useUpdateVideoPoster', () => {
 			data: { poster_attachment_id: 17 },
 		} );
 	} );
+} );
 
-	it( 'invalidates the library and item query keys on success', async () => {
-		mockedApiFetch.mockResolvedValueOnce( {} );
-		const { wrapper, invalidateSpy } = makeWrapper();
+describe( 'useUpdateVideoPoster — immediate (no generating)', () => {
+	it( 'skips polling, persists meta, and updates the cache when generating is false', async () => {
+		// POST resolves immediately with no generation needed.
+		mockedApiFetch
+			.mockResolvedValueOnce( { data: { generating: false, poster: 'P1' } } ) // POST /poster
+			.mockResolvedValueOnce( {} ); // POST /meta
+
+		const { wrapper, invalidateSpy, setQueryDataSpy } = makeWrapper();
 		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
 
 		await act( async () => {
@@ -91,17 +114,171 @@ describe( 'useUpdateVideoPoster', () => {
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
+		// No GET poll should have happened.
+		const getCalls = mockedApiFetch.mock.calls.filter( ( [ opts ] ) => opts?.method === 'GET' );
+		expect( getCalls ).toHaveLength( 0 );
+
+		// Meta POST should have been called with the poster URL.
+		expect( mockedApiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/videopress/meta',
+			method: 'POST',
+			data: { id: 42, poster: 'P1' },
+		} );
+
+		// setQueryData should have updated the item's thumbnailUrl.
+		expect( setQueryDataSpy ).toHaveBeenCalledWith(
+			[ LIBRARY_QUERY_KEY, 'item', '42' ],
+			expect.any( Function )
+		);
+
+		// Library list should be invalidated.
 		expect( invalidateSpy ).toHaveBeenCalledWith( {
 			queryKey: [ LIBRARY_QUERY_KEY ],
 		} );
-		expect( invalidateSpy ).toHaveBeenCalledWith( {
+
+		// The item key should NOT have been separately invalidated.
+		expect( invalidateSpy ).not.toHaveBeenCalledWith( {
 			queryKey: [ LIBRARY_QUERY_KEY, 'item', '42' ],
 		} );
 	} );
+} );
 
-	it( 'does not invalidate on API error', async () => {
+describe( 'useUpdateVideoPoster — polling until generated', () => {
+	it( 'polls the GET endpoint and persists the final poster URL', async () => {
+		jest.useFakeTimers();
+
+		// POST returns generating:true, then two GETs: first still generating,
+		// second returns the final poster URL.
+		mockedApiFetch
+			.mockResolvedValueOnce( { data: { generating: true } } ) // POST /poster
+			.mockResolvedValueOnce( { data: { generating: true } } ) // GET poll 1
+			.mockResolvedValueOnce( { data: { generating: false, poster: 'P2' } } ) // GET poll 2
+			.mockResolvedValueOnce( {} ); // POST /meta
+
+		const { wrapper, setQueryDataSpy } = makeWrapper();
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		let mutationPromise: Promise< { poster?: string } >;
+		act( () => {
+			mutationPromise = result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 1000,
+			} );
+		} );
+
+		// Advance past the first sleep (triggers poll 1 → still generating).
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( POSTER_POLL_INTERVAL_MS );
+		} );
+
+		// Advance past the second sleep (triggers poll 2 → done).
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( POSTER_POLL_INTERVAL_MS );
+		} );
+
+		// Let the meta POST and onSuccess run.
+		await act( async () => {
+			// @ts-expect-error — mutationPromise is assigned inside act above
+			await mutationPromise;
+		} );
+
+		// GET calls should have been made.
+		const getCalls = mockedApiFetch.mock.calls.filter( ( [ opts ] ) => opts?.method === 'GET' );
+		expect( getCalls ).toHaveLength( 2 );
+		expect( getCalls[ 0 ][ 0 ] ).toMatchObject( {
+			path: '/wpcom/v2/videopress/abc123/poster',
+			method: 'GET',
+		} );
+
+		// Meta POST should reference the final poster.
+		expect( mockedApiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/videopress/meta',
+			method: 'POST',
+			data: { id: 42, poster: 'P2' },
+		} );
+
+		// setQueryData should have updated thumbnailUrl to P2.
+		expect( setQueryDataSpy ).toHaveBeenCalledWith(
+			[ LIBRARY_QUERY_KEY, 'item', '42' ],
+			expect.any( Function )
+		);
+	} );
+} );
+
+describe( 'useUpdateVideoPoster — setQueryData patches existing cached item only', () => {
+	it( 'updates thumbnailUrl and preserves other fields in a pre-seeded cache entry', async () => {
+		mockedApiFetch
+			.mockResolvedValueOnce( { data: { generating: false, poster: 'NEW_POSTER' } } ) // POST /poster
+			.mockResolvedValueOnce( {} ); // POST /meta
+
+		const { client, wrapper } = makeWrapper();
+
+		// Pre-seed a minimal cached item.
+		const seedItem = { id: '42', thumbnailUrl: 'OLD', title: 'My video', isPrivate: false };
+		client.setQueryData( [ LIBRARY_QUERY_KEY, 'item', '42' ], seedItem );
+
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: '42',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 500,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		const cached = client.getQueryData< { thumbnailUrl: string; title: string } >( [
+			LIBRARY_QUERY_KEY,
+			'item',
+			'42',
+		] );
+		expect( cached?.thumbnailUrl ).toBe( 'NEW_POSTER' );
+		// Other fields are preserved.
+		expect( cached?.title ).toBe( 'My video' );
+	} );
+
+	it( 'does not call setQueryData if there is no pre-seeded item in the cache', async () => {
+		mockedApiFetch
+			.mockResolvedValueOnce( { data: { generating: false, poster: 'NEW_POSTER' } } )
+			.mockResolvedValueOnce( {} );
+
+		const { client, wrapper, setQueryDataSpy } = makeWrapper();
+		// Clear spy counts from construction.
+		setQueryDataSpy.mockClear();
+
+		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				id: '99',
+				guid: 'abc123',
+				source: 'frame',
+				atTimeMs: 500,
+			} );
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		// setQueryData was called but with no existing entry, the updater returns
+		// `old` (undefined), so the key stays absent.
+		const cached = client.getQueryData( [ LIBRARY_QUERY_KEY, 'item', '99' ] );
+		expect( cached ).toBeUndefined();
+	} );
+} );
+
+describe( 'useUpdateVideoPoster — error path', () => {
+	it( 'rejects and does not call setQueryData or invalidate on API error', async () => {
 		mockedApiFetch.mockRejectedValueOnce( new Error( 'boom' ) );
-		const { wrapper, invalidateSpy } = makeWrapper();
+		const { wrapper, invalidateSpy, setQueryDataSpy } = makeWrapper();
+		// Clear spy counts from construction.
+		invalidateSpy.mockClear();
+		setQueryDataSpy.mockClear();
+
 		const { result } = renderHook( () => useUpdateVideoPoster(), { wrapper } );
 
 		await act( async () => {
@@ -115,6 +292,7 @@ describe( 'useUpdateVideoPoster', () => {
 			).rejects.toThrow( 'boom' );
 		} );
 
+		expect( setQueryDataSpy ).not.toHaveBeenCalled();
 		expect( invalidateSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/hooks/use-update-video-poster.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-update-video-poster.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import { LIBRARY_QUERY_KEY } from './use-library';
+
+export type UpdatePosterVars =
+	| { id: string; guid: string; source: 'frame'; atTimeMs: number }
+	| { id: string; guid: string; source: 'attachment'; attachmentId: number };
+
+/**
+ * Build the POST body for the /poster endpoint from caller-supplied vars.
+ *
+ * @param vars - Discriminated union describing the poster source and its required fields.
+ * @return A plain object ready to pass as the `data` argument to apiFetch.
+ */
+function buildBody( vars: UpdatePosterVars ) {
+	if ( vars.source === 'frame' ) {
+		return { at_time: vars.atTimeMs, is_millisec: true };
+	}
+	return { poster_attachment_id: vars.attachmentId };
+}
+
+/**
+ * Return a TanStack Query mutation that POSTs a poster update to the
+ * /wpcom/v2/videopress/{guid}/poster endpoint and invalidates the library
+ * cache on success.
+ *
+ * @return A TanStack Query UseMutationResult for UpdatePosterVars.
+ */
+export function useUpdateVideoPoster() {
+	const client = useQueryClient();
+	return useMutation< unknown, Error, UpdatePosterVars >( {
+		mutationFn: async vars => {
+			return apiFetch( {
+				path: `/wpcom/v2/videopress/${ vars.guid }/poster`,
+				method: 'POST',
+				data: buildBody( vars ),
+			} );
+		},
+		onSuccess: ( _data, vars ) => {
+			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+			client.invalidateQueries( {
+				queryKey: [ LIBRARY_QUERY_KEY, 'item', String( vars.id ) ],
+			} );
+		},
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-update-video-poster.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-update-video-poster.ts
@@ -1,10 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { LIBRARY_QUERY_KEY } from './use-library';
+import type { LibraryItem } from '../types/library';
 
 export type UpdatePosterVars =
 	| { id: string; guid: string; source: 'frame'; atTimeMs: number }
 	| { id: string; guid: string; source: 'attachment'; attachmentId: number };
+
+/** Milliseconds between each poll of the poster-generation status endpoint. */
+export const POSTER_POLL_INTERVAL_MS = 2000;
+
+/** Maximum number of GET polls before giving up on poster generation. */
+export const POSTER_POLL_MAX_ATTEMPTS = 30;
+
+const sleep = ( ms: number ) => new Promise( resolve => setTimeout( resolve, ms ) );
 
 /**
  * Build the POST body for the /poster endpoint from caller-supplied vars.
@@ -19,28 +28,76 @@ function buildBody( vars: UpdatePosterVars ) {
 	return { poster_attachment_id: vars.attachmentId };
 }
 
+type PosterApiResponse = {
+	data?: {
+		generating?: boolean;
+		poster?: string;
+	};
+};
+
 /**
- * Return a TanStack Query mutation that POSTs a poster update to the
- * /wpcom/v2/videopress/{guid}/poster endpoint and invalidates the library
- * cache on success.
+ * POST the poster update, then poll until server-side generation completes,
+ * and persist the final poster URL to the video meta.
+ *
+ * @param vars - The mutation variables (guid, id, and poster source details).
+ * @return An object containing the final poster URL, or undefined if generation did not complete.
+ */
+async function mutationFn( vars: UpdatePosterVars ): Promise< { poster?: string } > {
+	const postResp = ( await apiFetch( {
+		path: `/wpcom/v2/videopress/${ vars.guid }/poster`,
+		method: 'POST',
+		data: buildBody( vars ),
+	} ) ) as PosterApiResponse;
+
+	let generating = postResp?.data?.generating;
+	let poster = postResp?.data?.poster;
+
+	if ( generating ) {
+		for ( let attempt = 0; attempt < POSTER_POLL_MAX_ATTEMPTS; attempt++ ) {
+			await sleep( POSTER_POLL_INTERVAL_MS );
+			const pollResp = ( await apiFetch( {
+				path: `/wpcom/v2/videopress/${ vars.guid }/poster`,
+				method: 'GET',
+			} ) ) as PosterApiResponse;
+			generating = pollResp?.data?.generating;
+			poster = pollResp?.data?.poster;
+			if ( ! generating ) {
+				break;
+			}
+		}
+	}
+
+	if ( poster ) {
+		await apiFetch( {
+			path: '/wpcom/v2/videopress/meta',
+			method: 'POST',
+			data: { id: Number( vars.id ), poster },
+		} );
+	}
+
+	return { poster };
+}
+
+/**
+ * Return a TanStack Query mutation that POSTs a poster update, polls until
+ * server-side generation completes, persists the final URL to video meta, and
+ * updates the cached item directly so the UI reflects the new poster without
+ * an extra refetch.
  *
  * @return A TanStack Query UseMutationResult for UpdatePosterVars.
  */
 export function useUpdateVideoPoster() {
 	const client = useQueryClient();
-	return useMutation< unknown, Error, UpdatePosterVars >( {
-		mutationFn: async vars => {
-			return apiFetch( {
-				path: `/wpcom/v2/videopress/${ vars.guid }/poster`,
-				method: 'POST',
-				data: buildBody( vars ),
-			} );
-		},
-		onSuccess: ( _data, vars ) => {
+	return useMutation< { poster?: string }, Error, UpdatePosterVars >( {
+		mutationFn,
+		onSuccess: ( { poster }, vars ) => {
+			if ( poster ) {
+				client.setQueryData(
+					[ LIBRARY_QUERY_KEY, 'item', String( vars.id ) ],
+					( old: LibraryItem | undefined ) => ( old ? { ...old, thumbnailUrl: poster } : old )
+				);
+			}
 			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
-			client.invalidateQueries( {
-				queryKey: [ LIBRARY_QUERY_KEY, 'item', String( vars.id ) ],
-			} );
 		},
 	} );
 }

--- a/projects/packages/videopress/src/dashboard/utils/select-image-from-media-library.ts
+++ b/projects/packages/videopress/src/dashboard/utils/select-image-from-media-library.ts
@@ -1,0 +1,61 @@
+import { __ } from '@wordpress/i18n';
+
+type Attachment = { id: number; url: string };
+
+type MediaFrame = {
+	state: () => { get: ( k: string ) => { first: () => { toJSON: () => Attachment } } };
+	on: ( evt: 'select' | 'close', fn: () => void ) => void;
+	open: () => void;
+};
+
+declare global {
+	interface Window {
+		wp?: {
+			media?: ( opts: {
+				title: string;
+				multiple: boolean;
+				library: { type: string };
+				button: { text: string };
+			} ) => MediaFrame;
+		};
+	}
+}
+
+/**
+ * Open the WordPress media library picker and prompt the user to select a
+ * single image. Resolves with the chosen attachment's `id` and `url`, or
+ * `null` when the user dismisses the dialog without making a selection.
+ * Rejects if `window.wp.media` is unavailable (i.e. the classic-editor media
+ * library script has not been enqueued).
+ *
+ * @return A Promise that resolves to the selected `{ id, url }` attachment, or `null` if the user closed the frame without selecting.
+ */
+export async function selectImageFromMediaLibrary(): Promise< Attachment | null > {
+	if ( ! window.wp?.media ) {
+		throw new Error( 'wp.media is not available' );
+	}
+	const frame = window.wp.media( {
+		title: __( 'Select thumbnail', 'jetpack-videopress-pkg' ),
+		multiple: false,
+		library: { type: 'image' },
+		button: { text: __( 'Use this image as thumbnail', 'jetpack-videopress-pkg' ) },
+	} );
+
+	return new Promise( resolve => {
+		let resolved = false;
+		frame.on( 'select', () => {
+			resolved = true;
+			const sel = frame.state().get( 'selection' ).first().toJSON();
+			resolve( { id: sel.id, url: sel.url } );
+		} );
+		frame.on( 'close', () => {
+			// `close` fires after `select` on confirm — defer so `select` resolves first.
+			setTimeout( () => {
+				if ( ! resolved ) {
+					resolve( null );
+				}
+			}, 0 );
+		} );
+		frame.open();
+	} );
+}

--- a/projects/packages/videopress/src/dashboard/utils/select-image-from-media-library.ts
+++ b/projects/packages/videopress/src/dashboard/utils/select-image-from-media-library.ts
@@ -8,19 +8,6 @@ type MediaFrame = {
 	open: () => void;
 };
 
-declare global {
-	interface Window {
-		wp?: {
-			media?: ( opts: {
-				title: string;
-				multiple: boolean;
-				library: { type: string };
-				button: { text: string };
-			} ) => MediaFrame;
-		};
-	}
-}
-
 /**
  * Open the WordPress media library picker and prompt the user to select a
  * single image. Resolves with the chosen attachment's `id` and `url`, or
@@ -31,10 +18,19 @@ declare global {
  * @return A Promise that resolves to the selected `{ id, url }` attachment, or `null` if the user closed the frame without selecting.
  */
 export async function selectImageFromMediaLibrary(): Promise< Attachment | null > {
-	if ( ! window.wp?.media ) {
+	const mediaFactory = window.wp?.media as
+		| ( ( opts: {
+				title: string;
+				multiple: boolean;
+				library: { type: string };
+				button: { text: string };
+		  } ) => MediaFrame )
+		| undefined;
+
+	if ( ! mediaFactory ) {
 		throw new Error( 'wp.media is not available' );
 	}
-	const frame = window.wp.media( {
+	const frame = mediaFactory( {
 		title: __( 'Select thumbnail', 'jetpack-videopress-pkg' ),
 		multiple: false,
 		library: { type: 'image' },

--- a/projects/packages/videopress/src/dashboard/utils/select-image-from-media-library.ts
+++ b/projects/packages/videopress/src/dashboard/utils/select-image-from-media-library.ts
@@ -45,7 +45,9 @@ export async function selectImageFromMediaLibrary(): Promise< Attachment | null 
 			resolve( { id: sel.id, url: sel.url } );
 		} );
 		frame.on( 'close', () => {
-			// `close` fires after `select` on confirm — defer so `select` resolves first.
+			// When the user confirms, wp.media fires `select` then `close` in the same
+			// tick. Deferring the null-resolve lets the `select` handler win; the
+			// `resolved` flag is the real guard against close overwriting the result.
 			setTimeout( () => {
 				if ( ! resolved ) {
 					resolve( null );

--- a/projects/packages/videopress/src/dashboard/utils/test/select-image-from-media-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/utils/test/select-image-from-media-library.test.ts
@@ -1,0 +1,64 @@
+import { selectImageFromMediaLibrary } from '../select-image-from-media-library';
+
+type Handler = () => void;
+
+/**
+ * Build a minimal wp.media frame stub with record-able event handlers and a
+ * fixed selection returning attachment id 77.
+ *
+ * @return A fake media frame object suitable for use in tests.
+ */
+function makeMediaFrame() {
+	const handlers: Record< string, Handler > = {};
+	const selection = {
+		first: () => ( {
+			toJSON: () => ( { id: 77, url: 'https://example.test/img.png' } ),
+		} ),
+	};
+	return {
+		handlers,
+		state: () => ( { get: () => selection } ),
+		on: ( evt: string, fn: Handler ) => {
+			handlers[ evt ] = fn;
+		},
+		open: jest.fn(),
+	};
+}
+
+describe( 'selectImageFromMediaLibrary', () => {
+	afterEach( () => {
+		delete ( window as unknown as { wp?: unknown } ).wp;
+	} );
+
+	it( 'resolves the selected attachment id and url', async () => {
+		const frame = makeMediaFrame();
+		( window as unknown as { wp: { media: jest.Mock } } ).wp = {
+			media: jest.fn( () => frame ),
+		};
+
+		const promise = selectImageFromMediaLibrary();
+		frame.handlers.select();
+
+		await expect( promise ).resolves.toEqual( {
+			id: 77,
+			url: 'https://example.test/img.png',
+		} );
+		expect( frame.open ).toHaveBeenCalled();
+	} );
+
+	it( 'resolves null when the user closes without selecting', async () => {
+		const frame = makeMediaFrame();
+		( window as unknown as { wp: { media: jest.Mock } } ).wp = {
+			media: jest.fn( () => frame ),
+		};
+
+		const promise = selectImageFromMediaLibrary();
+		frame.handlers.close();
+
+		await expect( promise ).resolves.toBeNull();
+	} );
+
+	it( 'rejects when window.wp.media is unavailable', async () => {
+		await expect( selectImageFromMediaLibrary() ).rejects.toThrow( /wp\.media/ );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/utils/test/select-image-from-media-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/utils/test/select-image-from-media-library.test.ts
@@ -58,6 +58,23 @@ describe( 'selectImageFromMediaLibrary', () => {
 		await expect( promise ).resolves.toBeNull();
 	} );
 
+	it( 'keeps the selection when close fires right after select', async () => {
+		const frame = makeMediaFrame();
+		( window as unknown as { wp: { media: jest.Mock } } ).wp = {
+			media: jest.fn( () => frame ),
+		};
+
+		const promise = selectImageFromMediaLibrary();
+		frame.handlers.select();
+		frame.handlers.close();
+		await new Promise( resolve => setTimeout( resolve, 0 ) ); // flush the deferred null-resolve
+
+		await expect( promise ).resolves.toEqual( {
+			id: 77,
+			url: 'https://example.test/img.png',
+		} );
+	} );
+
 	it( 'rejects when window.wp.media is unavailable', async () => {
 		await expect( selectImageFromMediaLibrary() ).rejects.toThrow( /wp\.media/ );
 	} );


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

Adds a thumbnail editor to the modernized VideoPress **Video details** screen (gated behind the `rsm_jetpack_ui_modernization_videopress` flag), porting the legacy edit-page capability.

* A pencil overlay button on the poster opens a popover with two actions:
  * **Select from video** — opens a `@wordpress/ui` `Dialog` with a `<video>` + `RangeControl` scrubber to pick a frame.
  * **Upload image** — opens the WordPress media library to choose an image.
* Both fire `POST /wpcom/v2/videopress/{guid}/poster` (frame timestamp or attachment id) via a TanStack mutation, with success/error snackbars through `useGlobalNotices`.
* **Async poster generation handled via polling:** the poster is regenerated server-side asynchronously (each run yields a new `…scrubthumb-N.jpg`). The mutation polls `GET …/poster` until `generating` is false, then persists the final URL to `/wpcom/v2/videopress/meta` so reloads show the correct image, and patches the query cache. (Without this, the immediate refetch grabbed a pre-generation URL that 404s.)
* The selected frame timestamp is clamped away from the very end of the video, matching the legacy behavior (the generator fails too close to the end).
* `wp_enqueue_media()` is now enqueued on the modernized dashboard page so the media library is available for the upload action.
* New unit/component tests cover the mutation (body shape, polling, poll-exhaustion, no-data response, cache update), the media-library helper, the overlay button (a11y menu roles, gating), the frame-time clamp, and the `ThumbnailCard` wiring (frame/upload paths, toasts, gating).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Part of the ongoing VideoPress dashboard modernization.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the modernization flag, e.g. add a snippet: `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );`
2. Go to **Jetpack → VideoPress** and open a video's details page (`?page=jetpack-videopress&p=/video/<id>`).
3. Confirm a pencil button appears in the top-right corner of the thumbnail (it is hidden for still-processing videos and non-VideoPress items).
4. Click the pencil → **Select from video**: the dialog opens with the video and a scrub bar. Drag to a frame, click **Select this frame**. The thumbnail shows an "Updating…" overlay during generation, then updates to the chosen frame. Reload the page and confirm the new thumbnail persists (no broken/404 image).
5. Click the pencil → **Upload image**: pick or upload an image and choose **Use this image as thumbnail**. Confirm the thumbnail updates and persists across a reload.
6. Cancel paths: dismissing the frame dialog (Cancel / Esc / close icon) or closing the media library without selecting leaves the thumbnail unchanged with no toast.
7. Verify the layout and pencil overlay at both desktop and mobile (<600px) viewports.
