### PR TITLE
Search Blocks overlay: admin-editable template via hidden CPT + block editor (SEARCH-216)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-216-overlay-editor-cpt
+++ b/projects/packages/search/changelog/SEARCH-216-overlay-editor-cpt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks overlay: Add a "Edit the Search overlay" entry point in the Jetpack Search dashboard that opens the experimental overlay template in the standard block editor (a hidden singleton CPT). Works on both block themes and classic themes. A "Restore default" link reverts to the bundled template.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -228,8 +228,11 @@ class Initial_State {
 			'editorUrl'    => $can_edit ? Overlay_Template::get_editor_url() : null,
 			'resetUrl'     => $can_edit ? Overlay_Template::get_reset_url() : null,
 			// `isCustomized` lets the React dashboard hide "Restore default"
-			// when there's nothing to restore (no singleton post yet).
-			'isCustomized' => $can_edit && Overlay_Template::get_post_id() > 0,
+			// when there's nothing to restore — checks both that the
+			// singleton exists AND that it isn't in the trash (admins can
+			// trash via post.php directly; in that state the front end
+			// already falls back to the bundled template).
+			'isCustomized' => $can_edit && Overlay_Template::is_customized(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -99,6 +99,15 @@ class Initial_State {
 				 * original cards unchanged.
 				 */
 				'blockOverlayEnabled'        => (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false ),
+				/**
+				 * Editor affordances for the experimental blocks-powered overlay.
+				 * Surfaces in the new Overlay search card so admins can edit the
+				 * rendered template via the standard block editor on `post.php` —
+				 * works on both block and classic themes. URLs are null for any
+				 * visitor without `manage_options`; the action handlers also
+				 * enforce that capability server-side.
+				 */
+				'blockTemplateOverlay'       => $this->get_block_template_overlay_config(),
 				// Gates the WooCommerce Product Search control to stores.
 				'isWooCommerceActive'        => Search_Blocks::woocommerce_blocks_enabled(),
 				/**
@@ -193,6 +202,35 @@ class Initial_State {
 	 */
 	protected function is_ai_agent_access_available() {
 		return $this->is_automattic_proxied_request() && ! $this->is_private_site();
+	}
+
+	/**
+	 * Build the block-template overlay editor config exposed to the dashboard.
+	 *
+	 * The action handlers gate on `current_user_can( 'manage_options' )`
+	 * server-side, so non-admins can't actually drive the flow. We also
+	 * skip emitting the nonce'd URLs (and the singleton-id lookup that
+	 * decides `isCustomized`) to those users — useless to them and
+	 * needlessly leaks internal URL shape.
+	 *
+	 * `enabled` mirrors `Search_Blocks::is_block_template_overlay_enabled()`,
+	 * which itself requires both the operator-level filter AND the site
+	 * owner having activated the `overlay_blocks` experience — so the
+	 * editor surface only appears when the new overlay is actually live.
+	 *
+	 * @return array{enabled: bool, editorUrl: string|null, resetUrl: string|null, isCustomized: bool}
+	 */
+	protected function get_block_template_overlay_config(): array {
+		$enabled  = Search_Blocks::is_block_template_overlay_enabled();
+		$can_edit = $enabled && current_user_can( 'manage_options' );
+		return array(
+			'enabled'      => $enabled,
+			'editorUrl'    => $can_edit ? Overlay_Template::get_editor_url() : null,
+			'resetUrl'     => $can_edit ? Overlay_Template::get_reset_url() : null,
+			// `isCustomized` lets the React dashboard hide "Restore default"
+			// when there's nothing to restore (no singleton post yet).
+			'isCustomized' => $can_edit && Overlay_Template::get_post_id() > 0,
+		);
 	}
 
 	/**

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -218,21 +218,27 @@ class Initial_State {
 	 * owner having activated the `overlay_blocks` experience — so the
 	 * editor surface only appears when the new overlay is actually live.
 	 *
-	 * @return array{enabled: bool, editorUrl: string|null, resetUrl: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
 	 */
 	protected function get_block_template_overlay_config(): array {
 		$enabled  = Search_Blocks::is_block_template_overlay_enabled();
 		$can_edit = $enabled && current_user_can( 'manage_options' );
 		return array(
-			'enabled'      => $enabled,
-			'editorUrl'    => $can_edit ? Overlay_Template::get_editor_url() : null,
-			'resetUrl'     => $can_edit ? Overlay_Template::get_reset_url() : null,
+			'enabled'       => $enabled,
+			'editorUrl'     => $can_edit ? Overlay_Template::get_editor_url() : null,
+			// `resetRestPath` is the path the dashboard sends to `apiFetch`
+			// as a DELETE — hits the CPT's built-in REST endpoint
+			// (`/wp/v2/jetpack-search-overlay/<id>?force=true`) so the
+			// reset happens via AJAX with no page navigation. Null when
+			// there's nothing to reset; the link is also gated on
+			// `isCustomized`.
+			'resetRestPath' => $can_edit ? Overlay_Template::get_reset_rest_path() : null,
 			// `isCustomized` lets the React dashboard hide "Restore default"
 			// when there's nothing to restore — checks both that the
 			// singleton exists AND that it isn't in the trash (admins can
 			// trash via post.php directly; in that state the front end
 			// already falls back to the bundled template).
-			'isCustomized' => $can_edit && Overlay_Template::is_customized(),
+			'isCustomized'  => $can_edit && Overlay_Template::is_customized(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -122,19 +122,27 @@ const getHoverHint = ( experience, blockOverlayEnabled = false ) => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const { active, isUpdating, activeThemeStylesheet, isBlockTheme, blockOverlayEnabled } =
-		useSelect(
-			select => ( {
-				active: select( STORE_ID ).getActiveExperience(),
-				isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
-				activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
-				isBlockTheme: select( STORE_ID ).isBlockTheme(),
-				blockOverlayEnabled: select( STORE_ID ).isBlockOverlayEnabled(),
-			} ),
-			[]
-		);
+	const {
+		active,
+		isUpdating,
+		activeThemeStylesheet,
+		isBlockTheme,
+		blockOverlayEnabled,
+		blockTemplateOverlay,
+	} = useSelect(
+		select => ( {
+			active: select( STORE_ID ).getActiveExperience(),
+			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
+			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
+			isBlockTheme: select( STORE_ID ).isBlockTheme(),
+			blockOverlayEnabled: select( STORE_ID ).isBlockOverlayEnabled(),
+			blockTemplateOverlay: select( STORE_ID ).getBlockTemplateOverlayConfig(),
+		} ),
+		[]
+	);
 	const { saveExperience } = useDispatch( STORE_ID );
 	const [ isConfirmOpen, setConfirmOpen ] = useState( false );
+	const [ isResetConfirmOpen, setResetConfirmOpen ] = useState( false );
 
 	const isActive = active === experience;
 	const isRecommended = experience === EXPERIENCE.EMBEDDED;
@@ -214,16 +222,48 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 				</Stack>
 			) }
 			{ /*
-			   The blocks-powered Overlay intentionally has no action links
-			   during the experimental phase: the FSE `jetpack-search`
-			   template only registers when Embedded is the active
-			   experience, so an "Edit search template" link would 404 from
-			   here, and the overlay actually renders from a separate
-			   bundled template (`templates/jetpack-search-overlay.html`)
-			   that the Site Editor cannot reach anyway. Skipping the
-			   action row keeps the card honest until the two templates
-			   converge — see SEARCH-213 review thread.
+			   SEARCH-216 — the blocks-powered Overlay renders from a
+			   separate bundled template the Site Editor cannot reach.
+			   "Edit the Search overlay" lands the admin in the standard
+			   block editor on a hidden singleton CPT seeded from that
+			   bundled template, with "Restore default" appearing once the
+			   admin has saved a customization. Works on classic themes
+			   too because `post.php` predates the Site Editor.
 			*/ }
+			{ experience === EXPERIENCE.OVERLAY_BLOCKS && (
+				<Stack
+					direction="row"
+					gap="sm"
+					align="start"
+					className="jp-search-experience-option__actions"
+				>
+					{ blockTemplateOverlay.enabled && blockTemplateOverlay.editorUrl && (
+						<CardLink
+							label={ __( 'Edit the Search overlay', 'jetpack-search-pkg' ) }
+							href={ blockTemplateOverlay.editorUrl }
+							disabled={ linksDisabled }
+						/>
+					) }
+					{ blockTemplateOverlay.enabled &&
+						blockTemplateOverlay.resetUrl &&
+						blockTemplateOverlay.isCustomized && (
+							<CardLink
+								label={ __( 'Restore default', 'jetpack-search-pkg' ) }
+								href={ blockTemplateOverlay.resetUrl }
+								disabled={ linksDisabled }
+								onClick={ event => {
+									// Destructive — open the confirm dialog
+									// instead of navigating directly. The
+									// dialog's confirm handler is the one
+									// that actually follows the `resetUrl`
+									// (server-side delete + redirect back).
+									event.preventDefault();
+									setResetConfirmOpen( true );
+								} }
+							/>
+						) }
+				</Stack>
+			) }
 			{ experience === EXPERIENCE.OVERLAY && (
 				<Stack
 					direction="row"
@@ -332,6 +372,35 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					) }
 				</ConfirmDialog>
 			) }
+			{ /*
+				   SEARCH-216 — confirm before nuking the customized overlay
+				   template. Navigating to `resetUrl` triggers a server-side
+				   delete + redirect, so we route through `window.location`
+				   here rather than letting the `<a>` follow the href directly.
+				*/ }
+			{ experience === EXPERIENCE.OVERLAY_BLOCKS && blockTemplateOverlay.enabled && (
+				<ConfirmDialog
+					isOpen={ isResetConfirmOpen }
+					onConfirm={ () => {
+						setResetConfirmOpen( false );
+						// Defensive guard: the dialog can only open via the
+						// `isCustomized && resetUrl` CardLink above, so
+						// `resetUrl` is non-null in practice — avoid
+						// navigating to the literal string "null" if the
+						// gating logic ever shifts.
+						if ( blockTemplateOverlay.resetUrl ) {
+							window.location.href = blockTemplateOverlay.resetUrl;
+						}
+					} }
+					onCancel={ () => setResetConfirmOpen( false ) }
+					confirmButtonText={ __( 'Restore default', 'jetpack-search-pkg' ) }
+				>
+					{ __(
+						'Restore the bundled Search overlay template? Your customizations will be deleted.',
+						'jetpack-search-pkg'
+					) }
+				</ConfirmDialog>
+			) }
 		</Stack>
 	);
 }
