### PR TITLE
ActivityPub: Widen Reader auth shim to user-actor routes

### DIFF
--- a/projects/plugins/jetpack/3rd-party/activitypub.php
+++ b/projects/plugins/jetpack/3rd-party/activitypub.php
@@ -7,7 +7,10 @@
  *
  * Scope:
  * - Three routes, with method affinity (inbox GET, proxy POST, outbox POST).
- * - Blog-mode AP sites only; user-mode is out of scope.
+ * - Blog-actor routes require the site to be in `blog` or `actor_blog` mode;
+ *   user-actor routes are accepted in any actor mode that exposes user actors
+ *   (`actor` or `actor_blog`). The AP plugin's downstream `verify_owner`
+ *   check enforces actor identity natively for both cases.
  * - Real OAuth flows are never overridden — when a Bearer is present we
  *   defer to the plugin's normal verification.
  *
@@ -84,11 +87,44 @@ function jetpack_activitypub_reader_auth_check_permission( $result, $request ) {
 		return $result;
 	}
 
-	if ( ! jetpack_activitypub_reader_auth_is_blog_mode() ) {
+	// The blog-mode gate is route-scoped: only the blog actor's existence
+	// depends on `blog` / `actor_blog` mode. User actors exist whenever the
+	// site exposes user actors at all, and the AP plugin's `verify_owner`
+	// check is what enforces actor identity for both cases (BLOG_USER_ID +
+	// user_can_act_as_blog for the blog actor; current-user equality for
+	// user actors).
+	if (
+		jetpack_activitypub_reader_auth_route_is_blog_actor( $request )
+		&& ! jetpack_activitypub_reader_auth_is_blog_mode()
+	) {
 		return $result;
 	}
 
 	return true;
+}
+
+/**
+ * Whether the request route targets the blog actor (`actors/0/...`).
+ *
+ * Used by the permission-check callback to decide whether the blog-mode
+ * gate is relevant: only the blog actor's existence depends on the site
+ * being in `blog` or `actor_blog` mode. User actors exist in `actor` and
+ * `actor_blog` modes, and the AP plugin's own `verify_owner` handles
+ * identity matching for both cases.
+ *
+ * @since $$next-version$$
+ *
+ * @param mixed $request The REST request.
+ * @return bool
+ */
+function jetpack_activitypub_reader_auth_route_is_blog_actor( $request ): bool {
+	if ( ! is_object( $request ) || ! method_exists( $request, 'get_route' ) ) {
+		return false;
+	}
+	return (bool) preg_match(
+		'#/(?:users|actors)/0/#',
+		(string) $request->get_route()
+	);
 }
 
 /**
@@ -132,14 +168,10 @@ function jetpack_activitypub_reader_auth_is_jetpack_signed(): bool {
  * Whether the destination AP plugin is configured to expose a blog actor.
  *
  * Accepts both `'blog'` (blog-only) and `'actor_blog'` (per-user + blog).
- * On `'actor_blog'` sites the blog actor behaves identically to pure
- * blog-mode and is the only actor the wpcom Reader operates on — the
- * route patterns are pinned to `user_id=0`, so widening the grant to
- * arbitrary user actors is not possible here.
- *
- * Pure user-mode (`'actor'`) is still rejected: the blog actor doesn't
- * exist on those sites, so authorizing `user_id=0` routes would be
- * nonsensical.
+ * Only consulted for blog-actor routes (`actors/0/...`) — pure user-mode
+ * (`'actor'`) sites have no blog actor, so authorising `user_id=0` routes
+ * there would be nonsensical. User-actor routes are gated separately by
+ * the AP plugin's own `verify_owner` check.
  *
  * Uses a `null` sentinel default so an unset option is treated as
  * "unknown, deny" rather than implicitly accepted — the AP plugin's own
@@ -179,17 +211,20 @@ function jetpack_activitypub_reader_auth_is_target_route( $request ): bool {
 	$route  = (string) $request->get_route();
 	$method = strtoupper( (string) $request->get_method() );
 
-	// Patterns are pinned to the blog actor (user_id 0) on purpose: the wpcom
-	// Reader only operates on the blog actor, and granting the OAuth bypass
-	// for arbitrary user ids would silently widen the surface if the AP
-	// plugin ever loosened its downstream `verify_owner` check.
+	// Patterns accept any user id (`actors/\d+/...`). The downstream
+	// `verify_owner` (`Activitypub\Rest\Verification::verify_owner`) is what
+	// enforces identity equality: `get_current_user_id() === (int) $user_id`
+	// for user actors (the wpcom user is installed by Rest_Authentication on
+	// Jetpack-signed calls), and `BLOG_USER_ID + user_can_act_as_blog()` for
+	// the blog actor. The shim's role here is bypassing the OAuth bearer
+	// check; it does not need to validate actor identity.
 	static $patterns = array(
 		'GET'  => array(
-			'#^/activitypub/\d+\.\d+/(?:users|actors)/0/inbox/?$#',
+			'#^/activitypub/\d+\.\d+/(?:users|actors)/\d+/inbox/?$#',
 		),
 		'POST' => array(
 			'#^/activitypub/\d+\.\d+/proxy/?$#',
-			'#^/activitypub/\d+\.\d+/(?:users|actors)/0/outbox/?$#',
+			'#^/activitypub/\d+\.\d+/(?:users|actors)/\d+/outbox/?$#',
 		),
 	);
 

--- a/projects/plugins/jetpack/changelog/ap-reader-auth-user-actors
+++ b/projects/plugins/jetpack/changelog/ap-reader-auth-user-actors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+ActivityPub: Allow Reader auth shim to cover user-actor routes, not just the blog actor.

--- a/projects/plugins/jetpack/tests/php/3rd-party/Jetpack_ActivityPub_Reader_Auth_Test.php
+++ b/projects/plugins/jetpack/tests/php/3rd-party/Jetpack_ActivityPub_Reader_Auth_Test.php
@@ -24,12 +24,14 @@ require_once JETPACK__PLUGIN_DIR . '3rd-party/activitypub.php';
  * @covers ::jetpack_activitypub_reader_auth_is_jetpack_signed
  * @covers ::jetpack_activitypub_reader_auth_is_oauth_request
  * @covers ::jetpack_activitypub_reader_auth_is_target_route
+ * @covers ::jetpack_activitypub_reader_auth_route_is_blog_actor
  */
 #[CoversFunction( 'jetpack_activitypub_reader_auth_check_permission' )]
 #[CoversFunction( 'jetpack_activitypub_reader_auth_is_blog_mode' )]
 #[CoversFunction( 'jetpack_activitypub_reader_auth_is_jetpack_signed' )]
 #[CoversFunction( 'jetpack_activitypub_reader_auth_is_oauth_request' )]
 #[CoversFunction( 'jetpack_activitypub_reader_auth_is_target_route' )]
