### PR TITLE
Layout Grid Usage Tracking: observe first usage on WoA sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-layout-grid-usage-tracking
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-layout-grid-usage-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Layout Grid Usage Tracking: log a logstash event the first time a `jetpack/layout-grid` block is observed on a WoA site so we can attribute its source to the responsible plugin or theme.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -295,6 +295,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/google-analytics/google-analytics.php';
 		require_once __DIR__ . '/features/holiday-snow/class-holiday-snow.php';
 		require_once __DIR__ . '/features/launch-button/index.php';
+		require_once __DIR__ . '/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
 		require_once __DIR__ . '/features/logo-tool/logo-tool.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -219,8 +219,11 @@ function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
  * Dispatch an observation to logstash. Returns true if dispatch was attempted
  * (filter passed and the wrapper class is loaded), false when short-circuited.
  * Callers use the return value to gate sticky side effects (sentinel, context
- * transients) so a blocked dispatch doesn't lock them out. Any failure inside
- * `Jetpack_Mu_Wpcom::log2logstash()` is swallowed by that method's try/catch.
+ * transients) so a blocked dispatch doesn't lock them out. Anything throwing
+ * during payload assembly (third-party filter callbacks, option lookups, etc.)
+ * or inside `Jetpack_Mu_Wpcom::log2logstash()` is caught and reported as a
+ * non-dispatch — telemetry must never escalate into a fatal on the host
+ * action chain (post save, front-end render).
  *
  * @param array $extra Caller-supplied payload. Caller keys win on collision.
  * @return bool
@@ -242,37 +245,42 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 		return false;
 	}
 
-	$active_plugins_raw = get_option( 'active_plugins' );
-	$active_plugins     = is_array( $active_plugins_raw ) ? array_values( $active_plugins_raw ) : array();
-	// Union network-activated plugins: WoA is multisite-shaped and the
-	// platform's plugins live in `active_sitewide_plugins`.
-	if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
-		$sitewide_raw = get_site_option( 'active_sitewide_plugins' );
-		if ( is_array( $sitewide_raw ) && ! empty( $sitewide_raw ) ) {
-			$active_plugins = array_values( array_unique( array_merge( $active_plugins, array_keys( $sitewide_raw ) ) ) );
+	try {
+		$active_plugins_raw = get_option( 'active_plugins' );
+		$active_plugins     = is_array( $active_plugins_raw ) ? array_values( $active_plugins_raw ) : array();
+		// Union network-activated plugins: WoA is multisite-shaped and the
+		// platform's plugins live in `active_sitewide_plugins`.
+		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+			$sitewide_raw = get_site_option( 'active_sitewide_plugins' );
+			if ( is_array( $sitewide_raw ) && ! empty( $sitewide_raw ) ) {
+				$active_plugins = array_values( array_unique( array_merge( $active_plugins, array_keys( $sitewide_raw ) ) ) );
+			}
 		}
+
+		// `array_merge( defaults, $extra )`: caller keys win on collision.
+		$payload = array_merge(
+			array(
+				'active_theme'   => function_exists( 'get_stylesheet' ) ? (string) get_stylesheet() : '',
+				'active_plugins' => $active_plugins,
+				'is_rest'        => defined( 'REST_REQUEST' ) && REST_REQUEST,
+				'is_cli'         => defined( 'WP_CLI' ) && WP_CLI,
+				'is_cron'        => defined( 'DOING_CRON' ) && DOING_CRON,
+				'is_importing'   => defined( 'WP_IMPORTING' ) && WP_IMPORTING,
+				'trace'          => wpcom_layout_grid_usage_attribute_source(),
+			),
+			$extra
+		);
+
+		\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
+			WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE,
+			WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE,
+			wpcom_layout_grid_usage_redact_paths( $payload )
+		);
+		return true;
+	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort: telemetry never escalates a failure into a fatal on the caller's action chain.
+		unset( $e );
+		return false;
 	}
-
-	// `array_merge( defaults, $extra )`: caller keys win on collision.
-	$payload = array_merge(
-		array(
-			'active_theme'   => function_exists( 'get_stylesheet' ) ? (string) get_stylesheet() : '',
-			'active_plugins' => $active_plugins,
-			'is_rest'        => defined( 'REST_REQUEST' ) && REST_REQUEST,
-			'is_cli'         => defined( 'WP_CLI' ) && WP_CLI,
-			'is_cron'        => defined( 'DOING_CRON' ) && DOING_CRON,
-			'is_importing'   => defined( 'WP_IMPORTING' ) && WP_IMPORTING,
-			'trace'          => wpcom_layout_grid_usage_attribute_source(),
-		),
-		$extra
-	);
-
-	\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
-		WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE,
-		WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE,
-		wpcom_layout_grid_usage_redact_paths( $payload )
-	);
-	return true;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -1,12 +1,11 @@
 <?php
 /**
  * Layout-grid usage tracking — emit a logstash event when a `jetpack/layout-grid`
- * block is inserted or first rendered on a WoA site. The payload captures the
+ * block is inserted or first rendered on a WoA site. The payload carries the
  * active theme, active plugins, request-context flags, and a sanitized
- * backtrace so the source can be attributed to the responsible plugin or
- * theme rather than just the candidate set.
- *
- * Events ship to the `atomic_layout_grid_block` logstash bucket.
+ * backtrace so the source can be attributed to a responsible plugin or theme
+ * rather than just the candidate set. Events ship to the
+ * `atomic_layout_grid_block` logstash bucket.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -21,9 +20,7 @@ const WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE      = 'atomic_layout_grid_block';
 const WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE      = 'layout_grid_block_observed';
 
 /**
- * Whether to register the detectors. WoA only — non-WoA Atomic / connected
- * Jetpack sites aren't in scope. Extracted so tests can require the file
- * without auto-registering hooks.
+ * WoA-only gate. Extracted so tests can require the file without registering hooks.
  *
  * @return bool
  */
@@ -42,34 +39,27 @@ if ( wpcom_layout_grid_usage_should_load() ) {
 }
 
 /**
- * Post-insert detector. Logs editor-driven first-landings per-event (low
- * volume, and repeat events from the same blog help corroborate single-cause
- * vs multi-cause patterns). Importer- and cron-driven inserts are rate-limited
- * to one event per blog per 24h via transients — same stack on every iteration,
- * so per-event repeats add zero attribution value but a lot of noise.
+ * `wp_after_insert_post` handler. Editor first-landings log per-event; import
+ * and cron contexts are rate-limited to one event per blog per 24h.
  *
  * @param int           $post_id     Post ID.
- * @param \WP_Post      $post        Post after the insert.
+ * @param mixed         $post        Typed as WP_Post by core; checked defensively.
  * @param bool          $update      Whether this is an update.
  * @param \WP_Post|null $post_before Previous post version (null on insert).
  * @return void
  */
 function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update, $post_before ) {
 	unset( $update );
-	// Revisions and autosaves are inserted as their own posts, so the
-	// `$post_before` check below can't see the parent post's previous state —
-	// without this guard every editor autosave on a layout-grid-using post
-	// would log a fresh event.
+	// Revisions/autosaves are inserted as their own posts, so the
+	// `$post_before` check below can't see the parent's prior state.
 	if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
 		return;
 	}
 	if ( ! $post instanceof \WP_Post ) {
 		return;
 	}
-	// `has_block( $name, $post )` would route through `get_post()`, which can
-	// re-fetch the post via cache (or DB) and return a different content
-	// snapshot than the WP_Post we were handed. Pass the raw content string
-	// directly so the scan is over the exact bytes we observed.
+	// Scan the raw content string so `has_block` doesn't route through
+	// `get_post()` and re-fetch a potentially different cache snapshot.
 	if ( ! has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, (string) $post->post_content ) ) {
 		return;
 	}
@@ -87,27 +77,22 @@ function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update,
 			'post_type' => (string) $post->post_type,
 		)
 	);
-	// Only burn the 24h budget if we actually dispatched. Setting the
-	// transient before dispatch would mean a filter-blocked or class-missing
-	// observation silently consumes the rate-limit window without recording
-	// anything in Kibana.
+	// Burn the 24h budget only after a successful dispatch — otherwise a
+	// filter-blocked observation consumes the window with nothing logged.
 	if ( $dispatched ) {
 		wpcom_layout_grid_usage_mark_context_seen( $is_importing, $is_cron );
 	}
 }
 
 /**
- * Read-only rate-limit gate for high-volume insert contexts. Returns false
- * when the per-context transient is already set (we've logged within the
- * window). Pair with `wpcom_layout_grid_usage_mark_context_seen()` after a successful
- * dispatch — splitting the read from the write means a logging failure no
- * longer burns the 24h budget.
+ * Read-only rate-limit gate. Returns false when the active context's transient
+ * is already set. Paired with `wpcom_layout_grid_usage_mark_context_seen()`
+ * post-dispatch so a logging failure doesn't burn the 24h budget. Import wins
+ * when both flags are set (cron-triggered import).
  *
- * Import takes precedence when both flags are set (cron-triggered import).
- *
- * @param bool $is_importing Whether `WP_IMPORTING` is set.
- * @param bool $is_cron      Whether `DOING_CRON` is set.
- * @return bool True if the caller should continue and log; false to skip.
+ * @param bool $is_importing WP_IMPORTING flag.
+ * @param bool $is_cron      DOING_CRON flag.
+ * @return bool True if the caller should log.
  */
 function wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) {
 	$key = wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron );
@@ -118,11 +103,10 @@ function wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron 
 }
 
 /**
- * Persist the rate-limit transient for the active context (if any) after a
- * successful dispatch. No-op outside import / cron.
+ * Write half of the rate-limit gate. No-op outside import / cron.
  *
- * @param bool $is_importing Whether `WP_IMPORTING` is set.
- * @param bool $is_cron      Whether `DOING_CRON` is set.
+ * @param bool $is_importing WP_IMPORTING flag.
+ * @param bool $is_cron      DOING_CRON flag.
  * @return void
  */
 function wpcom_layout_grid_usage_mark_context_seen( $is_importing, $is_cron ) {
@@ -134,11 +118,10 @@ function wpcom_layout_grid_usage_mark_context_seen( $is_importing, $is_cron ) {
 }
 
 /**
- * Resolve the transient key for the active rate-limit context. Returns null
- * outside import / cron. Import wins when both flags are set.
+ * Active rate-limit context's transient key, or null. Import wins.
  *
- * @param bool $is_importing Whether `WP_IMPORTING` is set.
- * @param bool $is_cron      Whether `DOING_CRON` is set.
+ * @param bool $is_importing WP_IMPORTING flag.
+ * @param bool $is_cron      DOING_CRON flag.
  * @return string|null
  */
 function wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron ) {
@@ -152,10 +135,9 @@ function wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron 
 }
 
 /**
- * `add_option_widget_block` handler. Fires the first time the option is
- * created; logs when the initial value contains layout-grid markup.
+ * `add_option_widget_block` handler. Logs when the initial value carries the block.
  *
- * @param string $option Option name (unused — pinned to `widget_block` via filter name).
+ * @param string $option Unused — pinned by hook name.
  * @param mixed  $value  New option value.
  * @return void
  */
@@ -168,9 +150,7 @@ function wpcom_layout_grid_usage_react_to_widget_block_added( $option, $value ) 
 }
 
 /**
- * `update_option_widget_block` handler. Logs only when the new value contains
- * the block and the previous value didn't — same "first landing" semantics as
- * the post detector.
+ * `update_option_widget_block` handler. Logs first-landings only (new has, old didn't).
  *
  * @param mixed $old_value Previous option value.
  * @param mixed $value     New option value.
@@ -187,27 +167,24 @@ function wpcom_layout_grid_usage_react_to_widget_block_updated( $old_value, $val
 }
 
 /**
- * Render-time backstop. Sentinel-guarded so it fires at most once per blog:
- * by render time the call stack no longer reaches the cause, so the marginal
- * attribution value of repeat events is zero — but the per-pageview cost on
- * layout-grid-using sites is high. One log per blog tells us the block came
- * from a theme-bundled template / pattern or direct `$wpdb` write that the
- * post / widget detectors didn't see.
+ * Render-time backstop. Sentinel-guarded to fire at most once per blog — by
+ * render time the stack no longer reaches the cause, so per-pageview repeats
+ * add zero attribution value at non-trivial cost. One log per blog still tells
+ * us the block came from a theme template, pattern, or direct `$wpdb` write
+ * that the post/widget detectors didn't see.
  *
  * @param string $block_content Rendered block HTML.
- * @param array  $parsed_block  Parsed block (unused).
- * @return string Unchanged content.
+ * @param array  $parsed_block  Unused.
+ * @return string Unchanged.
  */
 function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_block ) {
 	unset( $parsed_block );
 	if ( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) ) {
 		return $block_content;
 	}
-	// Only persist the sentinel after the dispatch attempt actually went out.
-	// Setting it first would mean a filter-blocked or class-missing
-	// observation permanently disables the render backstop for this blog,
-	// because the option has no TTL — even after the underlying cause is
-	// fixed, the backstop never fires again.
+	// Persist the sentinel only after a successful dispatch. The option has no
+	// TTL, so a filter-blocked observation that wrote it first would
+	// permanently disable the backstop for this blog.
 	if ( wpcom_layout_grid_usage_log_observation( array( 'surface' => 'render' ) ) ) {
 		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
 	}
