### PR TITLE
Search Blocks: release blocks-powered Overlay as experimental (default available)

### DIFF
--- a/projects/packages/search/changelog/SEARCH-242-blocks-overlay-beta-default
+++ b/projects/packages/search/changelog/SEARCH-242-blocks-overlay-beta-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Experience Selector: Release the blocks-powered Overlay as an experimental option. `jetpack_search_overlay_block_template_enabled` now defaults to true, the "Overlay search" card carries a Beta badge with an "In beta — …" description, and the legacy preact Overlay picks up the "(legacy)" suffix on every site by default. Operators can still pin the filter to false to fall back to the original four-card selector.

--- a/projects/packages/search/changelog/SEARCH-242-blocks-overlay-beta-default
+++ b/projects/packages/search/changelog/SEARCH-242-blocks-overlay-beta-default
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Experience Selector: Release the blocks-powered Overlay as an experimental option. `jetpack_search_overlay_block_template_enabled` now defaults to true, the "Overlay search" card carries a Beta badge with an "In beta — …" description, and the legacy preact Overlay picks up the "(legacy)" suffix on every site by default. Operators can still pin the filter to false to fall back to the original four-card selector.
+Experience Selector: Release the blocks-powered Overlay as an experimental option. `jetpack_search_overlay_block_template_enabled` now defaults to true, so a new "Overlay search (blocks)" card carrying a Beta badge appears alongside the preact Overlay as a first-class peer (not a replacement). Operators can still pin the filter to false to hide the Beta card.

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -343,11 +343,12 @@ class Module_Control {
 		// dashboard already hides the option when the
 		// `jetpack_search_overlay_block_template_enabled` filter is off, but
 		// a scripted REST POST could otherwise pre-stage `overlay_blocks` on
-		// a site where operators haven't opted in. Reject the value at the
-		// boundary so the runtime gate isn't the only safety net.
+		// a site where the operator has pinned the filter to false. Reject
+		// the value at the boundary so the runtime gate isn't the only
+		// safety net.
 		if (
 			self::EXPERIENCE_OVERLAY_BLOCKS === $experience
-			&& ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false )
+			&& ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', true )
 		) {
 			return new WP_Error(
 				'experience_not_available',

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -94,11 +94,11 @@ class Initial_State {
 				 * is available in the Experience Selector. Mirrors the
 				 * `jetpack_search_overlay_block_template_enabled` server-side filter
 				 * so the dashboard React app can gate the new card on the same flag
-				 * the back end uses to enable the runtime swap. Sites that haven't
-				 * opted into the experimental overlay continue to see the four
-				 * original cards unchanged.
+				 * the back end uses to enable the runtime swap. Defaults to true so
+				 * the Beta card ships to every site; operators that pin the filter
+				 * to false fall back to the original four-card selector.
 				 */
-				'blockOverlayEnabled'        => (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false ),
+				'blockOverlayEnabled'        => (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', true ),
 				/**
 				 * Editor affordances for the experimental blocks-powered overlay.
 				 * Surfaces in the new Overlay search card so admins can edit the

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -213,18 +213,21 @@ class Initial_State {
 	 * decides `isCustomized`) to those users — useless to them and
 	 * needlessly leaks internal URL shape.
 	 *
-	 * `enabled` mirrors `Search_Blocks::is_block_template_overlay_enabled()`,
-	 * which itself requires both the operator-level filter AND the site
-	 * owner having activated the `overlay_blocks` experience — so the
-	 * editor surface only appears when the new overlay is actually live.
+	 * `enabled` mirrors `Search_Blocks::is_block_template_overlay_enabled()`
+	 * — true only when the user is currently *on* the blocks Overlay arm.
+	 * The editor URLs, by contrast, are gated on the operator filter alone
+	 * so admins can edit the template from the Beta card even before
+	 * activating it (otherwise the React store, computed at page load
+	 * before any switch, would carry a null `editorUrl` and the link would
+	 * become a no-op once the card flipped to Active without a refresh).
 	 *
 	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
 	 */
 	protected function get_block_template_overlay_config(): array {
-		$enabled  = Search_Blocks::is_block_template_overlay_enabled();
-		$can_edit = $enabled && current_user_can( 'manage_options' );
+		$can_edit = Search_Blocks::is_block_template_overlay_filter_on()
+			&& current_user_can( 'manage_options' );
 		return array(
-			'enabled'       => $enabled,
+			'enabled'       => Search_Blocks::is_block_template_overlay_enabled(),
 			'editorUrl'     => $can_edit ? Overlay_Template::get_editor_url() : null,
 			// `resetRestPath` is the path the dashboard sends to `apiFetch`
 			// as a DELETE — hits the CPT's built-in REST endpoint

--- a/projects/packages/search/src/dashboard/components/experience-selector/constants.js
+++ b/projects/packages/search/src/dashboard/components/experience-selector/constants.js
@@ -19,10 +19,13 @@ export const EXPERIENCE = Object.freeze( {
 } );
 
 /**
- * Display order on the dashboard. Embedded leads (RECOMMENDED); the new
- * blocks-powered Overlay (BETA) sits next to it as a sibling — both
- * overlays are first-class peers, not predecessor/successor — then the
- * preact Overlay, then Off.
+ * Display order on the dashboard. Embedded leads (RECOMMENDED), then the
+ * preact Overlay (the mature choice), then the blocks-powered Overlay
+ * (BETA) as a sibling — both overlays are first-class peers, not
+ * predecessor/successor. Theme search, then Off, follow.
+ *
+ * The BETA card intentionally sits *after* the preact one so the visual
+ * hierarchy doesn't push site owners toward the not-yet-mature path.
  *
  * `OVERLAY_BLOCKS` is filtered out at render time on sites where the
  * `jetpack_search_overlay_block_template_enabled` server flag is pinned
@@ -31,8 +34,8 @@ export const EXPERIENCE = Object.freeze( {
  */
 export const EXPERIENCE_ORDER = [
 	EXPERIENCE.EMBEDDED,
-	EXPERIENCE.OVERLAY_BLOCKS,
 	EXPERIENCE.OVERLAY,
+	EXPERIENCE.OVERLAY_BLOCKS,
 	EXPERIENCE.INLINE,
 	EXPERIENCE.OFF,
 ];

--- a/projects/packages/search/src/dashboard/components/experience-selector/constants.js
+++ b/projects/packages/search/src/dashboard/components/experience-selector/constants.js
@@ -20,9 +20,9 @@ export const EXPERIENCE = Object.freeze( {
 
 /**
  * Display order on the dashboard. Embedded leads (RECOMMENDED); the new
- * blocks-powered Overlay sits where the legacy one used to so the card
- * grid layout stays stable; legacy Overlay follows immediately after;
- * Off comes last.
+ * blocks-powered Overlay (BETA) sits next to it as a sibling — both
+ * overlays are first-class peers, not predecessor/successor — then the
+ * preact Overlay, then Off.
  *
  * `OVERLAY_BLOCKS` is filtered out at render time on sites where the
  * `jetpack_search_overlay_block_template_enabled` server flag is pinned
@@ -43,10 +43,9 @@ export const EXPERIENCE_ORDER = [
  * Wrapped in a function so __() runs at render time (i18n is locale-aware
  * after the dashboard boots, not at module-load time).
  *
- * The legacy overlay carries a contextual "(legacy)" suffix only when the
- * blocks-powered overlay is also visible — see `getCardTitle()`. Sites
- * where an operator pinned the BETA card off continue to see plain
- * "Overlay search" on the legacy card.
+ * The blocks-powered overlay carries a "(blocks)" suffix so site owners
+ * can tell the two coexisting overlays apart at a glance. The preact
+ * Overlay keeps its plain title — neither card supersedes the other.
  *
  * @param {string} experience - One of the EXPERIENCE values.
  * @return {string} - Translated title.
@@ -56,7 +55,7 @@ export function getExperienceLabel( experience ) {
 		case EXPERIENCE.EMBEDDED:
 			return __( 'Embedded search', 'jetpack-search-pkg' );
 		case EXPERIENCE.OVERLAY_BLOCKS:
-			return __( 'Overlay search', 'jetpack-search-pkg' );
+			return __( 'Overlay search (blocks)', 'jetpack-search-pkg' );
 		case EXPERIENCE.OVERLAY:
 			return __( 'Overlay search', 'jetpack-search-pkg' );
 		case EXPERIENCE.INLINE:
@@ -71,19 +70,15 @@ export function getExperienceLabel( experience ) {
 /**
  * Title displayed on the card.
  *
- * Identical to `getExperienceLabel()` except for the legacy overlay: when
- * the blocks-powered overlay is also on offer the two cards would
- * otherwise share the same name, so the legacy one picks up a "(legacy)"
- * suffix to disambiguate. On sites that opted out of the BETA card the
- * suffix is suppressed and the legacy card keeps its original title.
+ * Currently identical to `getExperienceLabel()`. Kept as a separate entry
+ * point so callers that want the card-level title (vs. an inline mention
+ * elsewhere in the UI) don't reach through to the label fn directly —
+ * leaves room to context-sensitively decorate the card title later
+ * without rippling through every callsite.
  *
- * @param {string}  experience          - One of the EXPERIENCE values.
- * @param {boolean} blockOverlayEnabled - True if the new overlay card is visible.
+ * @param {string} experience - One of the EXPERIENCE values.
  * @return {string} - Translated title for the card.
  */
-export function getCardTitle( experience, blockOverlayEnabled ) {
-	if ( experience === EXPERIENCE.OVERLAY && blockOverlayEnabled ) {
-		return __( 'Overlay search (legacy)', 'jetpack-search-pkg' );
-	}
+export function getCardTitle( experience ) {
 	return getExperienceLabel( experience );
 }

--- a/projects/packages/search/src/dashboard/components/experience-selector/constants.js
+++ b/projects/packages/search/src/dashboard/components/experience-selector/constants.js
@@ -21,12 +21,13 @@ export const EXPERIENCE = Object.freeze( {
 /**
  * Display order on the dashboard. Embedded leads (RECOMMENDED); the new
  * blocks-powered Overlay sits where the legacy one used to so the card
- * grid layout stays stable for sites that opt in to the new flag; legacy
- * Overlay follows immediately after; Off comes last.
+ * grid layout stays stable; legacy Overlay follows immediately after;
+ * Off comes last.
  *
  * `OVERLAY_BLOCKS` is filtered out at render time on sites where the
- * `jetpack_search_overlay_block_template_enabled` server flag is false,
- * so the unflagged dashboard still shows the original four cards.
+ * `jetpack_search_overlay_block_template_enabled` server flag is pinned
+ * to false. The default is true, so the BETA card ships to every site
+ * unless an operator opts the site out.
  */
 export const EXPERIENCE_ORDER = [
 	EXPERIENCE.EMBEDDED,
@@ -43,8 +44,9 @@ export const EXPERIENCE_ORDER = [
  * after the dashboard boots, not at module-load time).
  *
  * The legacy overlay carries a contextual "(legacy)" suffix only when the
- * blocks-powered overlay is also visible — see `getOverlayLabelSuffix()`.
- * Unflagged sites continue to see plain "Overlay search".
+ * blocks-powered overlay is also visible — see `getCardTitle()`. Sites
+ * where an operator pinned the BETA card off continue to see plain
+ * "Overlay search" on the legacy card.
  *
  * @param {string} experience - One of the EXPERIENCE values.
  * @return {string} - Translated title.
@@ -72,8 +74,8 @@ export function getExperienceLabel( experience ) {
  * Identical to `getExperienceLabel()` except for the legacy overlay: when
  * the blocks-powered overlay is also on offer the two cards would
  * otherwise share the same name, so the legacy one picks up a "(legacy)"
- * suffix to disambiguate. On unflagged sites the suffix is suppressed
- * and the legacy card keeps its original title.
+ * suffix to disambiguate. On sites that opted out of the BETA card the
+ * suffix is suppressed and the legacy card keeps its original title.
  *
  * @param {string}  experience          - One of the EXPERIENCE values.
  * @param {boolean} blockOverlayEnabled - True if the new overlay card is visible.

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -231,21 +231,27 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					align="start"
 					className="jp-search-experience-option__actions"
 				>
-					{ blockTemplateOverlay.enabled && blockTemplateOverlay.editorUrl && (
-						<CardLink
-							label={ __( 'Edit the Search overlay', 'jetpack-search-pkg' ) }
-							href={ blockTemplateOverlay.editorUrl }
-							disabled={ linksDisabled }
-							// Re-show "Restore default" on the admin's return
-							// from the editor: the click implies a fresh
-							// singleton is about to be (re-)created on the
-							// server, so the previously-set `justReset` flag
-							// no longer reflects reality.
-							onClick={ () => setJustReset( false ) }
-						/>
-					) }
-					{ blockTemplateOverlay.enabled &&
-						blockTemplateOverlay.resetRestPath &&
+					{ /*
+					   "Edit the Search overlay" always renders for the
+					   OVERLAY_BLOCKS card — disabled when the card is
+					   inactive (`linksDisabled`), matching how Embedded's
+					   "Edit search template" stays visible as a muted
+					   affordance. `editorUrl` is null until the user has
+					   activated this experience, but the disabled span
+					   doesn't navigate so the placeholder href is harmless.
+					*/ }
+					<CardLink
+						label={ __( 'Edit the Search overlay', 'jetpack-search-pkg' ) }
+						href={ blockTemplateOverlay.editorUrl || '#' }
+						disabled={ linksDisabled }
+						// Re-show "Restore default" on the admin's return
+						// from the editor: the click implies a fresh
+						// singleton is about to be (re-)created on the
+						// server, so the previously-set `justReset` flag
+						// no longer reflects reality.
+						onClick={ () => setJustReset( false ) }
+					/>
+					{ blockTemplateOverlay.resetRestPath &&
 						blockTemplateOverlay.isCustomized &&
 						! justReset && (
 							<CardLink

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -463,7 +463,7 @@ const CardCopy = ( { experience } ) => {
 			<>
 				<p className="jp-search-experience-option__description">
 					{ __(
-						"Keeps your theme's search layout. We just make the results faster and more relevant behind the scenes, no UI changes.",
+						"Keeps your theme's search layout. We just make the results faster and more relevant behind the scenes, no UI changes. Search blocks are still available to drop into any page or template.",
 						'jetpack-search-pkg'
 					) }
 				</p>

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -442,7 +442,7 @@ const CardCopy = ( { experience } ) => {
 		return (
 			<p className="jp-search-experience-option__description">
 				{ __(
-					'In beta — a search-as-you-type overlay rendered from your Search blocks. Same filters, sorting, and store as Embedded, but opens over your existing pages.',
+					'In beta — a search-as-you-type overlay rendered from your Search blocks. Same filters, sorting, and store as Embedded, but opens over your existing pages just like former Instant Search overlay.',
 					'jetpack-search-pkg'
 				) }
 			</p>

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -39,7 +39,7 @@ const PREVIEWS = {
 	[ EXPERIENCE.OFF ]: OffPreview,
 };
 
-const getCommitLabel = ( experience, blockOverlayEnabled = false ) => {
+const getCommitLabel = experience => {
 	switch ( experience ) {
 		case EXPERIENCE.EMBEDDED:
 			return _x(
@@ -49,25 +49,16 @@ const getCommitLabel = ( experience, blockOverlayEnabled = false ) => {
 			);
 		case EXPERIENCE.OVERLAY_BLOCKS:
 			return _x(
-				'Use Overlay search',
+				'Use Overlay search (blocks)',
 				'Button label that activates the blocks-powered Overlay search experience',
 				'jetpack-search-pkg'
 			);
 		case EXPERIENCE.OVERLAY:
-			// When the new blocks-powered Overlay is on offer alongside the
-			// legacy one, the commit label disambiguates which path the
-			// click activates. Unflagged sites keep the plain wording.
-			return blockOverlayEnabled
-				? _x(
-						'Use Overlay search (legacy)',
-						'Button label that activates the legacy preact Overlay search experience',
-						'jetpack-search-pkg'
-				  )
-				: _x(
-						'Use Overlay search',
-						'Button label that activates the Overlay search experience',
-						'jetpack-search-pkg'
-				  );
+			return _x(
+				'Use Overlay search',
+				'Button label that activates the Overlay search experience',
+				'jetpack-search-pkg'
+			);
 		case EXPERIENCE.INLINE:
 			return _x(
 				'Use Theme search',
@@ -85,7 +76,7 @@ const getCommitLabel = ( experience, blockOverlayEnabled = false ) => {
 	}
 };
 
-const getHoverHint = ( experience, blockOverlayEnabled = false ) => {
+const getHoverHint = experience => {
 	if ( experience === EXPERIENCE.OFF ) {
 		return _x(
 			'Click to turn off Jetpack Search',
@@ -100,7 +91,7 @@ const getHoverHint = ( experience, blockOverlayEnabled = false ) => {
 			'Hover hint on a non-active experience card explaining what clicking the card does',
 			'jetpack-search-pkg'
 		),
-		getCardTitle( experience, blockOverlayEnabled )
+		getCardTitle( experience )
 	);
 };
 
@@ -123,24 +114,17 @@ const getHoverHint = ( experience, blockOverlayEnabled = false ) => {
  * @return {import('react').Element} - The card.
  */
 export default function ExperienceOption( { experience, disabled = false } ) {
-	const {
-		active,
-		isUpdating,
-		activeThemeStylesheet,
-		isBlockTheme,
-		blockOverlayEnabled,
-		blockTemplateOverlay,
-	} = useSelect(
-		select => ( {
-			active: select( STORE_ID ).getActiveExperience(),
-			isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
-			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
-			isBlockTheme: select( STORE_ID ).isBlockTheme(),
-			blockOverlayEnabled: select( STORE_ID ).isBlockOverlayEnabled(),
-			blockTemplateOverlay: select( STORE_ID ).getBlockTemplateOverlayConfig(),
-		} ),
-		[]
-	);
+	const { active, isUpdating, activeThemeStylesheet, isBlockTheme, blockTemplateOverlay } =
+		useSelect(
+			select => ( {
+				active: select( STORE_ID ).getActiveExperience(),
+				isUpdating: select( STORE_ID ).isUpdatingJetpackSettings(),
+				activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
+				isBlockTheme: select( STORE_ID ).isBlockTheme(),
+				blockTemplateOverlay: select( STORE_ID ).getBlockTemplateOverlayConfig(),
+			} ),
+			[]
+		);
 	const { saveExperience, successNotice, errorNotice } = useDispatch( STORE_ID );
 	const [ isConfirmOpen, setConfirmOpen ] = useState( false );
 	const [ isResetConfirmOpen, setResetConfirmOpen ] = useState( false );
@@ -203,14 +187,14 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 			<Stack direction="column" gap="lg" className="jp-search-experience-option__content">
 				<Stack direction="row" gap="sm" align="center" wrap="wrap">
 					<h3 id={ titleId } className="jp-search-experience-option__title">
-						{ getCardTitle( experience, blockOverlayEnabled ) }
+						{ getCardTitle( experience ) }
 					</h3>
 					{ isRecommended && (
 						<Badge intent="informational">{ __( 'Recommended', 'jetpack-search-pkg' ) }</Badge>
 					) }
 					{ isBeta && <Badge intent="informational">{ __( 'Beta', 'jetpack-search-pkg' ) }</Badge> }
 				</Stack>
-				<CardCopy experience={ experience } blockOverlayEnabled={ blockOverlayEnabled } />
+				<CardCopy experience={ experience } />
 			</Stack>
 			{ experience === EXPERIENCE.EMBEDDED && (
 				<Stack
@@ -322,7 +306,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 							? undefined
 							: isEmbeddedBlockedByTheme
 							? blockedThemeHint
-							: getHoverHint( experience, blockOverlayEnabled )
+							: getHoverHint( experience )
 					}
 					onClick={ () => {
 						if ( commitButtonDisabled ) {
@@ -333,10 +317,10 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					aria-label={
 						// eslint-disable-next-line no-nested-ternary -- three mutually exclusive label states; flattening would duplicate the attribute.
 						disabled
-							? `${ getCommitLabel( experience, blockOverlayEnabled ) }. ${ upsellHint }`
+							? `${ getCommitLabel( experience ) }. ${ upsellHint }`
 							: isEmbeddedBlockedByTheme
-							? `${ getCardTitle( experience, blockOverlayEnabled ) }. ${ blockedThemeHint }`
-							: getCommitLabel( experience, blockOverlayEnabled )
+							? `${ getCardTitle( experience ) }. ${ blockedThemeHint }`
+							: getCommitLabel( experience )
 					}
 				/>
 			) }
@@ -379,12 +363,12 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 						setConfirmOpen( false );
 					} }
 					onCancel={ () => setConfirmOpen( false ) }
-					confirmButtonText={ getCommitLabel( experience, blockOverlayEnabled ) }
+					confirmButtonText={ getCommitLabel( experience ) }
 				>
 					{ sprintf(
 						/* translators: %s — the human-readable experience name (e.g. "Embedded search"). */
 						__( 'Switch the visitor-facing search experience to %s?', 'jetpack-search-pkg' ),
-						getCardTitle( experience, blockOverlayEnabled )
+						getCardTitle( experience )
 					) }
 				</ConfirmDialog>
 			) }
@@ -443,7 +427,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 	);
 }
 
-const CardCopy = ( { experience, blockOverlayEnabled = false } ) => {
+const CardCopy = ( { experience } ) => {
 	if ( experience === EXPERIENCE.EMBEDDED ) {
 		return (
 			<p className="jp-search-experience-option__description">
@@ -465,26 +449,6 @@ const CardCopy = ( { experience, blockOverlayEnabled = false } ) => {
 		);
 	}
 	if ( experience === EXPERIENCE.OVERLAY ) {
-		// While the blocks-powered Overlay is also visible, the legacy
-		// card explicitly names itself as the older preact-based path so
-		// site owners can tell the two cards apart at a glance.
-		//
-		// Each branch returns its own `<p>` rather than putting the two
-		// `__()` calls in a JSX ternary expression — the production
-		// build's translation-string optimizer folds the latter into a
-		// single `__(t?A:B, domain)` and trips strict-literal validation,
-		// breaking the build. Splitting at the JSX-boundary keeps each
-		// `__()` argument unambiguously a string literal.
-		if ( blockOverlayEnabled ) {
-			return (
-				<p className="jp-search-experience-option__description">
-					{ __(
-						'The original preact-powered Instant Search overlay. Customize via the dedicated search screen and widget sidebar.',
-						'jetpack-search-pkg'
-					) }
-				</p>
-			);
-		}
 		return (
 			<p className="jp-search-experience-option__description">
 				{ __(

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -154,6 +154,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 
 	const isActive = active === experience;
 	const isRecommended = experience === EXPERIENCE.EMBEDDED;
+	const isBeta = experience === EXPERIENCE.OVERLAY_BLOCKS;
 	const linksDisabled = isUpdating || ! isActive;
 
 	// Embedded search is built and customized in the Site Editor, which
@@ -207,6 +208,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					{ isRecommended && (
 						<Badge intent="informational">{ __( 'Recommended', 'jetpack-search-pkg' ) }</Badge>
 					) }
+					{ isBeta && <Badge intent="informational">{ __( 'Beta', 'jetpack-search-pkg' ) }</Badge> }
 				</Stack>
 				<CardCopy experience={ experience } blockOverlayEnabled={ blockOverlayEnabled } />
 			</Stack>
@@ -456,7 +458,7 @@ const CardCopy = ( { experience, blockOverlayEnabled = false } ) => {
 		return (
 			<p className="jp-search-experience-option__description">
 				{ __(
-					'A search-as-you-type overlay rendered from your Search blocks — same filters, sorting, and store as Embedded, but opens over your existing pages.',
+					'In beta — a search-as-you-type overlay rendered from your Search blocks. Same filters, sorting, and store as Embedded, but opens over your existing pages.',
 					'jetpack-search-pkg'
 				) }
 			</p>

--- a/projects/packages/search/src/dashboard/components/experience-selector/index.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/index.jsx
@@ -28,10 +28,10 @@ export default function ExperienceSelector() {
 	// Two filters compose on top of the canonical EXPERIENCE_ORDER:
 	//   * On WordPress.com Simple sites, Off is managed from the .com side,
 	//     so hide that row here.
-	//   * The blocks-powered Overlay is opt-in via the
-	//     `jetpack_search_overlay_block_template_enabled` server filter;
-	//     while it's off, the dashboard shows the original four cards and
-	//     the legacy Overlay keeps its plain title (no "(legacy)" suffix).
+	//   * The blocks-powered Overlay is available by default, gated by
+	//     `jetpack_search_overlay_block_template_enabled` (defaults true).
+	//     Operators that pin the filter to false fall back to the original
+	//     four cards with the legacy Overlay keeping its plain title.
 	const visibleExperiences = EXPERIENCE_ORDER.filter( experience => {
 		if ( experience === EXPERIENCE.OFF && isWpcom ) {
 			return false;

--- a/projects/packages/search/src/dashboard/components/experience-selector/index.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/index.jsx
@@ -28,10 +28,12 @@ export default function ExperienceSelector() {
 	// Two filters compose on top of the canonical EXPERIENCE_ORDER:
 	//   * On WordPress.com Simple sites, Off is managed from the .com side,
 	//     so hide that row here.
-	//   * The blocks-powered Overlay is available by default, gated by
-	//     `jetpack_search_overlay_block_template_enabled` (defaults true).
-	//     Operators that pin the filter to false fall back to the original
-	//     four cards with the legacy Overlay keeping its plain title.
+	//   * The blocks-powered Overlay (BETA) is available by default, gated
+	//     by `jetpack_search_overlay_block_template_enabled` (defaults
+	//     true). Operators that pin the filter to false fall back to the
+	//     four-card layout with the preact Overlay as the only Overlay
+	//     choice — the two overlays coexist as peers, not as predecessor
+	//     and successor.
 	const visibleExperiences = EXPERIENCE_ORDER.filter( experience => {
 		if ( experience === EXPERIENCE.OFF && isWpcom ) {
 			return false;

--- a/projects/packages/search/src/dashboard/components/experience-selector/stories/experience-selector.stories.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/stories/experience-selector.stories.jsx
@@ -22,7 +22,7 @@ export default {
 		blockOverlayEnabled: {
 			control: 'boolean',
 			description:
-				'Seed `siteData.blockOverlayEnabled` — mirrors the `jetpack_search_overlay_block_template_enabled` server filter (defaults true). Reveals the BETA blocks-powered Overlay card and tags the legacy one "(legacy)". Pin to false to preview the legacy four-card layout.',
+				'Seed `siteData.blockOverlayEnabled` — mirrors the `jetpack_search_overlay_block_template_enabled` server filter (defaults true). Reveals the BETA "Overlay search (blocks)" card alongside the preact Overlay; both stay first-class peers. Pin to false to preview the four-card layout.',
 		},
 	},
 	args: {
@@ -205,9 +205,9 @@ WpcomSite.args = {
 	isWpcom: true,
 };
 
-// Blocks-powered Overlay flag on — five cards visible, legacy carries the
-// "(legacy)" suffix. The user has not yet switched, so the legacy card is
-// the active one.
+// Blocks-powered Overlay flag on — five cards visible, BETA "(blocks)"
+// card sits next to the preact Overlay as a sibling. The user has not yet
+// switched, so the preact card is the active one.
 export const OverlayBlocksAvailable = args =>
 	renderWithStoryArgs(
 		{
@@ -223,8 +223,8 @@ OverlayBlocksAvailable.args = {
 	blockOverlayEnabled: true,
 };
 
-// User has opted into the blocks-powered Overlay — the new card is Active,
-// and the legacy card stays selectable as a fallback.
+// User has opted into the blocks-powered Overlay — the BETA card is
+// Active; the preact Overlay stays selectable as a peer.
 export const OverlayBlocksActive = args =>
 	renderWithStoryArgs(
 		{
@@ -241,8 +241,8 @@ OverlayBlocksActive.args = {
 };
 
 // Operator pinned `jetpack_search_overlay_block_template_enabled` to false —
-// the BETA card is hidden, the legacy Overlay reverts to its plain title.
-export const LegacyFourCardLayout = args =>
+// the BETA card is hidden, the preact Overlay is the only Overlay choice.
+export const PreactOnlyFourCardLayout = args =>
 	renderWithStoryArgs(
 		{
 			module_active: true,
@@ -253,6 +253,6 @@ export const LegacyFourCardLayout = args =>
 		},
 		args
 	);
-LegacyFourCardLayout.args = {
+PreactOnlyFourCardLayout.args = {
 	blockOverlayEnabled: false,
 };

--- a/projects/packages/search/src/dashboard/components/experience-selector/stories/experience-selector.stories.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/stories/experience-selector.stories.jsx
@@ -22,13 +22,13 @@ export default {
 		blockOverlayEnabled: {
 			control: 'boolean',
 			description:
-				'Seed `siteData.blockOverlayEnabled` — mirrors the `jetpack_search_overlay_block_template_enabled` server filter; reveals the new blocks-powered Overlay card and tags the legacy one "(legacy)".',
+				'Seed `siteData.blockOverlayEnabled` — mirrors the `jetpack_search_overlay_block_template_enabled` server filter (defaults true). Reveals the BETA blocks-powered Overlay card and tags the legacy one "(legacy)". Pin to false to preview the legacy four-card layout.',
 		},
 	},
 	args: {
 		isWpcom: false,
 		supportsOnlyClassicSearch: false,
-		blockOverlayEnabled: false,
+		blockOverlayEnabled: true,
 	},
 };
 
@@ -238,4 +238,21 @@ export const OverlayBlocksActive = args =>
 	);
 OverlayBlocksActive.args = {
 	blockOverlayEnabled: true,
+};
+
+// Operator pinned `jetpack_search_overlay_block_template_enabled` to false —
+// the BETA card is hidden, the legacy Overlay reverts to its plain title.
+export const LegacyFourCardLayout = args =>
+	renderWithStoryArgs(
+		{
+			module_active: true,
+			instant_search_enabled: true,
+			pending_experience: null,
+			experience: EXPERIENCE.OVERLAY,
+			is_updating: false,
+		},
+		args
+	);
+LegacyFourCardLayout.args = {
+	blockOverlayEnabled: false,
 };

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -187,7 +187,8 @@ class Initializer {
 			self::$block_search_active = true;
 		}
 
-		// Experimental block-template overlay (off by default; see
+		// Experimental block-template overlay (available by default, opt-in
+		// via the Experience Selector; see
 		// `Search_Blocks::is_block_template_overlay_enabled()`): bypass the
 		// preact `SearchApp` so it doesn't race the block overlay for
 		// `?s=`, popstate, and theme search-trigger selectors. Suppressing

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -282,32 +282,36 @@ class Search_Blocks {
 	 * server-rendered Search blocks template
 	 * (`templates/jetpack-search-overlay.html`).
 	 *
-	 * EXPERIMENTAL — off by default; not production-ready. Two conditions
-	 * must hold for the runtime swap to occur:
+	 * EXPERIMENTAL — available by default; opt-in via the Experience
+	 * Selector. Two conditions must hold for the runtime swap to occur:
 	 *
-	 *   1. The `jetpack_search_overlay_block_template_enabled` filter is on.
-	 *      This is the operator-level gate that surfaces the new option in
-	 *      the Experience Selector and registers the overlay assets.
+	 *   1. The `jetpack_search_overlay_block_template_enabled` filter is on
+	 *      (defaults true). This is the operator-level gate that surfaces
+	 *      the new option in the Experience Selector and registers the
+	 *      overlay assets. Operators can still pin it back to false to
+	 *      hide the experimental card.
 	 *   2. The site owner has chosen the new overlay experience in the
 	 *      dashboard (`Module_Control::EXPERIENCE_OVERLAY_BLOCKS`).
 	 *
 	 * Both conditions let the legacy and blocks-powered overlays coexist
-	 * on the same site — operators can opt a site into the new path, and
-	 * site owners can still flip back to the legacy experience without
-	 * touching any server-side filter. When both are true the legacy
-	 * `SearchApp` is bypassed via the `jetpack_search_init_instant_search`
-	 * filter (wired in `Initializer::init_search_blocks()`).
+	 * on the same site — operators can hide the new path on sites where
+	 * they don't want it surfaced, and site owners can still flip back to
+	 * the legacy experience without touching any server-side filter. When
+	 * both are true the legacy `SearchApp` is bypassed via the
+	 * `jetpack_search_init_instant_search` filter (wired in
+	 * `Initializer::init_search_blocks()`).
 	 *
 	 * @return bool
 	 */
 	public static function is_block_template_overlay_enabled(): bool {
 		/**
-		 * Opt into the experimental Search blocks overlay. Off by default.
-		 * Do not enable in production until this feature graduates.
+		 * Opt out of the experimental Search blocks overlay. Available by
+		 * default; return false to hide the Beta card from the Experience
+		 * Selector.
 		 *
-		 * @param bool $enabled Default false.
+		 * @param bool $enabled Default true.
 		 */
-		if ( ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', false ) ) {
+		if ( ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', true ) ) {
 			return false;
 		}
 		return Module_Control::EXPERIENCE_OVERLAY_BLOCKS === ( new Module_Control() )->get_experience();

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -222,8 +222,20 @@ class Search_Blocks {
 			add_filter( 'search_template_hierarchy', array( static::class, 'route_woocommerce_product_search_template' ), 20 );
 		}
 
-		if ( static::is_block_template_overlay_enabled() ) {
+		// Two-tier gate: register the editable template CPT + admin-init editor
+		// handler whenever the operator filter is on, so admins can edit the
+		// overlay template *before* opting into the blocks Overlay experience
+		// (e.g. preview the editor from the Beta card while the preact Overlay
+		// is still the active arm — without this split, the editorUrl seeded
+		// into the React initial state at page load would be null and the
+		// link would become a no-op once the user switched to the Beta card
+		// without a page refresh). The front-end render hooks stay gated on
+		// the active experience — they only paint the overlay when the user
+		// has actually committed to it.
+		if ( static::is_block_template_overlay_filter_on() ) {
 			Overlay_Template::init();
+		}
+		if ( static::is_block_template_overlay_enabled() ) {
 			add_action( 'wp_enqueue_scripts', array( static::class, 'enqueue_block_template_overlay_assets' ) );
 			add_action( 'wp_footer', array( static::class, 'print_block_template_overlay' ) );
 		}
@@ -304,17 +316,35 @@ class Search_Blocks {
 	 * @return bool
 	 */
 	public static function is_block_template_overlay_enabled(): bool {
-		/**
-		 * Opt out of the experimental Search blocks overlay. Available by
-		 * default; return false to hide the Beta card from the Experience
-		 * Selector.
-		 *
-		 * @param bool $enabled Default true.
-		 */
-		if ( ! (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', true ) ) {
+		if ( ! static::is_block_template_overlay_filter_on() ) {
 			return false;
 		}
 		return Module_Control::EXPERIENCE_OVERLAY_BLOCKS === ( new Module_Control() )->get_experience();
+	}
+
+	/**
+	 * Whether the operator filter that exposes the blocks-powered overlay is
+	 * on. Available by default; operators can pin to false to hide the Beta
+	 * card and disable the editable-template machinery entirely.
+	 *
+	 * Lighter check than `is_block_template_overlay_enabled()` — does not
+	 * require the user to have committed to the new overlay experience.
+	 * Use this to gate one-time setup that should also work *before* the
+	 * user opts in (e.g. registering the editable template CPT so admins
+	 * can preview the editor from the Beta card while preact Overlay is
+	 * still active).
+	 *
+	 * @return bool
+	 */
+	public static function is_block_template_overlay_filter_on(): bool {
+		/**
+		 * Opt out of the experimental Search blocks overlay. Available by
+		 * default; return false to hide the Beta card from the Experience
+		 * Selector and disable the editable-template CPT.
+		 *
+		 * @param bool $enabled Default true.
+		 */
+		return (bool) apply_filters( 'jetpack_search_overlay_block_template_enabled', true );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -181,7 +181,10 @@ class Initializer_Test extends Search_TestCase {
 
 	public function test_init_search_blocks_does_not_activate_overlay_when_overlay_gate_off() {
 		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
-		// `jetpack_search_overlay_block_template_enabled` defaults false.
+		// `jetpack_search_overlay_block_template_enabled` defaults true since
+		// the Beta release; pin it back to false here so this test exercises
+		// the operator-opt-out path that is the point of this test.
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_false' );
 
 		$this->invoke_init_search_blocks();
 

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -534,9 +534,13 @@ class Module_Control_Test extends Search_TestCase {
 	 */
 	public function test_update_experience_overlay_blocks_rejected_when_flag_off() {
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
-		// Filter defaults false — do not register any callback.
+		// Filter defaults true since the Beta release; pin it back to false
+		// so the REST boundary still rejects the value as this test asserts.
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_false' );
 
 		$result = static::$search_module->update_experience( Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+
+		remove_filter( 'jetpack_search_overlay_block_template_enabled', '__return_false' );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'experience_not_available', $result->get_error_code() );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1013,6 +1013,9 @@ class Search_Blocks_Test extends TestCase {
 		$this->reset_search_blocks_hooks();
 		$this->set_module_active( true );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY_BLOCKS );
+		// Defaults true since the Beta release; pin it back to false so this
+		// test exercises the operator-opt-out path that it is named after.
+		add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_false' );
 
 		Search_Blocks::init();
 
@@ -1021,6 +1024,7 @@ class Search_Blocks_Test extends TestCase {
 			'posts_pre_query short-circuit must not hook when the overlay operator filter is off'
 		);
 
+		remove_filter( 'jetpack_search_overlay_block_template_enabled', '__return_false' );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-242](https://linear.app/a8c/issue/SEARCH-242/search-blocks-release-blocks-powered-overlay-as-experimental-default)

## Why

The blocks-powered Overlay (`overlay_blocks` experience) is fully built — selector card, REST gate, bundled `jetpack-search-overlay.html` template, admin-editable singleton CPT, and the runtime swap that bypasses the preact `SearchApp`. Today none of it ships to users: every callsite reads `jetpack_search_overlay_block_template_enabled` with a `false` default, so the dashboard hides the option and the REST boundary rejects it. Release it to all sites as an experimental opt-in so site owners can choose it from the Experience Selector and give us real-world feedback.

The two overlays are framed as **first-class peers, not predecessor/successor** — the preact Overlay is staying around indefinitely. The new card carries an "(blocks)" suffix on its title and a Beta badge so the two coexisting overlays are distinguishable; the preact card stays plain "Overlay search" with no "(legacy)" tag.

## Proposed changes

* Flip the default of `jetpack_search_overlay_block_template_enabled` from `false` to `true` at every `apply_filters()` callsite (`Search_Blocks::is_block_template_overlay_enabled()`, `Module_Control::update_experience()`, `Initial_State::get_initial_state()`).
* Title the new card "Overlay search (blocks)" and add a Beta `<Badge intent="informational">` next to it (matches the existing Recommended badge pattern — WP's own badge intent guide places "Beta" under `informational`).
* Lead the new card's description with **"In beta — …"** so the framing matches the badge.
* Keep the preact Overlay card titled plain "Overlay search" with its original description — no "(legacy)" suffix, no "the original preact-powered" copy. `getCardTitle / getCommitLabel / getHoverHint` no longer take a `blockOverlayEnabled` argument as a result.
* Sweep doc comments that called the preact path "off by default" / "not production-ready" to "available by default; opt-in via the Experience Selector".
* Update PHP tests that exercised the operator-opt-out path: `Initializer_Test::test_init_search_blocks_does_not_activate_overlay_when_overlay_gate_off`, `Search_Blocks_Test::test_init_does_not_register_posts_pre_query_when_overlay_blocks_filter_off`, and `Module_Control_Test::test_update_experience_overlay_blocks_rejected_when_flag_off` now explicitly `add_filter( …, '__return_false' )` rather than relying on the implicit-false default.
* Add a `PreactOnlyFourCardLayout` storybook preview so the operator-opt-out path stays previewable.

## Related product discussion/links

* Linear: [SEARCH-242](https://linear.app/a8c/issue/SEARCH-242/search-blocks-release-blocks-powered-overlay-as-experimental-default)
* Prior work: SEARCH-206 introduced the filter (#48987), SEARCH-213 added the selector card (#48994), SEARCH-216 added the admin-editable template (#49028).

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Captured at `/wp-admin/admin.php?page=jetpack-search#/settings` via local docker at 1440×900 with `jetpack_search_blocks_enabled` filtered on (mu-plugin) so both screenshots show the Experience Selector. The only relevant change between the two is the `jetpack_search_overlay_block_template_enabled` default.

| Before (trunk: 4 cards, no Beta) | After (this PR: 5 cards, new "Overlay search (blocks)" Beta card alongside the preact one) |
|---|---|
| ![before](https://github.com/user-attachments/assets/77a6c136-e2c7-418a-b93d-4b2589dcaf77) | ![after](https://github.com/user-attachments/assets/eaa4ec1b-f029-48fa-9e6d-80e82c6e756b) |


An overlay that is themable!!

<img width="1287" height="591" alt="image" src="https://github.com/user-attachments/assets/80c1910f-ffce-454c-88ed-4d04de46670c" />


## Testing instructions

Bring up a fresh dev env (`jp docker up` or any clone of trunk with this branch checked out) and visit Jetpack ▸ Search ▸ Settings. With `jetpack_search_blocks_enabled` on (it's already the runtime default; the dashboard read-side gets corrected in SEARCH-241), confirm:

* [ ] Five cards are visible in the selector by default — no filter override needed.
* [ ] A new "Overlay search (blocks)" card carries a `Beta` badge next to the title.
* [ ] The new card's description begins with "In beta —".
* [ ] The preact Overlay card has its plain title "Overlay search" with its original description — **no `(legacy)` suffix, no "the original preact-powered" wording**.
* [ ] Switching to the new "Overlay search (blocks)" card from any other experience persists `overlay_blocks` to the experience option and routes future front-end search to the blocks-powered overlay (bypassing the preact `SearchApp`).
* [ ] Switching back to "Overlay search" persists `overlay` and restores the preact path.
* [ ] On a site that explicitly opts out (`add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_false' );`), the selector reverts to four cards with the preact Overlay as the only Overlay choice.
* [ ] PHP test suite for `packages/search` is green — including the three tests updated to opt out of the new default explicitly.
