### PR TITLE
Search Blocks: Overlay shell honors legacy --background/--foreground tokens

### DIFF
--- a/projects/packages/search/changelog/sage-search-250-overlay-legacy-tokens
+++ b/projects/packages/search/changelog/sage-search-250-overlay-legacy-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: blocks-powered Overlay shell now also honors the legacy --background / --foreground theme color tokens, restoring legibility on themes (e.g. Kaze) that don't define --base / --contrast.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1298,12 +1298,18 @@ class Search_Blocks {
  * open/close animation, and the body-scroll-lock helper. Mirrors the
  * visual idiom of the legacy `instant-search/components/overlay.scss`.
  *
- * Surface + ink track the theme's `base` / `contrast` tokens (matching the
- * suggestions dropdown and sort popover treatment), so the modal reads as
- * part of the active palette on dark themes instead of a forced-white panel
- * with illegible inherited light text. Hairlines and the close-button hover
- * use `color-mix(currentColor)` so they keep a consistent contrast ratio
- * against whatever surface the theme chose.
+ * Surface + ink track the theme's color tokens — newer `base` / `contrast`
+ * (TT2/TT3/TT5-family) first, then legacy `background` / `foreground` (TT1,
+ * Kaze, many WPCOM themes) — matching the suggestions dropdown and sort
+ * popover treatment. The two-step fallback chain is required because legacy
+ * themes don't define `base` / `contrast` at all, so the older PR (#49125)
+ * fix landed on hardcoded `#fff` for the surface and inherited body
+ * `--foreground` (often white on dark themes) for the ink — i.e. the same
+ * white-on-white bug the fix was meant to remove. The chain is hoisted onto
+ * two local custom properties so any in-card surface that needs to match the
+ * card (e.g. the suggestions panel) reads from a single source of truth.
+ * Hairlines and the close-button hover use `color-mix(currentColor)` so they
+ * keep a consistent contrast ratio against whatever surface the theme chose.
  */
 .jetpack-search-block-overlay {
 	position: fixed;
@@ -1329,8 +1335,10 @@ class Search_Blocks {
 	position: relative;
 	width: 100%;
 	max-width: 1080px;
-	background: var(--wp--preset--color--base, #fff);
-	color: var(--wp--preset--color--contrast, inherit);
+	--jp-search-overlay-surface: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
+	--jp-search-overlay-ink: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
+	background: var(--jp-search-overlay-surface);
+	color: var(--jp-search-overlay-ink);
 	border-radius: 4px;
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 	padding-top: 60px;
@@ -1443,14 +1451,16 @@ class Search_Blocks {
  * / "Post Type" peeking out on the right; (2) lift `z-index` above the
  * other in-card popovers (`results-sort` and `filters-popover` both at
  * `z-index: 20`) so the panel reliably wins the stacking order even
- * when one of those is open underneath. Explicit `background: #fff`
- * matches the card's hardcoded surface as a final guard against any
- * theme that neutralises the global token fallback.
+ * when one of those is open underneath. Background reads from the card's
+ * `--jp-search-overlay-surface` so the panel surface tracks the resolved
+ * card surface on every theme — a hardcoded `#fff` here would be opaque
+ * white over a theme-coloured card on legacy `--background`/`--foreground`
+ * themes, the same bug the card itself dodges via the chained fallback.
  */
 .jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__suggestions {
 	right: -60px;
 	z-index: 30;
-	background: #fff;
+	background: var(--jp-search-overlay-surface);
 }
 /*
  * Top padding clears the absolutely-positioned 60px header strip — without

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1460,7 +1460,7 @@ class Search_Blocks {
 .jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__suggestions {
 	right: -60px;
 	z-index: 30;
-	background: var(--jp-search-overlay-surface);
+	background: var(--jp-search-overlay-surface, #fff);
 }
 /*
  * Top padding clears the absolutely-positioned 60px header strip — without


### PR DESCRIPTION
Fixes [SEARCH-250](https://linear.app/a8c/issue/SEARCH-250/search-blocks-overlay-shell-honors-legacy-background-foreground-token)

## Why
On block themes that use the legacy `--wp--preset--color--background` / `--wp--preset--color--foreground` token pair instead of the newer `--base` / `--contrast` pair, the blocks-powered Search Overlay still renders as an unreadable forced-white card with invisible white ink. PR #49125 (SEARCH-246) only consulted the newer token pair, so visitors on legacy-token themes (TT1, Kaze, many WPCOM themes) hit exactly the white-on-white illegibility that PR set out to fix. Initial repro on https://kangzj4.wordpress.com/?q=hello (Kaze theme, dark palette).

Extend the fallback chain to honor both conventions, with the resolved values hoisted onto two local custom properties so any in-card surface (the card itself and the suggestions dropdown today) reads from a single source of truth.

## Proposed changes
* `.jetpack-search-block-overlay__card` now defines two local custom properties:
  * `--jp-search-overlay-surface: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff))`
  * `--jp-search-overlay-ink: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit))`
  The card's `background` / `color` read from those instead of the previous single-step var chain, so legacy `--background` / `--foreground` themes resolve to the theme's actual surface + ink instead of the hardcoded fallback.
* The suggestions dropdown panel inside the card switches its hardcoded `background: #fff` to `var(--jp-search-overlay-surface)`, so the panel surface tracks the resolved card surface on every theme — fixing the same white-on-dark mismatch the card itself dodges.
* No JS/markup changes. No changes to the close-button divider/hover, the search-input row underline, or the filter-column divider — those already use `color-mix(currentColor, ...)` and pick up the resolved ink regardless of which token convention defines it.

## Screenshots

Captured at `/?s=hello` against the local docker (`https://jp-sage.jurassic.tube/`) at 1440×900. The `legacy-tokens` row simulates Kaze's `--background` / `--foreground` token convention via a small mu-plugin (`--base` and `--contrast` set to `initial`, `--background = #090909`, `--foreground = #ffffff`); the `tt5-default` row uses TT5 default styles as a no-regression baseline.

### Legacy `--background` / `--foreground` themes (the bug)

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/1ee40bfb-f805-45d2-968a-c003401b91ab) | ![after](https://github.com/user-attachments/assets/e7fd4957-529a-47c1-b430-0ca10ad63fae) |

`Before`: card surface falls back to `#fff`; ink inherits the body's `var(--wp--preset--color--foreground)` (white). Result counts, filter labels, post titles, helper text — all invisible white-on-white. Matches the kangzj4 repro screenshot.

`After`: card surface picks up `--background` (`#090909`); ink picks up `--foreground` (`#ffffff`); every label, count, and result row is fully legible. Filter-column divider, close-button hairline, and search-input row underline all track `currentColor` against the new dark surface and stay subtle.

### TT5 default (no-regression baseline)

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/05af14c5-4826-496b-9481-1ded2fe0bcdc) | ![after](https://github.com/user-attachments/assets/240b4bdc-e2c2-400c-a3b8-08c71a236336) |

Pixel-identical (byte-identical PNG, in fact) — on themes that already define `--base` / `--contrast`, the first step of the chain still wins and the existing PR #49125 behavior is preserved.

## Related product discussion/links
* Linear: [SEARCH-250](https://linear.app/a8c/issue/SEARCH-250/search-blocks-overlay-shell-honors-legacy-background-foreground-token)
* Follow-up to: [SEARCH-246](https://linear.app/a8c/issue/SEARCH-246) / #49125
* Initial reproduction reported on https://kangzj4.wordpress.com/?q=hello.

## Does this pull request change what data or activity we track or use?
No — CSS-only theming change, no data flow, telemetry, or persistence affected.

## Testing instructions
Verify each acceptance criterion below against the Before/After screenshots above and, for the legacy-tokens case, in a local env.

- [ ] On a dark block theme using the legacy `--background` / `--foreground` token pair (e.g. Kaze), the Overlay card surface picks up `--background`, ink picks up `--foreground`, and body text inside the Overlay is fully legible.
- [ ] On a block theme using the newer `--base` / `--contrast` pair (TT5 default + Midnight variation), no visual regression — the existing PR #49125 behavior is preserved.
- [ ] On a classic theme with no `theme.json` tokens defined, the final `#fff` / `inherit` fallbacks preserve today's behavior.
- [ ] The suggestions dropdown panel inside the card uses the same surface chain as the card — no more hardcoded `#fff` on `.jetpack-search-input__suggestions`.
- [ ] Existing hairlines (close-button divider/hover, search-input row underline, filters-column divider) continue to track `currentColor` and stay legible against the new surface.

Reproducing the legacy-tokens repro locally:

1. Activate a block theme that defines `--background` / `--foreground` instead of `--base` / `--contrast` (Kaze on WPCOM is the canonical example; or simulate by dropping the mu-plugin below into `wp-content/mu-plugins/` and visiting any page with `?simulate=kaze`):
   ```php
   <?php
   add_action( 'wp_head', function () {
       if ( empty( $_GET['simulate'] ) || 'kaze' !== $_GET['simulate'] ) { return; }
       echo '<style>:root{--wp--preset--color--base:initial;--wp--preset--color--contrast:initial;--wp--preset--color--background:#090909;--wp--preset--color--foreground:#ffffff;}body{background-color:var(--wp--preset--color--background)!important;color:var(--wp--preset--color--foreground)!important;}</style>';
   }, 999 );
   ```
2. Set the search experience to "Blocks Overlay" (Experience Selector / `jetpack_search_experience = overlay_blocks`).
3. Visit `/?s=hello&simulate=kaze` on the front end — the Overlay auto-opens.
4. On trunk: card is white, body text/results/labels are white = invisible. On this PR: card surface is dark (`#090909`), ink is white (`#ffffff`), every label and result row is legible.

Out of scope (deliberately): the legacy preact Instant Search overlay, the Embedded experience search page, layout / sizing / typography changes, any theme.json or PHP-side `wp_get_global_styles()` reading.