@@ -215,9 +192,8 @@ function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_
 }
 
 /**
- * Whether a `widget_block` option value contains the layout-grid block in
- * any of its widget entries. The option is an array keyed by widget id, with
- * each entry holding a `content` string of block markup.
+ * Whether a `widget_block` option value carries the layout-grid block in any
+ * widget entry's `content`.
  *
  * @param mixed $value Option value.
  * @return bool
@@ -240,29 +216,24 @@ function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
 }
 
 /**
- * Dispatch a layout-grid observation to logstash. Returns true when dispatch
- * was attempted (filter passed and `Jetpack_Mu_Wpcom` is loaded), false when
- * the call was short-circuited. Callers use the return value to gate sticky
- * side effects (the render sentinel, the import/cron transients) so that a
- * blocked dispatch doesn't lock those out for the next observation.
+ * Dispatch an observation to logstash. Returns true if dispatch was attempted
+ * (filter passed and the wrapper class is loaded), false when short-circuited.
+ * Callers use the return value to gate sticky side effects (sentinel, context
+ * transients) so a blocked dispatch doesn't lock them out. Any failure inside
+ * `Jetpack_Mu_Wpcom::log2logstash()` is swallowed by that method's try/catch.
  *
- * Best-effort beyond that point: a logging failure inside
- * `Jetpack_Mu_Wpcom::log2logstash()` is swallowed by that method's own
- * try/catch — we treat "dispatch was attempted" as the meaningful signal.
- *
- * @param array $extra Caller-supplied properties merged with the default payload.
- *                     Caller keys win on collision.
- * @return bool True if the dispatch was attempted; false if short-circuited.
+ * @param array $extra Caller-supplied payload. Caller keys win on collision.
+ * @return bool
  */
 function wpcom_layout_grid_usage_log_observation( array $extra ) {
 	/**
-	 * Whether layout-grid usage observations should be dispatched to logstash.
-	 * Defaults to true; tests short-circuit this to keep `log2logstash` (and
-	 * its HTTP fallback) out of the unit-test environment, and sites that
-	 * don't want the telemetry can disable it the same way.
+	 * Whether layout-grid usage observations should be dispatched. Tests
+	 * short-circuit this to keep `log2logstash` (and its HTTP fallback) out
+	 * of the unit-test environment; sites that don't want telemetry can
+	 * disable it the same way.
 	 *
-	 * @param bool  $enabled Whether to dispatch the log event.
-	 * @param array $extra   Surface-specific properties for the candidate event.
+	 * @param bool  $enabled
+	 * @param array $extra
 	 */
 	if ( ! (bool) apply_filters( 'wpcom_layout_grid_usage_log_enabled', true, $extra ) ) {
 		return false;
@@ -273,10 +244,8 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 
 	$active_plugins_raw = get_option( 'active_plugins' );
 	$active_plugins     = is_array( $active_plugins_raw ) ? array_values( $active_plugins_raw ) : array();
-	// WoA is multisite-shaped at the platform layer; the platform-managed
-	// plugins live in `active_sitewide_plugins`, not `active_plugins`. Without
-	// this merge, the most common attribution candidates would be invisible
-	// in the payload.
+	// Union network-activated plugins: WoA is multisite-shaped and the
+	// platform's plugins live in `active_sitewide_plugins`.
 	if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
 		$sitewide_raw = get_site_option( 'active_sitewide_plugins' );
 		if ( is_array( $sitewide_raw ) && ! empty( $sitewide_raw ) ) {
@@ -284,9 +253,7 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 		}
 	}
 
-	// Caller keys win on collision: `array_merge( defaults, $extra )` makes
-	// the caller-supplied `$extra` override same-named default keys, which
-	// matches the natural reading of the `$extra` API.
+	// `array_merge( defaults, $extra )`: caller keys win on collision.
 	$payload = array_merge(
 		array(
 			'active_theme'   => function_exists( 'get_stylesheet' ) ? (string) get_stylesheet() : '',
@@ -309,17 +276,15 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 }
 
 /**
- * Walk the PHP call stack and return up to 8 `file:line` strings whose `file`
- * lives under `wp-content/plugins/`, `wp-content/themes/`, or
- * `wp-content/mu-plugins/`. Those are the cause candidates; core / pluggable
- * frames are filtered out. `wp_debug_backtrace_summary()` is deliberately not
- * used here — it returns function-call summaries (e.g. `WP_Hook->apply_filters()`)
- * without file paths, so the extension-path filter would yield an empty trace.
+ * Walk `debug_backtrace()` and return up to 8 `<file>:<line>` strings for
+ * frames under `wp-content/(plugins|themes|mu-plugins)/`. Core / pluggable
+ * frames are filtered out. `wp_debug_backtrace_summary()` is deliberately
+ * not used: it returns function-call summaries, not file paths.
  *
  * @return string[]
  */
 function wpcom_layout_grid_usage_attribute_source() {
-	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Intentional: attribution backtrace for a logstash record.
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Attribution backtrace for a logstash record.
 	$frames    = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 	$self_file = __FILE__;
 	$relevant  = array();
@@ -337,21 +302,14 @@ function wpcom_layout_grid_usage_attribute_source() {
 }
 
 /**
- * Pure per-frame predicate for `wpcom_layout_grid_usage_attribute_source()`. Returns
- * `<file>:<line>` when the frame should be kept, or `null` to skip. Extracted
- * so the regex + self-skip behavior can be unit-tested without staging a
- * real PHP call stack.
- *
- * Skip rules, in order:
- *   - Malformed frame (no string `file` field).
- *   - Self-frame (`file === $self_file`) — the tracker's own frames would
- *     otherwise pass the extension-path regex (jetpack-mu-wpcom is loaded
- *     from `wp-content/mu-plugins/`) and crowd out real attribution within
- *     the caller's 8-frame cap.
- *   - File outside `wp-content/(plugins|themes|mu-plugins)/`.
+ * Per-frame predicate. Returns `<file>:<line>` for kept frames, null to skip.
+ * Skips: malformed frames, the tracker's own file (jetpack-mu-wpcom loads
+ * from `wp-content/mu-plugins/` and would otherwise dominate the 8-frame cap),
+ * and any file outside the three extension directories. Extracted from
+ * `wpcom_layout_grid_usage_attribute_source()` for unit-testability.
  *
  * @param mixed  $frame     One frame from `debug_backtrace()`.
- * @param string $self_file Path to compare against for the self-skip.
+ * @param string $self_file Tracker file path for the self-skip comparison.
  * @return string|null
  */
 function wpcom_layout_grid_usage_format_attribution_frame( $frame, string $self_file ) {
@@ -369,9 +327,8 @@ function wpcom_layout_grid_usage_format_attribution_frame( $frame, string $self_
 }
 
 /**
- * Strip ABSPATH / WP_CONTENT_DIR prefixes from any string values in the
- * payload so log lines don't leak the install layout. Mirrors the
- * `pcg_log_redact_paths` helper in the Plugin Conflicts Guardian feature.
+ * Strip ABSPATH / WP_CONTENT_DIR prefixes from string values, recursing into
+ * arrays. Mirrors `pcg_log_redact_paths` in Plugin Conflicts Guardian.
  *
  * @param mixed $value Scalar or array.
  * @return mixed

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -15,10 +15,12 @@
 
 declare(strict_types=1);
 
-const WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME  = 'jetpack/layout-grid';
-const WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION = 'wpcom_layout_grid_block_seen';
-const WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE = 'atomic_layout_grid_block';
-const WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE = 'layout_grid_block_observed';
+const WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME       = 'jetpack/layout-grid';
+const WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION      = 'wpcom_layout_grid_block_seen';
+const WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT = 'wpcom_layout_grid_block_import_seen';
+const WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT   = 'wpcom_layout_grid_block_cron_seen';
+const WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE      = 'atomic_layout_grid_block';
+const WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE      = 'layout_grid_block_observed';
 
 /**
  * Whether to register the detectors. WoA only — Simple has its own observer
@@ -42,11 +44,11 @@ if ( wpcom_layout_grid_usage_should_load() ) {
 }
 
 /**
- * Post-insert detector. Logs per-event (no sentinel): editor saves are
- * naturally low volume, and repeat events from the same blog corroborate
- * single-cause vs multi-cause patterns. Skips updates whose previous version
- * already contained the block so we don't log every edit of pre-existing
- * content — only the moment the block first lands in a given post.
+ * Post-insert detector. Logs editor-driven first-landings per-event (low
+ * volume, and repeat events from the same blog help corroborate single-cause
+ * vs multi-cause patterns). Importer- and cron-driven inserts are rate-limited
+ * to one event per blog per 24h via transients — same stack on every iteration,
+ * so per-event repeats add zero attribution value but a lot of noise.
  *
  * @param int           $post_id     Post ID.
  * @param \WP_Post      $post        Post after the insert.
@@ -72,12 +74,43 @@ function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update,
 	if ( $post_before instanceof \WP_Post && has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $post_before ) ) {
 		return;
 	}
+	$is_importing = defined( 'WP_IMPORTING' ) && WP_IMPORTING;
+	$is_cron      = defined( 'DOING_CRON' ) && DOING_CRON;
+	if ( ! wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) ) {
+		return;
+	}
 	wpcom_layout_grid_usage_log_observation(
 		array(
 			'surface'   => 'post_insert',
 			'post_type' => (string) $post->post_type,
 		)
 	);
+}
+
+/**
+ * Rate-limit gate for high-volume insert contexts. Importer / cron runs touch
+ * many posts with the same call stack, so per-event logging adds noise without
+ * attribution value. Sets a 24h transient on first observation for each
+ * context and short-circuits further observations until it expires. Import
+ * takes precedence when both flags happen to be set (cron-triggered import).
+ *
+ * @param bool $is_importing Whether `WP_IMPORTING` is set.
+ * @param bool $is_cron      Whether `DOING_CRON` is set.
+ * @return bool True if the caller should continue and log; false to skip.
+ */
+function wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) {
+	if ( $is_importing ) {
+		$transient_key = WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT;
+	} elseif ( $is_cron ) {
+		$transient_key = WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT;
+	} else {
+		return true;
+	}
+	if ( get_transient( $transient_key ) ) {
+		return false;
+	}
+	set_transient( $transient_key, 1, DAY_IN_SECONDS );
+	return true;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Layout-grid usage tracking — emit a logstash event when a `jetpack/layout-grid`
+ * block is inserted or first rendered on a WoA site. The payload captures the
+ * active theme, active plugins, request-context flags, and a sanitized
+ * backtrace so the source can be attributed to the responsible plugin or
+ * theme rather than just the candidate set.
+ *
+ * Companion to the Simple-side observer in wpcom's
+ * `wp-content/mu-plugins/wpcom-wpcom-blocks.php`. Distinct logstash feature
+ * bucket (`atomic_layout_grid_block`) so the two datasets don't co-mingle.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare(strict_types=1);
+
+const WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME  = 'jetpack/layout-grid';
+const WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION = 'wpcom_layout_grid_block_seen';
+const WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE = 'atomic_layout_grid_block';
+const WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE = 'layout_grid_block_observed';
+
+/**
+ * Whether to register the detectors. WoA only — Simple has its own observer
+ * in wpcom; non-WoA Atomic / connected Jetpack sites aren't in scope.
+ * Extracted so tests can require the file without auto-registering hooks.
+ *
+ * @return bool
+ */
+function wpcom_layout_grid_usage_should_load() {
+	if ( ! class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
+		return false;
+	}
+	return ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
+}
+
+if ( wpcom_layout_grid_usage_should_load() ) {
+	add_action( 'wp_after_insert_post', 'wpcom_layout_grid_usage_react_to_post_insert', 10, 4 );
+	add_action( 'add_option_widget_block', 'wpcom_layout_grid_usage_react_to_widget_block_added', 10, 2 );
+	add_action( 'update_option_widget_block', 'wpcom_layout_grid_usage_react_to_widget_block_updated', 10, 2 );
+	add_filter( 'render_block_' . WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, 'wpcom_layout_grid_usage_react_to_block_render', 10, 2 );
+}
+
+/**
+ * Post-insert detector. Logs per-event (no sentinel): editor saves are
+ * naturally low volume, and repeat events from the same blog corroborate
+ * single-cause vs multi-cause patterns. Skips updates whose previous version
+ * already contained the block so we don't log every edit of pre-existing
+ * content — only the moment the block first lands in a given post.
+ *
+ * @param int           $post_id     Post ID.
+ * @param \WP_Post      $post        Post after the insert.
+ * @param bool          $update      Whether this is an update.
+ * @param \WP_Post|null $post_before Previous post version (null on insert).
+ * @return void
+ */
+function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update, $post_before ) {
+	unset( $post_id, $update );
+	if ( ! $post instanceof \WP_Post ) {
+		return;
+	}
+	if ( ! has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $post ) ) {
+		return;
+	}
+	if ( $post_before instanceof \WP_Post && has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $post_before ) ) {
+		return;
+	}
+	wpcom_layout_grid_usage_log_observation(
+		array(
+			'surface'   => 'post_insert',
+			'post_type' => (string) $post->post_type,
+		)
+	);
+}
+
+/**
+ * `add_option_widget_block` handler. Fires the first time the option is
+ * created; logs when the initial value contains layout-grid markup.
+ *
+ * @param string $option Option name (unused — pinned to `widget_block` via filter name).
+ * @param mixed  $value  New option value.
+ * @return void
+ */
+function wpcom_layout_grid_usage_react_to_widget_block_added( $option, $value ) {
+	unset( $option );
+	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
+		return;
+	}
+	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_add' ) );
+}
+
+/**
+ * `update_option_widget_block` handler. Logs only when the new value contains
+ * the block and the previous value didn't — same "first landing" semantics as
+ * the post detector.
+ *
+ * @param mixed $old_value Previous option value.
+ * @param mixed $value     New option value.
+ * @return void
+ */
+function wpcom_layout_grid_usage_react_to_widget_block_updated( $old_value, $value ) {
+	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
+		return;
+	}
+	if ( wpcom_layout_grid_usage_widget_value_contains_block( $old_value ) ) {
+		return;
+	}
+	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_update' ) );
+}
+
+/**
+ * Render-time backstop. Sentinel-guarded so it fires at most once per blog:
+ * by render time the call stack no longer reaches the cause, so the marginal
+ * attribution value of repeat events is zero — but the per-pageview cost on
+ * layout-grid-using sites is high. One log per blog tells us the block came
+ * from a theme-bundled template / pattern or direct `$wpdb` write that the
+ * post / widget detectors didn't see.
+ *
+ * @param string $block_content Rendered block HTML.
+ * @param array  $parsed_block  Parsed block (unused).
+ * @return string Unchanged content.
+ */
+function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_block ) {
+	unset( $parsed_block );
+	if ( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) ) {
+		return $block_content;
+	}
+	update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
+	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'render' ) );
+	return $block_content;
+}
+
+/**
+ * Whether a `widget_block` option value contains the layout-grid block in
+ * any of its widget entries. The option is an array keyed by widget id, with
+ * each entry holding a `content` string of block markup.
+ *
+ * @param mixed $value Option value.
+ * @return bool
+ */
+function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
+	if ( ! is_array( $value ) ) {
+		return false;
+	}
+	foreach ( $value as $widget ) {
+		if (
+			is_array( $widget )
+			&& isset( $widget['content'] )
+			&& is_string( $widget['content'] )
+			&& has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $widget['content'] )
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Dispatch a layout-grid observation to logstash. Best-effort: a logging
+ * failure must not escalate into a fatal for the caller — guarded by the
+ * underlying `Jetpack_Mu_Wpcom::log2logstash()` wrapper.
+ *
+ * @param array $extra Surface-specific properties merged into the payload.
+ * @return void
+ */
+function wpcom_layout_grid_usage_log_observation( array $extra ) {
+	if ( ! class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom' ) ) {
+		return;
+	}
+
+	$active_plugins_raw = get_option( 'active_plugins' );
+	$active_plugins     = is_array( $active_plugins_raw ) ? array_values( $active_plugins_raw ) : array();
+
+	$payload = array_merge(
+		$extra,
+		array(
+			'active_theme'   => function_exists( 'get_stylesheet' ) ? (string) get_stylesheet() : '',
+			'active_plugins' => $active_plugins,
+			'is_rest'        => defined( 'REST_REQUEST' ) && REST_REQUEST,
+			'is_cli'         => defined( 'WP_CLI' ) && WP_CLI,
+			'is_cron'        => defined( 'DOING_CRON' ) && DOING_CRON,
+			'is_importing'   => defined( 'WP_IMPORTING' ) && WP_IMPORTING,
+			'trace'          => wpcom_layout_grid_usage_attribute_source(),
+		)
+	);
+
+	\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
+		WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE,
+		WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE,
+		wpcom_layout_grid_usage_redact_paths( $payload )
+	);
+}
+
+/**
+ * Walk the PHP call stack and return up to 8 frames that point at code under
+ * `wp-content/plugins/`, `wp-content/themes/`, or `wp-content/mu-plugins/`.
+ * Those are the cause candidates; core / pluggable frames are filtered out.
+ *
+ * @return string[]
+ */
+function wpcom_layout_grid_usage_attribute_source() {
+	if ( ! function_exists( 'wp_debug_backtrace_summary' ) ) {
+		return array();
+	}
+	// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- `null` is the documented default for $ignore_class; the wordpress-stubs signature is imprecise.
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary -- Intentional: attribution backtrace for a logstash record.
+	$frames = wp_debug_backtrace_summary( null, 0, false );
+	if ( ! is_array( $frames ) ) {
+		return array();
+	}
+	$relevant = array_values(
+		array_filter(
+			$frames,
+			static function ( $frame ) {
+				return is_string( $frame ) && preg_match( '#/wp-content/(plugins|themes|mu-plugins)/#', $frame );
+			}
+		)
+	);
+	return array_slice( $relevant, 0, 8 );
+}
+
+/**
+ * Strip ABSPATH / WP_CONTENT_DIR prefixes from any string values in the
+ * payload so log lines don't leak the install layout. Mirrors the
+ * `pcg_log_redact_paths` helper in the Plugin Conflicts Guardian feature.
+ *
+ * @param mixed $value Scalar or array.
+ * @return mixed
+ */
+function wpcom_layout_grid_usage_redact_paths( $value ) {
+	if ( is_array( $value ) ) {
+		return array_map( 'wpcom_layout_grid_usage_redact_paths', $value );
+	}
+	if ( ! is_string( $value ) || '' === $value ) {
+		return $value;
+	}
+	$replacements = array();
+	if ( defined( 'WP_CONTENT_DIR' ) && '' !== WP_CONTENT_DIR ) {
+		$replacements[ rtrim( WP_CONTENT_DIR, '/' ) . '/' ] = '.../';
+	}
+	if ( defined( 'ABSPATH' ) && '' !== ABSPATH ) {
+		$replacements[ rtrim( ABSPATH, '/' ) . '/' ] = '.../';
+	}
+	if ( empty( $replacements ) ) {
+		return $value;
+	}
+	return strtr( $value, $replacements );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -6,41 +6,39 @@
  * backtrace so the source can be attributed to the responsible plugin or
  * theme rather than just the candidate set.
  *
- * Companion to the Simple-side observer in wpcom's
- * `wp-content/mu-plugins/wpcom-wpcom-blocks.php`. Distinct logstash feature
- * bucket (`atomic_layout_grid_block`) so the two datasets don't co-mingle.
+ * Events ship to the `atomic_layout_grid_block` logstash bucket.
  *
  * @package automattic/jetpack-mu-wpcom
  */
 
 declare(strict_types=1);
 
-const WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME       = 'jetpack/layout-grid';
-const WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION      = 'wpcom_layout_grid_block_seen';
-const WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT = 'wpcom_layout_grid_block_import_seen';
-const WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT   = 'wpcom_layout_grid_block_cron_seen';
-const WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE      = 'atomic_layout_grid_block';
-const WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE      = 'layout_grid_block_observed';
+const LAYOUT_GRID_BLOCK_NAME       = 'jetpack/layout-grid';
+const LAYOUT_GRID_SEEN_OPTION      = 'layout_grid_block_seen';
+const LAYOUT_GRID_IMPORT_TRANSIENT = 'layout_grid_block_import_seen';
+const LAYOUT_GRID_CRON_TRANSIENT   = 'layout_grid_block_cron_seen';
+const LAYOUT_GRID_LOG_FEATURE      = 'atomic_layout_grid_block';
+const LAYOUT_GRID_LOG_MESSAGE      = 'layout_grid_block_observed';
 
 /**
- * Whether to register the detectors. WoA only — Simple has its own observer
- * in wpcom; non-WoA Atomic / connected Jetpack sites aren't in scope.
- * Extracted so tests can require the file without auto-registering hooks.
+ * Whether to register the detectors. WoA only — non-WoA Atomic / connected
+ * Jetpack sites aren't in scope. Extracted so tests can require the file
+ * without auto-registering hooks.
  *
  * @return bool
  */
-function wpcom_layout_grid_usage_should_load() {
+function layout_grid_should_load() {
 	if ( ! class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
 		return false;
 	}
 	return ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
 }
 
-if ( wpcom_layout_grid_usage_should_load() ) {
-	add_action( 'wp_after_insert_post', 'wpcom_layout_grid_usage_react_to_post_insert', 10, 4 );
-	add_action( 'add_option_widget_block', 'wpcom_layout_grid_usage_react_to_widget_block_added', 10, 2 );
-	add_action( 'update_option_widget_block', 'wpcom_layout_grid_usage_react_to_widget_block_updated', 10, 2 );
-	add_filter( 'render_block_' . WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, 'wpcom_layout_grid_usage_react_to_block_render', 10, 2 );
+if ( layout_grid_should_load() ) {
+	add_action( 'wp_after_insert_post', 'layout_grid_react_to_post_insert', 10, 4 );
+	add_action( 'add_option_widget_block', 'layout_grid_react_to_widget_block_added', 10, 2 );
+	add_action( 'update_option_widget_block', 'layout_grid_react_to_widget_block_updated', 10, 2 );
+	add_filter( 'render_block_' . LAYOUT_GRID_BLOCK_NAME, 'layout_grid_react_to_block_render', 10, 2 );
 }
 
 /**
@@ -56,7 +54,7 @@ if ( wpcom_layout_grid_usage_should_load() ) {
  * @param \WP_Post|null $post_before Previous post version (null on insert).
  * @return void
  */
-function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update, $post_before ) {
+function layout_grid_react_to_post_insert( $post_id, $post, $update, $post_before ) {
 	unset( $update );
 	// Revisions and autosaves are inserted as their own posts, so the
 	// `$post_before` check below can't see the parent post's previous state —
@@ -68,49 +66,89 @@ function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update,
 	if ( ! $post instanceof \WP_Post ) {
 		return;
 	}
-	if ( ! has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $post ) ) {
+	// `has_block( $name, $post )` would route through `get_post()`, which can
+	// re-fetch the post via cache (or DB) and return a different content
+	// snapshot than the WP_Post we were handed. Pass the raw content string
+	// directly so the scan is over the exact bytes we observed.
+	if ( ! has_block( LAYOUT_GRID_BLOCK_NAME, (string) $post->post_content ) ) {
 		return;
 	}
-	if ( $post_before instanceof \WP_Post && has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $post_before ) ) {
+	if ( $post_before instanceof \WP_Post && has_block( LAYOUT_GRID_BLOCK_NAME, (string) $post_before->post_content ) ) {
 		return;
 	}
 	$is_importing = defined( 'WP_IMPORTING' ) && WP_IMPORTING;
 	$is_cron      = defined( 'DOING_CRON' ) && DOING_CRON;
-	if ( ! wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) ) {
+	if ( ! layout_grid_should_log_in_context( $is_importing, $is_cron ) ) {
 		return;
 	}
-	wpcom_layout_grid_usage_log_observation(
+	$dispatched = layout_grid_log_observation(
 		array(
 			'surface'   => 'post_insert',
 			'post_type' => (string) $post->post_type,
 		)
 	);
+	// Only burn the 24h budget if we actually dispatched. Setting the
+	// transient before dispatch would mean a filter-blocked or class-missing
+	// observation silently consumes the rate-limit window without recording
+	// anything in Kibana.
+	if ( $dispatched ) {
+		layout_grid_mark_context_seen( $is_importing, $is_cron );
+	}
 }
 
 /**
- * Rate-limit gate for high-volume insert contexts. Importer / cron runs touch
- * many posts with the same call stack, so per-event logging adds noise without
- * attribution value. Sets a 24h transient on first observation for each
- * context and short-circuits further observations until it expires. Import
- * takes precedence when both flags happen to be set (cron-triggered import).
+ * Read-only rate-limit gate for high-volume insert contexts. Returns false
+ * when the per-context transient is already set (we've logged within the
+ * window). Pair with `layout_grid_mark_context_seen()` after a successful
+ * dispatch — splitting the read from the write means a logging failure no
+ * longer burns the 24h budget.
+ *
+ * Import takes precedence when both flags are set (cron-triggered import).
  *
  * @param bool $is_importing Whether `WP_IMPORTING` is set.
  * @param bool $is_cron      Whether `DOING_CRON` is set.
  * @return bool True if the caller should continue and log; false to skip.
  */
-function wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) {
-	if ( $is_importing ) {
-		$transient_key = WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT;
-	} elseif ( $is_cron ) {
-		$transient_key = WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT;
-	} else {
+function layout_grid_should_log_in_context( $is_importing, $is_cron ) {
+	$key = layout_grid_context_transient_key( $is_importing, $is_cron );
+	if ( null === $key ) {
 		return true;
 	}
-	if ( get_transient( $transient_key ) ) {
-		return false;
+	return ! get_transient( $key );
+}
+
+/**
+ * Persist the rate-limit transient for the active context (if any) after a
+ * successful dispatch. No-op outside import / cron.
+ *
+ * @param bool $is_importing Whether `WP_IMPORTING` is set.
+ * @param bool $is_cron      Whether `DOING_CRON` is set.
+ * @return void
+ */
+function layout_grid_mark_context_seen( $is_importing, $is_cron ) {
+	$key = layout_grid_context_transient_key( $is_importing, $is_cron );
+	if ( null === $key ) {
+		return;
 	}
-	set_transient( $transient_key, 1, DAY_IN_SECONDS );
-	return true;
+	set_transient( $key, 1, DAY_IN_SECONDS );
+}
+
+/**
+ * Resolve the transient key for the active rate-limit context. Returns null
+ * outside import / cron. Import wins when both flags are set.
+ *
+ * @param bool $is_importing Whether `WP_IMPORTING` is set.
+ * @param bool $is_cron      Whether `DOING_CRON` is set.
+ * @return string|null
+ */
+function layout_grid_context_transient_key( $is_importing, $is_cron ) {
+	if ( $is_importing ) {
+		return LAYOUT_GRID_IMPORT_TRANSIENT;
+	}
+	if ( $is_cron ) {
+		return LAYOUT_GRID_CRON_TRANSIENT;
+	}
+	return null;
 }
 
 /**
@@ -121,12 +159,12 @@ function wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron 
  * @param mixed  $value  New option value.
  * @return void
  */
-function wpcom_layout_grid_usage_react_to_widget_block_added( $option, $value ) {
+function layout_grid_react_to_widget_block_added( $option, $value ) {
 	unset( $option );
-	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
+	if ( ! layout_grid_widget_value_contains_block( $value ) ) {
 		return;
 	}
-	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_add' ) );
+	layout_grid_log_observation( array( 'surface' => 'widget_add' ) );
 }
 
 /**
@@ -138,14 +176,14 @@ function wpcom_layout_grid_usage_react_to_widget_block_added( $option, $value ) 
  * @param mixed $value     New option value.
  * @return void
  */
-function wpcom_layout_grid_usage_react_to_widget_block_updated( $old_value, $value ) {
-	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
+function layout_grid_react_to_widget_block_updated( $old_value, $value ) {
+	if ( ! layout_grid_widget_value_contains_block( $value ) ) {
 		return;
 	}
-	if ( wpcom_layout_grid_usage_widget_value_contains_block( $old_value ) ) {
+	if ( layout_grid_widget_value_contains_block( $old_value ) ) {
 		return;
 	}
-	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_update' ) );
+	layout_grid_log_observation( array( 'surface' => 'widget_update' ) );
 }
 
 /**
@@ -160,13 +198,19 @@ function wpcom_layout_grid_usage_react_to_widget_block_updated( $old_value, $val
  * @param array  $parsed_block  Parsed block (unused).
  * @return string Unchanged content.
  */
-function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_block ) {
+function layout_grid_react_to_block_render( $block_content, $parsed_block ) {
 	unset( $parsed_block );
-	if ( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) ) {
+	if ( get_option( LAYOUT_GRID_SEEN_OPTION ) ) {
 		return $block_content;
 	}
-	update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
-	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'render' ) );
+	// Only persist the sentinel after the dispatch attempt actually went out.
+	// Setting it first would mean a filter-blocked or class-missing
+	// observation permanently disables the render backstop for this blog,
+	// because the option has no TTL — even after the underlying cause is
+	// fixed, the backstop never fires again.
+	if ( layout_grid_log_observation( array( 'surface' => 'render' ) ) ) {
+		update_option( LAYOUT_GRID_SEEN_OPTION, 1, false );
+	}
 	return $block_content;
 }
 
@@ -178,7 +222,7 @@ function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_
  * @param mixed $value Option value.
  * @return bool
  */
-function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
+function layout_grid_widget_value_contains_block( $value ) {
 	if ( ! is_array( $value ) ) {
 		return false;
 	}
@@ -187,7 +231,7 @@ function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
 			is_array( $widget )
 			&& isset( $widget['content'] )
 			&& is_string( $widget['content'] )
-			&& has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $widget['content'] )
+			&& has_block( LAYOUT_GRID_BLOCK_NAME, $widget['content'] )
 		) {
 			return true;
 		}
@@ -196,14 +240,21 @@ function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
 }
 
 /**
- * Dispatch a layout-grid observation to logstash. Best-effort: a logging
- * failure must not escalate into a fatal for the caller — guarded by the
- * underlying `Jetpack_Mu_Wpcom::log2logstash()` wrapper.
+ * Dispatch a layout-grid observation to logstash. Returns true when dispatch
+ * was attempted (filter passed and `Jetpack_Mu_Wpcom` is loaded), false when
+ * the call was short-circuited. Callers use the return value to gate sticky
+ * side effects (the render sentinel, the import/cron transients) so that a
+ * blocked dispatch doesn't lock those out for the next observation.
  *
- * @param array $extra Surface-specific properties merged into the payload.
- * @return void
+ * Best-effort beyond that point: a logging failure inside
+ * `Jetpack_Mu_Wpcom::log2logstash()` is swallowed by that method's own
+ * try/catch — we treat "dispatch was attempted" as the meaningful signal.
+ *
+ * @param array $extra Caller-supplied properties merged with the default payload.
+ *                     Caller keys win on collision.
+ * @return bool True if the dispatch was attempted; false if short-circuited.
  */
-function wpcom_layout_grid_usage_log_observation( array $extra ) {
+function layout_grid_log_observation( array $extra ) {
 	/**
 	 * Whether layout-grid usage observations should be dispatched to logstash.
 	 * Defaults to true; tests short-circuit this to keep `log2logstash` (and
@@ -213,18 +264,30 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 	 * @param bool  $enabled Whether to dispatch the log event.
 	 * @param array $extra   Surface-specific properties for the candidate event.
 	 */
-	if ( ! apply_filters( 'wpcom_layout_grid_usage_log_enabled', true, $extra ) ) {
-		return;
+	if ( ! (bool) apply_filters( 'layout_grid_log_enabled', true, $extra ) ) {
+		return false;
 	}
 	if ( ! class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom' ) ) {
-		return;
+		return false;
 	}
 
 	$active_plugins_raw = get_option( 'active_plugins' );
 	$active_plugins     = is_array( $active_plugins_raw ) ? array_values( $active_plugins_raw ) : array();
+	// WoA is multisite-shaped at the platform layer; the platform-managed
+	// plugins live in `active_sitewide_plugins`, not `active_plugins`. Without
+	// this merge, the most common attribution candidates would be invisible
+	// in the payload.
+	if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+		$sitewide_raw = get_site_option( 'active_sitewide_plugins' );
+		if ( is_array( $sitewide_raw ) && ! empty( $sitewide_raw ) ) {
+			$active_plugins = array_values( array_unique( array_merge( $active_plugins, array_keys( $sitewide_raw ) ) ) );
+		}
+	}
 
+	// Caller keys win on collision: `array_merge( defaults, $extra )` makes
+	// the caller-supplied `$extra` override same-named default keys, which
+	// matches the natural reading of the `$extra` API.
 	$payload = array_merge(
-		$extra,
 		array(
 			'active_theme'   => function_exists( 'get_stylesheet' ) ? (string) get_stylesheet() : '',
 			'active_plugins' => $active_plugins,
@@ -232,15 +295,17 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 			'is_cli'         => defined( 'WP_CLI' ) && WP_CLI,
 			'is_cron'        => defined( 'DOING_CRON' ) && DOING_CRON,
 			'is_importing'   => defined( 'WP_IMPORTING' ) && WP_IMPORTING,
-			'trace'          => wpcom_layout_grid_usage_attribute_source(),
-		)
+			'trace'          => layout_grid_attribute_source(),
+		),
+		$extra
 	);
 
 	\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
-		WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE,
-		WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE,
-		wpcom_layout_grid_usage_redact_paths( $payload )
+		LAYOUT_GRID_LOG_FEATURE,
+		LAYOUT_GRID_LOG_MESSAGE,
+		layout_grid_redact_paths( $payload )
 	);
+	return true;
 }
 
 /**
@@ -253,31 +318,54 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
  *
  * @return string[]
  */
-function wpcom_layout_grid_usage_attribute_source() {
+function layout_grid_attribute_source() {
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Intentional: attribution backtrace for a logstash record.
 	$frames    = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 	$self_file = __FILE__;
 	$relevant  = array();
 	foreach ( $frames as $frame ) {
-		if ( ! is_array( $frame ) || empty( $frame['file'] ) || ! is_string( $frame['file'] ) ) {
+		$entry = layout_grid_format_attribution_frame( $frame, $self_file );
+		if ( null === $entry ) {
 			continue;
 		}
-		// `jetpack-mu-wpcom` itself is loaded from `wp-content/mu-plugins/`, so
-		// the tracker's own frames would match the extension-path regex and
-		// crowd out real plugin/theme attribution within the 8-frame cap.
-		if ( $frame['file'] === $self_file ) {
-			continue;
-		}
-		if ( ! preg_match( '#/wp-content/(plugins|themes|mu-plugins)/#', $frame['file'] ) ) {
-			continue;
-		}
-		$line       = isset( $frame['line'] ) ? (int) $frame['line'] : 0;
-		$relevant[] = $frame['file'] . ':' . $line;
+		$relevant[] = $entry;
 		if ( count( $relevant ) >= 8 ) {
 			break;
 		}
 	}
 	return $relevant;
+}
+
+/**
+ * Pure per-frame predicate for `layout_grid_attribute_source()`. Returns
+ * `<file>:<line>` when the frame should be kept, or `null` to skip. Extracted
+ * so the regex + self-skip behavior can be unit-tested without staging a
+ * real PHP call stack.
+ *
+ * Skip rules, in order:
+ *   - Malformed frame (no string `file` field).
+ *   - Self-frame (`file === $self_file`) — the tracker's own frames would
+ *     otherwise pass the extension-path regex (jetpack-mu-wpcom is loaded
+ *     from `wp-content/mu-plugins/`) and crowd out real attribution within
+ *     the caller's 8-frame cap.
+ *   - File outside `wp-content/(plugins|themes|mu-plugins)/`.
+ *
+ * @param mixed  $frame     One frame from `debug_backtrace()`.
+ * @param string $self_file Path to compare against for the self-skip.
+ * @return string|null
+ */
+function layout_grid_format_attribution_frame( $frame, string $self_file ) {
+	if ( ! is_array( $frame ) || empty( $frame['file'] ) || ! is_string( $frame['file'] ) ) {
+		return null;
+	}
+	if ( $frame['file'] === $self_file ) {
+		return null;
+	}
+	if ( ! preg_match( '#/wp-content/(plugins|themes|mu-plugins)/#', $frame['file'] ) ) {
+		return null;
+	}
+	$line = isset( $frame['line'] ) ? (int) $frame['line'] : 0;
+	return $frame['file'] . ':' . $line;
 }
 
 /**
@@ -288,9 +376,9 @@ function wpcom_layout_grid_usage_attribute_source() {
  * @param mixed $value Scalar or array.
  * @return mixed
  */
-function wpcom_layout_grid_usage_redact_paths( $value ) {
+function layout_grid_redact_paths( $value ) {
 	if ( is_array( $value ) ) {
-		return array_map( 'wpcom_layout_grid_usage_redact_paths', $value );
+		return array_map( 'layout_grid_redact_paths', $value );
 	}
 	if ( ! is_string( $value ) || '' === $value ) {
 		return $value;

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -222,10 +222,17 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
  */
 function wpcom_layout_grid_usage_attribute_source() {
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Intentional: attribution backtrace for a logstash record.
-	$frames   = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
-	$relevant = array();
+	$frames    = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+	$self_file = __FILE__;
+	$relevant  = array();
 	foreach ( $frames as $frame ) {
 		if ( ! is_array( $frame ) || empty( $frame['file'] ) || ! is_string( $frame['file'] ) ) {
+			continue;
+		}
+		// `jetpack-mu-wpcom` itself is loaded from `wp-content/mu-plugins/`, so
+		// the tracker's own frames would match the extension-path regex and
+		// crowd out real plugin/theme attribution within the 8-frame cap.
+		if ( $frame['file'] === $self_file ) {
 			continue;
 		}
 		if ( ! preg_match( '#/wp-content/(plugins|themes|mu-plugins)/#', $frame['file'] ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -55,7 +55,14 @@ if ( wpcom_layout_grid_usage_should_load() ) {
  * @return void
  */
 function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update, $post_before ) {
-	unset( $post_id, $update );
+	unset( $update );
+	// Revisions and autosaves are inserted as their own posts, so the
+	// `$post_before` check below can't see the parent post's previous state —
+	// without this guard every editor autosave on a layout-grid-using post
+	// would log a fresh event.
+	if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+		return;
+	}
 	if ( ! $post instanceof \WP_Post ) {
 		return;
 	}
@@ -164,6 +171,18 @@ function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
  * @return void
  */
 function wpcom_layout_grid_usage_log_observation( array $extra ) {
+	/**
+	 * Whether layout-grid usage observations should be dispatched to logstash.
+	 * Defaults to true; tests short-circuit this to keep `log2logstash` (and
+	 * its HTTP fallback) out of the unit-test environment, and sites that
+	 * don't want the telemetry can disable it the same way.
+	 *
+	 * @param bool  $enabled Whether to dispatch the log event.
+	 * @param array $extra   Surface-specific properties for the candidate event.
+	 */
+	if ( ! apply_filters( 'wpcom_layout_grid_usage_log_enabled', true, $extra ) ) {
+		return;
+	}
 	if ( ! class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom' ) ) {
 		return;
 	}
@@ -192,31 +211,33 @@ function wpcom_layout_grid_usage_log_observation( array $extra ) {
 }
 
 /**
- * Walk the PHP call stack and return up to 8 frames that point at code under
- * `wp-content/plugins/`, `wp-content/themes/`, or `wp-content/mu-plugins/`.
- * Those are the cause candidates; core / pluggable frames are filtered out.
+ * Walk the PHP call stack and return up to 8 `file:line` strings whose `file`
+ * lives under `wp-content/plugins/`, `wp-content/themes/`, or
+ * `wp-content/mu-plugins/`. Those are the cause candidates; core / pluggable
+ * frames are filtered out. `wp_debug_backtrace_summary()` is deliberately not
+ * used here — it returns function-call summaries (e.g. `WP_Hook->apply_filters()`)
+ * without file paths, so the extension-path filter would yield an empty trace.
  *
  * @return string[]
  */
 function wpcom_layout_grid_usage_attribute_source() {
-	if ( ! function_exists( 'wp_debug_backtrace_summary' ) ) {
-		return array();
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Intentional: attribution backtrace for a logstash record.
+	$frames   = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+	$relevant = array();
+	foreach ( $frames as $frame ) {
+		if ( ! is_array( $frame ) || empty( $frame['file'] ) || ! is_string( $frame['file'] ) ) {
+			continue;
+		}
+		if ( ! preg_match( '#/wp-content/(plugins|themes|mu-plugins)/#', $frame['file'] ) ) {
+			continue;
+		}
+		$line       = isset( $frame['line'] ) ? (int) $frame['line'] : 0;
+		$relevant[] = $frame['file'] . ':' . $line;
+		if ( count( $relevant ) >= 8 ) {
+			break;
+		}
 	}
-	// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- `null` is the documented default for $ignore_class; the wordpress-stubs signature is imprecise.
-	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary -- Intentional: attribution backtrace for a logstash record.
-	$frames = wp_debug_backtrace_summary( null, 0, false );
-	if ( ! is_array( $frames ) ) {
-		return array();
-	}
-	$relevant = array_values(
-		array_filter(
-			$frames,
-			static function ( $frame ) {
-				return is_string( $frame ) && preg_match( '#/wp-content/(plugins|themes|mu-plugins)/#', $frame );
-			}
-		)
-	);
-	return array_slice( $relevant, 0, 8 );
+	return $relevant;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php
@@ -13,12 +13,12 @@
 
 declare(strict_types=1);
 
-const LAYOUT_GRID_BLOCK_NAME       = 'jetpack/layout-grid';
-const LAYOUT_GRID_SEEN_OPTION      = 'layout_grid_block_seen';
-const LAYOUT_GRID_IMPORT_TRANSIENT = 'layout_grid_block_import_seen';
-const LAYOUT_GRID_CRON_TRANSIENT   = 'layout_grid_block_cron_seen';
-const LAYOUT_GRID_LOG_FEATURE      = 'atomic_layout_grid_block';
-const LAYOUT_GRID_LOG_MESSAGE      = 'layout_grid_block_observed';
+const WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME       = 'jetpack/layout-grid';
+const WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION      = 'wpcom_layout_grid_block_seen';
+const WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT = 'wpcom_layout_grid_block_import_seen';
+const WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT   = 'wpcom_layout_grid_block_cron_seen';
+const WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE      = 'atomic_layout_grid_block';
+const WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE      = 'layout_grid_block_observed';
 
 /**
  * Whether to register the detectors. WoA only — non-WoA Atomic / connected
@@ -27,18 +27,18 @@ const LAYOUT_GRID_LOG_MESSAGE      = 'layout_grid_block_observed';
  *
  * @return bool
  */
-function layout_grid_should_load() {
+function wpcom_layout_grid_usage_should_load() {
 	if ( ! class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
 		return false;
 	}
 	return ( new \Automattic\Jetpack\Status\Host() )->is_woa_site();
 }
 
-if ( layout_grid_should_load() ) {
-	add_action( 'wp_after_insert_post', 'layout_grid_react_to_post_insert', 10, 4 );
-	add_action( 'add_option_widget_block', 'layout_grid_react_to_widget_block_added', 10, 2 );
-	add_action( 'update_option_widget_block', 'layout_grid_react_to_widget_block_updated', 10, 2 );
-	add_filter( 'render_block_' . LAYOUT_GRID_BLOCK_NAME, 'layout_grid_react_to_block_render', 10, 2 );
+if ( wpcom_layout_grid_usage_should_load() ) {
+	add_action( 'wp_after_insert_post', 'wpcom_layout_grid_usage_react_to_post_insert', 10, 4 );
+	add_action( 'add_option_widget_block', 'wpcom_layout_grid_usage_react_to_widget_block_added', 10, 2 );
+	add_action( 'update_option_widget_block', 'wpcom_layout_grid_usage_react_to_widget_block_updated', 10, 2 );
+	add_filter( 'render_block_' . WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, 'wpcom_layout_grid_usage_react_to_block_render', 10, 2 );
 }
 
 /**
@@ -54,7 +54,7 @@ if ( layout_grid_should_load() ) {
  * @param \WP_Post|null $post_before Previous post version (null on insert).
  * @return void
  */
-function layout_grid_react_to_post_insert( $post_id, $post, $update, $post_before ) {
+function wpcom_layout_grid_usage_react_to_post_insert( $post_id, $post, $update, $post_before ) {
 	unset( $update );
 	// Revisions and autosaves are inserted as their own posts, so the
 	// `$post_before` check below can't see the parent post's previous state —
@@ -70,18 +70,18 @@ function layout_grid_react_to_post_insert( $post_id, $post, $update, $post_befor
 	// re-fetch the post via cache (or DB) and return a different content
 	// snapshot than the WP_Post we were handed. Pass the raw content string
 	// directly so the scan is over the exact bytes we observed.
-	if ( ! has_block( LAYOUT_GRID_BLOCK_NAME, (string) $post->post_content ) ) {
+	if ( ! has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, (string) $post->post_content ) ) {
 		return;
 	}
-	if ( $post_before instanceof \WP_Post && has_block( LAYOUT_GRID_BLOCK_NAME, (string) $post_before->post_content ) ) {
+	if ( $post_before instanceof \WP_Post && has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, (string) $post_before->post_content ) ) {
 		return;
 	}
 	$is_importing = defined( 'WP_IMPORTING' ) && WP_IMPORTING;
 	$is_cron      = defined( 'DOING_CRON' ) && DOING_CRON;
-	if ( ! layout_grid_should_log_in_context( $is_importing, $is_cron ) ) {
+	if ( ! wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) ) {
 		return;
 	}
-	$dispatched = layout_grid_log_observation(
+	$dispatched = wpcom_layout_grid_usage_log_observation(
 		array(
 			'surface'   => 'post_insert',
 			'post_type' => (string) $post->post_type,
@@ -92,14 +92,14 @@ function layout_grid_react_to_post_insert( $post_id, $post, $update, $post_befor
 	// observation silently consumes the rate-limit window without recording
 	// anything in Kibana.
 	if ( $dispatched ) {
-		layout_grid_mark_context_seen( $is_importing, $is_cron );
+		wpcom_layout_grid_usage_mark_context_seen( $is_importing, $is_cron );
 	}
 }
 
 /**
  * Read-only rate-limit gate for high-volume insert contexts. Returns false
  * when the per-context transient is already set (we've logged within the
- * window). Pair with `layout_grid_mark_context_seen()` after a successful
+ * window). Pair with `wpcom_layout_grid_usage_mark_context_seen()` after a successful
  * dispatch — splitting the read from the write means a logging failure no
  * longer burns the 24h budget.
  *
@@ -109,8 +109,8 @@ function layout_grid_react_to_post_insert( $post_id, $post, $update, $post_befor
  * @param bool $is_cron      Whether `DOING_CRON` is set.
  * @return bool True if the caller should continue and log; false to skip.
  */
-function layout_grid_should_log_in_context( $is_importing, $is_cron ) {
-	$key = layout_grid_context_transient_key( $is_importing, $is_cron );
+function wpcom_layout_grid_usage_should_log_in_context( $is_importing, $is_cron ) {
+	$key = wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron );
 	if ( null === $key ) {
 		return true;
 	}
@@ -125,8 +125,8 @@ function layout_grid_should_log_in_context( $is_importing, $is_cron ) {
  * @param bool $is_cron      Whether `DOING_CRON` is set.
  * @return void
  */
-function layout_grid_mark_context_seen( $is_importing, $is_cron ) {
-	$key = layout_grid_context_transient_key( $is_importing, $is_cron );
+function wpcom_layout_grid_usage_mark_context_seen( $is_importing, $is_cron ) {
+	$key = wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron );
 	if ( null === $key ) {
 		return;
 	}
@@ -141,12 +141,12 @@ function layout_grid_mark_context_seen( $is_importing, $is_cron ) {
  * @param bool $is_cron      Whether `DOING_CRON` is set.
  * @return string|null
  */
-function layout_grid_context_transient_key( $is_importing, $is_cron ) {
+function wpcom_layout_grid_usage_context_transient_key( $is_importing, $is_cron ) {
 	if ( $is_importing ) {
-		return LAYOUT_GRID_IMPORT_TRANSIENT;
+		return WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT;
 	}
 	if ( $is_cron ) {
-		return LAYOUT_GRID_CRON_TRANSIENT;
+		return WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT;
 	}
 	return null;
 }
@@ -159,12 +159,12 @@ function layout_grid_context_transient_key( $is_importing, $is_cron ) {
  * @param mixed  $value  New option value.
  * @return void
  */
-function layout_grid_react_to_widget_block_added( $option, $value ) {
+function wpcom_layout_grid_usage_react_to_widget_block_added( $option, $value ) {
 	unset( $option );
-	if ( ! layout_grid_widget_value_contains_block( $value ) ) {
+	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
 		return;
 	}
-	layout_grid_log_observation( array( 'surface' => 'widget_add' ) );
+	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_add' ) );
 }
 
 /**
@@ -176,14 +176,14 @@ function layout_grid_react_to_widget_block_added( $option, $value ) {
  * @param mixed $value     New option value.
  * @return void
  */
-function layout_grid_react_to_widget_block_updated( $old_value, $value ) {
-	if ( ! layout_grid_widget_value_contains_block( $value ) ) {
+function wpcom_layout_grid_usage_react_to_widget_block_updated( $old_value, $value ) {
+	if ( ! wpcom_layout_grid_usage_widget_value_contains_block( $value ) ) {
 		return;
 	}
-	if ( layout_grid_widget_value_contains_block( $old_value ) ) {
+	if ( wpcom_layout_grid_usage_widget_value_contains_block( $old_value ) ) {
 		return;
 	}
-	layout_grid_log_observation( array( 'surface' => 'widget_update' ) );
+	wpcom_layout_grid_usage_log_observation( array( 'surface' => 'widget_update' ) );
 }
 
 /**
@@ -198,9 +198,9 @@ function layout_grid_react_to_widget_block_updated( $old_value, $value ) {
  * @param array  $parsed_block  Parsed block (unused).
  * @return string Unchanged content.
  */
-function layout_grid_react_to_block_render( $block_content, $parsed_block ) {
+function wpcom_layout_grid_usage_react_to_block_render( $block_content, $parsed_block ) {
 	unset( $parsed_block );
-	if ( get_option( LAYOUT_GRID_SEEN_OPTION ) ) {
+	if ( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) ) {
 		return $block_content;
 	}
 	// Only persist the sentinel after the dispatch attempt actually went out.
@@ -208,8 +208,8 @@ function layout_grid_react_to_block_render( $block_content, $parsed_block ) {
 	// observation permanently disables the render backstop for this blog,
 	// because the option has no TTL — even after the underlying cause is
 	// fixed, the backstop never fires again.
-	if ( layout_grid_log_observation( array( 'surface' => 'render' ) ) ) {
-		update_option( LAYOUT_GRID_SEEN_OPTION, 1, false );
+	if ( wpcom_layout_grid_usage_log_observation( array( 'surface' => 'render' ) ) ) {
+		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
 	}
 	return $block_content;
 }
@@ -222,7 +222,7 @@ function layout_grid_react_to_block_render( $block_content, $parsed_block ) {
  * @param mixed $value Option value.
  * @return bool
  */
-function layout_grid_widget_value_contains_block( $value ) {
+function wpcom_layout_grid_usage_widget_value_contains_block( $value ) {
 	if ( ! is_array( $value ) ) {
 		return false;
 	}
@@ -231,7 +231,7 @@ function layout_grid_widget_value_contains_block( $value ) {
 			is_array( $widget )
 			&& isset( $widget['content'] )
 			&& is_string( $widget['content'] )
-			&& has_block( LAYOUT_GRID_BLOCK_NAME, $widget['content'] )
+			&& has_block( WPCOM_LAYOUT_GRID_USAGE_BLOCK_NAME, $widget['content'] )
 		) {
 			return true;
 		}
@@ -254,7 +254,7 @@ function layout_grid_widget_value_contains_block( $value ) {
  *                     Caller keys win on collision.
  * @return bool True if the dispatch was attempted; false if short-circuited.
  */
-function layout_grid_log_observation( array $extra ) {
+function wpcom_layout_grid_usage_log_observation( array $extra ) {
 	/**
 	 * Whether layout-grid usage observations should be dispatched to logstash.
 	 * Defaults to true; tests short-circuit this to keep `log2logstash` (and
@@ -264,7 +264,7 @@ function layout_grid_log_observation( array $extra ) {
 	 * @param bool  $enabled Whether to dispatch the log event.
 	 * @param array $extra   Surface-specific properties for the candidate event.
 	 */
-	if ( ! (bool) apply_filters( 'layout_grid_log_enabled', true, $extra ) ) {
+	if ( ! (bool) apply_filters( 'wpcom_layout_grid_usage_log_enabled', true, $extra ) ) {
 		return false;
 	}
 	if ( ! class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom' ) ) {
@@ -295,15 +295,15 @@ function layout_grid_log_observation( array $extra ) {
 			'is_cli'         => defined( 'WP_CLI' ) && WP_CLI,
 			'is_cron'        => defined( 'DOING_CRON' ) && DOING_CRON,
 			'is_importing'   => defined( 'WP_IMPORTING' ) && WP_IMPORTING,
-			'trace'          => layout_grid_attribute_source(),
+			'trace'          => wpcom_layout_grid_usage_attribute_source(),
 		),
 		$extra
 	);
 
 	\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
-		LAYOUT_GRID_LOG_FEATURE,
-		LAYOUT_GRID_LOG_MESSAGE,
-		layout_grid_redact_paths( $payload )
+		WPCOM_LAYOUT_GRID_USAGE_LOG_FEATURE,
+		WPCOM_LAYOUT_GRID_USAGE_LOG_MESSAGE,
+		wpcom_layout_grid_usage_redact_paths( $payload )
 	);
 	return true;
 }
@@ -318,13 +318,13 @@ function layout_grid_log_observation( array $extra ) {
  *
  * @return string[]
  */
-function layout_grid_attribute_source() {
+function wpcom_layout_grid_usage_attribute_source() {
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Intentional: attribution backtrace for a logstash record.
 	$frames    = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 	$self_file = __FILE__;
 	$relevant  = array();
 	foreach ( $frames as $frame ) {
-		$entry = layout_grid_format_attribution_frame( $frame, $self_file );
+		$entry = wpcom_layout_grid_usage_format_attribution_frame( $frame, $self_file );
 		if ( null === $entry ) {
 			continue;
 		}
@@ -337,7 +337,7 @@ function layout_grid_attribute_source() {
 }
 
 /**
- * Pure per-frame predicate for `layout_grid_attribute_source()`. Returns
+ * Pure per-frame predicate for `wpcom_layout_grid_usage_attribute_source()`. Returns
  * `<file>:<line>` when the frame should be kept, or `null` to skip. Extracted
  * so the regex + self-skip behavior can be unit-tested without staging a
  * real PHP call stack.
@@ -354,7 +354,7 @@ function layout_grid_attribute_source() {
  * @param string $self_file Path to compare against for the self-skip.
  * @return string|null
  */
-function layout_grid_format_attribution_frame( $frame, string $self_file ) {
+function wpcom_layout_grid_usage_format_attribution_frame( $frame, string $self_file ) {
 	if ( ! is_array( $frame ) || empty( $frame['file'] ) || ! is_string( $frame['file'] ) ) {
 		return null;
 	}
@@ -376,9 +376,9 @@ function layout_grid_format_attribution_frame( $frame, string $self_file ) {
  * @param mixed $value Scalar or array.
  * @return mixed
  */
-function layout_grid_redact_paths( $value ) {
+function wpcom_layout_grid_usage_redact_paths( $value ) {
 	if ( is_array( $value ) ) {
-		return array_map( 'layout_grid_redact_paths', $value );
+		return array_map( 'wpcom_layout_grid_usage_redact_paths', $value );
 	}
 	if ( ! is_string( $value ) || '' === $value ) {
 		return $value;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -47,8 +47,9 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-trackin
 #[CoversFunction( 'wpcom_layout_grid_usage_log_observation' )]
 class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
-	const WPCOM_LAYOUT_GRID_USAGE_MARKUP = '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->';
-	const PARAGRAPH_MARKUP               = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
+	const LAYOUT_GRID = '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->';
+	const PARAGRAPH   = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
+	const SELF_FILE   = '/srv/htdocs/__wp__/wp-content/mu-plugins/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
 
 	/**
 	 * Captured `$extra` payloads from `spy_observation()`.
@@ -79,8 +80,8 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Records the candidate `$extra` and passes the incoming `$enabled` through
-	 * (which is `false` in tests, set by the module-load `__return_false`).
+	 * Spy filter — records the candidate `$extra` and passes through the
+	 * incoming `$enabled` (false in tests, set by the module-load filter).
 	 *
 	 * @param bool  $enabled
 	 * @param array $extra
@@ -92,8 +93,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Build an in-memory `WP_Post`. Handlers scan `$post->post_content`
-	 * directly, so we don't need to persist to the DB.
+	 * Build an in-memory `WP_Post` for the handler's `post_content` scan.
 	 *
 	 * @param string $content
 	 * @param string $post_type
@@ -111,6 +111,16 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Build a `widget_block` option value with one widget carrying `$content`.
+	 *
+	 * @param string|null $content
+	 * @return array
+	 */
+	private function widget_with( $content ) {
+		return array( '1' => array( 'content' => $content ) );
+	}
+
+	/**
 	 * Widget content scan: true only for entries whose `content` carries the
 	 * layout-grid block; false for every other shape.
 	 */
@@ -118,22 +128,22 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->assertTrue(
 			wpcom_layout_grid_usage_widget_value_contains_block(
 				array(
-					'42' => array( 'content' => self::PARAGRAPH_MARKUP ),
-					'77' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
+					'42' => array( 'content' => self::PARAGRAPH ),
+					'77' => array( 'content' => self::LAYOUT_GRID ),
 				)
 			)
 		);
 
 		$negatives = array(
 			'other blocks only'        => array(
-				'1' => array( 'content' => self::PARAGRAPH_MARKUP ),
+				'1' => array( 'content' => self::PARAGRAPH ),
 				'2' => array( 'content' => '<!-- wp:heading --><h2>x</h2><!-- /wp:heading -->' ),
 			),
 			'missing option (false)'   => false,
 			'null option'              => null,
 			'empty string'             => '',
 			'widget without content'   => array( '1' => array( 'foo' => 'bar' ) ),
-			'widget with null content' => array( '1' => array( 'content' => null ) ),
+			'widget with null content' => $this->widget_with( null ),
 		);
 		foreach ( $negatives as $label => $value ) {
 			$this->assertFalse(
@@ -149,27 +159,25 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 * live PHPUnit stack (no extension frames), so this is the real coverage.
 	 */
 	public function test_format_attribution_frame_filters_and_formats_correctly() {
-		$self_file = '/srv/htdocs/__wp__/wp-content/mu-plugins/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
-
 		$skips = array(
-			'malformed (not array)'       => 'not-a-frame',
-			'malformed (missing file)'    => array( 'function' => 'foo' ),
-			'malformed (file is not str)' => array(
+			'not array'        => 'not-a-frame',
+			'missing file'     => array( 'function' => 'foo' ),
+			'non-string file'  => array(
 				'file' => 42,
 				'line' => 1,
 			),
-			'self frame'                  => array(
-				'file' => $self_file,
+			'self frame'       => array(
+				'file' => self::SELF_FILE,
 				'line' => 99,
 			),
-			'core wp-includes frame'      => array(
+			'core wp-includes' => array(
 				'file' => '/srv/htdocs/__wp__/wp-includes/post.php',
 				'line' => 1234,
 			),
 		);
 		foreach ( $skips as $label => $frame ) {
 			$this->assertNull(
-				wpcom_layout_grid_usage_format_attribution_frame( $frame, $self_file ),
+				wpcom_layout_grid_usage_format_attribution_frame( $frame, self::SELF_FILE ),
 				"expected null for: {$label}"
 			);
 		}
@@ -181,23 +189,23 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		);
 		foreach ( $keeps as $file => $line ) {
 			$this->assertSame(
-				$file . ':' . $line,
+				"{$file}:{$line}",
 				wpcom_layout_grid_usage_format_attribution_frame(
 					array(
 						'file' => $file,
 						'line' => $line,
 					),
-					$self_file
+					self::SELF_FILE
 				)
 			);
 		}
 
-		// Missing `line` field → 0.
+		// Missing `line` field falls back to 0 rather than tripping a notice.
 		$this->assertSame(
 			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php:0',
 			wpcom_layout_grid_usage_format_attribution_frame(
 				array( 'file' => '/srv/htdocs/__wp__/wp-content/plugins/example/example.php' ),
-				$self_file
+				self::SELF_FILE
 			)
 		);
 	}
@@ -236,96 +244,85 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 * posts without the block, `$post_before` already had the block, non-WP_Post.
 	 */
 	public function test_react_to_post_insert_logs_only_on_first_landing() {
-		// New insert (no $post_before).
-		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP, 'page' ), false, null );
+		$with    = $this->make_post( self::LAYOUT_GRID, 'page' );
+		$without = $this->make_post( self::PARAGRAPH );
+
+		// Happy: new insert (no $post_before).
+		wpcom_layout_grid_usage_react_to_post_insert( 0, $with, false, null );
+		$this->assertSame(
+			array(
+				array(
+					'surface'   => 'post_insert',
+					'post_type' => 'page',
+				),
+			),
+			$this->observations
+		);
+
+		// Happy: update where the prior version lacked the block.
+		$this->observations = array();
+		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::LAYOUT_GRID ), true, $without );
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'post_insert', $this->observations[0]['surface'] );
-		$this->assertSame( 'page', $this->observations[0]['post_type'] );
 
-		// Update where the prior version lacked the block.
-		wpcom_layout_grid_usage_react_to_post_insert(
-			0,
-			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
-			true,
-			$this->make_post( self::PARAGRAPH_MARKUP )
-		);
-		$this->assertCount( 2, $this->observations );
-
-		// Negatives must not add to the observation count.
-		$count = count( $this->observations );
-
-		// No block in the new post.
-		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::PARAGRAPH_MARKUP ), false, null );
-
-		// $post_before already had the block.
-		wpcom_layout_grid_usage_react_to_post_insert(
-			0,
-			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
-			true,
-			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP )
-		);
-
-		// Defensive: non-WP_Post inputs.
-		wpcom_layout_grid_usage_react_to_post_insert( 0, null, false, null );
-		wpcom_layout_grid_usage_react_to_post_insert( 0, 'not-a-post', false, null );
-
-		// Revisions short-circuit before the block scan.
+		// Set up a revision for the revisions-skip case.
 		$parent = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
 				'post_type'    => 'post',
 				'post_title'   => 'parent',
-				'post_content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP,
+				'post_content' => self::LAYOUT_GRID,
 			),
 			true
 		);
 		$this->assertIsInt( $parent );
 		$revision_id = _wp_put_post_revision( $parent );
 		$this->assertIsInt( $revision_id );
-		wpcom_layout_grid_usage_react_to_post_insert( $revision_id, get_post( $revision_id ), false, null );
 
-		$this->assertCount( $count, $this->observations );
+		$skips = array(
+			'no block in new post'    => array( 0, $without, false, null ),
+			'prior version had block' => array( 0, $this->make_post( self::LAYOUT_GRID ), true, $this->make_post( self::LAYOUT_GRID ) ),
+			'non-WP_Post: null'       => array( 0, null, false, null ),
+			'non-WP_Post: string'     => array( 0, 'not-a-post', false, null ),
+			'revision'                => array( $revision_id, get_post( $revision_id ), false, null ),
+		);
+		foreach ( $skips as $label => $args ) {
+			$this->observations = array();
+			wpcom_layout_grid_usage_react_to_post_insert( ...$args );
+			$this->assertSame( array(), $this->observations, "expected no observation for: {$label}" );
+		}
 	}
 
 	/**
-	 * Widget handlers log first-landings and skip every other shape: no block
-	 * in the new value, or an update whose old value already had it.
+	 * Widget handlers log first-landings and skip every other shape.
 	 */
 	public function test_react_to_widget_handlers_log_only_on_first_landing() {
 		// Add: initial value has the block.
-		wpcom_layout_grid_usage_react_to_widget_block_added(
-			'widget_block',
-			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
+		wpcom_layout_grid_usage_react_to_widget_block_added( 'widget_block', $this->widget_with( self::LAYOUT_GRID ) );
+		$this->assertSame(
+			array( array( 'surface' => 'widget_add' ) ),
+			$this->observations
 		);
-		$this->assertCount( 1, $this->observations );
-		$this->assertSame( 'widget_add', $this->observations[0]['surface'] );
 
 		// Update: new has, old didn't.
-		wpcom_layout_grid_usage_react_to_widget_block_updated(
-			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) ),
-			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
+		$this->observations = array();
+		wpcom_layout_grid_usage_react_to_widget_block_updated( $this->widget_with( self::PARAGRAPH ), $this->widget_with( self::LAYOUT_GRID ) );
+		$this->assertSame(
+			array( array( 'surface' => 'widget_update' ) ),
+			$this->observations
 		);
-		$this->assertCount( 2, $this->observations );
-		$this->assertSame( 'widget_update', $this->observations[1]['surface'] );
 
-		// Skips must not add to the count.
-		$count = count( $this->observations );
-		// Add: no layout-grid in the initial value.
-		wpcom_layout_grid_usage_react_to_widget_block_added(
-			'widget_block',
-			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
+		// Each skip case must leave the observations array empty.
+		$skips = array(
+			'add: no block in initial' => fn() => wpcom_layout_grid_usage_react_to_widget_block_added( 'widget_block', $this->widget_with( self::PARAGRAPH ) ),
+			'update: old already had'  => fn() => wpcom_layout_grid_usage_react_to_widget_block_updated( $this->widget_with( self::LAYOUT_GRID ), $this->widget_with( self::LAYOUT_GRID ) ),
+			'update: new lacks block'  => fn() => wpcom_layout_grid_usage_react_to_widget_block_updated( $this->widget_with( self::LAYOUT_GRID ), $this->widget_with( self::PARAGRAPH ) ),
 		);
-		// Update: old already had it.
-		wpcom_layout_grid_usage_react_to_widget_block_updated(
-			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) ),
-			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
-		);
-		// Update: new lacks the block.
-		wpcom_layout_grid_usage_react_to_widget_block_updated(
-			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) ),
-			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
-		);
-		$this->assertCount( $count, $this->observations );
+		foreach ( $skips as $label => $invoke ) {
+			$this->observations = array();
+			$invoke();
+			$this->assertSame( array(), $this->observations, "expected no observation for: {$label}" );
+		}
 	}
 
 	/**
@@ -340,15 +337,18 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		// Dispatch blocked → sentinel not persisted.
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
-		$this->assertCount( 1, $this->observations );
-		$this->assertSame( 'render', $this->observations[0]['surface'] );
+		$this->assertSame(
+			array( array( 'surface' => 'render' ) ),
+			$this->observations
+		);
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 
 		// Pre-seed a non-default value (catches accidental overwrites that
 		// `=== 1` checks would miss); the second render must leave it alone.
 		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 7, false );
+		$this->observations = array();
 		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
-		$this->assertCount( 1, $this->observations, 'sentinel-set render must not reach the dispatcher' );
+		$this->assertSame( array(), $this->observations, 'sentinel-set render must not reach the dispatcher' );
 		$this->assertSame( 7, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 	}
 
@@ -357,38 +357,44 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 * writes only the active context's transient, and import wins at both ends.
 	 */
 	public function test_context_gate_is_split_read_then_write_with_import_precedence() {
-		// Read: no transient set → pass-through.
+		// Read pass-through outside import/cron, and never mutates state.
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, false ) );
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
 		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
 		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
-		// Read: pre-set transient affects only its own context; import wins on collision.
+		// Pre-set transient affects only its own context; import wins on collision.
 		set_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT, 1, DAY_IN_SECONDS );
 		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
 		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, true ) );
 		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
 
-		// Write: each call sets only the active context's transient.
-		wpcom_layout_grid_usage_mark_context_seen( false, false );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+		// Each call to mark_context_seen sets only the active context's transient.
+		$writes = array(
+			'no context'         => array( array( false, false ), false, false ),
+			'import only'        => array( array( true, false ), true, false ),
+			'cron only'          => array( array( false, true ), false, true ),
+			'both (import wins)' => array( array( true, true ), true, false ),
+		);
+		foreach ( $writes as $label => $case ) {
+			delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
+			delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
 
-		wpcom_layout_grid_usage_mark_context_seen( true, false );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+			list( $args, $expect_import, $expect_cron ) = $case;
+			wpcom_layout_grid_usage_mark_context_seen( ...$args );
 
-		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
-		wpcom_layout_grid_usage_mark_context_seen( false, true );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
-
-		// Write: import wins on collision.
-		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
-		wpcom_layout_grid_usage_mark_context_seen( true, true );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+			$this->assertSame(
+				$expect_import ? 1 : false,
+				get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ),
+				"import transient for: {$label}"
+			);
+			$this->assertSame(
+				$expect_cron ? 1 : false,
+				get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ),
+				"cron transient for: {$label}"
+			);
+		}
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Tests for the layout-grid usage tracking feature.
+ *
+ * Focused on the pure helpers (widget content check, source attribution
+ * filter, path redaction) plus the render backstop's sentinel side-effect.
+ * The actual logstash dispatch is best-effort plumbing — tested via real
+ * deployment + Kibana verification rather than mocked here.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
+
+/**
+ * @covers ::wpcom_layout_grid_usage_widget_value_contains_block
+ * @covers ::wpcom_layout_grid_usage_attribute_source
+ * @covers ::wpcom_layout_grid_usage_redact_paths
+ * @covers ::wpcom_layout_grid_usage_react_to_block_render
+ */
+#[CoversFunction( 'wpcom_layout_grid_usage_widget_value_contains_block' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_attribute_source' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_redact_paths' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_react_to_block_render' )]
+class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Reset the sentinel option before each test so render-backstop tests
+	 * start from a known state.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION );
+	}
+
+	/**
+	 * Widget content scan returns true when any widget entry carries a
+	 * layout-grid block in its `content` field.
+	 */
+	public function test_widget_value_contains_block_returns_true_for_layout_grid() {
+		$value = array(
+			'42' => array( 'content' => '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->' ),
+			'77' => array( 'content' => '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->' ),
+		);
+		$this->assertTrue( wpcom_layout_grid_usage_widget_value_contains_block( $value ) );
+	}
+
+	/**
+	 * Returns false when no widget entry has the block.
+	 */
+	public function test_widget_value_contains_block_returns_false_for_other_blocks() {
+		$value = array(
+			'1' => array( 'content' => '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->' ),
+			'2' => array( 'content' => '<!-- wp:heading --><h2>x</h2><!-- /wp:heading -->' ),
+		);
+		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( $value ) );
+	}
+
+	/**
+	 * Returns false for non-array input (e.g. `false` from a missing option).
+	 */
+	public function test_widget_value_contains_block_returns_false_for_non_array() {
+		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( false ) );
+		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( null ) );
+		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( '' ) );
+	}
+
+	/**
+	 * Returns false for a widget entry without a `content` field — guards
+	 * against malformed option payloads.
+	 */
+	public function test_widget_value_contains_block_returns_false_for_widget_without_content() {
+		$value = array(
+			'1' => array( 'foo' => 'bar' ),
+			'2' => array( 'content' => null ),
+		);
+		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( $value ) );
+	}
+
+	/**
+	 * Source attribution keeps frames whose file paths point under
+	 * wp-content/plugins, wp-content/themes, or wp-content/mu-plugins and
+	 * drops everything else (core, pluggable, internal callers).
+	 *
+	 * Indirect: we can't easily stage a real call stack containing those
+	 * paths from a test, so this drives the underlying filter directly via
+	 * the same regex.
+	 */
+	public function test_attribute_source_filter_keeps_only_extension_frames() {
+		$frames   = array(
+			'WP_Hook->apply_filters()',
+			'do_action()',
+			'/srv/htdocs/__wp__/wp-includes/post.php:1234',
+			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php:42',
+			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/functions.php:88',
+			'/srv/htdocs/__wp__/wp-content/mu-plugins/example.php:5',
+		);
+		$pattern  = '#/wp-content/(plugins|themes|mu-plugins)/#';
+		$relevant = array_values(
+			array_filter(
+				$frames,
+				static fn( $frame ) => (bool) preg_match( $pattern, $frame )
+			)
+		);
+		$this->assertCount( 3, $relevant );
+		$this->assertStringContainsString( '/plugins/example/', $relevant[0] );
+		$this->assertStringContainsString( '/themes/twentytwentyfive/', $relevant[1] );
+		$this->assertStringContainsString( '/mu-plugins/example.php', $relevant[2] );
+	}
+
+	/**
+	 * Source attribution returns an array (possibly empty) and never fatals.
+	 * In a test environment the only frames in the stack are PHPUnit /
+	 * package internals, so the filter usually yields zero matches — we
+	 * just assert the shape is correct.
+	 */
+	public function test_attribute_source_returns_array() {
+		$result = wpcom_layout_grid_usage_attribute_source();
+		$this->assertIsArray( $result );
+		$this->assertLessThanOrEqual( 8, count( $result ) );
+	}
+
+	/**
+	 * Path redaction swaps WP_CONTENT_DIR prefixes with `.../` in strings.
+	 */
+	public function test_redact_paths_strips_wp_content_dir() {
+		$this->assertTrue( defined( 'WP_CONTENT_DIR' ) && '' !== WP_CONTENT_DIR );
+		$input    = WP_CONTENT_DIR . '/plugins/example/example.php:42';
+		$expected = '.../plugins/example/example.php:42';
+		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
+	}
+
+	/**
+	 * Path redaction swaps ABSPATH prefixes too — exercised for files outside
+	 * wp-content (rare in our payloads but cheap to cover).
+	 */
+	public function test_redact_paths_strips_abspath() {
+		$this->assertTrue( defined( 'ABSPATH' ) && '' !== ABSPATH );
+		$input    = ABSPATH . 'wp-includes/post.php:99';
+		$expected = '.../wp-includes/post.php:99';
+		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
+	}
+
+	/**
+	 * Path redaction recurses into nested arrays so the `trace` and
+	 * `active_plugins` fields get the same treatment as top-level strings.
+	 */
+	public function test_redact_paths_recurses_into_arrays() {
+		$input    = array(
+			'trace'        => array(
+				WP_CONTENT_DIR . '/plugins/a.php:1',
+				WP_CONTENT_DIR . '/themes/b/functions.php:2',
+			),
+			'active_theme' => 'twentytwentyfive',
+			'is_rest'      => true,
+		);
+		$expected = array(
+			'trace'        => array(
+				'.../plugins/a.php:1',
+				'.../themes/b/functions.php:2',
+			),
+			'active_theme' => 'twentytwentyfive',
+			'is_rest'      => true,
+		);
+		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
+	}
+
+	/**
+	 * Render backstop sets the sentinel and returns the rendered content
+	 * unchanged on first invocation.
+	 */
+	public function test_render_backstop_sets_sentinel_and_returns_content() {
+		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+
+		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
+		$result  = wpcom_layout_grid_usage_react_to_block_render( $content, array() );
+
+		$this->assertSame( $content, $result );
+		$this->assertSame( 1, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+	}
+
+	/**
+	 * Render backstop is idempotent: once the sentinel is set, subsequent
+	 * renders short-circuit before the log dispatch (and obviously still
+	 * pass the content through unchanged).
+	 */
+	public function test_render_backstop_noops_when_sentinel_already_set() {
+		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
+
+		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
+		$result  = wpcom_layout_grid_usage_react_to_block_render( $content, array() );
+
+		$this->assertSame( $content, $result );
+		$this->assertSame( 1, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -20,22 +20,26 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-trackin
  * @covers ::wpcom_layout_grid_usage_attribute_source
  * @covers ::wpcom_layout_grid_usage_redact_paths
  * @covers ::wpcom_layout_grid_usage_react_to_block_render
+ * @covers ::wpcom_layout_grid_usage_should_log_in_context
  */
 #[CoversFunction( 'wpcom_layout_grid_usage_widget_value_contains_block' )]
 #[CoversFunction( 'wpcom_layout_grid_usage_attribute_source' )]
 #[CoversFunction( 'wpcom_layout_grid_usage_redact_paths' )]
 #[CoversFunction( 'wpcom_layout_grid_usage_react_to_block_render' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_should_log_in_context' )]
 class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Reset the sentinel option and short-circuit the logstash dispatch
-	 * before each test. Without the filter, the render-backstop test would
-	 * fall through to `Jetpack_Mu_Wpcom::log2logstash()`, which can enqueue
-	 * a real HTTP POST against `public-api.wordpress.com` on shutdown.
+	 * Reset the per-test sentinel state and short-circuit the logstash
+	 * dispatch. Without the filter, the render backstop would fall through to
+	 * `Jetpack_Mu_Wpcom::log2logstash()`, which can enqueue a real HTTP POST
+	 * against `public-api.wordpress.com` on shutdown.
 	 */
 	public function set_up() {
 		parent::set_up();
 		delete_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
 		add_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
 	}
 
@@ -92,13 +96,9 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Source attribution keeps frames whose `file` field points under
-	 * wp-content/plugins, wp-content/themes, or wp-content/mu-plugins and
-	 * drops everything else (core, pluggable, internal callers).
-	 *
-	 * Indirect: we can't stage a real PHP call stack from a test, so this
-	 * drives the same regex the production helper applies to each frame's
-	 * `file` field.
+	 * Documents the regex the production helper applies to each frame's `file`
+	 * field. Asserts exact equality (not contains-substring) so accidental
+	 * widening of the filter is caught.
 	 */
 	public function test_attribute_source_filter_keeps_only_extension_frames() {
 		$files    = array(
@@ -114,22 +114,34 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 				static fn( $file ) => (bool) preg_match( $pattern, $file )
 			)
 		);
-		$this->assertCount( 3, $relevant );
-		$this->assertStringContainsString( '/plugins/example/', $relevant[0] );
-		$this->assertStringContainsString( '/themes/twentytwentyfive/', $relevant[1] );
-		$this->assertStringContainsString( '/mu-plugins/example.php', $relevant[2] );
+		$this->assertSame(
+			array(
+				'/srv/htdocs/__wp__/wp-content/plugins/example/example.php',
+				'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/functions.php',
+				'/srv/htdocs/__wp__/wp-content/mu-plugins/example.php',
+			),
+			$relevant
+		);
 	}
 
 	/**
-	 * Source attribution returns an array (possibly empty) and never fatals.
-	 * In a test environment the only frames in the stack are PHPUnit /
-	 * package internals, so the filter usually yields zero matches — we
-	 * just assert the shape is correct.
+	 * Source attribution returns an array capped at 8 entries, and every entry
+	 * must obey the `<file>:<line>` contract with `<file>` under an extension
+	 * directory. In a PHPUnit context the production call stack normally has
+	 * no extension frames, so the array is typically empty; when it isn't,
+	 * each entry must satisfy the per-entry shape.
 	 */
-	public function test_attribute_source_returns_array() {
+	public function test_attribute_source_returns_well_formed_entries() {
 		$result = wpcom_layout_grid_usage_attribute_source();
 		$this->assertIsArray( $result );
 		$this->assertLessThanOrEqual( 8, count( $result ) );
+		$tracker_file = Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
+		foreach ( $result as $entry ) {
+			$this->assertIsString( $entry );
+			$this->assertMatchesRegularExpression( '#^.+:\d+$#', $entry, 'each entry must be "<file>:<line>"' );
+			$this->assertMatchesRegularExpression( '#/wp-content/(plugins|themes|mu-plugins)/#', $entry, 'each entry must be under an extension directory' );
+			$this->assertStringNotContainsString( $tracker_file, $entry, 'self-frames must be skipped' );
+		}
 	}
 
 	/**
@@ -179,9 +191,9 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Render backstop sets the sentinel and returns the rendered content
-	 * unchanged on first invocation.
+	 * byte-for-byte unchanged on first invocation.
 	 */
-	public function test_render_backstop_sets_sentinel_and_returns_content() {
+	public function test_render_backstop_sets_sentinel_on_first_render() {
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 
 		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
@@ -193,16 +205,66 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Render backstop is idempotent: once the sentinel is set, subsequent
-	 * renders short-circuit before the log dispatch (and obviously still
-	 * pass the content through unchanged).
+	 * renders return the content unchanged, leave the sentinel untouched, and
+	 * never reach the dispatch path.
 	 */
 	public function test_render_backstop_noops_when_sentinel_already_set() {
-		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 1, false );
+		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 7, false );
 
 		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
 		$result  = wpcom_layout_grid_usage_react_to_block_render( $content, array() );
 
 		$this->assertSame( $content, $result );
-		$this->assertSame( 1, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+		// The handler must not overwrite a pre-existing sentinel value.
+		$this->assertSame( 7, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+	}
+
+	/**
+	 * Context gate is a no-op outside import and cron: returns true and
+	 * leaves both transients untouched.
+	 */
+	public function test_should_log_in_context_passes_through_outside_import_and_cron() {
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, false ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+	}
+
+	/**
+	 * Import context: first call returns true and sets the import transient
+	 * (only); second call returns false and does not touch the cron transient.
+	 */
+	public function test_should_log_in_context_rate_limits_import() {
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+
+		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+	}
+
+	/**
+	 * Cron context: first call returns true and sets the cron transient
+	 * (only); second call returns false and does not touch the import
+	 * transient.
+	 */
+	public function test_should_log_in_context_rate_limits_cron() {
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+
+		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+	}
+
+	/**
+	 * When both flags are set (cron-triggered import), import takes
+	 * precedence: only the import transient is written.
+	 */
+	public function test_should_log_in_context_prefers_import_when_both_flags_set() {
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, true ) );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -21,43 +21,43 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 // reach `Jetpack_Mu_Wpcom::log2logstash()` and its shutdown HTTP POST to
 // `public-api.wordpress.com`. Installed once at module load (not per-test)
 // so it survives across test classes and the bootstrap/inter-test windows.
-add_filter( 'layout_grid_log_enabled', '__return_false' );
+add_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
 
 /**
- * @covers ::layout_grid_widget_value_contains_block
- * @covers ::layout_grid_attribute_source
- * @covers ::layout_grid_format_attribution_frame
- * @covers ::layout_grid_redact_paths
- * @covers ::layout_grid_react_to_post_insert
- * @covers ::layout_grid_react_to_widget_block_added
- * @covers ::layout_grid_react_to_widget_block_updated
- * @covers ::layout_grid_react_to_block_render
- * @covers ::layout_grid_should_log_in_context
- * @covers ::layout_grid_mark_context_seen
- * @covers ::layout_grid_context_transient_key
- * @covers ::layout_grid_log_observation
+ * @covers ::wpcom_layout_grid_usage_widget_value_contains_block
+ * @covers ::wpcom_layout_grid_usage_attribute_source
+ * @covers ::wpcom_layout_grid_usage_format_attribution_frame
+ * @covers ::wpcom_layout_grid_usage_redact_paths
+ * @covers ::wpcom_layout_grid_usage_react_to_post_insert
+ * @covers ::wpcom_layout_grid_usage_react_to_widget_block_added
+ * @covers ::wpcom_layout_grid_usage_react_to_widget_block_updated
+ * @covers ::wpcom_layout_grid_usage_react_to_block_render
+ * @covers ::wpcom_layout_grid_usage_should_log_in_context
+ * @covers ::wpcom_layout_grid_usage_mark_context_seen
+ * @covers ::wpcom_layout_grid_usage_context_transient_key
+ * @covers ::wpcom_layout_grid_usage_log_observation
  */
-#[CoversFunction( 'layout_grid_widget_value_contains_block' )]
-#[CoversFunction( 'layout_grid_attribute_source' )]
-#[CoversFunction( 'layout_grid_format_attribution_frame' )]
-#[CoversFunction( 'layout_grid_redact_paths' )]
-#[CoversFunction( 'layout_grid_react_to_post_insert' )]
-#[CoversFunction( 'layout_grid_react_to_widget_block_added' )]
-#[CoversFunction( 'layout_grid_react_to_widget_block_updated' )]
-#[CoversFunction( 'layout_grid_react_to_block_render' )]
-#[CoversFunction( 'layout_grid_should_log_in_context' )]
-#[CoversFunction( 'layout_grid_mark_context_seen' )]
-#[CoversFunction( 'layout_grid_context_transient_key' )]
-#[CoversFunction( 'layout_grid_log_observation' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_widget_value_contains_block' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_attribute_source' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_format_attribution_frame' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_redact_paths' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_react_to_post_insert' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_react_to_widget_block_added' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_react_to_widget_block_updated' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_react_to_block_render' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_should_log_in_context' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_mark_context_seen' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_context_transient_key' )]
+#[CoversFunction( 'wpcom_layout_grid_usage_log_observation' )]
 class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
-	const LAYOUT_GRID_MARKUP = '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->';
-	const PARAGRAPH_MARKUP   = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
+	const WPCOM_LAYOUT_GRID_USAGE_MARKUP = '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->';
+	const PARAGRAPH_MARKUP               = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
 
 	/**
-	 * Captured `$extra` payloads from every `layout_grid_log_enabled` filter
+	 * Captured `$extra` payloads from every `wpcom_layout_grid_usage_log_enabled` filter
 	 * invocation during the current test.
 	 *
 	 * @var array<int, array>
@@ -71,11 +71,11 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		delete_option( LAYOUT_GRID_SEEN_OPTION );
-		delete_transient( LAYOUT_GRID_IMPORT_TRANSIENT );
-		delete_transient( LAYOUT_GRID_CRON_TRANSIENT );
+		delete_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
 		$this->observations = array();
-		add_filter( 'layout_grid_log_enabled', array( $this, 'spy_observation' ), 11, 2 );
+		add_filter( 'wpcom_layout_grid_usage_log_enabled', array( $this, 'spy_observation' ), 11, 2 );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 * The module-load `__return_false` at priority 10 stays installed.
 	 */
 	public function tear_down() {
-		remove_filter( 'layout_grid_log_enabled', array( $this, 'spy_observation' ), 11 );
+		remove_filter( 'wpcom_layout_grid_usage_log_enabled', array( $this, 'spy_observation' ), 11 );
 		parent::tear_down();
 	}
 
@@ -127,10 +127,10 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_widget_value_contains_block_detects_layout_grid_only() {
 		$this->assertTrue(
-			layout_grid_widget_value_contains_block(
+			wpcom_layout_grid_usage_widget_value_contains_block(
 				array(
 					'42' => array( 'content' => self::PARAGRAPH_MARKUP ),
-					'77' => array( 'content' => self::LAYOUT_GRID_MARKUP ),
+					'77' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
 				)
 			)
 		);
@@ -148,7 +148,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		);
 		foreach ( $negatives as $label => $value ) {
 			$this->assertFalse(
-				layout_grid_widget_value_contains_block( $value ),
+				wpcom_layout_grid_usage_widget_value_contains_block( $value ),
 				"expected false for: {$label}"
 			);
 		}
@@ -182,7 +182,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		);
 		foreach ( $skips as $label => $frame ) {
 			$this->assertNull(
-				layout_grid_format_attribution_frame( $frame, $self_file ),
+				wpcom_layout_grid_usage_format_attribution_frame( $frame, $self_file ),
 				"expected null for: {$label}"
 			);
 		}
@@ -195,7 +195,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		foreach ( $keeps as $file => $line ) {
 			$this->assertSame(
 				$file . ':' . $line,
-				layout_grid_format_attribution_frame(
+				wpcom_layout_grid_usage_format_attribution_frame(
 					array(
 						'file' => $file,
 						'line' => $line,
@@ -208,7 +208,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		// Missing `line` field falls back to 0.
 		$this->assertSame(
 			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php:0',
-			layout_grid_format_attribution_frame(
+			wpcom_layout_grid_usage_format_attribution_frame(
 				array( 'file' => '/srv/htdocs/__wp__/wp-content/plugins/example/example.php' ),
 				$self_file
 			)
@@ -241,7 +241,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 			'active_theme' => 'twentytwentyfive',
 			'is_rest'      => true,
 		);
-		$this->assertSame( $expected, layout_grid_redact_paths( $input ) );
+		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
 	}
 
 	/**
@@ -252,15 +252,15 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_react_to_post_insert_logs_only_on_first_landing() {
 		// Happy: new insert (no $post_before).
-		layout_grid_react_to_post_insert( 0, $this->make_post( self::LAYOUT_GRID_MARKUP, 'page' ), false, null );
+		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP, 'page' ), false, null );
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'post_insert', $this->observations[0]['surface'] );
 		$this->assertSame( 'page', $this->observations[0]['post_type'] );
 
 		// Happy: update where the previous version lacked the block.
-		layout_grid_react_to_post_insert(
+		wpcom_layout_grid_usage_react_to_post_insert(
 			0,
-			$this->make_post( self::LAYOUT_GRID_MARKUP ),
+			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
 			true,
 			$this->make_post( self::PARAGRAPH_MARKUP )
 		);
@@ -270,19 +270,19 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$negative_count = count( $this->observations );
 
 		// Skip: post without the block.
-		layout_grid_react_to_post_insert( 0, $this->make_post( self::PARAGRAPH_MARKUP ), false, null );
+		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::PARAGRAPH_MARKUP ), false, null );
 
 		// Skip: update where $post_before already had the block.
-		layout_grid_react_to_post_insert(
+		wpcom_layout_grid_usage_react_to_post_insert(
 			0,
-			$this->make_post( self::LAYOUT_GRID_MARKUP ),
+			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
 			true,
-			$this->make_post( self::LAYOUT_GRID_MARKUP )
+			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP )
 		);
 
 		// Skip: non-WP_Post arguments (defensive).
-		layout_grid_react_to_post_insert( 0, null, false, null );
-		layout_grid_react_to_post_insert( 0, 'not-a-post', false, null );
+		wpcom_layout_grid_usage_react_to_post_insert( 0, null, false, null );
+		wpcom_layout_grid_usage_react_to_post_insert( 0, 'not-a-post', false, null );
 
 		// Skip: revisions short-circuit before the block scan even runs.
 		$parent = wp_insert_post(
@@ -290,14 +290,14 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 				'post_status'  => 'publish',
 				'post_type'    => 'post',
 				'post_title'   => 'parent',
-				'post_content' => self::LAYOUT_GRID_MARKUP,
+				'post_content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP,
 			),
 			true
 		);
 		$this->assertIsInt( $parent );
 		$revision_id = _wp_put_post_revision( $parent );
 		$this->assertIsInt( $revision_id );
-		layout_grid_react_to_post_insert( $revision_id, get_post( $revision_id ), false, null );
+		wpcom_layout_grid_usage_react_to_post_insert( $revision_id, get_post( $revision_id ), false, null );
 
 		$this->assertCount( $negative_count, $this->observations );
 	}
@@ -309,35 +309,35 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_react_to_widget_handlers_log_only_on_first_landing() {
 		// Happy: add fires when the initial value contains the block.
-		layout_grid_react_to_widget_block_added(
+		wpcom_layout_grid_usage_react_to_widget_block_added(
 			'widget_block',
-			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) )
+			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
 		);
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'widget_add', $this->observations[0]['surface'] );
 
 		// Happy: update fires when the new value has the block and the old didn't.
-		layout_grid_react_to_widget_block_updated(
+		wpcom_layout_grid_usage_react_to_widget_block_updated(
 			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) ),
-			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) )
+			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
 		);
 		$this->assertCount( 2, $this->observations );
 		$this->assertSame( 'widget_update', $this->observations[1]['surface'] );
 
 		// Skip: add with no layout-grid in the initial value.
 		$count = count( $this->observations );
-		layout_grid_react_to_widget_block_added(
+		wpcom_layout_grid_usage_react_to_widget_block_added(
 			'widget_block',
 			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
 		);
 		// Skip: update where the old value already had the block.
-		layout_grid_react_to_widget_block_updated(
-			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) ),
-			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) )
+		wpcom_layout_grid_usage_react_to_widget_block_updated(
+			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) ),
+			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
 		);
 		// Skip: update where the new value lacks the block.
-		layout_grid_react_to_widget_block_updated(
-			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) ),
+		wpcom_layout_grid_usage_react_to_widget_block_updated(
+			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) ),
 			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
 		);
 		$this->assertCount( $count, $this->observations );
@@ -358,18 +358,18 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		// First invocation: spy sees the call, but the module-load filter
 		// blocks dispatch (`log_observation` returns false), so the sentinel
 		// is NOT persisted — the backstop stays reversible.
-		$this->assertFalse( get_option( LAYOUT_GRID_SEEN_OPTION ) );
-		$this->assertSame( $content, layout_grid_react_to_block_render( $content, array() ) );
+		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'render', $this->observations[0]['surface'] );
-		$this->assertFalse( get_option( LAYOUT_GRID_SEEN_OPTION ) );
+		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 
 		// Pre-seed a non-default sentinel to catch accidental overwrites: a
 		// subsequent render must short-circuit and leave the value untouched.
-		update_option( LAYOUT_GRID_SEEN_OPTION, 7, false );
-		$this->assertSame( $content, layout_grid_react_to_block_render( $content, array() ) );
+		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 7, false );
+		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
 		$this->assertCount( 1, $this->observations, 'no new observation when sentinel already set' );
-		$this->assertSame( 7, get_option( LAYOUT_GRID_SEEN_OPTION ) );
+		$this->assertSame( 7, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 	}
 
 	/**
@@ -380,38 +380,38 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_context_gate_is_split_read_then_write_with_import_precedence() {
 		// Read-only: no transient set, pass-through everywhere.
-		$this->assertTrue( layout_grid_should_log_in_context( false, false ) );
-		$this->assertTrue( layout_grid_should_log_in_context( true, false ) );
-		$this->assertTrue( layout_grid_should_log_in_context( false, true ) );
-		$this->assertFalse( get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, false ) );
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
 		// Read-only: pre-set transients only affect their own context.
-		set_transient( LAYOUT_GRID_IMPORT_TRANSIENT, 1, DAY_IN_SECONDS );
-		$this->assertFalse( layout_grid_should_log_in_context( true, false ) );
-		$this->assertTrue( layout_grid_should_log_in_context( false, true ) );
+		set_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT, 1, DAY_IN_SECONDS );
+		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
+		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
 		// Precedence: import wins when both flags are set.
-		$this->assertFalse( layout_grid_should_log_in_context( true, true ) );
-		delete_transient( LAYOUT_GRID_IMPORT_TRANSIENT );
+		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, true ) );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
 
 		// Write: each call sets only the active context's transient.
-		layout_grid_mark_context_seen( false, false );
-		$this->assertFalse( get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
+		wpcom_layout_grid_usage_mark_context_seen( false, false );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
-		layout_grid_mark_context_seen( true, false );
-		$this->assertSame( 1, get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
+		wpcom_layout_grid_usage_mark_context_seen( true, false );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
-		delete_transient( LAYOUT_GRID_IMPORT_TRANSIENT );
-		layout_grid_mark_context_seen( false, true );
-		$this->assertFalse( get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
-		$this->assertSame( 1, get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
+		wpcom_layout_grid_usage_mark_context_seen( false, true );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
 		// Precedence: import wins on the write side too.
-		delete_transient( LAYOUT_GRID_CRON_TRANSIENT );
-		layout_grid_mark_context_seen( true, true );
-		$this->assertSame( 1, get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
+		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
+		wpcom_layout_grid_usage_mark_context_seen( true, true );
+		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -262,8 +262,15 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		// Happy: update where the prior version lacked the block.
 		$this->observations = array();
 		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::LAYOUT_GRID ), true, $without );
-		$this->assertCount( 1, $this->observations );
-		$this->assertSame( 'post_insert', $this->observations[0]['surface'] );
+		$this->assertSame(
+			array(
+				array(
+					'surface'   => 'post_insert',
+					'post_type' => 'post',
+				),
+			),
+			$this->observations
+		);
 
 		// Set up a revision for the revisions-skip case.
 		$parent = wp_insert_post(

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -28,12 +28,23 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-trackin
 class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Reset the sentinel option before each test so render-backstop tests
-	 * start from a known state.
+	 * Reset the sentinel option and short-circuit the logstash dispatch
+	 * before each test. Without the filter, the render-backstop test would
+	 * fall through to `Jetpack_Mu_Wpcom::log2logstash()`, which can enqueue
+	 * a real HTTP POST against `public-api.wordpress.com` on shutdown.
 	 */
 	public function set_up() {
 		parent::set_up();
 		delete_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION );
+		add_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
+	}
+
+	/**
+	 * Tear down the test-only logging filter so it doesn't leak across cases.
+	 */
+	public function tear_down() {
+		remove_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
+		parent::tear_down();
 	}
 
 	/**
@@ -81,28 +92,26 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Source attribution keeps frames whose file paths point under
+	 * Source attribution keeps frames whose `file` field points under
 	 * wp-content/plugins, wp-content/themes, or wp-content/mu-plugins and
 	 * drops everything else (core, pluggable, internal callers).
 	 *
-	 * Indirect: we can't easily stage a real call stack containing those
-	 * paths from a test, so this drives the underlying filter directly via
-	 * the same regex.
+	 * Indirect: we can't stage a real PHP call stack from a test, so this
+	 * drives the same regex the production helper applies to each frame's
+	 * `file` field.
 	 */
 	public function test_attribute_source_filter_keeps_only_extension_frames() {
-		$frames   = array(
-			'WP_Hook->apply_filters()',
-			'do_action()',
-			'/srv/htdocs/__wp__/wp-includes/post.php:1234',
-			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php:42',
-			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/functions.php:88',
-			'/srv/htdocs/__wp__/wp-content/mu-plugins/example.php:5',
+		$files    = array(
+			'/srv/htdocs/__wp__/wp-includes/post.php',
+			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php',
+			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/functions.php',
+			'/srv/htdocs/__wp__/wp-content/mu-plugins/example.php',
 		);
 		$pattern  = '#/wp-content/(plugins|themes|mu-plugins)/#';
 		$relevant = array_values(
 			array_filter(
-				$frames,
-				static fn( $frame ) => (bool) preg_match( $pattern, $frame )
+				$files,
+				static fn( $file ) => (bool) preg_match( $pattern, $file )
 			)
 		);
 		$this->assertCount( 3, $relevant );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -1,12 +1,10 @@
 <?php
 /**
- * Tests for the layout-grid usage tracking feature.
- *
- * Drives the detector handlers and supporting helpers directly. A spy filter
- * at priority 11 records every `$extra` payload that reaches the dispatcher,
- * so tests assert what would have been logged without ever reaching
- * `Jetpack_Mu_Wpcom::log2logstash()` — the module-load `__return_false`
- * filter at priority 10 still blocks dispatch, the spy just observes.
+ * Tests for the layout-grid usage tracking feature. A spy filter at
+ * priority 11 records every `$extra` payload that reaches the dispatcher,
+ * while the module-load `__return_false` at priority 10 blocks real dispatch
+ * — tests assert what would have been logged without reaching
+ * `Jetpack_Mu_Wpcom::log2logstash()`.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -14,13 +12,9 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use PHPUnit\Framework\Attributes\CoversFunction;
 
-// Disable real logstash dispatch for the entire phpunit process before the
-// feature file is required — otherwise the hooks it registers at load time
-// (if `Host::is_woa_site()` ever returns true in CI) could fire from any
-// test that inserts a post / saves a widget, and `log_observation()` would
-// reach `Jetpack_Mu_Wpcom::log2logstash()` and its shutdown HTTP POST to
-// `public-api.wordpress.com`. Installed once at module load (not per-test)
-// so it survives across test classes and the bootstrap/inter-test windows.
+// Block real logstash dispatch for the entire phpunit process before the
+// feature file is required. Installed once (not per-test) so the safety net
+// also covers the bootstrap window and any cross-class test runs.
 add_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
@@ -57,17 +51,15 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	const PARAGRAPH_MARKUP               = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
 
 	/**
-	 * Captured `$extra` payloads from every `wpcom_layout_grid_usage_log_enabled` filter
-	 * invocation during the current test.
+	 * Captured `$extra` payloads from `spy_observation()`.
 	 *
 	 * @var array<int, array>
 	 */
 	private $observations = array();
 
 	/**
-	 * Reset per-test sentinel state and install the observation spy. The
-	 * module-load `__return_false` at priority 10 stays in place; the spy is
-	 * additive at priority 11 and captures but does not unblock.
+	 * Reset state and install the per-test spy at priority 11. The module-load
+	 * `__return_false` at priority 10 stays installed.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -79,8 +71,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Remove the per-test spy so its registration doesn't leak across classes.
-	 * The module-load `__return_false` at priority 10 stays installed.
+	 * Drop the per-test spy so it doesn't leak across classes.
 	 */
 	public function tear_down() {
 		remove_filter( 'wpcom_layout_grid_usage_log_enabled', array( $this, 'spy_observation' ), 11 );
@@ -88,11 +79,11 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Observation spy. Records every dispatch attempt; passes through the
-	 * incoming `$enabled` (false in tests, thanks to `__return_false` at 10).
+	 * Records the candidate `$extra` and passes the incoming `$enabled` through
+	 * (which is `false` in tests, set by the module-load `__return_false`).
 	 *
-	 * @param bool  $enabled Whether the dispatcher will proceed.
-	 * @param array $extra   Surface-specific payload.
+	 * @param bool  $enabled
+	 * @param array $extra
 	 * @return bool
 	 */
 	public function spy_observation( $enabled, $extra ) {
@@ -101,12 +92,11 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Build a minimal `WP_Post` instance with the given content. We don't
-	 * persist to the DB — handlers pass `$post->post_content` to `has_block`
-	 * directly, so an in-memory instance is enough.
+	 * Build an in-memory `WP_Post`. Handlers scan `$post->post_content`
+	 * directly, so we don't need to persist to the DB.
 	 *
-	 * @param string $content   Post content (block markup).
-	 * @param string $post_type Defaults to `'post'`.
+	 * @param string $content
+	 * @param string $post_type
 	 * @return \WP_Post
 	 */
 	private function make_post( $content, $post_type = 'post' ) {
@@ -121,9 +111,8 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Widget content scan returns true only when a widget entry's `content`
-	 * field carries the layout-grid block; every other shape (other blocks,
-	 * non-array option values, malformed widget entries) returns false.
+	 * Widget content scan: true only for entries whose `content` carries the
+	 * layout-grid block; false for every other shape.
 	 */
 	public function test_widget_value_contains_block_detects_layout_grid_only() {
 		$this->assertTrue(
@@ -155,11 +144,9 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The per-frame predicate skips malformed frames, the tracker's own
-	 * frames, and frames outside `wp-content/(plugins|themes|mu-plugins)/`,
-	 * and renders survivors as `<file>:<line>`. This is the real coverage
-	 * for the regex + self-skip behavior — `attribute_source()` itself runs
-	 * against the live PHPUnit stack which has no extension frames.
+	 * Per-frame predicate: skip malformed/self/core frames, format extension
+	 * frames as `<file>:<line>`. `attribute_source()` itself runs against the
+	 * live PHPUnit stack (no extension frames), so this is the real coverage.
 	 */
 	public function test_format_attribution_frame_filters_and_formats_correctly() {
 		$self_file = '/srv/htdocs/__wp__/wp-content/mu-plugins/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
@@ -188,9 +175,9 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		}
 
 		$keeps = array(
-			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php'      => 42,
-			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/x.php'    => 88,
-			'/srv/htdocs/__wp__/wp-content/mu-plugins/other.php'             => 5,
+			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php'   => 42,
+			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/x.php' => 88,
+			'/srv/htdocs/__wp__/wp-content/mu-plugins/other.php'          => 5,
 		);
 		foreach ( $keeps as $file => $line ) {
 			$this->assertSame(
@@ -205,7 +192,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 			);
 		}
 
-		// Missing `line` field falls back to 0.
+		// Missing `line` field → 0.
 		$this->assertSame(
 			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php:0',
 			wpcom_layout_grid_usage_format_attribution_frame(
@@ -216,8 +203,8 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Path redaction strips WP_CONTENT_DIR and ABSPATH prefixes, recurses
-	 * into nested arrays, and leaves non-string scalars unchanged.
+	 * Path redaction strips WP_CONTENT_DIR / ABSPATH prefixes and recurses
+	 * into arrays.
 	 */
 	public function test_redact_paths_strips_install_paths_recursively() {
 		$this->assertTrue( defined( 'WP_CONTENT_DIR' ) && '' !== WP_CONTENT_DIR );
@@ -245,19 +232,17 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * `react_to_post_insert` logs on first-landing (new insert, or an update
-	 * whose previous version lacked the block) and short-circuits on every
-	 * other shape: revisions, posts without the block, updates where
-	 * `$post_before` already had the block, and non-WP_Post args.
+	 * Post handler logs first-landings and skips every other shape: revisions,
+	 * posts without the block, `$post_before` already had the block, non-WP_Post.
 	 */
 	public function test_react_to_post_insert_logs_only_on_first_landing() {
-		// Happy: new insert (no $post_before).
+		// New insert (no $post_before).
 		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP, 'page' ), false, null );
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'post_insert', $this->observations[0]['surface'] );
 		$this->assertSame( 'page', $this->observations[0]['post_type'] );
 
-		// Happy: update where the previous version lacked the block.
+		// Update where the prior version lacked the block.
 		wpcom_layout_grid_usage_react_to_post_insert(
 			0,
 			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
@@ -266,13 +251,13 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		);
 		$this->assertCount( 2, $this->observations );
 
-		// Negatives — each must not capture an additional observation.
-		$negative_count = count( $this->observations );
+		// Negatives must not add to the observation count.
+		$count = count( $this->observations );
 
-		// Skip: post without the block.
+		// No block in the new post.
 		wpcom_layout_grid_usage_react_to_post_insert( 0, $this->make_post( self::PARAGRAPH_MARKUP ), false, null );
 
-		// Skip: update where $post_before already had the block.
+		// $post_before already had the block.
 		wpcom_layout_grid_usage_react_to_post_insert(
 			0,
 			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ),
@@ -280,11 +265,11 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 			$this->make_post( self::WPCOM_LAYOUT_GRID_USAGE_MARKUP )
 		);
 
-		// Skip: non-WP_Post arguments (defensive).
+		// Defensive: non-WP_Post inputs.
 		wpcom_layout_grid_usage_react_to_post_insert( 0, null, false, null );
 		wpcom_layout_grid_usage_react_to_post_insert( 0, 'not-a-post', false, null );
 
-		// Skip: revisions short-circuit before the block scan even runs.
+		// Revisions short-circuit before the block scan.
 		$parent = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
@@ -299,16 +284,15 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->assertIsInt( $revision_id );
 		wpcom_layout_grid_usage_react_to_post_insert( $revision_id, get_post( $revision_id ), false, null );
 
-		$this->assertCount( $negative_count, $this->observations );
+		$this->assertCount( $count, $this->observations );
 	}
 
 	/**
-	 * The widget detectors log on first-landing for both option add and
-	 * option update, and short-circuit on every other shape: no layout-grid
-	 * in the new value, or an update whose old value already had the block.
+	 * Widget handlers log first-landings and skip every other shape: no block
+	 * in the new value, or an update whose old value already had it.
 	 */
 	public function test_react_to_widget_handlers_log_only_on_first_landing() {
-		// Happy: add fires when the initial value contains the block.
+		// Add: initial value has the block.
 		wpcom_layout_grid_usage_react_to_widget_block_added(
 			'widget_block',
 			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
@@ -316,7 +300,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'widget_add', $this->observations[0]['surface'] );
 
-		// Happy: update fires when the new value has the block and the old didn't.
+		// Update: new has, old didn't.
 		wpcom_layout_grid_usage_react_to_widget_block_updated(
 			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) ),
 			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
@@ -324,18 +308,19 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->assertCount( 2, $this->observations );
 		$this->assertSame( 'widget_update', $this->observations[1]['surface'] );
 
-		// Skip: add with no layout-grid in the initial value.
+		// Skips must not add to the count.
 		$count = count( $this->observations );
+		// Add: no layout-grid in the initial value.
 		wpcom_layout_grid_usage_react_to_widget_block_added(
 			'widget_block',
 			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
 		);
-		// Skip: update where the old value already had the block.
+		// Update: old already had it.
 		wpcom_layout_grid_usage_react_to_widget_block_updated(
 			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) ),
 			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) )
 		);
-		// Skip: update where the new value lacks the block.
+		// Update: new lacks the block.
 		wpcom_layout_grid_usage_react_to_widget_block_updated(
 			array( '1' => array( 'content' => self::WPCOM_LAYOUT_GRID_USAGE_MARKUP ) ),
 			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
@@ -344,53 +329,45 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Render backstop captures the observation on first invocation but does
-	 * NOT persist the sentinel when the dispatch attempt was blocked — this
-	 * is the bugfix: a filter-blocked render must leave the backstop
-	 * reversible, otherwise the sentinel would lock the blog out of
-	 * attribution forever once the filter is removed. Then verifies the
-	 * idempotency property: once the sentinel IS set, subsequent renders
-	 * short-circuit before the dispatcher, leaving the existing value alone.
+	 * Render backstop: spy sees the call, but a filter-blocked dispatch must
+	 * NOT persist the sentinel (otherwise the backstop locks out for the blog
+	 * forever, since the option has no TTL). Once the sentinel is set,
+	 * subsequent renders short-circuit and leave its value alone.
 	 */
 	public function test_render_backstop_dispatch_gated_then_idempotent() {
 		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
 
-		// First invocation: spy sees the call, but the module-load filter
-		// blocks dispatch (`log_observation` returns false), so the sentinel
-		// is NOT persisted — the backstop stays reversible.
+		// Dispatch blocked → sentinel not persisted.
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
 		$this->assertCount( 1, $this->observations );
 		$this->assertSame( 'render', $this->observations[0]['surface'] );
 		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 
-		// Pre-seed a non-default sentinel to catch accidental overwrites: a
-		// subsequent render must short-circuit and leave the value untouched.
+		// Pre-seed a non-default value (catches accidental overwrites that
+		// `=== 1` checks would miss); the second render must leave it alone.
 		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 7, false );
 		$this->assertSame( $content, wpcom_layout_grid_usage_react_to_block_render( $content, array() ) );
-		$this->assertCount( 1, $this->observations, 'no new observation when sentinel already set' );
+		$this->assertCount( 1, $this->observations, 'sentinel-set render must not reach the dispatcher' );
 		$this->assertSame( 7, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
 	}
 
 	/**
-	 * The split context gate is read-only and write-only respectively:
-	 * `should_log_in_context` never mutates state, `mark_context_seen` writes
-	 * only the active context's transient, and import takes precedence at
-	 * both ends when both flags are set.
+	 * Context gate: `should_log_in_context` is read-only, `mark_context_seen`
+	 * writes only the active context's transient, and import wins at both ends.
 	 */
 	public function test_context_gate_is_split_read_then_write_with_import_precedence() {
-		// Read-only: no transient set, pass-through everywhere.
+		// Read: no transient set → pass-through.
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, false ) );
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
 		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
 		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
-		// Read-only: pre-set transients only affect their own context.
+		// Read: pre-set transient affects only its own context; import wins on collision.
 		set_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT, 1, DAY_IN_SECONDS );
 		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
 		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
-		// Precedence: import wins when both flags are set.
 		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, true ) );
 		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
 
@@ -408,7 +385,7 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
 		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
 
-		// Precedence: import wins on the write side too.
+		// Write: import wins on collision.
 		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
 		wpcom_layout_grid_usage_mark_context_seen( true, true );
 		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/layout-grid-usage-tracking/Layout_Grid_Usage_Tracking_Test.php
@@ -2,10 +2,11 @@
 /**
  * Tests for the layout-grid usage tracking feature.
  *
- * Focused on the pure helpers (widget content check, source attribution
- * filter, path redaction) plus the render backstop's sentinel side-effect.
- * The actual logstash dispatch is best-effort plumbing — tested via real
- * deployment + Kibana verification rather than mocked here.
+ * Drives the detector handlers and supporting helpers directly. A spy filter
+ * at priority 11 records every `$extra` payload that reaches the dispatcher,
+ * so tests assert what would have been logged without ever reaching
+ * `Jetpack_Mu_Wpcom::log2logstash()` — the module-load `__return_false`
+ * filter at priority 10 still blocks dispatch, the spy just observes.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -13,167 +14,220 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use PHPUnit\Framework\Attributes\CoversFunction;
 
+// Disable real logstash dispatch for the entire phpunit process before the
+// feature file is required — otherwise the hooks it registers at load time
+// (if `Host::is_woa_site()` ever returns true in CI) could fire from any
+// test that inserts a post / saves a widget, and `log_observation()` would
+// reach `Jetpack_Mu_Wpcom::log2logstash()` and its shutdown HTTP POST to
+// `public-api.wordpress.com`. Installed once at module load (not per-test)
+// so it survives across test classes and the bootstrap/inter-test windows.
+add_filter( 'layout_grid_log_enabled', '__return_false' );
+
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
 
 /**
- * @covers ::wpcom_layout_grid_usage_widget_value_contains_block
- * @covers ::wpcom_layout_grid_usage_attribute_source
- * @covers ::wpcom_layout_grid_usage_redact_paths
- * @covers ::wpcom_layout_grid_usage_react_to_block_render
- * @covers ::wpcom_layout_grid_usage_should_log_in_context
+ * @covers ::layout_grid_widget_value_contains_block
+ * @covers ::layout_grid_attribute_source
+ * @covers ::layout_grid_format_attribution_frame
+ * @covers ::layout_grid_redact_paths
+ * @covers ::layout_grid_react_to_post_insert
+ * @covers ::layout_grid_react_to_widget_block_added
+ * @covers ::layout_grid_react_to_widget_block_updated
+ * @covers ::layout_grid_react_to_block_render
+ * @covers ::layout_grid_should_log_in_context
+ * @covers ::layout_grid_mark_context_seen
+ * @covers ::layout_grid_context_transient_key
+ * @covers ::layout_grid_log_observation
  */
-#[CoversFunction( 'wpcom_layout_grid_usage_widget_value_contains_block' )]
-#[CoversFunction( 'wpcom_layout_grid_usage_attribute_source' )]
-#[CoversFunction( 'wpcom_layout_grid_usage_redact_paths' )]
-#[CoversFunction( 'wpcom_layout_grid_usage_react_to_block_render' )]
-#[CoversFunction( 'wpcom_layout_grid_usage_should_log_in_context' )]
+#[CoversFunction( 'layout_grid_widget_value_contains_block' )]
+#[CoversFunction( 'layout_grid_attribute_source' )]
+#[CoversFunction( 'layout_grid_format_attribution_frame' )]
+#[CoversFunction( 'layout_grid_redact_paths' )]
+#[CoversFunction( 'layout_grid_react_to_post_insert' )]
+#[CoversFunction( 'layout_grid_react_to_widget_block_added' )]
+#[CoversFunction( 'layout_grid_react_to_widget_block_updated' )]
+#[CoversFunction( 'layout_grid_react_to_block_render' )]
+#[CoversFunction( 'layout_grid_should_log_in_context' )]
+#[CoversFunction( 'layout_grid_mark_context_seen' )]
+#[CoversFunction( 'layout_grid_context_transient_key' )]
+#[CoversFunction( 'layout_grid_log_observation' )]
 class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 
+	const LAYOUT_GRID_MARKUP = '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->';
+	const PARAGRAPH_MARKUP   = '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->';
+
 	/**
-	 * Reset the per-test sentinel state and short-circuit the logstash
-	 * dispatch. Without the filter, the render backstop would fall through to
-	 * `Jetpack_Mu_Wpcom::log2logstash()`, which can enqueue a real HTTP POST
-	 * against `public-api.wordpress.com` on shutdown.
+	 * Captured `$extra` payloads from every `layout_grid_log_enabled` filter
+	 * invocation during the current test.
+	 *
+	 * @var array<int, array>
+	 */
+	private $observations = array();
+
+	/**
+	 * Reset per-test sentinel state and install the observation spy. The
+	 * module-load `__return_false` at priority 10 stays in place; the spy is
+	 * additive at priority 11 and captures but does not unblock.
 	 */
 	public function set_up() {
 		parent::set_up();
-		delete_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION );
-		delete_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT );
-		delete_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT );
-		add_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
+		delete_option( LAYOUT_GRID_SEEN_OPTION );
+		delete_transient( LAYOUT_GRID_IMPORT_TRANSIENT );
+		delete_transient( LAYOUT_GRID_CRON_TRANSIENT );
+		$this->observations = array();
+		add_filter( 'layout_grid_log_enabled', array( $this, 'spy_observation' ), 11, 2 );
 	}
 
 	/**
-	 * Tear down the test-only logging filter so it doesn't leak across cases.
+	 * Remove the per-test spy so its registration doesn't leak across classes.
+	 * The module-load `__return_false` at priority 10 stays installed.
 	 */
 	public function tear_down() {
-		remove_filter( 'wpcom_layout_grid_usage_log_enabled', '__return_false' );
+		remove_filter( 'layout_grid_log_enabled', array( $this, 'spy_observation' ), 11 );
 		parent::tear_down();
 	}
 
 	/**
-	 * Widget content scan returns true when any widget entry carries a
-	 * layout-grid block in its `content` field.
+	 * Observation spy. Records every dispatch attempt; passes through the
+	 * incoming `$enabled` (false in tests, thanks to `__return_false` at 10).
+	 *
+	 * @param bool  $enabled Whether the dispatcher will proceed.
+	 * @param array $extra   Surface-specific payload.
+	 * @return bool
 	 */
-	public function test_widget_value_contains_block_returns_true_for_layout_grid() {
-		$value = array(
-			'42' => array( 'content' => '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->' ),
-			'77' => array( 'content' => '<!-- wp:jetpack/layout-grid --><div></div><!-- /wp:jetpack/layout-grid -->' ),
-		);
-		$this->assertTrue( wpcom_layout_grid_usage_widget_value_contains_block( $value ) );
+	public function spy_observation( $enabled, $extra ) {
+		$this->observations[] = $extra;
+		return $enabled;
 	}
 
 	/**
-	 * Returns false when no widget entry has the block.
+	 * Build a minimal `WP_Post` instance with the given content. We don't
+	 * persist to the DB — handlers pass `$post->post_content` to `has_block`
+	 * directly, so an in-memory instance is enough.
+	 *
+	 * @param string $content   Post content (block markup).
+	 * @param string $post_type Defaults to `'post'`.
+	 * @return \WP_Post
 	 */
-	public function test_widget_value_contains_block_returns_false_for_other_blocks() {
-		$value = array(
-			'1' => array( 'content' => '<!-- wp:paragraph --><p>hi</p><!-- /wp:paragraph -->' ),
-			'2' => array( 'content' => '<!-- wp:heading --><h2>x</h2><!-- /wp:heading -->' ),
-		);
-		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( $value ) );
-	}
-
-	/**
-	 * Returns false for non-array input (e.g. `false` from a missing option).
-	 */
-	public function test_widget_value_contains_block_returns_false_for_non_array() {
-		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( false ) );
-		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( null ) );
-		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( '' ) );
-	}
-
-	/**
-	 * Returns false for a widget entry without a `content` field — guards
-	 * against malformed option payloads.
-	 */
-	public function test_widget_value_contains_block_returns_false_for_widget_without_content() {
-		$value = array(
-			'1' => array( 'foo' => 'bar' ),
-			'2' => array( 'content' => null ),
-		);
-		$this->assertFalse( wpcom_layout_grid_usage_widget_value_contains_block( $value ) );
-	}
-
-	/**
-	 * Documents the regex the production helper applies to each frame's `file`
-	 * field. Asserts exact equality (not contains-substring) so accidental
-	 * widening of the filter is caught.
-	 */
-	public function test_attribute_source_filter_keeps_only_extension_frames() {
-		$files    = array(
-			'/srv/htdocs/__wp__/wp-includes/post.php',
-			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php',
-			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/functions.php',
-			'/srv/htdocs/__wp__/wp-content/mu-plugins/example.php',
-		);
-		$pattern  = '#/wp-content/(plugins|themes|mu-plugins)/#';
-		$relevant = array_values(
-			array_filter(
-				$files,
-				static fn( $file ) => (bool) preg_match( $pattern, $file )
+	private function make_post( $content, $post_type = 'post' ) {
+		return new \WP_Post(
+			(object) array(
+				'ID'           => 0,
+				'post_type'    => $post_type,
+				'post_content' => $content,
+				'post_status'  => 'publish',
 			)
 		);
-		$this->assertSame(
-			array(
-				'/srv/htdocs/__wp__/wp-content/plugins/example/example.php',
-				'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/functions.php',
-				'/srv/htdocs/__wp__/wp-content/mu-plugins/example.php',
-			),
-			$relevant
-		);
 	}
 
 	/**
-	 * Source attribution returns an array capped at 8 entries, and every entry
-	 * must obey the `<file>:<line>` contract with `<file>` under an extension
-	 * directory. In a PHPUnit context the production call stack normally has
-	 * no extension frames, so the array is typically empty; when it isn't,
-	 * each entry must satisfy the per-entry shape.
+	 * Widget content scan returns true only when a widget entry's `content`
+	 * field carries the layout-grid block; every other shape (other blocks,
+	 * non-array option values, malformed widget entries) returns false.
 	 */
-	public function test_attribute_source_returns_well_formed_entries() {
-		$result = wpcom_layout_grid_usage_attribute_source();
-		$this->assertIsArray( $result );
-		$this->assertLessThanOrEqual( 8, count( $result ) );
-		$tracker_file = Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
-		foreach ( $result as $entry ) {
-			$this->assertIsString( $entry );
-			$this->assertMatchesRegularExpression( '#^.+:\d+$#', $entry, 'each entry must be "<file>:<line>"' );
-			$this->assertMatchesRegularExpression( '#/wp-content/(plugins|themes|mu-plugins)/#', $entry, 'each entry must be under an extension directory' );
-			$this->assertStringNotContainsString( $tracker_file, $entry, 'self-frames must be skipped' );
+	public function test_widget_value_contains_block_detects_layout_grid_only() {
+		$this->assertTrue(
+			layout_grid_widget_value_contains_block(
+				array(
+					'42' => array( 'content' => self::PARAGRAPH_MARKUP ),
+					'77' => array( 'content' => self::LAYOUT_GRID_MARKUP ),
+				)
+			)
+		);
+
+		$negatives = array(
+			'other blocks only'        => array(
+				'1' => array( 'content' => self::PARAGRAPH_MARKUP ),
+				'2' => array( 'content' => '<!-- wp:heading --><h2>x</h2><!-- /wp:heading -->' ),
+			),
+			'missing option (false)'   => false,
+			'null option'              => null,
+			'empty string'             => '',
+			'widget without content'   => array( '1' => array( 'foo' => 'bar' ) ),
+			'widget with null content' => array( '1' => array( 'content' => null ) ),
+		);
+		foreach ( $negatives as $label => $value ) {
+			$this->assertFalse(
+				layout_grid_widget_value_contains_block( $value ),
+				"expected false for: {$label}"
+			);
 		}
 	}
 
 	/**
-	 * Path redaction swaps WP_CONTENT_DIR prefixes with `.../` in strings.
+	 * The per-frame predicate skips malformed frames, the tracker's own
+	 * frames, and frames outside `wp-content/(plugins|themes|mu-plugins)/`,
+	 * and renders survivors as `<file>:<line>`. This is the real coverage
+	 * for the regex + self-skip behavior — `attribute_source()` itself runs
+	 * against the live PHPUnit stack which has no extension frames.
 	 */
-	public function test_redact_paths_strips_wp_content_dir() {
+	public function test_format_attribution_frame_filters_and_formats_correctly() {
+		$self_file = '/srv/htdocs/__wp__/wp-content/mu-plugins/jetpack-mu-wpcom/src/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
+
+		$skips = array(
+			'malformed (not array)'       => 'not-a-frame',
+			'malformed (missing file)'    => array( 'function' => 'foo' ),
+			'malformed (file is not str)' => array(
+				'file' => 42,
+				'line' => 1,
+			),
+			'self frame'                  => array(
+				'file' => $self_file,
+				'line' => 99,
+			),
+			'core wp-includes frame'      => array(
+				'file' => '/srv/htdocs/__wp__/wp-includes/post.php',
+				'line' => 1234,
+			),
+		);
+		foreach ( $skips as $label => $frame ) {
+			$this->assertNull(
+				layout_grid_format_attribution_frame( $frame, $self_file ),
+				"expected null for: {$label}"
+			);
+		}
+
+		$keeps = array(
+			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php'      => 42,
+			'/srv/htdocs/__wp__/wp-content/themes/twentytwentyfive/x.php'    => 88,
+			'/srv/htdocs/__wp__/wp-content/mu-plugins/other.php'             => 5,
+		);
+		foreach ( $keeps as $file => $line ) {
+			$this->assertSame(
+				$file . ':' . $line,
+				layout_grid_format_attribution_frame(
+					array(
+						'file' => $file,
+						'line' => $line,
+					),
+					$self_file
+				)
+			);
+		}
+
+		// Missing `line` field falls back to 0.
+		$this->assertSame(
+			'/srv/htdocs/__wp__/wp-content/plugins/example/example.php:0',
+			layout_grid_format_attribution_frame(
+				array( 'file' => '/srv/htdocs/__wp__/wp-content/plugins/example/example.php' ),
+				$self_file
+			)
+		);
+	}
+
+	/**
+	 * Path redaction strips WP_CONTENT_DIR and ABSPATH prefixes, recurses
+	 * into nested arrays, and leaves non-string scalars unchanged.
+	 */
+	public function test_redact_paths_strips_install_paths_recursively() {
 		$this->assertTrue( defined( 'WP_CONTENT_DIR' ) && '' !== WP_CONTENT_DIR );
-		$input    = WP_CONTENT_DIR . '/plugins/example/example.php:42';
-		$expected = '.../plugins/example/example.php:42';
-		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
-	}
-
-	/**
-	 * Path redaction swaps ABSPATH prefixes too — exercised for files outside
-	 * wp-content (rare in our payloads but cheap to cover).
-	 */
-	public function test_redact_paths_strips_abspath() {
 		$this->assertTrue( defined( 'ABSPATH' ) && '' !== ABSPATH );
-		$input    = ABSPATH . 'wp-includes/post.php:99';
-		$expected = '.../wp-includes/post.php:99';
-		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
-	}
 
-	/**
-	 * Path redaction recurses into nested arrays so the `trace` and
-	 * `active_plugins` fields get the same treatment as top-level strings.
-	 */
-	public function test_redact_paths_recurses_into_arrays() {
 		$input    = array(
 			'trace'        => array(
 				WP_CONTENT_DIR . '/plugins/a.php:1',
 				WP_CONTENT_DIR . '/themes/b/functions.php:2',
+				ABSPATH . 'wp-includes/post.php:99',
 			),
 			'active_theme' => 'twentytwentyfive',
 			'is_rest'      => true,
@@ -182,89 +236,182 @@ class Layout_Grid_Usage_Tracking_Test extends \WorDBless\BaseTestCase {
 			'trace'        => array(
 				'.../plugins/a.php:1',
 				'.../themes/b/functions.php:2',
+				'.../wp-includes/post.php:99',
 			),
 			'active_theme' => 'twentytwentyfive',
 			'is_rest'      => true,
 		);
-		$this->assertSame( $expected, wpcom_layout_grid_usage_redact_paths( $input ) );
+		$this->assertSame( $expected, layout_grid_redact_paths( $input ) );
 	}
 
 	/**
-	 * Render backstop sets the sentinel and returns the rendered content
-	 * byte-for-byte unchanged on first invocation.
+	 * `react_to_post_insert` logs on first-landing (new insert, or an update
+	 * whose previous version lacked the block) and short-circuits on every
+	 * other shape: revisions, posts without the block, updates where
+	 * `$post_before` already had the block, and non-WP_Post args.
 	 */
-	public function test_render_backstop_sets_sentinel_on_first_render() {
-		$this->assertFalse( get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+	public function test_react_to_post_insert_logs_only_on_first_landing() {
+		// Happy: new insert (no $post_before).
+		layout_grid_react_to_post_insert( 0, $this->make_post( self::LAYOUT_GRID_MARKUP, 'page' ), false, null );
+		$this->assertCount( 1, $this->observations );
+		$this->assertSame( 'post_insert', $this->observations[0]['surface'] );
+		$this->assertSame( 'page', $this->observations[0]['post_type'] );
 
+		// Happy: update where the previous version lacked the block.
+		layout_grid_react_to_post_insert(
+			0,
+			$this->make_post( self::LAYOUT_GRID_MARKUP ),
+			true,
+			$this->make_post( self::PARAGRAPH_MARKUP )
+		);
+		$this->assertCount( 2, $this->observations );
+
+		// Negatives — each must not capture an additional observation.
+		$negative_count = count( $this->observations );
+
+		// Skip: post without the block.
+		layout_grid_react_to_post_insert( 0, $this->make_post( self::PARAGRAPH_MARKUP ), false, null );
+
+		// Skip: update where $post_before already had the block.
+		layout_grid_react_to_post_insert(
+			0,
+			$this->make_post( self::LAYOUT_GRID_MARKUP ),
+			true,
+			$this->make_post( self::LAYOUT_GRID_MARKUP )
+		);
+
+		// Skip: non-WP_Post arguments (defensive).
+		layout_grid_react_to_post_insert( 0, null, false, null );
+		layout_grid_react_to_post_insert( 0, 'not-a-post', false, null );
+
+		// Skip: revisions short-circuit before the block scan even runs.
+		$parent = wp_insert_post(
+			array(
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_title'   => 'parent',
+				'post_content' => self::LAYOUT_GRID_MARKUP,
+			),
+			true
+		);
+		$this->assertIsInt( $parent );
+		$revision_id = _wp_put_post_revision( $parent );
+		$this->assertIsInt( $revision_id );
+		layout_grid_react_to_post_insert( $revision_id, get_post( $revision_id ), false, null );
+
+		$this->assertCount( $negative_count, $this->observations );
+	}
+
+	/**
+	 * The widget detectors log on first-landing for both option add and
+	 * option update, and short-circuit on every other shape: no layout-grid
+	 * in the new value, or an update whose old value already had the block.
+	 */
+	public function test_react_to_widget_handlers_log_only_on_first_landing() {
+		// Happy: add fires when the initial value contains the block.
+		layout_grid_react_to_widget_block_added(
+			'widget_block',
+			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) )
+		);
+		$this->assertCount( 1, $this->observations );
+		$this->assertSame( 'widget_add', $this->observations[0]['surface'] );
+
+		// Happy: update fires when the new value has the block and the old didn't.
+		layout_grid_react_to_widget_block_updated(
+			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) ),
+			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) )
+		);
+		$this->assertCount( 2, $this->observations );
+		$this->assertSame( 'widget_update', $this->observations[1]['surface'] );
+
+		// Skip: add with no layout-grid in the initial value.
+		$count = count( $this->observations );
+		layout_grid_react_to_widget_block_added(
+			'widget_block',
+			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
+		);
+		// Skip: update where the old value already had the block.
+		layout_grid_react_to_widget_block_updated(
+			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) ),
+			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) )
+		);
+		// Skip: update where the new value lacks the block.
+		layout_grid_react_to_widget_block_updated(
+			array( '1' => array( 'content' => self::LAYOUT_GRID_MARKUP ) ),
+			array( '1' => array( 'content' => self::PARAGRAPH_MARKUP ) )
+		);
+		$this->assertCount( $count, $this->observations );
+	}
+
+	/**
+	 * Render backstop captures the observation on first invocation but does
+	 * NOT persist the sentinel when the dispatch attempt was blocked — this
+	 * is the bugfix: a filter-blocked render must leave the backstop
+	 * reversible, otherwise the sentinel would lock the blog out of
+	 * attribution forever once the filter is removed. Then verifies the
+	 * idempotency property: once the sentinel IS set, subsequent renders
+	 * short-circuit before the dispatcher, leaving the existing value alone.
+	 */
+	public function test_render_backstop_dispatch_gated_then_idempotent() {
 		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
-		$result  = wpcom_layout_grid_usage_react_to_block_render( $content, array() );
 
-		$this->assertSame( $content, $result );
-		$this->assertSame( 1, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
+		// First invocation: spy sees the call, but the module-load filter
+		// blocks dispatch (`log_observation` returns false), so the sentinel
+		// is NOT persisted — the backstop stays reversible.
+		$this->assertFalse( get_option( LAYOUT_GRID_SEEN_OPTION ) );
+		$this->assertSame( $content, layout_grid_react_to_block_render( $content, array() ) );
+		$this->assertCount( 1, $this->observations );
+		$this->assertSame( 'render', $this->observations[0]['surface'] );
+		$this->assertFalse( get_option( LAYOUT_GRID_SEEN_OPTION ) );
+
+		// Pre-seed a non-default sentinel to catch accidental overwrites: a
+		// subsequent render must short-circuit and leave the value untouched.
+		update_option( LAYOUT_GRID_SEEN_OPTION, 7, false );
+		$this->assertSame( $content, layout_grid_react_to_block_render( $content, array() ) );
+		$this->assertCount( 1, $this->observations, 'no new observation when sentinel already set' );
+		$this->assertSame( 7, get_option( LAYOUT_GRID_SEEN_OPTION ) );
 	}
 
 	/**
-	 * Render backstop is idempotent: once the sentinel is set, subsequent
-	 * renders return the content unchanged, leave the sentinel untouched, and
-	 * never reach the dispatch path.
+	 * The split context gate is read-only and write-only respectively:
+	 * `should_log_in_context` never mutates state, `mark_context_seen` writes
+	 * only the active context's transient, and import takes precedence at
+	 * both ends when both flags are set.
 	 */
-	public function test_render_backstop_noops_when_sentinel_already_set() {
-		update_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION, 7, false );
+	public function test_context_gate_is_split_read_then_write_with_import_precedence() {
+		// Read-only: no transient set, pass-through everywhere.
+		$this->assertTrue( layout_grid_should_log_in_context( false, false ) );
+		$this->assertTrue( layout_grid_should_log_in_context( true, false ) );
+		$this->assertTrue( layout_grid_should_log_in_context( false, true ) );
+		$this->assertFalse( get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
 
-		$content = '<div class="wp-block-jetpack-layout-grid">hi</div>';
-		$result  = wpcom_layout_grid_usage_react_to_block_render( $content, array() );
+		// Read-only: pre-set transients only affect their own context.
+		set_transient( LAYOUT_GRID_IMPORT_TRANSIENT, 1, DAY_IN_SECONDS );
+		$this->assertFalse( layout_grid_should_log_in_context( true, false ) );
+		$this->assertTrue( layout_grid_should_log_in_context( false, true ) );
+		// Precedence: import wins when both flags are set.
+		$this->assertFalse( layout_grid_should_log_in_context( true, true ) );
+		delete_transient( LAYOUT_GRID_IMPORT_TRANSIENT );
 
-		$this->assertSame( $content, $result );
-		// The handler must not overwrite a pre-existing sentinel value.
-		$this->assertSame( 7, get_option( WPCOM_LAYOUT_GRID_USAGE_SEEN_OPTION ) );
-	}
+		// Write: each call sets only the active context's transient.
+		layout_grid_mark_context_seen( false, false );
+		$this->assertFalse( get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
 
-	/**
-	 * Context gate is a no-op outside import and cron: returns true and
-	 * leaves both transients untouched.
-	 */
-	public function test_should_log_in_context_passes_through_outside_import_and_cron() {
-		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, false ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
-	}
+		layout_grid_mark_context_seen( true, false );
+		$this->assertSame( 1, get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
 
-	/**
-	 * Import context: first call returns true and sets the import transient
-	 * (only); second call returns false and does not touch the cron transient.
-	 */
-	public function test_should_log_in_context_rate_limits_import() {
-		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+		delete_transient( LAYOUT_GRID_IMPORT_TRANSIENT );
+		layout_grid_mark_context_seen( false, true );
+		$this->assertFalse( get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
+		$this->assertSame( 1, get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
 
-		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( true, false ) );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
-	}
-
-	/**
-	 * Cron context: first call returns true and sets the cron transient
-	 * (only); second call returns false and does not touch the import
-	 * transient.
-	 */
-	public function test_should_log_in_context_rate_limits_cron() {
-		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-
-		$this->assertFalse( wpcom_layout_grid_usage_should_log_in_context( false, true ) );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-	}
-
-	/**
-	 * When both flags are set (cron-triggered import), import takes
-	 * precedence: only the import transient is written.
-	 */
-	public function test_should_log_in_context_prefers_import_when_both_flags_set() {
-		$this->assertTrue( wpcom_layout_grid_usage_should_log_in_context( true, true ) );
-		$this->assertSame( 1, get_transient( WPCOM_LAYOUT_GRID_USAGE_IMPORT_TRANSIENT ) );
-		$this->assertFalse( get_transient( WPCOM_LAYOUT_GRID_USAGE_CRON_TRANSIENT ) );
+		// Precedence: import wins on the write side too.
+		delete_transient( LAYOUT_GRID_CRON_TRANSIENT );
+		layout_grid_mark_context_seen( true, true );
+		$this->assertSame( 1, get_transient( LAYOUT_GRID_IMPORT_TRANSIENT ) );
+		$this->assertFalse( get_transient( LAYOUT_GRID_CRON_TRANSIENT ) );
 	}
 }


### PR DESCRIPTION
## Proposed changes

Adds an Atomic-side observer that logs a logstash event the first time a `jetpack/layout-grid` block is observed on a WoA site, so we can attribute the source plugin or theme instead of only seeing the candidate set on the blog.

- Loads only on WoA via `Host::is_woa_site()`.
- Observes four surfaces, each tagged with a distinct `surface` value:
  - `post_insert` — `wp_after_insert_post`, fires when the block first lands in a post. Revisions and autosaves are skipped, and updates whose previous version already had the block are skipped.
  - `widget_add` / `widget_update` — `widget_block` option add/update, with the same first-landing semantics.
  - `render` — `render_block_jetpack/layout-grid`, guarded by the `wpcom_layout_grid_block_seen` option so the render backstop fires at most once per blog.
- Rate-limits import and cron insert contexts to one event per blog per 24 hours via `wpcom_layout_grid_block_import_seen` and `wpcom_layout_grid_block_cron_seen` transients.
- Sends events to the `atomic_layout_grid_block` logstash bucket with active theme, active plugins including multisite network-active plugins, request-context flags, and a sanitized extension-code backtrace.
- Keeps logging best-effort: dispatch failures do not fatal callers, and sticky state is only persisted after dispatch is attempted.

## Related product discussion/links

* Internal Simple-side companion change is already landed.

## Does this pull request change what data or activity we track or use?

Yes. This adds a new logstash feature bucket, `atomic_layout_grid_block`, for first-observation events of the `jetpack/layout-grid` block on WoA sites. Each event includes blog ID, active theme stylesheet, active plugin slugs, request-context flags, and a path-redacted backtrace filtered to extension code under plugins, themes, and mu-plugins. No user PII is included.

## Testing instructions

1. On a WoA site, save a post or page containing a `jetpack/layout-grid` block.
2. Confirm a logstash record appears in Kibana under feature `atomic_layout_grid_block` with `surface=post_insert`, populated `active_theme` / `active_plugins`, and a non-empty `trace`.
3. Edit the same post again without removing the block. Confirm no new event is logged.
4. Remove the block, save, re-add it, and save again. Confirm a new event with `surface=post_insert` is logged.
5. Add a layout-grid block via the widget editor. Confirm `surface=widget_add` or `surface=widget_update` is recorded.
6. On a site where the block is rendered from a theme template or pattern, load a front-end page. Confirm exactly one `surface=render` event and that the `wpcom_layout_grid_block_seen` option is set to `1`.

Test plan:
- [x] Unit tests pass (`composer phpunit -- --filter Layout_Grid_Usage_Tracking`, 7 tests / 55 assertions).
- [x] `phpcs` clean on new files.
- [x] `git diff --check trunk...FETCH_HEAD` clean.
- [ ] Verify on a real WoA site after deploy that events land in Kibana with the expected shape.
