### PR TITLE
Search Blocks: Overlay shell honors theme color tokens

### DIFF
--- a/projects/packages/search/changelog/atlas-search-246-overlay-theme-tokens
+++ b/projects/packages/search/changelog/atlas-search-246-overlay-theme-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Overlay shell honors theme color tokens — card surface, ink, and hairlines track `--wp--preset--color--base`/`--contrast` instead of hardcoded #fff/#e0e0e0, so the modal stays readable on dark block themes.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1346,13 +1346,30 @@ class Search_Blocks {
 	justify-content: center;
 	background: transparent;
 	border: 0;
-	border-bottom: 1px solid color-mix(in sRGB, currentColor 15%, transparent);
+	border-bottom: 1px solid transparent;
 	cursor: pointer;
 	color: inherit;
 }
-.jetpack-search-block-overlay__close:hover,
-.jetpack-search-block-overlay__close:focus-visible {
-	background: color-mix(in sRGB, currentColor 8%, transparent);
+/*
+ * Hairlines and the close-button hover use `color-mix(currentColor)`. On
+ * browsers without color-mix support (~Chrome <111, Firefox <113, Safari
+ * <16.2) the entire `border-bottom`/`background` shorthand would be
+ * invalid and the cascade would land on initial values — `border-style:
+ * none` (no hairline) or `border-color: currentColor` full-opacity (stark
+ * ink on dark themes). The `transparent` defaults paired with `@supports`
+ * overrides give those older browsers a graceful no-affordance state
+ * instead of a stark one — same convention `_chip.scss` uses.
+ */
+@supports (border-color: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-block-overlay__close {
+		border-bottom-color: color-mix(in sRGB, currentColor 15%, transparent);
+	}
+}
+@supports (background: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-block-overlay__close:hover,
+	.jetpack-search-block-overlay__close:focus-visible {
+		background: color-mix(in sRGB, currentColor 8%, transparent);
+	}
 }
 .jetpack-search-block-overlay__close svg {
 	width: 24px;
@@ -1377,7 +1394,12 @@ class Search_Blocks {
 	height: 60px;
 	margin: 0;
 	padding: 0;
-	border-bottom: 1px solid color-mix(in sRGB, currentColor 15%, transparent);
+	border-bottom: 1px solid transparent;
+}
+@supports (border-color: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input {
+		border-bottom-color: color-mix(in sRGB, currentColor 15%, transparent);
+	}
 }
 .jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__inside-wrapper {
 	height: 100%;
@@ -1456,11 +1478,19 @@ class Search_Blocks {
  * Filter sidebar's left divider: track `currentColor` (i.e. the active
  * theme's ink) so the hairline stays subtle on light themes and visible on
  * dark themes, instead of rendering as flat grey on either. The width
- * comes from the column block's inline `border-left-width`; we only own
- * the color here.
+ * comes from the column block's inline `border-left-width` (and WP block
+ * border support fills in `border-left-style: solid`); we only own the
+ * color here. `transparent` base + `@supports` override avoids the stark
+ * full-opacity `currentColor` fallback that older browsers would otherwise
+ * land on — mirrors the close-button hairline treatment above.
  */
 .jetpack-search-block-overlay__filters-column {
-	border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
+	border-left-color: transparent;
+}
+@supports (border-color: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-block-overlay__filters-column {
+		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
+	}
 }
 @media (max-width: 781px) {
 	.jetpack-search-block-overlay {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1297,6 +1297,13 @@ class Search_Blocks {
  * the centered card, the header strip (search input + close button),
  * open/close animation, and the body-scroll-lock helper. Mirrors the
  * visual idiom of the legacy `instant-search/components/overlay.scss`.
+ *
+ * Surface + ink track the theme's `base` / `contrast` tokens (matching the
+ * suggestions dropdown and sort popover treatment), so the modal reads as
+ * part of the active palette on dark themes instead of a forced-white panel
+ * with illegible inherited light text. Hairlines and the close-button hover
+ * use `color-mix(currentColor)` so they keep a consistent contrast ratio
+ * against whatever surface the theme chose.
  */
 .jetpack-search-block-overlay {
 	position: fixed;
@@ -1322,7 +1329,8 @@ class Search_Blocks {
 	position: relative;
 	width: 100%;
 	max-width: 1080px;
-	background: #fff;
+	background: var(--wp--preset--color--base, #fff);
+	color: var(--wp--preset--color--contrast, inherit);
 	border-radius: 4px;
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 	padding-top: 60px;
@@ -1338,13 +1346,13 @@ class Search_Blocks {
 	justify-content: center;
 	background: transparent;
 	border: 0;
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid color-mix(in sRGB, currentColor 15%, transparent);
 	cursor: pointer;
 	color: inherit;
 }
 .jetpack-search-block-overlay__close:hover,
 .jetpack-search-block-overlay__close:focus-visible {
-	background: #f6f7f7;
+	background: color-mix(in sRGB, currentColor 8%, transparent);
 }
 .jetpack-search-block-overlay__close svg {
 	width: 24px;
@@ -1369,7 +1377,7 @@ class Search_Blocks {
 	height: 60px;
 	margin: 0;
 	padding: 0;
-	border-bottom: 1px solid #e0e0e0;
+	border-bottom: 1px solid color-mix(in sRGB, currentColor 15%, transparent);
 }
 .jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__inside-wrapper {
 	height: 100%;
@@ -1443,6 +1451,16 @@ class Search_Blocks {
 	flex-wrap: nowrap;
 	justify-content: space-between;
 	align-items: center;
+}
+/*
+ * Filter sidebar's left divider: track `currentColor` (i.e. the active
+ * theme's ink) so the hairline stays subtle on light themes and visible on
+ * dark themes, instead of rendering as flat grey on either. The width
+ * comes from the column block's inline `border-left-width`; we only own
+ * the color here.
+ */
+.jetpack-search-block-overlay__filters-column {
+	border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 }
 @media (max-width: 781px) {
 	.jetpack-search-block-overlay {

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -22,8 +22,8 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:column {"width":"260px","className":"jetpack-search-block-overlay__filters-column","style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column jetpack-search-block-overlay__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->


### PR DESCRIPTION
Fixes [SEARCH-246](https://linear.app/a8c/issue/SEARCH-246/search-blocks-overlay-shell-honors-theme-color-tokens-basecontrast)

## Why
Visitors on dark — or any non-white-surface — block themes couldn't read their own search results. The blocks-powered Search Overlay opened as a forced-white card, but body text inside inherited the theme's ink color (e.g. a light `contrast` token on a dark palette), so result titles, helper copy, and the search input field disappeared into the white card. The close-button divider, hover affordance, search-input underline, and filter sidebar divider were also hardcoded to neutral greys, which made the modal read as a foreign Gutenberg panel on any palette that wasn't TT5-default-light.

This change makes the Overlay shell track the active theme's `base` / `contrast` color tokens with safe fallbacks, mirroring the vocabulary the suggestions dropdown and sort popover already use — so the modal feels like part of the site on every theme.

## Proposed changes
* `.jetpack-search-block-overlay__card` surface uses `var(--wp--preset--color--base, #fff)`; ink pinned to `var(--wp--preset--color--contrast, inherit)` so the two track together even on themes that override only one of the two tokens.
* `.jetpack-search-block-overlay__close` divider + hover and `.wp-block-jetpack-search-search-input` row underline switch from hardcoded `#e0e0e0` / `#f6f7f7` to `color-mix(in sRGB, currentColor X%, transparent)`.
* `templates/jetpack-search-overlay.html` filter sidebar column drops its hardcoded `#e0e0e0` left border in block JSON; the overlay's inline stylesheet now paints that hairline via a dedicated `.jetpack-search-block-overlay__filters-column` class with the same `color-mix(currentColor 15%)` token.
* Scrim background unchanged — intentional page-dimmer, not a theming bug.
* Clear-filters and Load-more buttons already pick up theme colors via `wp-element-button`; no changes there.

## Screenshots
Captured at `/?s=hello` via local docker (`https://jp-atlas.jurassic.tube/`) at 1440×900 with the TT5 **Midnight** style variation applied (palette: `base = #4433A6`, `contrast = #79F3B1`) — a representative dark block-theme palette.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/5e9264ca-ae4a-4638-9f5b-539081f2fa3f) | ![after](https://github.com/user-attachments/assets/70ee0f3b-56c9-4605-9925-0c9d537fb741) |

`Before`: Mint-green theme ink renders on the hardcoded white card — "Found 2 results", result summaries, dates, category counts, and the powered-by tagline are all nearly invisible.

`After`: Card surface picks up the theme's Midnight purple `base`, mint `contrast` ink contrasts cleanly, sidebar divider tracks `currentColor` at low alpha, every element legible.

On light TT5 (where `--wp--preset--color--base` is already `#FFFFFF`), the Overlay looks identical to before — fallback values match.

## Related product discussion/links
* Linear: [SEARCH-246](https://linear.app/a8c/issue/SEARCH-246/search-blocks-overlay-shell-honors-theme-color-tokens-basecontrast)
* Initial reproduction reported on https://blog.kangzj.net/?s=hello.

## Does this pull request change what data or activity we track or use?
No — CSS-only theming change, no data flow, telemetry, or persistence affected.

## Testing instructions
Verify each acceptance criterion below against the Before/After screenshots above and, for the dark-theme case, in a local env.

- [ ] On a dark block theme, the Overlay card surface matches the theme's `--wp--preset--color--base`, ink tracks `--wp--preset--color--contrast`, and all body / results text inside the Overlay is fully legible.
- [ ] On a light block theme (TT5 default), no visual regression — the modal still reads as a white card on a dimmed page.
- [ ] On a classic theme (no `theme.json` tokens defined), the CSS-variable fallbacks (`#fff` surface + `inherit` ink) preserve today's behavior.
- [ ] Close-button × remains visible in both light and dark modes; its divider and hover affordance are subtle but readable on either surface.
- [ ] Filter sidebar column's left divider survives in both modes (no hardcoded grey; tracks `currentColor`).
- [ ] No changes to Clear-filters / Load-more / sort popover button styling — already themed via `wp-element-button`.
- [ ] Scrim (the dimmed area behind the modal) is unchanged — intentional page-dimmer.

Reproducing the dark-theme repro locally:

1. Activate Twenty Twenty-Five (or any block theme).
2. In Site Editor → Styles, pick a dark style variation — for TT5 use **Midnight** (palette: `base = #4433A6`, `contrast = #79F3B1`).
3. Set the search experience to "Blocks Overlay" (Experience Selector / `jetpack_search_experience = overlay_blocks`).
4. Visit `/?s=hello` on the front end — the Overlay auto-opens.
5. On trunk: text is mint-green on white, illegible. On this PR: card is purple, text is mint, fully legible.

Out of scope (deliberately): the legacy preact Instant Search overlay, the Embedded experience search page, layout / sizing / typography changes, theme-aware logic in PHP (`wp_get_global_styles()`).
