### PR TITLE
e2e-commons: match editor panel name exactly to unblock post-editor e2e

### DIFF
--- a/tools/e2e-commons/pages/editor-page.ts
+++ b/tools/e2e-commons/pages/editor-page.ts
@@ -64,7 +64,7 @@ export default class EditorPage extends Editor {
 		if ( target !== 'Settings' ) {
 			await this.openMoreOptionsMenu();
 
-			button = this.page.getByRole( 'menuitemcheckbox', { name: target } );
+			button = this.page.getByRole( 'menuitemcheckbox', { name: target, exact: true } );
 		}
 
 		if ( await this.#targetIsOpen( button ) ) {


### PR DESCRIPTION
Fixes the strict-mode violation currently breaking the **Jetpack post editor e2e tests** check on every PR (e.g. #49099, #49100, #49104).

## Proposed changes

* In `tools/e2e-commons/pages/editor-page.ts`, the `openSettings()` helper opens the editor's More menu and looks up the target panel toggle with `getByRole( 'menuitemcheckbox', { name: target } )`. Playwright's `name` does a **substring** match by default, so `openSettings( 'Jetpack' )` resolves to both the **"Jetpack"** panel and the **"Jetpack Newsletter"** panel (registered at `extensions/blocks/subscriptions/menu.js:42`).
* Result: strict-mode violation → `sidebar-social.test.ts` fails before it can even open the sidebar.
* Fix: pass `exact: true` so the matcher requires `name === target`.

## Why this only started failing now

The Newsletter panel has existed since #47857 (March), but it's only visible when the subscriptions module is active. **#49034** (merged 2026-05-22 14:42 UTC) flipped subscriptions on by default, which is when the Jetpack post editor e2e job started failing on every subsequent PR.

Timeline:
* PR #49093 ran at 12:43 UTC → passes (pre-#49034)
* PR #49100 (15:05), #49104 (17:27), #49099 (19:02) → all fail with the same strict-mode violation on the same selector

## Testing instructions

* Re-run the **Jetpack post editor e2e tests** job for this PR — it should pass.
* Once merged, rebasing any of the currently-broken PRs (#49099, #49100, #49104) will unblock their e2e check too.

## Does this pull request change what data or activity we track or use?

No.
