### PR TITLE
Abilities: opt remaining 15 abilities into MCP as public tools

### DIFF
--- a/projects/packages/connection/changelog/fix-mcp-tool
+++ b/projects/packages/connection/changelog/fix-mcp-tool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Abilities: opt jetpack/get-connection-status into the MCP tool surface (meta.mcp public tool).

--- a/projects/packages/connection/src/abilities/class-connection-abilities.php
+++ b/projects/packages/connection/src/abilities/class-connection-abilities.php
@@ -106,6 +106,10 @@ class Connection_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}

--- a/projects/packages/connection/tests/php/abilities/Connection_Abilities_Test.php
+++ b/projects/packages/connection/tests/php/abilities/Connection_Abilities_Test.php
@@ -427,4 +427,12 @@ class Connection_Abilities_Test extends TestCase {
 		$this->assertNull( $out['registration_url'], 'registration_url must be null once the site is registered.' );
 		$this->assertSame( Package_Version::PACKAGE_VERSION, $out['connection_version'] );
 	}
+
+	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
+		foreach ( Connection_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'mcp', $spec['meta'], "{$slug} must publish meta.mcp." );
+			$this->assertTrue( $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
 }

--- a/projects/packages/forms/changelog/fix-mcp-tool
+++ b/projects/packages/forms/changelog/fix-mcp-tool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Abilities: opt all 8 Jetpack Forms abilities into the MCP tool surface (meta.mcp public tool).

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -163,6 +163,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -194,6 +198,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -235,6 +243,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => false,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -266,6 +278,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -339,6 +355,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -379,6 +399,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -417,6 +441,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -466,6 +494,10 @@ class Forms_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -639,4 +639,12 @@ class Forms_Abilities_Test extends BaseTestCase {
 
 		$this->assertSame( array( $id ), $result['succeeded'], 'Duplicate IDs in input should collapse to one succeeded entry.' );
 	}
+
+	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
+		foreach ( Forms_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'mcp', $spec['meta'], "{$slug} must publish meta.mcp." );
+			$this->assertTrue( $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
 }

--- a/projects/plugins/jetpack/changelog/fix-mcp-tool
+++ b/projects/plugins/jetpack/changelog/fix-mcp-tool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Abilities: opt the Shortlinks, Sitemaps, and Newsletter abilities into the MCP tool surface (meta.mcp public tool).

--- a/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
+++ b/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
@@ -115,6 +115,10 @@ class Shortlinks_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 		);

--- a/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
+++ b/projects/plugins/jetpack/modules/sitemaps/abilities/class-sitemaps-abilities.php
@@ -121,6 +121,10 @@ class Sitemaps_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 
@@ -151,6 +155,10 @@ class Sitemaps_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 		);

--- a/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
+++ b/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
@@ -127,6 +127,10 @@ class Newsletter_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 
@@ -157,6 +161,10 @@ class Newsletter_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 
@@ -189,6 +197,10 @@ class Newsletter_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 		);

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -394,4 +394,12 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_newsletter_not_connected', $result->get_error_code() );
 	}
+
+	public function test_every_ability_opts_into_mcp_as_public_tool() {
+		foreach ( Newsletter_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'mcp', $spec['meta'], "{$slug} must publish meta.mcp." );
+			$this->assertTrue( $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
@@ -350,4 +350,12 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_shortlinks_blog_id_unavailable', $result->get_error_code() );
 	}
+
+	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
+		foreach ( Shortlinks_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'mcp', $spec['meta'], "{$slug} must publish meta.mcp." );
+			$this->assertTrue( $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Sitemaps_Abilities_Test.php
@@ -647,4 +647,12 @@ class Sitemaps_Abilities_Test extends WP_UnitTestCase {
 			'Sitemaps abilities must not be registered while the Sitemaps module is inactive (modules/sitemaps.php not loaded).'
 		);
 	}
+
+	public function test_every_ability_opts_into_mcp_as_public_tool() {
+		foreach ( Sitemaps_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'mcp', $spec['meta'], "{$slug} must publish meta.mcp." );
+			$this->assertTrue( $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add `meta.mcp = { public: true, type: 'tool' }` to the 15 Jetpack abilities that shipped without it, so every `wp_register_ability()` registration in the monorepo (33 across 10 registrars) uniformly opts into the MCP tool surface.
* Affected registrars: Connection (1), Forms (8), Shortlinks (1), Sitemaps (2), Newsletter (3).
* Mirrors the established shape already used by Stats, Backup, Boost, Modules, and Related Posts (18 abilities) — no new keys invented; downstream consumers in the WPCOM MCP bridge today read only `public` and `type`.
* Each affected registrar's test suite gets a parity test (`test_every_ability_opts_into_mcp_as_public_tool`) mirroring `Stats_Abilities_Test`, so future specs cannot regress.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run the per-package PHPUnit suites for the five touched registrars and confirm the new test passes:
  * `cd projects/packages/connection && composer phpunit -- --filter Connection_Abilities_Test`
  * `cd projects/packages/forms && composer phpunit -- --filter Forms_Abilities_Test`
  * `cd projects/plugins/jetpack && composer phpunit -- --filter 'Shortlinks_Abilities_Test|Sitemaps_Abilities_Test|Newsletter_Abilities_Test'`
* Sanity check the source — every ability spec should now publish `meta.mcp`:
  * `rg -n "'mcp'\s+=> array\(" projects/packages projects/plugins -g '!*test*' | wc -l` should return `33`.
* On a connected Jetpack site, hit `GET /wp-json/wp-abilities/v1/abilities` and confirm the previously-unenrolled abilities (e.g. `jetpack/get-connection-status`, `jetpack-forms/list-forms`, `jetpack-shortlinks/get-shortlinks`, `jetpack-sitemaps/get-status`, `jetpack-newsletter/get-settings`) now include `"mcp": { "public": true, "type": "tool" }` in their `meta` block.

## Rollout note
Forms abilities ship without the `jetpack_wp_abilities_enabled` rollout filter (see `Forms_Abilities::init()` override), so flipping `meta.mcp.public` takes effect on every site running the package as soon as this merges. The other four registrars are still gated by that filter and remain default-off until a site opts in.
