### PR TITLE
Search Dashboard: route Atomic to UpsellPage instead of mocked-only Overview

### DIFF
--- a/projects/packages/search/changelog/fix-atomic-overview-mockup-upsell
+++ b/projects/packages/search/changelog/fix-atomic-overview-mockup-upsell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: Route sites without instant search support (including Atomic) to the pricing upsell page instead of showing the Overview tab's mocked-only state.

--- a/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
@@ -67,13 +67,18 @@ function WrappedDashboard202208() {
 }
 
 /**
- * Returns SearchDashboardPage component if supports search otherwise UpsellPage component
+ * Returns SearchDashboardPage component if instant search is supported, otherwise UpsellPage.
+ *
+ * Gated on `supportsInstantSearch` rather than `supportsSearch` so that hosts
+ * which surface classic search "for free" — notably Atomic, where the
+ * Instant Search toggle is forced-disabled — land on the pricing page
+ * instead of the SearchDashboardPage's mocked-only Overview tab.
  *
  * @return {import('react').Component} AfterConnectionPage component.
  */
 function AfterConnectionPage() {
 	useSelect( select => select( STORE_ID ).getSearchPlanInfo(), [] );
-	const supportsSearch = useSelect( select => select( STORE_ID ).supportsSearch() );
+	const supportsInstantSearch = useSelect( select => select( STORE_ID ).supportsInstantSearch() );
 
 	const isPageLoading = useSelect(
 		select =>
@@ -83,8 +88,8 @@ function AfterConnectionPage() {
 
 	return (
 		<>
-			{ supportsSearch && <SearchDashboardPage isLoading={ isPageLoading } /> }
-			{ ! supportsSearch && <UpsellPage isLoading={ isPageLoading } /> }
+			{ supportsInstantSearch && <SearchDashboardPage isLoading={ isPageLoading } /> }
+			{ ! supportsInstantSearch && <UpsellPage isLoading={ isPageLoading } /> }
 		</>
 	);
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Gate `AfterConnectionPage` (the post-connection router in `wrapped-dashboard.jsx`) on `supportsInstantSearch` rather than `supportsSearch`.
* Atomic sites without a real Jetpack Search subscription land on the same `UpsellPage` (pricing grid) that self-hosted Jetpack sites without a subscription already see, instead of `SearchDashboardPage` with the mocked-only Overview tab.

### Why
`supportsSearch` composes `supports_instant_search || supports_only_classic_search`. On Atomic the classic-search flag is reported truthy regardless of subscription, so Atomic users slipped past the `! supportsSearch → UpsellPage` route. `supportsInstantSearch` is the same signal that already forces the Instant Search toggle disabled in `ModuleControl`, so this aligns the page-level routing with the toggle-level gating that's already in place.

### Blast radius
Same UpsellPage is now also shown to anyone on a legacy classic-only plan (`supports_only_classic_search=true && supports_instant_search=false`). Those users were already getting a degraded Overview tab (no `PlanInfo`, no `RecordMeter` — both are gated on `supportsInstantSearch`), so the pricing page is a strict improvement over the mocked-only state they had before.

## Related product discussion/links
* Verbal on Telegram with @kangzj — "On Atomic sites, the overview tab only shows a meaningless mock up… we should match it with regular Jetpack sites upsell."

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Baseline (no behaviour change for sites with a Search subscription):**
* Open the Search dashboard on a self-hosted Jetpack site with the free Jetpack Search subscription (`jetpack_search_free`, `supports_instant_search: true`).
* Expect: the existing `SearchDashboardPage` with the Overview / Settings / AI Answers tabs — no change.

**Atomic-style state (the fix):**
* Either visit a real Atomic site that doesn't have a paid Jetpack Search subscription, or simulate the Atomic flag state on a local docker env by adding this mu-plugin:
  ```php
  // wp-content/mu-plugins/atomic-sim.php
  <?php
  add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
      if ( false === strpos( $url, '/jetpack-search/plan' ) ) { return $preempt; }
      return array(
          'headers'  => array(),
          'body'     => wp_json_encode( array(
              'supports_instant_search'      => false,
              'supports_only_classic_search' => true,
              'supports_search'              => true,
              'effective_subscription'       => null,
              'search_subscriptions'         => array(),
              'plan_type'                    => '',
          ) ),
          'response' => array( 'code' => 200, 'message' => 'OK' ),
      );
  }, 10, 3 );
  ```
  (The HTTP intercept is needed because `Plan::get_plan_info_from_wpcom()` re-fetches and overwrites the `jetpack_search_plan_info` option on every dashboard load, so a direct option update gets clobbered.)
* On `trunk` (before this PR): the Overview tab shows only the mocked search interface with no usage stats below it.
* On this branch (after this PR): the dashboard redirects to the `UpsellPage` pricing grid (`The best WordPress search experience` with `Get Search` vs `Start for free` columns).