### PR TITLE
WIP: Blaze Woo MCP test stack

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-1036-campaign-preparer
+++ b/projects/packages/blaze/changelog/add-ads-1036-campaign-preparer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Extract campaign preparation into a reusable preparer.

--- a/projects/packages/blaze/changelog/add-ads-1037-intelligent-defaults
+++ b/projects/packages/blaze/changelog/add-ads-1037-intelligent-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Add intent-aware defaults and budget options to prepared campaign proposals.

--- a/projects/packages/blaze/changelog/add-ads-1038-forecast-estimates
+++ b/projects/packages/blaze/changelog/add-ads-1038-forecast-estimates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Add forecast estimates to prepared campaign proposals.

--- a/projects/packages/blaze/changelog/add-ads-1039-human-readable-preview
+++ b/projects/packages/blaze/changelog/add-ads-1039-human-readable-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Show a readable prepare-campaign preview in agent responses.

--- a/projects/packages/blaze/changelog/add-ads-1041-prepare-campaign-telemetry
+++ b/projects/packages/blaze/changelog/add-ads-1041-prepare-campaign-telemetry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze: Track server-side telemetry for prepare-campaign ability requests.

--- a/projects/packages/blaze/changelog/add-ads-1044-safe-audience-targeting
+++ b/projects/packages/blaze/changelog/add-ads-1044-safe-audience-targeting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Add safe audience targeting normalization for prepared campaign proposals.

--- a/projects/packages/blaze/changelog/add-ads-1057-portable-target-inputs
+++ b/projects/packages/blaze/changelog/add-ads-1057-portable-target-inputs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze: Allow campaign preparation from site URL plus post or product ID.

--- a/projects/packages/blaze/changelog/add-ads-1090-list-campaigns-context
+++ b/projects/packages/blaze/changelog/add-ads-1090-list-campaigns-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Abilities: Expose campaign status filtering and campaign context in list-campaigns.

--- a/projects/packages/blaze/changelog/add-ads-1091-get-campaign-stats
+++ b/projects/packages/blaze/changelog/add-ads-1091-get-campaign-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: Add a read-only `blaze-ads/get-campaign-stats` ability with derived display ad metrics.

--- a/projects/packages/blaze/changelog/add-ads-1092-stop-campaign
+++ b/projects/packages/blaze/changelog/add-ads-1092-stop-campaign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze MCP: Add stop-campaign preview and confirm ability.

--- a/projects/packages/blaze/changelog/add-ads-1116-chat-ready-prepared-packages
+++ b/projects/packages/blaze/changelog/add-ads-1116-chat-ready-prepared-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: Return chat-ready prepared campaign package details from prepare-campaign.

--- a/projects/packages/blaze/changelog/add-ads-1117-payment-eligibility
+++ b/projects/packages/blaze/changelog/add-ads-1117-payment-eligibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Prepare campaign: Add saved payment eligibility for chat-native submit.

--- a/projects/packages/blaze/changelog/add-ads-1118-exact-approval-contract
+++ b/projects/packages/blaze/changelog/add-ads-1118-exact-approval-contract
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Prepare campaign: Add exact approval contract data for chat-native submit.

--- a/projects/packages/blaze/changelog/add-ads-1132-submit-prepared-campaign-ability
+++ b/projects/packages/blaze/changelog/add-ads-1132-submit-prepared-campaign-ability
@@ -1,0 +1,3 @@
+Significance: patch
+Type: added
+Comment: Blaze: expose chat-native submit for approved prepared campaign packages.

--- a/projects/packages/blaze/changelog/add-ads-1134-chat-submit-next-action
+++ b/projects/packages/blaze/changelog/add-ads-1134-chat-submit-next-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: add chat-native submit approval next action to prepared campaign responses.

--- a/projects/packages/blaze/changelog/add-ads-1137-chat-submit-regression-coverage
+++ b/projects/packages/blaze/changelog/add-ads-1137-chat-submit-regression-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: make chat submit the leading next step for eligible prepared campaigns.

--- a/projects/packages/blaze/changelog/add-ads-952-blaze-mcp-ability
+++ b/projects/packages/blaze/changelog/add-ads-952-blaze-mcp-ability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: register a read-only `blaze-ads/list-campaigns` ability and opt it into WooCommerce's MCP server tool whitelist when Woo 10.7+ MCP is present.

--- a/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
+++ b/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: register a `blaze-ads/create-campaign` write ability with cross-cutting guardrails (TOS, spend ceiling, audit log) applied via a registration-time wrapper. Returns a draft campaign reference plus a deep-link to the Blaze widget for merchant approval.

--- a/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
+++ b/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blaze: register a `blaze-ads/create-campaign` write ability with cross-cutting guardrails (TOS, spend ceiling, audit log) applied via a registration-time wrapper. Returns a draft campaign reference plus a deep-link to the Blaze widget for merchant approval.

--- a/projects/packages/blaze/changelog/add-ads-953-blaze-prepare-campaign
+++ b/projects/packages/blaze/changelog/add-ads-953-blaze-prepare-campaign
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: register a `blaze-ads/prepare-campaign` write ability with cross-cutting guardrails (TOS, spend ceiling, audit log) applied via a registration-time wrapper. Returns a prepared campaign proposal plus a deep-link to the Blaze widget for merchant approval.

--- a/projects/packages/blaze/changelog/fix-ads-1137-payment-method-context
+++ b/projects/packages/blaze/changelog/fix-ads-1137-payment-method-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blaze: keep chat submit eligible when prepare fetches saved payment methods without a current WordPress user.

--- a/projects/packages/blaze/changelog/fix-ads-1137-preview-link-streaming
+++ b/projects/packages/blaze/changelog/fix-ads-1137-preview-link-streaming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blaze: avoid streaming raw prefill URLs in chat-facing prepare messages.

--- a/projects/packages/blaze/changelog/update-ads-1135-plain-language-submit-guidance
+++ b/projects/packages/blaze/changelog/update-ads-1135-plain-language-submit-guidance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze: clarify chat-native submit guidance for plain-language approval intent.

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -11,7 +11,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -21,18 +21,28 @@
 
 namespace Automattic\Jetpack\Blaze\Abilities;
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use WP_REST_Request;
 
 /**
- * Registers the `blaze-ads` category and the `blaze-ads/list-campaigns`
- * ability, and opts the ability into WooCommerce's MCP server.
+ * Registers the `blaze-ads` category and the Blaze abilities, and opts
+ * each ability into WooCommerce's MCP server.
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG          = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS = 'blaze-ads/list-campaigns';
+	const CATEGORY_SLUG           = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS  = 'blaze-ads/list-campaigns';
+	const ABILITY_CREATE_CAMPAIGN = 'blaze-ads/create-campaign';
+
+	/**
+	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
+	 */
+	const OWNED_ABILITY_SLUGS = array(
+		self::ABILITY_LIST_CAMPAIGNS,
+		self::ABILITY_CREATE_CAMPAIGN,
+	);
 
 	/**
 	 * Wire registration into the Abilities API lifecycle and opt the
@@ -57,6 +67,15 @@ class Blaze_Abilities extends Registrar {
 
 		add_filter( 'jetpack_wp_abilities_should_register', array( __CLASS__, 'guard_against_double_register' ), 10, 3 );
 		add_filter( 'woocommerce_mcp_include_ability', array( __CLASS__, 'opt_into_woo_mcp' ), 10, 2 );
+
+		// Wrap write-path abilities at registration time with cross-cutting
+		// guardrails (TOS, payment, spend ceiling). Inheritable by any future
+		// write ability — see `wrap_write_path_execute_callback` for the policy.
+		add_filter( 'wp_register_ability_args', array( __CLASS__, 'wrap_write_path_execute_callback' ), 10, 2 );
+
+		// Audit log for write-ability invocations. Read-path abilities are
+		// excluded by the listener itself.
+		add_action( 'wp_after_execute_ability', array( __CLASS__, 'audit_log_write_invocation' ), 10, 3 );
 
 		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
 			static::register_category();
@@ -98,7 +117,32 @@ class Blaze_Abilities extends Registrar {
 		if ( ! $enabled ) {
 			return $enabled;
 		}
-		if ( 'ability' === $type && self::ABILITY_LIST_CAMPAIGNS === $slug && function_exists( 'wp_get_ability' ) && wp_get_ability( $slug ) ) {
+		if ( 'ability' !== $type || ! in_array( $slug, self::OWNED_ABILITY_SLUGS, true ) ) {
+			return $enabled;
+		}
+
+		// Kill-switch: write abilities default to enabled but can be turned off
+		// centrally via filter without a release if abuse / errors emerge.
+		if ( self::ABILITY_CREATE_CAMPAIGN === $slug ) {
+			/**
+			 * Filters whether the Blaze `create-campaign` write ability is registered.
+			 *
+			 * Default true. Return false to keep the ability out of the registry —
+			 * MCP clients won't see it, REST callers get 404. Use as a kill-switch
+			 * if abuse, error rates, or infra issues require centrally disabling
+			 * the write path without shipping a release.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $enabled Whether to register the create-campaign ability. Default true.
+			 */
+			if ( ! apply_filters( 'blaze_abilities_create_campaign_enabled', true ) ) {
+				return false;
+			}
+		}
+
+		// Defensive: skip if something else has already registered the slug.
+		if ( function_exists( 'wp_get_ability' ) && wp_get_ability( $slug ) ) {
 			return false;
 		}
 		return $enabled;
@@ -112,7 +156,7 @@ class Blaze_Abilities extends Registrar {
 	 * @return bool
 	 */
 	public static function opt_into_woo_mcp( $include, $ability_id ) {
-		if ( self::ABILITY_LIST_CAMPAIGNS === $ability_id ) {
+		if ( in_array( $ability_id, self::OWNED_ABILITY_SLUGS, true ) ) {
 			return true;
 		}
 		return $include;
@@ -147,7 +191,7 @@ class Blaze_Abilities extends Registrar {
 	 */
 	public static function get_abilities(): array {
 		return array(
-			self::ABILITY_LIST_CAMPAIGNS => array(
+			self::ABILITY_LIST_CAMPAIGNS  => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
 				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -168,6 +212,68 @@ class Blaze_Abilities extends Registrar {
 						'readonly'    => true,
 						'destructive' => false,
 						'idempotent'  => true,
+					),
+				),
+			),
+			self::ABILITY_CREATE_CAMPAIGN => array(
+				'label'               => __( 'Draft a new Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Draft a new Blaze advertising campaign for an existing post or product on the site. The campaign is created in DRAFT state and requires the merchant to explicitly approve it in the Blaze UI before it goes live — the response includes a deep-link to that UI.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'target_urn', 'budget_total', 'duration_days' ),
+					'properties'           => array(
+						'target_urn'    => array(
+							'type'        => 'string',
+							'description' => __( 'The URN of the post or product to promote (e.g. urn:wpcom:post:123456:42).', 'jetpack-blaze' ),
+						),
+						'budget_total'  => array(
+							'type'        => 'number',
+							'description' => __( 'Total budget for the campaign in the site\'s currency.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'duration_days' => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of days the campaign should run.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+							'maximum'     => 90,
+						),
+						'objective'     => array(
+							'type'        => 'string',
+							'description' => __( 'Campaign objective.', 'jetpack-blaze' ),
+							'enum'        => array( 'VIEWS', 'CLICKS', 'SALES' ),
+							'default'     => 'VIEWS',
+						),
+					),
+					'additionalProperties' => true,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Draft campaign reference plus a deep-link to the Blaze UI for merchant approval.', 'jetpack-blaze' ),
+					'required'    => array( 'campaign_id', 'status', 'approval_url' ),
+					'properties'  => array(
+						'campaign_id'  => array(
+							'type'        => 'string',
+							'description' => __( 'The DSP-assigned ID of the draft campaign.', 'jetpack-blaze' ),
+						),
+						'status'       => array(
+							'type'        => 'string',
+							'description' => __( 'Campaign status. Always "draft" for the immediate response.', 'jetpack-blaze' ),
+						),
+						'approval_url' => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Deep-link to the Blaze widget where the merchant previews and approves this draft.', 'jetpack-blaze' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'create_campaign' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
 					),
 				),
 			),
@@ -223,5 +329,214 @@ class Blaze_Abilities extends Registrar {
 		}
 
 		return $response->get_data();
+	}
+
+	/**
+	 * Draft a new Blaze campaign by delegating to the existing DSP create
+	 * route. Returns a draft reference plus a deep-link to the Blaze widget
+	 * for merchant approval — the campaign does not go live until the
+	 * merchant explicitly approves it there.
+	 *
+	 * Note: cross-cutting guardrails (TOS, payment, spend ceiling) run
+	 * *before* this method via the registration-time wrapper applied in
+	 * `wrap_write_path_execute_callback()`. This method only handles the
+	 * happy-path delegation.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function create_campaign( $args = array() ) {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $args, JSON_UNESCAPED_SLASHES ) );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$data = $response->get_data();
+
+		return array(
+			'campaign_id'  => isset( $data['campaign_id'] ) ? (string) $data['campaign_id'] : ( isset( $data['id'] ) ? (string) $data['id'] : '' ),
+			'status'       => 'draft',
+			'approval_url' => self::get_approval_url( $args, $data ),
+			'campaign'     => $data,
+		);
+	}
+
+	/**
+	 * Build the deep-link the merchant follows to preview and approve a
+	 * draft campaign.
+	 *
+	 * Phase 2 punts to the existing Blaze management URL family — that's
+	 * the SPA where drafts can be reviewed today. The exact in-SPA route
+	 * for "approve this specific draft" may need a follow-up with the
+	 * Calypso team; for now we land the merchant in the advertising
+	 * dashboard with the campaign visible.
+	 *
+	 * @param array $args         Original ability input (used for target_urn fallback).
+	 * @param array $dsp_response Response payload from the DSP create route. Reserved for future use (campaign-id-based deep-link lookup).
+	 * @return string
+	 */
+	private static function get_approval_url( array $args, $dsp_response ) {
+		unset( $dsp_response );
+		// Try to extract a post ID from the target URN to leverage the
+		// existing `Blaze::get_campaign_management_url()` helper.
+		$post_id = 0;
+		$urn     = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
+		if ( $urn && preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $m ) ) {
+			$post_id = (int) $m[1];
+		}
+
+		if ( $post_id > 0 && class_exists( '\Automattic\Jetpack\Blaze' ) ) {
+			$url_data = Blaze::get_campaign_management_url( $post_id );
+			return is_array( $url_data ) && isset( $url_data['link'] ) ? $url_data['link'] : '';
+		}
+
+		// Fallback: the bare advertising dashboard.
+		return admin_url( 'tools.php?page=advertising' );
+	}
+
+	/**
+	 * Registration-time wrapper for write-path abilities.
+	 *
+	 * Applied via the `wp_register_ability_args` filter. For any of our
+	 * abilities marked `meta.annotations.readonly => false`, replaces the
+	 * configured `execute_callback` with a closure that runs cross-cutting
+	 * guardrails first (TOS / payment, per-session spend ceiling) and only
+	 * delegates to the original callback if all checks pass.
+	 *
+	 * Lives at registration time (not via `wp_before_execute_ability`)
+	 * because the action hook is fire-and-forget and cannot abort the
+	 * call. Lives at the wrapper level (not `permission_callback`)
+	 * because the Abilities API strips structured data from
+	 * permission errors — the merchant needs to receive a deep-link in
+	 * the error data, which only works from the execute path.
+	 *
+	 * Future Phase 3 write abilities inherit this wrapper for free as
+	 * long as they're registered with `meta.annotations.readonly => false`.
+	 *
+	 * @param array  $args         Args being registered for the ability.
+	 * @param string $ability_name The fully-qualified ability slug.
+	 * @return array
+	 */
+	public static function wrap_write_path_execute_callback( array $args, string $ability_name ): array {
+		// Only touch our own abilities.
+		if ( ! in_array( $ability_name, self::OWNED_ABILITY_SLUGS, true ) ) {
+			return $args;
+		}
+
+		$is_write = isset( $args['meta']['annotations']['readonly'] ) && false === $args['meta']['annotations']['readonly'];
+		if ( ! $is_write ) {
+			return $args;
+		}
+
+		$original_callback = isset( $args['execute_callback'] ) ? $args['execute_callback'] : null;
+		if ( ! is_callable( $original_callback ) ) {
+			return $args;
+		}
+
+		$args['execute_callback'] = static function ( $input = array() ) use ( $original_callback ) {
+			$tos_check = self::check_tos_and_payment();
+			if ( is_wp_error( $tos_check ) ) {
+				return $tos_check;
+			}
+
+			$spend_check = self::check_spend_ceiling( $input );
+			if ( is_wp_error( $spend_check ) ) {
+				return $spend_check;
+			}
+
+			return call_user_func( $original_callback, $input );
+		};
+
+		return $args;
+	}
+
+	/**
+	 * Verify the merchant's Blaze TOS acceptance and payment-method
+	 * status are good for write actions.
+	 *
+	 * STUB: implementation pending. Needs a call to the WPCOM Blaze status
+	 * endpoint to check TOS + payment method state. When either is missing,
+	 * return a `WP_Error` whose `data` carries a deep-link the merchant
+	 * follows to fix the issue (Abilities API surfaces `WP_Error` data
+	 * verbatim from `execute_callback`).
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function check_tos_and_payment() {
+		// TODO(ADS-953): wire to WPCOM Blaze status endpoint.
+		// Example shape of the failure case for the eventual implementation:
+		//
+		// return new WP_Error(
+		// 'blaze_tos_required',
+		// __( 'Blaze terms of service must be accepted before creating campaigns.', 'jetpack-blaze' ),
+		// array(
+		// 'status'    => 403,
+		// 'fix_url'   => admin_url( 'tools.php?page=advertising' ),
+		// 'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
+		// )
+		// );
+		return true;
+	}
+
+	/**
+	 * Enforce a per-session spend ceiling on the requested campaign budget.
+	 *
+	 * STUB: "session" semantics are still TBD for MCP — there's no obvious
+	 * server-side session boundary for an MCP client. Likely candidates:
+	 * per-user-per-day, per-application-password-per-day, or a transient
+	 * scoped to the current REST request user. To be decided when wiring.
+	 *
+	 * @param mixed $input Ability input — should include `budget_total`.
+	 * @return true|\WP_Error
+	 */
+	private static function check_spend_ceiling( $input ) {
+		// TODO(ADS-953): decide session model + ceiling, then enforce.
+		unset( $input );
+		return true;
+	}
+
+	/**
+	 * Audit-log listener for write-path ability invocations.
+	 *
+	 * Filters down to slugs we own and that are write-path; ignores
+	 * read-only abilities and anything outside our category. Logs to the
+	 * standard error log for now — a structured audit store is a follow-up.
+	 *
+	 * @param string $ability_name The slug of the executed ability.
+	 * @param mixed  $input        The input passed to the ability.
+	 * @param mixed  $result       The result the ability returned.
+	 * @return void
+	 */
+	public static function audit_log_write_invocation( string $ability_name, $input, $result ): void {
+		if ( ! in_array( $ability_name, self::OWNED_ABILITY_SLUGS, true ) ) {
+			return;
+		}
+		// Skip read-only abilities — only audit writes.
+		if ( self::ABILITY_LIST_CAMPAIGNS === $ability_name ) {
+			return;
+		}
+
+		$entry = array(
+			'ability'   => $ability_name,
+			'user_id'   => get_current_user_id(),
+			'site_id'   => \Automattic\Jetpack\Connection\Manager::get_site_id(),
+			'input'     => $input,
+			'is_error'  => is_wp_error( $result ),
+			'timestamp' => time(),
+		);
+
+		// TODO(ADS-953): replace with structured audit storage. For now, log
+		// to error_log for visibility during development and reviewer testing.
+		error_log( '[blaze-abilities-audit] ' . wp_json_encode( $entry, JSON_UNESCAPED_SLASHES ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 }

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -466,25 +466,39 @@ class Blaze_Abilities extends Registrar {
 	 *
 	 * STUB: implementation pending. Needs a call to the WPCOM Blaze status
 	 * endpoint to check TOS + payment method state. When either is missing,
-	 * return a `WP_Error` whose `data` carries a deep-link the merchant
-	 * follows to fix the issue (Abilities API surfaces `WP_Error` data
-	 * verbatim from `execute_callback`).
+	 * return a `WP_Error` whose **message** embeds a deep-link as a URL the
+	 * merchant follows to fix the issue.
+	 *
+	 * Why message-text and not the `data` field: the Woo MCP adapter strips
+	 * `WP_Error::data` when forwarding errors to MCP clients
+	 * (see vendor/wordpress/mcp-adapter ToolsHandler.php — only `message` +
+	 * `code` survive). Embedding the URL in the message ensures Claude /
+	 * other MCP clients can present it to the merchant. The `data` field is
+	 * kept too as belt-and-braces for direct WP Abilities REST callers,
+	 * which preserve it via standard WP REST error serialization.
 	 *
 	 * @return true|\WP_Error
 	 */
 	private static function check_tos_and_payment() {
-		// TODO(ADS-953): wire to WPCOM Blaze status endpoint.
-		// Example shape of the failure case for the eventual implementation:
-		//
-		// return new WP_Error(
-		// 'blaze_tos_required',
-		// __( 'Blaze terms of service must be accepted before creating campaigns.', 'jetpack-blaze' ),
-		// array(
-		// 'status'    => 403,
-		// 'fix_url'   => admin_url( 'tools.php?page=advertising' ),
-		// 'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
-		// )
-		// );
+		/*
+		 * TODO(ADS-953): wire to WPCOM Blaze status endpoint.
+		 * Example failure shape for the eventual implementation:
+		 *
+		 *   $fix_url = admin_url( 'tools.php?page=advertising' );
+		 *   return new WP_Error(
+		 *       'blaze_tos_required',
+		 *       sprintf(
+		 *           // Deep-link in the message text so MCP clients pass it through.
+		 *           __( 'Blaze terms of service must be accepted before creating campaigns. Accept them here: %s', 'jetpack-blaze' ),
+		 *           $fix_url
+		 *       ),
+		 *       array(
+		 *           'status'    => 403,
+		 *           'fix_url'   => $fix_url,
+		 *           'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
+		 *       )
+		 *   );
+		 */
 		return true;
 	}
 

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -410,15 +410,20 @@ class Blaze_Abilities extends Registrar {
 	 * Applied via the `wp_register_ability_args` filter. For any of our
 	 * abilities marked `meta.annotations.readonly => false`, replaces the
 	 * configured `execute_callback` with a closure that runs cross-cutting
-	 * guardrails first (TOS / payment, per-session spend ceiling) and only
-	 * delegates to the original callback if all checks pass.
+	 * guardrails first and only delegates to the original callback if all
+	 * checks pass.
+	 *
+	 * v1 guardrails: TOS / Blaze-eligibility check.
+	 * Deferred guardrails (tracked separately as ADS-989): per-session
+	 * spend ceiling, Picard creative moderation. The wrapper is the
+	 * intended insertion point for both.
 	 *
 	 * Lives at registration time (not via `wp_before_execute_ability`)
 	 * because the action hook is fire-and-forget and cannot abort the
 	 * call. Lives at the wrapper level (not `permission_callback`)
-	 * because the Abilities API strips structured data from
-	 * permission errors — the merchant needs to receive a deep-link in
-	 * the error data, which only works from the execute path.
+	 * because the Abilities API strips structured data from permission
+	 * errors — the merchant needs to receive a deep-link in the error,
+	 * which only works from the execute path.
 	 *
 	 * Future Phase 3 write abilities inherit this wrapper for free as
 	 * long as they're registered with `meta.annotations.readonly => false`.
@@ -449,10 +454,8 @@ class Blaze_Abilities extends Registrar {
 				return $tos_check;
 			}
 
-			$spend_check = self::check_spend_ceiling( $input );
-			if ( is_wp_error( $spend_check ) ) {
-				return $spend_check;
-			}
+			// Future write-path guardrails (per-session spend ceiling, Picard
+			// moderation gating) plug in here. Tracked separately as ADS-989.
 
 			return call_user_func( $original_callback, $input );
 		};
@@ -461,13 +464,16 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Verify the merchant's Blaze TOS acceptance and payment-method
-	 * status are good for write actions.
+	 * Verify the site is eligible for Blaze write actions.
 	 *
-	 * STUB: implementation pending. Needs a call to the WPCOM Blaze status
-	 * endpoint to check TOS + payment method state. When either is missing,
-	 * return a `WP_Error` whose **message** embeds a deep-link as a URL the
-	 * merchant follows to fix the issue.
+	 * Uses the existing `Blaze::site_supports_blaze()` helper — a coarse
+	 * single-call boolean that proxies the WPCOM `/sites/<id>/blaze/status`
+	 * endpoint and is true when the site has accepted TOS and is otherwise
+	 * eligible to run campaigns. Result is cached for a day inside that
+	 * helper, so the per-call cost is a transient lookup.
+	 *
+	 * On failure, returns a `WP_Error` whose **message** embeds a deep-link
+	 * URL the merchant can follow to fix the issue in the Blaze UI.
 	 *
 	 * Why message-text and not the `data` field: the Woo MCP adapter strips
 	 * `WP_Error::data` when forwarding errors to MCP clients
@@ -480,43 +486,32 @@ class Blaze_Abilities extends Registrar {
 	 * @return true|\WP_Error
 	 */
 	private static function check_tos_and_payment() {
-		/*
-		 * TODO(ADS-953): wire to WPCOM Blaze status endpoint.
-		 * Example failure shape for the eventual implementation:
-		 *
-		 *   $fix_url = admin_url( 'tools.php?page=advertising' );
-		 *   return new WP_Error(
-		 *       'blaze_tos_required',
-		 *       sprintf(
-		 *           // Deep-link in the message text so MCP clients pass it through.
-		 *           __( 'Blaze terms of service must be accepted before creating campaigns. Accept them here: %s', 'jetpack-blaze' ),
-		 *           $fix_url
-		 *       ),
-		 *       array(
-		 *           'status'    => 403,
-		 *           'fix_url'   => $fix_url,
-		 *           'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
-		 *       )
-		 *   );
-		 */
-		return true;
-	}
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) || ! $site_id ) {
+			// Without a connected site we can't check, and downstream calls
+			// will fail anyway — let the underlying execute_callback surface
+			// the connection error rather than fabricating one here.
+			return true;
+		}
 
-	/**
-	 * Enforce a per-session spend ceiling on the requested campaign budget.
-	 *
-	 * STUB: "session" semantics are still TBD for MCP — there's no obvious
-	 * server-side session boundary for an MCP client. Likely candidates:
-	 * per-user-per-day, per-application-password-per-day, or a transient
-	 * scoped to the current REST request user. To be decided when wiring.
-	 *
-	 * @param mixed $input Ability input — should include `budget_total`.
-	 * @return true|\WP_Error
-	 */
-	private static function check_spend_ceiling( $input ) {
-		// TODO(ADS-953): decide session model + ceiling, then enforce.
-		unset( $input );
-		return true;
+		if ( Blaze::site_supports_blaze( $site_id ) ) {
+			return true;
+		}
+
+		$fix_url = admin_url( 'tools.php?page=advertising' );
+		return new \WP_Error(
+			'blaze_setup_required',
+			sprintf(
+				/* translators: %s is a URL the merchant follows to set up Blaze. */
+				__( 'This site is not yet eligible to run Blaze campaigns. Complete Blaze setup (accept the terms of service and add a payment method) here: %s', 'jetpack-blaze' ),
+				$fix_url
+			),
+			array(
+				'status'    => 403,
+				'fix_url'   => $fix_url,
+				'fix_label' => __( 'Set up Blaze', 'jetpack-blaze' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -32,16 +32,18 @@ use WP_REST_Request;
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG           = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS  = 'blaze-ads/list-campaigns';
-	const ABILITY_CREATE_CAMPAIGN = 'blaze-ads/create-campaign';
+	const CATEGORY_SLUG                 = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS        = 'blaze-ads/list-campaigns';
+	const ABILITY_PREPARE_CAMPAIGN      = 'blaze-ads/prepare-campaign';
+	private const DEFAULT_BUDGET_TOTAL  = 50.0;
+	private const DEFAULT_DURATION_DAYS = 7;
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
 	 */
 	const OWNED_ABILITY_SLUGS = array(
 		self::ABILITY_LIST_CAMPAIGNS,
-		self::ABILITY_CREATE_CAMPAIGN,
+		self::ABILITY_PREPARE_CAMPAIGN,
 	);
 
 	/**
@@ -123,9 +125,9 @@ class Blaze_Abilities extends Registrar {
 
 		// Kill-switch: write abilities default to enabled but can be turned off
 		// centrally via filter without a release if abuse / errors emerge.
-		if ( self::ABILITY_CREATE_CAMPAIGN === $slug ) {
+		if ( self::ABILITY_PREPARE_CAMPAIGN === $slug ) {
 			/**
-			 * Filters whether the Blaze `create-campaign` write ability is registered.
+			 * Filters whether the Blaze `prepare-campaign` write ability is registered.
 			 *
 			 * Default true. Return false to keep the ability out of the registry —
 			 * MCP clients won't see it, REST callers get 404. Use as a kill-switch
@@ -134,9 +136,9 @@ class Blaze_Abilities extends Registrar {
 			 *
 			 * @since $$next-version$$
 			 *
-			 * @param bool $enabled Whether to register the create-campaign ability. Default true.
+			 * @param bool $enabled Whether to register the prepare-campaign ability. Default true.
 			 */
-			if ( ! apply_filters( 'blaze_abilities_create_campaign_enabled', true ) ) {
+			if ( ! apply_filters( 'blaze_abilities_prepare_campaign_enabled', true ) ) {
 				return false;
 			}
 		}
@@ -191,7 +193,7 @@ class Blaze_Abilities extends Registrar {
 	 */
 	public static function get_abilities(): array {
 		return array(
-			self::ABILITY_LIST_CAMPAIGNS  => array(
+			self::ABILITY_LIST_CAMPAIGNS   => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
 				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -215,48 +217,63 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
-			self::ABILITY_CREATE_CAMPAIGN => array(
-				'label'               => __( 'Draft a new Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Draft a Blaze advertising campaign for an existing post or product on the site. The ability does not write to the DSP itself — it derives sensible defaults from the target post (title, excerpt, featured image) and the caller\'s input (budget, duration, optional copy / objective overrides), bundles them into a prefill payload, and returns a deep-link the merchant clicks to land in the existing Blaze UI with every field already populated. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+			self::ABILITY_PREPARE_CAMPAIGN => array(
+				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
-					'required'             => array( 'target_urn', 'budget_total', 'duration_days' ),
+					'required'             => array( 'target_urn' ),
 					'properties'           => array(
-						'target_urn'    => array(
+						'target_urn'           => array(
 							'type'        => 'string',
 							'description' => __( 'The URN of the post or product to promote (e.g. urn:wpcom:post:123456:42).', 'jetpack-blaze' ),
 						),
-						'budget_total'  => array(
+						'goal'                 => array(
+							'type'        => 'string',
+							'description' => __( 'Optional natural-language campaign goal or intent. Blaze uses this as context while still owning the DSP objective internally.', 'jetpack-blaze' ),
+						),
+						'budget_total'         => array(
 							'type'        => 'number',
-							'description' => __( 'Total budget for the campaign in the site\'s currency.', 'jetpack-blaze' ),
+							'description' => __( 'Optional total budget for the campaign in USD. If omitted, Blaze applies its default budget for this proposal.', 'jetpack-blaze' ),
 							'minimum'     => 1,
 						),
-						'duration_days' => array(
+						'duration_days'        => array(
 							'type'        => 'integer',
-							'description' => __( 'Number of days the campaign should run.', 'jetpack-blaze' ),
+							'description' => __( 'Optional number of days the campaign should run. If omitted, Blaze applies its default duration for this proposal.', 'jetpack-blaze' ),
 							'minimum'     => 1,
 							'maximum'     => 90,
 						),
-						'objective'     => array(
+						'revision_instruction' => array(
 							'type'        => 'string',
-							'description' => __( 'Campaign objective. Defaults to VIEWS.', 'jetpack-blaze' ),
-							'enum'        => array( 'VIEWS', 'CLICKS', 'SALES' ),
-							'default'     => 'VIEWS',
+							'description' => __( 'Optional natural-language instruction for revising a previous proposal, such as “make it less salesy”.', 'jetpack-blaze' ),
 						),
-						'is_evergreen'  => array(
+						'is_evergreen'         => array(
 							'type'        => 'boolean',
 							'description' => __( 'Run until the merchant stops it. Defaults to true.', 'jetpack-blaze' ),
 							'default'     => true,
 						),
-						'site_name'     => array(
+						'site_name'            => array(
 							'type'        => 'string',
 							'description' => __( 'Optional ad heading override. Defaults to the post title.', 'jetpack-blaze' ),
 						),
-						'text_snippet'  => array(
+						'text_snippet'         => array(
 							'type'        => 'string',
 							'description' => __( 'Optional ad copy override. Defaults to the post excerpt (or first ~200 chars of content).', 'jetpack-blaze' ),
 						),
-						'languages'     => array(
+						'cta_text'             => array(
+							'type'        => 'string',
+							'description' => __( 'Optional call-to-action text override. Defaults to a post-type-aware Blaze choice.', 'jetpack-blaze' ),
+						),
+						'main_image_url'       => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Optional image URL override. Defaults to the target post featured image when available.', 'jetpack-blaze' ),
+						),
+						'main_image_mime_type' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional MIME type for main_image_url. Defaults to image/jpeg when omitted.', 'jetpack-blaze' ),
+						),
+						'languages'            => array(
 							'type'        => 'array',
 							'description' => __( 'Optional ISO 639-1 language codes to target (e.g. ["en", "es"]). Defaults to all languages when omitted; pass a non-empty array to narrow targeting.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -265,7 +282,7 @@ class Blaze_Abilities extends Registrar {
 								'maxLength' => 5,
 							),
 						),
-						'countries'     => array(
+						'countries'            => array(
 							'type'        => 'array',
 							'description' => __( 'Optional ISO 3166-1 alpha-2 country codes to target (e.g. ["US", "GB"]). Defaults to worldwide when omitted; pass a non-empty array to limit reach to those countries.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -298,11 +315,11 @@ class Blaze_Abilities extends Registrar {
 						),
 						'prefill'     => array(
 							'type'        => 'object',
-							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was drafted before the merchant clicks through.', 'jetpack-blaze' ),
+							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),
 					),
 				),
-				'execute_callback'    => array( __CLASS__, 'create_campaign' ),
+				'execute_callback'    => array( __CLASS__, 'prepare_campaign' ),
 				'permission_callback' => array( __CLASS__, 'permission_callback' ),
 				'meta'                => array(
 					'show_in_rest' => true,
@@ -368,7 +385,7 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Draft a new Blaze campaign by deriving sensible defaults from the
+	 * Prepare a Blaze campaign proposal by deriving sensible defaults from the
 	 * target post and bundling them into a prefill payload. Returns a
 	 * deep-link the merchant clicks to land in the existing Blaze widget
 	 * with every field already populated; the merchant reviews, accepts
@@ -388,7 +405,7 @@ class Blaze_Abilities extends Registrar {
 	 * @param array $args Ability input — see `get_abilities()` input_schema.
 	 * @return array|\WP_Error
 	 */
-	public static function create_campaign( $args = array() ) {
+	public static function prepare_campaign( $args = array() ) {
 		$args = is_array( $args ) ? $args : array();
 
 		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
@@ -416,8 +433,8 @@ class Blaze_Abilities extends Registrar {
 		return array(
 			'status'      => 'pending_merchant_review',
 			'message'     => sprintf(
-				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the drafted campaign. */
-				__( 'Draft prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
+				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the prepared campaign proposal. */
+				__( 'Campaign proposal prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
 				$prefill_url
 			),
 			'prefill_url' => $prefill_url,
@@ -430,7 +447,7 @@ class Blaze_Abilities extends Registrar {
 	 * the resolved target post. Pure function — no I/O — so it's easy to
 	 * test and easy for callers to inspect in the response.
 	 *
-	 * Caller input (`site_name`, `text_snippet`, `objective`, `is_evergreen`)
+	 * Caller input (`site_name`, `text_snippet`, `cta_text`, `is_evergreen`)
 	 * overrides the post-derived defaults. Anything we can't pull from
 	 * the post or the input is left out — the widget will fill blanks
 	 * with its own defaults at submission time.
@@ -463,21 +480,35 @@ class Blaze_Abilities extends Registrar {
 			// Default CTA varies by post type — products get a commerce-flavoured
 			// "Shop Now", everything else gets the neutral "Learn More". The widget
 			// requires a non-empty CTA to clear validation, so we always send one.
-			'cta_text'      => 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More',
+			'cta_text'      => isset( $args['cta_text'] ) && '' !== (string) $args['cta_text']
+				? (string) $args['cta_text']
+				: ( 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More' ),
 			'target_url'    => (string) get_permalink( $post ),
 			'budget'        => array(
 				'mode'     => 'total',
-				'amount'   => (float) ( $args['budget_total'] ?? 0 ),
+				'amount'   => (float) ( $args['budget_total'] ?? self::DEFAULT_BUDGET_TOTAL ),
 				'currency' => self::get_site_currency(),
 			),
-			'duration_days' => (int) ( $args['duration_days'] ?? 7 ),
+			'duration_days' => (int) ( $args['duration_days'] ?? self::DEFAULT_DURATION_DAYS ),
 			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
-			'objective'     => isset( $args['objective'] ) && '' !== (string) $args['objective']
-				? (string) $args['objective']
-				: 'VIEWS',
+			'objective'     => 'VIEWS',
 		);
 
-		if ( '' !== $featured_image_url ) {
+		if ( isset( $args['goal'] ) && '' !== (string) $args['goal'] ) {
+			$payload['goal'] = (string) $args['goal'];
+		}
+		if ( isset( $args['revision_instruction'] ) && '' !== (string) $args['revision_instruction'] ) {
+			$payload['revision_instruction'] = (string) $args['revision_instruction'];
+		}
+
+		if ( isset( $args['main_image_url'] ) && '' !== (string) $args['main_image_url'] ) {
+			$payload['main_image'] = array(
+				'url'       => (string) $args['main_image_url'],
+				'mime_type' => isset( $args['main_image_mime_type'] ) && '' !== (string) $args['main_image_mime_type']
+					? (string) $args['main_image_mime_type']
+					: 'image/jpeg',
+			);
+		} elseif ( '' !== $featured_image_url ) {
 			$payload['main_image'] = array(
 				'url'       => $featured_image_url,
 				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -289,6 +289,7 @@ class Blaze_Abilities extends Registrar {
 								'type'      => 'string',
 								'minLength' => 2,
 								'maxLength' => 2,
+								'pattern'   => '^[A-Z]{2}$',
 							),
 						),
 						'devices'              => array(
@@ -314,41 +315,79 @@ class Blaze_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
+					'required'    => array( 'status', 'message', 'campaign_preview', 'forecast_summary', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
 					'properties'  => array(
-						'status'          => array(
+						'status'           => array(
 							'type'        => 'string',
 							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
 							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'message'         => array(
+						'message'          => array(
 							'type'        => 'string',
 							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'intent'          => array(
+						'campaign_preview' => array(
+							'type'        => 'object',
+							'description' => __( 'Structured campaign preview rows used by the MCP adapter to render the merchant-readable table.', 'jetpack-blaze' ),
+							'required'    => array( 'ad_heading', 'ad_copy', 'call_to_action', 'objective', 'budget', 'duration', 'schedule', 'audience', 'landing_page' ),
+							'properties'  => array(
+								'ad_heading'     => array(
+									'type' => 'string',
+								),
+								'ad_copy'        => array(
+									'type' => 'string',
+								),
+								'call_to_action' => array(
+									'type' => 'string',
+								),
+								'objective'      => array(
+									'type' => 'string',
+								),
+								'budget'         => array(
+									'type' => 'string',
+								),
+								'duration'       => array(
+									'type' => 'string',
+								),
+								'schedule'       => array(
+									'type' => 'string',
+								),
+								'audience'       => array(
+									'type' => 'string',
+								),
+								'landing_page'   => array(
+									'type' => 'string',
+								),
+							),
+						),
+						'forecast_summary' => array(
+							'type'        => 'string',
+							'description' => __( 'Human-readable forecast summary for the recommended option, or a fallback note when forecasts are unavailable.', 'jetpack-blaze' ),
+						),
+						'intent'           => array(
 							'type'        => 'string',
 							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
 							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
 						),
-						'forecast'        => array(
+						'forecast'         => array(
 							'type'        => 'object',
 							'description' => __( 'Forecast estimates for the recommended option. Available forecasts include views/impressions and clicks ranges; unavailable forecasts do not block the review URL.', 'jetpack-blaze' ),
 						),
-						'assumptions'     => array(
+						'assumptions'      => array(
 							'type'        => 'array',
 							'description' => __( 'Plain-language assumptions used while preparing the recommended campaign.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
-						'recommendations' => array(
+						'recommendations'  => array(
 							'type'        => 'array',
 							'description' => __( 'Plain-language guidance for reviewing the prepared campaign.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
-						'budget_options'  => array(
+						'budget_options'   => array(
 							'type'        => 'array',
 							'description' => __( 'Lower, recommended, and higher budget options returned when budget or duration is omitted. The recommended option is encoded in prefill_url.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -376,12 +415,12 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'prefill_url'     => array(
+						'prefill_url'      => array(
 							'type'        => 'string',
 							'format'      => 'uri',
 							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
 						),
-						'prefill'         => array(
+						'prefill'          => array(
 							'type'        => 'object',
 							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),
@@ -484,13 +523,302 @@ class Blaze_Abilities extends Registrar {
 		return array_merge(
 			$proposal,
 			array(
-				'message' => sprintf(
-					/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the prepared campaign proposal. */
-					__( 'Campaign proposal prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
-					$proposal['prefill_url']
-				),
+				'campaign_preview' => self::build_campaign_preview( $proposal ),
+				'forecast_summary' => self::build_forecast_summary( $proposal ),
+				'message'          => self::format_prepare_campaign_message( $proposal ),
 			)
 		);
+	}
+
+	/**
+	 * Build structured preview values for clients that do not want to parse the
+	 * raw widget prefill payload.
+	 *
+	 * @param array $proposal Structured campaign proposal.
+	 * @return array
+	 */
+	private static function build_campaign_preview( array $proposal ): array {
+		$prefill = isset( $proposal['prefill'] ) && is_array( $proposal['prefill'] ) ? $proposal['prefill'] : array();
+		$budget  = isset( $prefill['budget'] ) && is_array( $prefill['budget'] ) ? $prefill['budget'] : array();
+
+		$budget_amount   = isset( $budget['amount'] ) ? (float) $budget['amount'] : 0.0;
+		$budget_currency = isset( $budget['currency'] ) ? (string) $budget['currency'] : 'USD';
+		$duration_days   = isset( $prefill['duration_days'] ) ? max( 1, (int) $prefill['duration_days'] ) : 1;
+
+		return array(
+			'ad_heading'     => isset( $prefill['site_name'] ) ? (string) $prefill['site_name'] : '',
+			'ad_copy'        => isset( $prefill['text_snippet'] ) ? (string) $prefill['text_snippet'] : '',
+			'call_to_action' => isset( $prefill['cta_text'] ) ? (string) $prefill['cta_text'] : '',
+			'objective'      => self::format_objective( isset( $prefill['objective'] ) ? (string) $prefill['objective'] : '' ),
+			'budget'         => sprintf(
+				/* translators: 1: formatted currency amount, 2: formatted daily currency amount. */
+				__( '%1$s total (%2$s/day)', 'jetpack-blaze' ),
+				self::format_currency_amount( $budget_amount, $budget_currency ),
+				self::format_currency_amount( $budget_amount / $duration_days, $budget_currency )
+			),
+			'duration'       => self::format_days( $duration_days ),
+			'schedule'       => ! isset( $prefill['is_evergreen'] ) || (bool) $prefill['is_evergreen']
+				? __( 'Run until the merchant stops it', 'jetpack-blaze' )
+				: __( 'Run for the selected duration', 'jetpack-blaze' ),
+			'audience'       => self::format_audience_summary( $prefill ),
+			'landing_page'   => isset( $prefill['target_url'] ) ? (string) $prefill['target_url'] : '',
+		);
+	}
+
+	/**
+	 * Format the prepare-campaign response as adapter-owned Markdown for chat
+	 * clients.
+	 *
+	 * @param array $proposal Structured campaign proposal.
+	 * @return string
+	 */
+	private static function format_prepare_campaign_message( array $proposal ): string {
+		$preview          = self::build_campaign_preview( $proposal );
+		$forecast_summary = self::build_forecast_summary( $proposal );
+		$message          = __( 'Campaign proposal prepared for review in Blaze.', 'jetpack-blaze' ) . "\n\n";
+
+		$message .= '| ' . __( 'Campaign preview', 'jetpack-blaze' ) . ' | ' . __( 'Prepared value', 'jetpack-blaze' ) . " |\n";
+		$message .= "| --- | --- |\n";
+
+		$rows = array(
+			array(
+				'label' => __( 'Ad heading', 'jetpack-blaze' ),
+				'value' => $preview['ad_heading'],
+			),
+			array(
+				'label' => __( 'Ad copy', 'jetpack-blaze' ),
+				'value' => $preview['ad_copy'],
+			),
+			array(
+				'label' => __( 'Call to action', 'jetpack-blaze' ),
+				'value' => $preview['call_to_action'],
+			),
+			array(
+				'label' => __( 'Objective', 'jetpack-blaze' ),
+				'value' => $preview['objective'],
+			),
+			array(
+				'label' => __( 'Budget', 'jetpack-blaze' ),
+				'value' => $preview['budget'],
+			),
+			array(
+				'label' => __( 'Duration', 'jetpack-blaze' ),
+				'value' => $preview['duration'],
+			),
+			array(
+				'label' => __( 'Schedule', 'jetpack-blaze' ),
+				'value' => $preview['schedule'],
+			),
+			array(
+				'label' => __( 'Audience', 'jetpack-blaze' ),
+				'value' => $preview['audience'],
+			),
+			array(
+				'label' => __( 'Landing page', 'jetpack-blaze' ),
+				'value' => $preview['landing_page'],
+			),
+		);
+
+		foreach ( $rows as $row ) {
+			$message .= '| ' . self::format_markdown_table_cell( $row['label'] ) . ' | ' . self::format_markdown_table_cell( $row['value'] ) . " |\n";
+		}
+
+		$message .= "\n" . __( 'Forecast:', 'jetpack-blaze' ) . ' ' . $forecast_summary . "\n";
+
+		if ( ! empty( $proposal['budget_options'] ) && is_array( $proposal['budget_options'] ) ) {
+			$message .= "\n" . __( 'Budget options:', 'jetpack-blaze' ) . "\n";
+			$message .= '| ' . __( 'Option', 'jetpack-blaze' ) . ' | ' . __( 'Total budget', 'jetpack-blaze' ) . ' | ' . __( 'Daily budget', 'jetpack-blaze' ) . ' | ' . __( 'Duration', 'jetpack-blaze' ) . ' | ' . __( 'Recommendation', 'jetpack-blaze' ) . " |\n";
+			$message .= "| --- | --- | --- | --- | --- |\n";
+
+			foreach ( $proposal['budget_options'] as $option ) {
+				if ( ! is_array( $option ) ) {
+					continue;
+				}
+
+				$budget         = isset( $option['budget'] ) && is_array( $option['budget'] ) ? $option['budget'] : array();
+				$daily_budget   = isset( $option['daily_budget'] ) && is_array( $option['daily_budget'] ) ? $option['daily_budget'] : array();
+				$currency       = isset( $budget['currency'] ) ? (string) $budget['currency'] : 'USD';
+				$daily_currency = isset( $daily_budget['currency'] ) ? (string) $daily_budget['currency'] : $currency;
+
+				$message .= '| ' . self::format_markdown_table_cell( $option['label'] ?? '' );
+				$message .= ' | ' . self::format_markdown_table_cell( self::format_currency_amount( isset( $budget['amount'] ) ? (float) $budget['amount'] : 0.0, $currency ) );
+				$message .= ' | ' . self::format_markdown_table_cell( self::format_currency_amount( isset( $daily_budget['amount'] ) ? (float) $daily_budget['amount'] : 0.0, $daily_currency ) );
+				$message .= ' | ' . self::format_markdown_table_cell( self::format_days( isset( $option['duration_days'] ) ? (int) $option['duration_days'] : 1 ) );
+				$message .= ' | ' . self::format_markdown_table_cell( $option['rationale'] ?? '' ) . " |\n";
+			}
+		}
+
+		$message .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
+		$message .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
+		$message .= "\n" . __( 'Review URL:', 'jetpack-blaze' ) . ' ' . (string) ( $proposal['prefill_url'] ?? '' );
+
+		return $message;
+	}
+
+	/**
+	 * Build a compact human-readable forecast sentence.
+	 *
+	 * @param array $proposal Structured campaign proposal.
+	 * @return string
+	 */
+	private static function build_forecast_summary( array $proposal ): string {
+		$forecast = isset( $proposal['forecast'] ) && is_array( $proposal['forecast'] ) ? $proposal['forecast'] : array();
+		if ( 'available' !== ( $forecast['status'] ?? '' ) ) {
+			return isset( $forecast['message'] ) && '' !== (string) $forecast['message']
+				? (string) $forecast['message']
+				: __( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', 'jetpack-blaze' );
+		}
+
+		$primary_metric   = isset( $forecast['primary_metric'] ) ? (string) $forecast['primary_metric'] : 'views';
+		$secondary_metric = isset( $forecast['secondary_metric'] ) ? (string) $forecast['secondary_metric'] : 'clicks';
+
+		return sprintf(
+			/* translators: 1: primary metric range, 2: primary metric label, 3: secondary metric range, 4: secondary metric label. */
+			__( 'Estimated %1$s %2$s and %3$s %4$s for the recommended option.', 'jetpack-blaze' ),
+			self::format_metric_range( isset( $forecast[ $primary_metric ] ) && is_array( $forecast[ $primary_metric ] ) ? $forecast[ $primary_metric ] : array() ),
+			self::format_metric_label( $primary_metric ),
+			self::format_metric_range( isset( $forecast[ $secondary_metric ] ) && is_array( $forecast[ $secondary_metric ] ) ? $forecast[ $secondary_metric ] : array() ),
+			self::format_metric_label( $secondary_metric )
+		);
+	}
+
+	/**
+	 * Format an array of natural-language strings as a Markdown list.
+	 *
+	 * @param string $heading List heading.
+	 * @param mixed  $items   List items.
+	 * @return string
+	 */
+	private static function format_text_list( string $heading, $items ): string {
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return '';
+		}
+
+		$message = "\n\n" . $heading . "\n";
+		foreach ( $items as $item ) {
+			$message .= '- ' . str_replace( array( "\r\n", "\r", "\n" ), ' ', (string) $item ) . "\n";
+		}
+
+		return rtrim( $message, "\n" );
+	}
+
+	/**
+	 * Format a value for safe use inside a Markdown table cell.
+	 *
+	 * @param mixed $value Cell value.
+	 * @return string
+	 */
+	private static function format_markdown_table_cell( $value ): string {
+		$value = str_replace( array( "\r\n", "\r", "\n" ), ' ', (string) $value );
+		return str_replace( '|', '\\|', $value );
+	}
+
+	/**
+	 * Format a currency amount.
+	 *
+	 * @param float  $amount   Amount.
+	 * @param string $currency ISO 4217 currency code.
+	 * @return string
+	 */
+	private static function format_currency_amount( float $amount, string $currency ): string {
+		return sprintf( '%s %s', strtoupper( $currency ), number_format_i18n( $amount, 2 ) );
+	}
+
+	/**
+	 * Format campaign duration.
+	 *
+	 * @param int $days Duration in days.
+	 * @return string
+	 */
+	private static function format_days( int $days ): string {
+		$days = max( 1, $days );
+		return sprintf(
+			/* translators: %d: number of campaign days. */
+			_n( '%d day', '%d days', $days, 'jetpack-blaze' ),
+			$days
+		);
+	}
+
+	/**
+	 * Format the server-owned objective for display.
+	 *
+	 * @param string $objective DSP objective code.
+	 * @return string
+	 */
+	private static function format_objective( string $objective ): string {
+		if ( 'CLICKS' === strtoupper( $objective ) ) {
+			return __( 'Clicks', 'jetpack-blaze' );
+		}
+		if ( 'VIEWS' === strtoupper( $objective ) ) {
+			return __( 'Views', 'jetpack-blaze' );
+		}
+		return '' === $objective ? __( 'Not specified', 'jetpack-blaze' ) : $objective;
+	}
+
+	/**
+	 * Format a forecast metric range.
+	 *
+	 * @param array $range Metric range with min/max values.
+	 * @return string
+	 */
+	private static function format_metric_range( array $range ): string {
+		$min = isset( $range['min'] ) ? (int) $range['min'] : 0;
+		$max = isset( $range['max'] ) ? (int) $range['max'] : $min;
+
+		if ( $min === $max ) {
+			return number_format_i18n( $min );
+		}
+
+		return number_format_i18n( $min ) . '-' . number_format_i18n( $max );
+	}
+
+	/**
+	 * Format a forecast metric label.
+	 *
+	 * @param string $metric Metric code.
+	 * @return string
+	 */
+	private static function format_metric_label( string $metric ): string {
+		if ( 'clicks' === $metric ) {
+			return __( 'clicks', 'jetpack-blaze' );
+		}
+		return __( 'views', 'jetpack-blaze' );
+	}
+
+	/**
+	 * Summarize audience overrides without exposing implementation-shaped JSON.
+	 *
+	 * @param array $prefill Prefill payload.
+	 * @return string
+	 */
+	private static function format_audience_summary( array $prefill ): string {
+		$parts = array();
+
+		$parts[] = empty( $prefill['countries'] ) ? __( 'all locations', 'jetpack-blaze' ) : sprintf(
+			/* translators: %s: comma-separated country codes. */
+			__( 'countries: %s', 'jetpack-blaze' ),
+			implode( ', ', array_map( 'strval', (array) $prefill['countries'] ) )
+		);
+		$parts[] = empty( $prefill['languages'] ) ? __( 'all languages', 'jetpack-blaze' ) : sprintf(
+			/* translators: %s: comma-separated language codes. */
+			__( 'languages: %s', 'jetpack-blaze' ),
+			implode( ', ', array_map( 'strval', (array) $prefill['languages'] ) )
+		);
+		$parts[] = empty( $prefill['devices'] ) ? __( 'all devices', 'jetpack-blaze' ) : sprintf(
+			/* translators: %s: comma-separated device codes. */
+			__( 'devices: %s', 'jetpack-blaze' ),
+			implode( ', ', array_map( 'strval', (array) $prefill['devices'] ) )
+		);
+
+		if ( ! empty( $prefill['page_topics'] ) ) {
+			$parts[] = sprintf(
+				/* translators: %s: comma-separated page topic codes. */
+				__( 'topics: %s', 'jetpack-blaze' ),
+				implode( ', ', array_map( 'strval', (array) $prefill['page_topics'] ) )
+			);
+		}
+
+		return implode( '; ', $parts );
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -217,7 +217,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_CREATE_CAMPAIGN => array(
 				'label'               => __( 'Draft a new Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Draft a new Blaze advertising campaign for an existing post or product on the site. The campaign is created in DRAFT state and requires the merchant to explicitly approve it in the Blaze UI before it goes live — the response includes a deep-link to that UI.', 'jetpack-blaze' ),
+				'description'         => __( 'Draft a Blaze advertising campaign for an existing post or product on the site. The ability does not write to the DSP itself — it derives sensible defaults from the target post (title, excerpt, featured image) and the caller\'s input (budget, duration, optional copy / objective overrides), bundles them into a prefill payload, and returns a deep-link the merchant clicks to land in the existing Blaze UI with every field already populated. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn', 'budget_total', 'duration_days' ),
@@ -239,30 +239,48 @@ class Blaze_Abilities extends Registrar {
 						),
 						'objective'     => array(
 							'type'        => 'string',
-							'description' => __( 'Campaign objective.', 'jetpack-blaze' ),
+							'description' => __( 'Campaign objective. Defaults to VIEWS.', 'jetpack-blaze' ),
 							'enum'        => array( 'VIEWS', 'CLICKS', 'SALES' ),
 							'default'     => 'VIEWS',
 						),
+						'is_evergreen'  => array(
+							'type'        => 'boolean',
+							'description' => __( 'Run until the merchant stops it. Defaults to true.', 'jetpack-blaze' ),
+							'default'     => true,
+						),
+						'site_name'     => array(
+							'type'        => 'string',
+							'description' => __( 'Optional ad heading override. Defaults to the post title.', 'jetpack-blaze' ),
+						),
+						'text_snippet'  => array(
+							'type'        => 'string',
+							'description' => __( 'Optional ad copy override. Defaults to the post excerpt (or first ~200 chars of content).', 'jetpack-blaze' ),
+						),
 					),
-					'additionalProperties' => true,
+					'additionalProperties' => false,
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
-					'description' => __( 'Draft campaign reference plus a deep-link to the Blaze UI for merchant approval.', 'jetpack-blaze' ),
-					'required'    => array( 'campaign_id', 'status', 'approval_url' ),
+					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
+					'required'    => array( 'status', 'prefill_url', 'prefill' ),
 					'properties'  => array(
-						'campaign_id'  => array(
+						'status'      => array(
 							'type'        => 'string',
-							'description' => __( 'The DSP-assigned ID of the draft campaign.', 'jetpack-blaze' ),
+							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
+							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'status'       => array(
+						'message'     => array(
 							'type'        => 'string',
-							'description' => __( 'Campaign status. Always "draft" for the immediate response.', 'jetpack-blaze' ),
+							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'approval_url' => array(
+						'prefill_url' => array(
 							'type'        => 'string',
 							'format'      => 'uri',
-							'description' => __( 'Deep-link to the Blaze widget where the merchant previews and approves this draft.', 'jetpack-blaze' ),
+							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
+						),
+						'prefill'     => array(
+							'type'        => 'object',
+							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was drafted before the merchant clicks through.', 'jetpack-blaze' ),
 						),
 					),
 				),
@@ -332,76 +350,193 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Draft a new Blaze campaign by delegating to the existing DSP create
-	 * route. Returns a draft reference plus a deep-link to the Blaze widget
-	 * for merchant approval — the campaign does not go live until the
-	 * merchant explicitly approves it there.
+	 * Draft a new Blaze campaign by deriving sensible defaults from the
+	 * target post and bundling them into a prefill payload. Returns a
+	 * deep-link the merchant clicks to land in the existing Blaze widget
+	 * with every field already populated; the merchant reviews, accepts
+	 * payment / T&C, and submits from inside the widget.
 	 *
-	 * Note: cross-cutting guardrails (TOS, payment, spend ceiling) run
-	 * *before* this method via the registration-time wrapper applied in
-	 * `wrap_write_path_execute_callback()`. This method only handles the
-	 * happy-path delegation.
+	 * Phase 2 v1 deliberately does NOT call the DSP create endpoint from
+	 * the agent path. The actual DSP write happens when the merchant
+	 * submits via the widget — we trust the existing flow for that.
+	 *
+	 * Cross-cutting guardrails (TOS / Blaze-eligibility) run before this
+	 * method via the wrapper installed in `wrap_write_path_execute_callback()`.
+	 *
+	 * The Blaze widget's prefill-from-URL behaviour is a separate piece
+	 * of work in `dsp-client` that this PR doesn't ship; until that
+	 * lands the merchant can still follow the link and edit manually.
 	 *
 	 * @param array $args Ability input — see `get_abilities()` input_schema.
 	 * @return array|\WP_Error
 	 */
 	public static function create_campaign( $args = array() ) {
-		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return $site_id;
+		$args = is_array( $args ) ? $args : array();
+
+		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
+		if ( '' === $urn || ! preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $matches ) ) {
+			return new \WP_Error(
+				'blaze_invalid_target_urn',
+				/* translators: %s: the malformed URN value supplied by the caller. */
+				sprintf( __( 'Invalid target_urn %s. Expected format: urn:wpcom:post:<site_id>:<post_id>.', 'jetpack-blaze' ), $urn ),
+				array( 'status' => 400 )
+			);
 		}
 
-		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
-		$request = new WP_REST_Request( 'POST', $route );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body( wp_json_encode( $args, JSON_UNESCAPED_SLASHES ) );
-
-		$response = rest_do_request( $request );
-		if ( $response->is_error() ) {
-			return $response->as_error();
+		$post = get_post( (int) $matches[1] );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'blaze_post_not_found',
+				__( 'Post referenced by target_urn does not exist on this site.', 'jetpack-blaze' ),
+				array( 'status' => 404 )
+			);
 		}
 
-		$data = $response->get_data();
+		$prefill     = self::build_prefill_payload( $args, $post );
+		$prefill_url = self::build_prefill_url( $post->ID, $prefill );
 
 		return array(
-			'campaign_id'  => isset( $data['campaign_id'] ) ? (string) $data['campaign_id'] : ( isset( $data['id'] ) ? (string) $data['id'] : '' ),
-			'status'       => 'draft',
-			'approval_url' => self::get_approval_url( $args, $data ),
-			'campaign'     => $data,
+			'status'      => 'pending_merchant_review',
+			'message'     => sprintf(
+				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the drafted campaign. */
+				__( 'Draft prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
+				$prefill_url
+			),
+			'prefill_url' => $prefill_url,
+			'prefill'     => $prefill,
 		);
 	}
 
 	/**
-	 * Build the deep-link the merchant follows to preview and approve a
-	 * draft campaign.
+	 * Build the campaign prefill payload from the caller's MCP input and
+	 * the resolved target post. Pure function — no I/O — so it's easy to
+	 * test and easy for callers to inspect in the response.
 	 *
-	 * Phase 2 punts to the existing Blaze management URL family — that's
-	 * the SPA where drafts can be reviewed today. The exact in-SPA route
-	 * for "approve this specific draft" may need a follow-up with the
-	 * Calypso team; for now we land the merchant in the advertising
-	 * dashboard with the campaign visible.
+	 * Caller input (`site_name`, `text_snippet`, `objective`, `is_evergreen`)
+	 * overrides the post-derived defaults. Anything we can't pull from
+	 * the post or the input is left out — the widget will fill blanks
+	 * with its own defaults at submission time.
 	 *
-	 * @param array $args         Original ability input (used for target_urn fallback).
-	 * @param array $dsp_response Response payload from the DSP create route. Reserved for future use (campaign-id-based deep-link lookup).
+	 * @param array    $args MCP input.
+	 * @param \WP_Post $post The target post.
+	 * @return array
+	 */
+	private static function build_prefill_payload( array $args, $post ): array {
+		$featured_image_id   = (int) get_post_thumbnail_id( $post->ID );
+		$featured_image_url  = $featured_image_id > 0 ? wp_get_attachment_image_url( $featured_image_id, 'full' ) : '';
+		$featured_image_mime = $featured_image_id > 0 ? get_post_mime_type( $featured_image_id ) : '';
+
+		// Sensible default snippet: post excerpt, or first ~200 chars of content stripped of HTML.
+		$default_snippet = (string) get_the_excerpt( $post );
+		if ( '' === $default_snippet ) {
+			$stripped        = trim( wp_strip_all_tags( (string) $post->post_content ) );
+			$default_snippet = function_exists( 'mb_substr' ) ? mb_substr( $stripped, 0, 200 ) : substr( $stripped, 0, 200 );
+		}
+
+		$payload = array(
+			'target_urn'    => (string) $args['target_urn'],
+			'type'          => (string) $post->post_type,
+			'site_name'     => isset( $args['site_name'] ) && '' !== (string) $args['site_name']
+				? (string) $args['site_name']
+				: (string) get_the_title( $post ),
+			'text_snippet'  => isset( $args['text_snippet'] ) && '' !== (string) $args['text_snippet']
+				? (string) $args['text_snippet']
+				: $default_snippet,
+			'target_url'    => (string) get_permalink( $post ),
+			'budget'        => array(
+				'mode'     => 'total',
+				'amount'   => (float) ( $args['budget_total'] ?? 0 ),
+				'currency' => self::get_site_currency(),
+			),
+			'duration_days' => (int) ( $args['duration_days'] ?? 7 ),
+			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
+			'objective'     => isset( $args['objective'] ) && '' !== (string) $args['objective']
+				? (string) $args['objective']
+				: 'VIEWS',
+		);
+
+		if ( '' !== $featured_image_url ) {
+			$payload['main_image'] = array(
+				'url'       => $featured_image_url,
+				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',
+			);
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Build the deep-link the merchant follows to land in the Blaze
+	 * widget with the campaign form pre-populated.
+	 *
+	 * URL shape: `<admin>/tools.php?page=advertising&blaze_prefill=<base64-json>#!/advertising/posts/promote/post-<id>/<hostname>`.
+	 *
+	 * The base path comes from `Blaze::get_campaign_management_url()` so
+	 * we stay aligned with how Blaze opens the promote-post flow today;
+	 * the `blaze_prefill` query param is the Phase 2 addition the widget
+	 * will read on load. The param goes in the query string (not the
+	 * hash) so it reaches the SPA on initial bootstrap reliably.
+	 *
+	 * @param int   $post_id The target post ID.
+	 * @param array $prefill The prefill payload to encode.
 	 * @return string
 	 */
-	private static function get_approval_url( array $args, $dsp_response ) {
-		unset( $dsp_response );
-		// Try to extract a post ID from the target URN to leverage the
-		// existing `Blaze::get_campaign_management_url()` helper.
-		$post_id = 0;
-		$urn     = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
-		if ( $urn && preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $m ) ) {
-			$post_id = (int) $m[1];
-		}
-
-		if ( $post_id > 0 && class_exists( '\Automattic\Jetpack\Blaze' ) ) {
+	private static function build_prefill_url( int $post_id, array $prefill ): string {
+		$base = '';
+		if ( class_exists( '\Automattic\Jetpack\Blaze' ) && method_exists( '\Automattic\Jetpack\Blaze', 'get_campaign_management_url' ) ) {
 			$url_data = Blaze::get_campaign_management_url( $post_id );
-			return is_array( $url_data ) && isset( $url_data['link'] ) ? $url_data['link'] : '';
+			if ( is_array( $url_data ) && isset( $url_data['link'] ) ) {
+				$base = (string) $url_data['link'];
+			}
+		}
+		if ( '' === $base ) {
+			$base = admin_url( 'tools.php?page=advertising' );
 		}
 
-		// Fallback: the bare advertising dashboard.
-		return admin_url( 'tools.php?page=advertising' );
+		$encoded = self::base64url_encode( (string) wp_json_encode( $prefill, JSON_UNESCAPED_SLASHES ) );
+		$param   = 'blaze_prefill=' . rawurlencode( $encoded );
+
+		// Insert the param before the hash if there is one; otherwise append.
+		$hash_pos = strpos( $base, '#' );
+		if ( false === $hash_pos ) {
+			$separator = ( false !== strpos( $base, '?' ) ) ? '&' : '?';
+			return $base . $separator . $param;
+		}
+
+		$pre_hash  = substr( $base, 0, $hash_pos );
+		$hash      = substr( $base, $hash_pos );
+		$separator = ( false !== strpos( $pre_hash, '?' ) ) ? '&' : '?';
+
+		return $pre_hash . $separator . $param . $hash;
+	}
+
+	/**
+	 * URL-safe base64 encode (RFC 4648 §5). Avoids `+` and `/` characters
+	 * that would otherwise need percent-encoding inside a URL.
+	 *
+	 * @param string $input Bytes to encode.
+	 * @return string
+	 */
+	private static function base64url_encode( string $input ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding a structured prefill payload, not obfuscation.
+		return rtrim( strtr( base64_encode( $input ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Resolve the site's currency code. Uses the WooCommerce currency
+	 * when Woo is active (most relevant for our v1 audience), otherwise
+	 * falls back to USD — DSP defaults to USD too.
+	 *
+	 * @return string ISO 4217 currency code.
+	 */
+	private static function get_site_currency(): string {
+		if ( function_exists( 'get_woocommerce_currency' ) ) {
+			$currency = (string) get_woocommerce_currency();
+			if ( '' !== $currency ) {
+				return $currency;
+			}
+		}
+		return 'USD';
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -324,7 +324,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'message'          => array(
 							'type'        => 'string',
-							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
+							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat before the review link; it includes a campaign preview table and the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
 						'campaign_preview' => array(
 							'type'        => 'object',
@@ -520,14 +520,12 @@ class Blaze_Abilities extends Registrar {
 			return $proposal;
 		}
 
-		return array_merge(
-			$proposal,
-			array(
-				'campaign_preview' => self::build_campaign_preview( $proposal ),
-				'forecast_summary' => self::build_forecast_summary( $proposal ),
-				'message'          => self::format_prepare_campaign_message( $proposal ),
-			)
-		);
+		return array(
+			'status'           => $proposal['status'],
+			'message'          => self::format_prepare_campaign_message( $proposal ),
+			'campaign_preview' => self::build_campaign_preview( $proposal ),
+			'forecast_summary' => self::build_forecast_summary( $proposal ),
+		) + $proposal;
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -314,23 +314,70 @@ class Blaze_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'prefill_url', 'prefill' ),
+					'required'    => array( 'status', 'intent', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
 					'properties'  => array(
-						'status'      => array(
+						'status'          => array(
 							'type'        => 'string',
 							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
 							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'message'     => array(
+						'message'         => array(
 							'type'        => 'string',
 							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'prefill_url' => array(
+						'intent'          => array(
+							'type'        => 'string',
+							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
+							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
+						),
+						'assumptions'     => array(
+							'type'        => 'array',
+							'description' => __( 'Plain-language assumptions used while preparing the recommended campaign.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'recommendations' => array(
+							'type'        => 'array',
+							'description' => __( 'Plain-language guidance for reviewing the prepared campaign.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+						'budget_options'  => array(
+							'type'        => 'array',
+							'description' => __( 'Lower, recommended, and higher budget options returned when budget or duration is omitted. The recommended option is encoded in prefill_url.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'       => 'object',
+								'properties' => array(
+									'key'           => array(
+										'type' => 'string',
+										'enum' => array( 'lower', 'recommended', 'higher' ),
+									),
+									'label'         => array(
+										'type' => 'string',
+									),
+									'budget'        => array(
+										'type' => 'object',
+									),
+									'daily_budget'  => array(
+										'type' => 'object',
+									),
+									'duration_days' => array(
+										'type' => 'integer',
+									),
+									'rationale'     => array(
+										'type' => 'string',
+									),
+								),
+							),
+						),
+						'prefill_url'     => array(
 							'type'        => 'string',
 							'format'      => 'uri',
 							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
 						),
-						'prefill'     => array(
+						'prefill'         => array(
 							'type'        => 'object',
 							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -218,7 +218,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and limited audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Public audience overrides are limited to country and language codes. Device targeting and interest/topic targeting are not public MCP inputs in v1 because they depend on DSP-supported device IDs and IAB category mappings; use the goal/copy fields for intent and let Blaze defaults or the review UI handle those settings. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and DSP/IAB interest category IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn' ),
@@ -279,6 +279,7 @@ class Blaze_Abilities extends Registrar {
 								'type'      => 'string',
 								'minLength' => 2,
 								'maxLength' => 5,
+								'enum'      => array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ),
 							),
 						),
 						'countries'            => array(
@@ -288,6 +289,23 @@ class Blaze_Abilities extends Registrar {
 								'type'      => 'string',
 								'minLength' => 2,
 								'maxLength' => 2,
+							),
+						),
+						'devices'              => array(
+							'type'        => 'array',
+							'description' => __( 'Optional narrowed device targeting value. Supported values are "mobile" and "desktop"; omit to target all devices. Tablet is not exposed until Blaze widget prefill support is verified end-to-end.', 'jetpack-blaze' ),
+							'maxItems'    => 1,
+							'items'       => array(
+								'type' => 'string',
+								'enum' => array( 'mobile', 'desktop' ),
+							),
+						),
+						'interests'            => array(
+							'type'        => 'array',
+							'description' => __( 'Optional DSP page topic / IAB category IDs to target (e.g. ["IAB18", "IAB1_IAB2"]). Use only IDs discovered from the Blaze/DSP targeting options; do not send free-form interest names. Invalid or unsupported IDs are ignored.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'    => 'string',
+								'pattern' => '^IAB\\d+(?:_IAB\\d+)*$',
 							),
 						),
 					),

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -195,16 +195,78 @@ class Blaze_Abilities extends Registrar {
 		return array(
 			self::ABILITY_LIST_CAMPAIGNS   => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
-				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
+				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including numeric campaign_id, campaign title/name, DSP status, schedule, spend, target, and performance context. Use campaign_id for follow-up operations; title/name is human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'default'              => array(),
-					'properties'           => new \stdClass(),
+					'properties'           => array(
+						'status' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional DSP campaign status filter. Values pass through to the existing Blaze DSP campaigns route; clients should use DSP status vocabulary returned by this ability rather than inventing MCP-only states.', 'jetpack-blaze' ),
+						),
+					),
 					'additionalProperties' => false,
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Campaigns payload as returned by the Blaze DSP API.', 'jetpack-blaze' ),
+					'properties'  => array(
+						'campaigns' => array(
+							'type'        => 'array',
+							'description' => __( 'Blaze campaigns returned by DSP. MCP clients should show these fields so the merchant can choose the right campaign before requesting stats or stop operations.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'additionalProperties' => true,
+								'properties'           => array(
+									'campaign_id'   => array(
+										'type'        => 'integer',
+										'description' => __( 'The numeric operation identifier for follow-up campaign operations such as stats or stop.', 'jetpack-blaze' ),
+									),
+									'title'         => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign title shown as human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
+									),
+									'name'          => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign name shown as human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
+									),
+									'status'        => array(
+										'type'        => 'string',
+										'description' => __( 'DSP status for the campaign, using the status vocabulary returned by Blaze/DSP.', 'jetpack-blaze' ),
+									),
+									'ui_status'     => array(
+										'type'        => 'string',
+										'description' => __( 'Display status returned by DSP for merchant-facing UI context, when available.', 'jetpack-blaze' ),
+									),
+									'start_date'    => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign start date returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+									'end_date'      => array(
+										'type'        => 'string',
+										'description' => __( 'Campaign end date returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+									'target_url'    => array(
+										'type'        => 'string',
+										'format'      => 'uri',
+										'description' => __( 'Target URL promoted by the campaign, when available.', 'jetpack-blaze' ),
+									),
+									'target_urn'    => array(
+										'type'        => 'string',
+										'description' => __( 'Target URN promoted by the campaign, when available.', 'jetpack-blaze' ),
+									),
+									'budget'        => array(
+										'type'        => 'object',
+										'description' => __( 'Campaign budget details returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+									'summary_stats' => array(
+										'type'        => 'object',
+										'description' => __( 'Existing campaign summary stats returned by DSP, when available.', 'jetpack-blaze' ),
+									),
+								),
+							),
+						),
+					),
 				),
 				'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
 				'permission_callback' => array( __CLASS__, 'permission_callback' ),
@@ -469,11 +531,11 @@ class Blaze_Abilities extends Registrar {
 	 * directly so we inherit the standard request lifecycle, permission
 	 * checks, and any third-party filters wired onto that route.
 	 *
-	 * @param array $args Ability input. Currently unused; reserved for future filtering params.
+	 * @param array $args Ability input.
 	 * @return array|\WP_Error
 	 */
 	public static function list_campaigns( $args = array() ) {
-		unset( $args );
+		$args = is_array( $args ) ? $args : array();
 
 		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
 		if ( is_wp_error( $site_id ) ) {
@@ -483,6 +545,9 @@ class Blaze_Abilities extends Registrar {
 		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
 		$request = new WP_REST_Request( 'GET', $route );
 		$request->set_param( 'api_version', 'v1.1' );
+		if ( isset( $args['status'] ) ) {
+			$request->set_param( 'status', $args['status'] );
+		}
 
 		$response = rest_do_request( $request );
 		if ( $response->is_error() ) {

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -34,15 +34,17 @@ use WP_REST_Request;
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG            = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS   = 'blaze-ads/list-campaigns';
-	const ABILITY_PREPARE_CAMPAIGN = 'blaze-ads/prepare-campaign';
+	const CATEGORY_SLUG                = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS       = 'blaze-ads/list-campaigns';
+	const ABILITY_GET_CAMPAIGN_STATS   = 'blaze-ads/get-campaign-stats';
+	const ABILITY_PREPARE_CAMPAIGN     = 'blaze-ads/prepare-campaign';
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
 	 */
 	const OWNED_ABILITY_SLUGS = array(
 		self::ABILITY_LIST_CAMPAIGNS,
+		self::ABILITY_GET_CAMPAIGN_STATS,
 		self::ABILITY_PREPARE_CAMPAIGN,
 	);
 
@@ -207,6 +209,116 @@ class Blaze_Abilities extends Registrar {
 					'description' => __( 'Campaigns payload as returned by the Blaze DSP API.', 'jetpack-blaze' ),
 				),
 				'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+			self::ABILITY_GET_CAMPAIGN_STATS => array(
+				'label'               => __( 'Get Blaze campaign stats', 'jetpack-blaze' ),
+				'description'         => __( 'Get raw Blaze display advertising stats for a campaign, plus basic derived CTR, CPM, CPC, and clicks-per-dollar metrics.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Numeric DSP campaign ID.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'start_date'  => array(
+							'type'        => 'string',
+							'format'      => 'date',
+							'description' => __( 'Optional stats start date in YYYY-MM-DD format.', 'jetpack-blaze' ),
+						),
+						'end_date'    => array(
+							'type'        => 'string',
+							'format'      => 'date',
+							'description' => __( 'Optional stats end date in YYYY-MM-DD format.', 'jetpack-blaze' ),
+						),
+						'time_zone'   => array(
+							'type'        => 'string',
+							'description' => __( 'Optional IANA timezone name used by the DSP stats endpoint.', 'jetpack-blaze' ),
+						),
+						'resolution'  => array(
+							'type'        => 'string',
+							'description' => __( 'Optional stats time-series resolution accepted by the DSP stats endpoint.', 'jetpack-blaze' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Campaign stats payload with raw totals, time series, country breakdown, derived metrics, and lightweight display-ad context.', 'jetpack-blaze' ),
+					'required'    => array( 'raw_stats', 'totals', 'time_series', 'country_breakdown', 'derived_metrics', 'context' ),
+					'properties'  => array(
+						'raw_stats'         => array(
+							'type'        => 'object',
+							'description' => __( 'Raw campaign stats payload as returned by the Blaze DSP stats endpoint.', 'jetpack-blaze' ),
+						),
+						'totals'            => array(
+							'type'       => 'object',
+							'required'   => array( 'impressions', 'clicks', 'spend' ),
+							'properties' => array(
+								'impressions' => array(
+									'type' => 'integer',
+								),
+								'clicks'      => array(
+									'type' => 'integer',
+								),
+								'spend'       => array(
+									'type' => 'number',
+								),
+							),
+						),
+						'time_series'       => array(
+							'type'        => 'array',
+							'description' => __( 'Raw time-series rows from the stats endpoint, including impressions, clicks, and spend when present.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'object',
+							),
+						),
+						'country_breakdown' => array(
+							'type'        => 'array',
+							'description' => __( 'Raw country breakdown rows from the stats endpoint.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type' => 'object',
+							),
+						),
+						'derived_metrics'   => array(
+							'type'       => 'object',
+							'required'   => array( 'ctr', 'cpm', 'cpc', 'clicks_per_dollar' ),
+							'properties' => array(
+								'ctr'               => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Click-through rate as clicks divided by impressions.', 'jetpack-blaze' ),
+								),
+								'cpm'               => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Cost per thousand impressions.', 'jetpack-blaze' ),
+								),
+								'cpc'               => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Cost per click.', 'jetpack-blaze' ),
+								),
+								'clicks_per_dollar' => array(
+									'type'        => array( 'number', 'null' ),
+									'description' => __( 'Clicks divided by spend.', 'jetpack-blaze' ),
+								),
+							),
+						),
+						'context'           => array(
+							'type'        => 'string',
+							'description' => __( 'Lightweight display-ad framing for interpreting CTR alongside CPM, CPC, and campaign goals.', 'jetpack-blaze' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_campaign_stats' ),
 				'permission_callback' => array( __CLASS__, 'permission_callback' ),
 				'meta'                => array(
 					'show_in_rest' => true,
@@ -482,7 +594,7 @@ class Blaze_Abilities extends Registrar {
 
 		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
 		$request = new WP_REST_Request( 'GET', $route );
-		$request->set_param( 'api_version', 'v1.1' );
+		$request->set_param( 'api_version', 'v1' );
 
 		$response = rest_do_request( $request );
 		if ( $response->is_error() ) {
@@ -490,6 +602,156 @@ class Blaze_Abilities extends Registrar {
 		}
 
 		return $response->get_data();
+	}
+
+	/**
+	 * Return a Blaze campaign stats payload.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function get_campaign_stats( $args = array() ) {
+		$args            = is_array( $args ) ? $args : array();
+		$raw_campaign_id = isset( $args['campaign_id'] ) ? $args['campaign_id'] : null;
+		$campaign_id     = 0;
+
+		if ( is_int( $raw_campaign_id ) ) {
+			$campaign_id = $raw_campaign_id;
+		} elseif ( is_string( $raw_campaign_id ) && ctype_digit( $raw_campaign_id ) ) {
+			$campaign_id = (int) $raw_campaign_id;
+		}
+
+		if ( $campaign_id < 1 ) {
+			return new \WP_Error(
+				'blaze_invalid_campaign_id',
+				__( 'A numeric DSP campaign ID is required.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1/stats/%d', $site_id, $campaign_id );
+		$request = new WP_REST_Request( 'GET', $route );
+		$request->set_param( 'api_version', 'v1' );
+
+		foreach ( array( 'start_date', 'end_date', 'time_zone', 'resolution' ) as $param ) {
+			if ( isset( $args[ $param ] ) && '' !== $args[ $param ] ) {
+				$request->set_param( $param, $args[ $param ] );
+			}
+		}
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$stats  = $response->get_data();
+		$totals = is_array( $stats ) ? self::extract_campaign_stats_totals( $stats ) : array(
+			'impressions' => 0,
+			'clicks'      => 0,
+			'spend'       => 0.0,
+		);
+
+		return array(
+			'raw_stats'         => $stats,
+			'totals'            => $totals,
+			'time_series'       => is_array( $stats ) ? self::extract_campaign_stats_time_series( $stats ) : array(),
+			'country_breakdown' => is_array( $stats ) ? self::extract_campaign_stats_country_breakdown( $stats ) : array(),
+			'derived_metrics'   => self::derive_campaign_stats_metrics( $totals ),
+			'context'           => __( 'Blaze is display advertising. A low CTR should be interpreted alongside CPM, CPC, and campaign goals before drawing conclusions.', 'jetpack-blaze' ),
+		);
+	}
+
+	/**
+	 * Extract raw total metrics from known stats payload shapes.
+	 *
+	 * @param array $stats Raw stats payload.
+	 * @return array
+	 */
+	private static function extract_campaign_stats_totals( array $stats ): array {
+		$source = isset( $stats['totals'] ) && is_array( $stats['totals'] ) ? $stats['totals'] : $stats;
+
+		return array(
+			'impressions' => (int) self::get_first_numeric_value( $source, array( 'impressions', 'total_impressions' ) ),
+			'clicks'      => (int) self::get_first_numeric_value( $source, array( 'clicks', 'total_clicks' ) ),
+			'spend'       => (float) self::get_first_numeric_value( $source, array( 'spend', 'total_spend' ) ),
+		);
+	}
+
+	/**
+	 * Extract time-series rows from known stats payload shapes.
+	 *
+	 * @param array $stats Raw stats payload.
+	 * @return array
+	 */
+	private static function extract_campaign_stats_time_series( array $stats ): array {
+		if ( isset( $stats['series'] ) && is_array( $stats['series'] ) ) {
+			return $stats['series'];
+		}
+
+		if ( isset( $stats['time_series'] ) && is_array( $stats['time_series'] ) ) {
+			return $stats['time_series'];
+		}
+
+		return array();
+	}
+
+	/**
+	 * Extract country breakdown rows from known stats payload shapes.
+	 *
+	 * @param array $stats Raw stats payload.
+	 * @return array
+	 */
+	private static function extract_campaign_stats_country_breakdown( array $stats ): array {
+		if ( isset( $stats['countries'] ) && is_array( $stats['countries'] ) ) {
+			return $stats['countries'];
+		}
+
+		if ( isset( $stats['country_breakdown'] ) && is_array( $stats['country_breakdown'] ) ) {
+			return $stats['country_breakdown'];
+		}
+
+		return array();
+	}
+
+	/**
+	 * Derive simple campaign stats metrics from totals.
+	 *
+	 * @param array $totals Normalized totals.
+	 * @return array
+	 */
+	private static function derive_campaign_stats_metrics( array $totals ): array {
+		$impressions = isset( $totals['impressions'] ) ? (int) $totals['impressions'] : 0;
+		$clicks      = isset( $totals['clicks'] ) ? (int) $totals['clicks'] : 0;
+		$spend       = isset( $totals['spend'] ) ? (float) $totals['spend'] : 0.0;
+
+		return array(
+			'ctr'               => $impressions > 0 ? $clicks / $impressions : null,
+			'cpm'               => $impressions > 0 ? ( $spend / $impressions ) * 1000 : null,
+			'cpc'               => $clicks > 0 ? $spend / $clicks : null,
+			'clicks_per_dollar' => $spend > 0 ? $clicks / $spend : null,
+		);
+	}
+
+	/**
+	 * Return the first numeric value found in an array.
+	 *
+	 * @param array $source Source data.
+	 * @param array $keys Candidate keys.
+	 * @return float|int
+	 */
+	private static function get_first_numeric_value( array $source, array $keys ) {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && is_numeric( $source[ $key ] ) ) {
+				return $source[ $key ];
+			}
+		}
+
+		return 0;
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Jetpack Blaze Abilities Registration
+ *
+ * Single source of truth for Blaze's WordPress Abilities API registration.
+ * Registers a read-only ability and opts it into WooCommerce's MCP server
+ * tool whitelist so MCP clients (e.g. Claude Desktop) can discover and
+ * invoke it alongside Woo's built-in abilities.
+ *
+ * Both delivery paths invoke this class:
+ * - The Jetpack plugin, via `Automattic\Jetpack\Blaze::init()` in this package.
+ * - The standalone `blaze-ads` plugin, via its own bootstrap.
+ *
+ * v1 scope is intentionally Woo-only: the class bails when a Woo MCP server
+ * is not detected on the site. See ADS-952 for the broader rollout plan.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; we guard with function_exists()/class_exists() so the file is safe on older WP and on sites without Woo MCP.
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_REST_Request;
+
+/**
+ * Registers the `blaze-ads` category and the `blaze-ads/list-campaigns`
+ * ability, and opts the ability into WooCommerce's MCP server.
+ */
+class Blaze_Abilities extends Registrar {
+
+	const CATEGORY_SLUG          = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS = 'blaze-ads/list-campaigns';
+
+	/**
+	 * Wire registration into the Abilities API lifecycle and opt the
+	 * ability into Woo's MCP server.
+	 *
+	 * Bails early when WooCommerce 10.7+ with the bundled MCP adapter is
+	 * not present — the v1 surface is Woo-only on purpose.
+	 *
+	 * Note: deliberately does not call `parent::init()`. The Registrar
+	 * base gates registration behind the `jetpack_wp_abilities_enabled`
+	 * filter (default false), and toggling that filter would force-enable
+	 * registration for *every* future Registrar consumer in the monorepo,
+	 * not just Blaze. We mirror parent::init()'s lifecycle wiring directly
+	 * so we only opt in our own abilities.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! self::is_woo_mcp_available() ) {
+			return;
+		}
+
+		add_filter( 'jetpack_wp_abilities_should_register', array( __CLASS__, 'guard_against_double_register' ), 10, 3 );
+		add_filter( 'woocommerce_mcp_include_ability', array( __CLASS__, 'opt_into_woo_mcp' ), 10, 2 );
+
+		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
+			static::register_category();
+		} else {
+			add_action( self::CATEGORIES_INIT_ACTION, array( static::class, 'register_category' ) );
+		}
+
+		if ( did_action( self::ABILITIES_INIT_ACTION ) ) {
+			static::register_abilities();
+		} else {
+			add_action( self::ABILITIES_INIT_ACTION, array( static::class, 'register_abilities' ) );
+		}
+	}
+
+	/**
+	 * Detect a Woo MCP server on the site. Single signal: the provider class
+	 * was added to WooCommerce in 10.7 and is only loaded when MCP is
+	 * available, so its presence is a sufficient gate.
+	 *
+	 * @return bool
+	 */
+	private static function is_woo_mcp_available(): bool {
+		return class_exists( '\Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider' );
+	}
+
+	/**
+	 * Defensive `wp_get_ability()` check, wired through the Registrar's
+	 * per-slug filter so we skip registration if something else (a previous
+	 * call, another plugin) has already registered the ability. Belt and
+	 * braces: with both delivery paths invoking the same class this should
+	 * be a no-op, but keeps us safe against anyone else registering the slug.
+	 *
+	 * @param bool   $enabled Whether the registrar would proceed.
+	 * @param string $type    'category' or 'ability'.
+	 * @param string $slug    The slug being registered.
+	 * @return bool
+	 */
+	public static function guard_against_double_register( $enabled, $type, $slug ) {
+		if ( ! $enabled ) {
+			return $enabled;
+		}
+		if ( 'ability' === $type && self::ABILITY_LIST_CAMPAIGNS === $slug && function_exists( 'wp_get_ability' ) && wp_get_ability( $slug ) ) {
+			return false;
+		}
+		return $enabled;
+	}
+
+	/**
+	 * Opt our ability into Woo's MCP server tool whitelist.
+	 *
+	 * @param bool   $include    Whether Woo would include the ability by default.
+	 * @param string $ability_id The ability ID being considered.
+	 * @return bool
+	 */
+	public static function opt_into_woo_mcp( $include, $ability_id ) {
+		if ( self::ABILITY_LIST_CAMPAIGNS === $ability_id ) {
+			return true;
+		}
+		return $include;
+	}
+
+	/**
+	 * Category slug owned by this registrar.
+	 *
+	 * @return string
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * Category definition passed to `wp_register_ability_category()`.
+	 *
+	 * @return array
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Blaze" is a product name and should not be translated.
+			'label'       => 'Blaze',
+			'description' => __( 'Abilities for managing Blaze ad campaigns.', 'jetpack-blaze' ),
+		);
+	}
+
+	/**
+	 * Abilities owned by this registrar, keyed by slug.
+	 *
+	 * @return array<string, array>
+	 */
+	public static function get_abilities(): array {
+		return array(
+			self::ABILITY_LIST_CAMPAIGNS => array(
+				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
+				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Campaigns payload as returned by the Blaze DSP API.', 'jetpack-blaze' ),
+				),
+				'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission gate: store-manager capability plus an active Jetpack user
+	 * connection. Both delivery paths route DSP calls through Jetpack
+	 * Connect, so the connection check is meaningful regardless of how the
+	 * package was loaded.
+	 *
+	 * @return bool
+	 */
+	public static function permission_callback() {
+		// `manage_woocommerce` is a WooCommerce-defined capability — sniff lacks it in its known list.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return false;
+		}
+
+		$connection = new Jetpack_Connection();
+		if ( ! $connection->is_user_connected() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the campaigns payload by delegating to the existing DSP REST
+	 * route. Using `rest_do_request()` rather than calling the controller
+	 * directly so we inherit the standard request lifecycle, permission
+	 * checks, and any third-party filters wired onto that route.
+	 *
+	 * @param array $args Ability input. Currently unused; reserved for future filtering params.
+	 * @return array|\WP_Error
+	 */
+	public static function list_campaigns( $args = array() ) {
+		unset( $args );
+
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
+		$request = new WP_REST_Request( 'GET', $route );
+		$request->set_param( 'api_version', 'v1.1' );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		return $response->get_data();
+	}
+}

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -314,7 +314,7 @@ class Blaze_Abilities extends Registrar {
 				'output_schema'       => array(
 					'type'        => 'object',
 					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'intent', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
+					'required'    => array( 'status', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
 					'properties'  => array(
 						'status'          => array(
 							'type'        => 'string',
@@ -329,6 +329,10 @@ class Blaze_Abilities extends Registrar {
 							'type'        => 'string',
 							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
 							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
+						),
+						'forecast'        => array(
+							'type'        => 'object',
+							'description' => __( 'Forecast estimates for the recommended option. Available forecasts include views/impressions and clicks ranges; unavailable forecasts do not block the review URL.', 'jetpack-blaze' ),
 						),
 						'assumptions'     => array(
 							'type'        => 'array',

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -37,6 +37,7 @@ class Blaze_Abilities extends Registrar {
 	const CATEGORY_SLUG            = 'blaze-ads';
 	const ABILITY_LIST_CAMPAIGNS   = 'blaze-ads/list-campaigns';
 	const ABILITY_PREPARE_CAMPAIGN = 'blaze-ads/prepare-campaign';
+	const ABILITY_STOP_CAMPAIGN    = 'blaze-ads/stop-campaign';
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
@@ -44,6 +45,7 @@ class Blaze_Abilities extends Registrar {
 	const OWNED_ABILITY_SLUGS = array(
 		self::ABILITY_LIST_CAMPAIGNS,
 		self::ABILITY_PREPARE_CAMPAIGN,
+		self::ABILITY_STOP_CAMPAIGN,
 	);
 
 	/**
@@ -438,6 +440,61 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
+			self::ABILITY_STOP_CAMPAIGN    => array(
+				'label'               => __( 'Stop a Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Preview or confirm stopping delivery for an existing Blaze campaign. Pass the numeric DSP campaign_id. By default this returns the current campaign context and consequence text without calling the DSP stop endpoint. Set confirm to true only after the merchant explicitly confirms they want to stop serving; confirm mode re-fetches campaign context and delegates stop eligibility to the existing DSP stop endpoint.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Numeric DSP campaign ID to stop.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'confirm'     => array(
+							'type'        => 'boolean',
+							'description' => __( 'Set to true only after the merchant explicitly confirms they want this campaign stopped from serving. Defaults to false, which previews the consequence without stopping the campaign.', 'jetpack-blaze' ),
+							'default'     => false,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Stop-campaign preview or confirmation response with campaign context and merchant-facing wording.', 'jetpack-blaze' ),
+					'required'    => array( 'status', 'message', 'campaign' ),
+					'properties'  => array(
+						'status'      => array(
+							'type'        => 'string',
+							'description' => __( 'pending_confirmation for preview responses, or stopped for successful confirm responses.', 'jetpack-blaze' ),
+							'enum'        => array( 'pending_confirmation', 'stopped' ),
+						),
+						'message'     => array(
+							'type'        => 'string',
+							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant.', 'jetpack-blaze' ),
+						),
+						'campaign'    => array(
+							'type'        => 'object',
+							'description' => __( 'Current campaign context fetched from the Blaze DSP API.', 'jetpack-blaze' ),
+						),
+						'consequence' => array(
+							'type'        => 'string',
+							'description' => __( 'Clear consequence text explaining that confirmation stops the campaign from serving.', 'jetpack-blaze' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'stop_campaign' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			),
 		);
 	}
 
@@ -527,6 +584,310 @@ class Blaze_Abilities extends Registrar {
 			'campaign_preview' => self::build_campaign_preview( $proposal ),
 			'forecast_summary' => self::build_forecast_summary( $proposal ),
 		) + $proposal;
+	}
+
+	/**
+	 * Preview or confirm stopping a Blaze campaign from serving.
+	 *
+	 * Preview mode fetches current campaign context and returns consequence
+	 * text without calling the DSP stop endpoint. Confirm mode re-fetches the
+	 * same context, then delegates stop eligibility and state handling to DSP.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function stop_campaign( $args = array() ) {
+		$args = is_array( $args ) ? $args : array();
+
+		$campaign_id = isset( $args['campaign_id'] ) ? (int) $args['campaign_id'] : 0;
+		if ( $campaign_id < 1 ) {
+			return new \WP_Error(
+				'blaze_invalid_campaign_id',
+				__( 'A numeric DSP campaign_id is required to stop a Blaze campaign.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$context = self::fetch_stop_campaign_context( $campaign_id );
+		if ( is_wp_error( $context ) ) {
+			return $context;
+		}
+
+		$campaign    = self::normalize_stop_campaign_context( $campaign_id, $context );
+		$consequence = self::build_stop_campaign_consequence( $campaign );
+		$confirmed   = isset( $args['confirm'] ) && true === $args['confirm'];
+
+		if ( ! $confirmed ) {
+			return array(
+				'status'      => 'pending_confirmation',
+				'message'     => self::format_stop_campaign_preview_message( $campaign, $consequence ),
+				'campaign'    => $campaign,
+				'consequence' => $consequence,
+			);
+		}
+
+		$stop_response = self::call_stop_campaign_endpoint( $campaign_id );
+		if ( is_wp_error( $stop_response ) ) {
+			return $stop_response;
+		}
+
+		return array(
+			'status'        => 'stopped',
+			'message'       => self::format_stop_campaign_confirmation_message( $campaign ),
+			'campaign'      => $campaign,
+			'consequence'   => __( 'The campaign was stopped from serving immediately.', 'jetpack-blaze' ),
+			'stop_response' => $stop_response,
+		);
+	}
+
+	/**
+	 * Fetch current campaign context through the existing Blaze proxy route.
+	 *
+	 * @param int $campaign_id Numeric DSP campaign ID.
+	 * @return array|\WP_Error
+	 */
+	private static function fetch_stop_campaign_context( int $campaign_id ) {
+		$route = self::get_dsp_campaign_route( $campaign_id );
+		if ( is_wp_error( $route ) ) {
+			return $route;
+		}
+
+		$request = new WP_REST_Request( 'GET', $route );
+		return self::dispatch_stop_campaign_rest_request( $request );
+	}
+
+	/**
+	 * Call the existing DSP stop endpoint through the Blaze proxy route.
+	 *
+	 * @param int $campaign_id Numeric DSP campaign ID.
+	 * @return array|\WP_Error
+	 */
+	private static function call_stop_campaign_endpoint( int $campaign_id ) {
+		$route = self::get_dsp_campaign_route( $campaign_id, '/stop' );
+		if ( is_wp_error( $route ) ) {
+			return $route;
+		}
+
+		$request = new WP_REST_Request( 'POST', $route );
+		return self::dispatch_stop_campaign_rest_request( $request );
+	}
+
+	/**
+	 * Build the local REST proxy route for a DSP campaign endpoint.
+	 *
+	 * @param int    $campaign_id Numeric DSP campaign ID.
+	 * @param string $suffix      Optional subpath suffix, e.g. /stop.
+	 * @return string|\WP_Error
+	 */
+	private static function get_dsp_campaign_route( int $campaign_id, string $suffix = '' ) {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		return sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns/%d%s', $site_id, $campaign_id, $suffix );
+	}
+
+	/**
+	 * Dispatch a stop-campaign REST proxy request and normalize error output.
+	 *
+	 * @param WP_REST_Request $request Request to dispatch.
+	 * @return array|\WP_Error
+	 */
+	private static function dispatch_stop_campaign_rest_request( WP_REST_Request $request ) {
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$status = $response->get_status();
+		$data   = $response->get_data();
+		if ( $status >= 400 ) {
+			return self::rest_response_to_wp_error( is_array( $data ) ? $data : array(), $status );
+		}
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Convert non-2xx REST proxy responses into WP_Error for Abilities/MCP.
+	 *
+	 * @param array $data   REST response data.
+	 * @param int   $status HTTP status.
+	 * @return \WP_Error
+	 */
+	private static function rest_response_to_wp_error( array $data, int $status ): \WP_Error {
+		$code = isset( $data['code'] ) ? (string) $data['code'] : 'blaze_dsp_error';
+
+		$message = '';
+		foreach ( array( 'message', 'errorMessage', 'error' ) as $message_key ) {
+			if ( isset( $data[ $message_key ] ) && '' !== (string) $data[ $message_key ] ) {
+				$message = (string) $data[ $message_key ];
+				break;
+			}
+		}
+		if ( '' === $message ) {
+			$message = __( 'The Blaze DSP API could not stop this campaign.', 'jetpack-blaze' );
+		}
+
+		$data['status'] = $status;
+		return new \WP_Error( $code, $message, $data );
+	}
+
+	/**
+	 * Normalize the DSP campaign shape into the MCP-facing context fields.
+	 *
+	 * @param int   $campaign_id Numeric DSP campaign ID requested by the caller.
+	 * @param array $context     Raw DSP campaign context.
+	 * @return array
+	 */
+	private static function normalize_stop_campaign_context( int $campaign_id, array $context ): array {
+		$campaign = isset( $context['campaign'] ) && is_array( $context['campaign'] ) ? $context['campaign'] : $context;
+
+		return array(
+			'campaign_id' => self::get_first_integer_value( $campaign, array( 'campaign_id', 'id' ), $campaign_id ),
+			'title'       => self::get_first_string_value( $campaign, array( 'title', 'name', 'campaign_name' ) ),
+			'status'      => self::get_first_string_value( $campaign, array( 'status', 'state' ) ),
+			'start_date'  => self::get_first_string_value( $campaign, array( 'start_date', 'startDate', 'start_at', 'startAt', 'start' ) ),
+			'end_date'    => self::get_first_string_value( $campaign, array( 'end_date', 'endDate', 'end_at', 'endAt', 'end' ) ),
+			'target_url'  => self::get_first_string_value( $campaign, array( 'target_url', 'targetUrl', 'destination_url', 'destinationUrl', 'landing_page', 'landingPage', 'url' ) ),
+			'target_urn'  => self::get_first_string_value( $campaign, array( 'target_urn', 'targetUrn', 'urn' ) ),
+		);
+	}
+
+	/**
+	 * Return the first non-empty string value for a set of keys.
+	 *
+	 * @param array $source Source array.
+	 * @param array $keys   Candidate keys.
+	 * @return string
+	 */
+	private static function get_first_string_value( array $source, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && '' !== (string) $source[ $key ] ) {
+				return (string) $source[ $key ];
+			}
+		}
+
+		if ( isset( $source['target'] ) && is_array( $source['target'] ) ) {
+			foreach ( $keys as $key ) {
+				if ( isset( $source['target'][ $key ] ) && '' !== (string) $source['target'][ $key ] ) {
+					return (string) $source['target'][ $key ];
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return the first positive integer value for a set of keys.
+	 *
+	 * @param array $source  Source array.
+	 * @param array $keys    Candidate keys.
+	 * @param int   $default Default value.
+	 * @return int
+	 */
+	private static function get_first_integer_value( array $source, array $keys, int $default ): int {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && (int) $source[ $key ] > 0 ) {
+				return (int) $source[ $key ];
+			}
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Build consequence text for preview mode.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function build_stop_campaign_consequence( array $campaign ): string {
+		return sprintf(
+			/* translators: %s: campaign title or ID. */
+			__( 'If confirmed, campaign "%s" will be stopped from serving immediately. This MCP tool cannot resume the campaign after it is stopped.', 'jetpack-blaze' ),
+			self::get_stop_campaign_display_name( $campaign )
+		);
+	}
+
+	/**
+	 * Format the preview response for chat clients.
+	 *
+	 * @param array  $campaign    Normalized campaign context.
+	 * @param string $consequence Consequence text.
+	 * @return string
+	 */
+	private static function format_stop_campaign_preview_message( array $campaign, string $consequence ): string {
+		$message  = __( 'Preview only: this campaign has not been stopped.', 'jetpack-blaze' ) . "\n\n";
+		$message .= self::format_stop_campaign_context_table( $campaign );
+		$message .= "\n" . $consequence;
+		$message .= "\n\n" . __( 'To stop serving, call this ability again with confirm set to true after the merchant explicitly confirms.', 'jetpack-blaze' );
+
+		return $message;
+	}
+
+	/**
+	 * Format the confirmation response for chat clients.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function format_stop_campaign_confirmation_message( array $campaign ): string {
+		return sprintf(
+			/* translators: %s: campaign title or ID. */
+			__( 'Campaign "%s" was stopped from serving.', 'jetpack-blaze' ),
+			self::get_stop_campaign_display_name( $campaign )
+		);
+	}
+
+	/**
+	 * Format normalized campaign context as a compact Markdown table.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function format_stop_campaign_context_table( array $campaign ): string {
+		$message  = '| ' . __( 'Campaign', 'jetpack-blaze' ) . ' | ' . __( 'Current value', 'jetpack-blaze' ) . " |\n";
+		$message .= "| --- | --- |\n";
+
+		$rows = array(
+			__( 'ID', 'jetpack-blaze' )         => $campaign['campaign_id'] ?? '',
+			__( 'Title', 'jetpack-blaze' )      => $campaign['title'] ?? '',
+			__( 'Status', 'jetpack-blaze' )     => $campaign['status'] ?? '',
+			__( 'Start date', 'jetpack-blaze' ) => $campaign['start_date'] ?? '',
+			__( 'End date', 'jetpack-blaze' )   => $campaign['end_date'] ?? '',
+			__( 'Target URL', 'jetpack-blaze' ) => $campaign['target_url'] ?? '',
+			__( 'Target URN', 'jetpack-blaze' ) => $campaign['target_urn'] ?? '',
+		);
+
+		foreach ( $rows as $label => $value ) {
+			if ( '' === (string) $value ) {
+				continue;
+			}
+			$message .= '| ' . self::format_markdown_table_cell( $label ) . ' | ' . self::format_markdown_table_cell( $value ) . " |\n";
+		}
+
+		return rtrim( $message, "\n" );
+	}
+
+	/**
+	 * Human-readable campaign name fallback.
+	 *
+	 * @param array $campaign Normalized campaign context.
+	 * @return string
+	 */
+	private static function get_stop_campaign_display_name( array $campaign ): string {
+		if ( ! empty( $campaign['title'] ) ) {
+			return (string) $campaign['title'];
+		}
+
+		return sprintf(
+			/* translators: %d: numeric DSP campaign ID. */
+			__( 'Campaign %d', 'jetpack-blaze' ),
+			(int) ( $campaign['campaign_id'] ?? 0 )
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -629,7 +629,7 @@ class Blaze_Abilities extends Registrar {
 			return $args;
 		}
 
-		$original_callback = isset( $args['execute_callback'] ) ? $args['execute_callback'] : null;
+		$original_callback = $args['execute_callback'] ?? null;
 		if ( ! is_callable( $original_callback ) ) {
 			return $args;
 		}

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -24,6 +24,7 @@ namespace Automattic\Jetpack\Blaze\Abilities;
 use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Blaze\Campaign_Preparer;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use WP_REST_Request;
 
@@ -863,16 +864,29 @@ class Blaze_Abilities extends Registrar {
 			return $args;
 		}
 
-		$args['execute_callback'] = static function ( $input = array() ) use ( $original_callback ) {
+		$args['execute_callback'] = static function ( $input = array() ) use ( $ability_name, $original_callback ) {
+			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+				self::record_prepare_campaign_event( 'called', is_array( $input ) ? $input : array() );
+			}
+
 			$tos_check = self::check_tos_and_payment();
 			if ( is_wp_error( $tos_check ) ) {
+				if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+					self::record_prepare_campaign_event( 'failed', is_array( $input ) ? $input : array(), $tos_check );
+				}
 				return $tos_check;
 			}
 
 			// Future write-path guardrails (per-session spend ceiling, Picard
 			// moderation gating) plug in here. Tracked separately as ADS-989.
 
-			return call_user_func( $original_callback, $input );
+			$result = call_user_func( $original_callback, $input );
+
+			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+				self::record_prepare_campaign_event( is_wp_error( $result ) ? 'failed' : 'succeeded', is_array( $input ) ? $input : array(), $result );
+			}
+
+			return $result;
 		};
 
 		return $args;
@@ -927,6 +941,99 @@ class Blaze_Abilities extends Registrar {
 				'fix_label' => __( 'Set up Blaze', 'jetpack-blaze' ),
 			)
 		);
+	}
+
+	/**
+	 * Record safe server-side telemetry for prepare-campaign.
+	 *
+	 * Never records caller prompts, ad copy, URLs, or the full prefill payload.
+	 * Keep properties deliberately low-cardinality so MCP and direct REST calls
+	 * are useful in aggregate without carrying merchant-sensitive data.
+	 *
+	 * @param string          $result  called|succeeded|failed.
+	 * @param array           $input   Ability input.
+	 * @param array|\WP_Error $outcome Optional callback result.
+	 * @return void
+	 */
+	private static function record_prepare_campaign_event( string $result, array $input, $outcome = null ): void {
+		$props = array(
+			'result'            => in_array( $result, array( 'called', 'succeeded', 'failed' ), true ) ? $result : 'unknown',
+			'target_type'       => self::get_prepare_campaign_target_type( $outcome ),
+			'inferred_intent'   => self::get_prepare_campaign_intent( $outcome ),
+			'budget_provided'   => array_key_exists( 'budget_total', $input ),
+			'duration_provided' => array_key_exists( 'duration_days', $input ),
+		);
+
+		if ( is_wp_error( $outcome ) ) {
+			$props['failure_category'] = self::get_prepare_campaign_failure_category( $outcome );
+		}
+
+		$event = array(
+			'name'  => 'blaze_prepare_campaign_' . $props['result'],
+			'props' => $props,
+		);
+
+		/**
+		 * Filters the prepare-campaign Tracks event before it is emitted.
+		 *
+		 * Returning false prevents emission. Primarily useful for tests and for
+		 * emergency suppression if the event contract ever needs to be disabled.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array|false     $event   Event name and safe props, or false to suppress.
+		 * @param string          $result  called|succeeded|failed.
+		 * @param array           $input   Ability input.
+		 * @param array|\WP_Error $outcome Optional callback result.
+		 */
+		$event = apply_filters( 'jetpack_blaze_prepare_campaign_tracks_event', $event, $result, $input, $outcome );
+		if ( false === $event || ! is_array( $event ) || empty( $event['name'] ) || ! isset( $event['props'] ) || ! is_array( $event['props'] ) ) {
+			return;
+		}
+
+		$tracking = new Tracking( 'jetpack' );
+		$tracking->record_user_event( (string) $event['name'], $event['props'] );
+	}
+
+	/**
+	 * Get the safe target type from a successful prepare outcome.
+	 *
+	 * @param mixed $outcome Callback result.
+	 * @return string
+	 */
+	private static function get_prepare_campaign_target_type( $outcome ): string {
+		$target_type = is_array( $outcome ) && isset( $outcome['prefill']['type'] ) ? (string) $outcome['prefill']['type'] : 'unknown';
+		return in_array( $target_type, array( 'post', 'page', 'product' ), true ) ? $target_type : 'unknown';
+	}
+
+	/**
+	 * Get the safe inferred intent from a successful prepare outcome.
+	 *
+	 * @param mixed $outcome Callback result.
+	 * @return string
+	 */
+	private static function get_prepare_campaign_intent( $outcome ): string {
+		$intent = is_array( $outcome ) && isset( $outcome['intent'] ) ? (string) $outcome['intent'] : 'unknown';
+		return in_array( $intent, array( 'ecommerce', 'content', 'unknown' ), true ) ? $intent : 'unknown';
+	}
+
+	/**
+	 * Map error codes to low-cardinality failure categories.
+	 *
+	 * @param \WP_Error $error Error returned by the prepare path.
+	 * @return string
+	 */
+	private static function get_prepare_campaign_failure_category( \WP_Error $error ): string {
+		switch ( $error->get_error_code() ) {
+			case 'blaze_invalid_target_urn':
+				return 'invalid_target';
+			case 'blaze_post_not_found':
+				return 'target_not_found';
+			case 'blaze_setup_required':
+				return 'setup_required';
+			default:
+				return 'prepare_failed';
+		}
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -442,6 +442,10 @@ class Blaze_Abilities extends Registrar {
 			'text_snippet'  => isset( $args['text_snippet'] ) && '' !== (string) $args['text_snippet']
 				? (string) $args['text_snippet']
 				: $default_snippet,
+			// Default CTA varies by post type — products get a commerce-flavoured
+			// "Shop Now", everything else gets the neutral "Learn More". The widget
+			// requires a non-empty CTA to clear validation, so we always send one.
+			'cta_text'      => 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More',
 			'target_url'    => (string) get_permalink( $post ),
 			'budget'        => array(
 				'mode'     => 'total',
@@ -523,19 +527,16 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Resolve the site's currency code. Uses the WooCommerce currency
-	 * when Woo is active (most relevant for our v1 audience), otherwise
-	 * falls back to USD — DSP defaults to USD too.
+	 * Currency code for the prefill payload.
+	 *
+	 * Always USD: the DSP only supports USD for billing, so reading the
+	 * Woo store currency would just produce a misleading number for
+	 * non-USD merchants (the DSP would re-interpret the amount as USD
+	 * regardless). Until the DSP gains multi-currency, normalize here.
 	 *
 	 * @return string ISO 4217 currency code.
 	 */
 	private static function get_site_currency(): string {
-		if ( function_exists( 'get_woocommerce_currency' ) ) {
-			$currency = (string) get_woocommerce_currency();
-			if ( '' !== $currency ) {
-				return $currency;
-			}
-		}
 		return 'USD';
 	}
 

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -218,7 +218,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and limited audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Public audience overrides are limited to country and language codes. Device targeting and interest/topic targeting are not public MCP inputs in v1 because they depend on DSP-supported device IDs and IAB category mappings; use the goal/copy fields for intent and let Blaze defaults or the review UI handle those settings. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn' ),
@@ -274,7 +274,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'languages'            => array(
 							'type'        => 'array',
-							'description' => __( 'Optional ISO 639-1 language codes to target (e.g. ["en", "es"]). Defaults to all languages when omitted; pass a non-empty array to narrow targeting.', 'jetpack-blaze' ),
+							'description' => __( 'Optional ISO 639-1 language codes supported by Blaze/DSP (e.g. ["en", "es"]). Infer from the user\'s natural language request when clear, but omit when unsure or unsupported. Defaults to all languages when omitted; the merchant can adjust language targeting in the Blaze review UI.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type'      => 'string',
 								'minLength' => 2,
@@ -283,7 +283,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'countries'            => array(
 							'type'        => 'array',
-							'description' => __( 'Optional ISO 3166-1 alpha-2 country codes to target (e.g. ["US", "GB"]). Defaults to worldwide when omitted; pass a non-empty array to limit reach to those countries.', 'jetpack-blaze' ),
+							'description' => __( 'Optional ISO 3166-1 alpha-2 country codes to target (e.g. ["US", "GB"]). Infer from the user\'s natural-language location request, but emit country codes rather than localized country names. Defaults to worldwide when omitted; pass a non-empty array to limit reach to those countries.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type'      => 'string',
 								'minLength' => 2,

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -22,6 +22,7 @@
 namespace Automattic\Jetpack\Blaze\Abilities;
 
 use Automattic\Jetpack\Blaze;
+use Automattic\Jetpack\Blaze\Campaign_Preparer;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use WP_REST_Request;
@@ -32,11 +33,9 @@ use WP_REST_Request;
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG                 = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS        = 'blaze-ads/list-campaigns';
-	const ABILITY_PREPARE_CAMPAIGN      = 'blaze-ads/prepare-campaign';
-	private const DEFAULT_BUDGET_TOTAL  = 50.0;
-	private const DEFAULT_DURATION_DAYS = 7;
+	const CATEGORY_SLUG            = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS   = 'blaze-ads/list-campaigns';
+	const ABILITY_PREPARE_CAMPAIGN = 'blaze-ads/prepare-campaign';
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
@@ -408,217 +407,21 @@ class Blaze_Abilities extends Registrar {
 	public static function prepare_campaign( $args = array() ) {
 		$args = is_array( $args ) ? $args : array();
 
-		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
-		if ( '' === $urn || ! preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $matches ) ) {
-			return new \WP_Error(
-				'blaze_invalid_target_urn',
-				/* translators: %s: the malformed URN value supplied by the caller. */
-				sprintf( __( 'Invalid target_urn %s. Expected format: urn:wpcom:post:<site_id>:<post_id>.', 'jetpack-blaze' ), $urn ),
-				array( 'status' => 400 )
-			);
+		$proposal = Campaign_Preparer::prepare( $args );
+		if ( is_wp_error( $proposal ) ) {
+			return $proposal;
 		}
 
-		$post = get_post( (int) $matches[1] );
-		if ( ! $post ) {
-			return new \WP_Error(
-				'blaze_post_not_found',
-				__( 'Post referenced by target_urn does not exist on this site.', 'jetpack-blaze' ),
-				array( 'status' => 404 )
-			);
-		}
-
-		$prefill     = self::build_prefill_payload( $args, $post );
-		$prefill_url = self::build_prefill_url( $post->ID, $prefill );
-
-		return array(
-			'status'      => 'pending_merchant_review',
-			'message'     => sprintf(
-				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the prepared campaign proposal. */
-				__( 'Campaign proposal prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
-				$prefill_url
-			),
-			'prefill_url' => $prefill_url,
-			'prefill'     => $prefill,
+		return array_merge(
+			$proposal,
+			array(
+				'message' => sprintf(
+					/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the prepared campaign proposal. */
+					__( 'Campaign proposal prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
+					$proposal['prefill_url']
+				),
+			)
 		);
-	}
-
-	/**
-	 * Build the campaign prefill payload from the caller's MCP input and
-	 * the resolved target post. Pure function — no I/O — so it's easy to
-	 * test and easy for callers to inspect in the response.
-	 *
-	 * Caller input (`site_name`, `text_snippet`, `cta_text`, `is_evergreen`)
-	 * overrides the post-derived defaults. Anything we can't pull from
-	 * the post or the input is left out — the widget will fill blanks
-	 * with its own defaults at submission time.
-	 *
-	 * @param array    $args MCP input.
-	 * @param \WP_Post $post The target post.
-	 * @return array
-	 */
-	private static function build_prefill_payload( array $args, $post ): array {
-		$featured_image_id   = (int) get_post_thumbnail_id( $post->ID );
-		$featured_image_url  = $featured_image_id > 0 ? wp_get_attachment_image_url( $featured_image_id, 'full' ) : '';
-		$featured_image_mime = $featured_image_id > 0 ? get_post_mime_type( $featured_image_id ) : '';
-
-		// Sensible default snippet: post excerpt, or first ~200 chars of content stripped of HTML.
-		$default_snippet = (string) get_the_excerpt( $post );
-		if ( '' === $default_snippet ) {
-			$stripped        = trim( wp_strip_all_tags( (string) $post->post_content ) );
-			$default_snippet = function_exists( 'mb_substr' ) ? mb_substr( $stripped, 0, 200 ) : substr( $stripped, 0, 200 );
-		}
-
-		$payload = array(
-			'target_urn'    => (string) $args['target_urn'],
-			'type'          => (string) $post->post_type,
-			'site_name'     => isset( $args['site_name'] ) && '' !== (string) $args['site_name']
-				? (string) $args['site_name']
-				: (string) get_the_title( $post ),
-			'text_snippet'  => isset( $args['text_snippet'] ) && '' !== (string) $args['text_snippet']
-				? (string) $args['text_snippet']
-				: $default_snippet,
-			// Default CTA varies by post type — products get a commerce-flavoured
-			// "Shop Now", everything else gets the neutral "Learn More". The widget
-			// requires a non-empty CTA to clear validation, so we always send one.
-			'cta_text'      => isset( $args['cta_text'] ) && '' !== (string) $args['cta_text']
-				? (string) $args['cta_text']
-				: ( 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More' ),
-			'target_url'    => (string) get_permalink( $post ),
-			'budget'        => array(
-				'mode'     => 'total',
-				'amount'   => (float) ( $args['budget_total'] ?? self::DEFAULT_BUDGET_TOTAL ),
-				'currency' => self::get_site_currency(),
-			),
-			'duration_days' => (int) ( $args['duration_days'] ?? self::DEFAULT_DURATION_DAYS ),
-			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
-			'objective'     => 'VIEWS',
-		);
-
-		if ( isset( $args['goal'] ) && '' !== (string) $args['goal'] ) {
-			$payload['goal'] = (string) $args['goal'];
-		}
-		if ( isset( $args['revision_instruction'] ) && '' !== (string) $args['revision_instruction'] ) {
-			$payload['revision_instruction'] = (string) $args['revision_instruction'];
-		}
-
-		if ( isset( $args['main_image_url'] ) && '' !== (string) $args['main_image_url'] ) {
-			$payload['main_image'] = array(
-				'url'       => (string) $args['main_image_url'],
-				'mime_type' => isset( $args['main_image_mime_type'] ) && '' !== (string) $args['main_image_mime_type']
-					? (string) $args['main_image_mime_type']
-					: 'image/jpeg',
-			);
-		} elseif ( '' !== $featured_image_url ) {
-			$payload['main_image'] = array(
-				'url'       => $featured_image_url,
-				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',
-			);
-		}
-
-		// Optional targeting overrides. Pass-through normalisation only — the
-		// widget resolves country codes to its internal geo records and the
-		// language codes map straight to the language picker. Empty arrays
-		// are dropped so the widget keeps its "all languages / worldwide"
-		// defaults instead of being forced to an empty selection.
-		if ( isset( $args['languages'] ) && is_array( $args['languages'] ) ) {
-			$languages = array_values(
-				array_filter(
-					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
-					static function ( $code ) {
-						return '' !== $code;
-					}
-				)
-			);
-			if ( ! empty( $languages ) ) {
-				$payload['languages'] = $languages;
-			}
-		}
-		if ( isset( $args['countries'] ) && is_array( $args['countries'] ) ) {
-			$countries = array_values(
-				array_filter(
-					array_map( 'strtoupper', array_map( 'strval', $args['countries'] ) ),
-					static function ( $code ) {
-						return 2 === strlen( $code );
-					}
-				)
-			);
-			if ( ! empty( $countries ) ) {
-				$payload['countries'] = $countries;
-			}
-		}
-
-		return $payload;
-	}
-
-	/**
-	 * Build the deep-link the merchant follows to land in the Blaze
-	 * widget with the campaign form pre-populated.
-	 *
-	 * URL shape: `<admin>/tools.php?page=advertising&blaze_prefill=<base64-json>#!/advertising/posts/promote/post-<id>/<hostname>`.
-	 *
-	 * The base path comes from `Blaze::get_campaign_management_url()` so
-	 * we stay aligned with how Blaze opens the promote-post flow today;
-	 * the `blaze_prefill` query param is the Phase 2 addition the widget
-	 * will read on load. The param goes in the query string (not the
-	 * hash) so it reaches the SPA on initial bootstrap reliably.
-	 *
-	 * @param int   $post_id The target post ID.
-	 * @param array $prefill The prefill payload to encode.
-	 * @return string
-	 */
-	private static function build_prefill_url( int $post_id, array $prefill ): string {
-		$base = '';
-		if ( class_exists( '\Automattic\Jetpack\Blaze' ) && method_exists( '\Automattic\Jetpack\Blaze', 'get_campaign_management_url' ) ) {
-			$url_data = Blaze::get_campaign_management_url( $post_id );
-			if ( is_array( $url_data ) && isset( $url_data['link'] ) ) {
-				$base = (string) $url_data['link'];
-			}
-		}
-		if ( '' === $base ) {
-			$base = admin_url( 'tools.php?page=advertising' );
-		}
-
-		$encoded = self::base64url_encode( (string) wp_json_encode( $prefill, JSON_UNESCAPED_SLASHES ) );
-		$param   = 'blaze_prefill=' . rawurlencode( $encoded );
-
-		// Insert the param before the hash if there is one; otherwise append.
-		$hash_pos = strpos( $base, '#' );
-		if ( false === $hash_pos ) {
-			$separator = ( false !== strpos( $base, '?' ) ) ? '&' : '?';
-			return $base . $separator . $param;
-		}
-
-		$pre_hash  = substr( $base, 0, $hash_pos );
-		$hash      = substr( $base, $hash_pos );
-		$separator = ( false !== strpos( $pre_hash, '?' ) ) ? '&' : '?';
-
-		return $pre_hash . $separator . $param . $hash;
-	}
-
-	/**
-	 * URL-safe base64 encode (RFC 4648 §5). Avoids `+` and `/` characters
-	 * that would otherwise need percent-encoding inside a URL.
-	 *
-	 * @param string $input Bytes to encode.
-	 * @return string
-	 */
-	private static function base64url_encode( string $input ): string {
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding a structured prefill payload, not obfuscation.
-		return rtrim( strtr( base64_encode( $input ), '+/', '-_' ), '=' );
-	}
-
-	/**
-	 * Currency code for the prefill payload.
-	 *
-	 * Always USD: the DSP only supports USD for billing, so reading the
-	 * Woo store currency would just produce a misleading number for
-	 * non-USD merchants (the DSP would re-interpret the amount as USD
-	 * regardless). Until the DSP gains multi-currency, normalize here.
-	 *
-	 * @return string ISO 4217 currency code.
-	 */
-	private static function get_site_currency(): string {
-		return 'USD';
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -218,7 +218,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and DSP/IAB interest category IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn' ),
@@ -302,10 +302,10 @@ class Blaze_Abilities extends Registrar {
 						),
 						'interests'            => array(
 							'type'        => 'array',
-							'description' => __( 'Optional DSP page topic / IAB category IDs to target (e.g. ["IAB18", "IAB1_IAB2"]). Use only IDs discovered from the Blaze/DSP targeting options; do not send free-form interest names. Invalid or unsupported IDs are ignored.', 'jetpack-blaze' ),
+							'description' => __( 'Optional Blaze public page topic IDs to target. Supported IDs are the public DSP topic groups: IAB1, IAB8_IAB18, IAB19, IAB5_IAB15, IAB6_IAB7_IAB16, IAB3_IAB4_IAB13, IAB11_IAB12, IAB14_IAB23, IAB17, IAB2_IAB20, IAB10_IAB21_IAB13, and IAB9_IAB22. If a user asks for a bare included IAB category such as fashion (IAB18), use the matching public group ID, e.g. IAB8_IAB18. Do not send free-form interest names. Invalid or unsupported IDs are ignored.', 'jetpack-blaze' ),
 							'items'       => array(
-								'type'    => 'string',
-								'pattern' => '^IAB\\d+(?:_IAB\\d+)*$',
+								'type' => 'string',
+								'enum' => array( 'IAB1', 'IAB8_IAB18', 'IAB19', 'IAB5_IAB15', 'IAB6_IAB7_IAB16', 'IAB3_IAB4_IAB13', 'IAB11_IAB12', 'IAB14_IAB23', 'IAB17', 'IAB2_IAB20', 'IAB10_IAB21_IAB13', 'IAB9_IAB22' ),
 							),
 						),
 					),

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -493,7 +493,9 @@ class Blaze_Abilities extends Registrar {
 			$languages = array_values(
 				array_filter(
 					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
-					static fn( $code ) => '' !== $code
+					static function ( $code ) {
+						return '' !== $code;
+					}
 				)
 			);
 			if ( ! empty( $languages ) ) {
@@ -504,7 +506,9 @@ class Blaze_Abilities extends Registrar {
 			$countries = array_values(
 				array_filter(
 					array_map( 'strtoupper', array_map( 'strval', $args['countries'] ) ),
-					static fn( $code ) => 2 === strlen( $code )
+					static function ( $code ) {
+						return 2 === strlen( $code );
+					}
 				)
 			);
 			if ( ! empty( $countries ) ) {

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -256,6 +256,24 @@ class Blaze_Abilities extends Registrar {
 							'type'        => 'string',
 							'description' => __( 'Optional ad copy override. Defaults to the post excerpt (or first ~200 chars of content).', 'jetpack-blaze' ),
 						),
+						'languages'     => array(
+							'type'        => 'array',
+							'description' => __( 'Optional ISO 639-1 language codes to target (e.g. ["en", "es"]). Defaults to all languages when omitted; pass a non-empty array to narrow targeting.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'      => 'string',
+								'minLength' => 2,
+								'maxLength' => 5,
+							),
+						),
+						'countries'     => array(
+							'type'        => 'array',
+							'description' => __( 'Optional ISO 3166-1 alpha-2 country codes to target (e.g. ["US", "GB"]). Defaults to worldwide when omitted; pass a non-empty array to limit reach to those countries.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'      => 'string',
+								'minLength' => 2,
+								'maxLength' => 2,
+							),
+						),
 					),
 					'additionalProperties' => false,
 				),
@@ -464,6 +482,34 @@ class Blaze_Abilities extends Registrar {
 				'url'       => $featured_image_url,
 				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',
 			);
+		}
+
+		// Optional targeting overrides. Pass-through normalisation only — the
+		// widget resolves country codes to its internal geo records and the
+		// language codes map straight to the language picker. Empty arrays
+		// are dropped so the widget keeps its "all languages / worldwide"
+		// defaults instead of being forced to an empty selection.
+		if ( isset( $args['languages'] ) && is_array( $args['languages'] ) ) {
+			$languages = array_values(
+				array_filter(
+					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
+					static fn( $code ) => '' !== $code
+				)
+			);
+			if ( ! empty( $languages ) ) {
+				$payload['languages'] = $languages;
+			}
+		}
+		if ( isset( $args['countries'] ) && is_array( $args['countries'] ) ) {
+			$countries = array_values(
+				array_filter(
+					array_map( 'strtoupper', array_map( 'strval', $args['countries'] ) ),
+					static fn( $code ) => 2 === strlen( $code )
+				)
+			);
+			if ( ! empty( $countries ) ) {
+				$payload['countries'] = $countries;
+			}
 		}
 
 		return $payload;

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -224,11 +224,26 @@ class Blaze_Abilities extends Registrar {
 				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
-					'required'             => array( 'target_urn' ),
+					'required'             => array(),
 					'properties'           => array(
 						'target_urn'           => array(
 							'type'        => 'string',
-							'description' => __( 'The URN of the post or product to promote (e.g. urn:wpcom:post:123456:42).', 'jetpack-blaze' ),
+							'description' => __( 'The canonical URN of the post or product to promote (e.g. urn:wpcom:post:123456:42). Advanced callers may pass this directly; other callers should use site_url plus post_id or site_url plus product_id.', 'jetpack-blaze' ),
+						),
+						'site_url'             => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Optional public WordPress.com site URL or domain used with post_id or product_id when target_urn is not known.', 'jetpack-blaze' ),
+						),
+						'post_id'              => array(
+							'type'        => 'integer',
+							'description' => __( 'Optional WordPress post ID to promote with site_url when target_urn is not known. Do not send post_id and product_id together.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'product_id'           => array(
+							'type'        => 'integer',
+							'description' => __( 'Optional WooCommerce product_id to promote with site_url when target_urn is not known. This is normalized into the canonical post target URN. Do not send post_id and product_id together.', 'jetpack-blaze' ),
+							'minimum'     => 1,
 						),
 						'goal'                 => array(
 							'type'        => 'string',
@@ -1387,7 +1402,12 @@ class Blaze_Abilities extends Registrar {
 	private static function get_prepare_campaign_failure_category( \WP_Error $error ): string {
 		switch ( $error->get_error_code() ) {
 			case 'blaze_invalid_target_urn':
+			case 'blaze_missing_target':
+			case 'blaze_ambiguous_target':
 				return 'invalid_target';
+			case 'blaze_site_lookup_failed':
+			case 'blaze_site_not_connected':
+				return 'site_lookup_failed';
 			case 'blaze_post_not_found':
 				return 'target_not_found';
 			case 'blaze_setup_required':

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -506,8 +506,25 @@ class Blaze_Abilities extends Registrar {
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
-					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'message', 'campaign_preview', 'forecast_summary', 'intent', 'forecast', 'assumptions', 'recommendations', 'prefill_url', 'prefill' ),
+					'description' => __( 'Chat-ready prepared campaign package plus a deep-link to the Blaze UI for fallback review and submit.', 'jetpack-blaze' ),
+					'required'    => array(
+						'status',
+						'message',
+						'campaign_preview',
+						'forecast_summary',
+						'prepared_campaign',
+						'rendered_preview',
+						'campaign_summary',
+						'fallback_url',
+						'submit_eligibility',
+						'material_edit_policy',
+						'intent',
+						'forecast',
+						'assumptions',
+						'recommendations',
+						'prefill_url',
+						'prefill',
+					),
 					'properties'  => array(
 						'status'           => array(
 							'type'        => 'string',
@@ -555,6 +572,83 @@ class Blaze_Abilities extends Registrar {
 						'forecast_summary' => array(
 							'type'        => 'string',
 							'description' => __( 'Human-readable forecast summary for the recommended option, or a fallback note when forecasts are unavailable.', 'jetpack-blaze' ),
+						),
+						'prepared_campaign' => array(
+							'type'        => 'object',
+							'description' => __( 'Immutable prepared package identity. Later submit actions must use this identity so the merchant approves the exact package being submitted.', 'jetpack-blaze' ),
+							'required'    => array( 'id', 'hash', 'version' ),
+							'properties'  => array(
+								'id'      => array(
+									'type' => 'string',
+								),
+								'hash'    => array(
+									'type' => 'string',
+								),
+								'version' => array(
+									'type' => 'string',
+								),
+							),
+						),
+						'rendered_preview'  => array(
+							'type'        => 'object',
+							'description' => __( 'Blaze-owned rendered preview artifact for chat clients. Clients should render this instead of composing ad HTML themselves.', 'jetpack-blaze' ),
+							'required'    => array( 'type', 'html' ),
+							'properties'  => array(
+								'type' => array(
+									'type' => 'string',
+									'enum' => array( 'html' ),
+								),
+								'html' => array(
+									'type' => 'string',
+								),
+							),
+						),
+						'campaign_summary' => array(
+							'type'        => 'object',
+							'description' => __( 'Structured campaign summary for chat display: destination, creative, budget, cadence, schedule, targeting, and source context.', 'jetpack-blaze' ),
+							'required'    => array(
+								'destination',
+								'creative',
+								'budget',
+								'cadence',
+								'schedule',
+								'targeting_summary',
+								'source_context',
+							),
+						),
+						'fallback_url'     => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Blaze widget or dashboard URL that can review and submit this prepared package when chat-native submit is unavailable or the merchant wants the full UI.', 'jetpack-blaze' ),
+						),
+						'submit_eligibility' => array(
+							'type'        => 'object',
+							'description' => __( 'Hints that tell chat clients whether chat-native submit can proceed or whether the merchant should use fallback_url.', 'jetpack-blaze' ),
+							'required'    => array( 'chat_native_submit', 'payment_method', 'reason', 'fallback_url' ),
+							'properties'  => array(
+								'chat_native_submit' => array(
+									'type' => 'boolean',
+								),
+								'payment_method'     => array(
+									'type' => array( 'string', 'boolean' ),
+								),
+								'reason'             => array(
+									'type' => array( 'string', 'null' ),
+								),
+								'fallback_url'       => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
+							),
+						),
+						'approval_block'   => array(
+							'type'        => 'object',
+							'description' => __( 'Approval wording keys and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
+						),
+						'material_edit_policy' => array(
+							'type'        => 'object',
+							'description' => __( 'Fields that require a new prepare-campaign call before approval or submit because they change the prepared package identity.', 'jetpack-blaze' ),
+							'required'    => array( 'requires_reprepare', 'material_fields', 'message' ),
 						),
 						'intent'           => array(
 							'type'        => 'string',
@@ -1583,7 +1677,18 @@ class Blaze_Abilities extends Registrar {
 			// Future write-path guardrails (per-session spend ceiling, Picard
 			// moderation gating) plug in here. Tracked separately as ADS-989.
 
-			$result = call_user_func( $original_callback, $input );
+			$adds_saved_payment_hint = self::ABILITY_PREPARE_CAMPAIGN === $ability_name;
+			if ( $adds_saved_payment_hint ) {
+				add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+			}
+
+			try {
+				$result = call_user_func( $original_callback, $input );
+			} finally {
+				if ( $adds_saved_payment_hint ) {
+					remove_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+				}
+			}
 
 			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
 				self::record_prepare_campaign_event( is_wp_error( $result ) ? 'failed' : 'succeeded', is_array( $input ) ? $input : array(), $result );

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -888,16 +888,16 @@ class Blaze_Abilities extends Registrar {
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
-					'description' => __( 'DSP submit response decorated for chat. Success means the campaign was submitted and is pending approval/moderation, not already running.', 'jetpack-blaze' ),
-					'required'    => array( 'status', 'message', 'campaign_status', 'dashboard_url', 'widget_url', 'selected_payment_method', 'budget', 'source_tracking', 'submit_response' ),
+					'description' => __( 'DSP submit response decorated for chat. Success means the campaign was submitted and is pending approval/moderation, not already running. Failure means the request did not create a campaign.', 'jetpack-blaze' ),
+					'required'    => array( 'status', 'message' ),
 					'properties'  => array(
 						'status'                  => array(
 							'type' => 'string',
-							'enum' => array( 'submitted_pending_approval' ),
+							'enum' => array( 'submitted_pending_approval', 'submit_failed' ),
 						),
 						'message'                 => array(
 							'type'        => 'string',
-							'description' => __( 'Human-readable pending confirmation for chat clients.', 'jetpack-blaze' ),
+							'description' => __( 'Human-readable submit confirmation or failure for chat clients.', 'jetpack-blaze' ),
 						),
 						'campaign_status'         => array(
 							'type' => 'string',
@@ -919,6 +919,24 @@ class Blaze_Abilities extends Registrar {
 						),
 						'submit_response'         => array(
 							'type' => 'object',
+						),
+						'error'                   => array(
+							'type'        => 'object',
+							'description' => __( 'Structured submit failure details when status is submit_failed.', 'jetpack-blaze' ),
+							'properties'  => array(
+								'code'    => array(
+									'type' => 'string',
+								),
+								'message' => array(
+									'type' => 'string',
+								),
+								'status'  => array(
+									'type' => array( 'integer', 'null' ),
+								),
+								'details' => array(
+									'type' => 'object',
+								),
+							),
 						),
 					),
 				),

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -555,7 +555,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'message'              => array(
 							'type'        => 'string',
-							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat before the review link; it includes a campaign preview table and the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
+							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat. It includes a campaign preview table and a Markdown preview link; the raw prefill_url stays in structured fields to avoid streaming partial long links.', 'jetpack-blaze' ),
 						),
 						'campaign_preview'     => array(
 							'type'        => 'object',
@@ -1955,9 +1955,16 @@ class Blaze_Abilities extends Registrar {
 			}
 		}
 
-		$message .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
-		$message .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
-		$message .= "\n" . __( 'Review URL:', 'jetpack-blaze' ) . ' ' . (string) ( $proposal['prefill_url'] ?? '' );
+		$message    .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
+		$message    .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
+		$preview_url = (string) ( $proposal['prefill_url'] ?? '' );
+		if ( '' !== $preview_url ) {
+			$message .= "\n" . sprintf(
+				/* translators: %s: Markdown link to preview the campaign in Blaze. */
+				__( 'Preview link: %s', 'jetpack-blaze' ),
+				'[Preview campaign in Blaze](' . $preview_url . ')'
+			);
+		}
 
 		if ( ! empty( $proposal['next_action'] ) && is_array( $proposal['next_action'] ) ) {
 			$message .= "\n\n" . __( 'Chat submit is available.', 'jetpack-blaze' );

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -35,10 +35,11 @@ use WP_REST_Request;
 class Blaze_Abilities extends Registrar {
 
 	const CATEGORY_SLUG                = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS       = 'blaze-ads/list-campaigns';
-	const ABILITY_GET_CAMPAIGN_STATS   = 'blaze-ads/get-campaign-stats';
-	const ABILITY_PREPARE_CAMPAIGN     = 'blaze-ads/prepare-campaign';
-	const ABILITY_STOP_CAMPAIGN        = 'blaze-ads/stop-campaign';
+	const ABILITY_LIST_CAMPAIGNS           = 'blaze-ads/list-campaigns';
+	const ABILITY_GET_CAMPAIGN_STATS       = 'blaze-ads/get-campaign-stats';
+	const ABILITY_PREPARE_CAMPAIGN         = 'blaze-ads/prepare-campaign';
+	const ABILITY_SUBMIT_PREPARED_CAMPAIGN = 'blaze-ads/submit-prepared-campaign';
+	const ABILITY_STOP_CAMPAIGN            = 'blaze-ads/stop-campaign';
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
@@ -47,6 +48,7 @@ class Blaze_Abilities extends Registrar {
 		self::ABILITY_LIST_CAMPAIGNS,
 		self::ABILITY_GET_CAMPAIGN_STATS,
 		self::ABILITY_PREPARE_CAMPAIGN,
+		self::ABILITY_SUBMIT_PREPARED_CAMPAIGN,
 		self::ABILITY_STOP_CAMPAIGN,
 	);
 
@@ -143,6 +145,21 @@ class Blaze_Abilities extends Registrar {
 			 * @param bool $enabled Whether to register the prepare-campaign ability. Default true.
 			 */
 			if ( ! apply_filters( 'blaze_abilities_prepare_campaign_enabled', true ) ) {
+				return false;
+			}
+		}
+		if ( self::ABILITY_SUBMIT_PREPARED_CAMPAIGN === $slug ) {
+			/**
+			 * Filters whether the Blaze `submit-prepared-campaign` write ability is registered.
+			 *
+			 * Default true. Return false to keep the paid chat submit path out
+			 * of the registry without hiding prepare/list/stats/stop.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $enabled Whether to register submit-prepared-campaign. Default true.
+			 */
+			if ( ! apply_filters( 'blaze_abilities_submit_prepared_campaign_enabled', true ) ) {
 				return false;
 			}
 		}
@@ -517,6 +534,7 @@ class Blaze_Abilities extends Registrar {
 						'campaign_preview',
 						'forecast_summary',
 						'prepared_campaign',
+						'submit_package',
 						'rendered_preview',
 						'campaign_summary',
 						'fallback_url',
@@ -589,6 +607,28 @@ class Blaze_Abilities extends Registrar {
 									'type' => 'string',
 								),
 								'version' => array(
+									'type' => 'string',
+								),
+							),
+						),
+						'submit_package'   => array(
+							'type'        => 'object',
+							'description' => __( 'Exact DSP submit payload and policy versions for the submit-prepared-campaign ability. Clients must add the structured approval event after explicit user approval; ordinary chat text is not approval.', 'jetpack-blaze' ),
+							'required'    => array( 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version' ),
+							'properties'  => array(
+								'prepared_package_id' => array(
+									'type' => 'string',
+								),
+								'prepared_campaign_hash' => array(
+									'type' => 'string',
+								),
+								'prepared_campaign' => array(
+									'type' => 'object',
+								),
+								'accepted_terms_version' => array(
+									'type' => 'string',
+								),
+								'accepted_policy_version' => array(
 									'type' => 'string',
 								),
 							),
@@ -804,15 +844,100 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
-			self::ABILITY_STOP_CAMPAIGN    => array(
-				'label'               => __( 'Stop a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Preview or confirm stopping delivery for an existing Blaze campaign. Pass the numeric DSP campaign_id. By default this returns the current campaign context and consequence text without calling the DSP stop endpoint. Set confirm to true only after the merchant explicitly confirms they want to stop serving; confirm mode re-fetches campaign context and delegates stop eligibility to the existing DSP stop endpoint.', 'jetpack-blaze' ),
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'required'             => array( 'campaign_id' ),
-					'properties'           => array(
-						'campaign_id' => array(
-							'type'        => 'integer',
+			self::ABILITY_SUBMIT_PREPARED_CAMPAIGN => array(
+					'label'               => __( 'Submit an approved prepared Blaze campaign', 'jetpack-blaze' ),
+					'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as “looks good”; call it only after the client has rendered the exact approval terms from prepare-campaign and captured a structured approval event for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'required'             => array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ),
+						'properties'           => array(
+							'idempotency_key'          => array(
+								'type'        => 'string',
+								'description' => __( 'Durable idempotency key from the prepared package approval event.', 'jetpack-blaze' ),
+							),
+							'prepared_package_id'      => array(
+								'type'        => 'string',
+								'description' => __( 'Prepared package ID returned by prepare-campaign.', 'jetpack-blaze' ),
+							),
+							'prepared_campaign_hash'   => array(
+								'type'        => 'string',
+								'description' => __( 'Stable hash of the exact prepared_campaign payload returned by prepare-campaign.', 'jetpack-blaze' ),
+							),
+							'prepared_campaign'        => array(
+								'type'        => 'object',
+								'description' => __( 'Exact DSP campaign payload returned in prepare-campaign submit_package.prepared_campaign. Do not edit this without preparing a new campaign.', 'jetpack-blaze' ),
+							),
+							'accepted_terms_version'   => array(
+								'type'        => 'string',
+								'description' => __( 'Terms version rendered for explicit approval.', 'jetpack-blaze' ),
+							),
+							'accepted_policy_version'  => array(
+								'type'        => 'string',
+								'description' => __( 'Advertising policy version rendered for explicit approval.', 'jetpack-blaze' ),
+							),
+							'approval'                 => array(
+								'type'        => 'object',
+								'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval.', 'jetpack-blaze' ),
+							),
+						),
+						'additionalProperties' => false,
+					),
+					'output_schema'       => array(
+						'type'        => 'object',
+						'description' => __( 'DSP submit response decorated for chat. Success means the campaign was submitted and is pending approval/moderation, not already running.', 'jetpack-blaze' ),
+						'required'    => array( 'status', 'message', 'campaign_status', 'dashboard_url', 'widget_url', 'selected_payment_method', 'budget', 'source_tracking', 'submit_response' ),
+						'properties'  => array(
+							'status'                  => array(
+								'type' => 'string',
+								'enum' => array( 'submitted_pending_approval' ),
+							),
+							'message'                 => array(
+								'type'        => 'string',
+								'description' => __( 'Human-readable pending confirmation for chat clients.', 'jetpack-blaze' ),
+							),
+							'campaign_status'         => array(
+								'type' => 'string',
+							),
+							'dashboard_url'           => array(
+								'type' => 'string',
+							),
+							'widget_url'              => array(
+								'type' => 'string',
+							),
+							'selected_payment_method' => array(
+								'type' => 'object',
+							),
+							'budget'                  => array(
+								'type' => 'object',
+							),
+							'source_tracking'         => array(
+								'type' => 'object',
+							),
+							'submit_response'         => array(
+								'type' => 'object',
+							),
+						),
+					),
+					'execute_callback'    => array( __CLASS__, 'submit_prepared_campaign' ),
+					'permission_callback' => array( __CLASS__, 'permission_callback' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => true,
+							'idempotent'  => true,
+						),
+					),
+				),
+			self::ABILITY_STOP_CAMPAIGN        => array(
+					'label'               => __( 'Stop a Blaze campaign', 'jetpack-blaze' ),
+					'description'         => __( 'Preview or confirm stopping delivery for an existing Blaze campaign. Pass the numeric DSP campaign_id. By default this returns the current campaign context and consequence text without calling the DSP stop endpoint. Set confirm to true only after the merchant explicitly confirms they want to stop serving; confirm mode re-fetches campaign context and delegates stop eligibility to the existing DSP stop endpoint.', 'jetpack-blaze' ),
+					'input_schema'        => array(
+						'type'                 => 'object',
+						'required'             => array( 'campaign_id' ),
+						'properties'           => array(
+							'campaign_id' => array(
+								'type'        => 'integer',
 							'description' => __( 'Numeric DSP campaign ID to stop.', 'jetpack-blaze' ),
 							'minimum'     => 1,
 						),
@@ -1104,6 +1229,91 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
+	 * Submit an explicitly approved prepared campaign through the DSP proxy.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function submit_prepared_campaign( $args = array() ) {
+		$args = is_array( $args ) ? $args : array();
+
+		foreach ( array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ) as $field ) {
+			if ( ! array_key_exists( $field, $args ) || null === $args[ $field ] || '' === $args[ $field ] ) {
+				return new \WP_Error(
+					'blaze_submit_prepared_campaign_missing_field',
+					sprintf(
+						/* translators: %s: missing submit field name. */
+						__( 'The approved prepared campaign submit request is missing %s.', 'jetpack-blaze' ),
+						$field
+					),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		if ( ! is_array( $args['prepared_campaign'] ) || ! is_array( $args['approval'] ) ) {
+			return new \WP_Error(
+				'blaze_submit_prepared_campaign_invalid_payload',
+				__( 'The prepared campaign and approval event must be structured objects.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$route = self::get_dsp_submit_prepared_campaign_route();
+		if ( is_wp_error( $route ) ) {
+			return $route;
+		}
+
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_body_params(
+			array(
+				'idempotency_key'          => (string) $args['idempotency_key'],
+				'prepared_package_id'      => (string) $args['prepared_package_id'],
+				'prepared_campaign_hash'   => (string) $args['prepared_campaign_hash'],
+				'prepared_campaign'        => $args['prepared_campaign'],
+				'accepted_terms_version'   => (string) $args['accepted_terms_version'],
+				'accepted_policy_version'  => (string) $args['accepted_policy_version'],
+				'approval'                 => self::build_dsp_submit_approval_event( $args ),
+			)
+		);
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$status = $response->get_status();
+		$data   = $response->get_data();
+		if ( $status >= 400 ) {
+			return self::rest_response_to_wp_error( is_array( $data ) ? $data : array(), $status );
+		}
+
+		$submit_response = is_array( $data ) ? $data : array();
+		return self::format_submit_prepared_campaign_response( $submit_response );
+	}
+
+	/**
+	 * Reduce Blaze's rich approval event to the DSP submit contract.
+	 *
+	 * @param array $args Submit ability input.
+	 * @return array
+	 */
+	private static function build_dsp_submit_approval_event( array $args ): array {
+		$approval = isset( $args['approval'] ) && is_array( $args['approval'] ) ? $args['approval'] : array();
+
+		return array(
+			'type'                    => 'prepared_campaign.approved',
+			'prepared_package_id'     => isset( $approval['prepared_package_id'] ) ? (string) $approval['prepared_package_id'] : (string) $args['prepared_package_id'],
+			'prepared_campaign_hash'  => isset( $approval['prepared_campaign_hash'] ) ? (string) $approval['prepared_campaign_hash'] : (string) $args['prepared_campaign_hash'],
+			'idempotency_key'         => isset( $approval['idempotency_key'] ) ? (string) $approval['idempotency_key'] : (string) $args['idempotency_key'],
+			'payment_method_id'       => isset( $approval['payment_method_id'] ) ? (string) $approval['payment_method_id'] : self::get_first_string_value( $args['prepared_campaign'], array( 'payment_method_id' ) ),
+			'accepted_terms_version'  => isset( $approval['accepted_terms_version'] ) ? (string) $approval['accepted_terms_version'] : (string) $args['accepted_terms_version'],
+			'accepted_policy_version' => isset( $approval['accepted_policy_version'] ) ? (string) $approval['accepted_policy_version'] : (string) $args['accepted_policy_version'],
+			'approved_at'             => isset( $approval['approved_at'] ) ? (string) $approval['approved_at'] : '',
+		);
+	}
+
+	/**
 	 * Preview or confirm stopping a Blaze campaign from serving.
 	 *
 	 * Preview mode fetches current campaign context and returns consequence
@@ -1190,6 +1400,20 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
+	 * Build the local REST proxy route for prepared campaign submit.
+	 *
+	 * @return string|\WP_Error
+	 */
+	private static function get_dsp_submit_prepared_campaign_route() {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		return sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns/submit-prepared-campaign', $site_id );
+	}
+
+	/**
 	 * Build the local REST proxy route for a DSP campaign endpoint.
 	 *
 	 * @param int    $campaign_id Numeric DSP campaign ID.
@@ -1244,11 +1468,64 @@ class Blaze_Abilities extends Registrar {
 			}
 		}
 		if ( '' === $message ) {
-			$message = __( 'The Blaze DSP API could not stop this campaign.', 'jetpack-blaze' );
-		}
+				$message = __( 'The Blaze DSP API could not complete this campaign request.', 'jetpack-blaze' );
+			}
 
 		$data['status'] = $status;
 		return new \WP_Error( $code, $message, $data );
+	}
+
+	/**
+	 * Decorate DSP submit response with chat-safe pending confirmation copy.
+	 *
+	 * @param array $submit_response Raw DSP submit response.
+	 * @return array
+	 */
+	private static function format_submit_prepared_campaign_response( array $submit_response ): array {
+		$dashboard_url = self::get_first_string_value( $submit_response, array( 'dashboard_url', 'widget_url' ) );
+		$widget_url    = self::get_first_string_value( $submit_response, array( 'widget_url', 'dashboard_url' ) );
+
+		return array(
+			'status'                  => 'submitted_pending_approval',
+			'message'                 => self::build_submit_prepared_campaign_message( $submit_response, $dashboard_url ),
+			'campaign_status'         => self::get_first_string_value( $submit_response, array( 'campaign_status', 'status' ) ),
+			'dashboard_url'           => $dashboard_url,
+			'widget_url'              => $widget_url,
+			'selected_payment_method' => isset( $submit_response['selected_payment_method'] ) && is_array( $submit_response['selected_payment_method'] ) ? $submit_response['selected_payment_method'] : array(),
+			'budget'                  => isset( $submit_response['budget'] ) && is_array( $submit_response['budget'] ) ? $submit_response['budget'] : array(),
+			'source_tracking'         => isset( $submit_response['source_tracking'] ) && is_array( $submit_response['source_tracking'] ) ? $submit_response['source_tracking'] : array(),
+			'submit_response'         => $submit_response,
+		);
+	}
+
+	/**
+	 * Build chat-facing submit confirmation.
+	 *
+	 * @param array  $submit_response Raw DSP submit response.
+	 * @param string $dashboard_url   Dashboard URL, when available.
+	 * @return string
+	 */
+	private static function build_submit_prepared_campaign_message( array $submit_response, string $dashboard_url ): string {
+		$campaign_id = self::get_first_string_value( $submit_response, array( 'id', 'campaign_id' ) );
+
+		$message = __( 'Your Blaze campaign has been submitted and is pending approval/moderation. It is not running yet.', 'jetpack-blaze' );
+		if ( '' !== $campaign_id ) {
+			$message .= "\n\n" . sprintf(
+				/* translators: %s: campaign ID. */
+				__( 'Campaign ID: %s', 'jetpack-blaze' ),
+				$campaign_id
+			);
+		}
+		if ( '' !== $dashboard_url ) {
+			$message .= "\n\n" . sprintf(
+				/* translators: %s: Blaze dashboard URL. */
+				__( 'You can view it in Blaze here: %s', 'jetpack-blaze' ),
+				$dashboard_url
+			);
+		}
+
+		$message .= "\n\n" . __( 'You should also receive the normal email confirmation for this campaign.', 'jetpack-blaze' );
+		return $message;
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -412,7 +412,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_PREPARE_CAMPAIGN         => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns chat-ready preview, approval, and fallback data. If submit_eligibility.chat_native_submit is true, chat-native approval/submit is the default continuation: when the merchant says natural language like "Looks good, submit it" or "go ahead and launch it", render the pasteable approval message from approval_block/next_action and wait for that explicit approval before calling submit-prepared-campaign. The Blaze preview/widget link may still be shown for optional review, but it is not the primary path for eligible users. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. Do not ask merchants to paste package hashes, idempotency keys, prepared package IDs, or tool names.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array(),
@@ -527,7 +527,7 @@ class Blaze_Abilities extends Registrar {
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
-					'description' => __( 'Chat-ready prepared campaign package plus a deep-link to the Blaze UI for fallback review and submit.', 'jetpack-blaze' ),
+					'description' => __( 'Chat-ready prepared campaign package with preview, optional Blaze UI fallback, and chat-native approval next action when eligible.', 'jetpack-blaze' ),
 					'required'    => array(
 						'status',
 						'message',
@@ -703,7 +703,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'approval_block'       => array(
 							'type'        => 'object',
-							'description' => __( 'Approval wording keys and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
+							'description' => __( 'Approval wording keys, pasteable approval message, and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
 							'required'    => array(
 								'prepared_campaign_id',
 								'prepared_campaign_hash',
@@ -711,6 +711,7 @@ class Blaze_Abilities extends Registrar {
 								'body_key',
 								'confirmation_label_key',
 								'approval_statement',
+								'pasteable_approval_message',
 								'approval_contract',
 								'approval_event',
 								'approval_event_required_fields',
@@ -743,6 +744,10 @@ class Blaze_Abilities extends Registrar {
 									'type'        => 'string',
 									'description' => __( 'Canonical fallback approval wording owned by Blaze.', 'jetpack-blaze' ),
 								),
+								'pasteable_approval_message' => array(
+									'type'        => 'string',
+									'description' => __( 'Plain-language approval sentence the merchant can paste or confirm after reviewing live prepared values. It includes campaign identity, maximum charge, currency, payment method summary, Terms of Service, and Advertising Policy acknowledgement, without exposing package hashes or idempotency keys.', 'jetpack-blaze' ),
+								),
 								'approval_contract'        => array(
 									'type'        => 'object',
 									'description' => __( 'Language-independent approval contract containing the exact package identity, terms/policy versions, charge terms, cancellation wording version, payment method, user, and site.', 'jetpack-blaze' ),
@@ -767,6 +772,51 @@ class Blaze_Abilities extends Registrar {
 								),
 								'requires_reprepare_edits' => array(
 									'type' => 'boolean',
+								),
+							),
+						),
+						'next_action'          => array(
+							'type'        => 'object',
+							'description' => __( 'Default next action for eligible prepared campaigns. When present, chat-native approval/submit is the default path, and the preview URL is optional review rather than widget-only handoff.', 'jetpack-blaze' ),
+							'required'    => array(
+								'type',
+								'default_flow',
+								'chat_native_submit',
+								'requires_explicit_approval',
+								'pasteable_approval_message',
+								'optional_preview_url',
+							),
+							'properties'  => array(
+								'type'                   => array(
+									'type'        => 'string',
+									'description' => __( 'Stable action type. request_explicit_approval means ask the merchant to paste or confirm the approval message before submit.', 'jetpack-blaze' ),
+									'enum'        => array( 'request_explicit_approval' ),
+								),
+								'default_flow'           => array(
+									'type'        => 'string',
+									'description' => __( 'chat_native_submit means the client should continue toward in-chat approval and submit by default.', 'jetpack-blaze' ),
+									'enum'        => array( 'chat_native_submit' ),
+								),
+								'chat_native_submit'     => array(
+									'type' => 'boolean',
+								),
+								'requires_explicit_approval' => array(
+									'type' => 'boolean',
+								),
+								'pasteable_approval_message' => array(
+									'type'        => 'string',
+									'description' => __( 'Approval message to render when the merchant says "submit it", "launch it", "go ahead", or similar plain-language intent.', 'jetpack-blaze' ),
+								),
+								'optional_preview_url'   => array(
+									'type'        => 'string',
+									'format'      => 'uri',
+									'description' => __( 'optional review URL for merchants who want to inspect the campaign in Blaze before approving in chat.', 'jetpack-blaze' ),
+								),
+								'optional_preview_label' => array(
+									'type' => 'string',
+								),
+								'message'                => array(
+									'type' => 'string',
 								),
 							),
 						),
@@ -850,7 +900,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_SUBMIT_PREPARED_CAMPAIGN => array(
 				'label'               => __( 'Submit an approved prepared Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as “looks good”; call it only after the client has rendered the exact approval terms from prepare-campaign and captured a structured approval event for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
+				'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as "looks good"; use that phrase to render the pasteable approval message instead. Call this only after the client has rendered the exact approval terms from prepare-campaign and captured a pasted or confirmed approval message, then built a structured approval event internally for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ),
@@ -881,7 +931,7 @@ class Blaze_Abilities extends Registrar {
 						),
 						'approval'                => array(
 							'type'        => 'object',
-							'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval.', 'jetpack-blaze' ),
+							'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval, but a merchant pasted or confirmed the rendered pasteable approval message after seeing the live terms is valid approval input for the client to convert into this event.', 'jetpack-blaze' ),
 						),
 					),
 					'additionalProperties' => false,
@@ -1898,6 +1948,13 @@ class Blaze_Abilities extends Registrar {
 		$message .= self::format_text_list( __( 'Assumptions:', 'jetpack-blaze' ), $proposal['assumptions'] ?? array() );
 		$message .= self::format_text_list( __( 'Recommendations:', 'jetpack-blaze' ), $proposal['recommendations'] ?? array() );
 		$message .= "\n" . __( 'Review URL:', 'jetpack-blaze' ) . ' ' . (string) ( $proposal['prefill_url'] ?? '' );
+
+		if ( ! empty( $proposal['next_action'] ) && is_array( $proposal['next_action'] ) ) {
+			$message .= "\n\n" . __( 'Chat submit is available.', 'jetpack-blaze' );
+			$message .= ' ' . __( 'You can preview it in Blaze if you want, but you can also approve and submit from chat.', 'jetpack-blaze' );
+			$message .= "\n" . __( 'To submit from chat, paste this approval message:', 'jetpack-blaze' ) . "\n";
+			$message .= (string) ( $proposal['next_action']['pasteable_approval_message'] ?? '' );
+		}
 
 		return $message;
 	}

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -2073,7 +2073,7 @@ class Blaze_Abilities extends Registrar {
 			return null;
 		}
 
-		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/payments/methods', (int) $site_id );
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/payment-methods', (int) $site_id );
 		$request = new WP_REST_Request( 'GET', $route );
 
 		$response = rest_do_request( $request );

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -2236,12 +2236,77 @@ class Blaze_Abilities extends Registrar {
 		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/payment-methods', (int) $site_id );
 		$request = new WP_REST_Request( 'GET', $route );
 
-		$response = rest_do_request( $request );
+		$response = self::do_prepare_campaign_payment_methods_request( $request );
 		if ( $response->is_error() ) {
 			return null;
 		}
 
 		return self::extract_payment_methods_response( $response->get_data() );
+	}
+
+	/**
+	 * Execute the internal payment-method proxy request with a site admin user
+	 * when ability execution has no current WordPress user.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response REST response.
+	 */
+	private static function do_prepare_campaign_payment_methods_request( WP_REST_Request $request ) {
+		if ( get_current_user_id() || current_user_can( 'manage_options' ) ) {
+			return rest_do_request( $request );
+		}
+
+		/**
+		 * Filters the admin-capable user used for internal prepare-campaign
+		 * payment-method proxy calls when ability execution has no current user.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $fallback_user_id Fallback user ID.
+		 */
+		$fallback_user_id = (int) apply_filters( 'jetpack_blaze_prepare_campaign_fallback_user_id', self::get_prepare_campaign_fallback_user_id() );
+		if ( ! $fallback_user_id ) {
+			return rest_do_request( $request );
+		}
+
+		$previous_user_id = get_current_user_id();
+		wp_set_current_user( $fallback_user_id );
+
+		try {
+			return rest_do_request( $request );
+		} finally {
+			wp_set_current_user( $previous_user_id );
+		}
+	}
+
+	/**
+	 * Find an admin-capable user for internal ability-owned REST proxy calls.
+	 *
+	 * @return int User ID, or 0 when unavailable.
+	 */
+	private static function get_prepare_campaign_fallback_user_id(): int {
+		$users = get_users(
+			array(
+				'blog_id' => 0,
+				'fields'  => 'ID',
+			)
+		);
+
+		if ( empty( $users ) ) {
+			return 0;
+		}
+
+		$previous_user_id = get_current_user_id();
+		foreach ( $users as $user_id ) {
+			wp_set_current_user( (int) $user_id );
+			if ( current_user_can( 'manage_options' ) ) {
+				wp_set_current_user( $previous_user_id );
+				return (int) $user_id;
+			}
+		}
+		wp_set_current_user( $previous_user_id );
+
+		return 0;
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -784,6 +784,7 @@ class Blaze_Abilities extends Registrar {
 								'chat_native_submit',
 								'requires_explicit_approval',
 								'pasteable_approval_message',
+								'plain_language_submit_intents',
 								'optional_preview_url',
 							),
 							'properties'  => array(
@@ -806,6 +807,13 @@ class Blaze_Abilities extends Registrar {
 								'pasteable_approval_message' => array(
 									'type'        => 'string',
 									'description' => __( 'Approval message to render when the merchant says "submit it", "launch it", "go ahead", or similar plain-language intent.', 'jetpack-blaze' ),
+								),
+								'plain_language_submit_intents' => array(
+									'type'        => 'array',
+									'description' => __( 'Plain-language merchant phrases such as "submit it", "launch it", "go ahead", or "looks good" that mean the client should render the pasteable approval message, not refuse or send the merchant to the widget-only flow.', 'jetpack-blaze' ),
+									'items'       => array(
+										'type' => 'string',
+									),
 								),
 								'optional_preview_url'   => array(
 									'type'        => 'string',
@@ -1872,7 +1880,9 @@ class Blaze_Abilities extends Registrar {
 	private static function format_prepare_campaign_message( array $proposal ): string {
 		$preview          = self::build_campaign_preview( $proposal );
 		$forecast_summary = self::build_forecast_summary( $proposal );
-		$message          = __( 'Campaign proposal prepared for review in Blaze.', 'jetpack-blaze' ) . "\n\n";
+		$message          = ! empty( $proposal['next_action'] ) && is_array( $proposal['next_action'] )
+			? __( 'Campaign proposal prepared. Chat submit is available after explicit approval.', 'jetpack-blaze' ) . "\n\n"
+			: __( 'Campaign proposal prepared for review in Blaze.', 'jetpack-blaze' ) . "\n\n";
 
 		$message .= '| ' . __( 'Campaign preview', 'jetpack-blaze' ) . ' | ' . __( 'Prepared value', 'jetpack-blaze' ) . " |\n";
 		$message .= "| --- | --- |\n";

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -464,6 +464,10 @@ class Blaze_Abilities extends Registrar {
 							'type'        => 'string',
 							'description' => __( 'Optional MIME type for main_image_url. Defaults to image/jpeg when omitted.', 'jetpack-blaze' ),
 						),
+						'payment_method_id'    => array(
+							'type'        => 'string',
+							'description' => __( 'Optional existing saved payment method ID to use for chat-native submit. Omit to let Blaze choose the default saved payment method. This does not add a new payment method.', 'jetpack-blaze' ),
+						),
 						'languages'            => array(
 							'type'        => 'array',
 							'description' => __( 'Optional ISO 639-1 language codes supported by Blaze/DSP (e.g. ["en", "es"]). Infer from the user\'s natural language request when clear, but omit when unsure or unsupported. Defaults to all languages when omitted; the merchant can adjust language targeting in the Blaze review UI.', 'jetpack-blaze' ),
@@ -624,7 +628,7 @@ class Blaze_Abilities extends Registrar {
 						'submit_eligibility' => array(
 							'type'        => 'object',
 							'description' => __( 'Hints that tell chat clients whether chat-native submit can proceed or whether the merchant should use fallback_url.', 'jetpack-blaze' ),
-							'required'    => array( 'chat_native_submit', 'payment_method', 'reason', 'fallback_url' ),
+							'required'    => array( 'chat_native_submit', 'payment_method', 'reason', 'fallback_url', 'selected_payment_method', 'available_payment_methods' ),
 							'properties'  => array(
 								'chat_native_submit' => array(
 									'type' => 'boolean',
@@ -638,6 +642,18 @@ class Blaze_Abilities extends Registrar {
 								'fallback_url'       => array(
 									'type'   => 'string',
 									'format' => 'uri',
+								),
+								'selected_payment_method' => array(
+									'type'        => array( 'object', 'null' ),
+									'description' => __( 'Compact safe summary of the saved payment method selected for chat-native submit, or null when unavailable.', 'jetpack-blaze' ),
+								),
+								'available_payment_methods' => array(
+									'type'        => 'array',
+									'description' => __( 'Compact safe summaries of usable existing saved payment methods that can be selected by re-running prepare-campaign with payment_method_id.', 'jetpack-blaze' ),
+								),
+								'supports_payment_method_switching' => array(
+									'type'        => 'boolean',
+									'description' => __( 'Whether more than one usable existing saved payment method is available for selection.', 'jetpack-blaze' ),
 								),
 							),
 						),
@@ -1677,16 +1693,20 @@ class Blaze_Abilities extends Registrar {
 			// Future write-path guardrails (per-session spend ceiling, Picard
 			// moderation gating) plug in here. Tracked separately as ADS-989.
 
-			$adds_saved_payment_hint = self::ABILITY_PREPARE_CAMPAIGN === $ability_name;
-			if ( $adds_saved_payment_hint ) {
-				add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+			$payment_methods_filter = null;
+			if ( self::ABILITY_PREPARE_CAMPAIGN === $ability_name ) {
+				$payment_methods        = self::get_prepare_campaign_payment_methods();
+				$payment_methods_filter = static function () use ( $payment_methods ) {
+					return $payment_methods;
+				};
+				add_filter( 'jetpack_blaze_prepare_campaign_payment_methods', $payment_methods_filter );
 			}
 
 			try {
 				$result = call_user_func( $original_callback, $input );
 			} finally {
-				if ( $adds_saved_payment_hint ) {
-					remove_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+				if ( null !== $payment_methods_filter ) {
+					remove_filter( 'jetpack_blaze_prepare_campaign_payment_methods', $payment_methods_filter );
 				}
 			}
 
@@ -1698,6 +1718,66 @@ class Blaze_Abilities extends Registrar {
 		};
 
 		return $args;
+	}
+
+	/**
+	 * Fetch usable saved payment methods through the existing Blaze REST proxy.
+	 *
+	 * @return array|null
+	 */
+	private static function get_prepare_campaign_payment_methods() {
+		$site_id = Jetpack_Connection::get_site_id();
+		if ( is_wp_error( $site_id ) || ! $site_id ) {
+			return null;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/payments/methods', (int) $site_id );
+		$request = new WP_REST_Request( 'GET', $route );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return null;
+		}
+
+		return self::extract_payment_methods_response( $response->get_data() );
+	}
+
+	/**
+	 * Extract a payment-method list from known DSP response shapes.
+	 *
+	 * @param mixed $data REST response data.
+	 * @return array|null
+	 */
+	private static function extract_payment_methods_response( $data ) {
+		if ( ! is_array( $data ) ) {
+			return null;
+		}
+
+		if ( self::is_list_array( $data ) ) {
+			return $data;
+		}
+
+		foreach ( array( 'payment_methods', 'paymentMethods', 'methods', 'data' ) as $key ) {
+			if ( isset( $data[ $key ] ) && is_array( $data[ $key ] ) ) {
+				return $data[ $key ];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Polyfill array_is_list() for the package PHP support floor.
+	 *
+	 * @param array $array Array to inspect.
+	 * @return bool
+	 */
+	private static function is_list_array( array $array ): bool {
+		if ( array() === $array ) {
+			return true;
+		}
+
+		return array_keys( $array ) === range( 0, count( $array ) - 1 );
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -34,7 +34,7 @@ use WP_REST_Request;
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG                = 'blaze-ads';
+	const CATEGORY_SLUG                    = 'blaze-ads';
 	const ABILITY_LIST_CAMPAIGNS           = 'blaze-ads/list-campaigns';
 	const ABILITY_GET_CAMPAIGN_STATS       = 'blaze-ads/get-campaign-stats';
 	const ABILITY_PREPARE_CAMPAIGN         = 'blaze-ads/prepare-campaign';
@@ -214,7 +214,7 @@ class Blaze_Abilities extends Registrar {
 	 */
 	public static function get_abilities(): array {
 		return array(
-			self::ABILITY_LIST_CAMPAIGNS   => array(
+			self::ABILITY_LIST_CAMPAIGNS           => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
 				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including numeric campaign_id, campaign title/name, DSP status, schedule, spend, target, and performance context. Use campaign_id for follow-up operations; title/name is human-readable context for the merchant, not as the operation identifier.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -300,7 +300,7 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
-			self::ABILITY_GET_CAMPAIGN_STATS => array(
+			self::ABILITY_GET_CAMPAIGN_STATS       => array(
 				'label'               => __( 'Get Blaze campaign stats', 'jetpack-blaze' ),
 				'description'         => __( 'Get raw Blaze display advertising stats for a campaign, plus basic derived CTR, CPM, CPC, and clicks-per-dollar metrics.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -410,7 +410,7 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
-			self::ABILITY_PREPARE_CAMPAIGN => array(
+			self::ABILITY_PREPARE_CAMPAIGN         => array(
 				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
 				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and safe audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. Audience overrides must use stable codes or closed enums: supported language codes, ISO country codes, supported device values, and Blaze public page topic IDs. Unsupported or ambiguous targeting should be omitted and handled by Blaze defaults or the review UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -548,16 +548,16 @@ class Blaze_Abilities extends Registrar {
 						'prefill',
 					),
 					'properties'  => array(
-						'status'           => array(
+						'status'               => array(
 							'type'        => 'string',
 							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
 							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'message'          => array(
+						'message'              => array(
 							'type'        => 'string',
 							'description' => __( 'Primary human-readable response for the MCP client to show to the merchant. Display this Markdown field verbatim in chat before the review link; it includes a campaign preview table and the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'campaign_preview' => array(
+						'campaign_preview'     => array(
 							'type'        => 'object',
 							'description' => __( 'Structured campaign preview rows used by the MCP adapter to render the merchant-readable table.', 'jetpack-blaze' ),
 							'required'    => array( 'ad_heading', 'ad_copy', 'call_to_action', 'objective', 'budget', 'duration', 'schedule', 'audience', 'landing_page' ),
@@ -591,11 +591,11 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'forecast_summary' => array(
+						'forecast_summary'     => array(
 							'type'        => 'string',
 							'description' => __( 'Human-readable forecast summary for the recommended option, or a fallback note when forecasts are unavailable.', 'jetpack-blaze' ),
 						),
-						'prepared_campaign' => array(
+						'prepared_campaign'    => array(
 							'type'        => 'object',
 							'description' => __( 'Immutable prepared package identity. Later submit actions must use this identity so the merchant approves the exact package being submitted.', 'jetpack-blaze' ),
 							'required'    => array( 'id', 'hash', 'version' ),
@@ -611,21 +611,25 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'submit_package'   => array(
+						'submit_package'       => array(
 							'type'        => 'object',
 							'description' => __( 'Exact DSP submit payload and policy versions for the submit-prepared-campaign ability. Clients must add the structured approval event after explicit user approval; ordinary chat text is not approval.', 'jetpack-blaze' ),
-							'required'    => array( 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version' ),
+							'required'    => array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version' ),
 							'properties'  => array(
-								'prepared_package_id' => array(
+								'idempotency_key'         => array(
+									'type'        => 'string',
+									'description' => __( 'Durable idempotency key that clients must pass to submit-prepared-campaign with the matching approval event.', 'jetpack-blaze' ),
+								),
+								'prepared_package_id'     => array(
 									'type' => 'string',
 								),
-								'prepared_campaign_hash' => array(
+								'prepared_campaign_hash'  => array(
 									'type' => 'string',
 								),
-								'prepared_campaign' => array(
+								'prepared_campaign'       => array(
 									'type' => 'object',
 								),
-								'accepted_terms_version' => array(
+								'accepted_terms_version'  => array(
 									'type' => 'string',
 								),
 								'accepted_policy_version' => array(
@@ -633,7 +637,7 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'rendered_preview'  => array(
+						'rendered_preview'     => array(
 							'type'        => 'object',
 							'description' => __( 'Blaze-owned rendered preview artifact for chat clients. Clients should render this instead of composing ad HTML themselves.', 'jetpack-blaze' ),
 							'required'    => array( 'type', 'html' ),
@@ -647,7 +651,7 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'campaign_summary' => array(
+						'campaign_summary'     => array(
 							'type'        => 'object',
 							'description' => __( 'Structured campaign summary for chat display: destination, creative, budget, cadence, schedule, targeting, and source context.', 'jetpack-blaze' ),
 							'required'    => array(
@@ -660,26 +664,26 @@ class Blaze_Abilities extends Registrar {
 								'source_context',
 							),
 						),
-						'fallback_url'     => array(
+						'fallback_url'         => array(
 							'type'        => 'string',
 							'format'      => 'uri',
 							'description' => __( 'Blaze widget or dashboard URL that can review and submit this prepared package when chat-native submit is unavailable or the merchant wants the full UI.', 'jetpack-blaze' ),
 						),
-						'submit_eligibility' => array(
+						'submit_eligibility'   => array(
 							'type'        => 'object',
 							'description' => __( 'Hints that tell chat clients whether chat-native submit can proceed or whether the merchant should use fallback_url.', 'jetpack-blaze' ),
 							'required'    => array( 'chat_native_submit', 'payment_method', 'reason', 'fallback_url', 'selected_payment_method', 'available_payment_methods' ),
 							'properties'  => array(
-								'chat_native_submit' => array(
+								'chat_native_submit'      => array(
 									'type' => 'boolean',
 								),
-								'payment_method'     => array(
+								'payment_method'          => array(
 									'type' => array( 'string', 'boolean' ),
 								),
-								'reason'             => array(
+								'reason'                  => array(
 									'type' => array( 'string', 'null' ),
 								),
-								'fallback_url'       => array(
+								'fallback_url'            => array(
 									'type'   => 'string',
 									'format' => 'uri',
 								),
@@ -697,7 +701,7 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'approval_block'   => array(
+						'approval_block'       => array(
 							'type'        => 'object',
 							'description' => __( 'Approval wording keys and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
 							'required'    => array(
@@ -715,35 +719,35 @@ class Blaze_Abilities extends Registrar {
 								'requires_reprepare_edits',
 							),
 							'properties'  => array(
-								'prepared_campaign_id' => array(
+								'prepared_campaign_id'     => array(
 									'type'        => 'string',
 									'description' => __( 'Prepared campaign package ID that must be echoed by the approval event.', 'jetpack-blaze' ),
 								),
-								'prepared_campaign_hash' => array(
+								'prepared_campaign_hash'   => array(
 									'type'        => 'string',
 									'description' => __( 'Prepared campaign package hash that must be echoed by the approval event.', 'jetpack-blaze' ),
 								),
-								'title_key'   => array(
+								'title_key'                => array(
 									'type'        => 'string',
 									'description' => __( 'Localization key for the approval title.', 'jetpack-blaze' ),
 								),
-								'body_key'    => array(
+								'body_key'                 => array(
 									'type'        => 'string',
 									'description' => __( 'Localization key for the approval body.', 'jetpack-blaze' ),
 								),
-								'confirmation_label_key' => array(
+								'confirmation_label_key'   => array(
 									'type'        => 'string',
 									'description' => __( 'Localization key for the explicit approval control label.', 'jetpack-blaze' ),
 								),
-								'approval_statement' => array(
+								'approval_statement'       => array(
 									'type'        => 'string',
 									'description' => __( 'Canonical fallback approval wording owned by Blaze.', 'jetpack-blaze' ),
 								),
-								'approval_contract' => array(
+								'approval_contract'        => array(
 									'type'        => 'object',
 									'description' => __( 'Language-independent approval contract containing the exact package identity, terms/policy versions, charge terms, cancellation wording version, payment method, user, and site.', 'jetpack-blaze' ),
 								),
-								'approval_event' => array(
+								'approval_event'           => array(
 									'type'        => 'object',
 									'description' => __( 'Approval event template. Clients must set approved_at and submit the full structured event; normal chat text is not approval.', 'jetpack-blaze' ),
 								),
@@ -754,11 +758,11 @@ class Blaze_Abilities extends Registrar {
 										'type' => 'string',
 									),
 								),
-								'charge_acknowledgement' => array(
+								'charge_acknowledgement'   => array(
 									'type'        => 'object',
 									'description' => __( 'Localization key and live prepared values for rendering the widget-equivalent charge acknowledgement.', 'jetpack-blaze' ),
 								),
-								'requires_exact_identity' => array(
+								'requires_exact_identity'  => array(
 									'type' => 'boolean',
 								),
 								'requires_reprepare_edits' => array(
@@ -771,30 +775,30 @@ class Blaze_Abilities extends Registrar {
 							'description' => __( 'Fields that require a new prepare-campaign call before approval or submit because they change the prepared package identity.', 'jetpack-blaze' ),
 							'required'    => array( 'requires_reprepare', 'material_fields', 'non_material_fields', 'message' ),
 						),
-						'intent'           => array(
+						'intent'               => array(
 							'type'        => 'string',
 							'description' => __( 'Inferred campaign intent used to choose server-owned defaults.', 'jetpack-blaze' ),
 							'enum'        => array( 'ecommerce', 'content', 'unknown' ),
 						),
-						'forecast'         => array(
+						'forecast'             => array(
 							'type'        => 'object',
 							'description' => __( 'Forecast estimates for the recommended option. Available forecasts include views/impressions and clicks ranges; unavailable forecasts do not block the review URL.', 'jetpack-blaze' ),
 						),
-						'assumptions'      => array(
+						'assumptions'          => array(
 							'type'        => 'array',
 							'description' => __( 'Plain-language assumptions used while preparing the recommended campaign.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
-						'recommendations'  => array(
+						'recommendations'      => array(
 							'type'        => 'array',
 							'description' => __( 'Plain-language guidance for reviewing the prepared campaign.', 'jetpack-blaze' ),
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
-						'budget_options'   => array(
+						'budget_options'       => array(
 							'type'        => 'array',
 							'description' => __( 'Lower, recommended, and higher budget options returned when budget or duration is omitted. The recommended option is encoded in prefill_url.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -822,12 +826,12 @@ class Blaze_Abilities extends Registrar {
 								),
 							),
 						),
-						'prefill_url'      => array(
+						'prefill_url'          => array(
 							'type'        => 'string',
 							'format'      => 'uri',
 							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
 						),
-						'prefill'          => array(
+						'prefill'              => array(
 							'type'        => 'object',
 							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),
@@ -845,99 +849,99 @@ class Blaze_Abilities extends Registrar {
 				),
 			),
 			self::ABILITY_SUBMIT_PREPARED_CAMPAIGN => array(
-					'label'               => __( 'Submit an approved prepared Blaze campaign', 'jetpack-blaze' ),
-					'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as “looks good”; call it only after the client has rendered the exact approval terms from prepare-campaign and captured a structured approval event for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
-					'input_schema'        => array(
-						'type'                 => 'object',
-						'required'             => array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ),
-						'properties'           => array(
-							'idempotency_key'          => array(
-								'type'        => 'string',
-								'description' => __( 'Durable idempotency key from the prepared package approval event.', 'jetpack-blaze' ),
-							),
-							'prepared_package_id'      => array(
-								'type'        => 'string',
-								'description' => __( 'Prepared package ID returned by prepare-campaign.', 'jetpack-blaze' ),
-							),
-							'prepared_campaign_hash'   => array(
-								'type'        => 'string',
-								'description' => __( 'Stable hash of the exact prepared_campaign payload returned by prepare-campaign.', 'jetpack-blaze' ),
-							),
-							'prepared_campaign'        => array(
-								'type'        => 'object',
-								'description' => __( 'Exact DSP campaign payload returned in prepare-campaign submit_package.prepared_campaign. Do not edit this without preparing a new campaign.', 'jetpack-blaze' ),
-							),
-							'accepted_terms_version'   => array(
-								'type'        => 'string',
-								'description' => __( 'Terms version rendered for explicit approval.', 'jetpack-blaze' ),
-							),
-							'accepted_policy_version'  => array(
-								'type'        => 'string',
-								'description' => __( 'Advertising policy version rendered for explicit approval.', 'jetpack-blaze' ),
-							),
-							'approval'                 => array(
-								'type'        => 'object',
-								'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval.', 'jetpack-blaze' ),
-							),
+				'label'               => __( 'Submit an approved prepared Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Submit one previously prepared Blaze campaign package after explicit structured approval from the merchant. This spends real money. Do not call this from a normal chat phrase such as “looks good”; call it only after the client has rendered the exact approval terms from prepare-campaign and captured a structured approval event for the same prepared package hash, payment method, terms version, policy version, and idempotency key.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ),
+					'properties'           => array(
+						'idempotency_key'         => array(
+							'type'        => 'string',
+							'description' => __( 'Durable idempotency key from the prepared package approval event.', 'jetpack-blaze' ),
 						),
-						'additionalProperties' => false,
-					),
-					'output_schema'       => array(
-						'type'        => 'object',
-						'description' => __( 'DSP submit response decorated for chat. Success means the campaign was submitted and is pending approval/moderation, not already running.', 'jetpack-blaze' ),
-						'required'    => array( 'status', 'message', 'campaign_status', 'dashboard_url', 'widget_url', 'selected_payment_method', 'budget', 'source_tracking', 'submit_response' ),
-						'properties'  => array(
-							'status'                  => array(
-								'type' => 'string',
-								'enum' => array( 'submitted_pending_approval' ),
-							),
-							'message'                 => array(
-								'type'        => 'string',
-								'description' => __( 'Human-readable pending confirmation for chat clients.', 'jetpack-blaze' ),
-							),
-							'campaign_status'         => array(
-								'type' => 'string',
-							),
-							'dashboard_url'           => array(
-								'type' => 'string',
-							),
-							'widget_url'              => array(
-								'type' => 'string',
-							),
-							'selected_payment_method' => array(
-								'type' => 'object',
-							),
-							'budget'                  => array(
-								'type' => 'object',
-							),
-							'source_tracking'         => array(
-								'type' => 'object',
-							),
-							'submit_response'         => array(
-								'type' => 'object',
-							),
+						'prepared_package_id'     => array(
+							'type'        => 'string',
+							'description' => __( 'Prepared package ID returned by prepare-campaign.', 'jetpack-blaze' ),
+						),
+						'prepared_campaign_hash'  => array(
+							'type'        => 'string',
+							'description' => __( 'Stable hash of the exact prepared_campaign payload returned by prepare-campaign.', 'jetpack-blaze' ),
+						),
+						'prepared_campaign'       => array(
+							'type'        => 'object',
+							'description' => __( 'Exact DSP campaign payload returned in prepare-campaign submit_package.prepared_campaign. Do not edit this without preparing a new campaign.', 'jetpack-blaze' ),
+						),
+						'accepted_terms_version'  => array(
+							'type'        => 'string',
+							'description' => __( 'Terms version rendered for explicit approval.', 'jetpack-blaze' ),
+						),
+						'accepted_policy_version' => array(
+							'type'        => 'string',
+							'description' => __( 'Advertising policy version rendered for explicit approval.', 'jetpack-blaze' ),
+						),
+						'approval'                => array(
+							'type'        => 'object',
+							'description' => __( 'Structured approval event for this exact package. It must include type prepared_campaign.approved and approved_at; ordinary chat text is not approval.', 'jetpack-blaze' ),
 						),
 					),
-					'execute_callback'    => array( __CLASS__, 'submit_prepared_campaign' ),
-					'permission_callback' => array( __CLASS__, 'permission_callback' ),
-					'meta'                => array(
-						'show_in_rest' => true,
-						'annotations'  => array(
-							'readonly'    => false,
-							'destructive' => true,
-							'idempotent'  => true,
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'DSP submit response decorated for chat. Success means the campaign was submitted and is pending approval/moderation, not already running.', 'jetpack-blaze' ),
+					'required'    => array( 'status', 'message', 'campaign_status', 'dashboard_url', 'widget_url', 'selected_payment_method', 'budget', 'source_tracking', 'submit_response' ),
+					'properties'  => array(
+						'status'                  => array(
+							'type' => 'string',
+							'enum' => array( 'submitted_pending_approval' ),
+						),
+						'message'                 => array(
+							'type'        => 'string',
+							'description' => __( 'Human-readable pending confirmation for chat clients.', 'jetpack-blaze' ),
+						),
+						'campaign_status'         => array(
+							'type' => 'string',
+						),
+						'dashboard_url'           => array(
+							'type' => 'string',
+						),
+						'widget_url'              => array(
+							'type' => 'string',
+						),
+						'selected_payment_method' => array(
+							'type' => 'object',
+						),
+						'budget'                  => array(
+							'type' => 'object',
+						),
+						'source_tracking'         => array(
+							'type' => 'object',
+						),
+						'submit_response'         => array(
+							'type' => 'object',
 						),
 					),
 				),
-			self::ABILITY_STOP_CAMPAIGN        => array(
-					'label'               => __( 'Stop a Blaze campaign', 'jetpack-blaze' ),
-					'description'         => __( 'Preview or confirm stopping delivery for an existing Blaze campaign. Pass the numeric DSP campaign_id. By default this returns the current campaign context and consequence text without calling the DSP stop endpoint. Set confirm to true only after the merchant explicitly confirms they want to stop serving; confirm mode re-fetches campaign context and delegates stop eligibility to the existing DSP stop endpoint.', 'jetpack-blaze' ),
-					'input_schema'        => array(
-						'type'                 => 'object',
-						'required'             => array( 'campaign_id' ),
-						'properties'           => array(
-							'campaign_id' => array(
-								'type'        => 'integer',
+				'execute_callback'    => array( __CLASS__, 'submit_prepared_campaign' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+			self::ABILITY_STOP_CAMPAIGN            => array(
+				'label'               => __( 'Stop a Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Preview or confirm stopping delivery for an existing Blaze campaign. Pass the numeric DSP campaign_id. By default this returns the current campaign context and consequence text without calling the DSP stop endpoint. Set confirm to true only after the merchant explicitly confirms they want to stop serving; confirm mode re-fetches campaign context and delegates stop eligibility to the existing DSP stop endpoint.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'campaign_id' ),
+					'properties'           => array(
+						'campaign_id' => array(
+							'type'        => 'integer',
 							'description' => __( 'Numeric DSP campaign ID to stop.', 'jetpack-blaze' ),
 							'minimum'     => 1,
 						),
@@ -1267,25 +1271,38 @@ class Blaze_Abilities extends Registrar {
 		$request = new WP_REST_Request( 'POST', $route );
 		$request->set_body_params(
 			array(
-				'idempotency_key'          => (string) $args['idempotency_key'],
-				'prepared_package_id'      => (string) $args['prepared_package_id'],
-				'prepared_campaign_hash'   => (string) $args['prepared_campaign_hash'],
-				'prepared_campaign'        => $args['prepared_campaign'],
-				'accepted_terms_version'   => (string) $args['accepted_terms_version'],
-				'accepted_policy_version'  => (string) $args['accepted_policy_version'],
-				'approval'                 => self::build_dsp_submit_approval_event( $args ),
+				'idempotency_key'         => (string) $args['idempotency_key'],
+				'prepared_package_id'     => (string) $args['prepared_package_id'],
+				'prepared_campaign_hash'  => (string) $args['prepared_campaign_hash'],
+				'prepared_campaign'       => $args['prepared_campaign'],
+				'accepted_terms_version'  => (string) $args['accepted_terms_version'],
+				'accepted_policy_version' => (string) $args['accepted_policy_version'],
+				'approval'                => self::build_dsp_submit_approval_event( $args ),
 			)
 		);
 
-		$response = rest_do_request( $request );
+		try {
+			$response = rest_do_request( $request );
+		} catch ( \Throwable $error ) {
+			return self::format_submit_prepared_campaign_error(
+				new \WP_Error(
+					'blaze_submit_prepared_campaign_exception',
+					$error->getMessage(),
+					array(
+						'status' => 500,
+						'class'  => get_class( $error ),
+					)
+				)
+			);
+		}
 		if ( $response->is_error() ) {
-			return $response->as_error();
+			return self::format_submit_prepared_campaign_error( $response->as_error() );
 		}
 
 		$status = $response->get_status();
 		$data   = $response->get_data();
 		if ( $status >= 400 ) {
-			return self::rest_response_to_wp_error( is_array( $data ) ? $data : array(), $status );
+			return self::format_submit_prepared_campaign_error( self::rest_response_to_wp_error( is_array( $data ) ? $data : array(), $status ) );
 		}
 
 		$submit_response = is_array( $data ) ? $data : array();
@@ -1468,11 +1485,33 @@ class Blaze_Abilities extends Registrar {
 			}
 		}
 		if ( '' === $message ) {
-				$message = __( 'The Blaze DSP API could not complete this campaign request.', 'jetpack-blaze' );
-			}
+			$message = __( 'The Blaze DSP API could not complete this campaign request.', 'jetpack-blaze' );
+		}
 
 		$data['status'] = $status;
 		return new \WP_Error( $code, $message, $data );
+	}
+
+	/**
+	 * Return submit failures as structured MCP output instead of a tool-level failure.
+	 *
+	 * @param \WP_Error $error Submit failure.
+	 * @return array
+	 */
+	private static function format_submit_prepared_campaign_error( \WP_Error $error ): array {
+		$data = $error->get_error_data();
+		$data = is_array( $data ) ? $data : array();
+
+		return array(
+			'status'  => 'submit_failed',
+			'message' => __( 'The Blaze campaign was not submitted. No campaign was created by this request.', 'jetpack-blaze' ),
+			'error'   => array(
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+				'status'  => isset( $data['status'] ) ? (int) $data['status'] : null,
+				'details' => $data,
+			),
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -1286,18 +1286,19 @@ class Blaze_Abilities extends Registrar {
 			return $route;
 		}
 
-		$request = new WP_REST_Request( 'POST', $route );
-		$request->set_body_params(
-			array(
-				'idempotency_key'         => (string) $args['idempotency_key'],
-				'prepared_package_id'     => (string) $args['prepared_package_id'],
-				'prepared_campaign_hash'  => (string) $args['prepared_campaign_hash'],
-				'prepared_campaign'       => $args['prepared_campaign'],
-				'accepted_terms_version'  => (string) $args['accepted_terms_version'],
-				'accepted_policy_version' => (string) $args['accepted_policy_version'],
-				'approval'                => self::build_dsp_submit_approval_event( $args ),
-			)
+		$submit_body = array(
+			'idempotency_key'         => (string) $args['idempotency_key'],
+			'prepared_package_id'     => (string) $args['prepared_package_id'],
+			'prepared_campaign_hash'  => (string) $args['prepared_campaign_hash'],
+			'prepared_campaign'       => $args['prepared_campaign'],
+			'accepted_terms_version'  => (string) $args['accepted_terms_version'],
+			'accepted_policy_version' => (string) $args['accepted_policy_version'],
+			'approval'                => self::build_dsp_submit_approval_event( $args ),
 		);
+
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( $submit_body, JSON_UNESCAPED_SLASHES ) );
 
 		try {
 			$response = rest_do_request( $request );

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -660,11 +660,76 @@ class Blaze_Abilities extends Registrar {
 						'approval_block'   => array(
 							'type'        => 'object',
 							'description' => __( 'Approval wording keys and exact package identity, present when a saved payment method makes chat-native submit eligible.', 'jetpack-blaze' ),
+							'required'    => array(
+								'prepared_campaign_id',
+								'prepared_campaign_hash',
+								'title_key',
+								'body_key',
+								'confirmation_label_key',
+								'approval_statement',
+								'approval_contract',
+								'approval_event',
+								'approval_event_required_fields',
+								'charge_acknowledgement',
+								'requires_exact_identity',
+								'requires_reprepare_edits',
+							),
+							'properties'  => array(
+								'prepared_campaign_id' => array(
+									'type'        => 'string',
+									'description' => __( 'Prepared campaign package ID that must be echoed by the approval event.', 'jetpack-blaze' ),
+								),
+								'prepared_campaign_hash' => array(
+									'type'        => 'string',
+									'description' => __( 'Prepared campaign package hash that must be echoed by the approval event.', 'jetpack-blaze' ),
+								),
+								'title_key'   => array(
+									'type'        => 'string',
+									'description' => __( 'Localization key for the approval title.', 'jetpack-blaze' ),
+								),
+								'body_key'    => array(
+									'type'        => 'string',
+									'description' => __( 'Localization key for the approval body.', 'jetpack-blaze' ),
+								),
+								'confirmation_label_key' => array(
+									'type'        => 'string',
+									'description' => __( 'Localization key for the explicit approval control label.', 'jetpack-blaze' ),
+								),
+								'approval_statement' => array(
+									'type'        => 'string',
+									'description' => __( 'Canonical fallback approval wording owned by Blaze.', 'jetpack-blaze' ),
+								),
+								'approval_contract' => array(
+									'type'        => 'object',
+									'description' => __( 'Language-independent approval contract containing the exact package identity, terms/policy versions, charge terms, cancellation wording version, payment method, user, and site.', 'jetpack-blaze' ),
+								),
+								'approval_event' => array(
+									'type'        => 'object',
+									'description' => __( 'Approval event template. Clients must set approved_at and submit the full structured event; normal chat text is not approval.', 'jetpack-blaze' ),
+								),
+								'approval_event_required_fields' => array(
+									'type'        => 'array',
+									'description' => __( 'Fields required for a valid structured approval event.', 'jetpack-blaze' ),
+									'items'       => array(
+										'type' => 'string',
+									),
+								),
+								'charge_acknowledgement' => array(
+									'type'        => 'object',
+									'description' => __( 'Localization key and live prepared values for rendering the widget-equivalent charge acknowledgement.', 'jetpack-blaze' ),
+								),
+								'requires_exact_identity' => array(
+									'type' => 'boolean',
+								),
+								'requires_reprepare_edits' => array(
+									'type' => 'boolean',
+								),
+							),
 						),
 						'material_edit_policy' => array(
 							'type'        => 'object',
 							'description' => __( 'Fields that require a new prepare-campaign call before approval or submit because they change the prepared package identity.', 'jetpack-blaze' ),
-							'required'    => array( 'requires_reprepare', 'material_fields', 'message' ),
+							'required'    => array( 'requires_reprepare', 'material_fields', 'non_material_fields', 'message' ),
 						),
 						'intent'           => array(
 							'type'        => 'string',

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -1314,6 +1314,10 @@ class Blaze_Abilities extends Registrar {
 			);
 		}
 		if ( $response->is_error() ) {
+			$data = $response->get_data();
+			if ( is_array( $data ) ) {
+				return self::format_submit_prepared_campaign_error( self::rest_response_to_wp_error( $data, $response->get_status() ) );
+			}
 			return self::format_submit_prepared_campaign_error( $response->as_error() );
 		}
 
@@ -1493,13 +1497,29 @@ class Blaze_Abilities extends Registrar {
 	 * @return \WP_Error
 	 */
 	private static function rest_response_to_wp_error( array $data, int $status ): \WP_Error {
-		$code = isset( $data['code'] ) ? (string) $data['code'] : 'blaze_dsp_error';
+		$code = isset( $data['code'] ) ? self::stringify_submit_error_value( $data['code'] ) : '';
+		if ( '' === $code && isset( $data['error']['code'] ) ) {
+			$code = self::stringify_submit_error_value( $data['error']['code'] );
+		}
+		if ( '' === $code ) {
+			$code = 'blaze_dsp_error';
+		}
 
 		$message = '';
 		foreach ( array( 'message', 'errorMessage', 'error' ) as $message_key ) {
-			if ( isset( $data[ $message_key ] ) && '' !== (string) $data[ $message_key ] ) {
-				$message = (string) $data[ $message_key ];
-				break;
+			if ( isset( $data[ $message_key ] ) ) {
+				$maybe_message = self::stringify_submit_error_value( $data[ $message_key ] );
+				if ( '' !== $maybe_message ) {
+					$message = $maybe_message;
+					break;
+				}
+			}
+			if ( isset( $data['error'][ $message_key ] ) ) {
+				$maybe_message = self::stringify_submit_error_value( $data['error'][ $message_key ] );
+				if ( '' !== $maybe_message ) {
+					$message = $maybe_message;
+					break;
+				}
 			}
 		}
 		if ( '' === $message ) {
@@ -1524,12 +1544,27 @@ class Blaze_Abilities extends Registrar {
 			'status'  => 'submit_failed',
 			'message' => __( 'The Blaze campaign was not submitted. No campaign was created by this request.', 'jetpack-blaze' ),
 			'error'   => array(
-				'code'    => $error->get_error_code(),
-				'message' => $error->get_error_message(),
+				'code'    => self::stringify_submit_error_value( $error->get_error_code() ),
+				'message' => self::stringify_submit_error_value( $error->get_error_message() ),
 				'status'  => isset( $data['status'] ) ? (int) $data['status'] : null,
 				'details' => $data,
 			),
 		);
+	}
+
+	/**
+	 * Normalize arbitrary DSP/WP error values for the ability output schema.
+	 *
+	 * @param mixed $value Error code or message value.
+	 * @return string
+	 */
+	private static function stringify_submit_error_value( $value ): string {
+		if ( is_scalar( $value ) || null === $value ) {
+			return (string) $value;
+		}
+
+		$encoded = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+		return is_string( $encoded ) ? $encoded : __( 'Unknown submit error.', 'jetpack-blaze' );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities;
 use Automattic\Jetpack\Blaze\Dashboard as Blaze_Dashboard;
 use Automattic\Jetpack\Blaze\Dashboard_REST_Controller as Blaze_Dashboard_REST_Controller;
 use Automattic\Jetpack\Blaze\REST_Controller;
@@ -59,6 +60,8 @@ class Blaze {
 		add_action( 'rest_api_init', array( new Blaze_Dashboard_REST_Controller(), 'register_rest_routes' ) );
 		// Add general Blaze REST API endpoints.
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+		// Register Blaze abilities and opt them into Woo's MCP server (no-op when Woo MCP isn't present).
+		Blaze_Abilities::init();
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Blaze campaign preparation.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+/**
+ * Prepares a structured Blaze campaign proposal for review in the Blaze UI.
+ */
+class Campaign_Preparer {
+
+	private const DEFAULT_BUDGET_TOTAL  = 50.0;
+	private const DEFAULT_DURATION_DAYS = 7;
+
+	/**
+	 * Prepare a Blaze campaign proposal from a target post and optional overrides.
+	 *
+	 * @param array $args Preparation input.
+	 * @return array|\WP_Error
+	 */
+	public static function prepare( array $args ) {
+		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
+		if ( '' === $urn || ! preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $matches ) ) {
+			return new \WP_Error(
+				'blaze_invalid_target_urn',
+				/* translators: %s: the malformed URN value supplied by the caller. */
+				sprintf( __( 'Invalid target_urn %s. Expected format: urn:wpcom:post:<site_id>:<post_id>.', 'jetpack-blaze' ), $urn ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$post = get_post( (int) $matches[1] );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'blaze_post_not_found',
+				__( 'Post referenced by target_urn does not exist on this site.', 'jetpack-blaze' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$prefill     = self::build_prefill_payload( $args, $post );
+		$prefill_url = self::build_prefill_url( $post->ID, $prefill );
+
+		return array(
+			'status'      => 'pending_merchant_review',
+			'prefill_url' => $prefill_url,
+			'prefill'     => $prefill,
+		);
+	}
+
+	/**
+	 * Build the campaign prefill payload from caller input and the target post.
+	 *
+	 * @param array    $args Preparation input.
+	 * @param \WP_Post $post The target post.
+	 * @return array
+	 */
+	private static function build_prefill_payload( array $args, $post ): array {
+		$featured_image_id   = (int) get_post_thumbnail_id( $post->ID );
+		$featured_image_url  = $featured_image_id > 0 ? wp_get_attachment_image_url( $featured_image_id, 'full' ) : '';
+		$featured_image_mime = $featured_image_id > 0 ? get_post_mime_type( $featured_image_id ) : '';
+
+		$default_snippet = (string) get_the_excerpt( $post );
+		if ( '' === $default_snippet ) {
+			$stripped        = trim( wp_strip_all_tags( (string) $post->post_content ) );
+			$default_snippet = function_exists( 'mb_substr' ) ? mb_substr( $stripped, 0, 200 ) : substr( $stripped, 0, 200 );
+		}
+
+		$payload = array(
+			'target_urn'    => (string) $args['target_urn'],
+			'type'          => (string) $post->post_type,
+			'site_name'     => isset( $args['site_name'] ) && '' !== (string) $args['site_name']
+				? (string) $args['site_name']
+				: (string) get_the_title( $post ),
+			'text_snippet'  => isset( $args['text_snippet'] ) && '' !== (string) $args['text_snippet']
+				? (string) $args['text_snippet']
+				: $default_snippet,
+			'cta_text'      => isset( $args['cta_text'] ) && '' !== (string) $args['cta_text']
+				? (string) $args['cta_text']
+				: ( 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More' ),
+			'target_url'    => (string) get_permalink( $post ),
+			'budget'        => array(
+				'mode'     => 'total',
+				'amount'   => (float) ( $args['budget_total'] ?? self::DEFAULT_BUDGET_TOTAL ),
+				'currency' => self::get_site_currency(),
+			),
+			'duration_days' => (int) ( $args['duration_days'] ?? self::DEFAULT_DURATION_DAYS ),
+			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
+			'objective'     => 'VIEWS',
+		);
+
+		if ( isset( $args['goal'] ) && '' !== (string) $args['goal'] ) {
+			$payload['goal'] = (string) $args['goal'];
+		}
+		if ( isset( $args['revision_instruction'] ) && '' !== (string) $args['revision_instruction'] ) {
+			$payload['revision_instruction'] = (string) $args['revision_instruction'];
+		}
+
+		if ( isset( $args['main_image_url'] ) && '' !== (string) $args['main_image_url'] ) {
+			$payload['main_image'] = array(
+				'url'       => (string) $args['main_image_url'],
+				'mime_type' => isset( $args['main_image_mime_type'] ) && '' !== (string) $args['main_image_mime_type']
+					? (string) $args['main_image_mime_type']
+					: 'image/jpeg',
+			);
+		} elseif ( '' !== $featured_image_url ) {
+			$payload['main_image'] = array(
+				'url'       => $featured_image_url,
+				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',
+			);
+		}
+
+		if ( isset( $args['languages'] ) && is_array( $args['languages'] ) ) {
+			$languages = array_values(
+				array_filter(
+					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
+					static function ( $code ) {
+						return '' !== $code;
+					}
+				)
+			);
+			if ( ! empty( $languages ) ) {
+				$payload['languages'] = $languages;
+			}
+		}
+		if ( isset( $args['countries'] ) && is_array( $args['countries'] ) ) {
+			$countries = array_values(
+				array_filter(
+					array_map( 'strtoupper', array_map( 'strval', $args['countries'] ) ),
+					static function ( $code ) {
+						return 2 === strlen( $code );
+					}
+				)
+			);
+			if ( ! empty( $countries ) ) {
+				$payload['countries'] = $countries;
+			}
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Build the Blaze review deep-link with the encoded prefill payload.
+	 *
+	 * @param int   $post_id The target post ID.
+	 * @param array $prefill The prefill payload to encode.
+	 * @return string
+	 */
+	private static function build_prefill_url( int $post_id, array $prefill ): string {
+		$base = '';
+		if ( class_exists( '\Automattic\Jetpack\Blaze' ) && method_exists( '\Automattic\Jetpack\Blaze', 'get_campaign_management_url' ) ) {
+			$url_data = \Automattic\Jetpack\Blaze::get_campaign_management_url( $post_id );
+			if ( is_array( $url_data ) && isset( $url_data['link'] ) ) {
+				$base = (string) $url_data['link'];
+			}
+		}
+		if ( '' === $base ) {
+			$base = admin_url( 'tools.php?page=advertising' );
+		}
+
+		$encoded = self::base64url_encode( (string) wp_json_encode( $prefill, JSON_UNESCAPED_SLASHES ) );
+		$param   = 'blaze_prefill=' . rawurlencode( $encoded );
+
+		$hash_pos = strpos( $base, '#' );
+		if ( false === $hash_pos ) {
+			$separator = ( false !== strpos( $base, '?' ) ) ? '&' : '?';
+			return $base . $separator . $param;
+		}
+
+		$pre_hash  = substr( $base, 0, $hash_pos );
+		$hash      = substr( $base, $hash_pos );
+		$separator = ( false !== strpos( $pre_hash, '?' ) ) ? '&' : '?';
+
+		return $pre_hash . $separator . $param . $hash;
+	}
+
+	/**
+	 * URL-safe base64 encode (RFC 4648 section 5).
+	 *
+	 * @param string $input Bytes to encode.
+	 * @return string
+	 */
+	private static function base64url_encode( string $input ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding a structured prefill payload, not obfuscation.
+		return rtrim( strtr( base64_encode( $input ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Currency code for the prefill payload.
+	 *
+	 * @return string ISO 4217 currency code.
+	 */
+	private static function get_site_currency(): string {
+		return 'USD';
+	}
+}

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -66,10 +66,12 @@ class Campaign_Preparer {
 		$recommendations = self::build_recommendations( $intent, $budget_context );
 		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
+		$forecast        = self::request_forecast( $prefill, $intent );
 
 		$proposal = array(
 			'status'          => 'pending_merchant_review',
 			'intent'          => $intent,
+			'forecast'        => $forecast,
 			'assumptions'     => $assumptions,
 			'recommendations' => $recommendations,
 			'prefill_url'     => $prefill_url,
@@ -202,6 +204,110 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Request a DSP forecast for the recommended prefilled campaign.
+	 *
+	 * @param array  $prefill Recommended campaign prefill payload.
+	 * @param string $intent  Inferred campaign intent.
+	 * @return array
+	 */
+	private static function request_forecast( array $prefill, string $intent ): array {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return self::unavailable_forecast( $site_id->get_error_code() );
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/forecast', (int) $site_id );
+		$request = new \WP_REST_Request( 'POST', $route );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) wp_json_encode( self::build_forecast_request_body( $prefill ), JSON_UNESCAPED_SLASHES ) );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			$error = $response->as_error();
+			return self::unavailable_forecast( $error->get_error_code() );
+		}
+
+		$data = $response->get_data();
+		if ( ! is_array( $data ) ) {
+			return self::unavailable_forecast( 'forecast_invalid_response' );
+		}
+
+		return self::normalize_forecast_response( $data, $intent );
+	}
+
+	/**
+	 * Build the request body expected by the DSP v1.1 forecast endpoint.
+	 *
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @return array
+	 */
+	private static function build_forecast_request_body( array $prefill ): array {
+		$duration_days = isset( $prefill['duration_days'] ) ? max( 1, (int) $prefill['duration_days'] ) : self::DEFAULT_DURATION_DAYS;
+		$start_date    = gmdate( 'Y-m-d' );
+		$end_date      = gmdate( 'Y-m-d', strtotime( '+' . ( $duration_days - 1 ) . ' days' ) );
+
+		return array(
+			'time_zone'       => self::get_site_timezone(),
+			'start_date'      => $start_date,
+			'end_date'        => $end_date,
+			'total_budget'    => isset( $prefill['budget']['amount'] ) ? (float) $prefill['budget']['amount'] : self::DEFAULT_BUDGET_TOTAL,
+			'is_evergreen'    => isset( $prefill['is_evergreen'] ) ? (bool) $prefill['is_evergreen'] : true,
+			'is_tsp_eligible' => false,
+			'targeting'       => array(
+				'locations'   => array(),
+				'languages'   => isset( $prefill['languages'] ) ? array_values( (array) $prefill['languages'] ) : array(),
+				'devices'     => isset( $prefill['devices'] ) ? array_values( (array) $prefill['devices'] ) : array(),
+				'page_topics' => isset( $prefill['page_topics'] ) ? array_values( (array) $prefill['page_topics'] ) : array(),
+			),
+		);
+	}
+
+	/**
+	 * Normalize the DSP forecast response into the prepare-campaign contract.
+	 *
+	 * @param array  $data   DSP forecast response.
+	 * @param string $intent Inferred campaign intent.
+	 * @return array
+	 */
+	private static function normalize_forecast_response( array $data, string $intent ): array {
+		$views  = array(
+			'min' => isset( $data['total_impressions_min'] ) ? (int) $data['total_impressions_min'] : 0,
+			'max' => isset( $data['total_impressions_max'] ) ? (int) $data['total_impressions_max'] : 0,
+		);
+		$clicks = array(
+			'min' => isset( $data['total_clicks_min'] ) ? (int) $data['total_clicks_min'] : 0,
+			'max' => isset( $data['total_clicks_max'] ) ? (int) $data['total_clicks_max'] : 0,
+		);
+
+		return array(
+			'status'           => 'available',
+			'primary_metric'   => self::INTENT_ECOMMERCE === $intent ? 'clicks' : 'views',
+			'secondary_metric' => self::INTENT_ECOMMERCE === $intent ? 'views' : 'clicks',
+			'views'            => $views,
+			'impressions'      => $views,
+			'clicks'           => $clicks,
+			'tsp_impressions'  => array(
+				'min' => isset( $data['total_tsp_impressions_min'] ) ? (int) $data['total_tsp_impressions_min'] : 0,
+				'max' => isset( $data['total_tsp_impressions_max'] ) ? (int) $data['total_tsp_impressions_max'] : 0,
+			),
+		);
+	}
+
+	/**
+	 * Build a non-blocking forecast failure response.
+	 *
+	 * @param string $reason Stable failure reason.
+	 * @return array
+	 */
+	private static function unavailable_forecast( string $reason ): array {
+		return array(
+			'status'  => 'unavailable',
+			'reason'  => $reason,
+			'message' => __( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', 'jetpack-blaze' ),
+		);
 	}
 
 	/**
@@ -501,5 +607,15 @@ class Campaign_Preparer {
 	 */
 	private static function get_site_currency(): string {
 		return 'USD';
+	}
+
+	/**
+	 * Site timezone for DSP forecast requests.
+	 *
+	 * @return string IANA timezone name.
+	 */
+	private static function get_site_timezone(): string {
+		$timezone = wp_timezone_string();
+		return '' !== $timezone ? $timezone : 'UTC';
 	}
 }

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -14,6 +14,9 @@ class Campaign_Preparer {
 
 	private const DEFAULT_BUDGET_TOTAL  = 50.0;
 	private const DEFAULT_DURATION_DAYS = 7;
+	private const INTENT_ECOMMERCE      = 'ecommerce';
+	private const INTENT_CONTENT        = 'content';
+	private const INTENT_UNKNOWN        = 'unknown';
 	private const SUPPORTED_LANGUAGES   = array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' );
 	private const SUPPORTED_DEVICES     = array( 'mobile', 'desktop' );
 	private const SUPPORTED_PAGE_TOPICS = array(
@@ -57,24 +60,39 @@ class Campaign_Preparer {
 			);
 		}
 
-		$prefill     = self::build_prefill_payload( $args, $post );
-		$prefill_url = self::build_prefill_url( $post->ID, $prefill );
+		$intent          = self::infer_intent( $args, $post );
+		$budget_context  = self::resolve_budget_context( $args );
+		$assumptions     = self::build_assumptions( $args, $post, $intent, $budget_context );
+		$recommendations = self::build_recommendations( $intent, $budget_context );
+		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
+		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 
-		return array(
-			'status'      => 'pending_merchant_review',
-			'prefill_url' => $prefill_url,
-			'prefill'     => $prefill,
+		$proposal = array(
+			'status'          => 'pending_merchant_review',
+			'intent'          => $intent,
+			'assumptions'     => $assumptions,
+			'recommendations' => $recommendations,
+			'prefill_url'     => $prefill_url,
+			'prefill'         => $prefill,
 		);
+
+		if ( $budget_context['include_options'] ) {
+			$proposal['budget_options'] = $budget_context['options'];
+		}
+
+		return $proposal;
 	}
 
 	/**
 	 * Build the campaign prefill payload from caller input and the target post.
 	 *
-	 * @param array    $args Preparation input.
-	 * @param \WP_Post $post The target post.
+	 * @param array    $args           Preparation input.
+	 * @param \WP_Post $post           The target post.
+	 * @param string   $intent         Inferred campaign intent.
+	 * @param array    $budget_context Resolved budget defaults and options.
 	 * @return array
 	 */
-	private static function build_prefill_payload( array $args, $post ): array {
+	private static function build_prefill_payload( array $args, $post, string $intent, array $budget_context ): array {
 		$featured_image_id   = (int) get_post_thumbnail_id( $post->ID );
 		$featured_image_url  = $featured_image_id > 0 ? wp_get_attachment_image_url( $featured_image_id, 'full' ) : '';
 		$featured_image_mime = $featured_image_id > 0 ? get_post_mime_type( $featured_image_id ) : '';
@@ -100,12 +118,12 @@ class Campaign_Preparer {
 			'target_url'    => (string) get_permalink( $post ),
 			'budget'        => array(
 				'mode'     => 'total',
-				'amount'   => (float) ( $args['budget_total'] ?? self::DEFAULT_BUDGET_TOTAL ),
-				'currency' => self::get_site_currency(),
+				'amount'   => $budget_context['budget_total'],
+				'currency' => $budget_context['currency'],
 			),
-			'duration_days' => (int) ( $args['duration_days'] ?? self::DEFAULT_DURATION_DAYS ),
+			'duration_days' => $budget_context['duration_days'],
 			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
-			'objective'     => 'VIEWS',
+			'objective'     => self::objective_for_intent( $intent ),
 		);
 
 		if ( isset( $args['goal'] ) && '' !== (string) $args['goal'] ) {
@@ -184,6 +202,222 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Infer the campaign intent from natural language and target type.
+	 *
+	 * @param array    $args Preparation input.
+	 * @param \WP_Post $post The target post.
+	 * @return string
+	 */
+	private static function infer_intent( array $args, $post ): string {
+		$goal = isset( $args['goal'] ) ? strtolower( (string) $args['goal'] ) : '';
+
+		if ( '' !== $goal ) {
+			if ( preg_match( '/\b(sale|sales|sell|shop|purchase|order|conversion|conversions|revenue|roi|customer|customers)\b/', $goal ) ) {
+				return self::INTENT_ECOMMERCE;
+			}
+			if ( preg_match( '/\b(read|reader|readers|readership|article|blog|post|story|content|awareness|visibility|views|traffic)\b/', $goal ) ) {
+				return self::INTENT_CONTENT;
+			}
+		}
+
+		if ( 'product' === (string) $post->post_type ) {
+			return self::INTENT_ECOMMERCE;
+		}
+		if ( in_array( (string) $post->post_type, array( 'post', 'page' ), true ) ) {
+			return self::INTENT_CONTENT;
+		}
+
+		return self::INTENT_UNKNOWN;
+	}
+
+	/**
+	 * Resolve the recommended budget and optional comparison choices.
+	 *
+	 * @param array $args Preparation input.
+	 * @return array
+	 */
+	private static function resolve_budget_context( array $args ): array {
+		$currency              = self::get_site_currency();
+		$has_budget_override   = isset( $args['budget_total'] );
+		$has_duration_override = isset( $args['duration_days'] );
+		$budget_total          = $has_budget_override ? max( 1.0, (float) $args['budget_total'] ) : self::DEFAULT_BUDGET_TOTAL;
+		$duration_days         = $has_duration_override ? max( 1, (int) $args['duration_days'] ) : self::DEFAULT_DURATION_DAYS;
+		$include_options       = ! $has_budget_override || ! $has_duration_override;
+
+		return array(
+			'budget_total'          => $budget_total,
+			'currency'              => $currency,
+			'duration_days'         => $duration_days,
+			'has_budget_override'   => $has_budget_override,
+			'has_duration_override' => $has_duration_override,
+			'include_options'       => $include_options,
+			'options'               => $include_options ? self::build_budget_options( $budget_total, $duration_days, $currency ) : array(),
+		);
+	}
+
+	/**
+	 * Build lower/recommended/higher budget options around the recommended campaign.
+	 *
+	 * @param float  $recommended_total Recommended total budget.
+	 * @param int    $duration_days     Campaign duration in days.
+	 * @param string $currency          ISO 4217 currency code.
+	 * @return array
+	 */
+	private static function build_budget_options( float $recommended_total, int $duration_days, string $currency ): array {
+		$lower_total  = max( 10.0, round( $recommended_total * 0.5, 2 ) );
+		$higher_total = round( $recommended_total * 3, 2 );
+
+		return array(
+			self::build_budget_option(
+				'lower',
+				__( 'Lower', 'jetpack-blaze' ),
+				$lower_total,
+				$duration_days,
+				$currency,
+				__( 'Lower-risk test budget for learning before spending more.', 'jetpack-blaze' )
+			),
+			self::build_budget_option(
+				'recommended',
+				__( 'Recommended', 'jetpack-blaze' ),
+				$recommended_total,
+				$duration_days,
+				$currency,
+				__( 'Conservative starting point for a first prepared Blaze campaign.', 'jetpack-blaze' )
+			),
+			self::build_budget_option(
+				'higher',
+				__( 'Higher', 'jetpack-blaze' ),
+				$higher_total,
+				$duration_days,
+				$currency,
+				__( 'More budget can buy more reach; choose this only when broader delivery is worth the extra spend.', 'jetpack-blaze' )
+			),
+		);
+	}
+
+	/**
+	 * Build one budget option row.
+	 *
+	 * @param string $key           Stable option key.
+	 * @param string $label         Human-readable option label.
+	 * @param float  $budget_total  Total budget.
+	 * @param int    $duration_days Campaign duration in days.
+	 * @param string $currency      ISO 4217 currency code.
+	 * @param string $rationale     Why this option exists.
+	 * @return array
+	 */
+	private static function build_budget_option( string $key, string $label, float $budget_total, int $duration_days, string $currency, string $rationale ): array {
+		return array(
+			'key'           => $key,
+			'label'         => $label,
+			'budget'        => array(
+				'mode'     => 'total',
+				'amount'   => $budget_total,
+				'currency' => $currency,
+			),
+			'daily_budget'  => array(
+				'amount'   => round( $budget_total / $duration_days, 2 ),
+				'currency' => $currency,
+			),
+			'duration_days' => $duration_days,
+			'rationale'     => $rationale,
+		);
+	}
+
+	/**
+	 * Build human-readable assumptions for the prepared recommendation.
+	 *
+	 * @param array    $args           Preparation input.
+	 * @param \WP_Post $post           The target post.
+	 * @param string   $intent         Inferred campaign intent.
+	 * @param array    $budget_context Resolved budget defaults and options.
+	 * @return array
+	 */
+	private static function build_assumptions( array $args, $post, string $intent, array $budget_context ): array {
+		$post_type   = (string) $post->post_type;
+		$assumptions = array();
+
+		if ( self::INTENT_ECOMMERCE === $intent ) {
+			$assumptions[] = isset( $args['goal'] ) && '' !== (string) $args['goal']
+				? sprintf(
+					/* translators: %s: user-supplied natural language campaign goal. */
+					__( 'Goal "%s" suggests ecommerce intent, so the proposal uses traffic-oriented product defaults.', 'jetpack-blaze' ),
+					(string) $args['goal']
+				)
+				: __( 'Target is a product, so the proposal uses ecommerce-oriented defaults.', 'jetpack-blaze' );
+		} elseif ( self::INTENT_CONTENT === $intent ) {
+			$assumptions[] = isset( $args['goal'] ) && '' !== (string) $args['goal']
+				? sprintf(
+					/* translators: %s: user-supplied natural language campaign goal. */
+					__( 'Goal "%s" suggests content intent, so the proposal optimizes for visibility.', 'jetpack-blaze' ),
+					(string) $args['goal']
+				)
+				: sprintf(
+					/* translators: %s: WordPress post type. */
+					__( 'Target type "%s" is treated as content, so the proposal optimizes for visibility.', 'jetpack-blaze' ),
+					$post_type
+				);
+		} else {
+			$assumptions[] = sprintf(
+				/* translators: %s: WordPress post type. */
+				__( 'Target type "%s" has unknown intent, so the proposal uses conservative visibility defaults.', 'jetpack-blaze' ),
+				$post_type
+			);
+		}
+
+		if ( ! $budget_context['has_budget_override'] ) {
+			$assumptions[] = __( 'No budget was supplied, so the recommended option uses a conservative default total budget.', 'jetpack-blaze' );
+		}
+		if ( ! $budget_context['has_duration_override'] ) {
+			$assumptions[] = __( 'No duration was supplied, so the recommended option uses a seven-day campaign.', 'jetpack-blaze' );
+		}
+		if ( isset( $args['revision_instruction'] ) && '' !== (string) $args['revision_instruction'] ) {
+			$assumptions[] = sprintf(
+				/* translators: %s: user-supplied revision instruction. */
+				__( 'Revision requested: %s', 'jetpack-blaze' ),
+				(string) $args['revision_instruction']
+			);
+		}
+
+		return $assumptions;
+	}
+
+	/**
+	 * Build compact campaign recommendations for clients to surface.
+	 *
+	 * @param string $intent         Inferred campaign intent.
+	 * @param array  $budget_context Resolved budget defaults and options.
+	 * @return array
+	 */
+	private static function build_recommendations( string $intent, array $budget_context ): array {
+		$recommendations = array();
+
+		if ( self::INTENT_ECOMMERCE === $intent ) {
+			$recommendations[] = __( 'Use product-focused copy and send shoppers to the product page.', 'jetpack-blaze' );
+		} elseif ( self::INTENT_CONTENT === $intent ) {
+			$recommendations[] = __( 'Use visibility-focused copy and send readers to the post or page.', 'jetpack-blaze' );
+		} else {
+			$recommendations[] = __( 'Review the prepared copy and target before submitting because the target intent is uncertain.', 'jetpack-blaze' );
+		}
+
+		if ( $budget_context['include_options'] ) {
+			$recommendations[] = __( 'The recommended budget option is conservative; the higher option is framed as broader reach, not guaranteed performance.', 'jetpack-blaze' );
+		}
+
+		return $recommendations;
+	}
+
+	/**
+	 * Server-owned DSP objective for the inferred intent.
+	 *
+	 * @param string $intent Inferred campaign intent.
+	 * @return string
+	 */
+	private static function objective_for_intent( string $intent ): string {
+		return self::INTENT_ECOMMERCE === $intent ? 'CLICKS' : 'VIEWS';
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -14,6 +14,8 @@ class Campaign_Preparer {
 
 	private const DEFAULT_BUDGET_TOTAL  = 50.0;
 	private const DEFAULT_DURATION_DAYS = 7;
+	private const SUPPORTED_LANGUAGES   = array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' );
+	private const SUPPORTED_DEVICES     = array( 'mobile', 'desktop' );
 
 	/**
 	 * Prepare a Blaze campaign proposal from a target post and optional overrides.
@@ -118,7 +120,7 @@ class Campaign_Preparer {
 				array_filter(
 					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
 					static function ( $code ) {
-						return '' !== $code;
+						return in_array( $code, self::SUPPORTED_LANGUAGES, true );
 					}
 				)
 			);
@@ -137,6 +139,36 @@ class Campaign_Preparer {
 			);
 			if ( ! empty( $countries ) ) {
 				$payload['countries'] = $countries;
+			}
+		}
+		if ( isset( $args['devices'] ) && is_array( $args['devices'] ) ) {
+			$devices = array_values(
+				array_unique(
+					array_filter(
+						array_map( 'strtolower', array_map( 'strval', $args['devices'] ) ),
+						static function ( $device ) {
+							return in_array( $device, self::SUPPORTED_DEVICES, true );
+						}
+					)
+				)
+			);
+			if ( 1 === count( $devices ) ) {
+				$payload['devices'] = $devices;
+			}
+		}
+		if ( isset( $args['interests'] ) && is_array( $args['interests'] ) ) {
+			$page_topics = array_values(
+				array_unique(
+					array_filter(
+						array_map( 'strval', $args['interests'] ),
+						static function ( $topic ) {
+							return 1 === preg_match( '/^IAB\d+(?:_IAB\d+)*$/', $topic ) && 'IAB24' !== $topic;
+						}
+					)
+				)
+			);
+			if ( ! empty( $page_topics ) ) {
+				$payload['page_topics'] = $page_topics;
 			}
 		}
 

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -16,6 +16,20 @@ class Campaign_Preparer {
 	private const DEFAULT_DURATION_DAYS = 7;
 	private const SUPPORTED_LANGUAGES   = array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' );
 	private const SUPPORTED_DEVICES     = array( 'mobile', 'desktop' );
+	private const SUPPORTED_PAGE_TOPICS = array(
+		'IAB1',
+		'IAB8_IAB18',
+		'IAB19',
+		'IAB5_IAB15',
+		'IAB6_IAB7_IAB16',
+		'IAB3_IAB4_IAB13',
+		'IAB11_IAB12',
+		'IAB14_IAB23',
+		'IAB17',
+		'IAB2_IAB20',
+		'IAB10_IAB21_IAB13',
+		'IAB9_IAB22',
+	);
 
 	/**
 	 * Prepare a Blaze campaign proposal from a target post and optional overrides.
@@ -160,10 +174,7 @@ class Campaign_Preparer {
 			$page_topics = array_values(
 				array_unique(
 					array_filter(
-						array_map( 'strval', $args['interests'] ),
-						static function ( $topic ) {
-							return 1 === preg_match( '/^IAB\d+(?:_IAB\d+)*$/', $topic ) && 'IAB24' !== $topic;
-						}
+						array_map( array( self::class, 'normalize_page_topic' ), $args['interests'] )
 					)
 				)
 			);
@@ -173,6 +184,34 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Normalize an MCP-supplied interest code to a public Blaze page topic.
+	 *
+	 * Blaze's public targeting endpoint exposes a compact set of custom topic
+	 * IDs, some of which group several IAB categories. If an agent supplies a
+	 * bare IAB category that belongs to a public group, emit the supported group
+	 * ID so the widget can display and submit it correctly.
+	 *
+	 * @param mixed $topic Raw topic value.
+	 * @return string|null Supported public page topic ID, or null to drop it.
+	 */
+	private static function normalize_page_topic( $topic ): ?string {
+		$topic = strtoupper( (string) $topic );
+		if ( in_array( $topic, self::SUPPORTED_PAGE_TOPICS, true ) ) {
+			return $topic;
+		}
+		if ( 1 !== preg_match( '/^IAB\d+$/', $topic ) ) {
+			return null;
+		}
+		foreach ( self::SUPPORTED_PAGE_TOPICS as $supported_topic ) {
+			$parts = explode( '_', $supported_topic );
+			if ( in_array( $topic, $parts, true ) ) {
+				return $supported_topic;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -41,6 +41,11 @@ class Campaign_Preparer {
 	 * @return array|\WP_Error
 	 */
 	public static function prepare( array $args ) {
+		$args = self::normalize_target_args( $args );
+		if ( is_wp_error( $args ) ) {
+			return $args;
+		}
+
 		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
 		if ( '' === $urn || ! preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $matches ) ) {
 			return new \WP_Error(
@@ -83,6 +88,81 @@ class Campaign_Preparer {
 		}
 
 		return $proposal;
+	}
+
+	/**
+	 * Normalize public target input forms into the canonical target URN.
+	 *
+	 * @param array $args Preparation input.
+	 * @return array|\WP_Error
+	 */
+	private static function normalize_target_args( array $args ) {
+		if ( isset( $args['target_urn'] ) && '' !== (string) $args['target_urn'] ) {
+			return $args;
+		}
+
+		$has_post_id    = isset( $args['post_id'] ) && '' !== (string) $args['post_id'];
+		$has_product_id = isset( $args['product_id'] ) && '' !== (string) $args['product_id'];
+
+		if ( $has_post_id && $has_product_id ) {
+			return new \WP_Error(
+				'blaze_ambiguous_target',
+				__( 'Provide only one of post_id or product_id when target_urn is omitted.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! isset( $args['site_url'] ) || '' === (string) $args['site_url'] || ( ! $has_post_id && ! $has_product_id ) ) {
+			return new \WP_Error(
+				'blaze_missing_target',
+				__( 'Provide target_urn, or provide site_url with exactly one of post_id or product_id.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$site_id = self::lookup_public_site_id( (string) $args['site_url'] );
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$target_id          = $has_product_id ? (int) $args['product_id'] : (int) $args['post_id'];
+		$args['target_urn'] = sprintf( 'urn:wpcom:post:%d:%d', (int) $site_id, $target_id );
+
+		return $args;
+	}
+
+	/**
+	 * Resolve a public WordPress.com site URL/domain to its site ID.
+	 *
+	 * @param string $site_url Public site URL or domain.
+	 * @return int|\WP_Error
+	 */
+	private static function lookup_public_site_id( string $site_url ) {
+		$response = wp_remote_get(
+			'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $site_url ),
+			array(
+				'timeout' => 5,
+			)
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return new \WP_Error(
+				'blaze_site_lookup_failed',
+				__( 'Could not resolve site_url through the public WordPress.com sites API.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $data ) || empty( $data['ID'] ) ) {
+			return new \WP_Error(
+				'blaze_site_not_connected',
+				__( 'The supplied site_url did not resolve to a connected WordPress.com site.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return (int) $data['ID'];
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -72,19 +72,31 @@ class Campaign_Preparer {
 		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 		$forecast        = self::request_forecast( $prefill, $intent );
+		$summary         = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
+		$package         = self::build_prepared_campaign_identity( $prefill, $summary );
+		$eligibility     = self::build_submit_eligibility( $args, $prefill, $prefill_url );
 
 		$proposal = array(
-			'status'          => 'pending_merchant_review',
-			'intent'          => $intent,
-			'forecast'        => $forecast,
-			'assumptions'     => $assumptions,
-			'recommendations' => $recommendations,
-			'prefill_url'     => $prefill_url,
-			'prefill'         => $prefill,
+			'status'               => 'pending_merchant_review',
+			'prepared_campaign'    => $package,
+			'rendered_preview'     => self::build_rendered_preview( $prefill, $package ),
+			'campaign_summary'     => $summary,
+			'fallback_url'         => $prefill_url,
+			'submit_eligibility'   => $eligibility,
+			'material_edit_policy' => self::build_material_edit_policy(),
+			'intent'               => $intent,
+			'forecast'             => $forecast,
+			'assumptions'          => $assumptions,
+			'recommendations'      => $recommendations,
+			'prefill_url'          => $prefill_url,
+			'prefill'              => $prefill,
 		);
 
 		if ( $budget_context['include_options'] ) {
 			$proposal['budget_options'] = $budget_context['options'];
+		}
+		if ( $eligibility['chat_native_submit'] ) {
+			$proposal['approval_block'] = self::build_approval_block( $package );
 		}
 
 		return $proposal;
@@ -284,6 +296,212 @@ class Campaign_Preparer {
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Build the immutable package identity for a prepared campaign.
+	 *
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @param array $summary Structured campaign summary.
+	 * @return array
+	 */
+	private static function build_prepared_campaign_identity( array $prefill, array $summary ): array {
+		$identity_payload = array(
+			'contract_version' => 'v1',
+			'prefill'          => $prefill,
+			'campaign_summary' => $summary,
+		);
+		$hash             = hash( 'sha256', (string) wp_json_encode( $identity_payload, JSON_UNESCAPED_SLASHES ) );
+
+		return array(
+			'id'      => $hash,
+			'hash'    => $hash,
+			'version' => 'v1',
+		);
+	}
+
+	/**
+	 * Build a Blaze-owned HTML preview artifact for chat clients.
+	 *
+	 * @param array $prefill  Recommended campaign prefill payload.
+	 * @param array $package  Prepared campaign identity.
+	 * @return array
+	 */
+	private static function build_rendered_preview( array $prefill, array $package ): array {
+		$image = isset( $prefill['main_image'] ) && is_array( $prefill['main_image'] ) ? $prefill['main_image'] : array();
+
+		$html  = '<article class="blaze-prepared-campaign-preview" data-blaze-prepared-campaign-id="';
+		$html .= esc_attr( $package['id'] ) . '">';
+		$html .= '<div class="blaze-prepared-campaign-preview__body">';
+		if ( ! empty( $image['url'] ) ) {
+			$html .= '<img class="blaze-prepared-campaign-preview__image" src="';
+			$html .= esc_url( (string) $image['url'] ) . '" alt="" />';
+		}
+		$html .= '<h3 class="blaze-prepared-campaign-preview__heading">';
+		$html .= esc_html( $prefill['site_name'] ?? '' ) . '</h3>';
+		$html .= '<p class="blaze-prepared-campaign-preview__copy">';
+		$html .= esc_html( $prefill['text_snippet'] ?? '' ) . '</p>';
+		$html .= '<span class="blaze-prepared-campaign-preview__cta">';
+		$html .= esc_html( $prefill['cta_text'] ?? '' ) . '</span>';
+		$html .= '</div>';
+		$html .= '</article>';
+
+		return array(
+			'type' => 'html',
+			'html' => $html,
+		);
+	}
+
+	/**
+	 * Build structured campaign summary values for chat display.
+	 *
+	 * @param \WP_Post $post           The target post.
+	 * @param array    $prefill        Recommended campaign prefill payload.
+	 * @param string   $intent         Inferred campaign intent.
+	 * @param array    $budget_context Resolved budget defaults and options.
+	 * @return array
+	 */
+	private static function build_campaign_summary( $post, array $prefill, string $intent, array $budget_context ): array {
+		$duration_days = isset( $prefill['duration_days'] ) ? max( 1, (int) $prefill['duration_days'] ) : self::DEFAULT_DURATION_DAYS;
+		$budget        = isset( $prefill['budget'] ) && is_array( $prefill['budget'] ) ? $prefill['budget'] : array();
+		$total_amount  = isset( $budget['amount'] ) ? (float) $budget['amount'] : self::DEFAULT_BUDGET_TOTAL;
+		$currency      = isset( $budget['currency'] ) ? (string) $budget['currency'] : $budget_context['currency'];
+		$start_date    = gmdate( 'Y-m-d' );
+		$end_date      = gmdate( 'Y-m-d', strtotime( '+' . ( $duration_days - 1 ) . ' days' ) );
+
+		return array(
+			'destination'       => array(
+				'url'        => isset( $prefill['target_url'] ) ? (string) $prefill['target_url'] : '',
+				'target_urn' => isset( $prefill['target_urn'] ) ? (string) $prefill['target_urn'] : '',
+			),
+			'creative'          => array(
+				'heading'        => isset( $prefill['site_name'] ) ? (string) $prefill['site_name'] : '',
+				'copy'           => isset( $prefill['text_snippet'] ) ? (string) $prefill['text_snippet'] : '',
+				'call_to_action' => isset( $prefill['cta_text'] ) ? (string) $prefill['cta_text'] : '',
+				'image_url'      => isset( $prefill['main_image']['url'] ) ? (string) $prefill['main_image']['url'] : '',
+			),
+			'budget'            => array(
+				'mode'  => isset( $budget['mode'] ) ? (string) $budget['mode'] : 'total',
+				'total' => array(
+					'amount'   => $total_amount,
+					'currency' => $currency,
+				),
+				'daily' => array(
+					'amount'   => round( $total_amount / $duration_days, 2 ),
+					'currency' => $currency,
+				),
+			),
+			'cadence'           => array(
+				'duration_days' => $duration_days,
+				'is_evergreen'  => isset( $prefill['is_evergreen'] ) ? (bool) $prefill['is_evergreen'] : true,
+			),
+			'schedule'          => array(
+				'start_date' => $start_date,
+				'end_date'   => $end_date,
+				'time_zone'  => self::get_site_timezone(),
+			),
+			'targeting_summary' => array(
+				'countries'   => isset( $prefill['countries'] ) ? array_values( (array) $prefill['countries'] ) : array(),
+				'languages'   => isset( $prefill['languages'] ) ? array_values( (array) $prefill['languages'] ) : array(),
+				'devices'     => isset( $prefill['devices'] ) ? array_values( (array) $prefill['devices'] ) : array(),
+				'page_topics' => isset( $prefill['page_topics'] ) ? array_values( (array) $prefill['page_topics'] ) : array(),
+			),
+			'source_context'    => array(
+				'source'     => 'wordpress_post',
+				'post_id'    => (int) $post->ID,
+				'post_type'  => (string) $post->post_type,
+				'target_urn' => isset( $prefill['target_urn'] ) ? (string) $prefill['target_urn'] : '',
+				'intent'     => $intent,
+			),
+		);
+	}
+
+	/**
+	 * Build chat-native submit eligibility hints.
+	 *
+	 * @param array  $args         Preparation input.
+	 * @param array  $prefill      Recommended campaign prefill payload.
+	 * @param string $fallback_url Blaze widget/dashboard fallback URL.
+	 * @return array
+	 */
+	private static function build_submit_eligibility( array $args, array $prefill, string $fallback_url ): array {
+		/**
+		 * Filters whether the prepared campaign can use an existing saved payment
+		 * method for chat-native submit.
+		 *
+		 * Return true when the site/user has a saved payment method available,
+		 * false when Blaze knows one is missing, or null when eligibility is
+		 * unknown and the caller should use the fallback URL.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool|null $has_saved_payment_method Saved-payment eligibility.
+		 * @param array     $args                     Preparation input.
+		 * @param array     $prefill                  Recommended campaign prefill payload.
+		 */
+		$has_saved_payment_method = apply_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', null, $args, $prefill );
+
+		if ( true === $has_saved_payment_method ) {
+			return array(
+				'chat_native_submit' => true,
+				'payment_method'     => 'saved_payment_method',
+				'reason'             => null,
+				'fallback_url'       => $fallback_url,
+			);
+		}
+
+		return array(
+			'chat_native_submit' => false,
+			'payment_method'     => false === $has_saved_payment_method
+				? 'missing_saved_payment_method'
+				: 'unknown',
+			'reason'             => false === $has_saved_payment_method
+				? 'saved_payment_method_required'
+				: 'payment_eligibility_unknown',
+			'fallback_url'       => $fallback_url,
+		);
+	}
+
+	/**
+	 * Build approval wording data for chat-native submit.
+	 *
+	 * @param array $package Prepared campaign identity.
+	 * @return array
+	 */
+	private static function build_approval_block( array $package ): array {
+		return array(
+			'prepared_campaign_id'     => $package['id'],
+			'prepared_campaign_hash'   => $package['hash'],
+			'title_key'                => 'blaze.approval.title',
+			'body_key'                 => 'blaze.approval.body',
+			'confirmation_label_key'   => 'blaze.approval.confirm_prepared_campaign',
+			'approval_statement'       => __( 'Approve this exact prepared Blaze campaign package for submission.', 'jetpack-blaze' ),
+			'requires_exact_identity'  => true,
+			'requires_reprepare_edits' => true,
+		);
+	}
+
+	/**
+	 * Describe which edits invalidate the prepared package identity.
+	 *
+	 * @return array
+	 */
+	private static function build_material_edit_policy(): array {
+		return array(
+			'requires_reprepare' => true,
+			'material_fields'    => array(
+				'destination',
+				'creative',
+				'budget',
+				'cadence',
+				'schedule',
+				'targeting',
+			),
+			'message'            => __(
+				'Changing destination, creative, budget, cadence, schedule, or targeting requires preparing a new Blaze campaign package before approval or submit.',
+				'jetpack-blaze'
+			),
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -77,17 +77,19 @@ class Campaign_Preparer {
 		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 		$forecast        = self::request_forecast( $prefill, $intent );
-		$summary            = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
+		$summary         = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
 		$payment_context    = self::resolve_payment_context( $args, $prefill );
 		$terms              = self::get_approval_terms();
 		$advertising_policy = self::get_approval_advertising_policy();
 		$cancellation_terms = self::get_approval_cancellation_terms();
-		$package            = self::build_prepared_campaign_identity( $prefill, $summary, $payment_context['selected_payment_method'], $terms, $advertising_policy );
+		$submit_payload     = self::build_submit_campaign_payload( $prefill, $summary, $payment_context['selected_payment_method'] );
+		$package            = self::build_prepared_campaign_identity( $submit_payload );
 		$eligibility        = self::build_submit_eligibility( $args, $prefill, $prefill_url, $payment_context );
 
 		$proposal = array(
 			'status'               => 'pending_merchant_review',
 			'prepared_campaign'    => $package,
+			'submit_package'       => self::build_submit_package( $package, $submit_payload, $terms, $advertising_policy ),
 			'rendered_preview'     => self::build_rendered_preview( $prefill, $package ),
 			'campaign_summary'     => $summary,
 			'fallback_url'         => $prefill_url,
@@ -419,26 +421,11 @@ class Campaign_Preparer {
 	/**
 	 * Build the immutable package identity for a prepared campaign.
 	 *
-	 * @param array      $prefill                 Recommended campaign prefill payload.
-	 * @param array      $summary                 Structured campaign summary.
-	 * @param array|null $selected_payment_method Selected saved payment method summary.
+	 * @param array $submit_payload Exact DSP create-campaign payload.
 	 * @return array
 	 */
-	private static function build_prepared_campaign_identity(
-		array $prefill,
-		array $summary,
-		$selected_payment_method = null,
-		array $terms = array(),
-		array $advertising_policy = array()
-	): array {
-		$identity_payload = array(
-			'contract_version'        => self::APPROVAL_VERSION,
-			'material_campaign'       => self::build_material_campaign_identity( $prefill, $summary ),
-			'selected_payment_method' => $selected_payment_method,
-			'terms'                   => $terms,
-			'advertising_policy'      => $advertising_policy,
-		);
-		$hash             = hash( 'sha256', (string) wp_json_encode( $identity_payload, JSON_UNESCAPED_SLASHES ) );
+	private static function build_prepared_campaign_identity( array $submit_payload ): array {
+		$hash = self::stable_hash( $submit_payload );
 
 		return array(
 			'id'      => $hash,
@@ -478,6 +465,102 @@ class Campaign_Preparer {
 			'objective'         => $prefill['objective'] ?? '',
 			'target_type'       => $prefill['type'] ?? '',
 		);
+	}
+
+	/**
+	 * Build the exact DSP create-campaign payload that chat submit will send.
+	 *
+	 * @param array      $prefill                 Recommended campaign prefill payload.
+	 * @param array      $summary                 Structured campaign summary.
+	 * @param array|null $selected_payment_method Selected saved payment method summary.
+	 * @return array
+	 */
+	private static function build_submit_campaign_payload( array $prefill, array $summary, $selected_payment_method ): array {
+		$schedule  = isset( $summary['schedule'] ) && is_array( $summary['schedule'] ) ? $summary['schedule'] : array();
+		$targeting = array();
+
+		foreach ( array( 'countries' => 'locations', 'languages' => 'languages', 'devices' => 'devices', 'page_topics' => 'page_topics' ) as $prefill_key => $targeting_key ) {
+			if ( ! empty( $prefill[ $prefill_key ] ) && is_array( $prefill[ $prefill_key ] ) ) {
+				$targeting[ $targeting_key ] = array_values( $prefill[ $prefill_key ] );
+			}
+		}
+
+		return array(
+			'origin'            => 'mcp_chat',
+			'origin_version'    => self::APPROVAL_VERSION,
+			'target_urn'        => isset( $prefill['target_urn'] ) ? (string) $prefill['target_urn'] : '',
+			'type'              => isset( $prefill['type'] ) ? (string) $prefill['type'] : 'post',
+			'payment_method_id' => is_array( $selected_payment_method ) && isset( $selected_payment_method['id'] ) ? (string) $selected_payment_method['id'] : '',
+			'start_date'        => isset( $schedule['start_date'] ) ? (string) $schedule['start_date'] : gmdate( 'Y-m-d' ),
+			'end_date'          => isset( $schedule['end_date'] ) ? (string) $schedule['end_date'] : gmdate( 'Y-m-d' ),
+			'time_zone'         => isset( $schedule['time_zone'] ) ? (string) $schedule['time_zone'] : self::get_site_timezone(),
+			'site_name'         => isset( $prefill['site_name'] ) ? (string) $prefill['site_name'] : '',
+			'text_snippet'      => isset( $prefill['text_snippet'] ) ? (string) $prefill['text_snippet'] : '',
+			'cta_text'          => isset( $prefill['cta_text'] ) ? (string) $prefill['cta_text'] : '',
+			'target_url'        => isset( $prefill['target_url'] ) ? (string) $prefill['target_url'] : '',
+			'url_params'        => '',
+			'main_image'        => isset( $prefill['main_image'] ) && is_array( $prefill['main_image'] ) ? $prefill['main_image'] : array(
+				'url'       => '',
+				'mime_type' => 'image/jpeg',
+			),
+			'budget'            => isset( $prefill['budget'] ) && is_array( $prefill['budget'] ) ? $prefill['budget'] : array(),
+			'objective'         => isset( $prefill['objective'] ) ? (string) $prefill['objective'] : 'views',
+			'is_evergreen'      => isset( $prefill['is_evergreen'] ) ? (bool) $prefill['is_evergreen'] : true,
+			'targeting'         => $targeting,
+		);
+	}
+
+	/**
+	 * Build the submit package clients can pass to submit-prepared-campaign.
+	 *
+	 * @param array $package            Prepared campaign identity.
+	 * @param array $submit_payload     Exact DSP create-campaign payload.
+	 * @param array $terms              Terms document identity.
+	 * @param array $advertising_policy Advertising policy document identity.
+	 * @return array
+	 */
+	private static function build_submit_package( array $package, array $submit_payload, array $terms, array $advertising_policy ): array {
+		return array(
+			'prepared_package_id'     => $package['id'],
+			'prepared_campaign_hash'  => $package['hash'],
+			'prepared_campaign'       => $submit_payload,
+			'accepted_terms_version'  => isset( $terms['version'] ) ? (string) $terms['version'] : '',
+			'accepted_policy_version' => isset( $advertising_policy['version'] ) ? (string) $advertising_policy['version'] : '',
+		);
+	}
+
+	/**
+	 * Stable JSON hash compatible with DSP's submit-prepared-campaign hash.
+	 *
+	 * @param mixed $value Value to hash.
+	 * @return string
+	 */
+	private static function stable_hash( $value ): string {
+		return hash( 'sha256', self::stable_json( $value ) );
+	}
+
+	/**
+	 * Stable JSON encoder: object keys sorted recursively, list order kept.
+	 *
+	 * @param mixed $value Value to encode.
+	 * @return string
+	 */
+	private static function stable_json( $value ): string {
+		if ( is_array( $value ) ) {
+			if ( self::is_list_array( $value ) ) {
+				$encoded = array_map( array( __CLASS__, 'stable_json' ), $value );
+				return '[' . implode( ',', $encoded ) . ']';
+			}
+
+			ksort( $value );
+			$parts = array();
+			foreach ( $value as $key => $item ) {
+				$parts[] = wp_json_encode( (string) $key ) . ':' . self::stable_json( $item );
+			}
+			return '{' . implode( ',', $parts ) . '}';
+		}
+
+		return (string) wp_json_encode( $value );
 	}
 
 	/**
@@ -951,18 +1034,28 @@ class Campaign_Preparer {
 			'approval_event'           => array_merge(
 				$contract,
 				array(
-					'approved_at'     => null,
-					'idempotency_key' => $idempotency_key,
+					'type'                    => 'prepared_campaign.approved',
+					'prepared_package_id'     => $package['id'],
+					'payment_method_id'       => $contract['selected_payment_method_id'],
+					'accepted_terms_version'  => $terms['version'] ?? '',
+					'accepted_policy_version' => $advertising_policy['version'] ?? '',
+					'approved_at'             => null,
+					'idempotency_key'         => $idempotency_key,
 				)
 			),
 			'approval_event_required_fields' => array(
+				'type',
 				'contract_version',
+				'prepared_package_id',
 				'prepared_campaign_id',
 				'prepared_campaign_hash',
 				'terms',
 				'advertising_policy',
+				'accepted_terms_version',
+				'accepted_policy_version',
 				'charge',
 				'cancellation',
+				'payment_method_id',
 				'selected_payment_method_id',
 				'selected_payment_method',
 				'user',

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -70,26 +70,27 @@ class Campaign_Preparer {
 			);
 		}
 
-		$intent          = self::infer_intent( $args, $post );
-		$budget_context  = self::resolve_budget_context( $args );
-		$assumptions     = self::build_assumptions( $args, $post, $intent, $budget_context );
-		$recommendations = self::build_recommendations( $intent, $budget_context );
-		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
-		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
-		$forecast        = self::request_forecast( $prefill, $intent );
-		$summary         = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
+		$intent             = self::infer_intent( $args, $post );
+		$budget_context     = self::resolve_budget_context( $args );
+		$assumptions        = self::build_assumptions( $args, $post, $intent, $budget_context );
+		$recommendations    = self::build_recommendations( $intent, $budget_context );
+		$prefill            = self::build_prefill_payload( $args, $post, $intent, $budget_context );
+		$prefill_url        = self::build_prefill_url( $post->ID, $prefill );
+		$forecast           = self::request_forecast( $prefill, $intent );
+		$summary            = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
 		$payment_context    = self::resolve_payment_context( $args, $prefill );
 		$terms              = self::get_approval_terms();
 		$advertising_policy = self::get_approval_advertising_policy();
 		$cancellation_terms = self::get_approval_cancellation_terms();
 		$submit_payload     = self::build_submit_campaign_payload( $prefill, $summary, $payment_context['selected_payment_method'] );
 		$package            = self::build_prepared_campaign_identity( $submit_payload );
+		$idempotency_key    = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : hash( 'sha256', wp_rand() . microtime() );
 		$eligibility        = self::build_submit_eligibility( $args, $prefill, $prefill_url, $payment_context );
 
 		$proposal = array(
 			'status'               => 'pending_merchant_review',
 			'prepared_campaign'    => $package,
-			'submit_package'       => self::build_submit_package( $package, $submit_payload, $terms, $advertising_policy ),
+			'submit_package'       => self::build_submit_package( $package, $submit_payload, $terms, $advertising_policy, $idempotency_key ),
 			'rendered_preview'     => self::build_rendered_preview( $prefill, $package ),
 			'campaign_summary'     => $summary,
 			'fallback_url'         => $prefill_url,
@@ -113,7 +114,8 @@ class Campaign_Preparer {
 				$payment_context['selected_payment_method'],
 				$terms,
 				$advertising_policy,
-				$cancellation_terms
+				$cancellation_terms,
+				$idempotency_key
 			);
 		}
 
@@ -479,7 +481,12 @@ class Campaign_Preparer {
 		$schedule  = isset( $summary['schedule'] ) && is_array( $summary['schedule'] ) ? $summary['schedule'] : array();
 		$targeting = array();
 
-		foreach ( array( 'countries' => 'locations', 'languages' => 'languages', 'devices' => 'devices', 'page_topics' => 'page_topics' ) as $prefill_key => $targeting_key ) {
+		foreach ( array(
+			'countries'   => 'locations',
+			'languages'   => 'languages',
+			'devices'     => 'devices',
+			'page_topics' => 'page_topics',
+		) as $prefill_key => $targeting_key ) {
 			if ( ! empty( $prefill[ $prefill_key ] ) && is_array( $prefill[ $prefill_key ] ) ) {
 				$targeting[ $targeting_key ] = array_values( $prefill[ $prefill_key ] );
 			}
@@ -513,14 +520,16 @@ class Campaign_Preparer {
 	/**
 	 * Build the submit package clients can pass to submit-prepared-campaign.
 	 *
-	 * @param array $package            Prepared campaign identity.
-	 * @param array $submit_payload     Exact DSP create-campaign payload.
-	 * @param array $terms              Terms document identity.
-	 * @param array $advertising_policy Advertising policy document identity.
+	 * @param array  $package            Prepared campaign identity.
+	 * @param array  $submit_payload     Exact DSP create-campaign payload.
+	 * @param array  $terms              Terms document identity.
+	 * @param array  $advertising_policy Advertising policy document identity.
+	 * @param string $idempotency_key   Durable submit idempotency key.
 	 * @return array
 	 */
-	private static function build_submit_package( array $package, array $submit_payload, array $terms, array $advertising_policy ): array {
+	private static function build_submit_package( array $package, array $submit_payload, array $terms, array $advertising_policy, string $idempotency_key ): array {
 		return array(
+			'idempotency_key'         => $idempotency_key,
 			'prepared_package_id'     => $package['id'],
 			'prepared_campaign_hash'  => $package['hash'],
 			'prepared_campaign'       => $submit_payload,
@@ -555,12 +564,12 @@ class Campaign_Preparer {
 			ksort( $value );
 			$parts = array();
 			foreach ( $value as $key => $item ) {
-				$parts[] = wp_json_encode( (string) $key ) . ':' . self::stable_json( $item );
+				$parts[] = wp_json_encode( (string) $key, JSON_UNESCAPED_SLASHES ) . ':' . self::stable_json( $item );
 			}
 			return '{' . implode( ',', $parts ) . '}';
 		}
 
-		return (string) wp_json_encode( $value );
+		return (string) wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
 	}
 
 	/**
@@ -608,16 +617,16 @@ class Campaign_Preparer {
 
 			return array(
 				'known'                       => true,
-				'available_payment_methods'  => $methods,
-				'selected_payment_method'    => $selected,
+				'available_payment_methods'   => $methods,
+				'selected_payment_method'     => $selected,
 				'requested_payment_method_id' => $requested_method_id,
 			);
 		}
 
 		return array(
 			'known'                       => false,
-			'available_payment_methods'  => array(),
-			'selected_payment_method'    => null,
+			'available_payment_methods'   => array(),
+			'selected_payment_method'     => null,
 			'requested_payment_method_id' => isset( $args['payment_method_id'] ) ? (string) $args['payment_method_id'] : '',
 		);
 	}
@@ -702,10 +711,10 @@ class Campaign_Preparer {
 		}
 
 		$summary = array(
-			'id'         => $id,
-			'type'       => $type,
-			'brand'      => $brand,
-			'last4'      => $last4,
+			'id'    => $id,
+			'type'  => $type,
+			'brand' => $brand,
+			'last4' => $last4,
 		);
 
 		if ( null !== $exp_month ) {
@@ -959,9 +968,9 @@ class Campaign_Preparer {
 	private static function build_submit_eligibility( array $args, array $prefill, string $fallback_url, array $payment_context ): array {
 		if ( $payment_context['known'] ) {
 			$base = array(
-				'fallback_url'                       => $fallback_url,
-				'selected_payment_method'            => $payment_context['selected_payment_method'],
-				'available_payment_methods'          => $payment_context['available_payment_methods'],
+				'fallback_url'                      => $fallback_url,
+				'selected_payment_method'           => $payment_context['selected_payment_method'],
+				'available_payment_methods'         => $payment_context['available_payment_methods'],
 				'supports_payment_method_switching' => count( $payment_context['available_payment_methods'] ) > 1,
 			);
 
@@ -1005,9 +1014,9 @@ class Campaign_Preparer {
 		$has_saved_payment_method = apply_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', null, $args, $prefill );
 
 		$base = array(
-			'fallback_url'                       => $fallback_url,
-			'selected_payment_method'            => null,
-			'available_payment_methods'          => array(),
+			'fallback_url'                      => $fallback_url,
+			'selected_payment_method'           => null,
+			'available_payment_methods'         => array(),
 			'supports_payment_method_switching' => false,
 		);
 
@@ -1045,6 +1054,7 @@ class Campaign_Preparer {
 	 * @param array      $terms                   Terms document identity.
 	 * @param array      $advertising_policy      Advertising policy document identity.
 	 * @param array      $cancellation_terms      Cancellation wording identity.
+	 * @param string     $idempotency_key         Durable submit idempotency key.
 	 * @return array
 	 */
 	private static function build_approval_block(
@@ -1053,20 +1063,20 @@ class Campaign_Preparer {
 		$selected_payment_method,
 		array $terms,
 		array $advertising_policy,
-		array $cancellation_terms
+		array $cancellation_terms,
+		string $idempotency_key
 	): array {
-		$contract        = self::build_approval_contract( $package, $summary, $selected_payment_method, $terms, $advertising_policy, $cancellation_terms );
-		$idempotency_key = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : hash( 'sha256', wp_rand() . microtime() );
+		$contract = self::build_approval_contract( $package, $summary, $selected_payment_method, $terms, $advertising_policy, $cancellation_terms );
 
 		return array(
-			'prepared_campaign_id'     => $package['id'],
-			'prepared_campaign_hash'   => $package['hash'],
-			'title_key'                => 'blaze.approval.title.v1',
-			'body_key'                 => 'blaze.approval.body.v1',
-			'confirmation_label_key'   => 'blaze.approval.confirm_prepared_campaign.v1',
-			'approval_statement'       => __( 'I approve this exact prepared Blaze campaign package and authorize the charge terms shown here.', 'jetpack-blaze' ),
-			'approval_contract'        => $contract,
-			'approval_event'           => array_merge(
+			'prepared_campaign_id'           => $package['id'],
+			'prepared_campaign_hash'         => $package['hash'],
+			'title_key'                      => 'blaze.approval.title.v1',
+			'body_key'                       => 'blaze.approval.body.v1',
+			'confirmation_label_key'         => 'blaze.approval.confirm_prepared_campaign.v1',
+			'approval_statement'             => __( 'I approve this exact prepared Blaze campaign package and authorize the charge terms shown here.', 'jetpack-blaze' ),
+			'approval_contract'              => $contract,
+			'approval_event'                 => array_merge(
 				$contract,
 				array(
 					'type'                    => 'prepared_campaign.approved',
@@ -1098,7 +1108,7 @@ class Campaign_Preparer {
 				'approved_at',
 				'idempotency_key',
 			),
-			'charge_acknowledgement'   => array(
+			'charge_acknowledgement'         => array(
 				'template_key' => 'blaze.approval.charge_acknowledgement',
 				'values'       => array(
 					'max_charge_amount'    => $contract['charge']['max_amount'],
@@ -1109,8 +1119,8 @@ class Campaign_Preparer {
 					'payment_method_label' => $contract['selected_payment_method']['label'] ?? '',
 				),
 			),
-			'requires_exact_identity'  => true,
-			'requires_reprepare_edits' => true,
+			'requires_exact_identity'        => true,
+			'requires_reprepare_edits'       => true,
 		);
 	}
 
@@ -1248,8 +1258,8 @@ class Campaign_Preparer {
 	 */
 	private static function build_material_edit_policy(): array {
 		return array(
-			'requires_reprepare' => true,
-			'material_fields'    => array(
+			'requires_reprepare'  => true,
+			'material_fields'     => array(
 				'destination',
 				'creative',
 				'budget',
@@ -1264,7 +1274,7 @@ class Campaign_Preparer {
 				'revision_instruction',
 				'localized_wording',
 			),
-			'message'            => __(
+			'message'             => __(
 				'Changing destination, creative, budget, cadence, schedule, targeting, payment method, or terms/policy version requires preparing a new Blaze campaign package before approval or submit.',
 				'jetpack-blaze'
 			),

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -117,6 +117,7 @@ class Campaign_Preparer {
 				$cancellation_terms,
 				$idempotency_key
 			);
+			$proposal['next_action']    = self::build_chat_submit_next_action( $prefill_url, $proposal['approval_block'] );
 		}
 
 		return $proposal;
@@ -1122,6 +1123,7 @@ class Campaign_Preparer {
 			'body_key'                       => 'blaze.approval.body.v1',
 			'confirmation_label_key'         => 'blaze.approval.confirm_prepared_campaign.v1',
 			'approval_statement'             => __( 'I approve this exact prepared Blaze campaign package and authorize the charge terms shown here.', 'jetpack-blaze' ),
+			'pasteable_approval_message'     => self::build_pasteable_approval_message( $summary, $contract ),
 			'approval_contract'              => $contract,
 			'approval_event'                 => array_merge(
 				$contract,
@@ -1169,6 +1171,74 @@ class Campaign_Preparer {
 			'requires_exact_identity'        => true,
 			'requires_reprepare_edits'       => true,
 		);
+	}
+
+	/**
+	 * Build the default next action for an eligible chat-native submit.
+	 *
+	 * @param string $prefill_url    Optional Blaze widget/dashboard preview URL.
+	 * @param array  $approval_block Structured approval block.
+	 * @return array
+	 */
+	private static function build_chat_submit_next_action( string $prefill_url, array $approval_block ): array {
+		return array(
+			'type'                       => 'request_explicit_approval',
+			'default_flow'               => 'chat_native_submit',
+			'chat_native_submit'         => true,
+			'requires_explicit_approval' => true,
+			'pasteable_approval_message' => $approval_block['pasteable_approval_message'] ?? '',
+			'optional_preview_url'       => $prefill_url,
+			'optional_preview_label'     => __( 'Preview campaign in Blaze', 'jetpack-blaze' ),
+			'message'                    => __(
+				'Ask the user to paste the approval message before submitting this prepared campaign. The preview link is optional for review, not required when chat-native submit is eligible.',
+				'jetpack-blaze'
+			),
+		);
+	}
+
+	/**
+	 * Build a simple user-facing approval sentence for chat clients.
+	 *
+	 * This deliberately omits package hashes, idempotency keys, and tool names.
+	 *
+	 * @param array $summary  Structured campaign summary.
+	 * @param array $contract Structured approval contract.
+	 * @return string
+	 */
+	private static function build_pasteable_approval_message( array $summary, array $contract ): string {
+		$heading              = isset( $summary['creative']['heading'] ) && '' !== (string) $summary['creative']['heading']
+			? (string) $summary['creative']['heading']
+			: __( 'this Blaze campaign', 'jetpack-blaze' );
+		$charge               = isset( $contract['charge'] ) && is_array( $contract['charge'] ) ? $contract['charge'] : array();
+		$currency             = isset( $charge['currency'] ) && '' !== (string) $charge['currency'] ? (string) $charge['currency'] : self::get_site_currency();
+		$amount               = isset( $charge['max_amount'] ) ? (float) $charge['max_amount'] : self::DEFAULT_BUDGET_TOTAL;
+		$payment_method       = isset( $contract['selected_payment_method'] ) && is_array( $contract['selected_payment_method'] ) ? $contract['selected_payment_method'] : array();
+		$payment_method_label = isset( $payment_method['label'] ) && '' !== (string) $payment_method['label']
+			? (string) $payment_method['label']
+			: __( 'the selected saved payment method', 'jetpack-blaze' );
+
+		return sprintf(
+			/* translators: 1: campaign heading, 2: currency code, 3: maximum charge amount, 4: payment method label. */
+			__( 'I approve submitting this Blaze campaign for %1$s with a maximum charge of %2$s %3$s using %4$s. I agree to the Terms of Service and Advertising Policy.', 'jetpack-blaze' ),
+			$heading,
+			$currency,
+			self::format_approval_amount( $amount ),
+			$payment_method_label
+		);
+	}
+
+	/**
+	 * Format an approval amount for readable charge acknowledgement copy.
+	 *
+	 * @param float $amount Approval amount.
+	 * @return string
+	 */
+	private static function format_approval_amount( float $amount ): string {
+		if ( floor( $amount ) === $amount ) {
+			return (string) (int) $amount;
+		}
+
+		return number_format( $amount, 2, '.', '' );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -14,6 +14,11 @@ class Campaign_Preparer {
 
 	private const DEFAULT_BUDGET_TOTAL  = 50.0;
 	private const DEFAULT_DURATION_DAYS = 7;
+	private const APPROVAL_VERSION      = 'v1';
+	private const TERMS_URL             = 'https://wordpress.com/tos/';
+	private const TERMS_VERSION         = 'v1';
+	private const AD_POLICY_URL         = 'https://automattic.com/advertising-policy/';
+	private const AD_POLICY_VERSION     = 'v1';
 	private const INTENT_ECOMMERCE      = 'ecommerce';
 	private const INTENT_CONTENT        = 'content';
 	private const INTENT_UNKNOWN        = 'unknown';
@@ -72,10 +77,13 @@ class Campaign_Preparer {
 		$prefill         = self::build_prefill_payload( $args, $post, $intent, $budget_context );
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 		$forecast        = self::request_forecast( $prefill, $intent );
-		$summary         = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
-		$payment_context = self::resolve_payment_context( $args, $prefill );
-		$package         = self::build_prepared_campaign_identity( $prefill, $summary, $payment_context['selected_payment_method'] );
-		$eligibility     = self::build_submit_eligibility( $args, $prefill, $prefill_url, $payment_context );
+		$summary            = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
+		$payment_context    = self::resolve_payment_context( $args, $prefill );
+		$terms              = self::get_approval_terms();
+		$advertising_policy = self::get_approval_advertising_policy();
+		$cancellation_terms = self::get_approval_cancellation_terms();
+		$package            = self::build_prepared_campaign_identity( $prefill, $summary, $payment_context['selected_payment_method'], $terms, $advertising_policy );
+		$eligibility        = self::build_submit_eligibility( $args, $prefill, $prefill_url, $payment_context );
 
 		$proposal = array(
 			'status'               => 'pending_merchant_review',
@@ -96,11 +104,85 @@ class Campaign_Preparer {
 		if ( $budget_context['include_options'] ) {
 			$proposal['budget_options'] = $budget_context['options'];
 		}
-		if ( $eligibility['chat_native_submit'] ) {
-			$proposal['approval_block'] = self::build_approval_block( $package );
+		if ( $eligibility['chat_native_submit'] && is_array( $payment_context['selected_payment_method'] ) ) {
+			$proposal['approval_block'] = self::build_approval_block(
+				$package,
+				$summary,
+				$payment_context['selected_payment_method'],
+				$terms,
+				$advertising_policy,
+				$cancellation_terms
+			);
 		}
 
 		return $proposal;
+	}
+
+	/**
+	 * Validate a structured approval event against one prepared campaign.
+	 *
+	 * @param array $approval_event Language-independent approval event.
+	 * @param array $proposal       Prepared campaign proposal returned by prepare().
+	 * @return true|\WP_Error
+	 */
+	public static function validate_approval_event( array $approval_event, array $proposal ) {
+		if ( empty( $proposal['approval_block']['approval_contract'] ) || ! is_array( $proposal['approval_block']['approval_contract'] ) ) {
+			return new \WP_Error(
+				'blaze_approval_contract_missing',
+				__( 'The prepared campaign package does not include an approval contract.', 'jetpack-blaze' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$required_fields = array();
+		if (
+			isset( $proposal['approval_block']['approval_event_required_fields'] )
+			&& is_array( $proposal['approval_block']['approval_event_required_fields'] )
+		) {
+			$required_fields = $proposal['approval_block']['approval_event_required_fields'];
+		}
+
+		foreach ( $required_fields as $field ) {
+			if ( ! array_key_exists( $field, $approval_event ) || null === $approval_event[ $field ] || '' === $approval_event[ $field ] ) {
+				return new \WP_Error(
+					'blaze_approval_event_incomplete',
+					sprintf(
+						/* translators: %s: missing approval event field name. */
+						__( 'The approval event is missing required field %s.', 'jetpack-blaze' ),
+						$field
+					),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		$contract = $proposal['approval_block']['approval_contract'];
+		if (
+			(string) ( $contract['prepared_campaign_id'] ?? '' ) !== (string) ( $approval_event['prepared_campaign_id'] ?? '' )
+			|| (string) ( $contract['prepared_campaign_hash'] ?? '' ) !== (string) ( $approval_event['prepared_campaign_hash'] ?? '' )
+		) {
+			return new \WP_Error(
+				'blaze_approval_package_mismatch',
+				__( 'The approval event does not match the prepared campaign package identity.', 'jetpack-blaze' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		foreach ( $contract as $field => $expected_value ) {
+			if ( ! array_key_exists( $field, $approval_event ) || ! self::approval_values_match( $expected_value, $approval_event[ $field ] ) ) {
+				return new \WP_Error(
+					'blaze_approval_contract_mismatch',
+					sprintf(
+						/* translators: %s: mismatched approval event field name. */
+						__( 'The approval event field %s no longer matches the prepared campaign package.', 'jetpack-blaze' ),
+						$field
+					),
+					array( 'status' => 409 )
+				);
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -142,6 +224,41 @@ class Campaign_Preparer {
 		$args['target_urn'] = sprintf( 'urn:wpcom:post:%d:%d', (int) $site_id, $target_id );
 
 		return $args;
+	}
+
+	/**
+	 * Compare approval contract values after JSON normalization.
+	 *
+	 * @param mixed $expected_value Expected contract value.
+	 * @param mixed $actual_value   Approval event value.
+	 * @return bool
+	 */
+	private static function approval_values_match( $expected_value, $actual_value ): bool {
+		return wp_json_encode( self::normalize_approval_value( $expected_value ), JSON_UNESCAPED_SLASHES )
+			=== wp_json_encode( self::normalize_approval_value( $actual_value ), JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * Sort associative arrays before comparing approval values.
+	 *
+	 * @param mixed $value Approval value.
+	 * @return mixed
+	 */
+	private static function normalize_approval_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$normalized = array();
+		foreach ( $value as $key => $item ) {
+			$normalized[ $key ] = self::normalize_approval_value( $item );
+		}
+
+		if ( ! empty( $normalized ) && array_keys( $normalized ) !== range( 0, count( $normalized ) - 1 ) ) {
+			ksort( $normalized );
+		}
+
+		return $normalized;
 	}
 
 	/**
@@ -307,19 +424,59 @@ class Campaign_Preparer {
 	 * @param array|null $selected_payment_method Selected saved payment method summary.
 	 * @return array
 	 */
-	private static function build_prepared_campaign_identity( array $prefill, array $summary, $selected_payment_method = null ): array {
+	private static function build_prepared_campaign_identity(
+		array $prefill,
+		array $summary,
+		$selected_payment_method = null,
+		array $terms = array(),
+		array $advertising_policy = array()
+	): array {
 		$identity_payload = array(
-			'contract_version'        => 'v1',
-			'prefill'                 => $prefill,
-			'campaign_summary'        => $summary,
+			'contract_version'        => self::APPROVAL_VERSION,
+			'material_campaign'       => self::build_material_campaign_identity( $prefill, $summary ),
 			'selected_payment_method' => $selected_payment_method,
+			'terms'                   => $terms,
+			'advertising_policy'      => $advertising_policy,
 		);
 		$hash             = hash( 'sha256', (string) wp_json_encode( $identity_payload, JSON_UNESCAPED_SLASHES ) );
 
 		return array(
 			'id'      => $hash,
 			'hash'    => $hash,
-			'version' => 'v1',
+			'version' => self::APPROVAL_VERSION,
+		);
+	}
+
+	/**
+	 * Build the material package identity payload.
+	 *
+	 * This intentionally excludes explanatory-only inputs such as revision
+	 * instructions so non-material chat copy changes do not force a new
+	 * approval when the actual campaign package is unchanged.
+	 *
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @param array $summary Structured campaign summary.
+	 * @return array
+	 */
+	private static function build_material_campaign_identity( array $prefill, array $summary ): array {
+		$main_image = isset( $prefill['main_image'] ) && is_array( $prefill['main_image'] ) ? $prefill['main_image'] : array();
+
+		return array(
+			'destination'       => $summary['destination'] ?? array(),
+			'creative'          => array(
+				'heading'         => $summary['creative']['heading'] ?? '',
+				'copy'            => $summary['creative']['copy'] ?? '',
+				'call_to_action'  => $summary['creative']['call_to_action'] ?? '',
+				'image_url'       => $summary['creative']['image_url'] ?? '',
+				'image_mime_type' => $main_image['mime_type'] ?? '',
+				'template'        => $prefill['template'] ?? '',
+			),
+			'budget'            => $summary['budget'] ?? array(),
+			'cadence'           => $summary['cadence'] ?? array(),
+			'schedule'          => $summary['schedule'] ?? array(),
+			'targeting_summary' => $summary['targeting_summary'] ?? array(),
+			'objective'         => $prefill['objective'] ?? '',
+			'target_type'       => $prefill['type'] ?? '',
 		);
 	}
 
@@ -739,9 +896,9 @@ class Campaign_Preparer {
 		if ( true === $has_saved_payment_method ) {
 			return array_merge(
 				array(
-					'chat_native_submit' => true,
+					'chat_native_submit' => false,
 					'payment_method'     => 'saved_payment_method',
-					'reason'             => null,
+					'reason'             => 'selected_payment_method_required',
 				),
 				$base
 			);
@@ -764,19 +921,195 @@ class Campaign_Preparer {
 	/**
 	 * Build approval wording data for chat-native submit.
 	 *
-	 * @param array $package Prepared campaign identity.
+	 * @param array      $package                 Prepared campaign identity.
+	 * @param array      $summary                 Structured campaign summary.
+	 * @param array|null $selected_payment_method Selected saved payment method summary.
+	 * @param array      $terms                   Terms document identity.
+	 * @param array      $advertising_policy      Advertising policy document identity.
+	 * @param array      $cancellation_terms      Cancellation wording identity.
 	 * @return array
 	 */
-	private static function build_approval_block( array $package ): array {
+	private static function build_approval_block(
+		array $package,
+		array $summary,
+		$selected_payment_method,
+		array $terms,
+		array $advertising_policy,
+		array $cancellation_terms
+	): array {
+		$contract        = self::build_approval_contract( $package, $summary, $selected_payment_method, $terms, $advertising_policy, $cancellation_terms );
+		$idempotency_key = function_exists( 'wp_generate_uuid4' ) ? wp_generate_uuid4() : hash( 'sha256', wp_rand() . microtime() );
+
 		return array(
 			'prepared_campaign_id'     => $package['id'],
 			'prepared_campaign_hash'   => $package['hash'],
-			'title_key'                => 'blaze.approval.title',
-			'body_key'                 => 'blaze.approval.body',
-			'confirmation_label_key'   => 'blaze.approval.confirm_prepared_campaign',
-			'approval_statement'       => __( 'Approve this exact prepared Blaze campaign package for submission.', 'jetpack-blaze' ),
+			'title_key'                => 'blaze.approval.title.v1',
+			'body_key'                 => 'blaze.approval.body.v1',
+			'confirmation_label_key'   => 'blaze.approval.confirm_prepared_campaign.v1',
+			'approval_statement'       => __( 'I approve this exact prepared Blaze campaign package and authorize the charge terms shown here.', 'jetpack-blaze' ),
+			'approval_contract'        => $contract,
+			'approval_event'           => array_merge(
+				$contract,
+				array(
+					'approved_at'     => null,
+					'idempotency_key' => $idempotency_key,
+				)
+			),
+			'approval_event_required_fields' => array(
+				'contract_version',
+				'prepared_campaign_id',
+				'prepared_campaign_hash',
+				'terms',
+				'advertising_policy',
+				'charge',
+				'cancellation',
+				'selected_payment_method_id',
+				'selected_payment_method',
+				'user',
+				'site',
+				'approved_at',
+				'idempotency_key',
+			),
+			'charge_acknowledgement'   => array(
+				'template_key' => 'blaze.approval.charge_acknowledgement',
+				'values'       => array(
+					'max_charge_amount'    => $contract['charge']['max_amount'],
+					'currency'             => $contract['charge']['currency'],
+					'billing_cadence'      => $contract['charge']['billing_cadence'],
+					'start_date'           => $contract['charge']['start_date'],
+					'cancellation_wording' => $contract['cancellation']['wording'],
+					'payment_method_label' => $contract['selected_payment_method']['label'] ?? '',
+				),
+			),
 			'requires_exact_identity'  => true,
 			'requires_reprepare_edits' => true,
+		);
+	}
+
+	/**
+	 * Build the structured approval contract that a later submit action must
+	 * validate before spending money.
+	 *
+	 * @param array      $package                 Prepared campaign identity.
+	 * @param array      $summary                 Structured campaign summary.
+	 * @param array|null $selected_payment_method Selected saved payment method summary.
+	 * @param array      $terms                   Terms document identity.
+	 * @param array      $advertising_policy      Advertising policy document identity.
+	 * @param array      $cancellation_terms      Cancellation wording identity.
+	 * @return array
+	 */
+	private static function build_approval_contract(
+		array $package,
+		array $summary,
+		$selected_payment_method,
+		array $terms,
+		array $advertising_policy,
+		array $cancellation_terms
+	): array {
+		$total_budget = isset( $summary['budget']['total'] ) && is_array( $summary['budget']['total'] ) ? $summary['budget']['total'] : array();
+		$schedule     = isset( $summary['schedule'] ) && is_array( $summary['schedule'] ) ? $summary['schedule'] : array();
+		$site_id      = \Automattic\Jetpack\Connection\Manager::get_site_id();
+
+		if ( is_wp_error( $site_id ) ) {
+			$site_id = 0;
+		}
+
+		return array(
+			'contract_version'           => self::APPROVAL_VERSION,
+			'prepared_campaign_id'       => $package['id'],
+			'prepared_campaign_hash'     => $package['hash'],
+			'terms'                      => $terms,
+			'advertising_policy'         => $advertising_policy,
+			'charge'                     => array(
+				'max_amount'      => isset( $total_budget['amount'] ) ? (float) $total_budget['amount'] : self::DEFAULT_BUDGET_TOTAL,
+				'currency'        => isset( $total_budget['currency'] ) ? (string) $total_budget['currency'] : self::get_site_currency(),
+				'billing_cadence' => 'one_time',
+				'start_date'      => isset( $schedule['start_date'] ) ? (string) $schedule['start_date'] : gmdate( 'Y-m-d' ),
+			),
+			'cancellation'               => $cancellation_terms,
+			'selected_payment_method_id' => isset( $selected_payment_method['id'] ) ? (string) $selected_payment_method['id'] : '',
+			'selected_payment_method'    => is_array( $selected_payment_method ) ? $selected_payment_method : null,
+			'user'                       => array(
+				'id' => get_current_user_id(),
+			),
+			'site'                       => array(
+				'id' => (int) $site_id,
+			),
+		);
+	}
+
+	/**
+	 * Get the terms document identity for approval contracts.
+	 *
+	 * @return array
+	 */
+	private static function get_approval_terms(): array {
+		$defaults = array(
+			'url'     => self::TERMS_URL,
+			'version' => self::TERMS_VERSION,
+		);
+
+		/**
+		 * Filters the Blaze approval terms document identity.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $terms Terms document identity with url and version.
+		 */
+		$terms = apply_filters( 'jetpack_blaze_approval_terms', $defaults );
+
+		return self::normalize_approval_document( is_array( $terms ) ? $terms : array(), $defaults );
+	}
+
+	/**
+	 * Get the advertising policy document identity for approval contracts.
+	 *
+	 * @return array
+	 */
+	private static function get_approval_advertising_policy(): array {
+		$defaults = array(
+			'url'     => self::AD_POLICY_URL,
+			'version' => self::AD_POLICY_VERSION,
+		);
+
+		/**
+		 * Filters the Blaze approval advertising policy document identity.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $policy Advertising policy document identity with url and version.
+		 */
+		$policy = apply_filters( 'jetpack_blaze_approval_advertising_policy', $defaults );
+
+		return self::normalize_approval_document( is_array( $policy ) ? $policy : array(), $defaults );
+	}
+
+	/**
+	 * Get the cancellation wording identity for approval contracts.
+	 *
+	 * @return array
+	 */
+	private static function get_approval_cancellation_terms(): array {
+		return array(
+			'wording' => __( 'You can cancel this campaign from Blaze. Charges may apply for delivery before cancellation, up to the approved maximum.', 'jetpack-blaze' ),
+			'version' => self::APPROVAL_VERSION,
+		);
+	}
+
+	/**
+	 * Normalize approval document identities.
+	 *
+	 * @param array $document Document identity.
+	 * @param array $defaults Default identity.
+	 * @return array
+	 */
+	private static function normalize_approval_document( array $document, array $defaults ): array {
+		$url     = isset( $document['url'] ) && '' !== (string) $document['url'] ? (string) $document['url'] : $defaults['url'];
+		$version = isset( $document['version'] ) && '' !== (string) $document['version'] ? (string) $document['version'] : $defaults['version'];
+
+		return array(
+			'url'     => $url,
+			'version' => $version,
 		);
 	}
 
@@ -796,9 +1129,15 @@ class Campaign_Preparer {
 				'schedule',
 				'targeting',
 				'payment_method',
+				'terms_policy_version',
+			),
+			'non_material_fields' => array(
+				'explanatory_copy',
+				'revision_instruction',
+				'localized_wording',
 			),
 			'message'            => __(
-				'Changing destination, creative, budget, cadence, schedule, targeting, or payment method requires preparing a new Blaze campaign package before approval or submit.',
+				'Changing destination, creative, budget, cadence, schedule, targeting, payment method, or terms/policy version requires preparing a new Blaze campaign package before approval or submit.',
 				'jetpack-blaze'
 			),
 		);

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -564,6 +564,20 @@ class Campaign_Preparer {
 	}
 
 	/**
+	 * Polyfill array_is_list() for the package PHP support floor.
+	 *
+	 * @param array $array Array to inspect.
+	 * @return bool
+	 */
+	private static function is_list_array( array $array ): bool {
+		if ( array() === $array ) {
+			return true;
+		}
+
+		return array_keys( $array ) === range( 0, count( $array ) - 1 );
+	}
+
+	/**
 	 * Resolve saved payment methods for chat-native submit.
 	 *
 	 * @param array $args    Preparation input.

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -73,8 +73,9 @@ class Campaign_Preparer {
 		$prefill_url     = self::build_prefill_url( $post->ID, $prefill );
 		$forecast        = self::request_forecast( $prefill, $intent );
 		$summary         = self::build_campaign_summary( $post, $prefill, $intent, $budget_context );
-		$package         = self::build_prepared_campaign_identity( $prefill, $summary );
-		$eligibility     = self::build_submit_eligibility( $args, $prefill, $prefill_url );
+		$payment_context = self::resolve_payment_context( $args, $prefill );
+		$package         = self::build_prepared_campaign_identity( $prefill, $summary, $payment_context['selected_payment_method'] );
+		$eligibility     = self::build_submit_eligibility( $args, $prefill, $prefill_url, $payment_context );
 
 		$proposal = array(
 			'status'               => 'pending_merchant_review',
@@ -301,15 +302,17 @@ class Campaign_Preparer {
 	/**
 	 * Build the immutable package identity for a prepared campaign.
 	 *
-	 * @param array $prefill Recommended campaign prefill payload.
-	 * @param array $summary Structured campaign summary.
+	 * @param array      $prefill                 Recommended campaign prefill payload.
+	 * @param array      $summary                 Structured campaign summary.
+	 * @param array|null $selected_payment_method Selected saved payment method summary.
 	 * @return array
 	 */
-	private static function build_prepared_campaign_identity( array $prefill, array $summary ): array {
+	private static function build_prepared_campaign_identity( array $prefill, array $summary, $selected_payment_method = null ): array {
 		$identity_payload = array(
-			'contract_version' => 'v1',
-			'prefill'          => $prefill,
-			'campaign_summary' => $summary,
+			'contract_version'        => 'v1',
+			'prefill'                 => $prefill,
+			'campaign_summary'        => $summary,
+			'selected_payment_method' => $selected_payment_method,
 		);
 		$hash             = hash( 'sha256', (string) wp_json_encode( $identity_payload, JSON_UNESCAPED_SLASHES ) );
 
@@ -318,6 +321,259 @@ class Campaign_Preparer {
 			'hash'    => $hash,
 			'version' => 'v1',
 		);
+	}
+
+	/**
+	 * Resolve saved payment methods for chat-native submit.
+	 *
+	 * @param array $args    Preparation input.
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @return array
+	 */
+	private static function resolve_payment_context( array $args, array $prefill ): array {
+		/**
+		 * Filters existing saved payment methods available to the prepared
+		 * campaign.
+		 *
+		 * Return an array of payment methods when known, an empty array when no
+		 * usable methods exist, or null when the caller cannot determine saved
+		 * payment method eligibility.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array|null $payment_methods Existing saved payment methods.
+		 * @param array      $args            Preparation input.
+		 * @param array      $prefill         Recommended campaign prefill payload.
+		 */
+		$payment_methods = apply_filters( 'jetpack_blaze_prepare_campaign_payment_methods', null, $args, $prefill );
+
+		if ( is_array( $payment_methods ) ) {
+			$methods             = self::normalize_payment_methods( $payment_methods );
+			$requested_method_id = isset( $args['payment_method_id'] ) ? (string) $args['payment_method_id'] : '';
+			$selected            = self::select_payment_method( $methods, $requested_method_id );
+
+			return array(
+				'known'                       => true,
+				'available_payment_methods'  => $methods,
+				'selected_payment_method'    => $selected,
+				'requested_payment_method_id' => $requested_method_id,
+			);
+		}
+
+		return array(
+			'known'                       => false,
+			'available_payment_methods'  => array(),
+			'selected_payment_method'    => null,
+			'requested_payment_method_id' => isset( $args['payment_method_id'] ) ? (string) $args['payment_method_id'] : '',
+		);
+	}
+
+	/**
+	 * Normalize saved payment methods into a compact safe display summary.
+	 *
+	 * @param array $payment_methods Raw payment methods.
+	 * @return array
+	 */
+	private static function normalize_payment_methods( array $payment_methods ): array {
+		$normalized = array();
+
+		foreach ( $payment_methods as $payment_method ) {
+			if ( ! is_array( $payment_method ) ) {
+				continue;
+			}
+
+			$method = self::normalize_payment_method( $payment_method );
+			if ( null !== $method ) {
+				$normalized[] = $method;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize one saved payment method.
+	 *
+	 * @param array $payment_method Raw payment method.
+	 * @return array|null
+	 */
+	private static function normalize_payment_method( array $payment_method ) {
+		$id = self::first_non_empty_string( $payment_method, array( 'id', 'payment_method_id', 'paymentMethodId', 'token_id', 'tokenId' ) );
+		if ( '' === $id || ! self::is_usable_payment_method( $payment_method ) ) {
+			return null;
+		}
+
+		$card      = isset( $payment_method['card'] ) && is_array( $payment_method['card'] ) ? $payment_method['card'] : array();
+		$type      = self::first_non_empty_string( $payment_method, array( 'type', 'payment_method_type', 'paymentMethodType', 'method' ) );
+		$brand     = self::first_non_empty_string( $payment_method, array( 'brand', 'card_brand', 'cardBrand' ) );
+		$last4     = self::first_non_empty_string( $payment_method, array( 'last4', 'last_4', 'card_last4', 'cardLast4' ) );
+		$exp_month = self::first_integer( $payment_method, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
+		$exp_year  = self::first_integer( $payment_method, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
+
+		if ( '' === $brand ) {
+			$brand = self::first_non_empty_string( $card, array( 'brand', 'card_brand', 'cardBrand' ) );
+		}
+		if ( '' === $last4 ) {
+			$last4 = self::first_non_empty_string( $card, array( 'last4', 'last_4', 'card_last4', 'cardLast4' ) );
+		}
+		if ( null === $exp_month ) {
+			$exp_month = self::first_integer( $card, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
+		}
+		if ( null === $exp_year ) {
+			$exp_year = self::first_integer( $card, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
+		}
+		if ( '' === $type ) {
+			$type = '' !== $last4 ? 'card' : 'saved_payment_method';
+		}
+
+		$summary = array(
+			'id'         => $id,
+			'type'       => $type,
+			'brand'      => $brand,
+			'last4'      => $last4,
+		);
+
+		if ( null !== $exp_month ) {
+			$summary['exp_month'] = $exp_month;
+		}
+		if ( null !== $exp_year ) {
+			$summary['exp_year'] = $exp_year;
+		}
+
+		$summary['label']      = self::build_payment_method_label( $type, $brand, $last4 );
+		$summary['is_default'] = self::is_default_payment_method( $payment_method );
+
+		return $summary;
+	}
+
+	/**
+	 * Whether a saved payment method is usable for chat-native submit.
+	 *
+	 * @param array $payment_method Raw payment method.
+	 * @return bool
+	 */
+	private static function is_usable_payment_method( array $payment_method ): bool {
+		foreach ( array( 'usable', 'is_usable', 'isUsable', 'eligible', 'enabled' ) as $key ) {
+			if ( array_key_exists( $key, $payment_method ) ) {
+				return (bool) $payment_method[ $key ];
+			}
+		}
+
+		foreach ( array( 'invalid', 'disabled', 'expired' ) as $key ) {
+			if ( ! empty( $payment_method[ $key ] ) ) {
+				return false;
+			}
+		}
+
+		if ( isset( $payment_method['status'] ) ) {
+			$status = strtolower( (string) $payment_method['status'] );
+			return in_array( $status, array( 'active', 'valid', 'usable', 'enabled' ), true );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a saved payment method is the server-owned default.
+	 *
+	 * @param array $payment_method Raw payment method.
+	 * @return bool
+	 */
+	private static function is_default_payment_method( array $payment_method ): bool {
+		foreach ( array( 'is_default', 'isDefault', 'default' ) as $key ) {
+			if ( array_key_exists( $key, $payment_method ) ) {
+				return (bool) $payment_method[ $key ];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Select the requested saved payment method, the default, or the first usable.
+	 *
+	 * @param array  $payment_methods     Normalized payment methods.
+	 * @param string $requested_method_id Requested payment method ID.
+	 * @return array|null
+	 */
+	private static function select_payment_method( array $payment_methods, string $requested_method_id ) {
+		if ( '' !== $requested_method_id ) {
+			foreach ( $payment_methods as $method ) {
+				if ( isset( $method['id'] ) && $requested_method_id === (string) $method['id'] ) {
+					return $method;
+				}
+			}
+
+			return null;
+		}
+
+		foreach ( $payment_methods as $method ) {
+			if ( ! empty( $method['is_default'] ) ) {
+				return $method;
+			}
+		}
+
+		return $payment_methods[0] ?? null;
+	}
+
+	/**
+	 * Build a compact display label for a saved payment method.
+	 *
+	 * @param string $type  Payment method type.
+	 * @param string $brand Payment brand.
+	 * @param string $last4 Last four digits.
+	 * @return string
+	 */
+	private static function build_payment_method_label( string $type, string $brand, string $last4 ): string {
+		if ( '' !== $last4 ) {
+			$display_brand = '' !== $brand ? ucwords( str_replace( array( '_', '-' ), ' ', $brand ) ) : __( 'Card', 'jetpack-blaze' );
+			return sprintf(
+				/* translators: 1: payment card brand, 2: last four digits. */
+				__( '%1$s ending in %2$s', 'jetpack-blaze' ),
+				$display_brand,
+				$last4
+			);
+		}
+
+		if ( '' !== $brand ) {
+			return ucwords( str_replace( array( '_', '-' ), ' ', $brand ) );
+		}
+
+		return ucwords( str_replace( array( '_', '-' ), ' ', $type ) );
+	}
+
+	/**
+	 * Return the first non-empty string field from an array.
+	 *
+	 * @param array $source Source array.
+	 * @param array $keys   Candidate keys.
+	 * @return string
+	 */
+	private static function first_non_empty_string( array $source, array $keys ): string {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && '' !== (string) $source[ $key ] ) {
+				return (string) $source[ $key ];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return the first integer field from an array.
+	 *
+	 * @param array $source Source array.
+	 * @param array $keys   Candidate keys.
+	 * @return int|null
+	 */
+	private static function first_integer( array $source, array $keys ) {
+		foreach ( $keys as $key ) {
+			if ( isset( $source[ $key ] ) && is_numeric( $source[ $key ] ) ) {
+				return (int) $source[ $key ];
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -419,12 +675,44 @@ class Campaign_Preparer {
 	/**
 	 * Build chat-native submit eligibility hints.
 	 *
-	 * @param array  $args         Preparation input.
-	 * @param array  $prefill      Recommended campaign prefill payload.
-	 * @param string $fallback_url Blaze widget/dashboard fallback URL.
+	 * @param array  $args            Preparation input.
+	 * @param array  $prefill         Recommended campaign prefill payload.
+	 * @param string $fallback_url    Blaze widget/dashboard fallback URL.
+	 * @param array  $payment_context Saved payment method context.
 	 * @return array
 	 */
-	private static function build_submit_eligibility( array $args, array $prefill, string $fallback_url ): array {
+	private static function build_submit_eligibility( array $args, array $prefill, string $fallback_url, array $payment_context ): array {
+		if ( $payment_context['known'] ) {
+			$base = array(
+				'fallback_url'                       => $fallback_url,
+				'selected_payment_method'            => $payment_context['selected_payment_method'],
+				'available_payment_methods'          => $payment_context['available_payment_methods'],
+				'supports_payment_method_switching' => count( $payment_context['available_payment_methods'] ) > 1,
+			);
+
+			if ( is_array( $payment_context['selected_payment_method'] ) ) {
+				return array_merge(
+					array(
+						'chat_native_submit' => true,
+						'payment_method'     => 'saved_payment_method',
+						'reason'             => null,
+					),
+					$base
+				);
+			}
+
+			return array_merge(
+				array(
+					'chat_native_submit' => false,
+					'payment_method'     => 'missing_saved_payment_method',
+					'reason'             => '' !== $payment_context['requested_payment_method_id']
+						? 'requested_payment_method_unavailable'
+						: 'saved_payment_method_required',
+				),
+				$base
+			);
+		}
+
 		/**
 		 * Filters whether the prepared campaign can use an existing saved payment
 		 * method for chat-native submit.
@@ -441,24 +729,35 @@ class Campaign_Preparer {
 		 */
 		$has_saved_payment_method = apply_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', null, $args, $prefill );
 
+		$base = array(
+			'fallback_url'                       => $fallback_url,
+			'selected_payment_method'            => null,
+			'available_payment_methods'          => array(),
+			'supports_payment_method_switching' => false,
+		);
+
 		if ( true === $has_saved_payment_method ) {
-			return array(
-				'chat_native_submit' => true,
-				'payment_method'     => 'saved_payment_method',
-				'reason'             => null,
-				'fallback_url'       => $fallback_url,
+			return array_merge(
+				array(
+					'chat_native_submit' => true,
+					'payment_method'     => 'saved_payment_method',
+					'reason'             => null,
+				),
+				$base
 			);
 		}
 
-		return array(
-			'chat_native_submit' => false,
-			'payment_method'     => false === $has_saved_payment_method
-				? 'missing_saved_payment_method'
-				: 'unknown',
-			'reason'             => false === $has_saved_payment_method
-				? 'saved_payment_method_required'
-				: 'payment_eligibility_unknown',
-			'fallback_url'       => $fallback_url,
+		return array_merge(
+			array(
+				'chat_native_submit' => false,
+				'payment_method'     => false === $has_saved_payment_method
+					? 'missing_saved_payment_method'
+					: 'unknown',
+				'reason'             => false === $has_saved_payment_method
+					? 'saved_payment_method_required'
+					: 'payment_eligibility_unknown',
+			),
+			$base
 		);
 	}
 
@@ -496,9 +795,10 @@ class Campaign_Preparer {
 				'cadence',
 				'schedule',
 				'targeting',
+				'payment_method',
 			),
 			'message'            => __(
-				'Changing destination, creative, budget, cadence, schedule, or targeting requires preparing a new Blaze campaign package before approval or submit.',
+				'Changing destination, creative, budget, cadence, schedule, targeting, or payment method requires preparing a new Blaze campaign package before approval or submit.',
 				'jetpack-blaze'
 			),
 		);

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -658,23 +658,44 @@ class Campaign_Preparer {
 		}
 
 		$card      = isset( $payment_method['card'] ) && is_array( $payment_method['card'] ) ? $payment_method['card'] : array();
+		$info      = isset( $payment_method['info'] ) && is_array( $payment_method['info'] ) ? $payment_method['info'] : array();
 		$type      = self::first_non_empty_string( $payment_method, array( 'type', 'payment_method_type', 'paymentMethodType', 'method' ) );
 		$brand     = self::first_non_empty_string( $payment_method, array( 'brand', 'card_brand', 'cardBrand' ) );
-		$last4     = self::first_non_empty_string( $payment_method, array( 'last4', 'last_4', 'card_last4', 'cardLast4' ) );
+		$last4     = self::first_non_empty_string( $payment_method, array( 'last4', 'last_4', 'last_digits', 'lastDigits', 'card_last4', 'cardLast4' ) );
 		$exp_month = self::first_integer( $payment_method, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
 		$exp_year  = self::first_integer( $payment_method, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
 
 		if ( '' === $brand ) {
 			$brand = self::first_non_empty_string( $card, array( 'brand', 'card_brand', 'cardBrand' ) );
 		}
+		if ( '' === $brand ) {
+			$brand = self::first_non_empty_string( $info, array( 'brand', 'type', 'card_brand', 'cardBrand' ) );
+		}
 		if ( '' === $last4 ) {
-			$last4 = self::first_non_empty_string( $card, array( 'last4', 'last_4', 'card_last4', 'cardLast4' ) );
+			$last4 = self::first_non_empty_string( $card, array( 'last4', 'last_4', 'last_digits', 'lastDigits', 'card_last4', 'cardLast4' ) );
+		}
+		if ( '' === $last4 ) {
+			$last4 = self::first_non_empty_string( $info, array( 'last4', 'last_4', 'last_digits', 'lastDigits', 'card_last4', 'cardLast4' ) );
 		}
 		if ( null === $exp_month ) {
 			$exp_month = self::first_integer( $card, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
 		}
+		if ( null === $exp_month ) {
+			$expiring  = isset( $info['expiring'] ) && is_array( $info['expiring'] ) ? $info['expiring'] : array();
+			$exp_month = self::first_integer( $info, array( 'exp_month', 'expMonth', 'expiry_month', 'expiryMonth' ) );
+			if ( null === $exp_month ) {
+				$exp_month = self::first_integer( $expiring, array( 'month' ) );
+			}
+		}
 		if ( null === $exp_year ) {
 			$exp_year = self::first_integer( $card, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
+		}
+		if ( null === $exp_year ) {
+			$expiring = isset( $info['expiring'] ) && is_array( $info['expiring'] ) ? $info['expiring'] : array();
+			$exp_year = self::first_integer( $info, array( 'exp_year', 'expYear', 'expiry_year', 'expiryYear' ) );
+			if ( null === $exp_year ) {
+				$exp_year = self::first_integer( $expiring, array( 'year' ) );
+			}
 		}
 		if ( '' === $type ) {
 			$type = '' !== $last4 ? 'card' : 'saved_payment_method';

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -1182,15 +1182,23 @@ class Campaign_Preparer {
 	 */
 	private static function build_chat_submit_next_action( string $prefill_url, array $approval_block ): array {
 		return array(
-			'type'                       => 'request_explicit_approval',
-			'default_flow'               => 'chat_native_submit',
-			'chat_native_submit'         => true,
-			'requires_explicit_approval' => true,
-			'pasteable_approval_message' => $approval_block['pasteable_approval_message'] ?? '',
-			'optional_preview_url'       => $prefill_url,
-			'optional_preview_label'     => __( 'Preview campaign in Blaze', 'jetpack-blaze' ),
-			'message'                    => __(
-				'Ask the user to paste the approval message before submitting this prepared campaign. The preview link is optional for review, not required when chat-native submit is eligible.',
+			'type'                          => 'request_explicit_approval',
+			'default_flow'                  => 'chat_native_submit',
+			'chat_native_submit'            => true,
+			'requires_explicit_approval'    => true,
+			'pasteable_approval_message'    => $approval_block['pasteable_approval_message'] ?? '',
+			'plain_language_submit_intents' => array(
+				'submit it',
+				'launch it',
+				'go ahead',
+				'looks good',
+				'create the campaign',
+				'run the campaign',
+			),
+			'optional_preview_url'          => $prefill_url,
+			'optional_preview_label'        => __( 'Preview campaign in Blaze', 'jetpack-blaze' ),
+			'message'                       => __(
+				'When the user asks to submit, launch, create, run, or says it looks good in plain language, render the pasteable approval message before submitting this prepared campaign. The preview link is optional for review, not required when chat-native submit is eligible.',
 				'jetpack-blaze'
 			),
 		);

--- a/projects/packages/blaze/src/class-campaign-preparer.php
+++ b/projects/packages/blaze/src/class-campaign-preparer.php
@@ -478,11 +478,13 @@ class Campaign_Preparer {
 	 * @return array
 	 */
 	private static function build_submit_campaign_payload( array $prefill, array $summary, $selected_payment_method ): array {
-		$schedule  = isset( $summary['schedule'] ) && is_array( $summary['schedule'] ) ? $summary['schedule'] : array();
-		$targeting = array();
+		$schedule      = isset( $summary['schedule'] ) && is_array( $summary['schedule'] ) ? $summary['schedule'] : array();
+		$cadence       = isset( $summary['cadence'] ) && is_array( $summary['cadence'] ) ? $summary['cadence'] : array();
+		$targeting     = self::build_submit_targeting( $prefill );
+		$start_date    = isset( $schedule['start_date'] ) ? (string) $schedule['start_date'] : gmdate( 'Y-m-d' );
+		$duration_days = isset( $cadence['duration_days'] ) ? max( 1, (int) $cadence['duration_days'] ) : self::DEFAULT_DURATION_DAYS;
 
 		foreach ( array(
-			'countries'   => 'locations',
 			'languages'   => 'languages',
 			'devices'     => 'devices',
 			'page_topics' => 'page_topics',
@@ -492,14 +494,14 @@ class Campaign_Preparer {
 			}
 		}
 
-		return array(
+		$submit_payload = array(
 			'origin'            => 'mcp_chat',
 			'origin_version'    => self::APPROVAL_VERSION,
 			'target_urn'        => isset( $prefill['target_urn'] ) ? (string) $prefill['target_urn'] : '',
 			'type'              => isset( $prefill['type'] ) ? (string) $prefill['type'] : 'post',
 			'payment_method_id' => is_array( $selected_payment_method ) && isset( $selected_payment_method['id'] ) ? (string) $selected_payment_method['id'] : '',
-			'start_date'        => isset( $schedule['start_date'] ) ? (string) $schedule['start_date'] : gmdate( 'Y-m-d' ),
-			'end_date'          => isset( $schedule['end_date'] ) ? (string) $schedule['end_date'] : gmdate( 'Y-m-d' ),
+			'start_date'        => $start_date,
+			'end_date'          => self::get_exclusive_submit_end_date( $start_date, $duration_days ),
 			'time_zone'         => isset( $schedule['time_zone'] ) ? (string) $schedule['time_zone'] : self::get_site_timezone(),
 			'site_name'         => isset( $prefill['site_name'] ) ? (string) $prefill['site_name'] : '',
 			'text_snippet'      => isset( $prefill['text_snippet'] ) ? (string) $prefill['text_snippet'] : '',
@@ -511,10 +513,55 @@ class Campaign_Preparer {
 				'mime_type' => 'image/jpeg',
 			),
 			'budget'            => isset( $prefill['budget'] ) && is_array( $prefill['budget'] ) ? $prefill['budget'] : array(),
-			'objective'         => isset( $prefill['objective'] ) ? (string) $prefill['objective'] : 'views',
+			'objective'         => self::objective_for_submit( isset( $prefill['objective'] ) ? (string) $prefill['objective'] : '' ),
 			'is_evergreen'      => isset( $prefill['is_evergreen'] ) ? (bool) $prefill['is_evergreen'] : true,
-			'targeting'         => $targeting,
 		);
+
+		if ( ! empty( $targeting ) ) {
+			$submit_payload['targeting'] = $targeting;
+		}
+
+		return $submit_payload;
+	}
+
+	/**
+	 * Build DSP-native targeting for chat submit.
+	 *
+	 * The Blaze widget prefill uses ISO country codes, but DSP create-campaign
+	 * expects numeric targeting location IDs. Until prepare resolves those IDs
+	 * through DSP-owned targeting data, omit countries from chat-native submit
+	 * rather than sending invalid values.
+	 *
+	 * @param array $prefill Recommended campaign prefill payload.
+	 * @return array
+	 */
+	private static function build_submit_targeting( array $prefill ): array {
+		$targeting = array();
+
+		foreach ( array(
+			'languages'   => 'languages',
+			'devices'     => 'devices',
+			'page_topics' => 'page_topics',
+		) as $prefill_key => $targeting_key ) {
+			if ( ! empty( $prefill[ $prefill_key ] ) && is_array( $prefill[ $prefill_key ] ) ) {
+				$targeting[ $targeting_key ] = array_values( $prefill[ $prefill_key ] );
+			}
+		}
+
+		return $targeting;
+	}
+
+	/**
+	 * DSP create validates campaign duration as the difference between start
+	 * and end date, so submit uses an exclusive end date.
+	 *
+	 * @param string $start_date    Start date in Y-m-d format.
+	 * @param int    $duration_days Duration in days.
+	 * @return string
+	 */
+	private static function get_exclusive_submit_end_date( string $start_date, int $duration_days ): string {
+		$timestamp = strtotime( $start_date . ' +' . max( 1, $duration_days ) . ' days' );
+		return gmdate( 'Y-m-d', false === $timestamp ? time() : $timestamp );
 	}
 
 	/**
@@ -1599,6 +1646,16 @@ class Campaign_Preparer {
 	 */
 	private static function objective_for_intent( string $intent ): string {
 		return self::INTENT_ECOMMERCE === $intent ? 'CLICKS' : 'VIEWS';
+	}
+
+	/**
+	 * Convert the review/widget objective into DSP's create-campaign enum.
+	 *
+	 * @param string $objective Review objective.
+	 * @return string
+	 */
+	private static function objective_for_submit( string $objective ): string {
+		return 'CLICKS' === strtoupper( $objective ) ? 'traffic' : 'views';
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -171,6 +171,16 @@ class Dashboard_REST_Controller {
 
 		register_rest_route(
 			static::$namespace,
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_dsp_forecast' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
 			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
@@ -1238,6 +1248,16 @@ class Dashboard_REST_Controller {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Redirect POST request to WordAds DSP Forecast endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array|WP_Error
+	 */
+	public function create_dsp_forecast( $req ) {
+		return $this->edit_dsp_generic( 'v1.1/forecast', $req, array( 'timeout' => 20 ) );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -181,6 +181,16 @@ class Dashboard_REST_Controller {
 
 		register_rest_route(
 			static::$namespace,
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/payment-methods', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_dsp_payment_methods' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
 			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
@@ -1192,6 +1202,16 @@ class Dashboard_REST_Controller {
 	 */
 	public function get_dsp_image( $req ) {
 		return $this->get_dsp_generic( 'v1/image', $req );
+	}
+
+	/**
+	 * Redirect GET requests to the WordAds DSP payment methods endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array|WP_Error
+	 */
+	public function get_dsp_payment_methods( $req ) {
+		return $this->get_dsp_generic( 'v1.1/payment-methods', $req );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -171,6 +171,16 @@ class Dashboard_REST_Controller {
 
 		register_rest_route(
 			static::$namespace,
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/campaigns/submit-prepared-campaign', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'submit_prepared_dsp_campaign' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
 			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
@@ -1268,6 +1278,16 @@ class Dashboard_REST_Controller {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Redirect POST request to WordAds DSP Submit Prepared Campaign endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array|WP_Error
+	 */
+	public function submit_prepared_dsp_campaign( $req ) {
+		return $this->edit_dsp_generic( 'v1.1/campaigns/submit-prepared-campaign', $req, array( 'timeout' => 60 ) );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -93,6 +93,131 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'A short summary about the product.', $prefill['text_snippet'] );
 		$this->assertSame( 75.0, $prefill['budget']['amount'] );
 		$this->assertSame( 10, $prefill['duration_days'] );
+		$this->assertSame( 'content', $result['intent'] );
+		$this->assertArrayHasKey( 'assumptions', $result );
+		$this->assertArrayHasKey( 'recommendations', $result );
+		$this->assertArrayNotHasKey( 'budget_options', $result );
+	}
+
+	/**
+	 * Product targets get ecommerce-oriented defaults and conservative budget
+	 * options when budget or duration is omitted.
+	 */
+	public function test_prepare_infers_ecommerce_intent_and_budget_options_for_products() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'product',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'ecommerce', $result['intent'] );
+		$this->assertSame( 'CLICKS', $result['prefill']['objective'] );
+		$this->assertSame( 50.0, $result['prefill']['budget']['amount'] );
+		$this->assertSame( 7, $result['prefill']['duration_days'] );
+		$this->assertArrayHasKey( 'budget_options', $result );
+		$this->assertCount( 3, $result['budget_options'] );
+		$this->assertSame( array( 'lower', 'recommended', 'higher' ), wp_list_pluck( $result['budget_options'], 'key' ) );
+
+		$recommended = $result['budget_options'][1];
+		$this->assertSame( 'recommended', $recommended['key'] );
+		$this->assertSame( 50.0, $recommended['budget']['amount'] );
+		$this->assertSame( 7.14, $recommended['daily_budget']['amount'] );
+		$this->assertSame( 7, $recommended['duration_days'] );
+		$this->assertStringContainsString( 'conservative', strtolower( $recommended['rationale'] ) );
+
+		$higher = $result['budget_options'][2];
+		$this->assertSame( 150.0, $higher['budget']['amount'] );
+		$this->assertStringContainsString( 'more reach', strtolower( $higher['rationale'] ) );
+		$this->assertStringContainsString( 'product', implode( ' ', $result['assumptions'] ) );
+	}
+
+	/**
+	 * Content targets retain visibility-oriented defaults.
+	 */
+	public function test_prepare_infers_content_intent_for_posts_and_pages() {
+		$post = $this->make_test_post(
+			array(
+				'post_type' => 'post',
+			)
+		);
+		$page = $this->make_test_post(
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$post_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $post['target_urn'],
+			)
+		);
+		$page_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $page['target_urn'],
+			)
+		);
+
+		$this->assertSame( 'content', $post_result['intent'] );
+		$this->assertSame( 'content', $page_result['intent'] );
+		$this->assertSame( 'VIEWS', $post_result['prefill']['objective'] );
+		$this->assertSame( 'VIEWS', $page_result['prefill']['objective'] );
+	}
+
+	/**
+	 * Unknown target types stay explicit so future intelligence can handle them
+	 * without pretending the preparer knows more than it does.
+	 */
+	public function test_prepare_infers_unknown_intent_for_custom_post_types() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'portfolio_item',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'unknown', $result['intent'] );
+		$this->assertSame( 'VIEWS', $result['prefill']['objective'] );
+		$this->assertStringContainsString( 'portfolio_item', implode( ' ', $result['assumptions'] ) );
+	}
+
+	/**
+	 * Natural-language goals can steer the inferred intent, and revision notes
+	 * remain visible as preparation assumptions.
+	 */
+	public function test_prepare_uses_goal_and_revision_instruction_in_assumptions() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'           => $ctx['target_urn'],
+				'goal'                 => 'Drive sales for a weekend offer.',
+				'revision_instruction' => 'Make the copy less salesy.',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'ecommerce', $result['intent'] );
+		$this->assertSame( 'CLICKS', $result['prefill']['objective'] );
+		$this->assertStringContainsString( 'goal', strtolower( implode( ' ', $result['assumptions'] ) ) );
+		$this->assertStringContainsString( 'Drive sales for a weekend offer.', implode( ' ', $result['assumptions'] ) );
+		$this->assertStringContainsString( 'Make the copy less salesy.', implode( ' ', $result['assumptions'] ) );
 	}
 
 	/**
@@ -138,7 +263,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( array( 'IAB8_IAB18', 'IAB9_IAB22' ), $prefill['page_topics'] );
 		$this->assertArrayNotHasKey( 'interests', $prefill );
 		$this->assertFalse( $prefill['is_evergreen'] );
-		$this->assertSame( 'VIEWS', $prefill['objective'] );
+		$this->assertSame( 'CLICKS', $prefill['objective'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -11,6 +11,8 @@ use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
 
 /**
  * @covers \Automattic\Jetpack\Blaze\Campaign_Preparer
@@ -30,6 +32,9 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	 */
 	public function set_up() {
 		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
 	}
 
 	/**
@@ -37,6 +42,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	 */
 	public function tear_down() {
 		Jetpack_Options::delete_option( 'id' );
+		unset( $GLOBALS['wp_rest_server'] );
 	}
 
 	/**
@@ -62,6 +68,23 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		return array(
 			'post_id'    => (int) $post_id,
 			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * Register a test forecast route that captures the preparer's proxied DSP request.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_forecast_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
 		);
 	}
 
@@ -136,6 +159,147 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 150.0, $higher['budget']['amount'] );
 		$this->assertStringContainsString( 'more reach', strtolower( $higher['rationale'] ) );
 		$this->assertStringContainsString( 'product', implode( ' ', $result['assumptions'] ) );
+	}
+
+	/**
+	 * Forecast requests use the DSP v1.1 forecast body shape and ecommerce
+	 * responses emphasize clicks before visibility.
+	 */
+	public function test_prepare_adds_click_first_forecast_for_ecommerce_intent() {
+		$ctx           = $this->make_test_post( array( 'post_type' => 'product' ) );
+		$captured_body = null;
+		$this->register_forecast_route(
+			static function ( WP_REST_Request $request ) use ( &$captured_body ) {
+				$captured_body = json_decode( $request->get_body(), true );
+				return array(
+					'total_impressions_min'     => 1200,
+					'total_impressions_max'     => 2400,
+					'total_clicks_min'          => 30,
+					'total_clicks_max'          => 60,
+					'total_tsp_impressions_min' => 100,
+					'total_tsp_impressions_max' => 200,
+				);
+			}
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 80,
+				'duration_days' => 8,
+				'languages'     => array( 'en' ),
+				'devices'       => array( 'mobile' ),
+				'interests'     => array( 'IAB8_IAB18' ),
+			)
+		);
+
+			$this->assertIsArray( $result );
+			$this->assertIsArray( $captured_body );
+			$captured_body = is_array( $captured_body ) ? $captured_body : array();
+			$this->assertSame(
+				array(
+					'time_zone',
+					'start_date',
+					'end_date',
+					'total_budget',
+					'is_evergreen',
+					'is_tsp_eligible',
+					'targeting',
+				),
+				array_keys( $captured_body )
+			);
+		$this->assertSame( 80, $captured_body['total_budget'] );
+		$this->assertSame( gmdate( 'Y-m-d' ), $captured_body['start_date'] );
+		$this->assertSame( gmdate( 'Y-m-d', strtotime( '+7 days' ) ), $captured_body['end_date'] );
+		$this->assertSame(
+			array(
+				'locations'   => array(),
+				'languages'   => array( 'en' ),
+				'devices'     => array( 'mobile' ),
+				'page_topics' => array( 'IAB8_IAB18' ),
+			),
+			$captured_body['targeting']
+		);
+
+		$this->assertSame( 'available', $result['forecast']['status'] );
+		$this->assertSame( 'clicks', $result['forecast']['primary_metric'] );
+		$this->assertSame( 'views', $result['forecast']['secondary_metric'] );
+		$this->assertSame(
+			array(
+				'min' => 30,
+				'max' => 60,
+			),
+			$result['forecast']['clicks']
+		);
+		$this->assertSame(
+			array(
+				'min' => 1200,
+				'max' => 2400,
+			),
+			$result['forecast']['views']
+		);
+		$this->assertSame(
+			array(
+				'min' => 1200,
+				'max' => 2400,
+			),
+			$result['forecast']['impressions']
+		);
+	}
+
+	/**
+	 * Content forecasts put visibility first and clicks second.
+	 */
+	public function test_prepare_adds_view_first_forecast_for_content_intent() {
+		$ctx = $this->make_test_post( array( 'post_type' => 'post' ) );
+		$this->register_forecast_route(
+			static function () {
+				return array(
+					'total_impressions_min'     => 5000,
+					'total_impressions_max'     => 8000,
+					'total_clicks_min'          => 20,
+					'total_clicks_max'          => 35,
+					'total_tsp_impressions_min' => 0,
+					'total_tsp_impressions_max' => 0,
+				);
+			}
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'content', $result['intent'] );
+		$this->assertSame( 'available', $result['forecast']['status'] );
+		$this->assertSame( 'views', $result['forecast']['primary_metric'] );
+		$this->assertSame( 'clicks', $result['forecast']['secondary_metric'] );
+	}
+
+	/**
+	 * Forecast failure does not block the proposal or review URL.
+	 */
+	public function test_prepare_degrades_gracefully_when_forecast_fails() {
+		$ctx = $this->make_test_post();
+		$this->register_forecast_route(
+			static function () {
+				return new WP_Error( 'forecast_unavailable', 'Forecast failed.', array( 'status' => 500 ) );
+			}
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
+		$this->assertSame( 'forecast_unavailable', $result['forecast']['reason'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -119,7 +119,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 				'languages'            => array( 'EN', '', 'es', 'xx' ),
 				'countries'            => array( 'gb', 'usa', 'FR' ),
 				'devices'              => array( 'mobile', 'tablet', 'spaceship' ),
-				'interests'            => array( 'IAB18', 'fashion', 'IAB1_IAB2', '0', 'IAB24' ),
+				'interests'            => array( 'IAB18', 'fashion', 'IAB1_IAB2', '0', 'IAB24', 'IAB9_IAB22' ),
 				'is_evergreen'         => false,
 			)
 		);
@@ -135,7 +135,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( array( 'en', 'es' ), $prefill['languages'] );
 		$this->assertSame( array( 'GB', 'FR' ), $prefill['countries'] );
 		$this->assertSame( array( 'mobile' ), $prefill['devices'] );
-		$this->assertSame( array( 'IAB18', 'IAB1_IAB2' ), $prefill['page_topics'] );
+		$this->assertSame( array( 'IAB8_IAB18', 'IAB9_IAB22' ), $prefill['page_topics'] );
 		$this->assertArrayNotHasKey( 'interests', $prefill );
 		$this->assertFalse( $prefill['is_evergreen'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -193,21 +193,21 @@ class Campaign_Preparer_Test extends BaseTestCase {
 			)
 		);
 
-			$this->assertIsArray( $result );
-			$this->assertIsArray( $captured_body );
-			$captured_body = is_array( $captured_body ) ? $captured_body : array();
-			$this->assertSame(
-				array(
-					'time_zone',
-					'start_date',
-					'end_date',
-					'total_budget',
-					'is_evergreen',
-					'is_tsp_eligible',
-					'targeting',
-				),
-				array_keys( $captured_body )
-			);
+		$this->assertIsArray( $result );
+		$this->assertIsArray( $captured_body );
+		$captured_body = is_array( $captured_body ) ? $captured_body : array();
+		$this->assertSame(
+			array(
+				'time_zone',
+				'start_date',
+				'end_date',
+				'total_budget',
+				'is_evergreen',
+				'is_tsp_eligible',
+				'targeting',
+			),
+			array_keys( $captured_body )
+		);
 		$this->assertSame( 80, $captured_body['total_budget'] );
 		$this->assertSame( gmdate( 'Y-m-d' ), $captured_body['start_date'] );
 		$this->assertSame( gmdate( 'Y-m-d', strtotime( '+7 days' ) ), $captured_body['end_date'] );

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Tests for the reusable Blaze campaign preparer.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+namespace Automattic\Jetpack\Blaze;
+
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+/**
+ * @covers \Automattic\Jetpack\Blaze\Campaign_Preparer
+ */
+#[CoversClass( Campaign_Preparer::class )]
+class Campaign_Preparer_Test extends BaseTestCase {
+
+	/**
+	 * Synthetic site ID used in target URNs.
+	 *
+	 * @var int
+	 */
+	private const TEST_SITE_ID = 12345;
+
+	/**
+	 * Set up a synthetic connected site ID.
+	 */
+	public function set_up() {
+		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+	}
+
+	/**
+	 * Clear synthetic connection state.
+	 */
+	public function tear_down() {
+		Jetpack_Options::delete_option( 'id' );
+	}
+
+	/**
+	 * Helper: insert a test post and return its ID and target URN.
+	 *
+	 * @param array $overrides Post field overrides.
+	 * @return array
+	 */
+	private function make_test_post( array $overrides = array() ): array {
+		$post_id = wp_insert_post(
+			array_merge(
+				array(
+					'post_title'   => 'Test product page',
+					'post_excerpt' => 'A short summary about the product.',
+					'post_content' => 'Long-form content that would otherwise be the fallback snippet source.',
+					'post_status'  => 'publish',
+					'post_type'    => 'post',
+				),
+				$overrides
+			)
+		);
+
+		return array(
+			'post_id'    => (int) $post_id,
+			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * The preparer returns reusable structured data and leaves MCP-specific
+	 * human-readable messaging to the ability adapter.
+	 */
+	public function test_prepare_returns_structured_proposal_without_mcp_message() {
+		$ctx = $this->make_test_post();
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 75,
+				'duration_days' => 10,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertArrayHasKey( 'prefill_url', $result );
+		$this->assertArrayHasKey( 'prefill', $result );
+		$this->assertArrayNotHasKey( 'message', $result );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+
+		$prefill = $result['prefill'];
+		$this->assertSame( $ctx['target_urn'], $prefill['target_urn'] );
+		$this->assertSame( 'Test product page', $prefill['site_name'] );
+		$this->assertSame( 'A short summary about the product.', $prefill['text_snippet'] );
+		$this->assertSame( 75.0, $prefill['budget']['amount'] );
+		$this->assertSame( 10, $prefill['duration_days'] );
+	}
+
+	/**
+	 * Caller overrides and targeting hints are normalized by the preparer.
+	 */
+	public function test_prepare_applies_overrides_and_targeting_hints() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'product',
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'           => $ctx['target_urn'],
+				'budget_total'         => 150,
+				'duration_days'        => 7,
+				'site_name'            => 'Custom heading',
+				'text_snippet'         => 'Custom ad copy.',
+				'goal'                 => 'Drive sales in the UK.',
+				'revision_instruction' => 'Make it more direct.',
+				'main_image_url'       => 'https://example.com/custom.jpg',
+				'main_image_mime_type' => 'image/jpeg',
+				'languages'            => array( 'EN', '', 'es' ),
+				'countries'            => array( 'gb', 'usa', 'FR' ),
+				'is_evergreen'         => false,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$prefill = $result['prefill'];
+		$this->assertSame( 'Custom heading', $prefill['site_name'] );
+		$this->assertSame( 'Custom ad copy.', $prefill['text_snippet'] );
+		$this->assertSame( 'Shop Now', $prefill['cta_text'] );
+		$this->assertSame( 'Drive sales in the UK.', $prefill['goal'] );
+		$this->assertSame( 'Make it more direct.', $prefill['revision_instruction'] );
+		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
+		$this->assertSame( array( 'en', 'es' ), $prefill['languages'] );
+		$this->assertSame( array( 'GB', 'FR' ), $prefill['countries'] );
+		$this->assertFalse( $prefill['is_evergreen'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Invalid targets remain hard stops owned by the preparation layer.
+	 */
+	public function test_prepare_returns_error_for_invalid_target_urn() {
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => 'not-a-urn',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_invalid_target_urn', $result->get_error_code() );
+	}
+}

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -116,8 +116,10 @@ class Campaign_Preparer_Test extends BaseTestCase {
 				'revision_instruction' => 'Make it more direct.',
 				'main_image_url'       => 'https://example.com/custom.jpg',
 				'main_image_mime_type' => 'image/jpeg',
-				'languages'            => array( 'EN', '', 'es' ),
+				'languages'            => array( 'EN', '', 'es', 'xx' ),
 				'countries'            => array( 'gb', 'usa', 'FR' ),
+				'devices'              => array( 'mobile', 'tablet', 'spaceship' ),
+				'interests'            => array( 'IAB18', 'fashion', 'IAB1_IAB2', '0', 'IAB24' ),
 				'is_evergreen'         => false,
 			)
 		);
@@ -132,8 +134,29 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
 		$this->assertSame( array( 'en', 'es' ), $prefill['languages'] );
 		$this->assertSame( array( 'GB', 'FR' ), $prefill['countries'] );
+		$this->assertSame( array( 'mobile' ), $prefill['devices'] );
+		$this->assertSame( array( 'IAB18', 'IAB1_IAB2' ), $prefill['page_topics'] );
+		$this->assertArrayNotHasKey( 'interests', $prefill );
 		$this->assertFalse( $prefill['is_evergreen'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Asking for both supported narrowed device targets is equivalent to
+	 * targeting all devices, so the prefill payload omits the field.
+	 */
+	public function test_prepare_omits_device_prefill_when_all_supported_devices_are_requested() {
+		$ctx = $this->make_test_post();
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+				'devices'    => array( 'mobile', 'desktop' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'devices', $result['prefill'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -230,6 +230,9 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
 		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
 		$this->assertTrue( $result['next_action']['chat_native_submit'] );
+		$this->assertContains( 'submit it', $result['next_action']['plain_language_submit_intents'] );
+		$this->assertContains( 'launch it', $result['next_action']['plain_language_submit_intents'] );
+		$this->assertContains( 'go ahead', $result['next_action']['plain_language_submit_intents'] );
 		$this->assertSame( $result['prefill_url'], $result['next_action']['optional_preview_url'] );
 		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
 		$this->assertStringContainsString( 'Test product page', $result['next_action']['pasteable_approval_message'] );

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -316,8 +316,50 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		);
 		$this->assertCount( 2, $default_result['submit_eligibility']['available_payment_methods'] );
 		$this->assertSame( 'pm_backup', $switched_result['submit_eligibility']['selected_payment_method']['id'] );
+		$this->assertSame( 'pm_default', $default_result['submit_package']['prepared_campaign']['payment_method_id'] );
+		$this->assertSame( 'pm_default', $default_result['approval_block']['approval_contract']['selected_payment_method_id'] );
+		$this->assertSame( 'pm_backup', $switched_result['submit_package']['prepared_campaign']['payment_method_id'] );
+		$this->assertSame( 'pm_backup', $switched_result['approval_block']['approval_contract']['selected_payment_method_id'] );
 		$this->assertNotSame( $default_result['prepared_campaign']['id'], $switched_result['prepared_campaign']['id'] );
 		$this->assertContains( 'payment_method', $default_result['material_edit_policy']['material_fields'] );
+	}
+
+	/**
+	 * A requested payment method must come from the current active method list.
+	 */
+	public function test_prepare_blocks_unavailable_requested_payment_method() {
+		add_filter(
+			'jetpack_blaze_prepare_campaign_payment_methods',
+			static function () {
+				return array(
+					array(
+						'id'         => 'PW-3272868',
+						'type'       => 'card',
+						'card_brand' => 'visa',
+						'last4'      => '4242',
+						'is_default' => true,
+					),
+				);
+			}
+		);
+
+		$ctx    = $this->make_test_post();
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'        => $ctx['target_urn'],
+				'payment_method_id' => 'PS-630976',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'missing_saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertSame( 'requested_payment_method_unavailable', $result['submit_eligibility']['reason'] );
+		$this->assertNull( $result['submit_eligibility']['selected_payment_method'] );
+		$this->assertCount( 1, $result['submit_eligibility']['available_payment_methods'] );
+		$this->assertSame( 'PW-3272868', $result['submit_eligibility']['available_payment_methods'][0]['id'] );
+		$this->assertArrayNotHasKey( 'approval_block', $result );
+		$this->assertArrayNotHasKey( 'next_action', $result );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -43,6 +43,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	public function tear_down() {
 		Jetpack_Options::delete_option( 'id' );
 		unset( $GLOBALS['wp_rest_server'] );
+		remove_all_filters( 'pre_http_request' );
 	}
 
 	/**
@@ -85,6 +86,29 @@ class Campaign_Preparer_Test extends BaseTestCase {
 				'callback'            => $callback,
 				'permission_callback' => '__return_true',
 			)
+		);
+	}
+
+	/**
+	 * Mock the public WordPress.com site lookup used by portable target inputs.
+	 *
+	 * @param string $expected_site_url Expected site URL.
+	 * @param array  $response          Mock HTTP response.
+	 */
+	private function mock_site_lookup( string $expected_site_url, array $response ) {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $expected_site_url, $response ) {
+				$expected_path = '/rest/v1.1/sites/' . rawurlencode( $expected_site_url );
+
+				if ( false !== strpos( $url, $expected_path ) ) {
+					return $response;
+				}
+
+				return $preempt;
+			},
+			10,
+			3
 		);
 	}
 
@@ -460,5 +484,111 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'blaze_invalid_target_urn', $result->get_error_code() );
+	}
+
+	/**
+	 * Friendly site URL + post ID inputs are normalized into the canonical
+	 * target URN before the existing proposal path runs.
+	 */
+	public function test_prepare_accepts_site_url_and_post_id() {
+		$ctx = $this->make_test_post();
+		$this->mock_site_lookup(
+			'https://example.com',
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ID' => self::TEST_SITE_ID ), JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url'      => 'https://example.com',
+				'post_id'       => $ctx['post_id'],
+				'budget_total'  => 25,
+				'duration_days' => 5,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $ctx['target_urn'], $result['prefill']['target_urn'] );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+	}
+
+	/**
+	 * Product_id is a Woo-friendly alias for the promoted post ID in the
+	 * canonical Blaze target URN.
+	 */
+	public function test_prepare_accepts_site_url_and_product_id() {
+		$ctx = $this->make_test_post( array( 'post_type' => 'product' ) );
+		$this->mock_site_lookup(
+			'https://shop.example.com',
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'ID' => self::TEST_SITE_ID ), JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url'   => 'https://shop.example.com',
+				'product_id' => $ctx['post_id'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $ctx['target_urn'], $result['prefill']['target_urn'] );
+		$this->assertSame( 'product', $result['prefill']['type'] );
+	}
+
+	/**
+	 * A failed public site lookup is a clear hard stop, not a malformed URN.
+	 */
+	public function test_prepare_returns_error_when_site_lookup_fails() {
+		$ctx = $this->make_test_post();
+		$this->mock_site_lookup(
+			'https://missing.example.com',
+			array(
+				'response' => array( 'code' => 404 ),
+				'body'     => wp_json_encode( array( 'error' => 'unknown_blog' ), JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url' => 'https://missing.example.com',
+				'post_id'  => $ctx['post_id'],
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_site_lookup_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * Callers must choose either post_id or product_id for friendly inputs.
+	 */
+	public function test_prepare_returns_error_for_ambiguous_friendly_target() {
+		$ctx = $this->make_test_post();
+
+		$result = Campaign_Preparer::prepare(
+			array(
+				'site_url'   => 'https://example.com',
+				'post_id'    => $ctx['post_id'],
+				'product_id' => $ctx['post_id'],
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_ambiguous_target', $result->get_error_code() );
+	}
+
+	/**
+	 * Missing target inputs get a specific error that can guide MCP clients.
+	 */
+	public function test_prepare_returns_error_for_missing_target_input() {
+		$result = Campaign_Preparer::prepare( array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_missing_target', $result->get_error_code() );
 	}
 }

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -44,6 +44,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		Jetpack_Options::delete_option( 'id' );
 		unset( $GLOBALS['wp_rest_server'] );
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method' );
 	}
 
 	/**
@@ -144,6 +145,72 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'assumptions', $result );
 		$this->assertArrayHasKey( 'recommendations', $result );
 		$this->assertArrayNotHasKey( 'budget_options', $result );
+	}
+
+	/**
+	 * Chat clients get a complete Blaze-owned package without composing ad HTML
+	 * or campaign defaults themselves.
+	 */
+	public function test_prepare_returns_chat_ready_prepared_campaign_package() {
+		add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+
+		$ctx = $this->make_test_post();
+
+		$args = array(
+			'target_urn'    => $ctx['target_urn'],
+			'budget_total'  => 75,
+			'duration_days' => 10,
+			'languages'     => array( 'en', 'es' ),
+			'countries'     => array( 'US' ),
+			'devices'       => array( 'mobile' ),
+			'interests'     => array( 'IAB8_IAB18' ),
+		);
+
+		$result = Campaign_Preparer::prepare( $args );
+		$again  = Campaign_Preparer::prepare( $args );
+
+		$this->assertIsArray( $result );
+		$this->assertIsArray( $again );
+
+		$this->assertArrayHasKey( 'prepared_campaign', $result );
+		$this->assertSame( $result['prepared_campaign'], $again['prepared_campaign'] );
+		$this->assertSame( 1, preg_match( '/^[a-f0-9]{64}$/', $result['prepared_campaign']['hash'] ) );
+		$this->assertSame( $result['prepared_campaign']['hash'], $result['prepared_campaign']['id'] );
+		$this->assertSame( 'v1', $result['prepared_campaign']['version'] );
+
+		$this->assertArrayHasKey( 'rendered_preview', $result );
+		$this->assertSame( 'html', $result['rendered_preview']['type'] );
+		$this->assertStringContainsString( 'data-blaze-prepared-campaign-id="' . $result['prepared_campaign']['id'] . '"', $result['rendered_preview']['html'] );
+		$this->assertStringContainsString( 'Test product page', $result['rendered_preview']['html'] );
+		$this->assertStringContainsString( 'A short summary about the product.', $result['rendered_preview']['html'] );
+
+		$this->assertSame( $result['prefill_url'], $result['fallback_url'] );
+
+		$summary = $result['campaign_summary'];
+		foreach ( array( 'destination', 'creative', 'budget', 'cadence', 'schedule', 'targeting_summary', 'source_context' ) as $section ) {
+			$this->assertArrayHasKey( $section, $summary );
+		}
+		$this->assertSame( get_permalink( $ctx['post_id'] ), $summary['destination']['url'] );
+		$this->assertSame( 'Test product page', $summary['creative']['heading'] );
+		$this->assertSame( 'A short summary about the product.', $summary['creative']['copy'] );
+		$this->assertSame( 75.0, $summary['budget']['total']['amount'] );
+		$this->assertSame( 10, $summary['cadence']['duration_days'] );
+		$this->assertSame( array( 'US' ), $summary['targeting_summary']['countries'] );
+		$this->assertSame( array( 'en', 'es' ), $summary['targeting_summary']['languages'] );
+		$this->assertSame( array( 'mobile' ), $summary['targeting_summary']['devices'] );
+		$this->assertSame( $ctx['target_urn'], $summary['source_context']['target_urn'] );
+		$this->assertSame( 'post', $summary['source_context']['post_type'] );
+
+		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertArrayHasKey( 'approval_block', $result );
+		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
+		$this->assertSame( 'blaze.approval.confirm_prepared_campaign', $result['approval_block']['confirmation_label_key'] );
+
+		$this->assertTrue( $result['material_edit_policy']['requires_reprepare'] );
+		$this->assertContains( 'creative', $result['material_edit_policy']['material_fields'] );
+		$this->assertContains( 'budget', $result['material_edit_policy']['material_fields'] );
+		$this->assertContains( 'targeting', $result['material_edit_policy']['material_fields'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -45,6 +45,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		unset( $GLOBALS['wp_rest_server'] );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
 	}
 
 	/**
@@ -211,6 +212,72 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertContains( 'creative', $result['material_edit_policy']['material_fields'] );
 		$this->assertContains( 'budget', $result['material_edit_policy']['material_fields'] );
 		$this->assertContains( 'targeting', $result['material_edit_policy']['material_fields'] );
+	}
+
+	/**
+	 * Saved payment details are summarized compactly and become part of the
+	 * prepared identity so switching methods requires fresh approval.
+	 */
+	public function test_prepare_selects_saved_payment_method_for_chat_native_submit() {
+		add_filter(
+			'jetpack_blaze_prepare_campaign_payment_methods',
+			static function () {
+				return array(
+					array(
+						'id'         => 'pm_backup',
+						'type'       => 'card',
+						'card_brand' => 'visa',
+						'last4'      => '4242',
+						'is_default' => false,
+					),
+					array(
+						'id'         => 'pm_default',
+						'type'       => 'card',
+						'card_brand' => 'mastercard',
+						'last4'      => '5555',
+						'exp_month'  => 8,
+						'exp_year'   => 2030,
+						'is_default' => true,
+					),
+				);
+			}
+		);
+
+		$ctx = $this->make_test_post();
+
+		$default_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+		$switched_result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'         => $ctx['target_urn'],
+				'payment_method_id'  => 'pm_backup',
+			)
+		);
+
+		$this->assertIsArray( $default_result );
+		$this->assertIsArray( $switched_result );
+		$this->assertTrue( $default_result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'saved_payment_method', $default_result['submit_eligibility']['payment_method'] );
+		$this->assertSame(
+			array(
+				'id'         => 'pm_default',
+				'type'       => 'card',
+				'brand'      => 'mastercard',
+				'last4'      => '5555',
+				'exp_month'  => 8,
+				'exp_year'   => 2030,
+				'label'      => 'Mastercard ending in 5555',
+				'is_default' => true,
+			),
+			$default_result['submit_eligibility']['selected_payment_method']
+		);
+		$this->assertCount( 2, $default_result['submit_eligibility']['available_payment_methods'] );
+		$this->assertSame( 'pm_backup', $switched_result['submit_eligibility']['selected_payment_method']['id'] );
+		$this->assertNotSame( $default_result['prepared_campaign']['id'], $switched_result['prepared_campaign']['id'] );
+		$this->assertContains( 'payment_method', $default_result['material_edit_policy']['material_fields'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -171,7 +171,11 @@ class Campaign_Preparer_Test extends BaseTestCase {
 			}
 		);
 
-		$ctx = $this->make_test_post();
+		$ctx = $this->make_test_post(
+			array(
+				'post_type' => 'product',
+			)
+		);
 
 		$args = array(
 			'target_urn'    => $ctx['target_urn'],
@@ -216,7 +220,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( array( 'en', 'es' ), $summary['targeting_summary']['languages'] );
 		$this->assertSame( array( 'mobile' ), $summary['targeting_summary']['devices'] );
 		$this->assertSame( $ctx['target_urn'], $summary['source_context']['target_urn'] );
-		$this->assertSame( 'post', $summary['source_context']['post_type'] );
+		$this->assertSame( 'product', $summary['source_context']['post_type'] );
 
 		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
 		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
@@ -224,6 +228,10 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'approval_block', $result );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
 		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $result['approval_block']['confirmation_label_key'] );
+		$this->assertSame( 'traffic', $result['submit_package']['prepared_campaign']['objective'] );
+		$this->assertSame( gmdate( 'Y-m-d', strtotime( '+10 days' ) ), $result['submit_package']['prepared_campaign']['end_date'] );
+		$this->assertArrayNotHasKey( 'locations', $result['submit_package']['prepared_campaign']['targeting'] );
+		$this->assertSame( array( 'en', 'es' ), $result['submit_package']['prepared_campaign']['targeting']['languages'] );
 
 		$this->assertTrue( $result['material_edit_policy']['requires_reprepare'] );
 		$this->assertContains( 'creative', $result['material_edit_policy']['material_fields'] );
@@ -445,7 +453,7 @@ class Campaign_Preparer_Test extends BaseTestCase {
 			'image'          => array( 'main_image_url' => 'https://example.com/new.jpg' ),
 			'budget'         => array( 'budget_total' => 125 ),
 			'schedule'       => array( 'duration_days' => 14 ),
-			'targeting'      => array( 'countries' => array( 'CA' ) ),
+			'targeting'      => array( 'languages' => array( 'es' ) ),
 		);
 
 		foreach ( $material_variants as $variant => $overrides ) {

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -226,6 +226,19 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
 		$this->assertSame( 'pm_default', $result['submit_eligibility']['selected_payment_method']['id'] );
 		$this->assertArrayHasKey( 'approval_block', $result );
+		$this->assertArrayHasKey( 'next_action', $result );
+		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
+		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
+		$this->assertTrue( $result['next_action']['chat_native_submit'] );
+		$this->assertSame( $result['prefill_url'], $result['next_action']['optional_preview_url'] );
+		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Test product page', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'USD 75', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Visa ending in 4242', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Terms of Service', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Advertising Policy', $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['prepared_campaign']['hash'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['submit_package']['idempotency_key'], $result['next_action']['pasteable_approval_message'] );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
 		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $result['approval_block']['confirmation_label_key'] );
 		$this->assertSame( 'traffic', $result['submit_package']['prepared_campaign']['objective'] );
@@ -382,6 +395,14 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'USD', $acknowledgement_values['currency'] );
 		$this->assertSame( 'one_time', $acknowledgement_values['billing_cadence'] );
 		$this->assertSame( 'Visa ending in 4242', $acknowledgement_values['payment_method_label'] );
+		$this->assertArrayHasKey( 'pasteable_approval_message', $approval_block );
+		$this->assertStringContainsString( 'Test product page', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'USD 75', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Visa ending in 4242', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Terms of Service', $approval_block['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Advertising Policy', $approval_block['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['prepared_campaign']['hash'], $approval_block['pasteable_approval_message'] );
+		$this->assertStringNotContainsString( $result['submit_package']['idempotency_key'], $approval_block['pasteable_approval_message'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -41,11 +41,14 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	 * Clear synthetic connection state.
 	 */
 	public function tear_down() {
+		wp_set_current_user( 0 );
 		Jetpack_Options::delete_option( 'id' );
 		unset( $GLOBALS['wp_rest_server'] );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_has_saved_payment_method' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
+		remove_all_filters( 'jetpack_blaze_approval_terms' );
+		remove_all_filters( 'jetpack_blaze_approval_advertising_policy' );
 	}
 
 	/**
@@ -153,7 +156,20 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	 * or campaign defaults themselves.
 	 */
 	public function test_prepare_returns_chat_ready_prepared_campaign_package() {
-		add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+		add_filter(
+			'jetpack_blaze_prepare_campaign_payment_methods',
+			static function () {
+				return array(
+					array(
+						'id'         => 'pm_default',
+						'type'       => 'card',
+						'card_brand' => 'visa',
+						'last4'      => '4242',
+						'is_default' => true,
+					),
+				);
+			}
+		);
 
 		$ctx = $this->make_test_post();
 
@@ -204,14 +220,17 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
 		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertSame( 'pm_default', $result['submit_eligibility']['selected_payment_method']['id'] );
 		$this->assertArrayHasKey( 'approval_block', $result );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
-		$this->assertSame( 'blaze.approval.confirm_prepared_campaign', $result['approval_block']['confirmation_label_key'] );
+		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $result['approval_block']['confirmation_label_key'] );
 
 		$this->assertTrue( $result['material_edit_policy']['requires_reprepare'] );
 		$this->assertContains( 'creative', $result['material_edit_policy']['material_fields'] );
 		$this->assertContains( 'budget', $result['material_edit_policy']['material_fields'] );
 		$this->assertContains( 'targeting', $result['material_edit_policy']['material_fields'] );
+		$this->assertContains( 'terms_policy_version', $result['material_edit_policy']['material_fields'] );
+		$this->assertContains( 'revision_instruction', $result['material_edit_policy']['non_material_fields'] );
 	}
 
 	/**
@@ -278,6 +297,218 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertSame( 'pm_backup', $switched_result['submit_eligibility']['selected_payment_method']['id'] );
 		$this->assertNotSame( $default_result['prepared_campaign']['id'], $switched_result['prepared_campaign']['id'] );
 		$this->assertContains( 'payment_method', $default_result['material_edit_policy']['material_fields'] );
+	}
+
+	/**
+	 * Chat-native submit approval is a structured contract tied to one exact
+	 * prepared package, not a localized chat phrase.
+	 */
+	public function test_prepare_exposes_exact_approval_contract_for_selected_package() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'blaze-approver-' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'blaze-approver-' . wp_rand() . '@example.com',
+			)
+		);
+		wp_set_current_user( (int) $user_id );
+
+		add_filter(
+			'jetpack_blaze_prepare_campaign_payment_methods',
+			static function () {
+				return array(
+					array(
+						'id'         => 'pm_default',
+						'type'       => 'card',
+						'card_brand' => 'visa',
+						'last4'      => '4242',
+						'is_default' => true,
+					),
+				);
+			}
+		);
+
+		$ctx    = $this->make_test_post();
+		$result = Campaign_Preparer::prepare(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 75,
+				'duration_days' => 10,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'approval_block', $result );
+
+		$approval_block = $result['approval_block'];
+		$this->assertSame( $result['prepared_campaign']['id'], $approval_block['prepared_campaign_id'] );
+		$this->assertSame( $result['prepared_campaign']['hash'], $approval_block['prepared_campaign_hash'] );
+		$this->assertSame( 'blaze.approval.charge_acknowledgement', $approval_block['charge_acknowledgement']['template_key'] );
+		$this->assertSame( 'blaze.approval.body.v1', $approval_block['body_key'] );
+		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $approval_block['confirmation_label_key'] );
+		$this->assertContains( 'approved_at', $approval_block['approval_event_required_fields'] );
+		$this->assertContains( 'idempotency_key', $approval_block['approval_event_required_fields'] );
+
+		$contract = $approval_block['approval_contract'];
+		$this->assertSame( 'v1', $contract['contract_version'] );
+		$this->assertSame( $result['prepared_campaign']['id'], $contract['prepared_campaign_id'] );
+		$this->assertSame( $result['prepared_campaign']['hash'], $contract['prepared_campaign_hash'] );
+		$this->assertSame( 'https://wordpress.com/tos/', $contract['terms']['url'] );
+		$this->assertSame( 'v1', $contract['terms']['version'] );
+		$this->assertSame( 'https://automattic.com/advertising-policy/', $contract['advertising_policy']['url'] );
+		$this->assertSame( 'v1', $contract['advertising_policy']['version'] );
+		$this->assertSame( 75.0, $contract['charge']['max_amount'] );
+		$this->assertSame( 'USD', $contract['charge']['currency'] );
+		$this->assertSame( 'one_time', $contract['charge']['billing_cadence'] );
+		$this->assertSame( gmdate( 'Y-m-d' ), $contract['charge']['start_date'] );
+		$this->assertSame( 'v1', $contract['cancellation']['version'] );
+		$this->assertSame( 'pm_default', $contract['selected_payment_method_id'] );
+		$this->assertSame( 'Visa ending in 4242', $contract['selected_payment_method']['label'] );
+		$this->assertSame( (int) $user_id, $contract['user']['id'] );
+		$this->assertSame( self::TEST_SITE_ID, $contract['site']['id'] );
+
+		$acknowledgement_values = $approval_block['charge_acknowledgement']['values'];
+		$this->assertSame( 75.0, $acknowledgement_values['max_charge_amount'] );
+		$this->assertSame( 'USD', $acknowledgement_values['currency'] );
+		$this->assertSame( 'one_time', $acknowledgement_values['billing_cadence'] );
+		$this->assertSame( 'Visa ending in 4242', $acknowledgement_values['payment_method_label'] );
+	}
+
+	/**
+	 * Approval validation accepts only the language-independent event for the
+	 * exact prepared campaign package.
+	 */
+	public function test_validate_approval_event_rejects_package_identity_mismatch() {
+		add_filter(
+			'jetpack_blaze_prepare_campaign_payment_methods',
+			static function () {
+				return array(
+					array(
+						'id'         => 'pm_default',
+						'type'       => 'card',
+						'card_brand' => 'visa',
+						'last4'      => '4242',
+						'is_default' => true,
+					),
+				);
+			}
+		);
+
+		$ctx      = $this->make_test_post();
+		$proposal = Campaign_Preparer::prepare(
+			array(
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $proposal );
+
+		$approval_event                = $proposal['approval_block']['approval_event'];
+		$approval_event['approved_at'] = '2026-05-19T12:00:00+00:00';
+		$valid_approval                = Campaign_Preparer::validate_approval_event( $approval_event, $proposal );
+		$mismatched_approval           = $approval_event;
+		$mismatched_approval['prepared_campaign_hash'] = str_repeat( '0', 64 );
+		$mismatched_result = Campaign_Preparer::validate_approval_event( $mismatched_approval, $proposal );
+
+		$this->assertTrue( $valid_approval );
+		$this->assertInstanceOf( WP_Error::class, $mismatched_result );
+		$this->assertSame( 'blaze_approval_package_mismatch', $mismatched_result->get_error_code() );
+	}
+
+	/**
+	 * Material campaign changes alter the prepared package hash so earlier
+	 * approval cannot be reused for a different paid submission.
+	 */
+	public function test_material_changes_update_prepared_package_hash() {
+		add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+
+		$ctx       = $this->make_test_post();
+		$base_args = array(
+			'target_urn'    => $ctx['target_urn'],
+			'budget_total'  => 75,
+			'duration_days' => 10,
+			'languages'     => array( 'en' ),
+			'countries'     => array( 'US' ),
+			'devices'       => array( 'mobile' ),
+			'interests'     => array( 'IAB8_IAB18' ),
+		);
+
+		$base = Campaign_Preparer::prepare( $base_args );
+		$this->assertIsArray( $base );
+
+		$material_variants = array(
+			'title'           => array( 'site_name' => 'Different title' ),
+			'copy'            => array( 'text_snippet' => 'Different ad copy.' ),
+			'call_to_action'  => array( 'cta_text' => 'Buy Now' ),
+			'image'           => array( 'main_image_url' => 'https://example.com/new.jpg' ),
+			'budget'          => array( 'budget_total' => 125 ),
+			'schedule'        => array( 'duration_days' => 14 ),
+			'targeting'       => array( 'countries' => array( 'CA' ) ),
+		);
+
+		foreach ( $material_variants as $variant => $overrides ) {
+			$result = Campaign_Preparer::prepare( array_merge( $base_args, $overrides ) );
+			$this->assertIsArray( $result, $variant );
+			$this->assertNotSame( $base['prepared_campaign']['hash'], $result['prepared_campaign']['hash'], $variant );
+		}
+
+		add_filter(
+			'jetpack_blaze_approval_terms',
+			static function () {
+				return array(
+					'url'     => 'https://wordpress.com/tos/',
+					'version' => 'v2',
+				);
+			}
+		);
+
+		$terms_change = Campaign_Preparer::prepare( $base_args );
+		$this->assertIsArray( $terms_change );
+		$this->assertNotSame( $base['prepared_campaign']['hash'], $terms_change['prepared_campaign']['hash'], 'terms' );
+
+		remove_all_filters( 'jetpack_blaze_approval_terms' );
+		add_filter(
+			'jetpack_blaze_approval_advertising_policy',
+			static function () {
+				return array(
+					'url'     => 'https://automattic.com/advertising-policy/',
+					'version' => 'v2',
+				);
+			}
+		);
+
+		$policy_change = Campaign_Preparer::prepare( $base_args );
+		$this->assertIsArray( $policy_change );
+		$this->assertNotSame( $base['prepared_campaign']['hash'], $policy_change['prepared_campaign']['hash'], 'policy' );
+	}
+
+	/**
+	 * Explanatory-only revision notes do not alter the exact paid package when
+	 * all material prepared values stay the same.
+	 */
+	public function test_non_material_revision_instruction_does_not_update_prepared_package_hash() {
+		add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
+
+		$ctx       = $this->make_test_post();
+		$base_args = array(
+			'target_urn'    => $ctx['target_urn'],
+			'budget_total'  => 75,
+			'duration_days' => 10,
+		);
+
+		$base    = Campaign_Preparer::prepare( $base_args );
+		$revised = Campaign_Preparer::prepare(
+			array_merge(
+				$base_args,
+				array(
+					'revision_instruction' => 'Explain the recommendation more clearly.',
+				)
+			)
+		);
+
+		$this->assertIsArray( $base );
+		$this->assertIsArray( $revised );
+		$this->assertSame( $base['prepared_campaign']['hash'], $revised['prepared_campaign']['hash'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
+++ b/projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
@@ -264,15 +264,15 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$ctx = $this->make_test_post();
 
-		$default_result = Campaign_Preparer::prepare(
+		$default_result  = Campaign_Preparer::prepare(
 			array(
 				'target_urn' => $ctx['target_urn'],
 			)
 		);
 		$switched_result = Campaign_Preparer::prepare(
 			array(
-				'target_urn'         => $ctx['target_urn'],
-				'payment_method_id'  => 'pm_backup',
+				'target_urn'        => $ctx['target_urn'],
+				'payment_method_id' => 'pm_backup',
 			)
 		);
 
@@ -343,6 +343,8 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$approval_block = $result['approval_block'];
 		$this->assertSame( $result['prepared_campaign']['id'], $approval_block['prepared_campaign_id'] );
 		$this->assertSame( $result['prepared_campaign']['hash'], $approval_block['prepared_campaign_hash'] );
+		$this->assertArrayHasKey( 'idempotency_key', $result['submit_package'] );
+		$this->assertSame( $result['submit_package']['idempotency_key'], $approval_block['approval_event']['idempotency_key'] );
 		$this->assertSame( 'blaze.approval.charge_acknowledgement', $approval_block['charge_acknowledgement']['template_key'] );
 		$this->assertSame( 'blaze.approval.body.v1', $approval_block['body_key'] );
 		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $approval_block['confirmation_label_key'] );
@@ -403,12 +405,12 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$this->assertIsArray( $proposal );
 
-		$approval_event                = $proposal['approval_block']['approval_event'];
-		$approval_event['approved_at'] = '2026-05-19T12:00:00+00:00';
-		$valid_approval                = Campaign_Preparer::validate_approval_event( $approval_event, $proposal );
-		$mismatched_approval           = $approval_event;
+		$approval_event                                = $proposal['approval_block']['approval_event'];
+		$approval_event['approved_at']                 = '2026-05-19T12:00:00+00:00';
+		$valid_approval                                = Campaign_Preparer::validate_approval_event( $approval_event, $proposal );
+		$mismatched_approval                           = $approval_event;
 		$mismatched_approval['prepared_campaign_hash'] = str_repeat( '0', 64 );
-		$mismatched_result = Campaign_Preparer::validate_approval_event( $mismatched_approval, $proposal );
+		$mismatched_result                             = Campaign_Preparer::validate_approval_event( $mismatched_approval, $proposal );
 
 		$this->assertTrue( $valid_approval );
 		$this->assertInstanceOf( WP_Error::class, $mismatched_result );
@@ -416,10 +418,10 @@ class Campaign_Preparer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Material campaign changes alter the prepared package hash so earlier
-	 * approval cannot be reused for a different paid submission.
+	 * Material campaign-body changes alter the prepared campaign hash, while
+	 * terms and policy versions stay in separate submit fields validated by DSP.
 	 */
-	public function test_material_changes_update_prepared_package_hash() {
+	public function test_material_changes_update_prepared_campaign_contract() {
 		add_filter( 'jetpack_blaze_prepare_campaign_has_saved_payment_method', '__return_true' );
 
 		$ctx       = $this->make_test_post();
@@ -437,13 +439,13 @@ class Campaign_Preparer_Test extends BaseTestCase {
 		$this->assertIsArray( $base );
 
 		$material_variants = array(
-			'title'           => array( 'site_name' => 'Different title' ),
-			'copy'            => array( 'text_snippet' => 'Different ad copy.' ),
-			'call_to_action'  => array( 'cta_text' => 'Buy Now' ),
-			'image'           => array( 'main_image_url' => 'https://example.com/new.jpg' ),
-			'budget'          => array( 'budget_total' => 125 ),
-			'schedule'        => array( 'duration_days' => 14 ),
-			'targeting'       => array( 'countries' => array( 'CA' ) ),
+			'title'          => array( 'site_name' => 'Different title' ),
+			'copy'           => array( 'text_snippet' => 'Different ad copy.' ),
+			'call_to_action' => array( 'cta_text' => 'Buy Now' ),
+			'image'          => array( 'main_image_url' => 'https://example.com/new.jpg' ),
+			'budget'         => array( 'budget_total' => 125 ),
+			'schedule'       => array( 'duration_days' => 14 ),
+			'targeting'      => array( 'countries' => array( 'CA' ) ),
 		);
 
 		foreach ( $material_variants as $variant => $overrides ) {
@@ -464,7 +466,8 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$terms_change = Campaign_Preparer::prepare( $base_args );
 		$this->assertIsArray( $terms_change );
-		$this->assertNotSame( $base['prepared_campaign']['hash'], $terms_change['prepared_campaign']['hash'], 'terms' );
+		$this->assertSame( $base['prepared_campaign']['hash'], $terms_change['prepared_campaign']['hash'], 'terms' );
+		$this->assertSame( 'v2', $terms_change['submit_package']['accepted_terms_version'] );
 
 		remove_all_filters( 'jetpack_blaze_approval_terms' );
 		add_filter(
@@ -479,7 +482,8 @@ class Campaign_Preparer_Test extends BaseTestCase {
 
 		$policy_change = Campaign_Preparer::prepare( $base_args );
 		$this->assertIsArray( $policy_change );
-		$this->assertNotSame( $base['prepared_campaign']['hash'], $policy_change['prepared_campaign']['hash'], 'policy' );
+		$this->assertSame( $base['prepared_campaign']['hash'], $policy_change['prepared_campaign']['hash'], 'policy' );
+		$this->assertSame( 'v2', $policy_change['submit_package']['accepted_policy_version'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/Dashboard_REST_Controller_Test.php
+++ b/projects/packages/blaze/tests/php/Dashboard_REST_Controller_Test.php
@@ -1396,6 +1396,19 @@ class Dashboard_REST_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test the submit prepared campaign route is registered for POST requests.
+	 */
+	public function test_submit_prepared_dsp_campaign_route_is_registered() {
+		$route = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns/submit-prepared-campaign', $this->site_id );
+
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $route, $routes );
+		$this->assertArrayHasKey( 'POST', $routes[ $route ][0]['methods'] );
+		$this->assertSame( array( $this->controller, 'submit_prepared_dsp_campaign' ), $routes[ $route ][0]['callback'] );
+	}
+
+	/**
 	 * Test the create_dsp_campaigns local processing of data (before redirection).
 	 */
 	public function test_create_dsp_campaigns_processed_it_locally() {

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -106,6 +106,32 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The stop-campaign ability is a destructive write tool with an
+	 * explicit preview/confirm contract.
+	 */
+	public function test_stop_campaign_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( Blaze_Abilities::ABILITY_STOP_CAMPAIGN, $abilities );
+
+		$ability = $abilities[ Blaze_Abilities::ABILITY_STOP_CAMPAIGN ];
+		$this->assertSame( array( Blaze_Abilities::class, 'stop_campaign' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertFalse( $ability['meta']['annotations']['readonly'] );
+		$this->assertTrue( $ability['meta']['annotations']['destructive'] );
+		$this->assertFalse( $ability['meta']['annotations']['idempotent'] );
+
+		$schema = $ability['input_schema'];
+		$this->assertSame( array( 'campaign_id' ), $schema['required'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertSame( 'integer', $schema['properties']['campaign_id']['type'] );
+		$this->assertSame( 1, $schema['properties']['campaign_id']['minimum'] );
+		$this->assertSame( 'boolean', $schema['properties']['confirm']['type'] );
+		$this->assertFalse( $schema['properties']['confirm']['default'] );
+	}
+
+	/**
 	 * The double-register guard preserves an existing disabled decision.
 	 */
 	public function test_guard_against_double_register_preserves_disabled_decision() {
@@ -427,6 +453,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
 		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
 		$this->assertContains( Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_STOP_CAMPAIGN, $owned );
 
 		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
 		// wrapped. We exercise prepare-campaign here as the canonical write slug.
@@ -437,6 +464,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
+
+		$out = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_STOP_CAMPAIGN );
 		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
 	}
 
@@ -476,6 +506,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	public function test_opt_into_woo_mcp_for_owned_slugs() {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_STOP_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
 		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'jetpack-forms/get-responses' ) );
@@ -586,6 +617,42 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Register a test campaign detail route for stop-campaign previews.
+	 *
+	 * @param int      $campaign_id Numeric DSP campaign ID.
+	 * @param callable $callback    Route callback.
+	 */
+	private function register_campaign_context_route( int $campaign_id, callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/campaigns/%d', self::TEST_SITE_ID, $campaign_id ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Register a test campaign stop route for confirm-mode calls.
+	 *
+	 * @param int      $campaign_id Numeric DSP campaign ID.
+	 * @param callable $callback    Route callback.
+	 */
+	private function register_campaign_stop_route( int $campaign_id, callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/campaigns/%d/stop', self::TEST_SITE_ID, $campaign_id ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
 	 * Invalid target_urn returns a WP_Error with status 400, not a partial proposal.
 	 */
 	public function test_prepare_campaign_returns_error_for_invalid_target_urn() {
@@ -615,6 +682,137 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'blaze_post_not_found', $result->get_error_code() );
 		$data = $result->get_error_data();
 		$this->assertSame( 404, $data['status'] ?? null );
+	}
+
+	/**
+	 * Preview mode fetches campaign context but does not call the DSP stop
+	 * endpoint.
+	 */
+	public function test_stop_campaign_preview_fetches_context_without_stop_call() {
+		$stop_calls = 0;
+		$this->register_campaign_context_route(
+			987,
+			static function () {
+				return array(
+					'id'         => 987,
+					'name'       => 'Spring launch',
+					'status'     => 'active',
+					'start_date' => '2026-05-01',
+					'end_date'   => '2026-05-31',
+					'target_url' => 'https://example.com/spring',
+					'target_urn' => 'urn:wpcom:post:12345:42',
+				);
+			}
+		);
+		$this->register_campaign_stop_route(
+			987,
+			static function () use ( &$stop_calls ) {
+				++$stop_calls;
+				return array( 'status' => 'stopped' );
+			}
+		);
+
+		$result = Blaze_Abilities::stop_campaign( array( 'campaign_id' => 987 ) );
+
+		$this->assertSame( 0, $stop_calls, 'Preview mode must not call the DSP stop endpoint.' );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_confirmation', $result['status'] );
+		$this->assertSame( 987, $result['campaign']['campaign_id'] );
+		$this->assertSame( 'Spring launch', $result['campaign']['title'] );
+		$this->assertSame( 'active', $result['campaign']['status'] );
+		$this->assertSame( '2026-05-01', $result['campaign']['start_date'] );
+		$this->assertSame( '2026-05-31', $result['campaign']['end_date'] );
+		$this->assertSame( 'https://example.com/spring', $result['campaign']['target_url'] );
+		$this->assertSame( 'urn:wpcom:post:12345:42', $result['campaign']['target_urn'] );
+		$this->assertStringContainsString( 'will be stopped from serving', $result['consequence'] );
+		$this->assertStringContainsString( 'Preview only', $result['message'] );
+		$this->assertStringContainsString( 'Spring launch', $result['message'] );
+	}
+
+	/**
+	 * Confirm mode re-fetches campaign context and delegates to the DSP stop
+	 * endpoint through the Jetpack Blaze proxy.
+	 */
+	public function test_stop_campaign_confirm_refetches_context_and_calls_stop_endpoint() {
+		$context_calls = 0;
+		$stop_calls    = 0;
+		$this->register_campaign_context_route(
+			987,
+			static function () use ( &$context_calls ) {
+				++$context_calls;
+				return array(
+					'id'         => 987,
+					'title'      => 'Spring launch',
+					'status'     => 'active',
+					'start_date' => '2026-05-01',
+					'end_date'   => '2026-05-31',
+					'target_url' => 'https://example.com/spring',
+				);
+			}
+		);
+		$this->register_campaign_stop_route(
+			987,
+			static function () use ( &$stop_calls ) {
+				++$stop_calls;
+				return array(
+					'id'     => 987,
+					'status' => 'stopped',
+				);
+			}
+		);
+
+		$result = Blaze_Abilities::stop_campaign(
+			array(
+				'campaign_id' => 987,
+				'confirm'     => true,
+			)
+		);
+
+		$this->assertSame( 1, $context_calls );
+		$this->assertSame( 1, $stop_calls );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'stopped', $result['status'] );
+		$this->assertSame( 'Spring launch', $result['campaign']['title'] );
+		$this->assertSame( array( 'id' => 987, 'status' => 'stopped' ), $result['stop_response'] );
+		$this->assertStringContainsString( 'Campaign "Spring launch" was stopped from serving.', $result['message'] );
+		$this->assertStringNotContainsString( 'deleted', strtolower( $result['message'] ) );
+		$this->assertStringNotContainsString( 'archived', strtolower( $result['message'] ) );
+	}
+
+	/**
+	 * DSP stop errors pass through without duplicating stop eligibility
+	 * rules in Jetpack.
+	 */
+	public function test_stop_campaign_confirm_passes_through_dsp_stop_error() {
+		$this->register_campaign_context_route(
+			987,
+			static function () {
+				return array(
+					'id'     => 987,
+					'title'  => 'Spring launch',
+					'status' => 'completed',
+				);
+			}
+		);
+		$this->register_campaign_stop_route(
+			987,
+			static function () {
+				return new WP_Error( 'campaign_not_stoppable', 'Campaign cannot be stopped from its current state.', array( 'status' => 409 ) );
+			}
+		);
+
+		$result = Blaze_Abilities::stop_campaign(
+			array(
+				'campaign_id' => 987,
+				'confirm'     => true,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'campaign_not_stoppable', $result->get_error_code() );
+		$this->assertSame( 'Campaign cannot be stopped from its current state.', $result->get_error_message() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] ?? null );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -374,7 +374,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
 		$this->assertStringContainsString( 'Audience overrides must use stable codes or closed enums', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
-		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
+		$ability    = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ];
+		$schema     = $ability['input_schema'];
 		$properties = $schema['properties'];
 
 		$this->assertSame( array( 'target_urn' ), $schema['required'] );
@@ -402,6 +403,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Blaze public page topic IDs', $properties['interests']['description'] );
 		$this->assertContains( 'IAB8_IAB18', $properties['interests']['items']['enum'] );
 		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
+
+		$output_properties = $ability['output_schema']['properties'];
+		$this->assertArrayHasKey( 'intent', $output_properties );
+		$this->assertArrayHasKey( 'assumptions', $output_properties );
+		$this->assertArrayHasKey( 'recommendations', $output_properties );
+		$this->assertArrayHasKey( 'budget_options', $output_properties );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---
@@ -513,6 +520,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 50.0, $prefill['budget']['amount'] );
 		$this->assertSame( 7, $prefill['duration_days'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
+		$this->assertSame( 'content', $result['intent'] );
+		$this->assertCount( 3, $result['budget_options'] );
 	}
 
 	/**
@@ -545,8 +554,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'Drive sales for a spring promotion.', $prefill['goal'] );
 		$this->assertSame( 'Make it less salesy.', $prefill['revision_instruction'] );
 		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
-		$this->assertSame( 'VIEWS', $prefill['objective'], 'DSP objective is server-owned and not overridden by public input.' );
+		$this->assertSame( 'CLICKS', $prefill['objective'], 'DSP objective is server-owned and inferred from public intent.' );
 		$this->assertFalse( $prefill['is_evergreen'] );
+		$this->assertArrayNotHasKey( 'budget_options', $result );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -66,6 +66,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_tracks_event' );
 		remove_all_actions( 'wp_after_execute_ability' );
 		unset( $GLOBALS['wp_rest_server'] );
 	}
@@ -251,6 +252,122 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->assertSame( array( 'campaign_id' => 'abc-123' ), $result, 'Original callback result should pass through unchanged.' );
 		$this->assertSame( array( 'budget_total' => 50 ), $received_input, 'Original callback should receive the original input.' );
+	}
+
+	/**
+	 * Prepare-campaign emits safe called + succeeded telemetry around
+	 * successful registered ability executions.
+	 */
+	public function test_wrapped_prepare_campaign_tracks_called_and_succeeded() {
+		$events = array();
+		add_filter(
+			'jetpack_blaze_prepare_campaign_tracks_event',
+			static function ( $event ) use ( &$events ) {
+				$events[] = $event;
+				return false;
+			},
+			10,
+			4
+		);
+
+		$callback = static function () {
+			return array(
+				'intent'  => 'ecommerce',
+				'prefill' => array(
+					'type'         => 'product',
+					'site_name'    => 'Secret merchant headline',
+					'text_snippet' => 'Secret merchant copy',
+					'target_url'   => 'https://example.com/private-product',
+				),
+			);
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'    => 'urn:wpcom:post:12345:42',
+				'budget_total'  => 50,
+				'duration_days' => 7,
+				'site_name'     => 'Secret caller headline',
+				'text_snippet'  => 'Secret caller copy',
+			)
+		);
+
+		$this->assertCount( 2, $events );
+		$called_event    = $events[0] ?? array();
+		$succeeded_event = $events[1] ?? array();
+
+		$this->assertSame( 'blaze_prepare_campaign_called', $called_event['name'] ?? null );
+		$this->assertSame(
+			array(
+				'result'            => 'called',
+				'target_type'       => 'unknown',
+				'inferred_intent'   => 'unknown',
+				'budget_provided'   => true,
+				'duration_provided' => true,
+			),
+			$called_event['props'] ?? array()
+		);
+		$succeeded_props = $succeeded_event['props'] ?? array();
+		$this->assertSame( 'blaze_prepare_campaign_succeeded', $succeeded_event['name'] ?? null );
+		$this->assertSame( 'succeeded', $succeeded_props['result'] ?? null );
+		$this->assertSame( 'product', $succeeded_props['target_type'] ?? null );
+		$this->assertSame( 'ecommerce', $succeeded_props['inferred_intent'] ?? null );
+		$this->assertStringNotContainsString( 'Secret', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
+		$this->assertStringNotContainsString( 'private-product', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * Failed prepare-campaign executions emit a low-cardinality failure
+	 * category without carrying raw input or error messages.
+	 */
+	public function test_wrapped_prepare_campaign_tracks_failed_with_safe_failure_category() {
+		$events = array();
+		add_filter(
+			'jetpack_blaze_prepare_campaign_tracks_event',
+			static function ( $event ) use ( &$events ) {
+				$events[] = $event;
+				return false;
+			},
+			10,
+			4
+		);
+
+		$callback = static function () {
+			return new WP_Error( 'blaze_invalid_target_urn', 'Secret malformed URN value' );
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'   => 'secret-bad-urn',
+				'budget_total' => 50,
+			)
+		);
+
+		$this->assertCount( 2, $events );
+		$called_event = $events[0] ?? array();
+		$failed_event = $events[1] ?? array();
+		$failed_props = $failed_event['props'] ?? array();
+
+		$this->assertSame( 'blaze_prepare_campaign_called', $called_event['name'] ?? null );
+		$this->assertSame( 'blaze_prepare_campaign_failed', $failed_event['name'] ?? null );
+		$this->assertSame( 'failed', $failed_props['result'] ?? null );
+		$this->assertSame( 'invalid_target', $failed_props['failure_category'] ?? null );
+		$this->assertSame( true, $failed_props['budget_provided'] ?? null );
+		$this->assertSame( false, $failed_props['duration_provided'] ?? null );
+		$this->assertStringNotContainsString( 'secret-bad-urn', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
+		$this->assertStringNotContainsString( 'Secret malformed', wp_json_encode( $events, JSON_UNESCAPED_SLASHES ) );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -372,7 +372,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$abilities = Blaze_Abilities::get_abilities();
 
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
-		$this->assertStringContainsString( 'Device targeting and interest/topic targeting are not public MCP inputs in v1', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'Audience overrides must use stable codes or closed enums', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
 		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
 		$properties = $schema['properties'];
@@ -389,12 +389,17 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'main_image_url', $properties );
 		$this->assertArrayHasKey( 'languages', $properties );
 		$this->assertArrayHasKey( 'countries', $properties );
+		$this->assertArrayHasKey( 'devices', $properties );
+		$this->assertArrayHasKey( 'interests', $properties );
 		$this->assertArrayNotHasKey( 'objective', $properties );
-		$this->assertArrayNotHasKey( 'devices', $properties );
-		$this->assertArrayNotHasKey( 'interests', $properties );
 		$this->assertArrayNotHasKey( 'page_topics', $properties );
 		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
 		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
+		$this->assertSame( array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ), $properties['languages']['items']['enum'] );
+		$this->assertSame( 1, $properties['devices']['maxItems'] );
+		$this->assertSame( array( 'mobile', 'desktop' ), $properties['devices']['items']['enum'] );
+		$this->assertStringContainsString( 'Tablet is not exposed', $properties['devices']['description'] );
+		$this->assertStringContainsString( 'IAB category IDs', $properties['interests']['description'] );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -103,6 +103,40 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
 		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
 		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+
+		$properties = $ability['input_schema']['properties'];
+		$this->assertIsArray( $properties );
+		$this->assertArrayHasKey( 'status', $properties );
+		$this->assertSame( 'string', $properties['status']['type'] );
+		$this->assertStringContainsString( 'DSP campaign status', $properties['status']['description'] );
+		$this->assertStringContainsString( 'pass through', $properties['status']['description'] );
+	}
+
+	/**
+	 * The list-campaigns output schema documents the campaign context agents
+	 * should show before follow-up operations.
+	 */
+	public function test_list_campaigns_output_schema_documents_agent_context() {
+		$abilities = Blaze_Abilities::get_abilities();
+		$ability   = $abilities[ Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ];
+
+		$this->assertStringContainsString( 'campaign_id', $ability['description'] );
+		$this->assertStringContainsString( 'title/name', $ability['description'] );
+		$this->assertStringContainsString( 'not as the operation identifier', $ability['description'] );
+
+		$output_properties = $ability['output_schema']['properties'];
+		$this->assertArrayHasKey( 'campaigns', $output_properties );
+
+		$campaign_properties = $output_properties['campaigns']['items']['properties'];
+		foreach ( array( 'campaign_id', 'title', 'name', 'status', 'ui_status', 'start_date', 'end_date', 'target_url', 'target_urn', 'budget', 'summary_stats' ) as $field ) {
+			$this->assertArrayHasKey( $field, $campaign_properties );
+		}
+
+		$this->assertStringContainsString( 'numeric operation identifier', $campaign_properties['campaign_id']['description'] );
+		$this->assertStringContainsString( 'human-readable context', $campaign_properties['title']['description'] );
+		$this->assertStringContainsString( 'not as the operation identifier', $campaign_properties['title']['description'] );
+		$this->assertStringContainsString( 'DSP status', $campaign_properties['status']['description'] );
+		$this->assertStringContainsString( 'when available', $campaign_properties['summary_stats']['description'] );
 	}
 
 	/**
@@ -150,6 +184,82 @@ class Blaze_Abilities_Test extends BaseTestCase {
 						'status' => 'active',
 					),
 				),
+			),
+			Blaze_Abilities::list_campaigns()
+		);
+	}
+
+	/**
+	 * List_campaigns forwards the optional status filter to the existing DSP route.
+	 */
+	public function test_list_campaigns_forwards_status_filter_to_blaze_rest_route() {
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1.1/campaigns',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function ( $request ) {
+					return array(
+						'status' => $request->get_param( 'status' ),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'status' => 'active',
+			),
+			Blaze_Abilities::list_campaigns(
+				array(
+					'status' => 'active',
+				)
+			)
+		);
+	}
+
+	/**
+	 * List_campaigns preserves campaign context returned by DSP for agent display.
+	 */
+	public function test_list_campaigns_preserves_campaign_context_from_blaze_rest_route() {
+		$campaign = array(
+			'campaign_id'   => 123,
+			'title'         => 'Spring product launch',
+			'name'          => 'Spring launch',
+			'status'        => 'active',
+			'ui_status'     => 'Running',
+			'start_date'    => '2026-05-01',
+			'end_date'      => '2026-05-31',
+			'target_url'    => 'https://example.com/product',
+			'target_urn'    => 'urn:wpcom:post:12345:678',
+			'budget'        => array(
+				'amount'   => 50,
+				'currency' => 'USD',
+			),
+			'summary_stats' => array(
+				'impressions' => 1000,
+				'clicks'      => 40,
+			),
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1.1/campaigns',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function () use ( $campaign ) {
+					return array(
+						'campaigns' => array( $campaign ),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'campaigns' => array( $campaign ),
 			),
 			Blaze_Abilities::list_campaigns()
 		);

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -106,6 +106,56 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The get-campaign-stats ability is read-only and exposes the DSP stats
+	 * query contract used by the Blaze proxy route.
+	 */
+	public function test_get_campaign_stats_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( 'blaze-ads/get-campaign-stats', $abilities );
+		$this->assertContains( 'blaze-ads/get-campaign-stats', Blaze_Abilities::OWNED_ABILITY_SLUGS );
+
+		$ability    = $abilities['blaze-ads/get-campaign-stats'];
+		$schema     = $ability['input_schema'];
+		$properties = $schema['properties'];
+
+		$this->assertSame( array( Blaze_Abilities::class, 'get_campaign_stats' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
+		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
+		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
+
+		$this->assertSame( array( 'campaign_id' ), $schema['required'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertSame( 'integer', $properties['campaign_id']['type'] );
+		$this->assertSame( 1, $properties['campaign_id']['minimum'] );
+		$this->assertArrayHasKey( 'start_date', $properties );
+		$this->assertArrayHasKey( 'end_date', $properties );
+		$this->assertArrayHasKey( 'time_zone', $properties );
+		$this->assertArrayHasKey( 'resolution', $properties );
+
+		$output_schema     = $ability['output_schema'];
+		$output_properties = $output_schema['properties'];
+
+		$this->assertContains( 'raw_stats', $output_schema['required'] );
+		$this->assertContains( 'totals', $output_schema['required'] );
+		$this->assertContains( 'time_series', $output_schema['required'] );
+		$this->assertContains( 'derived_metrics', $output_schema['required'] );
+		$this->assertContains( 'context', $output_schema['required'] );
+		$this->assertArrayHasKey( 'raw_stats', $output_properties );
+		$this->assertArrayHasKey( 'totals', $output_properties );
+		$this->assertArrayHasKey( 'time_series', $output_properties );
+		$this->assertArrayHasKey( 'country_breakdown', $output_properties );
+		$this->assertArrayHasKey( 'derived_metrics', $output_properties );
+		$this->assertArrayHasKey( 'ctr', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'cpm', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'cpc', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'clicks_per_dollar', $output_properties['derived_metrics']['properties'] );
+		$this->assertArrayHasKey( 'context', $output_properties );
+	}
+
+	/**
 	 * The double-register guard preserves an existing disabled decision.
 	 */
 	public function test_guard_against_double_register_preserves_disabled_decision() {
@@ -143,7 +193,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->assertSame(
 			array(
-				'api_version' => 'v1.1',
+				'api_version' => 'v1',
 				'campaigns'   => array(
 					array(
 						'id'     => 'campaign-1',
@@ -153,6 +203,197 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			),
 			Blaze_Abilities::list_campaigns()
 		);
+	}
+
+	/**
+	 * Get_campaign_stats delegates to the existing Blaze stats proxy route
+	 * and forwards the DSP stats query options.
+	 */
+	public function test_get_campaign_stats_delegates_to_blaze_stats_rest_route() {
+		$captured_params = null;
+
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1/stats/67890',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function ( $request ) use ( &$captured_params ) {
+					$captured_params = $request->get_params();
+					return array(
+						'totals' => array(
+							'impressions' => 1000,
+							'clicks'      => 20,
+							'spend'       => 5.0,
+						),
+						'series' => array(),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_stats(
+			array(
+				'campaign_id' => 67890,
+				'start_date'  => '2026-05-01',
+				'end_date'    => '2026-05-07',
+				'time_zone'   => 'America/New_York',
+				'resolution'  => 'day',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'totals' => array(
+					'impressions' => 1000,
+					'clicks'      => 20,
+					'spend'       => 5.0,
+				),
+				'series' => array(),
+			),
+			$result['raw_stats']
+		);
+		$this->assertSame( 'v1', $captured_params['api_version'] ?? null );
+		$this->assertSame( '2026-05-01', $captured_params['start_date'] ?? null );
+		$this->assertSame( '2026-05-07', $captured_params['end_date'] ?? null );
+		$this->assertSame( 'America/New_York', $captured_params['time_zone'] ?? null );
+		$this->assertSame( 'day', $captured_params['resolution'] ?? null );
+	}
+
+	/**
+	 * Campaign stats requires a numeric DSP campaign ID at execution time.
+	 */
+	public function test_get_campaign_stats_rejects_non_numeric_campaign_id() {
+		$result = Blaze_Abilities::get_campaign_stats(
+			array(
+				'campaign_id' => '123abc',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_invalid_campaign_id', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 400, $data['status'] ?? null );
+	}
+
+	/**
+	 * Get_campaign_stats returns raw DSP stats plus simple display-ad
+	 * derived metrics.
+	 */
+	public function test_get_campaign_stats_returns_derived_metrics_and_context() {
+		$stats_payload = array(
+			'totals'    => array(
+				'impressions' => 2000,
+				'clicks'      => 50,
+				'spend'       => 25.0,
+			),
+			'series'    => array(
+				array(
+					'date'        => '2026-05-01',
+					'impressions' => 1200,
+					'clicks'      => 30,
+					'spend'       => 15.0,
+				),
+				array(
+					'date'        => '2026-05-02',
+					'impressions' => 800,
+					'clicks'      => 20,
+					'spend'       => 10.0,
+				),
+			),
+			'countries' => array(
+				array(
+					'country'     => 'US',
+					'impressions' => 1500,
+					'clicks'      => 40,
+					'spend'       => 20.0,
+				),
+			),
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1/stats/67890',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function () use ( $stats_payload ) {
+					return $stats_payload;
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_stats( array( 'campaign_id' => 67890 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $stats_payload, $result['raw_stats'] );
+		$this->assertSame( $stats_payload['totals'], $result['totals'] );
+		$this->assertSame( $stats_payload['series'], $result['time_series'] );
+		$this->assertSame( $stats_payload['countries'], $result['country_breakdown'] );
+		$this->assertSame(
+			array(
+				'ctr'               => 0.025,
+				'cpm'               => 12.5,
+				'cpc'               => 0.5,
+				'clicks_per_dollar' => 2.0,
+			),
+			$result['derived_metrics']
+		);
+		$this->assertStringContainsString( 'display advertising', $result['context'] );
+		$this->assertStringContainsString( 'low CTR', $result['context'] );
+		$this->assertStringContainsString( 'CPM', $result['context'] );
+		$this->assertStringContainsString( 'CPC', $result['context'] );
+		$this->assertStringContainsString( 'campaign goals', $result['context'] );
+		$this->assertStringNotContainsString( 'ROAS', $result['context'] );
+		$this->assertStringNotContainsString( 'revenue', $result['context'] );
+	}
+
+	/**
+	 * Zero-value stats do not cause divide-by-zero derived metrics.
+	 */
+	public function test_get_campaign_stats_handles_zero_value_derived_metrics() {
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1/stats/67890',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function () {
+					return array(
+						'totals' => array(
+							'impressions' => 0,
+							'clicks'      => 0,
+							'spend'       => 0.0,
+						),
+						'series' => array(
+							array(
+								'date'        => '2026-05-01',
+								'impressions' => 0,
+								'clicks'      => 0,
+								'spend'       => 0.0,
+							),
+						),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$result = Blaze_Abilities::get_campaign_stats( array( 'campaign_id' => 67890 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array(
+				'ctr'               => null,
+				'cpm'               => null,
+				'cpc'               => null,
+				'clicks_per_dollar' => null,
+			),
+			$result['derived_metrics']
+		);
+		$this->assertSame( 0, $result['totals']['impressions'] );
+		$this->assertSame( 0, $result['totals']['clicks'] );
+		$this->assertSame( 0.0, $result['totals']['spend'] );
 	}
 
 	// --- Wrapper: shape and identity behaviour ---
@@ -426,6 +667,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	public function test_inheritance_documented_via_owned_slugs_constant() {
 		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
 		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_GET_CAMPAIGN_STATS, $owned );
 		$this->assertContains( Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN, $owned );
 
 		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
@@ -470,11 +712,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	// --- Woo MCP opt-in ---
 
 	/**
-	 * Both owned slugs are opted into Woo's MCP whitelist; foreign slugs
+	 * Owned slugs are opted into Woo's MCP whitelist; foreign slugs
 	 * are passed through unchanged.
 	 */
 	public function test_opt_into_woo_mcp_for_owned_slugs() {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_GET_CAMPAIGN_STATS ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -399,7 +399,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 1, $properties['devices']['maxItems'] );
 		$this->assertSame( array( 'mobile', 'desktop' ), $properties['devices']['items']['enum'] );
 		$this->assertStringContainsString( 'Tablet is not exposed', $properties['devices']['description'] );
-		$this->assertStringContainsString( 'IAB category IDs', $properties['interests']['description'] );
+		$this->assertStringContainsString( 'Blaze public page topic IDs', $properties['interests']['description'] );
+		$this->assertContains( 'IAB8_IAB18', $properties['interests']['items']['enum'] );
+		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -372,6 +372,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$abilities = Blaze_Abilities::get_abilities();
 
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
+		$this->assertStringContainsString( 'Device targeting and interest/topic targeting are not public MCP inputs in v1', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
 		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
 		$properties = $schema['properties'];
@@ -389,6 +390,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'languages', $properties );
 		$this->assertArrayHasKey( 'countries', $properties );
 		$this->assertArrayNotHasKey( 'objective', $properties );
+		$this->assertArrayNotHasKey( 'devices', $properties );
+		$this->assertArrayNotHasKey( 'interests', $properties );
+		$this->assertArrayNotHasKey( 'page_topics', $properties );
+		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
+		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
 	}
 
 	// --- prepare_campaign: prefill payload + URL ---

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -406,6 +406,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$output_properties = $ability['output_schema']['properties'];
 		$this->assertArrayHasKey( 'intent', $output_properties );
+		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
 		$this->assertArrayHasKey( 'recommendations', $output_properties );
 		$this->assertArrayHasKey( 'budget_options', $output_properties );
@@ -521,6 +522,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 7, $prefill['duration_days'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
 		$this->assertSame( 'content', $result['intent'] );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
 		$this->assertCount( 3, $result['budget_options'] );
 	}
 

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -14,6 +14,7 @@ use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WP_Error;
+use WP_REST_Server;
 
 /**
  * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
@@ -51,6 +52,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			array( 'approved' => true ),
 			DAY_IN_SECONDS
 		);
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
 	}
 
 	/**
@@ -63,6 +67,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
 		remove_all_actions( 'wp_after_execute_ability' );
+		unset( $GLOBALS['wp_rest_server'] );
 	}
 
 	// --- list-campaigns read ability ---
@@ -397,6 +402,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
 		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
 		$this->assertSame( array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ), $properties['languages']['items']['enum'] );
+		$this->assertSame( '^[A-Z]{2}$', $properties['countries']['items']['pattern'] );
 		$this->assertSame( 1, $properties['devices']['maxItems'] );
 		$this->assertSame( array( 'mobile', 'desktop' ), $properties['devices']['items']['enum'] );
 		$this->assertStringContainsString( 'Tablet is not exposed', $properties['devices']['description'] );
@@ -405,6 +411,14 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
 
 		$output_properties = $ability['output_schema']['properties'];
+		$this->assertContains( 'message', $ability['output_schema']['required'] );
+		$this->assertContains( 'campaign_preview', $ability['output_schema']['required'] );
+		$this->assertContains( 'forecast_summary', $ability['output_schema']['required'] );
+		$this->assertArrayHasKey( 'message', $output_properties );
+		$this->assertArrayHasKey( 'campaign_preview', $output_properties );
+		$this->assertArrayHasKey( 'forecast_summary', $output_properties );
+		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
+		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
@@ -434,6 +448,23 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		return array(
 			'post_id'    => (int) $post_id,
 			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * Register a test forecast route for the preparer's proxied DSP request.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_forecast_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
 		);
 	}
 
@@ -490,6 +521,19 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertNotEmpty( $result['prefill_url'] );
 		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
 		$this->assertStringContainsString( $result['prefill_url'], $result['message'] );
+		$this->assertArrayNotHasKey( 'budget_options', $result );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
+		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
+		$this->assertSame( 'Test product page', $result['campaign_preview']['ad_heading'] );
+		$this->assertSame( 'USD 50.00 total (USD 3.57/day)', $result['campaign_preview']['budget'] );
+		$this->assertStringContainsString( '| Campaign preview | Prepared value |', $result['message'] );
+		$this->assertStringContainsString( '| Ad heading | Test product page |', $result['message'] );
+		$this->assertStringContainsString( '| Budget | USD 50.00 total (USD 3.57/day) |', $result['message'] );
+		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
+		$this->assertStringContainsString( 'Assumptions:', $result['message'] );
+		$this->assertStringContainsString( 'Recommendations:', $result['message'] );
+		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringNotContainsString( 'Budget options:', $result['message'] );
 
 		$prefill = $result['prefill'];
 		$this->assertSame( $ctx['target_urn'], $prefill['target_urn'] );
@@ -524,6 +568,73 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'content', $result['intent'] );
 		$this->assertSame( 'unavailable', $result['forecast']['status'] );
 		$this->assertCount( 3, $result['budget_options'] );
+		$this->assertStringContainsString( 'Budget options:', $result['message'] );
+		$this->assertStringContainsString( '| Lower | USD 25.00 | USD 3.57 | 7 days |', $result['message'] );
+		$this->assertStringContainsString( '| Recommended | USD 50.00 | USD 7.14 | 7 days |', $result['message'] );
+		$this->assertStringContainsString( '| Higher | USD 150.00 | USD 21.43 | 7 days |', $result['message'] );
+	}
+
+	/**
+	 * Available DSP forecasts are summarized in the chat-facing message while
+	 * the structured forecast remains available.
+	 */
+	public function test_prepare_campaign_message_includes_forecast_summary_when_available() {
+		$ctx = $this->make_test_post();
+		$this->register_forecast_route(
+			static function () {
+				return array(
+					'total_impressions_min'     => 1200,
+					'total_impressions_max'     => 2400,
+					'total_clicks_min'          => 30,
+					'total_clicks_max'          => 60,
+					'total_tsp_impressions_min' => 0,
+					'total_tsp_impressions_max' => 0,
+				);
+			}
+		);
+
+		$result = Blaze_Abilities::prepare_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'available', $result['forecast']['status'] );
+		$this->assertSame( 'views', $result['forecast']['primary_metric'] );
+		$this->assertSame( 'Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['forecast_summary'] );
+		$this->assertStringContainsString( 'Forecast: Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['message'] );
+		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+	}
+
+	/**
+	 * Forecast failures should produce a useful fallback instead of hiding the
+	 * review URL or structured proposal.
+	 */
+	public function test_prepare_campaign_message_includes_forecast_fallback() {
+		$ctx = $this->make_test_post();
+		$this->register_forecast_route(
+			static function () {
+				return new WP_Error( 'forecast_unavailable', 'Forecast failed.', array( 'status' => 500 ) );
+			}
+		);
+
+		$result = Blaze_Abilities::prepare_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'unavailable', $result['forecast']['status'] );
+		$this->assertSame( 'forecast_unavailable', $result['forecast']['reason'] );
+		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
+		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
+		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -61,7 +61,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		Jetpack_Options::delete_option( 'id' );
 		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
-		remove_all_filters( 'blaze_abilities_create_campaign_enabled' );
+		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
 		remove_all_actions( 'wp_after_execute_ability' );
 	}
 
@@ -194,7 +194,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta' => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 
 		$this->assertSame( $args, $result, 'Missing callback should leave args untouched.' );
 	}
@@ -212,7 +212,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 
 		$this->assertNotSame( $callback, $result['execute_callback'], 'Write-ability callback must be wrapped.' );
 		$this->assertIsCallable( $result['execute_callback'] );
@@ -241,7 +241,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
 
 		$this->assertSame( array( 'campaign_id' => 'abc-123' ), $result, 'Original callback result should pass through unchanged.' );
@@ -272,7 +272,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
 
 		$this->assertFalse( $called, 'Original callback must not run when TOS check fails.' );
@@ -304,45 +304,45 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	public function test_inheritance_documented_via_owned_slugs_constant() {
 		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
 		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
-		$this->assertContains( Blaze_Abilities::ABILITY_CREATE_CAMPAIGN, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN, $owned );
 
 		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
-		// wrapped. We exercise create-campaign here as the canonical write slug.
+		// wrapped. We exercise prepare-campaign here as the canonical write slug.
 		$args = array(
 			'execute_callback' => static function () {
 				return 'x';
 			},
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
-		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
 	}
 
 	// --- Kill-switch ---
 
 	/**
-	 * Filter returning false on `blaze_abilities_create_campaign_enabled`
+	 * Filter returning false on `blaze_abilities_prepare_campaign_enabled`
 	 * makes the double-register guard refuse to register the slug —
 	 * MCP clients won't see the tool, REST callers get 404.
 	 */
-	public function test_kill_switch_drops_create_campaign_registration() {
-		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+	public function test_kill_switch_drops_prepare_campaign_registration() {
+		add_filter( 'blaze_abilities_prepare_campaign_enabled', '__return_false' );
 
-		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 
-		$this->assertFalse( $enabled, 'Kill-switch must drop create-campaign registration when set to false.' );
+		$this->assertFalse( $enabled, 'Kill-switch must drop prepare-campaign registration when set to false.' );
 	}
 
 	/**
-	 * Kill-switch is scoped to create-campaign — the read-only
+	 * Kill-switch is scoped to prepare-campaign — the read-only
 	 * list-campaigns ability is unaffected.
 	 */
 	public function test_kill_switch_does_not_affect_list_campaigns() {
-		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+		add_filter( 'blaze_abilities_prepare_campaign_enabled', '__return_false' );
 
 		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS );
 
-		$this->assertTrue( $enabled, 'Kill-switch must only affect create-campaign.' );
+		$this->assertTrue( $enabled, 'Kill-switch must only affect prepare-campaign.' );
 	}
 
 	// --- Woo MCP opt-in ---
@@ -353,7 +353,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 */
 	public function test_opt_into_woo_mcp_for_owned_slugs() {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
-		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
 		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'jetpack-forms/get-responses' ) );
@@ -361,11 +361,41 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
 
-	// --- create_campaign: prefill payload + URL ---
+	// --- prepare-campaign public schema ---
+
+	/**
+	 * The public write ability is prepare-campaign and its MCP-facing
+	 * input contract requires only the target. Budget/duration are
+	 * optional hints, and the raw DSP objective stays server-owned.
+	 */
+	public function test_prepare_campaign_schema_is_minimal_and_renamed() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
+
+		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
+		$properties = $schema['properties'];
+
+		$this->assertSame( array( 'target_urn' ), $schema['required'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertArrayHasKey( 'goal', $properties );
+		$this->assertArrayHasKey( 'budget_total', $properties );
+		$this->assertArrayHasKey( 'duration_days', $properties );
+		$this->assertArrayHasKey( 'revision_instruction', $properties );
+		$this->assertArrayHasKey( 'site_name', $properties );
+		$this->assertArrayHasKey( 'text_snippet', $properties );
+		$this->assertArrayHasKey( 'cta_text', $properties );
+		$this->assertArrayHasKey( 'main_image_url', $properties );
+		$this->assertArrayHasKey( 'languages', $properties );
+		$this->assertArrayHasKey( 'countries', $properties );
+		$this->assertArrayNotHasKey( 'objective', $properties );
+	}
+
+	// --- prepare_campaign: prefill payload + URL ---
 
 	/**
 	 * Helper: insert a test post and return its ID. Returns the
-	 * synthetic URN that callers should pass to create_campaign.
+	 * synthetic URN that callers should pass to prepare_campaign.
 	 */
 	private function make_test_post( array $overrides = array() ): array {
 		$post_id = wp_insert_post(
@@ -387,14 +417,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Invalid target_urn returns a WP_Error with status 400, not a partial draft.
+	 * Invalid target_urn returns a WP_Error with status 400, not a partial proposal.
 	 */
-	public function test_create_campaign_returns_error_for_invalid_target_urn() {
-		$result = Blaze_Abilities::create_campaign(
+	public function test_prepare_campaign_returns_error_for_invalid_target_urn() {
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
-				'target_urn'    => 'not-a-urn',
-				'budget_total'  => 50,
-				'duration_days' => 7,
+				'target_urn' => 'not-a-urn',
 			)
 		);
 
@@ -407,12 +435,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	/**
 	 * URN that parses but references a missing post returns a 404 WP_Error.
 	 */
-	public function test_create_campaign_returns_error_for_missing_post() {
-		$result = Blaze_Abilities::create_campaign(
+	public function test_prepare_campaign_returns_error_for_missing_post() {
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
-				'target_urn'    => sprintf( 'urn:wpcom:post:%d:9999999', self::TEST_SITE_ID ),
-				'budget_total'  => 50,
-				'duration_days' => 7,
+				'target_urn' => sprintf( 'urn:wpcom:post:%d:9999999', self::TEST_SITE_ID ),
 			)
 		);
 
@@ -427,10 +453,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 * prefill_url + prefill payload, and the defaults are pulled from
 	 * the target post.
 	 */
-	public function test_create_campaign_returns_prefill_payload_and_url() {
+	public function test_prepare_campaign_returns_prefill_payload_and_url() {
 		$ctx = $this->make_test_post();
 
-		$result = Blaze_Abilities::create_campaign(
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
 				'target_urn'    => $ctx['target_urn'],
 				'budget_total'  => 50,
@@ -457,20 +483,44 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Caller overrides take precedence over post-derived defaults.
+	 * Minimal input is enough to prepare a proposal. Budget/duration
+	 * defaults stay server-owned for this slice.
 	 */
-	public function test_create_campaign_caller_overrides_win() {
+	public function test_prepare_campaign_accepts_minimal_input() {
 		$ctx = $this->make_test_post();
 
-		$result = Blaze_Abilities::create_campaign(
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
-				'target_urn'    => $ctx['target_urn'],
-				'budget_total'  => 100,
-				'duration_days' => 30,
-				'site_name'     => 'Custom heading',
-				'text_snippet'  => 'Custom ad copy.',
-				'objective'     => 'CLICKS',
-				'is_evergreen'  => false,
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$prefill = $result['prefill'];
+		$this->assertSame( 50.0, $prefill['budget']['amount'] );
+		$this->assertSame( 7, $prefill['duration_days'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Caller overrides take precedence over post-derived defaults.
+	 */
+	public function test_prepare_campaign_caller_overrides_win() {
+		$ctx = $this->make_test_post();
+
+		$result = Blaze_Abilities::prepare_campaign(
+			array(
+				'target_urn'           => $ctx['target_urn'],
+				'budget_total'         => 100,
+				'duration_days'        => 30,
+				'site_name'            => 'Custom heading',
+				'text_snippet'         => 'Custom ad copy.',
+				'cta_text'             => 'Buy now',
+				'goal'                 => 'Drive sales for a spring promotion.',
+				'revision_instruction' => 'Make it less salesy.',
+				'main_image_url'       => 'https://example.com/custom.jpg',
+				'main_image_mime_type' => 'image/jpeg',
+				'is_evergreen'         => false,
 			)
 		);
 
@@ -478,7 +528,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$prefill = $result['prefill'];
 		$this->assertSame( 'Custom heading', $prefill['site_name'] );
 		$this->assertSame( 'Custom ad copy.', $prefill['text_snippet'] );
-		$this->assertSame( 'CLICKS', $prefill['objective'] );
+		$this->assertSame( 'Buy now', $prefill['cta_text'] );
+		$this->assertSame( 'Drive sales for a spring promotion.', $prefill['goal'] );
+		$this->assertSame( 'Make it less salesy.', $prefill['revision_instruction'] );
+		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'], 'DSP objective is server-owned and not overridden by public input.' );
 		$this->assertFalse( $prefill['is_evergreen'] );
 	}
 
@@ -487,7 +541,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 * stripped + truncated post content. This proves we don't return an
 	 * empty snippet (which the widget would surface as an empty heading).
 	 */
-	public function test_create_campaign_falls_back_to_stripped_content_when_no_excerpt() {
+	public function test_prepare_campaign_falls_back_to_stripped_content_when_no_excerpt() {
 		$ctx = $this->make_test_post(
 			array(
 				'post_excerpt' => '',
@@ -495,7 +549,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			)
 		);
 
-		$result = Blaze_Abilities::create_campaign(
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
 				'target_urn'    => $ctx['target_urn'],
 				'budget_total'  => 50,

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -517,6 +517,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		);
 
 		$this->assertIsArray( $result );
+		$this->assertSame( array( 'status', 'message' ), array_slice( array_keys( $result ), 0, 2 ) );
 		$this->assertSame( 'pending_merchant_review', $result['status'] );
 		$this->assertNotEmpty( $result['prefill_url'] );
 		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for Blaze Abilities registration.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; tests exercise guarded integration points directly.
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
+ */
+#[CoversClass( Blaze_Abilities::class )]
+class Blaze_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Synthetic site ID used by the Blaze list-campaigns REST delegation.
+	 *
+	 * @var int
+	 */
+	private const TEST_SITE_ID = 12345;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		Jetpack_Options::delete_option( 'id' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+	}
+
+	/**
+	 * Category metadata is stable for clients that group MCP tools.
+	 */
+	public function test_category_definition() {
+		$this->assertSame( 'blaze-ads', Blaze_Abilities::get_category_slug() );
+		$this->assertSame(
+			array(
+				'label'       => 'Blaze',
+				'description' => 'Abilities for managing Blaze ad campaigns.',
+			),
+			Blaze_Abilities::get_category_definition()
+		);
+	}
+
+	/**
+	 * The list-campaigns ability is read-only and has the expected public contract.
+	 */
+	public function test_list_campaigns_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $abilities );
+
+		$ability = $abilities[ Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ];
+		$this->assertSame( array( Blaze_Abilities::class, 'list_campaigns' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
+		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
+		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
+		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+	}
+
+	/**
+	 * Woo MCP should include the Blaze ability without altering other abilities.
+	 */
+	public function test_opt_into_woo_mcp_for_list_campaigns() {
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
+		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'woocommerce/list-products' ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
+	}
+
+	/**
+	 * The double-register guard preserves an existing disabled decision.
+	 */
+	public function test_guard_against_double_register_preserves_disabled_decision() {
+		$this->assertFalse(
+			Blaze_Abilities::guard_against_double_register( false, 'ability', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS )
+		);
+		$this->assertTrue(
+			Blaze_Abilities::guard_against_double_register( true, 'category', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS )
+		);
+	}
+
+	/**
+	 * List_campaigns delegates to the existing Blaze REST route and returns its data.
+	 */
+	public function test_list_campaigns_delegates_to_blaze_rest_route() {
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1.1/campaigns',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function ( $request ) {
+					return array(
+						'api_version' => $request->get_param( 'api_version' ),
+						'campaigns'   => array(
+							array(
+								'id'     => 'campaign-1',
+								'status' => 'active',
+							),
+						),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'api_version' => 'v1.1',
+				'campaigns'   => array(
+					array(
+						'id'     => 'campaign-1',
+						'status' => 'active',
+					),
+				),
+			),
+			Blaze_Abilities::list_campaigns()
+		);
+	}
+}

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Tests for Blaze Abilities registration.
+ * Tests for Blaze_Abilities — registration, the write-path wrapper,
+ * inheritance behaviour, and the audit-log listener.
  *
  * @package automattic/jetpack-blaze
  */
 
-// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; tests exercise guarded integration points directly.
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; tests gate with markTestSkipped() when the API isn't loaded in the test environment.
 
 namespace Automattic\Jetpack\Blaze\Abilities;
 
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
+use WP_Error;
 
 /**
  * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
@@ -20,26 +22,50 @@ use WorDBless\BaseTestCase;
 class Blaze_Abilities_Test extends BaseTestCase {
 
 	/**
-	 * Synthetic site ID used by the Blaze list-campaigns REST delegation.
+	 * Synthetic site ID used by Connection_Manager::get_site_id() and
+	 * by the Blaze::site_supports_blaze() transient lookup.
 	 *
 	 * @var int
 	 */
 	private const TEST_SITE_ID = 12345;
 
 	/**
-	 * Set up before each test.
+	 * Original `wp_register_ability_args` filter callbacks, captured so
+	 * we can restore them after each test.
+	 *
+	 * @var array|null
+	 */
+	private $original_args_filter;
+
+	/**
+	 * Set up: connect a synthetic site so Connection_Manager::get_site_id()
+	 * resolves, and pre-populate the Blaze eligibility transient so the
+	 * TOS check has a deterministic answer per test.
 	 */
 	public function set_up() {
 		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+
+		// Default: site is eligible. Individual tests can override.
+		set_transient(
+			'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID,
+			array( 'approved' => true ),
+			DAY_IN_SECONDS
+		);
 	}
 
 	/**
-	 * Tear down after each test.
+	 * Tear down: clear the transient and any filter we may have added.
 	 */
 	public function tear_down() {
+		delete_transient( 'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID );
 		Jetpack_Options::delete_option( 'id' );
+		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'blaze_abilities_create_campaign_enabled' );
+		remove_all_actions( 'wp_after_execute_ability' );
 	}
+
+	// --- list-campaigns read ability ---
 
 	/**
 	 * Category metadata is stable for clients that group MCP tools.
@@ -71,15 +97,6 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
 		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
 		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
-	}
-
-	/**
-	 * Woo MCP should include the Blaze ability without altering other abilities.
-	 */
-	public function test_opt_into_woo_mcp_for_list_campaigns() {
-		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
-		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'woocommerce/list-products' ) );
-		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
 
 	/**
@@ -130,5 +147,217 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			),
 			Blaze_Abilities::list_campaigns()
 		);
+	}
+
+	// --- Wrapper: shape and identity behaviour ---
+
+	/**
+	 * Args for an ability we don't own should pass through unchanged.
+	 */
+	public function test_wrapper_passes_through_unowned_abilities() {
+		$callback = static function () {
+			return 'untouched';
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, 'jetpack-forms/get-responses' );
+
+		$this->assertSame( $callback, $result['execute_callback'], 'Unowned-ability callback must be left alone.' );
+	}
+
+	/**
+	 * Args for an owned read-only ability should pass through unchanged.
+	 */
+	public function test_wrapper_passes_through_read_only_owned_abilities() {
+		$callback = static function () {
+			return 'list-result';
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => true ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS );
+
+		$this->assertSame( $callback, $result['execute_callback'], 'Read-only owned-ability callback must be left alone.' );
+	}
+
+	/**
+	 * Args missing an execute_callback are returned unchanged (defensive —
+	 * no closure to wrap).
+	 */
+	public function test_wrapper_no_op_when_callback_missing() {
+		$args = array(
+			'meta' => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+
+		$this->assertSame( $args, $result, 'Missing callback should leave args untouched.' );
+	}
+
+	/**
+	 * Args for an owned write ability must come back with a different
+	 * execute_callback (i.e. the wrapper actually swapped it).
+	 */
+	public function test_wrapper_replaces_callback_for_write_abilities() {
+		$callback = static function () {
+			return 'original-result';
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+
+		$this->assertNotSame( $callback, $result['execute_callback'], 'Write-ability callback must be wrapped.' );
+		$this->assertIsCallable( $result['execute_callback'] );
+	}
+
+	// --- Wrapped callback: TOS gate + delegation ---
+
+	/**
+	 * When the site is Blaze-eligible the wrapper delegates to the
+	 * original callback and forwards its return value.
+	 */
+	public function test_wrapped_callback_delegates_when_tos_passes() {
+		set_transient(
+			'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID,
+			array( 'approved' => true ),
+			DAY_IN_SECONDS
+		);
+
+		$received_input = null;
+		$callback       = static function ( $input ) use ( &$received_input ) {
+			$received_input = $input;
+			return array( 'campaign_id' => 'abc-123' );
+		};
+		$args           = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
+
+		$this->assertSame( array( 'campaign_id' => 'abc-123' ), $result, 'Original callback result should pass through unchanged.' );
+		$this->assertSame( array( 'budget_total' => 50 ), $received_input, 'Original callback should receive the original input.' );
+	}
+
+	/**
+	 * When the site is NOT Blaze-eligible the wrapper short-circuits with
+	 * a WP_Error before invoking the original callback. The deep-link must
+	 * appear in the message text (the Woo MCP adapter strips
+	 * WP_Error::data, so message is the only field that reaches MCP
+	 * clients).
+	 */
+	public function test_wrapped_callback_aborts_when_tos_fails() {
+		set_transient(
+			'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID,
+			array( 'approved' => false ),
+			HOUR_IN_SECONDS
+		);
+
+		$called   = false;
+		$callback = static function () use ( &$called ) {
+			$called = true;
+			return array( 'campaign_id' => 'should-not-happen' );
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
+
+		$this->assertFalse( $called, 'Original callback must not run when TOS check fails.' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_setup_required', $result->get_error_code() );
+
+		$message = $result->get_error_message();
+		$fix_url = admin_url( 'tools.php?page=advertising' );
+		$this->assertStringContainsString( $fix_url, $message, 'Deep-link URL must be embedded in the error message text — the Woo MCP adapter strips WP_Error::data.' );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( $fix_url, $data['fix_url'] ?? null, 'Belt-and-braces: data field still carries the fix_url for direct REST callers.' );
+	}
+
+	// --- Inheritance: synthetic write ability gets the same treatment ---
+
+	/**
+	 * The wrapper is keyed on `meta.annotations.readonly === false` and
+	 * `OWNED_ABILITY_SLUGS`. To prove future Phase 3 abilities inherit it
+	 * for free, this test uses a fictional slug as if it were owned and
+	 * confirms the wrapper would apply.
+	 *
+	 * (We can't actually add a slug to the OWNED_ABILITY_SLUGS const at
+	 * runtime — instead this test documents that *adding* a new write
+	 * slug to that array is the only step a Phase 3 ability has to take
+	 * to inherit the guardrails.)
+	 */
+	public function test_inheritance_documented_via_owned_slugs_constant() {
+		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
+		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_CREATE_CAMPAIGN, $owned );
+
+		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
+		// wrapped. We exercise create-campaign here as the canonical write slug.
+		$args = array(
+			'execute_callback' => static function () {
+				return 'x';
+			},
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
+	}
+
+	// --- Kill-switch ---
+
+	/**
+	 * Filter returning false on `blaze_abilities_create_campaign_enabled`
+	 * makes the double-register guard refuse to register the slug —
+	 * MCP clients won't see the tool, REST callers get 404.
+	 */
+	public function test_kill_switch_drops_create_campaign_registration() {
+		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+
+		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+
+		$this->assertFalse( $enabled, 'Kill-switch must drop create-campaign registration when set to false.' );
+	}
+
+	/**
+	 * Kill-switch is scoped to create-campaign — the read-only
+	 * list-campaigns ability is unaffected.
+	 */
+	public function test_kill_switch_does_not_affect_list_campaigns() {
+		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+
+		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS );
+
+		$this->assertTrue( $enabled, 'Kill-switch must only affect create-campaign.' );
+	}
+
+	// --- Woo MCP opt-in ---
+
+	/**
+	 * Both owned slugs are opted into Woo's MCP whitelist; foreign slugs
+	 * are passed through unchanged.
+	 */
+	public function test_opt_into_woo_mcp_for_owned_slugs() {
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN ) );
+
+		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
+		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'jetpack-forms/get-responses' ) );
+		// Foreign slug, default true (Woo's own) — should remain true.
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
 }

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -360,4 +360,153 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		// Foreign slug, default true (Woo's own) — should remain true.
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
+
+	// --- create_campaign: prefill payload + URL ---
+
+	/**
+	 * Helper: insert a test post and return its ID. Returns the
+	 * synthetic URN that callers should pass to create_campaign.
+	 */
+	private function make_test_post( array $overrides = array() ): array {
+		$post_id = wp_insert_post(
+			array_merge(
+				array(
+					'post_title'   => 'Test product page',
+					'post_excerpt' => 'A short summary about the product.',
+					'post_content' => 'Long-form content that would otherwise be the fallback snippet source.',
+					'post_status'  => 'publish',
+					'post_type'    => 'post',
+				),
+				$overrides
+			)
+		);
+		return array(
+			'post_id'    => (int) $post_id,
+			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * Invalid target_urn returns a WP_Error with status 400, not a partial draft.
+	 */
+	public function test_create_campaign_returns_error_for_invalid_target_urn() {
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => 'not-a-urn',
+				'budget_total'  => 50,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_invalid_target_urn', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 400, $data['status'] ?? null );
+	}
+
+	/**
+	 * URN that parses but references a missing post returns a 404 WP_Error.
+	 */
+	public function test_create_campaign_returns_error_for_missing_post() {
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => sprintf( 'urn:wpcom:post:%d:9999999', self::TEST_SITE_ID ),
+				'budget_total'  => 50,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_post_not_found', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 404, $data['status'] ?? null );
+	}
+
+	/**
+	 * Happy path: returns the canonical pending-review shape with
+	 * prefill_url + prefill payload, and the defaults are pulled from
+	 * the target post.
+	 */
+	public function test_create_campaign_returns_prefill_payload_and_url() {
+		$ctx = $this->make_test_post();
+
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertNotEmpty( $result['prefill_url'] );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+		$this->assertStringContainsString( $result['prefill_url'], $result['message'] );
+
+		$prefill = $result['prefill'];
+		$this->assertSame( $ctx['target_urn'], $prefill['target_urn'] );
+		$this->assertSame( 'post', $prefill['type'] );
+		$this->assertSame( 'Test product page', $prefill['site_name'] );
+		$this->assertSame( 'A short summary about the product.', $prefill['text_snippet'] );
+		$this->assertSame( 50.0, $prefill['budget']['amount'] );
+		$this->assertSame( 'total', $prefill['budget']['mode'] );
+		$this->assertSame( 14, $prefill['duration_days'] );
+		$this->assertTrue( $prefill['is_evergreen'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Caller overrides take precedence over post-derived defaults.
+	 */
+	public function test_create_campaign_caller_overrides_win() {
+		$ctx = $this->make_test_post();
+
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 100,
+				'duration_days' => 30,
+				'site_name'     => 'Custom heading',
+				'text_snippet'  => 'Custom ad copy.',
+				'objective'     => 'CLICKS',
+				'is_evergreen'  => false,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$prefill = $result['prefill'];
+		$this->assertSame( 'Custom heading', $prefill['site_name'] );
+		$this->assertSame( 'Custom ad copy.', $prefill['text_snippet'] );
+		$this->assertSame( 'CLICKS', $prefill['objective'] );
+		$this->assertFalse( $prefill['is_evergreen'] );
+	}
+
+	/**
+	 * When the post has no excerpt, the text_snippet falls back to the
+	 * stripped + truncated post content. This proves we don't return an
+	 * empty snippet (which the widget would surface as an empty heading).
+	 */
+	public function test_create_campaign_falls_back_to_stripped_content_when_no_excerpt() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_excerpt' => '',
+				'post_content' => '<p><strong>Hello world.</strong></p> Long-form HTML body that should be stripped.',
+			)
+		);
+
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$snippet = $result['prefill']['text_snippet'];
+		$this->assertNotEmpty( $snippet );
+		$this->assertStringContainsString( 'Hello world.', $snippet );
+		$this->assertStringNotContainsString( '<strong>', $snippet );
+	}
 }

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -241,8 +241,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			$ability['input_schema']['required']
 		);
 		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
-		$this->assertContains( 'message', $ability['output_schema']['required'] );
-		$this->assertContains( 'submit_response', $ability['output_schema']['required'] );
+		$this->assertSame( array( 'status', 'message' ), $ability['output_schema']['required'] );
+		$this->assertContains( 'submitted_pending_approval', $ability['output_schema']['properties']['status']['enum'] );
+		$this->assertContains( 'submit_failed', $ability['output_schema']['properties']['status']['enum'] );
+		$this->assertArrayHasKey( 'submit_response', $ability['output_schema']['properties'] );
+		$this->assertArrayHasKey( 'error', $ability['output_schema']['properties'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -230,7 +230,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( array( Blaze_Abilities::class, 'submit_prepared_campaign' ), $ability['execute_callback'] );
 		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
 		$this->assertStringContainsString( 'This spends real money', $ability['description'] );
+		$this->assertStringContainsString( 'pasted or confirmed approval message', $ability['description'] );
 		$this->assertStringContainsString( 'ordinary chat text is not approval', $ability['input_schema']['properties']['approval']['description'] );
+		$this->assertStringContainsString( 'rendered pasteable approval message', $ability['input_schema']['properties']['approval']['description'] );
 		$this->assertTrue( $ability['meta']['show_in_rest'] );
 		$this->assertFalse( $ability['meta']['annotations']['readonly'] );
 		$this->assertTrue( $ability['meta']['annotations']['destructive'] );
@@ -913,6 +915,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
 		$this->assertStringContainsString( 'Audience overrides must use stable codes or closed enums', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'If submit_eligibility.chat_native_submit is true', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'default continuation', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'optional review', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'Looks good, submit it', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
+		$this->assertStringContainsString( 'Do not ask merchants to paste package hashes', $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['description'] );
 
 		$ability    = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ];
 		$schema     = $ability['input_schema'];
@@ -976,6 +983,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'fallback_url', $output_properties );
 		$this->assertArrayHasKey( 'submit_eligibility', $output_properties );
 		$this->assertArrayHasKey( 'approval_block', $output_properties );
+		$this->assertArrayHasKey( 'next_action', $output_properties );
 		$this->assertArrayHasKey( 'material_edit_policy', $output_properties );
 		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
 		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
@@ -993,10 +1001,16 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'non_material_fields', $output_properties['material_edit_policy']['required'] );
 		$this->assertContains( 'approval_contract', $output_properties['approval_block']['required'] );
 		$this->assertContains( 'approval_event', $output_properties['approval_block']['required'] );
+		$this->assertContains( 'pasteable_approval_message', $output_properties['approval_block']['required'] );
 		$this->assertContains( 'charge_acknowledgement', $output_properties['approval_block']['required'] );
 		$this->assertArrayHasKey( 'approval_contract', $output_properties['approval_block']['properties'] );
 		$this->assertArrayHasKey( 'approval_event_required_fields', $output_properties['approval_block']['properties'] );
+		$this->assertArrayHasKey( 'pasteable_approval_message', $output_properties['approval_block']['properties'] );
 		$this->assertArrayHasKey( 'charge_acknowledgement', $output_properties['approval_block']['properties'] );
+		$this->assertContains( 'type', $output_properties['next_action']['required'] );
+		$this->assertContains( 'pasteable_approval_message', $output_properties['next_action']['required'] );
+		$this->assertStringContainsString( 'chat-native approval/submit is the default', $output_properties['next_action']['description'] );
+		$this->assertStringContainsString( 'optional review', $output_properties['next_action']['properties']['optional_preview_url']['description'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
@@ -1538,6 +1552,14 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 50.0, $result['approval_block']['approval_contract']['charge']['max_amount'] );
 		$this->assertSame( 'pm_default', $result['approval_block']['approval_contract']['selected_payment_method_id'] );
 		$this->assertSame( 'blaze.approval.charge_acknowledgement', $result['approval_block']['charge_acknowledgement']['template_key'] );
+		$this->assertArrayHasKey( 'next_action', $result );
+		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
+		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
+		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Chat submit is available', $result['message'] );
+		$this->assertStringContainsString( 'You can preview it in Blaze if you want', $result['message'] );
+		$this->assertStringContainsString( 'To submit from chat, paste this approval message', $result['message'] );
+		$this->assertStringContainsString( $result['next_action']['pasteable_approval_message'], $result['message'] );
 		$this->assertArrayHasKey( 'idempotency_key', $result['submit_package'] );
 		$this->assertSame( $result['submit_package']['idempotency_key'], $result['approval_block']['approval_event']['idempotency_key'] );
 		$this->assertContains( 'approved_at', $result['approval_block']['approval_event_required_fields'] );
@@ -1582,6 +1604,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertNull( $result['submit_eligibility']['selected_payment_method'] );
 		$this->assertSame( array(), $result['submit_eligibility']['available_payment_methods'] );
 		$this->assertArrayNotHasKey( 'approval_block', $result );
+		$this->assertArrayNotHasKey( 'next_action', $result );
 		$this->assertStringContainsString( 'Review URL: ' . $result['fallback_url'], $result['message'] );
 	}
 

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1479,7 +1479,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'pending_merchant_review', $result['status'] );
 		$this->assertNotEmpty( $result['prefill_url'] );
 		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
-		$this->assertStringContainsString( $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['prefill_url'] . ')', $result['message'] );
 		$this->assertArrayNotHasKey( 'budget_options', $result );
 		$this->assertSame( 'unavailable', $result['forecast']['status'] );
 		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
@@ -1491,7 +1491,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
 		$this->assertStringContainsString( 'Assumptions:', $result['message'] );
 		$this->assertStringContainsString( 'Recommendations:', $result['message'] );
-		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( 'Preview campaign in Blaze', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 		$this->assertStringNotContainsString( 'Budget options:', $result['message'] );
 
 		$prefill = $result['prefill'];
@@ -1684,7 +1685,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( array(), $result['submit_eligibility']['available_payment_methods'] );
 		$this->assertArrayNotHasKey( 'approval_block', $result );
 		$this->assertArrayNotHasKey( 'next_action', $result );
-		$this->assertStringContainsString( 'Review URL: ' . $result['fallback_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['fallback_url'] . ')', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 	}
 
 	/**
@@ -1746,7 +1748,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'views', $result['forecast']['primary_metric'] );
 		$this->assertSame( 'Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['forecast_summary'] );
 		$this->assertStringContainsString( 'Forecast: Estimated 1,200-2,400 views and 30-60 clicks for the recommended option.', $result['message'] );
-		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['prefill_url'] . ')', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 	}
 
 	/**
@@ -1774,7 +1777,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'forecast_unavailable', $result['forecast']['reason'] );
 		$this->assertSame( 'Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['forecast_summary'] );
 		$this->assertStringContainsString( 'Forecast: Forecast estimates are unavailable, but the campaign proposal can still be reviewed in Blaze.', $result['message'] );
-		$this->assertStringContainsString( 'Review URL: ' . $result['prefill_url'], $result['message'] );
+		$this->assertStringContainsString( '[Preview campaign in Blaze](' . $result['prefill_url'] . ')', $result['message'] );
+		$this->assertStringNotContainsString( 'Review URL:', $result['message'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1412,6 +1412,36 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * DSP submit errors with nested messages are stringified for MCP output schema validation.
+	 */
+	public function test_submit_prepared_campaign_stringifies_nested_dsp_error_message() {
+		$this->register_submit_prepared_campaign_route(
+			static function () {
+				return new \WP_REST_Response(
+					array(
+						'error' => array(
+							'code'    => 'payment_method_unavailable',
+							'message' => array(
+								'primary' => 'Payment method is unavailable.',
+							),
+						),
+					),
+					422
+				);
+			}
+		);
+
+		$result = Blaze_Abilities::submit_prepared_campaign( $this->make_submit_prepared_campaign_body() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'submit_failed', $result['status'] );
+		$this->assertSame( 'payment_method_unavailable', $result['error']['code'] );
+		$this->assertSame( '{"primary":"Payment method is unavailable."}', $result['error']['message'] );
+		$this->assertSame( 422, $result['error']['status'] );
+		$this->assertSame( 'Payment method is unavailable.', $result['error']['details']['error']['message']['primary'] );
+	}
+
+	/**
 	 * Happy path: returns the canonical pending-review shape with
 	 * prefill_url + prefill payload, and the defaults are pulled from
 	 * the target post.

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1354,7 +1354,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$this->register_submit_prepared_campaign_route(
 			static function ( $request ) use ( &$captured_body ) {
-				$captured_body = $request->get_body_params();
+				$captured_body = json_decode( $request->get_body(), true );
 				return array(
 					'id'                      => 'campaign-123',
 					'campaign_status'         => 'pending',

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -67,6 +67,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_tracks_event' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
 		remove_all_actions( 'wp_after_execute_ability' );
 		unset( $GLOBALS['wp_rest_server'] );
 	}
@@ -898,6 +899,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'text_snippet', $properties );
 		$this->assertArrayHasKey( 'cta_text', $properties );
 		$this->assertArrayHasKey( 'main_image_url', $properties );
+		$this->assertArrayHasKey( 'payment_method_id', $properties );
 		$this->assertArrayHasKey( 'languages', $properties );
 		$this->assertArrayHasKey( 'countries', $properties );
 		$this->assertArrayHasKey( 'devices', $properties );
@@ -918,6 +920,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Blaze public page topic IDs', $properties['interests']['description'] );
 		$this->assertContains( 'IAB8_IAB18', $properties['interests']['items']['enum'] );
 		$this->assertNotContains( 'IAB18', $properties['interests']['items']['enum'] );
+		$this->assertStringContainsString( 'existing saved payment method', $properties['payment_method_id']['description'] );
 
 		$output_properties = $ability['output_schema']['properties'];
 		$this->assertContains( 'message', $ability['output_schema']['required'] );
@@ -945,6 +948,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
 		$this->assertContains( 'destination', $output_properties['campaign_summary']['required'] );
 		$this->assertContains( 'chat_native_submit', $output_properties['submit_eligibility']['required'] );
+		$this->assertContains( 'selected_payment_method', $output_properties['submit_eligibility']['required'] );
+		$this->assertContains( 'available_payment_methods', $output_properties['submit_eligibility']['required'] );
 		$this->assertContains( 'material_fields', $output_properties['material_edit_policy']['required'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
@@ -989,6 +994,23 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			sprintf( '/sites/%d/wordads/dsp/api/v1.1/forecast', self::TEST_SITE_ID ),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Register a test payment methods route for the preparer's proxied DSP request.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_payment_methods_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/payments/methods', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => $callback,
 				'permission_callback' => '__return_true',
 			)
@@ -1254,6 +1276,21 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 */
 	public function test_wrapped_prepare_campaign_marks_chat_native_submit_eligible() {
 		$ctx = $this->make_test_post();
+		$this->register_payment_methods_route(
+			static function () {
+				return array(
+					'payment_methods' => array(
+						array(
+							'id'         => 'pm_default',
+							'type'       => 'card',
+							'card_brand' => 'visa',
+							'last4'      => '4242',
+							'is_default' => true,
+						),
+					),
+				);
+			}
+		);
 
 		$args = array(
 			'execute_callback' => array( Blaze_Abilities::class, 'prepare_campaign' ),
@@ -1273,9 +1310,52 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
 		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertSame( 'pm_default', $result['submit_eligibility']['selected_payment_method']['id'] );
+		$this->assertSame( 'Visa ending in 4242', $result['submit_eligibility']['selected_payment_method']['label'] );
 		$this->assertArrayHasKey( 'approval_block', $result );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
 		$this->assertSame( 'blaze.approval.confirm_prepared_campaign', $result['approval_block']['confirmation_label_key'] );
+	}
+
+	/**
+	 * Sites without a usable saved payment method still get prepare/preview
+	 * output, but chat-native submit remains blocked in favor of the Blaze UI.
+	 */
+	public function test_wrapped_prepare_campaign_blocks_chat_native_submit_without_saved_payment_method() {
+		$ctx = $this->make_test_post();
+		$this->register_payment_methods_route(
+			static function () {
+				return array(
+					'payment_methods' => array(),
+				);
+			}
+		);
+
+		$args = array(
+			'execute_callback' => array( Blaze_Abilities::class, 'prepare_campaign' ),
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		$result  = call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertNotEmpty( $result['fallback_url'] );
+		$this->assertFalse( $result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'missing_saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertSame( 'saved_payment_method_required', $result['submit_eligibility']['reason'] );
+		$this->assertNull( $result['submit_eligibility']['selected_payment_method'] );
+		$this->assertSame( array(), $result['submit_eligibility']['available_payment_methods'] );
+		$this->assertArrayNotHasKey( 'approval_block', $result );
+		$this->assertStringContainsString( 'Review URL: ' . $result['fallback_url'], $result['message'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -66,6 +66,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
+		remove_all_filters( 'blaze_abilities_submit_prepared_campaign_enabled' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_tracks_event' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
 		remove_all_actions( 'wp_after_execute_ability' );
@@ -214,6 +215,34 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 1, $schema['properties']['campaign_id']['minimum'] );
 		$this->assertSame( 'boolean', $schema['properties']['confirm']['type'] );
 		$this->assertFalse( $schema['properties']['confirm']['default'] );
+	}
+
+	/**
+	 * The submit-prepared-campaign ability is the paid chat submit boundary.
+	 */
+	public function test_submit_prepared_campaign_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( Blaze_Abilities::ABILITY_SUBMIT_PREPARED_CAMPAIGN, $abilities );
+		$this->assertContains( Blaze_Abilities::ABILITY_SUBMIT_PREPARED_CAMPAIGN, Blaze_Abilities::OWNED_ABILITY_SLUGS );
+
+		$ability = $abilities[ Blaze_Abilities::ABILITY_SUBMIT_PREPARED_CAMPAIGN ];
+		$this->assertSame( array( Blaze_Abilities::class, 'submit_prepared_campaign' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertStringContainsString( 'This spends real money', $ability['description'] );
+		$this->assertStringContainsString( 'ordinary chat text is not approval', $ability['input_schema']['properties']['approval']['description'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertFalse( $ability['meta']['annotations']['readonly'] );
+		$this->assertTrue( $ability['meta']['annotations']['destructive'] );
+		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
+
+		$this->assertSame(
+			array( 'idempotency_key', 'prepared_package_id', 'prepared_campaign_hash', 'prepared_campaign', 'accepted_terms_version', 'accepted_policy_version', 'approval' ),
+			$ability['input_schema']['required']
+		);
+		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+		$this->assertContains( 'message', $ability['output_schema']['required'] );
+		$this->assertContains( 'submit_response', $ability['output_schema']['required'] );
 	}
 
 	/**
@@ -860,6 +889,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_GET_CAMPAIGN_STATS ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_SUBMIT_PREPARED_CAMPAIGN ) );
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_STOP_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
@@ -923,20 +953,22 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'existing saved payment method', $properties['payment_method_id']['description'] );
 
 		$output_properties = $ability['output_schema']['properties'];
-		$this->assertContains( 'message', $ability['output_schema']['required'] );
-		$this->assertContains( 'campaign_preview', $ability['output_schema']['required'] );
-		$this->assertContains( 'forecast_summary', $ability['output_schema']['required'] );
-		$this->assertContains( 'prepared_campaign', $ability['output_schema']['required'] );
-		$this->assertContains( 'rendered_preview', $ability['output_schema']['required'] );
+			$this->assertContains( 'message', $ability['output_schema']['required'] );
+			$this->assertContains( 'campaign_preview', $ability['output_schema']['required'] );
+			$this->assertContains( 'forecast_summary', $ability['output_schema']['required'] );
+			$this->assertContains( 'prepared_campaign', $ability['output_schema']['required'] );
+			$this->assertContains( 'submit_package', $ability['output_schema']['required'] );
+			$this->assertContains( 'rendered_preview', $ability['output_schema']['required'] );
 		$this->assertContains( 'campaign_summary', $ability['output_schema']['required'] );
 		$this->assertContains( 'fallback_url', $ability['output_schema']['required'] );
 		$this->assertContains( 'submit_eligibility', $ability['output_schema']['required'] );
 		$this->assertContains( 'material_edit_policy', $ability['output_schema']['required'] );
 		$this->assertArrayHasKey( 'message', $output_properties );
 		$this->assertArrayHasKey( 'campaign_preview', $output_properties );
-		$this->assertArrayHasKey( 'forecast_summary', $output_properties );
-		$this->assertArrayHasKey( 'prepared_campaign', $output_properties );
-		$this->assertArrayHasKey( 'rendered_preview', $output_properties );
+			$this->assertArrayHasKey( 'forecast_summary', $output_properties );
+			$this->assertArrayHasKey( 'prepared_campaign', $output_properties );
+			$this->assertArrayHasKey( 'submit_package', $output_properties );
+			$this->assertArrayHasKey( 'rendered_preview', $output_properties );
 		$this->assertArrayHasKey( 'campaign_summary', $output_properties );
 		$this->assertArrayHasKey( 'fallback_url', $output_properties );
 		$this->assertArrayHasKey( 'submit_eligibility', $output_properties );
@@ -944,8 +976,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'material_edit_policy', $output_properties );
 		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
 		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
-		$this->assertContains( 'id', $output_properties['prepared_campaign']['required'] );
-		$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
+			$this->assertContains( 'id', $output_properties['prepared_campaign']['required'] );
+			$this->assertContains( 'prepared_campaign', $output_properties['submit_package']['required'] );
+			$this->assertContains( 'accepted_terms_version', $output_properties['submit_package']['required'] );
+			$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
 		$this->assertContains( 'destination', $output_properties['campaign_summary']['required'] );
 		$this->assertContains( 'chat_native_submit', $output_properties['submit_eligibility']['required'] );
 		$this->assertContains( 'selected_payment_method', $output_properties['submit_eligibility']['required'] );
@@ -1057,6 +1091,83 @@ class Blaze_Abilities_Test extends BaseTestCase {
 				'callback'            => $callback,
 				'permission_callback' => '__return_true',
 			)
+		);
+	}
+
+	/**
+	 * Register a test prepared campaign submit route.
+	 *
+	 * @param callable $callback Route callback.
+	 */
+	private function register_submit_prepared_campaign_route( callable $callback ) {
+		register_rest_route(
+			'jetpack/v4/blaze-app',
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/campaigns/submit-prepared-campaign', self::TEST_SITE_ID ),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => $callback,
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Build a valid prepared submit request body for ability tests.
+	 *
+	 * @return array
+	 */
+	private function make_submit_prepared_campaign_body(): array {
+		$prepared_campaign = array(
+			'origin'            => 'mcp_chat',
+			'origin_version'    => 'v1',
+			'target_urn'        => 'urn:wpcom:post:12345:42',
+			'type'              => 'post',
+			'payment_method_id' => 'pm_default',
+			'start_date'        => '2026-05-20',
+			'end_date'          => '2026-05-26',
+			'time_zone'         => 'UTC',
+			'site_name'         => 'Test product page',
+			'text_snippet'      => 'A short summary about the product.',
+			'cta_text'          => 'Learn More',
+			'target_url'        => 'https://example.com/test-product-page',
+			'url_params'        => '',
+			'main_image'        => array(
+				'url'       => 'https://example.com/image.jpg',
+				'mime_type' => 'image/jpeg',
+			),
+			'budget'            => array(
+				'mode'     => 'total',
+				'amount'   => 35,
+				'currency' => 'USD',
+			),
+			'objective'         => 'views',
+			'is_evergreen'      => true,
+			'targeting'         => array(
+				'languages' => array( 'en' ),
+			),
+		);
+
+		$prepared_campaign_hash = str_repeat( 'a', 64 );
+		$idempotency_key        = 'submit-123';
+		$prepared_package_id    = 'pkg-123';
+
+		return array(
+			'idempotency_key'          => $idempotency_key,
+			'prepared_package_id'      => $prepared_package_id,
+			'prepared_campaign_hash'   => $prepared_campaign_hash,
+			'prepared_campaign'        => $prepared_campaign,
+			'accepted_terms_version'   => '2026-05-01',
+			'accepted_policy_version'  => '2026-05-01',
+			'approval'                 => array(
+				'type'                    => 'prepared_campaign.approved',
+				'prepared_package_id'     => $prepared_package_id,
+				'prepared_campaign_hash'  => $prepared_campaign_hash,
+				'idempotency_key'         => $idempotency_key,
+				'payment_method_id'       => 'pm_default',
+				'accepted_terms_version'  => '2026-05-01',
+				'accepted_policy_version' => '2026-05-01',
+				'approved_at'             => '2026-05-20T12:00:00+00:00',
+			),
 		);
 	}
 
@@ -1227,6 +1338,70 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'Campaign cannot be stopped from its current state.', $result->get_error_message() );
 		$data = $result->get_error_data();
 		$this->assertSame( 409, $data['status'] ?? null );
+	}
+
+	/**
+	 * Submit-prepared-campaign delegates the exact approved payload to DSP.
+	 */
+	public function test_submit_prepared_campaign_delegates_to_blaze_rest_route() {
+		$captured_body = null;
+		$body          = $this->make_submit_prepared_campaign_body();
+
+		$this->register_submit_prepared_campaign_route(
+			static function ( $request ) use ( &$captured_body ) {
+				$captured_body = $request->get_body_params();
+				return array(
+					'id'                      => 'campaign-123',
+					'campaign_status'         => 'pending',
+					'dashboard_url'           => '/advertising/campaigns/campaign-123',
+					'widget_url'              => '/advertising/campaigns/campaign-123',
+					'selected_payment_method' => array(
+						'id'      => 'pm_default',
+						'summary' => 'Saved payment method pm_default',
+					),
+					'budget'                  => array(
+						'mode'     => 'total',
+						'amount'   => 35,
+						'currency' => 'USD',
+					),
+					'source_tracking'         => array(
+						'origin'         => 'mcp_chat',
+						'origin_version' => 'v1',
+					),
+				);
+			}
+		);
+
+		$result = Blaze_Abilities::submit_prepared_campaign( $body );
+
+		$this->assertSame( $body, $captured_body );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'submitted_pending_approval', $result['status'] );
+		$this->assertSame( 'pending', $result['campaign_status'] );
+		$this->assertSame( '/advertising/campaigns/campaign-123', $result['dashboard_url'] );
+		$this->assertSame( 'campaign-123', $result['submit_response']['id'] );
+		$this->assertStringContainsString( 'pending approval/moderation', $result['message'] );
+		$this->assertStringContainsString( 'email confirmation', $result['message'] );
+		$this->assertStringContainsString( 'not running yet', strtolower( $result['message'] ) );
+	}
+
+	/**
+	 * DSP submit errors are returned as WP_Error instead of optimistic success.
+	 */
+	public function test_submit_prepared_campaign_passes_through_dsp_error() {
+		$this->register_submit_prepared_campaign_route(
+			static function () {
+				return new WP_Error( 'prepared_campaign_hash_mismatch', 'Prepared campaign body does not match prepared campaign hash', array( 'status' => 422 ) );
+			}
+		);
+
+		$result = Blaze_Abilities::submit_prepared_campaign( $this->make_submit_prepared_campaign_body() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'prepared_campaign_hash_mismatch', $result->get_error_code() );
+		$this->assertSame( 'Prepared campaign body does not match prepared campaign hash', $result->get_error_message() );
+		$data = $result->get_error_data();
+		$this->assertSame( 422, $data['status'] ?? null );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -923,11 +923,29 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'message', $ability['output_schema']['required'] );
 		$this->assertContains( 'campaign_preview', $ability['output_schema']['required'] );
 		$this->assertContains( 'forecast_summary', $ability['output_schema']['required'] );
+		$this->assertContains( 'prepared_campaign', $ability['output_schema']['required'] );
+		$this->assertContains( 'rendered_preview', $ability['output_schema']['required'] );
+		$this->assertContains( 'campaign_summary', $ability['output_schema']['required'] );
+		$this->assertContains( 'fallback_url', $ability['output_schema']['required'] );
+		$this->assertContains( 'submit_eligibility', $ability['output_schema']['required'] );
+		$this->assertContains( 'material_edit_policy', $ability['output_schema']['required'] );
 		$this->assertArrayHasKey( 'message', $output_properties );
 		$this->assertArrayHasKey( 'campaign_preview', $output_properties );
 		$this->assertArrayHasKey( 'forecast_summary', $output_properties );
+		$this->assertArrayHasKey( 'prepared_campaign', $output_properties );
+		$this->assertArrayHasKey( 'rendered_preview', $output_properties );
+		$this->assertArrayHasKey( 'campaign_summary', $output_properties );
+		$this->assertArrayHasKey( 'fallback_url', $output_properties );
+		$this->assertArrayHasKey( 'submit_eligibility', $output_properties );
+		$this->assertArrayHasKey( 'approval_block', $output_properties );
+		$this->assertArrayHasKey( 'material_edit_policy', $output_properties );
 		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
 		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
+		$this->assertContains( 'id', $output_properties['prepared_campaign']['required'] );
+		$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
+		$this->assertContains( 'destination', $output_properties['campaign_summary']['required'] );
+		$this->assertContains( 'chat_native_submit', $output_properties['submit_eligibility']['required'] );
+		$this->assertContains( 'material_fields', $output_properties['material_edit_policy']['required'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
@@ -1228,6 +1246,36 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 14, $prefill['duration_days'] );
 		$this->assertTrue( $prefill['is_evergreen'] );
 		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Registered prepare-campaign executions that pass the Blaze setup guard
+	 * expose approval wording for chat-native submit.
+	 */
+	public function test_wrapped_prepare_campaign_marks_chat_native_submit_eligible() {
+		$ctx = $this->make_test_post();
+
+		$args = array(
+			'execute_callback' => array( Blaze_Abilities::class, 'prepare_campaign' ),
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		$result  = call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'saved_payment_method', $result['submit_eligibility']['payment_method'] );
+		$this->assertArrayHasKey( 'approval_block', $result );
+		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
+		$this->assertSame( 'blaze.approval.confirm_prepared_campaign', $result['approval_block']['confirmation_label_key'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1009,7 +1009,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'charge_acknowledgement', $output_properties['approval_block']['properties'] );
 		$this->assertContains( 'type', $output_properties['next_action']['required'] );
 		$this->assertContains( 'pasteable_approval_message', $output_properties['next_action']['required'] );
+		$this->assertContains( 'plain_language_submit_intents', $output_properties['next_action']['required'] );
 		$this->assertStringContainsString( 'chat-native approval/submit is the default', $output_properties['next_action']['description'] );
+		$this->assertStringContainsString( 'submit it', $output_properties['next_action']['properties']['plain_language_submit_intents']['description'] );
 		$this->assertStringContainsString( 'optional review', $output_properties['next_action']['properties']['optional_preview_url']['description'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
@@ -1555,7 +1557,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'next_action', $result );
 		$this->assertSame( 'request_explicit_approval', $result['next_action']['type'] );
 		$this->assertSame( 'chat_native_submit', $result['next_action']['default_flow'] );
+		$this->assertContains( 'submit it', $result['next_action']['plain_language_submit_intents'] );
+		$this->assertContains( 'looks good', $result['next_action']['plain_language_submit_intents'] );
 		$this->assertSame( $result['approval_block']['pasteable_approval_message'], $result['next_action']['pasteable_approval_message'] );
+		$this->assertStringContainsString( 'Campaign proposal prepared. Chat submit is available after explicit approval.', $result['message'] );
+		$this->assertStringNotContainsString( 'Campaign proposal prepared for review in Blaze.', $result['message'] );
 		$this->assertStringContainsString( 'Chat submit is available', $result['message'] );
 		$this->assertStringContainsString( 'You can preview it in Blaze if you want', $result['message'] );
 		$this->assertStringContainsString( 'To submit from chat, paste this approval message', $result['message'] );

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -965,10 +965,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'material_edit_policy', $ability['output_schema']['required'] );
 		$this->assertArrayHasKey( 'message', $output_properties );
 		$this->assertArrayHasKey( 'campaign_preview', $output_properties );
-			$this->assertArrayHasKey( 'forecast_summary', $output_properties );
-			$this->assertArrayHasKey( 'prepared_campaign', $output_properties );
-			$this->assertArrayHasKey( 'submit_package', $output_properties );
-			$this->assertArrayHasKey( 'rendered_preview', $output_properties );
+		$this->assertArrayHasKey( 'forecast_summary', $output_properties );
+		$this->assertArrayHasKey( 'prepared_campaign', $output_properties );
+		$this->assertArrayHasKey( 'submit_package', $output_properties );
+		$this->assertArrayHasKey( 'rendered_preview', $output_properties );
 		$this->assertArrayHasKey( 'campaign_summary', $output_properties );
 		$this->assertArrayHasKey( 'fallback_url', $output_properties );
 		$this->assertArrayHasKey( 'submit_eligibility', $output_properties );
@@ -976,10 +976,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'material_edit_policy', $output_properties );
 		$this->assertContains( 'ad_heading', $output_properties['campaign_preview']['required'] );
 		$this->assertArrayHasKey( 'landing_page', $output_properties['campaign_preview']['properties'] );
-			$this->assertContains( 'id', $output_properties['prepared_campaign']['required'] );
-			$this->assertContains( 'prepared_campaign', $output_properties['submit_package']['required'] );
-			$this->assertContains( 'accepted_terms_version', $output_properties['submit_package']['required'] );
-			$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
+		$this->assertContains( 'id', $output_properties['prepared_campaign']['required'] );
+		$this->assertContains( 'idempotency_key', $output_properties['submit_package']['required'] );
+		$this->assertArrayHasKey( 'idempotency_key', $output_properties['submit_package']['properties'] );
+		$this->assertContains( 'prepared_campaign', $output_properties['submit_package']['required'] );
+		$this->assertContains( 'accepted_terms_version', $output_properties['submit_package']['required'] );
+		$this->assertContains( 'html', $output_properties['rendered_preview']['required'] );
 		$this->assertContains( 'destination', $output_properties['campaign_summary']['required'] );
 		$this->assertContains( 'chat_native_submit', $output_properties['submit_eligibility']['required'] );
 		$this->assertContains( 'selected_payment_method', $output_properties['submit_eligibility']['required'] );
@@ -1049,7 +1051,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	private function register_payment_methods_route( callable $callback ) {
 		register_rest_route(
 			'jetpack/v4/blaze-app',
-			sprintf( '/sites/%d/wordads/dsp/api/v1.1/payments/methods', self::TEST_SITE_ID ),
+			sprintf( '/sites/%d/wordads/dsp/api/v1.1/payment-methods', self::TEST_SITE_ID ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => $callback,
@@ -1152,13 +1154,13 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$prepared_package_id    = 'pkg-123';
 
 		return array(
-			'idempotency_key'          => $idempotency_key,
-			'prepared_package_id'      => $prepared_package_id,
-			'prepared_campaign_hash'   => $prepared_campaign_hash,
-			'prepared_campaign'        => $prepared_campaign,
-			'accepted_terms_version'   => '2026-05-01',
-			'accepted_policy_version'  => '2026-05-01',
-			'approval'                 => array(
+			'idempotency_key'         => $idempotency_key,
+			'prepared_package_id'     => $prepared_package_id,
+			'prepared_campaign_hash'  => $prepared_campaign_hash,
+			'prepared_campaign'       => $prepared_campaign,
+			'accepted_terms_version'  => '2026-05-01',
+			'accepted_policy_version' => '2026-05-01',
+			'approval'                => array(
 				'type'                    => 'prepared_campaign.approved',
 				'prepared_package_id'     => $prepared_package_id,
 				'prepared_campaign_hash'  => $prepared_campaign_hash,
@@ -1386,9 +1388,9 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * DSP submit errors are returned as WP_Error instead of optimistic success.
+	 * DSP submit errors are returned as structured output instead of MCP tool failure.
 	 */
-	public function test_submit_prepared_campaign_passes_through_dsp_error() {
+	public function test_submit_prepared_campaign_returns_structured_dsp_error() {
 		$this->register_submit_prepared_campaign_route(
 			static function () {
 				return new WP_Error( 'prepared_campaign_hash_mismatch', 'Prepared campaign body does not match prepared campaign hash', array( 'status' => 422 ) );
@@ -1397,11 +1399,13 @@ class Blaze_Abilities_Test extends BaseTestCase {
 
 		$result = Blaze_Abilities::submit_prepared_campaign( $this->make_submit_prepared_campaign_body() );
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'prepared_campaign_hash_mismatch', $result->get_error_code() );
-		$this->assertSame( 'Prepared campaign body does not match prepared campaign hash', $result->get_error_message() );
-		$data = $result->get_error_data();
-		$this->assertSame( 422, $data['status'] ?? null );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'submit_failed', $result['status'] );
+		$this->assertStringContainsString( 'not submitted', $result['message'] );
+		$this->assertSame( 'prepared_campaign_hash_mismatch', $result['error']['code'] );
+		$this->assertSame( 'Prepared campaign body does not match prepared campaign hash', $result['error']['message'] );
+		$this->assertSame( 422, $result['error']['status'] );
+		$this->assertSame( 422, $result['error']['details']['status'] );
 	}
 
 	/**
@@ -1501,6 +1505,8 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 50.0, $result['approval_block']['approval_contract']['charge']['max_amount'] );
 		$this->assertSame( 'pm_default', $result['approval_block']['approval_contract']['selected_payment_method_id'] );
 		$this->assertSame( 'blaze.approval.charge_acknowledgement', $result['approval_block']['charge_acknowledgement']['template_key'] );
+		$this->assertArrayHasKey( 'idempotency_key', $result['submit_package'] );
+		$this->assertSame( $result['submit_package']['idempotency_key'], $result['approval_block']['approval_event']['idempotency_key'] );
 		$this->assertContains( 'approved_at', $result['approval_block']['approval_event_required_fields'] );
 		$this->assertContains( 'idempotency_key', $result['approval_block']['approval_event_required_fields'] );
 	}

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -69,6 +69,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		remove_all_filters( 'blaze_abilities_submit_prepared_campaign_enabled' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_tracks_event' );
 		remove_all_filters( 'jetpack_blaze_prepare_campaign_payment_methods' );
+		remove_all_filters( 'jetpack_blaze_prepare_campaign_fallback_user_id' );
 		remove_all_actions( 'wp_after_execute_ability' );
 		unset( $GLOBALS['wp_rest_server'] );
 	}
@@ -1067,14 +1068,14 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 *
 	 * @param callable $callback Route callback.
 	 */
-	private function register_payment_methods_route( callable $callback ) {
+	private function register_payment_methods_route( callable $callback, ?callable $permission_callback = null ) {
 		register_rest_route(
 			'jetpack/v4/blaze-app',
 			sprintf( '/sites/%d/wordads/dsp/api/v1.1/payment-methods', self::TEST_SITE_ID ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => $callback,
-				'permission_callback' => '__return_true',
+				'permission_callback' => $permission_callback ?? '__return_true',
 			)
 		);
 	}
@@ -1570,6 +1571,78 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( $result['submit_package']['idempotency_key'], $result['approval_block']['approval_event']['idempotency_key'] );
 		$this->assertContains( 'approved_at', $result['approval_block']['approval_event_required_fields'] );
 		$this->assertContains( 'idempotency_key', $result['approval_block']['approval_event_required_fields'] );
+	}
+
+	/**
+	 * Ability execution may not have a current WP user, but the internal
+	 * payment-method proxy still needs an admin-capable user context.
+	 */
+	public function test_wrapped_prepare_campaign_fetches_payment_methods_without_current_user() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'blaze-admin-' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'blaze-admin-' . wp_rand() . '@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		$this->assertIsInt( $admin_id );
+		wp_set_current_user( 0 );
+		add_filter(
+			'jetpack_blaze_prepare_campaign_fallback_user_id',
+			static function () use ( $admin_id ) {
+				return (int) $admin_id;
+			}
+		);
+
+		$ctx                = $this->make_test_post();
+		$permission_user_id = null;
+		$this->register_payment_methods_route(
+			static function () {
+				return array(
+					'payment_methods' => array(
+						array(
+							'id'   => 'PW-3272868',
+							'type' => 'credit_card',
+							'name' => 'Visa ending in 4242',
+							'info' => array(
+								'last_digits' => '4242',
+								'expiring'    => array(
+									'year'  => 2026,
+									'month' => 11,
+								),
+								'type'        => 'Visa',
+							),
+						),
+					),
+				);
+			},
+			static function () use ( &$permission_user_id ) {
+				$permission_user_id = get_current_user_id();
+				return current_user_can( 'manage_options' );
+			}
+		);
+
+		$args    = array(
+			'execute_callback' => array( Blaze_Abilities::class, 'prepare_campaign' ),
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
+		$result  = call_user_func(
+			$wrapped['execute_callback'],
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 35,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertSame( 0, get_current_user_id() );
+		$this->assertSame( (int) $admin_id, $permission_user_id );
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['submit_eligibility']['chat_native_submit'] );
+		$this->assertSame( 'PW-3272868', $result['submit_eligibility']['selected_payment_method']['id'] );
+		$this->assertArrayHasKey( 'next_action', $result );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -951,6 +951,13 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertContains( 'selected_payment_method', $output_properties['submit_eligibility']['required'] );
 		$this->assertContains( 'available_payment_methods', $output_properties['submit_eligibility']['required'] );
 		$this->assertContains( 'material_fields', $output_properties['material_edit_policy']['required'] );
+		$this->assertContains( 'non_material_fields', $output_properties['material_edit_policy']['required'] );
+		$this->assertContains( 'approval_contract', $output_properties['approval_block']['required'] );
+		$this->assertContains( 'approval_event', $output_properties['approval_block']['required'] );
+		$this->assertContains( 'charge_acknowledgement', $output_properties['approval_block']['required'] );
+		$this->assertArrayHasKey( 'approval_contract', $output_properties['approval_block']['properties'] );
+		$this->assertArrayHasKey( 'approval_event_required_fields', $output_properties['approval_block']['properties'] );
+		$this->assertArrayHasKey( 'charge_acknowledgement', $output_properties['approval_block']['properties'] );
 		$this->assertArrayHasKey( 'intent', $output_properties );
 		$this->assertArrayHasKey( 'forecast', $output_properties );
 		$this->assertArrayHasKey( 'assumptions', $output_properties );
@@ -1314,7 +1321,13 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertSame( 'Visa ending in 4242', $result['submit_eligibility']['selected_payment_method']['label'] );
 		$this->assertArrayHasKey( 'approval_block', $result );
 		$this->assertSame( $result['prepared_campaign']['id'], $result['approval_block']['prepared_campaign_id'] );
-		$this->assertSame( 'blaze.approval.confirm_prepared_campaign', $result['approval_block']['confirmation_label_key'] );
+		$this->assertSame( 'blaze.approval.confirm_prepared_campaign.v1', $result['approval_block']['confirmation_label_key'] );
+		$this->assertSame( $result['prepared_campaign']['hash'], $result['approval_block']['approval_contract']['prepared_campaign_hash'] );
+		$this->assertSame( 50.0, $result['approval_block']['approval_contract']['charge']['max_amount'] );
+		$this->assertSame( 'pm_default', $result['approval_block']['approval_contract']['selected_payment_method_id'] );
+		$this->assertSame( 'blaze.approval.charge_acknowledgement', $result['approval_block']['charge_acknowledgement']['template_key'] );
+		$this->assertContains( 'approved_at', $result['approval_block']['approval_event_required_fields'] );
+		$this->assertContains( 'idempotency_key', $result['approval_block']['approval_event_required_fields'] );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -531,8 +531,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$schema     = $ability['input_schema'];
 		$properties = $schema['properties'];
 
-		$this->assertSame( array( 'target_urn' ), $schema['required'] );
+		$this->assertSame( array(), $schema['required'] );
 		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertArrayHasKey( 'target_urn', $properties );
+		$this->assertArrayHasKey( 'site_url', $properties );
+		$this->assertArrayHasKey( 'post_id', $properties );
+		$this->assertArrayHasKey( 'product_id', $properties );
 		$this->assertArrayHasKey( 'goal', $properties );
 		$this->assertArrayHasKey( 'budget_total', $properties );
 		$this->assertArrayHasKey( 'duration_days', $properties );
@@ -547,6 +551,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'interests', $properties );
 		$this->assertArrayNotHasKey( 'objective', $properties );
 		$this->assertArrayNotHasKey( 'page_topics', $properties );
+		$this->assertStringContainsString( 'site_url plus post_id', $properties['target_urn']['description'] );
+		$this->assertStringContainsString( 'public WordPress.com site URL', $properties['site_url']['description'] );
+		$this->assertStringContainsString( 'post_id', $properties['post_id']['description'] );
+		$this->assertStringContainsString( 'product_id', $properties['product_id']['description'] );
 		$this->assertStringContainsString( 'ISO 639-1', $properties['languages']['description'] );
 		$this->assertStringContainsString( 'ISO 3166-1 alpha-2', $properties['countries']['description'] );
 		$this->assertSame( array( 'zh', 'nl', 'en', 'fr', 'de', 'hi', 'id', 'it', 'ja', 'ko', 'pl', 'pt', 'ru', 'es', 'tr' ), $properties['languages']['items']['enum'] );
@@ -773,7 +781,13 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertIsArray( $result );
 		$this->assertSame( 'stopped', $result['status'] );
 		$this->assertSame( 'Spring launch', $result['campaign']['title'] );
-		$this->assertSame( array( 'id' => 987, 'status' => 'stopped' ), $result['stop_response'] );
+		$this->assertSame(
+			array(
+				'id'     => 987,
+				'status' => 'stopped',
+			),
+			$result['stop_response']
+		);
 		$this->assertStringContainsString( 'Campaign "Spring launch" was stopped from serving.', $result['message'] );
 		$this->assertStringNotContainsString( 'deleted', strtolower( $result['message'] ) );
 		$this->assertStringNotContainsString( 'archived', strtolower( $result['message'] ) );

--- a/projects/plugins/jetpack/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/jetpack/changelog/add-ads-952-blaze-mcp-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: Update plugin lockfile for an internal Blaze package dependency.
+

--- a/projects/plugins/jetpack/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/jetpack/changelog/add-ads-952-blaze-mcp-locks
@@ -1,4 +1,3 @@
 Significance: patch
 Type: other
 Comment: Update plugin lockfile for an internal Blaze package dependency.
-

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -616,7 +616,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "07ecff35c9e4445f454e0b2d2977ffd4433e52ef"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -626,6 +626,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-ads-952-blaze-mcp-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Update plugin lockfile for an internal Blaze package dependency.
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-ads-952-blaze-mcp-locks
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update plugin lockfile for an internal Blaze package dependency.
-

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -275,7 +275,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "07ecff35c9e4445f454e0b2d2977ffd4433e52ef"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -285,6 +285,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/wpcomsh/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/wpcomsh/changelog/add-ads-952-blaze-mcp-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Update plugin lockfile for an internal Blaze package dependency.
+

--- a/projects/plugins/wpcomsh/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/wpcomsh/changelog/add-ads-952-blaze-mcp-locks
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Update plugin lockfile for an internal Blaze package dependency.
-

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -411,7 +411,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "07ecff35c9e4445f454e0b2d2977ffd4433e52ef"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -421,6 +421,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {


### PR DESCRIPTION
## Summary

Consolidated feature branch for the Blaze Woo MCP stack so the end-to-end MCP surface can be tested and reviewed together.

Merged slices:

- ADS-952 list-campaigns ability foundation
- ADS-953 prepare-campaign write ability
- ADS-1036 campaign preparer extraction
- ADS-1044 safe audience targeting
- ADS-1037 intelligent defaults
- ADS-1038 forecast estimates
- ADS-1039 readable preview response
- ADS-1041 server-side prepare telemetry
- ADS-1090 list-campaigns context
- ADS-1091 get-campaign-stats
- ADS-1092 stop-campaign
- ADS-1057 portable target inputs

Umbrella Linear review ticket: ADS-1034

## Testing

- php -l projects/packages/blaze/src/abilities/class-blaze-abilities.php
- php -l projects/packages/blaze/src/class-campaign-preparer.php
- php -l projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
- php -l projects/packages/blaze/tests/php/Campaign_Preparer_Test.php
- git diff --check origin/trunk...HEAD

Focused PHPUnit command was attempted but this fresh worktree is missing the local phpunit-select-config shim.