### PR TITLE
Forms: fix iOS Safari Private Browsing validation gate (FORMS-685)

### DIFF
--- a/projects/packages/forms/changelog/forms-685-ios-safari-validation
+++ b/projects/packages/forms/changelog/forms-685-ios-safari-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix client-side validation gate blocking submission in iOS Safari Private Browsing (FORMS-685) — reconcile field values from the live DOM before blocking when Interactivity store captures have been suppressed.

--- a/projects/packages/forms/src/modules/form/reconcile.ts
+++ b/projects/packages/forms/src/modules/form/reconcile.ts
@@ -1,0 +1,198 @@
+/**
+ * FORMS-685: Store↔DOM reconcile helper
+ *
+ * When iOS Safari (Private Browsing / Advanced Tracking & Fingerprinting
+ * Protection) suppresses the per-keystroke Interactivity-store captures, the
+ * store thinks every field is empty even though the DOM inputs hold the typed
+ * values.  `reconcileFieldsFromForm` recovers those values from the live DOM
+ * so the client-side gate can re-evaluate correctly before blocking submission.
+ *
+ * This module is intentionally free of any wordpress/interactivity imports so
+ * it can be unit-tested in plain jsdom without the Interactivity runtime.
+ */
+
+/**
+ * Shape of a field entry in the Interactivity store context.
+ * Only the fields relevant to reconciliation are listed.
+ */
+export interface StoreField {
+	id: string;
+	type: string;
+	label: string;
+	value: unknown;
+	isRequired: boolean;
+	extra: unknown;
+	isOtherSelected?: boolean;
+	otherLabel?: string | null;
+}
+
+/**
+ * The minimal slice of store context that reconcileFieldsFromForm needs.
+ */
+export interface ReconcileContext {
+	fields: Record< string, StoreField >;
+}
+
+/**
+ * Read the current submitted value(s) for a field directly from the form DOM.
+ *
+ * Returns `null` when we cannot faithfully reconstruct the store-expected
+ * value format (e.g. file fields, rating, image-select, hidden inputs, "Other"
+ * radio with a custom text value).  The caller must leave those fields' store
+ * values untouched when `null` is returned.
+ *
+ * @param {HTMLFormElement} form  - The form element.
+ * @param {StoreField}      field - The store field record.
+ * @return {unknown|null} The reconciled value, or null if unrecoverable.
+ */
+export const readFieldValueFromDom = (
+	form: HTMLFormElement,
+	field: StoreField
+): unknown | null => {
+	const { id, type } = field;
+
+	switch ( type ) {
+		// ── Simple single-value inputs ───────────────────────────────────────
+		case 'text':
+		case 'name':
+		case 'email':
+		case 'url':
+		case 'telephone':
+		case 'number':
+		case 'date':
+		case 'time':
+		case 'textarea': {
+			const el = form.querySelector< HTMLInputElement | HTMLTextAreaElement >(
+				`[name="${ CSS.escape( id ) }"]`
+			);
+			return el ? el.value : null;
+		}
+
+		// ── Single checkbox (value = '1' or '') ─────────────────────────────
+		case 'checkbox': {
+			const el = form.querySelector< HTMLInputElement >(
+				`input[type="checkbox"][name="${ CSS.escape( id ) }"]`
+			);
+			if ( ! el ) {
+				return null;
+			}
+			return el.checked ? '1' : '';
+		}
+
+		// ── Consent — implicit hidden always "Yes", explicit checkbox ────────
+		case 'consent': {
+			// Implicit consent: hidden input with value "Yes"
+			const hidden = form.querySelector< HTMLInputElement >(
+				`input[type="hidden"][name="${ CSS.escape( id ) }"]`
+			);
+			if ( hidden ) {
+				return hidden.value;
+			}
+			// Explicit consent: visible checkbox
+			const cb = form.querySelector< HTMLInputElement >(
+				`input[type="checkbox"][name="${ CSS.escape( id ) }"]`
+			);
+			if ( cb ) {
+				return cb.checked ? '1' : '';
+			}
+			return null;
+		}
+
+		// ── Radio (single choice) ────────────────────────────────────────────
+		// The "Other" radio stores "Label: custom text" — we can recover the
+		// label part from the input's data attribute, but recovering the custom
+		// text requires querying the companion "-other-text" input.
+		case 'radio': {
+			const checked = form.querySelector< HTMLInputElement >(
+				`input[type="radio"][name="${ CSS.escape( id ) }"]:checked`
+			);
+			if ( ! checked ) {
+				return '';
+			}
+
+			const otherLabel = checked.getAttribute( 'data-other-label' );
+			if ( otherLabel ) {
+				// "Other" option is checked — look for the companion text input
+				const fieldset = checked.closest( 'fieldset' );
+				const otherText = fieldset?.querySelector< HTMLInputElement >(
+					'input[name$="-other-text"]'
+				);
+				const customText = otherText?.value || '';
+				return customText ? `${ otherLabel }: ${ customText }` : otherLabel;
+			}
+
+			return checked.value;
+		}
+
+		// ── Checkbox-multiple (value = string[]) ─────────────────────────────
+		case 'checkbox-multiple':
+		case 'multiple-checkboxes': {
+			const checkboxes = form.querySelectorAll< HTMLInputElement >(
+				`input[type="checkbox"][name="${ CSS.escape( id ) }[]"]`
+			);
+			if ( checkboxes.length === 0 ) {
+				return null;
+			}
+			const values: string[] = [];
+			checkboxes.forEach( cb => {
+				if ( cb.checked ) {
+					values.push( cb.value );
+				}
+			} );
+			return values;
+		}
+
+		// ── Select (dropdown) ─────────────────────────────────────────────────
+		case 'select':
+		case 'dropdown': {
+			const el = form.querySelector< HTMLSelectElement >( `select[name="${ CSS.escape( id ) }"]` );
+			return el ? el.value : null;
+		}
+
+		// ── Slider/range ──────────────────────────────────────────────────────
+		case 'range':
+		case 'slider': {
+			const el = form.querySelector< HTMLInputElement >(
+				`input[type="range"][name="${ CSS.escape( id ) }"]`
+			);
+			return el ? el.value : null;
+		}
+
+		// ── Types we cannot faithfully reconstruct ─────────────────────────
+		// file    — FormData entries are File objects, not the store's [{name,size,isUploaded}] array
+		// rating  — hidden input stores "n/max" string; store uses structured object via getRating()
+		// image-select — store uses JSON with letter codes; DOM has individual radio/checkbox inputs
+		// hidden  — passive field; never blocks isFormValid
+		default:
+			return null;
+	}
+};
+
+/**
+ * Reconcile store field values from the live form DOM.
+ *
+ * For each field whose store value appears empty (or whose store entry doesn't
+ * exist yet), we attempt to read the actual value from the DOM.  Returns a map
+ * of field-id → recovered value for every field where we successfully read a
+ * non-null value.  Fields whose type we cannot handle are omitted so the
+ * caller can leave their store values untouched.
+ *
+ * @param {HTMLFormElement}  form    - The form element.
+ * @param {ReconcileContext} context - The Interactivity store context.
+ * @return {Map<string, unknown>} Map of field id → recovered DOM value.
+ */
+export const reconcileFieldsFromForm = (
+	form: HTMLFormElement,
+	context: ReconcileContext
+): Map< string, unknown > => {
+	const recovered = new Map< string, unknown >();
+
+	for ( const field of Object.values( context.fields ) ) {
+		const domValue = readFieldValueFromDom( form, field );
+		if ( domValue !== null ) {
+			recovered.set( field.id, domValue );
+		}
+	}
+
+	return recovered;
+};

--- a/projects/packages/forms/src/modules/form/reconcile.ts
+++ b/projects/packages/forms/src/modules/form/reconcile.ts
@@ -7,9 +7,16 @@
  * values.  `reconcileFieldsFromForm` recovers those values from the live DOM
  * so the client-side gate can re-evaluate correctly before blocking submission.
  *
+ * `isFormValidFromDom` computes validity directly from the live DOM, without
+ * touching or re-reading the store.  Because the store write/read is exactly
+ * what is unreliable under Safari's protection, this is the authoritative
+ * go/no-go signal in the recovery path.
+ *
  * This module is intentionally free of any wordpress/interactivity imports so
  * it can be unit-tested in plain jsdom without the Interactivity runtime.
  */
+
+import { validateField, isEmptyValue } from '../../contact-form/js/validate-helper.js';
 
 /**
  * Shape of a field entry in the Interactivity store context.
@@ -22,6 +29,10 @@ export interface StoreField {
 	value: unknown;
 	isRequired: boolean;
 	extra: unknown;
+	/** Validation result: 'yes' means valid, anything else is an error key. */
+	error?: string;
+	/** Step number this field belongs to (1-based, used for multistep forms). */
+	step?: number;
 	isOtherSelected?: boolean;
 	otherLabel?: string | null;
 }
@@ -195,4 +206,103 @@ export const reconcileFieldsFromForm = (
 	}
 
 	return recovered;
