### PR TITLE
My Jetpack: remove redundant in-page JetpackLogo header from product pages

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/_mixins.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/_mixins.scss
@@ -7,22 +7,6 @@
  */
 
 /**
- * Product header with logo and product name
- */
-@mixin product-header {
-	display: flex;
-	flex-wrap: nowrap;
-	padding-top: calc(var(--spacing-base) * 3);
-	padding-bottom: calc(var(--spacing-base) * 3);
-	align-items: center;
-	font-size: 22px;
-
-	.product-interstitial__product-header-name {
-		padding-inline-start: var(--spacing-base);
-	}
-}
-
-/**
  * Hero section - main layout container
  */
 @mixin hero-section {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -5,7 +5,6 @@ import {
 	AdminPage,
 	Col,
 	Container,
-	JetpackLogo,
 	AiIcon,
 	getRedirectUrl,
 	Notice,
@@ -212,19 +211,6 @@ export default function () {
 			}
 		>
 			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
-				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
-					<div
-						className={ clsx(
-							styles[ 'product-interstitial__section-wrapper-wide' ],
-							styles[ 'product-interstitial__product-header' ]
-						) }
-					>
-						<JetpackLogo />
-						<div className={ styles[ 'product-interstitial__product-header-name' ] }>
-							{ __( 'AI Assistant', 'jetpack-my-jetpack' ) }
-						</div>
-					</div>
-				</Col>
 				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
 					<div className={ styles[ 'product-interstitial__hero-section' ] }>
 						<div className={ styles[ 'product-interstitial__hero-content' ] }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
@@ -15,15 +15,6 @@
 }
 
 /* Interstitial */
-.product-interstitial__product-header {
-
-	@include mixins.product-header;
-
-	.product-interstitial__product-header-name {
-		padding-bottom: calc(var(--spacing-base) / 3);
-	}
-}
-
 .product-interstitial__hero-section {
 
 	@include mixins.hero-section;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	AdminPage,
-	Col,
-	Container,
-	JetpackLogo,
-	getRedirectUrl,
-} from '@automattic/jetpack-components';
+import { AdminPage, Col, Container, getRedirectUrl } from '@automattic/jetpack-components';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { Button, Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -99,21 +93,6 @@ export default function ProtectProductPage() {
 			}
 		>
 			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
-				{ /* Header Section */ }
-				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
-					<div
-						className={ clsx(
-							styles[ 'product-interstitial__section-wrapper-wide' ],
-							styles[ 'product-interstitial__product-header' ]
-						) }
-					>
-						<JetpackLogo />
-						<div className={ styles[ 'product-interstitial__product-header-name' ] }>
-							{ __( 'Protect', 'jetpack-my-jetpack' ) }
-						</div>
-					</div>
-				</Col>
-
 				{ /* Hero Section */ }
 				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
 					<div className={ styles[ 'product-interstitial__hero-section' ] }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/style.module.scss
@@ -1,11 +1,6 @@
 @use "../mixins";
 
 /* Protect Product Page Styles */
-.product-interstitial__product-header {
-
-	@include mixins.product-header;
-}
-
 .product-interstitial__hero-section {
 
 	@include mixins.hero-section;

--- a/projects/packages/my-jetpack/changelog/remove-product-page-jetpacklogo-header
+++ b/projects/packages/my-jetpack/changelog/remove-product-page-jetpacklogo-header
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove redundant in-page JetpackLogo header from product pages (AdminPage already renders the page header).
+
+


### PR DESCRIPTION
Fixes # — part of the ongoing My Jetpack page-header normalization effort. Sister to #48414, which introduced the unified back-link header via `AdminPage`'s `breadcrumbs` prop.

## Proposed changes

Removes the redundant in-page `<JetpackLogo /> + <product-name>` block from two product detail pages. `AdminPage` already renders the canonical page header (back link to "My Jetpack") via its `breadcrumbs` prop, so the in-page block was a visual duplicate of the same information.

- `projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx` — remove the `<Col>` containing `<JetpackLogo />` + "AI Assistant" header (was at lines 215–227 pre-change), drop the now-unused `JetpackLogo` import.
- `projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx` — remove the equivalent `<Col>` containing `<JetpackLogo />` + "Protect" header (was at lines ~103–115 pre-change), drop the now-unused `JetpackLogo` import.
- `projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss` — remove the `.product-interstitial__product-header { ... }` block.
- `projects/packages/my-jetpack/_inc/components/product-interstitial/protect/style.module.scss` — remove the `.product-interstitial__product-header { ... }` block.
- `projects/packages/my-jetpack/_inc/components/product-interstitial/_mixins.scss` — remove the now-orphaned `@mixin product-header` (sole consumers were the two SCSS files above; confirmed via grep across the whole monorepo).

Net diff: 6 insertions, 66 deletions. Pure deletion + import cleanup + dead-CSS removal — no new abstractions.

### JSX shape (both pages)

**Before:**
```
AdminPage[breadcrumbs=GoBackLink]
  └─ Container
      ├─ Col[product-header]  ← <JetpackLogo /> + product name (REMOVED)
      ├─ Col[hero-section]
      └─ Col[...other sections]
```

**After:**
```
AdminPage[breadcrumbs=GoBackLink]
  └─ Container
      ├─ Col[hero-section]
      └─ Col[...other sections]
```

The canonical page header (back link to "My Jetpack") still renders — it lives on `AdminPage`, not in the removed `<Col>`.

## Related product discussion/links
* Precedent PR: #48414 — "render interstitials with unified header (breadcrumbs-like back-link + license-key action)"

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Build my-jetpack: `pnpm jetpack build packages/my-jetpack`.
2. Go to **wp-admin → Jetpack → My Jetpack**.
3. Click **View** on the **AI Assistant** card.
   * The page should open with the "My Jetpack" back link at the top (rendered by `AdminPage`), and the hero ("Draft, transform, translate…") should appear directly below it.
   * The old standalone "JetpackLogo + AI Assistant" header block should be gone.
4. Click **View** on the **Protect** card.
   * Same expectation: the page should open with the "My Jetpack" back link, then the "Your site is protected" hero — no separate "JetpackLogo + Protect" block above it.
5. The back link in both pages should navigate back to `/products`.

### Verification approach for this PR
Static verification: read the compiled JSX before/after to confirm the header `<Col>` containing `<JetpackLogo />` and the product-name `<div>` is gone in both files. The remaining structure is `AdminPage → Container → Col[hero-section] → ...sections`. Gates run: `pnpm exec stylelint`, `pnpm exec eslint` (pre-existing `import/no-unresolved` for `@automattic/jetpack-components` and `@automattic/number-formatters` in this fresh worktree — not introduced by this change; the same errors fire on the pre-change tree), `pnpm jetpack build packages/my-jetpack` (success), `pnpm jetpack test js packages/my-jetpack` (success). Pre-commit hooks ran `eslint --fix` and `stylelint --fix` cleanly with no further diffs.

Visual confirmation in a live wp-admin against the AI + Protect product pages would be a nice last-mile check by the reviewer — the parent session's `jetpack_dev` was reserved for sister L1b work and a cloned docker wasn't spun up for this slice.
