### PR TITLE
Search Blocks: fix suggestions panel mixing with overlay content

### DIFF
--- a/projects/packages/search/changelog/SEARCH-245-overlay-suggestions-bleed
+++ b/projects/packages/search/changelog/SEARCH-245-overlay-suggestions-bleed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: the Search Input suggestions panel inside the blocks-powered Overlay now renders cleanly on top of the results + filters area instead of mixing with them — opaque surface, full-width coverage, and a higher stacking order than the Sort By / Filters popovers.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -92,11 +92,15 @@
 		max-height: 60vh;
 		overflow-y: auto;
 		overscroll-behavior: contain;
-		background: var(--wp--preset--color--base);
+		// Fallbacks keep the surface opaque on themes that don't define the
+		// `base` / `contrast` tokens — without them the rule resolves to
+		// nothing and the panel paints transparent, letting whatever sits
+		// behind it (results rows, filter labels) bleed through.
+		background: var(--wp--preset--color--base, #fff);
 		// The dropdown owns its surface, so pin the ink color too — otherwise
 		// the option text inherits a low-contrast theme accent from the
 		// surrounding page (e.g. a muted header link color).
-		color: var(--wp--preset--color--contrast);
+		color: var(--wp--preset--color--contrast, currentColor);
 		// Reset the inherited theme base size so option text tracks the
 		// other block surfaces (sort menu, filters popover) at 1rem instead
 		// of the host theme's oversized default.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1417,7 +1417,7 @@ class Search_Blocks {
  * matches the card's hardcoded surface as a final guard against any
  * theme that neutralises the global token fallback.
  */
-.jetpack-search-block-overlay__card .jetpack-search-input__suggestions {
+.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__suggestions {
 	right: -60px;
 	z-index: 30;
 	background: #fff;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1406,6 +1406,23 @@ class Search_Blocks {
 	line-height: 1;
 }
 /*
+ * Suggestions dropdown sits on top of the results + filters area below
+ * the input row. Two adjustments vs. the base style: (1) cancel out the
+ * input wrapper's `right: 60px` offset so the panel reaches the card's
+ * right edge and covers the filters column instead of leaving "Category"
+ * / "Post Type" peeking out on the right; (2) lift `z-index` above the
+ * other in-card popovers (`results-sort` and `filters-popover` both at
+ * `z-index: 20`) so the panel reliably wins the stacking order even
+ * when one of those is open underneath. Explicit `background: #fff`
+ * matches the card's hardcoded surface as a final guard against any
+ * theme that neutralises the global token fallback.
+ */
+.jetpack-search-block-overlay__card .jetpack-search-input__suggestions {
+	right: -60px;
+	z-index: 30;
+	background: #fff;
+}
+/*
  * Top padding clears the absolutely-positioned 60px header strip — without
  * it the "Found N results" / Sort by row sat flush against the search
  * input's bottom border and the modal felt cramped (SEARCH-243).


### PR DESCRIPTION
Fixes [SEARCH-245](https://linear.app/a8c/issue/SEARCH-245/search-blocks-suggestions-panel-mixes-with-resultsfilters-in-blocks-powered).

## Why

In the experimental blocks-powered Overlay (`overlay_blocks` experience), opening the overlay and typing into the Search Input showed the autocomplete suggestions panel sitting on top of part of the results + filters area below it — but the filter column at the card's right edge poked out past the panel's right edge, and on themes that don't define the `--wp--preset--color--base` token the panel's surface dropped to transparent so the content underneath bled straight through. The dropdown read as broken: visitors couldn't cleanly tell which row was a suggestion versus a result.

After: the panel is a solid opaque surface that covers the full width of the overlay content area, so the suggestions read as a real dropdown sitting on top of the page instead of mixing with it.

## Proposed changes

* `blocks/search-input/style.scss` — add `#fff` / `currentColor` fallbacks on the suggestions panel's `background` and `color` so themes without the `base` / `contrast` preset tokens still paint a fully opaque surface. (Fix is global — applies to every container the panel renders into, not just the overlay.)
* `class-search-blocks.php::block_template_overlay_inline_css()` — add a scoped rule for `.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__suggestions` that:
  * extends `right: -60px` to cancel the card-level `right: 60px` offset on the search-input wrapper so the panel reaches the card's right edge instead of stopping short of the filters column;
  * lifts `z-index: 30` above the in-card popovers (`results-sort` and `filters-popover` are both `z-index: 20`) so the panel reliably wins the stacking order;
  * pins `background: #fff` to match the card's hardcoded surface.
* The three-class selector is intentional — the block stylesheet (`.wp-block-jetpack-search-search-input .jetpack-search-input__suggestions`, 2 classes) loads after the overlay's inline `<style>` block via `<link>`, so a same-specificity override would lose the `right: 0` reset back. Anchoring through `.wp-block-jetpack-search-search-input` bumps the override to three classes so it wins at any load order.

## Related product discussion/links

* SEARCH-245 — `https://linear.app/a8c/issue/SEARCH-245/search-blocks-suggestions-panel-mixes-with-resultsfilters-in-blocks-powered`
* Regressed between two trunk commits that landed three days apart: `f96c33bf2d` (May 20, "Search Input: theme-aware suggestions dropdown") lowered the panel's `z-index` from `100` to `20` to match the `filters-popover` / `results-sort` menus, and `9f8d50a14d` (May 23, "Search Blocks: release blocks-powered Overlay as experimental") shipped the overlay card without re-checking how the dropdown stacked inside it.

## Does this pull request change what data or activity we track or use?

No — CSS-only change to an existing front-end surface. No new data is tracked, transmitted, or stored.

## Screenshots

### Before — filter column's count badges peek past the panel's right edge

![before](https://github.com/user-attachments/assets/595ad2d4-4375-435a-a0e1-de9cdb5f2500)

### After — panel spans the full overlay content width, cleanly opaque

![after](https://github.com/user-attachments/assets/a5d090a5-0ede-4f02-adc2-fa4e3c553dd1)

## Testing instructions

Reproduces against the blocks-powered Overlay (`overlay_blocks` experience) — flip a site over to that experience via the Experience Selector (`/wp-admin/admin.php?page=jetpack-search`).

* Make sure the overlay's Search Input has `enableSuggestions: true` in its block attributes (the saved overlay template's `wp:jetpack-search/search-input` block). Without this the suggestions panel never appears at all.
* Ensure there are at least a handful of posts whose titles share a common prefix (e.g. several `hello *` posts) so the suggestions list shows more than one row.
* Verify the acceptance criteria from SEARCH-245:
  - [ ] On the front-end (`/?s=hello`), the overlay opens and typing into the search input shows a suggestions panel with a fully opaque surface — no result rows or filter labels visible through it.
  - [ ] The panel horizontally covers the full overlay content area, including the filter column at the card's right edge — no "Category" / "Post Type" count badges peeking out on the right.
  - [ ] The X close button stays visible and clickable while the suggestions panel is open (panel sits below the input row vertically, never covers the X).
  - [ ] Outside the overlay (switch the experience to "Embedded" / classic-theme search page, or drop a standalone Search Input block on a normal page), the panel is also reliably opaque on themes that don't define `--wp--preset--color--base`.
  - [ ] Dark / token-driven themes don't regress — when `--wp--preset--color--base` and `--wp--preset--color--contrast` *are* defined, they continue to win over the new fallback values.
  - [ ] No regression in `results-sort` or `filters-popover` dropdowns when the suggestions panel is closed (open each, confirm they paint correctly).

