### PR TITLE
Search Blocks: let WooCommerce filter blocks follow WooCommerce active state (SEARCH-235)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-235-enable-woocommerce-blocks-default
+++ b/projects/packages/search/changelog/SEARCH-235-enable-woocommerce-blocks-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: enable the WooCommerce filter blocks by default — flip the `jetpack_search_woocommerce_blocks_enabled` filter to true so every Search-supported site gets the product attribute, price, rating, and stock-status filters out of the box. The filter is retained as a kill-switch (return false to opt out).

--- a/projects/packages/search/changelog/SEARCH-235-enable-woocommerce-blocks-default
+++ b/projects/packages/search/changelog/SEARCH-235-enable-woocommerce-blocks-default
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Search Blocks: enable the WooCommerce filter blocks by default — flip the `jetpack_search_woocommerce_blocks_enabled` filter to true so every Search-supported site gets the product attribute, price, rating, and stock-status filters out of the box. The filter is retained as a kill-switch (return false to opt out).
+Search Blocks: the WooCommerce filter blocks (product attribute, price, rating, and stock-status filters) now follow WooCommerce's active state instead of being force-disabled, so they register automatically on sites running WooCommerce. The `jetpack_search_woocommerce_blocks_enabled` filter remains available to force the gate either way.

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -167,11 +167,6 @@ class Initializer {
 			return;
 		}
 
-		// WooCommerce-only Search blocks ship on by default. The
-		// `jetpack_search_woocommerce_blocks_enabled` filter stays as a
-		// kill-switch — hook it at priority > 10 to return false and opt
-		// back out if a regression surfaces.
-		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_true' );
 		Search_Blocks::init();
 
 		// When the Search blocks own the front-end results (Embedded / blocks

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -167,10 +167,11 @@ class Initializer {
 			return;
 		}
 
-		// Phase 1 ships without WooCommerce-only Search blocks. Sites
-		// that want them back hook the same filter at priority > 10
-		// so their callback runs after this default.
-		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' );
+		// WooCommerce-only Search blocks ship on by default. The
+		// `jetpack_search_woocommerce_blocks_enabled` filter stays as a
+		// kill-switch — hook it at priority > 10 to return false and opt
+		// back out if a regression surfaces.
+		add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_true' );
 		Search_Blocks::init();
 
 		// When the Search blocks own the front-end results (Embedded / blocks

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -203,7 +203,7 @@ class Initializer_Test extends Search_TestCase {
 		// The WC blocks follow WooCommerce's active state — the initializer no
 		// longer forces the `jetpack_search_woocommerce_blocks_enabled` gate
 		// either way, leaving it a pass-through over the
-		// `class_exists( 'WooCommerce' )` probe.
+		// `class_exists( 'WooCommerce', false )` probe.
 		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
 
 		$this->invoke_init_search_blocks();

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -199,17 +199,18 @@ class Initializer_Test extends Search_TestCase {
 		);
 	}
 
