### PR TITLE
Search Blocks: Embedded experience on classic themes

### DIFF
--- a/projects/packages/search/changelog/SEARCH-219-embedded-classic-themes
+++ b/projects/packages/search/changelog/SEARCH-219-embedded-classic-themes
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search Blocks: Embedded search experience now works on classic themes. The bundled search template renders inside the theme's `get_header()` / `get_footer()` via `template_include`, mirroring the FSE block-template route used on block themes.
+Search Blocks: Embedded search experience now works on classic themes. The bundled search template renders inside the theme's `get_header()` / `get_footer()` via `template_include`, and the Embedded card surfaces an "Edit search template" link that opens a singleton-CPT block editor (mirroring the experimental Overlay path) so classic-theme admins can edit the template too. Block themes keep using the Site Editor for in-place customization.

--- a/projects/packages/search/changelog/SEARCH-219-embedded-classic-themes
+++ b/projects/packages/search/changelog/SEARCH-219-embedded-classic-themes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: Embedded search experience now works on classic themes. The bundled search template renders inside the theme's `get_header()` / `get_footer()` via `template_include`, mirroring the FSE block-template route used on block themes.

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -278,29 +278,28 @@ class Module_Control {
 	/**
 	 * Whether the active theme can render the Embedded search experience.
 	 *
-	 * Embedded takes over the theme's search results through an FSE block
-	 * template, which only exists on block themes. On a classic theme
-	 * `get_experience()` falls back to Theme search (inline) so the search
-	 * page keeps working instead of resolving to a missing template; the
-	 * saved `embedded` option is left untouched so the experience resumes
-	 * automatically once the site switches back to a block theme.
+	 * True for every theme by default: block themes resolve the bundled
+	 * `jetpack-search` block template through `search_template_hierarchy`,
+	 * classic themes get the same block markup wrapped in
+	 * `get_header()` / `get_footer()` via `template_include`. The filter
+	 * remains the escape hatch for sites that want to force Embedded back
+	 * to Theme search (inline) without changing the saved option.
 	 *
 	 * @return bool
 	 */
 	protected function theme_supports_embedded_experience(): bool {
-		$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
-
 		/**
 		 * Filter whether the active theme can render the Embedded search experience.
 		 *
-		 * Defaults to `wp_is_block_theme()`. Sites whose classic theme provides
-		 * block-template support through other means can force this true.
+		 * Defaults to true now that both block and classic themes are supported.
+		 * Sites that want to force Embedded to fall back to Theme search (inline)
+		 * regardless of theme can return false here.
 		 *
 		 * @since 0.60.0
 		 *
-		 * @param bool $supported Whether the active theme can render Embedded search (defaults to whether it is a block theme).
+		 * @param bool $supported Whether the active theme can render Embedded search.
 		 */
-		return (bool) apply_filters( 'jetpack_search_theme_supports_embedded_experience', $is_block_theme );
+		return (bool) apply_filters( 'jetpack_search_theme_supports_embedded_experience', true );
 	}
 
 	/**

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -108,6 +108,14 @@ class Initial_State {
 				 * enforce that capability server-side.
 				 */
 				'blockTemplateOverlay'       => $this->get_block_template_overlay_config(),
+				/**
+				 * Editor affordances for the classic-theme search-template
+				 * singleton CPT. The Embedded card surfaces these on
+				 * classic themes (which can't reach the Site Editor) so
+				 * admins still get an "Edit search template" entry — same
+				 * shape and same React link as `blockTemplateOverlay`.
+				 */
+				'searchTemplate'             => $this->get_search_template_config(),
 				// Gates the WooCommerce Product Search control to stores.
 				'isWooCommerceActive'        => Search_Blocks::woocommerce_blocks_enabled(),
 				/**
@@ -207,12 +215,6 @@ class Initial_State {
 	/**
 	 * Build the block-template overlay editor config exposed to the dashboard.
 	 *
-	 * The action handlers gate on `current_user_can( 'manage_options' )`
-	 * server-side, so non-admins can't actually drive the flow. We also
-	 * skip emitting the nonce'd URLs (and the singleton-id lookup that
-	 * decides `isCustomized`) to those users — useless to them and
-	 * needlessly leaks internal URL shape.
-	 *
 	 * `enabled` mirrors `Search_Blocks::is_block_template_overlay_enabled()`
 	 * — true only when the user is currently *on* the blocks Overlay arm.
 	 * The editor URLs, by contrast, are gated on the operator filter alone
@@ -224,24 +226,57 @@ class Initial_State {
 	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
 	 */
 	protected function get_block_template_overlay_config(): array {
-		$can_edit = Search_Blocks::is_block_template_overlay_filter_on()
-			&& current_user_can( 'manage_options' );
+		return $this->build_singleton_template_config(
+			Search_Blocks::is_block_template_overlay_enabled(),
+			Search_Blocks::is_block_template_overlay_filter_on() && current_user_can( 'manage_options' ),
+			Overlay_Template::class
+		);
+	}
+
+	/**
+	 * Build the classic-theme search-template editor config exposed to the
+	 * dashboard. Counterpart of `get_block_template_overlay_config()` —
+	 * same `{enabled, editorUrl, resetRestPath, isCustomized}` shape and
+	 * the same "expose URLs before activation" rule: admins can edit the
+	 * template from the Embedded card on any classic theme, even before
+	 * actually switching to Embedded.
+	 *
+	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 */
+	protected function get_search_template_config(): array {
+		$is_classic = ! wp_is_block_theme();
+		return $this->build_singleton_template_config(
+			$is_classic && Module_Control::EXPERIENCE_EMBEDDED === $this->module_control->get_experience(),
+			$is_classic && current_user_can( 'manage_options' ),
+			Search_Template::class
+		);
+	}
+
+	/**
+	 * Shared assembly for a {@see Singleton_Template_Cpt}-backed editor
+	 * config block. Both `blockTemplateOverlay` and `searchTemplate` ship
+	 * the same `{enabled, editorUrl, resetRestPath, isCustomized}` shape
+	 * to the React dashboard. The `$enabled` and `$can_edit` flags are
+	 * intentionally separate: the card lights up as "active" on
+	 * `$enabled`, but the URLs surface as soon as `$can_edit` is true so
+	 * admins can pre-customize the template before activating the
+	 * experience — without forcing a page reload after the switch.
+	 *
+	 * The action handlers re-check `manage_options` server-side, so
+	 * omitting the URLs here is just to keep the wire payload tight for
+	 * non-admins.
+	 *
+	 * @param bool   $enabled   Whether the CPT-backed route is currently live on the site.
+	 * @param bool   $can_edit  Whether to expose the nonce'd URLs (operator-level gate + capability).
+	 * @param string $cpt_class Concrete `Singleton_Template_Cpt` subclass to query.
+	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 */
+	protected function build_singleton_template_config( bool $enabled, bool $can_edit, string $cpt_class ): array {
 		return array(
-			'enabled'       => Search_Blocks::is_block_template_overlay_enabled(),
-			'editorUrl'     => $can_edit ? Overlay_Template::get_editor_url() : null,
-			// `resetRestPath` is the path the dashboard sends to `apiFetch`
-			// as a DELETE — hits the CPT's built-in REST endpoint
-			// (`/wp/v2/jetpack-search-overlay/<id>?force=true`) so the
-			// reset happens via AJAX with no page navigation. Null when
-			// there's nothing to reset; the link is also gated on
-			// `isCustomized`.
-			'resetRestPath' => $can_edit ? Overlay_Template::get_reset_rest_path() : null,
-			// `isCustomized` lets the React dashboard hide "Restore default"
-			// when there's nothing to restore — checks both that the
-			// singleton exists AND that it isn't in the trash (admins can
-			// trash via post.php directly; in that state the front end
-			// already falls back to the bundled template).
-			'isCustomized'  => $can_edit && Overlay_Template::is_customized(),
+			'enabled'       => $enabled,
+			'editorUrl'     => $can_edit ? $cpt_class::get_editor_url() : null,
+			'resetRestPath' => $can_edit ? $cpt_class::get_reset_rest_path() : null,
+			'isCustomized'  => $can_edit && $cpt_class::is_customized(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -125,10 +125,15 @@ class Initial_State {
 				 */
 				'activeThemeStylesheet'      => get_stylesheet(),
 				/**
-				 * Whether the active theme is a block theme. The Embedded search
-				 * experience is built and customized in the Site Editor, which
-				 * classic themes don't have, so the dashboard blocks switching to
-				 * Embedded when this is false.
+				 * Whether the active theme is a block theme. Embedded itself
+				 * works on every theme — block themes through the FSE
+				 * `search_template_hierarchy` route, classic themes through
+				 * the singleton-CPT shim — but the Embedded card's
+				 * customization affordances diverge: block themes get the
+				 * Site-Editor entry points ("Edit search template" / "Insert
+				 * pattern"), classic themes get the block-editor-on-a-hidden-
+				 * CPT path via `searchTemplate`. This flag is the dashboard's
+				 * branch selector for which to render.
 				 */
 				'themeSupportsBlocks'        => wp_is_block_theme(),
 			),

--- a/projects/packages/search/src/dashboard/components/experience-selector/card-link.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/card-link.jsx
@@ -1,0 +1,39 @@
+/**
+ * Small text-link CTA at the bottom of an experience card — "Edit search
+ * template", "Restore default", etc. Renders as an `<a>` when actionable
+ * and a non-interactive `<span>` when disabled (AT shouldn't announce a
+ * link the user can't follow), with the same `→` glyph either way so the
+ * row's visual rhythm doesn't shift on state changes.
+ *
+ * @param {object}   props           - Props.
+ * @param {string}   props.label     - Visible link text.
+ * @param {string}   props.href      - Link target — used only when not disabled.
+ * @param {boolean}  props.disabled  - When true, renders as a muted non-clickable span.
+ * @param {Function} [props.onClick] - Optional click handler — `event.preventDefault()` callers are responsible for guarding their own no-navigation logic.
+ * @return {import('react').Element} - The card link element.
+ */
+export default function CardLink( { label, href, disabled, onClick } ) {
+	if ( disabled ) {
+		// Render as a non-interactive <span> so AT doesn't announce a
+		// link the user can't follow. The `is-disabled` class is the
+		// CSS hook for the muted/not-allowed visual state —
+		// `aria-disabled` on a roleless <span> has no semantic effect
+		// for AT.
+		return (
+			<span className="jp-search-experience-option__action jp-search-experience-option__action-link is-disabled">
+				{ label }
+				<span aria-hidden="true"> →</span>
+			</span>
+		);
+	}
+	return (
+		<a
+			className="jp-search-experience-option__action jp-search-experience-option__action-link"
+			href={ href }
+			onClick={ onClick }
+		>
+			{ label }
+			<span aria-hidden="true"> →</span>
+		</a>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
-import { Button, Modal, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -18,7 +18,6 @@ import './experience-option.scss';
 
 const SEARCH_CUSTOMIZE_URL = 'admin.php?page=jetpack-search-configure';
 const WIDGETS_EDITOR_URL = 'widgets.php';
-const THEMES_URL = 'themes.php';
 // The Site Editor identifies templates by `<theme-stylesheet>//<template-slug>`
 // even for plugin-registered ones, so the active theme is part of the URL. Built
 // at render time so the link follows theme switches without a re-deploy. Falls
@@ -141,13 +140,6 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 	const isBeta = experience === EXPERIENCE.OVERLAY_BLOCKS;
 	const linksDisabled = isUpdating || ! isActive;
 
-	// Embedded search is built and customized in the Site Editor, which
-	// classic themes don't have. The card stays clickable so the click opens
-	// an explanatory modal instead of silently doing nothing — but the switch
-	// itself is never committed.
-	const isEmbeddedBlockedByTheme = experience === EXPERIENCE.EMBEDDED && ! isBlockTheme;
-	const blockedThemeHint = __( 'Embedded search requires a block theme', 'jetpack-search-pkg' );
-
 	const Preview = PREVIEWS[ experience ];
 
 	const className = clsx( 'jp-search-experience-option', {
@@ -196,7 +188,12 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 				</Stack>
 				<CardCopy experience={ experience } />
 			</Stack>
-			{ experience === EXPERIENCE.EMBEDDED && (
+			{ experience === EXPERIENCE.EMBEDDED && isBlockTheme && (
+				// Site-Editor-only entry points: omitted on classic themes
+				// (which have no Site Editor) so the card doesn't surface
+				// links that lead to a 404. Embedded itself still works on
+				// classic themes via the `template_include` route; only the
+				// in-place customization affordances are hidden.
 				<Stack
 					direction="row"
 					gap="sm"
@@ -306,14 +303,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					type="button"
 					className="jp-search-experience-option__commit-overlay"
 					aria-disabled={ commitButtonDisabled }
-					title={
-						// eslint-disable-next-line no-nested-ternary -- three mutually exclusive hint states; flattening would duplicate the attribute.
-						commitButtonDisabled
-							? undefined
-							: isEmbeddedBlockedByTheme
-							? blockedThemeHint
-							: getHoverHint( experience )
-					}
+					title={ commitButtonDisabled ? undefined : getHoverHint( experience ) }
 					onClick={ () => {
 						if ( commitButtonDisabled ) {
 							return;
@@ -321,63 +311,27 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 						setConfirmOpen( true );
 					} }
 					aria-label={
-						// eslint-disable-next-line no-nested-ternary -- three mutually exclusive label states; flattening would duplicate the attribute.
 						disabled
 							? `${ getCommitLabel( experience ) }. ${ upsellHint }`
-							: isEmbeddedBlockedByTheme
-							? `${ getCardTitle( experience ) }. ${ blockedThemeHint }`
 							: getCommitLabel( experience )
 					}
 				/>
 			) }
-			{ isEmbeddedBlockedByTheme ? (
-				isConfirmOpen && (
-					// Informational only: classic themes can't run Embedded
-					// search, so this modal explains why and points to theme
-					// management — no confirm path that would commit the
-					// switch. (ConfirmDialog always renders both a confirm and
-					// a cancel button, so Modal is the right primitive here.)
-					// `size="medium"` constrains the width so the explanation
-					// wraps to a readable measure instead of one long line.
-					<Modal
-						title={ __( 'Embedded search needs a block theme', 'jetpack-search-pkg' ) }
-						onRequestClose={ () => setConfirmOpen( false ) }
-						className="jp-search-experience-option__blocked-modal"
-						size="medium"
-					>
-						<p>
-							{ createInterpolateElement(
-								__(
-									'Embedded search is a search page built and customized in the Site Editor. Your active theme is a classic theme, which has no Site Editor. <a>Switch to a block theme</a> to use this experience.',
-									'jetpack-search-pkg'
-								),
-								{ a: <a href={ THEMES_URL } /> }
-							) }
-						</p>
-						<div className="jp-search-experience-option__blocked-modal-actions">
-							<Button variant="primary" onClick={ () => setConfirmOpen( false ) }>
-								{ __( 'Got it', 'jetpack-search-pkg' ) }
-							</Button>
-						</div>
-					</Modal>
-				)
-			) : (
-				<ConfirmDialog
-					isOpen={ isConfirmOpen }
-					onConfirm={ () => {
-						saveExperience( experience );
-						setConfirmOpen( false );
-					} }
-					onCancel={ () => setConfirmOpen( false ) }
-					confirmButtonText={ getCommitLabel( experience ) }
-				>
-					{ sprintf(
-						/* translators: %s — the human-readable experience name (e.g. "Embedded search"). */
-						__( 'Switch the visitor-facing search experience to %s?', 'jetpack-search-pkg' ),
-						getCardTitle( experience )
-					) }
-				</ConfirmDialog>
-			) }
+			<ConfirmDialog
+				isOpen={ isConfirmOpen }
+				onConfirm={ () => {
+					saveExperience( experience );
+					setConfirmOpen( false );
+				} }
+				onCancel={ () => setConfirmOpen( false ) }
+				confirmButtonText={ getCommitLabel( experience ) }
+			>
+				{ sprintf(
+					/* translators: %s — the human-readable experience name (e.g. "Embedded search"). */
+					__( 'Switch the visitor-facing search experience to %s?', 'jetpack-search-pkg' ),
+					getCardTitle( experience )
+				) }
+			</ConfirmDialog>
 			{ /*
 				   SEARCH-216 — confirm before nuking the customized overlay
 				   template. Sends a DELETE to the CPT's built-in REST

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -1,4 +1,3 @@
-import apiFetch from '@wordpress/api-fetch';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -8,12 +7,14 @@ import { Icon, cancelCircleFilled } from '@wordpress/icons';
 import { Badge, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { STORE_ID } from 'store';
+import CardLink from './card-link';
 import { EXPERIENCE, getCardTitle } from './constants';
 import EmbeddedPreview from './previews/embedded-preview';
 import InlinePreview from './previews/inline-preview';
 import OffPreview from './previews/off-preview';
 import OverlayBlocksPreview from './previews/overlay-blocks-preview';
 import OverlayPreview from './previews/overlay-preview';
+import SingletonTemplateActions from './singleton-template-actions';
 import './experience-option.scss';
 
 const SEARCH_CUSTOMIZE_URL = 'admin.php?page=jetpack-search-configure';
@@ -113,27 +114,26 @@ const getHoverHint = experience => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const { active, isUpdating, activeThemeStylesheet, isBlockTheme, blockTemplateOverlay } =
-		useSelect(
-			select => ( {
-				active: select( STORE_ID ).getActiveExperience(),
-				isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
-				activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
-				isBlockTheme: select( STORE_ID ).isBlockTheme(),
-				blockTemplateOverlay: select( STORE_ID ).getBlockTemplateOverlayConfig(),
-			} ),
-			[]
-		);
-	const { saveExperience, successNotice, errorNotice } = useDispatch( STORE_ID );
+	const {
+		active,
+		isUpdating,
+		activeThemeStylesheet,
+		isBlockTheme,
+		blockTemplateOverlay,
+		searchTemplate,
+	} = useSelect(
+		select => ( {
+			active: select( STORE_ID ).getActiveExperience(),
+			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
+			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
+			isBlockTheme: select( STORE_ID ).isBlockTheme(),
+			blockTemplateOverlay: select( STORE_ID ).getBlockTemplateOverlayConfig(),
+			searchTemplate: select( STORE_ID ).getSearchTemplateConfig(),
+		} ),
+		[]
+	);
+	const { saveExperience } = useDispatch( STORE_ID );
 	const [ isConfirmOpen, setConfirmOpen ] = useState( false );
-	const [ isResetConfirmOpen, setResetConfirmOpen ] = useState( false );
-	const [ isResetting, setIsResetting ] = useState( false );
-	// Local override after a successful reset: the server-side `isCustomized`
-	// stays true in the initial-state blob the page was rendered with, so
-	// we hide the "Restore default" link client-side once the AJAX DELETE
-	// returns. Cleared if the admin opens the editor again (which would
-	// lazy-create a fresh singleton).
-	const [ justReset, setJustReset ] = useState( false );
 
 	const isActive = active === experience;
 	const isRecommended = experience === EXPERIENCE.EMBEDDED;
@@ -189,11 +189,10 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 				<CardCopy experience={ experience } />
 			</Stack>
 			{ experience === EXPERIENCE.EMBEDDED && isBlockTheme && (
-				// Site-Editor-only entry points: omitted on classic themes
-				// (which have no Site Editor) so the card doesn't surface
-				// links that lead to a 404. Embedded itself still works on
-				// classic themes via the `template_include` route; only the
-				// in-place customization affordances are hidden.
+				// Block themes get the Site-Editor entry points — the FSE
+				// template editor is the native customization surface and
+				// integrates with theme parts / global styles. The classic-
+				// theme arm below uses the singleton-CPT path instead.
 				<Stack
 					direction="row"
 					gap="sm"
@@ -212,6 +211,26 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					/>
 				</Stack>
 			) }
+			{ experience === EXPERIENCE.EMBEDDED && ! isBlockTheme && (
+				// Classic themes have no Site Editor — route customization
+				// through the `Search_Template` singleton CPT instead.
+				// Same `post.php`-on-a-hidden-CPT pattern as the blocks
+				// Overlay below.
+				<SingletonTemplateActions
+					config={ searchTemplate }
+					editLabel={ __( 'Edit search template', 'jetpack-search-pkg' ) }
+					restoreConfirmMessage={ __(
+						'Restore the bundled Search template? Your customizations will be deleted.',
+						'jetpack-search-pkg'
+					) }
+					successMessage={ __(
+						'The Search template has been restored to the bundled default.',
+						'jetpack-search-pkg'
+					) }
+					errorMessage={ __( 'Could not restore the Search template.', 'jetpack-search-pkg' ) }
+					linksDisabled={ linksDisabled }
+				/>
+			) }
 			{ /*
 			   SEARCH-216 — the blocks-powered Overlay renders from a
 			   separate bundled template the Site Editor cannot reach.
@@ -222,50 +241,23 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 			   too because `post.php` predates the Site Editor.
 			*/ }
 			{ experience === EXPERIENCE.OVERLAY_BLOCKS && (
-				<Stack
-					direction="row"
-					gap="sm"
-					align="start"
-					className="jp-search-experience-option__actions"
-				>
-					{ /*
-					   "Edit the Search overlay" always renders for the
-					   OVERLAY_BLOCKS card — disabled when the card is
-					   inactive (`linksDisabled`), matching how Embedded's
-					   "Edit search template" stays visible as a muted
-					   affordance. `editorUrl` is null until the user has
-					   activated this experience, but the disabled span
-					   doesn't navigate so the placeholder href is harmless.
-					*/ }
-					<CardLink
-						label={ __( 'Edit the Search overlay', 'jetpack-search-pkg' ) }
-						href={ blockTemplateOverlay.editorUrl || '#' }
-						disabled={ linksDisabled }
-						// Re-show "Restore default" on the admin's return
-						// from the editor: the click implies a fresh
-						// singleton is about to be (re-)created on the
-						// server, so the previously-set `justReset` flag
-						// no longer reflects reality.
-						onClick={ () => setJustReset( false ) }
-					/>
-					{ blockTemplateOverlay.resetRestPath &&
-						blockTemplateOverlay.isCustomized &&
-						! justReset && (
-							<CardLink
-								label={ __( 'Restore default', 'jetpack-search-pkg' ) }
-								href="#"
-								disabled={ linksDisabled || isResetting }
-								onClick={ event => {
-									// Destructive — open the confirm dialog
-									// instead of running the AJAX delete
-									// directly. The dialog's confirm handler
-									// is the one that fires `apiFetch`.
-									event.preventDefault();
-									setResetConfirmOpen( true );
-								} }
-							/>
-						) }
-				</Stack>
+				<SingletonTemplateActions
+					config={ blockTemplateOverlay }
+					editLabel={ __( 'Edit the Search overlay', 'jetpack-search-pkg' ) }
+					restoreConfirmMessage={ __(
+						'Restore the bundled Search overlay template? Your customizations will be deleted.',
+						'jetpack-search-pkg'
+					) }
+					successMessage={ __(
+						'The Search overlay template has been restored to the bundled default.',
+						'jetpack-search-pkg'
+					) }
+					errorMessage={ __(
+						'Could not restore the Search overlay template.',
+						'jetpack-search-pkg'
+					) }
+					linksDisabled={ linksDisabled }
+				/>
 			) }
 			{ experience === EXPERIENCE.OVERLAY && (
 				<Stack
@@ -332,57 +324,6 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					getCardTitle( experience )
 				) }
 			</ConfirmDialog>
-			{ /*
-				   SEARCH-216 — confirm before nuking the customized overlay
-				   template. Sends a DELETE to the CPT's built-in REST
-				   endpoint via `apiFetch`; on success, the local `justReset`
-				   flag hides the link and a notice goes through the
-				   dashboard's global-notices store. No page navigation.
-				*/ }
-			{ experience === EXPERIENCE.OVERLAY_BLOCKS && blockTemplateOverlay.enabled && (
-				<ConfirmDialog
-					isOpen={ isResetConfirmOpen }
-					onConfirm={ async () => {
-						setResetConfirmOpen( false );
-						// Defensive guard: the dialog can only open via the
-						// `isCustomized && resetRestPath` CardLink above, so
-						// `resetRestPath` is non-null in practice — avoid
-						// firing a DELETE to `undefined` if the gating logic
-						// ever shifts.
-						if ( ! blockTemplateOverlay.resetRestPath ) {
-							return;
-						}
-						setIsResetting( true );
-						try {
-							await apiFetch( {
-								path: blockTemplateOverlay.resetRestPath,
-								method: 'DELETE',
-							} );
-							setJustReset( true );
-							successNotice(
-								__(
-									'The Search overlay template has been restored to the bundled default.',
-									'jetpack-search-pkg'
-								)
-							);
-						} catch ( error ) {
-							errorNotice(
-								error?.message ||
-									__( 'Could not restore the Search overlay template.', 'jetpack-search-pkg' )
-							);
-						} finally {
-							setIsResetting( false );
-						}
-					} }
-					onCancel={ () => setResetConfirmOpen( false ) }
-					confirmButtonText={ __( 'Restore default', 'jetpack-search-pkg' ) }
-				>
-					{ __(
-						'Restore the bundled Search overlay template? Your customizations will be deleted.',
-						'jetpack-search-pkg'
-					) }
-				</ConfirmDialog>
-			) }
 		</Stack>
 	);
 }
@@ -466,24 +407,3 @@ const CardCopy = ( { experience } ) => {
 		</>
 	);
 };
-
-const CardLink = ( { label, href, disabled, onClick } ) =>
-	disabled ? (
-		// Render as a non-interactive <span> so AT doesn't announce a link
-		// the user can't follow. The `is-disabled` class is the CSS hook for
-		// the muted/not-allowed visual state — `aria-disabled` on a roleless
-		// <span> has no semantic effect for AT.
-		<span className="jp-search-experience-option__action jp-search-experience-option__action-link is-disabled">
-			{ label }
-			<span aria-hidden="true"> →</span>
-		</span>
-	) : (
-		<a
-			className="jp-search-experience-option__action jp-search-experience-option__action-link"
-			href={ href }
-			onClick={ onClick }
-		>
-			{ label }
-			<span aria-hidden="true"> →</span>
-		</a>
-	);

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.scss
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.scss
@@ -173,9 +173,3 @@
 		flex-wrap: wrap;
 	}
 }
-
-.jp-search-experience-option__blocked-modal-actions {
-	display: flex;
-	justify-content: flex-end;
-	margin-top: var(--wpds-dimension-padding-lg);
-}

--- a/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
@@ -1,0 +1,129 @@
+import apiFetch from '@wordpress/api-fetch';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
+import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
+import { STORE_ID } from 'store';
+import CardLink from './card-link';
+
+/**
+ * Edit + Restore-default link pair for a `Singleton_Template_Cpt`-backed
+ * editor flow on the PHP side. The two consumers — the experimental
+ * blocks-powered Overlay (SEARCH-216) and the classic-theme Search
+ * template route — share an identical shape: one config blob describing
+ * the editor URL / reset REST path / isCustomized state, one "Edit …"
+ * link, one "Restore default" link that opens a destructive confirm
+ * dialog, and an AJAX DELETE that posts a notice on success / failure.
+ *
+ * Local state (`justReset`, `isResetting`, `isResetConfirmOpen`) is
+ * scoped here so two of these components can coexist on a single page
+ * (e.g. Embedded card + Overlay card both customized) without their
+ * reset flags cross-contaminating.
+ *
+ * @param {object}  props                       - Props.
+ * @param {object}  props.config                - The `{enabled, editorUrl, resetRestPath, isCustomized}` blob from the matching singleton-template selector.
+ * @param {string}  props.editLabel             - Visible label for the "Edit …" link.
+ * @param {string}  props.restoreConfirmMessage - Body copy for the destructive confirm dialog.
+ * @param {string}  props.successMessage        - Notice copy posted after a successful reset.
+ * @param {string}  props.errorMessage          - Notice copy posted when the AJAX reset fails (used as a fallback when the server doesn't supply an error message).
+ * @param {boolean} props.linksDisabled         - Mirrors the card's "is this experience inactive" state — disables both links the same way the inactive card's commit-overlay button does.
+ * @return {import('react').Element} - The link pair + reset confirm dialog.
+ */
+export default function SingletonTemplateActions( {
+	config,
+	editLabel,
+	restoreConfirmMessage,
+	successMessage,
+	errorMessage,
+	linksDisabled,
+} ) {
+	// Local override after a successful reset: the server-side
+	// `isCustomized` stays true in the initial-state blob the page was
+	// rendered with, so we hide the "Restore default" link client-side
+	// once the AJAX DELETE returns. Cleared if the admin opens the
+	// editor again (which would lazy-create a fresh singleton).
+	const [ justReset, setJustReset ] = useState( false );
+	const [ isResetting, setIsResetting ] = useState( false );
+	const [ isResetConfirmOpen, setResetConfirmOpen ] = useState( false );
+	const { successNotice, errorNotice } = useDispatch( STORE_ID );
+
+	const restoreLabel = __( 'Restore default', 'jetpack-search-pkg' );
+
+	return (
+		<>
+			<Stack
+				direction="row"
+				gap="sm"
+				align="start"
+				className="jp-search-experience-option__actions"
+			>
+				{ /*
+				   The edit link always renders so the affordance stays
+				   visible as a muted CTA on inactive cards too — matches the
+				   FSE "Edit search template" / "Insert pattern" pattern on
+				   the Embedded card. `config.editorUrl` is null until the
+				   experience is the active one (and for non-admins), but
+				   the disabled span doesn't navigate so the placeholder
+				   href is harmless.
+				*/ }
+				<CardLink
+					label={ editLabel }
+					href={ config.editorUrl || '#' }
+					disabled={ linksDisabled }
+					// Re-show "Restore default" on the admin's return from
+					// the editor: the click implies a fresh singleton is
+					// about to be (re-)created on the server, so the
+					// previously-set `justReset` flag no longer reflects
+					// reality.
+					onClick={ () => setJustReset( false ) }
+				/>
+				{ config.resetRestPath && config.isCustomized && ! justReset && (
+					<CardLink
+						label={ restoreLabel }
+						href="#"
+						disabled={ linksDisabled || isResetting }
+						onClick={ event => {
+							// Destructive — open the confirm dialog instead of
+							// running the AJAX delete directly. The dialog's
+							// confirm handler is the one that fires `apiFetch`.
+							event.preventDefault();
+							setResetConfirmOpen( true );
+						} }
+					/>
+				) }
+			</Stack>
+			<ConfirmDialog
+				isOpen={ isResetConfirmOpen }
+				onConfirm={ async () => {
+					setResetConfirmOpen( false );
+					// Defensive guard: the dialog can only open via the
+					// `isCustomized && resetRestPath` CardLink above, so
+					// `resetRestPath` is non-null in practice — avoid firing a
+					// DELETE to `undefined` if the gating logic ever shifts.
+					if ( ! config.resetRestPath ) {
+						return;
+					}
+					setIsResetting( true );
+					try {
+						await apiFetch( {
+							path: config.resetRestPath,
+							method: 'DELETE',
+						} );
+						setJustReset( true );
+						successNotice( successMessage );
+					} catch ( error ) {
+						errorNotice( error?.message || errorMessage );
+					} finally {
+						setIsResetting( false );
+					}
+				} }
+				onCancel={ () => setResetConfirmOpen( false ) }
+				confirmButtonText={ restoreLabel }
+			>
+				{ restoreConfirmMessage }
+			</ConfirmDialog>
+		</>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
@@ -63,15 +63,17 @@ export default function SingletonTemplateActions( {
 				   The edit link always renders so the affordance stays
 				   visible as a muted CTA on inactive cards too — matches the
 				   FSE "Edit search template" / "Insert pattern" pattern on
-				   the Embedded card. `config.editorUrl` is null until the
-				   experience is the active one (and for non-admins), but
-				   the disabled span doesn't navigate so the placeholder
-				   href is harmless.
+				   the Embedded card. Disabled when (a) the card isn't the
+				   active experience yet (the surrounding card's inactive
+				   state) or (b) the PHP side withheld `config.editorUrl` for
+				   non-admins — `CardLink` renders an inert `<span>` in that
+				   state, so a non-admin who somehow lands on this page
+				   doesn't get a live `<a href="#">` that navigates nowhere.
 				*/ }
 				<CardLink
 					label={ editLabel }
 					href={ config.editorUrl || '#' }
-					disabled={ linksDisabled }
+					disabled={ linksDisabled || ! config.editorUrl }
 					// Re-show "Restore default" on the admin's return from
 					// the editor: the click implies a fresh singleton is
 					// about to be (re-)created on the server, so the

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -1,3 +1,14 @@
+// Identity default for `Singleton_Template_Cpt`-backed dashboard configs
+// (overlay + search template). Empty defaults so a missing initial-state
+// blob safely renders as "no customization, no link" instead of crashing
+// on undefined property reads.
+const singletonTemplateConfigDefault = {
+	enabled: false,
+	editorUrl: null,
+	resetRestPath: null,
+	isCustomized: false,
+};
+
 const siteDataSelectors = {
 	getAPIRootUrl: state => state.siteData?.WP_API_root ?? null,
 	getWpcomOriginApiUrl: state => state.siteData?.wpcomOriginApiUrl ?? null,
@@ -24,12 +35,15 @@ const siteDataSelectors = {
 	// in one go. `resetRestPath` is the apiFetch path the "Restore
 	// default" link DELETEs to roll back the customization.
 	getBlockTemplateOverlayConfig: state =>
-		state.siteData?.blockTemplateOverlay ?? {
-			enabled: false,
-			editorUrl: null,
-			resetRestPath: null,
-			isCustomized: false,
-		},
+		state.siteData?.blockTemplateOverlay ?? singletonTemplateConfigDefault,
+	// Same shape as `getBlockTemplateOverlayConfig`, sibling under the
+	// same singleton-CPT pattern — see `Singleton_Template_Cpt` on the
+	// PHP side. Used by the Embedded card on classic themes (which
+	// can't reach the Site Editor) to surface "Edit search template" +
+	// "Restore default" links pointed at the `Search_Template` CPT
+	// instead of the FSE template editor.
+	getSearchTemplateConfig: state =>
+		state.siteData?.searchTemplate ?? singletonTemplateConfigDefault,
 	isWooCommerceActive: state => state.siteData?.isWooCommerceActive ?? false,
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 	// Defaults to true so Embedded is never blocked when the flag is absent

--- a/projects/packages/search/src/search-blocks/class-overlay-template.php
+++ b/projects/packages/search/src/search-blocks/class-overlay-template.php
@@ -17,339 +17,53 @@ namespace Automattic\Jetpack\Search;
  * bundled `templates/jetpack-search-overlay.html` file. Deleting the
  * singleton restores the default.
  *
- * Lifecycle:
- *
- * 1. `register_post_type()` registers the CPT at `init` priority 9, before
- *    block registration, so `do_blocks()` on the post content can resolve
- *    the search blocks.
- * 2. The admin clicks "Edit the Search overlay" in the Jetpack Search
- *    dashboard — a nonce'd URL that hits `maybe_handle_editor_request()`.
- *    That handler lazy-creates the singleton (seeding it from the bundled
- *    file) on first click, then redirects to `post.php?post=<id>&action=edit`.
- * 3. The admin edits + saves; WordPress writes the new block markup to the
- *    singleton's `post_content`.
- * 4. On the front end, `Search_Blocks::get_overlay_template_content()`
- *    prefers the singleton's content when present.
- * 5. "Restore default" calls the CPT's built-in REST endpoint
- *    (`DELETE /wp/v2/jetpack-search-overlay/<id>?force=true`) via
- *    `apiFetch`; the `before_delete_post` hook here cleans up the
- *    singleton option + per-request cache so subsequent renders fall
- *    back to the bundled file.
+ * Lifecycle, register-post-type behavior, capability lockdown, and reset
+ * semantics all live on {@see Singleton_Template_Cpt}; this subclass only
+ * declares the identifiers, copy, and seed source that vary per template.
  *
  * Gated behind both `jetpack_search_blocks_enabled` AND
  * `jetpack_search_overlay_block_template_enabled` — only initialized from
  * `Search_Blocks::init()` when the overlay path is wired up.
  */
-class Overlay_Template {
+class Overlay_Template extends Singleton_Template_Cpt {
 
-	// 20 char max per `register_post_type()`. `jp_` prefix instead of
-	// `jetpack_` to stay under the limit while remaining greppable.
 	const POST_TYPE          = 'jp_search_overlay';
 	const REST_BASE          = 'jetpack-search-overlay';
 	const OPTION_POST_ID     = 'jetpack_search_overlay_template_post_id';
 	const EDITOR_REQUEST_KEY = 'jetpack_search_open_overlay_editor';
 	const EDITOR_NONCE       = 'jetpack_search_overlay_editor';
+	const SEED_META_KEY      = '_jetpack_search_overlay_seeded_version';
 
 	/**
-	 * Per-request memo backing `get_customized_content()`. `null` means the
-	 * cache hasn't been populated yet for this request; an empty string or
-	 * a string with content is a real lookup result.
+	 * Subclass hook — labels for the hidden CPT.
 	 *
-	 * @var string|null|false `false` = no customization (use bundled file).
+	 * @return array{name:string,singular_name:string}
 	 */
-	private static $customized_content_cache = null;
-
-	/**
-	 * Wire the hooks. Called from `Search_Blocks::init()` only when the
-	 * overlay gate is on.
-	 */
-	public static function init() {
-		// Priority 9: register the CPT just before `Search_Blocks::register_blocks()`
-		// (also on `init`, default priority 10) so the search blocks are
-		// registered against a known CPT when `do_blocks()` runs on the
-		// singleton's content.
-		add_action( 'init', array( static::class, 'register_post_type' ), 9 );
-		add_action( 'admin_init', array( static::class, 'maybe_handle_editor_request' ) );
-		// Keep the singleton option + per-request cache consistent regardless
-		// of which delete path is taken: the dashboard's AJAX reset, the
-		// REST endpoint, or an admin trashing then permanently deleting via
-		// post.php. `before_delete_post` fires for force-delete too, which
-		// is what wp_delete_post( $id, true ) and REST DELETE ?force=true do.
-		add_action( 'before_delete_post', array( static::class, 'maybe_cleanup_on_singleton_delete' ) );
-	}
-
-	/**
-	 * Reset the option + per-request cache when our singleton post is
-	 * deleted, regardless of which delete path the admin took. Catches
-	 * deletions from any source — REST, post.php, our own dashboard flow
-	 * — so the state never drifts (option still pointing at a deleted
-	 * post would otherwise hide "Restore default" while the front end
-	 * already serves the bundled template).
-	 *
-	 * @param int $post_id The post being deleted.
-	 */
-	public static function maybe_cleanup_on_singleton_delete( $post_id ) {
-		$post = get_post( $post_id );
-		if ( ! $post || static::POST_TYPE !== $post->post_type ) {
-			return;
-		}
-		if ( (int) get_option( static::OPTION_POST_ID, 0 ) === (int) $post_id ) {
-			delete_option( static::OPTION_POST_ID );
-		}
-		self::$customized_content_cache = null;
-	}
-
-	/**
-	 * Register the hidden singleton CPT. No menu, no UI surface of its own;
-	 * the only way to land in the block editor on this post is via the
-	 * dashboard's "Edit the Search overlay" link.
-	 */
-	public static function register_post_type() {
-		register_post_type(
-			static::POST_TYPE,
-			array(
-				'labels'              => array(
-					'name'          => __( 'Search overlay template', 'jetpack-search-pkg' ),
-					'singular_name' => __( 'Search overlay template', 'jetpack-search-pkg' ),
-				),
-				'public'              => false,
-				'show_ui'             => true, // post.php / edit.php need the UI machinery even though we hide the menu.
-				'show_in_menu'        => false,
-				'show_in_admin_bar'   => false,
-				'show_in_nav_menus'   => false,
-				'show_in_rest'        => true,
-				'rest_base'           => static::REST_BASE,
-				'supports'            => array( 'editor', 'custom-fields', 'revisions' ),
-				// Lock every relevant capability to `manage_options` so editing
-				// requires admin, regardless of which entry point (post.php
-				// direct URL, REST API at /wp/v2/jetpack-search-overlay, the
-				// dashboard link) the user takes. The dashboard handlers
-				// already gate on `manage_options` themselves; this prevents
-				// an Editor-role user who happens to know the singleton's
-				// post ID from bypassing that gate via post.php or REST.
-				// `map_meta_cap: false` makes the literal capability names
-				// below the ones WordPress actually checks.
-				'capabilities'        => array(
-					'edit_post'              => 'manage_options',
-					'read_post'              => 'manage_options',
-					'delete_post'            => 'manage_options',
-					'edit_posts'             => 'manage_options',
-					'edit_others_posts'      => 'manage_options',
-					'delete_posts'           => 'manage_options',
-					'delete_others_posts'    => 'manage_options',
-					'publish_posts'          => 'manage_options',
-					'read_private_posts'     => 'manage_options',
-					'delete_private_posts'   => 'manage_options',
-					'delete_published_posts' => 'manage_options',
-					'edit_private_posts'     => 'manage_options',
-					'edit_published_posts'   => 'manage_options',
-					'create_posts'           => 'manage_options',
-				),
-				'map_meta_cap'        => false,
-				'has_archive'         => false,
-				'exclude_from_search' => true,
-				'rewrite'             => false,
-				'can_export'          => false,
-				'delete_with_user'    => false,
-				'template_lock'       => false,
-			)
+	protected static function labels(): array {
+		return array(
+			'name'          => __( 'Search overlay template', 'jetpack-search-pkg' ),
+			'singular_name' => __( 'Search overlay template', 'jetpack-search-pkg' ),
 		);
 	}
 
 	/**
-	 * Return the singleton post's content if present. `null` means there's
-	 * no customization on file and callers should fall back to the bundled
-	 * template. Memoized per-request.
-	 *
-	 * @return string|null
-	 */
-	public static function get_customized_content(): ?string {
-		if ( null !== self::$customized_content_cache ) {
-			return false === self::$customized_content_cache ? null : self::$customized_content_cache;
-		}
-		$post_id = static::get_post_id();
-		if ( ! $post_id ) {
-			self::$customized_content_cache = false;
-			return null;
-		}
-		$post = get_post( $post_id );
-		if ( ! $post || static::POST_TYPE !== $post->post_type || 'trash' === $post->post_status ) {
-			self::$customized_content_cache = false;
-			return null;
-		}
-		// Empty post content means the admin saved a blank canvas — honor
-		// that explicitly rather than silently falling back to the bundled
-		// default (the editor would loop with the bundled content on every
-		// save otherwise).
-		self::$customized_content_cache = (string) $post->post_content;
-		return self::$customized_content_cache;
-	}
-
-	/**
-	 * Singleton post ID, or 0 if no customization exists yet.
-	 *
-	 * @return int
-	 */
-	public static function get_post_id(): int {
-		return (int) get_option( static::OPTION_POST_ID, 0 );
-	}
-
-	/**
-	 * Whether a live customization exists — the singleton post is set AND
-	 * not in the trash. The trash check matters because `show_ui` is on,
-	 * so an admin could navigate to the post-list and trash the singleton
-	 * directly; the option would still point at the (trashed) post, but
-	 * `get_customized_content()` already returns null for trashed rows so
-	 * the front end falls back to the bundled template. Reflecting that
-	 * in the dashboard means "Restore default" disappears when there's
-	 * nothing the user would perceive as customized.
-	 *
-	 * @return bool
-	 */
-	public static function is_customized(): bool {
-		$post_id = static::get_post_id();
-		if ( ! $post_id ) {
-			return false;
-		}
-		$post = get_post( $post_id );
-		return $post && static::POST_TYPE === $post->post_type && 'trash' !== $post->post_status;
-	}
-
-	/**
-	 * Nonce'd admin URL that lazy-creates the singleton (if missing) and
-	 * redirects the admin into the block editor on it. Used by the
-	 * dashboard "Edit the Search overlay" link.
-	 *
-	 * Built with `add_query_arg` + `wp_create_nonce` (not `wp_nonce_url`)
-	 * so the returned string contains raw `&` separators, not the HTML-
-	 * encoded `&amp;` that `wp_nonce_url` emits. The URL is JSON-serialized
-	 * to the React dashboard's initial state and then set as an `<a href>`
-	 * value — React/JSX doesn't HTML-decode attribute values, so encoded
-	 * amps would round-trip into the browser's URL bar verbatim and break
-	 * the `$_GET` parse.
+	 * Subclass hook — default post title for the lazy-created singleton.
 	 *
 	 * @return string
 	 */
-	public static function get_editor_url(): string {
-		return add_query_arg(
-			array(
-				static::EDITOR_REQUEST_KEY => '1',
-				'_wpnonce'                 => wp_create_nonce( static::EDITOR_NONCE ),
-			),
-			admin_url( 'admin.php?page=jetpack-search' )
-		);
+	protected static function post_title(): string {
+		return __( 'Jetpack Search overlay', 'jetpack-search-pkg' );
 	}
 
 	/**
-	 * REST path used by the dashboard's "Restore default" link to delete
-	 * the singleton via the CPT's built-in REST endpoint
-	 * (`/wp/v2/jetpack-search-overlay/<id>?force=true`). The dashboard
-	 * calls this with `apiFetch({ method: 'DELETE', path: <…> })`; the
-	 * `before_delete_post` cleanup keeps the option + cache in sync.
-	 *
-	 * Returns `null` when no singleton exists — the React link is hidden
-	 * by `isCustomized` in that state, so this should never be hit, but
-	 * returning null keeps the type honest.
-	 *
-	 * @return string|null
-	 */
-	public static function get_reset_rest_path(): ?string {
-		if ( ! static::is_customized() ) {
-			return null;
-		}
-		return '/wp/v2/' . static::REST_BASE . '/' . static::get_post_id() . '?force=true';
-	}
-
-	/**
-	 * Handle the "open editor" admin request: create the singleton on first
-	 * click (seeded from the bundled template), then redirect to the block
-	 * editor on it.
-	 */
-	public static function maybe_handle_editor_request() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below.
-		if ( empty( $_GET[ static::EDITOR_REQUEST_KEY ] ) ) {
-			return;
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'You do not have permission to customize the Search overlay.', 'jetpack-search-pkg' ), '', array( 'response' => 403 ) );
-		}
-		check_admin_referer( static::EDITOR_NONCE );
-		$post_id = static::ensure_post_exists();
-		if ( ! $post_id ) {
-			wp_die( esc_html__( 'Could not create the Search overlay template.', 'jetpack-search-pkg' ), '', array( 'response' => 500 ) );
-		}
-		wp_safe_redirect( admin_url( 'post.php?post=' . $post_id . '&action=edit' ) );
-		exit;
-	}
-
-	/**
-	 * Ensure the singleton post exists. Returns its ID. If it doesn't
-	 * exist yet, creates it with the bundled-template content as the seed
-	 * (so the editor opens populated rather than empty).
-	 *
-	 * @return int Post ID on success, 0 on failure.
-	 */
-	protected static function ensure_post_exists(): int {
-		$existing = static::get_post_id();
-		if ( $existing ) {
-			$existing_post = get_post( $existing );
-			// Only reuse live singleton posts. If the option points to a trashed
-			// row (or a stale/mismatched ID), treat it as missing so clicking
-			// "Edit the Search overlay" recreates a fresh editable singleton.
-			if ( $existing_post && static::POST_TYPE === $existing_post->post_type && 'trash' !== $existing_post->post_status ) {
-				return $existing;
-			}
-			// Force-delete the stale post (typically trashed) before recreating,
-			// so admins who repeatedly trash the singleton don't accumulate
-			// orphan rows. before_delete_post will null the option + cache.
-			if ( $existing_post && static::POST_TYPE === $existing_post->post_type ) {
-				wp_delete_post( $existing, true );
-			} else {
-				delete_option( static::OPTION_POST_ID );
-				self::$customized_content_cache = null;
-			}
-		}
-		$seed_content = static::read_bundled_template();
-		$post_id      = wp_insert_post(
-			array(
-				'post_type'    => static::POST_TYPE,
-				'post_status'  => 'publish',
-				'post_title'   => __( 'Jetpack Search overlay', 'jetpack-search-pkg' ),
-				'post_content' => $seed_content,
-				'meta_input'   => array(
-					'_jetpack_search_overlay_seeded_version' => '1',
-				),
-			),
-			true
-		);
-		if ( is_wp_error( $post_id ) || ! $post_id ) {
-			return 0;
-		}
-		// Race-safe option write: if a parallel request also raced past
-		// the early `get_post_id()` check and inserted its own singleton +
-		// claimed the option in between, drop ours and adopt theirs. The
-		// orphaned post would otherwise never be deleted by the reset
-		// flow because that only follows the option pointer.
-		$other_post_id = (int) get_option( static::OPTION_POST_ID, 0 );
-		$other_post    = $other_post_id ? get_post( $other_post_id ) : null;
-		if ( $other_post && static::POST_TYPE === $other_post->post_type && 'trash' !== $other_post->post_status ) {
-			wp_delete_post( $post_id, true );
-			self::$customized_content_cache = null;
-			return $other_post_id;
-		}
-		update_option( static::OPTION_POST_ID, $post_id, false );
-		self::$customized_content_cache = $seed_content;
-		return (int) $post_id;
-	}
-
-	/**
-	 * Read the bundled overlay template file. Exposed for the seed path —
-	 * the equivalent read in `Search_Blocks::get_overlay_template_content()`
-	 * cannot be reused without introducing a circular dependency.
+	 * Subclass hook — seed `post_content` for the lazy-created singleton.
+	 * Reads the bundled overlay template file directly to avoid pulling
+	 * in `Search_Blocks::get_overlay_template_content()`, which would
+	 * loop back through this class's customization check.
 	 *
 	 * @return string
 	 */
-	protected static function read_bundled_template(): string {
+	protected static function read_seed_content(): string {
 		$path = __DIR__ . '/templates/jetpack-search-overlay.html';
 		if ( ! is_readable( $path ) ) {
 			return '';
@@ -359,9 +73,20 @@ class Overlay_Template {
 	}
 
 	/**
-	 * Reset the per-request content memo. Tests only.
+	 * Subclass hook — copy for the editor-URL forbidden response.
+	 *
+	 * @return string
 	 */
-	public static function reset_customized_content_cache() {
-		self::$customized_content_cache = null;
+	protected static function forbidden_message(): string {
+		return __( 'You do not have permission to customize the Search overlay.', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Subclass hook — copy for the editor-URL create-failure response.
+	 *
+	 * @return string
+	 */
+	protected static function create_failure_message(): string {
+		return __( 'Could not create the Search overlay template.', 'jetpack-search-pkg' );
 	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1650,6 +1650,14 @@ CSS;
 		if ( ! static::woocommerce_search_template_override_enabled() && static::is_woocommerce_product_search() ) {
 			return $template;
 		}
+		// Bail back to the theme's own search template if the bundled
+		// `jetpack-search.html` is somehow unreadable — rendering header /
+		// footer with nothing between them just looks like a broken page.
+		// Mirrors the block-theme path's empty-content bail-out in
+		// `register_search_template()`.
+		if ( '' === static::get_classic_theme_search_body() ) {
+			return $template;
+		}
 		return __DIR__ . '/templates/classic-theme-search.php';
 	}
 
@@ -1672,8 +1680,11 @@ CSS;
 		// The bundled template emits exactly two top-level `core/template-part`
 		// self-closing comments (header before the main group, footer after).
 		// On classic themes those slugs don't resolve to anything renderable,
-		// so drop the comments before `do_blocks()` walks the markup.
-		return (string) preg_replace( '#<!--\s*wp:template-part\s+\{[^}]*\}\s*/-->\s*#', '', $content );
+		// so drop the comments before `do_blocks()` walks the markup. The
+		// inner `.*?` is non-greedy and capped by the `-->` sentinel, so a
+		// future template revision that nests JSON (e.g. `{"theme":{"name":"x"}}`)
+		// in a `wp:template-part` attribute keeps matching cleanly.
+		return (string) preg_replace( '#<!--\s*wp:template-part\s+.*?/-->\s*#s', '', $content );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -206,6 +206,12 @@ class Search_Blocks {
 				// so the search page slots into the theme's chrome instead of
 				// replacing it.
 				add_filter( 'template_include', array( static::class, 'route_classic_theme_search_template' ) );
+				// Classic themes lose the Site Editor entry point for
+				// customizing the bundled template, so wire up the
+				// `Search_Template` singleton CPT — the standard block
+				// editor on a hidden post is the theme-agnostic editing
+				// surface, mirroring `Overlay_Template`.
+				Search_Template::init();
 			}
 		}
 
@@ -1650,12 +1656,13 @@ CSS;
 		if ( ! static::woocommerce_search_template_override_enabled() && static::is_woocommerce_product_search() ) {
 			return $template;
 		}
-		// Bail back to the theme's own search template if the bundled
-		// `jetpack-search.html` is somehow unreadable — rendering header /
-		// footer with nothing between them just looks like a broken page.
-		// Mirrors the block-theme path's empty-content bail-out in
-		// `register_search_template()`.
-		if ( '' === static::get_classic_theme_search_body() ) {
+		// Bail back to the theme's own search template if neither a
+		// customization nor a readable bundled body is available —
+		// rendering header / footer with nothing between them just
+		// looks like a broken page. A saved empty customization
+		// (Search_Template::get_customized_content() returning ''
+		// instead of null) is treated as intentional and honored.
+		if ( null === Search_Template::get_customized_content() && '' === static::get_classic_theme_search_body() ) {
 			return $template;
 		}
 		return __DIR__ . '/templates/classic-theme-search.php';
@@ -1667,12 +1674,27 @@ CSS;
 	 * and trailing `core/template-part` references stripped so the theme's
 	 * `get_header()` / `get_footer()` drive the chrome.
 	 *
+	 * Source of truth, in order:
+	 *
+	 *   1. The customized singleton CPT ({@see Search_Template}), if an
+	 *      admin has saved one via the dashboard's "Edit search template"
+	 *      link.
+	 *   2. The bundled `templates/jetpack-search.html` file, template-part
+	 *      wrappers stripped.
+	 *
 	 * Public because the bundled PHP shim (`templates/classic-theme-search.php`)
 	 * needs to call it from outside the class scope.
 	 *
 	 * @return string Block markup, no template-part wrappers.
 	 */
 	public static function get_classic_theme_search_body(): string {
+		// Customization first — singleton CPT seeded from the bundled
+		// markup, edited via post.php; theme-agnostic so the admin can
+		// reach the editor without a Site Editor.
+		$customized = Search_Template::get_customized_content();
+		if ( null !== $customized ) {
+			return $customized;
+		}
 		$content = static::get_search_template_content();
 		if ( '' === $content ) {
 			return '';

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -190,9 +190,23 @@ class Search_Blocks {
 		$experience = ( new Module_Control() )->get_experience();
 
 		if ( Module_Control::EXPERIENCE_EMBEDDED === $experience ) {
-			add_action( 'init', array( static::class, 'register_search_template' ) );
-			add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
-			Theme_Chrome_Slug_Resolver::register_hooks();
+			if ( static::block_templates_active() ) {
+				// Block themes: register the bundled template and front it via
+				// the FSE template-hierarchy filter so the Site Editor and the
+				// block-template render path both pick it up.
+				add_action( 'init', array( static::class, 'register_search_template' ) );
+				add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
+				Theme_Chrome_Slug_Resolver::register_hooks();
+			} else {
+				// Classic themes: there is no FSE hierarchy to prepend to and
+				// `locate_template()` can't resolve the `jetpack-search` slug to
+				// a theme PHP file, so swap the resolved template path post-
+				// hierarchy via `template_include`. The bundled block markup
+				// renders inside the theme's `get_header()` / `get_footer()`,
+				// so the search page slots into the theme's chrome instead of
+				// replacing it.
+				add_filter( 'template_include', array( static::class, 'route_classic_theme_search_template' ) );
+			}
 		}
 
 		// When the blocks own the front-end search results, the server-side
@@ -1608,6 +1622,81 @@ CSS;
 	}
 
 	/**
+	 * Classic-theme counterpart to `prepend_search_template()`.
+	 *
+	 * Prepending a slug to `search_template_hierarchy` only works on block
+	 * themes — `locate_template()` walks the slugs as `{slug}.php` files in
+	 * the active theme, which a classic theme never ships for our
+	 * `jetpack-search` slug, so the hierarchy filter is a no-op there.
+	 * Instead we let the hierarchy resolve normally (to the theme's
+	 * `search.php` / `index.php`) and then swap the resolved path
+	 * post-resolution via `template_include` for our bundled PHP shim, which
+	 * renders the same block markup inside the theme's
+	 * `get_header()` / `get_footer()`.
+	 *
+	 * Hooked only when `init()` already established Embedded + classic theme,
+	 * so we just guard on `is_search()` and the WooCommerce product-search
+	 * carve-out (the block-template registry doesn't reach classic themes,
+	 * so we don't ship a per-Woo classic shim — let WooCommerce's own
+	 * archive routing render the product search results).
+	 *
+	 * @param string $template Resolved template path.
+	 * @return string
+	 */
+	public static function route_classic_theme_search_template( $template ) {
+		if ( ! is_search() ) {
+			return $template;
+		}
+		if ( ! static::woocommerce_search_template_override_enabled() && static::is_woocommerce_product_search() ) {
+			return $template;
+		}
+		return __DIR__ . '/templates/classic-theme-search.php';
+	}
+
+	/**
+	 * Search template body for the classic-theme `template_include` route —
+	 * the same block markup the block-theme path registers, with the leading
+	 * and trailing `core/template-part` references stripped so the theme's
+	 * `get_header()` / `get_footer()` drive the chrome.
+	 *
+	 * Public because the bundled PHP shim (`templates/classic-theme-search.php`)
+	 * needs to call it from outside the class scope.
+	 *
+	 * @return string Block markup, no template-part wrappers.
+	 */
+	public static function get_classic_theme_search_body(): string {
+		$content = static::get_search_template_content();
+		if ( '' === $content ) {
+			return '';
+		}
+		// The bundled template emits exactly two top-level `core/template-part`
+		// self-closing comments (header before the main group, footer after).
+		// On classic themes those slugs don't resolve to anything renderable,
+		// so drop the comments before `do_blocks()` walks the markup.
+		return (string) preg_replace( '#<!--\s*wp:template-part\s+\{[^}]*\}\s*/-->\s*#', '', $content );
+	}
+
+	/**
+	 * Test override for `block_templates_active()`. Null means "no override
+	 * — read the live state via `wp_is_block_theme()`". Set in tests that
+	 * need to exercise the block-theme `init()` path without standing up a
+	 * real block theme; reset back to null in the teardown.
+	 *
+	 * @var bool|null
+	 */
+	private static $block_templates_active_for_testing = null;
+
+	/**
+	 * Test seam. Set true/false to force `block_templates_active()`'s return
+	 * value, or null to clear the override.
+	 *
+	 * @param bool|null $active Forced value, or null to clear.
+	 */
+	public static function set_block_templates_active_for_testing( ?bool $active ): void {
+		self::$block_templates_active_for_testing = $active;
+	}
+
+	/**
 	 * Whether the active theme resolves block templates. Wraps
 	 * `wp_is_block_theme()` as an overridable seam so tests can exercise the
 	 * block-theme path without standing up a block theme.
@@ -1615,6 +1704,9 @@ CSS;
 	 * @return bool
 	 */
 	protected static function block_templates_active(): bool {
+		if ( null !== self::$block_templates_active_for_testing ) {
+			return self::$block_templates_active_for_testing;
+		}
 		return wp_is_block_theme();
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-template.php
+++ b/projects/packages/search/src/search-blocks/class-search-template.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Singleton CPT + lifecycle for the classic-theme search template editor.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Lets admins customize the search results template on classic themes via
+ * the standard block editor (post.php) — a theme-agnostic editing surface
+ * for a route the Site Editor can't reach. Block themes keep using their
+ * existing Site Editor entry point; this class is the equivalent
+ * affordance for the classic-theme `template_include` render path.
+ *
+ * All lifecycle / registration / reset machinery lives on
+ * {@see Singleton_Template_Cpt}; only the identifiers, copy, and seed
+ * source differ from {@see Overlay_Template}. The seed is the same body
+ * `Search_Blocks::get_classic_theme_search_body()` returns at render time
+ * — placeholders substituted, template-part wrappers stripped — so what
+ * the admin edits matches what the front end renders.
+ */
+class Search_Template extends Singleton_Template_Cpt {
+
+	const POST_TYPE          = 'jp_search_template';
+	const REST_BASE          = 'jetpack-search-template';
+	const OPTION_POST_ID     = 'jetpack_search_template_post_id';
+	const EDITOR_REQUEST_KEY = 'jetpack_search_open_template_editor';
+	const EDITOR_NONCE       = 'jetpack_search_template_editor';
+	const SEED_META_KEY      = '_jetpack_search_template_seeded_version';
+
+	/**
+	 * Subclass hook — labels for the hidden CPT.
+	 *
+	 * @return array{name:string,singular_name:string}
+	 */
+	protected static function labels(): array {
+		return array(
+			'name'          => __( 'Search template', 'jetpack-search-pkg' ),
+			'singular_name' => __( 'Search template', 'jetpack-search-pkg' ),
+		);
+	}
+
+	/**
+	 * Subclass hook — default post title for the lazy-created singleton.
+	 *
+	 * @return string
+	 */
+	protected static function post_title(): string {
+		return __( 'Jetpack Search template', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Subclass hook — seed `post_content` for the lazy-created singleton.
+	 * Reuses `Search_Blocks::get_classic_theme_search_body()` so the seed
+	 * always matches what the front-end classic-theme route renders.
+	 *
+	 * Note: the body source itself preferences a saved customization, but
+	 * `ensure_post_exists()` only runs when one doesn't already exist —
+	 * so this resolves to the bundled (template-part-stripped) markup.
+	 *
+	 * @return string
+	 */
+	protected static function read_seed_content(): string {
+		return Search_Blocks::get_classic_theme_search_body();
+	}
+
+	/**
+	 * Subclass hook — copy for the editor-URL forbidden response.
+	 *
+	 * @return string
+	 */
+	protected static function forbidden_message(): string {
+		return __( 'You do not have permission to customize the Search template.', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Subclass hook — copy for the editor-URL create-failure response.
+	 *
+	 * @return string
+	 */
+	protected static function create_failure_message(): string {
+		return __( 'Could not create the Search template.', 'jetpack-search-pkg' );
+	}
+}

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -3,6 +3,15 @@
  * Abstract scaffolding for the bundled-template singleton-CPT editor flow.
  *
  * @package automattic/jetpack-search
+ *
+ * Phan can't statically prove our late-static-binding callers always
+ * resolve to a concrete subclass — every `static::abstract_method()`
+ * site in here is reached only through `Overlay_Template::init()` or
+ * `Search_Template::init()` (which forward `static::class` to the
+ * registered actions/filters), so the abstract methods are always
+ * resolved at runtime. The warning is a false positive for this file.
+ *
+ * @phan-file-suppress PhanAbstractStaticMethodCallInStatic
  */
 
 namespace Automattic\Jetpack\Search;

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Abstract scaffolding for the bundled-template singleton-CPT editor flow.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Shared machinery for "edit a bundled block template via the standard block
+ * editor on a hidden CPT" — a theme-agnostic customization surface that
+ * concrete subclasses ({@see Overlay_Template}, {@see Search_Template})
+ * specialize by declaring the post-type / option / nonce / REST identifiers
+ * and providing the seed content + admin-facing copy.
+ *
+ * The lifecycle (admin clicks "Edit …" → nonce'd handler lazy-creates a
+ * singleton seeded from the bundled markup → admin redirected to
+ * `post.php?post=<id>&action=edit` → front-end renderers prefer the
+ * customization → "Restore default" force-deletes the singleton via REST →
+ * `before_delete_post` clears the option + per-request cache) is identical
+ * across both subclasses. Keeping the variations to a handful of constants
+ * and abstract hooks lets a third bundled template (search-product, future
+ * variants) opt in with ~50 lines instead of a 350-line copy.
+ *
+ * Subclasses **must** override every const + abstract method below. The
+ * defaults are intentionally empty / unsatisfiable so a misconfigured
+ * subclass surfaces at registration time rather than silently broken at
+ * delete-cleanup time. Per-class state (the customization cache) is keyed
+ * by `static::class` so two subclasses can't cross-contaminate each
+ * other's memoized lookup within a request.
+ */
+abstract class Singleton_Template_Cpt {
+
+	/**
+	 * Hidden CPT slug. 20 char max per `register_post_type()`. Use a
+	 * `jp_` prefix to stay under the limit while remaining greppable.
+	 */
+	const POST_TYPE = '';
+
+	/**
+	 * REST base for the CPT — appears in `/wp/v2/<rest_base>/<id>` and
+	 * in `get_reset_rest_path()`.
+	 */
+	const REST_BASE = '';
+
+	/**
+	 * Option name that stores the singleton post ID (0 / absent ⇒
+	 * "no customization").
+	 */
+	const OPTION_POST_ID = '';
+
+	/**
+	 * `$_GET` key the nonce'd "open editor" URL sets.
+	 */
+	const EDITOR_REQUEST_KEY = '';
+
+	/**
+	 * Nonce action paired with EDITOR_REQUEST_KEY.
+	 */
+	const EDITOR_NONCE = '';
+
+	/**
+	 * Post-meta key stamped on freshly-seeded singletons so a future
+	 * re-seed pass (if the bundled markup evolves) can find rows it
+	 * created.
+	 */
+	const SEED_META_KEY = '';
+
+	/**
+	 * Per-request memo backing `get_customized_content()`, keyed by
+	 * subclass name so concrete subclasses can't cross-contaminate each
+	 * other's lookups.
+	 *
+	 * Values: missing key = uncached; `false` = "no customization on
+	 * file"; `string` = the customization's content (including the
+	 * empty string when the admin saved a blank canvas).
+	 *
+	 * @var array<class-string, string|false>
+	 */
+	private static $caches = array();
+
+	/**
+	 * Labels for `register_post_type()` — translation-aware so subclass
+	 * copy stays consistent with the rest of the admin UI.
+	 *
+	 * @return array{name:string,singular_name:string}
+	 */
+	abstract protected static function labels(): array;
+
+	/**
+	 * Default title for the singleton on first creation. Translation-
+	 * aware.
+	 *
+	 * @return string
+	 */
+	abstract protected static function post_title(): string;
+
+	/**
+	 * Initial `post_content` for the singleton. Called only during
+	 * lazy-creation in `ensure_post_exists()`.
+	 *
+	 * @return string
+	 */
+	abstract protected static function read_seed_content(): string;
+
+	/**
+	 * Copy used in `wp_die()` when a non-admin tries to trigger the
+	 * editor URL. Translation-aware.
+	 *
+	 * @return string
+	 */
+	abstract protected static function forbidden_message(): string;
+
+	/**
+	 * Copy used in `wp_die()` when the singleton creation fails (e.g.
+	 * `wp_insert_post()` returns a WP_Error). Translation-aware.
+	 *
+	 * @return string
+	 */
+	abstract protected static function create_failure_message(): string;
+
+	/**
+	 * Wire the hooks. Called from the subclass's own `init()` invocation
+	 * in `Search_Blocks::init()`.
+	 */
+	public static function init() {
+		// Priority 9: register the CPT just before
+		// `Search_Blocks::register_blocks()` (also on `init`, default
+		// priority 10) so the Search blocks are registered against a
+		// known CPT when `do_blocks()` runs on the singleton's content.
+		add_action( 'init', array( static::class, 'register_post_type' ), 9 );
+		add_action( 'admin_init', array( static::class, 'maybe_handle_editor_request' ) );
+		// Keep the singleton option + per-request cache consistent
+		// regardless of which delete path is taken: the dashboard's
+		// AJAX reset, the REST endpoint, or an admin trashing then
+		// permanently deleting via post.php. `before_delete_post` fires
+		// for force-delete too, which is what `wp_delete_post( $id, true )`
+		// and REST DELETE `?force=true` do.
+		add_action( 'before_delete_post', array( static::class, 'maybe_cleanup_on_singleton_delete' ) );
+	}
+
+	/**
+	 * Reset the option + per-request cache when our singleton post is
+	 * deleted, regardless of which delete path the admin took. Catches
+	 * deletions from any source — REST, post.php, our own dashboard
+	 * flow — so the state never drifts (option still pointing at a
+	 * deleted post would otherwise hide "Restore default" while the
+	 * front end already serves the bundled template).
+	 *
+	 * @param int $post_id The post being deleted.
+	 */
+	public static function maybe_cleanup_on_singleton_delete( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post || static::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		if ( (int) get_option( static::OPTION_POST_ID, 0 ) === (int) $post_id ) {
+			delete_option( static::OPTION_POST_ID );
+		}
+		unset( self::$caches[ static::class ] );
+	}
+
+	/**
+	 * Register the hidden singleton CPT. No menu, no UI surface of its
+	 * own; the only way to land in the block editor on this post is via
+	 * the dashboard's edit link.
+	 */
+	public static function register_post_type() {
+		register_post_type(
+			static::POST_TYPE,
+			array(
+				'labels'              => static::labels(),
+				'public'              => false,
+				'show_ui'             => true, // post.php / edit.php need the UI machinery even though we hide the menu.
+				'show_in_menu'        => false,
+				'show_in_admin_bar'   => false,
+				'show_in_nav_menus'   => false,
+				'show_in_rest'        => true,
+				'rest_base'           => static::REST_BASE,
+				'supports'            => array( 'editor', 'custom-fields', 'revisions' ),
+				// Lock every relevant capability to `manage_options` so
+				// editing requires admin, regardless of which entry
+				// point (post.php direct URL, REST API, the dashboard
+				// link) the user takes. The dashboard handlers already
+				// gate on `manage_options` themselves; this prevents an
+				// Editor-role user who happens to know the singleton's
+				// post ID from bypassing that gate via post.php or REST.
+				// `map_meta_cap: false` makes the literal capability
+				// names below the ones WordPress actually checks.
+				'capabilities'        => array(
+					'edit_post'              => 'manage_options',
+					'read_post'              => 'manage_options',
+					'delete_post'            => 'manage_options',
+					'edit_posts'             => 'manage_options',
+					'edit_others_posts'      => 'manage_options',
+					'delete_posts'           => 'manage_options',
+					'delete_others_posts'    => 'manage_options',
+					'publish_posts'          => 'manage_options',
+					'read_private_posts'     => 'manage_options',
+					'delete_private_posts'   => 'manage_options',
+					'delete_published_posts' => 'manage_options',
+					'edit_private_posts'     => 'manage_options',
+					'edit_published_posts'   => 'manage_options',
+					'create_posts'           => 'manage_options',
+				),
+				'map_meta_cap'        => false,
+				'has_archive'         => false,
+				'exclude_from_search' => true,
+				'rewrite'             => false,
+				'can_export'          => false,
+				'delete_with_user'    => false,
+				'template_lock'       => false,
+			)
+		);
+	}
+
+	/**
+	 * Return the singleton post's content if present. `null` means
+	 * there's no customization on file and callers should fall back to
+	 * the bundled template. Memoized per-request.
+	 *
+	 * @return string|null
+	 */
+	public static function get_customized_content(): ?string {
+		if ( array_key_exists( static::class, self::$caches ) ) {
+			$cached = self::$caches[ static::class ];
+			return false === $cached ? null : $cached;
+		}
+		$post_id = static::get_post_id();
+		if ( ! $post_id ) {
+			self::$caches[ static::class ] = false;
+			return null;
+		}
+		$post = get_post( $post_id );
+		if ( ! $post || static::POST_TYPE !== $post->post_type || 'trash' === $post->post_status ) {
+			self::$caches[ static::class ] = false;
+			return null;
+		}
+		// Empty post content means the admin saved a blank canvas —
+		// honor that explicitly rather than silently falling back to the
+		// bundled default (the editor would loop with the bundled
+		// content on every save otherwise).
+		self::$caches[ static::class ] = (string) $post->post_content;
+		return self::$caches[ static::class ];
+	}
+
+	/**
+	 * Singleton post ID, or 0 if no customization exists yet.
+	 *
+	 * @return int
+	 */
+	public static function get_post_id(): int {
+		return (int) get_option( static::OPTION_POST_ID, 0 );
+	}
+
+	/**
+	 * Whether a live customization exists — the singleton post is set
+	 * AND not in the trash. The trash check matters because `show_ui`
+	 * is on, so an admin could navigate to the post-list and trash the
+	 * singleton directly; the option would still point at the
+	 * (trashed) post, but `get_customized_content()` already returns
+	 * null for trashed rows so the front end falls back to the bundled
+	 * template. Reflecting that in the dashboard means "Restore default"
+	 * disappears when there's nothing the user would perceive as
+	 * customized.
+	 *
+	 * @return bool
+	 */
+	public static function is_customized(): bool {
+		$post_id = static::get_post_id();
+		if ( ! $post_id ) {
+			return false;
+		}
+		$post = get_post( $post_id );
+		return $post && static::POST_TYPE === $post->post_type && 'trash' !== $post->post_status;
+	}
+
+	/**
+	 * Nonce'd admin URL that lazy-creates the singleton (if missing)
+	 * and redirects the admin into the block editor on it. Used by the
+	 * dashboard edit links.
+	 *
+	 * Built with `add_query_arg` + `wp_create_nonce` (not
+	 * `wp_nonce_url`) so the returned string contains raw `&`
+	 * separators, not the HTML-encoded `&amp;` that `wp_nonce_url`
+	 * emits. The URL is JSON-serialized to the React dashboard's
+	 * initial state and then set as an `<a href>` value — React/JSX
+	 * doesn't HTML-decode attribute values, so encoded amps would
+	 * round-trip into the browser's URL bar verbatim and break the
+	 * `$_GET` parse.
+	 *
+	 * @return string
+	 */
+	public static function get_editor_url(): string {
+		return add_query_arg(
+			array(
+				static::EDITOR_REQUEST_KEY => '1',
+				'_wpnonce'                 => wp_create_nonce( static::EDITOR_NONCE ),
+			),
+			admin_url( 'admin.php?page=jetpack-search' )
+		);
+	}
+
+	/**
+	 * REST path used by the dashboard's "Restore default" link to
+	 * delete the singleton via the CPT's built-in REST endpoint
+	 * (`/wp/v2/<rest_base>/<id>?force=true`). The dashboard calls this
+	 * with `apiFetch({ method: 'DELETE', path: <…> })`; the
+	 * `before_delete_post` cleanup keeps the option + cache in sync.
+	 *
+	 * Returns `null` when no singleton exists — the React link is
+	 * hidden by `isCustomized` in that state, so this should never be
+	 * hit, but returning null keeps the type honest.
+	 *
+	 * @return string|null
+	 */
+	public static function get_reset_rest_path(): ?string {
+		if ( ! static::is_customized() ) {
+			return null;
+		}
+		return '/wp/v2/' . static::REST_BASE . '/' . static::get_post_id() . '?force=true';
+	}
+
+	/**
+	 * Handle the "open editor" admin request: create the singleton on
+	 * first click (seeded from the bundled template), then redirect to
+	 * the block editor on it.
+	 */
+	public static function maybe_handle_editor_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below.
+		if ( empty( $_GET[ static::EDITOR_REQUEST_KEY ] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html( static::forbidden_message() ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( static::EDITOR_NONCE );
+		$post_id = static::ensure_post_exists();
+		if ( ! $post_id ) {
+			wp_die( esc_html( static::create_failure_message() ), '', array( 'response' => 500 ) );
+		}
+		wp_safe_redirect( admin_url( 'post.php?post=' . $post_id . '&action=edit' ) );
+		exit;
+	}
+
+	/**
+	 * Ensure the singleton post exists. Returns its ID. If it doesn't
+	 * exist yet, creates it seeded with `read_seed_content()` so the
+	 * editor opens populated rather than empty.
+	 *
+	 * @return int Post ID on success, 0 on failure.
+	 */
+	protected static function ensure_post_exists(): int {
+		$existing = static::get_post_id();
+		if ( $existing ) {
+			$existing_post = get_post( $existing );
+			// Only reuse live singleton posts. If the option points to
+			// a trashed row (or a stale/mismatched ID), treat it as
+			// missing so clicking the edit link recreates a fresh
+			// editable singleton.
+			if ( $existing_post && static::POST_TYPE === $existing_post->post_type && 'trash' !== $existing_post->post_status ) {
+				return $existing;
+			}
+			// Force-delete the stale post (typically trashed) before
+			// recreating, so admins who repeatedly trash the singleton
+			// don't accumulate orphan rows. `before_delete_post` will
+			// null the option + cache.
+			if ( $existing_post && static::POST_TYPE === $existing_post->post_type ) {
+				wp_delete_post( $existing, true );
+			} else {
+				delete_option( static::OPTION_POST_ID );
+				unset( self::$caches[ static::class ] );
+			}
+		}
+		$seed_content = static::read_seed_content();
+		$post_id      = wp_insert_post(
+			array(
+				'post_type'    => static::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => static::post_title(),
+				'post_content' => $seed_content,
+				'meta_input'   => array(
+					static::SEED_META_KEY => '1',
+				),
+			),
+			true
+		);
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			return 0;
+		}
+		// Race-safe option write: if a parallel request also raced
+		// past the early `get_post_id()` check and inserted its own
+		// singleton + claimed the option in between, drop ours and
+		// adopt theirs. The orphaned post would otherwise never be
+		// deleted by the reset flow because that only follows the
+		// option pointer.
+		$other_post_id = (int) get_option( static::OPTION_POST_ID, 0 );
+		$other_post    = $other_post_id ? get_post( $other_post_id ) : null;
+		if ( $other_post && static::POST_TYPE === $other_post->post_type && 'trash' !== $other_post->post_status ) {
+			wp_delete_post( $post_id, true );
+			unset( self::$caches[ static::class ] );
+			return $other_post_id;
+		}
+		update_option( static::OPTION_POST_ID, $post_id, false );
+		self::$caches[ static::class ] = $seed_content;
+		return (int) $post_id;
+	}
+
+	/**
+	 * Reset the per-request content memo. Tests only.
+	 */
+	public static function reset_customized_content_cache() {
+		unset( self::$caches[ static::class ] );
+	}
+}

--- a/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
+++ b/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
@@ -21,6 +21,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
+// Classic themes don't emit core's layout block-supports CSS for the
+// `blockGap` attribute, so the 1.5rem gap declared on the bundled
+// template's `wp-block-group` wrapper collapses to 0 — the search input
+// runs straight into the results / filters row. Reapply it once, scoped
+// to our `<main class="wp-block-group">` so it can't leak into theme
+// content elsewhere. Falls back to the block-theme variable when a
+// theme.json-shipping classic theme happens to define one.
+?>
+<style id="jetpack-search-classic-theme-layout">
+main.wp-block-group .is-layout-flow > * + * {
+	margin-block-start: var(--wp--style--block-gap, 1.5rem);
+}
+</style>
+<?php
+
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks renders trusted bundled markup.
 echo do_blocks( \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_search_body() );
 

--- a/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
+++ b/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Classic-theme search results template for the Jetpack Search Embedded
+ * experience.
+ *
+ * Wraps the bundled `jetpack-search.html` block markup in the active theme's
+ * `get_header()` / `get_footer()` so the block-rendered results sit inside the
+ * theme's chrome — the classic-theme counterpart to the FSE block template
+ * fronted via `search_template_hierarchy` on block themes.
+ *
+ * Loaded via the `template_include` filter in
+ * `Search_Blocks::route_classic_theme_search_template()`; reachable only on
+ * `is_search()` with Embedded saved + classic theme.
+ *
+ * @package automattic/jetpack-search
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks renders trusted bundled markup.
+echo do_blocks( \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_search_body() );
+
+get_footer();

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -279,13 +279,12 @@ class Module_Control_Test extends Search_TestCase {
 	/**
 	 * Saved 'embedded' / 'overlay' values are returned when the module is active.
 	 *
-	 * 'embedded' only renders on a block theme, so the assertion forces the
-	 * block-theme seam true to isolate the saved-value behaviour from the
-	 * non-block-theme fallback covered separately below.
+	 * Embedded now renders on every theme by default (block themes through
+	 * `search_template_hierarchy`, classic themes through `template_include`),
+	 * so no theme-seam override is needed.
 	 */
 	public function test_get_experience_returns_saved_value() {
 		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 		$this->assertEquals( Module_Control::EXPERIENCE_EMBEDDED, static::$search_module->get_experience() );
@@ -293,18 +292,19 @@ class Module_Control_Test extends Search_TestCase {
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
 		$this->assertEquals( Module_Control::EXPERIENCE_OVERLAY, static::$search_module->get_experience() );
 
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
 
 	/**
-	 * Saved 'embedded' falls back to 'inline' (Theme search) on a non-block
-	 * theme so the search page keeps working instead of resolving to a missing
-	 * FSE template. The saved option must stay 'embedded' so the experience
-	 * resumes once the site switches back to a block theme.
+	 * Saved 'embedded' falls back to 'inline' (Theme search) when the
+	 * `jetpack_search_theme_supports_embedded_experience` filter returns false
+	 * — the opt-out escape hatch for sites that want the search page to keep
+	 * rendering through the theme's own template regardless of theme type.
+	 * The saved option must stay 'embedded' so removing the filter restores
+	 * the experience without a dashboard re-save.
 	 */
-	public function test_get_experience_embedded_falls_back_to_inline_on_non_block_theme() {
+	public function test_get_experience_embedded_falls_back_to_inline_when_filter_disables_support() {
 		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
 		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
@@ -316,21 +316,19 @@ class Module_Control_Test extends Search_TestCase {
 			'The saved experience option must be preserved across the fallback.'
 		);
 
-		// Switching back to a block theme restores the embedded experience without a re-save.
+		// Dropping the filter restores Embedded without a dashboard re-save.
 		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		$this->assertEquals( Module_Control::EXPERIENCE_EMBEDDED, static::$search_module->get_experience() );
 
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
 
 	/**
-	 * The non-block-theme fallback only affects 'embedded' — 'overlay' is
+	 * The opt-out filter only affects 'embedded' — 'overlay' is
 	 * theme-agnostic (modal overlay) and must be unaffected.
 	 */
-	public function test_get_experience_overlay_unaffected_by_non_block_theme() {
+	public function test_get_experience_overlay_unaffected_by_embedded_opt_out_filter() {
 		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
 		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -553,6 +553,102 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * On a classic-theme search request the router swaps the resolved
+	 * Theme PHP template for the bundled `classic-theme-search.php` shim.
+	 */
+	public function test_route_classic_theme_search_template_returns_bundled_path_on_search() {
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$result = Search_Blocks::route_classic_theme_search_template( '/var/www/html/wp-content/themes/twentytwentyone/search.php' );
+
+			$this->assertStringEndsWith(
+				'/src/search-blocks/templates/classic-theme-search.php',
+				$result,
+				'Search requests must resolve to the bundled classic-theme shim.'
+			);
+			$this->assertFileExists( $result, 'Bundled classic-theme shim must exist at the routed path.' );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * Off the search page the router is a strict no-op so non-search
+	 * Requests keep the theme's own template (single, archive, page, …).
+	 */
+	public function test_route_classic_theme_search_template_noop_off_search() {
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query();
+			$this->assertFalse( is_search() );
+
+			$input  = '/var/www/html/wp-content/themes/twentytwentyone/index.php';
+			$result = Search_Blocks::route_classic_theme_search_template( $input );
+
+			$this->assertSame( $input, $result );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * WC-on, override-off: a WooCommerce product search on a classic theme
+	 * Falls through the classic router so WooCommerce's own archive routing
+	 * Keeps owning product search results (we don't ship a product-search
+	 * Classic-theme shim).
+	 */
+	public function test_route_classic_theme_search_template_defers_to_woocommerce_when_override_off() {
+		delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		$anon           = get_class(
+			new class() extends Search_Blocks {
+				protected static function is_woocommerce_product_search(): bool {
+					return true;
+				}
+			}
+		);
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$input  = '/var/www/html/wp-content/themes/twentytwentyone/search.php';
+			$result = $anon::route_classic_theme_search_template( $input );
+
+			$this->assertSame( $input, $result, 'Classic router must defer to WooCommerce when override is off on a product search.' );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * `get_classic_theme_search_body()` returns the same block markup that
+	 * `register_search_template()` registers on block themes, with the two
+	 * Top-level `core/template-part` self-closing comments stripped so the
+	 * Theme's `get_header()` / `get_footer()` drive the chrome instead.
+	 */
+	public function test_get_classic_theme_search_body_strips_template_parts() {
+		$body = Search_Blocks::get_classic_theme_search_body();
+
+		$this->assertNotEmpty( $body, 'Body must be non-empty when the bundled template file exists.' );
+		$this->assertStringNotContainsString(
+			'wp:template-part',
+			$body,
+			'Body must not reference template-parts — those resolve only on block themes.'
+		);
+		$this->assertStringContainsString(
+			'wp:jetpack-search/search-input',
+			$body,
+			'Body must keep the core Search blocks so the page is usable.'
+		);
+		$this->assertStringContainsString(
+			'wp:jetpack-search/results-list',
+			$body,
+			'Body must keep the results-list block.'
+		);
+	}
+
+	/**
 	 * With the override on, `init()` registers both the product-search
 	 * Template and the priority-20 routing filter.
 	 */
@@ -877,37 +973,74 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * On the Embedded experience, the template-override hooks must be
-	 * Registered so `/?s=…` resolves to the Jetpack Search template instead
-	 * Of the theme's `search.html`.
+	 * On the Embedded experience under a block theme, the FSE template-override
+	 * Hooks must be registered so `/?s=…` resolves to the Jetpack Search
+	 * Template instead of the theme's `search.html`. The classic-theme
+	 * `template_include` route must NOT register on this path.
 	 */
-	public function test_init_registers_template_hooks_when_embedded() {
+	public function test_init_registers_block_theme_template_hooks_when_embedded_on_block_theme() {
 		$this->reset_search_blocks_hooks();
 		$this->set_module_active( true );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
+		Search_Blocks::set_block_templates_active_for_testing( true );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 
 		Search_Blocks::init();
 
 		$this->assertNotFalse(
 			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
-			'register_search_template must hook into init on embedded'
+			'register_search_template must hook into init on embedded + block theme'
 		);
 		$this->assertNotFalse(
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
-			'prepend_search_template must hook into search_template_hierarchy on embedded'
+			'prepend_search_template must hook into search_template_hierarchy on embedded + block theme'
+		);
+		$this->assertFalse(
+			has_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) ),
+			'classic-theme template_include route must not hook on a block theme'
 		);
 
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
 
 	/**
-	 * Saved Embedded but on a non-block theme: the experience resolves to Theme
-	 * Search (inline), so the FSE template-takeover hooks must NOT register —
-	 * Otherwise `/?s=…` would resolve to a template the theme can't render.
+	 * On the Embedded experience under a classic theme, prepending a slug to
+	 * `search_template_hierarchy` is a no-op (no `jetpack-search.php` in the
+	 * Theme), so the classic-theme `template_include` route is what takes over
+	 * The search page. The block-theme hooks must NOT register on this path.
 	 */
-	public function test_init_does_not_register_template_hooks_when_embedded_on_non_block_theme() {
+	public function test_init_registers_classic_theme_template_include_when_embedded_on_classic_theme() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		Search_Blocks::set_block_templates_active_for_testing( false );
+		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+
+		Search_Blocks::init();
+
+		$this->assertNotFalse(
+			has_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) ),
+			'classic-theme template_include route must hook on embedded + classic theme'
+		);
+		$this->assertFalse(
+			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
+			'register_search_template must not hook on a classic theme — the registry is FSE-only'
+		);
+		$this->assertFalse(
+			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
+			'prepend_search_template must not hook on a classic theme — the hierarchy filter is FSE-only'
+		);
+
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+	}
+
+	/**
+	 * Saved Embedded but the `jetpack_search_theme_supports_embedded_experience`
+	 * Filter forces Embedded off: `get_experience()` resolves to Theme search
+	 * (Inline), so neither the block-theme nor the classic-theme template-
+	 * Takeover hooks register. Guards the opt-out escape hatch — a site that
+	 * Returns false from the filter must keep the search page on the theme's
+	 * Own search template regardless of theme type.
+	 */
+	public function test_init_does_not_register_template_hooks_when_filter_disables_embedded() {
 		$this->reset_search_blocks_hooks();
 		$this->set_module_active( true );
 		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
@@ -917,11 +1050,15 @@ class Search_Blocks_Test extends TestCase {
 
 		$this->assertFalse(
 			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
-			'register_search_template must not hook into init when the theme cannot render Embedded'
+			'register_search_template must not hook when the filter disables Embedded'
 		);
 		$this->assertFalse(
 			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
-			'prepend_search_template must not hook into search_template_hierarchy on a non-block theme'
+			'prepend_search_template must not hook when the filter disables Embedded'
+		);
+		$this->assertFalse(
+			has_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) ),
+			'route_classic_theme_search_template must not hook when the filter disables Embedded'
 		);
 
 		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
@@ -1122,10 +1259,12 @@ class Search_Blocks_Test extends TestCase {
 		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
 		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) );
 		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'route_woocommerce_product_search_template' ), 20 );
+		remove_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) );
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
 		remove_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ), 10 );
+		Search_Blocks::set_block_templates_active_for_testing( null );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -622,6 +622,96 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * WC-on, override-on: with the override flipped on, a product search on
+	 * A classic theme routes through the same generic shim a non-product
+	 * Search would use. There's no dedicated product-results classic-theme
+	 * Template — block themes get one via `register_block_template()`,
+	 * Classic themes share the single shim and rely on the generic blocks
+	 * For the product layout. Pins that documented behavior so an accidental
+	 * WC carve-out for the classic path doesn't slip through.
+	 */
+	public function test_route_classic_theme_search_template_routes_to_shim_when_override_on() {
+		update_option( 'jetpack_search_override_woocommerce_search_template', true );
+		$anon           = get_class(
+			new class() extends Search_Blocks {
+				protected static function is_woocommerce_product_search(): bool {
+					return true;
+				}
+			}
+		);
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$result = $anon::route_classic_theme_search_template( '/var/www/html/wp-content/themes/twentytwentyone/search.php' );
+
+			$this->assertStringEndsWith(
+				'/src/search-blocks/templates/classic-theme-search.php',
+				$result,
+				'Classic router must route to the bundled shim on product searches when the override is on.'
+			);
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		}
+	}
+
+	/**
+	 * Defensive bail-out: if the bundled `jetpack-search.html` ever fails to
+	 * Load (returns empty markup), the router must return the input template
+	 * Unchanged so the theme's own `search.php` renders instead of the shim
+	 * Wrapping a blank body. Mirrors the block-theme path's empty-content
+	 * Bail-out in `register_search_template()`.
+	 */
+	public function test_route_classic_theme_search_template_bails_when_body_is_empty() {
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		$anon           = get_class(
+			new class() extends Search_Blocks {
+				public static function get_classic_theme_search_body(): string {
+					return '';
+				}
+			}
+		);
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$input  = '/var/www/html/wp-content/themes/twentytwentyone/search.php';
+			$result = $anon::route_classic_theme_search_template( $input );
+
+			$this->assertSame( $input, $result, 'Empty body must bail back to the theme template.' );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+		}
+	}
+
+	/**
+	 * Regression guard: the template-part stripper must keep working when
+	 * The attribute payload nests an object (e.g. a future revision that
+	 * Sets `wp:template-part {"theme":{"name":"foo"}} /-->`). The earlier
+	 * `[^}]*` shape would have left a stray `}}/-->` tail in the output —
+	 * Anchor the test on a `}}` inside the attribute so a tightening back
+	 * Up to a character-class fails visibly.
+	 */
+	public function test_get_classic_theme_search_body_strips_nested_attribute_template_parts() {
+		$anon = get_class(
+			new class() extends Search_Blocks {
+				protected static function get_search_template_content(): string {
+					return "<!-- wp:template-part {\"slug\":\"header\",\"theme\":{\"name\":\"twentytwentyfive\"}} /-->\n"
+						. "<!-- wp:jetpack-search/search-input /-->\n"
+						. '<!-- wp:template-part {"slug":"footer"} /-->';
+				}
+			}
+		);
+
+		$body = $anon::get_classic_theme_search_body();
+
+		$this->assertStringNotContainsString( 'wp:template-part', $body, 'Both wrappers must be stripped, even with nested JSON.' );
+		$this->assertStringNotContainsString( '}}', $body, 'No stray closing braces should leak from a partial strip.' );
+		$this->assertStringNotContainsString( '"name":"twentytwentyfive"', $body, 'Nested attribute tail must not leak after a partial strip.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/search-input', $body, 'Inner blocks must be preserved.' );
+	}
+
+	/**
 	 * `get_classic_theme_search_body()` returns the same block markup that
 	 * `register_search_template()` registers on block themes, with the two
 	 * Top-level `core/template-part` self-closing comments stripped so the

--- a/projects/packages/search/tests/php/Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Search_Template_Test.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Automattic\Jetpack\Search;
+
+use Automattic\Jetpack\Search\TestCase as Search_TestCase;
+
+/**
+ * Unit tests for the Search_Template singleton CPT and its integration with
+ * Search_Blocks's classic-theme render path.
+ *
+ * @package automattic/jetpack-search
+ */
+class Search_Template_Test extends Search_TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// The classmap-registered CPT needs to be live so wp_insert_post
+		// can stamp the right post_type. register_post_type() is
+		// idempotent.
+		Search_Template::register_post_type();
+		Search_Template::reset_customized_content_cache();
+		delete_option( Search_Template::OPTION_POST_ID );
+	}
+
+	public function tearDown(): void {
+		// Force-delete any singleton this test class created so other
+		// tests start clean.
+		$post_id = (int) get_option( Search_Template::OPTION_POST_ID, 0 );
+		if ( $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		delete_option( Search_Template::OPTION_POST_ID );
+		Search_Template::reset_customized_content_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * `Search_Template` and `Overlay_Template` must declare distinct
+	 * post-type / option / nonce identifiers — they're keyed by class
+	 * constant on the shared base so a typo collision would let two
+	 * subclasses share one singleton.
+	 */
+	public function test_subclass_constants_are_distinct_from_overlay() {
+		$this->assertNotSame( Overlay_Template::POST_TYPE, Search_Template::POST_TYPE );
+		$this->assertNotSame( Overlay_Template::REST_BASE, Search_Template::REST_BASE );
+		$this->assertNotSame( Overlay_Template::OPTION_POST_ID, Search_Template::OPTION_POST_ID );
+		$this->assertNotSame( Overlay_Template::EDITOR_REQUEST_KEY, Search_Template::EDITOR_REQUEST_KEY );
+		$this->assertNotSame( Overlay_Template::EDITOR_NONCE, Search_Template::EDITOR_NONCE );
+		$this->assertSame( 'jp_search_template', Search_Template::POST_TYPE );
+		$this->assertLessThanOrEqual(
+			20,
+			strlen( Search_Template::POST_TYPE ),
+			'register_post_type() limits the slug to 20 chars; staying under is a hard requirement.'
+		);
+	}
+
+	/**
+	 * No singleton on file ⇒ `get_customized_content()` returns null,
+	 * `is_customized()` is false, `get_reset_rest_path()` is null. The
+	 * shape callers depend on to fall back to the bundled template.
+	 */
+	public function test_uncustomized_state_returns_nulls() {
+		$this->assertNull( Search_Template::get_customized_content() );
+		$this->assertFalse( Search_Template::is_customized() );
+		$this->assertNull( Search_Template::get_reset_rest_path() );
+		$this->assertSame( 0, Search_Template::get_post_id() );
+	}
+
+	/**
+	 * A saved customization round-trips: `get_customized_content()`
+	 * returns the post content, `is_customized()` flips true, and
+	 * `get_reset_rest_path()` resolves to the CPT's REST endpoint.
+	 */
+	public function test_customized_state_returns_post_content_and_reset_path() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'Search Template Test',
+				'post_content' => '<!-- wp:paragraph --><p>SENTINEL_CONTENT</p><!-- /wp:paragraph -->',
+			)
+		);
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		Search_Template::reset_customized_content_cache();
+
+		$this->assertSame(
+			'<!-- wp:paragraph --><p>SENTINEL_CONTENT</p><!-- /wp:paragraph -->',
+			Search_Template::get_customized_content()
+		);
+		$this->assertTrue( Search_Template::is_customized() );
+		$this->assertSame(
+			'/wp/v2/' . Search_Template::REST_BASE . '/' . $post_id . '?force=true',
+			Search_Template::get_reset_rest_path()
+		);
+	}
+
+	/**
+	 * A trashed singleton must be treated as "no customization" — the
+	 * front end already falls back to the bundled template in that
+	 * state, and surfacing `isCustomized=true` to the dashboard would
+	 * show a "Restore default" link with nothing to restore.
+	 */
+	public function test_trashed_singleton_reads_as_uncustomized() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'trash-test',
+			)
+		);
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		wp_trash_post( $post_id );
+		Search_Template::reset_customized_content_cache();
+
+		$this->assertNull( Search_Template::get_customized_content() );
+		$this->assertFalse( Search_Template::is_customized() );
+		$this->assertNull( Search_Template::get_reset_rest_path() );
+	}
+
+	/**
+	 * The editor URL must carry both the request key + a verified
+	 * nonce so a CSRF can't lazy-create the singleton on behalf of an
+	 * authenticated admin.
+	 */
+	public function test_editor_url_includes_request_key_and_nonce() {
+		// nonces depend on a current user.
+		$user_id = wp_create_user( 'search_template_test_admin', 'p', 'admin@example.com' );
+		( new \WP_User( $user_id ) )->set_role( 'administrator' );
+		wp_set_current_user( $user_id );
+
+		try {
+			$url = Search_Template::get_editor_url();
+			parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $params );
+
+			$this->assertSame( '1', $params[ Search_Template::EDITOR_REQUEST_KEY ] ?? null );
+			$this->assertNotEmpty( $params['_wpnonce'] ?? '' );
+			$this->assertSame(
+				1,
+				wp_verify_nonce( $params['_wpnonce'], Search_Template::EDITOR_NONCE )
+			);
+		} finally {
+			wp_delete_user( $user_id );
+			wp_set_current_user( 0 );
+		}
+	}
+
+	/**
+	 * The seed content for a fresh singleton is exactly what
+	 * `Search_Blocks::get_classic_theme_search_body()` returns —
+	 * placeholders substituted, template-part wrappers stripped — so
+	 * the editor opens populated with the same markup the front end
+	 * renders.
+	 */
+	public function test_seed_content_matches_classic_theme_search_body() {
+		$seed = Search_Blocks::get_classic_theme_search_body();
+		$this->assertNotEmpty( $seed );
+		$this->assertStringNotContainsString( 'wp:template-part', $seed, 'Seed must have template-parts stripped.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/search-input', $seed );
+	}
+
+	/**
+	 * `Search_Blocks::get_classic_theme_search_body()` must prefer a
+	 * saved customization over the bundled file — the whole point of
+	 * the CPT path. An empty string customization (admin saved a blank
+	 * canvas) is honored verbatim.
+	 */
+	public function test_classic_theme_search_body_prefers_customization() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:heading --><h2>CUSTOMIZED</h2><!-- /wp:heading -->',
+			)
+		);
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		Search_Template::reset_customized_content_cache();
+
+		$body = Search_Blocks::get_classic_theme_search_body();
+		$this->assertStringContainsString( 'CUSTOMIZED', $body );
+		$this->assertStringNotContainsString( 'wp:jetpack-search/search-input', $body, 'When customized, the bundled body should NOT be merged in.' );
+	}
+
+	/**
+	 * Class-keyed cache on the shared base must not cross-contaminate
+	 * Overlay_Template and Search_Template lookups within a request —
+	 * the base shares one static cache for `static::class` keying.
+	 */
+	public function test_subclass_caches_are_isolated() {
+		// Prime Search_Template with a customization.
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'SEARCH_TEMPLATE_CONTENT',
+			)
+		);
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		Search_Template::reset_customized_content_cache();
+
+		$this->assertSame( 'SEARCH_TEMPLATE_CONTENT', Search_Template::get_customized_content() );
+		// Overlay_Template, having no singleton on file, must NOT pick
+		// up Search_Template's cached content.
+		$this->assertNull( Overlay_Template::get_customized_content() );
+	}
+
+	/**
+	 * Deleting the singleton through any path (REST DELETE, post.php,
+	 * wp_delete_post) clears the option pointer + per-request cache so
+	 * the next render falls back to the bundled file. Cuts state-drift
+	 * where the option still references a deleted post.
+	 */
+	public function test_delete_singleton_cleans_up_state() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'will-be-deleted',
+			)
+		);
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		Search_Template::reset_customized_content_cache();
+		$this->assertTrue( Search_Template::is_customized() );
+
+		wp_delete_post( $post_id, true );
+
+		$this->assertSame( 0, Search_Template::get_post_id() );
+		$this->assertNull( Search_Template::get_customized_content() );
+		$this->assertFalse( Search_Template::is_customized() );
+	}
+}


### PR DESCRIPTION
## Why

Picking the **Embedded** search experience used to require a block theme — on a classic theme the same setting silently demoted to Theme search and the block-based search results page was simply unreachable. Now the same Search blocks (filters, sort, paginated results) render on the classic-theme search page too, slotted inside the theme's own header/footer instead of replacing them.

## Proposed changes

- Add a `template_include` route for the search page on classic themes that swaps the resolved template for a bundled PHP shim. The shim wraps the same block markup `register_search_template()` registers on block themes — `<!-- wp:jetpack-search/* -->` blocks for input, results-list, filters, sort, etc. — inside `get_header()` / `get_footer()`, so the page mirrors what block themes get while still rendering in the active theme's chrome.
- Default `Module_Control::theme_supports_embedded_experience()` to true for every theme. The `jetpack_search_theme_supports_embedded_experience` filter is preserved as the opt-out escape hatch for sites that want Embedded to keep falling back to Theme search regardless.
- Drop the dashboard's "Embedded search needs a block theme" gate (modal + commit-overlay branch) — Embedded is now selectable on every theme.
- Hide the Site-Editor-only "Edit search template" / "Insert pattern" action links on classic themes (the experience itself works there; in-place customization is still FSE-only).

## Screenshots

Captured at `/?s=coffee` on the local docker env with the **Twenty Sixteen** classic theme active. Before is from `trunk`; after is from this branch.

### Before
![before](https://github.com/user-attachments/assets/903ec35f-0c74-4e97-91e3-63bcd57990d5)

### After
![after](https://github.com/user-attachments/assets/4aa58659-9c45-4404-8a0e-08ec2c224489)

Fixes #

## Related product discussion/links

* p3uVMr-9NK-p2 (Jetpack Search blocks rollout)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Bring up a Jetpack env on a **classic** theme (e.g. `wp theme activate twentysixteen`).
2. Activate the Search module and set the search experience to **Embedded** (Jetpack → Search → Switch to "Embedded").
3. Visit `/?s=<some-term>`:
   - The page renders inside the classic theme's header/footer.
   - The Jetpack Search blocks — search input, results list, sort control, filter sidebar — appear between them and load real results.
4. Switch back to a **block** theme (e.g. `wp theme activate twentytwentyfive`). `/?s=<some-term>` still resolves to the bundled `jetpack-search` block template (no regression on the existing path).
5. Open the dashboard's Search settings on a classic theme. The Embedded card no longer shows the "Embedded search needs a block theme" hint, switching to it works, and the "Edit search template" / "Insert pattern" action links (Site-Editor-only) are hidden.
6. Sanity-check the opt-out escape hatch:
   ```php
   add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
   ```
   On a classic theme with this filter active, `/?s=<term>` falls back to the theme's own search results page (Theme search / inline).

