### PR TITLE
Search Blocks: resolve theme chrome slugs from search.html (SEARCH-217)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-217-resolve-chrome-slugs
+++ b/projects/packages/search/changelog/SEARCH-217-resolve-chrome-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search blocks: render the active theme's header/footer template parts on the search page instead of the hardcoded 'header'/'footer' slugs (fixes blank chrome on themes like Career Development that ship variant-only part files).

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -170,6 +170,7 @@ class Search_Blocks {
 		if ( Module_Control::EXPERIENCE_EMBEDDED === $experience ) {
 			add_action( 'init', array( static::class, 'register_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
+			Theme_Chrome_Slug_Resolver::register_hooks();
 		}
 
 		// Priority 20: after WooCommerce's priority-10 prepend (so the
@@ -857,19 +858,10 @@ class Search_Blocks {
 	 * @return string Block markup for a complete page template.
 	 */
 	protected static function get_search_template_content(): string {
-		static $content = null;
-		if ( null !== $content ) {
-			return $content;
-		}
 		$template_path = __DIR__ . '/templates/jetpack-search.html';
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		$content = str_replace(
-			'{{FILTER_HEADING}}',
-			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
-			$raw
-		);
-		return $content;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
+		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		return static::substitute_template_placeholders( $raw );
 	}
 
 	/**
@@ -901,7 +893,7 @@ class Search_Blocks {
 		if ( '' === $content ) {
 			return;
 		}
-		register_block_template(
+		static::replace_block_template(
 			static::get_parent_plugin_slug() . '//' . self::SEARCH_TEMPLATE_SLUG,
 			array(
 				'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
@@ -1216,19 +1208,63 @@ CSS;
 	 * @return string Block markup for the product-search template.
 	 */
 	protected static function get_product_search_template_content(): string {
-		static $content = null;
-		if ( null !== $content ) {
-			return $content;
-		}
 		$template_path = __DIR__ . '/templates/jetpack-search-product-results.html';
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		$content = str_replace(
-			'{{FILTER_HEADING}}',
-			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
+		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		return static::substitute_template_placeholders( $raw );
+	}
+
+	/**
+	 * Substitute {{FILTER_HEADING}} / {{HEADER_SLUG}} / {{FOOTER_SLUG}}
+	 * in a bundled template's raw markup. Empty input passes through so
+	 * the "missing-file" bail-out in the registrars still fires.
+	 *
+	 * @param string $raw Raw template-file contents.
+	 * @return string
+	 */
+	protected static function substitute_template_placeholders( string $raw ): string {
+		if ( '' === $raw ) {
+			return $raw;
+		}
+		$slugs = static::resolve_chrome_slugs();
+		return str_replace(
+			array( '{{FILTER_HEADING}}', '{{HEADER_SLUG}}', '{{FOOTER_SLUG}}' ),
+			array(
+				esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+				$slugs['header'],
+				$slugs['footer'],
+			),
 			$raw
 		);
-		return $content;
+	}
+
+	/**
+	 * Active theme's chrome slugs. Seam — tests override to inject
+	 * canned values; the resolver itself lives in
+	 * Theme_Chrome_Slug_Resolver.
+	 *
+	 * @return array{header:string,footer:string}
+	 */
+	protected static function resolve_chrome_slugs(): array {
+		return Theme_Chrome_Slug_Resolver::resolve();
+	}
+
+	/**
+	 * Idempotent wrapper around register_block_template — unregisters
+	 * first so a stale entry from a prior init (long-lived PHP-FPM
+	 * worker) is replaced rather than triggering doing_it_wrong.
+	 *
+	 * @param string              $name Fully-qualified template name.
+	 * @param array<string,mixed> $args Args for register_block_template().
+	 */
+	protected static function replace_block_template( string $name, array $args ) {
+		if ( class_exists( '\WP_Block_Templates_Registry' ) ) {
+			$registry = \WP_Block_Templates_Registry::get_instance();
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+		register_block_template( $name, $args );
 	}
 
 	/**
@@ -1244,7 +1280,7 @@ CSS;
 		if ( '' === $content ) {
 			return;
 		}
-		register_block_template(
+		static::replace_block_template(
 			static::get_parent_plugin_slug() . '//' . self::PRODUCT_SEARCH_TEMPLATE_SLUG,
 			array(
 				'title'       => __( 'Jetpack Search Product Results', 'jetpack-search-pkg' ),

--- a/projects/packages/search/src/search-blocks/class-theme-chrome-slug-resolver.php
+++ b/projects/packages/search/src/search-blocks/class-theme-chrome-slug-resolver.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Resolves the header/footer template-part slugs the active theme uses for
+ * its search results so the bundled Jetpack Search template can mirror them.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Resolves chrome (header/footer) slugs for the bundled search templates,
+ * cached in a site option, invalidated on theme switch + relevant Site
+ * Editor saves.
+ *
+ * Resolution chain (per slot): theme's `search.html` → `index.html` →
+ * hardcoded `header`/`footer` defaults. The 237-theme wordpress.org
+ * survey behind SEARCH-217 found this two-rung chain covers every theme
+ * that ships parts at non-default slugs (the long tail of `wp:pattern`-
+ * wrap themes already works with the defaults because they still ship
+ * `parts/header.html` / `parts/footer.html`).
+ */
+class Theme_Chrome_Slug_Resolver {
+
+	const OPTION_NAME = 'jetpack_search_resolved_chrome_slugs';
+
+	const DEFAULTS = array(
+		'header' => 'header',
+		'footer' => 'footer',
+	);
+
+	/**
+	 * Hook invalidation actions. Idempotent — safe to call from init.
+	 */
+	public static function register_hooks() {
+		add_action( 'switch_theme', array( static::class, 'invalidate' ) );
+		add_action( 'save_post_wp_template', array( static::class, 'maybe_invalidate_on_template_save' ), 10, 2 );
+		add_action( 'save_post_wp_template_part', array( static::class, 'invalidate' ) );
+	}
+
+	/**
+	 * Resolved chrome slugs for the active theme.
+	 *
+	 * @return array{header:string,footer:string}
+	 */
+	public static function resolve(): array {
+		$stylesheet = (string) get_stylesheet();
+		if ( static::is_preview() ) {
+			// Preview themes: resolve fresh, never read or write the cache.
+			return static::compute( $stylesheet );
+		}
+		$cached = static::read_cache( $stylesheet );
+		if ( null !== $cached ) {
+			return $cached;
+		}
+		$computed = static::compute( $stylesheet );
+		static::write_cache( $stylesheet, $computed );
+		return $computed;
+	}
+
+	/**
+	 * Clear the cache. Hooked to `switch_theme` and template-part saves.
+	 */
+	public static function invalidate() {
+		delete_option( self::OPTION_NAME );
+	}
+
+	/**
+	 * `save_post_wp_template` handler — only invalidate when the saved
+	 * template is one we read from (`search` or `index`) on the active
+	 * theme. Cuts noise from unrelated template edits.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 */
+	public static function maybe_invalidate_on_template_save( $post_id, $post ) {
+		if ( ! $post instanceof \WP_Post ) {
+			return;
+		}
+		if ( 'search' !== $post->post_name && 'index' !== $post->post_name ) {
+			return;
+		}
+		$terms = wp_get_post_terms( $post_id, 'wp_theme', array( 'fields' => 'names' ) );
+		if ( is_wp_error( $terms ) || ! in_array( (string) get_stylesheet(), (array) $terms, true ) ) {
+			return;
+		}
+		static::invalidate();
+	}
+
+	/**
+	 * Pull the first and last top-level `core/template-part` slugs out of
+	 * template markup. Slugs outside `[a-zA-Z0-9_-]` are rejected so the
+	 * JSON round-trip in the bundled-template substitution can't break.
+	 * A single top-level template-part is treated as header-only.
+	 *
+	 * @param string $template_content Block markup.
+	 * @return array{header:?string,footer:?string}
+	 */
+	public static function extract_from_template_content( string $template_content ): array {
+		$header = null;
+		$footer = null;
+		$count  = 0;
+		if ( '' === $template_content || ! function_exists( 'parse_blocks' ) ) {
+			return array(
+				'header' => $header,
+				'footer' => $footer,
+			);
+		}
+		foreach ( parse_blocks( $template_content ) as $block ) {
+			if ( 'core/template-part' !== ( $block['blockName'] ?? '' ) ) {
+				continue;
+			}
+			$slug = $block['attrs']['slug'] ?? null;
+			if ( ! is_string( $slug ) || '' === $slug || ! preg_match( '/^[a-zA-Z0-9_-]+$/', $slug ) ) {
+				continue;
+			}
+			if ( null === $header ) {
+				$header = $slug;
+			}
+			$footer = $slug;
+			++$count;
+		}
+		if ( $count < 2 ) {
+			$footer = null;
+		}
+		return array(
+			'header' => $header,
+			'footer' => $footer,
+		);
+	}
+
+	/**
+	 * Run the resolution chain. Doesn't touch the cache (caller decides).
+	 *
+	 * @param string $stylesheet Active stylesheet.
+	 * @return array{header:string,footer:string}
+	 */
+	protected static function compute( string $stylesheet ): array {
+		unset( $stylesheet ); // stylesheet is implicit in `get_active_theme_template_content`.
+		$found = array(
+			'header' => null,
+			'footer' => null,
+		);
+		foreach ( array( 'search', 'index' ) as $template_name ) {
+			if ( null !== $found['header'] && null !== $found['footer'] ) {
+				break;
+			}
+			$content = static::get_active_theme_template_content( $template_name );
+			if ( null === $content ) {
+				continue;
+			}
+			$extracted       = static::extract_from_template_content( $content );
+			$found['header'] = $found['header'] ?? $extracted['header'];
+			$found['footer'] = $found['footer'] ?? $extracted['footer'];
+		}
+		return array(
+			'header' => $found['header'] ?? self::DEFAULTS['header'],
+			'footer' => $found['footer'] ?? self::DEFAULTS['footer'],
+		);
+	}
+
+	/**
+	 * Read the option-backed cache. Returns null on miss or when the
+	 * stored stylesheet doesn't match the active one (handles the rare
+	 * case where `switch_theme` fired without clearing the option).
+	 *
+	 * @param string $stylesheet Active stylesheet.
+	 * @return array{header:string,footer:string}|null
+	 */
+	protected static function read_cache( string $stylesheet ): ?array {
+		$raw = get_option( self::OPTION_NAME );
+		if ( ! is_array( $raw ) || ( $raw['stylesheet'] ?? null ) !== $stylesheet ) {
+			return null;
+		}
+		$header = $raw['header'] ?? null;
+		$footer = $raw['footer'] ?? null;
+		if ( ! is_string( $header ) || ! is_string( $footer ) ) {
+			return null;
+		}
+		return array(
+			'header' => $header,
+			'footer' => $footer,
+		);
+	}
+
+	/**
+	 * Persist the resolved slugs to the option-backed cache.
+	 *
+	 * @param string                             $stylesheet Active stylesheet.
+	 * @param array{header:string,footer:string} $slugs      Resolved slugs.
+	 */
+	protected static function write_cache( string $stylesheet, array $slugs ) {
+		update_option(
+			self::OPTION_NAME,
+			array(
+				'stylesheet' => $stylesheet,
+				'header'     => $slugs['header'],
+				'footer'     => $slugs['footer'],
+			),
+			false
+		);
+	}
+
+	/**
+	 * Whether the current request is a theme preview (Customizer or
+	 * Site Editor theme preview). Cache reads and writes are skipped in
+	 * this state so a preview never pollutes the production-theme cache.
+	 *
+	 * @return bool
+	 */
+	protected static function is_preview(): bool {
+		if ( function_exists( 'is_customize_preview' ) && is_customize_preview() ) {
+			return true;
+		}
+		// Site Editor theme preview surfaces as `?wp_theme_preview=<theme-slug>`.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only preview detection.
+		return ! empty( $_GET['wp_theme_preview'] );
+	}
+
+	/**
+	 * Resolved markup for an active-theme template. Overridable seam.
+	 *
+	 * @param string $template_name Bare template slug (no `theme//` prefix).
+	 * @return string|null
+	 */
+	protected static function get_active_theme_template_content( string $template_name ): ?string {
+		if ( ! function_exists( 'get_block_template' ) ) {
+			return null;
+		}
+		$tmpl = get_block_template( (string) get_stylesheet() . '//' . $template_name, 'wp_template' );
+		if ( ! $tmpl || empty( $tmpl->content ) ) {
+			return null;
+		}
+		return (string) $tmpl->content;
+	}
+}

--- a/projects/packages/search/src/search-blocks/class-theme-chrome-slug-resolver.php
+++ b/projects/packages/search/src/search-blocks/class-theme-chrome-slug-resolver.php
@@ -31,6 +31,10 @@ class Theme_Chrome_Slug_Resolver {
 
 	/**
 	 * Hook invalidation actions. Idempotent — safe to call from init.
+	 *
+	 * `save_post_wp_template_part` is broader than the wp_template hook
+	 * (no narrowing by slug or theme): part edits are rare and even an
+	 * over-eager invalidation is cheap (one extra `compute()` next request).
 	 */
 	public static function register_hooks() {
 		add_action( 'switch_theme', array( static::class, 'invalidate' ) );
@@ -47,13 +51,13 @@ class Theme_Chrome_Slug_Resolver {
 		$stylesheet = (string) get_stylesheet();
 		if ( static::is_preview() ) {
 			// Preview themes: resolve fresh, never read or write the cache.
-			return static::compute( $stylesheet );
+			return static::compute();
 		}
 		$cached = static::read_cache( $stylesheet );
 		if ( null !== $cached ) {
 			return $cached;
 		}
-		$computed = static::compute( $stylesheet );
+		$computed = static::compute();
 		static::write_cache( $stylesheet, $computed );
 		return $computed;
 	}
@@ -91,7 +95,10 @@ class Theme_Chrome_Slug_Resolver {
 	 * Pull the first and last top-level `core/template-part` slugs out of
 	 * template markup. Slugs outside `[a-zA-Z0-9_-]` are rejected so the
 	 * JSON round-trip in the bundled-template substitution can't break.
-	 * A single top-level template-part is treated as header-only.
+	 * A single top-level template-part is treated as header-only. Only
+	 * top-level blocks are walked — parts nested inside `wp:group`
+	 * containers are skipped on purpose (a theme that buries its chrome
+	 * inside a wrapper falls back to the resolver's later rungs).
 	 *
 	 * @param string $template_content Block markup.
 	 * @return array{header:?string,footer:?string}
@@ -131,12 +138,11 @@ class Theme_Chrome_Slug_Resolver {
 
 	/**
 	 * Run the resolution chain. Doesn't touch the cache (caller decides).
+	 * The active stylesheet is implicit via `get_active_theme_template_content()`.
 	 *
-	 * @param string $stylesheet Active stylesheet.
 	 * @return array{header:string,footer:string}
 	 */
-	protected static function compute( string $stylesheet ): array {
-		unset( $stylesheet ); // stylesheet is implicit in `get_active_theme_template_content`.
+	protected static function compute(): array {
 		$found = array(
 			'header' => null,
 			'footer' => null,
@@ -185,6 +191,16 @@ class Theme_Chrome_Slug_Resolver {
 
 	/**
 	 * Persist the resolved slugs to the option-backed cache.
+	 *
+	 * `autoload=false`: the option changes only on theme switches /
+	 * search.html edits, so we don't want it in the `alloptions` payload
+	 * fetched on every request. The first `get_option()` per request
+	 * issues its own DB query (or hits the object cache on sites that
+	 * have one) instead.
+	 *
+	 * Cache-cold race: two concurrent requests can both compute and write
+	 * with last-writer-wins semantics. Same input → same output, so
+	 * correctness isn't affected.
 	 *
 	 * @param string                             $stylesheet Active stylesheet.
 	 * @param array{header:string,footer:string} $slugs      Resolved slugs.

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
@@ -53,4 +53,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"{{FOOTER_SLUG}}"} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
@@ -48,4 +48,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"{{FOOTER_SLUG}}"} /-->

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -16,10 +16,10 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Clear `Search_Blocks::is_initial_loading()`'s per-request memo between
-	 * tests. PHPUnit runs every test in a single process, so without this
-	 * the first test that exercises a query/filter/price URL would pin the
-	 * cached value and every later test that sets `$_GET` would silently
-	 * read stale state.
+	 * Tests. PHPUnit runs every test in a single process, so without this
+	 * The first test that exercises a query/filter/price URL would pin the
+	 * Cached value and every later test that sets `$_GET` would silently
+	 * Read stale state.
 	 */
 	protected function tearDown(): void {
 		Search_Blocks::reset_initial_loading_cache();
@@ -66,7 +66,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The site's `date_format` Settings option flows into the seed so the JS
-	 * result card renders dates with the same layout as the rest of the site
+	 * Result card renders dates with the same layout as the rest of the site
 	 * (`F j, Y`, `Y-m-d`, etc.). Parsed client-side by `wp-date-format.js`.
 	 */
 	public function test_build_initial_state_seeds_site_date_format() {
@@ -87,8 +87,8 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * View-bundle strings seeded here are the sole i18n channel for the
 	 * Interactivity API bundle — it can't import @wordpress/i18n. Both
-	 * plural forms must be seeded so the client can pick based on the
-	 * live totalResults, and the format string must carry a `%d` token.
+	 * Plural forms must be seeded so the client can pick based on the
+	 * Live totalResults, and the format string must carry a `%d` token.
 	 */
 	public function test_build_initial_state_seeds_translated_strings() {
 		$state = Search_Blocks::build_initial_state();
@@ -106,8 +106,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A known `orderby` in the URL must seed sortOrder so SSR pre-fetches
-	 * the correct ordering. Values must stay aligned with the UI keys in
-	 * src/instant-search/lib/constants.js SORT_OPTIONS.
+	 * The correct ordering. Values must stay aligned with the UI keys in
+	 * Src/instant-search/lib/constants.js SORT_OPTIONS.
 	 */
 	public function test_build_initial_state_seeds_sort_order_from_url() {
 		$original_get = $_GET;
@@ -122,7 +122,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Unrecognized `orderby` values must fall back to the default `relevance`
-	 * sort, not propagate into the Elasticsearch query.
+	 * Sort, not propagate into the Elasticsearch query.
 	 */
 	public function test_build_initial_state_rejects_unknown_sort_order() {
 		$original_get = $_GET;
@@ -137,7 +137,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Product-format `?orderby` values seed `relevance` on non-Woo sites so
-	 * a deep link to a sort the API can't honour can't reach the
+	 * A deep link to a sort the API can't honour can't reach the
 	 * Elasticsearch query (RSM-1082).
 	 */
 	public function test_build_initial_state_rejects_product_sort_when_woocommerce_inactive() {
@@ -154,8 +154,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On Woo sites the same product-format `?orderby` values must seed the
-	 * matching sort and surface `isWooCommerceBlocksEnabled=true` on the IA store
-	 * so the JS-side url-state gate accepts them too (RSM-1082).
+	 * Matching sort and surface `isWooCommerceBlocksEnabled=true` on the IA store
+	 * So the JS-side url-state gate accepts them too (RSM-1082).
 	 */
 	public function test_build_initial_state_accepts_product_sort_when_woocommerce_active() {
 		$original_get = $_GET;
@@ -175,10 +175,10 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `jetpack_search_woocommerce_blocks_enabled` lets a site force the
-	 * gate true on a non-Woo install — useful for staging previews of
+	 * Gate true on a non-Woo install — useful for staging previews of
 	 * WC-only Search blocks. The filter result must be cached, so a
-	 * subsequent call returns the override even after the filter is
-	 * removed.
+	 * Subsequent call returns the override even after the filter is
+	 * Removed.
 	 */
 	public function test_woocommerce_blocks_enabled_filter_can_force_true() {
 		Search_Blocks::reset_woocommerce_blocks_enabled_cache();
@@ -192,12 +192,12 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Symmetry: the filter must also be able to force the gate false. We
-	 * can't construct a "WC is loaded" PHPUnit env without polluting the
-	 * global namespace with a `WooCommerce` stub class, so instead the
-	 * test pins the *contract*: the filter receives the probed bool and
-	 * its return value is what the function returns. The cast-to-bool
-	 * test below covers the related "filter result wins over probe" path
-	 * for non-bool returns.
+	 * Can't construct a "WC is loaded" PHPUnit env without polluting the
+	 * Global namespace with a `WooCommerce` stub class, so instead the
+	 * Test pins the *contract*: the filter receives the probed bool and
+	 * Its return value is what the function returns. The cast-to-bool
+	 * Test below covers the related "filter result wins over probe" path
+	 * For non-bool returns.
 	 */
 	public function test_woocommerce_blocks_enabled_filter_receives_probe_and_return_wins() {
 		Search_Blocks::reset_woocommerce_blocks_enabled_cache();
@@ -217,8 +217,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Pins the docblock promise: the filter fires once per request and
-	 * the result is cached, so a callback that probes the database or
-	 * reads an option pays its cost once even on a hot path.
+	 * The result is cached, so a callback that probes the database or
+	 * Reads an option pays its cost once even on a hot path.
 	 */
 	public function test_woocommerce_blocks_enabled_filter_only_fires_once_per_request() {
 		Search_Blocks::reset_woocommerce_blocks_enabled_cache();
@@ -240,8 +240,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A filter callback returning a truthy non-bool (`'1'`, `1`, etc.)
-	 * must not poison the strictly-typed `bool` cache. The function casts
-	 * before storing so callers using `===` against `true` still match.
+	 * Must not poison the strictly-typed `bool` cache. The function casts
+	 * Before storing so callers using `===` against `true` still match.
 	 */
 	public function test_woocommerce_blocks_enabled_filter_casts_truthy_non_bool_to_true() {
 		Search_Blocks::reset_woocommerce_blocks_enabled_cache();
@@ -258,11 +258,11 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Seeded `activeFilters` is the raw URL params — gating moved to
-	 * store/index.js's `initialize()` callback, which can apply it once
-	 * every filter block's render.php has contributed its filterConfig (and
-	 * the registry is complete). `build_seed_state()` must therefore pass
+	 * Store/index.js's `initialize()` callback, which can apply it once
+	 * Every filter block's render.php has contributed its filterConfig (and
+	 * The registry is complete). `build_seed_state()` must therefore pass
 	 * URL params through unchanged regardless of whether the matching filter
-	 * block was found in post content.
+	 * Block was found in post content.
 	 */
 	public function test_build_seed_state_passes_url_filters_through() {
 		$original_get   = $_GET;
@@ -295,9 +295,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A URL carrying a filter selection must leave isLoading=true so the JS
-	 * store shows the spinner until the first fetch resolves. JS-side gating
-	 * may later flip it back to false if every key gets dropped, but the
-	 * seed should default to true whenever activeFilters is non-empty.
+	 * Store shows the spinner until the first fetch resolves. JS-side gating
+	 * May later flip it back to false if every key gets dropped, but the
+	 * Seed should default to true whenever activeFilters is non-empty.
 	 */
 	public function test_build_seed_state_keeps_is_loading_for_active_filter() {
 		$original_get        = $_GET;
@@ -318,7 +318,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Subclass forcing `block_templates_active()` so the block-theme path
-	 * runs without a real block theme in the dbless env.
+	 * Runs without a real block theme in the dbless env.
 	 *
 	 * @return class-string<Search_Blocks>
 	 */
@@ -334,7 +334,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On a block-theme search request the slug is moved to the front of the
-	 * hierarchy, and a pre-existing copy is de-duplicated rather than doubled.
+	 * Hierarchy, and a pre-existing copy is de-duplicated rather than doubled.
 	 */
 	public function test_prepend_search_template_prepends_unique_slug() {
 		$original_query = $GLOBALS['wp_query'] ?? null;
@@ -356,7 +356,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The hierarchy is returned untouched unless the request is a search on a
-	 * block theme — the slug only resolves through the block-template system.
+	 * Block theme — the slug only resolves through the block-template system.
 	 */
 	public function test_prepend_search_template_skips_outside_block_theme_search() {
 		$original_query = $GLOBALS['wp_query'] ?? null;
@@ -405,9 +405,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * With the override option OFF, a WooCommerce product search must leave
-	 * the hierarchy untouched so WooCommerce's own priority-10 prepend of
+	 * The hierarchy untouched so WooCommerce's own priority-10 prepend of
 	 * `product-search-results` wins — that's the no-regression default for
-	 * stores that haven't opted in.
+	 * Stores that haven't opted in.
 	 */
 	public function test_prepend_search_template_defers_to_woocommerce_when_override_off() {
 		delete_option( 'jetpack_search_override_woocommerce_search_template' );
@@ -438,7 +438,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * With the override option ON, a WooCommerce product search falls
-	 * through the prepend carve-out (the priority-20 router then swaps
+	 * Through the prepend carve-out (the priority-20 router then swaps
 	 * WooCommerce's slug for `jetpack-search-product-results`).
 	 */
 	public function test_prepend_search_template_fronts_jetpack_when_override_on() {
@@ -503,7 +503,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * With the override on, `init()` registers both the product-search
-	 * template and the priority-20 routing filter.
+	 * Template and the priority-20 routing filter.
 	 */
 	public function test_init_registers_product_search_hooks_when_override_on() {
 		$this->reset_search_blocks_hooks();
@@ -557,11 +557,11 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The override only applies to the server-rendered experiences, mirroring
-	 * the dashboard's Embedded|Inline visibility gate. With the option on it
-	 * registers under Inline (server-rendered theme search); with the option
-	 * still on after the site switches to Overlay (client-side) or Off it must
+	 * The dashboard's Embedded|Inline visibility gate. With the option on it
+	 * Registers under Inline (server-rendered theme search); with the option
+	 * Still on after the site switches to Overlay (client-side) or Off it must
 	 * NOT register — a stale option from a since-switched experience can't keep
-	 * rerouting the hierarchy.
+	 * Rerouting the hierarchy.
 	 */
 	public function test_init_gates_product_search_hooks_on_server_rendered_experience() {
 		try {
@@ -630,9 +630,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `init()` must always register the block-level hooks AND the IA state
-	 * seeding regardless of which experience the site has saved — admins can
-	 * insert Search blocks anywhere blocks are configurable, and those blocks
-	 * need the seeded base state to hydrate.
+	 * Seeding regardless of which experience the site has saved — admins can
+	 * Insert Search blocks anywhere blocks are configurable, and those blocks
+	 * Need the seeded base state to hydrate.
 	 */
 	public function test_init_always_registers_block_and_seed_hooks() {
 		$this->reset_search_blocks_hooks();
@@ -684,7 +684,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Drop a script module from the WP_Script_Modules singleton. The class
-	 * exposes no public unregister, and the registry persists for the whole
+	 * Exposes no public unregister, and the registry persists for the whole
 	 * PHPUnit process, so reach into the private map to keep tests isolated.
 	 *
 	 * @param string $id Script module id.
@@ -703,7 +703,7 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * Place a fixture `store/index.asset.php` at the path
 	 * `register_store_script_module()` reads, without clobbering a real
-	 * build. Returns a cleanup callback that restores the prior state
+	 * Build. Returns a cleanup callback that restores the prior state
 	 * (original contents, or removal of anything this created).
 	 *
 	 * @param array $asset Asset array to write.
@@ -746,9 +746,9 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * The shared store must register as the `jetpack-search/store` Script
 	 * Module, sourced from the built `store/index.js` with the deps/version
-	 * declared in its generated asset file — that's what lets WordPress
-	 * resolve the dependency each block's view module declares instead of
-	 * shipping the store inlined per block.
+	 * Declared in its generated asset file — that's what lets WordPress
+	 * Resolve the dependency each block's view module declares instead of
+	 * Shipping the store inlined per block.
 	 */
 	public function test_register_store_script_module_registers_shared_module() {
 		$cleanup = $this->stub_store_asset_file(
@@ -780,8 +780,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * No build present (the common case in a fresh checkout / CI unit job):
-	 * the method must bail without registering anything or erroring, so
-	 * block registration is unaffected.
+	 * The method must bail without registering anything or erroring, so
+	 * Block registration is unaffected.
 	 */
 	public function test_register_store_script_module_noop_without_asset_file() {
 		$base = Package::get_installed_path() . 'build/search-blocks/store/index.asset.php';
@@ -804,8 +804,8 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * Off the Embedded experience, the template-override hooks
 	 * (`register_search_template` / `prepend_search_template`) must NOT be
-	 * registered — `/?s=…` should resolve to the theme's `search.html`, not
-	 * the Jetpack Search template.
+	 * Registered — `/?s=…` should resolve to the theme's `search.html`, not
+	 * The Jetpack Search template.
 	 */
 	public function test_init_does_not_register_template_hooks_when_not_embedded() {
 		$this->reset_search_blocks_hooks();
@@ -827,8 +827,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On the Embedded experience, the template-override hooks must be
-	 * registered so `/?s=…` resolves to the Jetpack Search template instead
-	 * of the theme's `search.html`.
+	 * Registered so `/?s=…` resolves to the Jetpack Search template instead
+	 * Of the theme's `search.html`.
 	 */
 	public function test_init_registers_template_hooks_when_embedded() {
 		$this->reset_search_blocks_hooks();
@@ -853,8 +853,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Saved Embedded but on a non-block theme: the experience resolves to Theme
-	 * search (inline), so the FSE template-takeover hooks must NOT register —
-	 * otherwise `/?s=…` would resolve to a template the theme can't render.
+	 * Search (inline), so the FSE template-takeover hooks must NOT register —
+	 * Otherwise `/?s=…` would resolve to a template the theme can't render.
 	 */
 	public function test_init_does_not_register_template_hooks_when_embedded_on_non_block_theme() {
 		$this->reset_search_blocks_hooks();
@@ -879,10 +879,10 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * If the module isn't active, the experience is `'off'` regardless of any
-	 * stale value in the experience option, so the template-override hooks
-	 * must not register. Guards against a leftover `'embedded'` value on a
-	 * site that's been deactivated. The block-level and seed hooks still
-	 * register so any post-content Search block continues to hydrate.
+	 * Stale value in the experience option, so the template-override hooks
+	 * Must not register. Guards against a leftover `'embedded'` value on a
+	 * Site that's been deactivated. The block-level and seed hooks still
+	 * Register so any post-content Search block continues to hydrate.
 	 */
 	public function test_init_does_not_register_template_hooks_when_module_inactive() {
 		$this->reset_search_blocks_hooks();
@@ -910,7 +910,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Remove every hook this class registers, so each `init()` test starts
-	 * from a known-empty state.
+	 * From a known-empty state.
 	 */
 	private function reset_search_blocks_hooks(): void {
 		remove_action( 'init', array( Search_Blocks::class, 'register_blocks' ) );
@@ -981,7 +981,7 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * `register_product_search_template()` registers the dedicated
 	 * `jetpack-search-product-results` template (its own Site Editor entry) seeded
-	 * from the product-search layout.
+	 * From the product-search layout.
 	 */
 	public function test_register_product_search_template_registers_via_block_template_api() {
 		if ( ! function_exists( 'register_block_template' ) ) {
@@ -1024,7 +1024,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Empty template content must be a no-op — otherwise the prepended slug
-	 * resolves to an empty template and renders a blank `/?s=...` page.
+	 * Resolves to an empty template and renders a blank `/?s=...` page.
 	 */
 	public function test_register_search_template_skips_when_content_empty() {
 		if ( ! function_exists( 'register_block_template' ) ) {
@@ -1056,7 +1056,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On a classic theme registration must be a no-op. The dbless default
-	 * theme is classic, so the real guard is exercised here.
+	 * Theme is classic, so the real guard is exercised here.
 	 */
 	public function test_register_search_template_skips_on_classic_theme() {
 		if ( ! function_exists( 'register_block_template' ) ) {
@@ -1079,8 +1079,146 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Registered template must reference resolved slugs, not raw
+	 * {{HEADER_SLUG}} / {{FOOTER_SLUG}} placeholders.
+	 */
+	public function test_register_search_template_substitutes_resolved_chrome_slugs() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function resolve_chrome_slugs(): array {
+					return array(
+						'header' => 'main-header',
+						'footer' => 'footer-columns',
+					);
+				}
+			}
+		);
+		$cls::register_search_template();
+
+		$expected   = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search';
+		$registered = $registry->get_registered( $expected );
+		$this->assertNotNull( $registered, "Template $expected should be registered." );
+		$this->assertStringContainsString( '"slug":"main-header"', $registered->content );
+		$this->assertStringContainsString( '"slug":"footer-columns"', $registered->content );
+		$this->assertStringNotContainsString( '{{HEADER_SLUG}}', $registered->content );
+		$this->assertStringNotContainsString( '{{FOOTER_SLUG}}', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
+	 * Replace_block_template wrapper makes registration idempotent: a
+	 * Second call with the same name replaces the prior entry instead
+	 * Of triggering doing_it_wrong (long-lived PHP-FPM workers).
+	 */
+	public function test_register_search_template_replaces_existing_registration() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$first = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function resolve_chrome_slugs(): array {
+					return array(
+						'header' => 'old-header',
+						'footer' => 'old-footer',
+					);
+				}
+			}
+		);
+		$first::register_search_template();
+
+		$second = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function resolve_chrome_slugs(): array {
+					return array(
+						'header' => 'new-header',
+						'footer' => 'new-footer',
+					);
+				}
+			}
+		);
+		$second::register_search_template();
+
+		$expected   = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search';
+		$registered = $registry->get_registered( $expected );
+		$this->assertNotNull( $registered );
+		$this->assertStringContainsString( '"slug":"new-header"', $registered->content );
+		$this->assertStringContainsString( '"slug":"new-footer"', $registered->content );
+		$this->assertStringNotContainsString( '"slug":"old-header"', $registered->content );
+		$this->assertStringNotContainsString( '"slug":"old-footer"', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
+	 * Product-results template goes through the same placeholder pipeline.
+	 */
+	public function test_register_product_search_template_substitutes_resolved_chrome_slugs() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search-product-results', 'jetpack//jetpack-search-product-results' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		$cls = get_class(
+			new class() extends Search_Blocks {
+				protected static function block_templates_active(): bool {
+					return true;
+				}
+				protected static function resolve_chrome_slugs(): array {
+					return array(
+						'header' => 'shop-header',
+						'footer' => 'shop-footer',
+					);
+				}
+			}
+		);
+		$cls::register_product_search_template();
+
+		$expected   = $this->invoke_protected( 'get_parent_plugin_slug' ) . '//jetpack-search-product-results';
+		$registered = $registry->get_registered( $expected );
+		$this->assertNotNull( $registered );
+		$this->assertStringContainsString( '"slug":"shop-header"', $registered->content );
+		$this->assertStringContainsString( '"slug":"shop-footer"', $registered->content );
+		$this->assertStringNotContainsString( '{{HEADER_SLUG}}', $registered->content );
+		$this->assertStringNotContainsString( '{{FOOTER_SLUG}}', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
 	 * When both the Jetpack monolith and the standalone Jetpack Search plugin
-	 * are active, the more-specific "Jetpack Search" label must win so the
+	 * Are active, the more-specific "Jetpack Search" label must win so the
 	 * Site Editor shows the template under Search rather than the umbrella
 	 * Jetpack plugin.
 	 */
@@ -1110,8 +1248,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Neither preferred plugin active (shouldn't happen — the package is only
-	 * loaded by one of them — but test the safe fallback so a misconfigured
-	 * site doesn't break template registration with an invalid namespace).
+	 * Loaded by one of them — but test the safe fallback so a misconfigured
+	 * Site doesn't break template registration with an invalid namespace).
 	 */
 	public function test_get_parent_plugin_slug_falls_back_when_neither_active() {
 		$original = get_option( 'active_plugins', array() );
@@ -1125,8 +1263,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On the WP search route, the inline blocks must keep using the
-	 * canonical `s` URL key so they interoperate with core's search
-	 * routing, body classes, and any theme/plugin code keyed off `s`.
+	 * Canonical `s` URL key so they interoperate with core's search
+	 * Routing, body classes, and any theme/plugin code keyed off `s`.
 	 */
 	public function test_get_search_param_name_uses_s_on_search_route() {
 		$original_query = $GLOBALS['wp_query'] ?? null;
@@ -1140,8 +1278,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On any non-search request (singular page, archive, front page),
-	 * the inline blocks must switch to `q` so a refresh of an inline-
-	 * search URL like `/about/?q=boots` doesn't trip core's
+	 * The inline blocks must switch to `q` so a refresh of an inline-
+	 * Search URL like `/about/?q=boots` doesn't trip core's
 	 * `WP_Query::get_posts()` AND'd `post_content LIKE` clause and
 	 * 404 the page (RSM-1754).
 	 */
@@ -1159,7 +1297,7 @@ class Search_Blocks_Test extends TestCase {
 	 * On the WP search route, the seed must read `searchQuery` from
 	 * `?s=…` and tell the JS store the active key is `s` so subsequent
 	 * URL writes (debounced search keystrokes, `popstate`) stay on the
-	 * canonical key.
+	 * Canonical key.
 	 */
 	public function test_build_initial_state_uses_s_on_search_route() {
 		$original_get        = $_GET;
@@ -1178,9 +1316,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On a non-search page (singular embed, archive, etc.), the seed
-	 * must read `searchQuery` from `?q=…` and ignore any stray `?s=…`
+	 * Must read `searchQuery` from `?q=…` and ignore any stray `?s=…`
 	 * (which is the URL shape we deliberately stopped writing to
-	 * dodge the singular 404 path).
+	 * Dodge the singular 404 path).
 	 */
 	public function test_build_initial_state_uses_q_off_search_route() {
 		$original_get        = $_GET;
@@ -1202,9 +1340,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Off the search route, an `?s=boots` URL must NOT seed the inline
-	 * search — the active key is `q`. Without this, a stray `s` (from
-	 * a pre-existing shared link or an unrelated plugin) would still
-	 * hydrate the Interactivity store and re-emit `?s=` on the next
+	 * Search — the active key is `q`. Without this, a stray `s` (from
+	 * A pre-existing shared link or an unrelated plugin) would still
+	 * Hydrate the Interactivity store and re-emit `?s=` on the next
 	 * URL push, walking us back into the singular 404 path.
 	 */
 	public function test_build_initial_state_ignores_legacy_s_param_off_search_route() {
@@ -1225,12 +1363,12 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * Both URL keys the inline blocks may write (`s` on the search route,
 	 * `q` off it) must be reserved by `parse_url_filters()` so a hostile
-	 * or malformed `?s[]=…&q[]=…` can't smuggle the search query into
+	 * Or malformed `?s[]=…&q[]=…` can't smuggle the search query into
 	 * `activeFilters` (which would forward it to ES as a filter clause
-	 * and round-trip it back into the URL on every keystroke). The real
-	 * filter alongside them proves the rest of the parser is still
-	 * working — i.e. the reservation gate is surgical, not a side
-	 * effect of an unrelated rejection earlier in the loop.
+	 * And round-trip it back into the URL on every keystroke). The real
+	 * Filter alongside them proves the rest of the parser is still
+	 * Working — i.e. the reservation gate is surgical, not a side
+	 * Effect of an unrelated rejection earlier in the loop.
 	 */
 	public function test_build_initial_state_reserves_both_s_and_q_from_active_filters() {
 		$original_get        = $_GET;
@@ -1253,8 +1391,8 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * The filter-checkbox inserter cards come from
 	 * Search_Blocks::inject_filter_checkbox_variations(); if these names or
-	 * seeded attributes drift, the editor stops offering the expected filter
-	 * presets or inserts them with the wrong defaults.
+	 * Seeded attributes drift, the editor stops offering the expected filter
+	 * Presets or inserts them with the wrong defaults.
 	 */
 	public function test_inject_filter_checkbox_variations_adds_expected_shapes() {
 		// Product variations are WC-gated; flip the probe so this matrix
@@ -1353,8 +1491,8 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * `product_brand` isn't a core WC taxonomy — it's added by extensions
 	 * (WC Brands, Perfect Brands, recent bundled WC versions). The variation
-	 * is registered only when the taxonomy is present so authors don't see
-	 * a silently-empty filter on sites without a brands extension.
+	 * Is registered only when the taxonomy is present so authors don't see
+	 * A silently-empty filter on sites without a brands extension.
 	 */
 	public function test_inject_filter_checkbox_variations_gates_product_brand_on_taxonomy_existence() {
 		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( true );
@@ -1393,9 +1531,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On non-Woo sites the three product taxonomy variations (product_cat,
-	 * product_tag, product_brand) must NOT appear in the inserter — the
-	 * underlying taxonomies don't exist there, so the variations would
-	 * render silently-empty filters. The non-WC variations stay registered.
+	 * Product_tag, product_brand) must NOT appear in the inserter — the
+	 * Underlying taxonomies don't exist there, so the variations would
+	 * Render silently-empty filters. The non-WC variations stay registered.
 	 */
 	public function test_inject_filter_checkbox_variations_drops_product_when_woocommerce_inactive() {
 		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( false );
@@ -1423,11 +1561,11 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `is_woocommerce_only_block()` is the canonical predicate that drives
-	 * the three coupled gates — `register_blocks()` registration loop, the
+	 * The three coupled gates — `register_blocks()` registration loop, the
 	 * `filter_block_helpers()` map, and the editor's `register-blocks.js`
-	 * bundle (after the localized list). Membership is decided by exact
-	 * match against `woocommerce_only_block_names()`, so adding a name to
-	 * that list auto-enrolls every gate without further plumbing.
+	 * Bundle (after the localized list). Membership is decided by exact
+	 * Match against `woocommerce_only_block_names()`, so adding a name to
+	 * That list auto-enrolls every gate without further plumbing.
 	 */
 	public function test_is_woocommerce_only_block_matches_canonical_list() {
 		// Every entry on the canonical list resolves to true under both
@@ -1465,10 +1603,10 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * `filter_block_helpers()` underwrites both `walk_blocks_for_filter_configs()`
 	 * (which reads block trees in post content) and any future caller that
-	 * needs to know whether a block name is filter-shaped. On non-Woo sites
-	 * the WC-only blocks aren't registered, so they must drop out of the
-	 * helper map too — keeping the registry symmetric with what the inserter
-	 * offered.
+	 * Needs to know whether a block name is filter-shaped. On non-Woo sites
+	 * The WC-only blocks aren't registered, so they must drop out of the
+	 * Helper map too — keeping the registry symmetric with what the inserter
+	 * Offered.
 	 */
 	public function test_filter_block_helpers_drops_wc_helpers_when_woocommerce_inactive() {
 		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( false );
@@ -1483,7 +1621,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * On Woo sites the helper map must include every WC-only block so
-	 * filter-config collection covers the full filter surface.
+	 * Filter-config collection covers the full filter surface.
 	 */
 	public function test_filter_block_helpers_includes_wc_helpers_when_woocommerce_active() {
 		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( true );
@@ -1496,10 +1634,10 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `min_price` / `max_price` are WC-only; `filter-wc-price` isn't
-	 * registered on non-Woo sites. A stray deep link must not seed the
+	 * Registered on non-Woo sites. A stray deep link must not seed the
 	 * `priceRange` slice — otherwise the JS store would re-emit the params
-	 * on the next URL push and the API request would carry a `range` clause
-	 * for a field the index doesn't have.
+	 * On the next URL push and the API request would carry a `range` clause
+	 * For a field the index doesn't have.
 	 */
 	public function test_build_initial_state_drops_price_range_when_woocommerce_inactive() {
 		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( false );
@@ -1524,8 +1662,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The same deep link on a Woo site must round-trip into `priceRange`
-	 * so the API request fires with the matching `range` clause on first
-	 * paint — this is the same contract `filter-wc-price` writes to URL.
+	 * So the API request fires with the matching `range` clause on first
+	 * Paint — this is the same contract `filter-wc-price` writes to URL.
 	 */
 	public function test_build_initial_state_seeds_price_range_when_woocommerce_active() {
 		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( true );
@@ -1550,8 +1688,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `?s=foo` is the established case: param present and non-empty. The
-	 * initial-loading gate must keep firing so `results-list/render.php`
-	 * paints the skeleton during the JS-side hydration round-trip.
+	 * Initial-loading gate must keep firing so `results-list/render.php`
+	 * Paints the skeleton during the JS-side hydration round-trip.
 	 */
 	public function test_is_initial_loading_with_non_empty_search_query() {
 		$original_get        = $_GET;
@@ -1572,12 +1710,12 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `?s=` (param present, value empty) is the SEARCH-183 case — visitor
-	 * submitted a blank search and expects an unfiltered result set. Both
-	 * the presence helper and the loading gate must flip true even though
+	 * Submitted a blank search and expects an unfiltered result set. Both
+	 * The presence helper and the loading gate must flip true even though
 	 * `parse_url_search_query()` trims to `''`. The `wp_query` is primed
-	 * with a non-empty `s` so `is_search()` reports the search route and
+	 * With a non-empty `s` so `is_search()` reports the search route and
 	 * `get_search_param_name()` picks the `s` key — the empty URL value
-	 * rides on `$_GET`.
+	 * Rides on `$_GET`.
 	 */
 	public function test_is_initial_loading_with_empty_search_query_string() {
 		$original_get        = $_GET;
@@ -1599,9 +1737,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Off the search route the active key is `q`. `?q=` (empty value) must
-	 * still trigger initial loading so an inline-search page on a singular
-	 * post matches the search-route behavior — visitor submitted a blank
-	 * inline search, expects the unfiltered result set.
+	 * Still trigger initial loading so an inline-search page on a singular
+	 * Post matches the search-route behavior — visitor submitted a blank
+	 * Inline search, expects the unfiltered result set.
 	 */
 	public function test_is_initial_loading_with_empty_q_param_off_search_route() {
 		$original_get        = $_GET;
@@ -1619,8 +1757,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A URL with no search param at all (homepage, archive, etc.) must not
-	 * flip into the loading state — there's no fetch to wait on, and a
-	 * seeded spinner would render placeholders that never resolve.
+	 * Flip into the loading state — there's no fetch to wait on, and a
+	 * Seeded spinner would render placeholders that never resolve.
 	 */
 	public function test_is_initial_loading_with_no_search_param_present() {
 		$original_get        = $_GET;
@@ -1641,9 +1779,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Array-shaped `?q[]=foo` is malformed input — `parse_url_search_query()`
-	 * bails to `''` via its `is_scalar()` guard, so `has_search_param()`
-	 * matches that contract and treats it as "not present" rather than
-	 * flipping the page into a loading state with no usable query.
+	 * Bails to `''` via its `is_scalar()` guard, so `has_search_param()`
+	 * Matches that contract and treats it as "not present" rather than
+	 * Flipping the page into a loading state with no usable query.
 	 */
 	public function test_has_search_param_rejects_non_scalar_input() {
 		$original_get        = $_GET;
@@ -1661,7 +1799,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The injector must be scoped to jetpack-search/filter-checkbox so it
-	 * can't leak Search-specific presets onto unrelated blocks.
+	 * Can't leak Search-specific presets onto unrelated blocks.
 	 */
 	public function test_inject_filter_checkbox_variations_ignores_other_block_types() {
 		$variations = array(
@@ -1679,9 +1817,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * If a variation with one of our preset names is already registered (via
-	 * block.json or a higher-priority filter), the existing entry must win —
-	 * otherwise `array_merge` would emit two inserter cards under the same
-	 * variation name and the editor would resolve `isActive` ambiguously.
+	 * Block.json or a higher-priority filter), the existing entry must win —
+	 * Otherwise `array_merge` would emit two inserter cards under the same
+	 * Variation name and the editor would resolve `isActive` ambiguously.
 	 */
 	public function test_inject_filter_checkbox_variations_skips_name_collisions() {
 		$existing_category = array(
@@ -1717,11 +1855,11 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The shared display-style normalizer powers the bucket-driven filter
-	 * blocks that opt into chips today (filter-checkbox, filter-date,
-	 * filter-wc-attribute). Per-block delegations are exercised in their
-	 * own tests; this case pins the source-of-truth contract so a `'chips'`
-	 * literal never gains a third synonym (`'chip'`, `'CHIPS'`, …) without
-	 * an explicit test update.
+	 * Blocks that opt into chips today (filter-checkbox, filter-date,
+	 * Filter-wc-attribute). Per-block delegations are exercised in their
+	 * Own tests; this case pins the source-of-truth contract so a `'chips'`
+	 * Literal never gains a third synonym (`'chip'`, `'CHIPS'`, …) without
+	 * An explicit test update.
 	 */
 	public function test_normalize_display_style_pins_enum() {
 		$this->assertSame( 'checkbox-list', Search_Blocks::normalize_display_style( null ) );
@@ -1735,9 +1873,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * No filter registered → empty map. Anchors the default behavior so a
-	 * site that hasn't opted into the slot-mapping feature pays nothing
-	 * for it (the `Custom Taxonomy` picker still works against the native
-	 * allowlist).
+	 * Site that hasn't opted into the slot-mapping feature pays nothing
+	 * For it (the `Custom Taxonomy` picker still works against the native
+	 * Allowlist).
 	 */
 	public function test_custom_taxonomy_map_empty_by_default() {
 		$this->assertSame( array(), Search_Blocks::custom_taxonomy_map() );
@@ -1745,7 +1883,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Valid mappings round-trip through the filter, including across multiple
-	 * slots — pins both the per-entry shape and the multi-entry support.
+	 * Slots — pins both the per-entry shape and the multi-entry support.
 	 */
 	public function test_custom_taxonomy_map_accepts_valid_entries() {
 		$callback = static function () {
@@ -1770,10 +1908,10 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Invalid slot values must be dropped — the slot field path determines
-	 * the ES field name, so an arbitrary string would query a non-existent
-	 * field and the filter would silently return zero buckets. The valid
-	 * sibling entry must still come through so one bad entry doesn't sink
-	 * the entire map.
+	 * The ES field name, so an arbitrary string would query a non-existent
+	 * Field and the filter would silently return zero buckets. The valid
+	 * Sibling entry must still come through so one bad entry doesn't sink
+	 * The entire map.
 	 */
 	public function test_custom_taxonomy_map_rejects_invalid_slot_values() {
 		$callback = static function () {
@@ -1802,9 +1940,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Two user-slugs pointing at the same slot would merge their term
-	 * spaces in the index (they'd both pull from the same `jetpack-search-tagN`
-	 * field) — the second filter would silently return results from the
-	 * first. Reject the duplicate; first-write wins.
+	 * Spaces in the index (they'd both pull from the same `jetpack-search-tagN`
+	 * Field) — the second filter would silently return results from the
+	 * First. Reject the duplicate; first-write wins.
 	 */
 	public function test_custom_taxonomy_map_rejects_duplicate_slot_assignment() {
 		$callback = static function () {
@@ -1828,9 +1966,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A filter callback that returns something other than an array must not
-	 * crash callers — empty map is the safe fallback. `_doing_it_wrong()` is
-	 * fired so a misconfiguration is visible during development; tested
-	 * separately below.
+	 * Crash callers — empty map is the safe fallback. `_doing_it_wrong()` is
+	 * Fired so a misconfiguration is visible during development; tested
+	 * Separately below.
 	 */
 	public function test_custom_taxonomy_map_handles_non_array_return() {
 		$callback = static function () {
@@ -1849,7 +1987,7 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * Pins the docblock promise that a non-array filter return fires a
 	 * `_doing_it_wrong()` notice, so site owners notice misconfiguration
-	 * during development rather than silently getting an empty picker.
+	 * During development rather than silently getting an empty picker.
 	 */
 	public function test_custom_taxonomy_map_fires_doing_it_wrong_on_non_array_return() {
 		$callback = static function () {
@@ -1880,8 +2018,8 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * The map's user-facing keys flow into the editor's whitelist (via
 	 * `supported_custom_taxonomies()`) so a mapped taxonomy appears in the
-	 * picker even if it's not in Jetpack Search's native allowlist. The
-	 * taxonomy must be registered on the site — otherwise the editor's
+	 * Picker even if it's not in Jetpack Search's native allowlist. The
+	 * Taxonomy must be registered on the site — otherwise the editor's
 	 * `core.getTaxonomies()` won't surface it anyway.
 	 */
 	public function test_supported_custom_taxonomies_includes_map_keys_when_registered() {
@@ -1900,9 +2038,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A map entry whose user-facing slug isn't registered locally must NOT
-	 * surface in the whitelist — the editor picker can't render a label for
-	 * an unregistered taxonomy, so silently dropping it keeps the surface
-	 * consistent with what the editor will actually display.
+	 * Surface in the whitelist — the editor picker can't render a label for
+	 * An unregistered taxonomy, so silently dropping it keeps the surface
+	 * Consistent with what the editor will actually display.
 	 */
 	public function test_supported_custom_taxonomies_drops_unregistered_map_keys() {
 		$callback = static function () {
@@ -1919,9 +2057,9 @@ class Search_Blocks_Test extends TestCase {
 	/**
 	 * Built-in taxonomies covered by their own filter variations
 	 * (`category`, `post_tag`, plus the three product taxonomies) must never
-	 * appear in the Custom Taxonomy picker even though they sit on the
+	 * Appear in the Custom Taxonomy picker even though they sit on the
 	 * Jetpack Search allowlist — the dedicated variation is the right
-	 * surface for those filters and a duplicate entry would be confusing.
+	 * Surface for those filters and a duplicate entry would be confusing.
 	 */
 	public function test_supported_custom_taxonomies_excludes_built_in_variations() {
 		// `category` and `post_tag` are registered by core in any WP env.
@@ -1932,14 +2070,14 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * A taxonomy that's in Jetpack Search's native allowlist must surface
-	 * automatically when registered on the site — without requiring an
-	 * entry in the slot map. This is the case the FAQ's
+	 * Automatically when registered on the site — without requiring an
+	 * Entry in the slot map. This is the case the FAQ's
 	 * `jetpack_search_allowed_taxonomies_for_widget_filters` walkthrough
-	 * covers: pre-allowlisted taxonomies just need to be registered.
+	 * Covers: pre-allowlisted taxonomies just need to be registered.
 	 *
 	 * `jetpack-search-tag0`…`jetpack-search-tag9` are themselves on the
 	 * Sync allowlist (they're the reserved slot taxonomies), so a site
-	 * that registers one directly gets it in the picker straight away.
+	 * That registers one directly gets it in the picker straight away.
 	 */
 	public function test_supported_custom_taxonomies_includes_natively_indexed_when_registered() {
 		register_taxonomy( 'jetpack-search-tag0', 'post', array( 'public' => true ) );
@@ -1952,11 +2090,11 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The slot map is resolved into each filterConfig's `effectiveSlug` at
-	 * config-build time rather than threaded through the IA state seed,
-	 * so the front-end query builders stay pure. `Filter_Checkbox::build_config()`
-	 * is exercised separately in this suite; this case anchors the
-	 * intentional absence of a global `customTaxonomyMap` on the seed so a
-	 * future refactor doesn't reintroduce the bidirectional plumbing.
+	 * Config-build time rather than threaded through the IA state seed,
+	 * So the front-end query builders stay pure. `Filter_Checkbox::build_config()`
+	 * Is exercised separately in this suite; this case anchors the
+	 * Intentional absence of a global `customTaxonomyMap` on the seed so a
+	 * Future refactor doesn't reintroduce the bidirectional plumbing.
 	 */
 	public function test_build_initial_state_does_not_carry_custom_taxonomy_map_globally() {
 		$state = Search_Blocks::build_initial_state();
@@ -1965,9 +2103,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The resolver routes mapped slugs to their slot and unmapped slugs to
-	 * themselves. Built-in slugs (covered by their own filter variations)
-	 * always return verbatim regardless of map content, so a stray entry
-	 * can't silently redirect a built-in filter.
+	 * Themselves. Built-in slugs (covered by their own filter variations)
+	 * Always return verbatim regardless of map content, so a stray entry
+	 * Can't silently redirect a built-in filter.
 	 */
 	public function test_resolve_taxonomy_slot_routes_mapped_and_built_in_slugs_correctly() {
 		$callback = static function ( $map ) {
@@ -1993,9 +2131,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Silence `_doing_it_wrong()` notices for tests that exercise the
-	 * misconfiguration branches. PHPUnit's deprecation/notice handlers
-	 * would otherwise flip the test red on the very codepath we want to
-	 * exercise.
+	 * Misconfiguration branches. PHPUnit's deprecation/notice handlers
+	 * Would otherwise flip the test red on the very codepath we want to
+	 * Exercise.
 	 *
 	 * @return callable|null Previous error handler, restored later.
 	 */
@@ -2020,8 +2158,8 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Invoke a protected static on Search_Blocks from test code. Reflection
-	 * is the cheapest way to cover this logic without leaking visibility
-	 * just for testability.
+	 * Is the cheapest way to cover this logic without leaking visibility
+	 * Just for testability.
 	 *
 	 * @param string $method Method name.
 	 * @param mixed  ...$args Positional args.

--- a/projects/packages/search/tests/php/Theme_Chrome_Slug_Resolver_Test.php
+++ b/projects/packages/search/tests/php/Theme_Chrome_Slug_Resolver_Test.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Theme_Chrome_Slug_Resolver tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\Search\Theme_Chrome_Slug_Resolver
+ */
+#[CoversClass( Theme_Chrome_Slug_Resolver::class )]
+class Theme_Chrome_Slug_Resolver_Test extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		delete_option( Theme_Chrome_Slug_Resolver::OPTION_NAME );
+		unset( $_GET['wp_theme_preview'] );
+	}
+
+	protected function tearDown(): void {
+		delete_option( Theme_Chrome_Slug_Resolver::OPTION_NAME );
+		unset( $_GET['wp_theme_preview'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Pure extractor coverage.
+	 *
+	 * @dataProvider provider_extract_from_template_content
+	 *
+	 * @param string                               $content  Markup.
+	 * @param array{header:?string,footer:?string} $expected Expected slugs.
+	 */
+	#[DataProvider( 'provider_extract_from_template_content' )]
+	public function test_extract_from_template_content( string $content, array $expected ) {
+		$this->assertSame( $expected, Theme_Chrome_Slug_Resolver::extract_from_template_content( $content ) );
+	}
+
+	/**
+	 * Extractor fixtures.
+	 *
+	 * @return array<string, array{0:string, 1:array{header:?string,footer:?string}}>
+	 */
+	public static function provider_extract_from_template_content(): array {
+		return array(
+			'Standard header + footer (TT3/4/5)'           => array(
+				'<!-- wp:template-part {"slug":"header","tagName":"header"} /-->' . "\n"
+				. '<main></main>' . "\n"
+				. '<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->',
+				array(
+					'header' => 'header',
+					'footer' => 'footer',
+				),
+			),
+			'Variant slugs (career-development)'           => array(
+				'<!-- wp:template-part {"slug":"main-header","theme":"career-development","tagName":"header"} /-->' . "\n"
+				. '<main></main>' . "\n"
+				. '<!-- wp:template-part {"slug":"footer-columns","theme":"career-development","tagName":"footer"} /-->',
+				array(
+					'header' => 'main-header',
+					'footer' => 'footer-columns',
+				),
+			),
+			'Single template-part is header-only'          => array(
+				'<!-- wp:template-part {"slug":"header"} /-->' . "\n"
+				. '<main></main>',
+				array(
+					'header' => 'header',
+					'footer' => null,
+				),
+			),
+			'Two template-parts sharing a slug are preserved' => array(
+				'<!-- wp:template-part {"slug":"site-shell"} /-->' . "\n"
+				. '<main></main>' . "\n"
+				. '<!-- wp:template-part {"slug":"site-shell"} /-->',
+				array(
+					'header' => 'site-shell',
+					'footer' => 'site-shell',
+				),
+			),
+			'Unsafe slug rejected (JSON round-trip guard)' => array(
+				'<!-- wp:template-part {"slug":"valid"} /-->' . "\n"
+				. '<!-- wp:template-part {"slug":"has space"} /-->',
+				array(
+					'header' => 'valid',
+					'footer' => null,
+				),
+			),
+			'wp:pattern wrap (Ollie shape) yields nulls'   => array(
+				'<!-- wp:pattern {"slug":"ollie/template-page-search"} /-->',
+				array(
+					'header' => null,
+					'footer' => null,
+				),
+			),
+			'Nested template-parts in a wrapper are ignored' => array(
+				'<!-- wp:group --><div class="wp-block-group">'
+				. '<!-- wp:template-part {"slug":"buried-header"} /-->'
+				. '</div><!-- /wp:group -->',
+				array(
+					'header' => null,
+					'footer' => null,
+				),
+			),
+			'Empty markup yields nulls'                    => array(
+				'',
+				array(
+					'header' => null,
+					'footer' => null,
+				),
+			),
+		);
+	}
+
+	/** Search.html wins when it declares both slots. */
+	public function test_resolve_prefers_search_template() {
+		$cls = static::stub_with_templates(
+			array( 'search' => '<!-- wp:template-part {"slug":"main-header"} /--><!-- wp:template-part {"slug":"footer-columns"} /-->' )
+		);
+		$this->assertSame(
+			array(
+				'header' => 'main-header',
+				'footer' => 'footer-columns',
+			),
+			$cls::resolve()
+		);
+	}
+
+	/** Falls through to index.html when search.html is silent. */
+	public function test_resolve_falls_back_to_index_template() {
+		$cls = static::stub_with_templates(
+			array( 'index' => '<!-- wp:template-part {"slug":"site-header"} /--><!-- wp:template-part {"slug":"site-footer"} /-->' )
+		);
+		$this->assertSame(
+			array(
+				'header' => 'site-header',
+				'footer' => 'site-footer',
+			),
+			$cls::resolve()
+		);
+	}
+
+	/** Per-slot mix: search.html supplies header, index.html supplies footer. */
+	public function test_resolve_per_slot_mix_across_search_and_index() {
+		$cls = static::stub_with_templates(
+			array(
+				'search' => '<!-- wp:template-part {"slug":"search-header"} /-->',
+				'index'  => '<!-- wp:template-part {"slug":"index-header"} /--><!-- wp:template-part {"slug":"index-footer"} /-->',
+			)
+		);
+		$this->assertSame(
+			array(
+				'header' => 'search-header',
+				'footer' => 'index-footer',
+			),
+			$cls::resolve()
+		);
+	}
+
+	/** Both templates silent → hardcoded defaults. */
+	public function test_resolve_falls_back_to_defaults_when_nothing_resolves() {
+		$cls = static::stub_with_templates( array() );
+		$this->assertSame( Theme_Chrome_Slug_Resolver::DEFAULTS, $cls::resolve() );
+	}
+
+	/** First resolve() writes the option; second reads from it (cache hit). */
+	public function test_resolve_writes_option_cache_on_first_call() {
+		$cls   = static::stub_with_templates(
+			array( 'search' => '<!-- wp:template-part {"slug":"main-header"} /--><!-- wp:template-part {"slug":"footer-columns"} /-->' )
+		);
+		$first = $cls::resolve();
+
+		$option = get_option( Theme_Chrome_Slug_Resolver::OPTION_NAME );
+		$this->assertIsArray( $option );
+		$this->assertSame( (string) get_stylesheet(), $option['stylesheet'] );
+		$this->assertSame( 'main-header', $option['header'] );
+		$this->assertSame( 'footer-columns', $option['footer'] );
+
+		// A second resolve() with the cache present should return the same shape.
+		$this->assertSame( $first, $cls::resolve() );
+	}
+
+	/** Cached entry from a different stylesheet is treated as a miss. */
+	public function test_cached_entry_for_other_stylesheet_is_ignored() {
+		update_option(
+			Theme_Chrome_Slug_Resolver::OPTION_NAME,
+			array(
+				'stylesheet' => 'other-theme',
+				'header'     => 'stale-header',
+				'footer'     => 'stale-footer',
+			),
+			false
+		);
+		$cls    = static::stub_with_templates(
+			array( 'search' => '<!-- wp:template-part {"slug":"new-header"} /--><!-- wp:template-part {"slug":"new-footer"} /-->' )
+		);
+		$result = $cls::resolve();
+		$this->assertSame( 'new-header', $result['header'] );
+		$this->assertSame( 'new-footer', $result['footer'] );
+	}
+
+	/** Invalidate() removes the option. */
+	public function test_invalidate_removes_the_option() {
+		update_option(
+			Theme_Chrome_Slug_Resolver::OPTION_NAME,
+			array(
+				'stylesheet' => (string) get_stylesheet(),
+				'header'     => 'h',
+				'footer'     => 'f',
+			),
+			false
+		);
+		Theme_Chrome_Slug_Resolver::invalidate();
+		$this->assertFalse( get_option( Theme_Chrome_Slug_Resolver::OPTION_NAME ) );
+	}
+
+	/** Preview requests bypass cache reads AND skip writes. */
+	public function test_preview_skips_cache_read_and_write() {
+		$cached_option = array(
+			'stylesheet' => (string) get_stylesheet(),
+			'header'     => 'cached-header',
+			'footer'     => 'cached-footer',
+		);
+		update_option( Theme_Chrome_Slug_Resolver::OPTION_NAME, $cached_option, false );
+
+		$_GET['wp_theme_preview'] = 'some-preview-theme';
+		$cls                      = static::stub_with_templates(
+			array( 'search' => '<!-- wp:template-part {"slug":"preview-header"} /--><!-- wp:template-part {"slug":"preview-footer"} /-->' )
+		);
+		$result                   = $cls::resolve();
+
+		$this->assertSame( 'preview-header', $result['header'], 'preview must not read from cache' );
+		$this->assertSame( 'preview-footer', $result['footer'] );
+		$this->assertSame( $cached_option, get_option( Theme_Chrome_Slug_Resolver::OPTION_NAME ), 'preview must not overwrite cache' );
+	}
+
+	/**
+	 * Save_post_wp_template handler: only invalidates when the saved
+	 * Template is `search` or `index` on the active theme.
+	 */
+	public function test_maybe_invalidate_on_template_save_ignores_unrelated_templates() {
+		update_option(
+			Theme_Chrome_Slug_Resolver::OPTION_NAME,
+			array(
+				'stylesheet' => (string) get_stylesheet(),
+				'header'     => 'h',
+				'footer'     => 'f',
+			),
+			false
+		);
+		Theme_Chrome_Slug_Resolver::maybe_invalidate_on_template_save( 0, (object) array( 'post_name' => 'single' ) );
+		$this->assertNotFalse(
+			get_option( Theme_Chrome_Slug_Resolver::OPTION_NAME ),
+			'unrelated template save must not invalidate the cache'
+		);
+	}
+
+	/** Register_hooks() wires the three invalidation actions. */
+	public function test_register_hooks_wires_invalidation_actions() {
+		remove_action( 'switch_theme', array( Theme_Chrome_Slug_Resolver::class, 'invalidate' ) );
+		remove_action( 'save_post_wp_template', array( Theme_Chrome_Slug_Resolver::class, 'maybe_invalidate_on_template_save' ) );
+		remove_action( 'save_post_wp_template_part', array( Theme_Chrome_Slug_Resolver::class, 'invalidate' ) );
+
+		Theme_Chrome_Slug_Resolver::register_hooks();
+
+		$this->assertNotFalse( has_action( 'switch_theme', array( Theme_Chrome_Slug_Resolver::class, 'invalidate' ) ) );
+		$this->assertNotFalse( has_action( 'save_post_wp_template', array( Theme_Chrome_Slug_Resolver::class, 'maybe_invalidate_on_template_save' ) ) );
+		$this->assertNotFalse( has_action( 'save_post_wp_template_part', array( Theme_Chrome_Slug_Resolver::class, 'invalidate' ) ) );
+	}
+
+	/**
+	 * Build an anonymous Theme_Chrome_Slug_Resolver subclass whose
+	 * `get_active_theme_template_content()` returns canned markup from
+	 * The given map (keyed by `search` / `index`). Each test gets its
+	 * Own subclass so stubs don't leak.
+	 *
+	 * @param array<string,string> $templates Map of template_name => markup.
+	 * @return class-string<Theme_Chrome_Slug_Resolver>
+	 */
+	protected static function stub_with_templates( array $templates ): string {
+		return get_class(
+			new class( $templates ) extends Theme_Chrome_Slug_Resolver {
+				/** @var array<string,string> */
+				private static $stub_templates = array();
+
+				public function __construct( array $templates ) {
+					self::$stub_templates = $templates;
+				}
+
+				protected static function get_active_theme_template_content( string $template_name ): ?string {
+					return self::$stub_templates[ $template_name ] ?? null;
+				}
+			}
+		);
+	}
+}

--- a/projects/packages/search/tests/php/Theme_Chrome_Slug_Resolver_Test.php
+++ b/projects/packages/search/tests/php/Theme_Chrome_Slug_Resolver_Test.php
@@ -254,7 +254,7 @@ class Theme_Chrome_Slug_Resolver_Test extends TestCase {
 			),
 			false
 		);
-		Theme_Chrome_Slug_Resolver::maybe_invalidate_on_template_save( 0, (object) array( 'post_name' => 'single' ) );
+		Theme_Chrome_Slug_Resolver::maybe_invalidate_on_template_save( 0, new \WP_Post( (object) array( 'post_name' => 'single' ) ) );
 		$this->assertNotFalse(
 			get_option( Theme_Chrome_Slug_Resolver::OPTION_NAME ),
 			'unrelated template save must not invalidate the cache'


### PR DESCRIPTION
Fixes [SEARCH-217](https://linear.app/a8c/issue/SEARCH-217/search-block-template-resolve-chrome-slugs-for-themes-that-ship-non)

## Why

A visitor on a Jetpack Search-enabled site running a theme like [Career Development](https://wordpress.org/themes/career-development/) — which ships `parts/main-header.html` + `parts/footer-columns.html` instead of plain `header.html`/`footer.html` — saw the search results page render **without any site header or footer**, because the bundled `jetpack-search` template hard-coded the slug names that the theme doesn't ship. The page looked broken: a bare result list with no chrome.

After this change, the bundled template reads the active theme's `search.html` (or `index.html` as fallback) to find whichever template-part slugs that theme actually declares for its chrome — `main-header`/`footer-columns` for Career Development, `header`/`footer` for the 98%+ of themes that match the default — and substitutes them into the registered template. The chrome renders.

## Screenshots

Captured on the atlas docker env with the Career Development theme activated.

| Before (trunk: hardcoded `header`/`footer` slugs don't resolve) | After (resolver picks `main-header`/`footer-columns` from `search.html`) |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/704d633f-cb07-48f2-ab70-aa8dc62313d3) | ![after](https://github.com/user-attachments/assets/10c65d03-3d3f-4685-9fb6-013535993499) |

## Proposed changes

* **New `Theme_Chrome_Slug_Resolver` class** (`src/search-blocks/class-theme-chrome-slug-resolver.php`) with a two-rung resolution chain: active theme's `search.html` → `index.html` → hardcoded `header`/`footer` defaults. Slugs are sanity-checked against `[a-zA-Z0-9_-]` so a malformed theme template can't break the JSON round-trip in the bundled template.
* **Site-option cache** (`jetpack_search_resolved_chrome_slugs` = `{ stylesheet, header, footer }`). One DB read per request via `alloptions`, no static cache, no `REQUEST_TIME_FLOAT` request-leak hacks.
* **Explicit invalidation**: hooked to `switch_theme` and `save_post_wp_template` / `save_post_wp_template_part`. The template-save handler narrows further — only invalidates when the saved `wp_template` is named `search` or `index` on the active theme, so unrelated Site Editor edits don't churn the cache.
* **Theme-preview guard**: `is_customize_preview()` and `?wp_theme_preview=` requests resolve fresh and never read/write the cache — a preview can't pollute the production-theme entry.
* **Idempotent registration helper** (`Search_Blocks::replace_block_template`) wraps `register_block_template` with unregister-before-register, so long-lived PHP-FPM workers serve fresh content after invalidation. WP's `WP_Block_Templates_Registry::register()` rejects same-name re-registration with `_doing_it_wrong()`; without this, the registry would serve stale chrome until the worker recycled.
* **Templates** (`templates/jetpack-search.html`, `templates/jetpack-search-product-results.html`) switch the hardcoded `slug:"header"` / `slug:"footer"` to `{{HEADER_SLUG}}` / `{{FOOTER_SLUG}}` placeholders, substituted by the same pipeline that already handles `{{FILTER_HEADING}}`.
* **PHPUnit coverage**: 93 tests / 273 assertions on this branch. New `Theme_Chrome_Slug_Resolver_Test` covers the extractor (data-provider over 8 markup shapes), the resolution chain, the cache round-trip, invalidation, preview guard, and the `register_hooks()` wiring. `Search_Blocks_Test` adds three integration tests for the registration substitution + replace-on-reregister.

## Scope (survey-backed)

Surveyed top 500 popular + top 100 latest themes from wordpress.org → 237 are block themes. Cohorts:

| Cohort | Count | Affected? |
|---|---|---|
| Plain `header` / `footer` in `search.html` (TT3/4/5/Frost shape) | 196 | No — no-op |
| Variant slug declared in `search.html` (e.g. `main-header`) | 6 | Partially — fixed when the variant isn't `header` |
| `search.html` wraps in `wp:pattern` (Ollie / Bluehost Blueprint / Newspaper FSE) | 23 | No — they ship `parts/header.html` + `parts/footer.html` so defaults work |
| **No `parts/header.html`/`parts/footer.html` at all** | **3** | **Yes — career-development, wellness-center, it-software-service** |

The cache + invalidation work is the only piece that's strictly needed for the 3 broken themes; the other 234 themes hit the same default path they always have.

## Related product discussion/links

* Linear: [SEARCH-217](https://linear.app/a8c/issue/SEARCH-217)
* Supersedes the closed-as-too-fragile [SEARCH-214](https://linear.app/a8c/issue/SEARCH-214) / PRs #48995 + #49024. Survey data drove the lean architecture here.

## Does this pull request change what data or activity we track or use?

No. The new `jetpack_search_resolved_chrome_slugs` site option stores only `{ stylesheet, header_slug, footer_slug }` — derived entirely from the active theme's own template files.

## Testing instructions

Acceptance criteria from SEARCH-217:

- [ ] On Career Development (`wp theme install career-development --activate`), `/?s=foo` renders the theme's site header (`main-header`) and footer (`footer-columns`). Verify against the bundled `parts/main-header.html` content.
- [ ] On TT3/4/5/Frost/Ollie/bee-real-estate, `/?s=foo` renders byte-identical chrome to trunk (the 98.7% no-regression cohort). Verify via:
  ```bash
  docker exec jetpack_<agent>-wordpress-1 wp eval '
    $c = (string) WP_Block_Templates_Registry::get_instance()
          ->get_registered( "jetpack-search//jetpack-search" )->content;
    preg_match_all( "#template-part \{\"slug\":\"([^\"]+)\"#", $c, $m );
    echo wp_json_encode( $m[1] ) . PHP_EOL;
  ' --allow-root --skip-themes
  ```
- [ ] Switching themes via `wp-admin/themes.php` (or `wp theme activate`) invalidates the option and the next request picks up the new theme's chrome (`wp option get jetpack_search_resolved_chrome_slugs` should reflect the active theme).
- [ ] Site Editor "Theme preview" / `?wp_theme_preview=<theme>` shows the preview theme's chrome but doesn't overwrite the cache (the option still reflects the production active theme after the preview).
- [ ] Same treatment for the product-search-results template (`jetpack-search-product-results.html`).
- [ ] PHPUnit: `composer phpunit -- --filter "Search_Blocks_Test|Theme_Chrome_Slug_Resolver_Test"` from `projects/packages/search` — 93 tests / 273 assertions, green.
