### PR TITLE
Write: sanitize pasted HTML to strip source typography

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-paste-sanitizer
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-paste-sanitizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write editor: strip source typography and unsupported tags from rich-text pastes to inherit the editor's styling.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -744,6 +744,106 @@ function normalizeFormattingTags( container ) {
 	} );
 }
 
+// Tags whose subtree is preserved on paste. Anything not listed here and not
+// in PASTE_DROP_TAGS is unwrapped — its children stay, but the element itself
+// is removed along with every attribute it carried.
+const PASTE_ALLOWED_TAGS = new Set( [
+	'P',
+	'BR',
+	'H1',
+	'H2',
+	'H3',
+	'H4',
+	'H5',
+	'H6',
+	'UL',
+	'OL',
+	'LI',
+	'BLOCKQUOTE',
+	'A',
+	'STRONG',
+	'B',
+	'EM',
+	'I',
+	'U',
+	'S',
+	'STRIKE',
+	'CODE',
+] );
+
+// Tags whose subtree is discarded entirely on paste — they carry no useful
+// content for the editor and unwrapping would dump CSS or script source as text.
+const PASTE_DROP_TAGS = new Set( [
+	'SCRIPT',
+	'STYLE',
+	'META',
+	'LINK',
+	'HEAD',
+	'TITLE',
+	'NOSCRIPT',
+] );
+
+/**
+ * Sanitize pasted HTML in place inside `container`.
+ *
+ * Source-document typography (font-size, font-family, color, background,
+ * line-height, font-weight) leaks into the editor via `style` attributes
+ * and wrapper tags, producing visible mismatches with the editor's own
+ * styling. This walks the tree depth-first, drops non-content subtrees
+ * (script/style/meta/etc.), unwraps tags that aren't in the allowlist
+ * (keeping their text and children), and strips every attribute except
+ * `href` on links.
+ *
+ * Google Docs wraps copied content in an outer `<b id="docs-internal-guid-…">`
+ * with a counteracting `style="font-weight:normal"`. Once we strip that style
+ * the bare `<b>` would bold the entire paste, so we unwrap any element with
+ * a `docs-internal-guid` id before deciding what to do with its tag.
+ *
+ * @param {Element} container - The container to sanitize in place.
+ */
+function sanitizePasteFragment( container ) {
+	for ( const child of Array.from( container.childNodes ) ) {
+		if ( child.nodeType === Node.ELEMENT_NODE ) {
+			sanitizePasteNode( child );
+		}
+	}
+}
+
+/**
+ * Sanitize a single element from a pasted fragment in place. Called by
+ * sanitizePasteFragment for each element child; see that function for the
+ * tag/attribute policy.
+ *
+ * @param {Element} el - Element to sanitize.
+ */
+function sanitizePasteNode( el ) {
+	const tag = el.tagName;
+
+	if ( PASTE_DROP_TAGS.has( tag ) ) {
+		el.remove();
+		return;
+	}
+
+	// Recurse first so children are already cleaned before we unwrap.
+	sanitizePasteFragment( el );
+
+	const id = el.getAttribute( 'id' );
+	if ( id && id.startsWith( 'docs-internal-guid' ) ) {
+		el.replaceWith( ...el.childNodes );
+		return;
+	}
+
+	if ( ! PASTE_ALLOWED_TAGS.has( tag ) ) {
+		el.replaceWith( ...el.childNodes );
+		return;
+	}
+
+	for ( const attr of Array.from( el.attributes ) ) {
+		if ( tag === 'A' && attr.name === 'href' ) continue;
+		el.removeAttribute( attr.name );
+	}
+}
+
 /**
  * Convert contentEditable HTML into WordPress block markup.
  *
@@ -1657,16 +1757,34 @@ if ( typeof MutationObserver !== 'undefined' ) {
 		addDeleteButtons();
 		new MutationObserver( addDeleteButtons ).observe( content, { childList: true, subtree: true } );
 
-		// Highlight text + paste URL → create a link.
 		content.addEventListener( 'paste', event => {
 			const sel = window.getSelection();
-			if ( ! sel.rangeCount || sel.isCollapsed ) return;
+			if ( ! sel.rangeCount ) return;
 
-			const pasted = event.clipboardData.getData( 'text/plain' );
-			if ( pasted && /^https?:\/\/\S+$/i.test( pasted.trim() ) ) {
-				event.preventDefault();
-				document.execCommand( 'createLink', false, pasted.trim() );
+			// Highlight text + paste URL → create a link. Only fires when
+			// something is selected; with a collapsed cursor a pasted URL
+			// should land as plain link text via the sanitizer path below.
+			if ( ! sel.isCollapsed ) {
+				const pastedText = event.clipboardData.getData( 'text/plain' );
+				if ( pastedText && /^https?:\/\/\S+$/i.test( pastedText.trim() ) ) {
+					event.preventDefault();
+					document.execCommand( 'createLink', false, pastedText.trim() );
+					return;
+				}
 			}
+
+			// Strip source typography (font-size, font-family, color, etc.)
+			// from rich-text pastes so they inherit the editor's styling.
+			// Plain-text pastes have no text/html payload — fall through to
+			// the browser default, which inserts a clean text node.
+			const html = event.clipboardData.getData( 'text/html' );
+			if ( ! html ) return;
+
+			event.preventDefault();
+			const tmp = document.createElement( 'div' );
+			tmp.innerHTML = html;
+			sanitizePasteFragment( tmp );
+			document.execCommand( 'insertHTML', false, tmp.innerHTML );
 		} );
 	}, 200 );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1855,28 +1855,24 @@ if ( typeof MutationObserver !== 'undefined' ) {
 
 			const tmp = document.createElement( 'div' );
 			// Element.setHTML is the native HTML Sanitizer API and the only
-			// recognized XSS barrier in this code path. Browsers without it
-			// (older versions of any engine) fall through to the default
-			// paste — the browser's own paste-into-contentEditable
-			// sanitization plus server-side wp_kses_post() still cover XSS;
-			// the only regression is that source typography isn't stripped.
+			// HTML parsing path for pasted markup. The browser's safety
+			// baseline drops <script>, dangerous attributes (onerror,
+			// onclick, etc.), and javascript: URLs before any of it reaches
+			// the live DOM. We allow style/id/href through so the custom
+			// pass below can read inline styles (to promote bold/italic to
+			// semantic tags), unwrap Google Docs' docs-internal-guid
+			// wrapper, and validate href schemes against a tighter
+			// allowlist than the Sanitizer baseline. Browsers without
+			// setHTML fall through to the default paste — the browser's
+			// own paste-into-contentEditable sanitization plus server-side
+			// wp_kses_post() still cover XSS; the only regression is that
+			// source typography isn't stripped.
 			if ( typeof tmp.setHTML !== 'function' ) return;
 
 			event.preventDefault();
-			// DOMParser parses the markup inertly — scripts don't run, images
-			// and iframes don't load, and inline event handlers don't fire
-			// during parse. promotePasteFormatting reads inline styles, and
-			// sanitizePasteFragment reads ids (to unwrap Google Docs' outer
-			// wrapper), so both must run before setHTML's safety baseline
-			// strips those attributes.
-			const parsed = new DOMParser().parseFromString( html, 'text/html' );
-			promotePasteFormatting( parsed.body );
-			sanitizePasteFragment( parsed.body );
-
-			// Final pass through the browser's native safety baseline:
-			// defense in depth on top of the custom sanitizer above, and
-			// a recognized XSS barrier for static analysis.
-			tmp.setHTML( parsed.body.innerHTML );
+			tmp.setHTML( html, { sanitizer: { attributes: [ 'style', 'id', 'href' ] } } );
+			promotePasteFormatting( tmp );
+			sanitizePasteFragment( tmp );
 
 			// execCommand('insertHTML') handles caret-aware block-level
 			// splitting (e.g. pasting a <p> inside an existing <p> correctly

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -889,9 +889,29 @@ function sanitizePasteNode( el ) {
 	}
 
 	for ( const attr of Array.from( el.attributes ) ) {
-		if ( tag === 'A' && attr.name === 'href' ) continue;
+		if ( tag === 'A' && attr.name === 'href' && isSafePasteHref( attr.value ) ) continue;
 		el.removeAttribute( attr.name );
 	}
+}
+
+/**
+ * Whether `href` is safe to preserve on a pasted link. Allows http(s),
+ * mailto, tel, and same-document/relative URLs; everything else (notably
+ * `javascript:`, `vbscript:`, and `data:`) is rejected so a pasted link
+ * can't smuggle script execution past the sanitizer.
+ *
+ * @param {string} href - The href value to check.
+ * @return {boolean} True when the href is safe to keep.
+ */
+function isSafePasteHref( href ) {
+	if ( ! href ) return false;
+	const trimmed = href.trim();
+	if ( ! trimmed ) return false;
+	// Relative / same-document / query / fragment URLs have no scheme.
+	if ( /^[#/?]/.test( trimmed ) || trimmed.startsWith( './' ) || trimmed.startsWith( '../' ) ) {
+		return true;
+	}
+	return /^(https?:|mailto:|tel:)/i.test( trimmed );
 }
 
 /**
@@ -1831,8 +1851,12 @@ if ( typeof MutationObserver !== 'undefined' ) {
 			if ( ! html ) return;
 
 			event.preventDefault();
-			const tmp = document.createElement( 'div' );
-			tmp.innerHTML = html;
+			// DOMParser parses the markup inertly — scripts don't run, images
+			// and iframes don't load, and inline event handlers don't fire. The
+			// sanitizer then strips everything outside the allowlist before we
+			// hand the result to execCommand for insertion at the caret.
+			const parsed = new DOMParser().parseFromString( html, 'text/html' );
+			const tmp = parsed.body;
 			promotePasteFormatting( tmp );
 			sanitizePasteFragment( tmp );
 			document.execCommand( 'insertHTML', false, tmp.innerHTML );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -810,6 +810,56 @@ function sanitizePasteFragment( container ) {
 }
 
 /**
+ * Promote inline-style formatting on pasted elements to semantic tags.
+ *
+ * Google Docs and Word commonly express bold/italic/underline/strikethrough
+ * as inline `font-weight`, `font-style`, and `text-decoration` styles on
+ * <span>s rather than as semantic tags. The main sanitize pass strips style
+ * attributes and unwraps <span>, which would lose the formatting. This walks
+ * every styled element once before sanitization and wraps its children in
+ * <strong>/<em>/<u>/<s> so the formatting survives the unwrap.
+ *
+ * @param {Element} container - The container to walk.
+ */
+function promotePasteFormatting( container ) {
+	for ( const el of container.querySelectorAll( '[style]' ) ) {
+		const fontWeight = el.style.fontWeight;
+		if ( fontWeight === 'bold' || fontWeight === 'bolder' || parseInt( fontWeight, 10 ) >= 600 ) {
+			wrapPasteChildren( el, 'strong' );
+		}
+		if ( el.style.fontStyle === 'italic' || el.style.fontStyle === 'oblique' ) {
+			wrapPasteChildren( el, 'em' );
+		}
+		// `text-decoration` is the legacy/shorthand property; `text-decoration-line`
+		// is what the CSSOM exposes when the parser splits the shorthand. Check
+		// both — sources vary.
+		const decoration = el.style.textDecorationLine || el.style.textDecoration || '';
+		if ( decoration.includes( 'underline' ) ) {
+			wrapPasteChildren( el, 'u' );
+		}
+		if ( decoration.includes( 'line-through' ) ) {
+			wrapPasteChildren( el, 's' );
+		}
+	}
+}
+
+/**
+ * Move every child of `el` into a freshly created `<tagName>` wrapper, then
+ * re-attach the wrapper as `el`'s sole child. No-op when `el` has no children.
+ *
+ * @param {Element} el      - Element whose children should be wrapped.
+ * @param {string}  tagName - Wrapper element tag name.
+ */
+function wrapPasteChildren( el, tagName ) {
+	if ( ! el.firstChild ) return;
+	const wrapper = document.createElement( tagName );
+	while ( el.firstChild ) {
+		wrapper.appendChild( el.firstChild );
+	}
+	el.appendChild( wrapper );
+}
+
+/**
  * Sanitize a single element from a pasted fragment in place. Called by
  * sanitizePasteFragment for each element child; see that function for the
  * tag/attribute policy.
@@ -1783,6 +1833,7 @@ if ( typeof MutationObserver !== 'undefined' ) {
 			event.preventDefault();
 			const tmp = document.createElement( 'div' );
 			tmp.innerHTML = html;
+			promotePasteFormatting( tmp );
 			sanitizePasteFragment( tmp );
 			document.execCommand( 'insertHTML', false, tmp.innerHTML );
 		} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1852,9 +1852,13 @@ if ( typeof MutationObserver !== 'undefined' ) {
 
 			event.preventDefault();
 			// DOMParser parses the markup inertly — scripts don't run, images
-			// and iframes don't load, and inline event handlers don't fire. The
-			// sanitizer then strips everything outside the allowlist before we
-			// hand the result to execCommand for insertion at the caret.
+			// and iframes don't load, and inline event handlers don't fire
+			// during parse. The sanitizer below then drops every dangerous
+			// element/attribute before any of it reaches the live DOM. We use
+			// execCommand('insertHTML') for the final insertion because it
+			// handles caret-aware block-level splitting (e.g. pasting a <p>
+			// inside an existing <p> correctly splits the paragraph) — manual
+			// Range.insertNode produces invalid nested-block markup.
 			const parsed = new DOMParser().parseFromString( html, 'text/html' );
 			const tmp = parsed.body;
 			promotePasteFormatting( tmp );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1862,12 +1862,21 @@ if ( typeof MutationObserver !== 'undefined' ) {
 			// pass below can read inline styles (to promote bold/italic to
 			// semantic tags), unwrap Google Docs' docs-internal-guid
 			// wrapper, and validate href schemes against a tighter
-			// allowlist than the Sanitizer baseline. Browsers without
-			// setHTML fall through to the default paste — the browser's
-			// own paste-into-contentEditable sanitization plus server-side
-			// wp_kses_post() still cover XSS; the only regression is that
-			// source typography isn't stripped.
-			if ( typeof tmp.setHTML !== 'function' ) return;
+			// allowlist than the Sanitizer baseline.
+			//
+			// Browsers without setHTML (older Chromium/Brave, pre-137 Firefox,
+			// pre-18.4 Safari) fall back to inserting the clipboard's
+			// text/plain representation. That loses formatting but guarantees
+			// no source typography or markup leaks in — and execCommand
+			// 'insertText' isn't an HTML sink, so we don't reintroduce the
+			// CodeQL js/xss flow we eliminated above.
+			if ( typeof tmp.setHTML !== 'function' ) {
+				const text = event.clipboardData.getData( 'text/plain' );
+				if ( ! text ) return;
+				event.preventDefault();
+				document.execCommand( 'insertText', false, text );
+				return;
+			}
 
 			event.preventDefault();
 			tmp.setHTML( html, { sanitizer: { attributes: [ 'style', 'id', 'href' ] } } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -867,7 +867,10 @@ function wrapPasteChildren( el, tagName ) {
  * @param {Element} el - Element to sanitize.
  */
 function sanitizePasteNode( el ) {
-	const tag = el.tagName;
+	// Normalize to uppercase: HTML-namespaced elements already report uppercase
+	// tagNames, but SVG/MathML-namespaced ones preserve the source casing — so
+	// a pasted <svg><script> would slip past the DROP_TAGS check otherwise.
+	const tag = el.tagName.toUpperCase();
 
 	if ( PASTE_DROP_TAGS.has( tag ) ) {
 		el.remove();
@@ -1850,19 +1853,35 @@ if ( typeof MutationObserver !== 'undefined' ) {
 			const html = event.clipboardData.getData( 'text/html' );
 			if ( ! html ) return;
 
+			const tmp = document.createElement( 'div' );
+			// Element.setHTML is the native HTML Sanitizer API and the only
+			// recognized XSS barrier in this code path. Browsers without it
+			// (older versions of any engine) fall through to the default
+			// paste — the browser's own paste-into-contentEditable
+			// sanitization plus server-side wp_kses_post() still cover XSS;
+			// the only regression is that source typography isn't stripped.
+			if ( typeof tmp.setHTML !== 'function' ) return;
+
 			event.preventDefault();
 			// DOMParser parses the markup inertly — scripts don't run, images
 			// and iframes don't load, and inline event handlers don't fire
-			// during parse. The sanitizer below then drops every dangerous
-			// element/attribute before any of it reaches the live DOM. We use
-			// execCommand('insertHTML') for the final insertion because it
-			// handles caret-aware block-level splitting (e.g. pasting a <p>
-			// inside an existing <p> correctly splits the paragraph) — manual
-			// Range.insertNode produces invalid nested-block markup.
+			// during parse. promotePasteFormatting reads inline styles, and
+			// sanitizePasteFragment reads ids (to unwrap Google Docs' outer
+			// wrapper), so both must run before setHTML's safety baseline
+			// strips those attributes.
 			const parsed = new DOMParser().parseFromString( html, 'text/html' );
-			const tmp = parsed.body;
-			promotePasteFormatting( tmp );
-			sanitizePasteFragment( tmp );
+			promotePasteFormatting( parsed.body );
+			sanitizePasteFragment( parsed.body );
+
+			// Final pass through the browser's native safety baseline:
+			// defense in depth on top of the custom sanitizer above, and
+			// a recognized XSS barrier for static analysis.
+			tmp.setHTML( parsed.body.innerHTML );
+
+			// execCommand('insertHTML') handles caret-aware block-level
+			// splitting (e.g. pasting a <p> inside an existing <p> correctly
+			// splits the paragraph) — manual Range.insertNode produces
+			// invalid nested-block markup.
 			document.execCommand( 'insertHTML', false, tmp.innerHTML );
 		} );
 	}, 200 );


