### PR TITLE
VideoPress: route modernized free-plan upgrade CTA through shared checkout workflow + add page-view analytics

### DIFF
--- a/projects/js-packages/connection/changelog/update-videopress-modernization-upgrade-plan
+++ b/projects/js-packages/connection/changelog/update-videopress-modernization-upgrade-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add direct useProductCheckoutWorkflow hook export

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.tsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.tsx
@@ -3,8 +3,8 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useEffect, useState, useMemo } from 'react';
-import { getCalypsoOrigin } from '@automattic/jetpack-connection';
 import useConnection from '../../components/use-connection';
+import getCalypsoOrigin from '../../helpers/get-calypso-origin';
 import { STORE_ID } from '../../state/store.jsx';
 import type { UseProductCheckoutWorkflowProps } from './types';
 

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -20,6 +20,7 @@
 	"type": "module",
 	"exports": {
 		".": "./index.jsx",
+		"./hooks/use-product-checkout-workflow": "./hooks/use-product-checkout-workflow/index.tsx",
 		"./use-connection": "./components/use-connection/index.ts"
 	},
 	"scripts": {

--- a/projects/packages/videopress/.gitignore
+++ b/projects/packages/videopress/.gitignore
@@ -5,3 +5,5 @@ vendor/
 node_modules/
 build/
 wordpress/
+
+routes/**/.content-entry.js

--- a/projects/packages/videopress/changelog/update-videopress-modernization-upgrade-plan
+++ b/projects/packages/videopress/changelog/update-videopress-modernization-upgrade-plan
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed checkout process on gated dashboard under feature flag
+
+

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -19,6 +19,9 @@ export declare global {
 				jetpackStatus: {
 					calypsoSlug: string;
 				};
+				product: {
+					slug: string;
+				};
 				siteData: {
 					id: number | string;
 					title: string;

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -38,6 +39,16 @@ class Initial_State {
 	const SCRIPT_HANDLE = 'jetpack-videopress-dashboard-wp-admin-prerequisites';
 
 	/**
+	 * WPCOM product slug purchased by the dashboard's upgrade CTA.
+	 *
+	 * Mirrors the product `Plan::get_product()` resolves to
+	 * (`$products->jetpack_videopress`). Kept as a constant rather than read
+	 * from `Plan::get_product()` because that helper issues a synchronous
+	 * WPCOM request, which we don't want to incur on every page render.
+	 */
+	const VIDEOPRESS_PRODUCT_SLUG = 'jetpack_videopress';
+
+	/**
 	 * Register the inline-state enqueue hook.
 	 *
 	 * Hooks `admin_enqueue_scripts` at priority 11 so the wp-build page
@@ -67,6 +78,13 @@ class Initial_State {
 		}
 
 		wp_add_inline_script( self::SCRIPT_HANDLE, ( new self() )->render(), 'before' );
+
+		// Hydrate the JP connection store (`window.JP_CONNECTION_INITIAL_STATE`)
+		// so shared connection-aware hooks — notably
+		// `useProductCheckoutWorkflow`, which powers the upgrade CTA — work on
+		// the modernized dashboard exactly as they do on the legacy one. This
+		// also sets `window.jpTracksContext.blog_id` for `@automattic/jetpack-analytics`.
+		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
 	}
 
 	/**
@@ -87,6 +105,10 @@ class Initial_State {
 			),
 			'jetpackStatus' => array(
 				'calypsoSlug' => ( new Status() )->get_site_suffix(),
+			),
+			'product'       => array(
+				// Fed to `useProductCheckoutWorkflow` as the product to purchase.
+				'slug' => self::VIDEOPRESS_PRODUCT_SLUG,
 			),
 			'siteData'      => array(
 				'id'                    => Jetpack_Options::get_option( 'id' ),

--- a/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
@@ -61,8 +61,13 @@ export default function FreeTierNotice(): ReactElement {
 
 	const handleUpgradeClick = useCallback(
 		( event: { preventDefault: () => void } ) => {
+			// Cancel the placeholder-href default, record the click, then defer the
+			// checkout redirect by a microtask so the Tracks pixel is dispatched
+			// before navigation can cancel it. Mirrors the legacy dashboard's
+			// `recordEvent( … ).then( run )`.
+			event.preventDefault();
 			analytics.tracks.recordEvent( UPGRADE_CLICK_EVENT );
-			run( event );
+			void Promise.resolve().then( () => run() );
 		},
 		[ run ]
 	);

--- a/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
@@ -1,35 +1,81 @@
+import analytics from '@automattic/jetpack-analytics';
+// Imported via its deep export rather than the package barrel: the barrel
+// (`@automattic/jetpack-connection`) re-exports the disconnect dialog, which
+// imports `.jpg` assets the wp-build esbuild pipeline has no loader for, so a
+// barrel import fails the build even though the hook itself needs none of it.
+import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
 import type { ReactElement } from 'react';
 
+// Tracks event recorded when the upgrade CTA is clicked. Carried over verbatim
+// from the legacy dashboard's `UpgradeTrigger` so both dashboards report
+// against the same funnel.
+const UPGRADE_CLICK_EVENT = 'jetpack_videopress_upgrade_trigger_link_click';
+
 /**
- * Build the WPCOM checkout URL for the VideoPress upgrade CTA. The slug
- * is read from `JPVIDEOPRESS_INITIAL_STATE.jetpackStatus.calypsoSlug`,
- * set on every initial-state render (`class-initial-state.php`). Falls
- * back to bare `/checkout/videopress` when the slug isn't available so
- * the link still works (WPCOM resolves the active site server-side).
+ * Read the inlined initial state, guarding for environments (tests, the
+ * legacy page) where the `var JPVIDEOPRESS_INITIAL_STATE` is absent.
  *
- * @return Absolute checkout URL.
+ * @return The initial-state payload, or undefined when it isn't present.
  */
-function buildUpgradeUrl(): string {
-	const base = 'https://wordpress.com/checkout';
-	const slug =
-		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
-			? JPVIDEOPRESS_INITIAL_STATE?.jetpackStatus?.calypsoSlug
-			: '';
-	return slug ? `${ base }/${ slug }/videopress` : `${ base }/videopress`;
+function getInitialState() {
+	return typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined' ? JPVIDEOPRESS_INITIAL_STATE : undefined;
 }
 
 /**
- * Permanent (non-dismissible) free-plan Notice rendered at the top of
- * the Overview tab. The `@wordpress/ui` Notice compound API expresses
- * non-dismissibility by omitting `<Notice.CloseIcon>` rather than via a
- * boolean prop. Uses `ActionLink` (not `ActionButton`) because the CTA
- * navigates to WPCOM checkout.
+ * Permanent (non-dismissible) free-plan Notice rendered at the top of the
+ * Overview tab. The `@wordpress/ui` Notice compound API expresses
+ * non-dismissibility by omitting `<Notice.CloseIcon>` rather than via a boolean
+ * prop.
+ *
+ * The upgrade CTA reuses the shared `useProductCheckoutWorkflow` hook — the
+ * same one the legacy dashboard used — so VideoPress stays in lockstep with
+ * every other product's checkout behavior instead of hand-rolling a URL. The
+ * connection details the hook needs are hydrated server-side by
+ * `class-initial-state.php` (`Connection_Initial_State::render_script()`); the
+ * product to purchase and the post-checkout redirect come from
+ * `JPVIDEOPRESS_INITIAL_STATE`. The hook exposes an action (`run`, which
+ * registers the site if needed then redirects) rather than a URL, so the CTA is
+ * an `ActionLink` with a placeholder `href` whose default `run` cancels before
+ * redirecting — keeping anchor semantics (focus, hover) while delegating
+ * navigation to the workflow.
  *
  * @return The Notice element.
  */
 export default function FreeTierNotice(): ReactElement {
+	const state = getInitialState();
+	const adminUrl = state?.siteData?.adminUrl ?? '';
+
+	const { run } = useProductCheckoutWorkflow( {
+		productSlug: state?.product?.slug ?? '',
+		redirectUrl: adminUrl ? `${ adminUrl }admin.php?page=jetpack-videopress` : '',
+		useBlogIdSuffix: true,
+		from: 'jetpack-videopress',
+	} );
+
+	// Identify the WPCOM user for Tracks once, mirroring the legacy
+	// `useAnalyticsTracks` initialization. Guarded for sites with no connected
+	// WPCOM user (e.g. self-hosted, not yet connected). The event's `blog_id`
+	// is supplied automatically by `window.jpTracksContext` (set alongside the
+	// connection state), so it doesn't need to be passed here.
+	useEffect( () => {
+		const wpcomUser = getScriptData()?.user?.current_user?.wpcom;
+		if ( wpcomUser?.ID && wpcomUser?.login ) {
+			analytics.initialize( wpcomUser.ID, wpcomUser.login );
+		}
+	}, [] );
+
+	const handleUpgradeClick = useCallback(
+		( event: { preventDefault: () => void } ) => {
+			analytics.tracks.recordEvent( UPGRADE_CLICK_EVENT );
+			run( event );
+		},
+		[ run ]
+	);
+
 	return (
 		<Notice.Root intent="info">
 			<Notice.Description>
@@ -39,7 +85,7 @@ export default function FreeTierNotice(): ReactElement {
 				) }
 			</Notice.Description>
 			<Notice.Actions>
-				<Notice.ActionLink href={ buildUpgradeUrl() }>
+				<Notice.ActionLink href="#" onClick={ handleUpgradeClick }>
 					{ __( 'Upgrade', 'jetpack-videopress-pkg' ) }
 				</Notice.ActionLink>
 			</Notice.Actions>

--- a/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
@@ -4,8 +4,7 @@ import analytics from '@automattic/jetpack-analytics';
 // imports `.jpg` assets the wp-build esbuild pipeline has no loader for, so a
 // barrel import fails the build even though the hook itself needs none of it.
 import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
-import { getScriptData } from '@automattic/jetpack-script-data';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
 import type { ReactElement } from 'react';
@@ -43,6 +42,10 @@ function getInitialState() {
  * redirecting — keeping anchor semantics (focus, hover) while delegating
  * navigation to the workflow.
  *
+ * Tracks identity is initialized centrally by `useDashboardAnalytics`, so the
+ * click handler only records the event; its `blog_id` is supplied
+ * automatically by `window.jpTracksContext`.
+ *
  * @return The Notice element.
  */
 export default function FreeTierNotice(): ReactElement {
@@ -55,18 +58,6 @@ export default function FreeTierNotice(): ReactElement {
 		useBlogIdSuffix: true,
 		from: 'jetpack-videopress',
 	} );
-
-	// Identify the WPCOM user for Tracks once, mirroring the legacy
-	// `useAnalyticsTracks` initialization. Guarded for sites with no connected
-	// WPCOM user (e.g. self-hosted, not yet connected). The event's `blog_id`
-	// is supplied automatically by `window.jpTracksContext` (set alongside the
-	// connection state), so it doesn't need to be passed here.
-	useEffect( () => {
-		const wpcomUser = getScriptData()?.user?.current_user?.wpcom;
-		if ( wpcomUser?.ID && wpcomUser?.login ) {
-			analytics.initialize( wpcomUser.ID, wpcomUser.login );
-		}
-	}, [] );
 
 	const handleUpgradeClick = useCallback(
 		( event: { preventDefault: () => void } ) => {

--- a/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
@@ -1,0 +1,95 @@
+import analytics from '@automattic/jetpack-analytics';
+import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FreeTierNotice from '../free-tier-notice';
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: jest.fn(),
+		tracks: { recordEvent: jest.fn() },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-connection/hooks/use-product-checkout-workflow', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: jest.fn(),
+} ) );
+
+const mockedGetScriptData = getScriptData as jest.Mock;
+const mockedCheckoutWorkflow = useProductCheckoutWorkflow as jest.Mock;
+const mockedAnalytics = analytics as unknown as {
+	initialize: jest.Mock;
+	tracks: { recordEvent: jest.Mock };
+};
+
+const setInitialState = ( state: unknown ) => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE =
+		state;
+};
+
+const DEFAULT_STATE = {
+	product: { slug: 'jetpack_videopress' },
+	siteData: { adminUrl: 'https://example.com/wp-admin/' },
+};
+
+const CONNECTED_USER = { user: { current_user: { wpcom: { ID: 7, login: 'jane' } } } };
+
+let mockRun: jest.Mock;
+
+describe( 'FreeTierNotice', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setInitialState( DEFAULT_STATE );
+		mockedGetScriptData.mockReturnValue( CONNECTED_USER );
+		mockRun = jest.fn();
+		mockedCheckoutWorkflow.mockReturnValue( { run: mockRun } );
+	} );
+
+	it( 'drives the shared checkout workflow with the VideoPress product and redirect', () => {
+		render( <FreeTierNotice /> );
+
+		expect( mockedCheckoutWorkflow ).toHaveBeenCalledWith( {
+			productSlug: 'jetpack_videopress',
+			redirectUrl: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+			useBlogIdSuffix: true,
+			from: 'jetpack-videopress',
+		} );
+	} );
+
+	it( 'records the upgrade-click Tracks event and runs the workflow on click', async () => {
+		const user = userEvent.setup();
+		render( <FreeTierNotice /> );
+
+		const link = screen.getByRole( 'link', { name: 'Upgrade' } );
+		// The CTA is an anchor with a placeholder href; the real `run` cancels the
+		// default before redirecting, but `run` is mocked here, so cancel it
+		// ourselves to keep jsdom from attempting navigation.
+		link.addEventListener( 'click', event => event.preventDefault() );
+		await user.click( link );
+
+		expect( mockedAnalytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_videopress_upgrade_trigger_link_click'
+		);
+		expect( mockRun ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'identifies the connected WPCOM user for Tracks on mount', () => {
+		render( <FreeTierNotice /> );
+
+		expect( mockedAnalytics.initialize ).toHaveBeenCalledWith( 7, 'jane' );
+	} );
+
+	it( 'does not identify a user for Tracks when none is connected', () => {
+		mockedGetScriptData.mockReturnValue( { user: { current_user: {} } } );
+		render( <FreeTierNotice /> );
+
+		expect( mockedAnalytics.initialize ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
@@ -1,6 +1,5 @@
 import analytics from '@automattic/jetpack-analytics';
 import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
-import { getScriptData } from '@automattic/jetpack-script-data';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FreeTierNotice from '../free-tier-notice';
@@ -18,14 +17,8 @@ jest.mock( '@automattic/jetpack-connection/hooks/use-product-checkout-workflow',
 	default: jest.fn(),
 } ) );
 
-jest.mock( '@automattic/jetpack-script-data', () => ( {
-	getScriptData: jest.fn(),
-} ) );
-
-const mockedGetScriptData = getScriptData as jest.Mock;
 const mockedCheckoutWorkflow = useProductCheckoutWorkflow as jest.Mock;
 const mockedAnalytics = analytics as unknown as {
-	initialize: jest.Mock;
 	tracks: { recordEvent: jest.Mock };
 };
 
@@ -39,15 +32,12 @@ const DEFAULT_STATE = {
 	siteData: { adminUrl: 'https://example.com/wp-admin/' },
 };
 
-const CONNECTED_USER = { user: { current_user: { wpcom: { ID: 7, login: 'jane' } } } };
-
 let mockRun: jest.Mock;
 
 describe( 'FreeTierNotice', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		setInitialState( DEFAULT_STATE );
-		mockedGetScriptData.mockReturnValue( CONNECTED_USER );
 		mockRun = jest.fn();
 		mockedCheckoutWorkflow.mockReturnValue( { run: mockRun } );
 	} );
@@ -78,18 +68,5 @@ describe( 'FreeTierNotice', () => {
 			'jetpack_videopress_upgrade_trigger_link_click'
 		);
 		expect( mockRun ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'identifies the connected WPCOM user for Tracks on mount', () => {
-		render( <FreeTierNotice /> );
-
-		expect( mockedAnalytics.initialize ).toHaveBeenCalledWith( 7, 'jane' );
-	} );
-
-	it( 'does not identify a user for Tracks when none is connected', () => {
-		mockedGetScriptData.mockReturnValue( { user: { current_user: {} } } );
-		render( <FreeTierNotice /> );
-
-		expect( mockedAnalytics.initialize ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
@@ -57,16 +57,12 @@ describe( 'FreeTierNotice', () => {
 		const user = userEvent.setup();
 		render( <FreeTierNotice /> );
 
-		const link = screen.getByRole( 'link', { name: 'Upgrade' } );
-		// The CTA is an anchor with a placeholder href; the real `run` cancels the
-		// default before redirecting, but `run` is mocked here, so cancel it
-		// ourselves to keep jsdom from attempting navigation.
-		link.addEventListener( 'click', event => event.preventDefault() );
-		await user.click( link );
+		await user.click( screen.getByRole( 'link', { name: 'Upgrade' } ) );
 
 		expect( mockedAnalytics.tracks.recordEvent ).toHaveBeenCalledWith(
 			'jetpack_videopress_upgrade_trigger_link_click'
 		);
+		// `run` is deferred to a microtask; userEvent's await flushes it.
 		expect( mockRun ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/components/query-client-wrapper/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/query-client-wrapper/index.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useDashboardAnalytics } from '../../hooks/use-dashboard-analytics';
 import type { ReactNode } from 'react';
 
 const STORE_KEY = '__jetpackVideopressQueryClient' as const;
@@ -32,9 +33,13 @@ function getClient(): QueryClient {
 	return window[ STORE_KEY ];
 }
 
-const QueryClientWrapper = ( { children }: { children: ReactNode } ) => (
-	<QueryClientProvider client={ getClient() }>{ children }</QueryClientProvider>
-);
+const QueryClientWrapper = ( { children }: { children: ReactNode } ) => {
+	// Rendered by every route stage, so it's the single shared spot to record
+	// the once-per-load dashboard page view.
+	useDashboardAnalytics();
+
+	return <QueryClientProvider client={ getClient() }>{ children }</QueryClientProvider>;
+};
 
 export default QueryClientWrapper;
 export { getClient as getVideopressQueryClient };

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-dashboard-analytics.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-dashboard-analytics.test.ts
@@ -1,0 +1,64 @@
+import analytics from '@automattic/jetpack-analytics';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { renderHook } from '@testing-library/react';
+import { useDashboardAnalytics } from '../use-dashboard-analytics';
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: jest.fn(),
+		tracks: { recordEvent: jest.fn() },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: jest.fn(),
+} ) );
+
+const mockedGetScriptData = getScriptData as jest.Mock;
+const mockedAnalytics = analytics as unknown as {
+	initialize: jest.Mock;
+	tracks: { recordEvent: jest.Mock };
+};
+
+const TRACKED_FLAG = '__jetpackVideoPressDashboardTracked';
+
+const CONNECTED_USER = { user: { current_user: { wpcom: { ID: 7, login: 'jane' } } } };
+
+describe( 'useDashboardAnalytics', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Reset the per-page-load guard so each test starts fresh.
+		delete ( window as unknown as Record< string, unknown > )[ TRACKED_FLAG ];
+		mockedGetScriptData.mockReturnValue( CONNECTED_USER );
+	} );
+
+	it( 'identifies the user and records the page-view event on first mount', () => {
+		renderHook( () => useDashboardAnalytics() );
+
+		expect( mockedAnalytics.initialize ).toHaveBeenCalledWith( 7, 'jane' );
+		expect( mockedAnalytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_videopress_admin_page_view'
+		);
+	} );
+
+	it( 'does not fire again when a route stage remounts (tab change)', () => {
+		// First mount fires; unmount + remount simulates client-side tab nav.
+		renderHook( () => useDashboardAnalytics() ).unmount();
+		renderHook( () => useDashboardAnalytics() );
+
+		expect( mockedAnalytics.tracks.recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( mockedAnalytics.initialize ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'still records the page view when no WPCOM user is connected', () => {
+		mockedGetScriptData.mockReturnValue( { user: { current_user: {} } } );
+
+		renderHook( () => useDashboardAnalytics() );
+
+		expect( mockedAnalytics.initialize ).not.toHaveBeenCalled();
+		expect( mockedAnalytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_videopress_admin_page_view'
+		);
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/use-dashboard-analytics.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-dashboard-analytics.ts
@@ -1,0 +1,46 @@
+import analytics from '@automattic/jetpack-analytics';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { useEffect } from '@wordpress/element';
+
+// Page-view Tracks event, carried over from the legacy dashboard
+// (`admin-page/index.tsx`).
+const PAGE_VIEW_EVENT = 'jetpack_videopress_admin_page_view';
+
+// window-scoped guard. The dashboard is a TanStack-routed SPA (`@wordpress/route`),
+// so switching tabs remounts route stages client-side without a page reload —
+// a per-mount effect would re-fire on every tab change. Keying the one-time
+// init + page view off `window` (which only resets on a real page load) fires
+// the page view once per load and never again on tab navigation, and shares
+// the flag across the separately-bundled route chunks. Mirrors the
+// window-singleton pattern used by the shared QueryClient.
+const TRACKED_FLAG = '__jetpackVideoPressDashboardTracked' as const;
+
+declare global {
+	interface Window {
+		[ TRACKED_FLAG ]?: boolean;
+	}
+}
+
+/**
+ * Identify the WPCOM user for Tracks and record the dashboard page-view event
+ * once per page load, regardless of which tab the visitor lands on. User
+ * identification is guarded for sites with no connected WPCOM user (e.g.
+ * self-hosted, not yet connected). The event's `blog_id` is supplied
+ * automatically by `window.jpTracksContext` (set alongside the connection
+ * state in `class-initial-state.php`).
+ */
+export function useDashboardAnalytics(): void {
+	useEffect( () => {
+		if ( window[ TRACKED_FLAG ] ) {
+			return;
+		}
+		window[ TRACKED_FLAG ] = true;
+
+		const wpcomUser = getScriptData()?.user?.current_user?.wpcom;
+		if ( wpcomUser?.ID && wpcomUser?.login ) {
+			analytics.initialize( wpcomUser.ID, wpcomUser.login );
+		}
+
+		analytics.tracks.recordEvent( PAGE_VIEW_EVENT );
+	}, [] );
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
The modernized (wp-build) VideoPress dashboard — gated behind the `rsm_jetpack_ui_modernization_videopress` filter — had a free-plan upgrade CTA that built its own checkout URL by hand and recorded no analytics. This brings it to parity with the legacy dashboard:

* The free-plan notice's **Upgrade** CTA now routes through the shared `useProductCheckoutWorkflow` hook (the same one the legacy dashboard uses) instead of a hand-rolled URL, so VideoPress stays in lockstep with every product's checkout behavior. It stays an `ActionLink` (placeholder `href`; the hook's `run` cancels the default before redirecting).
* Brought over both legacy Tracks events: `jetpack_videopress_upgrade_trigger_link_click` (on the CTA) and `jetpack_videopress_admin_page_view` (dashboard page view).
* The page view is recorded by a new `useDashboardAnalytics` hook, called from `QueryClientWrapper` (the shared shell rendered by every tab). It's guarded by a `window` flag so it fires **once per page load** and not again on client-side tab navigation (the dashboard is a TanStack-routed SPA, so tabs remount route stages without a reload). Tracks identity init is centralized there too.
* Bootstrapped the JP connection state on the modernized page (`Connection_Initial_State::render_script()`) so the shared hook has the connection details it needs; this also sets `window.jpTracksContext.blog_id` for analytics. The product slug is surfaced via `JPVIDEOPRESS_INITIAL_STATE`.
* Added a deep export to `@automattic/jetpack-connection` (`./hooks/use-product-checkout-workflow`) and import the hook through it rather than the package barrel — the barrel re-exports the disconnect dialog and its `.jpg` assets, which the wp-build esbuild pipeline has no loader for. The hook's own `getCalypsoOrigin` import was repointed at the helper so it no longer pulls the barrel (also removing a circular import).
* Added test coverage for the notice and the page-view hook.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No new data is collected. The dashboard records the **existing** `jetpack_videopress_upgrade_trigger_link_click` and `jetpack_videopress_admin_page_view` Tracks events — the same events the legacy dashboard already fires — now from the modernized dashboard. The connection bootstrap sets `window.jpTracksContext.blog_id`, identical to the legacy dashboard.

## Testing instructions
* Enable the modernized dashboard by returning `true` for the `rsm_jetpack_ui_modernization_videopress` filter, e.g. in a mu-plugin:
  ```php
  add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );
  ```
* Use a connected site **without** a paid VideoPress plan (free tier).
* Go to **Jetpack → VideoPress**. With dev tools open (watching the `_tkq` queue / requests to `pixel.wp.com`), confirm a single `jetpack_videopress_admin_page_view` event fires on load. Switch between the Overview / Library / Settings tabs and confirm it does **not** fire again. Reload the page and confirm it fires once more.
* On the Overview tab, confirm the "You're on the free plan…" notice shows an **Upgrade** link.
* Click **Upgrade** and confirm: (a) a `jetpack_videopress_upgrade_trigger_link_click` event is recorded, and (b) it sends you to WordPress.com checkout for the VideoPress product — the URL should match what the legacy dashboard produces (`/checkout/<blog id>/jetpack_videopress` with `site`, `source=jetpack-videopress`, and `redirect_to` back to the VideoPress page).
* Confirm `pnpm build:wp-build` succeeds (no `.jpg` "No loader is configured" error).
