### PR TITLE
ADS-1137: Cover customer-style Blaze chat submit flow

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1137-chat-submit-regression-coverage
+++ b/projects/packages/blaze/changelog/add-ads-1137-chat-submit-regression-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: make chat submit the leading next step for eligible prepared campaigns.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -784,6 +784,7 @@ class Blaze_Abilities extends Registrar {
 								'chat_native_submit',
 								'requires_explicit_approval',
 								'pasteable_approval_message',
+								'plain_language_submit_intents',
 								'optional_preview_url',
 							),
 							'properties'  => array(
@@ -806,6 +807,13 @@ class Blaze_Abilities extends Registrar {
 								'pasteable_approval_message' => array(
 									'type'        => 'string',
 									'description' => __( 'Approval message to render when the merchant says "submit it", "launch it", "go ahead", or similar plain-language intent.', 'jetpack-blaze' ),
+								),
+								'plain_language_submit_intents' => array(
+									'type'        => 'array',
+									'description' => __( 'Plain-language merchant phrases such as "submit it", "launch it", "go ahead", or "looks good" that mean the client should render the pasteable approval message, not refuse or send the merchant to the widget-only flow.', 'jetpack-blaze' ),
+									'items'       => array(
+										'type' => 'string',
+									),
 								),
 								'optional_preview_url'   => array(
 									'type'        => 'string',
@@ -1872,7 +1880,9 @@ class Blaze_Abilities extends Registrar {
 	private static function format_prepare_campaign_message( array $proposal ): string {
 		$preview          = self::build_campaign_preview( $proposal );
 		$forecast_summary = self::build_forecast_summary( $proposal );
-		$message          = __( 'Campaign proposal prepared for review in Blaze.', 'jetpack-blaze' ) . "\n\n";
+		$message          = ! empty( $proposal['next_action'] ) && is_array( $proposal['next_action'] )
+			? __( 'Campaign proposal prepared. Chat submit is available after explicit approval.', 'jetpack-blaze' ) . "\n\n"
+			: __( 'Campaign proposal prepared for review in Blaze.', 'jetpack-blaze' ) . "\n\n";
 
 		$message .= '| ' . __( 'Campaign preview', 'jetpack-blaze' ) . ' | ' . __( 'Prepared value', 'jetpack-blaze' ) . " |\n";
 		$message .= "| --- | --- |\n";

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -1182,15 +1182,23 @@ class Campaign_Preparer {
 	 */
 	private static function build_chat_submit_next_action( string $prefill_url, array $approval_block ): array {
 		return array(
-			'type'                       => 'request_explicit_approval',
-			'default_flow'               => 'chat_native_submit',
-			'chat_native_submit'         => true,
-			'requires_explicit_approval' => true,
-			'pasteable_approval_message' => $approval_block['pasteable_approval_message'] ?? '',
-			'optional_preview_url'       => $prefill_url,
-			'optional_preview_label'     => __( 'Preview campaign in Blaze', 'jetpack-blaze' ),
-			'message'                    => __(
-				'Ask the user to paste the approval message before submitting this prepared campaign. The preview link is optional for review, not required when chat-native submit is eligible.',
+			'type'                          => 'request_explicit_approval',
+			'default_flow'                  => 'chat_native_submit',
+			'chat_native_submit'            => true,
+			'requires_explicit_approval'    => true,
+			'pasteable_approval_message'    => $approval_block['pasteable_approval_message'] ?? '',
+			'plain_language_submit_intents' => array(
+				'submit it',
+				'launch it',
+				'go ahead',
+				'looks good',
+				'create the campaign',
+				'run the campaign',
+			),
+			'optional_preview_url'          => $prefill_url,
+			'optional_preview_label'        => __( 'Preview campaign in Blaze', 'jetpack-blaze' ),
+			'message'                       => __(
+				'When the user asks to submit, launch, create, run, or says it looks good in plain language, render the pasteable approval message before submitting this prepared campaign. The preview link is optional for review, not required when chat-native submit is eligible.',
 				'jetpack-blaze'
 			),
 		);

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -230,6 +230,9 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
 		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
 		$this->assertTrue( $result['next_action']['chat_native_submit'] );
+		$this->assertContains( 'submit it', $result['next_action']['plain_language_submit_intents'] );
+		$this->assertContains( 'launch it', $result['next_action']['plain_language_submit_intents'] );
+		$this->assertContains( 'go ahead', $result['next_action']['plain_language_submit_intents'] );
 		$this->assertSame( $result['prefill_url'], $result['next_action']['optional_preview_url'] );
 		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
 		$this->assertStringContainsString( 'Test product page', $result['next_action']['pasteable_approval_message'] );

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1009,7 +1009,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'charge_acknowledgement', $output_properties['approval_block']['properties'] );
 		$this->assertContains( 'type', $output_properties['next_action']['required'] );
 		$this->assertContains( 'pasteable_approval_message', $output_properties['next_action']['required'] );
+		$this->assertContains( 'plain_language_submit_intents', $output_properties['next_action']['required'] );
 		$this->assertStringContainsString( 'chat-native approval/submit is the default', $output_properties['next_action']['description'] );
+		$this->assertStringContainsString( 'submit it', $output_properties['next_action']['properties']['plain_language_submit_intents']['description'] );
 		$this->assertStringContainsString( 'optional review', $output_properties['next_action']['properties']['optional_preview_url']['description'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
@@ -1555,7 +1557,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'next_action', $result );
 		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
 		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
+		$this->assertContains( 'submit it', $result['next_action']['plain_language_submit_intents'] );
+		$this->assertContains( 'looks good', $result['next_action']['plain_language_submit_intents'] );
 		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Campaign proposal prepared. Chat submit is available after explicit approval.', $result['message'] );
+		$this->assertStringNotContainsString( 'Campaign proposal prepared for review in Blaze.', $result['message'] );
 		$this->assertStringContainsString( 'Chat submit is available', $result['message'] );
 		$this->assertStringContainsString( 'You can preview it in Blaze if you want', $result['message'] );
 		$this->assertStringContainsString( 'To submit from chat, paste this approval message', $result['message'] );


### PR DESCRIPTION
## Summary
- make eligible prepared campaigns lead with chat submit after explicit approval instead of review-in-Blaze copy
- expose plain-language submit intents such as `submit it`, `launch it`, `go ahead`, and `looks good` in `next_action`
- add regression coverage so eligible flows keep the preview link optional and render the pasteable approval path for natural customer wording

## Tests
- cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Campaign_Preparer_Test::test_prepare_returns_structured_campaign_proposal|Blaze_Abilities_Test::test_prepare_campaign_ability_definition|Blaze_Abilities_Test::test_wrapped_prepare_campaign_marks_chat_native_submit_eligible' --testdox
- cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Campaign_Preparer_Test|Blaze_Abilities_Test' --testdox