### PR TITLE
Require WP.com user connection for AI podcast

### DIFF
--- a/projects/packages/podcast/changelog/fix-create-ai-podcast-user-connection
+++ b/projects/packages/podcast/changelog/fix-create-ai-podcast-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Create AI Podcast: Require a connected WordPress.com account.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Podcast;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Automattic\Jetpack\Status\Host;
 
@@ -97,8 +98,9 @@ class Podcast {
 	 * proxy) is enabled for the current request.
 	 *
 	 * Mirrors the `jetpack_podcast_untangle` pattern: defaults to true for
-	 * A8C-proxied requests so Automatticians dogfood it, and can be flipped
-	 * globally via the `jetpack_posts_to_podcast` filter.
+	 * A8C-proxied requests from connected WordPress.com users so
+	 * Automatticians dogfood it, and can be flipped globally via the
+	 * `jetpack_posts_to_podcast` filter.
 	 */
 	public static function is_posts_to_podcast_enabled() {
 		/**
@@ -108,7 +110,23 @@ class Podcast {
 		 *
 		 * @param bool $enabled Whether to enable Posts to Podcast.
 		 */
-		return (bool) apply_filters( 'jetpack_posts_to_podcast', self::is_proxied_request() );
+		$enabled = self::is_proxied_request() && self::is_user_connected( get_current_user_id() );
+
+		return (bool) apply_filters( 'jetpack_posts_to_podcast', $enabled );
+	}
+
+	/**
+	 * Whether a user is connected to WordPress.com.
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool
+	 */
+	private static function is_user_connected( $user_id ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return true;
+		}
+
+		return ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Update the Posts to Podcast default gate in the podcast package so `apply_filters( 'jetpack_posts_to_podcast', ... )` receives true only for proxied requests from connected WordPress.com users.
* Keep the existing `jetpack_posts_to_podcast` filter as the override point for the Create AI Podcast page and REST proxy.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `php -l projects/packages/podcast/src/class-podcast.php`.
* Log in as a user without a connected WordPress.com account.
* Confirm `Media > Create AI Podcast` is not registered in wp-admin.
* Log in as a connected WordPress.com user with post editing/media permissions.
* Confirm `Media > Create AI Podcast` is available.
