### PR TITLE
Search Blocks: add load-on-scroll mode to results-load-more block (SEARCH-227)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-227-load-more-infinite-scroll
+++ b/projects/packages/search/changelog/SEARCH-227-load-more-infinite-scroll
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add an opt-in "Load on scroll" mode to the Load More block — when enabled, the next page of results fetches automatically as the visitor scrolls toward the end of the list, matching the legacy instant-search overlay's infinite-scroll behaviour.

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/block.json
@@ -13,7 +13,9 @@
 	],
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {
-		"buttonLabel": { "type": "string", "default": "" }
+		"buttonLabel": { "type": "string", "default": "" },
+		"loadOnScroll": { "type": "boolean", "default": false },
+		"loadOnScrollOffset": { "type": "number", "default": 200 }
 	},
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/results-load-more.js",

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/edit.js
@@ -7,11 +7,15 @@
  * baseline is too large. Includes the (hidden) loading-spinner span
  * render.php emits so the `.jetpack-search-load-more__spinner` CSS hook is
  * available to style. The Inspector exposes a text input for the
- * `buttonLabel` attribute; the saved value (or the translated default) is
- * what render.php prints on the front end.
+ * `buttonLabel` attribute, a toggle for `loadOnScroll` (auto-load on
+ * scroll), and a range for how early the auto-load fires. When auto-load is
+ * on the front end skips the button entirely (the IntersectionObserver
+ * handles pagination), so the preview swaps to a spinner-only state and the
+ * button-label control hides — the saved value stays around for when the
+ * author flips the toggle back off.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, RangeControl, TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -29,32 +33,79 @@ export default function LoadMoreEdit( { attributes, setAttributes } ) {
 	// in the preview so the editor mirrors the front-end behaviour the
 	// "Leave empty…" help text describes. The raw input is still stored.
 	const buttonLabel = ( attributes?.buttonLabel || '' ).trim() || defaultLabel;
+	const loadOnScroll = !! attributes?.loadOnScroll;
+	const loadOnScrollOffset = Number.isFinite( attributes?.loadOnScrollOffset )
+		? attributes.loadOnScrollOffset
+		: 200;
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
-					<TextControl
-						__next40pxDefaultSize
+					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Button label', 'jetpack-search-pkg' ) }
-						value={ attributes?.buttonLabel || '' }
-						placeholder={ defaultLabel }
-						onChange={ value => setAttributes( { buttonLabel: value } ) }
-						help={ __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ) }
+						label={ __( 'Load on scroll', 'jetpack-search-pkg' ) }
+						help={ __(
+							'Automatically load more results as the visitor scrolls toward the end of the list.',
+							'jetpack-search-pkg'
+						) }
+						checked={ loadOnScroll }
+						onChange={ value => setAttributes( { loadOnScroll: value } ) }
 					/>
