### PR TITLE
Search Blocks: add a per-instance post-type scope setting to the Search Input block

### DIFF
--- a/projects/packages/search/changelog/SEARCH-234-search-input-post-type-scope
+++ b/projects/packages/search/changelog/SEARCH-234-search-input-post-type-scope
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add a "Post types" setting to the Search Input block so authors can scope a search to specific post types (include or exclude) directly on the input, without a separate Post Type Scope block. The scope is per-instance — each Search Input only constrains the searches it initiates, falling back to any page-level filter-post-type block when unset.

--- a/projects/packages/search/src/search-blocks/blocks/filter-post-type/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-post-type/edit.js
@@ -2,80 +2,16 @@
  * Editor preview for jetpack-search/filter-post-type.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { FormTokenField, Icon, PanelBody, RadioControl } from '@wordpress/components';
+import { Icon, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useRef } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { unseen } from '@wordpress/icons';
-
-const MODE_INCLUDE = 'include';
-const MODE_EXCLUDE = 'exclude';
-
-/**
- * `sanitize_key()` (PHP) approximation: lowercase + strip everything that
- * is not `[a-z0-9_-]`. Mirrors the server normalizer so editor-stored
- * attributes match what eventually reaches ES.
- *
- * @param {string} value - Raw token string.
- * @return {string} Sanitized slug.
- */
-function sanitizeKey( value ) {
-	return String( value || '' )
-		.toLowerCase()
-		.replace( /[^a-z0-9_-]+/g, '' );
-}
-
-/**
- * Append `(slug)` to any label that occurs more than once so each suggestion
- * label maps 1:1 to a slug — without this the FormTokenField label→slug
- * lookup picks an arbitrary winner when two CPTs share a `singular_name`.
- *
- * @param {Array<{value: string, label: string}>} options - Raw slug/label list.
- * @return {Array<{value: string, label: string}>} Disambiguated.
- */
-function disambiguateLabels( options ) {
-	const counts = new Map();
-	for ( const { label } of options ) {
-		counts.set( label, ( counts.get( label ) || 0 ) + 1 );
-	}
-	return options.map( opt =>
-		counts.get( opt.label ) > 1 ? { ...opt, label: `${ opt.label } (${ opt.value })` } : opt
-	);
-}
-
-/**
- * Map slugs to FormTokenField's `{value, title}` shape.
- *
- * @param {string[]} slugs       - Stored slug list.
- * @param {Map}      labelBySlug - slug → label.
- * @return {Array<{ value: string, title: string }>} Token shape.
- */
-function toTokens( slugs, labelBySlug ) {
-	return ( slugs || [] ).map( slug => ( {
-		value: slug,
-		title: labelBySlug.get( slug ) || slug,
-	} ) );
-}
-
-/**
- * Convert FormTokenField output back to a sanitized, deduped slug list.
- * Free-typed values pass through `sanitizeKey` so editor and server agree.
- *
- * @param {Array<string|{value: string}>}         tokens  - Tokens from onChange.
- * @param {Array<{value: string, label: string}>} options - Resolved options for label→slug lookup.
- * @return {string[]} Sanitized slugs.
- */
-function tokensToSlugs( tokens, options ) {
-	const out = [];
-	for ( const token of tokens || [] ) {
-		const raw = typeof token === 'string' ? labelFromTokenString( token, options ) : token?.value;
-		const slug = sanitizeKey( raw );
-		if ( slug && ! out.includes( slug ) ) {
-			out.push( slug );
-		}
-	}
-	return out;
-}
+import PostTypeScopeControl, {
+	MODE_INCLUDE,
+	MODE_EXCLUDE,
+	disambiguateLabels,
+} from '../../editor/post-type-control';
 
 /**
  * Edit component for the filter-post-type block.
@@ -93,110 +29,40 @@ export default function FilterPostTypeEdit( { attributes, setAttributes } ) {
 		[ attributes?.postTypes ]
 	);
 
-	// `viewable !== false` filter is a UX nicety; the canonical allowlist
-	// (`exclude_from_search => false`) is enforced server-side because the
-	// REST endpoint does not expose that flag.
+	// A second `getPostTypes` selector (the control runs its own) only to build
+	// the slug→label map the canvas preview needs. `@wordpress/data` memoizes the
+	// resolver, so this resolves to the same cached store entry — no extra fetch.
 	const registeredTypes = useSelect(
 		select => select( 'core' ).getPostTypes( { per_page: -1 } ),
 		[]
 	);
-
-	const options = useMemo( () => {
-		if ( ! Array.isArray( registeredTypes ) ) {
-			return null;
-		}
-		return disambiguateLabels(
-			registeredTypes
-				.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
-				.map( type => ( {
-					value: type.slug,
-					label: type?.labels?.singular_name || type?.name || type.slug,
-				} ) )
-		);
-	}, [ registeredTypes ] );
-
 	const labelBySlug = useMemo( () => {
 		const map = new Map();
-		( options || [] ).forEach( option => map.set( option.value, option.label ) );
+		if ( Array.isArray( registeredTypes ) ) {
+			disambiguateLabels(
+				registeredTypes
+					.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
+					.map( type => ( {
+						value: type.slug,
+						label: type?.labels?.singular_name || type?.name || type.slug,
+					} ) )
+			).forEach( option => map.set( option.value, option.label ) );
+		}
 		return map;
-	}, [ options ] );
-
-	const suggestionList = useMemo(
-		() => ( options || [] ).map( option => option.label ),
-		[ options ]
-	);
+	}, [ registeredTypes ] );
 
 	const previewState = describePreview( mode, postTypes, labelBySlug );
-
-	// Per-mode draft cache. Flipping back to a previously-used mode restores
-	// the typed list; only the active mode's `postTypes` is persisted.
-	const draftRef = useRef( null );
-	if ( draftRef.current === null ) {
-		draftRef.current = {
-			[ MODE_INCLUDE ]: mode === MODE_INCLUDE ? postTypes : [],
-			[ MODE_EXCLUDE ]: mode === MODE_EXCLUDE ? postTypes : [],
-		};
-	}
-
-	const handleModeChange = nextMode => {
-		if ( nextMode === mode ) {
-			return;
-		}
-		draftRef.current = { ...draftRef.current, [ mode ]: postTypes };
-		setAttributes( {
-			mode: nextMode,
-			postTypes: draftRef.current[ nextMode ] || [],
-		} );
-	};
-
-	const handlePostTypesChange = tokens => {
-		const slugs = tokensToSlugs( tokens, options );
-		draftRef.current = { ...draftRef.current, [ mode ]: slugs };
-		setAttributes( { postTypes: slugs } );
-	};
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
-					<RadioControl
-						label={ __( 'Mode', 'jetpack-search-pkg' ) }
-						selected={ mode }
-						options={ [
-							{
-								label: __(
-									'Exclude — remove the selected post types from results',
-									'jetpack-search-pkg'
-								),
-								value: MODE_EXCLUDE,
-							},
-							{
-								label: __(
-									'Include only — search will return only the selected post types',
-									'jetpack-search-pkg'
-								),
-								value: MODE_INCLUDE,
-							},
-						] }
-						onChange={ handleModeChange }
-					/>
-					<FormTokenField
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={
-							mode === MODE_INCLUDE
-								? __( 'Post types to include', 'jetpack-search-pkg' )
-								: __(
-										'Post types to exclude',
-										'jetpack-search-pkg',
-										/* dummy arg to avoid bad minification */ 0
-								  )
+					<PostTypeScopeControl
+						mode={ mode }
+						postTypes={ postTypes }
+						onChange={ ( { mode: nextMode, postTypes: nextPostTypes } ) =>
+							setAttributes( { mode: nextMode, postTypes: nextPostTypes } )
 						}
