### PR TITLE
Search: store foundation for static-filter URL contract (SEARCH-219, 1/3)

### DIFF
--- a/projects/packages/search/changelog/search-219-store-static-filter-foundation
+++ b/projects/packages/search/changelog/search-219-store-static-filter-foundation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: internal — store now recognizes a `kind: 'static'` flag on `filterConfigs` entries to round-trip single-select selections through scalar `?filter_id=value` URL params (sibling of the `priceRange` state slice). Foundation for the upcoming `jetpack-search/filter-static` block; no user-visible change on its own.

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -471,6 +471,29 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 	return must.length ? { bool: { must } } : undefined;
 }
 
+/**
+ * Build ES `term` clauses for the single-select static filters contributed by
+ * `jetpack-search/filter-static`. Static filters target a flat field whose
+ * name equals the filter key — i.e., the `filter_id` from the host site's
+ * `jetpack_search_static_filters` registration is used directly as the ES
+ * field name. Mirrors the legacy instant-search overlay's static-filter
+ * behavior at src/instant-search/store/effects.js:176-187.
+ *
+ * @param {object} selections    - { [filterKey]: string } single-select values.
+ * @param {object} filterConfigs - { [filterKey]: FilterConfig } map.
+ * @return {Array<object>} `must` clauses, empty when nothing is selected.
+ */
+export function buildStaticFilterClauses( selections, filterConfigs ) {
+	const clauses = [];
+	for ( const [ filterKey, value ] of Object.entries( selections ?? {} ) ) {
+		if ( ! value || filterConfigs?.[ filterKey ]?.kind !== 'static' ) {
+			continue;
+		}
+		clauses.push( { term: { [ filterKey ]: value } } );
+	}
+	return clauses;
+}
+
 // Memoized: `filterItems` re-runs on every state read and may invoke
 // `formatDateBucketLabel` once per bucket.
 const monthLabelFormatters = new Map();
