### PR TITLE
Search Blocks: filters-popover becomes a responsive container (SEARCH-225)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-225-filters-popover-responsive
+++ b/projects/packages/search/changelog/SEARCH-225-filters-popover-responsive
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
-Search Blocks: filters-popover becomes a responsive container — renders inline at 992px and wider, collapses to the popover trigger below; existing always-collapsed behavior remains opt-in via the new display-mode select.
+Search Blocks: filters-popover becomes a responsive container — renders inline at 992px and wider, collapses to the popover trigger below. New `displayMode` attribute defaults to `responsive`, which changes the default front-end behaviour of the (feature-flagged) block; existing always-collapsed behaviour remains opt-in via the new display-mode select.

--- a/projects/packages/search/changelog/SEARCH-225-filters-popover-responsive
+++ b/projects/packages/search/changelog/SEARCH-225-filters-popover-responsive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: filters-popover becomes a responsive container — renders inline at 992px and wider, collapses to the popover trigger below; existing always-collapsed behavior remains opt-in via the new display-mode select.

--- a/projects/packages/search/changelog/SEARCH-225-filters-popover-responsive
+++ b/projects/packages/search/changelog/SEARCH-225-filters-popover-responsive
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Search Blocks: filters-popover becomes a responsive container — renders inline at 992px and wider, collapses to the popover trigger below. New `displayMode` attribute defaults to `responsive`, which changes the default front-end behaviour of the (feature-flagged) block; existing always-collapsed behaviour remains opt-in via the new display-mode select.
+Search Blocks: filters-popover gains a `displayMode` attribute. It still defaults to the always-collapsed popover; the new responsive layout — inline filters on wider screens that collapse to the popover trigger on narrow ones — is opt-in via the display-mode select.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
@@ -5,11 +5,11 @@
 	"version": "0.1.0",
 	"title": "Collapsible Filters",
 	"category": "jetpack-search",
-	"description": "Filter container — renders inline on wider screens and collapses to a popover trigger below 992px. Powered by Jetpack Search.",
+	"description": "Tucks the filters behind a compact button that opens them in a popover. Can also show them inline on wider screens. Powered by Jetpack Search.",
 	"attributes": {
 		"displayMode": {
 			"type": "string",
-			"default": "responsive"
+			"default": "popover-always"
 		}
 	},
 	"supports": {

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
@@ -5,7 +5,13 @@
 	"version": "0.1.0",
 	"title": "Collapsible Filters",
 	"category": "jetpack-search",
-	"description": "Compact filter trigger that opens a popover containing filter checkboxes. Powered by Jetpack Search.",
+	"description": "Filter container — renders inline on wider screens and collapses to a popover trigger below 992px. Powered by Jetpack Search.",
+	"attributes": {
+		"displayMode": {
+			"type": "string",
+			"default": "responsive"
+		}
+	},
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -93,7 +93,11 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 						</span>
 					</button>
 				) }
-				<div className="jetpack-search-filters-popover__panel">
+				<div
+					className="jetpack-search-filters-popover__panel"
+					role="region"
+					aria-label={ __( 'Search filters', 'jetpack-search-pkg' ) }
+				>
 					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
 				</div>
 			</div>

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -3,7 +3,8 @@
  *
  * Two display modes share this block. `responsive` (default) renders children inline,
  * mirroring the ≥992px front-end appearance; CSS swaps in the trigger + popover below.
- * `popover-always` keeps the legacy collapsed trigger + dialog preview at every width.
+ * `popover-always` shows the trigger button to signal the runtime collapse, but children
+ * still render inline so authors can edit them — runtime visibility is class-driven.
  */
 import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
@@ -48,7 +49,7 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 		attributes?.displayMode === 'popover-always' ? 'popover-always' : 'responsive';
 	const isResponsive = displayMode === 'responsive';
 	const blockProps = useBlockProps( {
-		className: `jetpack-search-filters-popover is-mode-${ displayMode }`,
+		className: `jetpack-search-filters-popover is-mode-${ displayMode } is-editor-preview`,
 	} );
 
 	return (
@@ -74,7 +75,6 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 					<button
 						type="button"
 						className="jetpack-search-filters-popover__trigger"
-						aria-haspopup="dialog"
 						aria-expanded="false"
 						disabled
 					>
@@ -93,16 +93,7 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 						</span>
 					</button>
 				) }
-				<div
-					className={
-						isResponsive
-							? 'jetpack-search-filters-popover__panel jetpack-search-filters-popover__panel--inline'
-							: 'jetpack-search-filters-popover__panel jetpack-search-filters-popover__panel--editor'
-					}
-					role={ isResponsive ? 'group' : 'dialog' }
-					aria-label={ __( 'Filters', 'jetpack-search-pkg' ) }
-					hidden={ ! isResponsive }
-				>
+				<div className="jetpack-search-filters-popover__panel">
 					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
 				</div>
 			</div>

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -1,10 +1,10 @@
 /**
  * Editor preview for jetpack-search/filters-popover.
  *
- * Two display modes share this block. `responsive` (default) renders children inline,
- * mirroring the ≥992px front-end appearance; CSS swaps in the trigger + popover below.
- * `popover-always` shows the trigger button to signal the runtime collapse, but children
- * still render inline so authors can edit them — runtime visibility is class-driven.
+ * Two display modes share this block. `popover-always` (default) shows the trigger button
+ * to signal the runtime collapse, but children still render inline so authors can edit them.
+ * `responsive` renders children inline, mirroring the ≥992px front-end appearance; CSS swaps
+ * in the trigger + popover below. Runtime visibility is class-driven.
  */
 import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
