### PR TITLE
Search Blocks: gate AI Answer block behind paid Search plan (SEARCH-221)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-221-gate-ai-answer-paid-plan
+++ b/projects/packages/search/changelog/SEARCH-221-gate-ai-answer-paid-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: gate the AI Answer block behind a paid Search plan — free / no-plan sites render nothing on the front end and see an upgrade prompt in the editor.

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/edit.js
@@ -5,15 +5,31 @@
  * the Interactivity store. The preview here is static markup mirroring the
  * `done` state with a sample answer + citations so authors can see what
  * they're placing without an SSE connection in the editor.
+ *
+ * AI Answer is a paid feature. On sites without a paid Search plan the
+ * preview is replaced with an upgrade Placeholder — mirrors the front-end
+ * gate in render.php so authors don't insert a block that won't render. The
+ * paid-plan flag is localized onto `window.JetpackSearchBlocksConfig`
+ * (`supportsPaidSearch`); the source of truth is the matching PHP gate.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { Button, PanelBody, Placeholder, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const SAMPLE_CITATIONS = [
 	{ title: 'Getting started with WordPress', url: 'https://example.com/getting-started' },
 	{ title: 'Customizing your theme', url: 'https://example.com/customizing' },
 ];
+
+// Editor preview defaults to "paid" when the localized config isn't present
+// (e.g. a Jest harness or a non-enqueued bundle context) so existing tests
+// see the full preview and the gate is opt-in via an explicit `false`.
+const supportsPaidSearch = () =>
+	typeof window === 'undefined' ||
+	! window.JetpackSearchBlocksConfig ||
+	window.JetpackSearchBlocksConfig.supportsPaidSearch !== false;
+
+const UPGRADE_URL = 'https://jetpack.com/upgrade/search/?utm_source=ai-answer-block';
 
 /**
  * Editor preview component.
@@ -24,10 +40,29 @@ const SAMPLE_CITATIONS = [
  * @return {object} Rendered element.
  */
 export default function AiAnswerEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+
+	if ( ! supportsPaidSearch() ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					label={ __( 'AI Answer', 'jetpack-search-pkg' ) }
+					instructions={ __(
+						'AI Answer is part of the paid Jetpack Search plan. Upgrade to enable AI-generated answers with citations on your search results.',
+						'jetpack-search-pkg'
+					) }
+				>
+					<Button variant="primary" href={ UPGRADE_URL } target="_blank" rel="noopener noreferrer">
+						{ __( 'Upgrade Jetpack Search', 'jetpack-search-pkg' ) }
+					</Button>
+				</Placeholder>
+			</div>
+		);
+	}
+
 	const heading = attributes?.heading?.trim() || __( 'AI answer', 'jetpack-search-pkg' );
 	const showCitations = attributes?.showCitations !== false;
 	const enableShowMore = attributes?.enableShowMore !== false;
