### PR TITLE
Search Blocks: default Clear Filters to Compact style in filters & filters-product

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"3388d88a-0f0a-4771-9d9c-e980cfc3ac73","pid":59378,"procStart":"Mon May 18 22:33:04 2026","acquiredAt":1779144613095}
+{"sessionId":"ebd19933-a4e9-48b7-8287-668d8af14c24","pid":42101,"procStart":"Fri May 22 03:41:04 2026","acquiredAt":1779429492741}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ebd19933-a4e9-48b7-8287-668d8af14c24","pid":42101,"procStart":"Fri May 22 03:41:04 2026","acquiredAt":1779429492741}

--- a/projects/packages/search/changelog/SEARCH-236-clear-filters-compact
+++ b/projects/packages/search/changelog/SEARCH-236-clear-filters-compact
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: default the Clear Filters button to the Compact style in the Filters and Product Filters compositions so it matches the slimmer sidebar filter controls.

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
@@ -20,7 +20,7 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 const TEMPLATE = [
 	[ 'jetpack-search/filter-post-type', { mode: 'include', postTypes: [ 'product' ] } ],
 	[ 'jetpack-search/active-filters' ],
-	[ 'jetpack-search/clear-filters' ],
+	[ 'jetpack-search/clear-filters', { className: 'is-style-compact' } ],
 	[
 		'jetpack-search/filter-checkbox',
 		{ filterType: 'taxonomy', taxonomy: 'product_cat', displayStyle: 'chips' },

--- a/projects/packages/search/src/search-blocks/blocks/filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters/edit.js
@@ -10,7 +10,7 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const TEMPLATE = [
 	[ 'jetpack-search/active-filters' ],
-	[ 'jetpack-search/clear-filters' ],
+	[ 'jetpack-search/clear-filters', { className: 'is-style-compact' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'author' } ],

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -35,7 +35,7 @@
 <!-- wp:jetpack-search/filters-product -->
 <!-- wp:jetpack-search/filter-post-type {"mode":"include","postTypes":["product"]} /-->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
+<!-- wp:jetpack-search/clear-filters {"className":"is-style-compact"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->

--- a/projects/packages/search/tests/js/search-blocks/filters-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-edit.test.jsx
@@ -19,7 +19,7 @@ describe( 'FiltersEdit', () => {
 		const props = InnerBlocks.mock.calls[ 0 ][ 0 ];
 		expect( props.template ).toEqual( [
 			[ 'jetpack-search/active-filters' ],
-			[ 'jetpack-search/clear-filters' ],
+			[ 'jetpack-search/clear-filters', { className: 'is-style-compact' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'author' } ],


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-236

## Why
The standalone Clear Filters block already ships a "Compact" style (slimmer padding/font, added in RSM-3507), but the Filters and Product Filters compositions still seeded the button at the theme's full button size — which looks oversized next to the slim filter controls in a sidebar. Now both compositions default the Clear Filters button to the Compact style, so it matches the surrounding filter UI out of the box.

## Proposed changes
* Seed `is-style-compact` on the `jetpack-search/clear-filters` child in the `filters` block template (`blocks/filters/edit.js`).
* Seed `is-style-compact` on the `jetpack-search/clear-filters` child in the `filters-product` block template (`blocks/filters-product/edit.js`).
* Apply the same style in the bundled product-results block template (`templates/jetpack-search-product-results.html`).

No new CSS or attributes — the Compact block style and its styling already shipped; this only changes the composition defaults. Existing saved posts are unaffected (defaults apply to new insertions and the bundled template).

## Screenshots
### Before
![before](https://github.com/user-attachments/assets/590d609d-a597-4d52-bd50-2dce2df6b564)
### After
![after](https://github.com/user-attachments/assets/965e0c12-75b3-418a-80e1-eca8fa98f601)

## Related product discussion/links
* https://linear.app/a8c/issue/SEARCH-236
* Builds on RSM-3507 (Compact block style) and RSM-2803 (clear-filters in the filters-product default template).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* In the block editor, insert the **Filters** block. Confirm its child **Clear Filters** button has the **Compact** style selected by default and renders slim.
* Insert the **Product Filters** block (on a WooCommerce site). Confirm its child **Clear Filters** button defaults to the **Compact** style. *(Note: Product Filters is WooCommerce-gated; verified here via the built editor bundle + front-end render since the test env has WooCommerce inactive.)*
* On the front end, with a filter active so the Clear Filters button shows, confirm it renders compact (slim padding, ~13px font) rather than the full theme button size.
* Confirm `filters-popover`, the `compact-search` / `blog-search` patterns, and standalone Clear Filters usages are unchanged.

<details>
<summary>Verification (computed styles, front-end render)</summary>

```text
Before (trunk default, no style): font-size 18px, padding 16px 36px
After  (is-style-compact):        font-size 13px, padding 3.25px 9.75px

Editor: inserting jetpack-search/filters seeds clear-filters child with
        attributes { hideWhenInactive: true, className: "is-style-compact" }
Built editor bundle contains 2 is-style-compact seedings (filters + filters-product)
```

</details>
