### PR TITLE
Search dashboard: rename Plan & Usage tab to Overview (SEARCH-223)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-223-rename-plan-usage-to-overview
+++ b/projects/packages/search/changelog/SEARCH-223-rename-plan-usage-to-overview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search dashboard: rename the "Plan & Usage" tab to "Overview". The URL slug is now `overview`; the legacy `plan-usage` slug continues to resolve to the renamed tab so existing bookmarks keep working.

--- a/projects/packages/search/src/dashboard/components/experience-selector/previews/embedded-preview.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/previews/embedded-preview.jsx
@@ -6,7 +6,7 @@ import './embedded-preview.scss';
 /**
  * Decorative Embedded mockup — `aria-hidden`. Text content is rendered with
  * the dashboard's existing `TextRowPlaceHolder` so the layout reads as a
- * skeleton, matching the Plan & Usage mocked-search interface.
+ * skeleton, matching the Overview mocked-search interface.
  *
  * @return {import('react').Element} - The preview.
  */

--- a/projects/packages/search/src/dashboard/components/experience-selector/previews/overlay-preview.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/previews/overlay-preview.jsx
@@ -6,7 +6,7 @@ import './overlay-preview.scss';
 /**
  * Decorative Overlay mockup — `aria-hidden`. Text content is rendered with
  * the dashboard's existing `TextRowPlaceHolder` so the layout reads as a
- * skeleton, matching the Plan & Usage mocked-search interface.
+ * skeleton, matching the Overview mocked-search interface.
  *
  * @return {import('react').Element} - The preview.
  */

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -18,13 +18,15 @@ import WooCommerceProductSearchControl from 'components/woocommerce-product-sear
 import { STORE_ID } from 'store';
 import { EXPERIENCE } from '../experience-selector/constants';
 import FirstRunSection from './sections/first-run-section';
-import PlanUsageSection from './sections/plan-usage-section';
+import OverviewSection from './sections/overview-section';
 import './dashboard-page.scss';
 
-const DEFAULT_TAB = 'plan-usage';
+const DEFAULT_TAB = 'overview';
 // Keep this allowlist in sync with the <Tabs.Tab value="..."> definitions below.
 const VALID_TABS = [ DEFAULT_TAB, 'settings', 'ai-answers' ];
 const TAB_QUERY_PARAM = 'tab';
+// Maps removed slugs to their current equivalents so existing bookmarks/links keep working.
+const LEGACY_TAB_ALIASES = { 'plan-usage': 'overview' };
 
 const getInitialTab = () => {
 	if ( typeof window === 'undefined' ) {
@@ -32,8 +34,9 @@ const getInitialTab = () => {
 	}
 
 	const requestedTab = new URLSearchParams( window.location.search ).get( TAB_QUERY_PARAM );
+	const resolvedTab = LEGACY_TAB_ALIASES[ requestedTab ] ?? requestedTab;
 
-	return VALID_TABS.includes( requestedTab ) ? requestedTab : DEFAULT_TAB;
+	return VALID_TABS.includes( resolvedTab ) ? resolvedTab : DEFAULT_TAB;
 };
 
 /**
@@ -208,7 +211,7 @@ export default function DashboardPage( { isLoading = false } ) {
 				<Tabs.Root value={ activeTab } onValueChange={ handleTabChange }>
 					<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 						<Tabs.List variant="minimal">
-							<Tabs.Tab value="plan-usage">{ __( 'Plan & Usage', 'jetpack-search-pkg' ) }</Tabs.Tab>
+							<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="ai-answers">
 								{ __( 'AI Answers', 'jetpack-search-pkg' ) }
@@ -218,7 +221,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							</Tabs.Tab>
 						</Tabs.List>
 					</div>
-					<Tabs.Panel value="plan-usage">
+					<Tabs.Panel value="overview">
 						<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
 							{ /* Always in the DOM so JITM JS finds it immediately (Path A). */ }
 							<div className="jp-search-dashboard-row">
