### PR TITLE
Port Search package 7.0.0 changes back to trunk

### DIFF
--- a/projects/js-packages/analytics/CHANGELOG.md
+++ b/projects/js-packages/analytics/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Analytics package releases.
 
+## [1.0.13] - 2026-05-21
+### Changed
+- Update package dependencies. [#49012]
+
 ## [1.0.12] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -200,6 +204,7 @@
 ### Added
 - Initial release of jetpack-api package.
 
+[1.0.13]: https://github.com/Automattic/jetpack-analytics/compare/v1.0.12...v1.0.13
 [1.0.12]: https://github.com/Automattic/jetpack-analytics/compare/v1.0.11...v1.0.12
 [1.0.11]: https://github.com/Automattic/jetpack-analytics/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/Automattic/jetpack-analytics/compare/v1.0.9...v1.0.10

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-analytics",
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"description": "Jetpack Analytics Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/analytics/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.0.26] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [1.0.25] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -522,6 +527,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[1.0.26]: https://github.com/Automattic/jetpack-api/compare/v1.0.25...v1.0.26
 [1.0.25]: https://github.com/Automattic/jetpack-api/compare/v1.0.24...v1.0.25
 [1.0.24]: https://github.com/Automattic/jetpack-api/compare/v1.0.23...v1.0.24
 [1.0.23]: https://github.com/Automattic/jetpack-api/compare/v1.0.22...v1.0.23

--- a/projects/js-packages/api/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/api/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "1.0.25",
+	"version": "1.0.26",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-05-21
+### Changed
+- Update package dependencies. [#49012]
+
 ## [1.1.1] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -257,6 +261,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.1.2]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.57...v1.1.0
 [1.0.57]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.56...v1.0.57

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"keywords": [
 		"babel",

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+
+### Fixed
+- Base styles: Update admin-page-layout mixin's header selector from `> header` to `> :first-child` so it keeps matching after @wordpress/admin-ui 2.1 changed the page header element from `<header>` to `<div>`. [#49006]
+
 ## [1.2.3] - 2026-05-19
 ### Changed
 - Admin page tabs: Add a minimal-tabs modifier and restore the intended tab font size in WP Admin. [#48908]
@@ -527,6 +534,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[1.2.4]: https://github.com/Automattic/jetpack-base-styles/compare/1.2.3...1.2.4
 [1.2.3]: https://github.com/Automattic/jetpack-base-styles/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/Automattic/jetpack-base-styles/compare/1.2.1...1.2.2
 [1.2.1]: https://github.com/Automattic/jetpack-base-styles/compare/1.2.0...1.2.1

--- a/projects/js-packages/base-styles/changelog/fix-admin-page-layout-header-selector
+++ b/projects/js-packages/base-styles/changelog/fix-admin-page-layout-header-selector
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Base styles: Update admin-page-layout mixin's header selector from `> header` to `> :first-child` so it keeps matching after @wordpress/admin-ui 2.1 changed the page header element from `<header>` to `<div>`.

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.43] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [1.0.42] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -456,6 +461,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[1.0.43]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.42...v1.0.43
 [1.0.42]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.41...v1.0.42
 [1.0.41]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.40...v1.0.41
 [1.0.40]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.39...v1.0.40

--- a/projects/js-packages/boost-score-api/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/boost-score-api/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "1.0.42",
+	"version": "1.0.43",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [1.4.1] - 2026-05-19
 ### Changed
 - Keep stacked area chart paths mounted on legend toggle so only the hidden series animates down and the y-axis stays fixed. [#48804]
@@ -833,6 +838,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[1.4.2]: https://github.com/Automattic/charts/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/Automattic/charts/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Automattic/charts/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/Automattic/charts/compare/v1.3.0...v1.3.1

--- a/projects/js-packages/charts/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/charts/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/charts/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/charts/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.11.3] - 2026-05-21
+### Changed
+- Mark ContextualUpgradeTrigger as @deprecated. Use Notice from @wordpress/ui instead. The implementation is unchanged. [#48909]
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [1.11.2] - 2026-05-19
 ### Changed
 - Deprecate Status; inline @wordpress/ui Text in consumers. [#48711]
@@ -1788,6 +1794,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[1.11.3]: https://github.com/Automattic/jetpack-components/compare/1.11.2...1.11.3
 [1.11.2]: https://github.com/Automattic/jetpack-components/compare/1.11.1...1.11.2
 [1.11.1]: https://github.com/Automattic/jetpack-components/compare/1.11.0...1.11.1
 [1.11.0]: https://github.com/Automattic/jetpack-components/compare/1.10.0...1.11.0

--- a/projects/js-packages/components/changelog/change-migrate-cut-wp-ui
+++ b/projects/js-packages/components/changelog/change-migrate-cut-wp-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Mark ContextualUpgradeTrigger as @deprecated. Use Notice from @wordpress/ui instead. The implementation is unchanged.

--- a/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "1.11.2",
+	"version": "1.11.3",
 	"description": "Jetpack Components Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/components/#readme",
 	"bugs": {

--- a/projects/js-packages/config/CHANGELOG.md
+++ b/projects/js-packages/config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.11] - 2026-05-21
+### Changed
+- Update package dependencies. [#49012]
+
 ## [1.0.10] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -164,6 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fixed and improved README
 
+[1.0.11]: https://github.com/Automattic/jetpack-config-js/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/Automattic/jetpack-config-js/compare/v1.0.9...v1.0.10
 [1.0.9]: https://github.com/Automattic/jetpack-config-js/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/Automattic/jetpack-config-js/compare/v1.0.7...v1.0.8

--- a/projects/js-packages/config/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/config/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-config",
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"description": "Handles Jetpack global configuration shared across all packages",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/config/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [1.4.52] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [1.4.51] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -1342,6 +1347,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[1.4.52]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.51...v1.4.52
 [1.4.51]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.50...v1.4.51
 [1.4.50]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.49...v1.4.50
 [1.4.49]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.48...v1.4.49

--- a/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "1.4.51",
+	"version": "1.4.52",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.38] - 2026-05-21
+### Changed
+- Update package dependencies. [#49012]
+
 ## [1.1.37] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -326,6 +330,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.38]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.37...v1.1.38
 [1.1.37]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.36...v1.1.37
 [1.1.36]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.35...v1.1.36
 [1.1.35]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.34...v1.1.35

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.37",
+	"version": "1.1.38",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"keywords": [
 		"webpack",

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.101] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [2.0.100] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -431,6 +436,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.101]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.100...v2.0.101
 [2.0.100]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.99...v2.0.100
 [2.0.99]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.98...v2.0.99
 [2.0.98]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.97...v2.0.98

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.100",
+	"version": "2.0.101",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"keywords": [
 		"webpack",

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.67 - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+
 ## 1.0.66 - 2026-05-19
 ### Changed
 - Internal updates.

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.66",
+	"version": "1.0.67",
 	"description": "Jetpack Connection Component",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.48 - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## 1.2.47 - 2026-05-19
 ### Changed
 - Internal updates.

--- a/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-licensing",
-	"version": "1.2.47",
+	"version": "1.2.48",
 	"private": true,
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",

--- a/projects/js-packages/number-formatters/CHANGELOG.md
+++ b/projects/js-packages/number-formatters/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.10] - 2026-05-21
+### Changed
+- Update package dependencies. [#49012]
+
 ## [1.1.9] - 2026-05-19
 ### Fixed
 - Currency formatting: use ISO 4217 minor-unit exponent for smallest-unit conversion to correctly format IDR and other currencies where browser ICU disagrees with ISO 4217. [#48967]
@@ -148,6 +152,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial release
 - Basic number formatting functionality
 
+[1.1.10]: https://github.com/Automattic/number-formatters/compare/1.1.9...1.1.10
 [1.1.9]: https://github.com/Automattic/number-formatters/compare/1.1.8...1.1.9
 [1.1.8]: https://github.com/Automattic/number-formatters/compare/1.1.7...1.1.8
 [1.1.7]: https://github.com/Automattic/number-formatters/compare/1.1.6...1.1.7

--- a/projects/js-packages/number-formatters/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/number-formatters/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.1.9",
+	"version": "1.1.10",
 	"description": "Number formatting utilities",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/number-formatters/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.16] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [1.5.15] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -941,6 +946,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[1.5.16]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.5.15...1.5.16
 [1.5.15]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.5.14...1.5.15
 [1.5.14]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.5.13...1.5.14
 [1.5.13]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.5.12...1.5.13

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "1.5.15",
+	"version": "1.5.16",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.8.7 - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+
 ## 3.8.6 - 2026-05-19
 ### Changed
 - Update package dependencies. [#48910]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.8.6",
+	"version": "3.8.7",
 	"private": true,
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+
 ## [0.8.5] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -259,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.8.6]: https://github.com/Automattic/jetpack-admin-ui/compare/0.8.5...0.8.6
 [0.8.5]: https://github.com/Automattic/jetpack-admin-ui/compare/0.8.4...0.8.5
 [0.8.4]: https://github.com/Automattic/jetpack-admin-ui/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/Automattic/jetpack-admin-ui/compare/0.8.2...0.8.3

--- a/projects/packages/admin-ui/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/admin-ui/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"private": true,
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.8.5';
+	const PACKAGE_VERSION = '0.8.6';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.38] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [4.3.37] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -836,6 +841,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.3.38]: https://github.com/Automattic/jetpack-assets/compare/v4.3.37...v4.3.38
 [4.3.37]: https://github.com/Automattic/jetpack-assets/compare/v4.3.36...v4.3.37
 [4.3.36]: https://github.com/Automattic/jetpack-assets/compare/v4.3.35...v4.3.36
 [4.3.35]: https://github.com/Automattic/jetpack-assets/compare/v4.3.34...v4.3.35

--- a/projects/packages/assets/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/assets/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.3.7] - 2026-05-21
+### Added
+- Connection: Signal to Calypso that the site already has a connection owner so the authorize page can show appropriate content for secondary user connections. [#48904]
+
+### Changed
+- Connection: Show the Jetpack icon beside the Connected label in the WordPress.com account column on the Users screen. [#48951]
+- Connectors: Show shorter, role-appropriate connect prompt for secondary user connections when the site already has a connection owner. [#48904]
+- Update package dependencies. [#48405]
+
+### Fixed
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+
 ## [8.3.6] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -1829,6 +1841,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.3.7]: https://github.com/Automattic/jetpack-connection/compare/v8.3.6...v8.3.7
 [8.3.6]: https://github.com/Automattic/jetpack-connection/compare/v8.3.5...v8.3.6
 [8.3.5]: https://github.com/Automattic/jetpack-connection/compare/v8.3.4...v8.3.5
 [8.3.4]: https://github.com/Automattic/jetpack-connection/compare/v8.3.3...v8.3.4

--- a/projects/packages/connection/changelog/add-connection-secondary-user-authorize-signal
+++ b/projects/packages/connection/changelog/add-connection-secondary-user-authorize-signal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Connection: Signal to Calypso that the site already has a connection owner so the authorize page can show appropriate content for secondary user connections.

--- a/projects/packages/connection/changelog/add-users-list-connected-jetpack-logo
+++ b/projects/packages/connection/changelog/add-users-list-connected-jetpack-logo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Connection: Show the Jetpack icon beside the Connected label in the WordPress.com account column on the Users screen.

--- a/projects/packages/connection/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/connection/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/connection/changelog/update-connector-card-secondary-prompt
+++ b/projects/packages/connection/changelog/update-connector-card-secondary-prompt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Connectors: Show shorter, role-appropriate connect prompt for secondary user connections when the site already has a connection owner.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.3.6';
+	const PACKAGE_VERSION = '8.3.7';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/explat/CHANGELOG.md
+++ b/projects/packages/explat/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.26] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
 ## [0.4.25] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -350,6 +355,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ExPlat: add condition to prevent fetching the experiment assignment if there's not anon id (meaning that Tracks is likely disabled) [#38327]
 - Updated package dependencies. [#38132]
 
+[0.4.26]: https://github.com/Automattic/jetpack-explat/compare/v0.4.25...v0.4.26
 [0.4.25]: https://github.com/Automattic/jetpack-explat/compare/v0.4.24...v0.4.25
 [0.4.24]: https://github.com/Automattic/jetpack-explat/compare/v0.4.23...v0.4.24
 [0.4.23]: https://github.com/Automattic/jetpack-explat/compare/v0.4.22...v0.4.23

--- a/projects/packages/explat/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/explat/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/explat/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/explat/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/explat/package.json
+++ b/projects/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-explat",
-	"version": "0.4.25",
+	"version": "0.4.26",
 	"private": true,
 	"description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/explat/#readme",

--- a/projects/packages/explat/src/class-explat.php
+++ b/projects/packages/explat/src/class-explat.php
@@ -20,7 +20,7 @@ class ExPlat {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.4.25';
+	const PACKAGE_VERSION = '0.4.26';
 
 	/**
 	 * Initializer.

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.36] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+
 ## [4.3.35] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -1106,6 +1110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[4.3.36]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.35...v4.3.36
 [4.3.35]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.34...v4.3.35
 [4.3.34]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.33...v4.3.34
 [4.3.33]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.32...v4.3.33

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class JITM {
 
-	const PACKAGE_VERSION = '4.3.35';
+	const PACKAGE_VERSION = '4.3.36';
 
 	/**
 	 * List of screen IDs where JITMs are allowed to display.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.37.3] - 2026-05-21
+### Changed
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
+### Fixed
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+
 ## [5.37.2] - 2026-05-19
 ### Changed
 - Update package dependencies. [#48910]
@@ -2664,6 +2672,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.37.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.37.2...5.37.3
 [5.37.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.37.1...5.37.2
 [5.37.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.37.0...5.37.1
 [5.37.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.36.0...5.37.0

--- a/projects/packages/my-jetpack/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/my-jetpack/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.37.2",
+	"version": "5.37.3",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.37.2';
+	const PACKAGE_VERSION = '5.37.3';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/protect-status/CHANGELOG.md
+++ b/projects/packages/protect-status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.11] - 2026-05-21
+### Fixed
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+
 ## [0.7.10] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -172,6 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#37894]
 
+[0.7.11]: https://github.com/Automattic/jetpack-protect-status/compare/v0.7.10...v0.7.11
 [0.7.10]: https://github.com/Automattic/jetpack-protect-status/compare/v0.7.9...v0.7.10
 [0.7.9]: https://github.com/Automattic/jetpack-protect-status/compare/v0.7.8...v0.7.9
 [0.7.8]: https://github.com/Automattic/jetpack-protect-status/compare/v0.7.7...v0.7.8

--- a/projects/packages/protect-status/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/protect-status/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/protect-status/package.json
+++ b/projects/packages/protect-status/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-protect-status",
-	"version": "0.7.10",
+	"version": "0.7.11",
 	"private": true,
 	"description": "This package contains the Protect Status API functionality to retrieve a site's scan status (WordPress, Themes, and Plugins threats).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/protect-status/#readme",

--- a/projects/packages/protect-status/src/class-status.php
+++ b/projects/packages/protect-status/src/class-status.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Protect_Models\Status_Model;
  */
 class Status {
 
-	const PACKAGE_VERSION = '0.7.10';
+	const PACKAGE_VERSION = '0.7.11';
 	/**
 	 * Name of the option where status is stored
 	 *

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.12] - 2026-05-21
+### Fixed
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+
 ## [3.0.11] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -261,6 +265,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[3.0.12]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.11...v3.0.12
 [3.0.11]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.10...v3.0.11
 [3.0.10]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.9...v3.0.10
 [3.0.9]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.8...v3.0.9

--- a/projects/packages/redirect/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/redirect/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2026-05-21
+### Added
+- Search: Add a "Compact" block style to the Clear Filters block and stop it inheriting the core Button block styling that rendered oversized on some themes — the default now uses the theme's lighter button baseline. [#48946]
+- Search: add an AI Answer block (`jetpack-search/ai-answer`) so authors can surface the AI Answers panel inside the embedded search template — previously only the instant-search overlay could render it. [#48986]
+- Search: Make the Load More block match the theme's regular core/button look and add a "Compact" block style so authors can right-size it without custom CSS. [#48984]
+- Search: surface the "Enable search suggestions" and "Enable AI Answers" toggles in the search customizer's Additional settings panel, alongside their existing home on the search dashboard. [#48990]
+- Search Blocks: Add experimental opt-in to replace the legacy instant-search overlay with the server-rendered Search blocks template; gated behind the `jetpack_search_overlay_block_template_enabled` filter (default false). [#48987]
+- Search Blocks: add optional autocomplete suggestions dropdown to the Search Input block — query, taxonomy, and post suggestions powered by the WPCOM search-suggestions endpoint. Authors opt in per block via the new "Show search suggestions" inspector toggle. Taxonomy picks apply as an inline filter when a matching filter block is on the page, otherwise navigate to the archive URL. [#48985]
+- Search dashboard: add a "WooCommerce Product Search" control that, when enabled, serves product searches from a dedicated Site-Editor-editable Jetpack Search template instead of WooCommerce's default product search template. [#48936]
+- Search Dashboard: add an "Additional settings" heading above the feature toggles in the search-blocks settings view. The heading only renders when at least one of those settings is available, so it never appears orphaned. [#48948]
+
+### Changed
+- Build: collapse the per-directory `production-exclude` rules for `src/**/*.js` into a single broad exclude with an explicit carve-out for `src/widgets/**/*.js` (which has no build step and must ship). [#48983]
+- Replace internal ContextualUpgradeTrigger upgrade prompts with @wordpress/ui Notice composition. Internal refactor with a Notice-style visual refresh. [#48909]
+- Search: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier. Bump @wordpress/ui to 0.13.0. [#48964]
+- Search: the AI Answer block (`jetpack-search/ai-answer`) no longer gates on the site-wide `jetpack_search_ai_answers_enabled` option — block presence in post content is the only switch. The option still governs the instant-search overlay. [#48993]
+- Search Blocks: let authors pick which suggestion sections appear in the Search Input dropdown (query completions, categories & tags, post titles) via a new per-block suggestionTypes attribute. Existing blocks default to all three. [#48991]
+- Update package dependencies. [#48405]
+- Update package dependencies. [#49012]
+
+### Fixed
+- AI Answers: Fix the answer panel colors in dark mode. [#49019]
+- Instant Search: Prevent the search modal from triggering on third-party form submissions. Forms embedding an input named "s" (e.g. ActiveCampaign sign-up widgets) would incorrectly open the search overlay and block the submission. The fix checks that the form's action URL shares the same origin as the site before intercepting. [#48958]
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+- Search: reject experience requests combined with ai_answers_enabled or search_suggestions_enabled instead of silently dropping them, and gate the WooCommerce product-search template override on the active experience so a stale option can't keep rerouting after a switch away from a server-rendered experience. [#48956]
+- Search Blocks: cap the filter-checkbox list at its configured "Maximum items" even after the session has retained options across multiple searches. [#48989]
+- Search Dashboard: Hide the AI Agent Access toggle for private sites and improve related settings spacing. [#48912]
+- Search dashboard: let the toggle description text span the full settings card width instead of wrapping in a narrow 7-column band. [#48944]
+
 ## [0.60.0] - 2026-05-19
 ### Added
 - Add a `wp jetpack-search backfill_taxonomy_slot_mapping [--mode=mirror|rebuild]` command for backfilling custom-taxonomy slot mappings. [#48849]
@@ -1665,6 +1694,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[7.0.0]: https://github.com/Automattic/jetpack-search/compare/v0.60.0...v7.0.0
 [0.60.0]: https://github.com/Automattic/jetpack-search/compare/v0.59.0...v0.60.0
 [0.59.0]: https://github.com/Automattic/jetpack-search/compare/v0.58.0...v0.59.0
 [0.58.0]: https://github.com/Automattic/jetpack-search/compare/v0.57.0...v0.58.0

--- a/projects/packages/search/changelog/2026-05-20-19-17-06-087798
+++ b/projects/packages/search/changelog/2026-05-20-19-17-06-087798
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Answers: Fix the answer panel colors in dark mode.

--- a/projects/packages/search/changelog/RSM-3497-woocommerce-product-search-takeover
+++ b/projects/packages/search/changelog/RSM-3497-woocommerce-product-search-takeover
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search dashboard: add a "WooCommerce Product Search" control that, when enabled, serves product searches from a dedicated Site-Editor-editable Jetpack Search template instead of WooCommerce's default product search template.

--- a/projects/packages/search/changelog/RSM-3507-clear-filters-button-customization
+++ b/projects/packages/search/changelog/RSM-3507-clear-filters-button-customization
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search: Add a "Compact" block style to the Clear Filters block and stop it inheriting the core Button block styling that rendered oversized on some themes — the default now uses the theme's lighter button baseline.

--- a/projects/packages/search/changelog/RSM-3588-load-more-default-compact
+++ b/projects/packages/search/changelog/RSM-3588-load-more-default-compact
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search: Make the Load More block match the theme's regular core/button look and add a "Compact" block style so authors can right-size it without custom CSS.

--- a/projects/packages/search/changelog/SEARCH-203-additional-settings-heading
+++ b/projects/packages/search/changelog/SEARCH-203-additional-settings-heading
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Search Dashboard: add an "Additional settings" heading above the feature toggles in the search-blocks settings view. The heading only renders when at least one of those settings is available, so it never appears orphaned.

--- a/projects/packages/search/changelog/SEARCH-206-block-template-overlay
+++ b/projects/packages/search/changelog/SEARCH-206-block-template-overlay
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search Blocks: Add experimental opt-in to replace the legacy instant-search overlay with the server-rendered Search blocks template; gated behind the `jetpack_search_overlay_block_template_enabled` filter (default false).

--- a/projects/packages/search/changelog/add-RSM-3591-ai-answer-block
+++ b/projects/packages/search/changelog/add-RSM-3591-ai-answer-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search: add an AI Answer block (`jetpack-search/ai-answer`) so authors can surface the AI Answers panel inside the embedded search template — previously only the instant-search overlay could render it.

--- a/projects/packages/search/changelog/change-migrate-cut-wp-ui
+++ b/projects/packages/search/changelog/change-migrate-cut-wp-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replace internal ContextualUpgradeTrigger upgrade prompts with @wordpress/ui Notice composition. Internal refactor with a Notice-style visual refresh.

--- a/projects/packages/search/changelog/fix-ai-agent-access-private-toggle
+++ b/projects/packages/search/changelog/fix-ai-agent-access-private-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search Dashboard: Hide the AI Agent Access toggle for private sites and improve related settings spacing.

--- a/projects/packages/search/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/search/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/search/changelog/fix-rsm-3545-wc-product-search-followup
+++ b/projects/packages/search/changelog/fix-rsm-3545-wc-product-search-followup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search: reject experience requests combined with ai_answers_enabled or search_suggestions_enabled instead of silently dropping them, and gate the WooCommerce product-search template override on the active experience so a stale option can't keep rerouting after a switch away from a server-rendered experience.

--- a/projects/packages/search/changelog/fix-search-gitattributes-negation
+++ b/projects/packages/search/changelog/fix-search-gitattributes-negation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: collapse the per-directory `production-exclude` rules for `src/**/*.js` into a single broad exclude with an explicit carve-out for `src/widgets/**/*.js` (which has no build step and must ship).

--- a/projects/packages/search/changelog/fix-search-modal-third-party-forms
+++ b/projects/packages/search/changelog/fix-search-modal-third-party-forms
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Instant Search: Prevent the search modal from triggering on third-party form submissions. Forms embedding an input named "s" (e.g. ActiveCampaign sign-up widgets) would incorrectly open the search overlay and block the submission. The fix checks that the form's action URL shares the same origin as the site before intercepting.

--- a/projects/packages/search/changelog/fix-search-toggle-description-width
+++ b/projects/packages/search/changelog/fix-search-toggle-description-width
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search dashboard: let the toggle description text span the full settings card width instead of wrapping in a narrow 7-column band.

--- a/projects/packages/search/changelog/normalize-tabs-minimal-variant
+++ b/projects/packages/search/changelog/normalize-tabs-minimal-variant
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Search: Normalize page tabs onto shared minimal variant + jp-admin-page-tabs--minimal wrapper modifier. Bump @wordpress/ui to 0.13.0.

--- a/projects/packages/search/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/search/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/search/changelog/search-204-externalize-blocks-store
+++ b/projects/packages/search/changelog/search-204-externalize-blocks-store
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Search blocks no longer inline a full copy of the shared store into every block's view script. The store ships once as the `jetpack-search/store` WordPress Script Module, cutting the search-blocks JS payload from ~14 duplicated bundles to one shared module.

--- a/projects/packages/search/changelog/search-205-search-input-autocomplete
+++ b/projects/packages/search/changelog/search-205-search-input-autocomplete
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search Blocks: add optional autocomplete suggestions dropdown to the Search Input block — query, taxonomy, and post suggestions powered by the WPCOM search-suggestions endpoint. Authors opt in per block via the new "Show search suggestions" inspector toggle. Taxonomy picks apply as an inline filter when a matching filter block is on the page, otherwise navigate to the archive URL.

--- a/projects/packages/search/changelog/search-208-filter-checkbox-cap-maxitems
+++ b/projects/packages/search/changelog/search-208-filter-checkbox-cap-maxitems
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search Blocks: cap the filter-checkbox list at its configured "Maximum items" even after the session has retained options across multiple searches.

--- a/projects/packages/search/changelog/search-211-customberg-suggestions-ai-toggles
+++ b/projects/packages/search/changelog/search-211-customberg-suggestions-ai-toggles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Search: surface the "Enable search suggestions" and "Enable AI Answers" toggles in the search customizer's Additional settings panel, alongside their existing home on the search dashboard.

--- a/projects/packages/search/changelog/search-212-suggestion-types-per-block
+++ b/projects/packages/search/changelog/search-212-suggestion-types-per-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Search Blocks: let authors pick which suggestion sections appear in the Search Input dropdown (query completions, categories & tags, post titles) via a new per-block suggestionTypes attribute. Existing blocks default to all three.

--- a/projects/packages/search/changelog/update-RSM-3608-ai-answer-block-decoupled-from-option
+++ b/projects/packages/search/changelog/update-RSM-3608-ai-answer-block-decoupled-from-option
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Search: the AI Answer block (`jetpack-search/ai-answer`) no longer gates on the site-wide `jetpack_search_ai_answers_enabled` option — block presence in post content is the only switch. The option still governs the instant-search overlay.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.60.x-dev"
+			"dev-trunk": "7.0.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.60.0';
+	const VERSION = '7.0.0';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.5] - 2026-05-21
+### Fixed
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+
 ## [6.1.4] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -532,6 +536,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[6.1.5]: https://github.com/Automattic/jetpack-status/compare/v6.1.4...v6.1.5
 [6.1.4]: https://github.com/Automattic/jetpack-status/compare/v6.1.3...v6.1.4
 [6.1.3]: https://github.com/Automattic/jetpack-status/compare/v6.1.2...v6.1.3
 [6.1.2]: https://github.com/Automattic/jetpack-status/compare/v6.1.1...v6.1.2

--- a/projects/packages/status/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/status/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.38.3] - 2026-05-21
+### Added
+- Sync: Whitelist the new Jetpack Search ai_answers_enabled, search_suggestions_enabled, override_woocommerce_search_template, and reader_chat options so they propagate to WPcom. [#48945]
+
+### Fixed
+- Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
+
 ## [4.38.2] - 2026-05-19
 ### Changed
 - Internal updates.
@@ -1747,6 +1754,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[4.38.3]: https://github.com/Automattic/jetpack-sync/compare/v4.38.2...v4.38.3
 [4.38.2]: https://github.com/Automattic/jetpack-sync/compare/v4.38.1...v4.38.2
 [4.38.1]: https://github.com/Automattic/jetpack-sync/compare/v4.38.0...v4.38.1
 [4.38.0]: https://github.com/Automattic/jetpack-sync/compare/v4.37.0...v4.38.0

--- a/projects/packages/sync/changelog/add-rsm-3508-sync-search-options
+++ b/projects/packages/sync/changelog/add-rsm-3508-sync-search-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Sync: Whitelist the new Jetpack Search ai_answers_enabled, search_suggestions_enabled, override_woocommerce_search_template, and reader_chat options so they propagate to WPcom.

--- a/projects/packages/sync/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
+++ b/projects/packages/sync/changelog/fix-phan-PhanPluginDuplicateConditionalNullCoalescing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.38.2';
+	const PACKAGE_VERSION = '4.38.3';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3110,7 +3110,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "fa951aa93b87ff70179dffadef8b188390a4a028"
+                "reference": "e23db070318492c3ccf04b08ae05cfa54bf2ded0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -3139,7 +3139,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.60.x-dev"
+                    "dev-trunk": "7.0.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/prerelease#6
+++ b/projects/plugins/search/changelog/prerelease#6
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1558,7 +1558,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "fa951aa93b87ff70179dffadef8b188390a4a028"
+                "reference": "e23db070318492c3ccf04b08ae05cfa54bf2ded0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1587,7 +1587,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.60.x-dev"
+                    "dev-trunk": "7.0.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
Fixes SEARCH-218 

## Proposed changes

This PR ports the Search package 7.0.0 release changes back to trunk. The 7.0.0 release includes:

**Added**
* Search: Add a "Compact" block style to the Clear Filters block, stopping it from inheriting oversized core Button block styling. [#48946]
* Search: Add an AI Answer block (`jetpack-search/ai-answer`) so authors can surface the AI Answers panel inside the embedded search template. [#48986]
* Search: Make the Load More block match the theme's regular core/button look and add a "Compact" block style. [#48984]
* Search: Surface "Enable search suggestions" and "Enable AI Answers" toggles in the search customizer's Additional settings panel. [#48990]
* Search Blocks: Add experimental opt-in to replace the legacy instant-search overlay with the server-rendered Search blocks template (gated behind `jetpack_search_overlay_block_template_enabled` filter). [#48987]
* Search Blocks: Add optional autocomplete suggestions dropdown to the Search Input block — query, taxonomy, and post suggestions powered by the WPCOM search-suggestions endpoint. [#48985]
* Search dashboard: Add a "WooCommerce Product Search" control for a dedicated Site-Editor-editable Jetpack Search template. [#48936]
* Search Dashboard: Add an "Additional settings" heading above the feature toggles in the search-blocks settings view. [#48948]

**Changed**
* Build: Collapse per-directory `production-exclude` rules for `src/**/*.js` into a single broad exclude. [#48983]
* Replace internal ContextualUpgradeTrigger upgrade prompts with `@wordpress/ui` Notice composition. [#48909]
* Search: Normalize page tabs onto shared minimal variant. Bump `@wordpress/ui` to 0.13.0. [#48964]
* Search: The AI Answer block no longer gates on the site-wide `jetpack_search_ai_answers_enabled` option — block presence in post content is the only switch. [#48993]
* Search Blocks: Let authors pick which suggestion sections appear in the Search Input dropdown via a new per-block `suggestionTypes` attribute. [#48991]
* Update package dependencies. [#48405] [#49012]

**Fixed**
* AI Answers: Fix the answer panel colors in dark mode. [#49019]
* Instant Search: Prevent the search modal from triggering on third-party form submissions (e.g. ActiveCampaign sign-up widgets with an `s` input). [#48958]
* Phan: Address PhanPluginDuplicateConditionalNullCoalescing violations. [#48887]
* Search: Reject experience requests combined with `ai_answers_enabled` or `search_suggestions_enabled` instead of silently dropping them. [#48956]
* Search Blocks: Cap the filter-checkbox list at its configured "Maximum items" even after the session retains options across multiple searches. [#48989]
* Search Dashboard: Hide the AI Agent Access toggle for private sites and improve related settings spacing. [#48912]
* Search dashboard: Let the toggle description text span the full settings card width. [#48944]

## Related product discussion/links

p1779309309701579-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Install Jetpack Search on a site and confirm the Search dashboard loads.
* Test the AI Answer block: add it to the embedded search template and confirm the AI Answers panel renders correctly.
* Test autocomplete suggestions in the Search Input block by enabling "Show search suggestions" in the block inspector and running a search.
* If WooCommerce is active, test the "WooCommerce Product Search" control in the Search dashboard.
* Test the "Compact" block style on the Clear Filters and Load More blocks.
* Verify dark mode styling for the AI Answers panel is correct.
* Verify that third-party forms with an `s` input field (e.g. newsletter sign-up forms) are not intercepted by the Jetpack Search overlay.
