### PR TITLE
Search Blocks: add vertical breathing room between Search Input and content in blocks Overlay

### DIFF
--- a/projects/packages/search/changelog/SEARCH-243-overlay-input-gap
+++ b/projects/packages/search/changelog/SEARCH-243-overlay-input-gap
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search Blocks: add a 1.5em top gap between the Search Input header and the first row of results / filter UI inside the blocks-powered Overlay so the modal no longer feels cramped. Mirrors a 1em gap into the mobile-narrow (`<=781px`) layout.
+Search Blocks: add a small (0.5em) top gap between the Search Input header and the first row of results / filter UI inside the blocks-powered Overlay so the modal no longer feels cramped. Same gap is applied in the mobile-narrow (`<=781px`) layout.

--- a/projects/packages/search/changelog/SEARCH-243-overlay-input-gap
+++ b/projects/packages/search/changelog/SEARCH-243-overlay-input-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: add a 1.5em top gap between the Search Input header and the first row of results / filter UI inside the blocks-powered Overlay so the modal no longer feels cramped. Mirrors a 1em gap into the mobile-narrow (`<=781px`) layout.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1385,8 +1385,13 @@ class Search_Blocks {
 	font-weight: 400;
 	line-height: 1;
 }
+/*
+ * Top padding clears the absolutely-positioned 60px header strip — without
+ * it the "Found N results" / Sort by row sat flush against the search
+ * input's bottom border and the modal felt cramped (SEARCH-243).
+ */
 .jetpack-search-block-overlay__content > .wp-block-group:first-child {
-	padding: 0 2em 2em;
+	padding: .5em 2em 2em;
 }
 /*
  * The "Found N results" + sort dropdown row sits inside the rendered
@@ -1412,7 +1417,7 @@ class Search_Blocks {
 		box-shadow: none;
 	}
 	.jetpack-search-block-overlay__content > .wp-block-group:first-child {
-		padding: 0 1em 1em;
+		padding: 1em 1em 1em;
 	}
 }
 /*

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1417,7 +1417,7 @@ class Search_Blocks {
 		box-shadow: none;
 	}
 	.jetpack-search-block-overlay__content > .wp-block-group:first-child {
-		padding: 1em 1em 1em;
+		padding: .5em 1em 1em;
 	}
 }
 /*


### PR DESCRIPTION
Fixes [SEARCH-243](https://linear.app/a8c/issue/SEARCH-243/search-blocks-add-vertical-breathing-room-between-search-input-and)

## Why

In the blocks-powered Overlay (the new `overlay_blocks` experience), the row that holds "Found N results" + the **Sort by** dropdown sat flush against the bottom border of the 60px header strip that holds the Search Input. The modal felt cramped and the eye had no place to land between query and results. This adds the missing breathing room.

This is **overlay-only** — Embedded, Theme search, and the preact Overlay are untouched.

## Proposed changes

* Bump `.jetpack-search-block-overlay__content > .wp-block-group:first-child` padding from `0 2em 2em` to `1.5em 2em 2em` so the content area no longer butts against the header.
* Mirror a smaller bump in the mobile-narrow variant (`@media (max-width: 781px)`): `0 1em 1em` → `1em 1em 1em`.
* Inline comment on the rule explaining what the top padding is clearing (the absolutely-positioned 60px header strip), citing SEARCH-243.

The fix stays entirely inside `Search_Blocks::block_template_overlay_inline_css()` — no new SCSS file, no new selector, no JS change.

## Screenshots

Captured on the local docker env's front-end at `/?s=hello` (SEARCH-227's URL-driven auto-open), with the `overlay_blocks` experience active and `jetpack_search_blocks_enabled` filtered on.

### Desktop (1440×1000)

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/acff0078-33b2-4b51-a27f-5afce8c55778) | ![after](https://github.com/user-attachments/assets/e38ec89d-2bb7-448d-8ada-535f1925e451) |

### Mobile-narrow (600×900)

| Before | After |
|---|---|
| ![before-mobile](https://github.com/user-attachments/assets/804fedbb-44ae-414e-af0d-f7d9b564c3b7) | ![after-mobile](https://github.com/user-attachments/assets/df5a922e-eeed-4609-8664-60aab0ac3708) |

The "after-mobile" capture caught the search in its loading state but the top breathing room is clearly visible above the skeleton — the rule applies regardless of whether the inner content is the loading skeleton, the loaded results, or the empty-state copy.

## Related product discussion/links

* Linear: [SEARCH-243](https://linear.app/a8c/issue/SEARCH-243/search-blocks-add-vertical-breathing-room-between-search-input-and)
* Builds on SEARCH-242 ([#49118](https://github.com/Automattic/jetpack/pull/49118)) — released the blocks Overlay as experimental, which is what made this layout regression visible to anyone trying the Beta card.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from the Linear ticket — work through with the screenshots above:

* [ ] In the blocks-powered Overlay, the "Found N results" + Sort by row has at least ~16px of breathing room above it (clearing the 60px header strip's bottom border).
* [ ] The same breathing room is reflected in the mobile-narrow layout (`@media (max-width: 781px)`).
* [ ] Embedded, Theme search, and the preact Overlay are unchanged.
* [ ] No new SCSS or stylesheet files — the fix stays inside `block_template_overlay_inline_css()` so the overlay's CSS surface remains self-contained.
* [ ] Before / after screenshots in the PR body.

Repro path: site with `jetpack_search_blocks_enabled` on (default since SEARCH-241), switch the experience to **Overlay search (blocks)** in Jetpack ▸ Search ▸ Settings, then visit any front-end URL with `?s=hello` (or open the search overlay manually). Compare the gap between the search input and the "Found N results" row against the before/after screenshots above.
