### PR TITLE
Components: fix AdminPage SCSS module header selectors for admin-ui 2.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,8 +558,8 @@ importers:
         specifier: 0.16.0
         version: 0.16.0
       '@wordpress/admin-ui':
-        specifier: 2.0.0
-        version: 2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.1.0
+        version: 2.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/browserslist-config':
         specifier: 6.46.0
         version: 6.46.0

--- a/projects/js-packages/components/changelog/fix-admin-page-scss-header-selectors
+++ b/projects/js-packages/components/changelog/fix-admin-page-scss-header-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Components: AdminPage SCSS module — replace `> header` selectors with `> :first-child` so they keep matching after `@wordpress/admin-ui` 2.1 changed the page header element from `<header>` to `<div>`. Mirrors the fix shipped in #49006 for the shared admin-page-layout mixin; together they resolve the publicize page header spacing regression flagged on PR #48404.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -15,15 +15,16 @@
 	// https://github.com/WordPress/gutenberg/issues/75428
 
 	// Anchor: `.jp-admin-page__page` is the className we pass to admin-ui's
-	// <Page>; admin-ui 2.0.0 renders the header as a stable <header> element
-	// directly inside that page node — no class hooks anymore.
-	&.without-bottom-border :global(.jp-admin-page__page > header) {
+	// <Page>; admin-ui ≥ 2.1.0 renders the header as a `<div>` (was `<header>`
+	// in 2.0). Target it positionally as `> :first-child` so we don't couple
+	// to the element tag or admin-ui's CSS-Modules-hashed class names.
+	&.without-bottom-border :global(.jp-admin-page__page > :first-child) {
 		border-bottom: none;
 	}
 
 	// Disable sticky header until we make it work better across all pages.
 	// JETPACK-1386
-	:global(.jp-admin-page__page > header) {
+	:global(.jp-admin-page__page > :first-child) {
 		position: relative;
 		z-index: 1;
 	}
@@ -34,12 +35,12 @@
 		clear: both;
 	}
 
-	// admin-ui 2.0.0's header `visual` slot is a 24px grid box but does not
-	// center its contents. Our JetpackLogo is 20px tall, so without this it
-	// pins to the top-left of the cell and looks misaligned vs. the title.
-	// admin-ui ships the slot as `<div aria-hidden="true">` in the header.
+	// admin-ui's header `visual` slot is a 24px grid box but does not center
+	// its contents. Our JetpackLogo is 20px tall, so without this it pins to
+	// the top-left of the cell and looks misaligned vs. the title. admin-ui
+	// ships the slot as `<div aria-hidden="true">` in the header.
 	// TODO: remove once upstream centers contents in `.header-visual`.
-	:global(.jp-admin-page__page > header [aria-hidden="true"]) {
+	:global(.jp-admin-page__page > :first-child [aria-hidden="true"]) {
 		place-items: center;
 	}
 

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -89,7 +89,7 @@
 		"@automattic/number-formatters": "workspace:*",
 		"@babel/runtime": "^7",
 		"@gravatar-com/hovercards": "0.16.0",
-		"@wordpress/admin-ui": "2.0.0",
+		"@wordpress/admin-ui": "2.1.0",
 		"@wordpress/browserslist-config": "6.46.0",
 		"@wordpress/components": "33.1.0",
 		"@wordpress/compose": "7.46.0",

--- a/projects/plugins/search/changelog/fix-search-e2e-admin-ui-2-1-header-locator
+++ b/projects/plugins/search/changelog/fix-search-e2e-admin-ui-2-1-header-locator
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: e2e: swap header-logo locator from `header` element to `.jp-admin-page__page > :first-child` for admin-ui 2.1 compatibility. Test-only.

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -62,15 +62,22 @@ test.describe( 'Search Dashboard', () => {
 			await expect( instantSearchToggle, 'Instant search toggle should be visible' ).toBeVisible();
 
 			await expect(
-				// admin-ui 2.0's <Page> wraps the visual slot in an
+				// admin-ui's <Page> wraps the visual slot in an
 				// `aria-hidden="true"` decorative container, so the logo no
 				// longer surfaces in the accessibility tree by role.
 				// `includeHidden: true` keeps the role-based query, and
-				// scoping to `<header>` distinguishes the page logo from the
-				// JetpackFooter logo (which is also aria-hidden + named
-				// "Jetpack Logo"). `toBeVisible()` continues to verify it's
-				// actually painted, not hidden via display/opacity/visibility.
-				page.locator( 'header' ).getByRole( 'img', { name: 'Jetpack Logo', includeHidden: true } ),
+				// scoping to the page wrapper's first child distinguishes the
+				// page logo from the JetpackFooter logo (which is also
+				// aria-hidden + named "Jetpack Logo"). We use the positional
+				// `> :first-child` selector rather than the `<header>` element
+				// tag because admin-ui 2.1 renders the page header as a `<div>`
+				// (see WordPress/gutenberg#78001); `:first-child` matches both
+				// the old `<header>` and the new `<div>`. `toBeVisible()`
+				// continues to verify it's actually painted, not hidden via
+				// display/opacity/visibility.
+				page
+					.locator( '.jp-admin-page__page > :first-child' )
+					.getByRole( 'img', { name: 'Jetpack Logo', includeHidden: true } ),
 				'Jetpack header logo should be visible'
 			).toBeVisible();
 


### PR DESCRIPTION
Sibling fix to #49006.

## Proposed changes

Adapt the AdminPage SCSS module in `js-packages/components` to `@wordpress/admin-ui` 2.1's DOM change. admin-ui 2.1 removed `render={ <header /> }` from the Page component's outer Stack (Gutenberg [PR #78001](https://github.com/WordPress/gutenberg/pull/78001) — "Fix nested landmark in header"), so the rendered page header is now a `<div>` instead of a `<header>`. The three jetpack-side overrides in this module all targeted the `<header>` element by tag and silently stopped matching on 2.1, restoring admin-ui's defaults beneath us.

* Replace the three `:global(.jp-admin-page__page > header)` selectors with `> :first-child`. `:first-child` matches the same element `<header>` did in 2.0 and the new `<div>` in 2.1 — backward + forward compatible. The selectors fix the three regressions:
  * `.without-bottom-border` mode (used by AdminPage when tabs are present) no longer hides admin-ui's hairline border under the header.
  * `position: relative; z-index: 1;` (JETPACK-1386, disables admin-ui's sticky header on Jetpack admin pages) no longer applies — sticky re-engages globally.
  * The visual-slot `[aria-hidden="true"]` centering rule no longer applies — the JetpackLogo pins to top-left of the 24px grid cell.
* Bump `@wordpress/admin-ui` from `2.0.0` to `2.1.0` in `js-packages/components`' `package.json` — consumer-side pin for the version this fix targets (same convention used in #49006 and #49007).

Together with #49006 (the sibling fix in the `js-packages/base-styles` admin-page-layout mixin), this resolves the publicize page header spacing regression that surfaced during local testing of [#48404](https://github.com/Automattic/jetpack/pull/48404) (Renovate's monorepo-wide `@wordpress/*` bump). On a connected dev install with admin-ui 2.1 + the bumped consumers, the Publicize dashboard's title and subtitle were rendering "compacted" — that turned out to be the cumulative visual effect of the three overrides above ceasing to fire, not a missing gap in admin-ui's CSS. Verified empirically: applying the swap restores Publicize to its expected appearance.

Why this dashboard was the visual canary: publicize's "Publish once. Share everywhere." subtitle is the shortest in the codebase at 33 characters (single line). Long subtitles (Newsletter, Scan, Search, VideoPress, Protect — all 45–71 chars) wrap and visually mask the symptom; publicize doesn't.

## Related product discussion/links

* Sibling fix on the shared mixin: #49006
* Renovate PR that surfaced this: #48404
* Upstream change: [WordPress/gutenberg#78001](https://github.com/WordPress/gutenberg/pull/78001)
* Newsletter SCSS adaptation (same admin-ui 2.1 fallout, different surface): #49007
* Pre-bump checklist (uncommitted in `js-packages/components/ADMIN_UI_BUMP_CHECKLIST.md` on the parent task's branch — to be split into its own PR) — context for why this class of regression keeps catching us out.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply the bump from [#48404](https://github.com/Automattic/jetpack/pull/48404) (or wait for it to land) so `@wordpress/admin-ui@2.1.0` is the resolved version. Without 2.1 in the tree, this PR is a no-op visually — the rules still match `<header>` via `:first-child`.
2. Build the affected packages:
   ```bash
   pnpm jetpack build --deps packages/publicize packages/newsletter packages/videopress packages/search packages/scan plugins/protect packages/my-jetpack
   ```
3. On a connected Jetpack dev install, navigate to **`/wp-admin/admin.php?page=jetpack-publicize`** — the Publicize page header. Confirm:
   * Title and subtitle have the expected vertical rhythm (no perceptible compaction).
   * Header is NOT stickily pinned (JETPACK-1386 behavior preserved — admin-ui's default sticky is suppressed).
   * When tabs are present on other dashboards (Newsletter, Protect, etc.), the hairline border between header and tabs row is removed (`.without-bottom-border` is firing).
   * JetpackLogo visual slot is vertically centered.
4. Spot-check the other dashboards (Newsletter, VideoPress, Search, Scan, Protect, My Jetpack) for the same three behaviors — none should have regressed.
5. No new build, lint, or test failures.
