### PR TITLE
ci: Use GH concurrency queue instead of turnstile in gardening.yml

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -5,15 +5,15 @@ on:
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.
+
+# On the workflow level, cancel any concurrent runs with the same type (e.g. "opened", "labeled") and branch.
+# Don't cancel any for other events, accomplished by grouping on the unique run_id.
+# Later, on the job level, we queue the job runs by branch to keep them from interfering with each other.
 concurrency:
-  # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
-  # Don't cancel any for other events, accomplished by grouping on the unique run_id.
   group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ case( github.event_name == 'pull_request_target', github.event.pull_request.head.ref, github.run_id ) }}
   cancel-in-progress: true
 
 permissions:
-  # ./.github/actions/turnstile
-  actions: read
   # actions/checkout
   contents: read
   # ./projects/github-actions/repo-gardening
@@ -30,7 +30,13 @@ jobs:
     name: "Manage labels and assignees"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    timeout-minutes: 10  # 2025-11-06: Successful runs seem to take a minute or two, primarily since we wait for previous runs to complete.
+    timeout-minutes: 5  # 2026-05-21: Successful runs take 1–2 minutes.
+
+    # See above.
+    concurrency:
+      group: gardening-xjobqueue-${{ github.ref }}
+      queue: max
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -55,9 +61,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           # DO NOT run any code in this checkout. Not even an `npm install`.
           path: ./pr-checkout
-
-      - name: Wait for prior instances of the workflow to finish
-        uses: ./.github/actions/turnstile
 
       - name: "Run the action (assign, manage milestones, for PRs)"
         uses: ./projects/github-actions/repo-gardening


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
GitHub has recently added the ability to have an actual queue (max 100 entries) for its concurrency feature. This should perform better than turnstile, so let's try it out.

It turns out that having `concurrency` set at both the workflow level and the job level works the way we need it: each declaration operates completely independently of the other, so the job-level concurrency can group jobs together even if the workflow-level puts them in separate groups. We do still need to worry about collisions though.

This does mean that multiple gardening jobs for a PR can't do the tool setup and build steps before waiting on the queue, but since that seems to take less than a minute I think we can accept that.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1779371671037339-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Set things up to run in a fork and see what happens.