### PR TITLE
Podcast feed: fix blog ID in Atomic

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-enclosure-url
+++ b/projects/packages/podcast/changelog/fix-podcast-enclosure-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast feed: default the enclosure stats URL blog ID to the Jetpack connection ID so Atomic feeds route to the correct WPCOM site instead of site 1.

--- a/projects/packages/podcast/changelog/fix-podcast-enclosure-url
+++ b/projects/packages/podcast/changelog/fix-podcast-enclosure-url
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast feed: default the enclosure stats URL blog ID to the Jetpack connection ID so Atomic feeds route to the correct WPCOM site instead of site 1.
+Podcast: resolve the blog ID via Connection_Manager::get_site_id() for feed enclosure URLs and tracks events so Atomic sites use the correct WPCOM site ID instead of 1.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\Jetpack\Podcast;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Throwable;
 use WP_Post;
@@ -411,7 +412,7 @@ class Tracks {
 	private static function record_event( string $event_name, array $properties, ?WP_User $user = null ) {
 		try {
 			$user                  = $user ?? wp_get_current_user();
-			$properties['blog_id'] = (int) get_current_blog_id();
+			$properties['blog_id'] = (int) Connection_Manager::get_site_id( true );
 
 			if ( ! function_exists( 'tracks_record_event' ) && function_exists( 'require_lib' ) ) {
 				require_lib( 'tracks/client' );

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\Jetpack\Podcast\Feed;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Podcast\Settings;
 use WP_Post;
 
@@ -272,15 +273,16 @@ class Customize_Feed {
 		$attachment_id = attachment_url_to_postid( $original_url );
 
 		if ( null !== $post_obj && $enable && $attachment_id > 0 ) {
+			// `get_current_blog_id()` is 1 on Atomic / self-hosted; the connection ID is the WPCOM-side ID on all platforms.
+			$default_blog_id = (int) Connection_Manager::get_site_id( true );
+
 			/**
-			 * Override the blog ID baked into the stats URL. Atomic / non-Simple
-			 * sites should return the WPCOM shadow ID so the public-api endpoint
-			 * routes to the right blog.
+			 * Override the blog ID baked into the stats URL.
 			 *
-			 * @param int     $blog_id Default current blog ID.
+			 * @param int     $blog_id Default Jetpack connection site ID.
 			 * @param WP_Post $post    The post being rendered.
 			 */
-			$blog_id   = (int) apply_filters( 'wpcom_podcasting_tracked_blog_id', get_current_blog_id(), $post_obj );
+			$blog_id   = (int) apply_filters( 'wpcom_podcasting_tracked_blog_id', $default_blog_id, $post_obj );
 			$stats_url = self::build_stats_url( $blog_id, (int) $post_obj->ID, $original_url );
 			$enclosure = preg_replace_callback(
 				'/url="[^"]*"/i',

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -273,34 +273,38 @@ class Customize_Feed {
 		$attachment_id = attachment_url_to_postid( $original_url );
 
 		if ( null !== $post_obj && $enable && $attachment_id > 0 ) {
-			// `get_current_blog_id()` is 1 on Atomic / self-hosted; the connection ID is the WPCOM-side ID on all platforms.
-			$default_blog_id = (int) Connection_Manager::get_site_id( true );
+			// `null` when the site isn't connected; passed through so the filter can still inject a value.
+			$default_blog_id = Connection_Manager::get_site_id( true );
 
 			/**
 			 * Override the blog ID baked into the stats URL.
 			 *
-			 * @param int     $blog_id Default Jetpack connection site ID.
-			 * @param WP_Post $post    The post being rendered.
+			 * @param int|null $blog_id Default Jetpack connection site ID, or null when unavailable.
+			 * @param WP_Post  $post    The post being rendered.
 			 */
-			$blog_id   = (int) apply_filters( 'wpcom_podcasting_tracked_blog_id', $default_blog_id, $post_obj );
-			$stats_url = self::build_stats_url( $blog_id, (int) $post_obj->ID, $original_url );
-			$enclosure = preg_replace_callback(
-				'/url="[^"]*"/i',
-				/**
-				 * Replace the matched `url="…"` attribute with the stats URL.
-				 * `$matches` is required by `preg_replace_callback`'s callable
-				 * signature but ignored — we always emit the same value.
-				 *
-				 * @param array $matches Regex matches.
-				 * @return string
-				 */
-				static function ( array $matches ) use ( $stats_url ) {
-					unset( $matches );
-					return 'url="' . esc_url( $stats_url ) . '"';
-				},
-				$enclosure,
-				1
-			);
+			$blog_id = (int) apply_filters( 'wpcom_podcasting_tracked_blog_id', $default_blog_id, $post_obj );
+
+			// Bail when we can't resolve a real blog ID — emit the original URL rather than a guaranteed-404 stats URL.
+			if ( $blog_id > 0 ) {
+				$stats_url = self::build_stats_url( $blog_id, (int) $post_obj->ID, $original_url );
+				$enclosure = preg_replace_callback(
+					'/url="[^"]*"/i',
+					/**
+					 * Replace the matched `url="…"` attribute with the stats URL.
+					 * `$matches` is required by `preg_replace_callback`'s callable
+					 * signature but ignored — we always emit the same value.
+					 *
+					 * @param array $matches Regex matches.
+					 * @return string
+					 */
+					static function ( array $matches ) use ( $stats_url ) {
+						unset( $matches );
+						return 'url="' . esc_url( $stats_url ) . '"';
+					},
+					$enclosure,
+					1
+				);
+			}
 		}
 
 		if ( 0 === $attachment_id ) {

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -197,6 +197,33 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 	}
 
+	public function test_rewrite_enclosure_keeps_original_url_when_blog_id_cannot_be_resolved() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'         => 42,
+				'post_type'  => 'post',
+				'post_title' => 'Test Episode',
+			)
+		);
+
+		// No Jetpack_Options 'id' set, no IS_WPCOM, no filter → no blog ID resolvable.
+		add_filter(
+			'pre_attachment_url_to_postid',
+			static function ( $pre, $url ) {
+				return 'https://example.com/path/episode.mp3' === $url ? 9001 : $pre;
+			},
+			10,
+			2
+		);
+
+		$original = '<enclosure url="https://example.com/path/episode.mp3" length="123" type="audio/mpeg" />';
+		$result   = Customize_Feed::rewrite_enclosure( $original );
+
+		$this->assertStringContainsString( 'url="https://example.com/path/episode.mp3"', $result );
+		$this->assertStringNotContainsString( 'public-api.wordpress.com', $result );
+	}
+
 	public function test_rewrite_enclosure_falls_back_to_jetpack_connection_id_when_no_filter_set() {
 		global $post;
 		$post = new WP_Post(

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -6,6 +6,7 @@
 namespace Automattic\Jetpack\Podcast\Tests\Feed;
 
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
+use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 use WP_Post;
@@ -36,6 +37,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'pre_attachment_url_to_postid' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
+		Jetpack_Options::delete_option( 'id' );
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
 	}
@@ -191,6 +193,36 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$this->assertStringContainsString(
 			'url="https://public-api.wordpress.com/wpcom/v2/sites/12345/podcast-play/42.m4a"',
+			$result
+		);
+	}
+
+	public function test_rewrite_enclosure_falls_back_to_jetpack_connection_id_when_no_filter_set() {
+		global $post;
+		$post = new WP_Post(
+			(object) array(
+				'ID'         => 42,
+				'post_type'  => 'post',
+				'post_title' => 'Test Episode',
+			)
+		);
+
+		Jetpack_Options::update_option( 'id', 111139149 );
+
+		add_filter(
+			'pre_attachment_url_to_postid',
+			static function ( $pre, $url ) {
+				return 'https://example.com/path/episode.mp3' === $url ? 9001 : $pre;
+			},
+			10,
+			2
+		);
+
+		$original = '<enclosure url="https://example.com/path/episode.mp3" length="123" type="audio/mpeg" />';
+		$result   = Customize_Feed::rewrite_enclosure( $original );
+
+		$this->assertStringContainsString(
+			'url="https://public-api.wordpress.com/wpcom/v2/sites/111139149/podcast-play/42.mp3"',
 			$result
 		);
 	}


### PR DESCRIPTION
## Proposed changes
* Default the blog ID baked into podcast enclosure stats URLs to `Connection_Manager::get_site_id()` instead of `get_current_blog_id()`. On Atomic / self-hosted Jetpack the latter returns `1` (single-site WP install), so feeds were emitting `https://public-api.wordpress.com/wpcom/v2/sites/1/podcast-play/{post}.mp3` — broken for every podcast that wasn't on WPCOM Simple. The `wpcom_podcasting_tracked_blog_id` filter still wins for any custom override.
* Add a regression test exercising the no-filter fallback on a connected site.

## Testing instructions
1. On an Atomic site with a podcast category configured, load the podcast feed (e.g. `/category/podcasts/feed/`).
2. Confirm the `<enclosure url="…">` URLs now contain the real WPCOM blog ID in the `/sites/{id}/podcast-play/…` path (not `sites/1`).
3. Click an enclosure URL → it should redirect to the audio file (no 404).
4. On WPCOM Simple, confirm feeds still emit the correct site ID (no regression — `Connection_Manager::get_site_id()` branches on `IS_WPCOM` and falls back to `get_current_blog_id()` there).
5. `composer phpunit -- --filter Customize_Feed_Test` in `projects/packages/podcast/` — 31 / 31 pass.
