### PR TITLE
number-formatters: add setCurrencyOverrides for dynamic per-currency overrides

### DIFF
--- a/projects/js-packages/number-formatters/changelog/add-currency-overrides-setter
+++ b/projects/js-packages/number-formatters/changelog/add-currency-overrides-setter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Currency formatting: add `setCurrencyOverrides` for installing a dynamic per-currency override map (eg: from the WPCOM currencies endpoint). Falls back to the hard-coded smallest-unit exponent overrides when not called.

--- a/projects/js-packages/number-formatters/src/create-number-formatters.ts
+++ b/projects/js-packages/number-formatters/src/create-number-formatters.ts
@@ -4,7 +4,13 @@ import {
 	getCurrencyObject as getCurrencyObjectFromCurrencyFormatter,
 } from './number-format-currency/index.ts';
 import { numberFormat, numberFormatCompact } from './number-format.ts';
-import type { CurrencyObject, FormatCurrency, FormatNumber, GetCurrencyObject } from './types.ts';
+import type {
+	CurrencyObject,
+	CurrencyOverride,
+	FormatCurrency,
+	FormatNumber,
+	GetCurrencyObject,
+} from './types.ts';
 
 declare global {
 	interface Window {
@@ -32,6 +38,24 @@ export interface NumberFormatters {
 	 * @param geoLocation - The geo location to use for formatting
 	 */
 	setGeoLocation( geoLocation: string ): void;
+
+	/**
+	 * Sets a dynamic map of per-currency overrides used by currency formatting.
+	 *
+	 * Typical use: load `{ "IDR": { "decimal": 0 } }` from the WPCOM currencies
+	 * endpoint at app boot and pass the parsed object here. Each entry can carry
+	 * a `symbol` and/or `decimal` (the smallest-unit exponent), and additional
+	 * fields may be added to `CurrencyOverride` in the future.
+	 *
+	 * If this setter is never called, the package falls back to the hard-coded
+	 * defaults shipped with the package, preserving previous behavior.
+	 *
+	 * When called with a partial map, missing currencies or fields fall back to
+	 * the hard-coded defaults — passing `{ IDR: { decimal: 0 } }` does not clear
+	 * the default IDR symbol, for example.
+	 * @param overrides - Map of currency code to override settings
+	 */
+	setCurrencyOverrides( overrides: Record< string, CurrencyOverride > ): void;
 
 	/**
 	 * Formats numbers using locale settings and/or passed options.
@@ -150,6 +174,7 @@ export interface NumberFormatters {
 function createNumberFormatters(): NumberFormatters {
 	let localeState: string | undefined;
 	let geoLocationState: string | undefined;
+	let currencyOverridesState: Record< string, CurrencyOverride > | undefined;
 
 	const setLocale = ( locale: string ): void => {
 		/**
@@ -158,6 +183,10 @@ function createNumberFormatters(): NumberFormatters {
 		 * should all be valid inputs for the constructor.
 		 */
 		localeState = locale;
+	};
+
+	const setCurrencyOverrides = ( overrides: Record< string, CurrencyOverride > ): void => {
+		currencyOverridesState = overrides;
 	};
 
 	/**
@@ -242,6 +271,7 @@ function createNumberFormatters(): NumberFormatters {
 			signForPositive,
 			geoLocation: geoLocationState,
 			forceLatin,
+			currencyOverrides: currencyOverridesState,
 		} );
 	};
 
@@ -259,12 +289,14 @@ function createNumberFormatters(): NumberFormatters {
 			signForPositive,
 			geoLocation: geoLocationState,
 			forceLatin,
+			currencyOverrides: currencyOverridesState,
 		} );
 	};
 
 	return {
 		setLocale,
 		setGeoLocation,
+		setCurrencyOverrides,
 		formatNumber,
 		formatNumberCompact,
 		formatCurrency,

--- a/projects/js-packages/number-formatters/src/index.ts
+++ b/projects/js-packages/number-formatters/src/index.ts
@@ -5,6 +5,7 @@ const defaultFormatter = createNumberFormatters();
 export const {
 	setLocale,
 	setGeoLocation,
+	setCurrencyOverrides,
 	formatNumber,
 	formatNumberCompact,
 	formatCurrency,

--- a/projects/js-packages/number-formatters/src/number-format-currency/index.ts
+++ b/projects/js-packages/number-formatters/src/number-format-currency/index.ts
@@ -8,30 +8,47 @@ const debug = debugFactory( 'number-formatters:number-format-currency' );
 
 /**
  * Retrieves the currency override for a given currency.
+ *
  * If the currency is USD and the user is not in the US, it will return `US$`.
- * @param  currency    - The currency to get the override for.
- * @param  geoLocation - The geo location of the user.
+ *
+ * Per-field merge order is: dynamic overrides (from `currencyOverrides`) → hard-coded defaults.
+ * This means a caller can supply a partial map (eg: only `decimal`) without losing the
+ * default `symbol`.
+ * @param  currency          - The currency to get the override for.
+ * @param  geoLocation       - The geo location of the user.
+ * @param  currencyOverrides - Dynamic per-currency overrides supplied by the host application.
  * @return {CurrencyOverride | undefined} The currency override.
  */
 function getCurrencyOverride(
 	currency: string,
-	geoLocation?: string
+	geoLocation?: string,
+	currencyOverrides?: Record< string, CurrencyOverride >
 ): CurrencyOverride | undefined {
 	if ( currency === 'USD' && geoLocation && geoLocation !== '' && geoLocation !== 'US' ) {
-		return { symbol: 'US$' };
+		return { symbol: 'US$', ...currencyOverrides?.USD };
 	}
-	return defaultCurrencyOverrides[ currency ];
+	const defaultOverride = defaultCurrencyOverrides[ currency ];
+	const dynamicOverride = currencyOverrides?.[ currency ];
+	if ( ! defaultOverride && ! dynamicOverride ) {
+		return undefined;
+	}
+	return { ...defaultOverride, ...dynamicOverride };
 }
 
 /**
  * Returns a valid currency code based on a shortlist of currency codes.
  * Only currencies from the shortlist are allowed. Everything else will fall back to `FALLBACK_CURRENCY`.
- * @param  currency    - The currency to get the valid currency for.
- * @param  geoLocation - The geo location of the user.
+ * @param  currency          - The currency to get the valid currency for.
+ * @param  geoLocation       - The geo location of the user.
+ * @param  currencyOverrides - Dynamic per-currency overrides supplied by the host application.
  * @return {string} The valid currency.
  */
-function getValidCurrency( currency: string, geoLocation?: string ): string {
-	if ( ! getCurrencyOverride( currency, geoLocation ) ) {
+function getValidCurrency(
+	currency: string,
+	geoLocation?: string,
+	currencyOverrides?: Record< string, CurrencyOverride >
+): string {
+	if ( ! getCurrencyOverride( currency, geoLocation, currencyOverrides ) ) {
 		debug(
 			`getValidCurrency was called with a non-existent currency "${ currency }"; falling back to ${ FALLBACK_CURRENCY }`
 		);
@@ -99,8 +116,13 @@ function getCurrencyFormatter( {
 }
 
 /**
- * Smallest-unit exponent overrides for currencies where browser ICU's
+ * Hard-coded smallest-unit exponent overrides for currencies where browser ICU's
  * `maximumFractionDigits` disagrees with the API's smallest-unit encoding.
+ *
+ * This list exists as a safety net for callers that have not yet wired up the
+ * dynamic `currencyOverrides` path (eg: the WPCOM currencies endpoint). Once a
+ * host application provides overrides via `setCurrencyOverrides`, those take
+ * precedence on a per-currency basis.
  *
  * Keep this list minimal — the backend is the source of truth for the API's
  * smallest-unit encoding, so adding speculative entries here risks silent
@@ -118,14 +140,24 @@ const SMALLEST_UNIT_EXPONENT_OVERRIDES: Record< string, number > = {
 /**
  * Returns the smallest unit exponent for a currency.
  *
- * Falls back to the browser-derived display precision for any currency not in
- * the override map — i.e. existing behavior is preserved for everything except
- * the explicitly listed currencies.
- * @param currency - The currency code (ISO 4217)
- * @param fallback - The browser-derived precision to use when no override applies
- * @return number  - The smallest unit exponent
+ * Lookup order:
+ * 1. The dynamic `currencyOverrides[currency].decimal` if a host application has supplied one (typically via `setCurrencyOverrides`).
+ * 2. The hard-coded `SMALLEST_UNIT_EXPONENT_OVERRIDES` map.
+ * 3. The browser-derived display precision (`fallback`).
+ * @param currency          - The currency code (ISO 4217)
+ * @param fallback          - The browser-derived precision to use when no override applies
+ * @param currencyOverrides - Dynamic per-currency overrides supplied by the host application
+ * @return number           - The smallest unit exponent
  */
-function getSmallestUnitExponent( currency: string, fallback: number ): number {
+function getSmallestUnitExponent(
+	currency: string,
+	fallback: number,
+	currencyOverrides?: Record< string, CurrencyOverride >
+): number {
+	const dynamicDecimal = currencyOverrides?.[ currency ]?.decimal;
+	if ( typeof dynamicDecimal === 'number' ) {
+		return dynamicDecimal;
+	}
 	return SMALLEST_UNIT_EXPONENT_OVERRIDES[ currency ] ?? fallback;
 }
 
@@ -173,13 +205,15 @@ function scaleNumberForPrecision( number: number, currencyPrecision: number ): n
  * @param  currencyPrecision - The display precision (from the browser) to round the result to.
  * @param  currency          - The currency code, used to look up any smallest-unit exponent override.
  * @param  isSmallestUnit    - Whether the number is the smallest unit of a currency.
+ * @param  currencyOverrides - Dynamic per-currency overrides supplied by the host application.
  * @return {number} The prepared number.
  */
 function prepareNumberForFormatting(
 	number: number,
 	currencyPrecision: number,
 	currency: string,
-	isSmallestUnit?: boolean
+	isSmallestUnit?: boolean,
+	currencyOverrides?: Record< string, CurrencyOverride >
 ): number {
 	if ( isNaN( number ) ) {
 		debug( 'formatCurrency was called with NaN' );
@@ -193,7 +227,8 @@ function prepareNumberForFormatting(
 				number
 			);
 		}
-		const smallestUnitDivisor = 10 ** getSmallestUnitExponent( currency, currencyPrecision );
+		const smallestUnitDivisor =
+			10 ** getSmallestUnitExponent( currency, currencyPrecision, currencyOverrides );
 		return scaleNumberForPrecision( Math.round( number ) / smallestUnitDivisor, currencyPrecision );
 	}
 
@@ -237,6 +272,7 @@ function prepareNumberForFormatting(
  * @param  params.signForPositive   - Whether to show the sign for positive numbers.
  * @param  params.geoLocation       - The geo location of the user.
  * @param  params.forceLatin        - Whether to force the latin locale.
+ * @param  params.currencyOverrides - Dynamic per-currency overrides supplied by the host application.
  * @return {string} A formatted string.
  */
 const numberFormatCurrency = ( {
@@ -248,9 +284,10 @@ const numberFormatCurrency = ( {
 	signForPositive,
 	geoLocation,
 	forceLatin,
+	currencyOverrides,
 }: NumberFormatCurrencyParams ) => {
-	const validCurrency = getValidCurrency( currency, geoLocation );
-	const currencyOverride = getCurrencyOverride( validCurrency, geoLocation );
+	const validCurrency = getValidCurrency( currency, geoLocation, currencyOverrides );
+	const currencyOverride = getCurrencyOverride( validCurrency, geoLocation, currencyOverrides );
 	const currencyPrecision = getPrecisionForLocaleAndCurrency(
 		browserSafeLocale,
 		validCurrency,
@@ -267,7 +304,8 @@ const numberFormatCurrency = ( {
 		number,
 		currencyPrecision ?? 0,
 		validCurrency,
-		isSmallestUnit
+		isSmallestUnit,
+		currencyOverrides
 	);
 	const formatter = getCurrencyFormatter( {
 		number: numberAsFloat,
@@ -336,6 +374,7 @@ const numberFormatCurrency = ( {
  * @param  params.signForPositive   - Whether to show the sign for positive numbers.
  * @param  params.geoLocation       - The geo location of the user.
  * @param  params.forceLatin        - Whether to force the latin locale.
+ * @param  params.currencyOverrides - Dynamic per-currency overrides supplied by the host application.
  * @return {CurrencyObject} A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
  */
 const getCurrencyObject = ( {
@@ -347,9 +386,10 @@ const getCurrencyObject = ( {
 	signForPositive,
 	geoLocation,
 	forceLatin,
+	currencyOverrides,
 }: NumberFormatCurrencyParams ): CurrencyObject => {
-	const validCurrency = getValidCurrency( currency, geoLocation );
-	const currencyOverride = getCurrencyOverride( validCurrency, geoLocation );
+	const validCurrency = getValidCurrency( currency, geoLocation, currencyOverrides );
+	const currencyOverride = getCurrencyOverride( validCurrency, geoLocation, currencyOverrides );
 	const currencyPrecision = getPrecisionForLocaleAndCurrency(
 		browserSafeLocale,
 		validCurrency,
@@ -359,7 +399,8 @@ const getCurrencyObject = ( {
 		number,
 		currencyPrecision ?? 0,
 		validCurrency,
-		isSmallestUnit
+		isSmallestUnit,
+		currencyOverrides
 	);
 	const formatter = getCurrencyFormatter( {
 		number: numberAsFloat,

--- a/projects/js-packages/number-formatters/src/test/create-number-formatters.test.ts
+++ b/projects/js-packages/number-formatters/src/test/create-number-formatters.test.ts
@@ -119,6 +119,50 @@ describe( 'createNumberFormatters()', () => {
 				expect( money ).toBe( '$9,800,900.32' );
 			} );
 		} );
+
+		describe( 'setCurrencyOverrides()', () => {
+			it( 'falls back to the hard-coded smallest-unit exponent when the setter is not called', () => {
+				const formatters = createNumberFormatters();
+				formatters.setLocale( 'in-ID' );
+				// IDR's hard-coded fallback exponent is 2, so 107280000 → 1,072,800.
+				const money = formatters.formatCurrency( 107280000, 'IDR', { isSmallestUnit: true } );
+				expect( money ).toBe( 'Rp 1.072.800' );
+			} );
+
+			it( 'uses the dynamic decimal override when provided', () => {
+				const formatters = createNumberFormatters();
+				formatters.setLocale( 'in-ID' );
+				formatters.setCurrencyOverrides( { IDR: { decimal: 0 } } );
+				// With decimal:0 the divisor becomes 10^0=1, so 107280000 stays at 107,280,000.
+				const money = formatters.formatCurrency( 107280000, 'IDR', { isSmallestUnit: true } );
+				expect( money ).toBe( 'Rp 107.280.000' );
+			} );
+
+			it( 'preserves the default symbol when a partial override (decimal only) is supplied', () => {
+				const formatters = createNumberFormatters();
+				formatters.setLocale( 'en-US' );
+				formatters.setCurrencyOverrides( { IDR: { decimal: 0 } } );
+				const obj = formatters.getCurrencyObject( 12345, 'IDR' );
+				expect( obj.symbol ).toBe( 'Rp' );
+			} );
+
+			it( 'allows overriding the symbol via the setter', () => {
+				const formatters = createNumberFormatters();
+				formatters.setLocale( 'en-US' );
+				formatters.setCurrencyOverrides( { EUR: { symbol: 'EURO' } } );
+				const money = formatters.formatCurrency( 10, 'EUR' );
+				expect( money ).toBe( 'EURO10.00' );
+			} );
+
+			it( 'leaves currencies not listed in the dynamic map alone', () => {
+				const formatters = createNumberFormatters();
+				formatters.setLocale( 'hu-HU' );
+				// Only override IDR; HUF should still hit its hard-coded exponent of 2.
+				formatters.setCurrencyOverrides( { IDR: { decimal: 0 } } );
+				const money = formatters.formatCurrency( 99900, 'HUF', { isSmallestUnit: true } );
+				expect( money ).toBe( '999 Ft' );
+			} );
+		} );
 	} );
 
 	describe( 'getCurrencyObject()', () => {

--- a/projects/js-packages/number-formatters/src/types.ts
+++ b/projects/js-packages/number-formatters/src/types.ts
@@ -22,6 +22,15 @@ export interface NumberFormatParams {
 
 export interface CurrencyOverride {
 	symbol?: string;
+	/**
+	 * Smallest-unit exponent for this currency, used when the browser's ICU
+	 * `maximumFractionDigits` disagrees with the API's smallest-unit encoding.
+	 *
+	 * For example, the WPCOM currencies endpoint sends `{ "IDR": { "decimal": 0 } }`
+	 * to indicate that IDR should be treated as a 0-decimal currency rather than
+	 * the 2 that modern browser ICU reports.
+	 */
+	decimal?: number;
 }
 
 export interface NumberFormatCurrencyParams {
@@ -76,6 +85,17 @@ export interface NumberFormatCurrencyParams {
 	 * sign (eg: `+$35.00`). Has no effect on negative numbers or 0.
 	 */
 	signForPositive?: boolean;
+
+	/**
+	 * Dynamic currency overrides, typically supplied by the host application
+	 * (eg: from a remote endpoint) via `setCurrencyOverrides`.
+	 *
+	 * When provided, entries here take precedence over the hard-coded defaults
+	 * baked into the package on a per-field basis. Anything not specified in
+	 * this map falls back to the hard-coded defaults, so passing a partial map
+	 * is safe.
+	 */
+	currencyOverrides?: Record< string, CurrencyOverride >;
 }
 
 export interface CurrencyObject {

--- a/projects/js-packages/number-formatters/src/types.ts
+++ b/projects/js-packages/number-formatters/src/types.ts
@@ -24,11 +24,15 @@ export interface CurrencyOverride {
 	symbol?: string;
 	/**
 	 * Smallest-unit exponent for this currency, used when the browser's ICU
-	 * `maximumFractionDigits` disagrees with the API's smallest-unit encoding.
+	 * `maximumFractionDigits` disagrees with the API's smallest-unit encoding,
+	 * or when this package's hard-coded fallback exponent (see
+	 * `SMALLEST_UNIT_EXPONENT_OVERRIDES` in `number-format-currency/index.ts`)
+	 * disagrees with the host application's source of truth.
 	 *
-	 * For example, the WPCOM currencies endpoint sends `{ "IDR": { "decimal": 0 } }`
-	 * to indicate that IDR should be treated as a 0-decimal currency rather than
-	 * the 2 that modern browser ICU reports.
+	 * For example, modern browser ICU (Chrome / Node 24+) reports IDR as
+	 * 0-decimal, but this package's hard-coded fallback applies an exponent of
+	 * 2 for legacy compatibility. The WPCOM currencies endpoint can send
+	 * `{ "IDR": { "decimal": 0 } }` to override that hard-coded 2 back to 0.
 	 */
 	decimal?: number;
 }
@@ -161,7 +165,7 @@ export type FormatCurrency = (
 	currency: string,
 	options?: Omit<
 		NumberFormatCurrencyParams,
-		'number' | 'currency' | 'browserSafeLocale' | 'geoLocation'
+		'number' | 'currency' | 'browserSafeLocale' | 'geoLocation' | 'currencyOverrides'
 	>
 ) => string;
 
@@ -170,6 +174,6 @@ export type GetCurrencyObject = (
 	currency: string,
 	options?: Omit<
 		NumberFormatCurrencyParams,
-		'number' | 'currency' | 'browserSafeLocale' | 'geoLocation'
+		'number' | 'currency' | 'browserSafeLocale' | 'geoLocation' | 'currencyOverrides'
 	>
 ) => CurrencyObject;


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-36/

## Proposed changes

Adds a `setCurrencyOverrides` setter to `@automattic/number-formatters` so the per-currency decimal/symbol overrides can be sourced at runtime (eg: from the new unauthenticated WPCOM currencies endpoint) instead of being baked into the package. The hard-coded fallback list stays in place so callers that haven't wired up the setter continue to behave exactly as before.

* Add `decimal?: number` to the `CurrencyOverride` type so the same shape that the endpoint returns (`{ "IDR": { "decimal": 0 } }`) can carry both symbol and decimal info.
* Add `currencyOverrides` to `NumberFormatCurrencyParams` and thread it through `numberFormatCurrency`, `getCurrencyObject`, `getCurrencyOverride`, `getValidCurrency`, `prepareNumberForFormatting`, and `getSmallestUnitExponent`.
* Add `setCurrencyOverrides( overrides )` to the `NumberFormatters` instance (and the default-export singleton) alongside `setLocale` / `setGeoLocation`.
* Per-field merge order is dynamic → hard-coded → browser ICU, so a partial map like `{ IDR: { decimal: 0 } }` overrides only the smallest-unit exponent and keeps the default IDR symbol.

## Why are these changes being made?

The smallest-unit exponent for currencies like IDR and HUF is currently hard-coded in `number-format-currency/index.ts` because modern browser ICU disagrees with the WPCOM API's encoding (DOTMART-131 fix). That list has to be updated and shipped in every consumer whenever the backend changes a currency's precision, which is painful and drifts silently. The new unauthenticated currencies endpoint solves that by exposing the same data the backend uses; this PR provides the hook to consume it.

The setter accepts a `CurrencyOverride` map rather than a decimal-only map because the endpoint response already has room for additional per-currency properties (eg: symbol), so anchoring the API to a generic override shape avoids a second migration later. To keep the rollout safe, the existing hard-coded list is still used when the setter is not called — callers can adopt the dynamic source incrementally without coordinated releases.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

TC:
```
cd projects/js-packages/number-formatters && pnpm test
```

All 89 tests pass, including 5 new ones under `createNumberFormatters() > formatCurrency() > setCurrencyOverrides()`.

Manual testing:
* In a consumer of `@automattic/number-formatters` (eg: a Calypso sandbox), confirm that without calling `setCurrencyOverrides`, smallest-unit formatting for IDR still produces `Rp 1.072.800` for `107280000` (hard-coded fallback path).
* Call `setCurrencyOverrides({ IDR: { decimal: 0 } })` at boot and confirm the same input now formats as `Rp 107.280.000` (dynamic path wins).
* Confirm currencies not in the map (eg: HUF smallest unit, EUR symbol) are unaffected.

