### PR TITLE
Settings: open Jetpack Settings support links in Help Center on WordPress.com

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
@@ -1,3 +1,5 @@
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import PropTypes from 'prop-types';
@@ -13,6 +15,11 @@ export default class SupportInfo extends Component {
 		text: PropTypes.string,
 		link: PropTypes.string,
 		privacyLink: PropTypes.string,
+		// On WordPress.com (Simple/Atomic) sites, prefer this wordpress.com/support
+		// URL and open it inside the Help Center instead of jetpack.com in a new
+		// tab. See DOTCOM-17147.
+		wpcomLink: PropTypes.string,
+		wpcomPostId: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -20,6 +27,8 @@ export default class SupportInfo extends Component {
 		text: '',
 		link: '',
 		privacyLink: '',
+		wpcomLink: '',
+		wpcomPostId: undefined,
 	};
 
 	constructor() {
@@ -57,8 +66,14 @@ export default class SupportInfo extends Component {
 	}
 
 	render() {
-		const { text, link } = this.props;
+		const { text, link, wpcomLink, wpcomPostId } = this.props;
 		let { privacyLink } = this.props;
+
+		// On WordPress.com (Simple/Atomic) sites, surface the Dotcom support doc and
+		// open it in the Help Center. The standalone "Privacy information" link is
+		// not relevant for Dotcom users. See DOTCOM-17147.
+		const isWpcom = isWpcomPlatformSite();
+		const useWpcomSupport = isWpcom && !! wpcomLink;
 
 		if ( ! privacyLink && link ) {
 			privacyLink = link + '#privacy';
@@ -72,28 +87,40 @@ export default class SupportInfo extends Component {
 					screenReaderText={ __( 'Learn more', 'jetpack' ) }
 				>
 					{ text + ' ' }
-					{ link && (
+					{ ( link || useWpcomSupport ) && (
 						<div className="jp-support-info__learn-more">
-							<Link
-								openInNewTab
-								href={ link }
-								onClick={ this.trackLearnMoreClick }
-								rel="noopener noreferrer"
-							>
-								{ __( 'Learn more', 'jetpack' ) }
-							</Link>
+							{ useWpcomSupport ? (
+								<WpcomSupportLink
+									supportLink={ wpcomLink }
+									supportPostId={ wpcomPostId }
+									onClick={ this.trackLearnMoreClick }
+								>
+									{ __( 'Learn more', 'jetpack' ) }
+								</WpcomSupportLink>
+							) : (
+								<Link
+									openInNewTab
+									href={ link }
+									onClick={ this.trackLearnMoreClick }
+									rel="noopener noreferrer"
+								>
+									{ __( 'Learn more', 'jetpack' ) }
+								</Link>
+							) }
 						</div>
 					) }
-					<span className="jp-support-info__privacy">
-						<Link
-							openInNewTab
-							href={ privacyLink }
-							onClick={ this.trackPrivacyInfoClick }
-							rel="noopener noreferrer"
-						>
-							{ __( 'Privacy information', 'jetpack' ) }
-						</Link>
-					</span>
+					{ ! isWpcom && (
+						<span className="jp-support-info__privacy">
+							<Link
+								openInNewTab
+								href={ privacyLink }
+								onClick={ this.trackPrivacyInfoClick }
+								rel="noopener noreferrer"
+							>
+								{ __( 'Privacy information', 'jetpack' ) }
+							</Link>
+						</span>
+					) }
 				</InfoPopover>
 			</div>
 		);

--- a/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
@@ -1,5 +1,5 @@
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
+import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import PropTypes from 'prop-types';
@@ -69,9 +69,9 @@ export default class SupportInfo extends Component {
 		const { text, link, wpcomLink, wpcomPostId } = this.props;
 		let { privacyLink } = this.props;
 
-		// On WordPress.com (Simple/Atomic) sites, surface the Dotcom support doc and
-		// open it in the Help Center. The standalone "Privacy information" link is
-		// not relevant for Dotcom users. See DOTCOM-17147.
+		// On WordPress.com (Simple/Atomic) sites with a wpcomLink, surface the Dotcom
+		// support doc and open it in the Help Center instead of the Jetpack support
+		// and privacy links. See DOTCOM-17147.
 		const isWpcom = isWpcomPlatformSite();
 		const useWpcomSupport = isWpcom && !! wpcomLink;
 
@@ -109,7 +109,7 @@ export default class SupportInfo extends Component {
 							) }
 						</div>
 					) }
-					{ ! isWpcom && (
+					{ ! useWpcomSupport && (
 						<span className="jp-support-info__privacy">
 							<Link
 								openInNewTab

--- a/projects/plugins/jetpack/_inc/client/discussion/comments.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/comments.jsx
@@ -79,6 +79,7 @@ class CommentsComponent extends Component {
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-comments' ),
+							wpcomLink: 'https://wordpress.com/support/comments/',
 						} }
 					>
 						<ModuleToggle

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -166,6 +166,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-ads' ),
+							wpcomLink: 'https://wordpress.com/support/wordads-and-earn/',
 						} }
 					>
 						<p>

--- a/projects/plugins/jetpack/_inc/client/earn/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/index.jsx
@@ -32,6 +32,7 @@ function EarnFeatureButton( props ) {
 		infoLink,
 		infoDescription,
 		supportLink,
+		wpcomSupportLink,
 		title,
 	} = props;
 
@@ -55,6 +56,7 @@ function EarnFeatureButton( props ) {
 				disableInSiteConnectionMode
 				support={ {
 					link: supportLink,
+					wpcomLink: wpcomSupportLink,
 				} }
 			>
 				{ infoDescription }
@@ -130,6 +132,7 @@ function Earn( props ) {
 					featureName="payments"
 					title={ __( 'Collect payments', 'jetpack' ) }
 					supportLink={ getRedirectUrl( 'jetpack-support-jetpack-blocks-payments-block' ) }
+					wpcomSupportLink="https://wordpress.com/support/wordpress-editor/blocks/payments/"
 					infoLink={ getRedirectUrl( 'wpcom-earn-payments', {
 						site: blogID ?? siteRawUrl,
 					} ) }
@@ -144,6 +147,7 @@ function Earn( props ) {
 					featureName="donations"
 					title={ __( 'Accept donations and tips', 'jetpack' ) }
 					supportLink={ getRedirectUrl( 'jetpack-support-jetpack-blocks-donations-block' ) }
+					wpcomSupportLink="https://wordpress.com/support/wordpress-editor/blocks/donations/"
 					infoLink={ getRedirectUrl( 'wpcom-earn-payments', {
 						site: blogID ?? siteRawUrl,
 					} ) }
@@ -158,6 +162,7 @@ function Earn( props ) {
 					featureName="paypal"
 					title={ __( 'Collect PayPal payments', 'jetpack' ) }
 					supportLink={ getRedirectUrl( 'jetpack-support-pay-with-paypal' ) }
+					wpcomSupportLink="https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/"
 					infoLink={ getRedirectUrl( 'jetpack-support-pay-with-paypal' ) }
 					infoDescription={ __(
 						'Accept credit card payments via PayPal for physical products, services, donations, or support of your creative work.',

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -75,6 +75,7 @@ class Media extends Component {
 				module={ videoPress }
 				support={ {
 					link: getRedirectUrl( 'jetpack-support-videopress' ),
+					wpcomLink: 'https://wordpress.com/support/videopress/',
 				} }
 			>
 				<FormLegend className="jp-form-label-wide">{ __( 'VideoPress', 'jetpack' ) }</FormLegend>

--- a/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
@@ -239,6 +239,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 								hasChild
 								support={ {
 									link: getRedirectUrl( 'jetpack-support-site-accelerator' ),
+									wpcomLink: 'https://wordpress.com/support/site-accelerator-cdn/',
 								} }
 							>
 								<p>

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -39,6 +39,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-monitor' ),
+							wpcomLink: 'https://wordpress.com/support/downtime-monitoring/',
 						} }
 					>
 						<ModuleToggle

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -28,6 +28,7 @@ const ProtectComponent = class extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-protect' ),
+						wpcomLink: 'https://wordpress.com/support/brute-force-attack-protection/',
 					} }
 				>
 					<ModuleToggle

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -158,6 +158,7 @@ export const SSO = withModuleSettingsFormHelpers(
 									'jetpack'
 								),
 								link: getRedirectUrl( 'jetpack-support-sso' ),
+								wpcomLink: 'https://wordpress.com/support/wordpress-com-secure-sign-on-sso/',
 							} }
 						>
 							<p>

--- a/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
@@ -65,6 +65,7 @@ export const Likes = withModuleSettingsFormHelpers(
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-likes' ),
+							wpcomLink: 'https://wordpress.com/support/likes/',
 						} }
 					>
 						<p>

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -53,6 +53,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-publicize' ),
+							wpcomLink: 'https://wordpress.com/support/post-automatically-to-social-media/',
 						} }
 					>
 						<p>

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -115,6 +115,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							link: shouldShowSharingBlock
 								? getRedirectUrl( 'jetpack-support-sharing-block' )
 								: sharingModuleSupportUrl,
+							wpcomLink: 'https://wordpress.com/support/sharing/',
 						} }
 					>
 						<p>

--- a/projects/plugins/jetpack/_inc/client/traffic/google-analytics/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/traffic/google-analytics/test/component.js
@@ -14,6 +14,7 @@ jest.mock( 'state/settings', () => {
 
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	isWoASite: jest.fn().mockReturnValue( true ),
+	isWpcomPlatformSite: jest.fn().mockReturnValue( false ),
 	getScriptData: jest.fn().mockReturnValue( {
 		site: {
 			suffix: null,

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -105,6 +105,7 @@ class RelatedPostsComponent extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-related-posts' ),
+						wpcomLink: 'https://wordpress.com/support/related-posts/',
 					} }
 				>
 					<p>

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -211,6 +211,7 @@ export const SEO = withModuleSettingsFormHelpers(
 									'jetpack'
 								),
 								link: getRedirectUrl( 'jetpack-support-seo-tools' ),
+								wpcomLink: 'https://wordpress.com/support/seo/seo-tools/',
 							} }
 						>
 							{ hasConflictingSeoPlugin && (

--- a/projects/plugins/jetpack/_inc/client/traffic/shortlinks.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/shortlinks.jsx
@@ -24,6 +24,7 @@ class Shortlinks extends Component {
 					support={ {
 						text: this.props.shortlinksModule.description,
 						link: getRedirectUrl( 'jetpack-support-shortlinks' ),
+						wpcomLink: 'https://wordpress.com/support/shortlinks/',
 					} }
 					disableInOfflineMode
 				>

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -227,6 +227,7 @@ class SiteStatsComponent extends Component {
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-wordpress-com-stats' ),
+							wpcomLink: 'https://wordpress.com/support/stats/',
 						} }
 					>
 						<FormFieldset className="jp-stats-form-fieldset">

--- a/projects/plugins/jetpack/_inc/client/traffic/sitemaps.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/sitemaps.jsx
@@ -53,6 +53,7 @@ export class Sitemaps extends Component {
 					module={ { module: 'sitemaps' } }
 					support={ {
 						link: getRedirectUrl( 'jetpack-support-sitemaps' ),
+						wpcomLink: 'https://wordpress.com/support/sitemaps/',
 					} }
 				>
 					<p>

--- a/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
@@ -90,6 +90,7 @@ class VerificationServicesComponent extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-site-verification-tools' ),
+						wpcomLink: 'https://wordpress.com/support/site-verification-services/',
 					} }
 				>
 					<ModuleToggle

--- a/projects/plugins/jetpack/_inc/client/writing/composing.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/composing.jsx
@@ -73,6 +73,7 @@ export class Composing extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-copy-post' ),
+						wpcomLink: 'https://wordpress.com/support/copy-a-post-or-page/',
 					} }
 				>
 					<FormFieldset>
@@ -96,6 +97,7 @@ export class Composing extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-markdown' ),
+						wpcomLink: 'https://wordpress.com/support/wordpress-editor/blocks/markdown-block/',
 					} }
 				>
 					<FormFieldset>