-						value={ toTokens( postTypes, labelBySlug ) }
-						suggestions={ suggestionList }
-						__experimentalExpandOnFocus
-						__experimentalShowHowTo={ false }
-						onChange={ handlePostTypesChange }
 					/>
 					<p
 						className="jetpack-search-filter-post-type__hint"
@@ -246,23 +112,6 @@ export default function FilterPostTypeEdit( { attributes, setAttributes } ) {
 }
 
 /**
- * Reverse `disambiguateLabels()`: a picked-suggestion label resolves back
- * to its slug.
- *
- * @param {string} token   - Token from FormTokenField.
- * @param {Array}  options - { value, label } option list.
- * @return {string} Slug, or the original token (free-typed input is
- * sanitized later in `tokensToSlugs`).
- */
-function labelFromTokenString( token, options ) {
-	if ( ! Array.isArray( options ) ) {
-		return token;
-	}
-	const match = options.find( option => option.label === token || option.value === token );
-	return match ? match.value : token;
-}
-
-/**
  * Build the canvas preview's `{ label, value }` for the current mode +
  * selection. An empty selection renders "(none selected)" so the
  * unconfigured state stays explicit.
@@ -272,7 +121,7 @@ function labelFromTokenString( token, options ) {
  * @param {Map}      labelBySlug - slug → label.
  * @return {{label: string, value: string}} Preview row.
  */
-function describePreview( mode, postTypes, labelBySlug ) {
+export function describePreview( mode, postTypes, labelBySlug ) {
 	const valueText =
 		postTypes.length > 0
 			? postTypes.map( slug => labelBySlug.get( slug ) || slug ).join( ', ' )
@@ -283,6 +132,3 @@ function describePreview( mode, postTypes, labelBySlug ) {
 	}
 	return { label: __( 'Exclude:', 'jetpack-search-pkg' ), value: valueText };
 }
-
-// Unit-test re-exports.
-export { sanitizeKey, disambiguateLabels, tokensToSlugs, describePreview };

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -19,6 +19,16 @@
 			"type": "array",
 			"default": [ "query", "taxonomy", "post" ],
 			"items": { "type": "string", "enum": [ "query", "taxonomy", "post" ] }
+		},
+		"postTypeMode": {
+			"type": "string",
+			"enum": [ "include", "exclude" ],
+			"default": "exclude"
+		},
+		"postTypes": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "string" }
 		}
 	},
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import PostTypeScopeControl from '../../editor/post-type-control';
 
 // Mirrors the enum on `block.json::attributes.suggestionTypes.items.enum`
 // and the canonical order rendered by `suggestion-rows.js::TYPE_ORDER`.
@@ -200,6 +201,21 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 							</p>
 						</fieldset>
 					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Post types', 'jetpack-search-pkg' ) } initialOpen={ false }>
+					<p className="components-base-control__help" style={ HELP_STYLE }>
+						{ __(
+							'Limit which post types this search returns. Leave the list empty to search everything.',
+							'jetpack-search-pkg'
+						) }
+					</p>
+					<PostTypeScopeControl
+						mode={ attributes?.postTypeMode }
+						postTypes={ attributes?.postTypes }
+						onChange={ ( { mode: postTypeMode, postTypes } ) =>
+							setAttributes( { postTypeMode, postTypes } )
+						}
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -209,6 +209,10 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 							'jetpack-search-pkg'
 						) }
 					</p>
+					{ /* The mode is stored as `postTypeMode` (not `mode`, which the
+						   standalone filter-post-type block uses) to avoid colliding
+						   with any future generic `mode` attribute on this block. The
+						   shared control only ever sees it as the neutral `mode` prop. */ }
 					<PostTypeScopeControl
 						mode={ attributes?.postTypeMode }
 						postTypes={ attributes?.postTypes }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -51,33 +51,52 @@ $input_id      = wp_unique_id( 'jetpack-search-input-' );
 // DOM ids. Only generated (and only emitted) when suggestions are on, to
 // keep the default DOM untouched for authors who haven't opted in.
 $listbox_id = $enable_suggestions ? wp_unique_id( 'jetpack-search-suggestions-' ) : '';
+// Per-instance post-type scope. Reusing `Filter_Post_Type::build_constraint()`
+// keeps slug sanitization + the live-post-type allowlist identical to the
+// standalone `jetpack-search/filter-post-type` block. Carried in this block's
+// own `data-wp-context` (not the shared store) so each Search Input only
+// constrains the searches it initiates — view.js hands the scope to
+// `actions.search()`, which overrides the page-global `state.staticPostTypes`
+// for that input while an unscoped input falls back to it.
+$post_type_scope     = Filter_Post_Type::build_constraint(
+	array(
+		'mode'      => ( $attributes['postTypeMode'] ?? 'exclude' ) === 'include' ? 'include' : 'exclude',
+		'postTypes' => $attributes['postTypes'] ?? array(),
+	)
+);
+$has_post_type_scope = ! empty( $post_type_scope['include'] ) || ! empty( $post_type_scope['exclude'] );
 // `data-wp-context` seeds the per-instance Interactivity state. Keeping it
 // per-block (rather than on the shared `jetpack-search` store) means a
 // header + sidebar Search Input on the same page never share a dropdown's
 // `showSuggestions` / `activeIndex` — each instance owns its own UI state
 // while still pulling the query from the shared `state.searchQuery`.
