### PR TITLE
Podcast: register Create AI Podcast menu in Calypso nav

### DIFF
--- a/projects/packages/podcast/changelog/fix-create-ai-podcast-calypso-menu
+++ b/projects/packages/podcast/changelog/fix-create-ai-podcast-calypso-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Create AI Podcast: Register the Media submenu without an is_admin() guard so it appears in the Calypso nav, not just wp-admin.

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -86,10 +86,15 @@ class Podcast {
 
 		// Posts to Podcast lives behind its own filter so the Create AI
 		// Podcast page can ship independently of the broader untangle.
+		//
+		// Note: no `is_admin()` guard here. The submenu must also register when
+		// Calypso builds its nav via the `wpcom/v2/admin-menu` REST endpoint,
+		// which fires `admin_menu` by loading `wp-admin/menu.php` but runs as a
+		// REST request where `is_admin()` is false. The hooks `init()` wires
+		// (`admin_menu`, `enqueue_block_editor_assets`) self-gate, so this is a
+		// no-op on non-admin/non-editor requests.
 		if ( self::is_posts_to_podcast_enabled() ) {
-			if ( is_admin() ) {
-				Create_AI_Podcast_Page::init();
-			}
+			Create_AI_Podcast_Page::init();
 		}
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* The **Media → Create AI Podcast** submenu appeared in `wp-admin` but was missing from the Calypso left nav.
* Calypso builds its nav from the `wpcom/v2/admin-menu` REST endpoint, which fires the `admin_menu` action by loading `wp-admin/menu.php` — but it runs as a REST request, where `is_admin()` is `false`.
* `Create_AI_Podcast_Page::init()` (which registers the `add_submenu_page( 'upload.php', … )` hook) was gated behind `if ( is_admin() )` in `Podcast::init()`, so in the REST context the hook never registered and the submenu never reached `$submenu['upload.php']` for Calypso to serialize.
* Dropped the `is_admin()` guard so the hook registers in the REST context too. This mirrors how the sibling Podcast dashboard menu is wired — `Podcast_Admin_Page::add_wp_admin_submenu()` runs unconditionally from an `admin_menu` callback in `wpcom-admin-menu.php` — which is why that menu already shows in Calypso. The hooks `init()` wires (`admin_menu`, `enqueue_block_editor_assets`) self-gate, so it stays a no-op on non-admin / non-editor requests.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WordPress.com Simple or WoA site with Posts to Podcast enabled, open the site in Calypso.
* Confirm **Media → Create AI Podcast** now appears in the left-hand nav (before this change it was absent in Calypso but present in `wp-admin`).
* Click it and confirm it routes to `/wp-admin/upload.php?page=create-ai-podcast` and the page renders.
* Confirm the existing wp-admin behavior is unchanged: the item still appears under Media in `wp-admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)