-	public function test_init_search_blocks_enables_woocommerce_blocks_gate_by_default() {
-		// The WC gate ships on by default — pass `false` as the base value
-		// so the assertion proves the override forces it true regardless of
-		// the `class_exists( 'WooCommerce' )` probe.
+	public function test_init_search_blocks_does_not_override_woocommerce_blocks_gate() {
+		// The WC blocks follow WooCommerce's active state — the initializer no
+		// longer forces the `jetpack_search_woocommerce_blocks_enabled` gate
+		// either way, leaving it a pass-through over the
+		// `class_exists( 'WooCommerce' )` probe.
 		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
 
 		$this->invoke_init_search_blocks();
 
-		$this->assertTrue(
-			(bool) apply_filters( 'jetpack_search_woocommerce_blocks_enabled', false ),
-			'WC-only Search blocks should be enabled by default.'
+		$this->assertFalse(
+			has_filter( 'jetpack_search_woocommerce_blocks_enabled' ),
+			'init_search_blocks() must not register a WC-gate override; the gate follows the WooCommerce probe.'
 		);
 	}
 

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -199,16 +199,17 @@ class Initializer_Test extends Search_TestCase {
 		);
 	}
 
-	public function test_init_search_blocks_sets_woocommerce_blocks_gate_off_by_default_when_enabled() {
-		// Verifies the Phase 1 default — opt-in sites get the non-WC subset
-		// unless they re-enable WC blocks at a later priority.
+	public function test_init_search_blocks_enables_woocommerce_blocks_gate_by_default() {
+		// The WC gate ships on by default — pass `false` as the base value
+		// so the assertion proves the override forces it true regardless of
+		// the `class_exists( 'WooCommerce' )` probe.
 		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
 
 		$this->invoke_init_search_blocks();
 
-		$this->assertFalse(
-			(bool) apply_filters( 'jetpack_search_woocommerce_blocks_enabled', true ),
-			'WC-only Search blocks should be disabled by default in Phase 1.'
+		$this->assertTrue(
+			(bool) apply_filters( 'jetpack_search_woocommerce_blocks_enabled', false ),
+			'WC-only Search blocks should be enabled by default.'
 		);
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-235](https://linear.app/a8c/issue/SEARCH-235/search-blocks-enable-woocommerce-filter-blocks-by-default)

## Why
Jetpack Search 3.0's WooCommerce-only filter blocks (product attribute / price / rating / stock-status filters, the product category/tag/brand variations, and the Product Filters composition) have been force-disabled everywhere by a Phase 1 kill-switch since SEARCH-180. Now that the core Search blocks are GA (SEARCH-222), store owners running WooCommerce should get the product filtering blocks automatically — without those filters leaking onto sites that don't run WooCommerce.

## Proposed changes
* Remove the initializer's hard `add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' )` override, so the gate falls back to its natural `class_exists( 'WooCommerce' )` probe in `Search_Blocks::woocommerce_blocks_enabled()`.
* Net effect: the WooCommerce-only Search blocks register on sites where WooCommerce is active, and stay hidden where it isn't — no longer force-disabled, and not force-enabled on non-Woo sites either.
* The `jetpack_search_woocommerce_blocks_enabled` filter remains available to force the gate either way (e.g. hide WC blocks on a non-shop area, or preview them in non-Woo staging).
* Update `Initializer_Test` to assert the initializer no longer registers a gate override.
* Changelog entry.

## Screenshots
Block inserter on a site **with WooCommerce active**, searching "filter by product". On trunk the WooCommerce filter blocks are suppressed even on a Woo store (only the non-WC "Checkbox Filter" shows); after this change they register and are available.

| Before (trunk, WooCommerce active) | After (this branch, WooCommerce active) |
|---|---|
| ![before](https://github.com/user-attachments/assets/4cdd5660-1c1c-47d9-9677-3db78676dcf7) | ![after](https://github.com/user-attachments/assets/79340a49-2f37-4495-93f7-5670851abe5a) |

## Verification
Confirmed on a local docker site that the gate now tracks WooCommerce's active state (and trunk does not), via `Search_Blocks::woocommerce_blocks_enabled()` plus block-registration checks:

<details>
<summary>Gate / registration matrix</summary>

```text
This branch, WooCommerce ACTIVE:
  class_exists('WooCommerce') = true
  woocommerce_blocks_enabled() = true
  initializer override registered = false
  jetpack-search/filter-wc-rating = REGISTERED   (+ wc-price, wc-attribute, wc-stock-status, filters-product)

This branch, WooCommerce INACTIVE:
  class_exists('WooCommerce') = false
  woocommerce_blocks_enabled() = false
  jetpack-search/filter-wc-rating = missing

trunk, WooCommerce ACTIVE:
  woocommerce_blocks_enabled() = false   (forced off by the __return_false override)
```

</details>

## Related product discussion/links
* [SEARCH-235](https://linear.app/a8c/issue/SEARCH-235/search-blocks-enable-woocommerce-filter-blocks-by-default)
* Phase 1 gate added in SEARCH-180; sibling GA flip SEARCH-222 (#49037) enabled the core blocks.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
On a connected site on a Search-supported plan:

* [ ] With **WooCommerce active**, open the block editor and confirm the WooCommerce filter blocks (Filter by Product Category/Tag/Brand/Attribute, Filter by Rating, Filter by Stock Status, Product Filters) appear in the inserter out of the box.
* [ ] **Deactivate WooCommerce** and confirm those WC-only blocks no longer register / disappear from the inserter (the non-WC Checkbox Filter still shows).
* [ ] Confirm the `jetpack_search_woocommerce_blocks_enabled` filter still forces the gate either way — e.g. `add_filter( 'jetpack_search_woocommerce_blocks_enabled', '__return_false' )` hides the WC blocks on a Woo site.