+					{ loadOnScroll && (
+						<RangeControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Load distance', 'jetpack-search-pkg' ) }
+							help={ __(
+								'Pixels before the bottom of the list at which the next page starts loading.',
+								'jetpack-search-pkg'
+							) }
+							value={ loadOnScrollOffset }
+							min={ 0 }
+							max={ 2000 }
+							step={ 50 }
+							onChange={ value =>
+								setAttributes( {
+									loadOnScrollOffset: Number.isFinite( value ) ? value : 200,
+								} )
+							}
+						/>
+					) }
+					{ ! loadOnScroll && (
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Button label', 'jetpack-search-pkg' ) }
+							value={ attributes?.buttonLabel || '' }
+							placeholder={ defaultLabel }
+							onChange={ value => setAttributes( { buttonLabel: value } ) }
+							help={ __(
+								'Leave empty to use the default translated label.',
+								'jetpack-search-pkg'
+							) }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<button
-					type="button"
-					className="jetpack-search-load-more__button wp-block-button__link wp-element-button"
-					disabled
-				>
-					{ buttonLabel }
-				</button>
-				<span className="jetpack-search-load-more__spinner" hidden>
-					{ __( 'Loading…', 'jetpack-search-pkg' ) }
-				</span>
+				{ loadOnScroll ? (
+					<span className="jetpack-search-load-more__spinner">
+						{ __( 'Loading…', 'jetpack-search-pkg' ) }
+					</span>
+				) : (
+					<>
+						<button
+							type="button"
+							className="jetpack-search-load-more__button wp-block-button__link wp-element-button"
+							disabled
+						>
+							{ buttonLabel }
+						</button>
+						<span className="jetpack-search-load-more__spinner" hidden>
+							{ __( 'Loading…', 'jetpack-search-pkg' ) }
+						</span>
+					</>
+				) }
 			</div>
 		</>
 	);

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/render.php
@@ -9,6 +9,11 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
+$load_on_scroll = ! empty( $attributes['loadOnScroll'] );
+// Clamp to a sane CSS-px range. 0 = fire exactly when the sentinel hits the
+// viewport bottom; very large values would pre-fetch the entire feed.
+$load_on_scroll_offset = max( 0, min( 2000, (int) ( $attributes['loadOnScrollOffset'] ?? 200 ) ) );
+
 // Trim before the empty check so a whitespace-only label (e.g. "   ")
 // renders the translated default rather than a blank button — matches the
 // "Leave empty to use the default" copy in the editor inspector.
@@ -21,27 +26,42 @@ if ( '' === $button_label ) {
 // theme's full core/button look (border-radius, hover, etc.). That class is
 // only styled when the core Button block's stylesheet is on the page —
 // without a core/button on the page, the handle isn't auto-enqueued and the
-// class is inert. Pull it in explicitly so this block stands alone.
-wp_enqueue_style( 'wp-block-button' );
+// class is inert. Pull it in explicitly so this block stands alone. Skipped
+// in the loadOnScroll path since the button doesn't render there.
+if ( ! $load_on_scroll ) {
+	wp_enqueue_style( 'wp-block-button' );
+}
+
+$wrapper_attrs = get_block_wrapper_attributes();
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	<?php echo wp_kses_data( $wrapper_attrs ); ?>
 	data-wp-interactive="jetpack-search"
 	data-wp-bind--hidden="!state.showLoadMore"
+	<?php if ( $load_on_scroll ) : ?>
+		data-wp-init--load-more-observer="callbacks.initLoadMoreObserver"
+		data-load-on-scroll="1"
+		data-load-on-scroll-offset="<?php echo esc_attr( (string) $load_on_scroll_offset ); ?>"
+	<?php endif; ?>
 	hidden
 >
-	<button
-		type="button"
-		class="jetpack-search-load-more__button wp-block-button__link wp-element-button"
-		data-wp-on--click="actions.loadMore"
-		data-wp-bind--hidden="state.isLoadingMore"
-	>
-		<?php echo esc_html( $button_label ); ?>
-	</button>
+	<?php if ( ! $load_on_scroll ) : ?>
+		<button
+			type="button"
+			class="jetpack-search-load-more__button wp-block-button__link wp-element-button"
+			data-wp-on--click="actions.loadMore"
+			data-wp-bind--hidden="state.isLoadingMore"
+		>
+			<?php echo esc_html( $button_label ); ?>
+		</button>
+	<?php endif; ?>
 	<span
 		class="jetpack-search-load-more__spinner"
 		data-wp-bind--hidden="!state.isLoadingMore"
 	>
 		<?php esc_html_e( 'Loading…', 'jetpack-search-pkg' ); ?>
 	</span>
+	<?php if ( $load_on_scroll ) : ?>
+		<span class="jetpack-search-load-more__sentinel" aria-hidden="true"></span>
+	<?php endif; ?>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/results-load-more/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-load-more/style.scss
@@ -41,4 +41,12 @@
 			display: none;
 		}
 	}