@@ -124,6 +126,7 @@ export class Composing extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-beautiful-math-with-latex' ),
+						wpcomLink: 'https://wordpress.com/support/latex/',
 					} }
 				>
 					<FormFieldset>
@@ -144,6 +147,7 @@ export class Composing extends Component {
 					support={ {
 						text: shortcodes.description,
 						link: getRedirectUrl( 'jetpack-support-shortcode-embeds' ),
+						wpcomLink: 'https://wordpress.com/support/wordpress-editor/blocks/shortcode-block/',
 					} }
 				>
 					<FormFieldset>

--- a/projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx
@@ -125,6 +125,7 @@ export class CustomContentTypes extends Component {
 						module={ { module: 'custom-content-types' } }
 						support={ {
 							link: getRedirectUrl( 'jetpack-support-custom-content-types' ),
+							wpcomLink: 'https://wordpress.com/support/testimonials/',
 						} }
 					>
 						<p> { testimonialText } </p>
@@ -164,6 +165,7 @@ export class CustomContentTypes extends Component {
 						module={ { module: 'custom-content-types' } }
 						support={ {
 							link: getRedirectUrl( 'jetpack-support-custom-content-types' ),
+							wpcomLink: 'https://wordpress.com/support/portfolios/',
 						} }
 					>
 						<p>{ portfolioText }</p>

--- a/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
@@ -61,6 +61,7 @@ class PostByEmail extends Component {
 							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-post-by-email' ),
+						wpcomLink: 'https://wordpress.com/support/post-by-email/',
 					} }
 				>
 					<p>

--- a/projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx
@@ -130,6 +130,7 @@ class ThemeEnhancements extends Component {
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-infinite-scroll' ),
+							wpcomLink: 'https://wordpress.com/support/infinite-scroll/',
 						} }
 					>
 						<FormLegend className="jp-form-label-wide">{ infScr.name }</FormLegend>

--- a/projects/plugins/jetpack/_inc/client/writing/widgets.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/widgets.jsx
@@ -31,6 +31,7 @@ class Widgets extends Component {
 						support={ {
 							text: this.props.widgetsModule.description,
 							link: getRedirectUrl( 'jetpack-support-extra-sidebar-widgets' ),
+							wpcomLink: 'https://wordpress.com/support/widgets/',
 						} }
 					>
 						<ModuleToggle
@@ -57,6 +58,7 @@ class Widgets extends Component {
 								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-widget-visibility' ),
+							wpcomLink: 'https://wordpress.com/support/widgets/',
 						} }
 					>
 						<ModuleToggle

--- a/projects/plugins/jetpack/changelog/fix-dotcom-17147-jetpack-settings-wpcom-support-links
+++ b/projects/plugins/jetpack/changelog/fix-dotcom-17147-jetpack-settings-wpcom-support-links
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: enhancement
 
-Settings: On WordPress.com sites, support links in Jetpack Settings now point to the matching wordpress.com/support docs and open inside the Help Center. The "Privacy information" link is hidden in this context.
+Settings: On WordPress.com sites, support links in Jetpack Settings now point to the matching wordpress.com/support docs and open inside the Help Center. The "Privacy information" link is hidden when a wordpress.com doc replaces it.

--- a/projects/plugins/jetpack/changelog/fix-dotcom-17147-jetpack-settings-wpcom-support-links
+++ b/projects/plugins/jetpack/changelog/fix-dotcom-17147-jetpack-settings-wpcom-support-links
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Settings: On WordPress.com sites, support links in Jetpack Settings now point to the matching wordpress.com/support docs and open inside the Help Center. The "Privacy information" link is hidden when a wordpress.com doc replaces it.
+Settings: On WordPress.com sites, support links in Jetpack Settings now open the matching WordPress.com Support docs inside the Help Center. The "Privacy information" link is hidden when a WordPress.com doc replaces it.

--- a/projects/plugins/jetpack/changelog/fix-dotcom-17147-jetpack-settings-wpcom-support-links
+++ b/projects/plugins/jetpack/changelog/fix-dotcom-17147-jetpack-settings-wpcom-support-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Settings: On WordPress.com sites, support links in Jetpack Settings now point to the matching wordpress.com/support docs and open inside the Help Center. The "Privacy information" link is hidden in this context.


### PR DESCRIPTION
Part of DOTCOM-17147

## Proposed changes

* Centralize Dotcom-aware behavior in `components/support-info`:
    * New optional `wpcomLink` / `wpcomPostId` props. When `isWpcomPlatformSite()` is true and `wpcomLink` is provided, the "Learn more" link renders as `WpcomSupportLink` so it opens inside the Help Center (or falls back to a new-tab anchor when the Help Center store is not present).
    * On WordPress.com (Simple/Atomic), hide the "Privacy information" link — it is not relevant to Dotcom users.
    * Standalone Jetpack continues to use the existing `jetpack.com/redirect` link, unchanged.
* Add `wpcomLink` to every settings card called out in the issue: Security (monitor, protect, sso), Performance (media, speed-up-site), Writing (composing, custom-content-types, theme-enhancements, widgets, post-by-email), Sharing (publicize, share-buttons, likes), Discussion (comments), Traffic (related-posts, seo, site-stats, shortlinks, sitemaps, verification-services), Monetize (ads, payments / donations / pay-with-paypal).
* `earn/index.jsx`: thread a new `wpcomSupportLink` prop through `EarnFeatureButton` into the shared `support` object so each earn feature card can specify its own Dotcom doc.

## Related product discussion/links

* DOTCOM-17147

## Does this pull request change what data or activity we track or use?

No. The existing `recordJetpackClick` tracking on the "Learn more" link is preserved (the `onClick` is passed through to `WpcomSupportLink`).

## Testing instructions

### WordPress.com (Atomic, Business / Commerce plan)

1. Sandbox the Jetpack plugin on an Atomic site (or run the Jetpack plugin from a branch build).
2. Go to **Jetpack → Settings** and click through the Security, Performance, Writing, Sharing, Discussion, Traffic, and Monetize tabs.
3. On each settings card, click the `(i)` info icon and then **Learn more**.
4. Expected:
    * The link opens **inside the Help Center** (the Help Center panel slides in showing the matching wordpress.com/support article), not a new browser tab.
    * The "Privacy information" link is **not** rendered in the popover.

### Standalone Jetpack site (Jurassic Ninja / self-hosted)

1. Connect Jetpack on a non-WordPress.com site.
2. Go to **Jetpack → Settings** and open any settings card's info popover.
3. Expected:
    * **Learn more** opens jetpack.com/redirect in a new tab (unchanged behavior).
    * The **Privacy information** link is still rendered (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)