### PR TITLE
Search Blocks: keep view-module URLs same-origin (fix CORS on multi-domain sites)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-252-same-origin-script-modules
+++ b/projects/packages/search/changelog/atlas-search-252-same-origin-script-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: keep view-module URLs same-origin so blocks load on Multisite mapped domains, www-vs-non-www mismatches, and CDN setups without CORS headers.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -125,6 +125,13 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
+		// Relativize `jetpack-search/*` Script Module URLs whose host matches
+		// the site canonical so the rendered `<script type="module">` is
+		// same-origin with the page. ES modules go through CORS even without
+		// a `crossorigin` attribute, and `wp-content/*` typically lacks the
+		// `Access-Control-Allow-Origin` header — see
+		// `same_origin_script_module_src()`.
+		add_filter( 'script_module_loader_src', array( static::class, 'same_origin_script_module_src' ), 10, 2 );
 		Custom_Taxonomy_Slot_Mapping::init();
 		// Both hooks needed; see AGENTS.md § Hydration & SSR seeding.
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
@@ -682,6 +689,70 @@ class Search_Blocks {
 			$asset['dependencies'] ?? array(),
 			$asset['version'] ?? false
 		);
+	}
+
+	/**
+	 * Relativize Jetpack Search Script Module URLs so the browser fetches them
+	 * same-origin with the page.
+	 *
+	 * `wp_register_script_module()` resolves src via `plugins_url()`, which
+	 * returns the canonical `site_url()` host. When a visitor is on a
+	 * different host (Multisite mapped domains, www vs non-www without a
+	 * canonical redirect, asset-offload plugins, reverse-proxy staging) the
+	 * `<script type="module">` becomes cross-origin and is blocked with
+	 * `MissingAllowOriginHeader` — ES modules always go through the CORS
+	 * algorithm, even without a `crossorigin` attribute, and typical WP
+	 * hosts don't send `Access-Control-Allow-Origin` for `wp-content/*`.
+	 *
+	 * Stripping scheme + host with `wp_make_link_relative()` lets the browser
+	 * resolve against the page's actual origin. No `$_SERVER['HTTP_HOST']`
+	 * trust — emitting an attacker-controllable host into a `<script src>`
+	 * would be a cache-poisoning vector.
+	 *
+	 * No-op when the src host is a deliberately external host (CDN that
+	 * doesn't match `home_url()`/`site_url()`); operators of those setups
+	 * configure CORS on the CDN themselves.
+	 *
+	 * Identifier gate covers both shapes Jetpack Search ships: directly-
+	 * registered modules with a slash (`jetpack-search/store`,
+	 * `jetpack-search/overlay-bootstrap`) and the per-block view modules
+	 * WP auto-registers from `block.json`'s `viewScriptModule`, which run
+	 * `generate_block_asset_handle()` and emit hyphen-joined IDs like
+	 * `jetpack-search-results-list-view-script-module`.
+	 *
+	 * @param string $src        Module src URL.
+	 * @param string $identifier Module identifier (e.g. `jetpack-search/results-list`
+	 *                           or `jetpack-search-results-list-view-script-module`).
+	 * @return string Relativized src on match, original otherwise.
+	 */
+	public static function same_origin_script_module_src( $src, $identifier ) {
+		if ( ! is_string( $src ) || '' === $src || ! is_string( $identifier ) ) {
+			return $src;
+		}
+		if ( 0 !== strpos( $identifier, 'jetpack-search/' ) && 0 !== strpos( $identifier, 'jetpack-search-' ) ) {
+			return $src;
+		}
+
+		$src_host = wp_parse_url( $src, PHP_URL_HOST );
+		if ( ! $src_host ) {
+			return $src;
+		}
+
+		$canonical_hosts = array_map(
+			'strtolower',
+			array_filter(
+				array(
+					wp_parse_url( home_url(), PHP_URL_HOST ),
+					wp_parse_url( site_url(), PHP_URL_HOST ),
+				)
+			)
+		);
+
+		if ( ! in_array( strtolower( $src_host ), $canonical_hosts, true ) ) {
+			return $src;
+		}
+
+		return wp_make_link_relative( $src );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -2814,9 +2814,9 @@ class Search_Blocks_Test extends TestCase {
 	 */
 	public function test_same_origin_script_module_src_defensive_guards(): void {
 		$this->assertSame( '', Search_Blocks::same_origin_script_module_src( '', 'jetpack-search/results-list' ) );
-		// @phpstan-ignore-next-line — deliberately exercising the non-string $src guard.
+		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Deliberately exercising the non-string $src guard.
 		$this->assertNull( Search_Blocks::same_origin_script_module_src( null, 'jetpack-search/results-list' ) );
-		// @phpstan-ignore-next-line — deliberately exercising the non-string $identifier guard.
+		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Deliberately exercising the non-string $identifier guard.
 		$this->assertSame( 'https://example.com/x.js', Search_Blocks::same_origin_script_module_src( 'https://example.com/x.js', null ) );
 	}
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -2814,8 +2814,10 @@ class Search_Blocks_Test extends TestCase {
 	 */
 	public function test_same_origin_script_module_src_defensive_guards(): void {
 		$this->assertSame( '', Search_Blocks::same_origin_script_module_src( '', 'jetpack-search/results-list' ) );
-		// @phpstan-ignore-next-line — deliberately exercising the non-string guard.
+		// @phpstan-ignore-next-line — deliberately exercising the non-string $src guard.
 		$this->assertNull( Search_Blocks::same_origin_script_module_src( null, 'jetpack-search/results-list' ) );
+		// @phpstan-ignore-next-line — deliberately exercising the non-string $identifier guard.
+		$this->assertSame( 'https://example.com/x.js', Search_Blocks::same_origin_script_module_src( 'https://example.com/x.js', null ) );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1354,6 +1354,7 @@ class Search_Blocks_Test extends TestCase {
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );
 		remove_filter( 'posts_pre_query', array( Search_Blocks::class, 'filter__posts_pre_query' ), 10 );
+		remove_filter( 'script_module_loader_src', array( Search_Blocks::class, 'same_origin_script_module_src' ), 10 );
 		Search_Blocks::set_block_templates_active_for_testing( null );
 	}
 
@@ -2607,5 +2608,252 @@ class Search_Blocks_Test extends TestCase {
 			$ref->setAccessible( true );
 		}
 		return $ref->invoke( null, ...$args );
+	}
+
+	/**
+	 * Force `home_url()` and `site_url()` to a known host via the
+	 * `pre_option_home` / `pre_option_siteurl` filters. Returns a cleanup
+	 * Callback so callers can restore the originals deterministically (a
+	 * Failed assertion before tearDown would otherwise leak the override).
+	 *
+	 * @param string $home Value to return from `home_url()`.
+	 * @param string $site Value to return from `site_url()`.
+	 * @return callable Cleanup callback.
+	 */
+	private function override_site_hosts( string $home, string $site ): callable {
+		$home_cb = static function () use ( $home ) {
+			return $home;
+		};
+		$site_cb = static function () use ( $site ) {
+			return $site;
+		};
+		add_filter( 'pre_option_home', $home_cb );
+		add_filter( 'pre_option_siteurl', $site_cb );
+		return static function () use ( $home_cb, $site_cb ) {
+			remove_filter( 'pre_option_home', $home_cb );
+			remove_filter( 'pre_option_siteurl', $site_cb );
+		};
+	}
+
+	/**
+	 * Canonical-host src on a Jetpack Search module ID gets relativized so
+	 * The browser resolves the script against the page's actual origin,
+	 * Sidestepping the CORS check on `wp-content/*` from a mapped domain.
+	 */
+	public function test_same_origin_script_module_src_relativizes_canonical_host_src(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$this->assertSame(
+				'/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+				Search_Blocks::same_origin_script_module_src(
+					'https://example.com/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+					'jetpack-search/results-list'
+				)
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * The version query string must survive relativization — it's what
+	 * Defeats stale-cache loads when a build ships a new bundle.
+	 */
+	public function test_same_origin_script_module_src_preserves_query_string(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$this->assertSame(
+				'/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js?ver=abc123',
+				Search_Blocks::same_origin_script_module_src(
+					'https://example.com/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js?ver=abc123',
+					'jetpack-search/results-list'
+				)
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * HTTP-scheme canonicals (local docker, http-only sites) get relativized
+	 * Like HTTPS — the browser binds the relative URL to whatever scheme the
+	 * Page is on, which is the desired behavior either way.
+	 */
+	public function test_same_origin_script_module_src_relativizes_http_canonical(): void {
+		$cleanup = $this->override_site_hosts( 'http://example.com', 'http://example.com' );
+		try {
+			$this->assertSame(
+				'/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+				Search_Blocks::same_origin_script_module_src(
+					'http://example.com/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+					'jetpack-search/results-list'
+				)
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * Hostname comparison must be case-insensitive — DNS treats `EXAMPLE.com`
+	 * And `example.com` as the same host, and a site whose home_url has been
+	 * Saved with mixed case shouldn't dodge the relativization.
+	 */
+	public function test_same_origin_script_module_src_canonical_match_is_case_insensitive(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$this->assertSame(
+				'/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+				Search_Blocks::same_origin_script_module_src(
+					'https://EXAMPLE.COM/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+					'jetpack-search/results-list'
+				)
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * `home_url()` and `site_url()` are checked independently — a site whose
+	 * `home_url()` lives on `example.com` and whose `site_url()` lives on
+	 * `wp.example.com` must relativize either canonical the URL was built
+	 * Against (Multisite sub-directory installs split the two).
+	 */
+	public function test_same_origin_script_module_src_relativizes_site_url_host_when_home_url_differs(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://wp.example.com' );
+		try {
+			$this->assertSame(
+				'/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+				Search_Blocks::same_origin_script_module_src(
+					'https://wp.example.com/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js',
+					'jetpack-search/results-list'
+				)
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * Genuine third-party CDN hosts (configured by the operator, e.g. via
+	 * `JETPACK_SEARCH_PLUGINS_URL` rewrites) pass through unchanged — the
+	 * Filter must not break setups where the operator wants the CDN to serve
+	 * Modules and has configured CORS on that CDN themselves.
+	 */
+	public function test_same_origin_script_module_src_leaves_third_party_cdn_alone(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$cdn_url = 'https://cdn.example.net/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js';
+			$this->assertSame(
+				$cdn_url,
+				Search_Blocks::same_origin_script_module_src( $cdn_url, 'jetpack-search/results-list' )
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * The identifier-prefix gate is the boundary that keeps this filter from
+	 * Touching other plugins' modules (e.g. core's `@wordpress/interactivity`,
+	 * Or any unrelated `vendor/foo` bundle). A non-`jetpack-search/*` id must
+	 * Pass through unchanged even when the src host matches a canonical.
+	 */
+	public function test_same_origin_script_module_src_skips_non_jetpack_search_identifier(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$src = 'https://example.com/wp-includes/js/dist/interactivity.min.js';
+			$this->assertSame(
+				$src,
+				Search_Blocks::same_origin_script_module_src( $src, '@wordpress/interactivity' )
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * `register_block_type()` runs `generate_block_asset_handle()` on
+	 * `viewScriptModule` fields and emits hyphen-joined IDs like
+	 * `jetpack-search-results-list-view-script-module` — that's what WP
+	 * Passes to the loader filter for every per-block view module. Without
+	 * Covering this prefix shape the filter would only catch directly-
+	 * Registered modules and miss the bulk of the block bundles, exactly
+	 * The case the bug report describes.
+	 */
+	public function test_same_origin_script_module_src_relativizes_block_generated_handle(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$this->assertSame(
+				'/wp-content/plugins/jetpack-search/build/search-blocks/results-list.js',
+				Search_Blocks::same_origin_script_module_src(
+					'https://example.com/wp-content/plugins/jetpack-search/build/search-blocks/results-list.js',
+					'jetpack-search-results-list-view-script-module'
+				)
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * An already-relative src has no parseable host — `wp_parse_url()` returns
+	 * Null — so the filter must short-circuit instead of feeding the value
+	 * Through `wp_make_link_relative()` (which would return it unchanged) or
+	 * Worse, treating an empty parsed host as a canonical match.
+	 */
+	public function test_same_origin_script_module_src_leaves_relative_src_alone(): void {
+		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
+		try {
+			$relative = '/wp-content/plugins/jetpack-search/build/search-blocks/results-list/view.js';
+			$this->assertSame(
+				$relative,
+				Search_Blocks::same_origin_script_module_src( $relative, 'jetpack-search/results-list' )
+			);
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * Defensive guards: empty src and non-string args from a misbehaving
+	 * Upstream filter must not throw — pass through unchanged.
+	 */
+	public function test_same_origin_script_module_src_defensive_guards(): void {
+		$this->assertSame( '', Search_Blocks::same_origin_script_module_src( '', 'jetpack-search/results-list' ) );
+		// @phpstan-ignore-next-line — deliberately exercising the non-string guard.
+		$this->assertNull( Search_Blocks::same_origin_script_module_src( null, 'jetpack-search/results-list' ) );
+	}
+
+	/**
+	 * `init()` must register the same-origin filter so every per-block view
+	 * Module URL goes through it. Registered alongside the other always-on
+	 * Block hooks (not gated on experience) because blocks may be inserted
+	 * Anywhere blocks are configurable.
+	 */
+	public function test_init_registers_script_module_loader_src_filter(): void {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( true );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+
+		try {
+			Search_Blocks::init();
+
+			$this->assertSame(
+				10,
+				has_filter(
+					'script_module_loader_src',
+					array( Search_Blocks::class, 'same_origin_script_module_src' )
+				),
+				'same_origin_script_module_src must hook script_module_loader_src at priority 10.'
+			);
+		} finally {
+			remove_filter(
+				'script_module_loader_src',
+				array( Search_Blocks::class, 'same_origin_script_module_src' ),
+				10
+			);
+		}
 	}
 }

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -2611,14 +2611,14 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Force `home_url()` and `site_url()` to a known host via the
-	 * `pre_option_home` / `pre_option_siteurl` filters. Returns a cleanup
-	 * Callback so callers can restore the originals deterministically (a
-	 * Failed assertion before tearDown would otherwise leak the override).
+	 * Override `home_url()` / `site_url()` for the scope of a test.
 	 *
-	 * @param string $home Value to return from `home_url()`.
-	 * @param string $site Value to return from `site_url()`.
-	 * @return callable Cleanup callback.
+	 * Returns a cleanup callback so a failed assertion can't leak the
+	 * override past `tearDown`.
+	 *
+	 * @param string $home Value `home_url()` should return.
+	 * @param string $site Value `site_url()` should return.
+	 * @return callable Cleanup callback — call from a `finally`.
 	 */
 	private function override_site_hosts( string $home, string $site ): callable {
 		$home_cb = static function () use ( $home ) {
@@ -2636,9 +2636,9 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Canonical-host src on a Jetpack Search module ID gets relativized so
-	 * The browser resolves the script against the page's actual origin,
-	 * Sidestepping the CORS check on `wp-content/*` from a mapped domain.
+	 * Golden path: a canonical-host src on a Jetpack Search module ID
+	 * comes back relativized so the browser resolves against the page
+	 * origin rather than triggering CORS on `wp-content/*`.
 	 */
 	public function test_same_origin_script_module_src_relativizes_canonical_host_src(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2656,8 +2656,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * The version query string must survive relativization — it's what
-	 * Defeats stale-cache loads when a build ships a new bundle.
+	 * The `?ver=…` cache-buster must survive relativization — it's what
+	 * keeps a stale bundle from sticking after a build.
 	 */
 	public function test_same_origin_script_module_src_preserves_query_string(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2675,9 +2675,9 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * HTTP-scheme canonicals (local docker, http-only sites) get relativized
-	 * Like HTTPS — the browser binds the relative URL to whatever scheme the
-	 * Page is on, which is the desired behavior either way.
+	 * HTTP-scheme canonicals (local docker, http-only sites) relativize
+	 * the same way HTTPS does — the browser binds the relative URL to the
+	 * page scheme either way.
 	 */
 	public function test_same_origin_script_module_src_relativizes_http_canonical(): void {
 		$cleanup = $this->override_site_hosts( 'http://example.com', 'http://example.com' );
@@ -2695,9 +2695,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Hostname comparison must be case-insensitive — DNS treats `EXAMPLE.com`
-	 * And `example.com` as the same host, and a site whose home_url has been
-	 * Saved with mixed case shouldn't dodge the relativization.
+	 * Host comparison is case-insensitive so a mixed-case `home_url`
+	 * (or an upper-case host in a hand-built src) doesn't dodge the gate.
 	 */
 	public function test_same_origin_script_module_src_canonical_match_is_case_insensitive(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2715,10 +2714,9 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * `home_url()` and `site_url()` are checked independently — a site whose
-	 * `home_url()` lives on `example.com` and whose `site_url()` lives on
-	 * `wp.example.com` must relativize either canonical the URL was built
-	 * Against (Multisite sub-directory installs split the two).
+	 * `home_url()` and `site_url()` are checked independently — Multisite
+	 * sub-directory installs split the two, and a src built against either
+	 * canonical must relativize.
 	 */
 	public function test_same_origin_script_module_src_relativizes_site_url_host_when_home_url_differs(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://wp.example.com' );
@@ -2736,10 +2734,9 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Genuine third-party CDN hosts (configured by the operator, e.g. via
-	 * `JETPACK_SEARCH_PLUGINS_URL` rewrites) pass through unchanged — the
-	 * Filter must not break setups where the operator wants the CDN to serve
-	 * Modules and has configured CORS on that CDN themselves.
+	 * Genuine third-party CDN hosts pass through unchanged so operators
+	 * who deliberately route assets through a configured CDN (with their
+	 * own CORS headers) aren't broken.
 	 */
 	public function test_same_origin_script_module_src_leaves_third_party_cdn_alone(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2755,10 +2752,9 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * The identifier-prefix gate is the boundary that keeps this filter from
-	 * Touching other plugins' modules (e.g. core's `@wordpress/interactivity`,
-	 * Or any unrelated `vendor/foo` bundle). A non-`jetpack-search/*` id must
-	 * Pass through unchanged even when the src host matches a canonical.
+	 * Identifier-prefix gate keeps the filter off other plugins' modules
+	 * (`@wordpress/interactivity`, etc.) even when their src host happens
+	 * to match a canonical site host.
 	 */
 	public function test_same_origin_script_module_src_skips_non_jetpack_search_identifier(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2774,13 +2770,10 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * `register_block_type()` runs `generate_block_asset_handle()` on
-	 * `viewScriptModule` fields and emits hyphen-joined IDs like
-	 * `jetpack-search-results-list-view-script-module` — that's what WP
-	 * Passes to the loader filter for every per-block view module. Without
-	 * Covering this prefix shape the filter would only catch directly-
-	 * Registered modules and miss the bulk of the block bundles, exactly
-	 * The case the bug report describes.
+	 * WP's `generate_block_asset_handle()` emits hyphen-joined IDs for
+	 * `viewScriptModule` (e.g. `jetpack-search-results-list-view-script-module`)
+	 * — that's the bulk of the block bundles and the prefix gate must
+	 * cover it, not only the slash-namespaced shape.
 	 */
 	public function test_same_origin_script_module_src_relativizes_block_generated_handle(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2798,10 +2791,9 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * An already-relative src has no parseable host — `wp_parse_url()` returns
-	 * Null — so the filter must short-circuit instead of feeding the value
-	 * Through `wp_make_link_relative()` (which would return it unchanged) or
-	 * Worse, treating an empty parsed host as a canonical match.
+	 * An already-relative src has no parseable host — short-circuit on the
+	 * `wp_parse_url() === null` branch rather than treating an empty parsed
+	 * host as a canonical match.
 	 */
 	public function test_same_origin_script_module_src_leaves_relative_src_alone(): void {
 		$cleanup = $this->override_site_hosts( 'https://example.com', 'https://example.com' );
@@ -2817,8 +2809,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Defensive guards: empty src and non-string args from a misbehaving
-	 * Upstream filter must not throw — pass through unchanged.
+	 * Empty src or a non-string from a misbehaving upstream filter must
+	 * not throw — pass through unchanged.
 	 */
 	public function test_same_origin_script_module_src_defensive_guards(): void {
 		$this->assertSame( '', Search_Blocks::same_origin_script_module_src( '', 'jetpack-search/results-list' ) );
@@ -2827,10 +2819,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * `init()` must register the same-origin filter so every per-block view
-	 * Module URL goes through it. Registered alongside the other always-on
-	 * Block hooks (not gated on experience) because blocks may be inserted
-	 * Anywhere blocks are configurable.
+	 * The filter is registered from `init()` unconditionally (no experience
+	 * gate) because blocks can be placed on any page that supports blocks.
 	 */
 	public function test_init_registers_script_module_loader_src_filter(): void {
 		$this->reset_search_blocks_hooks();


### PR DESCRIPTION
Fixes [SEARCH-252](https://linear.app/a8c/issue/SEARCH-252)

## Why

When a Jetpack Search Block page is served on a host that doesn't match `site_url()` — Multisite mapped domains, www-vs-non-www without a canonical redirect, asset-offload plugins, reverse-proxy staging — every block view module fails to load. The browser blocks them with `MissingAllowOriginHeader` and the search overlay is broken.

ES module scripts always go through the browser CORS algorithm (even without a `crossorigin` attribute), and typical WP hosts don't send `Access-Control-Allow-Origin` for `wp-content/*`. Legacy `<script src=>` enqueues are unaffected — classic scripts aren't subject to CORS.

End-user impact: site owners on any of those hosting configurations see a broken search experience — every interactive block silently fails to hydrate.

## Proposed changes

* Add a `script_module_loader_src` filter (`Search_Blocks::same_origin_script_module_src`) that calls `wp_make_link_relative()` on `jetpack-search/*` and `jetpack-search-*` module URLs when the src host matches a canonical site host (`home_url()` / `site_url()`). The browser then resolves the relative URL against the page origin, sidestepping the CORS check on `wp-content/*`.
* Identifier gate covers both shapes the package ships: directly-registered modules (`jetpack-search/store`, `jetpack-search/overlay-bootstrap`) and per-block view modules WP auto-registers from `block.json`'s `viewScriptModule`, which run `generate_block_asset_handle()` and emit hyphen-joined IDs like `jetpack-search-results-list-view-script-module`.
* No `$_SERVER['HTTP_HOST']` trust — emitting an attacker-controllable host into a `<script src>` would be a host-header-injection / cache-poisoning vector. Genuine third-party CDN hosts (src host that doesn't match `home_url()`/`site_url()`) pass through unchanged so legitimate CDN setups aren't touched.
* PHP unit tests cover the prefix gate (slash + hyphen shapes), canonical-host matches (HTTPS / HTTP / case-insensitive / `site_url`-only divergence), third-party CDN pass-through, query-string preservation, relative-src pass-through, defensive guards (empty / non-string), and the `init()` hook registration.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/SEARCH-252
* WPCOM-side counterpart already ships in `wp-content/mu-plugins/same-origin-files.php` (`force_same_origin_script_modules()`). This Jetpack-side fix layers underneath cleanly — by the time the WPCOM filter runs, the src is already relative, so the WPCOM filter is a no-op (the desired layering).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Acceptance criteria

- [ ] `Search_Blocks::same_origin_script_module_src` is registered on `script_module_loader_src` from `Search_Blocks::init()`.
- [ ] When the src host matches a canonical site host, `wp_make_link_relative()` runs and the returned src is `/wp-content/...`.
- [ ] When the src host is a deliberately external host (different from both `home_url()` and `site_url()` hosts), the filter no-ops — legitimate CDN setups untouched.
- [ ] Non-`jetpack-search/*` and non-`jetpack-search-*` module IDs no-op.
- [ ] Empty / non-string src no-ops.
- [ ] Already-relative src no-ops.
- [ ] No reads of `$_SERVER['HTTP_HOST']` — no host-header trust.

### Unit tests

From `projects/packages/search/`:

```
composer phpunit -- --filter "same_origin|Search_Blocks_Test"
```

All 106 cases in `Search_Blocks_Test` (one skipped — pre-existing, unrelated) should pass.

### Rendered-HTML evidence (live env)

On `https://jp-atlas.jurassic.tube/`, every Jetpack Search Script Module URL in the homepage HTML changes from absolute to relative after this PR. Non-Search modules are untouched.

#### Before (trunk)

<details>
<summary>Script tags for Jetpack Search modules</summary>

```
id=jetpack-search/overlay-bootstrap-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/overlay-bootstrap/index.js?ver=...
id=jetpack-search-search-results-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/search-results.js?ver=...
id=jetpack-search-search-input-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/search-input.js?ver=...
id=jetpack-search-results-count-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-count.js?ver=...
id=jetpack-search-results-sort-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-sort.js?ver=...
id=jetpack-search-results-list-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-list.js?ver=...
id=jetpack-search-results-load-more-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-load-more.js?ver=...
id=jetpack-search-active-filters-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/active-filters.js?ver=...
id=jetpack-search-clear-filters-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/clear-filters.js?ver=...
id=jetpack-search-filter-checkbox-view-script-module-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/filter-checkbox.js?ver=...
```

</details>

#### After (this PR)

<details>
<summary>Script tags for Jetpack Search modules</summary>

```
id=jetpack-search/overlay-bootstrap-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/overlay-bootstrap/index.js?ver=...
id=jetpack-search-search-results-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/search-results.js?ver=...
id=jetpack-search-search-input-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/search-input.js?ver=...
id=jetpack-search-results-count-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-count.js?ver=...
id=jetpack-search-results-sort-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-sort.js?ver=...
id=jetpack-search-results-list-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-list.js?ver=...
id=jetpack-search-results-load-more-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/results-load-more.js?ver=...
id=jetpack-search-active-filters-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/active-filters.js?ver=...
id=jetpack-search-clear-filters-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/clear-filters.js?ver=...
id=jetpack-search-filter-checkbox-view-script-module-js-module
  src=/wp-content/plugins/jetpack-search/jetpack_vendor/automattic/jetpack-search/build/search-blocks/filter-checkbox.js?ver=...
```

</details>

#### Non-Search modules are untouched

```
id=woocommerce/mini-cart-js-module
  src=https://jp-atlas.jurassic.tube/wp-content/plugins/woocommerce/.../mini-cart.js
id=@wordpress/block-library/navigation/view-js-module
  src=https://jp-atlas.jurassic.tube/wp-includes/js/dist/script-modules/.../view.js
```

### Manual verification on a multi-host setup

On a Multisite mapped-domain install (or any other setup where the visitor browses on a host that differs from `site_url()`):

1. Place any Jetpack Search Block on a page (e.g. Embedded experience or Blocks Overlay).
2. Browse the page via the *non-canonical* host.
3. DevTools → Network: confirm every `*/search-blocks/*.js` request goes to the page host and returns 200 without CORS errors.
4. Confirm the overlay opens, types accept input, and results render.
