### PR TITLE
Newsletter: gate the modernized Subscribers tab behind a WordPress.com connection + fix Settings API-root race

### DIFF
--- a/projects/packages/newsletter/_inc/components/newsletter-page.tsx
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.tsx
@@ -1,6 +1,6 @@
 import analytics from '@automattic/jetpack-analytics';
 import AdminPage from '@automattic/jetpack-components/admin-page';
-import { getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteData, getSiteType } from '@automattic/jetpack-script-data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
@@ -111,6 +111,8 @@ export default function NewsletterPage( {
 
 	return (
 		<AdminPage
+			apiRoot={ getSiteData()?.rest_root }
+			apiNonce={ getSiteData()?.rest_nonce }
 			title={ PRODUCT_NAME }
 			subTitle={ SUBTITLES[ activeTab ]() }
 			actions={ actions }

--- a/projects/packages/newsletter/_inc/subscribers/components/connection-gate.scss
+++ b/projects/packages/newsletter/_inc/subscribers/components/connection-gate.scss
@@ -1,0 +1,9 @@
+// Centered connect prompt shown inside the AdminPage content area when the
+// Subscribers tab is gated. Mirrors the spacing of the empty-state view.
+.jetpack-newsletter-connection-gate {
+	align-items: center;
+	text-align: center;
+	max-width: 480px;
+	margin: 0 auto;
+	padding: 48px 24px;
+}

--- a/projects/packages/newsletter/_inc/subscribers/components/connection-gate.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/connection-gate.tsx
@@ -1,0 +1,46 @@
+import { __ } from '@wordpress/i18n';
+import { Button, Stack, Text } from '@wordpress/ui';
+import './connection-gate.scss';
+
+type Props = {
+	/** Starts the site-registration + user-connection flow. */
+	onConnect: () => void;
+	/** True while registration or user connection is in flight. */
+	isConnecting: boolean;
+};
+
+/**
+ * Connect prompt shown in place of the Subscribers data view when the site or
+ * the current user isn't connected to WordPress.com. Subscriber management
+ * proxies to WP.com signed as the current user, so without a user token every
+ * request fails with `missing_token`; this prompt is the gate's fallback,
+ * decided in `routes/dashboard/stage.tsx`. Renders inside the existing
+ * `AdminPage` chrome, so it intentionally does not mount its own `AdminPage`.
+ *
+ * @param props              - Component props.
+ * @param props.onConnect    - Starts the connection flow.
+ * @param props.isConnecting - Whether the connection flow is in progress.
+ * @return The connect prompt element.
+ */
+export default function ConnectionGate( { onConnect, isConnecting }: Props ) {
+	return (
+		<Stack direction="column" gap="md" className="jetpack-newsletter-connection-gate">
+			<Text variant="heading-2xl">
+				{ __( 'Connect to manage your subscribers', 'jetpack-newsletter' ) }
+			</Text>
+			<Text>
+				{ __(
+					'Subscriber management needs a connection to WordPress.com before you can view and manage everyone subscribed to your site.',
+					'jetpack-newsletter'
+				) }
+			</Text>
+			<div>
+				<Button variant="solid" disabled={ isConnecting } onClick={ onConnect }>
+					{ isConnecting
+						? __( 'Connecting…', 'jetpack-newsletter' )
+						: __( 'Connect', 'jetpack-newsletter' ) }
+				</Button>
+			</div>
+		</Stack>
+	);
+}

--- a/projects/packages/newsletter/changelog/fix-newsletter-subscribers-connection-gate
+++ b/projects/packages/newsletter/changelog/fix-newsletter-subscribers-connection-gate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Gate the modernized Newsletter Subscribers tab behind a WordPress.com user connection (shows a connect prompt instead of failing subscriber requests) and pass the REST root/nonce to AdminPage so the Settings tab loads on direct navigation. Behind the off-by-default rsm_jetpack_ui_modernization_newsletter filter — no default behavior change.
+
+

--- a/projects/packages/newsletter/routes/dashboard/package.json
+++ b/projects/packages/newsletter/routes/dashboard/package.json
@@ -7,6 +7,7 @@
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@tanstack/react-query": "5.90.8",

--- a/projects/packages/newsletter/routes/dashboard/stage.tsx
+++ b/projects/packages/newsletter/routes/dashboard/stage.tsx
@@ -1,9 +1,12 @@
 import analytics from '@automattic/jetpack-analytics';
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { getSiteData } from '@automattic/jetpack-script-data';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { useSearch } from '@wordpress/route';
 import { Tabs } from '@wordpress/ui';
 import NewsletterPage, { type NewsletterTab } from '../../_inc/components/newsletter-page';
+import ConnectionGate from '../../_inc/subscribers/components/connection-gate';
 import SubscribersBody from '../../_inc/subscribers/components/subscribers-body';
 import { queryClient } from '../../_inc/subscribers/lib/query-client';
 import { NewsletterSettingsBody } from '../../src/settings/newsletter-settings';
@@ -14,6 +17,18 @@ import './route.scss';
 type StageSearch = Record< string, unknown > & {
 	tab?: string;
 };
+
+const NEWSLETTER_ADMIN_PAGE = 'admin.php?page=jetpack-newsletter';
+
+/**
+ * After connecting, return the visitor to the Newsletter dashboard.
+ *
+ * @return The absolute Newsletter admin URL, or undefined when the admin URL isn't in script data (e.g. tests).
+ */
+function getRedirectUri(): string | undefined {
+	const adminUrl = getSiteData()?.admin_url;
+	return adminUrl ? `${ adminUrl }${ NEWSLETTER_ADMIN_PAGE }` : undefined;
+}
 
 /**
  * Single stage that owns the unified Newsletter page chrome — Page header,
@@ -42,6 +57,28 @@ const Stage = () => {
 		activeTab = 'settings';
 	}
 
+	const {
+		isRegistered,
+		hasConnectedOwner,
+		isUserConnected,
+		siteIsRegistering,
+		userIsConnecting,
+		handleRegisterSite,
+	} = useConnection( {
+		from: 'jetpack-newsletter',
+		redirectUri: getRedirectUri(),
+	} );
+
+	// Subscriber management proxies to WP.com signed as the current user, so a
+	// fully connected site AND user are required. Mirrors the VideoPress gate.
+	const canManageSubscribers = isRegistered && hasConnectedOwner && isUserConnected;
+
+	// `handleRegisterSite` registers the site if needed and then connects the
+	// user; on an already-registered site it connects the user directly.
+	const handleConnect = useCallback( () => {
+		handleRegisterSite();
+	}, [ handleRegisterSite ] );
+
 	// Initialize analytics once for the entire page so future tab/section
 	// events fire regardless of which tab a visitor lands on. Mirrors the
 	// initialization that lived in the legacy `NewsletterSettingsApp`.
@@ -55,27 +92,40 @@ const Stage = () => {
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<SubscribersBody>
-				{ ( { body, actions } ) => (
-					<NewsletterPage
-						activeTab={ activeTab }
-						actions={ activeTab === 'subscribers' ? actions : undefined }
-						contentHasPadding={ activeTab === 'settings' }
-						hideFooter={ activeTab === 'subscribers' }
-					>
-						{ subscribersEnabled ? (
-							<>
-								<Tabs.Panel value="subscribers" focusable={ false }>
-									{ activeTab === 'subscribers' ? body : null }
-								</Tabs.Panel>
-								<Tabs.Panel value="settings" focusable={ false }>
-									{ activeTab === 'settings' ? <NewsletterSettingsBody isModernized /> : null }
-								</Tabs.Panel>
-							</>
-						) : (
-							<NewsletterSettingsBody isModernized />
-						) }
-					</NewsletterPage>
-				) }
+				{ ( { body, actions } ) => {
+					// Gate the Subscribers tab: connected visitors get the data view,
+					// everyone else gets the connect prompt.
+					const subscribersPanel = canManageSubscribers ? (
+						body
+					) : (
+						<ConnectionGate
+							onConnect={ handleConnect }
+							isConnecting={ siteIsRegistering || userIsConnecting }
+						/>
+					);
+
+					return (
+						<NewsletterPage
+							activeTab={ activeTab }
+							actions={ activeTab === 'subscribers' && canManageSubscribers ? actions : undefined }
+							contentHasPadding={ activeTab === 'settings' }
+							hideFooter={ activeTab === 'subscribers' }
+						>
+							{ subscribersEnabled ? (
+								<>
+									<Tabs.Panel value="subscribers" focusable={ false }>
+										{ activeTab === 'subscribers' ? subscribersPanel : null }
+									</Tabs.Panel>
+									<Tabs.Panel value="settings" focusable={ false }>
+										{ activeTab === 'settings' ? <NewsletterSettingsBody isModernized /> : null }
+									</Tabs.Panel>
+								</>
+							) : (
+								<NewsletterSettingsBody isModernized />
+							) }
+						</NewsletterPage>
+					);
+				} }
 			</SubscribersBody>
 		</QueryClientProvider>
 	);

--- a/projects/packages/newsletter/tests/connection-gate.test.tsx
+++ b/projects/packages/newsletter/tests/connection-gate.test.tsx
@@ -1,0 +1,55 @@
+// The subscribers connect prompt is the gate's fallback view (the branching
+// itself lives in `routes/dashboard/stage.tsx`). These tests assert only the
+// prompt's own markup + button behavior, with @wordpress/ui stubbed to plain
+// elements the way the sibling shell test does.
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Button: ( {
+		children,
+		onClick,
+		disabled,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+	} ) => (
+		<button onClick={ onClick } disabled={ disabled }>
+			{ children }
+		</button>
+	),
+	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import ConnectionGate from '../_inc/subscribers/components/connection-gate';
+
+describe( 'ConnectionGate (subscribers connect prompt)', () => {
+	it( 'renders the connect heading and an enabled Connect button when idle', () => {
+		render( <ConnectionGate onConnect={ jest.fn() } isConnecting={ false } /> );
+
+		expect( screen.getByText( 'Connect to manage your subscribers' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Connect' } ) ).toBeEnabled();
+	} );
+
+	it( 'invokes onConnect when the button is clicked', () => {
+		const onConnect = jest.fn();
+		render( <ConnectionGate onConnect={ onConnect } isConnecting={ false } /> );
+
+		// Native click via `.find()` mirrors the sibling shell test; the package
+		// doesn't pull in @testing-library/user-event.
+		screen
+			.getAllByRole( 'button' )
+			.find( button => button.textContent === 'Connect' )
+			?.click();
+
+		expect( onConnect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'shows a disabled "Connecting…" button while connecting', () => {
+		render( <ConnectionGate onConnect={ jest.fn() } isConnecting={ true } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Connecting…' } ) ).toBeDisabled();
+	} );
+} );

--- a/projects/packages/newsletter/tests/newsletter-page.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-page.test.tsx
@@ -12,6 +12,14 @@
 const mockRecordEvent = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetSiteType = jest.fn( () => 'jetpack' );
+const mockGetSiteData = jest.fn( () => ( {
+	rest_root: 'https://example.com/wp-json/',
+	rest_nonce: 'test-nonce',
+	admin_url: 'https://example.com/wp-admin/',
+} ) );
+// Captures the props the shell passes to `AdminPage` so we can assert the
+// REST root/nonce wiring that keeps the Settings tab off a relative root.
+const mockAdminPageProps = jest.fn();
 const mockGetNewsletterScriptData = jest.fn< unknown, [] >();
 // `mockTabsOnValueChange` is the `onValueChange` callback captured by the
 // `@wordpress/ui` mock below. Tests can call it directly to drive the
@@ -29,6 +37,7 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	getSiteType: () => mockGetSiteType(),
+	getSiteData: () => mockGetSiteData(),
 } ) );
 
 // `AdminPage` owns the header (logo + title) and the `JetpackFooter`. The mock
@@ -37,15 +46,19 @@ jest.mock( '@automattic/jetpack-script-data', () => ( {
 // wiring without pulling in admin-ui internals.
 jest.mock( '@automattic/jetpack-components/admin-page', () => ( {
 	__esModule: true,
-	default: ( { children, actions, title, subTitle, showFooter } ) => (
-		<div data-testid="admin-page">
-			<div data-testid="page-title">{ title }</div>
-			<div data-testid="page-subtitle">{ subTitle }</div>
-			<div data-testid="page-actions">{ actions }</div>
-			{ children }
-			{ showFooter && <div data-testid="jetpack-footer" /> }
-		</div>
-	),
+	default: props => {
+		mockAdminPageProps( props );
+		const { children, actions, title, subTitle, showFooter } = props;
+		return (
+			<div data-testid="admin-page">
+				<div data-testid="page-title">{ title }</div>
+				<div data-testid="page-subtitle">{ subTitle }</div>
+				<div data-testid="page-actions">{ actions }</div>
+				{ children }
+				{ showFooter && <div data-testid="jetpack-footer" /> }
+			</div>
+		);
+	},
 } ) );
 
 jest.mock( '@wordpress/route', () => ( {
@@ -100,6 +113,8 @@ beforeEach( () => {
 	mockNavigate.mockReset();
 	mockGetSiteType.mockReset();
 	mockGetSiteType.mockReturnValue( 'jetpack' );
+	mockGetSiteData.mockClear();
+	mockAdminPageProps.mockClear();
 	mockGetNewsletterScriptData.mockReset();
 	mockGetNewsletterScriptData.mockReturnValue( { subscriberManagementEnabled: true } );
 	mockTabsOnValueChange.current = null;
@@ -233,5 +248,24 @@ describe( 'NewsletterPage tab navigation', () => {
 		);
 
 		expect( screen.getByTestId( 'jetpack-footer' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'NewsletterPage AdminPage wiring', () => {
+	it( 'passes the REST API root and nonce from script data to AdminPage', () => {
+		// AdminPage's effect calls restApi.setApiRoot(apiRoot); with the default
+		// empty apiRoot it would clobber the root and 404 the Settings tab.
+		render(
+			<NewsletterPage activeTab="subscribers">
+				<div>panel body</div>
+			</NewsletterPage>
+		);
+
+		expect( mockAdminPageProps ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				apiRoot: 'https://example.com/wp-json/',
+				apiNonce: 'test-nonce',
+			} )
+		);
 	} );
 } );


### PR DESCRIPTION
Fixes #

## Proposed changes

On a site that is blog-connected but has no connected user, the modernized Newsletter dashboard surfaced two errors. This PR addresses both (the dashboard is behind the off-by-default `rsm_jetpack_ui_modernization_newsletter` filter, so there is no default behavior change):

* **Subscribers tab — gate behind a WordPress.com connection.** `/wpcom/v2/subscribers/list` proxies to WP.com signed as the current user (`wpcom_json_api_request_as_user`); with no user token it returns a raw `missing_token` 500, which the DataViews empty state masked as "No subscribers yet". The dashboard stage now reads connection state (`isRegistered && hasConnectedOwner && isUserConnected`, mirroring the VideoPress gate) and, when the site/user isn't fully connected, renders a connect prompt instead of the data view and hides the "Add subscribers" action. The Settings tab stays accessible (it needs no user token).
* **Settings tab — fix an API-root race.** `newsletter-page.tsx` rendered `<AdminPage>` without `apiRoot`/`apiNonce`; AdminPage's effect calls `restApi.setApiRoot('')`, clobbering the root `initializeApi()` set on the shared `@automattic/jetpack-api` singleton, so a settings fetch racing after it hit a relative `/wp-admin/jetpack/v4/settings` URL (404, "Failed to load settings"). The page now passes the real `rest_root`/`rest_nonce` from script data, so the set is correct instead of empty. This also affected connected users landing directly on the Settings tab.

New presentational `ConnectionGate` component (adapted from the VideoPress connect screen, reworded for subscriber management) renders inside the existing AdminPage chrome.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a self-hosted Jetpack site that is **blog-connected but has no connected user** (a `blog_token` in `jetpack_private_options` but no `user_tokens`):

* Go to **Jetpack → Newsletter** (`wp-admin/admin.php?page=jetpack-newsletter`) with the `rsm_jetpack_ui_modernization_newsletter` filter enabled.
* **Subscribers tab:** confirm it shows the "Connect to manage your subscribers" prompt with a **Connect** button, the "Add subscribers" header action is absent, and the Network panel shows **no** repeated 500s on `/wpcom/v2/subscribers/list`.
* **Settings tab (direct load):** open `…?page=jetpack-newsletter&p=%2F%3Ftab%3Dsettings` as a full page load. Confirm the Network panel shows a single `/wp-json/jetpack/v4/settings` request returning **200**, with **no** `/wp-admin/jetpack/v4/settings` 404, and the settings form renders.
* Confirm the Settings tab remains accessible even without a user connection.
* On a fully connected site (site + user), confirm the Subscribers data view and "Add subscribers" action render as before.
