### PR TITLE
Search blocks: skip server-side search for Embedded & blocks Overlay

### DIFF
--- a/projects/packages/search/changelog/SEARCH-233-shortcircuit-blocks-search-query
+++ b/projects/packages/search/changelog/SEARCH-233-shortcircuit-blocks-search-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search blocks: stop running a server-side search in the Embedded and blocks Overlay experiences, where results are fetched client-side via the Interactivity API. Classic Search is no longer initialized for these experiences (avoiding a wasted Elasticsearch query plus a WP_Query per request), and the core database search is short-circuited the same way Instant Search already does.

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -15,20 +15,20 @@ use WP_Error;
 class Initializer {
 
 	/**
-	 * Whether the experimental block-template overlay path has been wired
-	 * up this request. Set to `true` at the end of `init_search_blocks()`
-	 * only when BOTH the `jetpack_search_blocks_enabled` gate AND the
-	 * `jetpack_search_overlay_block_template_enabled` gate are on — never
-	 * by the overlay filter alone. `init()` reads this to decide whether
-	 * `init_search()` returning falsy is a real failure or a no-op-by-
-	 * design. Anchoring on the actually-wired-up state (not the filter
-	 * read) prevents the abort carve-out from being bypassed by setting
-	 * the overlay filter on a site that doesn't have Search Blocks
-	 * registered.
+	 * Whether a block-driven experience owns the search results this request
+	 * — Embedded, or the experimental blocks Overlay. Set to `true` in
+	 * `init_search_blocks()` only when the `jetpack_search_blocks_enabled`
+	 * gate is on AND the saved experience is one of those (the Overlay arm
+	 * additionally requires `jetpack_search_overlay_block_template_enabled`).
+	 * In those experiences both Classic and Instant Search are suppressed, so
+	 * `init_search()` returns falsy by design; `init()` reads this flag to
+	 * treat that as a no-op rather than a real failure. Anchoring on the
+	 * actually-wired-up state (not a filter read) prevents the abort carve-out
+	 * from being bypassed on a site that doesn't have Search Blocks registered.
 	 *
 	 * @var bool
 	 */
-	private static $block_template_overlay_active = false;
+	private static $block_search_active = false;
 
 	/**
 	 * Initialize the search package.
@@ -90,16 +90,15 @@ class Initializer {
 			return;
 		}
 
-		// Initialize search package. The block-template overlay path
-		// intentionally skips both instant and classic init (Search_Blocks
-		// owns the UI), so a falsy return there is by design — not an
-		// abort. Anything else falsy is a real failure. Anchor on the
-		// actually-wired-up flag (set in `init_search_blocks()` only when
-		// both gates passed) rather than the overlay filter alone, so
-		// flipping the overlay filter without the blocks gate can never
-		// bypass the abort.
+		// Initialize search package. The block-driven experiences (Embedded /
+		// blocks Overlay) intentionally skip both instant and classic init
+		// (Search_Blocks owns the UI), so a falsy return there is by design —
+		// not an abort. Anything else falsy is a real failure. Anchor on the
+		// actually-wired-up flag (set in `init_search_blocks()` only when the
+		// blocks gate passed) rather than a filter read, so flipping a filter
+		// without the blocks gate can never bypass the abort.
 		$initialized = static::init_search( $blog_id )
-			|| self::$block_template_overlay_active;
+			|| self::$block_search_active;
 
 		if ( ! $initialized ) {
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
@@ -174,17 +173,33 @@ class Initializer {
 		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' );
 		Search_Blocks::init();
 
+		// When the Search blocks own the front-end results (Embedded / blocks
+		// Overlay), Classic Search would otherwise run a server-side
+		// Elasticsearch query plus a WP_Query to hydrate the posts on every
+		// search request — work the blocks immediately discard. Suppress it so
+		// it never runs, the same way Instant Search replaces Classic;
+		// `Search_Blocks::filter__posts_pre_query` then short-circuits the
+		// remaining core database search. With both handlers gone `init_search()`
+		// returns false by design, so this flag tells `init()` not to treat that
+		// as an abort.
+		//
+		// Front-end only, matching the `posts_pre_query` registration guard:
+		// leaving Classic Search to initialize normally in wp-admin keeps the
+		// change scoped to the search page and avoids dropping admin-side hooks.
+		if ( ! is_admin() && Search_Blocks::owns_search_results() ) {
+			add_filter( 'jetpack_search_classic_search_enabled', '__return_false' );
+			self::$block_search_active = true;
+		}
+
 		// Experimental block-template overlay (off by default; see
 		// `Search_Blocks::is_block_template_overlay_enabled()`): bypass the
 		// preact `SearchApp` so it doesn't race the block overlay for
 		// `?s=`, popstate, and theme search-trigger selectors. Suppressing
-		// at the init filter is cleaner than dequeuing post-enqueue. The
-		// active flag set here is the single source of truth for the
-		// `init()` carve-out — it is true only when BOTH this branch ran
-		// (blocks gate passed) AND the overlay gate is on.
+		// at the init filter is cleaner than dequeuing post-enqueue. Gated on
+		// the overlay path specifically — Embedded never enables Instant Search,
+		// so there is nothing to suppress there.
 		if ( Search_Blocks::is_block_template_overlay_enabled() ) {
 			add_filter( 'jetpack_search_init_instant_search', '__return_false' );
-			self::$block_template_overlay_active = true;
 		}
 	}
 

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -2,6 +2,17 @@
 
 Notes for contributors (and AI agents) working in `src/search-blocks/`.
 
+## Search experiences & server-side search
+
+`Module_Control::get_experience()` decides who answers a front-end search, and whether the server runs a search at all:
+
+- **Theme search (`inline`)** — the theme's own `search.html` renders results server-side. `Classic_Search` (or `Inline_Search` when `swap_classic_to_inline_search` is on) handles `posts_pre_query` and returns real Elasticsearch results.
+- **Overlay (`overlay`)** — legacy preact Instant Search. `Instant_Search` short-circuits the main query (returns `[]`) and fetches results client-side.
+- **Embedded (`embedded`)** — the `jetpack-search.html` block template takes over the search page; the blocks fetch results client-side via the Interactivity API.
+- **Blocks Overlay (`overlay_blocks`, experimental)** — same client-side fetch, but painted as a full-screen modal over the theme's search page; gated behind `is_block_template_overlay_enabled()`.
+
+For the two blocks-driven experiences, `Search_Blocks::owns_search_results()` is the single predicate that says "the blocks render the results, so the server must do no search." It drives two suppressions that together remove all server-side search work: `Initializer::init_search_blocks()` stops Classic/Instant Search from initializing (no ES query, no hydration `WP_Query`), and `Search_Blocks::filter__posts_pre_query()` short-circuits the remaining core database query. Both are front-end only (`! is_admin()`). Note these are independent of how results are *fetched* — there is no opt-out filter to "fall back" to a server query, because the blocks never read `WP_Query` results anyway.
+
 ## Naming
 
 All blocks use the `jetpack-search/*` namespace (mirrors the composer package `automattic/jetpack-search`).

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -186,6 +186,14 @@ class Search_Blocks {
 			Theme_Chrome_Slug_Resolver::register_hooks();
 		}
 
+		// When the blocks own the front-end search results, the server-side
+		// search is wasted work — short-circuit the main query the way Instant
+		// Search already does. (Classic / Instant init is also suppressed in
+		// `Initializer::init_search_blocks()`; see `owns_search_results()`.)
+		if ( ! is_admin() && static::owns_search_results() ) {
+			add_filter( 'posts_pre_query', array( static::class, 'filter__posts_pre_query' ), 10, 2 );
+		}
+
 		// Priority 20: after WooCommerce's priority-10 prepend (so the
 		// result is load-order independent), leaving 11-19 free for other
 		// integrations. The WC/product-search guard lives in the callback,
@@ -210,6 +218,54 @@ class Search_Blocks {
 			add_action( 'wp_enqueue_scripts', array( static::class, 'enqueue_block_template_overlay_assets' ) );
 			add_action( 'wp_footer', array( static::class, 'print_block_template_overlay' ) );
 		}
+	}
+
+	/**
+	 * Whether the Search blocks own the front-end search results for the active
+	 * experience, meaning the server should run no search of its own.
+	 *
+	 * True for Embedded (the blocks template takes over the search page) and for
+	 * the enabled blocks Overlay (a full-screen modal over the theme's search
+	 * page). The Overlay arm goes through `is_block_template_overlay_enabled()`
+	 * — operator filter plus saved experience — so a stale `overlay_blocks`
+	 * option can't keep suppressing server search after the overlay is turned
+	 * off. Drives both the Classic/Instant init suppression in
+	 * `Initializer::init_search_blocks()` and the `posts_pre_query` short-circuit
+	 * registered in `init()`.
+	 *
+	 * @return bool
+	 */
+	public static function owns_search_results(): bool {
+		return Module_Control::EXPERIENCE_EMBEDDED === ( new Module_Control() )->get_experience()
+			|| static::is_block_template_overlay_enabled();
+	}
+
+	/**
+	 * Bypass the main search query for the blocks-driven experiences.
+	 *
+	 * Registered on `posts_pre_query` only when `owns_search_results()` is true
+	 * and off `is_admin()` (see `init()`). The guard here just has to confirm
+	 * this is the main front-end search query and let everything else (secondary
+	 * queries, REST requests, non-search routes) fall through.
+	 *
+	 * WP core skips `set_found_posts()` when `posts_pre_query` returns an array,
+	 * so the pagination totals are set by hand — `1` rather than `0` so
+	 * `have_posts()`-gated templates still render the shell the client hydrates.
+	 *
+	 * @param array|null $posts Posts to return in place of the query (null by default).
+	 * @param \WP_Query  $query The WP_Query being filtered.
+	 *
+	 * @return array|null Empty array to short-circuit the query, or $posts to let it run.
+	 */
+	public static function filter__posts_pre_query( $posts, $query ) {
+		if ( ! $query->is_main_query() || ! $query->is_search() ) {
+			return $posts;
+		}
+
+		$query->found_posts   = 1;
+		$query->max_num_pages = 1;
+
+		return array();
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -23,8 +23,10 @@ class Initializer_Test extends Search_TestCase {
 		remove_all_filters( 'jetpack_search_woocommerce_blocks_enabled' );
 		remove_all_filters( 'jetpack_search_overlay_block_template_enabled' );
 		remove_all_filters( 'jetpack_search_init_instant_search' );
+		remove_all_filters( 'jetpack_search_classic_search_enabled' );
+		remove_all_filters( 'jetpack_search_theme_supports_embedded_experience' );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
-		$this->reset_block_template_overlay_active();
+		$this->reset_block_search_active();
 		$this->remove_search_blocks_hooks();
 		parent::tearDown();
 	}
@@ -95,7 +97,7 @@ class Initializer_Test extends Search_TestCase {
 		// The overlay carve-out in `init()` must read the actually-wired-up
 		// flag, not just the overlay filter — otherwise flipping the
 		// overlay filter on a site without the blocks gate would bypass
-		// the abort path. Confirms `$block_template_overlay_active` stays
+		// the abort path. Confirms `$block_search_active` stays
 		// false when the blocks gate is off, regardless of the overlay
 		// filter.
 		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
@@ -105,7 +107,7 @@ class Initializer_Test extends Search_TestCase {
 
 		$this->invoke_init_search_blocks();
 
-		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}
@@ -132,7 +134,7 @@ class Initializer_Test extends Search_TestCase {
 
 		$this->invoke_init_search_blocks();
 
-		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}
@@ -161,7 +163,7 @@ class Initializer_Test extends Search_TestCase {
 
 		$this->invoke_init_search_blocks();
 
-		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}
@@ -183,7 +185,7 @@ class Initializer_Test extends Search_TestCase {
 
 		$this->invoke_init_search_blocks();
 
-		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}
@@ -210,6 +212,71 @@ class Initializer_Test extends Search_TestCase {
 		);
 	}
 
+	public function test_init_search_blocks_suppresses_classic_search_when_embedded() {
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+		( new \Automattic\Jetpack\Modules() )->activate( Module_Control::JETPACK_SEARCH_MODULE_SLUG, false, false );
+
+		$this->invoke_init_search_blocks();
+
+		$this->assertSame(
+			10,
+			has_filter( 'jetpack_search_classic_search_enabled', '__return_false' ),
+			'Classic Search must be suppressed on the Embedded experience so it does not run a server-side ES query.'
+		);
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertTrue( $property->getValue(), 'block_search_active must be set so init() does not abort on Embedded.' );
+		$this->assertFalse(
+			has_filter( 'jetpack_search_init_instant_search', '__return_false' ),
+			'Embedded never enables Instant Search, so the legacy-suppress filter must not be added.'
+		);
+
+		( new \Automattic\Jetpack\Modules() )->deactivate( Module_Control::JETPACK_SEARCH_MODULE_SLUG );
+	}
+
+	public function test_init_search_blocks_suppresses_classic_search_when_overlay_blocks() {
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+		( new \Automattic\Jetpack\Modules() )->activate( Module_Control::JETPACK_SEARCH_MODULE_SLUG, false, false );
+
+		$this->invoke_init_search_blocks();
+
+		$this->assertSame(
+			10,
+			has_filter( 'jetpack_search_classic_search_enabled', '__return_false' ),
+			'Classic Search must be suppressed on the blocks Overlay experience.'
+		);
+
+		( new \Automattic\Jetpack\Modules() )->deactivate( Module_Control::JETPACK_SEARCH_MODULE_SLUG );
+	}
+
+	public function test_init_search_blocks_keeps_classic_search_for_theme_search() {
+		// Blocks enabled but no embedded/overlay experience: Theme search must
+		// keep Classic Search running so the server still renders results.
+		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		( new \Automattic\Jetpack\Modules() )->activate( Module_Control::JETPACK_SEARCH_MODULE_SLUG, false, false );
+
+		$this->invoke_init_search_blocks();
+
+		$this->assertFalse(
+			has_filter( 'jetpack_search_classic_search_enabled', '__return_false' ),
+			'Classic Search must keep running on Theme search (no blocks-driven experience selected).'
+		);
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertFalse( $property->getValue(), 'block_search_active must stay false for Theme search.' );
+
+		( new \Automattic\Jetpack\Modules() )->deactivate( Module_Control::JETPACK_SEARCH_MODULE_SLUG );
+	}
+
 	/**
 	 * Invoke the protected `init_search_blocks()` directly so the gate can
 	 * be exercised without running the rest of `init()` (rest_api_init,
@@ -228,13 +295,13 @@ class Initializer_Test extends Search_TestCase {
 	}
 
 	/**
-	 * Reset the private `$block_template_overlay_active` flag between
+	 * Reset the private `$block_search_active` flag between
 	 * tests so the overlay carve-out can be exercised cleanly across
 	 * cases. Uses reflection because the property is package-private —
 	 * intentionally not part of the public surface, but tests own it.
 	 */
-	private function reset_block_template_overlay_active(): void {
-		$property = new \ReflectionProperty( Initializer::class, 'block_template_overlay_active' );
+	private function reset_block_search_active(): void {
+		$property = new \ReflectionProperty( Initializer::class, 'block_search_active' );
 		if ( PHP_VERSION_ID < 80100 ) {
 			$property->setAccessible( true );
 		}

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -15,6 +15,22 @@ use PHPUnit\Framework\TestCase;
 class Search_Blocks_Test extends TestCase {
 
 	/**
+	 * The main query as it was before a test replaced it, so the swap the
+	 * `posts_pre_query` callback tests perform doesn't leak across tests.
+	 *
+	 * @var \WP_Query|null
+	 */
+	private $original_wp_the_query;
+
+	/**
+	 * Snapshot the main query before each test so tearDown can restore it.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->original_wp_the_query = $GLOBALS['wp_the_query'] ?? null;
+	}
+
+	/**
 	 * Clear `Search_Blocks::is_initial_loading()`'s per-request memo between
 	 * Tests. PHPUnit runs every test in a single process, so without this
 	 * The first test that exercises a query/filter/price URL would pin the
@@ -27,6 +43,7 @@ class Search_Blocks_Test extends TestCase {
 		Search_Blocks::reset_custom_taxonomy_map_cache();
 		// Guards against a failed assertion leaking the option across tests.
 		delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		$GLOBALS['wp_the_query'] = $this->original_wp_the_query;
 		parent::tearDown();
 	}
 
@@ -909,6 +926,154 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * On the Embedded experience the main search query is rendered client-side,
+	 * So `init()` must register the `posts_pre_query` short-circuit.
+	 */
+	public function test_init_registers_posts_pre_query_when_embedded() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		Search_Blocks::init();
+
+		$this->assertSame(
+			10,
+			has_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ) ),
+			'posts_pre_query short-circuit must hook at priority 10 on embedded'
+		);
+
+		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * The experimental blocks Overlay also renders results client-side, so the
+	 * Short-circuit registers when the overlay is enabled (operator filter on +
+	 * Saved `overlay_blocks` experience).
+	 */
+	public function test_init_registers_posts_pre_query_when_overlay_blocks_enabled() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+
+		Search_Blocks::init();
+
+		$this->assertSame(
+			10,
+			has_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ) ),
+			'posts_pre_query short-circuit must hook at priority 10 when the blocks Overlay is enabled'
+		);
+
+		remove_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * A stale `overlay_blocks` option with the operator filter OFF must not
+	 * Bypass the query — otherwise the page would render no server results and
+	 * No overlay would cover them.
+	 */
+	public function test_init_does_not_register_posts_pre_query_when_overlay_blocks_filter_off() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+
+		Search_Blocks::init();
+
+		$this->assertFalse(
+			has_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ) ),
+			'posts_pre_query short-circuit must not hook when the overlay operator filter is off'
+		);
+
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * Theme search (inline), legacy Overlay, and Off all leave the server-side
+	 * Search query intact, so the short-circuit must not register.
+	 */
+	public function test_init_does_not_register_posts_pre_query_for_server_rendered_experiences() {
+		// Inline: module active, no opt-in saved.
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+		Search_Blocks::init();
+		$this->assertFalse(
+			has_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ) ),
+			'posts_pre_query short-circuit must not hook on Theme search (inline)'
+		);
+
+		// Legacy Overlay: Instant Search owns the short-circuit via its own hook.
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
+		Search_Blocks::init();
+		$this->assertFalse(
+			has_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ) ),
+			'posts_pre_query short-circuit must not hook on the legacy Overlay'
+		);
+
+		// Off: module inactive.
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( false );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+		Search_Blocks::init();
+		$this->assertFalse(
+			has_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ) ),
+			'posts_pre_query short-circuit must not hook when the module is off'
+		);
+
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * The callback bypasses the database on the main front-end search query:
+	 * Returns an empty array and sets the dummy pagination totals WP core skips
+	 * In the `posts_pre_query` path.
+	 */
+	public function test_filter_posts_pre_query_short_circuits_main_search_query() {
+		$query                   = new \WP_Query();
+		$query->is_search        = true;
+		$GLOBALS['wp_the_query'] = $query;
+
+		$result = Search_Blocks::filter__posts_pre_query( null, $query );
+
+		$this->assertSame( array(), $result, 'Main search query must be short-circuited to an empty array' );
+		$this->assertSame( 1, $query->found_posts );
+		$this->assertSame( 1, $query->max_num_pages );
+	}
+
+	/**
+	 * Secondary / non-search queries fall through untouched so widgets, related
+	 * Posts, etc. keep working on a search page.
+	 */
+	public function test_filter_posts_pre_query_passes_through_non_search_query() {
+		$main                    = new \WP_Query();
+		$main->is_search         = true;
+		$GLOBALS['wp_the_query'] = $main;
+
+		// A secondary query (not the main query) must be left alone.
+		$secondary            = new \WP_Query();
+		$secondary->is_search = true;
+		$sentinel             = array( 'untouched' );
+		$this->assertSame(
+			$sentinel,
+			Search_Blocks::filter__posts_pre_query( $sentinel, $secondary ),
+			'A secondary query must not be short-circuited'
+		);
+
+		// The main query on a non-search route must be left alone too.
+		$main->is_search = false;
+		$this->assertSame(
+			$sentinel,
+			Search_Blocks::filter__posts_pre_query( $sentinel, $main ),
+			'A non-search main query must not be short-circuited'
+		);
+	}
+
+	/**
 	 * Remove every hook this class registers, so each `init()` test starts
 	 * From a known-empty state.
 	 */
