### PR TITLE
Search Blocks overlay: auto-open on initial page load when URL has ?s=keyword

### DIFF
--- a/projects/packages/search/changelog/SEARCH-232-overlay-url-trigger
+++ b/projects/packages/search/changelog/SEARCH-232-overlay-url-trigger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks overlay: auto-open on initial page load when the URL contains `?s=` or `?q=`, matching the legacy instant-search overlay's deep-link behavior.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -298,3 +298,13 @@ const overlayEl = getOverlay();
 if ( overlayEl ) {
 	overlayEl.addEventListener( 'click', handleOverlayClick );
 }
+
+// Honor the URL on initial paint the same way `popstate` does on back/forward:
+// if the page loaded with `?s=` or `?q=`, open the overlay. This matches the
+// legacy instant-search behavior where deep links and core-search-form GET
+// submissions surface results in the overlay without a click.
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', handlePopState, { once: true } );
+} else {
+	handlePopState();
+}

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for the Search blocks overlay bootstrap's initial-load URL trigger.
+ *
+ * The module runs side effects at import time (registers listeners and syncs
+ * the overlay to the current URL), so each case sets up the DOM + URL +
+ * `document.readyState`, then imports the module fresh via `jest.resetModules`.
+ */
+
+// `ensureHydrated()` dynamically imports this; stub it so the hydration branch
+// no-ops instead of reaching for the real Interactivity runtime in jsdom.
+jest.mock( '@wordpress/interactivity', () => ( {} ), { virtual: true } );
+
+const OVERLAY_ID = 'jetpack-search-block-overlay';
+
+/**
+ * Render the server-side overlay shell (closed) into the document body.
+ */
+function renderOverlayShell() {
+	document.body.innerHTML = `
+		<div id="${ OVERLAY_ID }" hidden>
+			<div class="jetpack-search-block-overlay__content"></div>
+		</div>
+		<template id="jetpack-search-block-overlay-template"></template>
+	`;
+}
+
+/**
+ * Point `window.location` at the given path+query without a real navigation.
+ *
+ * @param {string} url - Path with optional query string, e.g. `/?s=foo`.
+ */
+function setUrl( url ) {
+	window.history.replaceState( {}, '', url );
+}
+
+/**
+ * Override `document.readyState` for the duration of a test.
+ *
+ * @param {string} value - `'loading'`, `'interactive'`, or `'complete'`.
+ */
+function setReadyState( value ) {
+	Object.defineProperty( document, 'readyState', {
+		configurable: true,
+		get: () => value,
+	} );
+}
+
+/**
+ * Import the bootstrap fresh and let the fire-and-forget `openOverlay` settle.
+ */
+async function loadBootstrap() {
+	jest.resetModules();
+	await import( '../index.js' );
+	// `handlePopState` → `openOverlay` awaits hydration before toggling `hidden`;
+	// flush the microtask queue so the attribute change has landed.
+	await new Promise( resolve => setTimeout( resolve, 0 ) );
+}
+
+const isOpen = () => ! document.getElementById( OVERLAY_ID ).hasAttribute( 'hidden' );
+
+afterEach( () => {
+	setReadyState( 'complete' );
+	setUrl( '/' );
+	document.body.innerHTML = '';
+} );
+
+describe( 'overlay-bootstrap initial-load URL trigger', () => {
+	it( 'opens the overlay on initial load when the URL has ?s=', async () => {
+		setReadyState( 'complete' );
+		renderOverlayShell();
+		setUrl( '/?s=hello' );
+
+		await loadBootstrap();
+
+		expect( isOpen() ).toBe( true );
+	} );
+
+	it( 'opens the overlay on initial load when the URL has ?q=', async () => {
+		setReadyState( 'complete' );
+		renderOverlayShell();
+		setUrl( '/?q=hello' );
+
+		await loadBootstrap();
+
+		expect( isOpen() ).toBe( true );
+	} );
+
+	it( 'leaves the overlay closed when the URL has no search param', async () => {
+		setReadyState( 'complete' );
+		renderOverlayShell();
+		setUrl( '/' );
+
+		await loadBootstrap();
+
+		expect( isOpen() ).toBe( false );
+	} );
+
+	it( 'waits for DOMContentLoaded when the document is still loading', async () => {
+		setReadyState( 'loading' );
+		renderOverlayShell();
+		setUrl( '/?s=hello' );
+
+		await loadBootstrap();
+		// Still parsing — the overlay must not open yet.
+		expect( isOpen() ).toBe( false );
+
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( isOpen() ).toBe( true );
+	} );
+
+	it( 'is a no-op when the overlay shell is not rendered', async () => {
+		setReadyState( 'complete' );
+		document.body.innerHTML = '';
+		setUrl( '/?s=hello' );
+
+		await expect( loadBootstrap() ).resolves.toBeUndefined();
+		expect( document.getElementById( OVERLAY_ID ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Fixes [SEARCH-232](https://linear.app/a8c/issue/SEARCH-232/search-blocks-overlay-auto-open-on-initial-page-load-when-url-has)

## Why

Loading a page with `?s=keyword` opens the legacy instant-search overlay automatically, so deep links and the WordPress core search form's GET submission surface results in the overlay. The new block-powered overlay didn't honor this — the overlay only opened on click, form submit, or browser back/forward, so a fresh page load with `?s=` left the overlay closed even though the Interactivity store had already read the query.

This PR closes the gap so the two overlays behave the same for URL-driven entry.

## Proposed changes

* In `projects/packages/search/src/search-blocks/overlay-bootstrap/index.js`, invoke the existing `handlePopState()` once at module load (after `DOMContentLoaded` when still parsing) so the URL → overlay-visibility logic runs for the initial paint, not only for back/forward navigation. The handler is the same single source of truth that already handles popstate.

## Screenshots

URL: `https://jp-nova.jurassic.tube/?s=hello`, viewport 1440×900.

| Before (overlay stays closed) | After (overlay auto-opens) |
|---|---|
| ![before](https://github.com/user-attachments/assets/6c790e93-75e6-4243-8642-fcb0a652ee17) | ![after](https://github.com/user-attachments/assets/074ee24c-2d67-4663-b3f8-b5c33f73672c) |

## Related product discussion/links

* Linear: [SEARCH-232](https://linear.app/a8c/issue/SEARCH-232/search-blocks-overlay-auto-open-on-initial-page-load-when-url-has)
* Predecessor work: [SEARCH-206](https://linear.app/a8c/issue/SEARCH-206/spike-server-render-the-search-blocks-template-as-the-entire-instant) introduced overlay-bootstrap with the `popstate` handler; [SEARCH-213](https://linear.app/a8c/issue/SEARCH-213/experience-selector-add-new-overlay-search-blocks-powered-option) added the Experience Selector option that made this parity gap user-visible.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Prerequisite: enable the experimental blocks-powered overlay on a test site —

```php
add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
```

…and set the experience via WP-CLI: `wp option update jetpack_search_experience overlay_blocks`.

Acceptance criteria:

- [ ] Load any front-end page with `/?s=keyword` directly — the Search blocks overlay opens automatically, with the input pre-filled.
- [ ] Load with `/?q=keyword` — same behavior (the IA store also accepts `q`).
- [ ] The input inside the auto-opened overlay shows the URL query.
- [ ] Load `/` with no search param — overlay stays closed; normal page renders.
- [ ] No regression on existing open paths: clicking a configured trigger element, intercepting a theme search form, and browser back/forward (`popstate`) still open/close the overlay.
- [ ] No regression on the legacy instant-search overlay (this PR is isolated to `src/search-blocks/overlay-bootstrap/`).
- [ ] No-op on pages where `#jetpack-search-block-overlay` is not rendered.
