### PR TITLE
Search: add jetpack-search/filter-static block (SEARCH-219)

### DIFF
--- a/projects/packages/search/changelog/search-219-filter-static-block
+++ b/projects/packages/search/changelog/search-219-filter-static-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: new `jetpack-search/filter-static` block — single-select radio filter whose options come from server config via the `jetpack_search_static_filters` (or legacy `jetpack_instant_search_options`) PHP filter. Selections round-trip through scalar `?filter_id=value` URL params.

--- a/projects/packages/search/src/search-blocks/blocks/filter-static/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-static/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/filter-static",
+	"version": "0.1.0",
+	"title": "Static Filter",
+	"category": "jetpack-search",
+	"description": "Single-select radio filter whose options come from server config (the `jetpack_search_static_filters` PHP filter). Mirrors the legacy instant-search static filter widget. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"variation": {
+			"type": "string",
+			"default": "sidebar",
+			"enum": [ "sidebar", "tabbed" ]
+		},
+		"filterId": { "type": "string", "default": "" },
+		"label": { "type": "string", "default": "" }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/filter-static.js",
+	"style": "file:../../../../build/search-blocks/filter-static.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-static/class-filter-static.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-static/class-filter-static.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Filter-static block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack-search/filter-static block.
+ *
+ * Static filters are configured entirely by the host site (no editor UI for
+ * adding values) and rendered as a single-select radio list. Selections
+ * round-trip through the URL as scalar `?filter_id=value` params (not the
+ * `?key[]=value` array shape used by dynamic facet filters). This mirrors the
+ * legacy instant-search overlay's static-filter widget so a site already wired
+ * up for the overlay gets the blocks for free — see
+ * src/instant-search/lib/filters.js getAvailableStaticFilters() and
+ * src/instant-search/store/effects.js updateStaticFilterQueryString().
+ */
+class Filter_Static {
+
+	/**
+	 * Per-request memo of the resolved static-filter config.
+	 *
+	 * @var array<int, array<string, mixed>>|null
+	 */
+	private static $cached = null;
+
+	/**
+	 * Read the site-configured static-filter list.
+	 *
+	 * Resolves the union of two filter hooks:
+	 *
+	 * 1. `jetpack_instant_search_options` — the legacy options blob already
+	 *    used by the instant-search overlay. Sites that registered static
+	 *    filters there get the blocks for free with zero migration.
+	 * 2. `jetpack_search_static_filters` — narrower sibling whose payload is
+	 *    just the static-filter array. New, blocks-only callers should use
+	 *    this one.
+	 *
+	 * Both feed into the same normalized list. Last-wins on duplicate
+	 * `filter_id`.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function get_static_filters_config(): array {
+		if ( null !== self::$cached ) {
+			return self::$cached;
+		}
+
+		$from_options = array();
+		if ( function_exists( 'apply_filters' ) ) {
+			$options      = apply_filters( 'jetpack_instant_search_options', array() );
+			$from_options = is_array( $options['staticFilters'] ?? null )
+				? $options['staticFilters']
+				: array();
+
+			$from_options = apply_filters( 'jetpack_search_static_filters', $from_options );
+		}
+
+		$seen   = array();
+		$normal = array();
+		foreach ( (array) $from_options as $entry ) {
+			$normalized = self::normalize_entry( $entry );
+			if ( null === $normalized ) {
+				continue;
+			}
+			$filter_id = $normalized['filter_id'];
+			if ( isset( $seen[ $filter_id ] ) ) {
+				if ( function_exists( '_doing_it_wrong' ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						esc_html(
+							sprintf(
+								/* translators: %s: duplicate filter ID. */
+								__( 'Duplicate static filter "%s" — last registration wins.', 'jetpack-search-pkg' ),
+								$filter_id
+							)
+						),
+						'jetpack-search 0.1.0'
+					);
+				}
+				// Replace prior entry rather than appending so iteration order
+				// stays deterministic (last write wins, position of the first).
+				$normal[ $seen[ $filter_id ] ] = $normalized;
+				continue;
+			}
+			$seen[ $filter_id ] = count( $normal );
+			$normal[]           = $normalized;
+		}
+
+		self::$cached = $normal;
+		return $normal;
+	}
+
+	/**
+	 * Reset the per-request memo. Tests only.
+	 */
+	public static function reset_cache_for_testing(): void {
+		self::$cached = null;
+	}
+
+	/**
+	 * Narrow the configured list by `variation` and (optionally) `filter_id`.
+	 *
+	 * @param string $variation Either 'sidebar' or 'tabbed'.
+	 * @param string $filter_id When non-empty, return only the matching entry.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function filters_for_variation( string $variation, string $filter_id = '' ): array {
+		$variation = self::normalize_variation( $variation );
+		$out       = array();
+		foreach ( self::get_static_filters_config() as $entry ) {
+			if ( self::normalize_variation( $entry['variation'] ?? '' ) !== $variation ) {
+				continue;
+			}
+			if ( '' !== $filter_id && $entry['filter_id'] !== $filter_id ) {
+				continue;
+			}
+			$out[] = $entry;
+		}
+		return $out;
+	}
+
+	/**
+	 * Normalize the variation value. Anything other than 'tabbed' collapses to
+	 * 'sidebar' — matches the legacy `getAvailableStaticFilters()` default.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string Either 'sidebar' or 'tabbed'.
+	 */
+	public static function normalize_variation( $value ): string {
+		return 'tabbed' === $value ? 'tabbed' : 'sidebar';
+	}
+
+	/**
+	 * Sanitize and validate a single configured entry. Returns null when the
+	 * entry is missing required fields or its `filter_id` collides with a
+	 * reserved URL param — the block then renders nothing for that entry
+	 * rather than silently failing on round-trip.
+	 *
+	 * @param mixed $entry Raw entry.
+	 * @return array<string, mixed>|null
+	 */
+	private static function normalize_entry( $entry ): ?array {
+		if ( ! is_array( $entry ) ) {
+			return null;
+		}
+		$filter_id = sanitize_key( (string) ( $entry['filter_id'] ?? '' ) );
+		if ( '' === $filter_id || in_array( $filter_id, Search_Blocks::RESERVED_QUERY_PARAMS, true ) ) {
+			return null;
+		}
+
+		$values = array();
+		foreach ( (array) ( $entry['values'] ?? array() ) as $value_entry ) {
+			if ( ! is_array( $value_entry ) ) {
+				continue;
+			}
+			$value = sanitize_text_field( (string) ( $value_entry['value'] ?? '' ) );
+			$name  = sanitize_text_field( (string) ( $value_entry['name'] ?? '' ) );
+			if ( '' === $value ) {
+				continue;
+			}
+			$values[] = array(
+				'value' => $value,
+				'name'  => '' === $name ? $value : $name,
+			);
+		}
+		if ( empty( $values ) ) {
+			return null;
+		}
+
+		return array(
+			'filter_id' => $filter_id,
+			'name'      => sanitize_text_field( (string) ( $entry['name'] ?? '' ) ),
+			'type'      => 'group',
+			'variation' => self::normalize_variation( $entry['variation'] ?? '' ),
+			'selected'  => sanitize_text_field( (string) ( $entry['selected'] ?? '' ) ),
+			'values'    => $values,
+		);
+	}
+
+	/**
+	 * Build the filterConfig entry this block contributes to the shared
+	 * Interactivity state. The `kind => 'static'` flag is what the JS store
+	 * keys off to decide URL serialization (scalar vs array shape) and the
+	 * single-select vs toggle action path.
+	 *
+	 * @param array<string, mixed> $entry      Normalized server-config entry.
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return array<string, mixed>
+	 */
+	public static function build_config( array $entry, array $attributes ): array {
+		return array(
+			'filterKey'  => $entry['filter_id'],
+			'kind'       => 'static',
+			'filterType' => 'static',
+			'label'      => self::derive_label( $entry, $attributes ),
+			'values'     => $entry['values'],
+			'selected'   => $entry['selected'],
+			'variation'  => $entry['variation'],
+		);
+	}
+
+	/**
+	 * Block-attribute label override beats server name; empty falls back.
+	 *
+	 * @param array<string, mixed> $entry      Normalized server-config entry.
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return string
+	 */
+	public static function derive_label( array $entry, array $attributes ): string {
+		$override = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' !== $override ) {
+			return $override;
+		}
+		return (string) ( $entry['name'] ?? '' );
+	}
+
+	/**
+	 * Parse scalar URL params that match a configured static-filter key into a
+	 * `{ filter_id => value }` map. Called from the seed path so a deep link
+	 * pre-checks the right radio and the SSR pass shows the filtered count.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function parse_url_selections(): array {
+		if ( ! function_exists( 'wp_unslash' ) ) {
+			return array();
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only URL state; sanitized per-value below.
+		$raw = wp_unslash( $_GET );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$keys = array();
+		foreach ( self::get_static_filters_config() as $entry ) {
+			$keys[ $entry['filter_id'] ] = true;
+		}
+		if ( empty( $keys ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $raw as $key => $value ) {
+			if ( ! is_string( $key ) || ! isset( $keys[ $key ] ) ) {
+				continue;
+			}
+			if ( is_array( $value ) ) {
+				// Scalar-only contract: an array-shaped param under a static
+				// filter key is a misuse (probably a stray `?section[]=…`).
+				// Drop it rather than guessing which entry to pick.
+				continue;
+			}
+			$clean = sanitize_text_field( (string) $value );
+			if ( '' === $clean ) {
+				continue;
+			}
+			$out[ $key ] = $clean;
+		}
+		return $out;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-static/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-static/edit.js
@@ -1,0 +1,220 @@
+/**
+ * Editor preview for jetpack-search/filter-static.
+ *
+ * The block's option list is supplied by the host site through the
+ * `jetpack_search_static_filters` (or legacy `jetpack_instant_search_options`)
+ * PHP filter — there are no per-instance values to edit. The inspector exposes
+ * the three block-level attributes (variation, label override, optional
+ * scoping to a single filter_id) and a SelectControl that lists the currently
+ * registered filters via a REST round-trip so authors can confirm what their
+ * filter hook returns without leaving the editor.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	Placeholder,
+	SelectControl,
+	TextControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+const SAMPLE_OPTIONS = [
+	{ value: 'one', label: __( 'First option', 'jetpack-search-pkg' ) },
+	{ value: 'two', label: __( 'Second option', 'jetpack-search-pkg' ) },
+	{ value: 'three', label: __( 'Third option', 'jetpack-search-pkg' ) },
+];
+
+/**
+ * Coerce a saved `variation` value to the supported enum. Mirrors
+ * `Filter_Static::normalize_variation()` on the PHP side — both must agree or
+ * the editor preview and the server-rendered front end would scope to
+ * different filter subsets.
+ *
+ * @param {unknown} value - Raw attribute value.
+ * @return {'sidebar' | 'tabbed'} Normalized variant.
+ */
+export function normalizeVariation( value ) {
+	return value === 'tabbed' ? 'tabbed' : 'sidebar';
+}
+
+/**
+ * Edit component for the filter-static block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function FilterStaticEdit( { attributes, setAttributes } ) {
+	const variation = normalizeVariation( attributes?.variation );
+	const filterId = attributes?.filterId || '';
+	const rawLabel = attributes?.label || '';
+	const blockProps = useBlockProps( { 'data-variation': variation } );
+
+	// Pull the current static-filter registration from the REST surface so the
+	// author can see (and pick from) the live list. `loading === null` is the
+	// pre-fetch sentinel; `[]` means the fetch resolved but the site has no
+	// static filters registered for this variation, which is the empty-state
+	// Placeholder branch below. Re-fetch when the variation changes so the
+	// picker only ever lists filters that would render at this surface.
+	const [ entries, setEntries ] = useState( null );
+	const [ fetchError, setFetchError ] = useState( false );
+	useEffect( () => {
+		let cancelled = false;
+		setFetchError( false );
+		apiFetch( {
+			path: addQueryArgs( '/jetpack-search/v1/static-filters', { variation } ),
+		} )
+			.then( data => {
+				if ( cancelled ) {
+					return;
+				}
+				setEntries( Array.isArray( data ) ? data : [] );
+			} )
+			.catch( () => {
+				if ( cancelled ) {
+					return;
+				}
+				setEntries( [] );
+				setFetchError( true );
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ variation ] );
+
+	const isLoading = entries === null;
+	const hasEntries = Array.isArray( entries ) && entries.length > 0;
+	const selectedEntry =
+		hasEntries && filterId ? entries.find( e => e.filter_id === filterId ) || null : null;
+
+	// Build the SelectControl options. The empty-string value ("All") tells
+	// render.php to surface every registered filter for the current variation
+	// — that's the default scoping, useful for sites that only have one
+	// static filter and want the block to render it without an extra pick.
+	const filterIdOptions = [
+		{ value: '', label: __( 'All registered filters', 'jetpack-search-pkg' ) },
+		...( hasEntries
+			? entries.map( e => ( {
+					value: e.filter_id,
+					label: e.name || e.filter_id,
+			  } ) )
+			: [] ),
+	];
+
+	const previewLabel =
+		rawLabel || ( selectedEntry && selectedEntry.name ) || __( 'Filter', 'jetpack-search-pkg' );
+
+	// Render an empty-state Placeholder when the fetch resolved but the site
+	// has no static filters registered. Avoids the misleading sample-radio
+	// preview making the block look configured when it would render nothing
+	// on the front end.
+	const showEmptyState = ! isLoading && ! hasEntries;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Variation', 'jetpack-search-pkg' ) }
+						value={ variation }
+						onChange={ value => setAttributes( { variation: normalizeVariation( value ) } ) }
+						help={ __(
+							'Scopes this block to filters registered with the matching variation.',
+							'jetpack-search-pkg'
+						) }
+					>
+						<ToggleGroupControlOption
+							value="sidebar"
+							label={ __( 'Sidebar', 'jetpack-search-pkg' ) }
+						/>
+						<ToggleGroupControlOption
+							value="tabbed"
+							label={ __( 'Tabbed', 'jetpack-search-pkg' ) }
+						/>
+					</ToggleGroupControl>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Filter', 'jetpack-search-pkg' ) }
+						value={ filterId }
+						options={ filterIdOptions }
+						disabled={ ! hasEntries }
+						onChange={ value => setAttributes( { filterId: value } ) }
+						help={
+							isLoading
+								? __( 'Loading registered filters…', 'jetpack-search-pkg' )
+								: __(
+										'Pick a specific filter, or leave on "All" to render every filter registered for this variation.',
+										'jetpack-search-pkg',
+										/* dummy arg to avoid bad minification */ 0
+								  )
+						}
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ previewLabel }
+						onChange={ value => setAttributes( { label: value } ) }
+						help={ __(
+							'Override the server-supplied filter name. Leave empty to use the registered name.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				{ showEmptyState ? (
+					<Placeholder
+						icon="filter"
+						label={ __( 'Static Filter', 'jetpack-search-pkg' ) }
+						instructions={
+							fetchError
+								? __(
+										"Couldn't reach the static-filter REST endpoint. The block will still render on the front end if filters are registered via the jetpack_search_static_filters PHP filter.",
+										'jetpack-search-pkg'
+								  )
+								: __(
+										'No static filters are registered for this variation. Register one via the jetpack_search_static_filters PHP filter to populate this block.',
+										'jetpack-search-pkg',
+										/* dummy arg to avoid bad minification */ 0
+								  )
+						}
+					/>
+				) : (
+					<fieldset className="jetpack-search-filter__group">
+						<legend className="jetpack-search-filter__title">{ previewLabel }</legend>
+						<ul className="jetpack-search-filter__list">
+							{ SAMPLE_OPTIONS.map( ( option, index ) => (
+								<li key={ option.value } className="jetpack-search-filter__item">
+									{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies */ }
+									<label>
+										<input
+											type="radio"
+											name="jetpack-search-filter-static-preview"
+											defaultChecked={ index === 0 }
+											disabled
+										/>
+										<span className="jetpack-search-filter__label">{ option.label }</span>
+									</label>
+								</li>
+							) ) }
+						</ul>
+					</fieldset>
+				) }
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-static/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-static/render.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Filter-static block render.
+ *
+ * Renders one or more single-select radio groups whose options come from the
+ * site-configured static-filter list. WordPress passes $attributes and $block
+ * at runtime; the VariableAnalysis suppressions mirror filter-checkbox.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// Phan flags `(array) $attributes` as an undeclared global even under a
+// namespace; subscripted access (`$attributes['key']`) isn't flagged.
+// WordPress always passes an array for the block's $attributes argument.
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$attrs     = (array) $attributes;
+$variation = Filter_Static::normalize_variation( $attrs['variation'] ?? 'sidebar' );
+$filter_id = sanitize_key( (string) ( $attrs['filterId'] ?? '' ) );
+$entries   = Filter_Static::filters_for_variation( $variation, $filter_id );
+
+// Short-circuit when nothing is configured for this variation, when the block
+// targets a specific filter that isn't registered, or when wp_interactivity_*
+// helpers aren't available (introduced in WP 6.5).
+if ( empty( $entries ) || ! function_exists( 'wp_interactivity_state' ) || ! function_exists( 'wp_interactivity_data_wp_context' ) ) {
+	return;
+}
+
+$url_selections = Filter_Static::parse_url_selections();
+
+$configs_payload    = array();
+$selections_payload = array();
+foreach ( $entries as $entry ) {
+	$key                     = $entry['filter_id'];
+	$configs_payload[ $key ] = Filter_Static::build_config( $entry, $attrs );
+	// URL selection wins over the server's `selected` default. The default
+	// seeds the radio for first-paint UX but does NOT push to the URL — match
+	// legacy overlay behavior so deep-link URLs only ever contain explicit
+	// user choices.
+	$selections_payload[ $key ] = $url_selections[ $key ] ?? (string) $entry['selected'];
+}
+
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'filterConfigs'          => $configs_payload,
+		'staticFilterSelections' => $selections_payload,
+	)
+);
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'data-variation' => $variation ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+>
+	<?php foreach ( $entries as $entry ) : ?>
+		<?php
+		$key      = $entry['filter_id'];
+		$label    = $configs_payload[ $key ]['label'];
+		$selected = $selections_payload[ $key ];
+		?>
+		<fieldset
+			class="jetpack-search-filter__group"
+			<?php
+			echo wp_kses_data(
+				wp_interactivity_data_wp_context(
+					array(
+						'filterKey' => $key,
+						'kind'      => 'static',
+					)
+				)
+			);
+			?>
+		>
+			<?php if ( '' !== $label ) : ?>
+				<legend class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></legend>
+			<?php endif; ?>
+			<ul class="jetpack-search-filter__list">
+				<?php foreach ( $entry['values'] as $option ) : ?>
+					<li class="jetpack-search-filter__item">
+						<label>
+							<input
+								type="radio"
+								name="<?php echo esc_attr( $key ); ?>"
+								value="<?php echo esc_attr( $option['value'] ); ?>"
+								data-wp-on--change="actions.onStaticFilterChange"
+								<?php checked( $option['value'], $selected ); ?>
+							/>
+							<span class="jetpack-search-filter__label"><?php echo esc_html( $option['name'] ); ?></span>
+						</label>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</fieldset>
+	<?php endforeach; ?>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-static/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-static/style.scss
@@ -1,0 +1,47 @@
+.wp-block-jetpack-search-filter-static {
+
+	&[hidden] {
+		display: none;
+	}
+
+	.jetpack-search-filter__group {
+		border: 0;
+		margin: 0 0 1rem;
+		padding: 0;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.jetpack-search-filter__title {
+		font-size: 0.85rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 0.5rem;
+		padding: 0;
+		color: inherit;
+	}
+
+	.jetpack-search-filter__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.jetpack-search-filter__item {
+		padding: 0.25rem 0;
+
+		label {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			cursor: pointer;
+		}
+	}
+
+	.jetpack-search-filter__label {
+		flex: 1;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-static/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-static/view.js
@@ -1,0 +1,5 @@
+// Runtime behavior lives on the shared store in `store/index.js`. Per-block
+// re-registration would clobber sibling filter blocks (Interactivity API
+// merges later `store()` patches).
+import 'jetpack-search/store';
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -144,6 +144,7 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
+		add_action( 'rest_api_init', array( static::class, 'register_rest_routes' ) );
 		Custom_Taxonomy_Slot_Mapping::init();
 		// FSE block-template rendering runs *before* `wp_head()` (see
 		// `wp-includes/template-canvas.php`), so blocks would resolve
@@ -559,6 +560,52 @@ class Search_Blocks {
 			'title' => __( 'Jetpack Search', 'jetpack-search-pkg' ),
 		);
 		return $categories;
+	}
+
+	/**
+	 * Register editor-facing REST routes that back the search blocks' inspector
+	 * controls. Currently exposes the site's static-filter configuration so
+	 * the `jetpack-search/filter-static` block's filter picker can list what
+	 * the host site has wired up via `jetpack_search_static_filters` without
+	 * needing the editor bundle to localize a snapshot.
+	 */
+	public static function register_rest_routes() {
+		if ( ! function_exists( 'register_rest_route' ) ) {
+			return;
+		}
+		register_rest_route(
+			'jetpack-search/v1',
+			'/static-filters',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( static::class, 'rest_get_static_filters' ),
+				'permission_callback' => static function () {
+					return function_exists( 'current_user_can' ) && current_user_can( 'edit_posts' );
+				},
+				'args'                => array(
+					'variation' => array(
+						'type'              => 'string',
+						'enum'              => array( 'sidebar', 'tabbed' ),
+						'default'           => 'sidebar',
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * REST callback: return the site-configured static filters for a given
+	 * variation. Used by the filter-static block's editor inspector.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function rest_get_static_filters( $request ) {
+		$variation = is_object( $request ) && method_exists( $request, 'get_param' )
+			? (string) $request->get_param( 'variation' )
+			: 'sidebar';
+		return Filter_Static::filters_for_variation( $variation );
 	}
 
 	/**
@@ -1238,6 +1285,13 @@ class Search_Blocks {
 			'activeFilters'              => $active_filters,
 			'filterLogic'                => $filter_logic,
 			'priceRange'                 => $price_range,
+			// Static filters (`jetpack-search/filter-static`) round-trip as
+			// scalar `?filter_id=value` URL params. The block's render.php
+			// merges the URL-seeded selections in alongside its filterConfig
+			// entry so a deep link pre-checks the right radio. Seeded as an
+			// empty object here so JS readers always see a defined shape on
+			// pages without the block.
+			'staticFilterSelections'     => (object) array(),
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -65,6 +65,7 @@ const BLOCK_ICONS = {
 	'jetpack-search/filter-checkbox': greened( formatListBullets ),
 	'jetpack-search/filter-date': greened( calendar ),
 	'jetpack-search/filter-post-type': greened( customPostType ),
+	'jetpack-search/filter-static': greened( postTerms ),
 	'jetpack-search/filter-wc-attribute': greened( tag ),
 	'jetpack-search/filter-wc-price': greened( currencyDollar ),
 	'jetpack-search/filter-wc-rating': greened( starFilled ),

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -25,6 +25,7 @@ import ClearFiltersEdit from '../blocks/clear-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPostTypeEdit from '../blocks/filter-post-type/edit';
+import FilterStaticEdit from '../blocks/filter-static/edit';
 import FilterWcAttributeEdit from '../blocks/filter-wc-attribute/edit';
 import FilterWcPriceEdit from '../blocks/filter-wc-price/edit';
 import FilterWcRatingEdit from '../blocks/filter-wc-rating/edit';
@@ -57,6 +58,7 @@ const BLOCKS = [
 	[ 'jetpack-search/active-filters', ActiveFiltersEdit ],
 	[ 'jetpack-search/clear-filters', ClearFiltersEdit ],
 	[ 'jetpack-search/filter-post-type', FilterPostTypeEdit ],
+	[ 'jetpack-search/filter-static', FilterStaticEdit ],
 	[ 'jetpack-search/filter-wc-rating', FilterWcRatingEdit ],
 	[ 'jetpack-search/filters', FiltersEdit, filtersSave ],
 	[ 'jetpack-search/filters-popover', FiltersPopoverEdit, filtersPopoverSave ],

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -471,6 +471,29 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 	return must.length ? { bool: { must } } : undefined;
 }
 
+/**
+ * Build ES `term` clauses for the single-select static filters contributed by
+ * `jetpack-search/filter-static`. Static filters target a flat field whose
+ * name equals the filter key — i.e., the `filter_id` from the host site's
+ * `jetpack_search_static_filters` registration is used directly as the ES
+ * field name. Mirrors the legacy instant-search overlay's static-filter
+ * behavior at src/instant-search/store/effects.js:176-187.
+ *
+ * @param {object} selections    - { [filterKey]: string } single-select values.
+ * @param {object} filterConfigs - { [filterKey]: FilterConfig } map.
+ * @return {Array<object>} `must` clauses, empty when nothing is selected.
+ */
+export function buildStaticFilterClauses( selections, filterConfigs ) {
+	const clauses = [];
+	for ( const [ filterKey, value ] of Object.entries( selections ?? {} ) ) {
+		if ( ! value || filterConfigs?.[ filterKey ]?.kind !== 'static' ) {
+			continue;
+		}
+		clauses.push( { term: { [ filterKey ]: value } } );
+	}
+	return clauses;
+}
+
 // Memoized: `filterItems` re-runs on every state read and may invoke
 // `formatDateBucketLabel` once per bucket.
 const monthLabelFormatters = new Map();
@@ -577,30 +600,35 @@ export function buildStaticPostTypeClauses( staticPostTypes ) {
  * Build the full search API URL with query params.
  * Mirrors the 3-path routing in src/instant-search/lib/api.js.
  *
- * @param {object}      opts                   - Options.
- * @param {number}      opts.siteId            - Site ID.
- * @param {string}      opts.searchQuery       - Search query string.
- * @param {string}      opts.sortOrder         - 'relevance' | 'newest' | 'oldest', plus
- *                                             'rating_desc' | 'price_asc' | 'price_desc'
- *                                             on WooCommerce sites.
- * @param {string|null} opts.pageHandle        - Cursor for pagination.
- * @param {boolean}     opts.isPrivateSite     - Whether the site is private.
- * @param {boolean}     opts.isWpcom           - Whether the site runs on WordPress.com.
- * @param {string}      opts.apiRoot           - WordPress REST API root URL.
- * @param {object}      [opts.activeFilters]   - { [filterKey]: string[] } selected filters.
- * @param {object}      [opts.filterConfigs]   - { [filterKey]: FilterConfig } registered filters.
- * @param {string}      [opts.homeUrl]         - Home URL; required for private WPcom sites.
- * @param {object|null} [opts.priceRange]      - `{ min, max }` numeric range against the
- *                                             `wc.price` ES field. Either bound may be null
- *                                             for a half-open range. Read by future product
- *                                             filter blocks driven by `min_price` / `max_price`
- *                                             URL params.
- * @param {object|null} [opts.staticPostTypes] - `{ include, exclude }` post-type slug lists
- *                                             contributed by `jetpack-search/filter-post-type`.
- *                                             Folded into the ES filter clause as `bool.should`
- *                                             (include) and `bool.must_not` (exclude). Hidden
- *                                             from visitors — not represented in `activeFilters`
- *                                             and not surfaced in the active-filters pill list.
+ * @param {object}      opts                          - Options.
+ * @param {number}      opts.siteId                   - Site ID.
+ * @param {string}      opts.searchQuery              - Search query string.
+ * @param {string}      opts.sortOrder                - 'relevance' | 'newest' | 'oldest', plus
+ *                                                    'rating_desc' | 'price_asc' | 'price_desc'
+ *                                                    on WooCommerce sites.
+ * @param {string|null} opts.pageHandle               - Cursor for pagination.
+ * @param {boolean}     opts.isPrivateSite            - Whether the site is private.
+ * @param {boolean}     opts.isWpcom                  - Whether the site runs on WordPress.com.
+ * @param {string}      opts.apiRoot                  - WordPress REST API root URL.
+ * @param {object}      [opts.activeFilters]          - { [filterKey]: string[] } selected filters.
+ * @param {object}      [opts.filterConfigs]          - { [filterKey]: FilterConfig } registered filters.
+ * @param {string}      [opts.homeUrl]                - Home URL; required for private WPcom sites.
+ * @param {object|null} [opts.priceRange]             - `{ min, max }` numeric range against the
+ *                                                    `wc.price` ES field. Either bound may be null
+ *                                                    for a half-open range. Read by future product
+ *                                                    filter blocks driven by `min_price` / `max_price`
+ *                                                    URL params.
+ * @param {object|null} [opts.staticPostTypes]        - `{ include, exclude }` post-type slug lists
+ *                                                    contributed by `jetpack-search/filter-post-type`.
+ *                                                    Folded into the ES filter clause as `bool.should`
+ *                                                    (include) and `bool.must_not` (exclude). Hidden
+ *                                                    from visitors — not represented in `activeFilters`
+ *                                                    and not surfaced in the active-filters pill list.
+ * @param {object}      [opts.staticFilterSelections] - { [filterKey]: string } single-select
+ *                                                    static filter values contributed by
+ *                                                    `jetpack-search/filter-static`. Each non-empty
+ *                                                    entry adds a `term` clause against an ES field
+ *                                                    whose name matches the filter key.
  * @return {string} Full URL to call.
  */
 export function buildSearchUrl( {
@@ -616,6 +644,7 @@ export function buildSearchUrl( {
 	homeUrl = '',
 	priceRange = null,
 	staticPostTypes = null,
+	staticFilterSelections = {},
 } ) {
 	// `qss.encode()` runs `encodeURIComponent` on every value, so we pass the
 	// raw query here. The instant-search code double-encodes (pre-encodes
@@ -643,6 +672,12 @@ export function buildSearchUrl( {
 		filter = filter
 			? { bool: { must: [ ...filter.bool.must, ...staticPostTypeClauses ] } }
 			: { bool: { must: [ ...staticPostTypeClauses ] } };
+	}
+	const staticFilterClauses = buildStaticFilterClauses( staticFilterSelections, filterConfigs );
+	if ( staticFilterClauses.length > 0 ) {
+		filter = filter
+			? { bool: { must: [ ...filter.bool.must, ...staticFilterClauses ] } }
+			: { bool: { must: [ ...staticFilterClauses ] } };
 	}
 	if ( priceRange && ( priceRange.min != null || priceRange.max != null ) ) {
 		const range = {};

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -144,6 +144,34 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
 }
 
 /**
+ * Drop static-filter selections whose key isn't registered (or isn't a
+ * `kind === 'static'` config). Mirrors `gateActiveFilters` for the
+ * scalar-URL counterpart so a stray `?section=x` URL from a deregistered
+ * static filter can't survive across renders.
+ *
+ * @param {object} selections    - { [filterKey]: string }.
+ * @param {object} filterConfigs - { [filterKey]: FilterConfig }.
+ * @return {object} Gated selections.
+ */
+export function gateStaticFilterSelections( selections, filterConfigs ) {
+	const allowedKeys = filterConfigs ?? {};
+	const gated = Object.create( null );
+	for ( const [ key, value ] of Object.entries( selections ?? {} ) ) {
+		if ( ! Object.hasOwn( allowedKeys, key ) ) {
+			continue;
+		}
+		if ( allowedKeys[ key ]?.kind !== 'static' ) {
+			continue;
+		}
+		if ( ! value ) {
+			continue;
+		}
+		gated[ key ] = value;
+	}
+	return gated;
+}
+
+/**
  * Drop filterLogic entries whose filter key is missing from `activeFilters`,
  * has an empty selection set, or targets a non-taxonomy filter. Mirrors the
  * cleanup `setFilter()` performs locally; called from popstate and at
@@ -553,6 +581,7 @@ function* fetchResults( pageHandle ) {
 		// downstream consumer (`buildFilterClause`) free of the override path.
 		filterConfigs: overlayFilterLogic( state.filterConfigs, state.filterLogic ),
 		priceRange: state.priceRange,
+		staticFilterSelections: state.staticFilterSelections,
 		staticPostTypes: state.staticPostTypes,
 	} );
 	const response = yield fetch( url, {
@@ -660,12 +689,13 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * True when any facet is active — selected filter values or a
-		 * price range. Drives the active-filters pill wrapper, the standalone
-		 * clear-filters block, and the filter-popover trigger. priceRange
-		 * counts as a filter here so a price-only selection (including a
-		 * half-open range like `?min_price=10`) doesn't leave the pill
-		 * wrapper hidden when the user has a chip to clear.
+		 * True when any facet is active — selected filter values, a
+		 * price range, or a static-filter selection. Drives the active-filters
+		 * pill wrapper, the standalone clear-filters block, and the
+		 * filter-popover trigger. priceRange counts as a filter here so a
+		 * price-only selection (including a half-open range like
+		 * `?min_price=10`) doesn't leave the pill wrapper hidden when the user
+		 * has a chip to clear.
 		 *
 		 * @return {boolean} Whether any filter is active.
 		 */
@@ -674,6 +704,12 @@ const { state, actions } = store( NAMESPACE, {
 				v => Array.isArray( v ) && v.length > 0
 			);
 			if ( hasSelections ) {
+				return true;
+			}
+			const hasStaticSelections = Object.values( state.staticFilterSelections ?? {} ).some(
+				v => !! v
+			);
+			if ( hasStaticSelections ) {
 				return true;
 			}
 			const range = state.priceRange;
@@ -687,7 +723,11 @@ const { state, actions } = store( NAMESPACE, {
 		 * @return {number} Count of selected filter values.
 		 */
 		get activeFilterCount() {
-			return countActiveFilters( state.activeFilters );
+			const dynamic = countActiveFilters( state.activeFilters );
+			const staticCount = Object.values( state.staticFilterSelections ?? {} ).filter(
+				v => !! v
+			).length;
+			return dynamic + staticCount;
 		},
 
 		/**
@@ -961,6 +1001,17 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * Replace the value of a single-select static filter (jetpack-search/filter-static).
+		 *
+		 * @param {Event} event - Change event from the radio input.
+		 * @yield {Promise} setStaticFilter action.
+		 */
+		*onStaticFilterChange( event ) {
+			const { filterKey } = getContext();
+			yield actions.setStaticFilter( filterKey, event.target.value );
+		},
+
+		/**
 		 * Run a search and replace the result list.
 		 *
 		 * @param {object}  [options]         - Options.
@@ -1097,6 +1148,33 @@ const { state, actions } = store( NAMESPACE, {
 		 * @param {string} filterValue - e.g. `news`, `post`.
 		 * @yield {Promise} search action.
 		 */
+		/**
+		 * Replace the value of a single-select static filter, then re-run the
+		 * search. Static filters store a scalar value per key (not an array
+		 * like `setFilter`) because each `jetpack-search/filter-static` block
+		 * renders mutually-exclusive radio inputs. Picking the currently
+		 * selected value clears it — same UX as legacy `setStaticFilter` in
+		 * the instant-search overlay.
+		 *
+		 * @param {string} filterKey   - The static filter's `filter_id`.
+		 * @param {string} filterValue - The newly-selected value, or '' to clear.
+		 * @yield {Promise} search action.
+		 */
+		*setStaticFilter( filterKey, filterValue ) {
+			const current = state.staticFilterSelections?.[ filterKey ] ?? '';
+			const next = current === filterValue ? '' : filterValue;
+			if ( next === '' ) {
+				const { [ filterKey ]: _removed, ...rest } = state.staticFilterSelections ?? {};
+				state.staticFilterSelections = rest;
+			} else {
+				state.staticFilterSelections = {
+					...( state.staticFilterSelections ?? {} ),
+					[ filterKey ]: next,
+				};
+			}
+			yield actions.search();
+		},
+
 		*setFilter( filterKey, filterValue ) {
 			const current = state.activeFilters[ filterKey ] ?? [];
 			const index = current.indexOf( filterValue );
@@ -1139,6 +1217,7 @@ const { state, actions } = store( NAMESPACE, {
 			state.activeFilters = {};
 			state.filterLogic = {};
 			state.priceRange = null;
+			state.staticFilterSelections = {};
 			yield actions.search();
 		},
 
@@ -1192,6 +1271,7 @@ const { state, actions } = store( NAMESPACE, {
 				filterLogic: state.filterLogic,
 				filterConfigs: state.filterConfigs,
 				priceRange: state.priceRange,
+				staticFilterSelections: state.staticFilterSelections,
 				searchParamName: state.searchParamName,
 				isWooCommerceBlocksEnabled: state.isWooCommerceBlocksEnabled,
 			} );
@@ -1203,12 +1283,19 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*handlePopState() {
-			const { searchQuery, hasSearchParam, sortOrder, activeFilters, filterLogic, priceRange } =
-				readStateFromUrl(
-					state.filterConfigs,
-					state.searchParamName,
-					state.isWooCommerceBlocksEnabled
-				);
+			const {
+				searchQuery,
+				hasSearchParam,
+				sortOrder,
+				activeFilters,
+				filterLogic,
+				priceRange,
+				staticFilterSelections,
+			} = readStateFromUrl(
+				state.filterConfigs,
+				state.searchParamName,
+				state.isWooCommerceBlocksEnabled
+			);
 			state.searchQuery = searchQuery;
 			// Keep `hasSearchParam` in lockstep with the live URL so any future
 			// reader (e.g. `showNoResults`) sees the current state rather than
@@ -1228,6 +1315,10 @@ const { state, actions } = store( NAMESPACE, {
 			// targets a non-taxonomy filter.
 			state.filterLogic = pickLogicForActive( filterLogic, gated, state.filterConfigs );
 			state.priceRange = priceRange;
+			state.staticFilterSelections = gateStaticFilterSelections(
+				staticFilterSelections,
+				state.filterConfigs
+			);
 			yield actions.search( { syncUrl: false } );
 		},
 
@@ -1573,6 +1664,23 @@ const { state, actions } = store( NAMESPACE, {
 			const { gated, droppedAny } = gateActiveFilters( state.activeFilters, state.filterConfigs );
 			if ( droppedAny ) {
 				state.activeFilters = gated;
+			}
+			// Symmetric gate for static-filter selections — drop any key whose
+			// filter-static block isn't on the page anymore (e.g. a stale deep
+			// link from a since-removed registration).
+			if (
+				state.staticFilterSelections &&
+				Object.keys( state.staticFilterSelections ).length > 0
+			) {
+				const gatedStatic = gateStaticFilterSelections(
+					state.staticFilterSelections,
+					state.filterConfigs
+				);
+				if (
+					Object.keys( gatedStatic ).length !== Object.keys( state.staticFilterSelections ).length
+				) {
+					state.staticFilterSelections = gatedStatic;
+				}
 			}
 			// Re-gate filterLogic against the (possibly trimmed) activeFilters
 			// AND against the just-registered filterConfigs so a

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -86,7 +86,15 @@ function parsePriceBound( raw ) {
  *                                                         read the block-author-configured `queryType`
  *                                                         so the URL also reflects block config when
  *                                                         `filterLogic` has no override for that key.
+ *                                                         Also gates which keys are eligible for
+ *                                                         scalar static-filter serialization.
  * @param {object|null} [state.priceRange]                 - { min, max } price range; either bound may be null.
+ * @param {object}      [state.staticFilterSelections]     - { [filterKey]: string } single-select static
+ *                                                         filter values contributed by
+ *                                                         `jetpack-search/filter-static`. Serialized as
+ *                                                         scalar `?filter_id=value` (not `[]=value`) so
+ *                                                         deep links round-trip with the legacy overlay's
+ *                                                         static-filter URL contract.
  * @param {string}      [state.searchParamName]            - URL key the search query is written under
  *                                                         (`s` on the WP search route, `q`
  *                                                         on non-search pages). Defaults to `s`.
@@ -103,6 +111,7 @@ export function stateToUrlParams( {
 	filterLogic = {},
 	filterConfigs = {},
 	priceRange = null,
+	staticFilterSelections = {},
 	searchParamName = DEFAULT_SEARCH_PARAM,
 	isWooCommerceBlocksEnabled = false,
 } ) {
@@ -151,6 +160,19 @@ export function stateToUrlParams( {
 		}
 	}
 
+	// Static filters write scalar `?filter_id=value` params — matches the
+	// legacy instant-search overlay's static-filter URL contract so deep
+	// links stay interchangeable between the two surfaces. Gated on
+	// `kind === 'static'` so a stale selection for a since-unregistered
+	// filter (e.g. the host site removed its filter hook) can't leak back
+	// into the URL on the next push.
+	for ( const [ key, value ] of Object.entries( staticFilterSelections ) ) {
+		if ( ! value || filterConfigs?.[ key ]?.kind !== 'static' ) {
+			continue;
+		}
+		params.set( key, String( value ) );
+	}
+
 	return params;
 }
 
@@ -174,7 +196,7 @@ export function stateToUrlParams( {
  *                                                       `max_price` range params). Falsy on non-Woo
  *                                                       sites ignores both rather than hydrating
  *                                                       them into store state.
- * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null, staticFilterSelections: object }} Partial state.
  */
 export function urlParamsToState(
 	params,
@@ -186,6 +208,7 @@ export function urlParamsToState(
 	const allowedSorts = validSortOrders( isWooCommerceBlocksEnabled );
 	const activeFilters = {};
 	const filterLogic = {};
+	const staticFilterSelections = {};
 	const hasFilterConfigGate = filterConfigs && Object.keys( filterConfigs ).length > 0;
 
 	for ( const [ rawKey, value ] of params.entries() ) {
@@ -219,6 +242,25 @@ export function urlParamsToState(
 			continue;
 		}
 		if ( ! rawKey.endsWith( '[]' ) ) {
+			// Static filters round-trip as scalar `?filter_id=value` params.
+			// Recognize them by `filterConfigs[rawKey].kind === 'static'` so
+			// arbitrary scalar params from other plugins don't leak into
+			// `staticFilterSelections` and re-emit on the next URL push.
+			if (
+				hasFilterConfigGate &&
+				! RESERVED_PARAMS.has( rawKey ) &&
+				filterConfigs[ rawKey ]?.kind === 'static'
+			) {
+				const normalized = String( value ?? '' ).trim();
+				if ( normalized ) {
+					// Last-write wins. A URL like `?section=a&section=b` is
+					// already malformed for a single-select filter; pick the
+					// latest value rather than ignoring the duplicate so the
+					// behavior mirrors the radio-input change handler (always
+					// the most recently clicked).
+					staticFilterSelections[ rawKey ] = normalized;
+				}
+			}
 			continue;
 		}
 		const filterKey = rawKey.slice( 0, -2 );
@@ -283,6 +325,7 @@ export function urlParamsToState(
 		activeFilters,
 		filterLogic,
 		priceRange,
+		staticFilterSelections,
 	};
 }
 
@@ -310,7 +353,7 @@ export function pushStateToUrl( state ) {
  * @param {boolean} [isWooCommerceBlocksEnabled] - Gate for WC-only URL surface (product-format
  *                                               sort keys + `min_price` / `max_price` range params);
  *                                               forwarded to `urlParamsToState`.
- * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null, staticFilterSelections: object }} Partial state.
  */
 export function readStateFromUrl(
 	filterConfigs = {},

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -5,6 +5,7 @@ import {
 	buildAggregations,
 	buildFilterClause,
 	buildSearchUrl,
+	buildStaticFilterClauses,
 	buildStaticPostTypeClauses,
 	formatDateBucketLabel,
 	resolveFilterFields,
@@ -1073,5 +1074,90 @@ describe( 'product-shaped filter helpers', () => {
 				'filter[bool][must][0][bool][should][1][term][category.slug]=sports'
 			);
 		} );
+	} );
+} );
+
+describe( 'buildStaticFilterClauses', () => {
+	it( 'emits one `term` clause per non-empty static-filter selection, keyed by the filter id', () => {
+		// Static filters target a flat ES field whose name equals the filter
+		// key — `?section=guides` ⇒ `{ term: { section: 'guides' } }`. Mirrors
+		// the legacy instant-search overlay's static-filter URL → ES mapping.
+		const clauses = buildStaticFilterClauses(
+			{ section: 'guides', audience: 'dev' },
+			{
+				section: { filterKey: 'section', kind: 'static' },
+				audience: { filterKey: 'audience', kind: 'static' },
+			}
+		);
+		expect( clauses ).toEqual( [ { term: { section: 'guides' } }, { term: { audience: 'dev' } } ] );
+	} );
+
+	it( 'gates on kind === "static" so a stray entry with a non-static config is dropped', () => {
+		// Belt-and-suspenders: even if a stale `staticFilterSelections` entry
+		// somehow names a dynamic filter, the gate prevents it from generating
+		// an ES clause that would target the wrong field.
+		const clauses = buildStaticFilterClauses(
+			{ category: 'news' },
+			{ category: { filterKey: 'category', filterType: 'taxonomy' } }
+		);
+		expect( clauses ).toEqual( [] );
+	} );
+
+	it( 'drops empty-value entries', () => {
+		// An empty string means "no selection" — equivalent to no entry.
+		// A `{ term: { section: '' } }` clause would match zero documents
+		// and silently zero the result set; drop it before the URL builder
+		// sees it.
+		const clauses = buildStaticFilterClauses(
+			{ section: '' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( clauses ).toEqual( [] );
+	} );
+
+	it( 'returns an empty array when nothing is selected', () => {
+		expect( buildStaticFilterClauses( {}, {} ) ).toEqual( [] );
+		expect( buildStaticFilterClauses( undefined, {} ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'buildSearchUrl: static filter selections', () => {
+	const baseOpts = {
+		siteId: 1,
+		searchQuery: '',
+		sortOrder: 'relevance',
+		pageHandle: null,
+		isPrivateSite: false,
+		isWpcom: false,
+		apiRoot: '',
+	};
+
+	it( 'folds static-filter term clauses into the existing bool.must pipeline', () => {
+		// A static filter alone should produce a single-clause bool.must.
+		const url = buildSearchUrl( {
+			...baseOpts,
+			staticFilterSelections: { section: 'guides' },
+			filterConfigs: { section: { filterKey: 'section', kind: 'static' } },
+		} );
+		const decoded = decodeURIComponent( url );
+		expect( decoded ).toContain( 'filter[bool][must][0][term][section]=guides' );
+	} );
+
+	it( 'combines static-filter clauses with active dynamic filters under one bool.must', () => {
+		// Dynamic + static together: bool.must accumulates both. The static
+		// clause appends after the dynamic clauses so the ES request keeps a
+		// flat must array rather than nested bool wrappers.
+		const url = buildSearchUrl( {
+			...baseOpts,
+			activeFilters: { category: [ 'news' ] },
+			staticFilterSelections: { section: 'guides' },
+			filterConfigs: {
+				category: { filterType: 'taxonomy', taxonomy: 'category' },
+				section: { filterKey: 'section', kind: 'static' },
+			},
+		} );
+		const decoded = decodeURIComponent( url );
+		expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
+		expect( decoded ).toContain( 'filter[bool][must][1][term][section]=guides' );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -32,6 +32,7 @@ import {
 	actions,
 	computeResultsCountText,
 	gateActiveFilters,
+	gateStaticFilterSelections,
 	remapAggregationsToFilterKeys,
 	state,
 } from '../../../src/search-blocks/store';
@@ -366,6 +367,49 @@ describe( 'store actions', () => {
 		await runGenerator( actions.setFilter( 'category', 'updates' ) );
 		expect( state.activeFilters ).toEqual( {} );
 		expect( search ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'setStaticFilter replaces the per-key value (single-select) and clears when re-picked', async () => {
+		// Static filters are mutually-exclusive radios — unlike setFilter,
+		// each call REPLACES rather than toggles within an array. Re-picking
+		// the currently selected value clears the entry (same UX as the
+		// legacy overlay's setStaticFilter).
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.staticFilterSelections = {};
+
+		await runGenerator( actions.setStaticFilter( 'section', 'news' ) );
+		expect( state.staticFilterSelections ).toEqual( { section: 'news' } );
+
+		// Picking a different value REPLACES (does not append).
+		await runGenerator( actions.setStaticFilter( 'section', 'guides' ) );
+		expect( state.staticFilterSelections ).toEqual( { section: 'guides' } );
+
+		// Re-picking the current value clears the entry — radio "deselect"
+		// affordance preserves the legacy overlay behavior.
+		await runGenerator( actions.setStaticFilter( 'section', 'guides' ) );
+		expect( state.staticFilterSelections ).toEqual( {} );
+
+		// Different keys stay independent — picking `audience` after a
+		// cleared `section` doesn't resurrect the old `section` entry.
+		await runGenerator( actions.setStaticFilter( 'audience', 'dev' ) );
+		expect( state.staticFilterSelections ).toEqual( { audience: 'dev' } );
+
+		expect( search ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'clearFilters wipes staticFilterSelections alongside activeFilters + priceRange', async () => {
+		// `clearFilters` is the standalone clear-all button — it must wipe
+		// every facet shape so a user doesn't have to click each filter
+		// type's clear affordance individually.
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.activeFilters = {};
+		state.priceRange = null;
+		state.staticFilterSelections = { section: 'guides' };
+
+		await runGenerator( actions.clearFilters() );
+
+		expect( state.staticFilterSelections ).toEqual( {} );
+		expect( search ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'clears every facet only when something is active', async () => {
@@ -822,6 +866,61 @@ describe( 'gateActiveFilters', () => {
 		} );
 		expect( gated ).toEqual( {} );
 		expect( droppedAny ).toBe( true );
+	} );
+} );
+
+describe( 'gateStaticFilterSelections', () => {
+	it( 'drops keys whose filterConfigs entry is missing', () => {
+		// Stale selections for a since-removed static-filter registration
+		// must not survive a popstate or `initialize()` re-gate.
+		const gated = gateStaticFilterSelections(
+			{ section: 'guides', dropped: 'x' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( gated ).toEqual( { section: 'guides' } );
+	} );
+
+	it( 'drops keys whose filterConfigs entry exists but is not kind=static', () => {
+		// A scalar URL param under a dynamic filter key (e.g. someone fat-fingered
+		// `?category=news` instead of `?category[]=news`) must not pollute the
+		// static-filter slice. The kind=static gate keeps the boundary explicit.
+		const gated = gateStaticFilterSelections(
+			{ category: 'news', section: 'guides' },
+			{
+				category: { filterKey: 'category', filterType: 'taxonomy' },
+				section: { filterKey: 'section', kind: 'static' },
+			}
+		);
+		expect( gated ).toEqual( { section: 'guides' } );
+	} );
+
+	it( 'drops empty values', () => {
+		// `''` is the "cleared" state — keeping the key would round-trip
+		// through pushStateToUrl and re-emit `?section=` indefinitely.
+		const gated = gateStaticFilterSelections(
+			{ section: '' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( gated ).toEqual( {} );
+	} );
+
+	it( 'returns a null-prototype object so __proto__ pollution cannot survive', () => {
+		// Same defence as gateActiveFilters — JSON.parse lets `__proto__`
+		// land as an own property; we must drop it because it isn't in
+		// filterConfigs, and the output object must not inherit anything that
+		// could be misread as a registered key downstream.
+		const selections = JSON.parse( '{"__proto__":"pwn","section":"guides"}' );
+		const gated = gateStaticFilterSelections( selections, {
+			section: { filterKey: 'section', kind: 'static' },
+		} );
+		expect( gated ).toEqual( { section: 'guides' } );
+		expect( Object.getPrototypeOf( gated ) ).toBeNull();
+	} );
+
+	it( 'tolerates undefined / null inputs', () => {
+		expect( gateStaticFilterSelections( undefined, {} ) ).toEqual( {} );
+		expect( gateStaticFilterSelections( null, {} ) ).toEqual( {} );
+		expect( gateStaticFilterSelections( { section: 'guides' }, null ) ).toEqual( {} );
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -148,6 +148,60 @@ describe( 'stateToUrlParams', () => {
 		expect( params.has( 's' ) ).toBe( false );
 	} );
 
+	it( 'serializes staticFilterSelections as scalar params (no `[]` suffix) gated on kind === "static"', () => {
+		// Static filters use scalar `?filter_id=value` URL params, matching
+		// the legacy instant-search overlay contract. The kind === "static"
+		// gate prevents a stray scalar entry under a dynamic key from being
+		// serialized.
+		const params = stateToUrlParams( {
+			searchQuery: 'shoes',
+			sortOrder: 'relevance',
+			staticFilterSelections: { section: 'guides', topic: 'wordpress' },
+			filterConfigs: {
+				section: { filterKey: 'section', kind: 'static' },
+				topic: { filterKey: 'topic', kind: 'static' },
+			},
+		} );
+		expect( params.get( 'section' ) ).toBe( 'guides' );
+		expect( params.get( 'topic' ) ).toBe( 'wordpress' );
+		// Crucially: no `[]` suffix anywhere.
+		expect( params.has( 'section[]' ) ).toBe( false );
+		expect( params.has( 'topic[]' ) ).toBe( false );
+	} );
+
+	it( 'skips static-filter keys whose filterConfigs entry is missing or not kind=static', () => {
+		// A stale staticFilterSelections entry for a since-removed
+		// registration shouldn't leak back into the URL. Gate on
+		// filterConfigs presence + the explicit `kind === "static"` marker.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			staticFilterSelections: { section: 'guides', dropped: 'x', dynamic: 'y' },
+			filterConfigs: {
+				// `section` is registered as static — passes.
+				section: { filterKey: 'section', kind: 'static' },
+				// `dynamic` exists but isn't a static filter — skipped.
+				dynamic: { filterKey: 'dynamic', filterType: 'taxonomy' },
+				// `dropped` isn't in filterConfigs at all — skipped.
+			},
+		} );
+		expect( params.get( 'section' ) ).toBe( 'guides' );
+		expect( params.has( 'dynamic' ) ).toBe( false );
+		expect( params.has( 'dropped' ) ).toBe( false );
+	} );
+
+	it( 'omits static-filter entries whose value is empty', () => {
+		// Empty string means "no selection" — equivalent to no entry. Drop
+		// it so the URL doesn't carry `?section=`.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			staticFilterSelections: { section: '' },
+			filterConfigs: { section: { filterKey: 'section', kind: 'static' } },
+		} );
+		expect( params.has( 'section' ) ).toBe( false );
+	} );
+
 	it( 'preserves empty search param so a refresh keeps the inline-search URL shape', () => {
 		// Same rationale as the empty-`s` case: dropping the param entirely
 		// when the user clears the input would drop the visible URL marker
@@ -496,5 +550,68 @@ describe( 'urlParamsToState: priceRange WooCommerce gate (RSM-2805)', () => {
 			true
 		);
 		expect( state.priceRange ).toEqual( { min: 10, max: 50 } );
+	} );
+
+	it( 'pulls scalar params into staticFilterSelections when the key is kind=static', () => {
+		// Scalar `?section=guides` is the static-filter URL contract. Only
+		// keys whose filterConfigs entry is kind === "static" are pulled;
+		// everything else falls through to the existing branches (or is
+		// ignored).
+		const state = urlParamsToState(
+			new URLSearchParams( '?s=shoes&section=guides&topic=wordpress' ),
+			{
+				section: { filterKey: 'section', kind: 'static' },
+				topic: { filterKey: 'topic', kind: 'static' },
+			}
+		);
+		expect( state.staticFilterSelections ).toEqual( {
+			section: 'guides',
+			topic: 'wordpress',
+		} );
+		// Static-keyed params don't end up in activeFilters even when they
+		// share a name with a hypothetical dynamic filter.
+		expect( state.activeFilters ).toEqual( {} );
+	} );
+
+	it( 'ignores scalar params for keys that are not registered as static filters', () => {
+		// Arbitrary plugin-emitted scalar params (`?utm_source=...`,
+		// `?page_id=42`) must not seep into staticFilterSelections.
+		const state = urlParamsToState(
+			new URLSearchParams( '?s=shoes&utm_source=newsletter&page_id=42&section=guides' ),
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( state.staticFilterSelections ).toEqual( { section: 'guides' } );
+	} );
+
+	it( 'leaves staticFilterSelections empty when filterConfigs has no kind=static entries', () => {
+		// The whole branch is filterConfig-driven — without a kind=static
+		// entry there is no way for a scalar URL param to mark itself as a
+		// static filter. Important: this is the behaviour the JS store
+		// relies on so plugin-emitted scalar params can't hijack the slice.
+		const state = urlParamsToState( new URLSearchParams( '?section=guides' ), {
+			section: { filterKey: 'section', filterType: 'taxonomy' },
+		} );
+		expect( state.staticFilterSelections ).toEqual( {} );
+	} );
+
+	it( 'drops scalar params whose value is empty', () => {
+		// `?section=` is the "cleared" state — equivalent to no selection.
+		// Drop it so a refresh doesn't keep an empty entry around that
+		// re-emits on the next URL push.
+		const state = urlParamsToState( new URLSearchParams( '?section=' ), {
+			section: { filterKey: 'section', kind: 'static' },
+		} );
+		expect( state.staticFilterSelections ).toEqual( {} );
+	} );
+
+	it( 'last-write wins for duplicate scalar static-filter params', () => {
+		// `?section=a&section=b` is malformed for a single-select filter.
+		// Mirror the radio-input change handler (latest click wins) rather
+		// than the first-wins ordering URLSearchParams.get() would default
+		// to.
+		const state = urlParamsToState( new URLSearchParams( '?section=a&section=b' ), {
+			section: { filterKey: 'section', kind: 'static' },
+		} );
+		expect( state.staticFilterSelections ).toEqual( { section: 'b' } );
 	} );
 } );

--- a/projects/packages/search/tests/php/Filter_Static_Test.php
+++ b/projects/packages/search/tests/php/Filter_Static_Test.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * Filter_Static helper tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
+
+/**
+ * Tests for the Filter_Static helpers that back the
+ * `jetpack-search/filter-static` block.
+ */
+class Filter_Static_Test extends PHPUnit_TestCase {
+
+	/**
+	 * Reset the per-request memo before each test so registrations from a
+	 * prior case don't leak into the next.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Filter_Static::reset_cache_for_testing();
+		// Clear any $_GET state a prior test may have set.
+		$_GET = array();
+	}
+
+	/**
+	 * Tear down: drop every filter we may have registered. Each test calls
+	 * `add_filter()` inline, so the safest cleanup is to walk the two hooks
+	 * Filter_Static reads.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'jetpack_search_static_filters' );
+		remove_all_filters( 'jetpack_instant_search_options' );
+		remove_all_filters( 'doing_it_wrong_trigger_error' );
+		$_GET = array();
+		Filter_Static::reset_cache_for_testing();
+	}
+
+	/**
+	 * The sibling `jetpack_search_static_filters` hook is the canonical
+	 * blocks-only registration surface. Entries flow straight through after
+	 * normalization.
+	 */
+	public function test_get_static_filters_config_reads_search_static_filters_hook() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(
+							array(
+								'name'  => 'News',
+								'value' => 'news',
+							),
+						),
+					),
+				);
+			}
+		);
+
+		$configs = Filter_Static::get_static_filters_config();
+
+		$this->assertCount( 1, $configs );
+		$this->assertSame( 'section', $configs[0]['filter_id'] );
+		$this->assertSame( 'Section', $configs[0]['name'] );
+		$this->assertSame( 'group', $configs[0]['type'] );
+		// Variation defaults to 'sidebar' when unset on the entry.
+		$this->assertSame( 'sidebar', $configs[0]['variation'] );
+		$this->assertSame( 'news', $configs[0]['values'][0]['value'] );
+	}
+
+	/**
+	 * Sites that registered static filters for the legacy instant-search
+	 * overlay via `jetpack_instant_search_options` should get the blocks for
+	 * free — Filter_Static must pick the same payload up without a second
+	 * registration.
+	 */
+	public function test_get_static_filters_config_reads_legacy_instant_search_options_hook() {
+		add_filter(
+			'jetpack_instant_search_options',
+			static function ( $options ) {
+				$options['staticFilters'] = array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'variation' => 'tabbed',
+						'values'    => array(
+							array(
+								'name'  => 'News',
+								'value' => 'news',
+							),
+						),
+					),
+				);
+				return $options;
+			}
+		);
+
+		$configs = Filter_Static::get_static_filters_config();
+
+		$this->assertCount( 1, $configs );
+		$this->assertSame( 'section', $configs[0]['filter_id'] );
+		$this->assertSame( 'tabbed', $configs[0]['variation'] );
+	}
+
+	/**
+	 * Result is memoised per request — re-registering after the first read
+	 * shouldn't change subsequent reads until the cache is reset.
+	 */
+	public function test_get_static_filters_config_memoises_per_request() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'a',
+						'name'      => 'A',
+						'values'    => array(
+							array(
+								'name'  => 'One',
+								'value' => 'one',
+							),
+						),
+					),
+				);
+			}
+		);
+		$first = Filter_Static::get_static_filters_config();
+
+		// Re-register so the underlying hook returns a different list. The
+		// memoised first read should still win.
+		remove_all_filters( 'jetpack_search_static_filters' );
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array();
+			}
+		);
+
+		$second = Filter_Static::get_static_filters_config();
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * Entries whose `filter_id` collides with a reserved query param (`s`,
+	 * `q`, `orderby`, `min_price`, `max_price`) round-trip through
+	 * `parse_url_filters()` as something other than a filter and would
+	 * silently fail. Reject them upfront so misconfiguration is visible.
+	 */
+	public function test_normalize_entry_rejects_reserved_filter_id() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 's',
+						'name'      => 'Search hijack',
+						'values'    => array(
+							array(
+								'name'  => 'One',
+								'value' => 'one',
+							),
+						),
+					),
+					array(
+						'filter_id' => 'orderby',
+						'name'      => 'Sort hijack',
+						'values'    => array(
+							array(
+								'name'  => 'One',
+								'value' => 'one',
+							),
+						),
+					),
+				);
+			}
+		);
+
+		$this->assertSame( array(), Filter_Static::get_static_filters_config() );
+	}
+
+	/**
+	 * An entry with no usable values would render an empty fieldset. Drop it
+	 * so render.php has nothing to emit rather than a labeled empty list.
+	 */
+	public function test_normalize_entry_rejects_empty_values() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(),
+					),
+					array(
+						'filter_id' => 'topic',
+						'name'      => 'Topic',
+						'values'    => 'not-an-array',
+					),
+				);
+			}
+		);
+
+		$this->assertSame( array(), Filter_Static::get_static_filters_config() );
+	}
+
+	/**
+	 * Values missing a `value` field are filtered out, and a missing display
+	 * `name` falls back to the value. An entry left with no usable values
+	 * after this is rejected.
+	 */
+	public function test_normalize_entry_sanitises_individual_values() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(
+							array(
+								'name'  => 'News',
+								'value' => 'news',
+							),
+							// Missing value — dropped.
+							array( 'name' => 'Orphan' ),
+							// Missing name — falls back to the value.
+							array( 'value' => 'guides' ),
+							// Not an array — skipped.
+							'garbage',
+						),
+					),
+				);
+			}
+		);
+
+		$values = Filter_Static::get_static_filters_config()[0]['values'];
+		$this->assertSame(
+			array(
+				array(
+					'value' => 'news',
+					'name'  => 'News',
+				),
+				array(
+					'value' => 'guides',
+					'name'  => 'guides',
+				),
+			),
+			$values
+		);
+	}
+
+	/**
+	 * Two entries with the same `filter_id` create an ambiguous URL contract
+	 * (which radio set owns `?section=...`?). Adopt the last write so the
+	 * behaviour mirrors PHP `apply_filters` semantics, and surface the
+	 * collision via `_doing_it_wrong()` so abuse is visible in debug.
+	 */
+	public function test_get_static_filters_config_dedupes_last_wins_on_duplicate_filter_id() {
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'First registration',
+						'values'    => array(
+							array(
+								'name'  => 'One',
+								'value' => 'one',
+							),
+						),
+					),
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Second registration',
+						'values'    => array(
+							array(
+								'name'  => 'Two',
+								'value' => 'two',
+							),
+						),
+					),
+				);
+			}
+		);
+
+		$configs = Filter_Static::get_static_filters_config();
+		$this->assertCount( 1, $configs );
+		$this->assertSame( 'Second registration', $configs[0]['name'] );
+		$this->assertSame( 'two', $configs[0]['values'][0]['value'] );
+	}
+
+	/**
+	 * `filters_for_variation` returns only entries whose `variation` matches.
+	 * Defaults coerce 'sidebar' so an entry with the field unset shows under
+	 * the sidebar variation and not the tabbed one.
+	 */
+	public function test_filters_for_variation_scopes_by_variation() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						// Variation omitted — defaults to sidebar.
+						'values'    => array(
+							array(
+								'name'  => 'A',
+								'value' => 'a',
+							),
+						),
+					),
+					array(
+						'filter_id' => 'audience',
+						'name'      => 'Audience',
+						'variation' => 'tabbed',
+						'values'    => array(
+							array(
+								'name'  => 'B',
+								'value' => 'b',
+							),
+						),
+					),
+				);
+			}
+		);
+
+		$this->assertCount( 1, Filter_Static::filters_for_variation( 'sidebar' ) );
+		$this->assertSame( 'section', Filter_Static::filters_for_variation( 'sidebar' )[0]['filter_id'] );
+
+		$this->assertCount( 1, Filter_Static::filters_for_variation( 'tabbed' ) );
+		$this->assertSame( 'audience', Filter_Static::filters_for_variation( 'tabbed' )[0]['filter_id'] );
+	}
+
+	/**
+	 * When the block scopes to a specific `filter_id`, only that one entry
+	 * (intersected with the variation) is returned.
+	 */
+	public function test_filters_for_variation_filters_by_specific_filter_id() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(
+							array(
+								'name'  => 'A',
+								'value' => 'a',
+							),
+						),
+					),
+					array(
+						'filter_id' => 'topic',
+						'name'      => 'Topic',
+						'values'    => array(
+							array(
+								'name'  => 'B',
+								'value' => 'b',
+							),
+						),
+					),
+				);
+			}
+		);
+
+		$narrowed = Filter_Static::filters_for_variation( 'sidebar', 'topic' );
+		$this->assertCount( 1, $narrowed );
+		$this->assertSame( 'topic', $narrowed[0]['filter_id'] );
+	}
+
+	/**
+	 * Anything other than the literal string 'tabbed' collapses to 'sidebar',
+	 * matching `getAvailableStaticFilters()` on the JS side.
+	 */
+	public function test_normalize_variation_defaults_to_sidebar() {
+		$this->assertSame( 'tabbed', Filter_Static::normalize_variation( 'tabbed' ) );
+		$this->assertSame( 'sidebar', Filter_Static::normalize_variation( 'sidebar' ) );
+		$this->assertSame( 'sidebar', Filter_Static::normalize_variation( '' ) );
+		$this->assertSame( 'sidebar', Filter_Static::normalize_variation( 'garbage' ) );
+		$this->assertSame( 'sidebar', Filter_Static::normalize_variation( null ) );
+	}
+
+	/**
+	 * `build_config` produces the filterConfig entry that render.php pushes
+	 * into the shared Interactivity state. The `kind => 'static'` marker is
+	 * what the JS store keys off to decide URL serialization (scalar vs
+	 * array shape) — locking it down here prevents silent drift between PHP
+	 * and JS contracts.
+	 */
+	public function test_build_config_shape() {
+		$entry = array(
+			'filter_id' => 'section',
+			'name'      => 'Section',
+			'type'      => 'group',
+			'variation' => 'sidebar',
+			'selected'  => 'news',
+			'values'    => array(
+				array(
+					'value' => 'news',
+					'name'  => 'News',
+				),
+			),
+		);
+
+		$config = Filter_Static::build_config( $entry, array() );
+
+		$this->assertSame( 'section', $config['filterKey'] );
+		$this->assertSame( 'static', $config['kind'] );
+		$this->assertSame( 'static', $config['filterType'] );
+		$this->assertSame( 'Section', $config['label'] );
+		$this->assertSame( 'news', $config['selected'] );
+		$this->assertSame( 'sidebar', $config['variation'] );
+		$this->assertSame(
+			array(
+				array(
+					'value' => 'news',
+					'name'  => 'News',
+				),
+			),
+			$config['values']
+		);
+	}
+
+	/**
+	 * The block's `label` attribute overrides the server-supplied `name`.
+	 * Empty falls back so a site that never set the override sees the
+	 * registered display name.
+	 */
+	public function test_derive_label_attribute_override_beats_server_name() {
+		$entry = array(
+			'filter_id' => 'section',
+			'name'      => 'Section',
+			'values'    => array(),
+		);
+
+		$this->assertSame(
+			'Custom Heading',
+			Filter_Static::derive_label( $entry, array( 'label' => 'Custom Heading' ) )
+		);
+		$this->assertSame( 'Section', Filter_Static::derive_label( $entry, array( 'label' => '' ) ) );
+		$this->assertSame( 'Section', Filter_Static::derive_label( $entry, array() ) );
+	}
+
+	/**
+	 * `parse_url_selections` pulls scalar `?filter_id=value` URL params into a
+	 * `{ filter_id => value }` map. Only keys that match a configured static
+	 * filter get through — arbitrary scalar params from other plugins never
+	 * reach `staticFilterSelections`.
+	 */
+	public function test_parse_url_selections_pulls_only_configured_keys() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(
+							array(
+								'name'  => 'News',
+								'value' => 'news',
+							),
+						),
+					),
+				);
+			}
+		);
+		$_GET = array(
+			'section'   => 'news',
+			'unrelated' => 'ignored',
+			's'         => 'search query',
+		);
+
+		$this->assertSame( array( 'section' => 'news' ), Filter_Static::parse_url_selections() );
+	}
+
+	/**
+	 * Array-shaped params under a static-filter key are misuse (the URL
+	 * contract for static filters is scalar). Drop them rather than guess
+	 * which array element to use.
+	 */
+	public function test_parse_url_selections_skips_array_shaped_values() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(
+							array(
+								'name'  => 'News',
+								'value' => 'news',
+							),
+						),
+					),
+				);
+			}
+		);
+		$_GET = array( 'section' => array( 'news', 'guides' ) );
+
+		$this->assertSame( array(), Filter_Static::parse_url_selections() );
+	}
+
+	/**
+	 * Empty-string values mean "no selection" — drop them so the gate stays
+	 * empty rather than seeding an empty string into staticFilterSelections.
+	 */
+	public function test_parse_url_selections_drops_empty_strings() {
+		add_filter(
+			'jetpack_search_static_filters',
+			static function () {
+				return array(
+					array(
+						'filter_id' => 'section',
+						'name'      => 'Section',
+						'values'    => array(
+							array(
+								'name'  => 'News',
+								'value' => 'news',
+							),
+						),
+					),
+				);
+			}
+		);
+		$_GET = array( 'section' => '' );
+
+		$this->assertSame( array(), Filter_Static::parse_url_selections() );
+	}
+}


