### PR TITLE
VideoPress modernized dashboard: storage-meter polish, added test coverage, and QA-override cleanup

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-modernization-tests
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: VideoPress modernized dashboard: Updates the tests for the modernized dashboard, update storage meter and remove the test overrides.

--- a/projects/packages/videopress/src/dashboard/components/overview/storage-meter-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/storage-meter-card.tsx
@@ -1,15 +1,19 @@
 import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { filesize } from 'filesize';
+import { useIsVideoPressUnlimited } from '../../hooks/use-is-videopress-unlimited';
 import { getStorageUsedBytes, useSite } from '../../hooks/use-site';
 import type { ReactElement } from 'react';
 
 const ONE_TB_BYTES = 1_000_000_000_000; // 1 TB — same as legacy VideoStorageMeter.
+const TWO_TB_BYTES = 2_000_000_000_000; // 2 TB — grandfathered "unlimited" cap.
 
 /**
  * Storage meter strip rendered below the Overview's trends chart and
  * above the bottom row. Ported from the legacy `VideoStorageMeter`:
- * same string, same denominator, same percentage-of-1-TB display.
+ * same string, same percentage display. The denominator is 1TB, or 2TB
+ * for sites grandfathered into the "unlimited" storage tier (Jetpack
+ * plans purchased before 2021-10-07, physically capped at 2TB).
  *
  * Sources storage usage internally from `useSite()` so callers no
  * longer need to thread a `usedBytes` prop through the stats shape.
@@ -21,13 +25,16 @@ const ONE_TB_BYTES = 1_000_000_000_000; // 1 TB — same as legacy VideoStorageM
  */
 export default function StorageMeterCard(): ReactElement | null {
 	const site = useSite();
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- Hook must run unconditionally (Rules of Hooks); its value is only read after the early return below.
+	const isUnlimited = useIsVideoPressUnlimited();
 	const usedBytes = getStorageUsedBytes( site.data );
 	if ( site.isLoading || ! usedBytes ) {
 		return null;
 	}
-	const progress = usedBytes / ONE_TB_BYTES;
+	const totalBytes = isUnlimited ? TWO_TB_BYTES : ONE_TB_BYTES;
+	const progress = usedBytes / totalBytes;
 	const progressLabel = `${ ( progress * 100 ).toFixed() }%`;
-	const totalLabel = filesize( ONE_TB_BYTES, { base: 10 } );
+	const totalLabel = filesize( totalBytes, { base: 10 } );
 	return (
 		<div className="vp-overview__storage-meter">
 			<span className="vp-overview__storage-meter-label">

--- a/projects/packages/videopress/src/dashboard/components/overview/storage-meter-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/storage-meter-card.tsx
@@ -1,5 +1,6 @@
 import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Card } from '@wordpress/ui';
 import { filesize } from 'filesize';
 import { useIsVideoPressUnlimited } from '../../hooks/use-is-videopress-unlimited';
 import { getStorageUsedBytes, useSite } from '../../hooks/use-site';
@@ -36,16 +37,20 @@ export default function StorageMeterCard(): ReactElement | null {
 	const progressLabel = `${ ( progress * 100 ).toFixed() }%`;
 	const totalLabel = filesize( totalBytes, { base: 10 } );
 	return (
-		<div className="vp-overview__storage-meter">
-			<span className="vp-overview__storage-meter-label">
-				{ sprintf(
-					/* translators: %1$s is the storage percentage, from 0% to 100%, %2$s is the total storage. */
-					__( '%1$s of %2$s of cloud video storage', 'jetpack-videopress-pkg' ),
-					progressLabel,
-					totalLabel
-				) }
-			</span>
-			<ProgressBar value={ Math.min( progress * 100, 100 ) } />
-		</div>
+		<Card.Root>
+			<Card.Content>
+				<div className="vp-overview__storage-meter">
+					<span className="vp-overview__storage-meter-label">
+						{ sprintf(
+							/* translators: %1$s is the storage percentage, from 0% to 100%, %2$s is the total storage. */
+							__( '%1$s of %2$s of cloud video storage', 'jetpack-videopress-pkg' ),
+							progressLabel,
+							totalLabel
+						) }
+					</span>
+					<ProgressBar value={ Math.min( progress * 100, 100 ) } />
+				</div>
+			</Card.Content>
+		</Card.Root>
 	);
 }

--- a/projects/packages/videopress/src/dashboard/components/overview/test/storage-meter-card.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/test/storage-meter-card.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../../test-utils/query-client-wrapper';
+import StorageMeterCard from '../storage-meter-card';
+
+// Control the unlimited flag directly; its own logic is covered by the hook's tests.
+let mockUnlimited = false;
+jest.mock( '../../../hooks/use-is-videopress-unlimited', () => ( {
+	useIsVideoPressUnlimited: () => mockUnlimited,
+} ) );
+
+// useSite fetches /videopress/v1/site; return a fixed used-storage payload.
+const mockSiteResponse = ( usedMb: number ) =>
+	mockApiFetch( async () => ( {
+		options: { videopress_storage_used: usedMb, is_wpcom_atomic: false },
+	} ) );
+
+const renderCard = () => render( <StorageMeterCard />, { wrapper: createTestWrapper() } );
+
+describe( 'StorageMeterCard', () => {
+	afterEach( () => {
+		mockUnlimited = false;
+	} );
+
+	it( 'shows a 1 TB denominator for non-unlimited sites', async () => {
+		mockUnlimited = false;
+		mockSiteResponse( 500000 ); // 0.5 TB used
+
+		renderCard();
+
+		// 0.5TB / 1TB = 50%
+		await expect(
+			screen.findByText( '50% of 1 TB of cloud video storage' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'shows a 2 TB denominator for unlimited (grandfathered) sites', async () => {
+		mockUnlimited = true;
+		mockSiteResponse( 500000 ); // 0.5 TB used
+
+		renderCard();
+
+		// 0.5TB / 2TB = 25%
+		await expect(
+			screen.findByText( '25% of 2 TB of cloud video storage' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when storage usage is zero', async () => {
+		mockUnlimited = false;
+		mockSiteResponse( 0 );
+
+		const { container } = renderCard();
+
+		// The `! usedBytes` guard returns null; give the query time to settle.
+		await waitFor( () => expect( container ).toBeEmptyDOMElement() );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-is-videopress-unlimited.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-is-videopress-unlimited.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { useIsVideoPressUnlimited } from '../use-is-videopress-unlimited';
+
+type InitialState = { siteData?: { isVideoPressUnlimited?: boolean } };
+const setInitialState = ( state: InitialState | undefined ) => {
+	(
+		window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: InitialState }
+	 ).JPVIDEOPRESS_INITIAL_STATE = state;
+};
+
+const featuresResponse = ( isUnlimited: boolean ) => ( {
+	isVideoPressSupported: true,
+	isVideoPress1TBSupported: false,
+	isVideoPressUnlimitedSupported: isUnlimited,
+} );
+
+describe( 'useIsVideoPressUnlimited', () => {
+	afterEach( () => setInitialState( undefined ) );
+
+	it( 'returns false when neither initial state nor the features flag indicate unlimited', async () => {
+		setInitialState( { siteData: { isVideoPressUnlimited: false } } );
+		mockApiFetch( async () => featuresResponse( false ) );
+
+		const { result } = renderHook( () => useIsVideoPressUnlimited(), {
+			wrapper: createTestWrapper(),
+		} );
+
+		// Give the features query a chance to resolve, then confirm still false.
+		await waitFor( () => expect( result.current ).toBe( false ) );
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns true synchronously from initial state', () => {
+		setInitialState( { siteData: { isVideoPressUnlimited: true } } );
+		mockApiFetch( async () => featuresResponse( false ) );
+
+		const { result } = renderHook( () => useIsVideoPressUnlimited(), {
+			wrapper: createTestWrapper(),
+		} );
+
+		// No waitFor: the initial-state signal is available on first render.
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'returns true from the features REST flag when initial state is not unlimited', async () => {
+		setInitialState( { siteData: { isVideoPressUnlimited: false } } );
+		mockApiFetch( async () => featuresResponse( true ) );
+
+		const { result } = renderHook( () => useIsVideoPressUnlimited(), {
+			wrapper: createTestWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current ).toBe( true ) );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-stats.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-stats.test.ts
@@ -1,6 +1,164 @@
-import { transformVideoPlays } from '../use-stats';
+import { act, renderHook } from '@testing-library/react';
+import { getApiFetchMock, mockApiFetch } from '../../test-utils/mock-api-fetch';
+import { createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { transformVideoPlays, useStats, videoPlaysQueryOptions } from '../use-stats';
 
 describe( 'transformVideoPlays', () => {
+	it( 'returns empty stats when neither window has loaded', () => {
+		const result = transformVideoPlays( undefined, undefined, 'days' );
+		expect( result.views ).toEqual( { current: 0, previousPeriod: 0 } );
+		expect( result.series ).toEqual( [] );
+		expect( result.topVideos ).toEqual( [] );
+		expect( result.topVideosByWatchTime ).toEqual( [] );
+	} );
+
+	it( 'treats a loaded-but-empty response (no days) as all zeros', () => {
+		const result = transformVideoPlays( {}, undefined, 'days' );
+		expect( result.views ).toEqual( { current: 0, previousPeriod: 0 } );
+		expect( result.series ).toEqual( [] );
+		expect( result.topVideos ).toEqual( [] );
+	} );
+
+	it( 'sums per-day totals and fills previousPeriod from the previous window', () => {
+		const current = {
+			days: {
+				'2026-05-15': { total: { views: 10, impressions: 100, watch_time: 1 } },
+				'2026-05-16': { total: { views: 20, impressions: 200, watch_time: 2 } },
+			},
+		};
+		const previous = {
+			days: {
+				'2026-05-13': { total: { views: 3, impressions: 30, watch_time: 0.5 } },
+			},
+		};
+		const result = transformVideoPlays( current, previous, 'days' );
+		expect( result.views ).toEqual( { current: 30, previousPeriod: 3 } );
+		expect( result.impressions ).toEqual( { current: 300, previousPeriod: 30 } );
+		expect( result.watchTimeSeconds ).toEqual( {
+			current: 3 * 3600,
+			previousPeriod: 0.5 * 3600,
+		} );
+	} );
+
+	it( 'aligns previous-window values to current buckets by ordinal position', () => {
+		const current = {
+			days: {
+				'2026-05-15': { total: { views: 10 } },
+				'2026-05-16': { total: { views: 20 } },
+			},
+		};
+		const previous = {
+			days: {
+				'2026-05-13': { total: { views: 1 } },
+				'2026-05-14': { total: { views: 2 } },
+			},
+		};
+		const result = transformVideoPlays( current, previous, 'days' );
+		expect( result.series ).toEqual( [
+			expect.objectContaining( { date: '2026-05-15', views: 10, previousPeriodViews: 1 } ),
+			expect.objectContaining( { date: '2026-05-16', views: 20, previousPeriodViews: 2 } ),
+		] );
+	} );
+
+	it( 'collapses same-week days into one bucket under weeks granularity', () => {
+		// 2026-05-11 is a Monday; the 11th, 12th and the Sunday 17th all
+		// share the week of the 11th, while the 18th opens the next week.
+		// The Sunday case exercises the `getUTCDay() || 7` wrap-around.
+		const current = {
+			days: {
+				'2026-05-11': { total: { views: 5 } },
+				'2026-05-12': { total: { views: 7 } },
+				'2026-05-17': { total: { views: 3 } },
+				'2026-05-18': { total: { views: 4 } },
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'weeks' );
+		expect( result.series ).toEqual( [
+			expect.objectContaining( { date: '2026-05-11', views: 15 } ),
+			expect.objectContaining( { date: '2026-05-18', views: 4 } ),
+		] );
+	} );
+
+	it( 'collapses same-month days into a first-of-month bucket under months granularity', () => {
+		const current = {
+			days: {
+				'2026-05-15': { total: { views: 5 } },
+				'2026-05-20': { total: { views: 7 } },
+				'2026-06-01': { total: { views: 4 } },
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'months' );
+		expect( result.series ).toEqual( [
+			expect.objectContaining( { date: '2026-05-01', views: 12 } ),
+			expect.objectContaining( { date: '2026-06-01', views: 4 } ),
+		] );
+	} );
+
+	it( 'accumulates a video across days and keys by post_id', () => {
+		const current = {
+			days: {
+				'2026-05-15': { data: [ { post_id: 1, title: 'A', views: 3, watch_time: 1 } ] },
+				'2026-05-16': { data: [ { post_id: 1, title: 'A', views: 4, watch_time: 0.5 } ] },
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideos ).toHaveLength( 1 );
+		expect( result.topVideos[ 0 ] ).toMatchObject( { id: '1', views: 7, watchTimeSeconds: 5400 } );
+	} );
+
+	it( 'falls back to the title as key when post_id is missing, and skips id-less entries', () => {
+		const current = {
+			days: {
+				'2026-05-15': {
+					data: [
+						{ title: 'Untagged', views: 9, watch_time: 1 },
+						{ views: 99, watch_time: 9 },
+					],
+				},
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideos ).toHaveLength( 1 );
+		expect( result.topVideos[ 0 ] ).toMatchObject( { id: 'Untagged', title: 'Untagged' } );
+	} );
+
+	it( 'uses the post_id as the display title when the entry has no title', () => {
+		const current = {
+			days: { '2026-05-15': { data: [ { post_id: 42, views: 1 } ] } },
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideos[ 0 ] ).toMatchObject( { id: '42', title: '42' } );
+	} );
+
+	it( 'caps top lists at five and sorts each by its own metric', () => {
+		const current = {
+			days: {
+				'2026-05-15': {
+					data: [
+						{ post_id: 1, title: 'A', views: 1, watch_time: 6 },
+						{ post_id: 2, title: 'B', views: 2, watch_time: 5 },
+						{ post_id: 3, title: 'C', views: 3, watch_time: 4 },
+						{ post_id: 4, title: 'D', views: 4, watch_time: 3 },
+						{ post_id: 5, title: 'E', views: 5, watch_time: 2 },
+						{ post_id: 6, title: 'F', views: 6, watch_time: 1 },
+					],
+				},
+			},
+		};
+		const result = transformVideoPlays( current, undefined, 'days' );
+		expect( result.topVideos ).toHaveLength( 5 );
+		// Views: F(6) > E(5) > D(4) > C(3) > B(2); A is dropped.
+		expect( result.topVideos.map( v => v.title ) ).toEqual( [ 'F', 'E', 'D', 'C', 'B' ] );
+		// Watch time: A(6h) > B(5h) > C(4h) > D(3h) > E(2h); F is dropped.
+		expect( result.topVideosByWatchTime.map( v => v.title ) ).toEqual( [
+			'A',
+			'B',
+			'C',
+			'D',
+			'E',
+		] );
+	} );
+
 	it( 'converts watch_time from hours (WPCOM unit) to seconds in totals', () => {
 		const current = {
 			days: {
@@ -47,5 +205,65 @@ describe( 'transformVideoPlays', () => {
 		const result = transformVideoPlays( current, undefined, 'days' );
 		expect( result.topVideos[ 0 ].views ).toBe( 0 );
 		expect( result.topVideosByWatchTime[ 0 ].watchTimeSeconds ).toBe( 0 );
+	} );
+} );
+
+describe( 'videoPlaysQueryOptions', () => {
+	it( 'keys the query by path and window params', () => {
+		const params = { num: 7, date: '2026-05-15' };
+		const options = videoPlaysQueryOptions( params );
+		expect( options.queryKey ).toEqual( [ 'jetpack-videopress-stats', 'video-plays', params ] );
+	} );
+
+	it( 'fetches the day-period video-plays endpoint with the window params', async () => {
+		mockApiFetch( async () => ( {} ) );
+		const options = videoPlaysQueryOptions( { num: 7, date: '2026-05-15' } );
+		await options.queryFn!( {} as never );
+
+		const [ [ args ] ] = getApiFetchMock().mock.calls;
+		const path = ( args as { path: string } ).path;
+		expect( path ).toContain( '/jetpack/v4/videopress/stats/video-plays' );
+		expect( path ).toContain( 'period=day' );
+		expect( path ).toContain( 'num=7' );
+		expect( path ).toContain( 'date=2026-05-15' );
+	} );
+} );
+
+describe( 'useStats', () => {
+	beforeEach( () => {
+		mockApiFetch( async () => ( {} ) );
+	} );
+
+	it( 'forces the previous_period comparison when Watch time becomes active', () => {
+		const { result } = renderHook( () => useStats(), { wrapper: createTestWrapper() } );
+		// Default comparison shares a unit with a sibling metric.
+		expect( result.current.compare ).toBe( 'secondary_and_previous_period' );
+
+		act( () => {
+			result.current.setActiveMetric( 'watch_time' );
+		} );
+
+		expect( result.current.activeMetric ).toBe( 'watch_time' );
+		// Watch time has no unit-sharing sibling, so the comparison must
+		// collapse to previous_period.
+		expect( result.current.compare ).toBe( 'previous_period' );
+
+		// Re-selecting Watch time is idempotent: the comparison is already
+		// previous_period, so it stays put rather than being reset.
+		act( () => {
+			result.current.setActiveMetric( 'watch_time' );
+		} );
+		expect( result.current.compare ).toBe( 'previous_period' );
+	} );
+
+	it( 'leaves the comparison untouched for metrics that share a unit', () => {
+		const { result } = renderHook( () => useStats(), { wrapper: createTestWrapper() } );
+
+		act( () => {
+			result.current.setActiveMetric( 'impressions' );
+		} );
+
+		expect( result.current.activeMetric ).toBe( 'impressions' );
+		expect( result.current.compare ).toBe( 'secondary_and_previous_period' );
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -31,38 +31,6 @@ const COUNT_VIEW: View = {
 	sort: { field: 'date', direction: 'desc' },
 };
 
-type Override = boolean | null;
-
-/**
- * Parse a `?vp_free=…` / `?vp_at_limit=…`-style query param into a
- * tri-state override: `true` when present and truthy, `false` when
- * present and falsy, `null` when absent.
- *
- * Designer/QA toggles are read once on first call and frozen. They are
- * deliberately non-reactive because they require a full page reload to
- * change in practice.
- *
- * @param search - The query string (with or without leading `?`).
- * @param key    - Param name to read.
- * @return The override, or `null` when absent.
- */
-function parseOverride( search: string, key: string ): Override {
-	const params = new URLSearchParams( search );
-	if ( ! params.has( key ) ) {
-		return null;
-	}
-	const raw = params.get( key );
-	if ( raw === null ) {
-		return null;
-	}
-	const normalized = raw.toLowerCase();
-	return ! ( normalized === '0' || normalized === 'false' || normalized === '' );
-}
-
-const SEARCH = typeof window === 'undefined' ? '' : window.location.search;
-const FREE_OVERRIDE: Override = parseOverride( SEARCH, 'vp_free' );
-const AT_LIMIT_OVERRIDE: Override = parseOverride( SEARCH, 'vp_at_limit' );
-
 /**
  * Free-tier state derived from real data sources: server-side library
  * count via useLibrary, in-flight uploads via useUpload, plan-tier flags
@@ -78,14 +46,13 @@ export function useFreeTier(): FreeTierState {
 			? JPVIDEOPRESS_INITIAL_STATE?.siteData
 			: undefined;
 
-	const isFree = FREE_OVERRIDE !== null ? FREE_OVERRIDE : ! siteData?.hasVideoPressAccess;
+	const isFree = ! siteData?.hasVideoPressAccess;
 
 	const completed = paginationInfo?.totalItems ?? 0;
 	const inFlight = uploadQueue.filter(
 		u => u.status === 'uploading' || u.status === 'pending'
 	).length;
-	const realVideoCount = completed + inFlight;
-	const videoCount = AT_LIMIT_OVERRIDE === true ? FREE_TIER_UPLOAD_LIMIT : realVideoCount;
+	const videoCount = completed + inFlight;
 
 	const isAtomic = isWoASite();
 	const isUnlimited = useIsVideoPressUnlimited();

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -1,5 +1,5 @@
 import { isWoASite } from '@automattic/jetpack-script-data';
-import { useFeatures } from './use-features';
+import { useIsVideoPressUnlimited } from './use-is-videopress-unlimited';
 import { useLibrary } from './use-library';
 import { useUpload } from './use-upload';
 import type { View } from '@wordpress/dataviews';
@@ -73,7 +73,6 @@ const AT_LIMIT_OVERRIDE: Override = parseOverride( SEARCH, 'vp_at_limit' );
 export function useFreeTier(): FreeTierState {
 	const { paginationInfo } = useLibrary( COUNT_VIEW );
 	const { uploadQueue } = useUpload();
-	const features = useFeatures();
 	const siteData =
 		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
 			? JPVIDEOPRESS_INITIAL_STATE?.siteData
@@ -89,9 +88,7 @@ export function useFreeTier(): FreeTierState {
 	const videoCount = AT_LIMIT_OVERRIDE === true ? FREE_TIER_UPLOAD_LIMIT : realVideoCount;
 
 	const isAtomic = isWoASite();
-	const isUnlimited = Boolean(
-		siteData?.isVideoPressUnlimited || features.data?.isVideoPressUnlimitedSupported
-	);
+	const isUnlimited = useIsVideoPressUnlimited();
 
 	const isAtLimit = isFree && videoCount >= FREE_TIER_UPLOAD_LIMIT;
 

--- a/projects/packages/videopress/src/dashboard/hooks/use-is-videopress-unlimited.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-is-videopress-unlimited.ts
@@ -1,0 +1,22 @@
+import { useFeatures } from './use-features';
+
+/**
+ * Whether the site is grandfathered into the larger (2TB) VideoPress storage
+ * cap. WPCOM grants the `videopress-unlimited-storage` feature to Jetpack
+ * Premium/Business/Security/Complete plans purchased before 2021-10-07, and
+ * that tier is physically capped at 2TB. The signal arrives two ways: a
+ * synchronous initial-state value (so the storage meter shows the right
+ * denominator on first paint) and the features REST flag as a fallback.
+ *
+ * @return `true` when the site holds the unlimited (2TB) storage feature.
+ */
+export function useIsVideoPressUnlimited(): boolean {
+	const features = useFeatures();
+	const siteData =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+			? JPVIDEOPRESS_INITIAL_STATE?.siteData
+			: undefined;
+	return Boolean(
+		siteData?.isVideoPressUnlimited || features.data?.isVideoPressUnlimitedSupported
+	);
+}

--- a/projects/packages/videopress/src/dashboard/utils/test/format.test.ts
+++ b/projects/packages/videopress/src/dashboard/utils/test/format.test.ts
@@ -1,0 +1,79 @@
+import { buildShortcode, formatBytes, formatDuration, formatWatchTime } from '../format';
+
+describe( 'buildShortcode', () => {
+	it( 'returns an empty string when the GUID is missing', () => {
+		expect( buildShortcode( undefined, 640, 360 ) ).toBe( '' );
+	} );
+
+	it( 'renders the GUID alone when no dimensions are known', () => {
+		expect( buildShortcode( 'abc123', undefined, undefined ) ).toBe( '[videopress abc123]' );
+	} );
+
+	it( 'appends bare w=/h= when both dimensions are present', () => {
+		expect( buildShortcode( 'abc123', 640, 360 ) ).toBe( '[videopress abc123 w=640 h=360]' );
+	} );
+
+	it( 'omits a dimension that is missing or zero', () => {
+		expect( buildShortcode( 'abc123', 640, undefined ) ).toBe( '[videopress abc123 w=640]' );
+		expect( buildShortcode( 'abc123', 0, 360 ) ).toBe( '[videopress abc123 h=360]' );
+	} );
+} );
+
+describe( 'formatDuration', () => {
+	it( 'pads to mm:ss below an hour', () => {
+		expect( formatDuration( 0 ) ).toBe( '00:00' );
+		expect( formatDuration( 5 ) ).toBe( '00:05' );
+		expect( formatDuration( 65 ) ).toBe( '01:05' );
+	} );
+
+	it( 'switches to h:mm:ss at and above an hour', () => {
+		expect( formatDuration( 3600 ) ).toBe( '1:00:00' );
+		expect( formatDuration( 3661 ) ).toBe( '1:01:01' );
+	} );
+
+	it( 'floors fractional seconds', () => {
+		expect( formatDuration( 65.9 ) ).toBe( '01:05' );
+	} );
+
+	it( 'clamps negative input to zero', () => {
+		expect( formatDuration( -10 ) ).toBe( '00:00' );
+	} );
+} );
+
+describe( 'formatWatchTime', () => {
+	it( 'reports whole seconds below a minute', () => {
+		expect( formatWatchTime( 0 ) ).toBe( '0 s' );
+		expect( formatWatchTime( 30.4 ) ).toBe( '30 s' );
+	} );
+
+	it( 'rounds to whole minutes from one minute up to an hour', () => {
+		expect( formatWatchTime( 60 ) ).toBe( '1 min' );
+		expect( formatWatchTime( 90 ) ).toBe( '2 min' );
+		// Just shy of an hour rounds up to 60 min rather than flipping to hours.
+		expect( formatWatchTime( 3599 ) ).toBe( '60 min' );
+	} );
+
+	it( 'shows one decimal place of hours at and above an hour', () => {
+		expect( formatWatchTime( 3600 ) ).toBe( '1.0 h' );
+		expect( formatWatchTime( 5400 ) ).toBe( '1.5 h' );
+	} );
+} );
+
+describe( 'formatBytes', () => {
+	it( 'renders raw bytes below 1 KiB', () => {
+		expect( formatBytes( 0 ) ).toBe( '0 B' );
+		expect( formatBytes( 512 ) ).toBe( '512 B' );
+	} );
+
+	it( 'scales to the largest binary unit with one decimal place', () => {
+		expect( formatBytes( 1024 ) ).toBe( '1.0 KB' );
+		expect( formatBytes( 1536 ) ).toBe( '1.5 KB' );
+		expect( formatBytes( 1024 * 1024 ) ).toBe( '1.0 MB' );
+		expect( formatBytes( 1024 ** 3 ) ).toBe( '1.0 GB' );
+		expect( formatBytes( 1024 ** 4 ) ).toBe( '1.0 TB' );
+	} );
+
+	it( 'caps at TB rather than overflowing into larger units', () => {
+		expect( formatBytes( 1024 ** 5 ) ).toBe( '1024.0 TB' );
+	} );
+} );


### PR DESCRIPTION
Fixes #

This bundles several small, previously-missed improvements to the modernized (wp-build) VideoPress dashboard: storage-meter polish, retroactive test coverage for untested logic, and removal of development-only QA toggles. All changes are behind the `rsm_jetpack_ui_modernization_videopress` modernization filter.

## Proposed changes
* **Storage meter — grandfathered (2TB) sites:** add a `useIsVideoPressUnlimited` hook and source `useFreeTier`'s unlimited flag from it, so the Overview storage meter shows the correct 2TB denominator for sites grandfathered into the unlimited-storage feature.
* **Storage meter — layout:** wrap the Overview storage meter in a `Card` to match the surrounding dashboard cards.
* **Remove QA query-param overrides:** drop the `?vp_free` / `?vp_at_limit` URL toggles from `useFreeTier`. These were development scaffolding; free-tier status and the video count now derive solely from real data sources.
* **Test coverage:** add a dedicated unit test for the `format` utilities (`formatDuration`, `formatWatchTime`, `formatBytes`, `buildShortcode`) and extend the `use-stats` transform tests (previous-period window, series alignment, weeks/months bucketing, per-video aggregation, top-list sorting/limit, `videoPlaysQueryOptions`, and the `watch_time` comparison fallback). `format.ts` reaches 100% coverage and `use-stats.ts` goes from ~58% to 100% statements / 98% branches.

## Related product discussion/links
* https://github.com/Automattic/jetpack/issues/48506 (VideoPress dashboard modernization)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

These changes live behind the modernization filter, so first enable the modernized dashboard:

```php
add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );
```

* Go to **Jetpack → VideoPress** to load the modernized dashboard, and open the **Overview** tab.
* Confirm the storage meter renders inside a Card consistent with the other Overview cards.
* On a site grandfathered into unlimited (2TB) storage, confirm the storage meter shows a **2TB** total rather than the standard cap. (The signal comes from `siteData.isVideoPressUnlimited` / the `isVideoPressUnlimitedSupported` feature flag.)
* Confirm appending `?vp_free=1` or `?vp_at_limit=1` to the dashboard URL **no longer** forces free-tier / at-limit state — the UI reflects only the real plan and video count.
* Run the package test suite and confirm it is green:
  ```
  cd projects/packages/videopress && pnpm test
  ```