@@ -577,30 +600,35 @@ export function buildStaticPostTypeClauses( staticPostTypes ) {
  * Build the full search API URL with query params.
  * Mirrors the 3-path routing in src/instant-search/lib/api.js.
  *
- * @param {object}      opts                   - Options.
- * @param {number}      opts.siteId            - Site ID.
- * @param {string}      opts.searchQuery       - Search query string.
- * @param {string}      opts.sortOrder         - 'relevance' | 'newest' | 'oldest', plus
- *                                             'rating_desc' | 'price_asc' | 'price_desc'
- *                                             on WooCommerce sites.
- * @param {string|null} opts.pageHandle        - Cursor for pagination.
- * @param {boolean}     opts.isPrivateSite     - Whether the site is private.
- * @param {boolean}     opts.isWpcom           - Whether the site runs on WordPress.com.
- * @param {string}      opts.apiRoot           - WordPress REST API root URL.
- * @param {object}      [opts.activeFilters]   - { [filterKey]: string[] } selected filters.
- * @param {object}      [opts.filterConfigs]   - { [filterKey]: FilterConfig } registered filters.
- * @param {string}      [opts.homeUrl]         - Home URL; required for private WPcom sites.
- * @param {object|null} [opts.priceRange]      - `{ min, max }` numeric range against the
- *                                             `wc.price` ES field. Either bound may be null
- *                                             for a half-open range. Read by future product
- *                                             filter blocks driven by `min_price` / `max_price`
- *                                             URL params.
- * @param {object|null} [opts.staticPostTypes] - `{ include, exclude }` post-type slug lists
- *                                             contributed by `jetpack-search/filter-post-type`.
- *                                             Folded into the ES filter clause as `bool.should`
- *                                             (include) and `bool.must_not` (exclude). Hidden
- *                                             from visitors — not represented in `activeFilters`
- *                                             and not surfaced in the active-filters pill list.
+ * @param {object}      opts                          - Options.
+ * @param {number}      opts.siteId                   - Site ID.
+ * @param {string}      opts.searchQuery              - Search query string.
+ * @param {string}      opts.sortOrder                - 'relevance' | 'newest' | 'oldest', plus
+ *                                                    'rating_desc' | 'price_asc' | 'price_desc'
+ *                                                    on WooCommerce sites.
+ * @param {string|null} opts.pageHandle               - Cursor for pagination.
+ * @param {boolean}     opts.isPrivateSite            - Whether the site is private.
+ * @param {boolean}     opts.isWpcom                  - Whether the site runs on WordPress.com.
+ * @param {string}      opts.apiRoot                  - WordPress REST API root URL.
+ * @param {object}      [opts.activeFilters]          - { [filterKey]: string[] } selected filters.
+ * @param {object}      [opts.filterConfigs]          - { [filterKey]: FilterConfig } registered filters.
+ * @param {string}      [opts.homeUrl]                - Home URL; required for private WPcom sites.
+ * @param {object|null} [opts.priceRange]             - `{ min, max }` numeric range against the
+ *                                                    `wc.price` ES field. Either bound may be null
+ *                                                    for a half-open range. Read by future product
+ *                                                    filter blocks driven by `min_price` / `max_price`
+ *                                                    URL params.
+ * @param {object|null} [opts.staticPostTypes]        - `{ include, exclude }` post-type slug lists
+ *                                                    contributed by `jetpack-search/filter-post-type`.
+ *                                                    Folded into the ES filter clause as `bool.should`
+ *                                                    (include) and `bool.must_not` (exclude). Hidden
+ *                                                    from visitors — not represented in `activeFilters`
+ *                                                    and not surfaced in the active-filters pill list.
+ * @param {object}      [opts.staticFilterSelections] - { [filterKey]: string } single-select
+ *                                                    static filter values contributed by
+ *                                                    `jetpack-search/filter-static`. Each non-empty
+ *                                                    entry adds a `term` clause against an ES field
+ *                                                    whose name matches the filter key.
  * @return {string} Full URL to call.
  */
 export function buildSearchUrl( {
@@ -616,6 +644,7 @@ export function buildSearchUrl( {
 	homeUrl = '',
 	priceRange = null,
 	staticPostTypes = null,
+	staticFilterSelections = {},
 } ) {
 	// `qss.encode()` runs `encodeURIComponent` on every value, so we pass the
 	// raw query here. The instant-search code double-encodes (pre-encodes
@@ -643,6 +672,12 @@ export function buildSearchUrl( {
 		filter = filter
 			? { bool: { must: [ ...filter.bool.must, ...staticPostTypeClauses ] } }
 			: { bool: { must: [ ...staticPostTypeClauses ] } };
+	}
+	const staticFilterClauses = buildStaticFilterClauses( staticFilterSelections, filterConfigs );
+	if ( staticFilterClauses.length > 0 ) {
+		filter = filter
+			? { bool: { must: [ ...filter.bool.must, ...staticFilterClauses ] } }
+			: { bool: { must: [ ...staticFilterClauses ] } };
 	}
 	if ( priceRange && ( priceRange.min != null || priceRange.max != null ) ) {
 		const range = {};

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -147,22 +147,26 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
  * Drop static-filter selections whose key isn't registered (or isn't a
  * `kind === 'static'` config). Mirrors `gateActiveFilters` for the
  * scalar-URL counterpart so a stray `?section=x` URL from a deregistered
- * static filter can't survive across renders.
+ * static filter can't survive across renders. Returns `{ gated, droppedAny }`
+ * so callers can write state only when something actually changed — same
+ * contract as `gateActiveFilters`.
  *
  * @param {object} selections    - { [filterKey]: string }.
  * @param {object} filterConfigs - { [filterKey]: FilterConfig }.
- * @return {object} Gated selections.
+ * @return {{ gated: object, droppedAny: boolean }} Filtered selections plus a drop flag.
  */
 export function gateStaticFilterSelections( selections, filterConfigs ) {
 	const allowedKeys = filterConfigs ?? {};
 	const gated = Object.create( null );
+	let droppedAny = false;
 	for ( const [ key, value ] of Object.entries( selections ?? {} ) ) {
 		if ( ! value || ! Object.hasOwn( allowedKeys, key ) || allowedKeys[ key ]?.kind !== 'static' ) {
+			droppedAny = true;
 			continue;
 		}
 		gated[ key ] = value;
 	}
-	return gated;
+	return { gated, droppedAny };
 }
 
 /**
@@ -1130,19 +1134,6 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Toggle a filter value on or off, then re-run the search.
-		 *
-		 * Multiple selected values under the same filter key are kept in an
-		 * array on `activeFilters`; different filter keys stay separate. How
-		 * the ES clause combines them (OR within a key, AND across keys) is
-		 * the responsibility of `buildFilterClause` — this action is just
-		 * bookkeeping on the selection set.
-		 *
-		 * @param {string} filterKey   - e.g. `category`, `post_types`.
-		 * @param {string} filterValue - e.g. `news`, `post`.
-		 * @yield {Promise} search action.
-		 */
-		/**
 		 * Replace the value of a single-select static filter, then re-run the
 		 * search. Static filters store a scalar value per key (not an array
 		 * like `setFilter`) because each `jetpack-search/filter-static` block
@@ -1168,6 +1159,19 @@ const { state, actions } = store( NAMESPACE, {
 			yield actions.search();
 		},
 
+		/**
+		 * Toggle a filter value on or off, then re-run the search.
+		 *
+		 * Multiple selected values under the same filter key are kept in an
+		 * array on `activeFilters`; different filter keys stay separate. How
+		 * the ES clause combines them (OR within a key, AND across keys) is
+		 * the responsibility of `buildFilterClause` — this action is just
+		 * bookkeeping on the selection set.
+		 *
+		 * @param {string} filterKey   - e.g. `category`, `post_types`.
+		 * @param {string} filterValue - e.g. `news`, `post`.
+		 * @yield {Promise} search action.
+		 */
 		*setFilter( filterKey, filterValue ) {
 			const current = state.activeFilters[ filterKey ] ?? [];
 			const index = current.indexOf( filterValue );
@@ -1311,7 +1315,7 @@ const { state, actions } = store( NAMESPACE, {
 			state.staticFilterSelections = gateStaticFilterSelections(
 				staticFilterSelections,
 				state.filterConfigs
-			);
+			).gated;
 			yield actions.search( { syncUrl: false } );
 		},
 
@@ -1665,13 +1669,11 @@ const { state, actions } = store( NAMESPACE, {
 				state.staticFilterSelections &&
 				Object.keys( state.staticFilterSelections ).length > 0
 			) {
-				const gatedStatic = gateStaticFilterSelections(
+				const { gated: gatedStatic, droppedAny: droppedStatic } = gateStaticFilterSelections(
 					state.staticFilterSelections,
 					state.filterConfigs
 				);
-				if (
-					Object.keys( gatedStatic ).length !== Object.keys( state.staticFilterSelections ).length
-				) {
+				if ( droppedStatic ) {
 					state.staticFilterSelections = gatedStatic;
 				}
 			}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -144,6 +144,28 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
 }
 
 /**
+ * Drop static-filter selections whose key isn't registered (or isn't a
+ * `kind === 'static'` config). Mirrors `gateActiveFilters` for the
+ * scalar-URL counterpart so a stray `?section=x` URL from a deregistered
+ * static filter can't survive across renders.
+ *
+ * @param {object} selections    - { [filterKey]: string }.
+ * @param {object} filterConfigs - { [filterKey]: FilterConfig }.
+ * @return {object} Gated selections.
+ */
+export function gateStaticFilterSelections( selections, filterConfigs ) {
+	const allowedKeys = filterConfigs ?? {};
+	const gated = Object.create( null );
+	for ( const [ key, value ] of Object.entries( selections ?? {} ) ) {
+		if ( ! value || ! Object.hasOwn( allowedKeys, key ) || allowedKeys[ key ]?.kind !== 'static' ) {
+			continue;
+		}
+		gated[ key ] = value;
+	}
+	return gated;
+}
+
+/**
  * Drop filterLogic entries whose filter key is missing from `activeFilters`,
  * has an empty selection set, or targets a non-taxonomy filter. Mirrors the
  * cleanup `setFilter()` performs locally; called from popstate and at
@@ -553,6 +575,7 @@ function* fetchResults( pageHandle ) {
 		// downstream consumer (`buildFilterClause`) free of the override path.
 		filterConfigs: overlayFilterLogic( state.filterConfigs, state.filterLogic ),
 		priceRange: state.priceRange,
+		staticFilterSelections: state.staticFilterSelections,
 		staticPostTypes: state.staticPostTypes,
 	} );
 	const response = yield fetch( url, {
@@ -660,12 +683,13 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * True when any facet is active — selected filter values or a
-		 * price range. Drives the active-filters pill wrapper, the standalone
-		 * clear-filters block, and the filter-popover trigger. priceRange
-		 * counts as a filter here so a price-only selection (including a
-		 * half-open range like `?min_price=10`) doesn't leave the pill
-		 * wrapper hidden when the user has a chip to clear.
+		 * True when any facet is active — selected filter values, a
+		 * price range, or a static-filter selection. Drives the active-filters
+		 * pill wrapper, the standalone clear-filters block, and the
+		 * filter-popover trigger. priceRange counts as a filter here so a
+		 * price-only selection (including a half-open range like
+		 * `?min_price=10`) doesn't leave the pill wrapper hidden when the user
+		 * has a chip to clear.
 		 *
 		 * @return {boolean} Whether any filter is active.
 		 */
@@ -674,6 +698,12 @@ const { state, actions } = store( NAMESPACE, {
 				v => Array.isArray( v ) && v.length > 0
 			);
 			if ( hasSelections ) {
+				return true;
+			}
+			const hasStaticSelections = Object.values( state.staticFilterSelections ?? {} ).some(
+				v => !! v
+			);
+			if ( hasStaticSelections ) {
 				return true;
 			}
 			const range = state.priceRange;
@@ -687,7 +717,11 @@ const { state, actions } = store( NAMESPACE, {
 		 * @return {number} Count of selected filter values.
 		 */
 		get activeFilterCount() {
-			return countActiveFilters( state.activeFilters );
+			const dynamic = countActiveFilters( state.activeFilters );
+			const staticCount = Object.values( state.staticFilterSelections ?? {} ).filter(
+				v => !! v
+			).length;
+			return dynamic + staticCount;
 		},
 
 		/**
@@ -961,6 +995,17 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * Replace the value of a single-select static filter (jetpack-search/filter-static).
+		 *
+		 * @param {Event} event - Change event from the radio input.
+		 * @yield {Promise} setStaticFilter action.
+		 */
+		*onStaticFilterChange( event ) {
+			const { filterKey } = getContext();
+			yield actions.setStaticFilter( filterKey, event.target.value );
+		},
+
+		/**
 		 * Run a search and replace the result list.
 		 *
 		 * @param {object}  [options]         - Options.
@@ -1097,6 +1142,32 @@ const { state, actions } = store( NAMESPACE, {
 		 * @param {string} filterValue - e.g. `news`, `post`.
 		 * @yield {Promise} search action.
 		 */
+		/**
+		 * Replace the value of a single-select static filter, then re-run the
+		 * search. Static filters store a scalar value per key (not an array
+		 * like `setFilter`) because each `jetpack-search/filter-static` block
+		 * renders mutually-exclusive radio inputs. Picking the currently
+		 * selected value clears it — same UX as legacy `setStaticFilter` in
+		 * the instant-search overlay.
+		 *
+		 * @param {string} filterKey   - The static filter's `filter_id`.
+		 * @param {string} filterValue - The newly-selected value, or '' to clear.
+		 * @yield {Promise} search action.
+		 */
+		*setStaticFilter( filterKey, filterValue ) {
+			const current = state.staticFilterSelections?.[ filterKey ] ?? '';
+			const next = { ...( state.staticFilterSelections ?? {} ) };
+			if ( current === filterValue ) {
+				// Re-picking the current radio clears the entry — mirrors the
+				// legacy overlay's radio "deselect" affordance.
+				delete next[ filterKey ];
+			} else {
+				next[ filterKey ] = filterValue;
+			}
+			state.staticFilterSelections = next;
+			yield actions.search();
+		},
+
 		*setFilter( filterKey, filterValue ) {
 			const current = state.activeFilters[ filterKey ] ?? [];
 			const index = current.indexOf( filterValue );
@@ -1139,6 +1210,7 @@ const { state, actions } = store( NAMESPACE, {
 			state.activeFilters = {};
 			state.filterLogic = {};
 			state.priceRange = null;
+			state.staticFilterSelections = {};
 			yield actions.search();
 		},
 
@@ -1192,6 +1264,7 @@ const { state, actions } = store( NAMESPACE, {
 				filterLogic: state.filterLogic,
 				filterConfigs: state.filterConfigs,
 				priceRange: state.priceRange,
+				staticFilterSelections: state.staticFilterSelections,
 				searchParamName: state.searchParamName,
 				isWooCommerceBlocksEnabled: state.isWooCommerceBlocksEnabled,
 			} );
@@ -1203,12 +1276,19 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*handlePopState() {
-			const { searchQuery, hasSearchParam, sortOrder, activeFilters, filterLogic, priceRange } =
-				readStateFromUrl(
-					state.filterConfigs,
-					state.searchParamName,
-					state.isWooCommerceBlocksEnabled
-				);
+			const {
+				searchQuery,
+				hasSearchParam,
+				sortOrder,
+				activeFilters,
+				filterLogic,
+				priceRange,
+				staticFilterSelections,
+			} = readStateFromUrl(
+				state.filterConfigs,
+				state.searchParamName,
+				state.isWooCommerceBlocksEnabled
+			);
 			state.searchQuery = searchQuery;
 			// Keep `hasSearchParam` in lockstep with the live URL so any future
 			// reader (e.g. `showNoResults`) sees the current state rather than
@@ -1228,6 +1308,10 @@ const { state, actions } = store( NAMESPACE, {
 			// targets a non-taxonomy filter.
 			state.filterLogic = pickLogicForActive( filterLogic, gated, state.filterConfigs );
 			state.priceRange = priceRange;
+			state.staticFilterSelections = gateStaticFilterSelections(
+				staticFilterSelections,
+				state.filterConfigs
+			);
 			yield actions.search( { syncUrl: false } );
 		},
 
@@ -1573,6 +1657,23 @@ const { state, actions } = store( NAMESPACE, {
 			const { gated, droppedAny } = gateActiveFilters( state.activeFilters, state.filterConfigs );
 			if ( droppedAny ) {
 				state.activeFilters = gated;
+			}
+			// Symmetric gate for static-filter selections — drop any key whose
+			// filter-static block isn't on the page anymore (e.g. a stale deep
+			// link from a since-removed registration).
+			if (
+				state.staticFilterSelections &&
+				Object.keys( state.staticFilterSelections ).length > 0
+			) {
+				const gatedStatic = gateStaticFilterSelections(
+					state.staticFilterSelections,
+					state.filterConfigs
+				);
+				if (
+					Object.keys( gatedStatic ).length !== Object.keys( state.staticFilterSelections ).length
+				) {
+					state.staticFilterSelections = gatedStatic;
+				}
 			}
 			// Re-gate filterLogic against the (possibly trimmed) activeFilters
 			// AND against the just-registered filterConfigs so a

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1641,6 +1641,23 @@ const { state, actions } = store( NAMESPACE, {
 
 	callbacks: {
 		/**
+		 * Reactive `checked` binding for a static-filter radio. Reads the
+		 * per-`<li>` context to know which `filterKey` + `optionValue` pair
+		 * this radio represents, then compares against the store's
+		 * `staticFilterSelections[filterKey]`. Used by
+		 * `jetpack-search/filter-static`'s `render.php` so radios stay in
+		 * lockstep with the store across `clearFilters()`, `handlePopState()`,
+		 * and any other path that mutates `state.staticFilterSelections`
+		 * outside the radio's own `change` event.
+		 *
+		 * @return {boolean} Whether this radio should appear checked.
+		 */
+		isStaticFilterSelected() {
+			const { filterKey, optionValue } = getContext();
+			return state.staticFilterSelections?.[ filterKey ] === optionValue;
+		},
+
+		/**
 		 * Fires when the search-results block mounts. Runs the initial
 		 * search if the URL seeded a query and registers the popstate
 		 * listener. Guarded so multiple blocks on the same page share a

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -86,7 +86,15 @@ function parsePriceBound( raw ) {
  *                                                         read the block-author-configured `queryType`
  *                                                         so the URL also reflects block config when
  *                                                         `filterLogic` has no override for that key.
+ *                                                         Also gates which keys are eligible for
+ *                                                         scalar static-filter serialization.
  * @param {object|null} [state.priceRange]                 - { min, max } price range; either bound may be null.
+ * @param {object}      [state.staticFilterSelections]     - { [filterKey]: string } single-select static
+ *                                                         filter values contributed by
+ *                                                         `jetpack-search/filter-static`. Serialized as
+ *                                                         scalar `?filter_id=value` (not `[]=value`) so
+ *                                                         deep links round-trip with the legacy overlay's
+ *                                                         static-filter URL contract.
  * @param {string}      [state.searchParamName]            - URL key the search query is written under
  *                                                         (`s` on the WP search route, `q`
  *                                                         on non-search pages). Defaults to `s`.
@@ -103,6 +111,7 @@ export function stateToUrlParams( {
 	filterLogic = {},
 	filterConfigs = {},
 	priceRange = null,
+	staticFilterSelections = {},
 	searchParamName = DEFAULT_SEARCH_PARAM,
 	isWooCommerceBlocksEnabled = false,
 } ) {
@@ -151,6 +160,19 @@ export function stateToUrlParams( {
 		}
 	}
 
+	// Static filters write scalar `?filter_id=value` params — matches the
+	// legacy instant-search overlay's static-filter URL contract so deep
+	// links stay interchangeable between the two surfaces. Gated on
+	// `kind === 'static'` so a stale selection for a since-unregistered
+	// filter (e.g. the host site removed its filter hook) can't leak back
+	// into the URL on the next push.
+	for ( const [ key, value ] of Object.entries( staticFilterSelections ) ) {
+		if ( ! value || filterConfigs?.[ key ]?.kind !== 'static' ) {
+			continue;
+		}
+		params.set( key, String( value ) );
+	}
+
 	return params;
 }
 
@@ -174,7 +196,7 @@ export function stateToUrlParams( {
  *                                                       `max_price` range params). Falsy on non-Woo
  *                                                       sites ignores both rather than hydrating
  *                                                       them into store state.
- * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null, staticFilterSelections: object }} Partial state.
  */
 export function urlParamsToState(
 	params,
@@ -186,6 +208,7 @@ export function urlParamsToState(
 	const allowedSorts = validSortOrders( isWooCommerceBlocksEnabled );
 	const activeFilters = {};
 	const filterLogic = {};
+	const staticFilterSelections = {};
 	const hasFilterConfigGate = filterConfigs && Object.keys( filterConfigs ).length > 0;
 
 	for ( const [ rawKey, value ] of params.entries() ) {
@@ -218,9 +241,27 @@ export function urlParamsToState(
 			}
 			continue;
 		}
+		// Scalar param. Either a static-filter selection (gated by
+		// `filterConfigs[rawKey].kind === 'static'`) or an unrelated scalar we
+		// ignore — keeps arbitrary plugin-emitted params out of state.
 		if ( ! rawKey.endsWith( '[]' ) ) {
+			if (
+				hasFilterConfigGate &&
+				! RESERVED_PARAMS.has( rawKey ) &&
+				filterConfigs[ rawKey ]?.kind === 'static'
+			) {
+				// Last-write wins. A URL like `?section=a&section=b` is already
+				// malformed for a single-select filter; pick the latest value
+				// to mirror the radio-input change handler.
+				const normalized = String( value ?? '' ).trim();
+				if ( normalized ) {
+					staticFilterSelections[ rawKey ] = normalized;
+				}
+			}
 			continue;
 		}
+
+		// Array-shaped param — dynamic facet filter.
 		const filterKey = rawKey.slice( 0, -2 );
 		if ( RESERVED_PARAMS.has( filterKey ) ) {
 			continue;
@@ -283,6 +324,7 @@ export function urlParamsToState(
 		activeFilters,
 		filterLogic,
 		priceRange,
+		staticFilterSelections,
 	};
 }
 
@@ -310,7 +352,7 @@ export function pushStateToUrl( state ) {
  * @param {boolean} [isWooCommerceBlocksEnabled] - Gate for WC-only URL surface (product-format
  *                                               sort keys + `min_price` / `max_price` range params);
  *                                               forwarded to `urlParamsToState`.
- * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null }} Partial state.
+ * @return {{ searchQuery: string, hasSearchParam: boolean, sortOrder: string, activeFilters: object, filterLogic: object, priceRange: object|null, staticFilterSelections: object }} Partial state.
  */
 export function readStateFromUrl(
 	filterConfigs = {},

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -165,9 +165,12 @@ export function stateToUrlParams( {
 	// links stay interchangeable between the two surfaces. Gated on
 	// `kind === 'static'` so a stale selection for a since-unregistered
 	// filter (e.g. the host site removed its filter hook) can't leak back
-	// into the URL on the next push.
+	// into the URL on the next push. RESERVED_PARAMS check is symmetric
+	// with `urlParamsToState`: a misconfigured filter whose `filter_id`
+	// collides with `s` / `orderby` / `min_price` / `max_price` mustn't
+	// overwrite the search query / sort / price params.
 	for ( const [ key, value ] of Object.entries( staticFilterSelections ) ) {
-		if ( ! value || filterConfigs?.[ key ]?.kind !== 'static' ) {
+		if ( ! value || RESERVED_PARAMS.has( key ) || filterConfigs?.[ key ]?.kind !== 'static' ) {
 			continue;
 		}
 		params.set( key, String( value ) );

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -5,6 +5,7 @@ import {
 	buildAggregations,
 	buildFilterClause,
 	buildSearchUrl,
+	buildStaticFilterClauses,
 	buildStaticPostTypeClauses,
 	formatDateBucketLabel,
 	resolveFilterFields,
@@ -1073,5 +1074,90 @@ describe( 'product-shaped filter helpers', () => {
 				'filter[bool][must][0][bool][should][1][term][category.slug]=sports'
 			);
 		} );
+	} );
+} );
+
+describe( 'buildStaticFilterClauses', () => {
+	it( 'emits one `term` clause per non-empty static-filter selection, keyed by the filter id', () => {
+		// Static filters target a flat ES field whose name equals the filter
+		// key — `?section=guides` ⇒ `{ term: { section: 'guides' } }`. Mirrors
+		// the legacy instant-search overlay's static-filter URL → ES mapping.
+		const clauses = buildStaticFilterClauses(
+			{ section: 'guides', audience: 'dev' },
+			{
+				section: { filterKey: 'section', kind: 'static' },
+				audience: { filterKey: 'audience', kind: 'static' },
+			}
+		);
+		expect( clauses ).toEqual( [ { term: { section: 'guides' } }, { term: { audience: 'dev' } } ] );
+	} );
+
+	it( 'gates on kind === "static" so a stray entry with a non-static config is dropped', () => {
+		// Belt-and-suspenders: even if a stale `staticFilterSelections` entry
+		// somehow names a dynamic filter, the gate prevents it from generating
+		// an ES clause that would target the wrong field.
+		const clauses = buildStaticFilterClauses(
+			{ category: 'news' },
+			{ category: { filterKey: 'category', filterType: 'taxonomy' } }
+		);
+		expect( clauses ).toEqual( [] );
+	} );
+
+	it( 'drops empty-value entries', () => {
+		// An empty string means "no selection" — equivalent to no entry.
+		// A `{ term: { section: '' } }` clause would match zero documents
+		// and silently zero the result set; drop it before the URL builder
+		// sees it.
+		const clauses = buildStaticFilterClauses(
+			{ section: '' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( clauses ).toEqual( [] );
+	} );
+
+	it( 'returns an empty array when nothing is selected', () => {
+		expect( buildStaticFilterClauses( {}, {} ) ).toEqual( [] );
+		expect( buildStaticFilterClauses( undefined, {} ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'buildSearchUrl: static filter selections', () => {
+	const baseOpts = {
+		siteId: 1,
+		searchQuery: '',
+		sortOrder: 'relevance',
+		pageHandle: null,
+		isPrivateSite: false,
+		isWpcom: false,
+		apiRoot: '',
+	};
+
+	it( 'folds static-filter term clauses into the existing bool.must pipeline', () => {
+		// A static filter alone should produce a single-clause bool.must.
+		const url = buildSearchUrl( {
+			...baseOpts,
+			staticFilterSelections: { section: 'guides' },
+			filterConfigs: { section: { filterKey: 'section', kind: 'static' } },
+		} );
+		const decoded = decodeURIComponent( url );
+		expect( decoded ).toContain( 'filter[bool][must][0][term][section]=guides' );
+	} );
+
+	it( 'combines static-filter clauses with active dynamic filters under one bool.must', () => {
+		// Dynamic + static together: bool.must accumulates both. The static
+		// clause appends after the dynamic clauses so the ES request keeps a
+		// flat must array rather than nested bool wrappers.
+		const url = buildSearchUrl( {
+			...baseOpts,
+			activeFilters: { category: [ 'news' ] },
+			staticFilterSelections: { section: 'guides' },
+			filterConfigs: {
+				category: { filterType: 'taxonomy', taxonomy: 'category' },
+				section: { filterKey: 'section', kind: 'static' },
+			},
+		} );
+		const decoded = decodeURIComponent( url );
+		expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
+		expect( decoded ).toContain( 'filter[bool][must][1][term][section]=guides' );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -942,6 +942,33 @@ describe( 'gateStaticFilterSelections', () => {
 describe( 'store callbacks', () => {
 	afterEach( () => {
 		jest.restoreAllMocks();
+		captured.context = {};
+	} );
+
+	it( 'isStaticFilterSelected reads filterKey + optionValue from context and compares against the store', () => {
+		// Pin the reactive-binding contract. render.php emits a per-<li>
+		// `data-wp-context` with `{ filterKey, optionValue }`, and each
+		// radio's `data-wp-bind--checked="callbacks.isStaticFilterSelected"`
+		// evaluates to this boolean. Without the binding, radios drift from
+		// the store after `clearFilters()` or `handlePopState()` since the
+		// `change` event only fires on user-initiated transitions.
+		state.staticFilterSelections = { section: 'guides' };
+
+		captured.context = { filterKey: 'section', optionValue: 'guides' };
+		expect( captured.callbacks.isStaticFilterSelected() ).toBe( true );
+
+		captured.context = { filterKey: 'section', optionValue: 'news' };
+		expect( captured.callbacks.isStaticFilterSelected() ).toBe( false );
+
+		// Unregistered key — defensive against a stale context that survives
+		// a filter being deregistered.
+		captured.context = { filterKey: 'missing', optionValue: 'whatever' };
+		expect( captured.callbacks.isStaticFilterSelected() ).toBe( false );
+
+		// Empty slice — clearFilters case. Every radio should report false.
+		state.staticFilterSelections = {};
+		captured.context = { filterKey: 'section', optionValue: 'guides' };
+		expect( captured.callbacks.isStaticFilterSelected() ).toBe( false );
 	} );
 
 	it( 'initializes popstate handling and runs one URL-seeded search', () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -144,6 +144,7 @@ describe( 'store actions', () => {
 			activeFilters: {},
 			filterConfigs: {},
 			priceRange: null,
+			staticFilterSelections: {},
 			results: [ { title: 'Existing result' } ],
 			locale: 'en-US',
 			isLoading: false,
@@ -580,6 +581,23 @@ describe( 'store actions', () => {
 		expect( writtenUrl ).not.toContain( 'max_price' );
 	} );
 
+	it( 'syncToUrl writes static-filter selections as scalar params alongside other state', () => {
+		// Regression guard: the staticFilterSelections slice must thread
+		// through pushStateToUrl so a shareable URL captures the radio
+		// selection. Scalar `?filter_id=value` format (no `[]`) is the
+		// legacy overlay's contract.
+		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
+		state.searchQuery = 'docs';
+		state.staticFilterSelections = { section: 'guides' };
+		state.filterConfigs = { section: { filterKey: 'section', kind: 'static' } };
+
+		actions.syncToUrl();
+
+		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
+		expect( writtenUrl ).toContain( 'section=guides' );
+		expect( writtenUrl ).not.toContain( 'section[]' );
+	} );
+
 	it( 'closes open popovers on Escape only', () => {
 		state.isFilterPopoverOpen = true;
 		state.isSortPopoverOpen = true;
@@ -710,6 +728,31 @@ describe( 'store getters', () => {
 
 		state.priceRange = { min: null, max: null };
 		expect( state.hasActiveFilters ).toBe( false );
+	} );
+
+	it( 'hasActiveFilters and activeFilterCount include staticFilterSelections', () => {
+		// Without this contribution, a deep link to `?section=guides` would
+		// leave the active-filters / clear-filters affordances hidden even
+		// though the static filter is constraining results.
+		state.activeFilters = {};
+		state.priceRange = null;
+		state.staticFilterSelections = {};
+		expect( state.hasActiveFilters ).toBe( false );
+		expect( state.activeFilterCount ).toBe( 0 );
+
+		state.staticFilterSelections = { section: 'guides' };
+		expect( state.hasActiveFilters ).toBe( true );
+		expect( state.activeFilterCount ).toBe( 1 );
+
+		// Combined with dynamic filters — totals add.
+		state.activeFilters = { category: [ 'news', 'wp' ] };
+		expect( state.activeFilterCount ).toBe( 3 );
+
+		// Empty-string entries don't count (they round-trip as 'cleared').
+		state.activeFilters = {};
+		state.staticFilterSelections = { section: '' };
+		expect( state.hasActiveFilters ).toBe( false );
+		expect( state.activeFilterCount ).toBe( 0 );
 	} );
 
 	it( 'enables the filter trigger for active filters or available aggregation buckets', () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -32,6 +32,7 @@ import {
 	actions,
 	computeResultsCountText,
 	gateActiveFilters,
+	gateStaticFilterSelections,
 	remapAggregationsToFilterKeys,
 	state,
 } from '../../../src/search-blocks/store';
@@ -366,6 +367,49 @@ describe( 'store actions', () => {
 		await runGenerator( actions.setFilter( 'category', 'updates' ) );
 		expect( state.activeFilters ).toEqual( {} );
 		expect( search ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'setStaticFilter replaces the per-key value (single-select) and clears when re-picked', async () => {
+		// Static filters are mutually-exclusive radios — unlike setFilter,
+		// each call REPLACES rather than toggles within an array. Re-picking
+		// the currently selected value clears the entry (same UX as the
+		// legacy overlay's setStaticFilter).
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.staticFilterSelections = {};
+
+		await runGenerator( actions.setStaticFilter( 'section', 'news' ) );
+		expect( state.staticFilterSelections ).toEqual( { section: 'news' } );
+
+		// Picking a different value REPLACES (does not append).
+		await runGenerator( actions.setStaticFilter( 'section', 'guides' ) );
+		expect( state.staticFilterSelections ).toEqual( { section: 'guides' } );
+
+		// Re-picking the current value clears the entry — radio "deselect"
+		// affordance preserves the legacy overlay behavior.
+		await runGenerator( actions.setStaticFilter( 'section', 'guides' ) );
+		expect( state.staticFilterSelections ).toEqual( {} );
+
+		// Different keys stay independent — picking `audience` after a
+		// cleared `section` doesn't resurrect the old `section` entry.
+		await runGenerator( actions.setStaticFilter( 'audience', 'dev' ) );
+		expect( state.staticFilterSelections ).toEqual( { audience: 'dev' } );
+
+		expect( search ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'clearFilters wipes staticFilterSelections alongside activeFilters + priceRange', async () => {
+		// `clearFilters` is the standalone clear-all button — it must wipe
+		// every facet shape so a user doesn't have to click each filter
+		// type's clear affordance individually.
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.activeFilters = {};
+		state.priceRange = null;
+		state.staticFilterSelections = { section: 'guides' };
+
+		await runGenerator( actions.clearFilters() );
+
+		expect( state.staticFilterSelections ).toEqual( {} );
+		expect( search ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'clears every facet only when something is active', async () => {
@@ -822,6 +866,61 @@ describe( 'gateActiveFilters', () => {
 		} );
 		expect( gated ).toEqual( {} );
 		expect( droppedAny ).toBe( true );
+	} );
+} );
+
+describe( 'gateStaticFilterSelections', () => {
+	it( 'drops keys whose filterConfigs entry is missing', () => {
+		// Stale selections for a since-removed static-filter registration
+		// must not survive a popstate or `initialize()` re-gate.
+		const gated = gateStaticFilterSelections(
+			{ section: 'guides', dropped: 'x' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( gated ).toEqual( { section: 'guides' } );
+	} );
+
+	it( 'drops keys whose filterConfigs entry exists but is not kind=static', () => {
+		// A scalar URL param under a dynamic filter key (e.g. someone fat-fingered
+		// `?category=news` instead of `?category[]=news`) must not pollute the
+		// static-filter slice. The kind=static gate keeps the boundary explicit.
+		const gated = gateStaticFilterSelections(
+			{ category: 'news', section: 'guides' },
+			{
+				category: { filterKey: 'category', filterType: 'taxonomy' },
+				section: { filterKey: 'section', kind: 'static' },
+			}
+		);
+		expect( gated ).toEqual( { section: 'guides' } );
+	} );
+
+	it( 'drops empty values', () => {
+		// `''` is the "cleared" state — keeping the key would round-trip
+		// through pushStateToUrl and re-emit `?section=` indefinitely.
+		const gated = gateStaticFilterSelections(
+			{ section: '' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( gated ).toEqual( {} );
+	} );
+
+	it( 'returns a null-prototype object so __proto__ pollution cannot survive', () => {
+		// Same defence as gateActiveFilters — JSON.parse lets `__proto__`
+		// land as an own property; we must drop it because it isn't in
+		// filterConfigs, and the output object must not inherit anything that
+		// could be misread as a registered key downstream.
+		const selections = JSON.parse( '{"__proto__":"pwn","section":"guides"}' );
+		const gated = gateStaticFilterSelections( selections, {
+			section: { filterKey: 'section', kind: 'static' },
+		} );
+		expect( gated ).toEqual( { section: 'guides' } );
+		expect( Object.getPrototypeOf( gated ) ).toBeNull();
+	} );
+
+	it( 'tolerates undefined / null inputs', () => {
+		expect( gateStaticFilterSelections( undefined, {} ) ).toEqual( {} );
+		expect( gateStaticFilterSelections( null, {} ) ).toEqual( {} );
+		expect( gateStaticFilterSelections( { section: 'guides' }, null ) ).toEqual( {} );
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -943,6 +943,9 @@ describe( 'store callbacks', () => {
 	afterEach( () => {
 		jest.restoreAllMocks();
 		captured.context = {};
+		// Reset the static-filter slice so it doesn't leak into later cases
+		// in this describe block.
+		state.staticFilterSelections = {};
 	} );
 
 	it( 'isStaticFilterSelected reads filterKey + optionValue from context and compares against the store', () => {
@@ -967,6 +970,17 @@ describe( 'store callbacks', () => {
 
 		// Empty slice — clearFilters case. Every radio should report false.
 		state.staticFilterSelections = {};
+		captured.context = { filterKey: 'section', optionValue: 'guides' };
+		expect( captured.callbacks.isStaticFilterSelected() ).toBe( false );
+	} );
+
+	it( 'isStaticFilterSelected tolerates an undefined staticFilterSelections slice', () => {
+		// The optional-chaining guard (`state.staticFilterSelections?.[…]`)
+		// handles the case where the PHP seed hasn't yet populated the slot
+		// — e.g. on a page with no filter-static block. The comparison
+		// falls through to `undefined === 'guides'`, which is `false`.
+		// Reading the slice directly would crash; this guards the contract.
+		state.staticFilterSelections = undefined;
 		captured.context = { filterKey: 'section', optionValue: 'guides' };
 		expect( captured.callbacks.isStaticFilterSelected() ).toBe( false );
 	} );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -873,18 +873,31 @@ describe( 'gateStaticFilterSelections', () => {
 	it( 'drops keys whose filterConfigs entry is missing', () => {
 		// Stale selections for a since-removed static-filter registration
 		// must not survive a popstate or `initialize()` re-gate.
-		const gated = gateStaticFilterSelections(
+		const { gated, droppedAny } = gateStaticFilterSelections(
 			{ section: 'guides', dropped: 'x' },
 			{ section: { filterKey: 'section', kind: 'static' } }
 		);
 		expect( gated ).toEqual( { section: 'guides' } );
+		expect( droppedAny ).toBe( true );
+	} );
+
+	it( 'reports droppedAny=false when nothing is dropped', () => {
+		// `initialize()` and `handlePopState` use `droppedAny` to skip the
+		// state write when the gate was a no-op — same idiom as
+		// `gateActiveFilters`.
+		const { gated, droppedAny } = gateStaticFilterSelections(
+			{ section: 'guides' },
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( gated ).toEqual( { section: 'guides' } );
+		expect( droppedAny ).toBe( false );
 	} );
 
 	it( 'drops keys whose filterConfigs entry exists but is not kind=static', () => {
 		// A scalar URL param under a dynamic filter key (e.g. someone fat-fingered
 		// `?category=news` instead of `?category[]=news`) must not pollute the
 		// static-filter slice. The kind=static gate keeps the boundary explicit.
-		const gated = gateStaticFilterSelections(
+		const { gated, droppedAny } = gateStaticFilterSelections(
 			{ category: 'news', section: 'guides' },
 			{
 				category: { filterKey: 'category', filterType: 'taxonomy' },
@@ -892,16 +905,18 @@ describe( 'gateStaticFilterSelections', () => {
 			}
 		);
 		expect( gated ).toEqual( { section: 'guides' } );
+		expect( droppedAny ).toBe( true );
 	} );
 
 	it( 'drops empty values', () => {
 		// `''` is the "cleared" state — keeping the key would round-trip
 		// through pushStateToUrl and re-emit `?section=` indefinitely.
-		const gated = gateStaticFilterSelections(
+		const { gated, droppedAny } = gateStaticFilterSelections(
 			{ section: '' },
 			{ section: { filterKey: 'section', kind: 'static' } }
 		);
 		expect( gated ).toEqual( {} );
+		expect( droppedAny ).toBe( true );
 	} );
 
 	it( 'returns a null-prototype object so __proto__ pollution cannot survive', () => {
@@ -910,7 +925,7 @@ describe( 'gateStaticFilterSelections', () => {
 		// filterConfigs, and the output object must not inherit anything that
 		// could be misread as a registered key downstream.
 		const selections = JSON.parse( '{"__proto__":"pwn","section":"guides"}' );
-		const gated = gateStaticFilterSelections( selections, {
+		const { gated } = gateStaticFilterSelections( selections, {
 			section: { filterKey: 'section', kind: 'static' },
 		} );
 		expect( gated ).toEqual( { section: 'guides' } );
@@ -918,9 +933,9 @@ describe( 'gateStaticFilterSelections', () => {
 	} );
 
 	it( 'tolerates undefined / null inputs', () => {
-		expect( gateStaticFilterSelections( undefined, {} ) ).toEqual( {} );
-		expect( gateStaticFilterSelections( null, {} ) ).toEqual( {} );
-		expect( gateStaticFilterSelections( { section: 'guides' }, null ) ).toEqual( {} );
+		expect( gateStaticFilterSelections( undefined, {} ).gated ).toEqual( {} );
+		expect( gateStaticFilterSelections( null, {} ).gated ).toEqual( {} );
+		expect( gateStaticFilterSelections( { section: 'guides' }, null ).gated ).toEqual( {} );
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -148,6 +148,60 @@ describe( 'stateToUrlParams', () => {
 		expect( params.has( 's' ) ).toBe( false );
 	} );
 
+	it( 'serializes staticFilterSelections as scalar params (no `[]` suffix) gated on kind === "static"', () => {
+		// Static filters use scalar `?filter_id=value` URL params, matching
+		// the legacy instant-search overlay contract. The kind === "static"
+		// gate prevents a stray scalar entry under a dynamic key from being
+		// serialized.
+		const params = stateToUrlParams( {
+			searchQuery: 'shoes',
+			sortOrder: 'relevance',
+			staticFilterSelections: { section: 'guides', topic: 'wordpress' },
+			filterConfigs: {
+				section: { filterKey: 'section', kind: 'static' },
+				topic: { filterKey: 'topic', kind: 'static' },
+			},
+		} );
+		expect( params.get( 'section' ) ).toBe( 'guides' );
+		expect( params.get( 'topic' ) ).toBe( 'wordpress' );
+		// Crucially: no `[]` suffix anywhere.
+		expect( params.has( 'section[]' ) ).toBe( false );
+		expect( params.has( 'topic[]' ) ).toBe( false );
+	} );
+
+	it( 'skips static-filter keys whose filterConfigs entry is missing or not kind=static', () => {
+		// A stale staticFilterSelections entry for a since-removed
+		// registration shouldn't leak back into the URL. Gate on
+		// filterConfigs presence + the explicit `kind === "static"` marker.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			staticFilterSelections: { section: 'guides', dropped: 'x', dynamic: 'y' },
+			filterConfigs: {
+				// `section` is registered as static — passes.
+				section: { filterKey: 'section', kind: 'static' },
+				// `dynamic` exists but isn't a static filter — skipped.
+				dynamic: { filterKey: 'dynamic', filterType: 'taxonomy' },
+				// `dropped` isn't in filterConfigs at all — skipped.
+			},
+		} );
+		expect( params.get( 'section' ) ).toBe( 'guides' );
+		expect( params.has( 'dynamic' ) ).toBe( false );
+		expect( params.has( 'dropped' ) ).toBe( false );
+	} );
+
+	it( 'omits static-filter entries whose value is empty', () => {
+		// Empty string means "no selection" — equivalent to no entry. Drop
+		// it so the URL doesn't carry `?section=`.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			staticFilterSelections: { section: '' },
+			filterConfigs: { section: { filterKey: 'section', kind: 'static' } },
+		} );
+		expect( params.has( 'section' ) ).toBe( false );
+	} );
+
 	it( 'preserves empty search param so a refresh keeps the inline-search URL shape', () => {
 		// Same rationale as the empty-`s` case: dropping the param entirely
 		// when the user clears the input would drop the visible URL marker
@@ -496,5 +550,68 @@ describe( 'urlParamsToState: priceRange WooCommerce gate (RSM-2805)', () => {
 			true
 		);
 		expect( state.priceRange ).toEqual( { min: 10, max: 50 } );
+	} );
+
+	it( 'pulls scalar params into staticFilterSelections when the key is kind=static', () => {
+		// Scalar `?section=guides` is the static-filter URL contract. Only
+		// keys whose filterConfigs entry is kind === "static" are pulled;
+		// everything else falls through to the existing branches (or is
+		// ignored).
+		const state = urlParamsToState(
+			new URLSearchParams( '?s=shoes&section=guides&topic=wordpress' ),
+			{
+				section: { filterKey: 'section', kind: 'static' },
+				topic: { filterKey: 'topic', kind: 'static' },
+			}
+		);
+		expect( state.staticFilterSelections ).toEqual( {
+			section: 'guides',
+			topic: 'wordpress',
+		} );
+		// Static-keyed params don't end up in activeFilters even when they
+		// share a name with a hypothetical dynamic filter.
+		expect( state.activeFilters ).toEqual( {} );
+	} );
+
+	it( 'ignores scalar params for keys that are not registered as static filters', () => {
+		// Arbitrary plugin-emitted scalar params (`?utm_source=...`,
+		// `?page_id=42`) must not seep into staticFilterSelections.
+		const state = urlParamsToState(
+			new URLSearchParams( '?s=shoes&utm_source=newsletter&page_id=42&section=guides' ),
+			{ section: { filterKey: 'section', kind: 'static' } }
+		);
+		expect( state.staticFilterSelections ).toEqual( { section: 'guides' } );
+	} );
+
+	it( 'leaves staticFilterSelections empty when filterConfigs has no kind=static entries', () => {
+		// The whole branch is filterConfig-driven — without a kind=static
+		// entry there is no way for a scalar URL param to mark itself as a
+		// static filter. Important: this is the behaviour the JS store
+		// relies on so plugin-emitted scalar params can't hijack the slice.
+		const state = urlParamsToState( new URLSearchParams( '?section=guides' ), {
+			section: { filterKey: 'section', filterType: 'taxonomy' },
+		} );
+		expect( state.staticFilterSelections ).toEqual( {} );
+	} );
+
+	it( 'drops scalar params whose value is empty', () => {
+		// `?section=` is the "cleared" state — equivalent to no selection.
+		// Drop it so a refresh doesn't keep an empty entry around that
+		// re-emits on the next URL push.
+		const state = urlParamsToState( new URLSearchParams( '?section=' ), {
+			section: { filterKey: 'section', kind: 'static' },
+		} );
+		expect( state.staticFilterSelections ).toEqual( {} );
+	} );
+
+	it( 'last-write wins for duplicate scalar static-filter params', () => {
+		// `?section=a&section=b` is malformed for a single-select filter.
+		// Mirror the radio-input change handler (latest click wins) rather
+		// than the first-wins ordering URLSearchParams.get() would default
+		// to.
+		const state = urlParamsToState( new URLSearchParams( '?section=a&section=b' ), {
+			section: { filterKey: 'section', kind: 'static' },
+		} );
+		expect( state.staticFilterSelections ).toEqual( { section: 'b' } );
 	} );
 } );


### PR DESCRIPTION
First of three sequential PRs for [SEARCH-219](https://linear.app/a8c/issue/SEARCH-219/add-jetpack-searchfilter-static-block-for-single-select-static-filters).

| Part | What ships | Status |
| --- | --- | --- |
| **1/3 (this PR)** | JS store plumbing — `staticFilterSelections` slice, scalar URL serialization, ES term clauses. Inert until a block contributes a `kind:'static'` filterConfig entry. | ⏳ this PR |
| 2/3 | PHP `Filter_Static` helper + `/wp-json/jetpack-search/v1/static-filters` REST endpoint + the `staticFilterSelections` seed slot. | next |
| 3/3 | The `jetpack-search/filter-static` block + editor wiring + user-visible changelog entry. | last |

## Proposed changes

* `store/url-state.js` — `stateToUrlParams` serializes `staticFilterSelections` as scalar `?filter_id=value` params, gated on `filterConfigs[key].kind === 'static'`. `urlParamsToState` mirrors the parse direction; only keys whose filterConfigs entry is registered as kind=static land in the slice, so plugin-emitted scalar params can't pollute it.
* `store/index.js` — new `staticFilterSelections` state slice (sibling of `priceRange`), `setStaticFilter` (replace, not toggle) and `onStaticFilterChange` actions, `gateStaticFilterSelections` helper. Slice is threaded through `syncToUrl`, `handlePopState`, `clearFilters`, `initialize()` re-gating, the search-request builder, and the `hasActiveFilters` / `activeFilterCount` getters.
* `store/api.js` — `buildStaticFilterClauses` emits ES `term` clauses keyed by the static filter id; folded into the existing `bool.must` pipeline alongside dynamic facet filters, static post-type clauses, and the price range.

URL contract matches the legacy instant-search overlay's static-filter shape (scalar, single value per key) so deep links round-trip between the two surfaces. Precedent: `priceRange` is a sibling slice with the same shape (see `search-blocks/AGENTS.md` "URL format").

## Related product discussion/links

* Linear: [SEARCH-219](https://linear.app/a8c/issue/SEARCH-219/add-jetpack-searchfilter-static-block-for-single-select-static-filters)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This PR is internal plumbing — nothing visible without parts 2 and 3. The new Jest cases exercise the surface:

* [ ] `pnpm exec jest tests/js/search-blocks/url-state.test.js` — 63 cases passing (8 new for the static-filter branch).
* [ ] `pnpm exec jest tests/js/search-blocks/store.test.js` — covers `gateStaticFilterSelections`, `setStaticFilter` replace/clear, `clearFilters` reset.
* [ ] `pnpm exec jest tests/js/search-blocks/api.test.js` — covers `buildStaticFilterClauses` plus `buildSearchUrl` integration alone and combined with dynamic filters.