### PR TITLE
Newsletter: import @wordpress/dataviews instead of /wp to fix toggle id collisions

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -1,4 +1,4 @@
-import { DataViews } from '@wordpress/dataviews/wp';
+import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
@@ -17,7 +17,7 @@ import CompModal from './modals/comp-modal';
 import RemoveCompModal from './modals/remove-comp-modal';
 import UnsubscribeModal from './modals/unsubscribe-modal';
 import type { Subscriber, SubscribersFilter, SubscribersSortField } from '../data/types';
-import type { Action, Field, View } from '@wordpress/dataviews/wp';
+import type { Action, Field, View } from '@wordpress/dataviews';
 
 const DEFAULT_PER_PAGE = 20;
 

--- a/projects/packages/newsletter/_inc/subscribers/lib/use-view-state.ts
+++ b/projects/packages/newsletter/_inc/subscribers/lib/use-view-state.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from '@wordpress/element';
 import type { SubscribersFilter, SubscribersSortField } from '../data/types';
-import type { View } from '@wordpress/dataviews/wp';
+import type { View } from '@wordpress/dataviews';
 
 const URL_KEYS = {
 	page: 'paged',

--- a/projects/packages/newsletter/changelog/fix-newsletter-dataviews
+++ b/projects/packages/newsletter/changelog/fix-newsletter-dataviews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Settings tab toggles that controlled the wrong setting due to duplicate element IDs.

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -4,7 +4,7 @@
 import analytics from '@automattic/jetpack-analytics';
 import { getAdminUrl, type SiteType } from '@automattic/jetpack-script-data';
 import { ToggleControl } from '@wordpress/components';
-import { type Field } from '@wordpress/dataviews/wp';
+import { type Field } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';

--- a/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getAdminUrl, getScriptData } from '@automattic/jetpack-script-data';
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Card, Text } from '@wordpress/ui';
 /**

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Card, Fieldset, Notice } from '@wordpress/ui';
 /**

--- a/projects/packages/newsletter/src/settings/sections/email-defaults-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-defaults-section.tsx
@@ -3,7 +3,7 @@
  */
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { ToggleControl } from '@wordpress/components';
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Card } from '@wordpress/ui';

--- a/projects/packages/newsletter/src/settings/sections/email-reply-to-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-reply-to-settings-section.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Card } from '@wordpress/ui';
 /**

--- a/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
@@ -3,7 +3,7 @@
  */
 import analytics from '@automattic/jetpack-analytics';
 import { getSiteData, getSiteType } from '@automattic/jetpack-script-data';
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Card, Fieldset, Text } from '@wordpress/ui';

--- a/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
@@ -4,7 +4,7 @@
 import analytics from '@automattic/jetpack-analytics';
 import { getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Card, Text } from '@wordpress/ui';

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -9,7 +9,7 @@ import {
 	isWpcomPlatformSite,
 } from '@automattic/jetpack-script-data';
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link';
-import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews/wp';
+import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews';
 import { createInterpolateElement, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Card, Fieldset, Link, Notice, Text } from '@wordpress/ui';

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -5,7 +5,7 @@ import analytics from '@automattic/jetpack-analytics';
 import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
 import { getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
 import { ToggleControl } from '@wordpress/components';
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Card, Link } from '@wordpress/ui';

--- a/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
@@ -3,7 +3,7 @@
  */
 import analytics from '@automattic/jetpack-analytics';
 import { getSiteType } from '@automattic/jetpack-script-data';
-import { DataForm, type Field } from '@wordpress/dataviews/wp';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Card, Fieldset, Text } from '@wordpress/ui';


### PR DESCRIPTION
Fixes #

## Proposed changes
* Switch the Newsletter dashboard from `@wordpress/dataviews/wp` to the root `@wordpress/dataviews` import across all bundled code (Settings + Subscribers tabs).
* Fixes a bug where Settings tab toggle labels controlled the *wrong* input — e.g. clicking "Include the post's featured image in the new post emails" toggled "Add the Subscribe block to the navigation".
* Root cause: the `/wp` (`build-wp`) artifact inlines its own `ToggleControl` + `useInstanceId` (it can't reach the private `ValidatedToggleControl` on the `wp.components` global), creating a second instance-id counter. `DataForm` toggles and the dashboard's hand-rolled `<ToggleControl>`s then emitted colliding `inspector-toggle-control-N` ids, and `<label for>` binds to whichever input shares the id first in document order.
* The root `build-module` artifact resolves `@wordpress/components`/`@wordpress/compose` to the `wp.*` globals (provided by `@automattic/jetpack-wp-build-polyfills`), so dataviews and the dashboard share one module instance and one id counter. All dataviews imports move together so only one artifact is bundled.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `jetpack build plugins/jetpack` (or build the Newsletter package) and open **Jetpack → Newsletter** in wp-admin.
* Open the **Settings** tab.
* Click each toggle's **label text** (not the switch itself) and confirm the switch directly beside that label flips — in particular:
  * "Include the post's featured image in the new post emails"
  * "Show author display name"
  * "Enable newsletter categories"
* Before this fix, clicking those labels flipped a Subscriptions toggle higher up the page instead.
* Optional DOM check in the console: every `input[id^="inspector-toggle-control-"]` should have a unique id (`new Set([...document.querySelectorAll('input[id^="inspector-toggle-control-"]')].map(i=>i.id)).size` equals the input count), and `document.getElementById(input.id) === input` for each.
* Confirm the **Subscribers** tab still loads and its DataViews table works.
