### PR TITLE
Write: fix mobile padding on resume-editing and beta banners

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-mobile-banner-padding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-mobile-banner-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: add horizontal padding to the resume-editing and beta banners on mobile so they no longer sit flush against the viewport edges.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -272,6 +272,7 @@
 	left: 0;
 	right: 0;
 	z-index: 100001;
+	box-sizing: border-box;
 	height: 44px;
 	background: #fef8ee;
 	border-bottom: 1px solid #f0e0c0;
@@ -1892,6 +1893,16 @@
 
 	.bw-editor {
 		padding: 0 16px;
+	}
+
+	.bw-recovery-banner,
+	.bw-disclaimer-banner {
+		padding: 0 16px;
+	}
+
+	.bw-recovery-btn {
+		height: auto;
+		padding: 8px 12px;
 	}
 
 	.bw-btn-draft {


### PR DESCRIPTION
Fixes [RSM-3771](https://linear.app/a8c/issue/RSM-3771/mobile-no-padding-on-resume-editing-and-beta-banners).

## Proposed changes
* Add `padding: 0 16px` to `.bw-recovery-banner` and `.bw-disclaimer-banner` inside the mobile media query (`@media (max-width: 768px)`), matching the existing `.bw-topbar` / `.bw-editor` pattern, so the banners no longer sit flush against the viewport edges on mobile.
* Add `box-sizing: border-box` to `.bw-recovery-banner` for parity with `.bw-disclaimer-banner` — required so the new padding doesn't push a `left: 0; right: 0;` fixed banner past the viewport.
* Allow the "Resume editing" button to grow vertically on mobile (`height: auto; padding: 8px 12px`), since the label wraps to two lines at 375px and was previously clipped by the desktop `height: 32px`.

Before | After
--- | ---
<img width="375" height="812" alt="write-banners-mobile-before" src="https://github.com/user-attachments/assets/9ffe8202-153a-4894-b8e5-80060d3c913d" /> | <img width="375" height="812" alt="write-banners-mobile-after" src="https://github.com/user-attachments/assets/17e333e5-d8ce-4b68-83f7-4d047eea9ad4" />


## Related product discussion/links
* Linear: [RSM-3771](https://linear.app/a8c/issue/RSM-3771/mobile-no-padding-on-resume-editing-and-beta-banners) (parent: [RSM-3564](https://linear.app/a8c/issue/RSM-3564/audit-mobile-behavior) — mobile audit for the Write editor)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Visit the Write editor on a WordPress.com site (or local dev: `/wp-admin/admin.php?page=write`).
2. Set the viewport to ≤768px (e.g. 375×812 mobile preset in devtools).
3. Trigger both banners — the beta disclaimer is shown automatically on first visit; to force the recovery banner, start a draft, refresh, and dismiss-undo (or remove `[hidden]` from `.bw-recovery-banner` in devtools).
4. Confirm:
   * Both banners have ~16px breathing room from the left/right edges.
   * The dismiss × buttons are no longer flush against the right edge.
   * The "Resume editing" button label is fully visible when wrapped to two lines.
5. On desktop (>768px), confirm the banners are unchanged.