### PR TITLE
Components: Replace self-imports with relative imports

### DIFF
--- a/projects/js-packages/components/changelog/cleanup-self-imports
+++ b/projects/js-packages/components/changelog/cleanup-self-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Components: Replace self-imports via package name with relative imports for clarity and to remove circular-dep risk.

--- a/projects/js-packages/components/components/pricing-card/index.tsx
+++ b/projects/js-packages/components/components/pricing-card/index.tsx
@@ -1,7 +1,7 @@
 import { getCurrencyObject } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { LoadingPlaceholder } from '@automattic/jetpack-components';
+import LoadingPlaceholder from '../loading-placeholder/index.tsx';
 import TermsOfService from '../terms-of-service/index.tsx';
 import type { PricingCardProps } from './types.ts';
 import type { CurrencyObject } from '@automattic/number-formatters';

--- a/projects/js-packages/components/components/upsell-banner/index.tsx
+++ b/projects/js-packages/components/components/upsell-banner/index.tsx
@@ -1,6 +1,6 @@
 import { Card, CardBody } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { Button } from '@automattic/jetpack-components';
+import Button from '../button/index.tsx';
 import { UpsellBannerProps } from './types.ts';
 import type { FC, ReactNode } from 'react';
 


### PR DESCRIPTION
Part of #48160 (jetpack-components migration to `@wordpress/ui`).

## Proposed changes

The `@automattic/jetpack-components` source package contained two imports from its own public package entrypoint:

- `components/pricing-card/index.tsx` imported `LoadingPlaceholder` from `@automattic/jetpack-components`.
- `components/upsell-banner/index.tsx` imported `Button` from `@automattic/jetpack-components`.

Both have been rewritten as relative imports from sibling source directories (`../loading-placeholder/index.tsx`, `../button/index.tsx`). The package shouldn't depend on its own public surface for source-internal usage — this is both a circular-dep risk and a code smell. Zero behavior change.

This also drops `js-packages/components` from 2 to 0 on the migration leaderboard's source-package self-import count.

## Related product discussion/links

* Issue #48160

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack build js-packages/components` — should build clean.
* Storybook/usages of `PricingCard` and `UpsellBanner` should render identically (no visual or behavioral change).
* `grep -rE "from '@automattic/jetpack-components'" projects/js-packages/components` should return nothing.