-$context_json = $enable_suggestions
-	? wp_json_encode(
-		array(
-			'showSuggestions' => false,
-			'activeIndex'     => -1,
-			'activeOptionId'  => '',
-			'rows'            => array(),
-			'listboxId'       => $listbox_id,
-			// `suggestionTypes` is seeded so the view bundle can filter
-			// rows client-side without re-reading the block attribute via
-			// a roundtrip. Per-instance because two Search Input blocks
-			// on the same page could pick different shapes.
-			'suggestionTypes' => $suggestion_types,
-		),
-		JSON_HEX_AMP | JSON_UNESCAPED_SLASHES
-	)
+$context = array();
+if ( $enable_suggestions ) {
+	$context = array(
+		'showSuggestions' => false,
+		'activeIndex'     => -1,
+		'activeOptionId'  => '',
+		'rows'            => array(),
+		'listboxId'       => $listbox_id,
+		// `suggestionTypes` is seeded so the view bundle can filter
+		// rows client-side without re-reading the block attribute via
+		// a roundtrip. Per-instance because two Search Input blocks
+		// on the same page could pick different shapes.
+		'suggestionTypes' => $suggestion_types,
+	);
+}
+if ( $has_post_type_scope ) {
+	$context['staticPostTypes'] = $post_type_scope;
+}
+$emit_context = ! empty( $context );
+$context_json = $emit_context
+	? wp_json_encode( $context, JSON_HEX_AMP | JSON_UNESCAPED_SLASHES )
 	: '';
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	<?php if ( $enable_suggestions ) : ?>
+	<?php if ( $emit_context ) : ?>
 	data-wp-context='<?php echo esc_attr( $context_json ); ?>'
 	<?php endif; ?>
 >

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -1,4 +1,4 @@
-import { store } from '@wordpress/interactivity';
+import { store, getContext } from '@wordpress/interactivity';
 import 'jetpack-search/store';
 import {
 	clearSuggestionsContext,
@@ -19,15 +19,32 @@ const debounceTimers = new WeakMap();
 /**
  * Start (or restart) the debounced search for a single input.
  *
- * @param {HTMLInputElement} input - The input whose timer should be reset.
+ * `staticPostTypes` is captured synchronously by the caller (the debounce fires
+ * outside the Interactivity element context, where `getContext()` is no longer
+ * available) and handed to `actions.search()` so this input's post-type scope
+ * overrides the page-global one for the search it initiates.
+ *
+ * @param {HTMLInputElement}                            input           - The input whose timer should be reset.
+ * @param {{include: string[], exclude: string[]}|null} staticPostTypes - This input's scope, or null.
  */
-function scheduleSearch( input ) {
+function scheduleSearch( input, staticPostTypes ) {
 	clearTimeout( debounceTimers.get( input ) );
 	const timer = setTimeout( () => {
 		debounceTimers.delete( input );
-		store( NAMESPACE ).actions.search();
+		store( NAMESPACE ).actions.search( { staticPostTypes } );
 	}, SEARCH_DEBOUNCE_MS );
 	debounceTimers.set( input, timer );
+}
+
+/**
+ * Read the post-type scope seeded into this input's `data-wp-context`. Returns
+ * null when the input has no scope so `actions.search()` clears any scope a
+ * previously-used input left active and falls back to the page-global seed.
+ *
+ * @return {{include: string[], exclude: string[]}|null} The scope, or null.
+ */
+function readPostTypeScope() {
+	return getContext()?.staticPostTypes ?? null;
 }
 
 /**
@@ -46,6 +63,9 @@ store( NAMESPACE, {
 		onSearchInput( event ) {
 			const { state } = store( NAMESPACE );
 			state.searchQuery = event.target.value;
+			// Captured here (synchronously, inside the element context) so the
+			// debounced fire can apply this input's post-type scope.
+			const staticPostTypes = readPostTypeScope();
 			// `submitOnly` inputs still keep `state.searchQuery` in sync so
 			// bindings render the typed value, but defer the actual API call
 			// until Enter / the clear button — useful for sites that want
@@ -53,7 +73,7 @@ store( NAMESPACE, {
 			if ( event.target.dataset.submitOnly === 'true' ) {
 				cancelPendingSearch( event.target );
 			} else {
-				scheduleSearch( event.target );
+				scheduleSearch( event.target, staticPostTypes );
 			}
 			// Delegated to ./suggestions.js — short-circuits on non-suggestions
 			// inputs, so this stays a single unconditional call.
@@ -70,7 +90,7 @@ store( NAMESPACE, {
 			}
 			if ( event.key === 'Enter' ) {
 				cancelPendingSearch( event.target );
-				store( NAMESPACE ).actions.search();
+				store( NAMESPACE ).actions.search( { staticPostTypes: readPostTypeScope() } );
 			}
 		},
 
@@ -83,7 +103,10 @@ store( NAMESPACE, {
 			const { state, actions } = store( NAMESPACE );
 			state.searchQuery = '';
 			clearSuggestionsContext();
-			yield actions.search();
+			// Read the scope before the first yield — `getContext()` needs the
+			// synchronous element context the clear button runs in.
+			const staticPostTypes = readPostTypeScope();
+			yield actions.search( { staticPostTypes } );
 		},
 	},
 } );

--- a/projects/packages/search/src/search-blocks/class-filter-post-type.php
+++ b/projects/packages/search/src/search-blocks/class-filter-post-type.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Filter-post-type block helpers.
+ * Post-type scope helpers shared by the search blocks.
  *
  * @package automattic/jetpack-search
  */
@@ -8,11 +8,13 @@
 namespace Automattic\Jetpack\Search;
 
 /**
- * Server-side helpers for jetpack-search/filter-post-type.
+ * Server-side post-type scope helpers.
  *
- * Single-mode block (`include` OR `exclude`); the helper translates the
- * `{ mode, postTypes }` attributes into the `{ include, exclude }` shape
- * `store/api.js`'s `buildStaticPostTypeClauses()` consumes.
+ * Shared by the standalone `jetpack-search/filter-post-type` block and the
+ * `jetpack-search/search-input` block's post-type setting. Single-mode
+ * (`include` OR `exclude`); translates the `{ mode, postTypes }` attributes
+ * into the `{ include, exclude }` shape `store/api.js`'s
+ * `buildStaticPostTypeClauses()` consumes.
  */
 class Filter_Post_Type {
 

--- a/projects/packages/search/src/search-blocks/editor/post-type-control.js
+++ b/projects/packages/search/src/search-blocks/editor/post-type-control.js
@@ -203,7 +203,13 @@ export default function PostTypeScopeControl( { mode, postTypes, onChange } ) {
 				label={
 					activeMode === MODE_INCLUDE
 						? __( 'Post types to include', 'jetpack-search-pkg' )
-						: __( 'Post types to exclude', 'jetpack-search-pkg' )
+						: __(
+								'Post types to exclude',
+								'jetpack-search-pkg',
+								/* dummy arg so the minifier can't fold both branches into
+								   `__( cond ? a : b )` — that yields a non-literal msgid and
+								   fails the production i18n-string check. */ 0
+						  )
 				}
 				value={ toTokens( slugs, labelBySlug ) }
 				suggestions={ suggestionList }

--- a/projects/packages/search/src/search-blocks/editor/post-type-control.js
+++ b/projects/packages/search/src/search-blocks/editor/post-type-control.js
@@ -1,0 +1,216 @@
+/**
+ * Shared post-type scope control for the editor.
+ *
+ * Renders the mode toggle (include / exclude) plus a slug picker, and owns the
+ * slug normalization, label disambiguation, and per-mode draft cache. Consumed
+ * by both the standalone `jetpack-search/filter-post-type` block and the
+ * `jetpack-search/search-input` block's "Post types" inspector panel so the two
+ * surfaces stay byte-for-byte consistent on what they store.
+ */
+import { FormTokenField, RadioControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export const MODE_INCLUDE = 'include';
+export const MODE_EXCLUDE = 'exclude';
+
+/**
+ * `sanitize_key()` (PHP) approximation: lowercase + strip everything that
+ * is not `[a-z0-9_-]`. Mirrors the server normalizer so editor-stored
+ * attributes match what eventually reaches ES.
+ *
+ * @param {string} value - Raw token string.
+ * @return {string} Sanitized slug.
+ */
+export function sanitizeKey( value ) {
+	return String( value || '' )
+		.toLowerCase()
+		.replace( /[^a-z0-9_-]+/g, '' );
+}
+
+/**
+ * Append `(slug)` to any label that occurs more than once so each suggestion
+ * label maps 1:1 to a slug — without this the FormTokenField label→slug
+ * lookup picks an arbitrary winner when two CPTs share a `singular_name`.
+ *
+ * @param {Array<{value: string, label: string}>} options - Raw slug/label list.
+ * @return {Array<{value: string, label: string}>} Disambiguated.
+ */
+export function disambiguateLabels( options ) {
+	const counts = new Map();
+	for ( const { label } of options ) {
+		counts.set( label, ( counts.get( label ) || 0 ) + 1 );
+	}
+	return options.map( opt =>
+		counts.get( opt.label ) > 1 ? { ...opt, label: `${ opt.label } (${ opt.value })` } : opt
+	);
+}
+
+/**
+ * Map slugs to FormTokenField's `{value, title}` shape.
+ *
+ * @param {string[]} slugs       - Stored slug list.
+ * @param {Map}      labelBySlug - slug → label.
+ * @return {Array<{ value: string, title: string }>} Token shape.
+ */
+export function toTokens( slugs, labelBySlug ) {
+	return ( slugs || [] ).map( slug => ( {
+		value: slug,
+		title: labelBySlug.get( slug ) || slug,
+	} ) );
+}
+
+/**
+ * Reverse `disambiguateLabels()`: a picked-suggestion label resolves back
+ * to its slug.
+ *
+ * @param {string} token   - Token from FormTokenField.
+ * @param {Array}  options - { value, label } option list.
+ * @return {string} Slug, or the original token (free-typed input is
+ * sanitized later in `tokensToSlugs`).
+ */
+export function labelFromTokenString( token, options ) {
+	if ( ! Array.isArray( options ) ) {
+		return token;
+	}
+	const match = options.find( option => option.label === token || option.value === token );
+	return match ? match.value : token;
+}
+
+/**
+ * Convert FormTokenField output back to a sanitized, deduped slug list.
+ * Free-typed values pass through `sanitizeKey` so editor and server agree.
+ *
+ * @param {Array<string|{value: string}>}         tokens  - Tokens from onChange.
+ * @param {Array<{value: string, label: string}>} options - Resolved options for label→slug lookup.
+ * @return {string[]} Sanitized slugs.
+ */
+export function tokensToSlugs( tokens, options ) {
+	const out = [];
+	for ( const token of tokens || [] ) {
+		const raw = typeof token === 'string' ? labelFromTokenString( token, options ) : token?.value;
+		const slug = sanitizeKey( raw );
+		if ( slug && ! out.includes( slug ) ) {
+			out.push( slug );
+		}
+	}
+	return out;
+}
+
+/**
+ * Post-type scope control: a mode toggle plus a slug picker.
+ *
+ * Stateless on the outside — `mode` / `postTypes` come in as props and every
+ * edit flows back through `onChange({ mode, postTypes })`. The per-mode draft
+ * cache (so flipping back to a previously-used mode restores its typed list)
+ * lives here because it's a UX property of the control, not of either host
+ * block's attribute shape.
+ *
+ * @param {object}   props           - Control props.
+ * @param {string}   props.mode      - 'include' | 'exclude'.
+ * @param {string[]} props.postTypes - Selected slug list for the active mode.
+ * @param {Function} props.onChange  - Called with `{ mode, postTypes }` on any edit.
+ * @return {object} Rendered element.
+ */
+export default function PostTypeScopeControl( { mode, postTypes, onChange } ) {
+	const activeMode = mode === MODE_INCLUDE ? MODE_INCLUDE : MODE_EXCLUDE;
+	const slugs = useMemo( () => ( Array.isArray( postTypes ) ? postTypes : [] ), [ postTypes ] );
+
+	// `viewable !== false` filter is a UX nicety; the canonical allowlist
+	// (`exclude_from_search => false`) is enforced server-side because the
+	// REST endpoint does not expose that flag.
+	const registeredTypes = useSelect(
+		select => select( 'core' ).getPostTypes( { per_page: -1 } ),
+		[]
+	);
+
+	const options = useMemo( () => {
+		if ( ! Array.isArray( registeredTypes ) ) {
+			return null;
+		}
+		return disambiguateLabels(
+			registeredTypes
+				.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
+				.map( type => ( {
+					value: type.slug,
+					label: type?.labels?.singular_name || type?.name || type.slug,
+				} ) )
+		);
+	}, [ registeredTypes ] );
+
+	const labelBySlug = useMemo( () => {
+		const map = new Map();
+		( options || [] ).forEach( option => map.set( option.value, option.label ) );
+		return map;
+	}, [ options ] );
+
+	const suggestionList = useMemo(
+		() => ( options || [] ).map( option => option.label ),
+		[ options ]
+	);
+
+	// Per-mode draft cache. Flipping back to a previously-used mode restores
+	// the typed list; only the active mode's selection is persisted upstream.
+	const draftRef = useRef( null );
+	if ( draftRef.current === null ) {
+		draftRef.current = {
+			[ MODE_INCLUDE ]: activeMode === MODE_INCLUDE ? slugs : [],
+			[ MODE_EXCLUDE ]: activeMode === MODE_EXCLUDE ? slugs : [],
+		};
+	}
+
+	const handleModeChange = nextMode => {
+		if ( nextMode === activeMode ) {
+			return;
+		}
+		draftRef.current = { ...draftRef.current, [ activeMode ]: slugs };
+		onChange( { mode: nextMode, postTypes: draftRef.current[ nextMode ] || [] } );
+	};
+
+	const handlePostTypesChange = tokens => {
+		const nextSlugs = tokensToSlugs( tokens, options );
+		draftRef.current = { ...draftRef.current, [ activeMode ]: nextSlugs };
+		onChange( { mode: activeMode, postTypes: nextSlugs } );
+	};
+
+	return (
+		<>
+			<RadioControl
+				label={ __( 'Mode', 'jetpack-search-pkg' ) }
+				selected={ activeMode }
+				options={ [
+					{
+						label: __(
+							'Exclude — remove the selected post types from results',
+							'jetpack-search-pkg'
+						),
+						value: MODE_EXCLUDE,
+					},
+					{
+						label: __(
+							'Include only — search will return only the selected post types',
+							'jetpack-search-pkg'
+						),
+						value: MODE_INCLUDE,
+					},
+				] }
+				onChange={ handleModeChange }
+			/>
+			<FormTokenField
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={
+					activeMode === MODE_INCLUDE
+						? __( 'Post types to include', 'jetpack-search-pkg' )
+						: __( 'Post types to exclude', 'jetpack-search-pkg' )
+				}
+				value={ toTokens( slugs, labelBySlug ) }
+				suggestions={ suggestionList }
+				__experimentalExpandOnFocus
+				__experimentalShowHowTo={ false }
+				onChange={ handlePostTypesChange }
+			/>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -521,6 +521,15 @@ function dateFilterItems( sharedState, filterKey, config ) {
 // can't overwrite fresh results when the user changes query or sort mid-fetch.
 let searchToken = 0;
 
+// Per-instance post-type scope of the Search Input that initiated the current
+// search session. Set by `actions.search()` whenever an input dispatches (an
+// object when that input is scoped, `null` when it isn't); filter / sort /
+// load-more re-runs leave it untouched so the session keeps the active scope.
+// `undefined` (initial) and `null` both fall through to the page-global
+// `state.staticPostTypes` seed in `fetchResults`, so an unscoped input never
+// clobbers a `jetpack-search/filter-post-type` block's contribution.
+let activePostTypeScope;
+
 /**
  * Build the human-readable results-count string from the live store state.
  * Returns "Searching…" while a search is in flight, "Found 42 results" once
@@ -580,7 +589,10 @@ function* fetchResults( pageHandle ) {
 		filterConfigs: overlayFilterLogic( state.filterConfigs, state.filterLogic ),
 		priceRange: state.priceRange,
 		staticFilterSelections: state.staticFilterSelections,
-		staticPostTypes: state.staticPostTypes,
+		// The active input's per-instance scope wins over the page-global
+		// `state.staticPostTypes` seed; falls through to the seed when no scoped
+		// input has dispatched (`activePostTypeScope` undefined or null).
+		staticPostTypes: activePostTypeScope ?? state.staticPostTypes,
 	} );
 	const response = yield fetch( url, {
 		headers: state.isPrivateSite ? { 'X-WP-Nonce': state.nonce } : {},
@@ -1012,18 +1024,33 @@ const { state, actions } = store( NAMESPACE, {
 		/**
 		 * Run a search and replace the result list.
 		 *
-		 * @param {object}  [options]         - Options.
-		 * @param {boolean} [options.syncUrl] - Push new state to the URL after a
-		 *                                    successful fetch. Default `true`;
-		 *                                    pass `false` when the search was
-		 *                                    itself triggered by a URL change
-		 *                                    (e.g. `popstate`) so we don't
-		 *                                    bounce a new history entry back
-		 *                                    on top of the one the browser
-		 *                                    just navigated to.
+		 * @param {object}      [options]                 - Options.
+		 * @param {boolean}     [options.syncUrl]         - Push new state to the URL after a
+		 *                                                successful fetch. Default `true`;
+		 *                                                pass `false` when the search was
+		 *                                                itself triggered by a URL change
+		 *                                                (e.g. `popstate`) so we don't
+		 *                                                bounce a new history entry back
+		 *                                                on top of the one the browser
+		 *                                                just navigated to.
+		 * @param {object|null} [options.staticPostTypes] - The initiating Search Input's
+		 *                                                per-instance post-type scope
+		 *                                                (`{ include, exclude }`), or `null`
+		 *                                                for an unscoped input. Present only
+		 *                                                on input-initiated searches; persisted
+		 *                                                as the session's active scope. Re-runs
+		 *                                                from filters / sort / load-more omit
+		 *                                                the key so the active scope survives.
 		 * @yield {Promise} fetch + response.json() promises.
 		 */
-		*search( { syncUrl = true } = {} ) {
+		*search( options = {} ) {
+			const { syncUrl = true } = options;
+			// Persist the initiating input's scope (object or null) so subsequent
+			// non-input re-runs reuse it. Omitting the key (every non-input caller)
+			// leaves the active scope untouched.
+			if ( 'staticPostTypes' in options ) {
+				activePostTypeScope = options.staticPostTypes ?? null;
+			}
 			const myToken = ++searchToken;
 			state.isLoading = true;
 			state.isLoadingMore = false;

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -531,6 +531,16 @@ let searchToken = 0;
 let activePostTypeScope;
 
 /**
+ * Reset the module-level active post-type scope. Tests only — the `beforeEach`
+ * in `store.test.js` can reset `state`/`actions` but not this module variable,
+ * so it would otherwise leak across cases (mirrors the Reflection reset of
+ * `Filter_Post_Type::$searchable_cache` on the PHP side).
+ */
+export function resetActivePostTypeScopeForTesting() {
+	activePostTypeScope = undefined;
+}
+
+/**
  * Build the human-readable results-count string from the live store state.
  * Returns "Searching…" while a search is in flight, "Found 42 results" once
  * a query resolves with hits, or an empty string in every other case
@@ -1343,6 +1353,11 @@ const { state, actions } = store( NAMESPACE, {
 				staticFilterSelections,
 				state.filterConfigs
 			).gated;
+			// No `staticPostTypes` key: a back/forward restore reuses the active
+			// per-instance scope from the last input interaction rather than the
+			// URL, because that scope is session-local and never serialized — a
+			// fresh load of the same URL won't carry it. Accepted trade-off of
+			// per-instance (vs. URL-round-tripped) scope.
 			yield actions.search( { syncUrl: false } );
 		},
 

--- a/projects/packages/search/tests/js/search-blocks/filter-post-type-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-post-type-edit.test.js
@@ -1,99 +1,11 @@
 /**
- * Editor-only helpers for jetpack-search/filter-post-type.
+ * Canvas-preview helper for jetpack-search/filter-post-type.
  *
- * Single-mode UX: the block carries one `mode` ('include'|'exclude') plus
- * one `postTypes` slug list, never both lists at once. The editor's
- * algorithmic surface (slug normalization, label disambiguation, preview
- * copy) is unit-tested here; component-level rendering follows the same
- * approach the rest of the package uses (no React-Testing-Library mounts).
+ * The slug/label algorithmic surface lives in the shared post-type control
+ * (`post-type-control.test.js`); this file covers the block's own
+ * frontend-invisible canvas preview copy.
  */
-import {
-	sanitizeKey,
-	disambiguateLabels,
-	tokensToSlugs,
-	describePreview,
-} from '../../../src/search-blocks/blocks/filter-post-type/edit';
-
-describe( 'sanitizeKey', () => {
-	it( 'lowercases and strips disallowed characters', () => {
-		expect( sanitizeKey( 'Post' ) ).toBe( 'post' );
-		expect( sanitizeKey( 'My Custom Type' ) ).toBe( 'mycustomtype' );
-	} );
-
-	it( 'preserves underscores and hyphens (PHP sanitize_key allows both)', () => {
-		expect( sanitizeKey( 'shop_order' ) ).toBe( 'shop_order' );
-		expect( sanitizeKey( 'jetpack-portfolio' ) ).toBe( 'jetpack-portfolio' );
-	} );
-
-	it( 'returns an empty string for null / undefined / non-string input', () => {
-		expect( sanitizeKey( null ) ).toBe( '' );
-		expect( sanitizeKey( undefined ) ).toBe( '' );
-		expect( sanitizeKey( '' ) ).toBe( '' );
-	} );
-} );
-
-describe( 'disambiguateLabels', () => {
-	it( 'leaves unique labels untouched', () => {
-		const opts = [
-			{ value: 'post', label: 'Post' },
-			{ value: 'page', label: 'Page' },
-		];
-		expect( disambiguateLabels( opts ) ).toEqual( opts );
-	} );
-
-	it( 'appends the slug to every collision so labels round-trip 1:1 to slugs', () => {
-		const opts = [
-			{ value: 'jetpack-portfolio', label: 'Portfolio' },
-			{ value: 'custom-portfolio', label: 'Portfolio' },
-			{ value: 'page', label: 'Page' },
-		];
-		expect( disambiguateLabels( opts ) ).toEqual( [
-			{ value: 'jetpack-portfolio', label: 'Portfolio (jetpack-portfolio)' },
-			{ value: 'custom-portfolio', label: 'Portfolio (custom-portfolio)' },
-			{ value: 'page', label: 'Page' },
-		] );
-	} );
-} );
-
-describe( 'tokensToSlugs', () => {
-	const options = [
-		{ value: 'post', label: 'Post' },
-		{ value: 'page', label: 'Page' },
-		{ value: 'jetpack-portfolio', label: 'Portfolio (jetpack-portfolio)' },
-	];
-
-	it( 'resolves picked-suggestion labels back to their slugs', () => {
-		expect( tokensToSlugs( [ 'Post', 'Portfolio (jetpack-portfolio)' ], options ) ).toEqual( [
-			'post',
-			'jetpack-portfolio',
-		] );
-	} );
-
-	it( 'sanitize_key-normalizes free-typed strings', () => {
-		expect( tokensToSlugs( [ 'My Custom Type' ], options ) ).toEqual( [ 'mycustomtype' ] );
-	} );
-
-	it( 'collapses case-different free-typed values to the same slug', () => {
-		expect( tokensToSlugs( [ 'Post', 'post' ], options ) ).toEqual( [ 'post' ] );
-	} );
-
-	it( 'accepts the {value, title} object shape we emit from toTokens', () => {
-		expect(
-			tokensToSlugs(
-				[
-					{ value: 'post', title: 'Post' },
-					{ value: 'page', title: 'Page' },
-				],
-				options
-			)
-		).toEqual( [ 'post', 'page' ] );
-	} );
-
-	it( 'returns an empty list for null / undefined input', () => {
-		expect( tokensToSlugs( null, options ) ).toEqual( [] );
-		expect( tokensToSlugs( undefined, options ) ).toEqual( [] );
-	} );
-} );
+import { describePreview } from '../../../src/search-blocks/blocks/filter-post-type/edit';
 
 describe( 'describePreview', () => {
 	const labelBySlug = new Map( [
@@ -131,9 +43,9 @@ describe( 'describePreview', () => {
 	} );
 
 	it( 'falls back to the raw slug when the type is not yet loaded', () => {
-		// Simulates the brief window where core-data has not resolved
-		// `getPostTypes()` yet — the picker shows raw slugs as token
-		// titles, and the preview should match.
+		// Simulates the brief window before core-data resolves `getPostTypes()`
+		// — the picker shows raw slugs as token titles, and the preview should
+		// match.
 		expect( describePreview( 'exclude', [ 'unknown-cpt' ], new Map() ) ).toEqual( {
 			label: 'Exclude:',
 			value: 'unknown-cpt',

--- a/projects/packages/search/tests/js/search-blocks/post-type-control.test.js
+++ b/projects/packages/search/tests/js/search-blocks/post-type-control.test.js
@@ -1,0 +1,94 @@
+/**
+ * Shared post-type scope control helpers.
+ *
+ * The control's algorithmic surface (slug normalization, label
+ * disambiguation, token→slug resolution) is unit-tested here; it's consumed by
+ * both the `jetpack-search/filter-post-type` block and the
+ * `jetpack-search/search-input` block's post-type setting.
+ */
+import {
+	sanitizeKey,
+	disambiguateLabels,
+	tokensToSlugs,
+} from '../../../src/search-blocks/editor/post-type-control';
+
+describe( 'sanitizeKey', () => {
+	it( 'lowercases and strips disallowed characters', () => {
+		expect( sanitizeKey( 'Post' ) ).toBe( 'post' );
+		expect( sanitizeKey( 'My Custom Type' ) ).toBe( 'mycustomtype' );
+	} );
+
+	it( 'preserves underscores and hyphens (PHP sanitize_key allows both)', () => {
+		expect( sanitizeKey( 'shop_order' ) ).toBe( 'shop_order' );
+		expect( sanitizeKey( 'jetpack-portfolio' ) ).toBe( 'jetpack-portfolio' );
+	} );
+
+	it( 'returns an empty string for null / undefined / non-string input', () => {
+		expect( sanitizeKey( null ) ).toBe( '' );
+		expect( sanitizeKey( undefined ) ).toBe( '' );
+		expect( sanitizeKey( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'disambiguateLabels', () => {
+	it( 'leaves unique labels untouched', () => {
+		const opts = [
+			{ value: 'post', label: 'Post' },
+			{ value: 'page', label: 'Page' },
+		];
+		expect( disambiguateLabels( opts ) ).toEqual( opts );
+	} );
+
+	it( 'appends the slug to every collision so labels round-trip 1:1 to slugs', () => {
+		const opts = [
+			{ value: 'jetpack-portfolio', label: 'Portfolio' },
+			{ value: 'custom-portfolio', label: 'Portfolio' },
+			{ value: 'page', label: 'Page' },
+		];
+		expect( disambiguateLabels( opts ) ).toEqual( [
+			{ value: 'jetpack-portfolio', label: 'Portfolio (jetpack-portfolio)' },
+			{ value: 'custom-portfolio', label: 'Portfolio (custom-portfolio)' },
+			{ value: 'page', label: 'Page' },
+		] );
+	} );
+} );
+
+describe( 'tokensToSlugs', () => {
+	const options = [
+		{ value: 'post', label: 'Post' },
+		{ value: 'page', label: 'Page' },
+		{ value: 'jetpack-portfolio', label: 'Portfolio (jetpack-portfolio)' },
+	];
+
+	it( 'resolves picked-suggestion labels back to their slugs', () => {
+		expect( tokensToSlugs( [ 'Post', 'Portfolio (jetpack-portfolio)' ], options ) ).toEqual( [
+			'post',
+			'jetpack-portfolio',
+		] );
+	} );
+
+	it( 'sanitize_key-normalizes free-typed strings', () => {
+		expect( tokensToSlugs( [ 'My Custom Type' ], options ) ).toEqual( [ 'mycustomtype' ] );
+	} );
+
+	it( 'collapses case-different free-typed values to the same slug', () => {
+		expect( tokensToSlugs( [ 'Post', 'post' ], options ) ).toEqual( [ 'post' ] );
+	} );
+
+	it( 'accepts the {value, title} object shape we emit from toTokens', () => {
+		expect(
+			tokensToSlugs(
+				[
+					{ value: 'post', title: 'Post' },
+					{ value: 'page', title: 'Page' },
+				],
+				options
+			)
+		).toEqual( [ 'post', 'page' ] );
+	} );
+
+	it( 'returns an empty list for null / undefined input', () => {
+		expect( tokensToSlugs( null, options ) ).toEqual( [] );
+		expect( tokensToSlugs( undefined, options ) ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/search-input-block-json.test.js
+++ b/projects/packages/search/tests/js/search-blocks/search-input-block-json.test.js
@@ -12,4 +12,18 @@ describe( 'search-input block.json', () => {
 		expect( attrs.showIcon ).toEqual( { type: 'boolean', default: true } );
 		expect( attrs.submitOnly ).toEqual( { type: 'boolean', default: false } );
 	} );
+
+	it( 'declares the post-type scope attributes with exclude-by-default semantics', () => {
+		const attrs = blockJson.attributes;
+		expect( attrs.postTypeMode ).toEqual( {
+			type: 'string',
+			enum: [ 'include', 'exclude' ],
+			default: 'exclude',
+		} );
+		expect( attrs.postTypes ).toEqual( {
+			type: 'array',
+			default: [],
+			items: { type: 'string' },
+		} );
+	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -36,6 +36,7 @@ import {
 	gateActiveFilters,
 	gateStaticFilterSelections,
 	remapAggregationsToFilterKeys,
+	resetActivePostTypeScopeForTesting,
 	state,
 } from '../../../src/search-blocks/store';
 import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
@@ -134,6 +135,9 @@ describe( 'store helpers round-trip', () => {
 describe( 'store actions', () => {
 	beforeEach( () => {
 		Object.assign( actions, originalActions );
+		// The active per-instance scope lives in a module variable the state
+		// reset below can't reach, so clear it explicitly to keep cases isolated.
+		resetActivePostTypeScopeForTesting();
 		Object.assign( state, {
 			siteId: 123,
 			searchQuery: 'old query',
@@ -238,6 +242,21 @@ describe( 'store actions', () => {
 		const decoded = decodeURIComponent( global.fetch.mock.calls[ 2 ][ 0 ] );
 		expect( decoded ).toContain( 'filter[bool][must][0][term][post_type]=page' );
 		expect( decoded ).not.toContain( '[post_type]=post&' );
+	} );
+
+	it( 'reuses the active per-instance scope on popstate (omits the scope key)', async () => {
+		// A back/forward restore re-runs search without a `staticPostTypes` key
+		// so the session-local scope from the last input survives — the scope is
+		// never serialized to the URL, so passing one here would be wrong.
+		state.searchParamName = 's';
+		state.isWooCommerceBlocksEnabled = false;
+		const searchSpy = jest.spyOn( actions, 'search' ).mockImplementation( function* () {} );
+		await runGenerator( actions.handlePopState() );
+		expect( searchSpy ).toHaveBeenCalledTimes( 1 );
+		const arg = searchSpy.mock.calls[ 0 ][ 0 ];
+		expect( arg ).toEqual( { syncUrl: false } );
+		expect( 'staticPostTypes' in arg ).toBe( false );
+		searchSpy.mockRestore();
 	} );
 
 	it( 'sets hasError on a failed loadMore and clears it on the next loadMore', async () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -147,6 +147,7 @@ describe( 'store actions', () => {
 			filterConfigs: {},
 			priceRange: null,
 			staticFilterSelections: {},
+			staticPostTypes: undefined,
 			results: [ { title: 'Existing result' } ],
 			locale: 'en-US',
 			isLoading: false,
@@ -205,6 +206,38 @@ describe( 'store actions', () => {
 		expect( state.skeletonHidden ).toBe( true );
 		expect( state.hasError ).toBe( true );
 		expect( state.isLoading ).toBe( false );
+	} );
+
+	it( 'applies a per-instance post-type scope, reuses it across re-runs, and falls back to the global seed for an unscoped input', async () => {
+		const ok = () =>
+			createResponse( { results: [], total: 0, page_handle: null, aggregations: {} } );
+
+		// 1. A scoped Search Input dispatches — its include list constrains the
+		//    ES filter clause for the search it initiates.
+		global.fetch.mockResolvedValueOnce( ok() );
+		await runGenerator(
+			actions.search( { syncUrl: false, staticPostTypes: { include: [ 'post' ], exclude: [] } } )
+		);
+		expect( decodeURIComponent( global.fetch.mock.calls[ 0 ][ 0 ] ) ).toContain(
+			'filter[bool][must][0][term][post_type]=post'
+		);
+
+		// 2. A filter / sort re-run omits the scope key, so the session keeps the
+		//    active scope rather than dropping the constraint.
+		global.fetch.mockResolvedValueOnce( ok() );
+		await runGenerator( actions.search( { syncUrl: false } ) );
+		expect( decodeURIComponent( global.fetch.mock.calls[ 1 ][ 0 ] ) ).toContain(
+			'filter[bool][must][0][term][post_type]=post'
+		);
+
+		// 3. An unscoped input passes null, clearing the active scope and falling
+		//    back to the page-global seed a filter-post-type block contributed.
+		state.staticPostTypes = { include: [ 'page' ], exclude: [] };
+		global.fetch.mockResolvedValueOnce( ok() );
+		await runGenerator( actions.search( { syncUrl: false, staticPostTypes: null } ) );
+		const decoded = decodeURIComponent( global.fetch.mock.calls[ 2 ][ 0 ] );
+		expect( decoded ).toContain( 'filter[bool][must][0][term][post_type]=page' );
+		expect( decoded ).not.toContain( '[post_type]=post&' );
 	} );
 
 	it( 'sets hasError on a failed loadMore and clears it on the next loadMore', async () => {

--- a/projects/packages/search/tests/php/Search_Input_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Input_Render_Test.php
@@ -31,17 +31,25 @@ class Search_Input_Render_Test extends TestCase {
 			'jetpack-search/search-input',
 			array(
 				'attributes'      => array(
-					'placeholder' => array(
+					'placeholder'  => array(
 						'type'    => 'string',
 						'default' => '',
 					),
-					'showIcon'    => array(
+					'showIcon'     => array(
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'submitOnly'  => array(
+					'submitOnly'   => array(
 						'type'    => 'boolean',
 						'default' => false,
+					),
+					'postTypeMode' => array(
+						'type'    => 'string',
+						'default' => 'exclude',
+					),
+					'postTypes'    => array(
+						'type'    => 'array',
+						'default' => array(),
 					),
 				),
 				// $attributes is consumed by the included render.php via the
@@ -148,5 +156,68 @@ class Search_Input_Render_Test extends TestCase {
 	public function test_submit_only_default_omits_data_attribute() {
 		$markup = $this->render();
 		$this->assertStringNotContainsString( 'data-submit-only', $markup );
+	}
+
+	/**
+	 * An include scope must seed the per-instance `staticPostTypes` constraint
+	 * into this block's own `data-wp-context` so view.js can hand it to
+	 * `actions.search()` for the searches this input initiates.
+	 */
+	public function test_post_type_include_scope_emits_context() {
+		$markup  = $this->render(
+			array(
+				'postTypeMode' => 'include',
+				'postTypes'    => array( 'post' ),
+			)
+		);
+		$decoded = html_entity_decode( $markup );
+		$this->assertStringContainsString( 'data-wp-context', $markup );
+		$this->assertStringContainsString(
+			'"staticPostTypes":{"include":["post"],"exclude":[]}',
+			$decoded
+		);
+	}
+
+	/**
+	 * An exclude scope must seed the same constraint shape with the slug in the
+	 * exclude list.
+	 */
+	public function test_post_type_exclude_scope_emits_context() {
+		$markup  = $this->render(
+			array(
+				'postTypeMode' => 'exclude',
+				'postTypes'    => array( 'page' ),
+			)
+		);
+		$decoded = html_entity_decode( $markup );
+		$this->assertStringContainsString(
+			'"staticPostTypes":{"include":[],"exclude":["page"]}',
+			$decoded
+		);
+	}
+
+	/**
+	 * With no scope (and no suggestions) the block must not emit a
+	 * `data-wp-context` attribute — the default DOM stays untouched for authors
+	 * who haven't configured a post-type constraint.
+	 */
+	public function test_no_post_type_scope_omits_context() {
+		$markup = $this->render();
+		$this->assertStringNotContainsString( 'data-wp-context', $markup );
+	}
+
+	/**
+	 * Slugs that aren't registered as searchable post types are dropped by
+	 * `Filter_Post_Type::build_constraint()`, collapsing the constraint to
+	 * empty — so no context is emitted for a bogus slug.
+	 */
+	public function test_unknown_post_type_scope_is_dropped() {
+		$markup = $this->render(
+			array(
+				'postTypeMode' => 'include',
+				'postTypes'    => array( 'definitely_not_a_real_post_type' ),
+			)
+		);
+		$this->assertStringNotContainsString( 'data-wp-context', $markup );
 	}
 }

--- a/projects/packages/search/tests/php/Search_Input_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Input_Render_Test.php
@@ -170,7 +170,7 @@ class Search_Input_Render_Test extends TestCase {
 				'postTypes'    => array( 'post' ),
 			)
 		);
-		$decoded = html_entity_decode( $markup );
+		$decoded = html_entity_decode( $markup, ENT_QUOTES | ENT_HTML401 );
 		$this->assertStringContainsString( 'data-wp-context', $markup );
 		$this->assertStringContainsString(
 			'"staticPostTypes":{"include":["post"],"exclude":[]}',
@@ -189,7 +189,7 @@ class Search_Input_Render_Test extends TestCase {
 				'postTypes'    => array( 'page' ),
 			)
 		);
-		$decoded = html_entity_decode( $markup );
+		$decoded = html_entity_decode( $markup, ENT_QUOTES | ENT_HTML401 );
 		$this->assertStringContainsString(
 			'"staticPostTypes":{"include":[],"exclude":["page"]}',
 			$decoded


### PR DESCRIPTION
Fixes [SEARCH-234](https://linear.app/a8c/issue/SEARCH-234/search-blocks-move-post-type-filter-onto-the-search-input-block-as-a)

## Why

To constrain a Jetpack Search to specific post types today, an author has to drop a second, headless **Post Type Scope** block (`jetpack-search/filter-post-type`) into the template next to the Search Input. That block renders nothing visible, its relationship to the input is invisible in the editor, and its stacking semantics are subtle. This PR puts the same configuration right on the Search Input block — where the search actually starts — so the common case no longer needs a second block. It also lays the groundwork for a follow-up where the same data drives a visitor-facing post-type selector.

## Proposed changes

* Add a **Post types** panel to the Search Input block's inspector: an include/exclude mode toggle plus a post-type slug picker.
* The scope is **per-instance** — each Search Input only constrains the searches *it* initiates. The constraint is seeded into the block's own `data-wp-context` and handed to `actions.search()`, which keeps it for the follow-up filter/sort/load-more re-runs in that session.
* An **unscoped** Search Input falls back to any page-level `jetpack-search/filter-post-type` block, so existing patterns/templates (e.g. the WooCommerce product-results template) keep working unchanged. `filter-post-type` is intentionally kept for now.
* Extract the mode toggle + slug picker into a shared `PostTypeScopeControl` component, and move the `Filter_Post_Type` helper up to the `search-blocks` root, so the Search Input panel and the standalone `filter-post-type` block reuse the same slug sanitization + live-post-type allowlist (`build_constraint()`).

## Screenshots

Block-editor inspector for a selected Search Input block, before and after this change (local docker, 1440×900).

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/a9a37dab-200a-4e6e-9186-421e68e3947c) | ![after](https://github.com/user-attachments/assets/5e382b46-f17f-4d98-bc05-d371e837e3fe) |

## Verification

The new setting threads through to the rendered front-end markup: a scoped Search Input seeds `staticPostTypes` into its per-instance `data-wp-context`, an unscoped one emits no context, and invalid slugs are dropped by the live-post-type allowlist. Captured against the built plugin in the local docker env:

<details>
<summary>Rendered <code>do_blocks()</code> output</summary>

```text
# include "post"
data-wp-context='{"staticPostTypes":{"include":["post"],"exclude":[]}}'

# exclude "page"
data-wp-context='{"staticPostTypes":{"include":[],"exclude":["page"]}}'

# unknown slug -> dropped, no context emitted
(no data-wp-context attribute)

# suggestions + scope coexist in one context object
data-wp-context='{"showSuggestions":false,"activeIndex":-1,"activeOptionId":"","rows":[],"listboxId":"…","suggestionTypes":["query","taxonomy","post"],"staticPostTypes":{"include":["post"],"exclude":[]}}'
```

</details>

Automated coverage: new PHP render tests (`Search_Input_Render_Test`), a new JS store test for the per-instance scope + global-seed fallback, the shared-control helper tests (`post-type-control.test.js`), and an updated `block.json` contract test. Full search-blocks suite green (560 JS / 22 PHP touched-area tests).

## Related product discussion/links

* [SEARCH-234](https://linear.app/a8c/issue/SEARCH-234/search-blocks-move-post-type-filter-onto-the-search-input-block-as-a)

## Does this pull request change what data or activity we track or use?

No. This only changes which post types a search query is scoped to; it adds no new tracking.

## Testing instructions

Acceptance criteria — verify each against the editor + the rendered markup:

* [ ] Add a **Search Input** block in the editor; its inspector shows a **Post types** panel with an include/exclude mode toggle and a slug picker.
* [ ] A single Search Input configured with **Include only** + `post`, `page` scopes searches to those post types.
* [ ] A single Search Input configured with **Exclude** + `page` removes that post type from results.
* [ ] Two Search Input blocks on one page with different scopes each apply their own constraint to the searches they initiate (per-instance scope).
* [ ] An unscoped Search Input on a page that also has a `filter-post-type` block inherits that block's constraint (no regression to existing patterns/templates).
* [ ] An invalid / unregistered post-type slug is dropped (no `data-wp-context` emitted for it).
* [ ] The standalone **Post Type Scope** (`filter-post-type`) block still works unchanged.

To exercise the rendered markup directly:

* Create a page with `<!-- wp:jetpack-search/search-input {"postTypeMode":"include","postTypes":["post"]} /-->` and confirm the front-end wrapper carries `data-wp-context='{"staticPostTypes":{"include":["post"],"exclude":[]}}'`.
