### PR TITLE
Jetpack AI Sidebar: filter Big Sky provider

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-sidebar-filter-bigsky-provider
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-sidebar-filter-bigsky-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI Sidebar: Fix block editing when another agent provider is present.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -19,15 +19,16 @@ use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 require_once __DIR__ . '/../../../shared/cdn-locale.php';
 
-const AM_ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
-const AM_ASSET_TRANSIENT         = 'jetpack_am_gutenberg_asset';
-const AM_ASSET_DC_TRANSIENT      = 'jetpack_am_gutenberg_dc_asset';
-const AI_SIDEBAR_ASSET_TRANSIENT = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
+const AM_ASSET_BASE_PATH          = 'widgets.wp.com/agents-manager/';
+const AM_ASSET_TRANSIENT          = 'jetpack_am_gutenberg_asset';
+const AM_ASSET_DC_TRANSIENT       = 'jetpack_am_gutenberg_dc_asset';
+const AI_SIDEBAR_ASSET_TRANSIENT  = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL           = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL      = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID         = 'wp-orchestrator';
+const BIG_SKY_AGENT_PROVIDER_PATH = '/big-sky-plugin/build/calypso-agent-provider/';
 
 /**
  * Handles loading the Agents Manager from CDN and registering the
@@ -557,10 +558,30 @@ class Jetpack_AI_Sidebar {
 
 		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
 		// intentional overrides should use the AI Editorial Review and preview filters.
+		if ( isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] ) ) {
+			$data['agentProviders'] = self::filter_agent_providers_for_jetpack_ai_sidebar( $data['agentProviders'] );
+		}
 		$data['agentId']                  = AI_SIDEBAR_AGENT_ID;
 		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
+	}
+
+	/**
+	 * Remove providers that should not participate in the Jetpack AI Sidebar surface.
+	 *
+	 * @param array $providers Provider URLs.
+	 * @return array Filtered provider URLs.
+	 */
+	private static function filter_agent_providers_for_jetpack_ai_sidebar( array $providers ): array {
+		return array_values(
+			array_filter(
+				$providers,
+				static function ( $provider ): bool {
+					return ! is_string( $provider ) || ! str_contains( $provider, BIG_SKY_AGENT_PROVIDER_PATH );
+				}
+			)
+		);
 	}
 
 	/**
@@ -620,10 +641,15 @@ class Jetpack_AI_Sidebar {
 			AI_SIDEBAR_AGENT_ID,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
+		$big_sky_provider_payload    = wp_json_encode(
+			BIG_SKY_AGENT_PROVIDER_PATH,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
 
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
+				. ' if ( Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter( function( provider ) { return typeof provider !== "string" || provider.indexOf( ' . $big_sky_provider_payload . ' ) === -1; } ); }'
 				. ' agentsManagerData.agentId = ' . $agent_id_payload . ';'
 				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
 				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -552,6 +552,32 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Big Sky's provider should not participate in the Jetpack AI Sidebar surface.
+	 */
+	public function test_add_agents_manager_data_filters_big_sky_provider() {
+		$this->set_block_editor_screen();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName'    => 'gutenberg',
+				'agentProviders' => array(
+					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+					'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+					array( 'provider' => 'metadata' ),
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+				array( 'provider' => 'metadata' ),
+			),
+			$data['agentProviders']
+		);
+	}
+
+	/**
 	 * Preview and AI Editorial Review have separate gates.
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
@@ -711,13 +737,25 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		// Simulate external host (mu-wpcom / Big Sky) having enqueued AM and
-		// declared the upstream const.
+		// Simulate an external host having enqueued AM and declared upstream
+		// data with both Jetpack AI Sidebar and Big Sky providers.
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
-		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
+		wp_add_inline_script(
+			'agents-manager',
+			'const agentsManagerData = { sectionName: "gutenberg", agentProviders: [ "https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123", "https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs" ] };',
+			'before'
+		);
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'/big-sky-plugin/build/calypso-agent-provider/',
+			$this->get_agents_manager_inline_script()
+		);
 		$this->assertStringContainsString(
 			'agentsManagerData.agentId = "wp-orchestrator"',
 			$this->get_agents_manager_inline_script()


### PR DESCRIPTION
Fixes #

## Proposed changes
* Keep Jetpack AI Sidebar's `agentsManagerData.agentProviders` scoped to the Jetpack provider by filtering the Big Sky provider path out of externally emitted payloads.
* Apply the same filtering in the external AM inline patch path used before the Jetpack AI Sidebar data filter is available.
* Add focused tests and a Jetpack changelog entry.

## Related product discussion/links
* Stacked on #48961.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Enable Jetpack AI Sidebar Preview with Big Sky also active.
* Open a post in the block editor and select a paragraph block.
* Run a Jetpack AI Sidebar block edit, such as Check grammar.
* Confirm `agentsManagerData.agentProviders` no longer includes `/big-sky-plugin/build/calypso-agent-provider/` for the Jetpack AI Sidebar surface.
* Confirm the selected block updates in the editor and subsequent block edits still target the selected block.

Automated checks run locally:
* `php -l projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php`
* `php -l projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php`
* `composer phpcs:changed -- projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php`

I also attempted `JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 jetpack docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test`, but the local Docker test bootstrap failed before this test class with `Class "Automattic\\Jetpack\\Sync\\Activity_Log_Event" not found`.