### PR TITLE
Newsletter: enable the subscriptions module by default

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-module-default-on
+++ b/projects/plugins/jetpack/changelog/update-newsletter-module-default-on
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: enable the subscriptions module by default for all sites

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2719,6 +2719,40 @@ p {
 	}
 
 	/**
+	 * Enables the Newsletter (subscriptions) module for existing sites now that it is a default-on module.
+	 *
+	 * Fresh installs receive the module via its "Auto Activate: Yes" header, so this only handles sites
+	 * upgrading from a version where the module defaulted off. It runs once per site (guarded by the
+	 * subscriptions_default_on_migrated option). After it has run, the user's choice to deactivate the
+	 * module again (for example from the My Jetpack Products page) is respected and never reverted.
+	 *
+	 * The module requires a connection, so on a disconnected site the migration is deferred without setting
+	 * the guard, allowing a later version bump to retry once the site is connected.
+	 *
+	 * @param string       $version     New Jetpack version:timestamp.
+	 * @param string|false $old_version Previous Jetpack version:timestamp, or false on a fresh install.
+	 */
+	public static function activate_subscriptions_module_for_existing_sites( $version, $old_version ) {
+		if ( ! $old_version ) {
+			return;
+		}
+
+		if ( get_option( 'jetpack_subscriptions_default_on_migrated' ) ) {
+			return;
+		}
+
+		if ( ! self::is_connection_ready() ) {
+			return;
+		}
+
+		update_option( 'jetpack_subscriptions_default_on_migrated', true );
+
+		if ( ! self::is_module_active( 'subscriptions' ) ) {
+			self::activate_module( 'subscriptions', false, false );
+		}
+	}
+
+	/**
 	 * Sets the display_update_modal state.
 	 */
 	public static function set_update_modal_display() {

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2723,8 +2723,9 @@ p {
 	 *
 	 * Fresh installs receive the module via its "Auto Activate: Yes" header, so this only handles sites
 	 * upgrading from a version where the module defaulted off. It runs once per site (guarded by the
-	 * subscriptions_default_on_migrated option). After it has run, the user's choice to deactivate the
-	 * module again (for example from the My Jetpack Products page) is respected and never reverted.
+	 * subscriptions_default_on_migrated option). Fresh installs are marked as migrated immediately so the
+	 * migration never runs for them. After it has run, the user's choice to deactivate the module again
+	 * (for example from the My Jetpack Products page) is respected and never reverted.
 	 *
 	 * The module requires a connection, so on a disconnected site the migration is deferred without setting
 	 * the guard, allowing a later version bump to retry once the site is connected.
@@ -2733,11 +2734,14 @@ p {
 	 * @param string|false $old_version Previous Jetpack version:timestamp, or false on a fresh install.
 	 */
 	public static function activate_subscriptions_module_for_existing_sites( $version, $old_version ) {
-		if ( ! $old_version ) {
+		if ( get_option( 'jetpack_subscriptions_default_on_migrated' ) ) {
 			return;
 		}
 
-		if ( get_option( 'jetpack_subscriptions_default_on_migrated' ) ) {
+		// Fresh installs get the module via its "Auto Activate: Yes" header. Mark them as migrated so a
+		// later opt-out is never reverted by the existing-site path on a subsequent version bump.
+		if ( ! $old_version ) {
+			update_option( 'jetpack_subscriptions_default_on_migrated', true );
 			return;
 		}
 
@@ -2745,10 +2749,10 @@ p {
 			return;
 		}
 
-		update_option( 'jetpack_subscriptions_default_on_migrated', true );
-
-		if ( ! self::is_module_active( 'subscriptions' ) ) {
-			self::activate_module( 'subscriptions', false, false );
+		// Mark as migrated only once the module is active, so a transient activation failure is retried on
+		// a later version bump rather than being silently skipped.
+		if ( self::is_module_active( 'subscriptions' ) || self::activate_module( 'subscriptions', false, false ) ) {
+			update_option( 'jetpack_subscriptions_default_on_migrated', true );
 		}
 	}
 

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -80,6 +80,7 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 require_once JETPACK__PLUGIN_DIR . '_inc/blogging-prompts.php';
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
+add_action( 'updating_jetpack_version', array( 'Jetpack', 'activate_subscriptions_module_for_existing_sites' ), 10, 2 );
 add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -7,7 +7,7 @@
  * First Introduced: 1.2
  * Requires Connection: Yes
  * Requires User Connection: Yes
- * Auto Activate: No
+ * Auto Activate: Yes
  * Module Tags: Social
  * Feature: Engagement
  * Additional Search Queries: subscriptions, subscription, email, follow, followers, subscribers, signup, newsletter, creator


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/48530

## Proposed changes
* Flip the Newsletter (`subscriptions`) module's `Auto Activate` header from `No` to `Yes`, so the module is enabled by default on fresh installs via `Jetpack::get_default_modules()`.
* Add a one-shot migration (`Jetpack::activate_subscriptions_module_for_existing_sites()`) hooked on `updating_jetpack_version` that enables the module for existing sites on upgrade.
  * Skips fresh installs (the header already covers those).
  * Guarded by a `jetpack_subscriptions_default_on_migrated` option so it runs at most once per site.
  * Deferred on disconnected sites (the module requires a connection) without setting the guard, so a later version bump retries once the site is connected.
  * Only activates when the module isn't already active.
* After the migration has run, a user deactivating the module again (e.g. from the My Jetpack Products page) is respected and never reverted — `jetpack_active_modules` becomes the single source of truth and nothing re-activates it.

## Related product discussion/links
* This unblocks removing the legacy "Let visitors subscribe to this site…" toggle from the Newsletter dashboard by making the module on-by-default for everyone. (No external link.)

## Does this pull request change what data or activity we track or use?
This does **not** change what data Jetpack itself collects or how. The `subscriptions` module's behavior is unchanged — only its default activation state. That said, because the Newsletter/subscriber feature now becomes active by default on more sites, reviewers may want to confirm whether any support/privacy documentation should be updated to reflect the new default. Flagging for that judgment rather than asserting no review is needed.

## Testing instructions

**Fresh install (default-on):**
* On a fresh, connected Jetpack site, confirm the Newsletter module is active by default — e.g. `wp jetpack module list` shows `subscriptions` active, or My Jetpack → Products shows Newsletter enabled.

**Existing-site migration:**
* On a connected site, deactivate the module: `wp jetpack module deactivate subscriptions` and `wp option delete jetpack_subscriptions_default_on_migrated`.
* Trigger a version bump (e.g. `wp option update jetpack_version "1.0:1"` then load wp-admin, or update the plugin).
* Confirm `subscriptions` is now active and `wp option get jetpack_subscriptions_default_on_migrated` returns `1`.

**Respect explicit off:**
* After the above, deactivate the module again from My Jetpack → Products (or `wp jetpack module deactivate subscriptions`).
* Trigger another version bump and confirm the module stays **off** (the guard option prevents re-activation).

**Disconnected site:**
* On a disconnected site, trigger a version bump and confirm the migration is deferred — `jetpack_subscriptions_default_on_migrated` is **not** set, so it will retry on a later bump once connected.
