### PR TITLE
My Jetpack: migrate link-variant Buttons to @wordpress/ui Link

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -1,5 +1,3 @@
-// TODO: migrate Button usages to @wordpress/ui Link (handled in a separate PR — all Buttons here use variant="link" + href + isExternalLink + weight="regular", which @wordpress/ui Button does not support).
-import { Button } from '@automattic/jetpack-components';
 import { getUserConnectionUrl } from '@automattic/jetpack-connection';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { dateI18n, getDate } from '@wordpress/date';
@@ -110,16 +108,16 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 
 		if ( isExpiringSoon ) {
 			return (
-				<Button href={ renewUrl } isExternalLink={ true } variant="link" weight="regular">
+				<Link href={ renewUrl } openInNewTab>
 					{ __( 'Renew subscription', 'jetpack-my-jetpack' ) }
-				</Button>
+				</Link>
 			);
 		}
 
 		return (
-			<Button href={ managePurchaseUrl } isExternalLink={ true } variant="link" weight="regular">
+			<Link href={ managePurchaseUrl } openInNewTab>
 				{ __( 'Resume subscription', 'jetpack-my-jetpack' ) }
-			</Button>
+			</Link>
 		);
 	}, [ isExpiringPurchase, isExpiringSoon, managePurchaseUrl, renewUrl ] );
 
@@ -243,39 +241,29 @@ const PlanSectionFooter: FC< PlanSectionHeaderAndFooterProps > = ( { numberOfPur
 			) }
 			{ numberOfPurchases > 0 && (
 				<li className={ styles[ 'actions-list-item' ] }>
-					<Button
+					<Link
 						onClick={ viewIncludedFeaturesClickHandler }
 						href={ getMyJetpackUrl( '#/products?filter=included' ) }
-						variant="link"
-						weight="regular"
 					>
 						{ __( 'View included features', 'jetpack-my-jetpack' ) }
-					</Button>
+					</Link>
 				</li>
 			) }
 			{ ! hasComplete && (
 				<li className={ styles[ 'actions-list-item' ] }>
-					<Button
-						onClick={ planPurchaseClickHandler }
-						href={ getPurchasePlanUrl() }
-						weight="regular"
-						variant="link"
-						isExternalLink={ true }
-					>
+					<Link onClick={ planPurchaseClickHandler } href={ getPurchasePlanUrl() } openInNewTab>
 						{ planPurchaseDescription }
-					</Button>
+					</Link>
 				</li>
 			) }
 			{ ! hasComplete && loadAddLicenseScreen && (
 				<li className={ styles[ 'actions-list-item' ] }>
-					<Button
+					<Link
 						onClick={ activateLicenseClickHandler }
 						href={ isUserConnected ? getMyJetpackUrl( '#/add-license' ) : getUserConnectionUrl() }
-						variant="link"
-						weight="regular"
 					>
 						{ activateLicenceDescription }
-					</Button>
+					</Link>
 				</li>
 			) }
 		</ul>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-modal.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-modal.tsx
@@ -1,6 +1,7 @@
 import { Text, Button, ThemeProvider, Col, Container } from '@automattic/jetpack-components';
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Link } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useState, cloneElement } from 'react';
 import LoadingBlock from '../loading-block';
