### PR TITLE
[RSM] Blog Talks Back: AI Agent Access toggle > Sync late option whitelist entries

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-late-options-whitelist
+++ b/projects/packages/sync/changelog/fix-sync-late-options-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Options: Include late sync whitelist entries in cached option modules.

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -114,6 +114,7 @@ class Options extends Module {
 	public function set_late_default() {
 		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
 		$late_options = apply_filters( 'jetpack_options_whitelist', array() );
+		$late_options = apply_filters( 'jetpack_sync_options_whitelist', $late_options );
 		if ( ! empty( $late_options ) && is_array( $late_options ) ) {
 			$this->options_whitelist = array_merge( $this->options_whitelist, $late_options );
 		}

--- a/projects/packages/sync/tests/php/modules/Options_Module_Test.php
+++ b/projects/packages/sync/tests/php/modules/Options_Module_Test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Test file for Automattic\Jetpack\Sync\Modules\Options
+ *
+ * @package automattic/jetpack-sync
+ */
+
+namespace Automattic\Jetpack\Sync;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Options_Module_Test
+ *
+ * @covers Automattic\Jetpack\Sync\Modules\Options
+ */
+#[CoversClass( Modules\Options::class )]
+class Options_Module_Test extends BaseTestCase {
+
+	/**
+	 * The Options sync module instance.
+	 *
+	 * @var Modules\Options
+	 */
+	private $options_module;
+
+	/**
+	 * Runs before every test in this class.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->options_module = new Modules\Options();
+		$this->options_module->set_options_whitelist( array( 'test_option' ) );
+	}
+
+	/**
+	 * Runs after every test in this class.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_late_sync_option' ) );
+		delete_option( 'late_sync_option' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Late sync option whitelist entries should be added to the cached module whitelist.
+	 */
+	public function test_set_late_default_adds_late_sync_options_whitelist_entries() {
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_late_sync_option' ) );
+
+		$this->assertNotContains( 'late_sync_option', $this->options_module->get_options_whitelist() );
+
+		$this->options_module->set_late_default();
+
+		$this->assertContains( 'late_sync_option', $this->options_module->get_options_whitelist() );
+
+		update_option( 'late_sync_option', 'enabled' );
+		$options = $this->options_module->get_all_options();
+
+		$this->assertSame( 'enabled', $options['late_sync_option'] );
+	}
+
+	/**
+	 * Adds an option through the sync-specific option whitelist filter.
+	 *
+	 * @param array $options Option names.
+	 * @return array
+	 */
+	public function add_late_sync_option( array $options ) {
+		$options[] = 'late_sync_option';
+		return $options;
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Apply the sync-specific option whitelist filter when the Options sync module refreshes late defaults, so cached module instances include options added through `jetpack_sync_options_whitelist` later in the load order.
* Add package-level regression coverage for late Sync option whitelist entries.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Internal follow-up from AI Agent Access sync validation.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No new data is tracked or used. This only ensures options already explicitly added to the Sync whitelist through the late sync filter are included in the cached options module whitelist.

## Testing instructions
- Install this PR on Atomic/JN
- Enable AI Agent Access toggle
- Wait for 5 minutes
- Check RC for the sticker `jetpack-ai-agents-enabled`
