### PR TITLE
Newsletter: stage the modernized dashboard rollout across all sites (held at 0%)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Newsletter: Retire the legacy Calypso Subscribers submenu for Automatticians and for the 5% of WordPress.com Simple sites in the modernized dashboard rollout.
+Newsletter: Retire the legacy Calypso Subscribers submenu for Automatticians and for the 5% of WordPress.com sites (Simple and WoA) in the modernized dashboard rollout.

--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Newsletter: retire the legacy Calypso Subscribers submenu now that the modernized dashboard is enabled by default.

--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Newsletter: Retire the legacy Calypso Subscribers submenu for Automatticians and for the 5% of WordPress.com sites (Simple and WoA) in the modernized dashboard rollout.
+Newsletter: Retire the legacy Calypso Subscribers submenu for Automatticians and for the modernized-dashboard percentage cohort (currently 0%, bucketed by the stable wpcom blog ID).

--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Newsletter: retire the legacy Calypso Subscribers submenu for the 5% of WordPress.com Simple sites in the modernized dashboard rollout.
+Newsletter: Retire the legacy Calypso Subscribers submenu for the 5% of WordPress.com Simple sites in the modernized dashboard rollout.

--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Newsletter: retire the legacy Calypso Subscribers submenu now that the modernized dashboard is enabled by default.
+Newsletter: retire the legacy Calypso Subscribers submenu for the 5% of WordPress.com Simple sites in the modernized dashboard rollout.

