### PR TITLE
VideoPress: gate the modernized dashboard behind a WordPress.com connection

### DIFF
--- a/projects/js-packages/components/changelog/add-pricing-table-subpath-exports
+++ b/projects/js-packages/components/changelog/add-pricing-table-subpath-exports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add subpath exports for Button, PricingTable, and ProductPrice so they can be imported directly (e.g. from wp-build bundles that cannot import the package barrel).

--- a/projects/js-packages/components/components/terms-of-service/index.tsx
+++ b/projects/js-packages/components/components/terms-of-service/index.tsx
@@ -2,7 +2,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import clsx from 'clsx';
-import { getRedirectUrl } from '../../index.ts';
+// Deep import rather than the package barrel (`../../index.ts`): the barrel
+// pulls in heavy, asset-importing components (e.g. boost-score-graph) that the
+// wp-build esbuild pipeline can't bundle, which breaks any wp-build dashboard
+// that deep-imports pricing-table (which renders TermsOfService).
+import getRedirectUrl from '../../tools/jp-redirect/index.ts';
 import Text from '../text/index.tsx';
 import type { TermsOfServiceProps } from './types.ts';
 import type { FC, ReactNode } from 'react';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -28,6 +28,11 @@
 			"types": "./build/components/admin-page/index.d.ts",
 			"default": "./build/components/admin-page/index.js"
 		},
+		"./button": {
+			"jetpack:src": "./components/button/index.tsx",
+			"types": "./build/components/button/index.d.ts",
+			"default": "./build/components/button/index.js"
+		},
 		"./global-notices": {
 			"jetpack:src": "./components/global-notices/index.ts",
 			"types": "./build/components/global-notices/index.d.ts",
@@ -47,6 +52,16 @@
 			"jetpack:src": "./components/jetpack-logo/index.tsx",
 			"types": "./build/components/jetpack-logo/index.d.ts",
 			"default": "./build/components/jetpack-logo/index.js"
+		},
+		"./pricing-table": {
+			"jetpack:src": "./components/pricing-table/index.tsx",
+			"types": "./build/components/pricing-table/index.d.ts",
+			"default": "./build/components/pricing-table/index.js"
+		},
+		"./product-price": {
+			"jetpack:src": "./components/product-price/index.tsx",
+			"types": "./build/components/product-price/index.d.ts",
+			"default": "./build/components/product-price/index.js"
 		},
 		"./tools/jp-redirect": {
 			"jetpack:src": "./tools/jp-redirect/index.ts",

--- a/projects/packages/videopress/changelog/add-videopress-modernization-connection-gate
+++ b/projects/packages/videopress/changelog/add-videopress-modernization-connection-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Modernized VideoPress dashboard (gated behind rsm_jetpack_ui_modernization_videopress): gate the dashboard behind a WordPress.com connection so the uploader is no longer exposed pre-connection. Unregistered sites see the pricing upsell (ported from the legacy dashboard); registered sites without a connected owner/user see a connect screen.

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -37,5 +37,19 @@ export declare global {
 				assets: {
 					buildUrl: string;
 				};
+				pricing: null | {
+					title: string;
+					features: string[];
+					yearly: {
+						slug: string;
+						name: string;
+						price: number;
+						priceByMonth: number;
+						currency: string;
+						discount?: number;
+						salePrice?: number;
+						salePriceByMonth?: number;
+					};
+				};
 		  };
 }

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -8,7 +8,9 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
@@ -131,6 +133,38 @@ class Initial_State {
 			'assets'        => array(
 				'buildUrl' => plugins_url( '../build/', __FILE__ ),
 			),
+			// Product/pricing payload for the pre-connection upsell. Only
+			// populated when the site isn't connected — the only time the
+			// connection gate renders the upsell — so connected dashboards never
+			// incur the synchronous WPCOM pricing request `get_pricing_data()`
+			// makes.
+			'pricing'       => ( new Connection_Manager() )->is_connected() ? null : $this->get_pricing_data(),
+		);
+	}
+
+	/**
+	 * Product description, feature list, and yearly price for the
+	 * pre-connection upsell (a port of the legacy dashboard's pricing table).
+	 *
+	 * Backed by `Plan::get_product_price()`, which issues a synchronous WPCOM
+	 * request, so this only runs for disconnected sites. Returns null when the
+	 * product or price data isn't available (e.g. the WPCOM request fails), in
+	 * which case the gate falls back to the plain connect screen.
+	 *
+	 * @return array|null The upsell payload, or null when it can't be built.
+	 */
+	private function get_pricing_data() {
+		$site_product  = My_Jetpack_Products::get_product( 'videopress' );
+		$product_price = Plan::get_product_price();
+
+		if ( ! is_array( $site_product ) || ! isset( $product_price['yearly'] ) ) {
+			return null;
+		}
+
+		return array(
+			'title'    => isset( $site_product['description'] ) ? (string) $site_product['description'] : '',
+			'features' => isset( $site_product['features'] ) ? array_values( (array) $site_product['features'] ) : array(),
+			'yearly'   => $product_price['yearly'],
 		);
 	}
 