+};
+
+/**
+ * Options for isFormValidFromDom.
+ */
+export interface IsFormValidFromDomOptions {
+	/** True when the form is a multistep form. */
+	isMultiStep: boolean;
+	/** The current active step (1-based). */
+	currentStep: number;
+	/** The total number of steps (used to detect multistep mode). */
+	maxSteps: number;
+}
+
+/**
+ * Determine form validity directly from the live DOM, without touching or
+ * re-reading the Interactivity store.
+ *
+ * This is the authoritative go/no-go signal in the FORMS-685 recovery path.
+ * Because the store write/read is exactly what is unreliable under Safari's
+ * Advanced Tracking & Fingerprinting Protection, we deliberately bypass the
+ * store here and validate the values that FormData would actually submit.
+ *
+ * Algorithm: for each field in `context.fields` (considering only current-step
+ * fields in multistep forms): if `readFieldValueFromDom` returns a non-null
+ * DOM value, validate that value with `validateField` (must return `'yes'`).
+ * If `readFieldValueFromDom` returns null (file, rating, image-select, hidden),
+ * fall back to the field's existing store `field.error` value — do NOT falsely
+ * pass or fail these; trust whatever the store recorded.
+ *
+ * The `isFormEmpty` short-circuit is preserved: for non-multistep forms, if
+ * every field appears empty in both the DOM and the store, the form is treated
+ * as empty (invalid), matching the `state.isFormValid` behaviour.
+ *
+ * @param {HTMLFormElement}           form    - The live form element.
+ * @param {ReconcileContext}          context - The Interactivity store context.
+ * @param {IsFormValidFromDomOptions} opts    - Step/multistep configuration.
+ * @return {boolean} True only if every considered field is valid.
+ */
+export const isFormValidFromDom = (
+	form: HTMLFormElement,
+	context: ReconcileContext,
+	opts: IsFormValidFromDomOptions
+): boolean => {
+	const { isMultiStep, currentStep, maxSteps } = opts;
+	const fields = Object.values( context.fields );
+
+	// --- isFormEmpty short-circuit (mirrors state.isFormEmpty) ---------------
+	// Multistep forms never fire the "empty form" message (maxSteps guard).
+	const isMultiStepForm = isMultiStep && maxSteps > 0;
+	if ( ! isMultiStepForm ) {
+		// Check whether every field has an empty DOM value.  If so, the form is
+		// "empty" — matches the behaviour of `state.isFormEmpty` in the store.
+		//
+		// For unreadable types (rating, file, image-select): use the store value,
+		// but if the store has error='yes' we treat the value as non-empty (because
+		// the store successfully captured it — it's just not readable from the DOM).
+		const allEmpty = fields.every( field => {
+			const domValue = readFieldValueFromDom( form, field );
+			if ( domValue !== null ) {
+				return isEmptyValue( domValue );
+			}
+			// Unreadable type: if the store says it's valid, it's non-empty.
+			if ( field.error === 'yes' ) {
+				return false;
+			}
+			return isEmptyValue( field.value );
+		} );
+		if ( allEmpty ) {
+			return false;
+		}
+	}
+
+	// --- Per-field validity --------------------------------------------------
+	// For multistep forms, only validate fields on the current step.
+	const fieldsToCheck = isMultiStepForm
+		? fields.filter( field => field.step === currentStep )
+		: fields;
+
+	for ( const field of fieldsToCheck ) {
+		const domValue = readFieldValueFromDom( form, field );
+
+		let fieldValid: boolean;
+		if ( domValue !== null ) {
+			// We can read the DOM — validate the actual submitted value.
+			const result = validateField( field.type, domValue, field.isRequired, field.extra ?? null );
+			fieldValid = result === 'yes';
+		} else {
+			// Unreadable type (file, rating, image-select, hidden…).
+			// Fall back to whatever the store recorded.
+			fieldValid = field.error === 'yes';
+		}
+
+		if ( ! fieldValid ) {
+			return false;
+		}
+	}
+
+	return true;
 };

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -14,7 +14,7 @@ import {
 import { validateField, isEmptyValue } from '../../contact-form/js/validate-helper.js';
 import { getRating } from '../field-rating/view.js';
 import { maybeAddColonToLabel, maybeTransformValue, getImages, getUrl } from './helpers.js';
-import { reconcileFieldsFromForm } from './reconcile.ts';
+import { reconcileFieldsFromForm, isFormValidFromDom } from './reconcile.ts';
 import { focusNextInput, submitForm } from './shared.ts';
 // Import field type icons view to register its callbacks.
 import './field-type-icons-view.js';
@@ -698,30 +698,43 @@ const { state, actions } = store( NAMESPACE, {
 				// submit them correctly.  The server re-validates authoritatively,
 				// so it's safe to let a DOM-confirmed submission through.
 				//
-				// Before blocking, attempt to reconcile each field's value from
-				// the live DOM.  If after reconciliation the form is valid, allow
-				// the submission to proceed.  If still invalid, block as normal —
-				// the user genuinely hasn't filled in required fields.
+				// Recovery strategy (DOM-DIRECT):
+				//   1. Reconcile each readable field's value from the live DOM and
+				//      call updateField() for each — this keeps the store/UI in sync
+				//      for when reactivity IS working (so error messages render
+				//      correctly if we do end up blocking).
+				//   2. Compute the actual go/no-go from the DOM directly via
+				//      isFormValidFromDom(), which never re-reads the store.
+				//      Because the store write/read is exactly what is unreliable
+				//      under Safari's protection, isFormValidFromDom() is the only
+				//      signal we trust here.
 				const form = event.target instanceof HTMLFormElement ? event.target : null;
+				let domSaysValid = false;
 				if ( form ) {
+					// Step 1 — keep store/UI in sync (best-effort; may be no-op under Safari).
 					const recovered = reconcileFieldsFromForm( form, context );
 					if ( recovered.size > 0 ) {
 						recovered.forEach( ( value, fieldId ) => {
 							actions.updateField( fieldId, value );
 						} );
 					}
+
+					// Step 2 — DOM-direct validity: do NOT re-read state.isFormValid.
+					domSaysValid = isFormValidFromDom( form, context, {
+						isMultiStep: !! context.isMultiStep,
+						currentStep: context.currentStep || 1,
+						maxSteps: context.maxSteps || 0,
+					} );
 				}
 
-				// Re-evaluate after the reconcile attempt.
-				if ( ! state.isFormValid ) {
+				if ( ! domSaysValid ) {
 					context.showErrors = true;
 					event.preventDefault();
 					event.stopPropagation();
 
 					return;
 				}
-				// If we reach here, reconcile recovered valid values — fall through
-				// to the normal submission path below.
+				// DOM-direct says valid — fall through to the normal submission path.
 			}
 
 			if ( context.isMultiStep && context.currentStep < context.maxSteps ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -14,6 +14,7 @@ import {
 import { validateField, isEmptyValue } from '../../contact-form/js/validate-helper.js';
 import { getRating } from '../field-rating/view.js';
 import { maybeAddColonToLabel, maybeTransformValue, getImages, getUrl } from './helpers.js';
+import { reconcileFieldsFromForm } from './reconcile.ts';
 import { focusNextInput, submitForm } from './shared.ts';
 // Import field type icons view to register its callbacks.
 import './field-type-icons-view.js';
@@ -27,6 +28,25 @@ const withSyncEvent =
 const NAMESPACE = 'jetpack/form';
 const config = getConfig( NAMESPACE );
 let errorTimeout = null;
+
+// DEBUG FORMS-685: remove before final merge
+// When ?jetpack_forms_debug_skip_store_capture=1 is present in the URL, the
+// per-keystroke store captures (onFieldChange / onFieldBlur and their variants)
+// are silently no-op'd, leaving store field values empty while the DOM inputs
+// hold the typed text.  This deterministically simulates the iOS Safari
+// Private Browsing failure so the reconcile recovery path can be verified on a
+// real device via Jurassic Ninja without needing Safari fingerprinting
+// protection to actually trigger.
+//
+// Usage:
+//   https://<your-jn-site>/your-form-page/?jetpack_forms_debug_skip_store_capture=1
+//
+// With the flag ON and fix ABSENT  → form blocks with "Please fill out the form correctly"
+// With the flag ON and fix PRESENT → reconcile recovers DOM values and form submits
+const DEBUG_SKIP_STORE_CAPTURE =
+	typeof window !== 'undefined' &&
+	new URLSearchParams( window.location.search ).has( 'jetpack_forms_debug_skip_store_capture' );
+// END DEBUG FORMS-685
 
 const updateField = ( fieldId, value, showFieldError = false, validatorCallback = null ) => {
 	const context = getContext();
@@ -478,6 +498,12 @@ const { state, actions } = store( NAMESPACE, {
 		} ),
 
 		onFieldChange: event => {
+			// DEBUG FORMS-685: remove before final merge
+			if ( DEBUG_SKIP_STORE_CAPTURE ) {
+				return;
+			}
+			// END DEBUG FORMS-685
+
 			let value = event.target.value;
 			const context = getContext();
 			const fieldId = context.fieldId;
@@ -506,6 +532,12 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		onOtherRadioChange: event => {
+			// DEBUG FORMS-685: remove before final merge
+			if ( DEBUG_SKIP_STORE_CAPTURE ) {
+				return;
+			}
+			// END DEBUG FORMS-685
+
 			const context = getContext();
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ];
@@ -533,6 +565,12 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		onOtherTextInput: event => {
+			// DEBUG FORMS-685: remove before final merge
+			if ( DEBUG_SKIP_STORE_CAPTURE ) {
+				return;
+			}
+			// END DEBUG FORMS-685
+
 			const context = getContext();
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ];
@@ -546,6 +584,12 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		onMultipleFieldChange: event => {
+			// DEBUG FORMS-685: remove before final merge
+			if ( DEBUG_SKIP_STORE_CAPTURE ) {
+				return;
+			}
+			// END DEBUG FORMS-685
+
 			const context = getContext();
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ];
@@ -604,6 +648,12 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		onFieldBlur: event => {
+			// DEBUG FORMS-685: remove before final merge
+			if ( DEBUG_SKIP_STORE_CAPTURE ) {
+				return;
+			}
+			// END DEBUG FORMS-685
+
 			const context = getContext();
 			actions.updateField( context.fieldId, event.target.value, true );
 		},
@@ -638,11 +688,40 @@ const { state, actions } = store( NAMESPACE, {
 			// code can still detect preview context if needed.
 
 			if ( ! state.isFormValid ) {
-				context.showErrors = true;
-				event.preventDefault();
-				event.stopPropagation();
+				// FORMS-685: Store↔DOM divergence recovery.
+				//
+				// In some environments (iOS Safari Private Browsing with Advanced
+				// Tracking & Fingerprinting Protection), the per-keystroke store
+				// captures (onFieldChange / onFieldBlur) are suppressed.  The
+				// store thinks every field is empty, but the DOM inputs hold the
+				// real typed values — and FormData (used by submitForm) would
+				// submit them correctly.  The server re-validates authoritatively,
+				// so it's safe to let a DOM-confirmed submission through.
+				//
+				// Before blocking, attempt to reconcile each field's value from
+				// the live DOM.  If after reconciliation the form is valid, allow
+				// the submission to proceed.  If still invalid, block as normal —
+				// the user genuinely hasn't filled in required fields.
+				const form = event.target instanceof HTMLFormElement ? event.target : null;
+				if ( form ) {
+					const recovered = reconcileFieldsFromForm( form, context );
+					if ( recovered.size > 0 ) {
+						recovered.forEach( ( value, fieldId ) => {
+							actions.updateField( fieldId, value );
+						} );
+					}
+				}
 
-				return;
+				// Re-evaluate after the reconcile attempt.
+				if ( ! state.isFormValid ) {
+					context.showErrors = true;
+					event.preventDefault();
+					event.stopPropagation();
+
+					return;
+				}
+				// If we reach here, reconcile recovered valid values — fall through
+				// to the normal submission path below.
 			}
 
 			if ( context.isMultiStep && context.currentStep < context.maxSteps ) {

--- a/projects/packages/forms/tests/js/modules/form/isFormValidFromDom.test.js
+++ b/projects/packages/forms/tests/js/modules/form/isFormValidFromDom.test.js
@@ -1,0 +1,756 @@
+/**
+ * Unit tests for isFormValidFromDom — FORMS-685 DOM-direct validity helper.
+ *
+ * These tests run in jsdom without any Interactivity runtime.
+ * The helper is intentionally store-free so it can be tested in isolation.
+ *
+ * Coverage checklist (each field type must have filled-valid + empty-invalid):
+ * text, name, email, url, number, date, time, textarea
+ * single checkbox, checkbox-multiple, radio, radio-with-"Other"
+ * select/dropdown, range/slider, consent
+ * file, rating, image-select (unreadable, falls back to store error)
+ * multistep, only current-step fields are considered
+ * mixed unreadable + readable in one form
+ */
+
+import { describe, expect, test, beforeEach } from '@jest/globals';
+import { isFormValidFromDom } from '../../../../src/modules/form/reconcile.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal store field record.
+ *
+ * @param {object} overrides - Field property overrides.
+ * @return {object} Store field record.
+ */
+const makeField = ( overrides = {} ) => ( {
+	id: 'field-1',
+	type: 'text',
+	label: 'Field',
+	value: '',
+	isRequired: true,
+	extra: null,
+	error: 'is_required',
+	step: 1,
+	...overrides,
+} );
+
+/**
+ * Default non-multistep opts.
+ */
+const SINGLE_STEP_OPTS = { isMultiStep: false, currentStep: 1, maxSteps: 0 };
+
+/**
+ * Multistep opts for step N of M.
+ *
+ * @param {number} currentStep - The active step (1-based).
+ * @param {number} maxSteps    - Total number of steps.
+ * @return {object} opts
+ */
+const multiStepOpts = ( currentStep, maxSteps ) => ( {
+	isMultiStep: true,
+	currentStep,
+	maxSteps,
+} );
+
+/**
+ * Build a context object from a fields map.
+ *
+ * @param {object} fieldsMap - Map of field id → field record.
+ * @return {object} Context.
+ */
+const makeContext = fieldsMap => ( { fields: fieldsMap } );
+
+/**
+ * Create a real jsdom <form> with the given inner HTML and append to document.
+ *
+ * @param {string} html - Inner HTML.
+ * @return {HTMLFormElement} The form element.
+ */
+const makeForm = html => {
+	document.body.innerHTML = '';
+	const form = document.createElement( 'form' );
+	form.innerHTML = html;
+	document.body.appendChild( form );
+	return form;
+};
+
+// ---------------------------------------------------------------------------
+// text / name / textarea
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — text-like inputs', () => {
+	test( 'text: filled DOM + empty store → valid', () => {
+		const form = makeForm( '<input type="text" name="f1" value="Alice" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'text' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'text: empty DOM + empty store → invalid (isRequired)', () => {
+		const form = makeForm( '<input type="text" name="f1" value="" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'text' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'text: optional empty field in a single-field form → invalid (form is "empty")', () => {
+		// Mirrors state.isFormValid behaviour: isFormEmpty fires first and returns
+		// false for a form where every field has an empty value, even if optional.
+		// This matches the "please fill out the form" UX — don't submit a blank form.
+		const form = makeForm( '<input type="text" name="f1" value="" />' );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'text', isRequired: false, error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'text: optional empty field alongside a filled field → valid (form not empty, optional fields pass)', () => {
+		const form = makeForm( `
+			<input type="text" name="f1" value="Alice" />
+			<input type="text" name="f2" value="" />
+		` );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'text', isRequired: true } ),
+			f2: makeField( { id: 'f2', type: 'text', isRequired: false, error: 'yes' } ),
+		} );
+		// f1 is filled and required → valid; f2 is optional and empty → validateField returns 'yes'
+		// Form is not empty (f1 has a value) → passes the isFormEmpty check
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'name: filled DOM → valid', () => {
+		const form = makeForm( '<input type="text" name="f1" value="Jane Doe" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'name' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'textarea: filled DOM → valid', () => {
+		const form = makeForm( '<textarea name="f1"></textarea>' );
+		form.querySelector( 'textarea' ).value = 'Some long text.';
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'textarea' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'textarea: empty DOM → invalid', () => {
+		const form = makeForm( '<textarea name="f1"></textarea>' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'textarea' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// email
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — email', () => {
+	test( 'valid email in DOM → valid', () => {
+		const form = makeForm( '<input type="email" name="f1" value="user@example.com" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'email' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'invalid email format in DOM → invalid', () => {
+		const form = makeForm( '<input type="email" name="f1" value="not-an-email" />' );
+		const context = makeContext( {
+			// store wouldn't even know about the invalid value under Safari bug
+			f1: makeField( { id: 'f1', type: 'email', error: 'is_required' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'empty required email → invalid', () => {
+		const form = makeForm( '<input type="email" name="f1" value="" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'email' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// url
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — url', () => {
+	test( 'valid url in DOM → valid', () => {
+		const form = makeForm( '<input type="url" name="f1" value="https://example.com" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'url' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'invalid url in DOM → invalid', () => {
+		const form = makeForm( '<input type="url" name="f1" value="not a url at all!!" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'url' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'empty required url → invalid', () => {
+		const form = makeForm( '<input type="url" name="f1" value="" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'url' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// number
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — number', () => {
+	test( 'valid number → valid', () => {
+		const form = makeForm( '<input type="number" name="f1" value="42" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'number' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'number within min/max bounds → valid', () => {
+		const form = makeForm( '<input type="number" name="f1" value="5" />' );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'number', extra: { min: 1, max: 10 } } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'number below min → invalid', () => {
+		const form = makeForm( '<input type="number" name="f1" value="0" />' );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'number', extra: { min: 1 } } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'empty required number → invalid', () => {
+		const form = makeForm( '<input type="number" name="f1" value="" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'number' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// date / time
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — date', () => {
+	test( 'valid yy-mm-dd date → valid', () => {
+		const form = makeForm( '<input type="date" name="f1" value="2024-06-15" />' );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'date', extra: 'yy-mm-dd' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'empty required date → invalid', () => {
+		const form = makeForm( '<input type="date" name="f1" value="" />' );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'date', extra: 'yy-mm-dd' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+describe( 'isFormValidFromDom — time', () => {
+	test( 'filled time input → valid (time has no special regex in validateField)', () => {
+		const form = makeForm( '<input type="time" name="f1" value="09:30" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'time' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'empty required time → invalid', () => {
+		const form = makeForm( '<input type="time" name="f1" value="" />' );
+		const context = makeContext( { f1: makeField( { id: 'f1', type: 'time' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// single checkbox
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — single checkbox', () => {
+	test( 'checked checkbox → valid', () => {
+		const form = makeForm( '<input type="checkbox" name="agree" value="Yes" />' );
+		form.querySelector( 'input' ).checked = true;
+		const context = makeContext( {
+			agree: makeField( { id: 'agree', type: 'checkbox' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'unchecked required checkbox → invalid', () => {
+		const form = makeForm( '<input type="checkbox" name="agree" value="Yes" />' );
+		form.querySelector( 'input' ).checked = false;
+		const context = makeContext( {
+			agree: makeField( { id: 'agree', type: 'checkbox' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'unchecked optional checkbox alone → invalid (form is "empty")', () => {
+		// A single unchecked checkbox gives value='' → form is empty → invalid.
+		// This is consistent with state.isFormValid which also treats empty-form as invalid.
+		const form = makeForm( '<input type="checkbox" name="agree" value="Yes" />' );
+		form.querySelector( 'input' ).checked = false;
+		const context = makeContext( {
+			agree: makeField( { id: 'agree', type: 'checkbox', isRequired: false, error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'unchecked optional checkbox + filled required text → valid (optional checkbox passes, form not empty)', () => {
+		const form = makeForm( `
+			<input type="text" name="name" value="Alice" />
+			<input type="checkbox" name="agree" value="Yes" />
+		` );
+		form.querySelector( 'input[type="checkbox"]' ).checked = false;
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text', isRequired: true } ),
+			agree: makeField( { id: 'agree', type: 'checkbox', isRequired: false, error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// consent
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — consent', () => {
+	test( 'implicit consent (hidden input with "Yes") → valid', () => {
+		const form = makeForm( '<input type="hidden" name="consent" value="Yes" />' );
+		const context = makeContext( {
+			consent: makeField( { id: 'consent', type: 'consent' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'explicit consent checkbox checked → valid', () => {
+		const form = makeForm( '<input type="checkbox" name="consent" value="Yes" />' );
+		form.querySelector( 'input' ).checked = true;
+		const context = makeContext( {
+			consent: makeField( { id: 'consent', type: 'consent' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'explicit consent checkbox unchecked → invalid', () => {
+		const form = makeForm( '<input type="checkbox" name="consent" value="Yes" />' );
+		form.querySelector( 'input' ).checked = false;
+		const context = makeContext( {
+			consent: makeField( { id: 'consent', type: 'consent' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// checkbox-multiple
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — checkbox-multiple', () => {
+	test( 'at least one checked → valid', () => {
+		const form = makeForm( `
+			<input type="checkbox" name="opts[]" value="A" checked />
+			<input type="checkbox" name="opts[]" value="B" />
+		` );
+		const context = makeContext( {
+			opts: makeField( { id: 'opts', type: 'checkbox-multiple', value: [] } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'none checked, required → invalid', () => {
+		const form = makeForm( `
+			<input type="checkbox" name="opts[]" value="A" />
+			<input type="checkbox" name="opts[]" value="B" />
+		` );
+		const context = makeContext( {
+			opts: makeField( { id: 'opts', type: 'checkbox-multiple', value: [] } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'multiple-checkboxes type alias works too', () => {
+		const form = makeForm( `
+			<input type="checkbox" name="colors[]" value="Red" checked />
+			<input type="checkbox" name="colors[]" value="Blue" checked />
+		` );
+		const context = makeContext( {
+			colors: makeField( { id: 'colors', type: 'multiple-checkboxes', value: [] } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// radio
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — radio', () => {
+	test( 'radio selection in DOM → valid', () => {
+		const form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Red" />
+				<input type="radio" name="color" value="Blue" checked />
+			</fieldset>
+		` );
+		const context = makeContext( { color: makeField( { id: 'color', type: 'radio' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'required radio with no selection → invalid', () => {
+		const form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Red" />
+				<input type="radio" name="color" value="Blue" />
+			</fieldset>
+		` );
+		const context = makeContext( { color: makeField( { id: 'color', type: 'radio' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'radio "Other" with companion text → valid', () => {
+		const form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Other" data-other-label="Other" checked />
+				<input name="color-other-text" value="Turquoise" />
+			</fieldset>
+		` );
+		const context = makeContext( { color: makeField( { id: 'color', type: 'radio' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'radio "Other" selected but companion text empty → valid (Other label alone is non-empty)', () => {
+		const form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Other" data-other-label="Other" checked />
+				<input name="color-other-text" value="" />
+			</fieldset>
+		` );
+		// readFieldValueFromDom returns 'Other' (just the label) when text is empty
+		const context = makeContext( { color: makeField( { id: 'color', type: 'radio' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// select / dropdown
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — select / dropdown', () => {
+	test( 'select with non-empty selection → valid', () => {
+		const form = makeForm( `
+			<select name="size">
+				<option value="">Choose…</option>
+				<option value="M" selected>Medium</option>
+			</select>
+		` );
+		const context = makeContext( { size: makeField( { id: 'size', type: 'select' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'select with empty (placeholder) selection, required → invalid', () => {
+		const form = makeForm( `
+			<select name="size">
+				<option value="" selected>Choose…</option>
+				<option value="M">Medium</option>
+			</select>
+		` );
+		const context = makeContext( { size: makeField( { id: 'size', type: 'select' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'dropdown type alias works', () => {
+		const form = makeForm( `
+			<select name="plan">
+				<option value="pro" selected>Pro</option>
+			</select>
+		` );
+		const context = makeContext( { plan: makeField( { id: 'plan', type: 'dropdown' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// range / slider
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — range / slider', () => {
+	test( 'range input with value → valid', () => {
+		const form = makeForm( '<input type="range" name="vol" value="7" min="0" max="10" />' );
+		const context = makeContext( { vol: makeField( { id: 'vol', type: 'range' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'slider type alias works', () => {
+		const form = makeForm( '<input type="range" name="vol" value="3" />' );
+		const context = makeContext( { vol: makeField( { id: 'vol', type: 'slider' } ) } );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Unreadable types: file, rating, image-select
+// (fall back to field.error in the store)
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — unreadable types fall back to store error', () => {
+	test( 'rating field with store error="yes" → valid (fallback passes)', () => {
+		// The form has a hidden input (that's how the rating field stores the submitted
+		// value for the server), but readFieldValueFromDom returns null for type=rating.
+		const form = makeForm( '<input type="hidden" name="rating" value="4/5" />' );
+		const context = makeContext( {
+			rating: makeField( { id: 'rating', type: 'rating', error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'rating field with store error="is_required" → invalid (fallback blocks)', () => {
+		const form = makeForm( '<input type="hidden" name="rating" value="" />' );
+		const context = makeContext( {
+			rating: makeField( { id: 'rating', type: 'rating', error: 'is_required' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'file field with store error="yes" → valid', () => {
+		const form = makeForm( '<input type="file" name="upload" />' );
+		const context = makeContext( {
+			upload: makeField( { id: 'upload', type: 'file', error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'file field with store error="invalid_file_uploading" → invalid', () => {
+		const form = makeForm( '<input type="file" name="upload" />' );
+		const context = makeContext( {
+			upload: makeField( {
+				id: 'upload',
+				type: 'file',
+				error: 'invalid_file_uploading',
+			} ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'image-select field with store error="yes" → valid', () => {
+		const form = makeForm( '<div></div>' ); // no readable DOM for image-select
+		const context = makeContext( {
+			img: makeField( { id: 'img', type: 'image-select', error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'image-select field with store error="is_required" → invalid', () => {
+		const form = makeForm( '<div></div>' );
+		const context = makeContext( {
+			img: makeField( { id: 'img', type: 'image-select', error: 'is_required' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Mixed: readable + unreadable in one form
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — mixed readable + unreadable fields', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'text filled + rating valid in store → form valid', () => {
+		const form = makeForm( `
+			<input type="text" name="name" value="Alice" />
+			<input type="hidden" name="stars" value="4/5" />
+		` );
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text' } ),
+			stars: makeField( { id: 'stars', type: 'rating', error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'text filled + rating MISSING in store → form invalid', () => {
+		const form = makeForm( `
+			<input type="text" name="name" value="Alice" />
+			<input type="hidden" name="stars" value="" />
+		` );
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text' } ),
+			stars: makeField( { id: 'stars', type: 'rating', error: 'is_required' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'text EMPTY + rating valid in store → form invalid', () => {
+		const form = makeForm( `
+			<input type="text" name="name" value="" />
+			<input type="hidden" name="stars" value="3/5" />
+		` );
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text' } ),
+			stars: makeField( { id: 'stars', type: 'rating', error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'file valid + email filled → form valid', () => {
+		const form = makeForm( `
+			<input type="file" name="doc" />
+			<input type="email" name="em" value="a@b.com" />
+		` );
+		const context = makeContext( {
+			doc: makeField( { id: 'doc', type: 'file', error: 'yes' } ),
+			em: makeField( { id: 'em', type: 'email' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// isFormEmpty short-circuit
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — isFormEmpty short-circuit', () => {
+	test( 'all fields empty in DOM → invalid (form empty)', () => {
+		const form = makeForm( `
+			<input type="text" name="f1" value="" />
+			<input type="text" name="f2" value="" />
+		` );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'text' } ),
+			f2: makeField( { id: 'f2', type: 'text' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'one field filled → NOT treated as empty, per-field logic runs', () => {
+		const form = makeForm( `
+			<input type="text" name="f1" value="Alice" />
+			<input type="text" name="f2" value="" />
+		` );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'text' } ),
+			f2: makeField( { id: 'f2', type: 'text' } ),
+		} );
+		// f2 is empty and required → form invalid, but NOT via empty short-circuit
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'multistep form is never treated as empty even if all DOM values are empty', () => {
+		// Multistep forms always return false from isFormEmpty (maxSteps guard)
+		const form = makeForm( `
+			<input type="text" name="f1" value="Alice" />
+		` );
+		const context = makeContext( {
+			f1: makeField( { id: 'f1', type: 'text', step: 1 } ),
+		} );
+		// Even with maxSteps=2, isMultiStep=true, the empty-short-circuit is skipped
+		expect( isFormValidFromDom( form, context, multiStepOpts( 1, 2 ) ) ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Multistep: only current-step fields are considered
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — multistep', () => {
+	test( 'step 1 filled, step 2 empty → valid on step 1 check', () => {
+		// Step 1 has "name" filled; step 2 has "email" empty.
+		// isFormValidFromDom on step 1 should only look at step-1 fields.
+		const form = makeForm( `
+			<input type="text"  name="name"  value="Alice" />
+			<input type="email" name="email" value="" />
+		` );
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text', step: 1 } ),
+			email: makeField( { id: 'email', type: 'email', step: 2 } ),
+		} );
+		expect( isFormValidFromDom( form, context, multiStepOpts( 1, 2 ) ) ).toBe( true );
+	} );
+
+	test( 'step 1 has empty required field → invalid on step 1 check', () => {
+		const form = makeForm( `
+			<input type="text"  name="name"  value="" />
+			<input type="email" name="email" value="a@b.com" />
+		` );
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text', step: 1 } ),
+			email: makeField( { id: 'email', type: 'email', step: 2, error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, multiStepOpts( 1, 2 ) ) ).toBe( false );
+	} );
+
+	test( 'step 2 filled, step 1 fields are NOT re-checked on step 2 submission', () => {
+		const form = makeForm( `
+			<input type="text"  name="name"  value="" />
+			<input type="email" name="email" value="a@b.com" />
+		` );
+		// On step 2: only email (step=2) is checked; name (step=1) is ignored.
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text', step: 1 } ),
+			email: makeField( { id: 'email', type: 'email', step: 2 } ),
+		} );
+		expect( isFormValidFromDom( form, context, multiStepOpts( 2, 2 ) ) ).toBe( true );
+	} );
+
+	test( 'multistep — unreadable field on current step falls back to store error', () => {
+		const form = makeForm( `
+			<input type="text" name="name" value="Alice" />
+			<input type="hidden" name="stars" value="3/5" />
+		` );
+		// Both fields are on step 1.  Rating is unreadable → fallback to store.
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text', step: 1 } ),
+			stars: makeField( { id: 'stars', type: 'rating', step: 1, error: 'yes' } ),
+		} );
+		expect( isFormValidFromDom( form, context, multiStepOpts( 1, 3 ) ) ).toBe( true );
+	} );
+
+	test( 'multistep — unreadable field on current step missing in store → invalid', () => {
+		const form = makeForm( `
+			<input type="text" name="name" value="Alice" />
+		` );
+		const context = makeContext( {
+			name: makeField( { id: 'name', type: 'text', step: 1 } ),
+			stars: makeField( { id: 'stars', type: 'rating', step: 1, error: 'is_required' } ),
+		} );
+		expect( isFormValidFromDom( form, context, multiStepOpts( 1, 3 ) ) ).toBe( false );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe( 'isFormValidFromDom — edge cases', () => {
+	test( 'empty context (no fields) → valid (nothing to fail)', () => {
+		const form = makeForm( '<input type="text" name="x" value="y" />' );
+		const context = makeContext( {} );
+		// With no fields, there's nothing to invalidate, and it's not "empty"
+		// (the isFormEmpty check iterates no fields → allEmpty=true → invalid).
+		// Actually: no fields → allEmpty=true → returns false (treats as empty).
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+
+	test( 'unknown field type → returns null → falls back to store error=yes → valid', () => {
+		const form = makeForm( '<div>custom widget</div>' );
+		// The field value must be non-empty so the form doesn't hit the isFormEmpty short-circuit.
+		const context = makeContext( {
+			widget: makeField( {
+				id: 'widget',
+				type: 'custom-unknown-type',
+				error: 'yes',
+				value: 'something', // non-empty value so the form is not "empty"
+			} ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( true );
+	} );
+
+	test( 'unknown field type with store error=is_required → invalid', () => {
+		const form = makeForm( '<div>custom widget</div>' );
+		const context = makeContext( {
+			widget: makeField( { id: 'widget', type: 'custom-unknown-type', error: 'is_required' } ),
+		} );
+		expect( isFormValidFromDom( form, context, SINGLE_STEP_OPTS ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/form/reconcile.test.js
+++ b/projects/packages/forms/tests/js/modules/form/reconcile.test.js
@@ -1,0 +1,393 @@
+/**
+ * Unit tests for the FORMS-685 store↔DOM reconcile helper.
+ *
+ * All tests run in jsdom (the jest default environment) without any
+ * wordpress/interactivity runtime — the helper is intentionally side-effect
+ * free so these tests can be fast and isolated.
+ */
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import {
+	readFieldValueFromDom,
+	reconcileFieldsFromForm,
+} from '../../../../src/modules/form/reconcile.ts';
+
+// ---------------------------------------------------------------------------
+// Helper to create a minimal store field record
+// ---------------------------------------------------------------------------
+const makeField = ( overrides = {} ) => ( {
+	id: 'field-1',
+	type: 'text',
+	label: 'Name',
+	value: '',
+	isRequired: true,
+	extra: null,
+	...overrides,
+} );
+
+// ---------------------------------------------------------------------------
+// Helper to create a real (jsdom) <form> element with given inner HTML
+// ---------------------------------------------------------------------------
+const makeForm = html => {
+	const form = document.createElement( 'form' );
+	form.innerHTML = html;
+	document.body.appendChild( form );
+	return form;
+};
+
+// ---------------------------------------------------------------------------
+// readFieldValueFromDom
+// ---------------------------------------------------------------------------
+
+describe( 'readFieldValueFromDom — text-like inputs', () => {
+	let form;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		form = makeForm( '<input type="text" name="field-1" value="Hello world" />' );
+	} );
+
+	test( 'reads value from a text input', () => {
+		const result = readFieldValueFromDom( form, makeField( { id: 'field-1', type: 'text' } ) );
+		expect( result ).toBe( 'Hello world' );
+	} );
+
+	test( 'reads value from an email input', () => {
+		document.body.innerHTML = '';
+		form = makeForm( '<input type="email" name="email-field" value="user@example.com" />' );
+		const result = readFieldValueFromDom( form, makeField( { id: 'email-field', type: 'email' } ) );
+		expect( result ).toBe( 'user@example.com' );
+	} );
+
+	test( 'returns empty string when input is present but empty', () => {
+		document.body.innerHTML = '';
+		form = makeForm( '<input type="text" name="field-1" value="" />' );
+		const result = readFieldValueFromDom( form, makeField( { id: 'field-1', type: 'text' } ) );
+		expect( result ).toBe( '' );
+	} );
+
+	test( 'returns null when input element is absent', () => {
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'missing-field', type: 'text' } )
+		);
+		expect( result ).toBeNull();
+	} );
+
+	test( 'reads value from a textarea (type=textarea)', () => {
+		document.body.innerHTML = '';
+		form = makeForm( '<textarea name="msg"></textarea>' );
+		form.querySelector( 'textarea' ).value = 'Multi\nline text';
+		const result = readFieldValueFromDom( form, makeField( { id: 'msg', type: 'textarea' } ) );
+		expect( result ).toBe( 'Multi\nline text' );
+	} );
+
+	test( 'reads value from a url input', () => {
+		document.body.innerHTML = '';
+		form = makeForm( '<input type="url" name="website" value="https://example.com" />' );
+		const result = readFieldValueFromDom( form, makeField( { id: 'website', type: 'url' } ) );
+		expect( result ).toBe( 'https://example.com' );
+	} );
+} );
+
+describe( 'readFieldValueFromDom — checkbox (single)', () => {
+	let form;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'returns "1" for a checked checkbox', () => {
+		form = makeForm( '<input type="checkbox" name="agree" value="Yes" />' );
+		form.querySelector( 'input' ).checked = true;
+		const result = readFieldValueFromDom( form, makeField( { id: 'agree', type: 'checkbox' } ) );
+		expect( result ).toBe( '1' );
+	} );
+
+	test( 'returns "" for an unchecked checkbox', () => {
+		form = makeForm( '<input type="checkbox" name="agree" value="Yes" />' );
+		form.querySelector( 'input' ).checked = false;
+		const result = readFieldValueFromDom( form, makeField( { id: 'agree', type: 'checkbox' } ) );
+		expect( result ).toBe( '' );
+	} );
+
+	test( 'returns null when checkbox is absent', () => {
+		form = makeForm( '<input type="text" name="other" />' );
+		const result = readFieldValueFromDom( form, makeField( { id: 'agree', type: 'checkbox' } ) );
+		expect( result ).toBeNull();
+	} );
+} );
+
+describe( 'readFieldValueFromDom — radio', () => {
+	let form;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'returns the checked radio value', () => {
+		form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Red" />
+				<input type="radio" name="color" value="Blue" checked />
+			</fieldset>
+		` );
+		const result = readFieldValueFromDom( form, makeField( { id: 'color', type: 'radio' } ) );
+		expect( result ).toBe( 'Blue' );
+	} );
+
+	test( 'returns "" when no radio is checked', () => {
+		form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Red" />
+				<input type="radio" name="color" value="Blue" />
+			</fieldset>
+		` );
+		const result = readFieldValueFromDom( form, makeField( { id: 'color', type: 'radio' } ) );
+		expect( result ).toBe( '' );
+	} );
+
+	test( 'builds "Label: text" value for Other radio with companion input', () => {
+		form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Other" data-other-label="Other" checked />
+				<input name="color-other-text" value="Magenta" />
+			</fieldset>
+		` );
+		const result = readFieldValueFromDom( form, makeField( { id: 'color', type: 'radio' } ) );
+		expect( result ).toBe( 'Other: Magenta' );
+	} );
+
+	test( 'returns just the label for Other radio with empty companion input', () => {
+		form = makeForm( `
+			<fieldset>
+				<input type="radio" name="color" value="Other" data-other-label="Other" checked />
+				<input name="color-other-text" value="" />
+			</fieldset>
+		` );
+		const result = readFieldValueFromDom( form, makeField( { id: 'color', type: 'radio' } ) );
+		expect( result ).toBe( 'Other' );
+	} );
+} );
+
+describe( 'readFieldValueFromDom — checkbox-multiple', () => {
+	let form;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'returns array of checked values', () => {
+		form = makeForm( `
+			<input type="checkbox" name="colors[]" value="Red" checked />
+			<input type="checkbox" name="colors[]" value="Blue" />
+			<input type="checkbox" name="colors[]" value="Green" checked />
+		` );
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'colors', type: 'checkbox-multiple' } )
+		);
+		expect( result ).toEqual( [ 'Red', 'Green' ] );
+	} );
+
+	test( 'returns empty array when no checkboxes are checked', () => {
+		form = makeForm( `
+			<input type="checkbox" name="colors[]" value="Red" />
+			<input type="checkbox" name="colors[]" value="Blue" />
+		` );
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'colors', type: 'checkbox-multiple' } )
+		);
+		expect( result ).toEqual( [] );
+	} );
+
+	test( 'returns null when no checkbox inputs with that name exist', () => {
+		form = makeForm( '<input type="text" name="other" />' );
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'colors', type: 'checkbox-multiple' } )
+		);
+		expect( result ).toBeNull();
+	} );
+
+	test( 'also handles multiple-checkboxes type alias', () => {
+		form = makeForm( `
+			<input type="checkbox" name="opts[]" value="A" checked />
+			<input type="checkbox" name="opts[]" value="B" checked />
+		` );
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'opts', type: 'multiple-checkboxes' } )
+		);
+		expect( result ).toEqual( [ 'A', 'B' ] );
+	} );
+} );
+
+describe( 'readFieldValueFromDom — select', () => {
+	let form;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'returns the selected option value', () => {
+		form = makeForm( `
+			<select name="size">
+				<option value="S">Small</option>
+				<option value="M" selected>Medium</option>
+				<option value="L">Large</option>
+			</select>
+		` );
+		const result = readFieldValueFromDom( form, makeField( { id: 'size', type: 'select' } ) );
+		expect( result ).toBe( 'M' );
+	} );
+
+	test( 'returns null when select element is absent', () => {
+		form = makeForm( '<input type="text" name="other" />' );
+		const result = readFieldValueFromDom( form, makeField( { id: 'size', type: 'select' } ) );
+		expect( result ).toBeNull();
+	} );
+} );
+
+describe( 'readFieldValueFromDom — unrecoverable types', () => {
+	let form;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		form = makeForm( '<input type="hidden" name="rating" value="4/5" />' );
+	} );
+
+	test( 'returns null for file type', () => {
+		const result = readFieldValueFromDom( form, makeField( { id: 'rating', type: 'file' } ) );
+		expect( result ).toBeNull();
+	} );
+
+	test( 'returns null for rating type', () => {
+		const result = readFieldValueFromDom( form, makeField( { id: 'rating', type: 'rating' } ) );
+		expect( result ).toBeNull();
+	} );
+
+	test( 'returns null for image-select type', () => {
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'rating', type: 'image-select' } )
+		);
+		expect( result ).toBeNull();
+	} );
+
+	test( 'returns null for unknown type', () => {
+		const result = readFieldValueFromDom(
+			form,
+			makeField( { id: 'rating', type: 'custom-widget' } )
+		);
+		expect( result ).toBeNull();
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// reconcileFieldsFromForm
+// ---------------------------------------------------------------------------
+
+describe( 'reconcileFieldsFromForm', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'returns a Map with recovered values for recognisable field types', () => {
+		const form = makeForm( `
+			<input type="text"  name="name-field"  value="Jane Doe" />
+			<input type="email" name="email-field" value="jane@example.com" />
+			<select name="size-field">
+				<option value="L" selected>Large</option>
+			</select>
+		` );
+
+		const context = {
+			fields: {
+				'name-field': makeField( { id: 'name-field', type: 'text', value: '' } ),
+				'email-field': makeField( { id: 'email-field', type: 'email', value: '' } ),
+				'size-field': makeField( { id: 'size-field', type: 'select', value: '' } ),
+			},
+		};
+
+		const recovered = reconcileFieldsFromForm( form, context );
+
+		expect( recovered.size ).toBe( 3 );
+		expect( recovered.get( 'name-field' ) ).toBe( 'Jane Doe' );
+		expect( recovered.get( 'email-field' ) ).toBe( 'jane@example.com' );
+		expect( recovered.get( 'size-field' ) ).toBe( 'L' );
+	} );
+
+	test( 'omits unrecoverable field types (file, rating, image-select)', () => {
+		const form = makeForm( '<input type="hidden" name="rating" value="4/5" />' );
+
+		const context = {
+			fields: {
+				rating: makeField( { id: 'rating', type: 'rating', value: '' } ),
+			},
+		};
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.size ).toBe( 0 );
+	} );
+
+	test( 'returns empty Map when context has no fields', () => {
+		const form = makeForm( '<input type="text" name="name" value="Test" />' );
+		const recovered = reconcileFieldsFromForm( form, { fields: {} } );
+		expect( recovered.size ).toBe( 0 );
+	} );
+
+	test( 'recovers checkbox-multiple as array', () => {
+		const form = makeForm( `
+			<input type="checkbox" name="hobbies[]" value="Reading" checked />
+			<input type="checkbox" name="hobbies[]" value="Gaming" />
+			<input type="checkbox" name="hobbies[]" value="Cooking" checked />
+		` );
+
+		const context = {
+			fields: {
+				hobbies: makeField( { id: 'hobbies', type: 'checkbox-multiple', value: [] } ),
+			},
+		};
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'hobbies' ) ).toEqual( [ 'Reading', 'Cooking' ] );
+	} );
+
+	test( 'recovers a checked radio value', () => {
+		const form = makeForm( `
+			<fieldset>
+				<input type="radio" name="plan" value="basic" />
+				<input type="radio" name="plan" value="pro" checked />
+			</fieldset>
+		` );
+
+		const context = {
+			fields: {
+				plan: makeField( { id: 'plan', type: 'radio', value: '' } ),
+			},
+		};
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'plan' ) ).toBe( 'pro' );
+	} );
+
+	test( 'handles mixed recoverable and unrecoverable fields in one pass', () => {
+		const form = makeForm( `
+			<input type="text"   name="name"   value="Alice" />
+			<input type="hidden" name="rating" value="5/5" />
+		` );
+
+		const context = {
+			fields: {
+				name: makeField( { id: 'name', type: 'text', value: '' } ),
+				rating: makeField( { id: 'rating', type: 'rating', value: '' } ),
+			},
+		};
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.size ).toBe( 1 );
+		expect( recovered.get( 'name' ) ).toBe( 'Alice' );
+		expect( recovered.has( 'rating' ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/form/view-submit.test.js
+++ b/projects/packages/forms/tests/js/modules/form/view-submit.test.js
@@ -1,0 +1,211 @@
+/**
+ * FORMS-685 — onFormSubmit recovery path tests.
+ *
+ * These tests exercise `actions.onFormSubmit` from view.js directly to ensure
+ * the Store↔DOM divergence recovery branch introduced in FORMS-685 is covered.
+ *
+ * Mocking strategy: `@wordpress/interactivity` is mocked so `store()` captures
+ * the config and returns `{ state, actions }` directly; `getContext()` returns a
+ * per-test mutable context object; `withSyncEvent` is a plain pass-through.
+ * `./shared.ts` `submitForm` is mocked to resolve immediately. All other
+ * side-effectful imports (field-rating/view, field-type-icons-view) are mocked
+ * as no-ops so view.js can be imported in jsdom.
+ */
+
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+// ── 1. Set up mocks BEFORE any dynamic imports ────────────────────────────────
+
+/**
+ * The single mutable context object the test controls.
+ * All mock interactivity functions read/write via this reference.
+ */
+let testContext = null;
+
+/**
+ * Collected store configs (one per store() call in view.js and its deps).
+ * We merge all into a single object so state getters and actions are accessible.
+ */
+const mergedStore = { state: {}, actions: {}, callbacks: {}, effects: {} };
+
+const mockSubmitForm = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/interactivity', () => ( {
+	store: ( _namespace, config ) => {
+		// Merge each slice as store() may be called multiple times (view.js, field-rating/view.js, field-type-icons-view.js).
+		if ( config.state ) {
+			Object.defineProperties(
+				mergedStore.state,
+				Object.getOwnPropertyDescriptors( config.state )
+			);
+		}
+		if ( config.actions ) {
+			Object.assign( mergedStore.actions, config.actions );
+		}
+		if ( config.callbacks ) {
+			Object.assign( mergedStore.callbacks, config.callbacks );
+		}
+		// Return the merged store so view.js destructures { state, actions } correctly.
+		return mergedStore;
+	},
+	getContext: () => testContext,
+	getConfig: () => ( {
+		error_types: {
+			is_required: 'This field is required.',
+			invalid_email: 'Invalid email.',
+			invalid_form: 'Please fill out the form correctly.',
+			invalid_form_empty: 'Please fill out the form.',
+		},
+	} ),
+	getElement: () => ( { ref: null } ),
+	withSyncEvent:
+		cb =>
+		( ...args ) =>
+			cb( ...args ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/modules/form/shared.ts', () => ( {
+	submitForm: mockSubmitForm,
+	focusNextInput: jest.fn(),
+	dispatchSubmitEvent: jest.fn(),
+} ) );
+
+// field-rating/view.js calls store() too — the mock above handles it.
+// field-type-icons-view.js similarly calls store() — handled.
+
+// ── 2. Dynamically import view.js AFTER mocks are set up ─────────────────────
+
+// (view.js side-effect import registers the store config into mergedStore)
+await import( '../../../../src/modules/form/view.js' );
+
+// ── 3. Helper to drive a generator to completion ──────────────────────────────
+
+/**
+ * Run a generator (possibly async yield) to completion.
+ * Each yielded value is awaited; the resolved value is sent back via .next().
+ *
+ * @param {Generator} gen - The generator to drive.
+ * @return {Promise<void>} Resolves when the generator is done.
+ */
+const driveGenerator = async gen => {
+	let result = gen.next();
+	while ( ! result.done ) {
+		// Yield values are Promises (e.g. submitForm returns a Promise).
+		const resolved = await Promise.resolve( result.value );
+		result = gen.next( resolved );
+	}
+};
+
+/**
+ * Build a minimal fake submit event.
+ *
+ * @param {HTMLFormElement|null} formElement - The form element to set as event.target.
+ * @return {object} Fake event object.
+ */
+const makeFakeEvent = ( formElement = null ) => ( {
+	target: formElement,
+	preventDefault: jest.fn(),
+	stopPropagation: jest.fn(),
+} );
+
+// ── 4. Tests ──────────────────────────────────────────────────────────────────
+
+describe( 'FORMS-685 — onFormSubmit recovery path (Store↔DOM divergence)', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+		mockSubmitForm.mockResolvedValue( { success: true, data: [] } );
+	} );
+
+	test( 'recovery path: store empty but DOM filled → reconcile recovers value, form submits via AJAX', async () => {
+		// Build a jsdom form with a filled text input.
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-testhash';
+		form.innerHTML = '<input type="text" name="name" value="Alice" />';
+		document.body.appendChild( form );
+
+		// Context: store thinks the field is empty (store capture was suppressed in Safari).
+		testContext = {
+			fields: {
+				name: {
+					id: 'name',
+					type: 'text',
+					label: 'Name',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required', // ← what validateField('text', '', true) returns
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'testhash',
+			isMultiStep: false,
+			elementId: 'jp-form-testhash',
+		};
+
+		const event = makeFakeEvent( form );
+
+		// Drive the generator — should NOT block; should call submitForm.
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		// The recovery path found 'Alice' in the DOM, re-validated as valid,
+		// then let submission proceed.
+		expect( mockSubmitForm ).toHaveBeenCalledWith( 'testhash' );
+		// showErrors must NOT have been set to true (that only happens on genuine block).
+		expect( testContext.showErrors ).toBe( false );
+	} );
+
+	test( 'genuine-empty path: store empty AND DOM empty → blocks, submitForm never called', async () => {
+		// Build a jsdom form with an unfilled required input.
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-emptyhash';
+		form.innerHTML = '<input type="text" name="username" value="" />';
+		document.body.appendChild( form );
+
+		// Context: store thinks field is empty AND DOM is also empty.
+		testContext = {
+			fields: {
+				username: {
+					id: 'username',
+					type: 'text',
+					label: 'Username',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'emptyhash',
+			isMultiStep: false,
+			elementId: 'jp-form-emptyhash',
+		};
+
+		const event = makeFakeEvent( form );
+
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		// The form was genuinely empty — must have blocked.
+		expect( mockSubmitForm ).not.toHaveBeenCalled();
+		expect( testContext.showErrors ).toBe( true );
+		expect( event.preventDefault ).toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/form/view-submit.test.js
+++ b/projects/packages/forms/tests/js/modules/form/view-submit.test.js
@@ -208,4 +208,311 @@ describe( 'FORMS-685 — onFormSubmit recovery path (Store↔DOM divergence)', (
 		expect( testContext.showErrors ).toBe( true );
 		expect( event.preventDefault ).toHaveBeenCalled();
 	} );
+
+	test( 'DOM-direct: recovery uses isFormValidFromDom — store re-read NOT used for decision', async () => {
+		// Even if updateField() fails to persist (as happens under Safari protection),
+		// the DOM-direct path should still proceed because it reads DOM, not store.
+		// We simulate this by: store empty, DOM filled with valid email.
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-ddrect';
+		form.innerHTML = '<input type="email" name="em" value="user@example.com" />';
+		document.body.appendChild( form );
+
+		testContext = {
+			fields: {
+				em: {
+					id: 'em',
+					type: 'email',
+					label: 'Email',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'ddrect',
+			isMultiStep: false,
+			elementId: 'jp-form-ddrect',
+		};
+
+		const event = makeFakeEvent( form );
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		// DOM-direct check found a valid email → form proceeds.
+		expect( mockSubmitForm ).toHaveBeenCalledWith( 'ddrect' );
+		// Note: useAjax=true always calls preventDefault() to prevent native form
+		// submission and use AJAX instead — this is expected and correct behaviour.
+		// The key signal is that submitForm was called (not blocked).
+	} );
+
+	test( 'radio field: DOM selection filled, store empty → recovery proceeds', async () => {
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-radiohash';
+		form.innerHTML = `
+			<fieldset>
+				<input type="radio" name="plan" value="basic" />
+				<input type="radio" name="plan" value="pro" checked />
+			</fieldset>
+		`;
+		document.body.appendChild( form );
+
+		testContext = {
+			fields: {
+				plan: {
+					id: 'plan',
+					type: 'radio',
+					label: 'Plan',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'radiohash',
+			isMultiStep: false,
+			elementId: 'jp-form-radiohash',
+		};
+
+		const event = makeFakeEvent( form );
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		expect( mockSubmitForm ).toHaveBeenCalledWith( 'radiohash' );
+		expect( testContext.showErrors ).toBe( false );
+	} );
+
+	test( 'mixed: text filled + rating valid in store → recovery proceeds', async () => {
+		// rating is unreadable → isFormValidFromDom falls back to field.error='yes'
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-mixedhash';
+		form.innerHTML = `
+			<input type="text" name="name" value="Alice" />
+			<input type="hidden" name="stars" value="4/5" />
+		`;
+		document.body.appendChild( form );
+
+		testContext = {
+			fields: {
+				name: {
+					id: 'name',
+					type: 'text',
+					label: 'Name',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+				stars: {
+					id: 'stars',
+					type: 'rating',
+					label: 'Rating',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'yes', // ← store has valid rating captured via separate mechanism
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'mixedhash',
+			isMultiStep: false,
+			elementId: 'jp-form-mixedhash',
+		};
+
+		const event = makeFakeEvent( form );
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		expect( mockSubmitForm ).toHaveBeenCalledWith( 'mixedhash' );
+		expect( testContext.showErrors ).toBe( false );
+	} );
+
+	test( 'mixed: text filled + rating missing in store → recovery blocks', async () => {
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-ratingmiss';
+		form.innerHTML = `
+			<input type="text" name="name" value="Alice" />
+			<input type="hidden" name="stars" value="" />
+		`;
+		document.body.appendChild( form );
+
+		testContext = {
+			fields: {
+				name: {
+					id: 'name',
+					type: 'text',
+					label: 'Name',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+				stars: {
+					id: 'stars',
+					type: 'rating',
+					label: 'Rating',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required', // ← rating genuinely not set
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'ratingmiss',
+			isMultiStep: false,
+			elementId: 'jp-form-ratingmiss',
+		};
+
+		const event = makeFakeEvent( form );
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		expect( mockSubmitForm ).not.toHaveBeenCalled();
+		expect( testContext.showErrors ).toBe( true );
+		expect( event.preventDefault ).toHaveBeenCalled();
+	} );
+
+	test( 'multistep: step-1 fields filled in DOM → recovery proceeds on step 1', async () => {
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-mshash';
+		form.innerHTML = `
+			<input type="text" name="name" value="Alice" />
+			<input type="email" name="email" value="" />
+		`;
+		document.body.appendChild( form );
+
+		// step 1 has 'name'; step 2 has 'email' (empty but not current step).
+		testContext = {
+			fields: {
+				name: {
+					id: 'name',
+					type: 'text',
+					label: 'Name',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+				email: {
+					id: 'email',
+					type: 'email',
+					label: 'Email',
+					value: '',
+					isRequired: true,
+					extra: null,
+					error: 'is_required',
+					showFieldError: false,
+					step: 2,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: false, // native POST for multistep to avoid submitForm complexity
+			formHash: 'mshash',
+			isMultiStep: true,
+			currentStep: 1,
+			maxSteps: 2,
+			elementId: 'jp-form-mshash',
+		};
+
+		const event = makeFakeEvent( form );
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		// DOM-direct says step 1 is valid → recovery proceeds (advances step, doesn't block).
+		// The multistep branch increments currentStep and returns, so submitForm is not called yet.
+		expect( testContext.showErrors ).toBe( false );
+	} );
+
+	test( 'happy path: state.isFormValid already true → recovery never runs, submitForm called directly', async () => {
+		const form = document.createElement( 'form' );
+		form.id = 'jp-form-happy';
+		form.innerHTML = '<input type="text" name="name" value="Bob" />';
+		document.body.appendChild( form );
+
+		testContext = {
+			fields: {
+				name: {
+					id: 'name',
+					type: 'text',
+					label: 'Name',
+					value: 'Bob',
+					isRequired: true,
+					extra: null,
+					error: 'yes', // ← store already valid (normal path, Safari not involved)
+					showFieldError: false,
+					step: 1,
+					isOtherSelected: false,
+					otherLabel: null,
+				},
+			},
+			showErrors: false,
+			isSubmitting: false,
+			submissionSuccess: false,
+			submissionError: null,
+			useAjax: true,
+			formHash: 'happy',
+			isMultiStep: false,
+			elementId: 'jp-form-happy',
+		};
+
+		const event = makeFakeEvent( form );
+		const gen = mergedStore.actions.onFormSubmit( event );
+		await driveGenerator( gen );
+
+		// Happy path: submitForm called without going through the recovery block.
+		expect( mockSubmitForm ).toHaveBeenCalledWith( 'happy' );
+		// Note: useAjax=true always calls preventDefault() for AJAX submission.
+		expect( testContext.showErrors ).toBe( false );
+	} );
 } );

--- a/projects/packages/forms/tests/js/modules/form/view.test.js
+++ b/projects/packages/forms/tests/js/modules/form/view.test.js
@@ -1,4 +1,5 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test, beforeEach } from '@jest/globals';
+import { validateField } from '../../../../src/contact-form/js/validate-helper.js';
 import { getRating } from '../../../../src/modules/field-rating/helpers.js';
 import {
 	maybeAddColonToLabel,
@@ -6,6 +7,7 @@ import {
 	getImages,
 	getUrl,
 } from '../../../../src/modules/form/helpers.js';
+import { reconcileFieldsFromForm } from '../../../../src/modules/form/reconcile.ts';
 
 /**
  * Tests for the showPlainValue logic in form submission data formatting.
@@ -616,5 +618,205 @@ describe( 'Form View - getRating helper', () => {
 		} );
 
 		expect( result.iconStyle ).toBe( 'hearts' );
+	} );
+} );
+
+/**
+ * FORMS-685 — Store↔DOM divergence recovery integration tests.
+ *
+ * These tests document the exact failure mode (store empty, DOM filled) and
+ * verify that the reconcile helper bridges the gap so the gate re-evaluates
+ * to valid.
+ *
+ * The tests use only pure helpers (reconcileFieldsFromForm + validateField)
+ * without needing the wordpress/interactivity runtime, matching how the fix
+ * works in onFormSubmit.
+ */
+describe( 'FORMS-685 — store↔DOM divergence recovery', () => {
+	/**
+	 * Simulate the Safari failure: store fields are all at their initial empty
+	 * state (onFieldChange never fired), but DOM inputs have been filled by the
+	 * user.  Verify that after reconciliation every field validates correctly.
+	 *
+	 * @param {object} overrides - Field property overrides.
+	 * @return {object} Store field record with defaults.
+	 */
+	const makeStoreField = ( overrides = {} ) => ( {
+		id: 'f1',
+		type: 'text',
+		label: 'Name',
+		value: '', // ← empty because store capture was suppressed
+		isRequired: true,
+		extra: null,
+		...overrides,
+	} );
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	test( 'text field: store empty, DOM filled → reconcile recovers value and validates', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = '<input type="text" name="name" value="Alice" />';
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'name', type: 'text' } );
+		const context = { fields: { name: storeField } };
+
+		// Pre-fix: store value is empty → validateField returns is_required
+		expect( validateField( storeField.type, storeField.value, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
+
+		// Apply reconcile (mirrors what onFormSubmit does on recovery path)
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'name' ) ).toBe( 'Alice' );
+
+		// Post-reconcile: DOM value validates correctly
+		expect( validateField( storeField.type, recovered.get( 'name' ), storeField.isRequired ) ).toBe(
+			'yes'
+		);
+	} );
+
+	test( 'email field: store empty, DOM filled → reconcile recovers value and validates', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = '<input type="email" name="email" value="alice@example.com" />';
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'email', type: 'email' } );
+		const context = { fields: { email: storeField } };
+
+		expect( validateField( storeField.type, storeField.value, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'email' ) ).toBe( 'alice@example.com' );
+		expect(
+			validateField( storeField.type, recovered.get( 'email' ), storeField.isRequired )
+		).toBe( 'yes' );
+	} );
+
+	test( 'checkbox: checked in DOM → reconcile returns "1" and validates', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = '<input type="checkbox" name="agree" value="Yes" />';
+		form.querySelector( 'input' ).checked = true;
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'agree', type: 'checkbox' } );
+		const context = { fields: { agree: storeField } };
+
+		expect( validateField( storeField.type, storeField.value, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'agree' ) ).toBe( '1' );
+		expect(
+			validateField( storeField.type, recovered.get( 'agree' ), storeField.isRequired )
+		).toBe( 'yes' );
+	} );
+
+	test( 'radio: selection in DOM → reconcile returns selected value and validates', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = `
+			<fieldset>
+				<input type="radio" name="plan" value="basic" />
+				<input type="radio" name="plan" value="pro" checked />
+			</fieldset>
+		`;
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'plan', type: 'radio' } );
+		const context = { fields: { plan: storeField } };
+
+		expect( validateField( storeField.type, storeField.value, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'plan' ) ).toBe( 'pro' );
+		expect( validateField( storeField.type, recovered.get( 'plan' ), storeField.isRequired ) ).toBe(
+			'yes'
+		);
+	} );
+
+	test( 'checkbox-multiple: selections in DOM → reconcile returns array and validates', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = `
+			<input type="checkbox" name="hobbies[]" value="Reading" checked />
+			<input type="checkbox" name="hobbies[]" value="Gaming" />
+			<input type="checkbox" name="hobbies[]" value="Cooking" checked />
+		`;
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'hobbies', type: 'checkbox-multiple', value: [] } );
+		const context = { fields: { hobbies: storeField } };
+
+		expect( validateField( storeField.type, storeField.value, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'hobbies' ) ).toEqual( [ 'Reading', 'Cooking' ] );
+		expect(
+			validateField( storeField.type, recovered.get( 'hobbies' ), storeField.isRequired )
+		).toBe( 'yes' );
+	} );
+
+	test( 'select: selection in DOM → reconcile returns selected value and validates', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = `
+			<select name="size">
+				<option value="">Choose…</option>
+				<option value="M" selected>Medium</option>
+				<option value="L">Large</option>
+			</select>
+		`;
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'size', type: 'select' } );
+		const context = { fields: { size: storeField } };
+
+		expect( validateField( storeField.type, storeField.value, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.get( 'size' ) ).toBe( 'M' );
+		expect( validateField( storeField.type, recovered.get( 'size' ), storeField.isRequired ) ).toBe(
+			'yes'
+		);
+	} );
+
+	test( 'unrecoverable fields (file, rating) are not included in recovered map', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = '<input type="hidden" name="rating" value="4/5" />';
+		document.body.appendChild( form );
+
+		const context = {
+			fields: {
+				rating: makeStoreField( { id: 'rating', type: 'rating', value: '' } ),
+			},
+		};
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		expect( recovered.has( 'rating' ) ).toBe( false );
+	} );
+
+	test( 'genuinely empty required field: store empty AND DOM empty → still invalid after reconcile', () => {
+		const form = document.createElement( 'form' );
+		form.innerHTML = '<input type="text" name="name" value="" />';
+		document.body.appendChild( form );
+
+		const storeField = makeStoreField( { id: 'name', type: 'text' } );
+		const context = { fields: { name: storeField } };
+
+		const recovered = reconcileFieldsFromForm( form, context );
+		// DOM is also empty, so recovered value is still ''
+		const reconciledValue = recovered.get( 'name' );
+		expect( validateField( storeField.type, reconciledValue, storeField.isRequired ) ).toBe(
+			'is_required'
+		);
 	} );
 } );


### PR DESCRIPTION
Fixes #FORMS-685

See also: 219887-ghe-Automattic/wpcom

## Summary

In iOS Safari Private Browsing with **Advanced Tracking & Fingerprinting Protection** (default on iOS 17+ private, extending to all browsing in iOS 26), Jetpack Form submissions are blocked with "Please fill out the form correctly" even when every field is filled.

> **Positioning:** This is proposed as **defense-in-depth** to reinforce the fix, not the root fix. The root cause appears to be how the `@wordpress/interactivity` runtime is delivered on WordPress.com (cross-origin from `s0.wp.com`), which a **platform-level companion fix is addressing separately: 219887-ghe-Automattic/wpcom **. This PR makes the Forms client resilient to the symptom regardless of cause or platform, so it complements that fix and also protects non-WordPress.com/self-hosted contexts and future regressions.

## Proposed changes

- **Symptom / mechanism:** `onFormSubmit` in `view.js` blocks submission when `state.isFormValid` is false. `isFormValid` reads the Interactivity **store**, which is populated by `onFieldChange`/`onFieldBlur`. Under this Safari protection the per-keystroke store updates don't persist — the store sees empty fields while the **DOM `<input>`s hold the real typed values** (which is what `FormData`/the server would receive). So the client gate blocks a submission the server would have accepted.

- **Fix (DOM-direct recovery):** when `onFormSubmit` is about to block, it reconciles each field's value from the live form DOM and **decides validity directly from those DOM values** (`validateField`) via a new pure helper — it does **not** depend on a store write/read for the go/no-go (the store is exactly what's unreliable here). If the DOM says valid, submission proceeds; if genuinely empty, it blocks as before. The happy path (store already valid) is unchanged, and the server remains authoritative.

- **New file** `src/modules/form/reconcile.ts` — pure, no `@wordpress/interactivity` dependency, unit-testable in jsdom. `readFieldValueFromDom` reads text/email/url/telephone/name/number/date/time/textarea, single checkbox, radio (incl. "Other" + companion text), checkbox-multiple, select/dropdown, range/slider; returns `null` for types it can't faithfully reconstruct (file, rating, image-select, hidden) so their store values are left untouched. `isFormValidFromDom` mirrors `state.isFormValid` + `isFormEmpty` semantics (multistep-aware; store-`error` fallback for the `null` types).

- **Debug flag (⚠️ removed in the final pre-merge commit):** `?jetpack_forms_debug_skip_store_capture=1` makes the shared form handlers skip the store write, reproducing the failure deterministically on any device/domain so reviewers can verify before/after without needing real fingerprinting protection. Every line is tagged `// DEBUG FORMS-685: remove before final merge`.

## Root-cause notes (FORMS-685)

Confirmed on a real iOS Safari Private Browsing session (fingerprinting protection on) on a WordPress.com-classified domain, via Web Inspector:

- **Verified:** the cross-origin `@wordpress/interactivity` runtime **loads** (not blocked); `onFieldChange` **fires and reads the correct** `event.target.value` (value-read is NOT suppressed); yet the reactive store never reflects it (`data-wp-class--has-value` stays absent, `aria-invalid` stays true) and the gate blocks. The DOM `<input>` retains the typed value throughout.
- **Refuted:** an "async/deferred handler → detached context" theory — the Interactivity `on` directive invokes handlers synchronously (only the deprecated `on-async` defers), so `onFieldChange` runs in a synchronous scope with the correct context.
- **Working theory (unconfirmed):** the `s0.wp.com`-origin interactivity module is treated as **third-party** under Safari's protection and its script **state is partitioned/suppressed** — so the store (living in that module's scope) can't persist writes, even though it loaded and ran; the first-party DOM is unaffected. This is consistent with the platform fix's same-origin approach (PR 219887) and would affect **any** Interactivity block, not just Forms (plausibly related to SEARCH-104). To be confirmed post-deploy on a classified domain.

## Testing instructions

**Automated (CI):** from `projects/packages/forms/`: `pnpm run test` (756 JS tests — reconcile + `isFormValidFromDom` units + `onFormSubmit` integration), `composer phpunit`, `pnpm run typecheck`. No PHP changed.

**Pre-merge, deterministic — exercise every field type (Jurassic Ninja + debug flag):**
1. On a connected JN site running this branch build, create one Contact Form containing **every field type**: Name, Text, Textarea, Email, URL, Telephone, Number, Date, Time, Checkbox (single), Consent, Multiple choice (checkbox group), Single choice (radio) — include an "Other" option, Dropdown (select), Slider (range), Rating, File, Image select. Make the text-like and choice fields required.
2. Load with `?jetpack_forms_debug_skip_store_capture=1`, fill every field, Submit → **must succeed** (reconcile recovers the readable types; rating/file/image-select pass via their own field modules + store-error fallback).
3. Without the flag → normal submit succeeds.
4. With or without the flag, leave a required field empty → still blocks with "Please fill out the form correctly" (no false-positives).

**Post-merge, real confirmation (Rung 3 — the genuine failure only reproduces on a classified domain):** on `https://cgtest30.wordpress.com/2025/06/03/form/`, iPhone iOS 17+ Private Browsing (protection on), fill + submit → succeeds after this deploys. Already verified pre-merge that the live failure is exactly "DOM filled / store empty" (Web Inspector), which this fix recovers.

## Revert plan

The change is isolated and additive — the recovery branch in `view.js` runs **only** when the gate would otherwise block, plus the standalone `reconcile.ts`. On merge, a **revert PR will be opened immediately** (so its build/CI runs) and kept on standby; if Rung 3 or anything else surfaces a problem, we merge the revert.

## Pre-merge checklist

- [ ] Remove all `// DEBUG FORMS-685` lines and the `DEBUG_SKIP_STORE_CAPTURE` constant from `view.js`.

## Does this pull request change what data or activity we track or use?

No. Client-side validation only — it reads DOM values to recover a suppressed-store scenario. No tracking, no new data collection.