@@ -234,13 +235,12 @@ const ProductInterstitialModal: FC< ProductInterstitialModalProps > = props => {
 								</div>
 								<div className={ styles[ 'primary-footer' ] }>
 									{ PrimaryButton }
-									<Button
-										variant="link"
-										isExternalLink={ secondaryButtonHasExternalLink }
+									<Link
+										openInNewTab={ secondaryButtonHasExternalLink }
 										href={ secondaryButtonHref }
 									>
 										{ __( 'Learn more', 'jetpack-my-jetpack' ) }
-									</Button>
+									</Link>
 								</div>
 							</Col>
 							{

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/style.module.scss
@@ -70,6 +70,7 @@ $interstitial-modal-padding: 40px;
 .primary-footer {
 	display: flex;
 	flex-direction: row;
+	align-items: center;
 	gap: 8px 24px;
 }
 

--- a/projects/packages/my-jetpack/changelog/update-link-variant-buttons-to-wp-ui-link
+++ b/projects/packages/my-jetpack/changelog/update-link-variant-buttons-to-wp-ui-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: migrate link-variant Buttons in Plans section and product interstitial modal to @wordpress/ui Link.


### PR DESCRIPTION
Refs #48160

## Proposed changes

Sweep `@automattic/jetpack-components` `Button variant="link"` usages in `packages/my-jetpack` and migrate them to `@wordpress/ui` Link. Continues the migration tracked in issue #48160 and follows the cross-cutting `ExternalLink` → `Link` precedent set by #48529.

Six call sites across two files were migrated. The Plans Section file already had `Link` imported from `@wordpress/ui` (the "Manage your plan" link in the same `<ul>`), so the new sites adopt a treatment already in production on the same screen.


BEFORE:

<img width="1488" height="800" alt="trunk-before-modal-ai" src="https://github.com/user-attachments/assets/bddb0060-4db9-4dbc-8f16-52c878596d7e" />
<img width="1488" height="800" alt="trunk-before-plans-section" src="https://github.com/user-attachments/assets/e900d73c-b0c7-49aa-ac0e-bb967d8b1414" />

AFTER:

<img width="1488" height="800" alt="L1b-after-modal-ai-aligned" src="https://github.com/user-attachments/assets/cd01a245-ca66-44aa-94b2-b0672053c38a" />

<img width="1488" height="800" alt="L1b-after-plans-section" src="https://github.com/user-attachments/assets/0faedbb9-8605-4c59-a9b7-80df89f6de33" />


### Sites migrated

| File | Line (pre-change) | Old prop set | New element |
|---|---|---|---|
| `_inc/components/plans-section/index.tsx` | 113 | `Button href isExternalLink variant="link" weight="regular"` | `Link href openInNewTab` (Renew subscription) |
| `_inc/components/plans-section/index.tsx` | 120 | `Button href isExternalLink variant="link" weight="regular"` | `Link href openInNewTab` (Resume subscription) |
| `_inc/components/plans-section/index.tsx` | 249 | `Button onClick href variant="link" weight="regular"` | `Link onClick href` (View included features) |
| `_inc/components/plans-section/index.tsx` | 262 | `Button onClick href isExternalLink variant="link" weight="regular"` | `Link onClick href openInNewTab` (Purchase a plan) |
| `_inc/components/plans-section/index.tsx` | 274 | `Button onClick href variant="link" weight="regular"` | `Link onClick href` (Activate a license) |
| `_inc/components/product-interstitial-modal/product-interstitial-modal.tsx` | 238 | `Button variant="link" isExternalLink href` | `Link openInNewTab href` (Learn more) |

`plans-section/index.tsx` no longer imports `Button` from `@automattic/jetpack-components`. `product-interstitial-modal.tsx` keeps its `Button` import because the modal-trigger `<Button variant={ modalTriggerButtonVariant }>` (primary/secondary) is out of scope for this slice.

### Prop mapping (`jetpack-components` Button → `@wordpress/ui` Link)

| Old prop | New prop | Notes |
|---|---|---|
| `href` | `href` | 1:1 |
| `isExternalLink={ true }` | `openInNewTab` | Verified against `gutenberg/packages/ui/src/link/link.tsx`: `openInNewTab` sets `target="_blank"` and appends an aria-labelled new-tab icon. |
| `variant="link"` | _dropped_ | `@wordpress/ui` Link is link-styled by default (`variant="default"`, `tone="brand"`). |
| `weight="regular"` | _dropped_ | `@wordpress/ui` Link does not expose a weight prop. Inherits the surrounding text weight, matching the existing already-migrated `Link` at the top of the same `<ul>` in `plans-section`. |
| `children` | `children` | 1:1 |
| `onClick` | `onClick` | Forwarded via `LinkProps extends ComponentProps<'a'>`. |

### Sites NOT migrated (intentional)

| Site | Reason |
|---|---|
| `_inc/components/connection-status-card/index.tsx:178` | `Button` is imported from `@wordpress/components`, not `@automattic/jetpack-components` — out of scope for this slice. |
| `_inc/components/product-interstitial-modal/product-interstitial-my-jetpack.tsx:154` | Reserved for a sibling sub-slice (L1a) that touches that file holistically. |
| `_inc/components/golden-token/tooltip/index.tsx:48` | Icon-trigger borderless Button (variant="link" used to render an inline info icon, not a textual link). Needs design call; deferred. |


## Related product discussion/links

* Tracking issue: #48160
* Cross-cutting precedent: #48529 (`@wordpress/components` ExternalLink → `@wordpress/ui` Link)
* Strategy doc: internal task context (`jetpack-components-migration` ledger)

## Does this pull request change what data or activity we track or use?

No. `onClick` handlers preserve the existing analytics events (`jetpack_myjetpack_plans_manage_click`, `_view_included_features_click`, `_plans_purchase_click`, `_activate_license_click`).

## Testing instructions

1. From a connected My Jetpack admin user, navigate to **wp-admin → Jetpack → My Jetpack**.
2. Scroll to the **Plans** section.
3. With at least one paid plan, verify:
   - The "Manage your plan" / "View included features" / "Purchase a plan" / "Activate a license" links render as inline text links (brand-blue), inherit the surrounding list typography, and visually match the already-migrated "Manage your plan" link at the top of the list.
   - Clicking each link still navigates to the correct URL.
   - "Purchase a plan" should open in a new tab (look for the new-tab icon next to the label and `target="_blank"` on the anchor).
4. For an expiring/expired purchase, verify the **Renew subscription** / **Resume subscription** link renders inline, navigates correctly, and opens in a new tab.
5. Open any product interstitial modal (e.g., MJ → Add new product → Backup), then click the modal trigger to open the modal. Verify the **Learn more** link in the left column of the modal renders as a link, navigates correctly, and opens in a new tab when `secondaryButtonHasExternalLink` defaults to `true`.
6. Confirm no console errors related to the changed files.

### Gating note

Per #48529, `@wordpress/ui` Link still has a style-parity gap with `@wordpress/components` ExternalLink that is tracked upstream as gutenberg#77790. If reviewers spot any visual regressions stemming from that same gap, this PR may need to wait for the upstream fix — same as #48529. The component swap here is mechanically equivalent to what #48529 already shipped, so the parity story should be identical.
