### PR TITLE
Connection: migrate ActionButton, Button, and Text to @wordpress/ui

### DIFF
--- a/projects/js-packages/connection/changelog/migrate-jetpack-components-to-wp-ui
+++ b/projects/js-packages/connection/changelog/migrate-jetpack-components-to-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: Migrate ActionButton, Button, and Text consumers off @automattic/jetpack-components to @wordpress/ui equivalents; brings the package to zero migration-relevant jetpack-components imports.

--- a/projects/js-packages/connection/components/connect-button/index.jsx
+++ b/projects/js-packages/connection/components/connect-button/index.jsx
@@ -1,5 +1,5 @@
-import { ActionButton } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import PropTypes from 'prop-types';
 import useConnection from '../use-connection';
 
@@ -39,12 +39,16 @@ const ConnectButton = props => {
 	return (
 		<>
 			{ ( ! isRegistered || ! isUserConnected ) && (
-				<ActionButton
-					label={ connectLabel }
-					onClick={ handleRegisterSite }
-					displayError={ registrationError ? true : false }
-					isLoading={ siteIsRegistering || userIsConnecting }
-				/>
+				<>
+					<Button onClick={ handleRegisterSite } loading={ siteIsRegistering || userIsConnecting }>
+						{ connectLabel }
+					</Button>
+					{ registrationError && (
+						<p className="jp-action-button__error">
+							{ __( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
+						</p>
+					) }
+				</>
 			) }
 		</>
 	);

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -17,25 +17,16 @@
 		}
 	}
 
-	.jp-action-button {
+	// Structural-only: top spacing + responsive width. All other treatment
+	// (colors, padding, border-radius, font-weight) honors the
+	// @wordpress/ui Button defaults.
+	.jp-connection__connect-screen__action-button {
 		margin-top: 40px;
+		max-width: 100%;
 
-		&--button {
-			border-radius: 4px;
-			font-weight: 600;
-		}
-
-		button {
-			max-width: 100%;
-
-			&:disabled {
-				color: hsla(0, 0%, 100%, 0.4);
-			}
-
-			@media ( max-width: breakpoints.$break-medium ) {
-				max-width: none;
-				width: 100%;
-			}
+		@media ( max-width: breakpoints.$break-medium ) {
+			max-width: none;
+			width: 100%;
 		}
 	}
 

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
@@ -1,6 +1,7 @@
-import { ActionButton, TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
+import { TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import ConnectScreenLayout from '../layout';
 import type { Props as ConnectScreenProps } from '../basic';
 import type { WithRequired } from '../types';
@@ -102,14 +103,15 @@ const ConnectScreenVisual: FC< Props > = ( {
 			<div className="jp-connection__connect-screen__tos">
 				<TermsOfService agreeButtonLabel={ buttonLabel } />
 			</div>
-			<ActionButton
-				label={ buttonLabel }
-				onClick={ handleButtonClick }
-				displayError={ displayButtonError || isOfflineMode }
-				errorMessage={ getErrorMessage( errorCode, isOfflineMode ) }
-				isLoading={ buttonIsLoading }
-				isDisabled={ isOfflineMode }
-			/>
+			<Button onClick={ handleButtonClick } loading={ buttonIsLoading } disabled={ isOfflineMode }>
+				{ buttonLabel }
+			</Button>
+			{ ( displayButtonError || isOfflineMode ) && (
+				<p className="jp-action-button__error">
+					{ getErrorMessage( errorCode, isOfflineMode ) ||
+						__( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
+				</p>
+			) }
 			<span className="jp-connection__connect-screen__loading-message" role="status">
 				{ buttonIsLoading ? loadingLabel || __( 'Loading', 'jetpack-connection-js' ) : '' }
 			</span>

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
@@ -1,6 +1,7 @@
-import { ActionButton, TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
+import { TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import ConnectScreenLayout from '../layout';
 import type { Props as ConnectScreenProps } from '../basic';
 import type { WithRequired } from '../types';
@@ -102,14 +103,20 @@ const ConnectScreenVisual: FC< Props > = ( {
 			<div className="jp-connection__connect-screen__tos">
 				<TermsOfService agreeButtonLabel={ buttonLabel } />
 			</div>
-			<ActionButton
-				label={ buttonLabel }
+			<Button
+				className="jp-connection__connect-screen__action-button"
 				onClick={ handleButtonClick }
-				displayError={ displayButtonError || isOfflineMode }
-				errorMessage={ getErrorMessage( errorCode, isOfflineMode ) }
-				isLoading={ buttonIsLoading }
-				isDisabled={ isOfflineMode }
-			/>
+				loading={ buttonIsLoading }
+				disabled={ isOfflineMode }
+			>
+				{ buttonLabel }
+			</Button>
+			{ ( displayButtonError || isOfflineMode ) && (
+				<p className="jp-connection__connect-screen__error">
+					{ getErrorMessage( errorCode, isOfflineMode ) ||
+						__( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
+				</p>
+			) }
 			<span className="jp-connection__connect-screen__loading-message" role="status">
 				{ buttonIsLoading ? loadingLabel || __( 'Loading', 'jetpack-connection-js' ) : '' }
 			</span>

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.tsx
@@ -1,7 +1,6 @@
-import { TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
+import { ActionButton, TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
 import ConnectScreenLayout from '../layout';
 import type { Props as ConnectScreenProps } from '../basic';
 import type { WithRequired } from '../types';
@@ -103,15 +102,14 @@ const ConnectScreenVisual: FC< Props > = ( {
 			<div className="jp-connection__connect-screen__tos">
 				<TermsOfService agreeButtonLabel={ buttonLabel } />
 			</div>
-			<Button onClick={ handleButtonClick } loading={ buttonIsLoading } disabled={ isOfflineMode }>
-				{ buttonLabel }
-			</Button>
-			{ ( displayButtonError || isOfflineMode ) && (
-				<p className="jp-action-button__error">
-					{ getErrorMessage( errorCode, isOfflineMode ) ||
-						__( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
-				</p>
-			) }
+			<ActionButton
+				label={ buttonLabel }
+				onClick={ handleButtonClick }
+				displayError={ displayButtonError || isOfflineMode }
+				errorMessage={ getErrorMessage( errorCode, isOfflineMode ) }
+				isLoading={ buttonIsLoading }
+				isDisabled={ isOfflineMode }
+			/>
 			<span className="jp-connection__connect-screen__loading-message" role="status">
 				{ buttonIsLoading ? loadingLabel || __( 'Loading', 'jetpack-connection-js' ) : '' }
 			</span>

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -82,6 +82,8 @@
 			text-decoration: underline;
 			font: inherit;
 			padding: 0;
+			min-width: calc(var(--spacing-base) * 8);
+			justify-content: center;
 
 			// @wordpress/components Spinner ships with `margin: 5px 11px 0`
 			// for use inside button chrome we no longer have. Zero it out

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -43,23 +43,12 @@
 			right: calc(var(--spacing-base) * 12);
 		}
 
-		.jp-action-button--button.components-button {
+		// Structural-only: span the pricing card width and keep the vertical
+		// rhythm inside the card. All other treatment (colors, padding,
+		// font-size, border-radius) honors the @wordpress/ui Button defaults.
+		.jp-connection__connect-screen__action-button {
 			width: 100%;
-			height: auto;
-			font-size: 18px;
-			font-weight: 500;
-			background: var(--jp-black) !important;
-			color: var(--jp-white) !important;
-			border-radius: var(--jp-border-radius);
-			padding: 14px 24px;
-			margin: 24px 0 32px;
-			justify-content: center;
-			align-items: center;
-
-			&:disabled {
-				background: var(--jp-gray) !important;
-				color: var(--jp-gray-20) !important;
-			}
+			margin: 24px 0;
 		}
 
 		.terms-of-service {
@@ -77,33 +66,29 @@
 		gap: 1ch;
 		line-height: 1;
 
-		.jp-action-button--button.components-button.is-primary {
-			display: inline;
-			color: var(--jp-black) !important;
-			background: inherit !important;
+		// Inline button styled as a text link inside the surrounding sentence.
+		// `variant="unstyled"` strips @wordpress/ui Button's chrome so we can
+		// flow it inline with the prefix copy; we keep `<button>` semantics so
+		// the element stays keyboard-focusable and screen readers announce
+		// "button" + aria-busy when in-flight (a `<Link>` couldn't do that).
+		// `inline-flex` + `align-items: center` keeps either the label or the
+		// loading spinner vertically centered within the button row, and
+		// `align-self: baseline` aligns the whole button with the prefix
+		// text's baseline inside the parent flex container.
+		.jp-connection__connect-screen__inline-action {
+			display: inline-flex;
+			align-items: center;
+			align-self: baseline;
 			text-decoration: underline;
-
-			width: auto;
-			min-width: 0;
-			height: auto;
 			font: inherit;
 			padding: 0;
 
-			&:hover {
-				background: inherit;
-				text-decoration-thickness: var(--jp-underline-thickness);
+			// @wordpress/components Spinner ships with `margin: 5px 11px 0`
+			// for use inside button chrome we no longer have. Zero it out
+			// so the spinner sits flush in the inline-flex row.
+			.components-spinner {
+				margin: 0;
 			}
-
-			&:focus {
-				background: inherit;
-				box-shadow: none !important;
-			}
-		}
-
-		.jp-components-spinner__inner,
-		.jp-components-spinner__outer {
-			border-top-color: var(--jp-black);
-			border-right-color: var(--jp-black);
 		}
 	}
 }

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -1,11 +1,8 @@
-import {
-	ActionButton,
-	getRedirectUrl,
-	PricingCard,
-	TermsOfService,
-} from '@automattic/jetpack-components';
+import { getRedirectUrl, PricingCard, TermsOfService } from '@automattic/jetpack-components';
+import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
@@ -45,11 +42,15 @@ const ConnectScreenRequiredPlanVisual = props => {
 		__( 'Already have a subscription? <connectButton/>', 'jetpack-connection-js' ),
 		{
 			connectButton: (
-				<ActionButton
-					label={ __( 'Log in to get started', 'jetpack-connection-js' ) }
+				<Button
+					variant="unstyled"
+					className="jp-connection__connect-screen__inline-action"
 					onClick={ handleButtonClick }
-					isLoading={ buttonIsLoading }
-				/>
+					disabled={ buttonIsLoading }
+					aria-busy={ buttonIsLoading }
+				>
+					{ buttonIsLoading ? <Spinner /> : __( 'Log in to get started', 'jetpack-connection-js' ) }
+				</Button>
 			),
 		}
 	);
@@ -92,14 +93,20 @@ const ConnectScreenRequiredPlanVisual = props => {
 						priceAfter={ priceAfter }
 					>
 						<TermsOfService agreeButtonLabel={ buttonLabel } />
-						<ActionButton
-							label={ buttonLabel }
+						<Button
+							className="jp-connection__connect-screen__action-button"
 							onClick={ handleButtonClick }
-							displayError={ displayButtonError || isOfflineMode }
-							errorMessage={ errorMessage }
-							isLoading={ buttonIsLoading }
-							isDisabled={ isOfflineMode }
-						/>
+							loading={ buttonIsLoading }
+							disabled={ isOfflineMode }
+						>
+							{ buttonLabel }
+						</Button>
+						{ ( displayButtonError || isOfflineMode ) && (
+							<p className="jp-connection__connect-screen__error">
+								{ errorMessage ||
+									__( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
+							</p>
+						) }
 					</PricingCard>
 				</div>
 

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -1,11 +1,7 @@
-import {
-	ActionButton,
-	getRedirectUrl,
-	PricingCard,
-	TermsOfService,
-} from '@automattic/jetpack-components';
+import { getRedirectUrl, PricingCard, TermsOfService } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
@@ -45,11 +41,9 @@ const ConnectScreenRequiredPlanVisual = props => {
 		__( 'Already have a subscription? <connectButton/>', 'jetpack-connection-js' ),
 		{
 			connectButton: (
-				<ActionButton
-					label={ __( 'Log in to get started', 'jetpack-connection-js' ) }
-					onClick={ handleButtonClick }
-					isLoading={ buttonIsLoading }
-				/>
+				<Button onClick={ handleButtonClick } loading={ buttonIsLoading }>
+					{ __( 'Log in to get started', 'jetpack-connection-js' ) }
+				</Button>
 			),
 		}
 	);
@@ -92,14 +86,19 @@ const ConnectScreenRequiredPlanVisual = props => {
 						priceAfter={ priceAfter }
 					>
 						<TermsOfService agreeButtonLabel={ buttonLabel } />
-						<ActionButton
-							label={ buttonLabel }
+						<Button
 							onClick={ handleButtonClick }
-							displayError={ displayButtonError || isOfflineMode }
-							errorMessage={ errorMessage }
-							isLoading={ buttonIsLoading }
-							isDisabled={ isOfflineMode }
-						/>
+							loading={ buttonIsLoading }
+							disabled={ isOfflineMode }
+						>
+							{ buttonLabel }
+						</Button>
+						{ ( displayButtonError || isOfflineMode ) && (
+							<p className="jp-action-button__error">
+								{ errorMessage ||
+									__( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
+							</p>
+						) }
 					</PricingCard>
 				</div>
 

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -1,7 +1,11 @@
-import { getRedirectUrl, PricingCard, TermsOfService } from '@automattic/jetpack-components';
+import {
+	ActionButton,
+	getRedirectUrl,
+	PricingCard,
+	TermsOfService,
+} from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
@@ -41,9 +45,11 @@ const ConnectScreenRequiredPlanVisual = props => {
 		__( 'Already have a subscription? <connectButton/>', 'jetpack-connection-js' ),
 		{
 			connectButton: (
-				<Button onClick={ handleButtonClick } loading={ buttonIsLoading }>
-					{ __( 'Log in to get started', 'jetpack-connection-js' ) }
-				</Button>
+				<ActionButton
+					label={ __( 'Log in to get started', 'jetpack-connection-js' ) }
+					onClick={ handleButtonClick }
+					isLoading={ buttonIsLoading }
+				/>
 			),
 		}
 	);
@@ -86,19 +92,14 @@ const ConnectScreenRequiredPlanVisual = props => {
 						priceAfter={ priceAfter }
 					>
 						<TermsOfService agreeButtonLabel={ buttonLabel } />
-						<Button
+						<ActionButton
+							label={ buttonLabel }
 							onClick={ handleButtonClick }
-							loading={ buttonIsLoading }
-							disabled={ isOfflineMode }
-						>
-							{ buttonLabel }
-						</Button>
-						{ ( displayButtonError || isOfflineMode ) && (
-							<p className="jp-action-button__error">
-								{ errorMessage ||
-									__( 'An error occurred. Please try again.', 'jetpack-connection-js' ) }
-							</p>
-						) }
+							displayError={ displayButtonError || isOfflineMode }
+							errorMessage={ errorMessage }
+							isLoading={ buttonIsLoading }
+							isDisabled={ isOfflineMode }
+						/>
 					</PricingCard>
 				</div>
 

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -3,13 +3,13 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
-import { Button, getRedirectUrl, Text } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isWoASite } from '@automattic/jetpack-script-data';
 import { Modal } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight, external } from '@wordpress/icons';
-import { Link } from '@wordpress/ui';
+import { Button, Link, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useState, useMemo } from 'react';
@@ -316,8 +316,7 @@ const HelpFooter = ( { onClose, disabled } ) => {
 			</div>
 			<div className="jp-connection__manage-dialog__button-wrap lg-col-span-3 md-col-span-1 sm-col-span-1">
 				<Button
-					weight="regular"
-					variant="secondary"
+					variant="outline"
 					onClick={ onClose }
 					className="jp-connection__manage-dialog__btn-dismiss"
 					disabled={ disabled }


### PR DESCRIPTION
Part of #48160.

## Proposed changes

Migrate the remaining 5 migration-relevant `@automattic/jetpack-components` imports in `@automattic/jetpack-connection` to `@wordpress/ui`, taking the package to **zero** on the migration leaderboard.

* `ActionButton` × 3 → `@wordpress/ui` `Button`
* `Button` × 1 → `@wordpress/ui` `Button`
* `Text` × 1 → `@wordpress/ui` `Text`

Keepers (`DecorativeCard`, `getRedirectUrl`, `JetpackLogo`, `PricingCard`, `TermsOfService`) remain on `@automattic/jetpack-components`; the package dependency stays.

### Props mapping

`ActionButton` call sites in `connection/` use more than just `label` + `onClick`, so this slice exercises the full mapping (unlike #49098, where every call site was trivial):

| `ActionButton` prop | `@wordpress/ui` Button equivalent |
|---|---|
| `label="…"` | `children` (button text) |
| `onClick={…}` | `onClick={…}` |
| `isLoading={…}` | `loading={…}` (auto-disables the button + announces via a11y) |
| `isDisabled={…}` | `disabled={…}` |
| `displayError` + `errorMessage` | Sibling `<p className="jp-action-button__error">` rendered conditionally |
| `variant` (default `"primary"`) | default (solid) — no prop needed |

`ActionButton`'s default error string (`__( 'An error occurred. Please try again.', 'jetpack-components' )`) is reproduced inline with the connection text domain so the existing `it( 'shows error into button' )` test assertions match unchanged.

For the `<Button weight="regular" variant="secondary">` call site in `manage-connection-dialog`, `variant="secondary"` maps to `variant="outline"` (matching the precedent in `scan/src/js/screens/overview/*-modal.tsx` and `videopress/src/dashboard/components/video-details/`). `weight="regular"` was the default and has no `@wordpress/ui` equivalent — dropped.

For `Text`, both call sites use the default `variant="body"`, which maps cleanly to `@wordpress/ui` Text's default `variant="body-md"` (verified against #48909).

### Files changed

* `components/connect-button/index.jsx` — `ActionButton` (used by RNA connection flow). Error rendered as sibling `<p>`.
* `components/connect-screen/basic/visual.tsx` — `ActionButton` inside `<ConnectScreen>`. Preserves `displayButtonError || isOfflineMode` error branch with the offline / error-code message.
* `components/connect-screen/required-plan/visual.jsx` — two `ActionButton` call sites (main CTA inside `<PricingCard>` + "Log in to get started" interpolated link).
* `components/manage-connection-dialog/index.jsx` — `Button` (Cancel in help footer) + two `Text` usages.
* `changelog/migrate-jetpack-components-to-wp-ui` — patch / changed.

`@wordpress/ui@0.11.0` was already a direct dep — no `package.json` change needed.

### Acceptance

- Post-migration scan (`scan-imports.py`) shows `js-packages/connection` migration-relevant total = **0**. ✅
- `pnpm jetpack build js-packages/connection` clean. ✅
- `pnpm --filter @automattic/jetpack-connection test` — **12 suites, 70 passed, 2 todo** (unchanged from trunk). ✅ The `'shows error into button'` tests in both `connect-screen/basic/test/component.jsx` and `connect-screen/required-plan/test/component.jsx` continue to find "An error occurred. Please try again." in the document. The `getByRole( 'button', { name: ... } )` assertions match the new `@wordpress/ui` Button without test changes.
- ESLint + Prettier clean on all touched files. ✅

## Related product discussion/links

* Tracking issue: #48160 — Jetpack UI Modernization
* Precedent (Publicize): #48150
* Precedent (My Jetpack interstitials): #48489
* Precedent (Partner Coupon — `ActionButton` minimal): #49098
* Precedent (CUT migration, `Text` variant mapping): #48909

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The connection package powers the Jetpack site/user connection flows. Spot-checks I'd suggest reviewers run:

1. **Visual / functional smoke** on any site that mounts `<ConnectScreen>` (e.g. a fresh Jetpack install or any flow that drops a user on the basic Connect screen). The "Set up Jetpack" CTA should render as a primary `@wordpress/ui` Button, with the Terms of Service text immediately above it. Click it — the existing connection flow should trigger.
2. **Required-plan variant**: any consumer using `<ConnectScreenRequiredPlan>` (e.g. paid Jetpack product onboarding screens with a `priceBefore`/`priceAfter`). Confirm the main CTA renders as primary inside `<PricingCard>` and the "Already have a subscription? Log in to get started" interpolated button still works.
3. **Error states** (the key non-trivial mapping): force `displayButtonError` or `isOfflineMode` truthy at any `ConnectScreen*` call site — the error paragraph "An error occurred. Please try again." (or the offline-mode interpolated link) should render immediately below the button.
4. **Loading state**: trigger `siteIsRegistering` / `userIsConnecting` (e.g. click Connect on a fresh site). The button should show the `@wordpress/ui` Button loading spinner and be disabled.
5. **Manage Connection dialog**: open `<ManageConnectionDialog>` from any consumer (My Jetpack → Connection settings is the easy reach). The "Cancel" button in the help footer should render as an outline-variant `@wordpress/ui` Button; both `<Text>` usages (large opening paragraph + help-footer copy) should render with the default `body-md` typography.

If a visual reviewer can capture before/after of the connect screen + manage-connection dialog, please drop them on this PR — happy to update the body with the URLs.

