### PR TITLE
Search Blocks: empty state for filters & filters-product when no facets to show

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ca5c3bc7-9af8-4863-a2cb-8baa02c4f503","pid":28465,"procStart":"Fri May 22 03:14:46 2026","acquiredAt":1779430834665}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"3388d88a-0f0a-4771-9d9c-e980cfc3ac73","pid":59378,"procStart":"Mon May 18 22:33:04 2026","acquiredAt":1779144613095}
+{"sessionId":"ca5c3bc7-9af8-4863-a2cb-8baa02c4f503","pid":28465,"procStart":"Fri May 22 03:14:46 2026","acquiredAt":1779430834665}

--- a/projects/packages/search/changelog/SEARCH-238-filters-empty-state
+++ b/projects/packages/search/changelog/SEARCH-238-filters-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: the Filters and Product Filters containers now show a "No filters available" empty state when a search resolves with no facets to show, instead of rendering a blank box.

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/render.php
@@ -20,4 +20,10 @@ namespace Automattic\Jetpack\Search;
 	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
 	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
 	?>
+	<p
+		class="jetpack-search-filters-product__empty"
+		data-wp-interactive="jetpack-search"
+		data-wp-bind--hidden="!state.showFiltersEmpty"
+		hidden
+	><?php esc_html_e( 'No filters available', 'jetpack-search-pkg' ); ?></p>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/style.scss
@@ -9,3 +9,12 @@
 .jetpack-search-filters-product {
 	gap: var(--wp--style--block-gap, 1.5rem);
 }