### PR DESCRIPTION
Fixes [SEARCH-219](https://linear.app/a8c/issue/SEARCH-219/add-jetpack-searchfilter-static-block-for-single-select-static-filters)

## Proposed changes

* New Search 3.0 block `jetpack-search/filter-static` mirroring the legacy instant-search overlay's static-filter widget — a single-select radio list whose options come from server config (no per-instance editor UI for values).
* Options resolve from the existing `jetpack_instant_search_options` hook (so sites already wired up for the legacy overlay get the blocks for free) and from a narrower sibling `jetpack_search_static_filters` for blocks-only registrations.
* Selections round-trip as scalar `?filter_id=value` URL params — matches the legacy contract so deep links stay interchangeable between the overlay and the blocks surface. New sibling state slice `staticFilterSelections` follows the `priceRange` precedent (also scalar, also a sibling slice), gated on `filterConfigs[key].kind === 'static'` to prevent stale or plugin-emitted scalar params from leaking back into the URL.
* ES term clauses (`{ term: { <filter_id>: <value> } }`) folded into the existing `bool.must` pipeline so the static filter applies alongside dynamic facet selections.
* New REST route `GET /jetpack-search/v1/static-filters?variation=<sidebar|tabbed>` (permission `edit_posts`) backs the editor inspector's filter-id picker.
* Falls under the existing `jetpack_search_blocks_enabled` gate — no new flag.
* Test coverage:
  - 15 new PHPUnit cases (`Filter_Static_Test`) for `get_static_filters_config` (both hooks, last-wins on duplicates, reserved-param rejection, empty-values rejection), `filters_for_variation`, `normalize_variation`, `build_config`, `derive_label`, `parse_url_selections`.
  - 21 new Jest cases across `url-state`, `api`, and `store` for the scalar URL serialization branch, the `kind === 'static'` parse gate, `buildStaticFilterClauses`, `buildSearchUrl` integration, `setStaticFilter` single-select semantics, `clearFilters` reset, and `gateStaticFilterSelections`.

## Related product discussion/links

* Linear: [SEARCH-219](https://linear.app/a8c/issue/SEARCH-219/add-jetpack-searchfilter-static-block-for-single-select-static-filters) (Jetpack Search blocks project)
* Legacy reference: `projects/packages/search/src/instant-search/components/search-filter.jsx:225-245` (`renderGroup`) and `store/effects.js:176-187` (URL update).

## Does this pull request change what data or activity we track or use?

No — purely client-side UI state and ES query construction. No new tracking events; no new data collection.

## Testing instructions

A site needs to register at least one static filter for the block to render anything. Drop this into an mu-plugin:

\`\`\`php
add_filter( 'jetpack_search_static_filters', function () {
    return [ [
        'filter_id' => 'section',
        'name'      => 'Section',
        'type'      => 'group',
        'variation' => 'sidebar',
        'selected'  => '',
        'values'    => [
            [ 'name' => 'News',   'value' => 'news' ],
            [ 'name' => 'Guides', 'value' => 'guides' ],
        ],
    ] ];
} );
\`\`\`

Build + enable Search 3.0 blocks (`jetpack_search_blocks_enabled=true`), then:

* [ ] Insert "Static Filter" on a page that also has \`search-results\`. In the inspector, confirm the "Filter" SelectControl lists "Section" (REST round-trip).
* [ ] Page load with no URL param: two radios appear, none checked. Server-rendered \`<fieldset>\` with \`data-wp-interactive="jetpack-search"\` and \`<input type="radio" name="section">\`.
* [ ] Click **Guides**: URL becomes \`?section=guides\` (scalar — no \`[]\`). Network shows one search request with \`bool.filter\` carrying \`{ term: { section: 'guides' } }\`.
* [ ] Reload \`?section=guides\`: "Guides" radio stays checked, results stay filtered.
* [ ] Pick **News**: URL \`section\` *replaces* (does not append) — confirms single-select semantics.
* [ ] Re-pick the currently selected radio: clears the filter (\`?section=\` is dropped from the URL).
* [ ] Disable the host filter (return \`[]\`): block renders nothing on the front end; editor Placeholder shows an empty-state message.
* [ ] Confirm the "Tabbed" variation in the inspector renders only the tabbed-registered filters (registered with \`variation => 'tabbed'\`).