### PR TITLE
RSM - Fetch GutenPen patterns for WP.com sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-gutenpen-integration
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-gutenpen-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Fetch patterns from GutenPen source site

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
@@ -59,6 +59,14 @@ function register_patterns_on_api_request( $register_patterns_func ) {
 		// to handle the API format of both WordPress.com and WordPress core.
 		$request_allowed = preg_match( '/^\/wp\/v2\/(sites\/[0-9]+\/)?block\-patterns\/(patterns|categories)$/', $route );
 
+		// The Site Editor patterns sidebar gets its category list from view-config,
+		// so register API-backed pattern categories for that request too.
+		$request_allowed = $request_allowed || (
+				preg_match( '/^\/wp\/v2\/(sites\/[0-9]+\/)?view\-config$/', $route ) &&
+				'postType' === $request->get_param( 'kind' ) &&
+				'wp_block' === $request->get_param( 'name' )
+			);
+
 		if ( ! $request_allowed || ! apply_filters( 'a8c_enable_block_patterns_api', false ) ) {
 			return $response;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -168,10 +168,7 @@ class Wpcom_Block_Patterns_From_Api {
 
 		if ( $disable_cache || false === $patterns ) {
 			$path = add_query_arg(
-				array(
-					'site'      => $override_source_site ?? self::GUTENPEN_PATTERNS_SOURCE_SITE,
-					'post_type' => 'wp_block',
-				),
+				array(),
 				'/gutenpen/patterns'
 			);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -46,20 +46,7 @@ class Wpcom_Block_Patterns_From_Api {
 
 		$pattern_categories = array();
 		$block_patterns     = $this->get_patterns( $patterns_cache_key );
-
-		$gutenpen_patterns_cache_key = sprintf(
-			'gutenpen_patterns_%d',
-			get_current_user_id()
-		);
-
-		// Optimization: On Simple sites, we check if the user is marketed as a gutenpen user. If they never used the feature, then don't make an API call.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! get_user_attribute( get_current_user_id(), 'is_gutenpen_user' ) ) {
-			$gutenpen_patterns = array();
-		} else {
-			$gutenpen_patterns = $this->get_patterns( $gutenpen_patterns_cache_key, self::GUTENPEN_PATTERNS_SOURCE_SITE );
-		}
-
-		$block_patterns = array_merge( $block_patterns, $gutenpen_patterns );
+		$block_patterns     = array_merge( $block_patterns, $this->get_gutenpen_patterns() );
 
 		// Register categories from first pattern in each category.
 		foreach ( (array) $block_patterns as $pattern ) {
@@ -155,6 +142,47 @@ class Wpcom_Block_Patterns_From_Api {
 		}
 
 		return $block_patterns;
+	}
+
+	/**
+	 * Returns the list of GutenPen patterns for the current user.
+	 *
+	 * GutenPen patterns are scoped to the requesting user, so the request must be signed/dispatched
+	 * as the current user (see Wpcom_Block_Patterns_Utils::remote_get_as_user). On Simple sites we
+	 * additionally short-circuit users who have never used the feature, based on the
+	 * `is_gutenpen_user` user attribute, to avoid an unnecessary API call.
+	 *
+	 * @return array The list of GutenPen patterns, or an empty array when the feature is unavailable to the current user.
+	 */
+	private function get_gutenpen_patterns() {
+		// On Simple sites, only users marketed as GutenPen users may have patterns to fetch.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! get_user_attribute( get_current_user_id(), 'is_gutenpen_user' ) ) {
+			return array();
+		}
+
+		$cache_key            = sprintf( 'gutenpen_patterns_%d', get_current_user_id() );
+		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', null );
+
+		$patterns      = $this->utils->cache_get( $cache_key, 'ptk_patterns' );
+		$disable_cache = ( function_exists( 'is_automattician' ) && is_automattician() ) || $override_source_site || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE );
+
+		if ( $disable_cache || false === $patterns ) {
+			$path = add_query_arg(
+				array(
+					'site'      => $override_source_site ?? self::GUTENPEN_PATTERNS_SOURCE_SITE,
+					'post_type' => 'wp_block',
+				),
+				'/ptk/patterns/' . $this->utils->get_block_patterns_locale()
+			);
+
+			$patterns = $this->utils->remote_get_as_user( $path, '1', 'rest' );
+
+			if ( ! $disable_cache ) {
+				$this->utils->cache_add( $cache_key, $patterns, 'ptk_patterns', 5 * MINUTE_IN_SECONDS );
+			}
+		}
+
+		return $patterns;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -167,12 +167,7 @@ class Wpcom_Block_Patterns_From_Api {
 		$disable_cache = ( function_exists( 'is_automattician' ) && is_automattician() ) || $override_source_site || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE );
 
 		if ( $disable_cache || false === $patterns ) {
-			$path = add_query_arg(
-				array(),
-				'/gutenpen/patterns'
-			);
-
-			$patterns = $this->utils->remote_get_as_user( $path, '1', 'rest' );
+			$patterns = $this->utils->remote_get_as_user( '/gutenpen/patterns' );
 
 			if ( ! $disable_cache ) {
 				$this->utils->cache_add( $cache_key, $patterns, 'ptk_patterns', 5 * MINUTE_IN_SECONDS );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -14,7 +14,8 @@ require_once __DIR__ . '/class-wpcom-block-patterns-utils.php';
  * Class Wpcom_Block_Patterns_From_Api
  */
 class Wpcom_Block_Patterns_From_Api {
-	const PATTERN_NAMESPACE = 'a8c/';
+	const PATTERN_NAMESPACE             = 'a8c/';
+	const GUTENPEN_PATTERNS_SOURCE_SITE = 'gutenpenpatternsourcesite.wordpress.com';
 
 	/**
 	 * A collection of utility methods.
@@ -45,6 +46,20 @@ class Wpcom_Block_Patterns_From_Api {
 
 		$pattern_categories = array();
 		$block_patterns     = $this->get_patterns( $patterns_cache_key );
+
+		$gutenpen_patterns_cache_key = sprintf(
+			'gutenpen_patterns_%d',
+			get_current_user_id()
+		);
+
+		// Optimization: On Simple sites, we check if the user is marketed as a gutenpen user. If they never used the feature, then don't make an API call.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! get_user_attribute( get_current_user_id(), 'is_gutenpen_user' ) ) {
+			$gutenpen_patterns = array();
+		} else {
+			$gutenpen_patterns = $this->get_patterns( $gutenpen_patterns_cache_key, self::GUTENPEN_PATTERNS_SOURCE_SITE );
+		}
+
+		$block_patterns = array_merge( $block_patterns, $gutenpen_patterns );
 
 		// Register categories from first pattern in each category.
 		foreach ( (array) $block_patterns as $pattern ) {
@@ -110,10 +125,11 @@ class Wpcom_Block_Patterns_From_Api {
 	 * Returns a list of patterns.
 	 *
 	 * @param string $patterns_cache_key Key to store responses to and fetch responses from cache.
+	 * @param string $source_site        Source site ID or domain.
 	 * @return array The list of patterns.
 	 */
-	private function get_patterns( $patterns_cache_key ) {
-		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
+	private function get_patterns( $patterns_cache_key, $source_site = 'dotcompatterns.wordpress.com' ) {
+		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', null );
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
 		$disable_cache  = ( function_exists( 'is_automattician' ) && is_automattician() ) || $override_source_site || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE );
@@ -123,7 +139,7 @@ class Wpcom_Block_Patterns_From_Api {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'site'      => $override_source_site ?? 'dotcompatterns.wordpress.com',
+						'site'      => $override_source_site ?? $source_site,
 						'post_type' => 'wp_block',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -172,7 +172,7 @@ class Wpcom_Block_Patterns_From_Api {
 					'site'      => $override_source_site ?? self::GUTENPEN_PATTERNS_SOURCE_SITE,
 					'post_type' => 'wp_block',
 				),
-				'/ptk/patterns/' . $this->utils->get_block_patterns_locale()
+				'/gutenpen/patterns'
 			);
 
 			$patterns = $this->utils->remote_get_as_user( $path, '1', 'rest' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-utils.php
@@ -5,6 +5,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 /**
@@ -29,6 +30,41 @@ class Wpcom_Block_Patterns_Utils {
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return array();
 		}
+		return json_decode( wp_remote_retrieve_body( $response ), true );
+	}
+
+	/**
+	 * Make a GET request to the WordPress.com REST API as the current user.
+	 *
+	 * On WPCOM Simple sites the request is dispatched in-process via WPCOM_API_Direct so the
+	 * current logged-in WP.com user is the authenticated user. Everywhere else we route through
+	 * Jetpack's Client::wpcom_json_api_request_as_user, which signs the request with the user's
+	 * Jetpack token.
+	 *
+	 * @param string $path          API path (e.g. `/ptk/patterns/en?site=...`). The full URL is built by the Jetpack Client.
+	 * @param string $version       API version. Default `2`.
+	 * @param string $base_api_path API root segment, `wpcom` or `rest`. Default `wpcom`.
+	 * @return array                Decoded response body, or an empty array on failure.
+	 */
+	public function remote_get_as_user( $path, $version = '2', $base_api_path = 'wpcom' ) {
+		$args = array(
+			'method'  => 'GET',
+			'timeout' => 20,
+		);
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			require_lib( 'wpcom-api-direct' );
+			$validated_args            = Client::validate_args_for_wpcom_json_api_request( $path, $version, $args, $base_api_path );
+			$validated_args['user_id'] = get_current_user_id();
+			$response                  = \WPCOM_API_Direct::do_request( $validated_args );
+		} else {
+			$response = Client::wpcom_json_api_request_as_user( $path, $version, $args, null, $base_api_path );
+		}
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+
 		return json_decode( wp_remote_retrieve_body( $response ), true );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
@@ -140,9 +140,9 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 	/**
 	 *  Tests that we're making a request where we're overriding the source site.
 	 *
-	 *  The override applies to both the dotcompatterns and GutenPen fetches: dotcompatterns goes
-	 *  through remote_get with the full URL, GutenPen goes through remote_get_as_user with the
-	 *  same override propagated into the `site` query arg.
+	 *  The override rewrites the `site` query arg on the dotcompatterns PTK URL. The GutenPen
+	 *  endpoint is dedicated and does not take a `site` arg, so the override only influences its
+	 *  cache behavior (disables caching for that fetch).
 	 */
 	public function test_patterns_request_succeeds_with_override_source_site() {
 		$example_site = function () {
@@ -162,7 +162,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get_as_user' )
-			->with( '/ptk/patterns/fr?site=dotcom&post_type=wp_block', '1', 'rest' );
+			->with( '/gutenpen/patterns' );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
@@ -65,6 +65,9 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$mock->method( 'remote_get' )
 			->willReturn( $pattern_mock_response );
 
+		$mock->method( 'remote_get_as_user' )
+			->willReturn( $pattern_mock_response );
+
 		$mock->method( 'cache_get' )
 			->willReturn( $cache_get );
 
@@ -99,14 +102,18 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 	/**
 	 *  Tests that we're making a request.
 	 *
-	 *  Two calls are expected: one for the default dotcompatterns source and one for the GutenPen source.
+	 *  Dotcompatterns is fetched anonymously via remote_get; GutenPen is fetched as the current
+	 *  user via remote_get_as_user.
 	 */
 	public function test_patterns_site_editor_source_site() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
 
-		$utils_mock->expects( $this->exactly( 2 ) )
+		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' );
+
+		$utils_mock->expects( $this->once() )
+			->method( 'remote_get_as_user' );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
@@ -133,7 +140,9 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 	/**
 	 *  Tests that we're making a request where we're overriding the source site.
 	 *
-	 *  The override applies to both the dotcompatterns and GutenPen fetches, so we expect two requests to the same URL.
+	 *  The override applies to both the dotcompatterns and GutenPen fetches: dotcompatterns goes
+	 *  through remote_get with the full URL, GutenPen goes through remote_get_as_user with the
+	 *  same override propagated into the `site` query arg.
 	 */
 	public function test_patterns_request_succeeds_with_override_source_site() {
 		$example_site = function () {
@@ -147,9 +156,13 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );
 
-		$utils_mock->expects( $this->exactly( 2 ) )
+		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&post_type=wp_block' );
+
+		$utils_mock->expects( $this->once() )
+			->method( 'remote_get_as_user' )
+			->with( '/ptk/patterns/fr?site=dotcom&post_type=wp_block', '1', 'rest' );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Block_Patterns_From_Api_Test.php
@@ -82,42 +82,47 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 	/**
 	 *  Tests that we're making a request where there are no cached patterns.
+	 *
+	 *  Two calls are expected: one for the default dotcompatterns source and one for the GutenPen source.
 	 */
 	public function test_patterns_request_succeeds_with_empty_cache() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
 
-		$utils_mock->expects( $this->once() )
+		$utils_mock->expects( $this->exactly( 2 ) )
 			->method( 'cache_add' )
-			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', 5 * MINUTE_IN_SECONDS );
+			->with( $this->anything(), array( $this->pattern_mock_object ), 'ptk_patterns', 5 * MINUTE_IN_SECONDS );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
 
 	/**
-	 *  Tests that we're making a request
+	 *  Tests that we're making a request.
+	 *
+	 *  Two calls are expected: one for the default dotcompatterns source and one for the GutenPen source.
 	 */
 	public function test_patterns_site_editor_source_site() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
 
-		$utils_mock->expects( $this->once() )
-			->method( 'remote_get' )
-			->willReturn( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block' );
+		$utils_mock->expects( $this->exactly( 2 ) )
+			->method( 'remote_get' );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
 
 	/**
 	 *  Tests that we're NOT making a request where there ARE cached patterns.
+	 *
+	 *  Two cache_get calls are expected: one for the default dotcompatterns source and one for the GutenPen source.
 	 */
 	public function test_patterns_request_succeeds_with_set_cache() {
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ), array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
 
-		$utils_mock->expects( $this->once() )
+		$utils_mock->expects( $this->exactly( 2 ) )
 			->method( 'cache_get' )
-			->with( $this->stringContains( 'key-largo' ), 'ptk_patterns' );
+			->with( $this->anything(), 'ptk_patterns' );
 
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );
@@ -127,6 +132,8 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 	/**
 	 *  Tests that we're making a request where we're overriding the source site.
+	 *
+	 *  The override applies to both the dotcompatterns and GutenPen fetches, so we expect two requests to the same URL.
 	 */
 	public function test_patterns_request_succeeds_with_override_source_site() {
 		$example_site = function () {
@@ -140,7 +147,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );
 
-		$utils_mock->expects( $this->once() )
+		$utils_mock->expects( $this->exactly( 2 ) )
 			->method( 'remote_get' )
 			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&post_type=wp_block' );
 


### PR DESCRIPTION
Fixes DOTCOM-17196

## Proposed changes
<!--- Explain what functional changes your PR includes -->
- Fetch block patterns from the GutenPen source site in Wpcom_Block_Patterns_From_Api and merge them with the existing
  dotcompatterns results so they show up in the inserter / Site Editor patterns alongside the standard catalog.
 - Parameterize get_patterns() so it can be called with an arbitrary source site, and cache GutenPen results under a per-user cache key (gutenpen_patterns_{user_id}).
 - On Simple sites (IS_WPCOM), short-circuit the GutenPen fetch for users without the is_gutenpen_user attribute to avoid an unnecessary API call for everyone who
  never used the feature.
 - Switch the a8c_override_patterns_source_site filter default from false to null so the ?? fallback to the per-call source site works (previously false would have
  been treated as an explicit override).
 - In register_patterns_on_api_request, also allow the API-backed pattern registration to run for /wp/v2/view-config requests with kind=postType&name=wp_block, since
  the Site Editor patterns sidebar pulls its category list from view-config rather than the patterns/categories endpoints.
## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to GutenPen.com/share
* Login with your WP.com account
* Add a new pattern entry. Make sure to add a collection for it (from the visibility dropdown)
* Save it
* Go to a Simple Site / Atomic site
* in WP-Admin/post-new.php - make sure the pattern you've just created is displayed
* in WP-admin/site-editor.php > Patterns - make sure the category (collection) is there

