### PR TITLE
Search Blocks: horizontal gutters + content-width cap on classic-theme search template

### DIFF
--- a/projects/packages/search/changelog/SEARCH-247-classic-theme-horizontal-gutters
+++ b/projects/packages/search/changelog/SEARCH-247-classic-theme-horizontal-gutters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: add horizontal gutters and a content-width cap to the Embedded search page on classic themes — content no longer hugs the viewport edges, and stops stretching edge-to-edge on wide screens. Honors `--wp--style--global--wide-size` when a classic theme ships theme.json.

--- a/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
+++ b/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
@@ -21,15 +21,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
-// Classic themes don't emit core's layout block-supports CSS for the
-// `blockGap` attribute, so the 1.5rem gap declared on the bundled
-// template's `wp-block-group` wrapper collapses to 0 — the search input
-// runs straight into the results / filters row. Reapply it once, scoped
-// to our `<main class="wp-block-group">` so it can't leak into theme
-// content elsewhere. Falls back to the block-theme variable when a
-// theme.json-shipping classic theme happens to define one.
+// Classic themes don't emit core's layout block-supports CSS, so two
+// layout traits the bundled `jetpack-search.html` relies on collapse on
+// classic themes:
+//
+// 1. The 1.5rem `blockGap` declared on the inner `wp-block-group`
+// vanishes — search input runs straight into the results / filters row.
+// 2. The `alignwide` class on the inner group has no effect — content
+// hugs the viewport edges and stretches edge-to-edge on wide screens
+// because `template_include` bypasses the theme's own content wrapper.
+//
+// Reapply both once, scoped to our `<main class="wp-block-group">` so the
+// rules can't leak into theme content elsewhere. CSS-variable fallbacks
+// honor a theme.json-shipping classic theme's tokens when present.
 ?>
 <style id="jetpack-search-classic-theme-layout">
+main.wp-block-group {
+	max-width: var(--wp--style--global--wide-size, 1280px);
+	margin-inline: auto;
+	padding-inline: clamp(1rem, 4vw, 2rem);
+}
 main.wp-block-group .is-layout-flow > * + * {
 	margin-block-start: var(--wp--style--block-gap, 1.5rem);
 }


### PR DESCRIPTION
Fixes [SEARCH-247](https://linear.app/a8c/issue/SEARCH-247/search-blocks-horizontal-gutters-content-width-cap-on-classic-theme)

## Why

When the Embedded search experience takes over a classic theme's search page (via `template_include`), the rendered `<main class="wp-block-group">` sits directly inside the theme's `get_header()` / `get_footer()` — bypassing the theme's own content wrapper. On older classic themes the result is that the search input, results list, and filter column hug the viewport edges with no breathing room, and on wide displays the content stretches edge-to-edge with no upper bound.

This is the horizontal counterpart to the vertical `blockGap` fix already in this file. Classic themes don't emit core's layout block-supports CSS, so the `alignwide` on the bundled template's inner group has no effect either.

## Proposed changes

* Extend the existing scoped `<style id="jetpack-search-classic-theme-layout">` block in `projects/packages/search/src/search-blocks/templates/classic-theme-search.php` with one rule on `main.wp-block-group`:
  ```css
  max-width: var(--wp--style--global--wide-size, 1280px);
  margin-inline: auto;
  padding-inline: clamp(1rem, 4vw, 2rem);
  ```
* Update the inline PHP comment to cover both the vertical (blockGap) and horizontal (alignwide / content gutters) layout traits we reapply on classic themes.
* Block themes are unaffected — `templates/classic-theme-search.php` is only loaded via `route_classic_theme_search_template()` on classic themes.

## Screenshots

### Narrow viewport (600×900, Twenty Sixteen)

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/ea49af5d-8844-47c8-a6bf-21d8e06b22e4) | ![after](https://github.com/user-attachments/assets/bbebe7ec-7821-441c-81a9-325dc0efe802) |

Search input, results, and the Filter options header now clear the viewport edges instead of butting against them.

### Wide viewport (1440×900, Twenty Sixteen)

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/5459d2c6-1c8f-4586-b736-54b60ec7a7f6) | ![after](https://github.com/user-attachments/assets/24482f0e-8faa-452e-abe9-8a50d7b62d10) |

Subtler at this width — 32px gutter is added on each side, with the content still capped at 1280px on still-wider screens.

## Related product discussion/links

* [SEARCH-247](https://linear.app/a8c/issue/SEARCH-247/search-blocks-horizontal-gutters-content-width-cap-on-classic-theme)
* Precedent: #49120 (`SEARCH-243`) — analogous vertical-breathing-room fix scoped to the blocks Overlay.
* Related: #49117 (`SEARCH-219`) — introduced the classic-theme `template_include` route this PR refines.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-247 — verify each against the live env:

* [ ] On a classic theme (e.g. Twenty Twenty-One, Twenty Sixteen), the Embedded search page has visible left/right gutters at all viewport widths — content no longer butts against the viewport edges.
* [ ] On wide viewports (≥1280px), the search content is capped at `var(--wp--style--global--wide-size, 1280px)` and centered with `margin-inline: auto`.
* [ ] On narrow viewports (mobile), gutters scale via `clamp(1rem, 4vw, 2rem)` — never less than 1rem, never more than 2rem.
* [ ] Block themes are unaffected (file only loads via `template_include` on classic themes).
* [ ] Existing vertical block-gap fix in the same `<style>` block still works.
* [ ] A theme that ships `--wp--style--global--wide-size` via theme.json gets its value honored (CSS variable fallback respected).

### Setup

1. Activate Jetpack and the Jetpack Search plugin.
2. In **Jetpack → Search → Experience**, select **Embedded**.
3. Activate a classic theme (e.g. Twenty Twenty-One or Twenty Sixteen).

### Steps

1. Visit `/?s=hello` (or any search term that returns results) on the front end.
2. Resize the viewport between ~360px and ~1920px and observe the search input, results column, and Filter options column.
3. Switch to a block theme (e.g. Twenty Twenty-Five) and confirm the search page is unchanged from before this PR.
