### PR TITLE
Partner Coupon: migrate ActionButton to @wordpress/ui

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1209,6 +1209,9 @@ importers:
       '@wordpress/i18n':
         specifier: 6.19.0
         version: 6.19.0
+      '@wordpress/ui':
+        specifier: 0.11.0
+        version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/projects/js-packages/partner-coupon/changelog/migrate-actionbutton-to-wp-ui
+++ b/projects/js-packages/partner-coupon/changelog/migrate-actionbutton-to-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Partner Coupon: Migrate ActionButton to @wordpress/ui Button; brings the package to zero ActionButton imports.

--- a/projects/js-packages/partner-coupon/components/redeem-partner-coupon-post-connection/index.jsx
+++ b/projects/js-packages/partner-coupon/components/redeem-partner-coupon-post-connection/index.jsx
@@ -1,5 +1,6 @@
-import { ActionButton, JetpackLogo } from '@automattic/jetpack-components';
+import { JetpackLogo } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import PropTypes from 'prop-types';
 import { useCallback, useState } from 'react';
 import { usePartnerCouponRedemption } from '../../hooks.js';
@@ -127,14 +128,13 @@ const RedeemPartnerCouponPostConnection = props => {
 
 					<div className="jetpack-redeem-partner-coupon-post-connection__actions">
 						<div>
-							<ActionButton
-								label={ sprintf(
+							<Button onClick={ onClick }>
+								{ sprintf(
 									/* translators: %s: Name of a Jetpack product. */
 									__( 'Redeem %s', 'jetpack-partner-coupon' ),
 									partnerCoupon.product.title
 								) }
-								onClick={ onClick }
-							/>
+							</Button>
 						</div>
 						<div>
 							<button

--- a/projects/js-packages/partner-coupon/components/redeem-partner-coupon-pre-connection/index.jsx
+++ b/projects/js-packages/partner-coupon/components/redeem-partner-coupon-pre-connection/index.jsx
@@ -1,6 +1,6 @@
-import { ActionButton } from '@automattic/jetpack-components';
 import { ConnectScreen } from '@automattic/jetpack-connection';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { usePartnerCouponRedemption } from '../../hooks.js';
@@ -74,14 +74,13 @@ const RedeemPartnerCouponPreConnection = props => {
 					) ) }
 				</ul>
 				{ connectionStatus.hasConnectedOwner && (
-					<ActionButton
-						label={ sprintf(
+					<Button onClick={ onClick }>
+						{ sprintf(
 							/* translators: %s: Name of a Jetpack product. */
 							__( 'Redeem %s', 'jetpack-partner-coupon' ),
 							partnerCoupon.product.title
 						) }
-						onClick={ onClick }
-					/>
+					</Button>
 				) }
 			</ConnectScreen>
 		</div>

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -26,6 +26,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@wordpress/i18n": "6.19.0",
+		"@wordpress/ui": "0.11.0",
 		"clsx": "2.1.1",
 		"prop-types": "15.8.1"
 	},


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/48160

## Proposed changes

Migrates the two `ActionButton` consumers in `@automattic/jetpack-partner-coupon` (`redeem-partner-coupon-pre-connection`, `redeem-partner-coupon-post-connection`) to the new `Button` from `@wordpress/ui`, in line with the broader [Jetpack UI Modernization](https://github.com/Automattic/jetpack/issues/48160) effort. Follows the pattern established in #48150 (Publicize) and #48489 (My Jetpack interstitials).

Brings the partner-coupon package to **zero** `ActionButton` imports — closing out the leaderboard for this package on that import. Two other `@automattic/jetpack-components` imports remain (`getRedirectUrl`, `JetpackLogo`) and are out of scope here; the package dep stays.

### Props mapping

Both call sites used `ActionButton` minimally — only `label` (the visible text) and `onClick`, defaulting to the primary variant. The `@wordpress/ui` Button's default `solid` variant is the matching primary, so:

| `ActionButton` prop | `@wordpress/ui` Button equivalent |
|---|---|
| `label="…"` | children (button text) |
| `onClick={…}` | `onClick={…}` |
| `variant` (default `"primary"`) | default (solid) — no prop needed |

No translation needed for `isLoading`, `isDisabled`, `displayError`, `errorMessage`, `isExternalLink`, `customClass`, `loadingText` — none were used at either call site.

### Files changed

- `redeem-partner-coupon-pre-connection/index.jsx` — "Redeem {product}" CTA inside `<ConnectScreen>` (rendered only when `connectionStatus.hasConnectedOwner` is true).
- `redeem-partner-coupon-post-connection/index.jsx` — "Redeem {product}" CTA in the post-connection redemption flow (sits next to the "Remind me later" plain button).
- `package.json` — drops the implicit ActionButton dep, adds `@wordpress/ui` at `0.11.0` (matching the version pinned by my-jetpack, publicize, etc.).
- `pnpm-lock.yaml` — workspace import block for partner-coupon now resolves `@wordpress/ui`.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/48160 — Jetpack UI Modernization tracker
* https://github.com/Automattic/jetpack/pull/48150 — Publicize migration (precedent)
* https://github.com/Automattic/jetpack/pull/48489 — My Jetpack interstitial migration (precedent)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The partner-coupon flow is a deep integration that surfaces when a user lands on a Jetpack admin page with a `partnerCoupon` query parameter and a matching partner record. Spot-checks I'd suggest reviewers run:

* `pnpm jetpack build js-packages/partner-coupon` — builds clean.
* `cd projects/js-packages/partner-coupon && pnpm run test` — all 22 existing tests pass; `getByRole( 'button', { name: ... } )` still matches the new `@wordpress/ui` Button since it renders an accessible button with the same accessible name.
* Visual: if you have a partner-coupon test surface handy (e.g. a sandbox with a queued partner coupon), confirm the "Redeem {product}" button still renders as a primary action in both:
  * the pre-connection screen (`hasConnectedOwner === true` branch of `<ConnectScreen>`)
  * the post-connection notice (the dismissable in-dashboard banner)

If a visual reviewer can capture before/after of the redemption banner, please drop them on this PR — happy to update the body with the URLs.
