### PR TITLE
ci: Use GH concurrency queue instead of turnstile in autotagger.yml

### DIFF
--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -7,9 +7,11 @@ on:
       - prerelease
       - '*/branch-*'
 
+concurrency:
+  group: autotagger-${{ case( contains( github.ref, '/branch-' ), github.ref, 'unprefixed' ) }}
+  queue: max
+
 permissions:
-  # ./.github/actions/turnstile
-  actions: read
   # read: actions/checkout
   # write: `git push`
   contents: write
@@ -25,8 +27,12 @@ jobs:
         run: |
           git fetch --depth=1 --filter=blob:none origin 'refs/tags/*:refs/tags/*'
 
-      - name: Determine needed tags
-        id: get-tags
+      - name: Tag projects
+        env:
+          GIT_AUTHOR_NAME: matticbot
+          GIT_AUTHOR_EMAIL: 'matticbot@users.noreply.github.com'
+          GIT_COMMITTER_NAME: matticbot
+          GIT_COMMITTER_EMAIL: 'matticbot@users.noreply.github.com'
         run: |
           REF=${GITHUB_REF#refs/heads/}
           if [[ "$REF" == */branch-* ]]; then
@@ -35,7 +41,6 @@ jobs:
               echo "Branch $REF seems to be a release branch, checking matching projects."
             else
               echo "::notice::Branch $REF seems to be a release branch, but nothing uses that prefix so not checking any projects."
-              echo "any=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           else
@@ -44,12 +49,12 @@ jobs:
               echo "Branch $REF is not a release branch, checking only projects without a release-branch-prefix."
             else
               echo "::notice::Branch $REF is not a release branch, but somehow no projects lack a release-branch-prefix?"
-              echo "any=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
 
-          TAGS=()
+          EXIT=0
+          TOPUSH=()
           while IFS= read -r SLUG; do
             echo "Checking $SLUG..."
             cd "$GITHUB_WORKSPACE/projects/$SLUG"
@@ -67,50 +72,17 @@ jobs:
                 echo " Version $VER is already tagged"
               else
                 echo " Version $VER ok to tag"
-                TAGS+=( "$SLUG@$VER" )
+                if git tag "$SLUG@$VER"; then
+                  TOPUSH+=( "$SLUG@$VER" )
+                else
+                  echo " \`git tag $SLUG@$VER\` failed"
+                  EXIT=1
+                fi
               fi
             else
               echo " Not tagging version $VER"
             fi
           done <<<"$PROJECTS"
-
-          if [[ ${#TAGS[@]} -eq 0 ]]; then
-            echo "::notice::Nothing to tag."
-            echo "any=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          printf "%s\n" "${TAGS[@]}" > "$GITHUB_WORKSPACE/to-tag.txt"
-          echo "any=true" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for prior instances of the workflow to finish
-        if: steps.get-tags.outputs.any == 'true'
-        uses: ./.github/actions/turnstile
-        with:
-          # Tagging should be reasonably quick, so poll more frequently.
-          poll-interval: 15
-
-      - name: Fetch tags, shallowly and blobless
-        if: steps.get-tags.outputs.any == 'true'
-        run: |
-          git fetch --force --depth=1 --filter=blob:none origin 'refs/tags/*:refs/tags/*'
-
-      - name: Tag projects
-        if: steps.get-tags.outputs.any == 'true'
-        run: |
-          export GIT_AUTHOR_NAME=matticbot
-          export GIT_AUTHOR_EMAIL=matticbot@users.noreply.github.com
-          export GIT_COMMITTER_NAME=matticbot
-          export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
-
-          EXIT=0
-          echo "Creating tags..."
-          TOPUSH=()
-          while IFS= read -r T; do
-            if git tag "$T"; then
-              TOPUSH+=( "$T" )
-            fi
-          done < "$GITHUB_WORKSPACE/to-tag.txt"
 
           if [[ ${#TOPUSH[@]} -gt 0 ]]; then
             echo "Pushing tags..."


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
GitHub has recently added the ability to have an actual queue (max 100 entries) for its concurrency feature. This should perform better than turnstile, so let's try it out.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1779371671037339-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Fork, merge this into trunk in the fork, then push a bunch of releases to trunk in quick succession. Check that the queuing works and the right tags get created.
  * [x] https://github.com/anomiex/jetpack/actions/workflows/autotagger.yml