@@ -922,6 +1087,7 @@ class Search_Blocks_Test extends TestCase {
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
+		remove_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ), 10 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-233

## Why

When a site uses the **Embedded** or experimental **blocks Overlay** Search experience, the Search blocks render results entirely client-side via the Interactivity API — but the server was still doing a full search on every request, then throwing the results away. This removes that wasted work, mirroring how Instant Search already short-circuits the query.

## Proposed changes

* Add `Search_Blocks::owns_search_results()` — a single predicate for "the blocks render the results, so the server must do no search" (true for Embedded and the enabled blocks Overlay).
* **Suppress Classic Search** for those experiences in `Initializer::init_search_blocks()`. Previously they still initialized Classic Search, which ran a server-side Elasticsearch query (`do_search()`) plus a `WP_Query` to hydrate the posts on every request — work the blocks discard. Now it never runs, the same way Instant Search replaces Classic.
* **Short-circuit the core database search** via `posts_pre_query` for these experiences, so the normal `posts_search` SQL is skipped too.
* Both suppressions are front-end only (`! is_admin()`), keeping the change scoped to the search page.
* Document the per-experience server-side-search behaviour in `src/search-blocks/AGENTS.md`.

Behaviour is unchanged for `overlay` (Instant Search), `inline` (Theme search — Classic Search still runs and renders server-side), and `off`.