+
+.jetpack-search-filters-product__empty {
+	margin: 0;
+	opacity: 0.6;
+
+	&[hidden] {
+		display: none;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/view.js
@@ -1,3 +1,4 @@
-// Webpack entry point for style compilation — this block has no JS behaviour,
-// but the build system extracts CSS only when it has a view.js entry to process.
+// Imports the shared store so the container's empty-state directives hydrate
+// even when it is the only interactive Search block on the page.
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters/render.php
@@ -19,4 +19,10 @@ namespace Automattic\Jetpack\Search;
 	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
 	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
 	?>
+	<p
+		class="jetpack-search-filters__empty"
+		data-wp-interactive="jetpack-search"
+		data-wp-bind--hidden="!state.showFiltersEmpty"
+		hidden
+	><?php esc_html_e( 'No filters available', 'jetpack-search-pkg' ); ?></p>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters/style.scss
@@ -6,3 +6,12 @@
 	// spacing.blockGap support.
 	gap: var(--wp--style--block-gap, 1rem);
 }
+
+.jetpack-search-filters__empty {
+	margin: 0;
+	opacity: 0.6;
+
+	&[hidden] {
+		display: none;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters/view.js
@@ -1,2 +1,4 @@
+// Imports the shared store so the container's empty-state directives hydrate
+// even when it is the only interactive Search block on the page.
 import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters/view.js
@@ -1,1 +1,2 @@
+import 'jetpack-search/store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/store/filters-empty.js
+++ b/projects/packages/search/src/search-blocks/store/filters-empty.js
@@ -10,6 +10,11 @@
  * visibility — without the retained / selection check a narrower query
  * could hide the section that holds the user's own selection.
  *
+ * Static filters render their server-provided `values` regardless of the
+ * result set (they don't aggregate, retain, or write to `activeFilters`), so
+ * a non-empty `values` list always counts as content — otherwise a sidebar
+ * holding only a static filter would falsely report itself empty.
+ *
  * Date filters bail out before the retention / selection clauses: they
  * don't accumulate retained options (mergeRetainedFilterOptions skips
  * them) and dateFilterItems doesn't render selected values that aren't
@@ -25,7 +30,11 @@ export function filterHasContent( sharedState, filterKey ) {
 	if ( ( sharedState.aggregations?.[ filterKey ]?.buckets?.length ?? 0 ) > 0 ) {
 		return true;
 	}
-	if ( sharedState.filterConfigs?.[ filterKey ]?.filterType === 'date' ) {
+	const config = sharedState.filterConfigs?.[ filterKey ];
+	if ( config?.filterType === 'static' ) {
+		return ( config.values?.length ?? 0 ) > 0;
+	}
+	if ( config?.filterType === 'date' ) {
 		return false;
 	}
 	return (
@@ -79,6 +88,10 @@ export function filtersHaveNothingToShow( sharedState ) {
 	if ( ! ( sharedState.searchQuery || sharedState.hasSearchParam ) ) {
 		return false;
 	}
+	// `skeletonHidden` is intentionally stricter here than `showNoResults`,
+	// which doesn't gate on it: a flash in the sidebar before hydration is
+	// more disorienting than in the results region, so "No filters available"
+	// waits for the skeleton to clear even when "No results" can already show.
 	if ( ! sharedState.skeletonHidden || sharedState.isLoading || sharedState.hasError ) {
 		return false;
 	}

--- a/projects/packages/search/src/search-blocks/store/filters-empty.js
+++ b/projects/packages/search/src/search-blocks/store/filters-empty.js
@@ -1,0 +1,94 @@
+/**
+ * Filter-visibility predicates, kept as pure functions of a plain state object
+ * so they're unit-testable without the Interactivity runtime. The store wires
+ * them into `data-wp-bind` via thin getters.
+ */
+
+/**
+ * True when a filter key has anything to render: live aggregation buckets,
+ * session-retained options, or an active selection. Drives wrapper
+ * visibility — without the retained / selection check a narrower query
+ * could hide the section that holds the user's own selection.
+ *
+ * Date filters bail out before the retention / selection clauses: they
+ * don't accumulate retained options (mergeRetainedFilterOptions skips
+ * them) and dateFilterItems doesn't render selected values that aren't
+ * in the current aggregation, so an empty bucket list means an empty
+ * <ul> and the wrapper should hide. Selections still surface via the
+ * active-filters pills.
+ *
+ * @param {object} sharedState - Live store state.
+ * @param {string} filterKey   - Filter key.
+ * @return {boolean} True when the wrapper has something to show.
+ */
+export function filterHasContent( sharedState, filterKey ) {
+	if ( ( sharedState.aggregations?.[ filterKey ]?.buckets?.length ?? 0 ) > 0 ) {
+		return true;
+	}
+	if ( sharedState.filterConfigs?.[ filterKey ]?.filterType === 'date' ) {
+		return false;
+	}
+	return (
+		( sharedState.retainedFilterOptions?.[ filterKey ]?.length ?? 0 ) > 0 ||
+		( sharedState.activeFilters?.[ filterKey ]?.length ?? 0 ) > 0
+	);
+}
+
+/**
+ * True when any facet is active — selected filter values, a static-filter
+ * selection, or a price range. priceRange counts so a price-only selection
+ * (including a half-open range like `?min_price=10`) still reads as active.
+ *
+ * @param {object} sharedState - Live store state.
+ * @return {boolean} Whether any filter is active.
+ */
+export function hasAnyActiveFilter( sharedState ) {
+	const hasSelections = Object.values( sharedState.activeFilters ?? {} ).some(
+		v => Array.isArray( v ) && v.length > 0
+	);
+	if ( hasSelections ) {
+		return true;
+	}
+	const hasStaticSelections = Object.values( sharedState.staticFilterSelections ?? {} ).some(
+		v => !! v
+	);
+	if ( hasStaticSelections ) {
+		return true;
+	}
+	const range = sharedState.priceRange;
+	return !! range && ( range.min != null || range.max != null );
+}
+
+/**
+ * True when the `filters` / `filters-product` containers have nothing to show
+ * and should surface their empty state. Those are layout-only wrappers, so
+ * when a search resolves with no buckets, no retained (session-cached)
+ * options, and no active selections, every child filter hides itself and the
+ * wrapper renders an empty box.
+ *
+ * Gated like `showNoResults` (a search has run, hydration is done, not
+ * loading, no error) so it doesn't flash on a bare `/search/` page or
+ * mid-fetch. Any active filter short-circuits it because the active-filters /
+ * clear-filters children still have something to show. `filterHasContent`
+ * already counts `retainedFilterOptions`, so a cached filter keeps this false.
+ *
+ * @param {object} sharedState - Live store state.
+ * @return {boolean} True when the filters empty state should show.
+ */
+export function filtersHaveNothingToShow( sharedState ) {
+	if ( ! ( sharedState.searchQuery || sharedState.hasSearchParam ) ) {
+		return false;
+	}
+	if ( ! sharedState.skeletonHidden || sharedState.isLoading || sharedState.hasError ) {
+		return false;
+	}
+	if ( hasAnyActiveFilter( sharedState ) ) {
+		return false;
+	}
+	for ( const filterKey of Object.keys( sharedState.filterConfigs ?? {} ) ) {
+		if ( filterHasContent( sharedState, filterKey ) ) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -8,6 +8,7 @@ import { markdownToHtml } from '../../instant-search/lib/markdown';
 import { streamAiAnswer } from './ai-stream';
 import { buildSearchUrl, formatDateBucketLabel } from './api';
 import { bucketLabel, bucketValue } from './bucket-key';
+import { filterHasContent, filtersHaveNothingToShow, hasAnyActiveFilter } from './filters-empty';
 import { isEventInsidePopoverRoot } from './popover-events';
 import { countActiveFilters, normalizeResult, setSeededDateFormat } from './result-utils';
 import {
@@ -265,36 +266,6 @@ export function remapAggregationsToFilterKeys( aggregations, filterConfigs ) {
 		remapped[ target ] = value;
 	}
 	return remapped;
-}
-
-/**
- * True when a filter key has anything to render: live aggregation buckets,
- * session-retained options, or an active selection. Drives wrapper
- * visibility — without the retained / selection check a narrower query
- * could hide the section that holds the user's own selection.
- *
- * Date filters bail out before the retention / selection clauses: they
- * don't accumulate retained options (mergeRetainedFilterOptions skips
- * them) and dateFilterItems doesn't render selected values that aren't
- * in the current aggregation, so an empty bucket list means an empty
- * <ul> and the wrapper should hide. Selections still surface via the
- * active-filters pills.
- *
- * @param {object} sharedState - Live store state.
- * @param {string} filterKey   - Filter key.
- * @return {boolean} True when the wrapper has something to show.
- */
-function filterHasContent( sharedState, filterKey ) {
-	if ( ( sharedState.aggregations?.[ filterKey ]?.buckets?.length ?? 0 ) > 0 ) {
-		return true;
-	}
-	if ( sharedState.filterConfigs?.[ filterKey ]?.filterType === 'date' ) {
-		return false;
-	}
-	return (
-		( sharedState.retainedFilterOptions?.[ filterKey ]?.length ?? 0 ) > 0 ||
-		( sharedState.activeFilters?.[ filterKey ]?.length ?? 0 ) > 0
-	);
 }
 
 /**
@@ -679,6 +650,16 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * Visibility flag for the empty state inside the `filters` /
+		 * `filters-product` containers — see `filtersHaveNothingToShow`.
+		 *
+		 * @return {boolean} True when the filters empty state should show.
+		 */
+		get showFiltersEmpty() {
+			return filtersHaveNothingToShow( state );
+		},
+
+		/**
 		 * Visibility flag for the error region inside `jetpack-search/results-list`.
 		 * Gated on both `!isLoading` and `!isLoadingMore` so the message hides
 		 * the moment the user retries — covering the `loadMore()` failure path
@@ -720,20 +701,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * @return {boolean} Whether any filter is active.
 		 */
 		get hasActiveFilters() {
-			const hasSelections = Object.values( state.activeFilters ?? {} ).some(
-				v => Array.isArray( v ) && v.length > 0
-			);
-			if ( hasSelections ) {
-				return true;
-			}
-			const hasStaticSelections = Object.values( state.staticFilterSelections ?? {} ).some(
-				v => !! v
-			);
-			if ( hasStaticSelections ) {
-				return true;
-			}
-			const range = state.priceRange;
-			return !! range && ( range.min != null || range.max != null );
+			return hasAnyActiveFilter( state );
 		},
 
 		/**

--- a/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
+++ b/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
@@ -158,6 +158,12 @@ describe( 'filterHasContent', () => {
 			)
 		).toBe( true );
 	} );
+
+	it( 'is true when a non-date filter has an active selection', () => {
+		expect(
+			filterHasContent( state( { activeFilters: { category: [ 'news' ] } } ), 'category' )
+		).toBe( true );
+	} );
 } );
 
 describe( 'hasAnyActiveFilter', () => {

--- a/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
+++ b/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
@@ -1,0 +1,84 @@
+import { filtersHaveNothingToShow } from '../filters-empty';
+
+/**
+ * A "search ran, hydrated, nothing to show" baseline where
+ * `filtersHaveNothingToShow` is expected to return `true`. Individual cases
+ * spread an override on top to assert the suppressors.
+ *
+ * @param {object} overrides - Fields to override on the baseline.
+ * @return {object} A plain state object.
+ */
+function emptySearchedState( overrides = {} ) {
+	return {
+		searchQuery: 'test',
+		hasSearchParam: true,
+		skeletonHidden: true,
+		isLoading: false,
+		hasError: false,
+		aggregations: {},
+		retainedFilterOptions: {},
+		activeFilters: {},
+		staticFilterSelections: {},
+		priceRange: null,
+		filterConfigs: { category: { filterType: 'taxonomy' } },
+		...overrides,
+	};
+}
+
+describe( 'filtersHaveNothingToShow', () => {
+	it( 'is true when a search ran but no filter has any content', () => {
+		expect( filtersHaveNothingToShow( emptySearchedState() ) ).toBe( true );
+	} );
+
+	it( 'is false on a bare page with no search', () => {
+		expect(
+			filtersHaveNothingToShow( emptySearchedState( { searchQuery: '', hasSearchParam: false } ) )
+		).toBe( false );
+	} );
+
+	it( 'is false while the search is loading', () => {
+		expect( filtersHaveNothingToShow( emptySearchedState( { isLoading: true } ) ) ).toBe( false );
+	} );
+
+	it( 'is false while the pre-hydration skeleton is up', () => {
+		expect( filtersHaveNothingToShow( emptySearchedState( { skeletonHidden: false } ) ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'is false when the fetch errored', () => {
+		expect( filtersHaveNothingToShow( emptySearchedState( { hasError: true } ) ) ).toBe( false );
+	} );
+
+	it( 'is false when a filter has aggregation buckets', () => {
+		expect(
+			filtersHaveNothingToShow(
+				emptySearchedState( {
+					aggregations: { category: { buckets: [ { key: 'news', doc_count: 3 } ] } },
+				} )
+			)
+		).toBe( false );
+	} );
+
+	it( 'is false when a filter has retained (session-cached) options', () => {
+		expect(
+			filtersHaveNothingToShow(
+				emptySearchedState( {
+					retainedFilterOptions: { category: [ { value: 'news', label: 'News' } ] },
+				} )
+			)
+		).toBe( false );
+	} );
+
+	it( 'is false when a filter has an active selection', () => {
+		expect(
+			filtersHaveNothingToShow( emptySearchedState( { activeFilters: { category: [ 'news' ] } } ) )
+		).toBe( false );
+	} );
+
+	it( 'is false when a price range is active', () => {
+		expect(
+			filtersHaveNothingToShow( emptySearchedState( { priceRange: { min: 10, max: null } } ) )
+		).toBe( false );
+	} );
+} );

--- a/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
+++ b/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
@@ -1,4 +1,4 @@
-import { filtersHaveNothingToShow } from '../filters-empty';
+import { filterHasContent, filtersHaveNothingToShow, hasAnyActiveFilter } from '../filters-empty';
 
 /**
  * A "search ran, hydrated, nothing to show" baseline where
@@ -80,5 +80,102 @@ describe( 'filtersHaveNothingToShow', () => {
 		expect(
 			filtersHaveNothingToShow( emptySearchedState( { priceRange: { min: 10, max: null } } ) )
 		).toBe( false );
+	} );
+
+	it( 'is false when a static filter selection is active', () => {
+		expect(
+			filtersHaveNothingToShow(
+				emptySearchedState( { staticFilterSelections: { postType: 'post' } } )
+			)
+		).toBe( false );
+	} );
+
+	it( 'is false when an unselected static filter still renders its values', () => {
+		expect(
+			filtersHaveNothingToShow(
+				emptySearchedState( {
+					filterConfigs: { scope: { filterType: 'static', values: [ { value: 'docs' } ] } },
+				} )
+			)
+		).toBe( false );
+	} );
+} );
+
+describe( 'filterHasContent', () => {
+	const state = ( overrides = {} ) => ( {
+		aggregations: {},
+		retainedFilterOptions: {},
+		activeFilters: {},
+		filterConfigs: {},
+		...overrides,
+	} );
+
+	it( 'is true when the filter has aggregation buckets', () => {
+		expect(
+			filterHasContent(
+				state( { aggregations: { category: { buckets: [ { key: 'news', doc_count: 1 } ] } } } ),
+				'category'
+			)
+		).toBe( true );
+	} );
+
+	it( 'is true for a static filter with values, even with no buckets or selection', () => {
+		expect(
+			filterHasContent(
+				state( { filterConfigs: { scope: { filterType: 'static', values: [ { value: 'a' } ] } } } ),
+				'scope'
+			)
+		).toBe( true );
+	} );
+
+	it( 'is false for a static filter with no values', () => {
+		expect(
+			filterHasContent(
+				state( { filterConfigs: { scope: { filterType: 'static', values: [] } } } ),
+				'scope'
+			)
+		).toBe( false );
+	} );
+
+	it( 'bails out to false for a date filter with no buckets, ignoring retained/active', () => {
+		expect(
+			filterHasContent(
+				state( {
+					filterConfigs: { posted: { filterType: 'date' } },
+					retainedFilterOptions: { posted: [ { value: '2024' } ] },
+					activeFilters: { posted: [ '2024' ] },
+				} ),
+				'posted'
+			)
+		).toBe( false );
+	} );
+
+	it( 'is true when a non-date filter has retained options', () => {
+		expect(
+			filterHasContent(
+				state( { retainedFilterOptions: { category: [ { value: 'news' } ] } } ),
+				'category'
+			)
+		).toBe( true );
+	} );
+} );
+
+describe( 'hasAnyActiveFilter', () => {
+	it( 'is false when nothing is selected', () => {
+		expect(
+			hasAnyActiveFilter( { activeFilters: {}, staticFilterSelections: {}, priceRange: null } )
+		).toBe( false );
+	} );
+
+	it( 'is true with a dynamic selection', () => {
+		expect( hasAnyActiveFilter( { activeFilters: { category: [ 'news' ] } } ) ).toBe( true );
+	} );
+
+	it( 'is true with a static selection', () => {
+		expect( hasAnyActiveFilter( { staticFilterSelections: { scope: 'docs' } } ) ).toBe( true );
+	} );
+
+	it( 'is true with a half-open price range', () => {
+		expect( hasAnyActiveFilter( { priceRange: { min: 10, max: null } } ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-238/search-blocks-empty-state-for-filters-and-filters-product-when-no

## Why

On a Search Blocks page, the Filters and Product Filters blocks are layout-only wrappers. When a search returns no results (and the visitor hasn't built up any filter options yet this session), every child filter hides itself and the container collapses to a blank gap — leaving the visitor staring at empty space next to "No results found." This adds a clear **"No filters available"** message in that case so the sidebar reads as intentional rather than broken.

## Proposed changes

* Add a derived store getter `state.showFiltersEmpty`, backed by a new pure, unit-tested `store/filters-empty.js` module (`filtersHaveNothingToShow` + the relocated `filterHasContent` and an extracted `hasAnyActiveFilter`, which `hasActiveFilters` now reuses).
* Render a `No filters available` element in both `filters` and `filters-product` `render.php`, bound via `data-wp-bind--hidden="!state.showFiltersEmpty"` (hidden on first paint, revealed once the client-side search resolves empty).
* Import the shared store in both containers' `view.js` so the directives hydrate even when the container is the only interactive Search block on the page.
* The empty state is suppressed whenever a search is still loading/errored, hasn't run, any filter has buckets, **or any filter has session-cached (`retainedFilterOptions`) options** — so cached filters keep showing (with count 0) instead of the empty message.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/28cf65a8-fdf0-4af8-95d3-fc7c4a187963) | ![after](https://github.com/user-attachments/assets/902386ac-a05b-4666-8594-f89844a5f8e2) |

Captured from local docker (Embedded experience, twentytwentyfive) at 1440×900 — a no-results search with no cached filters.

## Related product discussion/links

* [SEARCH-238](https://linear.app/a8c/issue/SEARCH-238/search-blocks-empty-state-for-filters-and-filters-product-when-no)
* Related polish (separate): [SEARCH-230](https://linear.app/a8c/issue/SEARCH-230/search-blocks-no-results-state-polish-empty-results-count-orphan)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Set up a Search Blocks page (Embedded experience) with a `Filters` block (or `Product Filters` on a WooCommerce site) and a `Search Results` region, then verify:

* [ ] A search that resolves with no facets, no cached/retained filter options, and no active selections shows "No filters available" in the `filters` container.
* [ ] Same behavior for the `filters-product` container.
* [ ] The empty state stays hidden while the pre-hydration skeleton / loading is up, and on a bare `/search/` page with no query.
* [ ] When any filter has buckets, retained (cached) options, or an active selection, the empty state does not show and existing behavior is unchanged.
* [ ] When there are active filters to clear, the empty state stays hidden (active-filters / clear-filters children remain visible).

Verified end-to-end on the `filters` container via local docker: bare page (hidden) → nonsense query with no cache (shows message) → real query (filters populate, hidden) → nonsense query with cached filters (cached options shown, hidden). `filters-product` is WC-only and shares the identical `render.php` markup and `showFiltersEmpty` getter; its facet behavior wasn't exercised against a live product index, but the getter is unit-tested (`store/test/filters-empty.test.js`, 9 cases).