-	const blockProps = useBlockProps();
 	return (
 		<>
 			<InspectorControls>

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -4,15 +4,28 @@
  *
  * Renders the panel scaffold that the Interactivity store hydrates with the
  * streaming brief / extended AI answer. The author's decision to insert the
- * block in their post content is the only switch — there's no site-wide
+ * block in their post content is the only opt-in switch — there's no site-wide
  * option gate here. The `jetpack_search_ai_answers_enabled` option still
  * governs the instant-search overlay's AI Answers, which is the default UX
  * on any search page; the embedded block is an explicit opt-in surface.
+ *
+ * AI Answer is a paid feature, so the render is additionally gated on the
+ * site having a paid Search plan. Free / no-plan sites emit nothing — the
+ * saved block instance is silently hidden on the front end, matching how
+ * WordAds / Premium Content behave when their plan check fails.
  *
  * @package automattic/jetpack-search
  */
 
 namespace Automattic\Jetpack\Search;
+
+// Paid-plan gate. AI Answer requires Jetpack Search's paid plan; on a free
+// or no-plan site the block contributes nothing to the page (no panel
+// scaffold, no `data-wp-interactive` div, no Interactivity hydration). The
+// editor surface shows an upgrade prompt instead — see `edit.js`.
+if ( ! Search_Blocks::supports_paid_search() ) {
+	return;
+}
 
 // $attributes is injected by WordPress at block-render time via the
 // `render_callback` include scope; static analysis can't see the binding,

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -87,6 +87,19 @@ class Search_Blocks {
 	private static $is_free_plan_cache = null;
 
 	/**
+	 * Per-request memo backing `supports_paid_search()`. Reads the same
+	 * `Plan::get_plan_info()` option as `is_free_plan_cache`, but answers
+	 * the inverse question — "does the site have a paid Search plan?" —
+	 * which is what paid-only block surfaces (today: AI Answer) gate on.
+	 * Kept separate from `is_free_plan_cache` because the two helpers can
+	 * disagree: a site with no plan info at all is neither on the free
+	 * plan nor on a paid one.
+	 *
+	 * @var bool|null
+	 */
+	private static $supports_paid_search_cache = null;
+
+	/**
 	 * Per-request memo backing `woocommerce_blocks_enabled()`. Centralized here
 	 * (rather than inside any one WC-aware block helper) so every gate that
 	 * needs the answer — block-registration filters that hide WC-only blocks
@@ -244,6 +257,40 @@ class Search_Blocks {
 	 */
 	public static function reset_is_free_plan_cache() {
 		self::$is_free_plan_cache = null;
+	}
+
+	/**
+	 * Whether the site has a paid Jetpack Search subscription. Paid-only
+	 * block surfaces (AI Answer's `render.php` and editor preview) call
+	 * this on every render to decide whether to emit the panel scaffold
+	 * or short-circuit; same cold-cache WPCOM round-trip hazard
+	 * `is_free_plan()` guards against, so memoize the same way.
+	 *
+	 * Why both probes: WPCOM reports `supports_instant_search: true` on
+	 * the free Search plan too — "this plan supports instant search as a
+	 * feature," not "the plan is paid." So `supports_instant_search()`
+	 * alone would let the free plan through. Combining with
+	 * `! is_free_plan()` rules out both the free product
+	 * (`jetpack_search_free`) and the forced-free filter, while
+	 * `supports_instant_search()` still rules out the no-plan / no-Search
+	 * case (which `is_free_plan()` returns false for).
+	 *
+	 * @return bool
+	 */
+	public static function supports_paid_search(): bool {
+		if ( null === self::$supports_paid_search_cache ) {
+			$plan                             = new Plan();
+			self::$supports_paid_search_cache = $plan->supports_instant_search() && ! $plan->is_free_plan();
+		}
+		return self::$supports_paid_search_cache;
+	}
+
+	/**
+	 * Reset the `supports_paid_search()` memo. Tests only — production
+	 * callers should never need this.
+	 */
+	public static function reset_supports_paid_search_cache() {
+		self::$supports_paid_search_cache = null;
 	}
 
 	/**
@@ -561,6 +608,13 @@ class Search_Blocks {
 				array(
 					'isWooCommerceBlocksEnabled' => self::woocommerce_blocks_enabled(),
 					'woocommerceOnlyBlocks'      => self::woocommerce_only_block_names(),
+					// `supportsPaidSearch` mirrors the PHP gate the AI Answer
+					// block applies in its `render.php` — paid-only block
+					// edits read this flag and swap their preview for an
+					// upgrade Placeholder when it's false. Server-side is
+					// the source of truth; the editor flag just lets the
+					// preview match what the front end will actually emit.
+					'supportsPaidSearch'         => self::supports_paid_search(),
 					// `supportedCustomTaxonomies` drives the "Custom Taxonomy"
 					// picker in filter-checkbox/edit.js — only taxonomies in
 					// this list (Jetpack-Search-indexed OR mapped to a

--- a/projects/packages/search/tests/js/search-blocks/ai-answer-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/ai-answer-edit.test.jsx
@@ -12,6 +12,22 @@ jest.mock( '@wordpress/components', () => ( {
 			{ children }
 		</section>
 	),
+	Placeholder: ( { label, instructions, children } ) => (
+		<div data-testid="placeholder" aria-label={ label }>
+			<p>{ instructions }</p>
+			{ children }
+		</div>
+	),
+	Button: ( { children, href, ...rest } ) =>
+		href ? (
+			<a href={ href } { ...rest }>
+				{ children }
+			</a>
+		) : (
+			<button type="button" { ...rest }>
+				{ children }
+			</button>
+		),
 	ToggleControl: ( { label, checked, onChange } ) => {
 		const id = `toggle-${ String( label ).toLowerCase().replace( /\s+/g, '-' ) }`;
 		return (
@@ -44,6 +60,13 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 describe( 'AiAnswerEdit', () => {
+	afterEach( () => {
+		// `supportsPaidSearch()` reads window.JetpackSearchBlocksConfig on
+		// every render, so resetting between tests keeps a single case
+		// from pinning the gate state for everything that follows.
+		delete globalThis.JetpackSearchBlocksConfig;
+	} );
+
 	it( 'renders the default heading when none is set', () => {
 		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
 		expect( screen.getByText( 'AI answer' ) ).toBeInTheDocument();
@@ -89,5 +112,32 @@ describe( 'AiAnswerEdit', () => {
 			target: { value: 'Quick reply' },
 		} );
 		expect( setAttributes ).toHaveBeenCalledWith( { heading: 'Quick reply' } );
+	} );
+
+	it( 'renders the upgrade Placeholder instead of the preview when supportsPaidSearch is false', () => {
+		globalThis.JetpackSearchBlocksConfig = { supportsPaidSearch: false };
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+
+		expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+		// The Upgrade button is a link to the search upgrade page — utm
+		// suffix differentiates this surface in analytics.
+		const upgradeLink = screen.getByRole( 'link', { name: 'Upgrade Jetpack Search' } );
+		expect( upgradeLink ).toHaveAttribute(
+			'href',
+			'https://jetpack.com/upgrade/search/?utm_source=ai-answer-block'
+		);
+		// Preview / inspector are hidden so the author isn't tweaking
+		// attributes for a block that won't render.
+		expect( screen.queryByText( 'Getting started with WordPress' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'inspector' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Show more' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the preview when supportsPaidSearch is explicitly true', () => {
+		globalThis.JetpackSearchBlocksConfig = { supportsPaidSearch: true };
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+
+		expect( screen.queryByTestId( 'placeholder' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'AI answer' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -59,6 +59,35 @@ class Ai_Answer_Render_Test extends TestCase {
 	}
 
 	/**
+	 * Seed a paid-plan option so the per-render paid-plan gate in
+	 * `render.php` lets through; the assertions in this suite are about
+	 * markup shape, not plan logic. The `supports_paid_search()` memo is
+	 * cleared in setUp / tearDown so cases that explicitly hide the plan
+	 * (`test_renders_nothing_without_paid_search_plan`) get a clean read.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Paid Search plan: `supports_instant_search: true` AND a
+		// non-free product_slug. The slug matters because WPCOM also
+		// reports `supports_instant_search: true` on the free plan, so
+		// the gate combines both probes to rule it out.
+		update_option(
+			Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY,
+			array(
+				'supports_instant_search' => true,
+				'effective_subscription'  => array( 'product_slug' => 'jetpack_search' ),
+			)
+		);
+		Search_Blocks::reset_supports_paid_search_cache();
+	}
+
+	public function tearDown(): void {
+		delete_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY );
+		Search_Blocks::reset_supports_paid_search_cache();
+		parent::tearDown();
+	}
+
+	/**
 	 * Render the ai-answer block via `do_blocks()`.
 	 *
 	 * @param array $attributes Block attributes.
@@ -135,6 +164,39 @@ class Ai_Answer_Render_Test extends TestCase {
 		$markup = $this->render( array( 'enableShowMore' => false ) );
 		$this->assertStringNotContainsString( 'jp-search-answers-panel__toggle', $markup );
 		$this->assertStringNotContainsString( 'showExtendedAiAnswer', $markup );
+	}
+
+	public function test_renders_nothing_without_paid_search_plan() {
+		// Drop the plan and re-prime the memo: a no-plan site must not
+		// emit the panel scaffold (no wrapper, no `data-wp-interactive`
+		// hook). Mirrors how WordAds / Premium Content's render_callbacks
+		// short-circuit when their plan check fails.
+		delete_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY );
+		Search_Blocks::reset_supports_paid_search_cache();
+
+		$markup = $this->render();
+
+		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
+	}
+
+	public function test_renders_nothing_on_free_search_plan() {
+		// WPCOM reports `supports_instant_search: true` on the free
+		// Search plan too, so the gate has to combine that probe with
+		// the product_slug check. This case exercises that second probe.
+		update_option(
+			Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY,
+			array(
+				'supports_instant_search' => true,
+				'effective_subscription'  => array( 'product_slug' => Plan::JETPACK_SEARCH_FREE_PRODUCT_SLUG ),
+			)
+		);
+		Search_Blocks::reset_supports_paid_search_cache();
+
+		$markup = $this->render();
+
+		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
 	}
 
 	public function test_panel_is_hidden_until_status_changes() {


### PR DESCRIPTION
Fixes [SEARCH-221](https://linear.app/a8c/issue/SEARCH-221/search-blocks-gate-ai-answer-block-behind-paid-search-plan)

## Why

AI Answer is a paid Jetpack Search feature, but the block was rendering for every visitor regardless of plan. Free / no-plan sites got a non-functional panel scaffold on the front end, and authors on those sites could insert the block in the editor with nothing to tell them it wouldn't actually do anything once published. After this change, free / no-plan sites silently render nothing on the front end and see a clear "Upgrade Jetpack Search" prompt in the editor — same pattern Jetpack uses for WordAds / Premium Content.

## Proposed changes

* Add a memoized `Search_Blocks::supports_paid_search()` helper. `Plan::supports_instant_search()` alone isn't sufficient (WPCOM reports it `true` on the free Search plan too), so the helper combines it with `! Plan::is_free_plan()` to rule out both the free product slug and the no-plan case.
* Gate `ai-answer/render.php` on the helper — early-return `''` when the gate denies, so saved instances vanish on the front end (no panel scaffold, no `data-wp-interactive` div). Mirrors how WordAds / Premium Content's render callbacks short-circuit on a missing plan.
* Localize `supportsPaidSearch` onto `window.JetpackSearchBlocksConfig` (next to the existing `isWooCommerceBlocksEnabled` flag) so the editor bundle can match the PHP gate.
* In `ai-answer/edit.js`, swap the static preview for a Gutenberg `<Placeholder>` with an "Upgrade Jetpack Search" link to `https://jetpack.com/upgrade/search/?utm_source=ai-answer-block` when `supportsPaidSearch` is false. Hide the InspectorControls in that branch too — no point letting the author tweak attributes on a block that won't render.
* PHP test: seed a paid-plan option in `setUp`, add explicit cases for both the free-plan branch (slug `jetpack_search_free`) and the no-plan branch.
* JS test: cover both editor branches (Placeholder vs preview).
* Keeps the block decoupled from `jetpack_search_ai_answers_enabled` (per SEARCH-217 / cd6e6f6ce9d) — this is a separate, plan-based gate, not a re-coupling to the overlay flag.

## Related product discussion/links

* Linear: [SEARCH-221](https://linear.app/a8c/issue/SEARCH-221/search-blocks-gate-ai-answer-block-behind-paid-search-plan)
* Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586)
* Related context (decoupling commit referenced above): cd6e6f6ce9d "Search: decouple AI Answer block from jetpack_search_ai_answers_enabled (RSM-3608)"

## Does this pull request change what data or activity we track or use?

No.

## Screenshots — editor preview, free plan vs paid plan

Captured against the local docker env at `http://localhost:18080/` (1440×900). Same post, same browser session — only `jetpack_search_plan_info.effective_subscription.product_slug` was flipped between captures.

| Free plan (gate denies) | Paid plan (gate allows) |
|---|---|
| ![free](https://github.com/user-attachments/assets/296eec3c-7786-4896-b94f-2a2f929d5f1f) | ![paid](https://github.com/user-attachments/assets/ad9d6b87-8cb1-44db-bf4c-ea56f49bd422) |

## Verification

Front-end render of the same post:

```bash
# Free / no-paid plan — block contributes nothing to the page:
$ curl -s "$SITE/search-221-ai-answer-gate/" | grep -c "jp-search-answers-panel"
0

# Paid plan — panel scaffold + Interactivity hookup present:
$ curl -s "$SITE/search-221-ai-answer-gate/?_cb=1" | grep -c 'data-wp-interactive="jetpack-search"'
1
```

Plan-helper readout from the live env:

```text
$ wp eval '... supports_paid_search() ...'  # free plan
supports_instant_search: true        # WPCOM says yes on free too
is_free_plan: true
supports_paid_search (helper): false  # combined probe correctly rules it out

# After flipping product_slug to jetpack_search:
supports_paid_search (helper): true
```

Tests:

```text
$ composer phpunit -- --filter Ai_Answer_Render_Test
OK (10 tests, 21 assertions)

$ pnpm jest tests/js/search-blocks/ai-answer-edit.test.jsx
Tests: 9 passed, 9 total
```

## Testing instructions

1. Check out this branch on a Jetpack-connected env. Activate the Jetpack Search plugin if it isn't already.
2. Create a page (or use an existing one) containing the AI Answer block:
   ```
   wp post create --post_type=page --post_status=publish --post_title='AI Answer Gate Test' \
     --post_content='<!-- wp:jetpack-search/ai-answer /-->'
   ```
3. Confirm the site is on the free Search plan (`wp option get jetpack_search_plan_info` should show `effective_subscription.product_slug` of `jetpack_search_free`, or no plan info at all).
4. **Free / no-plan, front end:** visit the published page. The AI Answer block should render nothing — view source and confirm there's no `jp-search-answers-panel` or `data-wp-interactive="jetpack-search"` for the AI Answer block.
5. **Free / no-plan, editor:** open the page in the block editor. The AI Answer block should display a `<Placeholder>` with the label "AI Answer", the message "AI Answer is part of the paid Jetpack Search plan…", and an "Upgrade Jetpack Search" button that links to `https://jetpack.com/upgrade/search/?utm_source=ai-answer-block`. The inspector / sidebar controls for the block should not appear.
6. **Paid plan:** flip the product slug to a paid one and bust any caches:
   ```
   wp eval '$p = get_option("jetpack_search_plan_info"); $p["effective_subscription"]["product_slug"] = "jetpack_search"; update_option("jetpack_search_plan_info", $p);'
   ```
   Reload the front-end page: the AI Answer panel scaffold should render (look for `jp-search-answers-panel` + `data-wp-interactive="jetpack-search"`). Reload the editor: the static preview should be back (AI ANSWER heading, sample body text, sample citations, Show more button) and inspector controls should reappear.