## Related product discussion/links

* [SEARCH-233](https://linear.app/a8c/issue/SEARCH-233)

## Does this pull request change what data or activity we track or use?

No.

## Verification

Backend-only change (no UI change — the blocks render identically; only server-side query work is removed). Verified on a local env in the `embedded` and `overlay_blocks` experiences: after the change `owns_search_results()` is true, Classic Search is no longer hooked on `posts_pre_query`, and with `SAVEQUERIES` enabled a search request runs **0 server-side search queries** (`found_posts=1, posts=0`).

<details>
<summary>Before / after (wp eval, SAVEQUERIES)</summary>

```text
BEFORE (Classic suppressed, no blocks short-circuit): core search SQL queries=1
AFTER  (blocks short-circuit on): core search SQL queries=0, found_posts=1, posts=0, max_num_pages=1
```

After the change, the only `posts_pre_query` handler in embedded/overlay_blocks:

```text
prio 10: Automattic\Jetpack\Search\Search_Blocks::filter__posts_pre_query
classic_suppressed=YES
```

</details>

<details>
<summary>PHP unit tests</summary>

```text
OK (548 tests, 1244 assertions, 1 skipped)   # full jetpack-search PHP suite
```

</details>

## Testing instructions

* On a connected site with a Search plan and the Search blocks feature enabled, set the experience to **Embedded** (block theme) or the **blocks Overlay** (with `jetpack_search_overlay_block_template_enabled`).
* With Query Monitor active, perform a front-end search (`/?s=keyword`).
  * [ ] In `embedded` mode: no server-side Elasticsearch query and no core `posts_search` SQL runs.
  * [ ] In enabled `overlay_blocks` mode: same — no server-side search SQL.
  * [ ] The Search blocks still render and results still populate client-side via the Interactivity API.
* [ ] Switch the experience to **Overlay** (Instant Search): behaviour unchanged (Instant Search still short-circuits via its own hook).
* [ ] Switch to **Theme search** (`inline`): the WP/Classic search query runs normally and renders results server-side.
* [ ] Confirm only the main search query is affected — secondary queries (sidebar widgets, related posts) run normally.
* [ ] Confirm wp-admin is unaffected (Classic Search still initializes there).
