### PR TITLE
My Jetpack: migrate product interstitial modal Buttons to @wordpress/ui

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-modal-cta.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-modal-cta.tsx
@@ -1,11 +1,10 @@
-import { Button } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { useCallback, type FC } from 'react';
 import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import { useRedirectToReferrer } from '../../hooks/use-redirect-to-referrer';
-import styles from './style.module.scss';
 
 interface ProductInterstitialModalCtaProps {
 	slug: string;
@@ -74,17 +73,41 @@ const ProductInterstitialModalCta: FC< ProductInterstitialModalCtaProps > = ( {
 			useBlogIdSuffix: true,
 		} );
 
+	const isDisabled = disabled || isProductLoading;
+	const isLoading = isProductLoading || hasMainCheckoutStarted;
+	const label = buttonLabel || __( 'Upgrade', 'jetpack-my-jetpack' );
+
+	if ( href ) {
+		return (
+			<Button
+				variant="solid"
+				loading={ isLoading }
+				onClick={ mainCheckoutRedirect }
+				disabled={ isDisabled }
+				nativeButton={ false }
+				render={
+					<a
+						href={ href }
+						{ ...( isExternalLink && {
+							target: '_blank',
+							rel: 'noopener noreferrer',
+						} ) }
+					/>
+				}
+			>
+				{ label }
+			</Button>
+		);
+	}
+
 	return (
 		<Button
-			variant="primary"
-			className={ styles[ 'action-button' ] }
-			isLoading={ isProductLoading || hasMainCheckoutStarted }
+			variant="solid"
+			loading={ isLoading }
 			onClick={ mainCheckoutRedirect }
-			isExternalLink={ isExternalLink }
-			href={ href }
-			disabled={ disabled || isProductLoading }
+			disabled={ isDisabled }
 		>
-			{ buttonLabel || __( 'Upgrade', 'jetpack-my-jetpack' ) }
+			{ label }
 		</Button>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-my-jetpack.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-my-jetpack.tsx
@@ -1,7 +1,8 @@
-import { Button, ProductPrice, getRedirectUrl } from '@automattic/jetpack-components';
+import { ProductPrice, getRedirectUrl } from '@automattic/jetpack-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
+import { Link } from '@wordpress/ui';
 import { useCallback } from 'react';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
@@ -148,15 +149,7 @@ const ProductInterstitialPlugin: FC< ProductInterstitialPluginProps > = ( {
 						'jetpack-my-jetpack'
 					),
 					{
-						link: (
-							<Button
-								href={ getRedirectUrl( 'ai-assistant-fair-usage-policy' ) }
-								variant="link"
-								weight="regular"
-								size="small"
-								target="_blank"
-							/>
-						),
+						link: <Link href={ getRedirectUrl( 'ai-assistant-fair-usage-policy' ) } openInNewTab />,
 					}
 				) }
 			</p>

--- a/projects/packages/my-jetpack/changelog/update-product-interstitial-modal-buttons-to-wp-ui
+++ b/projects/packages/my-jetpack/changelog/update-product-interstitial-modal-buttons-to-wp-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor to use core WordPress UI primitives. No user-facing change.
+
+


### PR DESCRIPTION
Fixes #48160

## Proposed changes

Migrates the remaining two `@automattic/jetpack-components` Button consumers under `projects/packages/my-jetpack/_inc/components/product-interstitial-modal/` to `@wordpress/ui`, completing the modal directory sweep started in #49109.

<img width="1488" height="800" alt="trunk-before-modal-ai" src="https://github.com/user-attachments/assets/bddb0060-4db9-4dbc-8f16-52c878596d7e" />

<img width="1488" height="800" alt="L1a-after-modal-ai" src="https://github.com/user-attachments/assets/5c950b53-10a3-4881-9d59-4e4282f0a4ee" />


| File | Line | Component | Before | After |
| --- | --- | --- | --- | --- |
| `product-interstitial-modal-cta.tsx` | 78 | Upgrade CTA Button | `@automattic/jetpack-components` Button, `variant="primary"`, `isLoading`, optional `href`+`isExternalLink` | `@wordpress/ui` Button, `variant="solid"`, `loading`, anchor-rendered when `href` is present (`render={<a />}` + `nativeButton={false}`) |
| `product-interstitial-my-jetpack.tsx` | 152 | Inline AI "Learn more" link | `@automattic/jetpack-components` Button, `variant="link"`, `weight="regular"`, `size="small"`, `target="_blank"` | `@wordpress/ui` Link, `openInNewTab` |

### Prop mapping — Button → @wordpress/ui Button (anchor render)

| Old prop (jetpack-components Button) | New prop (@wordpress/ui Button) | Notes |
| --- | --- | --- |
| `variant="primary"` | `variant="solid"` | |
| `isLoading` | `loading` | |
| `disabled` | `disabled` | |
| `onClick` | `onClick` | preserved on the Button itself |
| `href` (optional) | `render={<a href={href} />}` + `nativeButton={false}` | follows precedent in #48489 |
| `isExternalLink` | spreads `target="_blank"` + `rel="noopener noreferrer"` onto the rendered `<a>` | only when `isExternalLink` is true |
| `className={ styles['action-button'] }` | dropped | the SCSS module has no `.action-button` rule — `styles['action-button']` resolved to `undefined`, so the className was already a no-op |

Because the CTA's `href` prop is optional (and the only in-tree caller — `product-interstitial-my-jetpack.tsx`'s `<ProductInterstitialModalCta slug={ slug } />` — never passes one), the new implementation renders a native button when `href` is absent and an anchor when it's provided. Runtime behaviour for the actual caller is unchanged: a native `<button>` driven by the `useProductCheckoutWorkflow` `onClick` handler.

