### PR TITLE
External Media: migrate QRCode usage to direct qrcode.react import

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2488,6 +2488,9 @@ importers:
       moment:
         specifier: 2.30.1
         version: 2.30.1
+      qrcode.react:
+        specifier: 4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1

--- a/projects/packages/external-media/changelog/migrate-qrcode-to-direct-import
+++ b/projects/packages/external-media/changelog/migrate-qrcode-to-direct-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+External Media: migrate QRCode usage off @automattic/jetpack-components to qrcode.react direct import.

--- a/projects/packages/external-media/package.json
+++ b/projects/packages/external-media/package.json
@@ -45,6 +45,7 @@
 		"clsx": "2.1.1",
 		"lodash": "4.18.1",
 		"moment": "2.30.1",
+		"qrcode.react": "4.2.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1"
 	},

--- a/projects/packages/external-media/src/shared/sources/jetpack-app-media/index.js
+++ b/projects/packages/external-media/src/shared/sources/jetpack-app-media/index.js
@@ -1,10 +1,10 @@
-import { QRCode } from '@automattic/jetpack-components';
 import { useRefInterval } from '@automattic/jetpack-shared-extension-utils';
 import { JetpackAppIcon } from '@automattic/jetpack-shared-extension-utils/icons';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { QRCodeCanvas } from 'qrcode.react';
 import MediaBrowser from '../../media-browser';
 import { MediaSource } from '../../media-service/types';
 import withMedia from '../with-media';
@@ -116,8 +116,8 @@ function JetpackAppMedia( props ) {
 			{ ! hasImageUploaded && (
 				<div className="jetpack-external-media-wrapper__jetpack_app_media-qr-code-wrapper">
 					<div className="jetpack-external-media-wrapper__jetpack_app_media-qr-code">
-						<QRCode
-							size="100"
+						<QRCodeCanvas
+							size={ 100 }
 							value={ `https://apps.wordpress.com/get/?campaign=qr-code-media&postId=${ postId }#%2Fmedia%2F${ wpcomBlogId }` }
 						/>
 					</div>


### PR DESCRIPTION
Refs #48160

## Proposed changes
* Drop the `QRCode` import from `@automattic/jetpack-components` in the External Media package and use `qrcode.react`'s `QRCodeCanvas` directly. The jetpack-components `QRCode` is a thin wrapper around `qrcode.react`'s `QRCodeCanvas`/`QRCodeSVG` (default `renderAs='canvas'`), so this swap preserves DOM (`<canvas>`) and visual output exactly.
* Add `qrcode.react@4.2.0` as a direct dependency of `packages/external-media` (same version `js-packages/components` pins).
* Coerce the `size` prop from string `"100"` to numeric `100` while we're here — `qrcode.react` types it as `number` and the previous string slipped through via coercion.
* `@automattic/jetpack-components` is **not** removed from the package's deps yet — `filter-option.js` still imports `NumberControl` from it. That migration is a separate slice; this PR reduces external-media's jetpack-components imports from 2 to 1.

## Related product discussion/links
* Jetpack UI Modernization tracker: #48160

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The affected component is the QR code shown inside Gutenberg's External Media modal under "Upload from your phone" (`MediaSource.JetpackAppMedia`), used to point a phone camera at a deep link into the WordPress.com mobile app. Reaching this UI requires a WordPress.com-connected site.

* Connect a Jetpack site to WordPress.com.
* In the post editor, open the inserter, add an Image block, and pick "Insert from Phone" (or whichever entry exposes the Jetpack App Media source).
* Confirm a 100x100 QR code renders in the modal (canvas element).
* Scan the QR code with a phone — it should open `https://apps.wordpress.com/get/?campaign=qr-code-media&postId=<id>#%2Fmedia%2F<blogId>` in the camera/browser, identical to before.

Visual smoke screenshots were not captured locally because this UI requires a live wp.com connection that the worktree's isolated Docker doesn't have. The DOM is unchanged (same `<canvas>` element, same `.jetpack-external-media-wrapper__jetpack_app_media-qr-code canvas` styling applies). Reviewer spot-check on a connected sandbox appreciated.
