### PR TITLE
Write editor: fix heading and color dropdowns being trapped inside the toolbar on iOS Safari

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-mobile-dropdown-z-index
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-mobile-dropdown-z-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix heading and color dropdowns rendering behind the toolbar on mobile.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-mobile-dropdown-z-index
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-mobile-dropdown-z-index
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Write: Fix heading and color dropdowns rendering behind the toolbar on mobile.
+Write: Fix heading and color dropdowns being trapped inside the toolbar on iOS Safari.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1926,13 +1926,16 @@
 		display: none;
 	}
 
-	/* Escape the overflow scroll container on mobile */
+	/* Escape the overflow scroll container on mobile. Switching to position:
+	   fixed leaves the toolbar's stacking context, so the base z-index of 210
+	   no longer beats .bw-toolbar (99999) — re-declare a value above it. */
 	.bw-heading-menu {
 		position: fixed;
 		top: 104px;
 		left: 16px;
 		transform: none;
 		margin-top: 0;
+		z-index: 100000;
 	}
 
 	.bw-color-menu {
@@ -1942,6 +1945,7 @@
 		left: auto;
 		transform: none;
 		margin-top: 0;
+		z-index: 100000;
 	}
 
 	.bw-color-menu:not([hidden]) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1913,12 +1913,14 @@
 		display: none;
 	}
 
-	/* Toolbar scrolls horizontally on mobile */
+	/* Toolbar scrolls horizontally on mobile. Avoid -webkit-overflow-scrolling:
+	   touch — it's deprecated and historically traps position:fixed descendants
+	   (like .bw-heading-menu / .bw-color-menu) inside this scroll container on
+	   iOS Safari, so the dropdowns can't paint outside the toolbar's bounds. */
 	.bw-toolbar-scroll {
 		justify-content: flex-start;
 		padding: 0 12px;
 		overflow-x: auto;
-		-webkit-overflow-scrolling: touch;
 		scrollbar-width: none;
 	}
 


### PR DESCRIPTION
Fixes [RSM-3772](https://linear.app/a8c/issue/RSM-3772/mobile-heading-and-color-dropdowns-dont-open).

## Proposed changes
On iOS Safari, opening the **Text style** or **Text color** dropdown in the Write editor toolbar appeared to do nothing — the dropdown panel was actually opening, but stayed visually trapped inside the toolbar's horizontal scroll row. Tapping a swatch or heading option from there was impossible because the panel wasn't reachable.

Root cause: the menus (`.bw-heading-menu`, `.bw-color-menu`) are descendants of `.bw-toolbar-scroll`, which had `-webkit-overflow-scrolling: touch` set inside the mobile media query. That property — deprecated, and ignored by modern iOS Safari for scrolling behavior — still triggers a long-standing WebKit quirk where `position: fixed` descendants are clipped to the scrolling container's content box, defeating the menus' attempt to escape it.

Changes:
- **Drop `-webkit-overflow-scrolling: touch` from `.bw-toolbar-scroll`.** This is the actual fix. Modern iOS uses smooth scrolling by default, so removing it doesn't change scroll behavior — it just releases the trap on `position: fixed` descendants.
- **Bump `z-index` on the mobile dropdowns to `100000`.** With `position: fixed` the menus leave the toolbar's stacking context and compete at the root against `.bw-toolbar` (z-index 99999). Their base `z-index: 210` would lose if the toolbar and menu ever overlapped (e.g. if the dynamic JS positioning lags for a frame). Belt-and-braces.

Desktop behavior is unchanged.


<img width="563" height="1218" alt="IMG_0728" src="https://github.com/user-attachments/assets/5137c10f-4c33-4218-bf68-0ae2ead173fd" />
<img width="563" height="1218" alt="IMG_0727" src="https://github.com/user-attachments/assets/716404fb-7754-4d18-bc12-0519347e4c70" />

## Related product discussion/links
* [RSM-3772](https://linear.app/a8c/issue/RSM-3772/mobile-heading-and-color-dropdowns-dont-open)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Open the Write editor on a **real iOS device** (the bug doesn't reproduce in Chrome devtools mobile emulation — it's WebKit-specific).
2. Tap **Text style** in the toolbar. The Normal / Heading 2 / Heading 3 menu should appear immediately below the toolbar, fully tappable.
3. Tap **Text color** in the toolbar. The swatch picker should appear below the toolbar, not trapped inside the toolbar row.
4. Repeat with the recovery / disclaimer banner shown. Dropdowns should still appear right under the toolbar (which is pushed down by the banner).
5. On desktop (>768px), dropdowns should still anchor under their toolbar buttons exactly as before.