### PR TITLE
Search package: bump version to 7.0.0

### DIFF
--- a/projects/packages/search/changelog/search-218-bump-package-version-to-7-0-0
+++ b/projects/packages/search/changelog/search-218-bump-package-version-to-7-0-0
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Bump package version to 7.0.0.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.60.x-dev"
+			"dev-trunk": "7.0.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.60.0';
+	const VERSION = '7.0.0';
 	const SLUG    = 'search';
 
 	/**


### PR DESCRIPTION
Fixes [SEARCH-218](https://linear.app/a8c/issue/SEARCH-218/bump-jetpack-search-package-version-to-700).

## Why
Bump the `automattic/jetpack-search` package version from `0.60.0` to `7.0.0`. Metadata-only change — no functional code is affected.

## Proposed changes
* `projects/packages/search/composer.json` — `branch-alias.dev-trunk`: `0.60.x-dev` → `7.0.x-dev`.
* `projects/packages/search/src/class-package.php` — `const VERSION`: `'0.60.0'` → `'7.0.0'`.
* Add changelog entry (major, changed).

Generated via `./tools/project-version.sh -u 7.0.0 packages/search` — the canonical monorepo dev script for package version bumps. Historical `@since 0.60.0` doc tags and `_doing_it_wrong( …, 'jetpack-search-pkg 0.60.0' )` deprecation markers are left untouched because they reference *when* a feature was introduced/deprecated, not the current version. No `package.json` `version` field exists for this package, and every dependent (`config`, `sync`, `my-jetpack`, `plugins/jetpack`, `plugins/search`) pins `automattic/jetpack-search` as `"@dev"` — so there are no intra-monorepo constraints to update.

## Related product discussion/links
* [SEARCH-218](https://linear.app/a8c/issue/SEARCH-218/bump-jetpack-search-package-version-to-700)

## Does this pull request change what data or activity we track or use?
No.

## Verification
The change is metadata-only — no UI to screenshot, no REST surface to call, no built asset to inspect. The monorepo's own dev script verifies the result:

<details>
<summary>./tools/project-version.sh -c 7.0.0 packages/search</summary>

```text
$ ./tools/project-version.sh -c 7.0.0 packages/search
$ echo $?
0
```

(Script exits 0 with no output when every version surface matches the target.)

</details>

<details>
<summary>php -l projects/packages/search/src/class-package.php</summary>

```text
$ php -l projects/packages/search/src/class-package.php
No syntax errors detected in projects/packages/search/src/class-package.php
```

</details>

<details>
<summary>Stray-reference sweep</summary>

```text
$ grep -rn '0\.60' projects/packages/search/ \
    | grep -vE 'node_modules|vendor|changelog/|CHANGELOG\.md|@since|_doing_it_wrong'
(no output — only @since / _doing_it_wrong historical markers remain, as expected)
```

</details>

## Testing instructions
* Check out this branch.
* Run `./tools/project-version.sh -c 7.0.0 packages/search` from the repo root and confirm it exits 0.
* Open `projects/packages/search/src/class-package.php` and confirm `const VERSION = '7.0.0';` on line 18.
* Open `projects/packages/search/composer.json` and confirm `branch-alias.dev-trunk` is `"7.0.x-dev"`.
* `grep -rn '0\.60' projects/packages/search/ | grep -vE 'node_modules|vendor|changelog/|CHANGELOG\.md|@since|_doing_it_wrong'` should produce no output.
