### PR TITLE
Marketing Tools: update SEO course CTA to "Watch the course"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-05-22-05-43-37-499908
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-05-22-05-43-37-499908
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Marketing Tools: update SEO course CTA from "Register now" to "Watch the course"

--- a/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.php
@@ -163,7 +163,7 @@ function wpcom_display_marketing_tools_page() {
 				'Take our free introductory course about search engine optimization (SEO) and learn how to improve your site or blog for both search engines and humans.',
 				'jetpack-mu-wpcom'
 			),
-			'action'      => __( 'Register now', 'jetpack-mu-wpcom' ),
+			'action'      => __( 'Watch the course', 'jetpack-mu-wpcom' ),
 			'icon'        => plugins_url( 'images/rocket.svg', __FILE__ ),
 			'url'         => 'https://wordpress.com/support/courses/seo/',
 			'event'       => 'calypso_marketing_tools_seo_course_button_click',


### PR DESCRIPTION
## Proposed changes
* Update the CTA label on the "Increase traffic to your WordPress.com site" card under Tools → Marketing from "Register now" to "Watch the course".

The card links directly to https://wordpress.com/support/courses/seo/, which is a free SEO course video — there is no registration step — so the previous label was misleading.

Note: the surrounding code already gates this card to English locales (`$locale === 'en'`), so no translation fallback is needed.

## Related product discussion/links

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On an English-locale WordPress.com site (Simple or Atomic), go to Tools → Marketing.
* Find the card titled "Increase traffic to your WordPress.com site".
* Confirm the CTA button now reads "Watch the course" (previously "Register now").
* Click it and confirm it still opens https://wordpress.com/support/courses/seo/ in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)