### PR TITLE
Docker: chown WordPress install to web user so wp-admin updates work

### DIFF
--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -146,6 +146,15 @@ if [ -e $APACHE_PID_FILE ]; then
 	rm -f $APACHE_PID_FILE
 fi
 
+# Provisioning above runs as root, so the WordPress install ends up owned
+# by root:root. Apache then runs as $user:$group and can't write its own
+# install — every plugin/theme/core auto-update from wp-admin fails with
+# "files_not_writable" and surfaces the "An automated WordPress update
+# has failed to complete" admin notice. Chown unconditionally so that
+# both new installs and existing ones provisioned before this fix are
+# corrected on `jetpack docker up`.
+chown -R "$user:$group" /var/www/html
+
 echo
 echo "Open http://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
 echo


### PR DESCRIPTION
Fixes MONOREP-406

## Proposed changes

* Add `chown -R "$user:$group" /var/www/html` to `tools/docker/bin/run.sh` just before Apache starts.
* Provisioning steps in `run.sh` (`wp core download`, `wp config set`, the plugin symlinks loop, etc.) all run as **root**, but Apache subsequently runs as **www-data**. Without a chown step, the WordPress install stays owned by `root:root` and the auto-updater fails with `files_not_writable`. From the user's side this shows up as:
  * The `An automated WordPress update has failed to complete - please attempt the update again now.` admin notice.
  * Every plugin / theme / core update from wp-admin failing silently or with a generic error.
  * `wp core update` succeeding only when run as root via `docker exec -u root`, never via the normal admin flow.
* The chown is intentionally unconditional (every container start, not just first-install), so existing environments provisioned before this fix self-heal on the next `jetpack docker up` — no manual `chown` required by anyone hitting this today.

## Related product discussion/links

* Surfaced while diagnosing a developer's Docker env where wp-admin had been showing the failed-update notice for weeks and core was pinned at `7.0-beta2-61800` because nothing could overwrite the existing files. Setup workflow referenced: PCYsg-GJ2-p2.
* Adjacent gap (not addressed here): `jetpack docker update-core` was announced on +jetpackdevelopment in Feb 2025 but is still undocumented in `tools/docker/README.md` — separate doc PR could follow.

## Does this pull request change what data or activity we track or use?

No — local dev environment script only.

## Testing instructions

1. Start fresh: `jetpack docker clean && jetpack docker up -d` (or just `jetpack docker down && jetpack docker up -d` against an existing install that's currently broken).
2. Once the WordPress container is up, verify ownership inside the container:
   ```
   docker exec jetpack_dev-wordpress-1 stat -c '%U:%G' /var/www/html/wp-includes/version.php
   ```
   Expected: `www-data:www-data` (previously: `root:root`).
3. Visit `wp-admin`. If a previously-installed environment had been showing **"An automated WordPress update has failed to complete - please attempt the update again now"**, that notice should be gone (or clear after the next update check).
4. From wp-admin → Dashboard → Updates, click **Update to latest version** (or run `jetpack docker wp core update`). It should succeed instead of `files_not_writable`.
5. Same for `jetpack docker wp plugin update --all` and `jetpack docker wp theme update --all`.
6. (Optional sanity check) On the host: `ls -la tools/docker/wordpress/wp-includes/version.php` — Docker Desktop's user namespacing should still present the file as readable from the host.

