### PR TITLE
Write: add Save draft to kebab menu on small screens

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_small_screen_save
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_small_screen_save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Write: add Save draft to the kebab menu on narrow screens where the toolbar button is hidden

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -265,6 +265,12 @@
 	outline: none;
 }
 
+/* "Save draft" only appears in the kebab menu on narrow screens
+   where the standalone toolbar button is hidden. */
+.bw-more-save-draft {
+	display: none;
+}
+
 /* ===== Recovery banner ===== */
 .bw-recovery-banner {
 	position: fixed;
@@ -1911,6 +1917,10 @@
 
 	.bw-btn-draft {
 		display: none;
+	}
+
+	.bw-more-save-draft {
+		display: block;
 	}
 
 	/* Toolbar scrolls horizontally on mobile. Avoid -webkit-overflow-scrolling:

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1919,7 +1919,7 @@
 		display: none;
 	}
 
-	.bw-more-save-draft {
+	.bw-more-save-draft:not([hidden]) {
 		display: block;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -4453,6 +4453,11 @@ const { state } = store( 'wpcom-write', {
 			await savePost( 'draft' );
 		},
 
+		async saveDraftFromMenu() {
+			state.showMoreMenu = false;
+			await savePost( 'draft' );
+		},
+
 		/**
 		 * Perform a periodic autosave if the editor is dirty.
 		 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -830,6 +830,14 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				><span class="bw-more-dots" aria-hidden="true">&#x22EE;</span></button>
 				<div class="bw-more-menu" role="menu" aria-label="<?php echo esc_attr__( 'More options', 'jetpack-mu-wpcom' ); ?>" hidden data-wp-bind--hidden="!state.showMoreMenu">
 					<button
+						class="bw-more-menu-item bw-more-save-draft"
+						role="menuitem"
+						tabindex="-1"
+						data-wp-on--click="actions.saveDraftFromMenu"
+						data-wp-bind--hidden="state.isPublishedPost"
+						<?php echo 'publish' === $post_status ? 'hidden' : ''; ?>
+					><?php echo esc_html__( 'Save draft', 'jetpack-mu-wpcom' ); ?></button>
+					<button
 						class="bw-more-menu-item"
 						role="menuitem"
 						tabindex="-1"


### PR DESCRIPTION
Fixes RSM-1688

## Proposed changes

* Add a "Save draft" menu item to the Write editor's kebab (more options) menu on viewports ≤768px, where the toolbar "Save draft" button is hidden via `display: none`.
* The menu item is hidden on desktop (where the toolbar button is visible) and hidden for published posts (matching the toolbar button's behavior).
* A new `saveDraftFromMenu` action closes the menu before saving, consistent with how `openInBlockEditor` and `previewPost` behave.

## Related product discussion/links

* RSM-1688

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Write editor on a WordPress.com site or local dev environment (`/wp-admin/admin.php?page=write`).
2. At desktop width (>768px), confirm the "Save draft" button is visible in the toolbar and does **not** appear in the kebab menu.
3. Resize the browser to ≤768px (or use device emulation).
4. Confirm the toolbar "Save draft" button disappears.
5. Click the kebab menu (⋮) — "Save draft" should now appear as the first menu item.
6. Type some content, then click "Save draft" from the kebab menu. Confirm:
   - The menu closes.
   - The draft is saved (status indicator updates).
7. Publish the post, then reopen it in Write. Confirm "Save draft" does **not** appear in the kebab menu at any width (matches the toolbar button behavior for published posts).

Co-authored by [Claude Sonnet 4.6](https://claude.ai).