@@ -436,7 +505,7 @@ const CardCopy = ( { experience, blockOverlayEnabled = false } ) => {
 	);
 };
 
-const CardLink = ( { label, href, disabled } ) =>
+const CardLink = ( { label, href, disabled, onClick } ) =>
 	disabled ? (
 		// Render as a non-interactive <span> so AT doesn't announce a link
 		// the user can't follow. The `is-disabled` class is the CSS hook for
@@ -450,6 +519,7 @@ const CardLink = ( { label, href, disabled } ) =>
 		<a
 			className="jp-search-experience-option__action jp-search-experience-option__action-link"
 			href={ href }
+			onClick={ onClick }
 		>
 			{ label }
 			<span aria-hidden="true"> →</span>

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -1,3 +1,4 @@
+import apiFetch from '@wordpress/api-fetch';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
 import { Button, Modal, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -140,9 +141,16 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 		} ),
 		[]
 	);
-	const { saveExperience } = useDispatch( STORE_ID );
+	const { saveExperience, successNotice, errorNotice } = useDispatch( STORE_ID );
 	const [ isConfirmOpen, setConfirmOpen ] = useState( false );
 	const [ isResetConfirmOpen, setResetConfirmOpen ] = useState( false );
+	const [ isResetting, setIsResetting ] = useState( false );
+	// Local override after a successful reset: the server-side `isCustomized`
+	// stays true in the initial-state blob the page was rendered with, so
+	// we hide the "Restore default" link client-side once the AJAX DELETE
+	// returns. Cleared if the admin opens the editor again (which would
+	// lazy-create a fresh singleton).
+	const [ justReset, setJustReset ] = useState( false );
 
 	const isActive = active === experience;
 	const isRecommended = experience === EXPERIENCE.EMBEDDED;
@@ -242,21 +250,27 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 							label={ __( 'Edit the Search overlay', 'jetpack-search-pkg' ) }
 							href={ blockTemplateOverlay.editorUrl }
 							disabled={ linksDisabled }
