### PR TITLE
Release Smart Dictation to all paid English-locale users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-smart-dictation-paid-rollout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-smart-dictation-paid-rollout
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Smart Dictation: Make the feature available to 50% of paid English-language simple-site users.
+Smart Dictation: Make the feature available to all paid English-language simple-site users.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -16,7 +16,7 @@ class WPCOM_Smart_Dictation {
 	/**
 	 * Percentage of paid users eligible for Smart Dictation.
 	 */
-	private const PAID_USER_ROLLOUT_PERCENTAGE = 50;
+	private const PAID_USER_ROLLOUT_PERCENTAGE = 100;
 
 	/**
 	 * WPCOM_Smart_Dictation constructor.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Increase the Smart Dictation paid-user rollout from 50% to 100% while keeping the existing modulo percentage gate in place.
* Update the Smart Dictation changelog entry to describe availability for all paid English-language simple-site users.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `php -l projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php`.
* Run `php -d error_reporting=24575 vendor/bin/phpcs --standard=projects/packages/jetpack-mu-wpcom/.phpcs.dir.xml projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php`.
* Confirm paid-user rollout eligibility still uses the modulo percentage logic and now compares against `100`.
* Note: `composer -d projects/packages/jetpack-mu-wpcom phpunit` currently fails locally in `A8C\FSE\Agents_Manager_Test::test_css_enqueued_only_for_wp_admin_variants`, outside this change.
