### PR TITLE
Search dashboard: mirror jetpack_search_blocks_enabled default (SEARCH-241)

### DIFF
--- a/projects/packages/search/changelog/search-241-mirror-blocks-enabled-default
+++ b/projects/packages/search/changelog/search-241-mirror-blocks-enabled-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search dashboard: mirror the `jetpack_search_blocks_enabled` server default in the React initial state so the Experience Selector renders on stock sites after the SEARCH-222 GA flip.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -88,7 +88,7 @@ class Initial_State {
 				 * dashboard React app can gate the new feature-selection UI on the
 				 * same flag the back end uses to register the blocks themselves.
 				 */
-				'searchBlocksEnabled'        => (bool) apply_filters( 'jetpack_search_blocks_enabled', false ),
+				'searchBlocksEnabled'        => (bool) apply_filters( 'jetpack_search_blocks_enabled', true ),
 				/**
 				 * Whether the experimental blocks-powered Overlay search experience
 				 * is available in the Experience Selector. Mirrors the

--- a/projects/packages/search/tests/php/Initial_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_State_Test.php
@@ -48,21 +48,24 @@ class Initial_State_Test extends Search_TestCase {
 	}
 
 	/**
-	 * The flag must default to false when no filter is registered.
+	 * The flag defaults to true so the Experience Selector is visible on
+	 * stock sites, mirroring the server-side filter default flipped in
+	 * SEARCH-222.
 	 */
-	public function test_search_blocks_enabled_defaults_false() {
+	public function test_search_blocks_enabled_defaults_true() {
 		$state = ( new Initial_State() )->get_initial_state();
 		$this->assertArrayHasKey( 'searchBlocksEnabled', $state['siteData'] );
-		$this->assertFalse( $state['siteData']['searchBlocksEnabled'] );
+		$this->assertTrue( $state['siteData']['searchBlocksEnabled'] );
 	}
 
 	/**
-	 * The flag must be true when the filter returns true.
+	 * The filter still works as a kill-switch — returning false hides the
+	 * Experience Selector and falls back to the legacy module control.
 	 */
-	public function test_search_blocks_enabled_reflects_filter() {
-		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
+	public function test_search_blocks_enabled_kill_switch() {
+		add_filter( 'jetpack_search_blocks_enabled', '__return_false' );
 		$state = ( new Initial_State() )->get_initial_state();
-		$this->assertTrue( $state['siteData']['searchBlocksEnabled'] );
+		$this->assertFalse( $state['siteData']['searchBlocksEnabled'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-241

## Why

On a stock connected site with a Search-supported plan, the new Experience Selector at `Jetpack › Search › Settings` was meant to be visible by default after the SEARCH-222 GA flip. It wasn't — admins still landed on the legacy on/off module toggles and had no way to pick between Embedded / Overlay / Theme search experiences without manually filtering things on themselves. This restores the intended out-of-the-box experience.

## Proposed changes

- Flip the dashboard `Initial_State` default for `jetpack_search_blocks_enabled` from `false` to `true`, mirroring the server-side default flipped in SEARCH-222 (#49037). The block comment was already claiming the mirror — this makes it honest.
- The `jetpack_search_blocks_enabled` filter remains as the documented kill-switch on both layers: returning `false` from a single `add_filter` call restores the pre-SEARCH-222 view end-to-end.

## Screenshots

### Before
Stock site on `trunk` → legacy module toggles (Enable Jetpack Search / Enable instant search / Enable Reader Chat). No Experience Selector.

![before](https://github.com/user-attachments/assets/e3d0764f-04dc-4e25-a75f-67d8c2900026)

### After
Same stock site, this branch → Experience Selector renders with the four cards (Embedded — Recommended, Overlay, Theme, Off).

![after](https://github.com/user-attachments/assets/2273b8d8-cea4-4879-b57b-d7e293a80c5b)

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-241
* Server-side flip this is the follow-up to: https://linear.app/a8c/issue/SEARCH-222 / #49037

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-241:

- [ ] On a stock connected site with a Search-supported plan and no filter override, `/wp-admin/admin.php?page=jetpack-search#/settings` renders the **Experience Selector** with four cards (Embedded — Recommended, Overlay, Theme, Off), not the legacy on/off module toggles.
- [ ] Drop an mu-plugin containing `add_filter( 'jetpack_search_blocks_enabled', '__return_false' );`. Reload the same page → falls back to the pre-SEARCH-222 view. Remove the mu-plugin → Experience Selector returns. Kill-switch behaviour matches the server-side filter end-to-end.

Reference commands for the kill-switch test:

```bash
docker exec <wp-container> bash -lc 'echo "<?php add_filter( \"jetpack_search_blocks_enabled\", \"__return_false\" );" > /var/www/html/wp-content/mu-plugins/disable-search-blocks.php'
docker exec <wp-container> wp eval 'echo (int) apply_filters("jetpack_search_blocks_enabled", true);' --allow-root
# Expect: 0
```
