### PR TITLE
[codex] Fix AI answers dark mode styling

### DIFF
--- a/projects/packages/search/changelog/2026-05-20-19-17-06-087798
+++ b/projects/packages/search/changelog/2026-05-20-19-17-06-087798
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Answers: Fix the answer panel colors in dark mode.

--- a/projects/packages/search/src/instant-search/components/answers-panel.scss
+++ b/projects/packages/search/src/instant-search/components/answers-panel.scss
@@ -6,6 +6,7 @@
 	border: 1px solid helper.$color-border;
 	border-radius: helper.$border-radius-panel;
 	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+	color: helper.$color-text;
 	margin: 0 helper.$results-margin-lg 16px;
 	overflow: hidden;
 
@@ -207,4 +208,42 @@
 
 .jp-search-answers-panel__citation-icon {
 	flex-shrink: 0;
+}
+
+.jetpack-instant-search__overlay.jetpack-instant-search__overlay--dark {
+
+	.jp-search-answers-panel {
+		background: helper.$color-dark-modal-background;
+		border-color: helper.$color-dark-layout-borders;
+		box-shadow: none;
+		color: helper.$color-dark-text;
+	}
+
+	.jp-search-answers-panel--error {
+		border-color: helper.$color-error;
+	}
+
+	.jp-search-answers-panel__heading,
+	.jp-search-answers-panel__error-detail,
+	.jp-search-answers-panel__loading,
+	.jp-search-answers-panel__loading-hint {
+		color: helper.$color-dark-text-lighter;
+	}
+
+	.jp-search-answers-panel__content--collapsed::after {
+		background: linear-gradient(transparent, helper.$color-dark-modal-background);
+	}
+
+	.jp-search-answers-panel__toggle {
+		border-top-color: helper.$color-dark-layout-borders;
+		color: helper.$color-dark-link;
+
+		&:hover {
+			background: rgba(255, 255, 255, 0.08);
+		}
+	}
+
+	.jp-search-answers-panel__citations {
+		border-top-color: helper.$color-dark-layout-borders;
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fix the AI Answers panel colors in the instant-search overlay dark theme so light text no longer appears on a white panel.
* Add dark-theme styles for the panel surface, text, muted labels, dividers, collapse fade, toggle hover state, and error border.
* Add a Search package changelog entry.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Enable AI Answers for Jetpack Search and use the instant-search overlay with the dark color theme.
* Search for a query that renders the AI answer panel.
* Confirm the answer text and supporting UI are readable on the dark panel background.
* Run `pnpm --dir projects/packages/search run build-instant`.