### Prop mapping — Button (variant=link) → @wordpress/ui Link

| Old prop | New prop | Notes |
| --- | --- | --- |
| `href` | `href` | |
| `target="_blank"` | `openInNewTab` | `@wordpress/ui` Link omits `target` from its `<a>` prop surface and exposes `openInNewTab` instead, which sets `target="_blank"` and the visual external-link indicator |
| `variant="link"` | dropped | Link is link-styled by default |
| `weight="regular"` | dropped | Link has no weight prop |
| `size="small"` | dropped | Link has no size prop |

Same recipe as the six call sites migrated by #49109.

## Related product discussion/links

* Tracking issue: #48160
* Precedent — anchor-rendered Button (`render={<a/>}` + `nativeButton={false}`): #48489 (merged)
* Precedent — `variant="link"` → @wordpress/ui Link sweep across My Jetpack, including the secondary "Learn more" Button in this same modal directory: #49109

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build: `pnpm jetpack build packages/my-jetpack`.
2. Boot My Jetpack on a Jetpack-connected site (`/wp-admin/admin.php?page=my-jetpack`).
3. Trigger the product interstitial modal by clicking a product card's upgrade entry point (e.g. Jetpack AI, Jetpack Backup, Jetpack Boost).
4. Verify:
   - The primary "Upgrade" CTA renders with WPDS solid styling, is keyboard-focusable, fires the checkout redirect on click, and shows the `loading` state while `useProductCheckoutWorkflow` runs.
   - The "Learn more" link in the modal footer (already migrated in #49109) is unaffected.
   - For Jetpack AI specifically, the inline "Learn more about it here" link in the modal's additional content opens the AI fair-usage policy URL in a new tab, with the WPDS external-link indicator.
5. Confirm `disabled` state still cascades while the product detail is loading.

### Automated gates run locally

- `pnpm jetpack build packages/my-jetpack` — pass
- `pnpm jetpack test js packages/my-jetpack` — pass
- ESLint (via lint-staged on commit) — pass after prettier-format

## Designer-review triggers from `design.md`

Surfaced for the reviewer (not blocking):
- "A primary CTA for a flow" — the Upgrade CTA completes the user's job.
- "Anything touching payments, checkout" — the CTA initiates checkout.

Mitigation: this is a like-for-like component migration to the canonical WPDS primitive. The visual treatment is the WPDS `solid` variant, the documented analogue of the legacy `primary` variant; no brand-color overrides or structural-only SCSS was introduced.
