### PR TITLE
ADS-1135 Clarify Blaze plain-language submit guidance

### DIFF
--- a/projects/packages/blaze/changelog/update-ads-1135-plain-language-submit-guidance
+++ b/projects/packages/blaze/changelog/update-ads-1135-plain-language-submit-guidance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: clarify chat-native submit guidance for plain-language approval intent.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -412,7 +412,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN         => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns chat-ready preview, approval, and fallback data. If submit_eligibility.chat_native_submit is true, chat-native approval/submit is the default continuation: when the merchant says natural language like "Looks good, submit it" or "go ahead and launch it", render the pasteable approval message from approval_block/next_action and wait for that explicit approval before calling submit-prepared-campaign. The Blaze preview/widget link may still be shown for optional review, but it is not the primary path for eligible users. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. Do not ask merchants to paste package hashes, idempotency keys, prepared package IDs, or tool names.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array(),
@@ -527,7 +527,7 @@ class Blaze_Abilities extends Registrar {
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
-					'description' => __( 'Chat-ready prepared campaign package plus a deep-link to the Blaze UI for fallback review and submit.', 'jetpack-blaze' ),
+					'description' => __( 'Chat-ready prepared campaign package with preview, optional Blaze UI fallback, and chat-native approval next action when eligible.', 'jetpack-blaze' ),
 					'required'    => array(
 						'status',
 						'message',
@@ -703,7 +703,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'approval_block'       => array(
 							'type'        => 'object',
-							'description' => __( 'Approval wording keys and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
+							'description' => __( 'Approval wording keys, pasteable approval message, and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
 							'required'    => array(
 								'prepared_campaign_id',
 								'prepared_campaign_hash',
@@ -711,6 +711,7 @@ class Blaze_Abilities extends Registrar {
 								'body_key',
 								'confirmation_label_key',
 								'approval_statement',
+								'pasteable_approval_message',
 								'approval_contract',
 								'approval_event',
 								'approval_event_required_fields',
@@ -743,6 +744,10 @@ class Blaze_Abilities extends Registrar {
 									'type'        => 'string',
 									'description' => __( 'Canonical fallback approval wording owned by Blaze.', 'jetpack-blaze' ),
 								),
+								'pasteable_approval_message' => array(
+									'type'        => 'string',
+									'description' => __( 'Plain-language approval sentence the merchant can paste or confirm after reviewing live prepared values. It includes campaign identity, maximum charge, currency, payment method summary, Terms of Service, and Advertising Policy acknowledgement, without exposing package hashes or idempotency keys.', 'jetpack-blaze' ),
+								),
 								'approval_contract'        => array(
 									'type'        => 'object',
 									'description' => __( 'Language-independent approval contract containing the exact package identity, terms/policy versions, charge terms, cancellation wording version, payment method, user, and site.', 'jetpack-blaze' ),
@@ -767,6 +772,51 @@ class Blaze_Abilities extends Registrar {
 								),
 								'requires_reprepare_edits' => array(
 									'type' => 'boolean',
+								),
+							),
+						),
+						'next_action'          => array(
+							'type'        => 'object',
+							'description' => __( 'Default next action for eligible prepared campaigns. When present, chat-native approval/submit is the default path, and the preview URL is optional review rather than widget-only handoff.', 'jetpack-blaze' ),
+							'required'    => array(
+								'type',
+								'default_flow',
+								'chat_native_submit',
+								'requires_explicit_approval',
+								'pasteable_approval_message',
+								'optional_preview_url',
+							),
+							'properties'  => array(
+								'type'                   => array(
+									'type'        => 'string',
+									'description' => __( 'Stable action type. request_explicit_approval means ask the merchant to paste or confirm the approval message before submit.', 'jetpack-blaze' ),
+									'enum'        => array( 'request_explicit_approval' ),
+								),
+								'default_flow'           => array(
+									'type'        => 'string',
+									'description' => __( 'chat_native_submit means the client should continue toward in-chat approval and submit by default.', 'jetpack-blaze' ),
+									'enum'        => array( 'chat_native_submit' ),
+								),
+								'chat_native_submit'     => array(
+									'type' => 'boolean',
+								),
+								'requires_explicit_approval' => array(
+									'type' => 'boolean',
+								),
+								'pasteable_approval_message' => array(
+									'type'        => 'string',
+									'description' => __( 'Approval message to render when the merchant says "submit it", "launch it", "go ahead", or similar plain-language intent.', 'jetpack-blaze' ),
+								),
+								'optional_preview_url'   => array(
+									'type'        => 'string',
+									'format'      => 'uri',
+									'description' => __( 'optional review URL for merchants who want to inspect the campaign in Blaze before approving in chat.', 'jetpack-blaze' ),
+								),
+								'optional_preview_label' => array(
+									'type' => 'string',
+								),
+								'message'                => array(
+									'type' => 'string',
 								),
 							),
 						),
@@ -850,7 +900,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_SUBMIT_PREPARED_CAMPAIGN => array(
 				'label'               => __( 'Submit an approved prepared Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as “looks good”; call it only after the client has rendered the exact approval terms from prepare-campaign and captured a structured approval event for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
+				'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as "looks good"; use that phrase to render the pasteable approval message instead. Call this only after the client has rendered the exact approval terms from prepare-campaign and captured a pasted or confirmed approval message, then built a structured approval event internally for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ),
@@ -881,7 +931,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'approval'                => array(
 							'type'        => 'object',
-							'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval.', 'jetpack-blaze' ),
+							'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval, but a merchant pasted or confirmed the rendered pasteable approval message after seeing the live terms is valid approval input for the client to convert into this event.', 'jetpack-blaze' ),
 						),
 					),
 					'additionalProperties' => false,
@@ -1898,6 +1948,13 @@ class Blaze_Abilities extends Registrar {
 		$message .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
 		$message .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
 		$message .= "\n" . __( 'Review URL:', 'jetpack-blaze' ) . ' ' . (string) ( $proposal['prefill_url'] ?? '' );
+
+		if ( ! empty( $proposal['next_action'] ) && is_array( $proposal['next_action'] ) ) {
+			$message .= "\n\n" . __( 'Chat submit is available.', 'jetpack-blaze' );
+			$message .= ' ' . __( 'You can preview it in Blaze if you want, but you can also approve and submit from chat.', 'jetpack-blaze' );
+			$message .= "\n" . __( 'To submit from chat, paste this approval message:', 'jetpack-blaze' ) . "\n";
+			$message .= (string) ( $proposal['next_action']['pasteable_approval_message'] ?? '' );
+		}
 
 		return $message;
 	}

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -230,7 +230,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( array( Blaze_Abilities::class, 'submit_prepared_campaign' ), $ability['execute_callback'] );
 		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
 		$this->assertStringContainsString( 'This spends real money', $ability['description'] );
+		$this->assertStringContainsString( 'pasted or confirmed approval message', $ability['description'] );
 		$this->assertStringContainsString( 'ordinary chat text is not approval', $ability['input_schema']['properties']['approval']['description'] );
+		$this->assertStringContainsString( 'rendered pasteable approval message', $ability['input_schema']['properties']['approval']['description'] );
 		$this->assertTrue( $ability['meta']['show_in_rest'] );
 		$this->assertFalse( $ability['meta']['annotations']['readonly'] );
 		$this->assertTrue( $ability['meta']['annotations']['destructive'] );
@@ -913,6 +915,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
 		$this->assertStringContainsString( 'Audience overrides must use stable codes or closed enums', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'If submit_eligibility.chat_native_submit is true', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'default continuation', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'optional review', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'Looks good, submit it', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'Do not ask merchants to paste package hashes', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
 		$ability    = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ];
 		$schema     = $ability['input_schema'];
@@ -976,6 +983,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'fallback_url', $output_properties );
 		$this->assertArrayHasKey( 'submit_eligibility', $output_properties );
 		$this->assertArrayHasKey( 'approval_block', $output_properties );
+		$this->assertArrayHasKey( 'next_action', $output_properties );
 		$this->assertArrayHasKey( 'material_edit_policy', $output_properties );
 		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
 		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
@@ -993,10 +1001,16 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'non_material_fields', $output_properties['material_edit_policy']['required'] );
 		$this->assertContains( 'approval_contract', $output_properties['approval_block']['required'] );
 		$this->assertContains( 'approval_event', $output_properties['approval_block']['required'] );
+		$this->assertContains( 'pasteable_approval_message', $output_properties['approval_block']['required'] );
 		$this->assertContains( 'charge_acknowledgement', $output_properties['approval_block']['required'] );
 		$this->assertArrayHasKey( 'approval_contract', $output_properties['approval_block']['properties'] );
 		$this->assertArrayHasKey( 'approval_event_required_fields', $output_properties['approval_block']['properties'] );
+		$this->assertArrayHasKey( 'pasteable_approval_message', $output_properties['approval_block']['properties'] );
 		$this->assertArrayHasKey( 'charge_acknowledgement', $output_properties['approval_block']['properties'] );
+		$this->assertContains( 'type', $output_properties['next_action']['required'] );
+		$this->assertContains( 'pasteable_approval_message', $output_properties['next_action']['required'] );
+		$this->assertStringContainsString( 'chat-native approval/submit is the default', $output_properties['next_action']['description'] );
+		$this->assertStringContainsString( 'optional review', $output_properties['next_action']['properties']['optional_preview_url']['description'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
@@ -1538,6 +1552,14 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 50.0, $result['approval_block']['approval_contract']['charge']['max_amount'] );
 		$this->assertSame( 'pm_default', $result['approval_block']['approval_contract']['selected_payment_method_id'] );
 		$this->assertSame( 'blaze.approval.charge_acknowledgement', $result['approval_block']['charge_acknowledgement']['template_key'] );
+		$this->assertArrayHasKey( 'next_action', $result );
+		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
+		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
+		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Chat submit is available', $result['message'] );
+		$this->assertStringContainsString( 'You can preview it in Blaze if you want', $result['message'] );
+		$this->assertStringContainsString( 'To submit from chat, paste this approval message', $result['message'] );
+		$this->assertStringContainsString( $result['next_action']['pasteable_approval_message'], $result['message'] );
 		$this->assertArrayHasKey( 'idempotency_key', $result['submit_package'] );
 		$this->assertSame( $result['submit_package']['idempotency_key'], $result['approval_block']['approval_event']['idempotency_key'] );
 		$this->assertContains( 'approved_at', $result['approval_block']['approval_event_required_fields'] );
@@ -1582,6 +1604,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertNull( $result['submit_eligibility']['selected_payment_method'] );
 		$this->assertSame( array(), $result['submit_eligibility']['available_payment_methods'] );
 		$this->assertArrayNotHasKey( 'approval_block', $result );
+		$this->assertArrayNotHasKey( 'next_action', $result );
 		$this->assertStringContainsString( 'Review URL: ' . $result['fallback_url'], $result['message'] );
 	}
 


### PR DESCRIPTION
## Summary
- Updates prepare/submit ability guidance so eligible users continue toward chat-native approval by default.
- Adds `next_action` and pasteable approval wording to the public output schema.
- Updates the prepared campaign chat message to show optional preview plus the pasteable approval path.

## Testing
- `cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Campaign_Preparer_Test|Blaze_Abilities_Test' --testdox`

Linear: ADS-1135