+							// Re-show "Restore default" on the admin's return
+							// from the editor: the click implies a fresh
+							// singleton is about to be (re-)created on the
+							// server, so the previously-set `justReset` flag
+							// no longer reflects reality.
+							onClick={ () => setJustReset( false ) }
 						/>
 					) }
 					{ blockTemplateOverlay.enabled &&
-						blockTemplateOverlay.resetUrl &&
-						blockTemplateOverlay.isCustomized && (
+						blockTemplateOverlay.resetRestPath &&
+						blockTemplateOverlay.isCustomized &&
+						! justReset && (
 							<CardLink
 								label={ __( 'Restore default', 'jetpack-search-pkg' ) }
-								href={ blockTemplateOverlay.resetUrl }
-								disabled={ linksDisabled }
+								href="#"
+								disabled={ linksDisabled || isResetting }
 								onClick={ event => {
 									// Destructive — open the confirm dialog
-									// instead of navigating directly. The
-									// dialog's confirm handler is the one
-									// that actually follows the `resetUrl`
-									// (server-side delete + redirect back).
+									// instead of running the AJAX delete
+									// directly. The dialog's confirm handler
+									// is the one that fires `apiFetch`.
 									event.preventDefault();
 									setResetConfirmOpen( true );
 								} }
@@ -374,22 +388,44 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 			) }
 			{ /*
 				   SEARCH-216 — confirm before nuking the customized overlay
-				   template. Navigating to `resetUrl` triggers a server-side
-				   delete + redirect, so we route through `window.location`
-				   here rather than letting the `<a>` follow the href directly.
+				   template. Sends a DELETE to the CPT's built-in REST
+				   endpoint via `apiFetch`; on success, the local `justReset`
+				   flag hides the link and a notice goes through the
+				   dashboard's global-notices store. No page navigation.
 				*/ }
 			{ experience === EXPERIENCE.OVERLAY_BLOCKS && blockTemplateOverlay.enabled && (
 				<ConfirmDialog
 					isOpen={ isResetConfirmOpen }
-					onConfirm={ () => {
+					onConfirm={ async () => {
 						setResetConfirmOpen( false );
 						// Defensive guard: the dialog can only open via the
-						// `isCustomized && resetUrl` CardLink above, so
-						// `resetUrl` is non-null in practice — avoid
-						// navigating to the literal string "null" if the
-						// gating logic ever shifts.
-						if ( blockTemplateOverlay.resetUrl ) {
-							window.location.href = blockTemplateOverlay.resetUrl;
+						// `isCustomized && resetRestPath` CardLink above, so
+						// `resetRestPath` is non-null in practice — avoid
+						// firing a DELETE to `undefined` if the gating logic
+						// ever shifts.
+						if ( ! blockTemplateOverlay.resetRestPath ) {
+							return;
+						}
+						setIsResetting( true );
+						try {
+							await apiFetch( {
+								path: blockTemplateOverlay.resetRestPath,
+								method: 'DELETE',
+							} );
+							setJustReset( true );
+							successNotice(
+								__(
+									'The Search overlay template has been restored to the bundled default.',
+									'jetpack-search-pkg'
+								)
+							);
+						} catch ( error ) {
+							errorNotice(
+								error?.message ||
+									__( 'Could not restore the Search overlay template.', 'jetpack-search-pkg' )
+							);
+						} finally {
+							setIsResetting( false );
 						}
 					} }
 					onCancel={ () => setResetConfirmOpen( false ) }

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -17,6 +17,17 @@ const siteDataSelectors = {
 	isPlanJustUpgraded: state => state.siteData?.isPlanJustUpgraded ?? false,
 	isSearchBlocksEnabled: state => state.siteData?.searchBlocksEnabled ?? false,
 	isBlockOverlayEnabled: state => state.siteData?.blockOverlayEnabled ?? false,
+	// Editor affordances for the blocks-powered Overlay. Surface in the
+	// Overlay search card when the active experience is `overlay_blocks`
+	// (the PHP gate). Returns the whole config blob so callers can
+	// destructure `{ enabled, editorUrl, resetUrl, isCustomized }` in one go.
+	getBlockTemplateOverlayConfig: state =>
+		state.siteData?.blockTemplateOverlay ?? {
+			enabled: false,
+			editorUrl: null,
+			resetUrl: null,
+			isCustomized: false,
+		},
 	isWooCommerceActive: state => state.siteData?.isWooCommerceActive ?? false,
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 	// Defaults to true so Embedded is never blocked when the flag is absent

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -20,12 +20,14 @@ const siteDataSelectors = {
 	// Editor affordances for the blocks-powered Overlay. Surface in the
 	// Overlay search card when the active experience is `overlay_blocks`
 	// (the PHP gate). Returns the whole config blob so callers can
-	// destructure `{ enabled, editorUrl, resetUrl, isCustomized }` in one go.
+	// destructure `{ enabled, editorUrl, resetRestPath, isCustomized }`
+	// in one go. `resetRestPath` is the apiFetch path the "Restore
+	// default" link DELETEs to roll back the customization.
 	getBlockTemplateOverlayConfig: state =>
 		state.siteData?.blockTemplateOverlay ?? {
 			enabled: false,
 			editorUrl: null,
-			resetUrl: null,
+			resetRestPath: null,
 			isCustomized: false,
 		},
 	isWooCommerceActive: state => state.siteData?.isWooCommerceActive ?? false,

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -118,7 +118,7 @@ class Overlay_Template {
 				'show_in_admin_bar'   => false,
 				'show_in_nav_menus'   => false,
 				'show_in_rest'        => true,
-				'rest_base'           => 'jetpack-search-overlay',
+				'rest_base'           => static::REST_BASE,
 				'supports'            => array( 'editor', 'custom-fields', 'revisions' ),
 				// Lock every relevant capability to `manage_options` so editing
 				// requires admin, regardless of which entry point (post.php

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Singleton CPT + lifecycle for the experimental block-template overlay.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Lets admins customize the experimental Search blocks overlay template via
+ * the standard block editor (post.php), which is theme-agnostic — works on
+ * both block themes and classic themes, no Site Editor dependency.
+ *
+ * The customized markup lives in a single hidden CPT post; if the post
+ * doesn't exist (admin hasn't customized), the overlay falls back to the
+ * bundled `templates/jetpack-search-overlay.html` file. Deleting the
+ * singleton restores the default.
+ *
+ * Lifecycle:
+ *
+ * 1. `register_post_type()` registers the CPT at `init` priority 9, before
+ *    block registration, so `do_blocks()` on the post content can resolve
+ *    the search blocks.
+ * 2. The admin clicks "Edit the Search overlay" in the Jetpack Search
+ *    dashboard — a nonce'd URL that hits `maybe_handle_editor_request()`.
+ *    That handler lazy-creates the singleton (seeding it from the bundled
+ *    file) on first click, then redirects to `post.php?post=<id>&action=edit`.
+ * 3. The admin edits + saves; WordPress writes the new block markup to the
+ *    singleton's `post_content`.
+ * 4. On the front end, `Search_Blocks::get_overlay_template_content()`
+ *    prefers the singleton's content when present.
+ * 5. "Restore default" hits `maybe_handle_reset_request()`, which deletes
+ *    the singleton; the next request falls back to the bundled file again.
+ *
+ * Gated behind both `jetpack_search_blocks_enabled` AND
+ * `jetpack_search_overlay_block_template_enabled` — only initialized from
+ * `Search_Blocks::init()` when the overlay path is wired up.
+ */
+class Overlay_Template {
+
+	// 20 char max per `register_post_type()`. `jp_` prefix instead of
+	// `jetpack_` to stay under the limit while remaining greppable.
+	const POST_TYPE          = 'jp_search_overlay';
+	const OPTION_POST_ID     = 'jetpack_search_overlay_template_post_id';
+	const EDITOR_REQUEST_KEY = 'jetpack_search_open_overlay_editor';
+	const RESET_REQUEST_KEY  = 'jetpack_search_reset_overlay_template';
+	const EDITOR_NONCE       = 'jetpack_search_overlay_editor';
+	const RESET_NONCE        = 'jetpack_search_overlay_reset';
+	const REDIRECT_QUERY_ARG = 'jetpack_search_overlay_template';
+
+	/**
+	 * Per-request memo backing `get_customized_content()`. `null` means the
+	 * cache hasn't been populated yet for this request; an empty string or
+	 * a string with content is a real lookup result.
+	 *
+	 * @var string|null|false `false` = no customization (use bundled file).
+	 */
+	private static $customized_content_cache = null;
+
+	/**
+	 * Wire the hooks. Called from `Search_Blocks::init()` only when the
+	 * overlay gate is on.
+	 */
+	public static function init() {
+		// Priority 9: register the CPT just before `Search_Blocks::register_blocks()`
+		// (also on `init`, default priority 10) so the search blocks are
+		// registered against a known CPT when `do_blocks()` runs on the
+		// singleton's content.
+		add_action( 'init', array( static::class, 'register_post_type' ), 9 );
+		add_action( 'admin_init', array( static::class, 'maybe_handle_editor_request' ) );
+		add_action( 'admin_init', array( static::class, 'maybe_handle_reset_request' ) );
+		add_action( 'admin_notices', array( static::class, 'maybe_render_admin_notices' ) );
+	}
+
+	/**
+	 * Register the hidden singleton CPT. No menu, no UI surface of its own;
+	 * the only way to land in the block editor on this post is via the
+	 * dashboard's "Edit the Search overlay" link.
+	 */
+	public static function register_post_type() {
+		register_post_type(
+			static::POST_TYPE,
+			array(
+				'labels'              => array(
+					'name'          => __( 'Search overlay template', 'jetpack-search-pkg' ),
+					'singular_name' => __( 'Search overlay template', 'jetpack-search-pkg' ),
+				),
+				'public'              => false,
+				'show_ui'             => true, // post.php / edit.php need the UI machinery even though we hide the menu.
+				'show_in_menu'        => false,
+				'show_in_admin_bar'   => false,
+				'show_in_nav_menus'   => false,
+				'show_in_rest'        => true,
+				'rest_base'           => 'jetpack-search-overlay',
+				'supports'            => array( 'editor', 'custom-fields', 'revisions' ),
+				'capability_type'     => 'page',
+				'map_meta_cap'        => true,
+				'has_archive'         => false,
+				'exclude_from_search' => true,
+				'rewrite'             => false,
+				'can_export'          => false,
+				'delete_with_user'    => false,
+				'template_lock'       => false,
+			)
+		);
+	}
+
+	/**
+	 * Return the singleton post's content if present. `null` means there's
+	 * no customization on file and callers should fall back to the bundled
+	 * template. Memoized per-request.
+	 *
+	 * @return string|null
+	 */
+	public static function get_customized_content(): ?string {
+		if ( null !== self::$customized_content_cache ) {
+			return false === self::$customized_content_cache ? null : self::$customized_content_cache;
+		}
+		$post_id = static::get_post_id();
+		if ( ! $post_id ) {
+			self::$customized_content_cache = false;
+			return null;
+		}
+		$post = get_post( $post_id );
+		if ( ! $post || static::POST_TYPE !== $post->post_type || 'trash' === $post->post_status ) {
+			self::$customized_content_cache = false;
+			return null;
+		}
+		// Empty post content means the admin saved a blank canvas — honor
+		// that explicitly rather than silently falling back to the bundled
+		// default (the editor would loop with the bundled content on every
+		// save otherwise).
+		self::$customized_content_cache = (string) $post->post_content;
+		return self::$customized_content_cache;
+	}
+
+	/**
+	 * Singleton post ID, or 0 if no customization exists yet.
+	 *
+	 * @return int
+	 */
+	public static function get_post_id(): int {
+		return (int) get_option( static::OPTION_POST_ID, 0 );
+	}
+
+	/**
+	 * Nonce'd admin URL that lazy-creates the singleton (if missing) and
+	 * redirects the admin into the block editor on it. Used by the
+	 * dashboard "Edit the Search overlay" link.
+	 *
+	 * Built with `add_query_arg` + `wp_create_nonce` (not `wp_nonce_url`)
+	 * so the returned string contains raw `&` separators, not the HTML-
+	 * encoded `&amp;` that `wp_nonce_url` emits. The URL is JSON-serialized
+	 * to the React dashboard's initial state and then set as an `<a href>`
+	 * value — React/JSX doesn't HTML-decode attribute values, so encoded
+	 * amps would round-trip into the browser's URL bar verbatim and break
+	 * the `$_GET` parse.
+	 *
+	 * @return string
+	 */
+	public static function get_editor_url(): string {
+		return add_query_arg(
+			array(
+				static::EDITOR_REQUEST_KEY => '1',
+				'_wpnonce'                 => wp_create_nonce( static::EDITOR_NONCE ),
+			),
+			admin_url( 'admin.php?page=jetpack-search' )
+		);
+	}
+
+	/**
+	 * Nonce'd admin URL that deletes the singleton (restoring the bundled
+	 * template) and redirects back to the dashboard. Built raw for the
+	 * same reason as `get_editor_url()`.
+	 *
+	 * @return string
+	 */
+	public static function get_reset_url(): string {
+		return add_query_arg(
+			array(
+				static::RESET_REQUEST_KEY => '1',
+				'_wpnonce'                => wp_create_nonce( static::RESET_NONCE ),
+			),
+			admin_url( 'admin.php?page=jetpack-search' )
+		);
+	}
+
+	/**
+	 * Handle the "open editor" admin request: create the singleton on first
+	 * click (seeded from the bundled template), then redirect to the block
+	 * editor on it.
+	 */
+	public static function maybe_handle_editor_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below.
+		if ( empty( $_GET[ static::EDITOR_REQUEST_KEY ] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to customize the Search overlay.', 'jetpack-search-pkg' ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( static::EDITOR_NONCE );
+		$post_id = static::ensure_post_exists();
+		if ( ! $post_id ) {
+			wp_die( esc_html__( 'Could not create the Search overlay template.', 'jetpack-search-pkg' ), '', array( 'response' => 500 ) );
+		}
+		wp_safe_redirect( admin_url( 'post.php?post=' . $post_id . '&action=edit' ) );
+		exit;
+	}
+
+	/**
+	 * Handle the "reset to default" admin request: delete the singleton
+	 * (and the option pointing to it) so the next render falls back to the
+	 * bundled template.
+	 */
+	public static function maybe_handle_reset_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below.
+		if ( empty( $_GET[ static::RESET_REQUEST_KEY ] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to reset the Search overlay.', 'jetpack-search-pkg' ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( static::RESET_NONCE );
+		$post_id = static::get_post_id();
+		if ( $post_id ) {
+			wp_delete_post( $post_id, true );
+			delete_option( static::OPTION_POST_ID );
+			self::$customized_content_cache = null;
+		}
+		wp_safe_redirect(
+			add_query_arg( static::REDIRECT_QUERY_ARG, 'reset', admin_url( 'admin.php?page=jetpack-search' ) )
+		);
+		exit;
+	}
+
+	/**
+	 * Surface the success / restore-default notice — but only on the
+	 * Jetpack Search settings page itself. Without the screen guard the
+	 * notice could surface on any admin page whose URL happens to carry
+	 * the redirect query arg (anyone could land on
+	 * `wp-admin/index.php?jetpack_search_overlay_template=reset`).
+	 */
+	public static function maybe_render_admin_notices() {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen || 'toplevel_page_jetpack-search' !== $screen->id ) {
+			return;
+		}
+		// Read-only query arg used only to flip the success banner on after
+		// the nonce'd reset handler redirected back. No state mutated here,
+		// so nonce verification is intentionally not required.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$redirect_signal = isset( $_GET[ static::REDIRECT_QUERY_ARG ] )
+			? sanitize_text_field( wp_unslash( $_GET[ static::REDIRECT_QUERY_ARG ] ) )
+			: '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		if ( 'reset' !== $redirect_signal ) {
+			return;
+		}
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( 'The Search overlay template has been restored to the bundled default.', 'jetpack-search-pkg' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Ensure the singleton post exists. Returns its ID. If it doesn't
+	 * exist yet, creates it with the bundled-template content as the seed
+	 * (so the editor opens populated rather than empty).
+	 *
+	 * @return int Post ID on success, 0 on failure.
+	 */
+	protected static function ensure_post_exists(): int {
+		$existing = static::get_post_id();
+		if ( $existing && get_post( $existing ) ) {
+			return $existing;
+		}
+		$seed_content = static::read_bundled_template();
+		$post_id      = wp_insert_post(
+			array(
+				'post_type'    => static::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => __( 'Jetpack Search overlay', 'jetpack-search-pkg' ),
+				'post_content' => $seed_content,
+				'meta_input'   => array(
+					'_jetpack_search_overlay_seeded_version' => '1',
+				),
+			),
+			true
+		);
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			return 0;
+		}
+		// Race-safe option write: if a parallel request also raced past
+		// the early `get_post_id()` check and inserted its own singleton +
+		// claimed the option in between, drop ours and adopt theirs. The
+		// orphaned post would otherwise never be deleted by the reset
+		// flow because that only follows the option pointer.
+		$other_post_id = (int) get_option( static::OPTION_POST_ID, 0 );
+		if ( $other_post_id && get_post( $other_post_id ) ) {
+			wp_delete_post( $post_id, true );
+			self::$customized_content_cache = null;
+			return $other_post_id;
+		}
+		update_option( static::OPTION_POST_ID, $post_id, false );
+		self::$customized_content_cache = $seed_content;
+		return (int) $post_id;
+	}
+
+	/**
+	 * Read the bundled overlay template file. Exposed for the seed path —
+	 * the equivalent read in `Search_Blocks::get_overlay_template_content()`
+	 * cannot be reused without introducing a circular dependency.
+	 *
+	 * @return string
+	 */
+	protected static function read_bundled_template(): string {
+		$path = __DIR__ . '/templates/jetpack-search-overlay.html';
+		if ( ! is_readable( $path ) ) {
+			return '';
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
+		return (string) file_get_contents( $path );
+	}
+
+	/**
+	 * Reset the per-request content memo. Tests only.
+	 */
+	public static function reset_customized_content_cache() {
+		self::$customized_content_cache = null;
+	}
+}

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -94,8 +94,32 @@ class Overlay_Template {
 				'show_in_rest'        => true,
 				'rest_base'           => 'jetpack-search-overlay',
 				'supports'            => array( 'editor', 'custom-fields', 'revisions' ),
-				'capability_type'     => 'page',
-				'map_meta_cap'        => true,
+				// Lock every relevant capability to `manage_options` so editing
+				// requires admin, regardless of which entry point (post.php
+				// direct URL, REST API at /wp/v2/jetpack-search-overlay, the
+				// dashboard link) the user takes. The dashboard handlers
+				// already gate on `manage_options` themselves; this prevents
+				// an Editor-role user who happens to know the singleton's
+				// post ID from bypassing that gate via post.php or REST.
+				// `map_meta_cap: false` makes the literal capability names
+				// below the ones WordPress actually checks.
+				'capabilities'        => array(
+					'edit_post'              => 'manage_options',
+					'read_post'              => 'manage_options',
+					'delete_post'            => 'manage_options',
+					'edit_posts'             => 'manage_options',
+					'edit_others_posts'      => 'manage_options',
+					'delete_posts'           => 'manage_options',
+					'delete_others_posts'    => 'manage_options',
+					'publish_posts'          => 'manage_options',
+					'read_private_posts'     => 'manage_options',
+					'delete_private_posts'   => 'manage_options',
+					'delete_published_posts' => 'manage_options',
+					'edit_private_posts'     => 'manage_options',
+					'edit_published_posts'   => 'manage_options',
+					'create_posts'           => 'manage_options',
+				),
+				'map_meta_cap'        => false,
 				'has_archive'         => false,
 				'exclude_from_search' => true,
 				'rewrite'             => false,
@@ -142,6 +166,27 @@ class Overlay_Template {
 	 */
 	public static function get_post_id(): int {
 		return (int) get_option( static::OPTION_POST_ID, 0 );
+	}
+
+	/**
+	 * Whether a live customization exists — the singleton post is set AND
+	 * not in the trash. The trash check matters because `show_ui` is on,
+	 * so an admin could navigate to the post-list and trash the singleton
+	 * directly; the option would still point at the (trashed) post, but
+	 * `get_customized_content()` already returns null for trashed rows so
+	 * the front end falls back to the bundled template. Reflecting that
+	 * in the dashboard means "Restore default" disappears when there's
+	 * nothing the user would perceive as customized.
+	 *
+	 * @return bool
+	 */
+	public static function is_customized(): bool {
+		$post_id = static::get_post_id();
+		if ( ! $post_id ) {
+			return false;
+		}
+		$post = get_post( $post_id );
+		return $post && static::POST_TYPE === $post->post_type && 'trash' !== $post->post_status;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -291,8 +291,16 @@ class Overlay_Template {
 	 */
 	protected static function ensure_post_exists(): int {
 		$existing = static::get_post_id();
-		if ( $existing && get_post( $existing ) ) {
-			return $existing;
+		if ( $existing ) {
+			$existing_post = get_post( $existing );
+			// Only reuse live singleton posts. If the option points to a trashed
+			// row (or a stale/mismatched ID), treat it as missing so clicking
+			// "Edit the Search overlay" recreates a fresh editable singleton.
+			if ( $existing_post && static::POST_TYPE === $existing_post->post_type && 'trash' !== $existing_post->post_status ) {
+				return $existing;
+			}
+			delete_option( static::OPTION_POST_ID );
+			self::$customized_content_cache = null;
 		}
 		$seed_content = static::read_bundled_template();
 		$post_id      = wp_insert_post(
@@ -316,7 +324,8 @@ class Overlay_Template {
 		// orphaned post would otherwise never be deleted by the reset
 		// flow because that only follows the option pointer.
 		$other_post_id = (int) get_option( static::OPTION_POST_ID, 0 );
-		if ( $other_post_id && get_post( $other_post_id ) ) {
+		$other_post    = $other_post_id ? get_post( $other_post_id ) : null;
+		if ( $other_post && static::POST_TYPE === $other_post->post_type && 'trash' !== $other_post->post_status ) {
 			wp_delete_post( $post_id, true );
 			self::$customized_content_cache = null;
 			return $other_post_id;

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -299,8 +299,15 @@ class Overlay_Template {
 			if ( $existing_post && static::POST_TYPE === $existing_post->post_type && 'trash' !== $existing_post->post_status ) {
 				return $existing;
 			}
-			delete_option( static::OPTION_POST_ID );
-			self::$customized_content_cache = null;
+			// Force-delete the stale post (typically trashed) before recreating,
+			// so admins who repeatedly trash the singleton don't accumulate
+			// orphan rows. before_delete_post will null the option + cache.
+			if ( $existing_post && static::POST_TYPE === $existing_post->post_type ) {
+				wp_delete_post( $existing, true );
+			} else {
+				delete_option( static::OPTION_POST_ID );
+				self::$customized_content_cache = null;
+			}
 		}
 		$seed_content = static::read_bundled_template();
 		$post_id      = wp_insert_post(

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -30,8 +30,11 @@ namespace Automattic\Jetpack\Search;
  *    singleton's `post_content`.
  * 4. On the front end, `Search_Blocks::get_overlay_template_content()`
  *    prefers the singleton's content when present.
- * 5. "Restore default" hits `maybe_handle_reset_request()`, which deletes
- *    the singleton; the next request falls back to the bundled file again.
+ * 5. "Restore default" calls the CPT's built-in REST endpoint
+ *    (`DELETE /wp/v2/jetpack-search-overlay/<id>?force=true`) via
+ *    `apiFetch`; the `before_delete_post` hook here cleans up the
+ *    singleton option + per-request cache so subsequent renders fall
+ *    back to the bundled file.
  *
  * Gated behind both `jetpack_search_blocks_enabled` AND
  * `jetpack_search_overlay_block_template_enabled` — only initialized from
@@ -42,12 +45,10 @@ class Overlay_Template {
 	// 20 char max per `register_post_type()`. `jp_` prefix instead of
 	// `jetpack_` to stay under the limit while remaining greppable.
 	const POST_TYPE          = 'jp_search_overlay';
+	const REST_BASE          = 'jetpack-search-overlay';
 	const OPTION_POST_ID     = 'jetpack_search_overlay_template_post_id';
 	const EDITOR_REQUEST_KEY = 'jetpack_search_open_overlay_editor';
-	const RESET_REQUEST_KEY  = 'jetpack_search_reset_overlay_template';
 	const EDITOR_NONCE       = 'jetpack_search_overlay_editor';
-	const RESET_NONCE        = 'jetpack_search_overlay_reset';
-	const REDIRECT_QUERY_ARG = 'jetpack_search_overlay_template';
 
 	/**
 	 * Per-request memo backing `get_customized_content()`. `null` means the
@@ -69,8 +70,33 @@ class Overlay_Template {
 		// singleton's content.
 		add_action( 'init', array( static::class, 'register_post_type' ), 9 );
 		add_action( 'admin_init', array( static::class, 'maybe_handle_editor_request' ) );
-		add_action( 'admin_init', array( static::class, 'maybe_handle_reset_request' ) );
-		add_action( 'admin_notices', array( static::class, 'maybe_render_admin_notices' ) );
+		// Keep the singleton option + per-request cache consistent regardless
+		// of which delete path is taken: the dashboard's AJAX reset, the
+		// REST endpoint, or an admin trashing then permanently deleting via
+		// post.php. `before_delete_post` fires for force-delete too, which
+		// is what wp_delete_post( $id, true ) and REST DELETE ?force=true do.
+		add_action( 'before_delete_post', array( static::class, 'maybe_cleanup_on_singleton_delete' ) );
+	}
+
+	/**
+	 * Reset the option + per-request cache when our singleton post is
+	 * deleted, regardless of which delete path the admin took. Catches
+	 * deletions from any source — REST, post.php, our own dashboard flow
+	 * — so the state never drifts (option still pointing at a deleted
+	 * post would otherwise hide "Restore default" while the front end
+	 * already serves the bundled template).
+	 *
+	 * @param int $post_id The post being deleted.
+	 */
+	public static function maybe_cleanup_on_singleton_delete( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post || static::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		if ( (int) get_option( static::OPTION_POST_ID, 0 ) === (int) $post_id ) {
+			delete_option( static::OPTION_POST_ID );
+		}
+		self::$customized_content_cache = null;
 	}
 
 	/**
@@ -215,20 +241,23 @@ class Overlay_Template {
 	}
 
 	/**
-	 * Nonce'd admin URL that deletes the singleton (restoring the bundled
-	 * template) and redirects back to the dashboard. Built raw for the
-	 * same reason as `get_editor_url()`.
+	 * REST path used by the dashboard's "Restore default" link to delete
+	 * the singleton via the CPT's built-in REST endpoint
+	 * (`/wp/v2/jetpack-search-overlay/<id>?force=true`). The dashboard
+	 * calls this with `apiFetch({ method: 'DELETE', path: <…> })`; the
+	 * `before_delete_post` cleanup keeps the option + cache in sync.
 	 *
-	 * @return string
+	 * Returns `null` when no singleton exists — the React link is hidden
+	 * by `isCustomized` in that state, so this should never be hit, but
+	 * returning null keeps the type honest.
+	 *
+	 * @return string|null
 	 */
-	public static function get_reset_url(): string {
-		return add_query_arg(
-			array(
-				static::RESET_REQUEST_KEY => '1',
-				'_wpnonce'                => wp_create_nonce( static::RESET_NONCE ),
-			),
-			admin_url( 'admin.php?page=jetpack-search' )
-		);
+	public static function get_reset_rest_path(): ?string {
+		if ( ! static::is_customized() ) {
+			return null;
+		}
+		return '/wp/v2/' . static::REST_BASE . '/' . static::get_post_id() . '?force=true';
 	}
 
 	/**
@@ -251,62 +280,6 @@ class Overlay_Template {
 		}
 		wp_safe_redirect( admin_url( 'post.php?post=' . $post_id . '&action=edit' ) );
 		exit;
-	}
-
-	/**
-	 * Handle the "reset to default" admin request: delete the singleton
-	 * (and the option pointing to it) so the next render falls back to the
-	 * bundled template.
-	 */
-	public static function maybe_handle_reset_request() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below.
-		if ( empty( $_GET[ static::RESET_REQUEST_KEY ] ) ) {
-			return;
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'You do not have permission to reset the Search overlay.', 'jetpack-search-pkg' ), '', array( 'response' => 403 ) );
-		}
-		check_admin_referer( static::RESET_NONCE );
-		$post_id = static::get_post_id();
-		if ( $post_id ) {
-			wp_delete_post( $post_id, true );
-			delete_option( static::OPTION_POST_ID );
-			self::$customized_content_cache = null;
-		}
-		wp_safe_redirect(
-			add_query_arg( static::REDIRECT_QUERY_ARG, 'reset', admin_url( 'admin.php?page=jetpack-search' ) )
-		);
-		exit;
-	}
-
-	/**
-	 * Surface the success / restore-default notice — but only on the
-	 * Jetpack Search settings page itself. Without the screen guard the
-	 * notice could surface on any admin page whose URL happens to carry
-	 * the redirect query arg (anyone could land on
-	 * `wp-admin/index.php?jetpack_search_overlay_template=reset`).
-	 */
-	public static function maybe_render_admin_notices() {
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		if ( ! $screen || 'toplevel_page_jetpack-search' !== $screen->id ) {
-			return;
-		}
-		// Read-only query arg used only to flip the success banner on after
-		// the nonce'd reset handler redirected back. No state mutated here,
-		// so nonce verification is intentionally not required.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$redirect_signal = isset( $_GET[ static::REDIRECT_QUERY_ARG ] )
-			? sanitize_text_field( wp_unslash( $_GET[ static::REDIRECT_QUERY_ARG ] ) )
-			: '';
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-		if ( 'reset' !== $redirect_signal ) {
-			return;
-		}
-		?>
-		<div class="notice notice-success is-dismissible">
-			<p><?php esc_html_e( 'The Search overlay template has been restored to the bundled default.', 'jetpack-search-pkg' ); ?></p>
-		</div>
-		<?php
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -206,6 +206,7 @@ class Search_Blocks {
 		}
 
 		if ( static::is_block_template_overlay_enabled() ) {
+			Overlay_Template::init();
 			add_action( 'wp_enqueue_scripts', array( static::class, 'enqueue_block_template_overlay_assets' ) );
 			add_action( 'wp_footer', array( static::class, 'print_block_template_overlay' ) );
 		}
@@ -1009,11 +1010,26 @@ class Search_Blocks {
 	 * the headings directly, matching the legacy overlay's per-filter
 	 * subheading layout.
 	 *
+	 * Source of truth, in order:
+	 *
+	 *   1. The customized singleton CPT (`Overlay_Template`), if an admin
+	 *      has saved one via the dashboard's "Edit the Search overlay" link.
+	 *   2. The bundled `templates/jetpack-search-overlay.html` file.
+	 *
+	 * Memoized per-request. The customization branch is hit at most once
+	 * per request even when the singleton's content is empty, because
+	 * `Overlay_Template::get_customized_content()` does its own caching.
+	 *
 	 * @return string Block markup for the overlay body.
 	 */
 	protected static function get_overlay_template_content(): string {
 		static $content = null;
 		if ( null !== $content ) {
+			return $content;
+		}
+		$customized = Overlay_Template::get_customized_content();
+		if ( null !== $customized ) {
+			$content = $customized;
 			return $content;
 		}
 		$template_path = __DIR__ . '/templates/jetpack-search-overlay.html';


### PR DESCRIPTION
Fixes [SEARCH-216](https://linear.app/a8c/issue/SEARCH-216/search-blocks-overlay-admin-editable-template-via-hidden-cpt-block)

> [!NOTE]
> **Stacks on #48994 (SEARCH-213).** That PR adds the new `overlay_blocks` experience as its own card in the Experience Selector and deliberately leaves the action-link row empty with a comment calling out SEARCH-216 as the path forward. This PR fills that row in. Base will flip from `sage/search-213-overlay-blocks-experience` to `trunk` once #48994 lands.

## Why

#48994 introduces a new "Overlay search" card backed by the rendered Search blocks template, but the template itself can only be edited by forking the package. The legacy overlay's card ships configurable affordances (Customize / Edit widgets); this is parity for the new card so admins can shape the rendered template through the standard block editor.

## Proposed changes

- New `Overlay_Template` class registers a hidden, single-instance CPT (`jp_search_overlay`) and exposes two nonce'd admin actions: open-editor (lazy-creates the singleton + redirects to `post.php`) and reset-default (deletes the singleton + redirects back with a success banner, scoped to the Jetpack Search page only).
- `Search_Blocks::get_overlay_template_content()` now prefers the singleton's `post_content` when present and falls back to the bundled file.
- Dashboard exposes a `blockTemplateOverlay` config blob (`enabled`, `editorUrl`, `resetUrl`, `isCustomized`) under `siteData` alongside #48994's `blockOverlayEnabled`. URLs / `isCustomized` are cap-gated server-side on `manage_options`.
- The OVERLAY_BLOCKS card in `experience-option.jsx` renders "Edit the Search overlay" + "Restore default" action links (replacing #48994's "intentionally no action links" placeholder comment that specifically referenced SEARCH-216). "Restore default" is hidden until the singleton exists, and routes through a `ConfirmDialog` before the destructive navigation.
- `CardLink` gains an optional `onClick` prop so the reset link can intercept and route through the confirm dialog instead of letting the `<a>` follow the href directly.
- `ensure_post_exists` re-reads the option after insert to avoid orphaning a post when two admin requests race the click.

**Implementation note worth surfacing in review:** the URLs are built with `add_query_arg` + `wp_create_nonce`, **not** `wp_nonce_url`. `wp_nonce_url` returns HTML-encoded URLs (`&amp;`); JSON-serialized into the React store and set as an `<a href>`, React/JSX doesn't decode entities in attribute values — encoded amps would round-trip into the browser's URL bar verbatim and break the `$_GET` parse.

## Related product discussion/links

* Parent: [SEARCH-213](https://linear.app/a8c/issue/SEARCH-213) (PR #48994)
* Grandparent: [SEARCH-206](https://linear.app/a8c/issue/SEARCH-206) (PR #48987, merged)
* This issue: [SEARCH-216](https://linear.app/a8c/issue/SEARCH-216)
* Linear project: https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586

## Does this pull request change what data or activity we track or use?

No. The CPT is local-only, not Jetpack-Sync-allowlisted, and admin-editable only by `manage_options` users.

## Screenshots

### Overlay search card — default state (no customization yet)

![dashboard default](https://github.com/user-attachments/assets/95769e4e-fbdf-4947-a957-c30d64a9fe4e)

Only "Edit the Search overlay" surfaces until the admin saves a customization.

### Overlay search card — after the admin saves a customization

![dashboard customized](https://github.com/user-attachments/assets/7b23a354-ede2-4ef7-b7e6-8958264c427a)

"Restore default" appears alongside once the singleton exists; clicking it routes through a `ConfirmDialog` before the destructive navigation.

### Block editor opens on the singleton CPT, seeded with the bundled template

![block editor](https://github.com/user-attachments/assets/d57a2e65-7d70-4bc4-9f09-126067005cd1)

## Verification

End-to-end smoke test on the local docker env (block theme: Twenty Twenty-Five; classic theme: Twenty Sixteen). Sequence: switch experience to `overlay_blocks` → dashboard click → editor → edit → save → front-end shows the customization → reset → front-end falls back to the bundled template.

<details>
<summary>Gate behaviour</summary>

```text
$ wp option update jetpack_search_experience overlay_blocks
$ wp eval 'echo Automattic\Jetpack\Search\Search_Blocks::is_block_template_overlay_enabled() ? "true" : "false";'
true
$ wp eval 'echo post_type_exists("jp_search_overlay") ? "yes" : "no";'
yes
```

</details>

<details>
<summary>Edit + save round-trip</summary>

```text
$ wp post update <singleton-id> --post_content="<!-- wp:paragraph --><p>CUSTOMIZED-MARKER-216</p><!-- /wp:paragraph -->"
Success: Updated post …

$ curl -s "https://jp-echo.jurassic.tube/?cb=verify" | grep -c "CUSTOMIZED-MARKER-216"
1
```

</details>

<details>
<summary>Reset flow</summary>

```text
After clicking "Restore default" → confirming the dialog → server-side:

$ wp post get <singleton-id> --field=post_status
Error: Could not find the post with ID …

$ wp option get jetpack_search_overlay_template_post_id
Error: Could not get … Does it exist?

$ curl -s "https://jp-echo.jurassic.tube/?cb=after-reset" | grep -c "CUSTOMIZED-MARKER-216"
0
```

Dashboard shows the "Search overlay template has been restored to the bundled default" success notice on the redirect-back render.

</details>

<details>
<summary>Classic-theme parity (Twenty Sixteen)</summary>

```text
$ wp theme activate twentysixteen
Success: Switched to 'Twenty Sixteen' theme.

$ wp eval 'echo wp_is_block_theme() ? "true" : "false";'
false

$ <Playwright clicks "Edit the Search overlay" link>
editor URL: https://jp-echo.jurassic.tube/wp-admin/post.php?post=<id>&action=edit
has block editor: true
```

`post.php` predates the Site Editor and works on any theme.

</details>

## Testing instructions

Per the SEARCH-216 acceptance criteria:

- [ ] When `jetpack_search_overlay_block_template_enabled` is on AND the active experience is `overlay_blocks`, the Jetpack Search settings page shows an "Edit the Search overlay" link on the Overlay search card.
- [ ] Clicking it lands the admin in the block editor with the current overlay markup loaded.
- [ ] Editing + saving updates the rendered overlay on the front end.
- [ ] After the first save, a "Restore default" affordance appears alongside; clicking it (and confirming) reverts to the bundled `jetpack-search-overlay.html` and the link disappears again.
- [ ] Works on a block theme (e.g. Twenty Twenty-Five) AND a classic theme (e.g. Twenty Sixteen).
- [ ] When the overlay gate is off (or the experience is not `overlay_blocks`), neither link is shown.

Reproduce locally:

1. Check out #48994's branch + this PR on top.
2. Build: `jp build packages/search --no-deps`.
3. On a docker env with Search 3.0 blocks enabled, also enable the overlay gate:
   ```php
   add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
   ```
4. Visit Jetpack > Search > Settings and switch to the new "Overlay search" card.
5. "Edit the Search overlay" → block editor on a `jp_search_overlay` post seeded from the bundled file. Edit, save.
6. Front-end search → overlay shows your customization.
7. "Restore default" (now visible) → confirm → singleton deleted, success notice shown, front-end overlay falls back to the bundled file.
8. Switch to a classic theme → repeat 5–7. Identical flow (`post.php` is theme-agnostic).