+#[CoversFunction( 'jetpack_activitypub_reader_auth_route_is_blog_actor' )]
 class Jetpack_ActivityPub_Reader_Auth_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -174,20 +176,21 @@ class Jetpack_ActivityPub_Reader_Auth_Test extends WP_UnitTestCase {
 	 */
 	public static function target_route_provider(): array {
 		return array(
-			'inbox GET (actors)'                       => array( '/activitypub/1.0/actors/0/inbox', 'GET', true ),
+			'inbox GET (blog actor)'                   => array( '/activitypub/1.0/actors/0/inbox', 'GET', true ),
 			'inbox GET (users alias)'                  => array( '/activitypub/1.0/users/0/inbox', 'GET', true ),
 			'inbox GET (trailing slash)'               => array( '/activitypub/1.0/actors/0/inbox/', 'GET', true ),
+			'inbox GET (user actor 1)'                 => array( '/activitypub/1.0/actors/1/inbox', 'GET', true ),
+			'inbox GET (user actor via users alias)'   => array( '/activitypub/1.0/users/7/inbox', 'GET', true ),
 			'proxy POST'                               => array( '/activitypub/1.0/proxy', 'POST', true ),
 			'proxy POST (trailing slash)'              => array( '/activitypub/1.0/proxy/', 'POST', true ),
-			'outbox POST (actors)'                     => array( '/activitypub/1.0/actors/0/outbox', 'POST', true ),
+			'outbox POST (blog actor)'                 => array( '/activitypub/1.0/actors/0/outbox', 'POST', true ),
 			'outbox POST (users alias)'                => array( '/activitypub/1.0/users/0/outbox', 'POST', true ),
 			'outbox POST (trailing slash)'             => array( '/activitypub/1.0/actors/0/outbox/', 'POST', true ),
+			'outbox POST (user actor 42)'              => array( '/activitypub/1.0/actors/42/outbox', 'POST', true ),
 			'inbox POST is wrong method'               => array( '/activitypub/1.0/actors/0/inbox', 'POST', false ),
 			'outbox GET is wrong method'               => array( '/activitypub/1.0/actors/0/outbox', 'GET', false ),
 			'proxy GET is wrong method'                => array( '/activitypub/1.0/proxy', 'GET', false ),
 			'inbox GET (negative user_id rejected)'    => array( '/activitypub/1.0/actors/-1/inbox', 'GET', false ),
-			'inbox GET (non-blog user_id rejected)'    => array( '/activitypub/1.0/actors/1/inbox', 'GET', false ),
-			'outbox POST (non-blog user_id rejected)'  => array( '/activitypub/1.0/actors/42/outbox', 'POST', false ),
 			'inbox GET (non-numeric user_id rejected)' => array( '/activitypub/1.0/actors/abc/inbox', 'GET', false ),
 			'followers GET not a target'               => array( '/activitypub/1.0/actors/0/followers', 'GET', false ),
 			'following GET not a target'               => array( '/activitypub/1.0/actors/0/following', 'GET', false ),
@@ -230,12 +233,45 @@ class Jetpack_ActivityPub_Reader_Auth_Test extends WP_UnitTestCase {
 	 * Mixed actor_blog mode → true.
 	 *
 	 * On `actor_blog` sites the blog actor exists alongside per-user actors
-	 * and behaves identically to pure blog-mode. Route patterns are pinned
-	 * to `user_id=0`, so the grant cannot widen to arbitrary user actors.
+	 * and behaves identically to pure blog-mode. The downstream `verify_owner`
+	 * check is what enforces actor identity on the resulting request.
 	 */
 	public function test_is_blog_mode_actor_blog_true(): void {
 		update_option( 'activitypub_actor_mode', 'actor_blog' );
 		$this->assertTrue( jetpack_activitypub_reader_auth_is_blog_mode() );
+	}
+
+	/**
+	 * Route_is_blog_actor → true for `user_id=0` routes.
+	 */
+	public function test_route_is_blog_actor_true_for_user_id_0(): void {
+		$request = self::make_request( '/activitypub/1.0/actors/0/inbox', 'GET' );
+		$this->assertTrue( jetpack_activitypub_reader_auth_route_is_blog_actor( $request ) );
+	}
+
+	/**
+	 * Route_is_blog_actor → true via the `users/0/` alias.
+	 */
+	public function test_route_is_blog_actor_true_for_users_alias(): void {
+		$request = self::make_request( '/activitypub/1.0/users/0/outbox', 'POST' );
+		$this->assertTrue( jetpack_activitypub_reader_auth_route_is_blog_actor( $request ) );
+	}
+
+	/**
+	 * Route_is_blog_actor → false for user-actor routes.
+	 */
+	public function test_route_is_blog_actor_false_for_user_actor(): void {
+		$request = self::make_request( '/activitypub/1.0/actors/5/inbox', 'GET' );
+		$this->assertFalse( jetpack_activitypub_reader_auth_route_is_blog_actor( $request ) );
+	}
+
+	/**
+	 * Route_is_blog_actor → false for non-request payloads (defensive guard).
+	 */
+	public function test_route_is_blog_actor_handles_non_request_payloads(): void {
+		$this->assertFalse( jetpack_activitypub_reader_auth_route_is_blog_actor( null ) );
+		$this->assertFalse( jetpack_activitypub_reader_auth_route_is_blog_actor( 'not-a-request' ) );
+		$this->assertFalse( jetpack_activitypub_reader_auth_route_is_blog_actor( new \stdClass() ) );
 	}
 
 	/**
@@ -376,10 +412,10 @@ class Jetpack_ActivityPub_Reader_Auth_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Pure user-mode AP site → null. No blog actor exists, so `user_id=0`
-	 * routes cannot be authorized.
+	 * Pure user-mode AP site, blog-actor route → null. No blog actor exists
+	 * on `actor`-mode sites, so `user_id=0` routes are still rejected.
 	 */
-	public function test_check_permission_null_in_user_mode(): void {
+	public function test_check_permission_null_for_blog_actor_in_user_mode(): void {
 		wp_set_current_user( $this->admin_id );
 		update_option( 'activitypub_actor_mode', 'actor' );
 		self::set_jetpack_signed( 'user' );
@@ -387,6 +423,35 @@ class Jetpack_ActivityPub_Reader_Auth_Test extends WP_UnitTestCase {
 		$request = self::make_request( '/activitypub/1.0/actors/0/inbox', 'GET' );
 
 		$this->assertNull( jetpack_activitypub_reader_auth_check_permission( null, $request ) );
+	}
+
+	/**
+	 * Pure user-mode AP site, user-actor route → true. The blog-mode gate is
+	 * scoped to blog-actor routes; user actors exist on `actor`-mode sites
+	 * and the AP plugin's `verify_owner` handles actor identity downstream.
+	 */
+	public function test_check_permission_grants_user_actor_in_user_mode(): void {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'activitypub_actor_mode', 'actor' );
+		self::set_jetpack_signed( 'user' );
+
+		$request = self::make_request( '/activitypub/1.0/actors/' . $this->admin_id . '/inbox', 'GET' );
+
+		$this->assertTrue( jetpack_activitypub_reader_auth_check_permission( null, $request ) );
+	}
+
+	/**
+	 * Actor_blog mode also grants user-actor routes (parallel to the blog-actor
+	 * grant in `test_check_permission_grants_actor_blog_mode`).
+	 */
+	public function test_check_permission_grants_user_actor_in_actor_blog_mode(): void {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'activitypub_actor_mode', 'actor_blog' );
+		self::set_jetpack_signed( 'user' );
+
+		$request = self::make_request( '/activitypub/1.0/actors/' . $this->admin_id . '/outbox', 'POST' );
+
+		$this->assertTrue( jetpack_activitypub_reader_auth_check_permission( null, $request ) );
 	}
 
 	/**


### PR DESCRIPTION
See CM-776

## Proposed changes

The Jetpack-signed Reader-auth shim previously accepted only blog-actor routes (`actors/0/...`) and required the AP site to be in `blog` or `actor_blog` mode. The wpcom Reader also signs requests for user-actor routes when a Jetpack user token is available, so those calls were being rejected even though `Rest_Authentication` had installed the matching wpcom user.

* `jetpack_activitypub_reader_auth_is_target_route()` now accepts any user id (`actors/\d+/...`), not just `actors/0/...`. The AP plugin's own `Activitypub\Rest\Verification::verify_owner` enforces actor identity natively (`get_current_user_id() === (int) $user_id` for user actors; `BLOG_USER_ID + user_can_act_as_blog()` for the blog actor), so the shim does not need to repeat that check — its role is bypassing the OAuth bearer requirement on Jetpack-signed calls.
* The `is_blog_mode` early-return in `jetpack_activitypub_reader_auth_check_permission()` is now route-scoped via a new `jetpack_activitypub_reader_auth_route_is_blog_actor()` helper. User-actor existence is independent of `activitypub_actor_mode`, so the blog-mode gate is only relevant when the route targets the blog actor.
* Surrounding docblocks were updated to match the new contract (file-top scope description, `is_blog_mode` purpose, `is_target_route` rationale).

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Unit tests cover the new behaviour. Run them with:

```
jp docker phpunit jetpack -- --filter Jetpack_ActivityPub_Reader_Auth_Test
```

The suite in `projects/plugins/jetpack/tests/php/3rd-party/Jetpack_ActivityPub_Reader_Auth_Test.php` was extended with:

* New positive cases — user-actor inbox in `actor` mode, user-actor outbox in `actor_blog` mode (`test_check_permission_grants_user_actor_in_user_mode`, `test_check_permission_grants_user_actor_in_actor_blog_mode`).
* New data-provider cases for `is_target_route` accepting non-zero user ids (`user_id 1`, `user_id 42`, `users/7` alias).
* New tests for the `route_is_blog_actor` helper (positive for `actors/0/`, negative for `actors/5/`, defensive against non-request payloads).
* The existing negative case is preserved and renamed (`test_check_permission_null_for_blog_actor_in_user_mode`) — a blog-actor route on a pure `actor`-mode site still abstains, since no blog actor exists there.

End-to-end manual verification (on a Jetpack-connected AP site in `actor` mode, signed-in admin via the wpcom Reader):

1. GET `/wp-json/activitypub/1.0/actors/<your-user-id>/inbox` — previously 401, now serves the user's inbox.
2. POST `/wp-json/activitypub/1.0/actors/<your-user-id>/outbox` with a Note — previously 401, now publishes.
3. GET `/wp-json/activitypub/1.0/actors/0/inbox` on the same `actor`-mode site — still returns 401, because the blog actor doesn't exist.

### Local gates run

* PHPCS: clean on both changed files.
* PHP syntax: clean.
* Phan: 0 issues on the touched code (analyzer crashed later on an unrelated WordPress-stubs polyfill path; not a regression introduced here).
* PHPUnit: deferred to CI — this branch was prepared in implement-only mode without a local Docker WP environment.
