### PR TITLE
AdminPage: keep header height consistent across tabs

### DIFF
--- a/projects/js-packages/components/changelog/fix-admin-page-header-consistent-height
+++ b/projects/js-packages/components/changelog/fix-admin-page-header-consistent-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AdminPage: keep header height consistent across tabs so the tab strip no longer shifts vertically when switching tabs

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -43,6 +43,19 @@
 		place-items: center;
 	}
 
+	// Keep the header a constant height across tabs. The content row's height
+	// is driven by its tallest child (the `actions` slot), so tabs with
+	// differently-sized action controls — or none at all — render headers of
+	// different heights, which shifts the tab strip below them vertically.
+	// Reserve the standard 40px WP control height as a floor and center the
+	// row's items so a shorter control neither stretches nor collapses it.
+	// The content row is identified by the visual logo slot it contains
+	// (`aria-hidden="true"`), so a breadcrumbs-only header isn't affected.
+	:global(.jp-admin-page__page > header > div:has([aria-hidden="true"])) {
+		min-height: 40px;
+		align-items: center;
+	}
+
 	.admin-page-header {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Fixes #

## Proposed changes
* Reserve a consistent height on the `AdminPage` header content row so the tab strip below it no longer shifts vertically when switching tabs.
* The header content row's height tracks its tallest child (the `actions` slot). Dashboard tabs that pass differently-sized action controls — or none at all — produced headers of different heights, moving the tabs (e.g. 8px in VideoPress Overview→Library, 4px in Newsletter Subscribers→Settings).
* The rule sets the standard 40px WordPress control height as a `min-height` floor and `align-items: center` on the content row, so a shorter or absent action control neither stretches nor collapses the row.
* The row is matched via the visual logo slot it contains (`[aria-hidden="true"]`) rather than position, so breadcrumb-only headers are unaffected. This lives in the shared `admin-page` stylesheet next to the existing header-normalization rules, so it fixes every AdminPage dashboard at once.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the affected dashboards so they pick up the updated `jetpack-components` artifact. `wp-build` consumes `jetpack-components` from its `build/` output, so rebuild that package first, then the dashboard:
  * `pnpm --filter @automattic/jetpack-components build`
  * `pnpm --filter @automattic/jetpack-videopress build:wp-build` (and/or the Newsletter package)
* Visit VideoPress (`wp-admin/admin.php?page=jetpack-videopress`) and switch between the Overview, Library, and Settings tabs.
* Visit Newsletter (`wp-admin/admin.php?page=jetpack-newsletter`) and switch between the Subscribers and Settings tabs.
* Confirm the tab strip stays at the same vertical position on every tab — the header no longer grows/shrinks as you switch.
* Confirm the header still looks correct on each tab (logo, title, subtitle, and any action control aligned), including tabs that have no action control.