@@ -27,12 +27,12 @@ const ALLOWED = [
 
 const DISPLAY_MODE_OPTIONS = [
 	{
-		value: 'responsive',
-		label: __( 'Inline on desktop, popover on mobile', 'jetpack-search-pkg' ),
-	},
-	{
 		value: 'popover-always',
 		label: __( 'Always collapsed (popover)', 'jetpack-search-pkg' ),
+	},
+	{
+		value: 'responsive',
+		label: __( 'Inline on desktop, popover on mobile', 'jetpack-search-pkg' ),
 	},
 ];
 
@@ -45,8 +45,7 @@ const DISPLAY_MODE_OPTIONS = [
  * @return {object} Rendered element.
  */
 export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
-	const displayMode =
-		attributes?.displayMode === 'popover-always' ? 'popover-always' : 'responsive';
+	const displayMode = attributes?.displayMode === 'responsive' ? 'responsive' : 'popover-always';
 	const isResponsive = displayMode === 'responsive';
 	const blockProps = useBlockProps( {
 		className: `jetpack-search-filters-popover is-mode-${ displayMode } is-editor-preview`,
@@ -64,7 +63,7 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 						options={ DISPLAY_MODE_OPTIONS }
 						onChange={ value => setAttributes( { displayMode: value } ) }
 						help={ __(
-							'Responsive shows filters inline at 992px and wider, then collapses to a popover button on narrower screens.',
+							'Responsive shows the filters inline on wider screens and collapses them to a popover button on narrow ones.',
 							'jetpack-search-pkg'
 						) }
 					/>

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -1,10 +1,12 @@
 /**
  * Editor preview for jetpack-search/filters-popover.
  *
- * Renders the trigger + a closed panel in the editor so the full Search
- * pattern preview mirrors the front-end default state.
+ * Two display modes share this block. `responsive` (default) renders children inline,
+ * mirroring the ≥992px front-end appearance; CSS swaps in the trigger + popover below.
+ * `popover-always` keeps the legacy collapsed trigger + dialog preview at every width.
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const TEMPLATE = [
@@ -22,43 +24,89 @@ const ALLOWED = [
 	'jetpack-search/filter-post-type',
 ];
 
+const DISPLAY_MODE_OPTIONS = [
+	{
+		value: 'responsive',
+		label: __( 'Inline on desktop, popover on mobile', 'jetpack-search-pkg' ),
+	},
+	{
+		value: 'popover-always',
+		label: __( 'Always collapsed (popover)', 'jetpack-search-pkg' ),
+	},
+];
+
 /**
  * Edit component for the filters-popover block.
  *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function FiltersPopoverEdit() {
-	const blockProps = useBlockProps( { className: 'jetpack-search-filters-popover' } );
+export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
+	const displayMode =
+		attributes?.displayMode === 'popover-always' ? 'popover-always' : 'responsive';
+	const isResponsive = displayMode === 'responsive';
+	const blockProps = useBlockProps( {
+		className: `jetpack-search-filters-popover is-mode-${ displayMode }`,
+	} );
+
 	return (
-		<div { ...blockProps }>
-			<button
-				type="button"
-				className="jetpack-search-filters-popover__trigger"
-				aria-haspopup="dialog"
-				aria-expanded="false"
-				disabled
-			>
-				<svg
-					className="jetpack-search-filters-popover__icon"
-					width={ 18 }
-					height={ 18 }
-					viewBox="0 0 24 24"
-					aria-hidden="true"
-					focusable="false"
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Display mode', 'jetpack-search-pkg' ) }
+						value={ displayMode }
+						options={ DISPLAY_MODE_OPTIONS }
+						onChange={ value => setAttributes( { displayMode: value } ) }
+						help={ __(
+							'Responsive shows filters inline at 992px and wider, then collapses to a popover button on narrower screens.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				{ ! isResponsive && (
+					<button
+						type="button"
+						className="jetpack-search-filters-popover__trigger"
+						aria-haspopup="dialog"
+						aria-expanded="false"
+						disabled
+					>
+						<svg
+							className="jetpack-search-filters-popover__icon"
+							width={ 18 }
+							height={ 18 }
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+							focusable="false"
+						>
+							<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z" />
+						</svg>
+						<span className="screen-reader-text">
+							{ __( 'Filter results', 'jetpack-search-pkg' ) }
+						</span>
+					</button>
+				) }
+				<div
+					className={
+						isResponsive
+							? 'jetpack-search-filters-popover__panel jetpack-search-filters-popover__panel--inline'
+							: 'jetpack-search-filters-popover__panel jetpack-search-filters-popover__panel--editor'
+					}
+					role={ isResponsive ? 'group' : 'dialog' }
+					aria-label={ __( 'Filters', 'jetpack-search-pkg' ) }
+					hidden={ ! isResponsive }
 				>
-					<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z" />
-				</svg>
-				<span className="screen-reader-text">{ __( 'Filter results', 'jetpack-search-pkg' ) }</span>
-			</button>
-			<div
-				className="jetpack-search-filters-popover__panel jetpack-search-filters-popover__panel--editor"
-				role="dialog"
-				aria-label={ __( 'Filters', 'jetpack-search-pkg' ) }
-				hidden
-			>
-				<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+				</div>
 			</div>
-		</div>
+		</>
 	);
 }
 

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
@@ -27,13 +27,13 @@ $wrapper_class = 'jetpack-search-filters-popover is-mode-' . $display_mode;
 	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => $wrapper_class ) ) ); ?>
 	data-wp-interactive="jetpack-search"
 	data-jetpack-search-popover-root
+	data-wp-class--is-popover-open="state.isFilterPopoverOpen"
 	data-wp-on-window--click="actions.onWindowClickClosePopovers"
 	data-wp-on-window--keydown="actions.onEscapeClosePopovers"
 >
 	<button
 		type="button"
 		class="jetpack-search-filters-popover__trigger"
-		aria-haspopup="dialog"
 		aria-expanded="false"
 		data-wp-bind--aria-expanded="state.isFilterPopoverOpen"
 		disabled
@@ -59,10 +59,6 @@ $wrapper_class = 'jetpack-search-filters-popover is-mode-' . $display_mode;
 	<div
 		id="<?php echo esc_attr( $panel_id ); ?>"
 		class="jetpack-search-filters-popover__panel"
-		role="dialog"
-		aria-label="<?php esc_attr_e( 'Filters', 'jetpack-search-pkg' ); ?>"
-		data-wp-bind--hidden="!state.isFilterPopoverOpen"
-		hidden
 	>
 		<?php
 		// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
@@ -59,6 +59,8 @@ $wrapper_class = 'jetpack-search-filters-popover is-mode-' . $display_mode;
 	<div
 		id="<?php echo esc_attr( $panel_id ); ?>"
 		class="jetpack-search-filters-popover__panel"
+		role="region"
+		aria-label="<?php esc_attr_e( 'Search filters', 'jetpack-search-pkg' ); ?>"
 	>
 		<?php
 		// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
@@ -14,9 +14,17 @@ namespace Automattic\Jetpack\Search;
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
+
+// `responsive` (default) renders inline ≥992px and collapses to the popover trigger below.
+// `popover-always` keeps the trigger+popover at every viewport. Any unknown value falls
+// back to `responsive` so a serialised typo can't end up with no styling.
+$display_mode  = isset( $attributes['displayMode'] ) && 'popover-always' === $attributes['displayMode']
+	? 'popover-always'
+	: 'responsive';
+$wrapper_class = 'jetpack-search-filters-popover is-mode-' . $display_mode;
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filters-popover' ) ) ); ?>
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => $wrapper_class ) ) ); ?>
 	data-wp-interactive="jetpack-search"
 	data-jetpack-search-popover-root
 	data-wp-on-window--click="actions.onWindowClickClosePopovers"

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
@@ -15,12 +15,13 @@ namespace Automattic\Jetpack\Search;
 
 $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
 
-// `responsive` (default) renders inline ≥992px and collapses to the popover trigger below.
-// `popover-always` keeps the trigger+popover at every viewport. Any unknown value falls
-// back to `responsive` so a serialised typo can't end up with no styling.
-$display_mode  = isset( $attributes['displayMode'] ) && 'popover-always' === $attributes['displayMode']
-	? 'popover-always'
-	: 'responsive';
+// `popover-always` (default) keeps the trigger+popover at every viewport.
+// `responsive` renders inline ≥992px and collapses to the popover trigger below.
+// Any unknown value falls back to `popover-always` so a serialised typo can't
+// end up with no styling.
+$display_mode  = isset( $attributes['displayMode'] ) && 'responsive' === $attributes['displayMode']
+	? 'responsive'
+	: 'popover-always';
 $wrapper_class = 'jetpack-search-filters-popover is-mode-' . $display_mode;
 ?>
 <div

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -1,3 +1,7 @@
+// Match Instant Search's $break-lg so the two Search experiences flip layouts
+// at the same width.
+$jetpack-search-filters-popover-collapse: 992px;
+
 .jetpack-search-filters-popover {
 	position: relative;
 	display: inline-block;
@@ -91,9 +95,52 @@
 			display: none;
 		}
 
-		&--editor {
+		&--editor,
+		&--inline {
 			position: static;
 			box-shadow: none;
+		}
+
+		&--inline[hidden] {
+			// Editor preview for responsive mode renders children inline; the
+			// `hidden` attribute on the wrapper still applies via the rule
+			// above, so neutralise it here for this preview variant only.
+			display: flex;
+		}
+	}
+
+	// Responsive mode: above the collapse threshold the popover is gone — the
+	// container becomes an inline sidebar surface. The trigger button is taken
+	// out of the flow (so its `aria-haspopup` is unreachable too) and the panel
+	// drops every popover-only style (absolute positioning, max-width, chrome,
+	// hidden override) and renders as a vertical stack the way the `filters`
+	// block does.
+	&.is-mode-responsive {
+
+		@media (min-width: $jetpack-search-filters-popover-collapse) {
+			display: block;
+
+			.jetpack-search-filters-popover__trigger {
+				display: none;
+			}
+
+			// Override the `[hidden]` attribute the Interactivity API toggles
+			// below the breakpoint — selector specificity (0,3,1) beats the
+			// base `&__panel[hidden]` rule (0,2,1).
+			.jetpack-search-filters-popover__panel,
+			.jetpack-search-filters-popover__panel[hidden] {
+				position: static;
+				display: flex;
+				min-width: 0;
+				max-width: none;
+				padding: 0;
+				background: transparent;
+				color: inherit;
+				border: none;
+				border-radius: 0;
+				box-shadow: none;
+				z-index: auto;
+			}
 		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -66,6 +66,12 @@ $jetpack-search-filters-popover-collapse: 992px;
 		color: var(--wp--preset--color--background, #fff);
 	}
 
+	// Panel base — popover form. Collapsed by default; visibility is driven
+	// by `.is-popover-open` on the root (toggled by the Interactivity store
+	// via `data-wp-class--is-popover-open`) rather than the `hidden`
+	// attribute — overriding `[hidden]` via CSS leaves the attribute set,
+	// which screen readers still respect even though sighted users see the
+	// content.
 	&__panel {
 		position: absolute;
 		inset-inline-end: 0;
@@ -73,7 +79,7 @@ $jetpack-search-filters-popover-collapse: 992px;
 		min-width: 260px;
 		max-width: min(360px, 90vw);
 		z-index: 20;
-		display: flex;
+		display: none;
 		flex-direction: column;
 		gap: 1rem;
 		padding: 12px;
@@ -90,31 +96,16 @@ $jetpack-search-filters-popover-collapse: 992px;
 		border-color: color-mix(in sRGB, currentColor 15%, transparent);
 		border-radius: 4px;
 		box-shadow: 0 4px 16px color-mix(in sRGB, currentColor 12%, transparent);
-
-		&[hidden] {
-			display: none;
-		}
-
-		&--editor,
-		&--inline {
-			position: static;
-			box-shadow: none;
-		}
-
-		&--inline[hidden] {
-			// Editor preview for responsive mode renders children inline; the
-			// `hidden` attribute on the wrapper still applies via the rule
-			// above, so neutralise it here for this preview variant only.
-			display: flex;
-		}
 	}
 
-	// Responsive mode: above the collapse threshold the popover is gone — the
-	// container becomes an inline sidebar surface. The trigger button is taken
-	// out of the flow (so its `aria-haspopup` is unreachable too) and the panel
-	// drops every popover-only style (absolute positioning, max-width, chrome,
-	// hidden override) and renders as a vertical stack the way the `filters`
-	// block does.
+	&.is-popover-open &__panel {
+		display: flex;
+	}
+
+	// Responsive mode above the breakpoint: the popover becomes an inline
+	// sidebar. The trigger is taken out of the flow (its `aria-controls` is
+	// unreachable too, which is correct — the target panel is now an inline
+	// region) and the panel sheds every popover-only style.
 	&.is-mode-responsive {
 
 		@media (min-width: $jetpack-search-filters-popover-collapse) {
@@ -124,11 +115,7 @@ $jetpack-search-filters-popover-collapse: 992px;
 				display: none;
 			}
 
-			// Override the `[hidden]` attribute the Interactivity API toggles
-			// below the breakpoint — selector specificity (0,3,1) beats the
-			// base `&__panel[hidden]` rule (0,2,1).
-			.jetpack-search-filters-popover__panel,
-			.jetpack-search-filters-popover__panel[hidden] {
+			.jetpack-search-filters-popover__panel {
 				position: static;
 				display: flex;
 				min-width: 0;
@@ -142,5 +129,23 @@ $jetpack-search-filters-popover-collapse: 992px;
 				z-index: auto;
 			}
 		}
+	}
+
+	// Editor preview always shows children inline regardless of `displayMode`
+	// so authors can edit them. The popover-always trigger button still
+	// renders to signal the runtime collapse, but the panel doesn't hide
+	// behind it in the canvas.
+	&.is-editor-preview &__panel {
+		position: static;
+		display: flex;
+		min-width: 0;
+		max-width: none;
+		padding: 0;
+		background: transparent;
+		color: inherit;
+		border: none;
+		border-radius: 0;
+		box-shadow: none;
+		z-index: auto;
 	}
 }

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -28,7 +28,7 @@ register_block_pattern(
 <!-- wp:group {"className":"jetpack-search-compact-toolbar","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group jetpack-search-compact-toolbar">
 <!-- wp:jetpack-search/search-input /-->
-<!-- wp:jetpack-search/filters-popover -->
+<!-- wp:jetpack-search/filters-popover {"displayMode":"popover-always"} -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -23,16 +23,17 @@ const renderEdit = ( attributes = {} ) =>
 
 describe( 'FiltersPopoverEdit', () => {
 	describe( 'default (responsive) mode', () => {
-		it( 'renders inline children with no trigger when no displayMode is set', () => {
+		it( 'renders an inline labelled region with no trigger when no displayMode is set', () => {
 			renderEdit();
 			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );
 
 		it( 'falls back to responsive for an unknown displayMode value', () => {
 			renderEdit( { displayMode: 'something-else' } );
 			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
-			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -42,12 +43,13 @@ describe( 'FiltersPopoverEdit', () => {
 		// trigger button being present alongside. Front-end visibility is
 		// class-driven by the Interactivity store — covered by
 		// `Filters_Popover_Render_Test` on the PHP side.
-		it( 'renders the disabled trigger alongside the inline children', () => {
+		it( 'renders the disabled trigger alongside the labelled inline region', () => {
 			renderEdit( { displayMode: 'popover-always' } );
 
 			const trigger = screen.getByRole( 'button', { name: 'Filter results' } );
 			expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
 			expect( trigger ).toBeDisabled();
+			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );
 	} );

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -22,33 +22,33 @@ const renderEdit = ( attributes = {} ) =>
 	render( <FiltersPopoverEdit attributes={ attributes } setAttributes={ jest.fn() } /> );
 
 describe( 'FiltersPopoverEdit', () => {
-	describe( 'default (responsive) mode', () => {
-		it( 'renders an inline labelled region with no trigger when no displayMode is set', () => {
-			renderEdit();
-			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
-			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
-		} );
-
-		it( 'falls back to responsive for an unknown displayMode value', () => {
-			renderEdit( { displayMode: 'something-else' } );
-			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
-		} );
-	} );
-
-	describe( 'popover-always mode', () => {
+	describe( 'default (popover-always) mode', () => {
 		// In popover-always mode the editor still renders children inline so
 		// authors can edit them; the visual collapse is signalled by the
 		// trigger button being present alongside. Front-end visibility is
 		// class-driven by the Interactivity store — covered by
 		// `Filters_Popover_Render_Test` on the PHP side.
-		it( 'renders the disabled trigger alongside the labelled inline region', () => {
-			renderEdit( { displayMode: 'popover-always' } );
+		it( 'renders the disabled trigger alongside the labelled inline region when no displayMode is set', () => {
+			renderEdit();
 
 			const trigger = screen.getByRole( 'button', { name: 'Filter results' } );
 			expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
 			expect( trigger ).toBeDisabled();
+			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls back to popover-always for an unknown displayMode value', () => {
+			renderEdit( { displayMode: 'something-else' } );
+			expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'responsive mode', () => {
+		it( 'renders an inline labelled region with no trigger', () => {
+			renderEdit( { displayMode: 'responsive' } );
+			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
 			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -4,24 +4,62 @@ import FiltersPopoverEdit from '../../../src/search-blocks/blocks/filters-popove
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: props => ( { ...props, className: props?.className } ),
 	InnerBlocks: () => <div data-testid="filters-popover-inner-blocks" />,
+	InspectorControls: ( { children } ) => (
+		<div data-testid="filters-popover-inspector">{ children }</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children } ) => <div>{ children }</div>,
+	SelectControl: ( { label } ) => <span data-testid="filters-popover-mode-select">{ label }</span>,
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: text => text,
 } ) );
 
-describe( 'FiltersPopoverEdit', () => {
-	it( 'renders the editor preview with the filter panel closed', () => {
-		render( <FiltersPopoverEdit /> );
+const renderEdit = ( attributes = {} ) =>
+	render( <FiltersPopoverEdit attributes={ attributes } setAttributes={ jest.fn() } /> );
 
-		expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toHaveAttribute(
-			'aria-expanded',
-			'false'
-		);
-		expect( screen.getByRole( 'dialog', { hidden: true } ) ).toHaveAttribute( 'hidden' );
-		expect( screen.getByRole( 'dialog', { hidden: true } ) ).toHaveAttribute(
-			'aria-label',
-			'Filters'
+describe( 'FiltersPopoverEdit', () => {
+	describe( 'default (responsive) mode', () => {
+		it( 'renders inline children with no trigger when no displayMode is set', () => {
+			renderEdit();
+			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
+			const panel = screen.getByRole( 'group', { name: 'Filters' } );
+			expect( panel ).not.toHaveAttribute( 'hidden' );
+			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls back to responsive for an unknown displayMode value', () => {
+			renderEdit( { displayMode: 'something-else' } );
+			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'group', { name: 'Filters' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'popover-always mode', () => {
+		it( 'renders the closed trigger + dialog preview', () => {
+			renderEdit( { displayMode: 'popover-always' } );
+
+			expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toHaveAttribute(
+				'aria-expanded',
+				'false'
+			);
+			const dialog = screen.getByRole( 'dialog', { hidden: true } );
+			expect( dialog ).toHaveAttribute( 'hidden' );
+			expect( dialog ).toHaveAttribute( 'aria-label', 'Filters' );
+			// The dialog being the panel (not a group) is the mode-distinguishing
+			// signal; the `is-mode-*` class is an internal CSS hook covered by
+			// `Filters_Popover_Render_Test` on the PHP side.
+			expect( screen.queryByRole( 'group', { name: 'Filters' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'exposes the display-mode select in the inspector', () => {
+		renderEdit();
+		expect( screen.getByTestId( 'filters-popover-mode-select' ) ).toHaveTextContent(
+			'Display mode'
 		);
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -26,33 +26,29 @@ describe( 'FiltersPopoverEdit', () => {
 		it( 'renders inline children with no trigger when no displayMode is set', () => {
 			renderEdit();
 			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
-			const panel = screen.getByRole( 'group', { name: 'Filters' } );
-			expect( panel ).not.toHaveAttribute( 'hidden' );
 			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );
 
 		it( 'falls back to responsive for an unknown displayMode value', () => {
 			renderEdit( { displayMode: 'something-else' } );
 			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
-			expect( screen.getByRole( 'group', { name: 'Filters' } ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'popover-always mode', () => {
-		it( 'renders the closed trigger + dialog preview', () => {
+		// In popover-always mode the editor still renders children inline so
+		// authors can edit them; the visual collapse is signalled by the
+		// trigger button being present alongside. Front-end visibility is
+		// class-driven by the Interactivity store — covered by
+		// `Filters_Popover_Render_Test` on the PHP side.
+		it( 'renders the disabled trigger alongside the inline children', () => {
 			renderEdit( { displayMode: 'popover-always' } );
 
-			expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toHaveAttribute(
-				'aria-expanded',
-				'false'
-			);
-			const dialog = screen.getByRole( 'dialog', { hidden: true } );
-			expect( dialog ).toHaveAttribute( 'hidden' );
-			expect( dialog ).toHaveAttribute( 'aria-label', 'Filters' );
-			// The dialog being the panel (not a group) is the mode-distinguishing
-			// signal; the `is-mode-*` class is an internal CSS hook covered by
-			// `Filters_Popover_Render_Test` on the PHP side.
-			expect( screen.queryByRole( 'group', { name: 'Filters' } ) ).not.toBeInTheDocument();
+			const trigger = screen.getByRole( 'button', { name: 'Filter results' } );
+			expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
+			expect( trigger ).toBeDisabled();
+			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -102,11 +102,11 @@ class Filters_Popover_Render_Test extends TestCase {
 	}
 
 	/**
-	 * The trigger button + popover panel scaffolding must render in every mode —
-	 * CSS toggles their visibility, the markup doesn't change. Re-confirms that
-	 * the Interactivity API bindings (`data-wp-bind--*`, `data-wp-on--*`) are
-	 * still emitted so the popover continues to work below the breakpoint and
-	 * in always-collapsed mode.
+	 * The trigger button + panel scaffolding must render in every mode — CSS
+	 * and `.is-popover-open` toggle visibility, the markup itself doesn't
+	 * change. Confirms the Interactivity bindings (`data-wp-on--*`,
+	 * `data-wp-class--*`) are emitted so the runtime popover toggle keeps
+	 * working below the breakpoint and in always-collapsed mode.
 	 */
 	public function test_trigger_and_panel_scaffolding_always_render() {
 		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
@@ -114,7 +114,32 @@ class Filters_Popover_Render_Test extends TestCase {
 			$this->assertStringContainsString( 'jetpack-search-filters-popover__trigger', $markup, "mode=$mode" );
 			$this->assertStringContainsString( 'jetpack-search-filters-popover__panel', $markup, "mode=$mode" );
 			$this->assertStringContainsString( 'data-wp-on--click="actions.toggleFilterPopover"', $markup, "mode=$mode" );
-			$this->assertStringContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup, "mode=$mode" );
+			$this->assertStringContainsString( 'data-wp-class--is-popover-open="state.isFilterPopoverOpen"', $markup, "mode=$mode" );
+		}
+	}
+
+	/**
+	 * The panel must NOT carry the `hidden` HTML attribute, `role="dialog"`,
+	 * or `aria-label` — those were the source of the original a11y bug, where
+	 * responsive mode at ≥992px kept the panel `hidden` from screen readers
+	 * even though CSS overrode the visual `display`. Class-driven visibility
+	 * via `.is-popover-open` keeps sighted and AT users in sync. Regression
+	 * guard for PR feedback by Copilot on filters-popover/style.scss.
+	 */
+	public function test_panel_has_no_hidden_attribute_or_dialog_role() {
+		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
+			$markup = $this->render( array( 'displayMode' => $mode ) );
+			$this->assertSame(
+				0,
+				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*\bhidden\b[^>]*>/', $markup ),
+				"mode=$mode: panel must not carry the hidden attribute"
+			);
+			$this->assertSame(
+				0,
+				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="dialog"[^>]*>/', $markup ),
+				"mode=$mode: panel must not carry role=\"dialog\""
+			);
+			$this->assertStringNotContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup, "mode=$mode" );
 		}
 	}
 }

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Filters Popover block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the filters-popover block's render template.
+ *
+ * Each test renders the block through `do_blocks()` so WordPress wires up the
+ * block context (`WP_Block_Supports::$block_to_render`) the template relies on
+ * via `get_block_wrapper_attributes()` — exercising the same path the front
+ * end takes.
+ */
+class Filters_Popover_Render_Test extends TestCase {
+
+	/**
+	 * Register the filters-popover block inline (rather than from its block.json
+	 * directory) so `do_blocks()` can resolve it without depending on the
+	 * `build/` artifacts referenced by block.json's `viewScriptModule` and
+	 * `style` entries — those aren't present in a fresh checkout, and our
+	 * PHPUnit config has `failOnNotice` set, so any missing-asset notice
+	 * during metadata resolution would fail the suite.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			'jetpack-search/filters-popover',
+			array(
+				'attributes'      => array(
+					'displayMode' => array(
+						'type'    => 'string',
+						'default' => 'responsive',
+					),
+				),
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes, $content ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/filters-popover/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack-search/filters-popover' );
+	}
+
+	/**
+	 * Render the filters-popover block via `do_blocks` with the given attributes.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		// Pass an empty inner-block payload — render.php only cares about $content
+		// being defined for the echo, not its contents.
+		return do_blocks( '<!-- wp:jetpack-search/filters-popover ' . $json . ' --><!-- /wp:jetpack-search/filters-popover -->' );
+	}
+
+	/**
+	 * Missing `displayMode` (block.json default takes over) must paint the
+	 * responsive mode class so the desktop CSS path activates by default.
+	 */
+	public function test_missing_display_mode_renders_as_responsive() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'is-mode-responsive', $markup );
+		$this->assertStringNotContainsString( 'is-mode-popover-always', $markup );
+	}
+
+	/**
+	 * Explicit `popover-always` must paint the popover-only mode class so the
+	 * responsive desktop CSS path stays off.
+	 */
+	public function test_popover_always_renders_popover_mode_class() {
+		$markup = $this->render( array( 'displayMode' => 'popover-always' ) );
+		$this->assertStringContainsString( 'is-mode-popover-always', $markup );
+		$this->assertStringNotContainsString( 'is-mode-responsive', $markup );
+	}
+
+	/**
+	 * An unknown / malformed `displayMode` value must fall back to responsive
+	 * so a serialised typo can't end up with no styling applied.
+	 */
+	public function test_unknown_display_mode_falls_back_to_responsive() {
+		$markup = $this->render( array( 'displayMode' => 'something-else' ) );
+		$this->assertStringContainsString( 'is-mode-responsive', $markup );
+		$this->assertStringNotContainsString( 'is-mode-popover-always', $markup );
+		$this->assertStringNotContainsString( 'is-mode-something-else', $markup );
+	}
+
+	/**
+	 * The trigger button + popover panel scaffolding must render in every mode —
+	 * CSS toggles their visibility, the markup doesn't change. Re-confirms that
+	 * the Interactivity API bindings (`data-wp-bind--*`, `data-wp-on--*`) are
+	 * still emitted so the popover continues to work below the breakpoint and
+	 * in always-collapsed mode.
+	 */
+	public function test_trigger_and_panel_scaffolding_always_render() {
+		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
+			$markup = $this->render( array( 'displayMode' => $mode ) );
+			$this->assertStringContainsString( 'jetpack-search-filters-popover__trigger', $markup, "mode=$mode" );
+			$this->assertStringContainsString( 'jetpack-search-filters-popover__panel', $markup, "mode=$mode" );
+			$this->assertStringContainsString( 'data-wp-on--click="actions.toggleFilterPopover"', $markup, "mode=$mode" );
+			$this->assertStringContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup, "mode=$mode" );
+		}
+	}
+}

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -34,7 +34,7 @@ class Filters_Popover_Render_Test extends TestCase {
 				'attributes'      => array(
 					'displayMode' => array(
 						'type'    => 'string',
-						'default' => 'responsive',
+						'default' => 'popover-always',
 					),
 				),
 				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
@@ -72,12 +72,12 @@ class Filters_Popover_Render_Test extends TestCase {
 
 	/**
 	 * Missing `displayMode` (block.json default takes over) must paint the
-	 * responsive mode class so the desktop CSS path activates by default.
+	 * popover-always mode class so the block stays collapsed by default.
 	 */
-	public function test_missing_display_mode_renders_as_responsive() {
+	public function test_missing_display_mode_renders_as_popover_always() {
 		$markup = $this->render();
-		$this->assertStringContainsString( 'is-mode-responsive', $markup );
-		$this->assertStringNotContainsString( 'is-mode-popover-always', $markup );
+		$this->assertStringContainsString( 'is-mode-popover-always', $markup );
+		$this->assertStringNotContainsString( 'is-mode-responsive', $markup );
 	}
 
 	/**
@@ -91,13 +91,13 @@ class Filters_Popover_Render_Test extends TestCase {
 	}
 
 	/**
-	 * An unknown / malformed `displayMode` value must fall back to responsive
+	 * An unknown / malformed `displayMode` value must fall back to popover-always
 	 * so a serialised typo can't end up with no styling applied.
 	 */
-	public function test_unknown_display_mode_falls_back_to_responsive() {
+	public function test_unknown_display_mode_falls_back_to_popover_always() {
 		$markup = $this->render( array( 'displayMode' => 'something-else' ) );
-		$this->assertStringContainsString( 'is-mode-responsive', $markup );
-		$this->assertStringNotContainsString( 'is-mode-popover-always', $markup );
+		$this->assertStringContainsString( 'is-mode-popover-always', $markup );
+		$this->assertStringNotContainsString( 'is-mode-responsive', $markup );
 		$this->assertStringNotContainsString( 'is-mode-something-else', $markup );
 	}
 

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -119,12 +119,12 @@ class Filters_Popover_Render_Test extends TestCase {
 	}
 
 	/**
-	 * The panel must NOT carry the `hidden` HTML attribute, `role="dialog"`,
-	 * or `aria-label` — those were the source of the original a11y bug, where
-	 * responsive mode at ≥992px kept the panel `hidden` from screen readers
-	 * even though CSS overrode the visual `display`. Class-driven visibility
-	 * via `.is-popover-open` keeps sighted and AT users in sync. Regression
-	 * guard for PR feedback by Copilot on filters-popover/style.scss.
+	 * The panel must NOT carry the `hidden` HTML attribute or `role="dialog"` —
+	 * those were the source of the original a11y bug, where responsive mode at
+	 * ≥992px kept the panel `hidden` from screen readers even though CSS
+	 * overrode the visual `display`. Class-driven visibility via
+	 * `.is-popover-open` keeps sighted and AT users in sync. Regression guard
+	 * for PR feedback by Copilot on filters-popover/style.scss.
 	 */
 	public function test_panel_has_no_hidden_attribute_or_dialog_role() {
 		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
@@ -140,6 +140,28 @@ class Filters_Popover_Render_Test extends TestCase {
 				"mode=$mode: panel must not carry role=\"dialog\""
 			);
 			$this->assertStringNotContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup, "mode=$mode" );
+		}
+	}
+
+	/**
+	 * The panel must expose a labelled landmark (`role="region"` +
+	 * `aria-label="Search filters"`) so AT users navigating by landmarks can
+	 * find the filter controls in both the inline-sidebar and popover forms.
+	 * Regression guard for PR feedback by claude[bot] on filters-popover.
+	 */
+	public function test_panel_exposes_search_filters_landmark() {
+		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
+			$markup = $this->render( array( 'displayMode' => $mode ) );
+			$this->assertSame(
+				1,
+				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="region"[^>]*>/', $markup ),
+				"mode=$mode: panel must carry role=\"region\""
+			);
+			$this->assertSame(
+				1,
+				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*aria-label="Search filters"[^>]*>/', $markup ),
+				"mode=$mode: panel must carry aria-label=\"Search filters\""
+			);
 		}
 	}
 }