--- a/projects/packages/videopress/src/dashboard/admin-shell.scss
+++ b/projects/packages/videopress/src/dashboard/admin-shell.scss
@@ -14,6 +14,20 @@ body.jetpack_page_jetpack-videopress {
 	// fallback) and future tweaks have one place to land.
 	--vp-page-bg-canvas: #fcfcfc;
 
+	// jetpack-components typography & spacing tokens. Components consumed by
+	// the connection gate (pricing table, ProductPrice, Text) reference these
+	// custom properties but don't define them — each host dashboard supplies
+	// its own set (cf. Jetpack Boost's `.jb-dashboard` root). base-styles'
+	// root-variables.scss covers the title/body/color tokens but leaves these
+	// out, so without them those components fall back to unstyled defaults
+	// (e.g. the price renders at 13px and the cards lose all padding).
+	--font-headline-medium: 48px;
+	--font-headline-small: 36px;
+	--font-title-medium: 24px;
+	--font-body-small: 14px;
+	--font-body-extra-small: 14px;
+	--spacing-base: 8px;
+
 	// `…-wp-build` rather than `…-page-layout` because the modernized
 	// dashboard mounts `@wordpress/admin-ui` 2.x components (notably
 	// `<Breadcrumbs>`) whose semantic markup collides with wp-admin's

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
@@ -1,0 +1,51 @@
+import AdminPage from '@automattic/jetpack-components/admin-page';
+import { __ } from '@wordpress/i18n';
+import { Button, Stack, Text } from '@wordpress/ui';
+import './style.scss';
+
+type Props = {
+	/** Starts the site-registration + user-connection flow. */
+	onConnect: () => void;
+	/** True while registration or user connection is in flight. */
+	isConnecting: boolean;
+};
+
+/**
+ * Pre-connection screen rendered in place of the dashboard when the site or the
+ * current user isn't connected to WordPress.com. VideoPress can't upload or
+ * manage videos without that connection, so the dashboard (and its uploader)
+ * stays behind it. Reuses the same `AdminPage` chrome as `DashboardLayout` so
+ * the header and footer match the connected dashboard.
+ *
+ * @param props              - Component props.
+ * @param props.onConnect    - Starts the connection flow.
+ * @param props.isConnecting - Whether the connection flow is in progress.
+ * @return The connect screen element.
+ */
+export default function ConnectScreen( { onConnect, isConnecting }: Props ) {
+	return (
+		<AdminPage
+			title={ 'VideoPress' /* product name; not translated */ }
+			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+		>
+			<Stack direction="column" gap="md" className="vp-connection-gate">
+				<Text variant="heading-2xl">
+					{ __( 'Connect to set up VideoPress', 'jetpack-videopress-pkg' ) }
+				</Text>
+				<Text>
+					{ __(
+						'VideoPress needs a connection to WordPress.com before you can upload and manage your videos.',
+						'jetpack-videopress-pkg'
+					) }
+				</Text>
+				<div>
+					<Button variant="solid" disabled={ isConnecting } onClick={ onConnect }>
+						{ isConnecting
+							? __( 'Connecting…', 'jetpack-videopress-pkg' )
+							: __( 'Connect', 'jetpack-videopress-pkg' ) }
+					</Button>
+				</div>
+			</Stack>
+		</AdminPage>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/index.tsx
@@ -1,0 +1,79 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import ConnectScreen from './connect-screen';
+import PricingUpsell from './pricing-upsell';
+import type { ReactNode } from 'react';
+
+const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
+
+/**
+ * After connecting, return the user to the VideoPress dashboard — the same
+ * redirect the legacy dashboard's connection flow used.
+ *
+ * @return The absolute VideoPress admin URL, or undefined when the admin URL isn't in the inlined initial state (e.g. tests).
+ */
+function getRedirectUri(): string | undefined {
+	const adminUrl =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+			? JPVIDEOPRESS_INITIAL_STATE?.siteData?.adminUrl
+			: undefined;
+	return adminUrl ? `${ adminUrl }${ VIDEOPRESS_ADMIN_PAGE }` : undefined;
+}
+
+/**
+ * Gates the whole dashboard behind a WordPress.com connection. VideoPress
+ * uploads and the management REST endpoints require a connected site *and* a
+ * connected user, so when either is missing we render a connection screen
+ * instead of the dashboard — otherwise the uploader is exposed and every upload
+ * fails. Mirrors the legacy dashboard's `usePermission` gate
+ * (`isRegistered && hasConnectedOwner && isUserConnected`).
+ *
+ * When the site isn't registered we show the pricing upsell (ported from the
+ * legacy dashboard); once registered but missing a connected owner/user we show
+ * the lighter connect screen — the same split the legacy dashboard made between
+ * its `PricingSection` and `NeedUserConnectionGlobalNotice`.
+ *
+ * Rendered inside `QueryClientWrapper` — the single wrapper every route stage
+ * shares — so all four routes (overview, library, settings, video) are gated
+ * from one mount point.
+ *
+ * @param props          - Component props.
+ * @param props.children - The dashboard content to render once connected.
+ * @return The dashboard children when connected, otherwise a connection screen.
+ */
+export default function ConnectionGate( { children }: { children: ReactNode } ) {
+	const {
+		isRegistered,
+		hasConnectedOwner,
+		isUserConnected,
+		siteIsRegistering,
+		userIsConnecting,
+		handleRegisterSite,
+	} = useConnection( {
+		from: 'jetpack-videopress',
+		redirectUri: getRedirectUri(),
+	} );
+
+	const canPerformAction = isRegistered && hasConnectedOwner && isUserConnected;
+
+	if ( canPerformAction ) {
+		return <>{ children }</>;
+	}
+
+	const hasPricing =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined' &&
+		Boolean( JPVIDEOPRESS_INITIAL_STATE?.pricing );
+
+	// Unregistered sites get the full pricing upsell; everything else (registered
+	// but no connected owner/user, or missing pricing data) gets the lighter
+	// connect screen, whose CTA registers the site and/or connects the user.
+	if ( ! isRegistered && hasPricing ) {
+		return <PricingUpsell />;
+	}
+
+	return (
+		<ConnectScreen
+			onConnect={ () => handleRegisterSite() }
+			isConnecting={ siteIsRegistering || userIsConnecting }
+		/>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
@@ -1,0 +1,130 @@
+import AdminPage from '@automattic/jetpack-components/admin-page';
+import Button from '@automattic/jetpack-components/button';
+import PricingTable, {
+	PricingTableColumn,
+	PricingTableHeader,
+	PricingTableItem,
+} from '@automattic/jetpack-components/pricing-table';
+import ProductPrice from '@automattic/jetpack-components/product-price';
+import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import './style.scss';
+
+const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
+
+/**
+ * Pre-connection upsell shown when the site isn't registered yet. A port of the
+ * legacy dashboard's pricing table (`PricingSection`): the paid column drives
+ * `useProductCheckoutWorkflow` (Get VideoPress), the free column registers the
+ * site and connects the user via `useConnection` (Start for free). Reads the
+ * product/price payload from `JPVIDEOPRESS_INITIAL_STATE.pricing`, which the
+ * server only populates for disconnected sites.
+ *
+ * Returns null when the pricing payload is absent (e.g. the WPCOM price request
+ * failed); the gate renders the plain connect screen in that case.
+ *
+ * @return The pricing table element, or null when pricing data is unavailable.
+ */
+export default function PricingUpsell() {
+	const state =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined' ? JPVIDEOPRESS_INITIAL_STATE : undefined;
+	const pricing = state?.pricing;
+	const adminUrl = state?.siteData?.adminUrl ?? '';
+	const siteSuffix = state?.jetpackStatus?.calypsoSlug ?? '';
+	const redirectUrl = adminUrl ? `${ adminUrl }${ VIDEOPRESS_ADMIN_PAGE }` : '';
+
+	// These hooks must run unconditionally (Rules of Hooks) and therefore precede
+	// the `! pricing` guard below, which the gate already makes unreachable in
+	// practice — so the assignments are never actually wasted.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const [ isConnecting, setIsConnecting ] = useState( false );
+
+	const { handleRegisterSite, userIsConnecting } = useConnection( {
+		from: 'jetpack-videopress',
+		redirectUri: redirectUrl,
+	} );
+
+	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+		productSlug: pricing?.yearly?.slug ?? '',
+		redirectUrl,
+		siteSuffix,
+		useBlogIdSuffix: true,
+		from: 'jetpack-videopress',
+	} );
+
+	if ( ! pricing ) {
+		return null;
+	}
+
+	const { title, features, yearly } = pricing;
+	const pricingItems = features.map( feature => ( { name: feature } ) );
+
+	return (
+		<AdminPage
+			title={ 'VideoPress' /* product name; not translated */ }
+			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+		>
+			<div className="vp-connection-gate__upsell">
+				<PricingTable title={ title } items={ pricingItems }>
+					<PricingTableColumn primary>
+						<PricingTableHeader>
+							<ProductPrice
+								offPrice={ yearly.discount ? yearly.salePriceByMonth : undefined }
+								price={ yearly.priceByMonth }
+								promoLabel={
+									yearly.discount
+										? sprintf(
+												/* translators: %1$s: the discount amount */
+												__( '%1$s%% off', 'jetpack-videopress-pkg' ),
+												String( yearly.discount )
+										  )
+										: undefined
+								}
+								legend={ __( '/month, billed yearly', 'jetpack-videopress-pkg' ) }
+								currency={ yearly.currency }
+							/>
+							<Button
+								onClick={ () => run() }
+								isLoading={ hasCheckoutStarted }
+								fullWidth
+								disabled={ isConnecting || hasCheckoutStarted || userIsConnecting }
+							>
+								{ __( 'Get VideoPress', 'jetpack-videopress-pkg' ) }
+							</Button>
+						</PricingTableHeader>
+						<PricingTableItem isIncluded />
+						<PricingTableItem isIncluded />
+						<PricingTableItem isIncluded />
+						<PricingTableItem isIncluded />
+					</PricingTableColumn>
+					<PricingTableColumn>
+						<PricingTableHeader>
+							<ProductPrice price={ 0 } legend="" currency={ yearly.currency } hidePriceFraction />
+							<Button
+								fullWidth
+								variant="secondary"
+								onClick={ () => {
+									setIsConnecting( true );
+									handleRegisterSite();
+								} }
+								isLoading={ userIsConnecting || isConnecting }
+								disabled={ userIsConnecting || isConnecting || hasCheckoutStarted }
+							>
+								{ __( 'Start for free', 'jetpack-videopress-pkg' ) }
+							</Button>
+						</PricingTableHeader>
+						<PricingTableItem
+							isIncluded={ false }
+							label={ <strong>{ __( 'Upload one video', 'jetpack-videopress-pkg' ) }</strong> }
+						/>
+						<PricingTableItem isIncluded />
+						<PricingTableItem isIncluded={ false } />
+						<PricingTableItem isIncluded={ false } />
+					</PricingTableColumn>
+				</PricingTable>
+			</div>
+		</AdminPage>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/style.scss
@@ -1,0 +1,22 @@
+// Both screens are centered with a max-width; the inline padding keeps a
+// gutter to the viewport edges on tablet/mobile, where the viewport is
+// narrower than the max-width and `margin-inline: auto` collapses to zero.
+// `border-box` keeps the padding inside the max-width rather than widening
+// the element past it.
+.vp-connection-gate {
+	box-sizing: border-box;
+	max-width: 480px;
+	margin-block: 48px;
+	margin-inline: auto;
+	padding-inline: 24px;
+	text-align: center;
+}
+
+.vp-connection-gate__upsell {
+	box-sizing: border-box;
+	max-width: 1080px;
+	margin-block: 32px;
+	margin-inline: auto;
+	padding-inline: 24px;
+	padding-bottom: 24px;
+}

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/test/connection-gate.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/test/connection-gate.test.tsx
@@ -1,0 +1,96 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { render, screen } from '@testing-library/react';
+import ConnectionGate from '../index';
+
+jest.mock( '@automattic/jetpack-connection/use-connection', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// Stub the two connection screens so these tests assert only the gate's
+// branching, not the screens' internals (the pricing table and its hooks).
+jest.mock( '../pricing-upsell', () => ( {
+	__esModule: true,
+	default: () => <div>Pricing upsell</div>,
+} ) );
+jest.mock( '../connect-screen', () => ( {
+	__esModule: true,
+	default: () => <div>Connect screen</div>,
+} ) );
+
+const mockUseConnection = useConnection as jest.Mock;
+
+const connected = {
+	handleRegisterSite: jest.fn(),
+	handleConnectUser: jest.fn(),
+	siteIsRegistering: false,
+	userIsConnecting: false,
+	isRegistered: true,
+	isUserConnected: true,
+	hasConnectedOwner: true,
+};
+
+const setPricing = ( pricing: unknown ) => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE = {
+		pricing,
+	};
+};
+
+const DashboardContent = () => <div>Dashboard content</div>;
+
+const renderGate = () =>
+	render(
+		<ConnectionGate>
+			<DashboardContent />
+		</ConnectionGate>
+	);
+
+describe( 'ConnectionGate', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setPricing( undefined );
+	} );
+
+	it( 'renders the dashboard when the site and user are fully connected', () => {
+		mockUseConnection.mockReturnValue( connected );
+
+		renderGate();
+
+		expect( screen.getByText( 'Dashboard content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Pricing upsell' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Connect screen' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the pricing upsell when the site is not registered and pricing data is present', () => {
+		setPricing( { title: 'VideoPress', features: [], yearly: {} } );
+		mockUseConnection.mockReturnValue( { ...connected, isRegistered: false } );
+
+		renderGate();
+
+		expect( screen.queryByText( 'Dashboard content' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Pricing upsell' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to the connect screen when not registered but pricing data is absent', () => {
+		mockUseConnection.mockReturnValue( { ...connected, isRegistered: false } );
+
+		renderGate();
+
+		expect( screen.getByText( 'Connect screen' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Pricing upsell' ) ).not.toBeInTheDocument();
+	} );
+
+	it.each( [
+		[ 'there is no connected owner', { hasConnectedOwner: false } ],
+		[ 'the current user is not connected', { isUserConnected: false } ],
+	] )( 'shows the connect screen when the site is registered but %s', ( _label, overrides ) => {
+		// Pricing present to prove a registered site never sees the upsell.
+		setPricing( { title: 'VideoPress', features: [], yearly: {} } );
+		mockUseConnection.mockReturnValue( { ...connected, ...overrides } );
+
+		renderGate();
+
+		expect( screen.getByText( 'Connect screen' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Pricing upsell' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/test/pricing-upsell.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/test/pricing-upsell.test.tsx
@@ -1,0 +1,115 @@
+import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PricingUpsell from '../pricing-upsell';
+import type { ReactNode } from 'react';
+
+jest.mock( '@automattic/jetpack-connection/use-connection', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+jest.mock( '@automattic/jetpack-connection/hooks/use-product-checkout-workflow', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+jest.mock( '@automattic/jetpack-components/admin-page', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+// Render the jetpack-components pricing primitives as light passthroughs so the
+// test exercises the upsell's data/CTA wiring without pulling the real (heavy)
+// components and their transitive dependencies into jsdom.
+jest.mock( '@automattic/jetpack-components/pricing-table', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	PricingTableColumn: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	PricingTableHeader: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	PricingTableItem: () => null,
+} ) );
+jest.mock( '@automattic/jetpack-components/product-price', () => ( {
+	__esModule: true,
+	default: () => <div>price</div>,
+} ) );
+jest.mock( '@automattic/jetpack-components/button', () => ( {
+	__esModule: true,
+	default: ( { children, onClick }: { children: ReactNode; onClick?: () => void } ) => (
+		<button onClick={ onClick }>{ children }</button>
+	),
+} ) );
+
+const mockUseConnection = useConnection as jest.Mock;
+const mockCheckoutWorkflow = useProductCheckoutWorkflow as jest.Mock;
+
+const PRICING = {
+	title: 'High quality, ad-free video',
+	features: [
+		'1TB of storage',
+		'Built into WordPress editor',
+		'Ad-free player',
+		'Unlimited users',
+	],
+	yearly: {
+		slug: 'jetpack_videopress',
+		name: 'VideoPress',
+		price: 60,
+		priceByMonth: 5,
+		currency: 'USD',
+	},
+};
+
+const setPricing = ( pricing: unknown ) => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE = {
+		siteData: { adminUrl: 'https://example.com/wp-admin/' },
+		jetpackStatus: { calypsoSlug: 'example.com' },
+		pricing,
+	};
+};
+
+let mockRun: jest.Mock;
+let mockRegisterSite: jest.Mock;
+
+describe( 'PricingUpsell', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockRun = jest.fn();
+		mockRegisterSite = jest.fn();
+		mockCheckoutWorkflow.mockReturnValue( { run: mockRun, hasCheckoutStarted: false } );
+		mockUseConnection.mockReturnValue( {
+			handleRegisterSite: mockRegisterSite,
+			userIsConnecting: false,
+		} );
+		setPricing( PRICING );
+	} );
+
+	it( 'drives the checkout workflow with the yearly product slug and redirect', () => {
+		render( <PricingUpsell /> );
+
+		expect( mockCheckoutWorkflow ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				productSlug: 'jetpack_videopress',
+				redirectUrl: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+				siteSuffix: 'example.com',
+				from: 'jetpack-videopress',
+			} )
+		);
+	} );
+
+	it( 'runs checkout on "Get VideoPress" and registers the site on "Start for free"', async () => {
+		const user = userEvent.setup();
+		render( <PricingUpsell /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Get VideoPress' } ) );
+		expect( mockRun ).toHaveBeenCalledTimes( 1 );
+
+		await user.click( screen.getByRole( 'button', { name: 'Start for free' } ) );
+		expect( mockRegisterSite ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'renders nothing when pricing data is absent', () => {
+		setPricing( undefined );
+		const { container } = render( <PricingUpsell /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/query-client-wrapper/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/query-client-wrapper/index.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useDashboardAnalytics } from '../../hooks/use-dashboard-analytics';
+import ConnectionGate from '../connection-gate';
 import type { ReactNode } from 'react';
 
 const STORE_KEY = '__jetpackVideopressQueryClient' as const;
@@ -38,7 +39,11 @@ const QueryClientWrapper = ( { children }: { children: ReactNode } ) => {
 	// the once-per-load dashboard page view.
 	useDashboardAnalytics();
 
-	return <QueryClientProvider client={ getClient() }>{ children }</QueryClientProvider>;
+	return (
+		<QueryClientProvider client={ getClient() }>
+			<ConnectionGate>{ children }</ConnectionGate>
+		</QueryClientProvider>
+	);
 };
 
 export default QueryClientWrapper;


### PR DESCRIPTION
Fixes #

The modernized (wp-build) VideoPress dashboard, gated behind `rsm_jetpack_ui_modernization_videopress`, rendered unconditionally — exposing the uploader pre-connection, so every upload failed. This adds a connection gate that mirrors the legacy dashboard's `usePermission` behavior.

## Proposed changes
* **`jetpack-videopress`:** Add a `ConnectionGate` in the shared `QueryClientWrapper` (the one wrapper all four routes use), so the whole modernized dashboard is gated from a single mount point. Gate logic mirrors the legacy `usePermission`: `isRegistered && hasConnectedOwner && isUserConnected`.
  * Unregistered sites see the **pricing upsell**, ported from the legacy dashboard's `PricingTable` (Get VideoPress / Start for free).
  * Registered sites without a connected owner/user see a lighter **connect screen**.
  * Connected sites see the dashboard unchanged.
* Inject the product/price payload into the modernized initial state **only when the site isn't connected**, so connected dashboards never incur the synchronous WPCOM pricing request. Falls back to the connect screen if the pricing request is unavailable.
* Define the jetpack-components typography/spacing CSS custom properties the upsell relies on (`--spacing-base`, `--font-headline-medium`, …) on the dashboard shell — `base-styles` root variables omit them and the components only consume them.
* **`jetpack-components`:** Add subpath exports for `Button`, `PricingTable`, and `ProductPrice` so they can be imported without the package barrel (which pulls asset-importing components the wp-build esbuild pipeline can't bundle). Repoint `terms-of-service`'s `getRedirectUrl` import to its `tools/jp-redirect` deep path for the same reason.

## Related product discussion/links
* Part of the VideoPress dashboard modernization (gated behind `rsm_jetpack_ui_modernization_videopress`).

## Does this pull request change what data or activity we track or use?
No. The gate reuses the existing dashboard page-view analytics and the existing `useProductCheckoutWorkflow` flow; no new tracking is added.

## Testing instructions

Enable the modernized dashboard via the `rsm_jetpack_ui_modernization_videopress` filter (e.g. a Code Snippet returning `true`), then:

* **Unregistered site → pricing upsell:** On a site not connected to WordPress.com, go to **Jetpack → VideoPress**. Confirm you see the pricing table (Get VideoPress / Start for free) with the feature list — and that the video library / "Upload video" button are **not** shown.
* **Simulating a disconnected state on a connected dev site:** temporarily filter `jetpack_connection_status` to return `isRegistered`/`isUserConnected`/`hasConnectedOwner` as `false`. Note the pricing payload only injects when PHP `Connection_Manager::is_connected()` is `false`; if it's still connected server-side (or the WPCOM price request fails), the gate falls back to the plain connect screen — which is expected.
* **Registered but no user connection → connect screen:** with the site registered but no connected user, confirm the "Connect to set up VideoPress" screen renders with a Connect button (no uploader).
* **Connected → dashboard:** connect the site and user, reload, and confirm the full dashboard (Overview / Library / Settings / Video) renders with the uploader, exactly as before.
* **Responsive:** view the upsell at tablet/mobile widths and confirm the cards keep a gutter to the viewport edges.
* Run `jetpack docker ... ` or `pnpm test` in `projects/packages/videopress` — the `connection-gate` suite and the full dashboard test suite (122 tests) should pass.