--- a/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Newsletter: Retire the legacy Calypso Subscribers submenu for the 5% of WordPress.com Simple sites in the modernized dashboard rollout.
+Newsletter: Retire the legacy Calypso Subscribers submenu for Automatticians and for the 5% of WordPress.com Simple sites in the modernized dashboard rollout.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -403,13 +403,15 @@ function wpcom_add_jetpack_submenu() {
 	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally
 	// — ahead of the class_exists-guarded Subscribers_Announcement use below — so
 	// the filter name and the cohort math are inlined rather than referenced from
-	// the class.
+	// the class. Keep $rollout_percentage in sync with
+	// Settings::MODERNIZATION_ROLLOUT_PERCENTAGE.
 	//
 	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
 	// wpcom to avoid a duplicate.
-	$modernization_rollout_default = $is_simple_site && ( (int) $blog_id % 100 ) < 5;
+	$rollout_percentage            = 5;
+	$modernization_rollout_default = $is_simple_site && ( (int) $blog_id % 100 ) < $rollout_percentage;
 	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 		add_submenu_page(
 			'jetpack',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Podcast\Admin_Page as Podcast_Admin_Page;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status\Host;
 
 require_once __DIR__ . '/../../common/wpcom-callout.php';
 
@@ -398,23 +399,33 @@ function wpcom_add_jetpack_submenu() {
 	// package and isn't restored.)
 	//
 	// The filter default is the staged-rollout cohort: on for Automatticians (so
-	// a12s can dogfood and test fixes) and for 5% of WordPress.com Simple sites,
-	// bucketed by blog ID. This mirrors the canonical
-	// Newsletter\Settings::is_modernization_rollout_enabled(); the newsletter
-	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally
-	// — ahead of the class_exists-guarded Subscribers_Announcement use below — so
-	// the filter name, the a11n check, and the cohort math are inlined rather than
-	// referenced from the class. Keep $rollout_percentage in sync with
-	// Settings::MODERNIZATION_ROLLOUT_PERCENTAGE. `is_automattician()` is a
-	// WordPress.com global that only exists on Simple sites.
+	// a12s can dogfood and test fixes) and for 5% of WordPress.com sites — Simple
+	// AND WoA — bucketed by the site's stable wpcom blog ID. This mirrors the
+	// canonical Newsletter\Settings::is_modernization_rollout_enabled(); the
+	// newsletter package isn't a dependency of jetpack-mu-wpcom and this runs
+	// unconditionally — ahead of the class_exists-guarded Subscribers_Announcement
+	// use below — so the filter name, the a11n check, and the cohort math are
+	// inlined rather than referenced from the class. Keep this in sync with
+	// Settings::is_modernization_rollout_enabled() / MODERNIZATION_ROLLOUT_PERCENTAGE.
+	//
+	// The cohort keys on the wpcom platform + wpcom blog ID (current blog ID on
+	// Simple, stored wpcom ID on WoA) rather than the transient `IS_WPCOM` constant,
+	// so a site keeps its cohort decision when it is upgraded from Simple to Atomic
+	// and doesn't lose the modernized experience on transfer. `is_automattician()`
+	// is a WordPress.com global that only exists on Simple sites.
 	//
 	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
 	// wpcom to avoid a duplicate.
 	$rollout_percentage            = 5;
+	$host                          = new Host();
 	$is_automattician              = function_exists( 'is_automattician' ) && is_automattician();
-	$modernization_rollout_default = $is_automattician || ( $is_simple_site && ( (int) $blog_id % 100 ) < $rollout_percentage );
+	$rollout_blog_id               = $host->is_wpcom_simple()
+		? (int) get_current_blog_id()
+		: (int) \Jetpack_Options::get_option( 'id' );
+	$modernization_rollout_default = $is_automattician
+		|| ( $host->is_wpcom_platform() && $rollout_blog_id > 0 && ( $rollout_blog_id % 100 ) < $rollout_percentage );
 	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 		add_submenu_page(
 			'jetpack',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -397,21 +397,24 @@ function wpcom_add_jetpack_submenu() {
 	// subscriber-management variant was removed with the subscribers-dashboard
 	// package and isn't restored.)
 	//
-	// The filter default is the staged-rollout cohort: on for 5% of WordPress.com
-	// Simple sites, bucketed by blog ID. This mirrors the canonical
+	// The filter default is the staged-rollout cohort: on for Automatticians (so
+	// a12s can dogfood and test fixes) and for 5% of WordPress.com Simple sites,
+	// bucketed by blog ID. This mirrors the canonical
 	// Newsletter\Settings::is_modernization_rollout_enabled(); the newsletter
 	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally
 	// — ahead of the class_exists-guarded Subscribers_Announcement use below — so
-	// the filter name and the cohort math are inlined rather than referenced from
-	// the class. Keep $rollout_percentage in sync with
-	// Settings::MODERNIZATION_ROLLOUT_PERCENTAGE.
+	// the filter name, the a11n check, and the cohort math are inlined rather than
+	// referenced from the class. Keep $rollout_percentage in sync with
+	// Settings::MODERNIZATION_ROLLOUT_PERCENTAGE. `is_automattician()` is a
+	// WordPress.com global that only exists on Simple sites.
 	//
 	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
 	// wpcom to avoid a duplicate.
 	$rollout_percentage            = 5;
-	$modernization_rollout_default = $is_simple_site && ( (int) $blog_id % 100 ) < $rollout_percentage;
+	$is_automattician              = function_exists( 'is_automattician' ) && is_automattician();
+	$modernization_rollout_default = $is_automattician || ( $is_simple_site && ( (int) $blog_id % 100 ) < $rollout_percentage );
 	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 		add_submenu_page(
 			'jetpack',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -390,21 +390,27 @@ function wpcom_add_jetpack_submenu() {
 	// Jetpack > Subscribers. Always hide the auto-added Calypso redirect link.
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
 
-	// With the Newsletter modernization filter on (the default), the unified
-	// Newsletter page owns the Subscribers tab and the legacy Calypso "Subscribers"
-	// submenu is retired, replaced by a transitional announcement page that points
-	// there. Hosts that opt out of the filter keep the legacy Calypso submenu.
-	// (The wp-admin subscriber-management variant was removed with the
-	// subscribers-dashboard package and isn't restored.)
+	// When the Newsletter modernization filter is on, the unified Newsletter page
+	// owns the Subscribers tab and the legacy Calypso "Subscribers" submenu is
+	// retired, replaced by a transitional announcement page that points there;
+	// otherwise we keep the legacy Calypso submenu. (The wp-admin
+	// subscriber-management variant was removed with the subscribers-dashboard
+	// package and isn't restored.)
+	//
+	// The filter default is the staged-rollout cohort: on for 5% of WordPress.com
+	// Simple sites, bucketed by blog ID. This mirrors the canonical
+	// Newsletter\Settings::is_modernization_rollout_enabled(); the newsletter
+	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally
+	// — ahead of the class_exists-guarded Subscribers_Announcement use below — so
+	// the filter name and the cohort math are inlined rather than referenced from
+	// the class.
 	//
 	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
-	// wpcom to avoid a duplicate. Referenced as a string literal (mirrors
-	// Newsletter\Settings::MODERNIZATION_FILTER): the newsletter package isn't a
-	// dependency of jetpack-mu-wpcom, and the filter runs unconditionally — ahead
-	// of the class_exists-guarded Subscribers_Announcement use.
-	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
+	// wpcom to avoid a duplicate.
+	$modernization_rollout_default = $is_simple_site && ( (int) $blog_id % 100 ) < 5;
+	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 		add_submenu_page(
 			'jetpack',
 			__( 'Subscribers', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -401,15 +401,17 @@ function wpcom_add_jetpack_submenu() {
 	//
 	// The filter default is the staged-rollout cohort: on for Automatticians (so
 	// a12s can dogfood and test fixes) and for the percentage cohort, bucketed by
-	// the site's stable wpcom blog ID. The percentage is currently 0 — the
-	// Simple-site rollout is driven from the WordPress.com backend instead, and the
-	// number is bumped to open the wider rollout. This mirrors the canonical
+	// the site's stable wpcom blog ID. This mirrors the canonical
 	// Newsletter\Settings::is_modernization_rollout_enabled(); the newsletter
 	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally —
 	// ahead of the class_exists-guarded Subscribers_Announcement use below — so the
-	// filter name, the a11n check, and the cohort math are inlined rather than
-	// referenced from the class. Keep this in sync with
-	// Settings::is_modernization_rollout_enabled() / MODERNIZATION_ROLLOUT_PERCENTAGE.
+	// a11n check and the bucket math are inlined rather than referenced from the
+	// class. The rollout percentage — the one value that moves to widen the rollout —
+	// is read from the canonical MODERNIZATION_ROLLOUT_PERCENTAGE constant when the
+	// newsletter package is loaded (always so on WordPress.com), falling back to 0
+	// otherwise, so there is no second copy of the number to keep in sync. The
+	// percentage is currently 0 — the Simple-site rollout is driven from the
+	// WordPress.com backend instead.
 	//
 	// The cohort keys on the wpcom blog ID (current blog ID on Simple, stored wpcom
 	// ID on WoA) rather than the transient `IS_WPCOM` constant, so a site keeps its
@@ -424,7 +426,9 @@ function wpcom_add_jetpack_submenu() {
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
 	// wpcom to avoid a duplicate.
-	$rollout_percentage            = 0;
+	$rollout_percentage            = defined( '\Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_ROLLOUT_PERCENTAGE' )
+		? (int) constant( '\Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_ROLLOUT_PERCENTAGE' )
+		: 0;
 	$host                          = new Host();
 	$is_automattician              = ( function_exists( 'is_automattician' ) && is_automattician() )
 		|| ( new Visitor() )->is_automattician_feature_flags_only();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Podcast\Admin_Page as Podcast_Admin_Page;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Status\Visitor;
 
 require_once __DIR__ . '/../../common/wpcom-callout.php';
 
@@ -399,33 +400,39 @@ function wpcom_add_jetpack_submenu() {
 	// package and isn't restored.)
 	//
 	// The filter default is the staged-rollout cohort: on for Automatticians (so
-	// a12s can dogfood and test fixes) and for 5% of WordPress.com sites — Simple
-	// AND WoA — bucketed by the site's stable wpcom blog ID. This mirrors the
-	// canonical Newsletter\Settings::is_modernization_rollout_enabled(); the
-	// newsletter package isn't a dependency of jetpack-mu-wpcom and this runs
-	// unconditionally — ahead of the class_exists-guarded Subscribers_Announcement
-	// use below — so the filter name, the a11n check, and the cohort math are
-	// inlined rather than referenced from the class. Keep this in sync with
+	// a12s can dogfood and test fixes) and for the percentage cohort, bucketed by
+	// the site's stable wpcom blog ID. The percentage is currently 0 — the
+	// Simple-site rollout is driven from the WordPress.com backend instead, and the
+	// number is bumped to open the wider rollout. This mirrors the canonical
+	// Newsletter\Settings::is_modernization_rollout_enabled(); the newsletter
+	// package isn't a dependency of jetpack-mu-wpcom and this runs unconditionally —
+	// ahead of the class_exists-guarded Subscribers_Announcement use below — so the
+	// filter name, the a11n check, and the cohort math are inlined rather than
+	// referenced from the class. Keep this in sync with
 	// Settings::is_modernization_rollout_enabled() / MODERNIZATION_ROLLOUT_PERCENTAGE.
 	//
-	// The cohort keys on the wpcom platform + wpcom blog ID (current blog ID on
-	// Simple, stored wpcom ID on WoA) rather than the transient `IS_WPCOM` constant,
-	// so a site keeps its cohort decision when it is upgraded from Simple to Atomic
-	// and doesn't lose the modernized experience on transfer. `is_automattician()`
-	// is a WordPress.com global that only exists on Simple sites.
+	// The cohort keys on the wpcom blog ID (current blog ID on Simple, stored wpcom
+	// ID on WoA) rather than the transient `IS_WPCOM` constant, so a site keeps its
+	// cohort decision when it is upgraded from Simple to Atomic and doesn't lose the
+	// modernized experience on transfer. The a12s check mirrors the canonical helper:
+	// `is_automattician()` is a WordPress.com global that only exists on Simple sites,
+	// so WoA falls back to the proxied-request check. (This mu-plugin only loads on
+	// WordPress.com, so the canonical helper's all-sites percentage gate reduces to
+	// the wpcom-blog-ID bucket here.)
 	//
 	// On WordPress.com (Simple and WoA) this menu is the canonical owner of the
 	// Subscribers entry, so the announcement page is registered here for both
 	// platforms; the standalone plugin's subscriptions module defers to it on
 	// wpcom to avoid a duplicate.
-	$rollout_percentage            = 5;
+	$rollout_percentage            = 0;
 	$host                          = new Host();
-	$is_automattician              = function_exists( 'is_automattician' ) && is_automattician();
+	$is_automattician              = ( function_exists( 'is_automattician' ) && is_automattician() )
+		|| ( new Visitor() )->is_automattician_feature_flags_only();
 	$rollout_blog_id               = $host->is_wpcom_simple()
 		? (int) get_current_blog_id()
 		: (int) \Jetpack_Options::get_option( 'id' );
 	$modernization_rollout_default = $is_automattician
-		|| ( $host->is_wpcom_platform() && $rollout_blog_id > 0 && ( $rollout_blog_id % 100 ) < $rollout_percentage );
+		|| ( $rollout_blog_id > 0 && ( $rollout_blog_id % 100 ) < $rollout_percentage );
 	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 		add_submenu_page(
 			'jetpack',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -390,10 +390,10 @@ function wpcom_add_jetpack_submenu() {
 	// Jetpack > Subscribers. Always hide the auto-added Calypso redirect link.
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
 
-	// Once the Newsletter modernization filter is on, the unified Newsletter
-	// page owns the Subscribers tab and the legacy Calypso "Subscribers" submenu
-	// is retired, replaced by a transitional announcement page that points there.
-	// While the filter is off (the default) we keep the legacy Calypso submenu.
+	// With the Newsletter modernization filter on (the default), the unified
+	// Newsletter page owns the Subscribers tab and the legacy Calypso "Subscribers"
+	// submenu is retired, replaced by a transitional announcement page that points
+	// there. Hosts that opt out of the filter keep the legacy Calypso submenu.
 	// (The wp-admin subscriber-management variant was removed with the
 	// subscribers-dashboard package and isn't restored.)
 	//
@@ -404,7 +404,7 @@ function wpcom_add_jetpack_submenu() {
 	// Newsletter\Settings::MODERNIZATION_FILTER): the newsletter package isn't a
 	// dependency of jetpack-mu-wpcom, and the filter runs unconditionally — ahead
 	// of the class_exists-guarded Subscribers_Announcement use.
-	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
+	if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
 		add_submenu_page(
 			'jetpack',
 			__( 'Subscribers', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-menu/WPCOM_Admin_Menu_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-menu/WPCOM_Admin_Menu_Test.php
@@ -5,7 +5,9 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-menu/wpcom-admin-menu.php';
 
@@ -57,6 +59,100 @@ class WPCOM_Admin_Menu_Test extends \WorDBless\BaseTestCase {
 		$submenu = array();
 
 		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Tear down each test.
+	 *
+	 * Undo the platform constants, Host cache and modernization filter the rollout
+	 * tests set, so they don't leak into the next case. (`jetpack_options['id']` is
+	 * stored in the WorDBless DB, which is reset between tests.)
+	 */
+	public function tear_down() {
+		Constants::clear_single_constant( 'IS_WPCOM' );
+		Status_Cache::clear();
+		remove_all_filters( 'rsm_jetpack_ui_modernization_newsletter' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The Jetpack submenu slug for the legacy Calypso "Subscribers" link, or null when
+	 * it isn't present. `wpcom_add_jetpack_submenu()` registers
+	 * `https://wordpress.com/subscribers/<domain>` while the Newsletter modernization
+	 * gate is off, and retires it once the gate is on.
+	 *
+	 * @return string|null
+	 */
+	private function get_legacy_subscribers_submenu_slug() {
+		global $submenu;
+
+		foreach ( $submenu['jetpack'] ?? array() as $item ) {
+			if ( isset( $item[2] ) && str_starts_with( $item[2], 'https://wordpress.com/subscribers/' ) ) {
+				return $item[2];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * By default — outside the staged-rollout cohort (percentage held at 0%, no
+	 * Automattician) — `wpcom_add_jetpack_submenu()` keeps the legacy Calypso
+	 * "Subscribers" submenu. This drives the non-Simple arm of the inlined cohort
+	 * gate: with no `IS_WPCOM`, the site is bucketed on its stored wpcom blog ID
+	 * (`jetpack_options['id']`), and `200 % 100 = 0` is not `< 0`, so it isn't
+	 * enrolled.
+	 */
+	public function test_jetpack_submenu_keeps_legacy_subscribers_link_by_default_on_non_simple_site() {
+		\Jetpack_Options::update_option( 'id', 200 );
+
+		wpcom_add_jetpack_submenu();
+
+		$this->assertSame(
+			'https://wordpress.com/subscribers/' . self::$domain,
+			$this->get_legacy_subscribers_submenu_slug(),
+			'The legacy Subscribers submenu must remain when the site is outside the rollout cohort.'
+		);
+	}
+
+	/**
+	 * The same default on a WordPress.com Simple site, which buckets on the current
+	 * blog ID rather than the stored option — exercising the Simple arm of the cohort
+	 * gate. `Constants::set_constant` flips `Host::is_wpcom_simple()` without an
+	 * irreversible `define()`; the stored option still satisfies the connection's
+	 * site-ID lookup so the function doesn't bail early.
+	 */
+	public function test_jetpack_submenu_keeps_legacy_subscribers_link_by_default_on_simple_site() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		Status_Cache::clear();
+		\Jetpack_Options::update_option( 'id', 200 );
+
+		wpcom_add_jetpack_submenu();
+
+		$this->assertSame(
+			'https://wordpress.com/subscribers/' . self::$domain,
+			$this->get_legacy_subscribers_submenu_slug(),
+			'A Simple site outside the rollout cohort must keep the legacy Subscribers submenu.'
+		);
+	}
+
+	/**
+	 * When the Newsletter modernization gate is forced on, the unified Newsletter page
+	 * owns the Subscribers tab and the legacy Calypso "Subscribers" submenu is retired.
+	 * (The transitional announcement page is registered by the Newsletter package,
+	 * which isn't a dependency of jetpack-mu-wpcom, so here the link is simply absent.)
+	 */
+	public function test_jetpack_submenu_retires_legacy_subscribers_link_when_modernization_filter_on() {
+		\Jetpack_Options::update_option( 'id', 200 );
+		add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );
+
+		wpcom_add_jetpack_submenu();
+
+		$this->assertNull(
+			$this->get_legacy_subscribers_submenu_slug(),
+			'The legacy Subscribers submenu must be retired when the modernization gate is on.'
+		);
 	}
 
 	/**

--- a/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Enable the modernized Newsletter dashboard by default by defaulting the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters to true.
+Start the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for 5% of WordPress.com Simple sites, bucketed by blog ID.

--- a/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Start the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for Automatticians and for 5% of WordPress.com sites (Simple and WoA), bucketed by the stable wpcom blog ID so the cohort persists across a Simple→Atomic transfer.
+Stage the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for Automatticians and for a percentage cohort of all sites (currently 0%), bucketed by the stable wpcom blog ID so the cohort persists across a Simple→Atomic transfer. The Simple-site rollout is driven separately from the WordPress.com backend.

--- a/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Start the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for 5% of WordPress.com Simple sites, bucketed by blog ID.
+Start the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for Automatticians and for 5% of WordPress.com Simple sites, bucketed by blog ID.

--- a/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Start the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for Automatticians and for 5% of WordPress.com Simple sites, bucketed by blog ID.
+Start the modernized Newsletter dashboard rollout: default the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters on for Automatticians and for 5% of WordPress.com sites (Simple and WoA), bucketed by the stable wpcom blog ID so the cohort persists across a Simple→Atomic transfer.

--- a/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
+++ b/projects/packages/newsletter/changelog/release-newsletter-dashboard-default-on
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable the modernized Newsletter dashboard by default by defaulting the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters to true.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -507,13 +507,23 @@ class Settings {
 	 * installs paired with a wpcom shadow blog) run where `IS_WPCOM` is undefined,
 	 * so `is_wpcom_simple()` is false and they are excluded.
 	 *
-	 * This is only the filter *default*: hosts can still force the experience on or
-	 * off with the `rsm_jetpack_ui_modernization_newsletter` /
+	 * Automatticians get the modernized experience by default regardless of the
+	 * percentage cohort, so a12s can dogfood it and test fixes ahead of the wider
+	 * rollout. `is_automattician()` is a WordPress.com global that only exists on
+	 * Simple sites, so the check naturally no-ops on Atomic/self-hosted.
+	 *
+	 * This is only the filter *default*: hosts (and a11ns who want the legacy view
+	 * back) can still force the experience on or off with the
+	 * `rsm_jetpack_ui_modernization_newsletter` /
 	 * `jetpack_wp_admin_subscriber_management_enabled` filters.
 	 *
 	 * @return bool
 	 */
 	public static function is_modernization_rollout_enabled() {
+		if ( function_exists( 'is_automattician' ) && is_automattician() ) {
+			return true;
+		}
+
 		$host = new Host();
 		if ( ! $host->is_wpcom_simple() ) {
 			return false;

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Status\Visitor;
 use Jetpack_Tracks_Client;
 
 /**
@@ -34,13 +35,20 @@ class Settings {
 	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_newsletter';
 
 	/**
-	 * Percentage of WordPress.com Simple sites the modernized Newsletter
-	 * experience defaults on for during the staged rollout.
+	 * Percentage of sites the modernized Newsletter experience defaults on for
+	 * during the staged rollout.
 	 *
-	 * Sites are bucketed deterministically by their wpcom blog ID, so every
-	 * gate that reads this lands on the same answer for a given site.
+	 * Currently 0: the Simple-site rollout is driven from the WordPress.com backend
+	 * instead (a server-side feature-flag value that can be rolled back instantly),
+	 * so the Jetpack-side cohort is held at zero. The cohort code stays in place for
+	 * Atomic (WoA) and self-hosted Jetpack sites; bumping this single number is the
+	 * one-line change that widens the rollout once the Simple cohort is validated.
+	 * Automatticians get the experience regardless of this percentage.
+	 *
+	 * Sites are bucketed deterministically by their wpcom blog ID, so every gate
+	 * that reads this lands on the same answer for a given site.
 	 */
-	const MODERNIZATION_ROLLOUT_PERCENTAGE = 5;
+	const MODERNIZATION_ROLLOUT_PERCENTAGE = 0;
 
 	/**
 	 * Whether the class has been initialized
@@ -502,21 +510,26 @@ class Settings {
 	 *
 	 * The release is staged: the modernized dashboard, wp-admin subscriber
 	 * management, and the retired Calypso Subscribers submenu all default on for a
-	 * deterministic 5% slice of WordPress.com sites, keyed on the wpcom blog ID.
+	 * deterministic slice of sites, keyed on the wpcom blog ID, plus all
+	 * Automatticians.
 	 *
-	 * The cohort spans both Simple and WoA (Atomic) and is bucketed on the *wpcom*
-	 * blog ID (`get_current_blog_id()` on Simple, `jetpack_options['id']` on WoA),
-	 * which is preserved when a Simple site is upgraded to Atomic. Keying on the
-	 * wpcom platform + wpcom blog ID — rather than the transient `IS_WPCOM`
-	 * constant — means a site keeps its cohort decision across the transfer and does
-	 * not lose the modernized experience on upgrade. Self-hosted/shadow Jetpack
-	 * sites are still excluded: they are neither Simple nor WoA, so
-	 * `is_wpcom_platform()` is false.
+	 * The percentage cohort (see `MODERNIZATION_ROLLOUT_PERCENTAGE`) spans *all*
+	 * sites — Simple, WoA (Atomic) and self-hosted Jetpack — and is bucketed on the
+	 * wpcom blog ID (`get_current_blog_id()` on Simple, `jetpack_options['id']`
+	 * elsewhere), which is preserved when a Simple site is upgraded to Atomic. Keying
+	 * on the wpcom blog ID rather than the transient `IS_WPCOM` constant means a site
+	 * keeps its cohort decision across the transfer. The percentage is currently 0:
+	 * the Simple-site rollout is driven from the WordPress.com backend instead, and
+	 * this gate stays at zero until the wider rollout is opened by bumping the
+	 * constant. A site with no resolvable wpcom blog ID (e.g. a self-hosted Jetpack
+	 * site that isn't connected) is never bucketed in.
 	 *
 	 * Automatticians get the modernized experience by default regardless of the
 	 * percentage cohort, so a12s can dogfood it and test fixes ahead of the wider
-	 * rollout. `is_automattician()` is a WordPress.com global that only exists on
-	 * Simple sites, so the check naturally no-ops on Atomic/self-hosted.
+	 * rollout. This is a dogfooding gate, not an authorization check, so the Simple
+	 * `is_automattician()` global is used without the usual proxied-request pairing;
+	 * Atomic has no non-proxied a12s signal, so it falls back to
+	 * `Visitor::is_automattician_feature_flags_only()` (true for proxied a8c requests).
 	 *
 	 * This is only the filter *default*: hosts (and a11ns who want the legacy view
 	 * back) can still force the experience on or off with the
@@ -526,23 +539,27 @@ class Settings {
 	 * @return bool
 	 */
 	public static function is_modernization_rollout_enabled() {
-		if ( function_exists( 'is_automattician' ) && is_automattician() ) {
+		// Automatticians are enrolled regardless of the percentage cohort so they
+		// can dogfood ahead of the wider rollout. Simple exposes the
+		// `is_automattician()` global; Atomic has no non-proxied a12s signal, so we
+		// fall back to the proxied-request check. (Dogfooding gate, so no
+		// `wpcom_is_proxied_request()` pairing on the Simple branch.)
+		if (
+			( function_exists( 'is_automattician' ) && is_automattician() )
+			|| ( new Visitor() )->is_automattician_feature_flags_only()
+		) {
 			return true;
 		}
 
-		$host = new Host();
-		if ( ! $host->is_wpcom_platform() ) {
-			return false;
-		}
-
 		// Bucket on the wpcom blog ID, which is stable across a Simple→Atomic
-		// transfer: the current blog ID on Simple, the stored wpcom ID on WoA. We
-		// read the WoA ID from Jetpack options directly rather than via
+		// transfer: the current blog ID on Simple, the stored wpcom ID elsewhere. We
+		// read the WoA/Jetpack ID from Jetpack options directly rather than via
 		// `Host::get_wpcom_site_id()`, which additionally requires the Jetpack
 		// connection to be "ready" — that would drop a freshly transferred site out
 		// of the cohort until its connection settles. Guard against an unresolvable
-		// ID so a site without one isn't bucketed as blog ID 0 (`0 % 100 < 5`) and
-		// enrolled by accident.
+		// ID so a site without one isn't bucketed as blog ID 0 and enrolled by
+		// accident once the percentage is non-zero.
+		$host    = new Host();
 		$blog_id = $host->is_wpcom_simple()
 			? (int) get_current_blog_id()
 			: (int) \Jetpack_Options::get_option( 'id' );
@@ -557,8 +574,9 @@ class Settings {
 	 * Returns true when the wp-build modernization filter is enabled.
 	 *
 	 * Defaults to the staged-rollout cohort (see
-	 * `is_modernization_rollout_enabled()`): on for 5% of WordPress.com Simple
-	 * sites, off everywhere else. Hosts can opt in or out explicitly with
+	 * `is_modernization_rollout_enabled()`): on for Automatticians and for the
+	 * percentage cohort (currently 0%), off everywhere else. Hosts can opt in or out
+	 * explicitly with
 	 * `add_filter( self::MODERNIZATION_FILTER, '__return_true' / '__return_false' );`.
 	 *
 	 * @return bool

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -502,10 +502,16 @@ class Settings {
 	 *
 	 * The release is staged: the modernized dashboard, wp-admin subscriber
 	 * management, and the retired Calypso Subscribers submenu all default on for a
-	 * deterministic 5% slice of WordPress.com Simple sites, keyed on the wpcom blog
-	 * ID. Only genuine Simple sites qualify — shadow Jetpack sites (self-hosted
-	 * installs paired with a wpcom shadow blog) run where `IS_WPCOM` is undefined,
-	 * so `is_wpcom_simple()` is false and they are excluded.
+	 * deterministic 5% slice of WordPress.com sites, keyed on the wpcom blog ID.
+	 *
+	 * The cohort spans both Simple and WoA (Atomic) and is bucketed on the *wpcom*
+	 * blog ID (`get_current_blog_id()` on Simple, `jetpack_options['id']` on WoA),
+	 * which is preserved when a Simple site is upgraded to Atomic. Keying on the
+	 * wpcom platform + wpcom blog ID — rather than the transient `IS_WPCOM`
+	 * constant — means a site keeps its cohort decision across the transfer and does
+	 * not lose the modernized experience on upgrade. Self-hosted/shadow Jetpack
+	 * sites are still excluded: they are neither Simple nor WoA, so
+	 * `is_wpcom_platform()` is false.
 	 *
 	 * Automatticians get the modernized experience by default regardless of the
 	 * percentage cohort, so a12s can dogfood it and test fixes ahead of the wider
@@ -525,11 +531,24 @@ class Settings {
 		}
 
 		$host = new Host();
-		if ( ! $host->is_wpcom_simple() ) {
+		if ( ! $host->is_wpcom_platform() ) {
 			return false;
 		}
 
-		$blog_id = (int) $host->get_wpcom_site_id();
+		// Bucket on the wpcom blog ID, which is stable across a Simple→Atomic
+		// transfer: the current blog ID on Simple, the stored wpcom ID on WoA. We
+		// read the WoA ID from Jetpack options directly rather than via
+		// `Host::get_wpcom_site_id()`, which additionally requires the Jetpack
+		// connection to be "ready" — that would drop a freshly transferred site out
+		// of the cohort until its connection settles. Guard against an unresolvable
+		// ID so a site without one isn't bucketed as blog ID 0 (`0 % 100 < 5`) and
+		// enrolled by accident.
+		$blog_id = $host->is_wpcom_simple()
+			? (int) get_current_blog_id()
+			: (int) \Jetpack_Options::get_option( 'id' );
+		if ( $blog_id <= 0 ) {
+			return false;
+		}
 
 		return ( $blog_id % 100 ) < self::MODERNIZATION_ROLLOUT_PERCENTAGE;
 	}

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -34,6 +34,15 @@ class Settings {
 	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_newsletter';
 
 	/**
+	 * Percentage of WordPress.com Simple sites the modernized Newsletter
+	 * experience defaults on for during the staged rollout.
+	 *
+	 * Sites are bucketed deterministically by their wpcom blog ID, so every
+	 * gate that reads this lands on the same answer for a given site.
+	 */
+	const MODERNIZATION_ROLLOUT_PERCENTAGE = 5;
+
+	/**
 	 * Whether the class has been initialized
 	 *
 	 * @var boolean
@@ -269,7 +278,7 @@ class Settings {
 		$is_block_theme         = wp_is_block_theme();
 		$setup_payment_plan_url = ( $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . $site_suffix;
 
-		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true );
+		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', self::is_modernization_rollout_enabled() );
 
 		// Populate blog_id which is needed for API calls on Simple sites.
 		$data['site']['wpcom']['blog_id'] = $blog_id;
@@ -489,16 +498,44 @@ class Settings {
 	}
 
 	/**
+	 * Whether the modernized Newsletter experience should default on for this site.
+	 *
+	 * The release is staged: the modernized dashboard, wp-admin subscriber
+	 * management, and the retired Calypso Subscribers submenu all default on for a
+	 * deterministic 5% slice of WordPress.com Simple sites, keyed on the wpcom blog
+	 * ID. Only genuine Simple sites qualify — shadow Jetpack sites (self-hosted
+	 * installs paired with a wpcom shadow blog) run where `IS_WPCOM` is undefined,
+	 * so `is_wpcom_simple()` is false and they are excluded.
+	 *
+	 * This is only the filter *default*: hosts can still force the experience on or
+	 * off with the `rsm_jetpack_ui_modernization_newsletter` /
+	 * `jetpack_wp_admin_subscriber_management_enabled` filters.
+	 *
+	 * @return bool
+	 */
+	public static function is_modernization_rollout_enabled() {
+		$host = new Host();
+		if ( ! $host->is_wpcom_simple() ) {
+			return false;
+		}
+
+		$blog_id = (int) $host->get_wpcom_site_id();
+
+		return ( $blog_id % 100 ) < self::MODERNIZATION_ROLLOUT_PERCENTAGE;
+	}
+
+	/**
 	 * Returns true when the wp-build modernization filter is enabled.
 	 *
-	 * Defaults to `true`: the modernized Newsletter dashboard is the shipped
-	 * experience. Hosts can opt out with
-	 * `add_filter( self::MODERNIZATION_FILTER, '__return_false' );`.
+	 * Defaults to the staged-rollout cohort (see
+	 * `is_modernization_rollout_enabled()`): on for 5% of WordPress.com Simple
+	 * sites, off everywhere else. Hosts can opt in or out explicitly with
+	 * `add_filter( self::MODERNIZATION_FILTER, '__return_true' / '__return_false' );`.
 	 *
 	 * @return bool
 	 */
 	private static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, self::is_modernization_rollout_enabled() );
 	}
 
 	/**

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -269,7 +269,7 @@ class Settings {
 		$is_block_theme         = wp_is_block_theme();
 		$setup_payment_plan_url = ( $is_wpcom ? 'https://wordpress.com/earn/payments/' : 'https://cloud.jetpack.com/monetize/payments/' ) . $site_suffix;
 
-		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false );
+		$wp_admin_subscriber_management_enabled = apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true );
 
 		// Populate blog_id which is needed for API calls on Simple sites.
 		$data['site']['wpcom']['blog_id'] = $blog_id;
@@ -491,15 +491,14 @@ class Settings {
 	/**
 	 * Returns true when the wp-build modernization filter is enabled.
 	 *
-	 * Defaults to `false`: the modernization prep work ships behind the filter,
-	 * and a separate PR flips the default on so the feature switch lands in
-	 * isolation. Hosts can opt in early with
-	 * `add_filter( self::MODERNIZATION_FILTER, '__return_true' );`.
+	 * Defaults to `true`: the modernized Newsletter dashboard is the shipped
+	 * experience. Hosts can opt out with
+	 * `add_filter( self::MODERNIZATION_FILTER, '__return_false' );`.
 	 *
 	 * @return bool
 	 */
 	private static function is_modernized() {
-		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+		return (bool) apply_filters( self::MODERNIZATION_FILTER, true );
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -166,13 +166,13 @@ class Settings_Test extends BaseTestCase {
 	/**
 	 * `is_modernized()` is the canonical gate used by `maybe_load_wp_build`,
 	 * `add_wp_admin_menu`, and `load_admin_scripts`. Its default — the value
-	 * `apply_filters` receives — must be false; the feature switch lands in a
-	 * separate PR that flips the default on.
+	 * `apply_filters` receives — must be true now that the modernized
+	 * Newsletter dashboard is the shipped experience.
 	 */
-	public function test_is_modernized_defaults_to_false() {
-		$this->assertFalse(
+	public function test_is_modernized_defaults_to_true() {
+		$this->assertTrue(
 			self::call_private_static_is_modernized(),
-			'Modernization gate must default to false until the flag-flip PR lands.'
+			'Modernization gate must default to true now that the dashboard has shipped.'
 		);
 	}
 

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -26,6 +26,9 @@ class Settings_Test extends BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Reset the in-process Host platform cache so per-test constants take effect.
+		\Automattic\Jetpack\Status\Cache::clear();
+
 		// Reset the static initialized flag between tests.
 		$reflection = new \ReflectionClass( Settings::class );
 		$property   = $reflection->getProperty( 'initialized' );
@@ -179,15 +182,96 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The rollout cohort is limited to genuine WordPress.com Simple sites. A
-	 * non-Simple site (no `IS_WPCOM`) — including shadow Jetpack sites — must
-	 * never be enrolled regardless of its blog ID.
+	 * The rollout cohort is limited to genuine WordPress.com sites (Simple or WoA).
+	 * A non-wpcom site (no `IS_WPCOM`, not Atomic) — including shadow/self-hosted
+	 * Jetpack sites — must never be enrolled regardless of its blog ID.
 	 */
-	public function test_rollout_disabled_on_non_wpcom_simple_site() {
+	public function test_rollout_disabled_on_non_wpcom_site() {
 		$this->assertFalse(
 			Settings::is_modernization_rollout_enabled(),
-			'Only WordPress.com Simple sites may enter the modernization rollout cohort.'
+			'Only WordPress.com sites (Simple or WoA) may enter the modernization rollout cohort.'
 		);
+	}
+
+	/**
+	 * Simple sites can be upgraded to Atomic (WoA). The cohort keys on the wpcom
+	 * blog ID, which is preserved across the transfer, so an in-bucket site that had
+	 * the modernized experience on Simple keeps it on WoA — it must not silently
+	 * revert to the legacy dashboard on upgrade.
+	 */
+	public function test_rollout_enabled_for_in_bucket_woa_site() {
+		$this->set_woa_constants();
+		\Jetpack_Options::update_option( 'id', 200 ); // 200 % 100 = 0, in bucket.
+
+		try {
+			$this->assertTrue(
+				Settings::is_modernization_rollout_enabled(),
+				'An in-bucket WoA site (post Simple→Atomic transfer) must stay enrolled in the rollout.'
+			);
+		} finally {
+			$this->clear_woa_constants();
+		}
+	}
+
+	/**
+	 * Including WoA in the cohort must not enroll every Atomic site — only the same
+	 * deterministic blog-ID slice. An out-of-bucket WoA site stays on the legacy
+	 * experience.
+	 */
+	public function test_rollout_disabled_for_out_of_bucket_woa_site() {
+		$this->set_woa_constants();
+		\Jetpack_Options::update_option( 'id', 150 ); // 150 % 100 = 50, out of bucket.
+
+		try {
+			$this->assertFalse(
+				Settings::is_modernization_rollout_enabled(),
+				'An out-of-bucket WoA site must not be enrolled in the rollout.'
+			);
+		} finally {
+			$this->clear_woa_constants();
+		}
+	}
+
+	/**
+	 * On a wpcom site where the wpcom blog ID can't be resolved (e.g. a freshly
+	 * transferred WoA site before its connection settles), the site must not be
+	 * bucketed as blog ID 0 (`0 % 100 < 5`) and enrolled by accident.
+	 */
+	public function test_rollout_disabled_when_wpcom_blog_id_unavailable() {
+		$this->set_woa_constants();
+		\Jetpack_Options::delete_option( 'id' );
+
+		try {
+			$this->assertFalse(
+				Settings::is_modernization_rollout_enabled(),
+				'A wpcom site with no resolvable wpcom blog ID must not be enrolled.'
+			);
+		} finally {
+			$this->clear_woa_constants();
+		}
+	}
+
+	/**
+	 * Mark the environment as a WordPress.com on Atomic (WoA) site: Atomic platform
+	 * constants plus the wpcomsh marker `Host::is_woa_site()` keys on. Clears the
+	 * Host cache so the freshly-set constants are observed.
+	 */
+	private function set_woa_constants() {
+		\Automattic\Jetpack\Constants::set_constant( 'ATOMIC_SITE_ID', 12345 );
+		\Automattic\Jetpack\Constants::set_constant( 'ATOMIC_CLIENT_ID', 70 );
+		\Automattic\Jetpack\Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', '/wpcomsh/wpcomsh.php' );
+		\Automattic\Jetpack\Status\Cache::clear();
+	}
+
+	/**
+	 * Undo `set_woa_constants()` and any wpcom blog ID stored for the WoA scenario.
+	 */
+	private function clear_woa_constants() {
+		\Automattic\Jetpack\Constants::clear_single_constant( 'ATOMIC_SITE_ID' );
+		\Automattic\Jetpack\Constants::clear_single_constant( 'ATOMIC_CLIENT_ID' );
+		\Automattic\Jetpack\Constants::clear_single_constant( 'WPCOMSH__PLUGIN_FILE' );
+		\Automattic\Jetpack\Status\Cache::clear();
+		\Jetpack_Options::delete_option( 'id' );
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -56,6 +56,7 @@ class Settings_Test extends BaseTestCase {
 		( new Connection_Manager() )->reset_connection_status();
 
 		unset( $_GET['page'] );
+		unset( $GLOBALS['jetpack_newsletter_test_is_automattician'] );
 		remove_all_filters( Settings::MODERNIZATION_FILTER );
 		remove_all_filters( 'site_url' );
 		remove_all_filters( 'home_url' );
@@ -204,6 +205,37 @@ class Settings_Test extends BaseTestCase {
 		} finally {
 			\Automattic\Jetpack\Constants::clear_single_constant( 'IS_WPCOM' );
 		}
+	}
+
+	/**
+	 * Automatticians get the modernized experience by default so they can dogfood
+	 * it outside the percentage cohort. `is_automattician()` only exists on
+	 * WordPress.com Simple sites, so this enrolls a11ns regardless of whether the
+	 * site's blog ID falls in the rollout bucket.
+	 */
+	public function test_rollout_enabled_for_automattician() {
+		$GLOBALS['jetpack_newsletter_test_is_automattician'] = true;
+
+		$this->assertTrue(
+			Settings::is_modernization_rollout_enabled(),
+			'Automatticians must be enrolled in the modernization rollout by default.'
+		);
+	}
+
+	/**
+	 * The a11n enrollment is only the filter *default*: an Automattician who wants
+	 * the legacy view back must still be able to force it with `__return_false`,
+	 * so the check has to live in the default fed to `apply_filters`, never as a
+	 * post-filter override.
+	 */
+	public function test_automattician_default_is_still_overridable_by_filter() {
+		$GLOBALS['jetpack_newsletter_test_is_automattician'] = true;
+		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
+
+		$this->assertFalse(
+			self::call_private_static_is_modernized(),
+			'An Automattician must be able to opt back into the legacy view with __return_false.'
+		);
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -166,14 +166,44 @@ class Settings_Test extends BaseTestCase {
 	/**
 	 * `is_modernized()` is the canonical gate used by `maybe_load_wp_build`,
 	 * `add_wp_admin_menu`, and `load_admin_scripts`. Its default — the value
-	 * `apply_filters` receives — must be true now that the modernized
-	 * Newsletter dashboard is the shipped experience.
+	 * `apply_filters` receives — is the staged-rollout cohort. Outside a
+	 * WordPress.com Simple site (the test environment) the cohort is empty, so
+	 * the default must be false.
 	 */
-	public function test_is_modernized_defaults_to_true() {
-		$this->assertTrue(
+	public function test_is_modernized_defaults_to_false_outside_rollout() {
+		$this->assertFalse(
 			self::call_private_static_is_modernized(),
-			'Modernization gate must default to true now that the dashboard has shipped.'
+			'Modernization gate must default to false when the site is not in the rollout cohort.'
 		);
+	}
+
+	/**
+	 * The rollout cohort is limited to genuine WordPress.com Simple sites. A
+	 * non-Simple site (no `IS_WPCOM`) — including shadow Jetpack sites — must
+	 * never be enrolled regardless of its blog ID.
+	 */
+	public function test_rollout_disabled_on_non_wpcom_simple_site() {
+		$this->assertFalse(
+			Settings::is_modernization_rollout_enabled(),
+			'Only WordPress.com Simple sites may enter the modernization rollout cohort.'
+		);
+	}
+
+	/**
+	 * A WordPress.com Simple site whose blog ID falls in the rollout bucket
+	 * (id % 100 < 5) is enrolled. WorDBless reports blog ID 1, which is in-bucket.
+	 */
+	public function test_rollout_enabled_for_in_bucket_wpcom_simple_site() {
+		\Automattic\Jetpack\Constants::set_constant( 'IS_WPCOM', true );
+
+		try {
+			$this->assertTrue(
+				Settings::is_modernization_rollout_enabled(),
+				'An in-bucket WordPress.com Simple site must be enrolled in the rollout cohort.'
+			);
+		} finally {
+			\Automattic\Jetpack\Constants::clear_single_constant( 'IS_WPCOM' );
+		}
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\Newsletter\Tests;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -170,9 +172,9 @@ class Settings_Test extends BaseTestCase {
 	/**
 	 * `is_modernized()` is the canonical gate used by `maybe_load_wp_build`,
 	 * `add_wp_admin_menu`, and `load_admin_scripts`. Its default — the value
-	 * `apply_filters` receives — is the staged-rollout cohort. Outside a
-	 * WordPress.com Simple site (the test environment) the cohort is empty, so
-	 * the default must be false.
+	 * `apply_filters` receives — is the staged-rollout cohort. With the percentage
+	 * cohort held at 0% and no Automattician in the test environment, the default
+	 * must be false.
 	 */
 	public function test_is_modernized_defaults_to_false_outside_rollout() {
 		$this->assertFalse(
@@ -182,31 +184,42 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The rollout cohort is limited to genuine WordPress.com sites (Simple or WoA).
-	 * A non-wpcom site (no `IS_WPCOM`, not Atomic) — including shadow/self-hosted
-	 * Jetpack sites — must never be enrolled regardless of its blog ID.
+	 * The rollout now spans *all* sites: removing the old wpcom-platform gate means a
+	 * self-hosted (non-wpcom) Jetpack site with a resolvable wpcom blog ID enters the
+	 * percentage cohort just like Simple/WoA, bucketed on its stored wpcom ID. At the
+	 * current 0% it is not enrolled; once the percentage is raised it would be, which
+	 * is exactly the "all sites" behavior this asserts against the live constant.
 	 */
-	public function test_rollout_disabled_on_non_wpcom_site() {
-		$this->assertFalse(
-			Settings::is_modernization_rollout_enabled(),
-			'Only WordPress.com sites (Simple or WoA) may enter the modernization rollout cohort.'
-		);
+	public function test_self_hosted_connected_site_bucketed_on_wpcom_id() {
+		\Jetpack_Options::update_option( 'id', 200 ); // Non-wpcom site, but a connected wpcom blog ID.
+
+		try {
+			$this->assertSame(
+				( 200 % 100 ) < Settings::MODERNIZATION_ROLLOUT_PERCENTAGE,
+				Settings::is_modernization_rollout_enabled(),
+				'A self-hosted connected Jetpack site must be bucketed on its wpcom blog ID against the rollout percentage.'
+			);
+		} finally {
+			\Jetpack_Options::delete_option( 'id' );
+		}
 	}
 
 	/**
-	 * Simple sites can be upgraded to Atomic (WoA). The cohort keys on the wpcom
-	 * blog ID, which is preserved across the transfer, so an in-bucket site that had
-	 * the modernized experience on Simple keeps it on WoA — it must not silently
-	 * revert to the legacy dashboard on upgrade.
+	 * Simple sites can be upgraded to Atomic (WoA). The cohort keys on the wpcom blog
+	 * ID, which is preserved across the transfer (read from `jetpack_options['id']` on
+	 * WoA, not the current blog ID), so a site's enrollment decision is identical
+	 * before and after the upgrade — it never silently flips on transfer. Asserted
+	 * against the live percentage so it holds at 0% and after a bump alike.
 	 */
-	public function test_rollout_enabled_for_in_bucket_woa_site() {
+	public function test_woa_site_bucketed_on_stable_wpcom_blog_id() {
 		$this->set_woa_constants();
-		\Jetpack_Options::update_option( 'id', 200 ); // 200 % 100 = 0, in bucket.
+		\Jetpack_Options::update_option( 'id', 200 ); // 200 % 100 = 0.
 
 		try {
-			$this->assertTrue(
+			$this->assertSame(
+				( 200 % 100 ) < Settings::MODERNIZATION_ROLLOUT_PERCENTAGE,
 				Settings::is_modernization_rollout_enabled(),
-				'An in-bucket WoA site (post Simple→Atomic transfer) must stay enrolled in the rollout.'
+				'A WoA site must be bucketed on its stable wpcom blog ID against the rollout percentage.'
 			);
 		} finally {
 			$this->clear_woa_constants();
@@ -214,28 +227,10 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Including WoA in the cohort must not enroll every Atomic site — only the same
-	 * deterministic blog-ID slice. An out-of-bucket WoA site stays on the legacy
-	 * experience.
-	 */
-	public function test_rollout_disabled_for_out_of_bucket_woa_site() {
-		$this->set_woa_constants();
-		\Jetpack_Options::update_option( 'id', 150 ); // 150 % 100 = 50, out of bucket.
-
-		try {
-			$this->assertFalse(
-				Settings::is_modernization_rollout_enabled(),
-				'An out-of-bucket WoA site must not be enrolled in the rollout.'
-			);
-		} finally {
-			$this->clear_woa_constants();
-		}
-	}
-
-	/**
-	 * On a wpcom site where the wpcom blog ID can't be resolved (e.g. a freshly
-	 * transferred WoA site before its connection settles), the site must not be
-	 * bucketed as blog ID 0 (`0 % 100 < 5`) and enrolled by accident.
+	 * On a site where the wpcom blog ID can't be resolved (e.g. a freshly transferred
+	 * WoA site before its connection settles, or a disconnected self-hosted site), the
+	 * site must not be bucketed as blog ID 0 and enrolled by accident once the
+	 * percentage is non-zero. This holds regardless of the percentage.
 	 */
 	public function test_rollout_disabled_when_wpcom_blog_id_unavailable() {
 		$this->set_woa_constants();
@@ -244,7 +239,7 @@ class Settings_Test extends BaseTestCase {
 		try {
 			$this->assertFalse(
 				Settings::is_modernization_rollout_enabled(),
-				'A wpcom site with no resolvable wpcom blog ID must not be enrolled.'
+				'A site with no resolvable wpcom blog ID must not be enrolled.'
 			);
 		} finally {
 			$this->clear_woa_constants();
@@ -275,16 +270,19 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A WordPress.com Simple site whose blog ID falls in the rollout bucket
-	 * (id % 100 < 5) is enrolled. WorDBless reports blog ID 1, which is in-bucket.
+	 * A WordPress.com Simple site is bucketed on its current blog ID (not the stored
+	 * `jetpack_options['id']`). WorDBless reports blog ID 1, so this verifies the
+	 * Simple branch feeds the right ID into the bucket math. Asserted against the live
+	 * percentage so it holds at 0% and after a bump alike.
 	 */
-	public function test_rollout_enabled_for_in_bucket_wpcom_simple_site() {
+	public function test_wpcom_simple_site_bucketed_on_current_blog_id() {
 		\Automattic\Jetpack\Constants::set_constant( 'IS_WPCOM', true );
 
 		try {
-			$this->assertTrue(
+			$this->assertSame(
+				( (int) get_current_blog_id() % 100 ) < Settings::MODERNIZATION_ROLLOUT_PERCENTAGE,
 				Settings::is_modernization_rollout_enabled(),
-				'An in-bucket WordPress.com Simple site must be enrolled in the rollout cohort.'
+				'A WordPress.com Simple site must be bucketed on its current blog ID against the rollout percentage.'
 			);
 		} finally {
 			\Automattic\Jetpack\Constants::clear_single_constant( 'IS_WPCOM' );
@@ -292,10 +290,11 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Automatticians get the modernized experience by default so they can dogfood
-	 * it outside the percentage cohort. `is_automattician()` only exists on
-	 * WordPress.com Simple sites, so this enrolls a11ns regardless of whether the
-	 * site's blog ID falls in the rollout bucket.
+	 * Automatticians get the modernized experience by default so they can dogfood it
+	 * outside the percentage cohort. On Simple this rides the `is_automattician()`
+	 * global, which enrolls a11ns regardless of whether the site's blog ID falls in
+	 * the percentage bucket — the only path that enrolls anyone while the percentage
+	 * is held at 0%.
 	 */
 	public function test_rollout_enabled_for_automattician() {
 		$GLOBALS['jetpack_newsletter_test_is_automattician'] = true;
@@ -303,6 +302,28 @@ class Settings_Test extends BaseTestCase {
 		$this->assertTrue(
 			Settings::is_modernization_rollout_enabled(),
 			'Automatticians must be enrolled in the modernization rollout by default.'
+		);
+	}
+
+	/**
+	 * On Atomic (WoA) the `is_automattician()` global does not exist, so the a12s
+	 * carve-out falls back to `Visitor::is_automattician_feature_flags_only()`
+	 * (`AT_PROXIED_REQUEST`). A proxied a8c request must therefore be enrolled even
+	 * though no Simple a11n global is present and the percentage is 0%. Runs in a
+	 * separate process because `AT_PROXIED_REQUEST` can only be set with a real
+	 * `define()`, which would otherwise leak into every later test.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_rollout_enabled_for_atomic_proxied_automattician() {
+		define( 'AT_PROXIED_REQUEST', true );
+
+		$this->assertTrue(
+			Settings::is_modernization_rollout_enabled(),
+			'A proxied Automattician request on Atomic must be enrolled via the Visitor fallback.'
 		);
 	}
 

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -10,8 +10,6 @@ namespace Automattic\Jetpack\Newsletter\Tests;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -295,6 +293,15 @@ class Settings_Test extends BaseTestCase {
 	 * global, which enrolls a11ns regardless of whether the site's blog ID falls in
 	 * the percentage bucket — the only path that enrolls anyone while the percentage
 	 * is held at 0%.
+	 *
+	 * The Atomic half of the carve-out — `Visitor::is_automattician_feature_flags_only()`,
+	 * driven by `AT_PROXIED_REQUEST` — is intentionally not given a dedicated test: its
+	 * *true* path is `Visitor`'s own contract (covered in the jetpack-status package), and
+	 * setting `AT_PROXIED_REQUEST` requires an irreversible `define()` that would need
+	 * `@runInSeparateProcess` (which trips a PHP 7.x WP-core bootstrap warning under
+	 * `failOnWarning`). Its *false* path — that the `Visitor` call is wired in and doesn't
+	 * fatal — is already exercised by every non-a11n cohort test below, where the `||`
+	 * does not short-circuit and so evaluates the `Visitor` branch.
 	 */
 	public function test_rollout_enabled_for_automattician() {
 		$GLOBALS['jetpack_newsletter_test_is_automattician'] = true;
@@ -302,28 +309,6 @@ class Settings_Test extends BaseTestCase {
 		$this->assertTrue(
 			Settings::is_modernization_rollout_enabled(),
 			'Automatticians must be enrolled in the modernization rollout by default.'
-		);
-	}
-
-	/**
-	 * On Atomic (WoA) the `is_automattician()` global does not exist, so the a12s
-	 * carve-out falls back to `Visitor::is_automattician_feature_flags_only()`
-	 * (`AT_PROXIED_REQUEST`). A proxied a8c request must therefore be enrolled even
-	 * though no Simple a11n global is present and the percentage is 0%. Runs in a
-	 * separate process because `AT_PROXIED_REQUEST` can only be set with a real
-	 * `define()`, which would otherwise leak into every later test.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_rollout_enabled_for_atomic_proxied_automattician() {
-		define( 'AT_PROXIED_REQUEST', true );
-
-		$this->assertTrue(
-			Settings::is_modernization_rollout_enabled(),
-			'A proxied Automattician request on Atomic must be enrolled via the Visitor fallback.'
 		);
 	}
 

--- a/projects/packages/newsletter/tests/php/bootstrap.php
+++ b/projects/packages/newsletter/tests/php/bootstrap.php
@@ -13,3 +13,19 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 define( 'WP_DEBUG', true );
 
 \Automattic\Jetpack\Test_Environment::init();
+
+if ( ! function_exists( 'is_automattician' ) ) {
+	/**
+	 * Test stub for the WordPress.com-global `is_automattician()`, which only
+	 * exists on Simple sites and is therefore absent from the package test
+	 * runtime. Tests toggle the return value per case via the
+	 * `$GLOBALS['jetpack_newsletter_test_is_automattician']` flag (defaults to
+	 * false), and reset it in tear down so the stub stays inert elsewhere.
+	 *
+	 * @param int|false $user_id Unused; mirrors the wpcom signature.
+	 * @return bool
+	 */
+	function is_automattician( $user_id = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- mirrors the wpcom global signature.
+		return ! empty( $GLOBALS['jetpack_newsletter_test_is_automattician'] );
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -247,7 +247,7 @@ class Jetpack_Redux_State_Helper {
 			'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
 			'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),
 			/* This filter is already documented in jetpack/modules/subscriptions.php */
-			'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ),
+			'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true ),
 		);
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -246,8 +246,18 @@ class Jetpack_Redux_State_Helper {
 			'isSubscriptionSiteEnabled'            => apply_filters( 'jetpack_subscription_site_enabled', false ),
 			'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
 			'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),
-			/* This filter is already documented in jetpack/modules/subscriptions.php */
-			'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true ),
+
+			/*
+			 * This filter is already documented in jetpack/modules/subscriptions.php.
+			 * Default is the staged rollout (5% of WordPress.com Simple sites, by blog
+			 * ID), delegated to the canonical Newsletter\Settings helper and guarded so
+			 * an older packaged copy can't fatal.
+			 */
+			'isWpAdminSubscriberManagementEnabled' => apply_filters(
+				'jetpack_wp_admin_subscriber_management_enabled',
+				method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
+					&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled()
+			),
 		);
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -249,9 +249,10 @@ class Jetpack_Redux_State_Helper {
 
 			/*
 			 * This filter is already documented in jetpack/modules/subscriptions.php.
-			 * Default is the staged rollout (5% of WordPress.com Simple sites, by blog
-			 * ID), delegated to the canonical Newsletter\Settings helper and guarded so
-			 * an older packaged copy can't fatal.
+			 * Default is the staged rollout (Automatticians plus the percentage cohort,
+			 * currently 0%, bucketed by the stable wpcom blog ID), delegated to the
+			 * canonical Newsletter\Settings helper and guarded so an older packaged copy
+			 * can't fatal.
 			 */
 			'isWpAdminSubscriberManagementEnabled' => apply_filters(
 				'jetpack_wp_admin_subscriber_management_enabled',

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -43,7 +43,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * `rest_api_init`, so theme-added filters have a chance to land before the gate evaluates.
 	 */
 	public function register_routes() {
-		if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
+		if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -41,9 +41,15 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * Gated behind the same `rsm_jetpack_ui_modernization_newsletter` filter the dashboard UI uses
 	 * (mirrors `Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_FILTER`). Checked here, on
 	 * `rest_api_init`, so theme-added filters have a chance to land before the gate evaluates.
+	 *
+	 * The filter default is the staged rollout (5% of WordPress.com Simple sites, by blog ID),
+	 * delegated to the canonical Newsletter\Settings helper and guarded so an older packaged copy
+	 * can't fatal.
 	 */
 	public function register_routes() {
-		if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
+		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
+			&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled();
+		if ( ! apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -42,9 +42,9 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * (mirrors `Automattic\Jetpack\Newsletter\Settings::MODERNIZATION_FILTER`). Checked here, on
 	 * `rest_api_init`, so theme-added filters have a chance to land before the gate evaluates.
 	 *
-	 * The filter default is the staged rollout (5% of WordPress.com Simple sites, by blog ID),
-	 * delegated to the canonical Newsletter\Settings helper and guarded so an older packaged copy
-	 * can't fatal.
+	 * The filter default is the staged rollout (Automatticians plus the percentage cohort,
+	 * currently 0%, bucketed by the stable wpcom blog ID), delegated to the canonical
+	 * Newsletter\Settings helper and guarded so an older packaged copy can't fatal.
 	 */
 	public function register_routes() {
 		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: roll out the modernized Newsletter dashboard and wp-admin subscriber management to 5% of WordPress.com Simple sites, bucketed by blog ID.
+Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to 5% of WordPress.com Simple sites, bucketed by blog ID.

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to Automatticians and to a percentage cohort of all sites (currently 0%), bucketed by the stable wpcom blog ID.
+Newsletter: Begin a staged rollout of the modernized Newsletter dashboard and wp-admin subscriber management, off by default during the initial rollout. Hosts can opt in or out with the rsm_jetpack_ui_modernization_newsletter and jetpack_wp_admin_subscriber_management_enabled filters.

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to Automatticians and to 5% of WordPress.com Simple sites, bucketed by blog ID.
+Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to Automatticians and to 5% of WordPress.com sites (Simple and WoA), bucketed by the stable wpcom blog ID.

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: enable the modernized Newsletter dashboard and wp-admin subscriber management by default.

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to 5% of WordPress.com Simple sites, bucketed by blog ID.
+Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to Automatticians and to 5% of WordPress.com Simple sites, bucketed by blog ID.

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: enable the modernized Newsletter dashboard and wp-admin subscriber management by default.
+Newsletter: roll out the modernized Newsletter dashboard and wp-admin subscriber management to 5% of WordPress.com Simple sites, bucketed by blog ID.

--- a/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
+++ b/projects/plugins/jetpack/changelog/release-newsletter-dashboard-default-on
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to Automatticians and to 5% of WordPress.com sites (Simple and WoA), bucketed by the stable wpcom blog ID.
+Newsletter: Roll out the modernized Newsletter dashboard and wp-admin subscriber management to Automatticians and to a percentage cohort of all sites (currently 0%), bucketed by the stable wpcom blog ID.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1035,8 +1035,8 @@ class Jetpack_Subscriptions {
 		 * Delegated to the canonical Newsletter\Settings::is_modernization_rollout_enabled()
 		 * so the cohort math has a single source of truth; guarded with method_exists so
 		 * this bootstrap path stays safe if the packaged Newsletter Settings class is an
-		 * older copy that doesn't expose the helper yet. The Jetpack plugin only runs on
-		 * self-hosted/Atomic sites, so in practice this evaluates to false here.
+		 * older copy that doesn't expose the helper yet. The helper returns true only for
+		 * cohort WordPress.com Simple sites, so it is false in every other context.
 		 */
 		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
 			&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled();
@@ -1097,7 +1097,8 @@ class Jetpack_Subscriptions {
 		 *
 		 * @since 9.5.0
 		 *
-		 * @param bool If the new dashboard is enabled. Default false.
+		 * @param bool If the new dashboard is enabled. Defaults to the staged-rollout
+		 *             cohort: true for 5% of WordPress.com Simple sites, false elsewhere.
 		 */
 		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', $modernization_rollout_default ) ) {
 			return;

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1030,6 +1030,18 @@ class Jetpack_Subscriptions {
 	 */
 	public function add_subscribers_menu() {
 		/*
+		 * Staged-rollout default for both modernization filters: on for 5% of
+		 * WordPress.com Simple sites (bucketed by blog ID), off everywhere else.
+		 * Delegated to the canonical Newsletter\Settings::is_modernization_rollout_enabled()
+		 * so the cohort math has a single source of truth; guarded with method_exists so
+		 * this bootstrap path stays safe if the packaged Newsletter Settings class is an
+		 * older copy that doesn't expose the helper yet. The Jetpack plugin only runs on
+		 * self-hosted/Atomic sites, so in practice this evaluates to false here.
+		 */
+		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
+			&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled();
+
+		/*
 		 * Once the Newsletter modernization filter is on, the unified Newsletter
 		 * page owns the Subscribers tab and this standalone Calypso shortcut is
 		 * retired. In its place, a transitional announcement page tells people
@@ -1049,7 +1061,7 @@ class Jetpack_Subscriptions {
 		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
 		 * not expose the constant yet.
 		 */
-		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
+		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', $modernization_rollout_default ) ) {
 			if (
 				! ( new Host() )->is_wpcom_platform()
 				&& class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' )
@@ -1087,7 +1099,7 @@ class Jetpack_Subscriptions {
 		 *
 		 * @param bool If the new dashboard is enabled. Default false.
 		 */
-		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', $modernization_rollout_default ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1049,7 +1049,7 @@ class Jetpack_Subscriptions {
 		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
 		 * not expose the constant yet.
 		 */
-		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
+		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', true ) ) {
 			if (
 				! ( new Host() )->is_wpcom_platform()
 				&& class_exists( '\Automattic\Jetpack\Newsletter\Subscribers_Announcement' )
@@ -1087,7 +1087,7 @@ class Jetpack_Subscriptions {
 		 *
 		 * @param bool If the new dashboard is enabled. Default false.
 		 */
-		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', true ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1030,13 +1030,13 @@ class Jetpack_Subscriptions {
 	 */
 	public function add_subscribers_menu() {
 		/*
-		 * Staged-rollout default for both modernization filters: on for 5% of
-		 * WordPress.com Simple sites (bucketed by blog ID), off everywhere else.
-		 * Delegated to the canonical Newsletter\Settings::is_modernization_rollout_enabled()
-		 * so the cohort math has a single source of truth; guarded with method_exists so
-		 * this bootstrap path stays safe if the packaged Newsletter Settings class is an
-		 * older copy that doesn't expose the helper yet. The helper returns true only for
-		 * cohort WordPress.com Simple sites, so it is false in every other context.
+		 * Staged-rollout default for both modernization filters: on for
+		 * Automatticians and for the percentage cohort (currently 0%, bucketed by
+		 * the stable wpcom blog ID), off everywhere else. Delegated to the canonical
+		 * Newsletter\Settings::is_modernization_rollout_enabled() so the cohort math
+		 * has a single source of truth; guarded with method_exists so this bootstrap
+		 * path stays safe if the packaged Newsletter Settings class is an older copy
+		 * that doesn't expose the helper yet.
 		 */
 		$modernization_rollout_default = method_exists( '\Automattic\Jetpack\Newsletter\Settings', 'is_modernization_rollout_enabled' )
 			&& \Automattic\Jetpack\Newsletter\Settings::is_modernization_rollout_enabled();
@@ -1098,7 +1098,8 @@ class Jetpack_Subscriptions {
 		 * @since 9.5.0
 		 *
 		 * @param bool If the new dashboard is enabled. Defaults to the staged-rollout
-		 *             cohort: true for 5% of WordPress.com Simple sites, false elsewhere.
+		 *             cohort: true for Automatticians and the percentage cohort
+		 *             (currently 0%), false elsewhere.
 		 */
 		if ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', $modernization_rollout_default ) ) {
 			return;


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/48530

## Proposed changes
* Begin a **staged rollout** of the modernized Newsletter wp-admin experience. Instead of flipping the feature on globally, the two feature filters now **default** to a deterministic cohort: **on for Automatticians** (so a12s can dogfood ahead of the wider rollout) and **on for a percentage slice of all sites** — currently **0%**, so off for everyone else.
  * **The Simple-site rollout is driven separately from the WordPress.com backend** (a server-side feature-flag value that can be rolled back instantly). This PR's Jetpack-side gate is therefore held at **0%** and stays in place to cover **Atomic (WoA) and self-hosted Jetpack** sites; once the wpcom-driven Simple cohort is validated, the Jetpack-side rollout widens by bumping a single constant.
  * The percentage cohort now spans **all** sites — Simple, WoA, and self-hosted Jetpack — bucketed on the **stable wpcom blog ID** (`get_current_blog_id()` on Simple, `Jetpack_Options['id']` elsewhere), which is preserved when a Simple site is upgraded to Atomic, so a site keeps its cohort decision across the transfer. A site with no resolvable wpcom blog ID (e.g. a disconnected self-hosted install) is never enrolled.
  * The **Automattician** carve-out is cross-platform and independent of the percentage: `is_automattician()` on Simple (no `wpcom_is_proxied_request()` pairing — this is a dogfooding gate, not authorization), falling back to `Visitor::is_automattician_feature_flags_only()` on Atomic (true for proxied a8c requests).
  * `rsm_jetpack_ui_modernization_newsletter` — the canonical gate for the wp-build Newsletter dashboard. The cohort default is applied in `Newsletter\Settings::is_modernized()`, the `wpcom/v2/subscribers/*` REST route registration, the `subscriptions` module menu, and the jetpack-mu-wpcom admin menu (the legacy Calypso "Subscribers" submenu is retired for the cohort).
  * `jetpack_wp_admin_subscriber_management_enabled` — the cohort default is applied in the Newsletter script data, the `subscriptions` module menu, and the Jetpack Redux state.
* The cohort math lives canonically in `Newsletter\Settings::is_modernization_rollout_enabled()` (with a `MODERNIZATION_ROLLOUT_PERCENTAGE` constant). Jetpack-plugin call sites delegate to it (guarded with `method_exists` so an older packaged copy can't fatal); jetpack-mu-wpcom mirrors the math inline since it can't depend on the newsletter package.
* Hosts can still force the experience on or off with `add_filter( '<flag>', '__return_true' / '__return_false' )`.
* Updated the related docblocks/comments, the changelog entries, and the PHP tests. Cohort tests are asserted against the `MODERNIZATION_ROLLOUT_PERCENTAGE` constant so a future bump needs no test changes; a separate-process test covers the new Atomic a12s branch.
* The Backup, VideoPress, and Scan `MODERNIZATION_FILTER` constants are separate flags and are intentionally untouched.

To widen the rollout later, bump `MODERNIZATION_ROLLOUT_PERCENTAGE` (and the mirrored value in `wpcom-admin-menu.php`); at 100% the scaffolding can be removed in favor of a plain `true` default.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* As an **Automattician**, go to **Jetpack → Newsletter** in wp-admin (on a Simple or proxied Atomic site) and confirm the modernized wp-build dashboard loads with the Subscribers / Settings tabs (rather than the legacy Settings-only screen), and that the standalone Calypso **Jetpack → Subscribers** submenu is gone.
* In that same a12s context, confirm `GET /wpcom/v2/subscribers/list` is registered (returns a `401`/data response, not `rest_no_route`).
* As a **non-Automattician** on any site, confirm the legacy experience is unchanged — the percentage cohort is currently 0%, so nobody is enrolled by the bucket.
* To preview the cohort path, temporarily bump `MODERNIZATION_ROLLOUT_PERCENTAGE` (or force `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_true' );`); `'__return_false'` confirms the opt-out still wins over the default.
* Confirm a Simple→Atomic (WoA) transfer keeps the same cohort decision, since both platforms bucket on the same stable wpcom blog ID.
