### PR TITLE
ci: Use GH concurrency queue instead of turnstile in pr-is-up-to-date.yml

### DIFF
--- a/.github/workflows/pr-is-up-to-date-trunk-push.yml
+++ b/.github/workflows/pr-is-up-to-date-trunk-push.yml
@@ -1,0 +1,27 @@
+name: PR is up-to-date (trunk push)
+on:
+  push:
+    branches: [ trunk ]
+
+concurrency:
+  group: pr-is-up-to-date-trunk-push-
+  queue: max
+
+# Everything, including actions/checkout, is using secrets.API_TOKEN_GITHUB, so no need for permissions.
+permissions: {}
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5 # 2026-05-21: Should be fairly quick, unless lots of tags need updating.
+    steps:
+      - name: Checkout push to trunk
+        uses: actions/checkout@v6
+        with:
+          # Script needs the previous commit for diffing.
+          fetch-depth: 2
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+
+      - name: Check whether the tag needs updating for trunk commit
+        run: .github/files/pr-update-to.sh

--- a/.github/workflows/pr-is-up-to-date-trunk-push.yml
+++ b/.github/workflows/pr-is-up-to-date-trunk-push.yml
@@ -4,7 +4,7 @@ on:
     branches: [ trunk ]
 
 concurrency:
-  group: pr-is-up-to-date-trunk-push-
+  group: pr-is-up-to-date-trunk-push-all
   queue: max
 
 # Everything, including actions/checkout, is using secrets.API_TOKEN_GITHUB, so no need for permissions.

--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -3,15 +3,12 @@ on:
   pull_request_target:
     branches: [ trunk ]
   push:
-    branches: [ trunk ]
     tags:
       - pr-update-to
       - pr-update-to-projects/**
 
-permissions:
-  # ./.github/actions/turnstile
-  actions: read
-  # Note everything else, including actions/checkout, is using secrets.API_TOKEN_GITHUB, so no need for permissions.
+# Everything, including actions/checkout, is using secrets.API_TOKEN_GITHUB, so no need for permissions.
+permissions: {}
 
 jobs:
   check:
@@ -20,15 +17,8 @@ jobs:
     timeout-minutes: 5 # 2025-11-20: The run on push to the tag might take a minute or two.
     steps:
 
-      # We basically have two workflows in one here, one for pushes to trunk and one for PRs and pushes to tags.
-      # The reason we don't separate them into two is because GitHub's UI would then always be showing a skipped job
-      # in the PR check list, which is kind of annoying.
-
-      # First, the "PR or tag" job.
-
       - name: Checkout trunk for tag push or PR
         uses: actions/checkout@v6
-        if: github.event_name != 'push' || github.ref != 'refs/heads/trunk'
         with:
           ref: trunk
           token: ${{ secrets.API_TOKEN_GITHUB }}
@@ -42,7 +32,6 @@ jobs:
 
       - name: Determine tags for PR or tag and paths for tag push
         id: determine
-        if: github.event_name != 'push' || github.ref != 'refs/heads/trunk'
         env:
           REF: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -64,7 +53,6 @@ jobs:
           echo "push-paths=$PATHS" >> "$GITHUB_OUTPUT"
 
       - name: Check PR or tag push
-        if: github.event_name != 'push' || github.ref != 'refs/heads/trunk'
         uses: ./projects/github-actions/pr-is-up-to-date
         with:
           tags: ${{ steps.determine.outputs.pr-tags }}
@@ -72,21 +60,3 @@ jobs:
           paths: ${{ steps.determine.outputs.push-paths }}
           token: ${{ secrets.API_TOKEN_GITHUB }}
           status: PR is up to date
-
-      # Second, the "push to trunk" job.
-
-      - name: Checkout push to trunk
-        uses: actions/checkout@v6
-        if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
-        with:
-          # The "Check whether the tag needs updating for trunk commit" needs the previous commit for diffing.
-          fetch-depth: 2
-          token: ${{ secrets.API_TOKEN_GITHUB }}
-
-      - name: Wait for prior instances of the workflow to finish
-        if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
-        uses: ./.github/actions/turnstile
-
-      - name: Check whether the tag needs updating for trunk commit
-        if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
-        run: .github/files/pr-update-to.sh


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
GitHub has recently added the ability to have an actual queue (max 100 entries) for its concurrency feature. This should perform better than turnstile, so let's try it out.

Also, there's a bit of cruft in the file: when I originally wrote it, I thought of it as one feature so I put it all in one file, and then had to get a bit hacky to avoid always having a skipped job in the PR check list. But we can also avoid that, more cleanly, by just having two independent workflows.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1779371671037339-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Fork, set up secrets in the fork, merge this, and then try stuff and see how it runs.
  * [x] https://github.com/anomiex/jetpack/actions/workflows/pr-is-up-to-date-trunk-push.yml
  * [x] https://github.com/anomiex/jetpack/actions/workflows/pr-is-up-to-date.yml 