### PR DESCRIPTION
Fixes [SEARCH-225](https://linear.app/a8c/issue/SEARCH-225/search-blocks-make-filters-popover-a-responsive-container-sidebar)

## Why

Today `jetpack-search/filters-popover` always renders as a button-anchored popover regardless of viewport width, while the sibling `jetpack-search/filters` block is always a vertical sidebar stack with no responsive behavior. Neither matches the industry pattern used by Amazon, Shopify, Algolia, or our own Instant Search (sidebar on desktop, "Filters" button on mobile).

This change evolves `filters-popover` into a responsive filters container — a superset of today's behavior. Above 992px it renders its children inline as a sidebar stack; below 992px it collapses to the existing button + anchored popover. Authors who want the always-collapsed compact-toolbar style flip the new "Display mode" select to `Always collapsed (popover)`.

## Proposed changes

* Add a `displayMode` attribute to `jetpack-search/filters-popover` — `responsive` (new default) | `popover-always` (today's behavior).
* CSS adds a single `@media (min-width: 992px)` block that, when the wrapper has `is-mode-responsive`, hides the trigger, drops the absolute / max-width / chrome / `[hidden]`-attribute popover-only styles, and lets children flow inline as a vertical stack like the `filters` block. Below the breakpoint everything reverts to today's anchored popover automatically — the Interactivity-API store stays untouched.
* Breakpoint pinned to 992px (Instant Search's `$break-lg`) so the two Search experiences flip layouts at the same width.
* Editor preview branches on `displayMode` so authors see the same visual story they'll ship to readers — inline children in responsive mode, collapsed dialog preview in popover-always mode. An Inspector "Display mode" select switches between them.
* The bundled `compact-search` pattern pins `displayMode: popover-always` so its single-row toolbar doesn't expand into a sidebar at desktop width.
* Unit tests cover the JS edit component in both modes and the PHP render path emits the right `is-mode-*` wrapper class. Existing JS / PHP suites stay green (523 JS / 527 PHP).

## Related product discussion/links

* Linear: [SEARCH-225](https://linear.app/a8c/issue/SEARCH-225/search-blocks-make-filters-popover-a-responsive-container-sidebar) (in the `Jetpack Search blocks` project)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-225 — work through this list against the screenshots below or a live env.

* [ ] **New** instances default to `displayMode: responsive` (pick `Collapsible Filters` from the block inserter — the new block should expand inline on the editor canvas, not collapse to a button).
* [ ] **At ≥992px in responsive mode:** children render inline as a stack, trigger button is hidden, the panel has no absolute positioning / z-index / popover chrome.
* [ ] **At <992px in responsive mode:** trigger button is visible, panel is hidden until clicked, clicking opens the existing anchored popover (today's behavior preserved).
* [ ] **`displayMode: popover-always`** matches today's behavior at every viewport (trigger + anchored popover; never an inline sidebar).
* [ ] **Inspector control:** the `Settings` panel exposes a `Display mode` select with the two options.
* [ ] **Manual QA at 768 / 992 / 1200 px** viewport widths.

Suggested fixture (the screenshots below were taken from this exact page):

```
<!-- wp:columns -->
  <!-- wp:column {"width":"260px"} -->
    <!-- wp:jetpack-search/filters-popover -->
      <!-- wp:jetpack-search/active-filters /-->
      <!-- wp:jetpack-search/clear-filters /-->
      <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
      <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
      <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
    <!-- /wp:jetpack-search/filters-popover -->
  <!-- /wp:column -->
  <!-- wp:column -->
    <!-- wp:jetpack-search/search-results -->
      <!-- wp:jetpack-search/results-count /-->
      <!-- wp:jetpack-search/results-list /-->
    <!-- /wp:jetpack-search/search-results -->
  <!-- /wp:column -->
<!-- /wp:columns -->
```

## Screenshots

Captured at 1440×900 against an `echo` per-agent docker via the Jurassic Tube tunnel.

| Before (trunk — popover-only) | After (`displayMode: responsive`, ≥992px) |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/422d92ad-ad50-49be-a70a-998620b7c654) | ![after](https://github.com/user-attachments/assets/be82da42-e354-4f7d-b103-d558de5e897b) |

