### PR TITLE
VideoPress: enable modernized dashboard by default

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-modernization-release
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-release
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Dashboard: Release modernized VideoPress dashboard

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -522,7 +522,7 @@ class Admin_UI {
 	 * @return bool
 	 */
 	public static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-videopress-modernization-release
+++ b/projects/plugins/jetpack/changelog/update-videopress-modernization-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress dashboard update, not included in Jetpack plugin

--- a/projects/plugins/videopress/changelog/update-videopress-modernization-release
+++ b/projects/plugins/videopress/changelog/update-videopress-modernization-release
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Dashboard: Release modernized VideoPress dashboard


### PR DESCRIPTION
Fixes #48506

## Proposed changes
* Flip the VideoPress dashboard modernization filter (`rsm_jetpack_ui_modernization_videopress`) to default `true`, so the modernized wp-build dashboard is now served by default.
* Leave the legacy dashboard code in place so it can still be reached during the test period by overriding the filter (e.g. `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_false' )`) in case a regression needs a quick fallback.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with the VideoPress plugin (or Jetpack VideoPress) active, go to **VideoPress** in wp-admin (`wp-admin/admin.php?page=jetpack-videopress`).
* Confirm the **modernized** dashboard loads by default, with no filter overrides in place.
* Add `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_false' );` (e.g. in a mu-plugin or snippet) and reload the page; confirm the **legacy** dashboard is served, verifying the fallback path still works.
