### PR TITLE
Sync: replicate Search blocks overlay template CPT to WPcom

### DIFF
--- a/projects/packages/sync/changelog/echo-search-237-overlay-cpt-sync
+++ b/projects/packages/sync/changelog/echo-search-237-overlay-cpt-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync: replicate the Search blocks overlay template CPT to WPcom when the block-template overlay is enabled.

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -53,6 +53,8 @@ class Search extends Module {
 		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_search_options_whitelist' ), 10 );
 		// AI Answers CPTs and post meta (gated by feature flag).
 		add_filter( 'jetpack_sync_post_types_whitelist', array( $this, 'add_ai_answer_post_types' ), 10 );
+		// Block-template overlay singleton CPT (gated by feature flag).
+		add_filter( 'jetpack_sync_post_types_whitelist', array( $this, 'add_overlay_template_post_type' ), 10 );
 	}
 
 	/**
@@ -1827,6 +1829,26 @@ class Search extends Module {
 			return $list;
 		}
 		$list[] = 'wp_guideline';
+		return $list;
+	}
+
+	/**
+	 * Add the Search blocks overlay template CPT to the post types sync whitelist
+	 * when the experimental block-template overlay is enabled.
+	 *
+	 * Mirrors `Overlay_Template::POST_TYPE` from the jetpack-search package; the
+	 * value is hardcoded to avoid a cross-package dependency. Without it, a
+	 * customized overlay template lands in `jps_non-reg` status on the cache
+	 * site and never replicates to WPcom.
+	 *
+	 * @param array $list Existing post types whitelist.
+	 * @return array Updated whitelist.
+	 */
+	public function add_overlay_template_post_type( $list ) {
+		if ( ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false ) ) {
+			return $list;
+		}
+		$list[] = 'jp_search_overlay';
 		return $list;
 	}
 

--- a/projects/packages/sync/tests/php/modules/Search_Module_Test.php
+++ b/projects/packages/sync/tests/php/modules/Search_Module_Test.php
@@ -38,6 +38,7 @@ class Search_Module_Test extends BaseTestCase {
 	 */
 	protected function tearDown(): void {
 		remove_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+		remove_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
 		parent::tearDown();
 	}
 
@@ -70,5 +71,25 @@ class Search_Module_Test extends BaseTestCase {
 		delete_option( 'jetpack_search_ai_answers_enabled' );
 		$this->assertContains( 'wp_guideline', $list );
 		$this->assertNotContains( 'jetpack_search_topic', $list );
+	}
+
+	/**
+	 * The overlay template CPT should NOT be in the whitelist when the
+	 * block-template overlay is off (default).
+	 */
+	public function test_overlay_cpt_not_in_whitelist_when_disabled() {
+		$list = apply_filters( 'jetpack_sync_post_types_whitelist', array() );
+		$this->assertNotContains( 'jp_search_overlay', $list );
+	}
+
+	/**
+	 * The overlay template CPT should be in the whitelist when the
+	 * block-template overlay is enabled via filter.
+	 */
+	public function test_overlay_cpt_in_whitelist_when_enabled() {
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		$list = apply_filters( 'jetpack_sync_post_types_whitelist', array() );
+		remove_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
+		$this->assertContains( 'jp_search_overlay', $list );
 	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-237

## Why
When an admin customizes the experimental Search blocks overlay, that customization is stored in a hidden `jp_search_overlay` post. Until now that post type wasn't registered for sync, so the customized overlay would land in `jps_non-reg` status on the WordPress.com cache site and never replicate. This makes the overlay customization actually reach WPcom (the JS-only feature flag sites that opt into the experimental overlay).

## Proposed changes
* Register the `jp_search_overlay` CPT on the `jetpack_sync_post_types_whitelist` filter, gated behind the `jetpack_search_overlay_block_template_enabled` feature flag — mirroring the existing AI Answers (`wp_guideline`) handler in the same module.
* Add unit coverage for both states (flag off → not whitelisted; flag on → whitelisted).

> [!IMPORTANT]
> **WPcom coordination required.** Whitelisting the CPT here only controls what is *sent*. For the post to be *retained* it must also be allowlisted in WPcom's shadow replicastore — that is the separate WPcom-side fix tracked on the same issue. This Jetpack PR is the sending half.

## Verification
Backend-only change (no user-visible UI). Exercised the actual filter path via the package's PHPUnit suite.

<details>
<summary>Output</summary>

```text
$ ./vendor/bin/phpunit -c phpunit.11.xml.dist --filter='test_overlay_cpt' --testdox

Search_Module_ (Automattic\Jetpack\Sync\Search_Module_)
 ✔ Overlay cpt not in whitelist when disabled
 ✔ Overlay cpt in whitelist when enabled

OK (2 tests, 2 assertions)

$ jetpack test php packages/sync
OK (136 tests, 507 assertions)
```

</details>

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/SEARCH-237
* Search blocks overlay project: https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586

## Does this pull request change what data or activity we track or use?
Yes — it adds the `jp_search_overlay` custom post type (the Search blocks overlay template singleton) to the data synced to WordPress.com, but only on sites where the experimental `jetpack_search_overlay_block_template_enabled` flag is on. No new personal or visitor data is involved; the post stores block markup for the overlay template.

## Testing instructions
* Apply `add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );` (mu-plugin or snippet).
* Confirm the CPT is now in the sync whitelist:
  * `wp eval 'var_dump( in_array( "jp_search_overlay", apply_filters( "jetpack_sync_post_types_whitelist", array() ), true ) );'` → `bool(true)`
* Remove the filter and re-run → `bool(false)`.
* In the Jetpack Search dashboard, click "Edit the Search overlay", save a customization, and confirm a `jp_search_overlay` post is enqueued for sync (e.g. via `wp jetpack sync status` / the Sync Validator on jptools) rather than being dropped as `jps_non-reg`.