### PR DESCRIPTION
Fixes RSM-3505.

## What this does

When you paste rich text into Write from Google Docs, Word, or a styled web page, the source's typography (custom fonts, colors, sizes, weights) currently leaks through and overrides Write's clean styling. This PR fixes that: pasted content gets reduced to its semantic structure — paragraphs, headings, lists, links, bold/italic — and inherits Write's own visual style.

A couple of common quirks are handled along the way: Google Docs wraps its copied content in an outer `<b>` that would otherwise leave everything bold, and Word emits bold/italic as inline styles on `<span>`s rather than semantic tags. Both get normalized so formatting survives the strip.

## How it works

Pasted markup runs through `Element.setHTML` — the browser's native HTML Sanitizer API — which handles the XSS-relevant work. A small custom pass on top does the editor-specific cleanup: promoting inline-style bold/italic to semantic tags, then unwrapping anything outside the small tag allowlist Write actually serializes.

`setHTML` is the load-bearing security primitive. Browsers without it (older Chromium/Brave, pre-137 Firefox, pre-18.4 Safari) fall back to inserting the clipboard's plain-text representation — loses formatting, but no source markup or styling can leak in. XSS is still covered by the browser's built-in paste sanitization plus `wp_kses_post()` on save.

## Related links

* RSM-3505

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with Write available, open `wp-admin/admin.php?page=write`.
2. **Browser support check:** open DevTools, run `typeof document.createElement('div').setHTML`. If it returns `'function'` you're on the full-sanitizer path (Chrome/Edge ≥ 134, Firefox ≥ 137, Safari ≥ 18.4). If it returns `'undefined'`, your browser is on the plain-text fallback path — update first or test the fallback separately (step 10).
3. **Google Docs:** type a sentence in a non-default font and color, copy it, paste. The text should appear in Write's styling, not Google's. Bold / italic / underline should survive.
4. **Web page:** copy a paragraph from a styled article. Editor styling should win.
5. **Tables:** copy a small table from any source. Cells should flatten into the surrounding paragraph.
6. **Headings and lists:** heading levels and list structure should be preserved; inline styling should be gone.
7. **Plain text:** copy from Terminal or any plain-text source. Should land as plain text — no interception.
8. **URL paste over selection:** select some text in Write, copy a URL, paste. The existing "wrap selection in a link" behavior should still work.
9. **Safe links:** paste a paragraph containing `<a href="https://…">`. The link survives with its href intact; other link attributes are stripped.
10. **Fallback path (simulate older browser):** in DevTools console, run `Element.prototype.setHTML = undefined;`. Now paste a styled paragraph from any source. Expected: lands as plain text — no styling, no markup, no formatting. Hard-refresh the page to restore the full sanitizer path.
11. **Undo:** after a paste, ⌘Z should remove it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)