### PR TITLE
ADS-1137: Avoid raw Blaze prefill links in chat messages

### DIFF
--- a/projects/packages/blaze/changelog/fix-ads-1137-preview-link-streaming
+++ b/projects/packages/blaze/changelog/fix-ads-1137-preview-link-streaming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blaze: avoid streaming raw prefill URLs in chat-facing prepare messages.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -555,7 +555,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'message'              => array(
 							'type'        => 'string',
-							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat before the review link; it includes a campaign preview table and the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
+							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat. It includes a campaign preview table and a Markdown preview link; the raw prefill_url stays in structured fields to avoid streaming partial long links.', 'jetpack-blaze' ),
 						),
 						'campaign_preview'     => array(
 							'type'        => 'object',
@@ -1955,9 +1955,16 @@ class Blaze_Abilities extends Registrar {
 			}
 		}
 
-		$message .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
-		$message .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
-		$message .= "\n" . __( 'Review URL:', 'jetpack-blaze' ) . ' ' . (string) ( $proposal['prefill_url'] ?? '' );
+		$message    .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
+		$message    .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
+		$preview_url = (string) ( $proposal['prefill_url'] ?? '' );
+		if ( '' !== $preview_url ) {
+			$message .= "\n" . sprintf(
+				/* translators: %s: Markdown link to preview the campaign in Blaze. */
+				__( 'Preview link: %s', 'jetpack-blaze' ),
+				'[Preview campaign in Blaze](' . $preview_url . ')'
+			);
+		}
 
 		if ( ! empty( $proposal['next_action'] ) && is_array( $proposal['next_action'] ) ) {
 			$message .= "\n\n" . __( 'Chat submit is available.', 'jetpack-blaze' );

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1479,7 +1479,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'pending_merchant_review', $result['status'] );
 		$this->assertNotEmpty( $result['prefill_url'] );
 		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
-		$this->assertStringContainsString( $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['prefill_url'] . ')', $result['message'] );
 		$this->assertArrayNotHasKey( 'budget_options', $result );
 		$this->assertSame( 'unavailable', $result['forecast']['status'] );
 		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
@@ -1491,7 +1491,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
 		$this->assertStringContainsString( 'Assumptions:', $result['message'] );
 		$this->assertStringContainsString( 'Recommendations:', $result['message'] );
-		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( 'Preview campaign in Blaze', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 		$this->assertStringNotContainsString( 'Budget options:', $result['message'] );
 
 		$prefill = $result['prefill'];
@@ -1684,7 +1685,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( array(), $result['submit_eligibility']['available_payment_methods'] );
 		$this->assertArrayNotHasKey( 'approval_block', $result );
 		$this->assertArrayNotHasKey( 'next_action', $result );
-		$this->assertStringContainsString( 'Review URL: ' . $result['fallback_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['fallback_url'] . ')', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 	}
 
 	/**
@@ -1746,7 +1748,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'views', $result['forecast']['primary_metric'] );
 		$this->assertSame( 'Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['forecast_summary'] );
 		$this->assertStringContainsString( 'Forecast: Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['message'] );
-		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['prefill_url'] . ')', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 	}
 
 	/**
@@ -1774,7 +1777,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'forecast_unavailable', $result['forecast']['reason'] );
 		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
 		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
-		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['prefill_url'] . ')', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- render the Blaze preview as a Markdown link instead of streaming the raw long prefill URL
- keep the raw `prefill_url` in structured output for clients that need it
- update tests so chat messages no longer contain `Review URL:` raw-link text

## Tests
- cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Blaze_Abilities_Test::test_prepare_campaign_returns_prefill_payload_and_url|Blaze_Abilities_Test::test_wrapped_prepare_campaign_blocks_chat_native_submit_without_saved_payment_method|Blaze_Abilities_Test::test_prepare_campaign_message_includes_forecast_summary_when_available|Blaze_Abilities_Test::test_prepare_campaign_message_includes_forecast_fallback' --testdox
- cd projects/packages/blaze && composer run --timeout=0 phpunit -- --filter='Campaign_Preparer_Test|Blaze_Abilities_Test' --testdox