### PR TITLE
Custom Colors: fix theme background color ignoring 'Use theme styles' toggle

### DIFF
--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -201,7 +201,7 @@ class Colors_Manager_Common {
 			// If colors are set, print them in the Block Editor as well.
 			if ( self::theme_has_set_colors() ) {
 				self::override_themecolors();
-				add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'print_block_editor_css' ), 20 );
+				add_filter( 'block_editor_settings_all', array( __CLASS__, 'add_block_editor_color_styles' ) );
 			}
 		}
 	}
@@ -1447,6 +1447,40 @@ class Colors_Manager_Common {
 		wp_register_style( 'custom-colors-editor-css', false, array(), '20210311' ); // Register an empty stylesheet to append custom CSS to.
 		wp_enqueue_style( 'custom-colors-editor-css' );
 		wp_add_inline_style( 'custom-colors-editor-css', $css ); // Append inline style to our new stylesheet
+	}
+
+	/**
+	 * Add theme color styles to the block editor settings so Gutenberg
+	 * treats them as theme styles, allowing the "Use theme styles"
+	 * toggle to control them.
+	 *
+	 * @param array $editor_settings The block editor settings.
+	 * @return array
+	 */
+	public static function add_block_editor_color_styles( $editor_settings ) {
+		if ( ! self::should_enable_colors() ) {
+			return $editor_settings;
+		}
+
+		$css = self::get_theme_css();
+
+		// Gutenberg 22.6.0+ renders the editor in an iframe for all themes.
+		// #editor no longer exists inside the iframe, so extend any
+		// "#editor .editor-styles-wrapper" selector to also match the
+		// iframe context while keeping the original for older versions.
+		$css = str_replace(
+			'#editor .editor-styles-wrapper',
+			'#editor .editor-styles-wrapper, :root :where(.editor-styles-wrapper)',
+			$css
+		);
+
+		$editor_settings['styles'][] = array(
+			'css'            => $css,
+			'__unstableType' => 'theme',
+			'isGlobalStyles' => false,
+		);
+
+		return $editor_settings;
 	}
 
 	/**


### PR DESCRIPTION
## What
Fixes [EDI-504](https://linear.app/a8c/issue/EDI-504/gutenberg-theme-background-color-displays-in-the-editor-when-use-theme) — theme background color displays in the editor when "Use theme styles" is disabled on classic themes (Atomic/WoA sites).

Companion PR to wpcom #218901 which fixes the same issue on Simple sites.

## Why
Classic themes (Twenty Sixteen, Twenty Twenty, etc.) with custom background colors inject those colors into the block editor via `wp_add_inline_style()`, which bypasses Gutenberg's style management. The "Use theme styles" toggle has no effect on these injected styles.

## How
Switches the CSS injection from `enqueue_block_editor_assets` + `wp_add_inline_style()` to the `block_editor_settings_all` filter with `__unstableType => 'theme'`, so Gutenberg treats them as theme styles and the toggle controls them.

The existing `print_block_editor_css()` method is left in place as it may be called from other contexts or subclasses.

## Testing
- [ ] On an Atomic site with **Twenty Sixteen** + custom background color:
  - "Use theme styles" ON → custom background shows in editor
  - "Use theme styles" OFF → custom background removed from editor
- [ ] Repeat with **Twenty Twenty**
- [ ] Verify published posts display correctly in both states
- [ ] Verify no regressions in editor color rendering for other classic themes

Note: Verified via code review and parity with the wpcom Simple site fix. Reviewer input on live-site behavior requested.

Note: The Linear issue was auto-marked "In Progress" when the wpcom PR opened. This is review-ready, not actively worked by an engineer.