### PR TITLE
Search dashboard: route tabs via URL hash (SEARCH-224)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-224-hash-tab-routing
+++ b/projects/packages/search/changelog/SEARCH-224-hash-tab-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search dashboard: route tabs via the URL hash (`#/<slug>`) instead of the `?tab=<slug>` query parameter, matching the my-jetpack admin's HashRouter convention. Existing `?tab=<slug>` URLs (including the legacy `plan-usage` slug) are normalized to the equivalent hash on mount so existing bookmarks keep working.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -3,7 +3,7 @@ import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-c
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Stack, Tabs } from '@wordpress/ui';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AIAgentAccessControl from 'components/ai-agent-access-control';
 import AiAnswersTab from 'components/ai-answers-tab';
 import ExperienceSelector from 'components/experience-selector';
@@ -24,19 +24,44 @@ import './dashboard-page.scss';
 const DEFAULT_TAB = 'overview';
 // Keep this allowlist in sync with the <Tabs.Tab value="..."> definitions below.
 const VALID_TABS = [ DEFAULT_TAB, 'settings', 'ai-answers' ];
-const TAB_QUERY_PARAM = 'tab';
+// Tabs are now routed via the URL hash (#/<slug>) to match the my-jetpack
+// admin's HashRouter convention. The pre-hash `?tab=<slug>` query param is
+// still honored on mount so existing bookmarks resolve correctly; mount-time
+// normalization rewrites the URL to the canonical hash form.
+const LEGACY_TAB_QUERY_PARAM = 'tab';
 // Maps removed slugs to their current equivalents so existing bookmarks/links keep working.
 const LEGACY_TAB_ALIASES = { 'plan-usage': 'overview' };
 
