### PR TITLE
Search Blocks: hide Load More button while "Loading…" is showing (SEARCH-226)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-226-load-more-hide-button-while-loading
+++ b/projects/packages/search/changelog/SEARCH-226-load-more-hide-button-while-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: hide the Load More button while the "Loading…" indicator is showing, so visitors don't see both stacked together during a load-more fetch.

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/style.scss
@@ -13,6 +13,15 @@
 	.jetpack-search-load-more__button {
 		cursor: pointer;
 
+		// The button carries `wp-block-button__link` / `wp-element-button`, which
+		// set `display: inline-block` and override the native `hidden` attribute's
+		// `display: none`. The render binding toggles `hidden` during load-more
+		// fetches; re-apply `display: none` so the button actually disappears
+		// while the spinner takes over.
+		&[hidden] {
+			display: none;
+		}
+
 		&:disabled {
 			opacity: 0.5;
 			cursor: not-allowed;


### PR DESCRIPTION
Fixes [SEARCH-226](https://linear.app/a8c/issue/SEARCH-226/search-blocks-load-more-button-stays-visible-while-loading-is-shown)

## Why

When a visitor clicks **Load more results** in a Search Blocks-powered results page, the `Loading…` indicator now appears in place of the button instead of stacked beneath a still-visible button. That removes the visual ambiguity about whether the click registered and prevents a second click against an already in-flight request.

## Proposed changes
* Add a `.jetpack-search-load-more__button[hidden] { display: none; }` rule in `results-load-more/style.scss` so the HTML `hidden` attribute the existing `data-wp-bind--hidden="state.isLoadingMore"` binding sets actually takes effect on the button. `wp-block-button__link` / `wp-element-button` set `display: inline-block`, which was overriding the native `hidden` behaviour and was the reason the button stayed visible during the next-page fetch.

## Related product discussion/links
* [SEARCH-226](https://linear.app/a8c/issue/SEARCH-226/search-blocks-load-more-button-stays-visible-while-loading-is-shown)

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/0589a9a5-7b6a-4706-a141-a5eccee04665) | ![after](https://github.com/user-attachments/assets/80c5f738-4a7d-4d3a-8513-442c9d75ffc3) |

Captured at `/?s=the` against the local docker env, mid-fetch with the next-page request artificially slowed so the loading state is easy to catch.

## Testing instructions

* On a site running Jetpack Search 3.0 with a Search Blocks results template that includes **Load more results**, visit a search query that returns enough results to need a second page (e.g. `/?s=the` on a site with 20+ matches).
* Click **Load more results**.
  * Expected: the button disappears while `Loading…` shows underneath; once the next page lands, the button reappears (or the whole wrapper hides if there are no more pages).
* Test again with the **Compact** block style applied to the Load More block — same behaviour should hold.