+
+	// 1px sentinel observed by IntersectionObserver when loadOnScroll is on.
+	// Visually inert; the observer's rootMargin handles the trigger distance.
+	.jetpack-search-load-more__sentinel {
+		display: block;
+		height: 1px;
+		width: 100%;
+	}
 }

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1629,21 +1629,37 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			const offset = Number( wrapper.dataset.loadOnScrollOffset );
 			const rootMargin = `0px 0px ${ Number.isFinite( offset ) ? offset : 200 }px 0px`;
+			// IntersectionObserver only fires on intersection *state changes*.
+			// When a page of results is too short to push the sentinel back
+			// outside the rootMargin after a fetch, no further events arrive
+			// and auto-load silently stalls. After each load settles we
+			// `unobserve` + `observe` again so the observer re-delivers its
+			// initial-state event against the current layout; if the sentinel
+			// is still intersecting we get a fresh `isIntersecting: true` and
+			// the next page fires without the user having to nudge the scroll.
+			let pending = false;
 			const observer = new IntersectionObserver(
 				entries => {
 					if ( ! entries.some( e => e.isIntersecting ) ) {
 						return;
 					}
-					// The store's own `*loadMore()` already short-circuits when
-					// there's no `pageHandle` or another request is in flight,
-					// so we don't need to mirror that guard here — but reading
-					// the same derived `showLoadMore` keeps us symmetric with
-					// the wrapper's own visibility binding and avoids a noop
-					// generator step on the first idle intersection after
-					// `state.pageHandle` goes null.
-					if ( state.showLoadMore && ! state.isLoadingMore ) {
-						actions.loadMore();
+					if ( pending || ! state.showLoadMore || state.isLoadingMore ) {
+						return;
 					}
+					pending = true;
+					actions.loadMore();
+					const settle = () => {
+						if ( state.isLoadingMore ) {
+							setTimeout( settle, 100 );
+							return;
+						}
+						pending = false;
+						if ( state.showLoadMore ) {
+							observer.unobserve( sentinel );
+							observer.observe( sentinel );
+						}
+					};
+					setTimeout( settle, 100 );
 				},
 				{ root: null, rootMargin, threshold: 0 }
 			);

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1607,6 +1607,51 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * Wires the results-load-more block's IntersectionObserver when its
+		 * `loadOnScroll` attribute is on. Returns a teardown that disconnects
+		 * the observer — the Interactivity runtime calls it on unmount and on
+		 * HMR re-init so listeners never leak.
+		 *
+		 * @return {Function|undefined} cleanup callback or undefined when the
+		 * block opted out at render time.
+		 */
+		initLoadMoreObserver() {
+			const wrapper = getElement?.()?.ref;
+			if ( ! wrapper || wrapper.dataset?.loadOnScroll !== '1' ) {
+				return;
+			}
+			if ( typeof IntersectionObserver === 'undefined' ) {
+				return;
+			}
+			const sentinel = wrapper.querySelector( '.jetpack-search-load-more__sentinel' );
+			if ( ! sentinel ) {
+				return;
+			}
+			const offset = Number( wrapper.dataset.loadOnScrollOffset );
+			const rootMargin = `0px 0px ${ Number.isFinite( offset ) ? offset : 200 }px 0px`;
+			const observer = new IntersectionObserver(
+				entries => {
+					if ( ! entries.some( e => e.isIntersecting ) ) {
+						return;
+					}
+					// The store's own `*loadMore()` already short-circuits when
+					// there's no `pageHandle` or another request is in flight,
+					// so we don't need to mirror that guard here — but reading
+					// the same derived `showLoadMore` keeps us symmetric with
+					// the wrapper's own visibility binding and avoids a noop
+					// generator step on the first idle intersection after
+					// `state.pageHandle` goes null.
+					if ( state.showLoadMore && ! state.isLoadingMore ) {
+						actions.loadMore();
+					}
+				},
+				{ root: null, rootMargin, threshold: 0 }
+			);
+			observer.observe( sentinel );
+			return () => observer.disconnect();
+		},
+
+		/**
 		 * Fires when the `ai-answer` block mounts. Flips the module-scope
 		 * `aiBlockPresent` flag so `actions.search()` knows to dispatch the
 		 * AI fetch alongside the results fetch, and kicks off a first fetch

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -933,6 +933,9 @@ describe( 'store callbacks', () => {
 		beforeEach( () => {
 			originalIO = global.IntersectionObserver;
 			observerInstances = [];
+			// Direct assignment (not `jest.spyOn`) because jsdom doesn't ship
+			// an IntersectionObserver — spying requires the property to
+			// pre-exist on the object.
 			jest.spyOn( global, 'IntersectionObserver' ).mockImplementation( function ( cb, opts ) {
 				this.cb = cb;
 				this.opts = opts;
@@ -943,7 +946,11 @@ describe( 'store callbacks', () => {
 		} );
 
 		afterEach( () => {
-			global.IntersectionObserver = originalIO;
+			if ( originalIO === undefined ) {
+				delete global.IntersectionObserver;
+			} else {
+				global.IntersectionObserver = originalIO;
+			}
 			captured.element.ref = null;
 		} );
 
@@ -1008,12 +1015,16 @@ describe( 'store callbacks', () => {
 			expect( loadMore ).not.toHaveBeenCalled();
 
 			// Intersecting and showLoadMore (derived from pageHandle && !isLoading) → fetch.
+			// Flip isLoadingMore true to mirror what `*loadMore()` would do; this
+			// proves the in-flight guard prevents a second call.
+			loadMore.mockImplementation( () => {
+				state.isLoadingMore = true;
+			} );
 			observer.cb( [ { isIntersecting: true } ] );
 			expect( loadMore ).toHaveBeenCalledTimes( 1 );
 
 			// Already loading more → skipped (the store's own guard would no-op
 			// too, but mirroring the check here avoids a noop generator step).
-			state.isLoadingMore = true;
 			observer.cb( [ { isIntersecting: true } ] );
 			expect( loadMore ).toHaveBeenCalledTimes( 1 );
 
@@ -1022,6 +1033,53 @@ describe( 'store callbacks', () => {
 			state.pageHandle = null;
 			observer.cb( [ { isIntersecting: true } ] );
 			expect( loadMore ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'no-ops when IntersectionObserver is unavailable in the environment', () => {
+			const saved = global.IntersectionObserver;
+			// Match the `typeof … === 'undefined'` runtime check by removing the
+			// global outright — assigning `undefined` would still leave the
+			// binding declared, which doesn't trip a `typeof` guard.
+			delete global.IntersectionObserver;
+			captured.element.ref = makeWrapper( { loadOnScroll: '1' } );
+			const cleanup = captured.callbacks.initLoadMoreObserver();
+			expect( cleanup ).toBeUndefined();
+			global.IntersectionObserver = saved;
+		} );
+
+		it( 're-observes the sentinel after a load settles so a short result page does not stall auto-load', () => {
+			jest.useFakeTimers();
+			captured.element.ref = makeWrapper( { loadOnScroll: '1', loadOnScrollOffset: '200' } );
+			Object.assign( actions, originalActions );
+			const loadMore = jest.spyOn( actions, 'loadMore' ).mockImplementation( () => {
+				state.isLoadingMore = true;
+			} );
+
+			state.pageHandle = { offset: 10 };
+			state.isLoading = false;
+			state.isLoadingMore = false;
+
+			captured.callbacks.initLoadMoreObserver();
+			const observer = observerInstances[ 0 ];
+			jest.spyOn( observer, 'unobserve' ).mockImplementation();
+
+			// First intersection fires loadMore and schedules a settle probe.
+			observer.cb( [ { isIntersecting: true } ] );
+			expect( loadMore ).toHaveBeenCalledTimes( 1 );
+			expect( observer.unobserve ).not.toHaveBeenCalled();
+
+			// Probe finds isLoadingMore still true → reschedules itself.
+			jest.advanceTimersByTime( 100 );
+			expect( observer.unobserve ).not.toHaveBeenCalled();
+
+			// Fetch settles. Probe re-arms the observer so a sentinel that
+			// never left the rootMargin gets a fresh initial-state event.
+			state.isLoadingMore = false;
+			jest.advanceTimersByTime( 100 );
+			expect( observer.unobserve ).toHaveBeenCalledTimes( 1 );
+			expect( observer.observe ).toHaveBeenCalledTimes( 2 );
+
+			jest.useRealTimers();
 		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -6,6 +6,7 @@ const captured = {
 	actions: {},
 	callbacks: {},
 	context: {},
+	element: { ref: null },
 };
 const originalFetch = global.fetch;
 
@@ -24,6 +25,7 @@ jest.mock(
 			return { state: captured.state, actions: captured.actions };
 		},
 		getContext: () => captured.context,
+		getElement: () => captured.element,
 	} ),
 	{ virtual: true }
 );
@@ -921,6 +923,105 @@ describe( 'store callbacks', () => {
 			// Drop the flag so it doesn't leak into the `handlePopState` describe
 			// below — captured.state is a singleton across the mocked module.
 			fresh.state.hasSearchParam = false;
+		} );
+	} );
+
+	describe( 'initLoadMoreObserver', () => {
+		let originalIO;
+		let observerInstances;
+
+		beforeEach( () => {
+			originalIO = global.IntersectionObserver;
+			observerInstances = [];
+			jest.spyOn( global, 'IntersectionObserver' ).mockImplementation( function ( cb, opts ) {
+				this.cb = cb;
+				this.opts = opts;
+				jest.spyOn( this, 'observe' ).mockImplementation();
+				jest.spyOn( this, 'disconnect' ).mockImplementation();
+				observerInstances.push( this );
+			} );
+		} );
+
+		afterEach( () => {
+			global.IntersectionObserver = originalIO;
+			captured.element.ref = null;
+		} );
+
+		/**
+		 * Build a fake wrapper DOM with the dataset + sentinel render.php emits.
+		 *
+		 * @param {object} dataset - dataset attributes to attach.
+		 * @return {object} fake wrapper element.
+		 */
+		function makeWrapper( dataset ) {
+			const sentinel = { tagName: 'SPAN' };
+			return {
+				dataset,
+				querySelector: jest.fn( () => sentinel ),
+				_sentinel: sentinel,
+			};
+		}
+
+		it( 'no-ops when loadOnScroll is not enabled on the wrapper', () => {
+			captured.element.ref = makeWrapper( {} );
+			const cleanup = captured.callbacks.initLoadMoreObserver();
+			expect( cleanup ).toBeUndefined();
+			expect( global.IntersectionObserver ).not.toHaveBeenCalled();
+		} );
+
+		it( 'observes the sentinel with the configured rootMargin and returns a teardown', () => {
+			const wrapper = makeWrapper( { loadOnScroll: '1', loadOnScrollOffset: '150' } );
+			captured.element.ref = wrapper;
+
+			const cleanup = captured.callbacks.initLoadMoreObserver();
+
+			expect( global.IntersectionObserver ).toHaveBeenCalledTimes( 1 );
+			expect( observerInstances[ 0 ].opts.rootMargin ).toBe( '0px 0px 150px 0px' );
+			expect( observerInstances[ 0 ].observe ).toHaveBeenCalledWith( wrapper._sentinel );
+			expect( typeof cleanup ).toBe( 'function' );
+
+			cleanup();
+			expect( observerInstances[ 0 ].disconnect ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'falls back to a 200px rootMargin when the offset is missing or unparseable', () => {
+			captured.element.ref = makeWrapper( { loadOnScroll: '1' } );
+			captured.callbacks.initLoadMoreObserver();
+			expect( observerInstances[ 0 ].opts.rootMargin ).toBe( '0px 0px 200px 0px' );
+		} );
+
+		it( 'fires loadMore() only when showLoadMore is true and a fetch is not already in flight', () => {
+			captured.element.ref = makeWrapper( { loadOnScroll: '1', loadOnScrollOffset: '200' } );
+			Object.assign( actions, originalActions );
+			const loadMore = jest.spyOn( actions, 'loadMore' ).mockImplementation();
+
+			// Seed a state where the next page exists and nothing's loading.
+			state.pageHandle = { offset: 10 };
+			state.isLoading = false;
+			state.isLoadingMore = false;
+
+			captured.callbacks.initLoadMoreObserver();
+			const observer = observerInstances[ 0 ];
+
+			// Not intersecting → no fetch.
+			observer.cb( [ { isIntersecting: false } ] );
+			expect( loadMore ).not.toHaveBeenCalled();
+
+			// Intersecting and showLoadMore (derived from pageHandle && !isLoading) → fetch.
+			observer.cb( [ { isIntersecting: true } ] );
+			expect( loadMore ).toHaveBeenCalledTimes( 1 );
+
+			// Already loading more → skipped (the store's own guard would no-op
+			// too, but mirroring the check here avoids a noop generator step).
+			state.isLoadingMore = true;
+			observer.cb( [ { isIntersecting: true } ] );
+			expect( loadMore ).toHaveBeenCalledTimes( 1 );
+
+			// No more pages → skipped.
+			state.isLoadingMore = false;
+			state.pageHandle = null;
+			observer.cb( [ { isIntersecting: true } ] );
+			expect( loadMore ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -933,18 +933,20 @@ describe( 'store callbacks', () => {
 		beforeEach( () => {
 			originalIO = global.IntersectionObserver;
 			observerInstances = [];
-			// jsdom doesn't ship IntersectionObserver; direct assignment lets
-			// us mock it without forcing the test to register a no-op global
-			// first just so `jest.spyOn` can attach to it.
-			// eslint-disable-next-line jest/prefer-spy-on -- nothing to spy on.
+			// jsdom doesn't ship IntersectionObserver, and the instance methods
+			// (`observe`, `unobserve`, `disconnect`) don't exist on a fresh
+			// `this` either — so `jest.spyOn` has nothing to attach to. Direct
+			// assignment is the right tool here.
+			/* eslint-disable jest/prefer-spy-on -- nothing to spy on. */
 			global.IntersectionObserver = jest.fn( function ( cb, opts ) {
 				this.cb = cb;
 				this.opts = opts;
-				jest.spyOn( this, 'observe' ).mockImplementation();
-				jest.spyOn( this, 'unobserve' ).mockImplementation();
-				jest.spyOn( this, 'disconnect' ).mockImplementation();
+				this.observe = jest.fn();
+				this.unobserve = jest.fn();
+				this.disconnect = jest.fn();
 				observerInstances.push( this );
 			} );
+			/* eslint-enable jest/prefer-spy-on */
 		} );
 
 		afterEach( () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -933,13 +933,15 @@ describe( 'store callbacks', () => {
 		beforeEach( () => {
 			originalIO = global.IntersectionObserver;
 			observerInstances = [];
-			// Direct assignment (not `jest.spyOn`) because jsdom doesn't ship
-			// an IntersectionObserver — spying requires the property to
-			// pre-exist on the object.
-			jest.spyOn( global, 'IntersectionObserver' ).mockImplementation( function ( cb, opts ) {
+			// jsdom doesn't ship IntersectionObserver; direct assignment lets
+			// us mock it without forcing the test to register a no-op global
+			// first just so `jest.spyOn` can attach to it.
+			// eslint-disable-next-line jest/prefer-spy-on -- nothing to spy on.
+			global.IntersectionObserver = jest.fn( function ( cb, opts ) {
 				this.cb = cb;
 				this.opts = opts;
 				jest.spyOn( this, 'observe' ).mockImplementation();
+				jest.spyOn( this, 'unobserve' ).mockImplementation();
 				jest.spyOn( this, 'disconnect' ).mockImplementation();
 				observerInstances.push( this );
 			} );
@@ -1061,7 +1063,6 @@ describe( 'store callbacks', () => {
 
 			captured.callbacks.initLoadMoreObserver();
 			const observer = observerInstances[ 0 ];
-			jest.spyOn( observer, 'unobserve' ).mockImplementation();
 
 			// First intersection fires loadMore and schedules a settle probe.
 			observer.cb( [ { isIntersecting: true } ] );


### PR DESCRIPTION
Fixes [SEARCH-227](https://linear.app/a8c/issue/SEARCH-227/search-blocks-add-infinite-scroll-auto-load-to-results-load-more-block)

## Why

The Search Blocks' `results-load-more` block only paginated on explicit click. The legacy instant-search overlay had infinite-scroll baked in via its `ScrollButton`. This PR brings the same affordance to the block — when an author flips a new "Load on scroll" toggle, the next page of results fetches automatically as the visitor scrolls toward the end of the list.

## Proposed changes

* Add a `loadOnScroll` (bool, default `false`) + `loadOnScrollOffset` (number, default `200`) attribute to `jetpack-search/results-load-more`.
* `render.php`: when `loadOnScroll` is on, skip the `<button>` and the `wp-block-button` style enqueue, emit a 1px `__sentinel` span, and wire a `data-wp-init--load-more-observer` hook on the wrapper.
* `store/index.js`: register `callbacks.initLoadMoreObserver` — reads the wrapper dataset, attaches an `IntersectionObserver` against the sentinel with a configurable `rootMargin`, fires `actions.loadMore()` on intersection (gated on `state.showLoadMore && !state.isLoadingMore`), returns a teardown that disconnects the observer on unmount.
* `edit.js`: inspector exposes a "Load on scroll" toggle and a "Load distance" range; hides the button-label control when the toggle is on; preview swaps the button for a `Loading…` spinner so the editor mirrors front-end shape.
* `store.test.js`: four new tests covering the callback — no-op when the toggle is off, correct attach + teardown, default 200px rootMargin when offset is unset, and the gate on `showLoadMore` / `isLoadingMore`.

## Screenshots

| Before (default — manual button) | After (`loadOnScroll: true`) |
|---|---|
| ![before](https://github.com/user-attachments/assets/a086728d-9f43-4417-b90b-682cd4268c52) | ![after](https://github.com/user-attachments/assets/c884ee77-4a88-4407-ac01-be4d2b1352dd) |

"Before" is also the back-compat path: existing posts/patterns that include the block keep the click-to-load button unchanged.

## Related product discussion/links

* Linear: [SEARCH-227](https://linear.app/a8c/issue/SEARCH-227/search-blocks-add-infinite-scroll-auto-load-to-results-load-more-block)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from the Linear issue:

- [ ] `loadOnScroll` + `loadOnScrollOffset` attributes added with defaults that preserve current behavior (button-only, today's UX).
- [ ] Editor inspector exposes both controls; the "Load distance" range is hidden until the toggle is on; the "Button label" control is hidden when the toggle is on.
- [ ] Front end renders a sentinel + spinner (no button) when `loadOnScroll` is on, and the button + spinner when it's off.
- [ ] When `loadOnScroll` is on, scrolling within 200px of the sentinel fires `actions.loadMore()`; the wrapper hides cleanly once `state.pageHandle` becomes null.
- [ ] No regression in the existing manual-click flow (saved patterns still render the button).
- [ ] Store tests cover the new callback (`pnpm --filter @automattic/jetpack-search jest tests/js/search-blocks/store.test.js`).
- [ ] Changelog entry added at `projects/packages/search/changelog/SEARCH-227-load-more-infinite-scroll`.

To exercise manually:

1. Insert the Load More block on a page that also contains `jetpack-search/search-input` + `jetpack-search/search-results` + `jetpack-search/results-list`.
2. Default state: visitor sees a "Load more results" button; clicking it appends the next page (unchanged from trunk).
3. Open the block inspector and flip **Load on scroll** on; optionally tune the distance slider.
4. Reload the front end and run a query: the button is gone; scrolling toward the end of the list automatically fetches the next page, the spinner appears during the fetch, and the whole region hides once there are no more pages.
