### PR TITLE
Search Blocks: release publicly — drop jetpack_search_blocks_enabled filter gate

### DIFF
--- a/projects/packages/search/changelog/SEARCH-222-ga-search-blocks
+++ b/projects/packages/search/changelog/SEARCH-222-ga-search-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: enable by default — flip the `jetpack_search_blocks_enabled` filter default to true so every connected, Search-supported site gets the new Interactivity-API blocks. The filter is retained as a kill-switch (return false to opt out).

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -162,9 +162,9 @@ class Initializer {
 		 * requires the site to be connected and on a plan that supports
 		 * Search (paid plans or the free `jetpack_search_free` product).
 		 *
-		 * @param bool $enabled Default false.
+		 * @param bool $enabled Default true.
 		 */
-		if ( ! apply_filters( 'jetpack_search_blocks_enabled', false ) ) {
+		if ( ! apply_filters( 'jetpack_search_blocks_enabled', true ) ) {
 			return;
 		}
 

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -79,7 +79,10 @@ class Initializer_Test extends Search_TestCase {
 	}
 
 	public function test_init_search_blocks_does_not_register_when_feature_flag_off() {
-		// Feature flag defaults to false — no filter registered.
+		// The flag defaults to true, so opt out explicitly to exercise the
+		// kill-switch path.
+		add_filter( 'jetpack_search_blocks_enabled', '__return_false' );
+
 		$this->invoke_init_search_blocks();
 
 		$this->assertFalse(
@@ -96,7 +99,9 @@ class Initializer_Test extends Search_TestCase {
 		// false when the blocks gate is off, regardless of the overlay
 		// filter.
 		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
-		// `jetpack_search_blocks_enabled` defaults false — not registered.
+		// The flag defaults to true, so opt out explicitly to keep the
+		// blocks gate off for this carve-out check.
+		add_filter( 'jetpack_search_blocks_enabled', '__return_false' );
 
 		$this->invoke_init_search_blocks();
 


### PR DESCRIPTION
Fixes [SEARCH-222](https://linear.app/a8c/issue/SEARCH-222/search-blocks-release-publicly-drop-jetpack-search-blocks-enabled)

## Why

Phase 1 shipped the Interactivity-API Search blocks (Embedded search page, Overlay blocks, AI Answer, filter-checkbox / filter-date / filter-post-type, results region, etc.) behind the `jetpack_search_blocks_enabled` opt-in filter so we could land the surface incrementally. Enough polish has merged — Overlay-blocks experience, AI Answer plan gating, filter-checkbox retention cap, podcast/iTunes metadata, third-party form interception, theme button styling, free-tier counting fix — to flip the default on. Connection + Search-plan are already enforced upstream in `Initializer::init()`, so removing the feature flag layer lets every supported site see the new Experience Selector and Search blocks without a manual opt-in.

WooCommerce-only blocks stay opt-in: `Search_Blocks::woocommerce_blocks_enabled()` (filterable via `jetpack_search_woocommerce_blocks_enabled`) is untouched, and `init_search_blocks()` still defaults that filter to `false` for non-Woo sites.

## Proposed changes

- Drop the `apply_filters( 'jetpack_search_blocks_enabled', false )` early-return in `Initializer::init_search_blocks()`; blocks now register unconditionally once the connection + plan abort has passed.
- Drop `searchBlocksEnabled` from the dashboard `Initial_State` payload and the matching `isSearchBlocksEnabled` Redux selector.
- Remove the dashboard's legacy `<ModuleControl>` render branch and its now-dead supporting selectors (`isModuleEnabled`, `isTogglingModule`, `isTogglingInstantSearch`, `isInstantSearchPromotionActive`, `supportsSearch`); the Settings tab always renders `<ExperienceSelector>` plus Reader Chat, AI Agent Access, Search Suggestions, and the WooCommerce template-override controls.
- Always include the Jetpack Search blocks rows in the upsell pricing table.
- Update PHP + JS test suites to remove the gate-off / gate-on matrix; keep the WooCommerce default-off assertion and the overlay-blocks gating tests.
- Refresh inline docblocks that referenced the removed gate.

The `<ModuleControl>` component file is kept in place so a revert remains a single-PR change; it's just no longer rendered.

## Related product discussion/links

* [SEARCH-222](https://linear.app/a8c/issue/SEARCH-222/search-blocks-release-publicly-drop-jetpack-search-blocks-enabled)
* Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586)

## Does this pull request change what data or activity we track or use?

No. No new tracking events, REST endpoints, or stored options. The same `jetpack_search_experience_save` event already used by the Experience Selector now fires for every site instead of only opted-in ones.

## Testing instructions

### Golden path — non-Woo site

* Connect a Jetpack site on a Search-supported plan (paid plan or the free `jetpack_search_free` product).
* Do **not** register `add_filter( 'jetpack_search_blocks_enabled', '__return_true' )`.
* Visit *Jetpack → Search → Settings*. The tab now renders the **Experience Selector** with Embedded / Overlay / Inline / Off cards (see screenshots below), not the legacy two-toggle ModuleControl.
* Switch experiences and confirm the saved value sticks across reloads.
* Open the block editor and confirm the Jetpack Search blocks (search-input, filter-checkbox, filter-date, search-results, results-list, …) appear in the inserter without any extra opt-in.
* Visit *Jetpack → Search → Plan & Usage*. The free / paid pricing table shows the "Jetpack Search blocks" and "Embedded search page" rows in both columns.

### WooCommerce blocks remain gated

* On a non-Woo site, confirm that `filter-wc-attribute`, `filter-wc-price`, `filter-wc-rating`, `filter-wc-stock-status`, and `filters-product` do **not** appear in the block inserter (`Search_Blocks::woocommerce_blocks_enabled()` resolves to `false`).
* On a Woo site that re-enables the gate: `add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_true' );` — the WC-only blocks appear and the dashboard surfaces the WooCommerce Product Search control under the Embedded / Inline experiences.

### Test suites

* From `projects/packages/search`:
  * `composer phpunit` — 14 PHP tests pass (Initializer gate / overlay paths + Initial_State payload shape + WC default-off).
  * `pnpm run test` — 1,506 JS tests + size-limit checks pass.

## Screenshots

Captured at `/wp-admin/admin.php?page=jetpack-search&tab=settings` on the per-agent docker WP env at 1440×900. The "Before" image was captured against trunk with no opt-in filter present (simulating a real production site today); the "After" image is from this branch.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/fc95ed1f-43a0-473a-8a6e-e13752e86841) | ![after](https://github.com/user-attachments/assets/18313a4d-ad9f-46f2-9248-2c3d7b0a8e27) |
