### PR TITLE
AdminPage: keep header-height rule matching on admin-ui 2.1

### DIFF
--- a/projects/js-packages/components/changelog/fix-admin-page-header-height-admin-ui-2-1
+++ b/projects/js-packages/components/changelog/fix-admin-page-header-height-admin-ui-2-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AdminPage: fix header-height tab-shift rule not matching after admin-ui 2.1 changed the page header element from header to div

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -52,7 +52,9 @@
 	// row's items so a shorter control neither stretches nor collapses it.
 	// The content row is identified by the visual logo slot it contains
 	// (`aria-hidden="true"`), so a breadcrumbs-only header isn't affected.
-	:global(.jp-admin-page__page > header > div:has([aria-hidden="true"])) {
+	// `> :first-child` targets the page header positionally (a `<div>` in
+	// admin-ui ≥ 2.1, a `<header>` in 2.0) — matching the sibling rules above.
+	:global(.jp-admin-page__page > :first-child > div:has([aria-hidden="true"])) {
 		min-height: 40px;
 		align-items: center;
 	}


### PR DESCRIPTION
Fixes #

Follow-up to #49080 (consistent AdminPage header height) which regressed against #49018.

## Proposed changes
* Fix the AdminPage "consistent header height across tabs" rule so it keeps matching on admin-ui 2.1.
* #49080 selected the page header via `.jp-admin-page__page > header`, but #49018 bumped `@wordpress/admin-ui` to 2.1, which renders the page header as a `<div>` instead of a `<header>` (WordPress/gutenberg#78001). The selector matched nothing, so the rule stopped firing and the tab strip began shifting vertically again on admin-ui 2.1 consumers (Newsletter).
* Switch the selector to `.jp-admin-page__page > :first-child > div:has(...)`, matching the three sibling header-normalization rules that #49018 already converted to `> :first-child`. This targets the header positionally and works for both admin-ui 2.0's `<header>` (VideoPress) and 2.1's `<div>` (Newsletter).

## Related product discussion/links
* #49080
* #49018

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `wp-build` consumes `jetpack-components` from its `build/` output, so rebuild that package first, then the dashboards:
  * `pnpm --filter @automattic/jetpack-components build`
  * `pnpm --filter @automattic/jetpack-newsletter build:wp-build` and `pnpm --filter @automattic/jetpack-videopress build:wp-build`
* On Newsletter (`wp-admin/admin.php?page=jetpack-newsletter`), switch between Subscribers and Settings. Confirm the tab strip stays at the same vertical position (the header no longer grows/shrinks).
* On VideoPress (`wp-admin/admin.php?page=jetpack-videopress`), switch between Overview, Library, and Settings. Confirm the same — verifying the change also holds on the still-2.0.0-pinned VideoPress (`<header>`) consumer.
* Confirm the header still looks correct (logo, title, subtitle, any action control aligned) on every tab, including tabs with no action control.