-const getInitialTab = () => {
+const resolveTabFromLocation = () => {
 	if ( typeof window === 'undefined' ) {
 		return DEFAULT_TAB;
 	}
 
-	const requestedTab = new URLSearchParams( window.location.search ).get( TAB_QUERY_PARAM );
+	// Hash wins (canonical); fall back to legacy `?tab=` query param.
+	const fromHash = window.location.hash.replace( /^#\/?/, '' );
+	const fromQuery = new URLSearchParams( window.location.search ).get( LEGACY_TAB_QUERY_PARAM );
+	const requestedTab = fromHash || fromQuery;
 	const resolvedTab = LEGACY_TAB_ALIASES[ requestedTab ] ?? requestedTab;
 
 	return VALID_TABS.includes( resolvedTab ) ? resolvedTab : DEFAULT_TAB;
+};
+
+// Rewrites the URL to the canonical `#/<tab>` form and strips any legacy
+// `?tab=` query param. Uses `replaceState` so it doesn't add a back-button
+// entry and doesn't fire a `hashchange` event (safe to call from a
+// `hashchange` handler).
+const normalizeUrlToHash = tab => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const url = new URL( window.location.href );
+	const desiredHash = `#/${ tab }`;
+	if ( url.hash === desiredHash && ! url.searchParams.has( LEGACY_TAB_QUERY_PARAM ) ) {
+		return;
+	}
+	url.searchParams.delete( LEGACY_TAB_QUERY_PARAM );
+	url.hash = desiredHash;
+	window.history.replaceState( {}, '', url.toString() );
 };
 
 /**
@@ -48,7 +73,29 @@ const getInitialTab = () => {
  * @return {import('react').Component} Search dashboard component.
  */
 export default function DashboardPage( { isLoading = false } ) {
-	const [ activeTab, setActiveTab ] = useState( getInitialTab );
+	const [ activeTab, setActiveTab ] = useState( resolveTabFromLocation );
+
+	// On mount, canonicalize the URL to `#/<tab>` and drop any legacy `?tab=`
+	// query string so reloads stop carrying it.
+	useEffect( () => {
+		normalizeUrlToHash( activeTab );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	// Keep the active tab in sync with external hash changes (back/forward button, manual edit).
+	useEffect( () => {
+		if ( typeof window === 'undefined' ) {
+			return;
+		}
+		const onHashChange = () => {
+			const resolved = resolveTabFromLocation();
+			setActiveTab( resolved );
+			// External nav might have landed on a legacy slug; canonicalize too.
+			normalizeUrlToHash( resolved );
+		};
+		window.addEventListener( 'hashchange', onHashChange );
+		return () => window.removeEventListener( 'hashchange', onHashChange );
+	}, [] );
 
 	const handleTabChange = tab => {
 		setActiveTab( tab );
@@ -56,10 +103,9 @@ export default function DashboardPage( { isLoading = false } ) {
 		if ( typeof window === 'undefined' ) {
 			return;
 		}
-
-		const url = new URL( window.location.href );
-		url.searchParams.set( TAB_QUERY_PARAM, tab );
-		window.history.replaceState( {}, '', url.toString() );
+		// Assigning to .hash (not replaceState) creates a back-button entry,
+		// matching my-jetpack's HashRouter navigation behavior.
+		window.location.hash = `/${ tab }`;
 	};
 
 	useSelect( select => select( STORE_ID ).getSearchPlanInfo(), [] );

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -61,7 +61,9 @@ const normalizeUrlToHash = tab => {
 	}
 	url.searchParams.delete( LEGACY_TAB_QUERY_PARAM );
 	url.hash = desiredHash;
-	window.history.replaceState( {}, '', url.toString() );
+	// Preserve any existing history.state — assigning {} would clobber state
+	// stashed by other scripts running on the same admin page.
+	window.history.replaceState( window.history.state ?? {}, '', url.toString() );
 };
 
 /**
@@ -79,6 +81,8 @@ export default function DashboardPage( { isLoading = false } ) {
 	// query string so reloads stop carrying it.
 	useEffect( () => {
 		normalizeUrlToHash( activeTab );
+		// Intentional: canonicalize once with the initial `activeTab`. Later
+		// hash changes are handled by the `hashchange` listener below.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
@@ -89,7 +93,10 @@ export default function DashboardPage( { isLoading = false } ) {
 		}
 		const onHashChange = () => {
 			const resolved = resolveTabFromLocation();
-			setActiveTab( resolved );
+			// Skip the state update when the resolved tab already matches —
+			// otherwise user-initiated clicks would `setActiveTab` twice (once
+			// in `handleTabChange`, once via the `hashchange` event echo).
+			setActiveTab( prev => ( prev === resolved ? prev : resolved ) );
 			// External nav might have landed on a legacy slug; canonicalize too.
 			normalizeUrlToHash( resolved );
 		};

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -60,7 +60,7 @@ jest.mock( '../sections/first-run-section', () => () => <div data-testid="first-
 jest.mock( '../sections/overview-section', () => () => <div data-testid="overview-section" /> );
 
 /* eslint-disable testing-library/prefer-user-event */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DashboardPage from '../dashboard-page';
 
@@ -300,8 +300,8 @@ describe( 'DashboardPage', () => {
 		expect( mockReaderChatControl ).not.toHaveBeenCalled();
 	} );
 
-	test( 'hydrates active tab from the URL query string', () => {
-		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=ai-answers` );
+	test( 'hydrates active tab from the URL hash', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }#/ai-answers` );
 
 		render( <DashboardPage /> );
 
@@ -316,9 +316,8 @@ describe( 'DashboardPage', () => {
 		expect( screen.getByTestId( 'ai-answers-tab' ) ).toBeInTheDocument();
 	} );
 
-	test( 'falls back to the default tab when URL tab is unknown', () => {
-		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=unknown` );
-		const replaceStateSpy = jest.spyOn( window.history, 'replaceState' );
+	test( 'falls back to the default tab when the URL hash is unknown', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }#/unknown` );
 
 		render( <DashboardPage /> );
 
@@ -326,12 +325,37 @@ describe( 'DashboardPage', () => {
 			'aria-selected',
 			'true'
 		);
-		expect( replaceStateSpy ).not.toHaveBeenCalled();
-		expect( window.location.search ).toContain( 'tab=unknown' );
-		replaceStateSpy.mockRestore();
+		// Mount-time normalization rewrites the unknown hash to the canonical default.
+		expect( window.location.hash ).toBe( '#/overview' );
 	} );
 
-	test( 'resolves the legacy plan-usage slug to the Overview tab (backwards compat)', () => {
+	test( 'resolves the legacy plan-usage slug in the hash to the Overview tab', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }#/plan-usage` );
+
+		render( <DashboardPage /> );
+
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		// Normalized to the canonical Overview hash.
+		expect( window.location.hash ).toBe( '#/overview' );
+	} );
+
+	test( 'normalizes legacy ?tab= query strings to the equivalent hash on mount', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=ai-answers` );
+
+		render( <DashboardPage /> );
+
+		expect( screen.getByRole( 'tab', { name: /ai answers/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect( window.location.hash ).toBe( '#/ai-answers' );
+		expect( window.location.search ).not.toContain( 'tab=' );
+	} );
+
+	test( 'normalizes legacy ?tab=plan-usage to the new Overview hash on mount', () => {
 		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=plan-usage` );
 
 		render( <DashboardPage /> );
@@ -340,22 +364,35 @@ describe( 'DashboardPage', () => {
 			'aria-selected',
 			'true'
 		);
+		expect( window.location.hash ).toBe( '#/overview' );
+		expect( window.location.search ).not.toContain( 'tab=' );
 	} );
 
-	test( 'updates the URL tab query string when tabs are changed', async () => {
+	test( 'updates the URL hash when tabs are changed', async () => {
 		const user = userEvent.setup();
-		const replaceStateSpy = jest.spyOn( window.history, 'replaceState' );
 
 		render( <DashboardPage /> );
 		await user.click( screen.getByRole( 'tab', { name: /ai answers/i } ) );
 
-		await waitFor( () =>
-			expect( replaceStateSpy ).toHaveBeenCalledWith(
-				{},
-				'',
-				`${ DEFAULT_TEST_URL }&tab=ai-answers`
-			)
+		await waitFor( () => expect( window.location.hash ).toBe( '#/ai-answers' ) );
+	} );
+
+	test( 'syncs active tab when the hash changes externally (back/forward)', () => {
+		render( <DashboardPage /> );
+
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
 		);
-		replaceStateSpy.mockRestore();
+
+		act( () => {
+			window.location.hash = '/settings';
+			window.dispatchEvent( new HashChangeEvent( 'hashchange' ) );
+		} );
+
+		expect( screen.getByRole( 'tab', { name: /settings/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -395,4 +395,43 @@ describe( 'DashboardPage', () => {
 			'true'
 		);
 	} );
+
+	test( 'normalizes a plain URL to the canonical #/overview hash on mount', () => {
+		// No hash, no `?tab=` — the canonical default for first-time visitors.
+		render( <DashboardPage /> );
+
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect( window.location.hash ).toBe( '#/overview' );
+	} );
+
+	test( 'normalizes the current-slug legacy query (?tab=overview) to #/overview on mount', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=overview` );
+
+		render( <DashboardPage /> );
+
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect( window.location.hash ).toBe( '#/overview' );
+		expect( window.location.search ).not.toContain( 'tab=' );
+	} );
+
+	test( 'canonicalizes the URL when an external hashchange lands on a legacy slug', () => {
+		render( <DashboardPage /> );
+
+		act( () => {
+			window.location.hash = '/plan-usage';
+			window.dispatchEvent( new HashChangeEvent( 'hashchange' ) );
+		} );
+
+		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect( window.location.hash ).toBe( '#/overview' );
+	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -44,7 +44,7 @@ function Search( props ) {
 				<Card
 					compact
 					className="jp-settings-card__configure-link"
-					href="admin.php?page=jetpack-search&tab=settings"
+					href="admin.php?page=jetpack-search#/settings"
 				>
 					{ SEARCH_DASHBOARD_CTA }
 				</Card>

--- a/projects/plugins/jetpack/_inc/client/performance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/component.js
@@ -8,7 +8,7 @@ describe( 'Performance tab', () => {
 
 		const link = screen.getByRole( 'link', { name: 'Manage Search settings' } );
 		expect( link ).toBeInTheDocument();
-		expect( link ).toHaveAttribute( 'href', 'admin.php?page=jetpack-search&tab=settings' );
+		expect( link ).toHaveAttribute( 'href', 'admin.php?page=jetpack-search#/settings' );
 	} );
 
 	it( 'hides the Search dashboard link in offline mode', () => {

--- a/projects/plugins/jetpack/changelog/SEARCH-224-hash-tab-routing
+++ b/projects/plugins/jetpack/changelog/SEARCH-224-hash-tab-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Search: point the Performance page's "Manage Search settings" link at the Search dashboard's new `#/settings` hash route.


### PR DESCRIPTION
Fixes [SEARCH-224](https://linear.app/a8c/issue/SEARCH-224/search-dashboard-route-tabs-via-url-hash-instead-of-query-parameter)

> **Stacked PR.** Base branch is `nova/search-223-rename-plan-usage-to-overview` (#49041). Merge that first, then this PR rebases cleanly onto trunk.

## Why
Today the Search dashboard tracks the active tab via `?tab=<slug>`. Aligning with the my-jetpack admin's `HashRouter` (`projects/packages/my-jetpack/_inc/admin.jsx`) gives us one mental model for deep-linking across Jetpack admin and unlocks two practical wins:

1. **Survives WP admin URL rewrites.** Hash fragments are never sent to the server, so any future query-string rewriting in `admin.php` (filters, redirects, multisite plumbing) can't strip the active tab.
2. **Native back/forward navigation between tabs** — we assign to `window.location.hash` (not `history.replaceState`), so the browser's own history stack records each tab change.

## Proposed changes
* Switch tab routing from `?tab=<slug>` to `#/<slug>`.
* New `resolveTabFromLocation()` reads `window.location.hash` first, falls back to the legacy `?tab=` query, and resolves through `LEGACY_TAB_ALIASES` (so the `plan-usage` → `overview` mapping from SEARCH-223 still applies in either form).
* New `normalizeUrlToHash()` helper rewrites the URL to the canonical `#/<tab>` form and strips any leftover `?tab=` query. Called from both the mount effect and the `hashchange` listener, so legacy slugs get canonicalized regardless of how they arrive.
* `handleTabChange` sets `window.location.hash = '/' + tab` (browser back/forward traverses tabs).
* A `hashchange` listener keeps `activeTab` in sync with external hash changes.

## Backwards compatibility — full matrix verified in browser
| Incoming URL | Active tab | Final URL |
| --- | --- | --- |
| `?page=jetpack-search` (no hash, no query) | Overview | `#/overview` |
| `?page=jetpack-search&tab=plan-usage` (legacy query + legacy slug) | Overview | `#/overview`, no `?tab=` |
| `?page=jetpack-search&tab=ai-answers` (legacy query) | AI Answers | `#/ai-answers`, no `?tab=` |
| `?page=jetpack-search#/plan-usage` (legacy slug via hash) | Overview | `#/overview` |
| `?page=jetpack-search#/settings` | Settings | `#/settings` |
| Click `Overview` then `AI Answers` then browser **Back** | Overview | `#/overview` |

## Related product discussion/links
* Linear: [SEARCH-224](https://linear.app/a8c/issue/SEARCH-224/search-dashboard-route-tabs-via-url-hash-instead-of-query-parameter)
* Predecessor PR (stacked under): #49041 (SEARCH-223 — rename Plan & Usage → Overview)
* Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-c0f71109ba96)
* my-jetpack precedent: `projects/packages/my-jetpack/_inc/admin.jsx` (`HashRouter`, `useNavigate`).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Acceptance criteria from SEARCH-224:

- [ ] Clicking a tab updates `window.location.hash` to `#/<slug>` (no `?tab=` in the URL).
- [ ] `admin.php?page=jetpack-search` (no hash, no query) lands on Overview, and the URL is normalised to `…#/overview` automatically.
- [ ] `admin.php?page=jetpack-search#/settings` opens Settings.
- [ ] `admin.php?page=jetpack-search#/plan-usage` opens Overview (legacy slug via hash) and is normalised to `…#/overview`.
- [ ] `admin.php?page=jetpack-search&tab=plan-usage` opens Overview, URL becomes `…#/overview`, the `?tab=` is gone (legacy query + legacy slug).
- [ ] `admin.php?page=jetpack-search&tab=overview` opens Overview, URL becomes `…#/overview`, the `?tab=` is gone.
- [ ] Click `Overview` → `AI Answers` → browser **Back** lands you back on Overview (back/forward traverses the tab history).
- [ ] `pnpm jetpack test packages/search` and the dashboard-page suite pass — including the new hashchange-sync and legacy-query-normalize cases.
