### PR TITLE
Search Blocks: address SEARCH-221 review nits (test setter + filter-by-design note)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-221-followup-test-setter
+++ b/projects/packages/search/changelog/SEARCH-221-followup-test-setter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: add `Search_Blocks::set_supports_paid_search_for_testing( ?bool )` and a "no filter by design" note on `supports_paid_search()` to align with the canonical gate pattern in `src/search-blocks/AGENTS.md`. No runtime behavior change.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -322,8 +322,10 @@ class Search_Blocks {
 	/**
 	 * Reset the `supports_paid_search()` memo. Tests only — production
 	 * callers should never need this.
+	 *
+	 * @internal
 	 */
-	public static function reset_supports_paid_search_cache() {
+	public static function reset_supports_paid_search_cache(): void {
 		self::$supports_paid_search_cache = null;
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -288,6 +288,12 @@ class Search_Blocks {
 	 * `supports_instant_search()` still rules out the no-plan / no-Search
 	 * case (which `is_free_plan()` returns false for).
 	 *
+	 * No `apply_filters()` wrapper here by design (cf. the
+	 * `jetpack_search_woocommerce_blocks_enabled` filter on the WC gate).
+	 * This is a paid-feature gate — a filter that any plugin could flip
+	 * would defeat its purpose. Tests bypass the probe via
+	 * `set_supports_paid_search_for_testing()`.
+	 *
 	 * @return bool
 	 */
 	public static function supports_paid_search(): bool {
@@ -296,6 +302,21 @@ class Search_Blocks {
 			self::$supports_paid_search_cache = $plan->supports_instant_search() && ! $plan->is_free_plan();
 		}
 		return self::$supports_paid_search_cache;
+	}
+
+	/**
+	 * Force the `supports_paid_search()` answer to a specific boolean —
+	 * tests only. Pass `null` to clear the override and revive the real
+	 * `Plan` probe (also done by `reset_supports_paid_search_cache()`).
+	 * Mirrors `set_woocommerce_blocks_enabled_for_testing()`, the
+	 * canonical setter pattern documented in `AGENTS.md`.
+	 *
+	 * @internal
+	 *
+	 * @param bool|null $value Forced answer or null to clear.
+	 */
+	public static function set_supports_paid_search_for_testing( ?bool $value ): void {
+		self::$supports_paid_search_cache = $value;
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #49033 — addresses the two nits [claude[bot] flagged](https://github.com/Automattic/jetpack/pull/49033#issuecomment-4504343896) that landed ~5 minutes after the parent PR was merged, so they couldn't ride along.

## Why

Test authors writing new cases against the AI Answer paid-plan gate currently have to know to manipulate `Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY` directly to flip the gate state. That's the same friction `set_woocommerce_blocks_enabled_for_testing()` already removed for the WC gate, and `src/search-blocks/AGENTS.md` names that setter as the canonical pattern. No runtime behavior change — only a testing-API addition and a docblock clarification.

## Proposed changes

* Add `Search_Blocks::set_supports_paid_search_for_testing( ?bool $value )` — mirrors `set_woocommerce_blocks_enabled_for_testing()`. Pass `null` to revive the real `Plan` probe.
* Append a paragraph to the `supports_paid_search()` docblock explaining why this gate — unlike the WC one — intentionally has no `apply_filters()` wrapper: a filter that any plugin could flip would defeat a paid-feature gate. Future contributors won't add one assuming it was an oversight.

## Related product discussion/links

* Parent PR: #49033 (merged)
* Linear: [SEARCH-221](https://linear.app/a8c/issue/SEARCH-221/search-blocks-gate-ai-answer-block-behind-paid-search-plan)
* Originating review comment: [claude[bot] on #49033](https://github.com/Automattic/jetpack/pull/49033#issuecomment-4504343896)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Verify the new setter is reachable and that the existing gate tests still pass:

```bash
cd projects/packages/search

# All AI Answer render tests should still pass — the existing suite
# already exercises both branches of the gate via the option seed.
composer phpunit -- --filter Ai_Answer_Render_Test
# Expected: OK (10 tests, 21 assertions)

# Spot-check the new setter via a one-liner eval:
docker exec jetpack_<agent>-wordpress-1 wp eval '
  Automattic\Jetpack\Search\Search_Blocks::set_supports_paid_search_for_testing( true );
  var_dump( Automattic\Jetpack\Search\Search_Blocks::supports_paid_search() );  // bool(true)
  Automattic\Jetpack\Search\Search_Blocks::set_supports_paid_search_for_testing( false );
  var_dump( Automattic\Jetpack\Search\Search_Blocks::supports_paid_search() );  // bool(false)
  Automattic\Jetpack\Search\Search_Blocks::set_supports_paid_search_for_testing( null );
  var_dump( Automattic\Jetpack\Search\Search_Blocks::supports_paid_search() );  // real probe value
' --allow-root
```

No front-end / editor changes to verify — this PR is API-only.
