### PR TITLE
Search Blocks: stop suggestion clicks from dismissing the blocks Overlay

### DIFF
--- a/projects/packages/search/changelog/atlas-search-249-overlay-suggestion-dismiss
+++ b/projects/packages/search/changelog/atlas-search-249-overlay-suggestion-dismiss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: clicking a search suggestion no longer dismisses the blocks-powered Overlay.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -256,13 +256,20 @@ function handleOverlayClick( event ) {
 	if ( ! isOpen( overlay ) ) {
 		return;
 	}
-	if ( event.target.closest( '.jetpack-search-block-overlay__close' ) ) {
+	// `composedPath()` snapshots the propagation path at dispatch time, so
+	// child blocks that detach the clicked node mid-bubble (e.g. the Search
+	// Input's `data-wp-each` re-render on suggestion select) don't leave
+	// `event.target` orphaned by the time we walk for the card.
+	const path = event.composedPath();
+	const inPath = selector =>
+		path.some( el => el instanceof Element && el.classList.contains( selector ) );
+	if ( inPath( 'jetpack-search-block-overlay__close' ) ) {
 		event.preventDefault();
 		closeOverlay();
 		return;
 	}
 	// Click on the scrim — anywhere outside the card — closes.
-	if ( ! event.target.closest( '.jetpack-search-block-overlay__card' ) ) {
+	if ( ! inPath( 'jetpack-search-block-overlay__card' ) ) {
 		closeOverlay();
 	}
 }

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -14,14 +14,28 @@ const OVERLAY_ID = 'jetpack-search-block-overlay';
 
 /**
  * Render the server-side overlay shell (closed) into the document body.
+ *
+ * @param {object}  [options]      - Shell variants.
+ * @param {boolean} [options.full] - When true, include the card + close button + a nested suggestion-row marker for the dismissal tests.
  */
-function renderOverlayShell() {
+function renderOverlayShell( { full = false } = {} ) {
+	const inner = full
+		? `
+			<div class="jetpack-search-block-overlay__card">
+				<button class="jetpack-search-block-overlay__close" type="button">close</button>
+				<div class="jetpack-search-block-overlay__content">
+					<ul class="jetpack-search-input__suggestions">
+						<li class="jetpack-search-input__suggestions-option" id="suggestion-row"></li>
+					</ul>
+				</div>
+			</div>
+		`
+		: `<div class="jetpack-search-block-overlay__content"></div>`;
 	document.body.innerHTML = `
-		<div id="${ OVERLAY_ID }" hidden>
-			<div class="jetpack-search-block-overlay__content"></div>
-		</div>
+		<div id="${ OVERLAY_ID }">${ inner }</div>
 		<template id="jetpack-search-block-overlay-template"></template>
 	`;
+	document.getElementById( OVERLAY_ID ).setAttribute( 'hidden', '' );
 }
 
 /**
@@ -117,5 +131,67 @@ describe( 'overlay-bootstrap initial-load URL trigger', () => {
 
 		await expect( loadBootstrap() ).resolves.toBeUndefined();
 		expect( document.getElementById( OVERLAY_ID ) ).toBeNull();
+	} );
+} );
+
+describe( 'overlay-bootstrap click dismissal', () => {
+	/**
+	 * Render the full overlay, open it via the URL trigger, and stub
+	 * `window.scrollTo` (which `closeOverlay` calls when restoring scroll
+	 * position). jsdom doesn't implement scrollTo and the close-path tests
+	 * would otherwise trip `@wordpress/jest-console`'s strict error guard.
+	 */
+	async function setUpOpenOverlay() {
+		window.scrollTo = () => {};
+		setReadyState( 'complete' );
+		renderOverlayShell( { full: true } );
+		setUrl( '/?s=hello' );
+		await loadBootstrap();
+	}
+
+	it( 'closes when the X close button is clicked', async () => {
+		await setUpOpenOverlay();
+
+		const closeBtn = document.querySelector( '.jetpack-search-block-overlay__close' );
+		closeBtn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+
+		expect( isOpen() ).toBe( false );
+	} );
+
+	it( 'closes when the scrim (outside the card) is clicked', async () => {
+		await setUpOpenOverlay();
+
+		document
+			.getElementById( OVERLAY_ID )
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+
+		expect( isOpen() ).toBe( false );
+	} );
+
+	it( 'stays open when a click target inside the card is detached mid-bubble', async () => {
+		// Reproduces the suggestion-click bug: the `<li>` lives inside the card,
+		// but the Interactivity action that fires on click empties the surrounding
+		// `data-wp-each` array, which removes the `<li>` from the DOM before the
+		// click event finishes bubbling to the overlay's outside-click handler.
+		// `event.target.closest('.jetpack-search-block-overlay__card')` then returns
+		// null and the overlay dismisses. With `composedPath()` the path is frozen
+		// at dispatch time, so the detach no longer fools the handler.
+		await setUpOpenOverlay();
+
+		const row = document.getElementById( 'suggestion-row' );
+		row.addEventListener( 'click', () => row.remove() );
+		row.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+
+		expect( isOpen() ).toBe( true );
+	} );
+
+	it( 'stays open when a non-suggestion click inside the card bubbles up', async () => {
+		await setUpOpenOverlay();
+
+		document
+			.querySelector( '.jetpack-search-block-overlay__content' )
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+
+		expect( isOpen() ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Fixes [SEARCH-249](https://linear.app/a8c/issue/SEARCH-249/search-blocks-clicking-a-suggestion-in-the-blocks-overlay-dismisses)

## Why

In the new blocks-powered Search Overlay (experimental), picking a search suggestion made the overlay vanish before the suggestion could do anything. Authors who turn on suggestions on the Search Input block expect "pick a suggestion → see refreshed results in the overlay" or "pick a taxonomy → filter inline." Today they get "pick a suggestion → modal disappears" and the search context is lost. This restores the expected behavior so suggestions are usable inside the Overlay.

## Proposed changes

- `overlay-bootstrap/index.js`: in the overlay's outside-click handler, replace `event.target.closest(...)` with `event.composedPath()` checks for the close button and the card. `composedPath()` is captured at dispatch time, so any child block that detaches the clicked node mid-bubble (the suggestion `<li>` is removed when `acceptSuggestion` empties `ctx.rows` via `data-wp-each`) no longer leaves the outside-click check walking an orphan target.
- Adds four regression tests in `overlay-bootstrap/test/index.test.js`:
  - X close button still dismisses the overlay.
  - Clicking the scrim (outside the card) still dismisses.
  - Clicking a target inside the card that gets detached mid-bubble keeps the overlay open (the exact failure mode of the suggestion bug).
  - Ordinary clicks inside the card keep the overlay open.

## Screenshots

Tested in the local docker env on twentytwentyfive (atlas) with the blocks Overlay experience active and `enableSuggestions: true` on the Search Input.

Both shots are taken **after** clicking a suggestion (`woocommerce beta tester plugin vulnerability`):

### Before
![before](https://github.com/user-attachments/assets/6f5f17d8-80db-4ec7-9c61-ddd02b223d85)

The overlay has dismissed and the user is dumped back on the theme's bare search page.

### After
![after](https://github.com/user-attachments/assets/4283f82e-2a6d-4914-818a-ebbb722bca78)

The overlay stays open with the suggestion's text in the search field and the results region refreshed.

## Related product discussion/links

- Linear: [SEARCH-249](https://linear.app/a8c/issue/SEARCH-249/search-blocks-clicking-a-suggestion-in-the-blocks-overlay-dismisses)
- Adjacent recent work: SEARCH-205 (suggestions feature), SEARCH-245 (suggestions panel visual mixing), SEARCH-242 (blocks Overlay experimental release).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the blocks-powered Overlay search experience: `wp option update jetpack_search_experience overlay_blocks`.
2. Customize the overlay template to enable suggestions on the Search Input block — either edit the overlay template via the dashboard "Edit the Search overlay" link, or create the singleton CPT directly:
   ```bash
   wp post create --post_type=jp_search_overlay --post_status=publish --post_title='Overlay Template' \
     --post_content='<!-- wp:jetpack-search/search-input {"enableSuggestions":true} /-->'
   wp option update jetpack_search_overlay_template_post_id <new-post-id>
   ```
3. Open the front end with `?s=` (or click any overlay trigger) to open the Search Overlay.
4. Type a query that returns suggestions, e.g. `test`.
5. Click a `query`-type suggestion. **Expected:** the overlay stays open, the input fills with the suggestion's text, the results region refreshes.
6. Repeat with a `taxonomy`-type suggestion that maps to a registered filter on the overlay. **Expected:** the overlay stays open and the filter applies inline.
7. Repeat with a `post`-type (or unmapped `taxonomy`-type) suggestion that has a URL. **Expected:** the page navigates to that URL (the overlay close is moot — the page changes).
8. Sanity-check the overlay's normal dismissal paths haven't regressed:
   - Click the `×` close button → overlay closes.
   - Click outside the card (on the scrim) → overlay closes.
   - Click anywhere inside the card that isn't a navigation control (filter checkbox, sort dropdown, results area, header strip) → overlay stays open.
