### PR TITLE
ADS-1134 Add Blaze chat submit next action

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1134-chat-submit-next-action
+++ b/projects/packages/blaze/changelog/add-ads-1134-chat-submit-next-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: add chat-native submit approval next action to prepared campaign responses.

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -117,6 +117,7 @@ class Campaign_Preparer {
 				$cancellation_terms,
 				$idempotency_key
 			);
+			$proposal['next_action']    = self::build_chat_submit_next_action( $prefill_url, $proposal['approval_block'] );
 		}
 
 		return $proposal;
@@ -1122,6 +1123,7 @@ class Campaign_Preparer {
 			'body_key'                       => 'blaze.approval.body.v1',
 			'confirmation_label_key'         => 'blaze.approval.confirm_prepared_campaign.v1',
 			'approval_statement'             => __( 'I approve this exact prepared Blaze campaign package and authorize the charge terms shown here.', 'jetpack-blaze' ),
+			'pasteable_approval_message'     => self::build_pasteable_approval_message( $summary, $contract ),
 			'approval_contract'              => $contract,
 			'approval_event'                 => array_merge(
 				$contract,
@@ -1169,6 +1171,74 @@ class Campaign_Preparer {
 			'requires_exact_identity'        => true,
 			'requires_reprepare_edits'       => true,
 		);
+	}
+
+	/**
+	 * Build the default next action for an eligible chat-native submit.
+	 *
+	 * @param string $prefill_url    Optional Blaze widget/dashboard preview URL.
+	 * @param array  $approval_block Structured approval block.
+	 * @return array
+	 */
+	private static function build_chat_submit_next_action( string $prefill_url, array $approval_block ): array {
+		return array(
+			'type'                       => 'request_explicit_approval',
+			'default_flow'               => 'chat_native_submit',
+			'chat_native_submit'         => true,
+			'requires_explicit_approval' => true,
+			'pasteable_approval_message' => $approval_block['pasteable_approval_message'] ?? '',
+			'optional_preview_url'       => $prefill_url,
+			'optional_preview_label'     => __( 'Preview campaign in Blaze', 'jetpack-blaze' ),
+			'message'                    => __(
+				'Ask the user to paste the approval message before submitting this prepared campaign. The preview link is optional for review, not required when chat-native submit is eligible.',
+				'jetpack-blaze'
+			),
+		);
+	}
+
+	/**
+	 * Build a simple user-facing approval sentence for chat clients.
+	 *
+	 * This deliberately omits package hashes, idempotency keys, and tool names.
+	 *
+	 * @param array $summary  Structured campaign summary.
+	 * @param array $contract Structured approval contract.
+	 * @return string
+	 */
+	private static function build_pasteable_approval_message( array $summary, array $contract ): string {
+		$heading              = isset( $summary['creative']['heading'] ) && '' !== (string) $summary['creative']['heading']
+			? (string) $summary['creative']['heading']
+			: __( 'this Blaze campaign', 'jetpack-blaze' );
+		$charge               = isset( $contract['charge'] ) && is_array( $contract['charge'] ) ? $contract['charge'] : array();
+		$currency             = isset( $charge['currency'] ) && '' !== (string) $charge['currency'] ? (string) $charge['currency'] : self::get_site_currency();
+		$amount               = isset( $charge['max_amount'] ) ? (float) $charge['max_amount'] : self::DEFAULT_BUDGET_TOTAL;
+		$payment_method       = isset( $contract['selected_payment_method'] ) && is_array( $contract['selected_payment_method'] ) ? $contract['selected_payment_method'] : array();
+		$payment_method_label = isset( $payment_method['label'] ) && '' !== (string) $payment_method['label']
+			? (string) $payment_method['label']
+			: __( 'the selected saved payment method', 'jetpack-blaze' );
+
+		return sprintf(
+			/* translators: 1: campaign heading, 2: currency code, 3: maximum charge amount, 4: payment method label. */
+			__( 'I approve submitting this Blaze campaign for %1$s with a maximum charge of %2$s %3$s using %4$s. I agree to the Terms of Service and Advertising Policy.', 'jetpack-blaze' ),
+			$heading,
+			$currency,
+			self::format_approval_amount( $amount ),
+			$payment_method_label
+		);
+	}
+
+	/**
+	 * Format an approval amount for readable charge acknowledgement copy.
+	 *
+	 * @param float $amount Approval amount.
+	 * @return string
+	 */
+	private static function format_approval_amount( float $amount ): string {
+		if ( floor( $amount ) === $amount ) {
+			return (string) (int) $amount;
+		}
+
+		return number_format( $amount, 2, '.', '' );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -226,6 +226,19 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
 		$this->assertSame( 'pm_default', $result['submit_eligibility']['selected_payment_method']['id'] );
 		$this->assertArrayHasKey( 'approval_block', $result );
+		$this->assertArrayHasKey( 'next_action', $result );
+		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
+		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
+		$this->assertTrue( $result['next_action']['chat_native_submit'] );
+		$this->assertSame( $result['prefill_url'], $result['next_action']['optional_preview_url'] );
+		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Test product page', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'USD 75', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Visa ending in 4242', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Terms of Service', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Advertising Policy', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['prepared_campaign']['hash'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['submit_package']['idempotency_key'], $result['next_action']['pasteable_approval_message'] );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
 		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $result['approval_block']['confirmation_label_key'] );
 		$this->assertSame( 'traffic', $result['submit_package']['prepared_campaign']['objective'] );
@@ -382,6 +395,14 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'USD', $acknowledgement_values['currency'] );
 		$this->assertSame( 'one_time', $acknowledgement_values['billing_cadence'] );
 		$this->assertSame( 'Visa ending in 4242', $acknowledgement_values['payment_method_label'] );
+		$this->assertArrayHasKey( 'pasteable_approval_message', $approval_block );
+		$this->assertStringContainsString( 'Test product page', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'USD 75', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Visa ending in 4242', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Terms of Service', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Advertising Policy', $approval_block['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['prepared_campaign']['hash'], $approval_block['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['submit_package']['idempotency_key'], $approval_block['pasteable_approval_message'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds a structured `next_action` for eligible chat-native Blaze campaign prepares.
- Adds a safe pasteable approval message derived from the approval contract.
- Keeps package hashes and idempotency keys out of user-facing approval copy.

## Testing
- `cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Campaign_Preparer_Test' --testdox`
- `cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Campaign_Preparer_Test|Blaze_Abilities_Test' --testdox`

Linear: ADS-1134