### PR TITLE
Write: Fix inline text color persistence and block editor compatibility

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_text_colors
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_text_colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix inline text color persistence and compatibility with block editor color picker.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1151,6 +1151,10 @@
 	text-wrap: stable;
 }
 
+.bw-content mark.has-inline-color {
+	background-color: transparent;
+}
+
 .bw-content.bw-is-empty {
 	position: relative;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -527,20 +527,32 @@ function escapeAttr( str ) {
 }
 
 /**
+ * Convert an rgb() color string to hex (#rrggbb). Returns the input
+ * unchanged if it is not in rgb() format.
+ *
+ * @param {string} rgb - A CSS color value, e.g. "rgb(214, 54, 56)".
+ * @return {string} Hex color string, e.g. "#d63638".
+ */
+function rgbToHex( rgb ) {
+	const m = rgb.match( /^rgb\(\s*(\d+),\s*(\d+),\s*(\d+)\s*\)$/ );
+	if ( ! m ) return rgb;
+	const hex = i => ( '0' + parseInt( m[ i ], 10 ).toString( 16 ) ).slice( -2 );
+	return '#' + hex( 1 ) + hex( 2 ) + hex( 3 );
+}
+
+/**
  * Normalize color markup from contentEditable before block serialization.
  *
- * The foreColor command creates <font color="..."> (legacy) or
- * <span style="color:..."> (modern). Convert both to clean <span> elements
- * with inline styles, and strip the default text color (#1a1a1a).
+ * Write edits colors as spans (via foreColor), saves colors as Gutenberg marks.
+ * Three passes: font→span, mark→span, span→mark.
  *
  * @param {HTMLElement} container - The container to normalize in place.
  */
 function normalizeColorMarkup( container ) {
-	// Convert <font color="..."> to <span style="color:...">.
+	// Pass 1: <font color> → <span style="color:"> for uniform handling.
 	container.querySelectorAll( 'font[color]' ).forEach( font => {
 		const color = font.getAttribute( 'color' );
 		const span = document.createElement( 'span' );
-		// Skip default color — unwrap the element entirely.
 		if ( color && color.toLowerCase() !== '#1a1a1a' ) {
 			span.style.color = color;
 		}
@@ -548,14 +560,40 @@ function normalizeColorMarkup( container ) {
 		font.replaceWith( span );
 	} );
 
-	// Strip default-colored spans (unwrap them, keeping their content).
+	// Pass 2: existing <mark class="has-inline-color"> → <span> so the
+	// span pass handles all colored elements uniformly.
+	container.querySelectorAll( 'mark.has-inline-color' ).forEach( mark => {
+		const span = document.createElement( 'span' );
+		if ( mark.style.color ) {
+			span.style.color = mark.style.color;
+		}
+		span.innerHTML = mark.innerHTML;
+		mark.replaceWith( span );
+	} );
+
+	// Pass 3: colored spans → Gutenberg <mark> format. Default color stripped.
 	container.querySelectorAll( 'span' ).forEach( span => {
 		const color = span.style.color;
 		if ( ! color ) return;
-		// Detect default color in various formats.
 		const isDefault = color === '#1a1a1a' || color === 'rgb(26, 26, 26)';
 		if ( isDefault ) {
 			span.replaceWith( ...span.childNodes );
+			return;
+		}
+		const hexColor = rgbToHex( color );
+		const mark = document.createElement( 'mark' );
+		mark.className = 'has-inline-color';
+		// Raw string avoids CSS OM normalizing hex back to rgb().
+		// rgba(0, 0, 0, 0) is Gutenberg's exact transparent sentinel.
+		mark.setAttribute( 'style', 'background-color:rgba(0, 0, 0, 0);color:' + hexColor );
+		mark.innerHTML = span.innerHTML;
+		// Preserve other styles (e.g. text-decoration) by nesting the mark.
+		span.style.color = '';
+		if ( span.getAttribute( 'style' )?.trim() ) {
+			span.innerHTML = '';
+			span.appendChild( mark );
+		} else {
+			span.replaceWith( mark );
 		}
 	} );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -340,10 +340,8 @@ function wpcom_write_is_transparent_background( $value ) {
  * @return bool True if unsupported color classes are found.
  */
 function wpcom_write_has_unsupported_color_class( $content ) {
-	return (bool) (
-		preg_match( '/class="[^"]*\bhas-(?!inline-color\b)[\w-]+-color\b[^"]*"/', $content ) ||
-		preg_match( "/class='[^']*\bhas-(?!inline-color\b)[\w-]+-color\b[^']*'/", $content )
-	);
+	return preg_match( '/class="[^"]*\bhas-(?!inline-color\b)[\w-]+-color\b[^"]*"/', $content ) ||
+		preg_match( "/class='[^']*\bhas-(?!inline-color\b)[\w-]+-color\b[^']*'/", $content );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -297,21 +297,81 @@ function wpcom_write_detect_unsupported_content( $content ) {
 		return 'block-editor';
 	}
 
-	// HTML-level classes that Write can't round-trip.  convertToBlocks()
-	// reconstructs the outer element, losing any classes set by the block
-	// editor.  Match only inside class attributes to avoid false positives
-	// from plain text mentioning these class names.
-	//
-	// Note: has-text-align-* is NOT checked here — those classes are
-	// converted to inline styles on load (see wpcom_write_alignment_classes_to_inline)
-	// so convertToBlocks() can read them via node.style.textAlign.
-	//
-	// - has-inline-color / has-text-color: rich-text color classes.
-	if (
-		preg_match( '/class="[^"]*has-(?:inline-color|text-color)[^"]*"/', $content ) ||
-		preg_match( "/class='[^']*has-(?:inline-color|text-color)[^']*'/", $content )
-	) {
+	// Write supports inline custom text colors only.
+	// Palette colors and highlights stay block-editor-only.
+	// has-text-align-* is not checked — it's converted to inline styles on load.
+	if ( wpcom_write_has_unsupported_color_class( $content ) ) {
 		return 'block-editor';
+	}
+
+	if ( wpcom_write_has_unsupported_mark( $content ) ) {
+		return 'block-editor';
+	}
+
+	return false;
+}
+
+/**
+ * Check whether a CSS background-color value is transparent.
+ *
+ * Matches "transparent", "rgba(0, 0, 0, 0)", and whitespace/case variants.
+ *
+ * @param string $value A CSS background-color value.
+ * @return bool True if the value is transparent.
+ */
+function wpcom_write_is_transparent_background( $value ) {
+	$value = strtolower( trim( $value ) );
+	if ( 'transparent' === $value ) {
+		return true;
+	}
+	// Normalize whitespace so rgba(0,0,0,0) and rgba( 0, 0, 0, 0 ) both match.
+	$value = preg_replace( '/\s+/', '', $value );
+	return 'rgba(0,0,0,0)' === $value;
+}
+
+/**
+ * Check whether content has color classes that Write can't preserve.
+ *
+ * Palette classes (has-vivid-red-color, etc.) and has-text-color indicate
+ * block editor content.  has-inline-color alone is fine — Write produces it.
+ * Only matches inside class attributes to avoid false positives from plain text.
+ *
+ * @param string $content Raw post_content.
+ * @return bool True if unsupported color classes are found.
+ */
+function wpcom_write_has_unsupported_color_class( $content ) {
+	return (bool) (
+		preg_match( '/class="[^"]*\bhas-(?!inline-color\b)[\w-]+-color\b[^"]*"/', $content ) ||
+		preg_match( "/class='[^']*\bhas-(?!inline-color\b)[\w-]+-color\b[^']*'/", $content )
+	);
+}
+
+/**
+ * Check whether content has <mark> elements that Write can't round-trip.
+ *
+ * Catches two cases:
+ * - <mark> without has-inline-color (block editor highlights).
+ * - <mark> with has-inline-color AND a non-transparent background
+ *   (combined text color + highlight from the block editor).
+ *
+ * @param string $content Raw post_content.
+ * @return bool True if unsupported marks are found.
+ */
+function wpcom_write_has_unsupported_mark( $content ) {
+	// Highlights: <mark> without has-inline-color.
+	if ( preg_match( '/<mark\b(?![^>]*\bclass="[^"]*has-inline-color)/', $content ) ) {
+		return true;
+	}
+
+	// Combined text color + highlight: has-inline-color with a real background.
+	if ( preg_match_all( '/<mark\b[^>]*\bclass="[^"]*has-inline-color[^"]*"[^>]*>/', $content, $marks ) ) {
+		foreach ( $marks[0] as $tag ) {
+			if ( preg_match( '/background-color\s*:\s*([^;"]+)/', $tag, $bg ) ) {
+				if ( ! wpcom_write_is_transparent_background( $bg[1] ) ) {
+					return true;
+				}
+			}
+		}
 	}
 
 	return false;
@@ -446,6 +506,34 @@ function wpcom_write_alignment_classes_to_inline( $html ) {
 			}
 
 			return $tag;
+		},
+		$html
+	);
+}
+
+/**
+ * Convert Gutenberg inline-color marks to spans for contentEditable.
+ *
+ * Write edits colors as spans, saves colors as Gutenberg marks.
+ * On load, marks are converted back to spans so foreColor can interact
+ * with existing colors. normalizeColorMarkup() in view.js reverses this.
+ *
+ * @param string $html Rendered HTML content.
+ * @return string HTML with inline-color marks replaced by color spans.
+ */
+function wpcom_write_inline_color_marks_to_spans( $html ) {
+	return preg_replace_callback(
+		'/<mark\b([^>]*\bclass="[^"]*has-inline-color[^"]*"[^>]*)>(.*?)<\/mark>/s',
+		function ( $m ) {
+			$attrs = $m[1];
+			$inner = $m[2];
+			// Extract the color value from the style attribute.
+			// Use (?<!-) to match the `color` property but not `background-color`.
+			if ( preg_match( '/(?<!-)color\s*:\s*([^;"]+)/', $attrs, $cm ) ) {
+				return '<span style="color:' . $cm[1] . '">' . $inner . '</span>';
+			}
+			// No color found — just unwrap to a plain span.
+			return '<span>' . $inner . '</span>';
 		},
 		$html
 	);
@@ -905,6 +993,11 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				// Convert block-editor alignment classes to inline styles so
 				// convertToBlocks() can read them via node.style.textAlign.
 				$edit_content = wpcom_write_alignment_classes_to_inline( $edit_content );
+				// Convert Gutenberg <mark class="has-inline-color"> to
+				// <span style="color:#hex"> so foreColor can interact with
+				// existing colors.  Done before kses so the simpler span+hex
+				// format passes through without needing a custom kses filter.
+				$edit_content = wpcom_write_inline_color_marks_to_spans( $edit_content );
 				// Sanitize through wp_kses_post — video embed tokens (HTML comments)
 				// pass through untouched, then we swap them for the real iframe HTML.
 				// This avoids the pre_kses filter that converts iframes to shortcodes.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -877,11 +877,19 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that inline color classes return 'block-editor'.
+	 * Test that inline palette color classes return 'block-editor'.
 	 */
-	public function test_detect_unsupported_inline_color_class() {
-		$content = '<!-- wp:paragraph --><p>Some <span class="has-inline-color has-vivid-red-color">red</span> text</p><!-- /wp:paragraph -->';
+	public function test_detect_unsupported_inline_palette_color_class() {
+		$content = '<!-- wp:paragraph --><p>Some <mark class="has-inline-color has-vivid-red-color">red</mark> text</p><!-- /wp:paragraph -->';
 		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that has-inline-color alone (Write's format) is supported.
+	 */
+	public function test_detect_supported_inline_custom_color() {
+		$content = '<!-- wp:paragraph --><p>Some <mark class="has-inline-color" style="background-color:rgba(0, 0, 0, 0);color:#d63638">red</mark> text</p><!-- /wp:paragraph -->';
+		$this->assertFalse( wpcom_write_detect_unsupported_content( $content ) );
 	}
 
 	/**
@@ -889,6 +897,22 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_detect_unsupported_has_text_color_class() {
 		$content = '<!-- wp:paragraph --><p class="has-text-color has-vivid-red-color">Colored</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that custom highlight mark (no palette class) returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_custom_highlight_mark() {
+		$content = '<!-- wp:paragraph --><p>Some <mark style="background-color:#fcb900">highlighted</mark> text</p><!-- /wp:paragraph -->';
+		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
+	}
+
+	/**
+	 * Test that has-inline-color with a real background color returns 'block-editor'.
+	 */
+	public function test_detect_unsupported_inline_color_with_highlight() {
+		$content = '<!-- wp:paragraph --><p><mark class="has-inline-color" style="background-color:#fcb900;color:#d63638">both</mark></p><!-- /wp:paragraph -->';
 		$this->assertSame( 'block-editor', wpcom_write_detect_unsupported_content( $content ) );
 	}
 
@@ -1000,6 +1024,42 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			'<p style="text-align:center;color:red">Centered</p>',
 			wpcom_write_alignment_classes_to_inline( $html )
 		);
+	}
+
+	/**
+	 * Test that inline color marks are converted to spans for contentEditable.
+	 */
+	public function test_inline_color_marks_to_spans() {
+		// Gutenberg custom color (with rgba transparent background).
+		$html = '<p>Some <mark class="has-inline-color" style="background-color:rgba(0, 0, 0, 0);color:#d63638">red</mark> text</p>';
+		$this->assertSame(
+			'<p>Some <span style="color:#d63638">red</span> text</p>',
+			wpcom_write_inline_color_marks_to_spans( $html )
+		);
+
+		// No color in style — unwraps to plain span.
+		$html = '<p><mark class="has-inline-color">text</mark></p>';
+		$this->assertSame(
+			'<p><span>text</span></p>',
+			wpcom_write_inline_color_marks_to_spans( $html )
+		);
+
+		// Non-inline-color mark — left unchanged.
+		$html = '<p><mark style="background-color:#ff0">highlighted</mark></p>';
+		$this->assertSame( $html, wpcom_write_inline_color_marks_to_spans( $html ) );
+	}
+
+	/**
+	 * Test transparent background detection with whitespace/case variants.
+	 */
+	public function test_is_transparent_background() {
+		$this->assertTrue( wpcom_write_is_transparent_background( 'transparent' ) );
+		$this->assertTrue( wpcom_write_is_transparent_background( 'Transparent' ) );
+		$this->assertTrue( wpcom_write_is_transparent_background( 'rgba(0, 0, 0, 0)' ) );
+		$this->assertTrue( wpcom_write_is_transparent_background( 'rgba(0,0,0,0)' ) );
+		$this->assertTrue( wpcom_write_is_transparent_background( ' rgba( 0, 0, 0, 0 ) ' ) );
+		$this->assertFalse( wpcom_write_is_transparent_background( '#fcb900' ) );
+		$this->assertFalse( wpcom_write_is_transparent_background( 'rgba(255, 0, 0, 0.5)' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes RSM-3349 and RSM-2050

## Proposed changes

* Serialize Write editor text colors as Gutenberg's inline text color format (`<mark class="has-inline-color">`) so the block editor can recognize and modify them.
* On load, convert Gutenberg marks back to `<span style="color:#hex">` so contentEditable's `foreColor` command works for re-coloring existing text.
* Add `rgbToHex()` to convert browser-normalized rgb() values back to hex for the serialized style attribute.
* Detect block editor highlights and combined text+highlight markup as unsupported content (Write supports inline custom text colors only; palette colors and highlights stay block-editor-only).
* Preserve other span styles (e.g. underline) when nesting color marks.
* Extract unsupported-content helpers (`wpcom_write_has_unsupported_color_class`, `wpcom_write_has_unsupported_mark`, `wpcom_write_is_transparent_background`) for readability.

## Related product discussion/links

* RSM-3349
* RSM-2050

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Block editor compatibility

1. Create a post in the Write editor with colored text (multiple colors on different words).
2. Save the post, then open it in the block editor.
3. Verify the text colors display correctly (no yellow highlight background).
4. Verify the block editor recognizes the colors (selecting colored text should show the color in the text color picker, not highlight).

### Re-coloring in Write

1. Create a post with colored text in Write, save it.
2. Reopen in Write, select the colored text, and change it to a different color.
3. Verify the color changes correctly for all selected text.

### Unsupported content detection

1. In the block editor, apply a Highlight (background color) to some text and save.
2. Open the post in Write — verify the unsupported content warning appears.
3. In the block editor, apply a palette text color (e.g. "Vivid Red" from the sidebar color picker) to a whole paragraph and save.
4. Open in Write — verify the unsupported content warning appears.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