@@ -381,7 +384,7 @@ const PlanInfo = ( { hasIndex, recordMeterInfo, isFreePlan, sendPaidPlanToCart }
 			{ ! hasIndex && <FirstRunSection siteTitle={ siteTitle } planInfo={ planInfo } /> }
 			{ hasIndex && (
 				<>
-					<PlanUsageSection
+					<OverviewSection
 						isFreePlan={ isFreePlan }
 						isPlanJustUpgraded={ isPlanJustUpgraded }
 						planInfo={ planInfo }

--- a/projects/packages/search/src/dashboard/components/pages/sections/overview-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/overview-section.jsx
@@ -5,7 +5,7 @@ import { useState, useCallback, useMemo } from 'react';
 import DonutMeterContainer, { formatNumber } from '../../donut-meter-container';
 import PlanSummary from './plan-summary';
 
-// import './plan-usage-section.scss';
+// import './overview-section.scss';
 
 const usageInfoFromAPIData = apiData => {
 	// Transform the data as necessary.
@@ -234,7 +234,7 @@ const upgradeMessageFromAPIData = apiData => {
 	return upgradeMessageNoOverage();
 };
 
-const PlanUsageSection = ( { isFreePlan, planInfo, sendPaidPlanToCart, isPlanJustUpgraded } ) => {
+const OverviewSection = ( { isFreePlan, planInfo, sendPaidPlanToCart, isPlanJustUpgraded } ) => {
 	// For free plan, we want to show the CTA early.
 	// For complete plan, we only show the final CTA once search is already disabled.
 	// It's just because it was added later, and we didn't want to redesign existing CTAs at the time.
@@ -423,4 +423,4 @@ const AboutPlanLimits = () => {
 	);
 };
 
-export default PlanUsageSection;
+export default OverviewSection;

--- a/projects/packages/search/src/dashboard/components/pages/sections/test/overview-section.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/test/overview-section.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import PlanUsageSection from '../plan-usage-section';
+import OverviewSection from '../overview-section';
 
 jest.mock( '@wordpress/ui', () => ( {
 	Link: ( { children, href } ) => <a href={ href }>{ children }</a>,
@@ -52,37 +52,37 @@ const defaultProps = {
 	isPlanJustUpgraded: false,
 };
 
-describe( 'PlanUsageSection', () => {
+describe( 'OverviewSection', () => {
 	it( 'renders usage meters', () => {
-		render( <PlanUsageSection { ...defaultProps } /> );
+		render( <OverviewSection { ...defaultProps } /> );
 		const meters = screen.getAllByTestId( 'donut-meter' );
 		expect( meters ).toHaveLength( 2 );
 	} );
 
 	it( 'renders plan summary', () => {
-		render( <PlanUsageSection { ...defaultProps } /> );
+		render( <OverviewSection { ...defaultProps } /> );
 		expect( screen.getByTestId( 'plan-summary' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders "tell me more" link', () => {
-		render( <PlanUsageSection { ...defaultProps } /> );
+		render( <OverviewSection { ...defaultProps } /> );
 		expect( screen.getByRole( 'link', { name: /record indexing/i } ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render upgrade trigger for paid plan with no overage', () => {
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ false } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ false } /> );
 		expect( screen.queryByTestId( 'upgrade-trigger' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders upgrade trigger for free plan when should_upgrade is true', () => {
 		const planInfo = makePlanInfo( { should_upgrade: true } );
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-trigger' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders search-disabled message when must_upgrade is true', () => {
 		const planInfo = makePlanInfo( { must_upgrade: true } );
-		render( <PlanUsageSection { ...defaultProps } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-description' ) ).toHaveTextContent(
 			/exceeded the limits/i
 		);
@@ -94,7 +94,7 @@ describe( 'PlanUsageSection', () => {
 			upgrade_reason: { records: true, requests: false },
 			months_over_plan_records_limit: 1,
 		} );
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-description' ) ).toHaveTextContent( /records/i );
 	} );
 
@@ -104,7 +104,7 @@ describe( 'PlanUsageSection', () => {
 			upgrade_reason: { records: false, requests: true },
 			months_over_plan_requests_limit: 1,
 		} );
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-description' ) ).toHaveTextContent( /requests/i );
 	} );
 
@@ -114,7 +114,7 @@ describe( 'PlanUsageSection', () => {
 			upgrade_reason: { records: true, requests: true },
 			months_over_plan_records_limit: 1,
 		} );
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-description' ) ).toHaveTextContent(
 			/records and search requests/i
 		);
@@ -125,7 +125,7 @@ describe( 'PlanUsageSection', () => {
 			should_upgrade: true,
 			upgrade_reason: { records: false, requests: false },
 		} );
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-description' ) ).toHaveTextContent(
 			/increase your site records/i
 		);
@@ -137,13 +137,13 @@ describe( 'PlanUsageSection', () => {
 			upgrade_reason: { records: true, requests: false },
 			months_over_plan_records_limit: 3,
 		} );
-		render( <PlanUsageSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } isFreePlan={ true } planInfo={ planInfo } /> );
 		expect( screen.getByTestId( 'upgrade-cta' ) ).toHaveTextContent( /continue using/i );
 	} );
 
 	it( 'does not render upgrade trigger when planInfo has no currentUsage', () => {
 		const planInfo = { ...makePlanInfo(), currentUsage: undefined };
-		render( <PlanUsageSection { ...defaultProps } planInfo={ planInfo } /> );
+		render( <OverviewSection { ...defaultProps } planInfo={ planInfo } /> );
 		expect( screen.queryByTestId( 'upgrade-trigger' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -57,7 +57,7 @@ jest.mock( 'components/woocommerce-product-search-control', () => props => {
 } );
 jest.mock( 'components/record-meter', () => () => <div data-testid="record-meter" /> );
 jest.mock( '../sections/first-run-section', () => () => <div data-testid="first-run-section" /> );
-jest.mock( '../sections/plan-usage-section', () => () => <div data-testid="plan-usage-section" /> );
+jest.mock( '../sections/overview-section', () => () => <div data-testid="overview-section" /> );
 
 /* eslint-disable testing-library/prefer-user-event */
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -309,7 +309,7 @@ describe( 'DashboardPage', () => {
 			'aria-selected',
 			'true'
 		);
-		expect( screen.getByRole( 'tab', { name: /plan & usage/i } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
 			'aria-selected',
 			'false'
 		);
@@ -322,13 +322,24 @@ describe( 'DashboardPage', () => {
 
 		render( <DashboardPage /> );
 
-		expect( screen.getByRole( 'tab', { name: /plan & usage/i } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
 			'aria-selected',
 			'true'
 		);
 		expect( replaceStateSpy ).not.toHaveBeenCalled();
 		expect( window.location.search ).toContain( 'tab=unknown' );
 		replaceStateSpy.mockRestore();
+	} );
+
+	test( 'resolves the legacy plan-usage slug to the Overview tab (backwards compat)', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=plan-usage` );
+
+		render( <DashboardPage /> );
+
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
 	} );
 
 	test( 'updates the URL tab query string when tabs are changed', async () => {

--- a/projects/packages/search/tests/js/dashboard/pages/dashboard-page.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/pages/dashboard-page.test.jsx
@@ -141,9 +141,9 @@ const settings = {
 };
 
 describe( '<DashboardPage> branch', () => {
-	test( 'renders Plan & Usage and AI Answers tabs', () => {
+	test( 'renders Overview and AI Answers tabs', () => {
 		renderWith( { searchBlocksEnabled: false, jetpackSettings: settings } );
-		expect( screen.getByRole( 'tab', { name: /plan & usage/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'tab', { name: /ai answers/i } ) ).toBeInTheDocument();
 	} );
 

--- a/projects/plugins/search/changelog/SEARCH-223-rename-plan-usage-to-overview
+++ b/projects/plugins/search/changelog/SEARCH-223-rename-plan-usage-to-overview
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: e2e: update stale tab-name comment after Plan & Usage → Overview rename. Test-only.

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -53,7 +53,7 @@ test.describe( 'Search Dashboard', () => {
 			).toBeVisible( { timeout: 30000 } );
 
 			// ModuleControl moved into the Settings tab in Search 3.0; the
-			// dashboard now opens on Plan & Usage by default, so the toggles
+			// dashboard now opens on Overview by default, so the toggles
 			// aren't on the initial panel.
 			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 


### PR DESCRIPTION
Fixes [SEARCH-223](https://linear.app/a8c/issue/SEARCH-223/rename-search-dashboard-tab-plan-and-usage-to-overview)

## Why
The Search dashboard's default landing tab has been labeled "Plan & Usage" since Search 3.0 — but the tab itself has grown beyond plan/usage info: it sits above Settings and AI Answers, and is what users land on for any Search admin task. **Overview** is a more accurate, durable name for the default landing page.

Renaming the URL slug to match (`plan-usage` → `overview`) keeps the admin's URL state honest, and preserving the old slug as an alias means existing bookmarks / docs / cross-page links keep landing on the right tab without anyone having to chase them.

## Proposed changes
* Rename the **Plan & Usage** dashboard tab to **Overview** (label + URL slug `plan-usage` → `overview`).
* Backwards compatibility: `getInitialTab()` honors `?tab=plan-usage` via a `LEGACY_TAB_ALIASES` map and resolves it to the new `overview` slug so existing bookmarks / cross-links keep working.
* Rename `sections/plan-usage-section.jsx` → `sections/overview-section.jsx` and component `PlanUsageSection` → `OverviewSection` for consistency.
* Update jest tests (mock path + tab-name regexes) and add a new test for the legacy-slug back-compat path.
* Touch up the stale "Plan & Usage" comment in `experience-selector/previews/{embedded,overlay}-preview.jsx` and `search-dashboard.test.ts`.

Out of scope: the backend `state.sitePlan.plan_usage` selectors, which key into the data shape returned by the server and are unrelated to the page label.

## Screenshots
### Before
![before](https://github.com/user-attachments/assets/febdc782-9164-44a2-b6ea-19d272c8f0a1)
### After
![after](https://github.com/user-attachments/assets/b856cb44-4ad1-4b12-ac81-8b5064e6e945)

## Related product discussion/links
* Linear: [SEARCH-223](https://linear.app/a8c/issue/SEARCH-223/rename-search-dashboard-tab-plan-and-usage-to-overview)
* Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-c0f71109ba96)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Acceptance criteria from SEARCH-223:

- [ ] Visit **wp-admin → Jetpack → Search**: the first tab now reads **Overview** (not "Plan & Usage").
- [ ] `admin.php?page=jetpack-search&tab=overview` opens the renamed tab.
- [ ] `admin.php?page=jetpack-search&tab=plan-usage` still opens the renamed tab (backwards compatibility for existing bookmarks).
- [ ] Clicking a different tab and back updates the URL to `&tab=overview` (not `plan-usage`).
- [ ] Settings tab and AI Answers tab continue to work as before.
- [ ] `pnpm jetpack test packages/search` and the dashboard-page suite pass — including the new `resolves the legacy plan-usage slug to the Overview tab` case.
