### PR TITLE
Search Blocks: drop the stale embedded→inline fallback in Module_Control

### DIFF
--- a/projects/packages/search/changelog/sage-search-253-drop-embedded-inline-fallback
+++ b/projects/packages/search/changelog/sage-search-253-drop-embedded-inline-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: drop the stale embedded→inline fallback for non-block themes. Embedded now stays Embedded regardless of theme; the dormant `jetpack_search_theme_supports_embedded_experience` filter is removed alongside it.

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -257,7 +257,7 @@ class Module_Control {
 
 		$saved = get_option( self::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, false );
 		if ( self::EXPERIENCE_EMBEDDED === $saved ) {
-			return $this->theme_supports_embedded_experience() ? self::EXPERIENCE_EMBEDDED : self::EXPERIENCE_INLINE;
+			return self::EXPERIENCE_EMBEDDED;
 		}
 		if ( self::EXPERIENCE_OVERLAY === $saved ) {
 			return self::EXPERIENCE_OVERLAY;
@@ -273,33 +273,6 @@ class Module_Control {
 		}
 
 		return self::EXPERIENCE_INLINE;
-	}
-
-	/**
-	 * Whether the active theme can render the Embedded search experience.
-	 *
-	 * True for every theme by default: block themes resolve the bundled
-	 * `jetpack-search` block template through `search_template_hierarchy`,
-	 * classic themes get the same block markup wrapped in
-	 * `get_header()` / `get_footer()` via `template_include`. The filter
-	 * remains the escape hatch for sites that want to force Embedded back
-	 * to Theme search (inline) without changing the saved option.
-	 *
-	 * @return bool
-	 */
-	protected function theme_supports_embedded_experience(): bool {
-		/**
-		 * Filter whether the active theme can render the Embedded search experience.
-		 *
-		 * Defaults to true now that both block and classic themes are supported.
-		 * Sites that want to force Embedded to fall back to Theme search (inline)
-		 * regardless of theme can return false here.
-		 *
-		 * @since 0.60.0
-		 *
-		 * @param bool $supported Whether the active theme can render Embedded search.
-		 */
-		return (bool) apply_filters( 'jetpack_search_theme_supports_embedded_experience', true );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Initializer_Test.php
+++ b/projects/packages/search/tests/php/Initializer_Test.php
@@ -24,7 +24,6 @@ class Initializer_Test extends Search_TestCase {
 		remove_all_filters( 'jetpack_search_overlay_block_template_enabled' );
 		remove_all_filters( 'jetpack_search_init_instant_search' );
 		remove_all_filters( 'jetpack_search_classic_search_enabled' );
-		remove_all_filters( 'jetpack_search_theme_supports_embedded_experience' );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 		$this->reset_block_search_active();
 		$this->remove_search_blocks_hooks();
@@ -219,7 +218,6 @@ class Initializer_Test extends Search_TestCase {
 
 	public function test_init_search_blocks_suppresses_classic_search_when_embedded() {
 		add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 		( new \Automattic\Jetpack\Modules() )->activate( Module_Control::JETPACK_SEARCH_MODULE_SLUG, false, false );
 

--- a/projects/packages/search/tests/php/Module_Control_Test.php
+++ b/projects/packages/search/tests/php/Module_Control_Test.php
@@ -277,11 +277,9 @@ class Module_Control_Test extends Search_TestCase {
 	}
 
 	/**
-	 * Saved 'embedded' / 'overlay' values are returned when the module is active.
-	 *
-	 * Embedded now renders on every theme by default (block themes through
-	 * `search_template_hierarchy`, classic themes through `template_include`),
-	 * so no theme-seam override is needed.
+	 * Saved 'embedded' / 'overlay' values are returned verbatim when the module
+	 * is active — Embedded renders on every theme (block themes through
+	 * `search_template_hierarchy`, classic themes through `template_include`).
 	 */
 	public function test_get_experience_returns_saved_value() {
 		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
@@ -292,50 +290,6 @@ class Module_Control_Test extends Search_TestCase {
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
 		$this->assertEquals( Module_Control::EXPERIENCE_OVERLAY, static::$search_module->get_experience() );
 
-		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
-		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
-	}
-
-	/**
-	 * Saved 'embedded' falls back to 'inline' (Theme search) when the
-	 * `jetpack_search_theme_supports_embedded_experience` filter returns false
-	 * — the opt-out escape hatch for sites that want the search page to keep
-	 * rendering through the theme's own template regardless of theme type.
-	 * The saved option must stay 'embedded' so removing the filter restores
-	 * the experience without a dashboard re-save.
-	 */
-	public function test_get_experience_embedded_falls_back_to_inline_when_filter_disables_support() {
-		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
-		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
-
-		$this->assertEquals( Module_Control::EXPERIENCE_INLINE, static::$search_module->get_experience() );
-		$this->assertEquals(
-			Module_Control::EXPERIENCE_EMBEDDED,
-			get_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY ),
-			'The saved experience option must be preserved across the fallback.'
-		);
-
-		// Dropping the filter restores Embedded without a dashboard re-save.
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
-		$this->assertEquals( Module_Control::EXPERIENCE_EMBEDDED, static::$search_module->get_experience() );
-
-		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
-		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
-	}
-
-	/**
-	 * The opt-out filter only affects 'embedded' — 'overlay' is
-	 * theme-agnostic (modal overlay) and must be unaffected.
-	 */
-	public function test_get_experience_overlay_unaffected_by_embedded_opt_out_filter() {
-		add_filter( 'jetpack_options', array( $this, 'return_search_active_array' ), 10, 2 );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
-		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_OVERLAY );
-
-		$this->assertEquals( Module_Control::EXPERIENCE_OVERLAY, static::$search_module->get_experience() );
-
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
 		remove_filter( 'jetpack_options', array( $this, 'return_search_active_array' ) );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -472,9 +472,6 @@ class REST_Controller_Test extends Search_TestCase {
 	 */
 	public function test_update_settings_experience_embedded() {
 		wp_set_current_user( $this->admin_id );
-		// Embedded only reports back as 'embedded' on a block theme; force the
-		// seam true so this exercises persistence, not the non-block fallback.
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$request->set_header( 'content-type', 'application/json' );
@@ -485,8 +482,6 @@ class REST_Controller_Test extends Search_TestCase {
 		$this->assertTrue( $data['module_active'] );
 		$this->assertFalse( $data['instant_search_enabled'] );
 		$this->assertEquals( 'embedded', $data['experience'] );
-
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 	}
 
 	/**
@@ -602,7 +597,6 @@ class REST_Controller_Test extends Search_TestCase {
 	 */
 	public function test_get_settings_returns_persisted_experience() {
 		wp_set_current_user( $this->admin_id );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 
 		// Save experience=embedded.
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -616,8 +610,6 @@ class REST_Controller_Test extends Search_TestCase {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'embedded', $response->get_data()['experience'] );
-
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1123,39 +1123,6 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Saved Embedded but the `jetpack_search_theme_supports_embedded_experience`
-	 * Filter forces Embedded off: `get_experience()` resolves to Theme search
-	 * (Inline), so neither the block-theme nor the classic-theme template-
-	 * Takeover hooks register. Guards the opt-out escape hatch — a site that
-	 * Returns false from the filter must keep the search page on the theme's
-	 * Own search template regardless of theme type.
-	 */
-	public function test_init_does_not_register_template_hooks_when_filter_disables_embedded() {
-		$this->reset_search_blocks_hooks();
-		$this->set_module_active( true );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
-		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
-
-		Search_Blocks::init();
-
-		$this->assertFalse(
-			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),
-			'register_search_template must not hook when the filter disables Embedded'
-		);
-		$this->assertFalse(
-			has_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) ),
-			'prepend_search_template must not hook when the filter disables Embedded'
-		);
-		$this->assertFalse(
-			has_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) ),
-			'route_classic_theme_search_template must not hook when the filter disables Embedded'
-		);
-
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );
-		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
-	}
-
-	/**
 	 * If the module isn't active, the experience is `'off'` regardless of any
 	 * Stale value in the experience option, so the template-override hooks
 	 * Must not register. Guards against a leftover `'embedded'` value on a
@@ -1193,7 +1160,6 @@ class Search_Blocks_Test extends TestCase {
 	public function test_init_registers_posts_pre_query_when_embedded() {
 		$this->reset_search_blocks_hooks();
 		$this->set_module_active( true );
-		add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 
 		Search_Blocks::init();
@@ -1204,7 +1170,6 @@ class Search_Blocks_Test extends TestCase {
 			'posts_pre_query short-circuit must hook at priority 10 on embedded'
 		);
 
-		remove_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_true' );
 		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-253](https://linear.app/a8c/issue/SEARCH-253/search-blocks-drop-the-stale-embeddedinline-fallback-in-module-control)

## Why

When the Embedded search experience first shipped it required a block theme, so `Module_Control::get_experience()` quietly downgraded a saved `embedded` to `inline` whenever the active theme couldn't render block templates. That precondition no longer exists — [#49117](https://github.com/Automattic/jetpack/pull/49117) added a classic-theme rendering path that wraps the same block markup in `get_header()` / `get_footer()` via `template_include`, so Embedded works on every theme.

The downgrade conditional and its gate have been left behind. The gate (`theme_supports_embedded_experience()`) is now just `apply_filters( 'jetpack_search_theme_supports_embedded_experience', true )` — no theme detection, a dead default no core code path flips false. Removing it so the experience the user saves is the experience they get.

## Proposed changes

* `Module_Control::get_experience()` now returns `EXPERIENCE_EMBEDDED` unconditionally when the saved option is `embedded` — no theme-based downgrade.
* `theme_supports_embedded_experience()` method and the `jetpack_search_theme_supports_embedded_experience` filter are deleted.
* Four test cases that exercised the dead path are removed; the `__return_true` `add_filter` / `remove_filter` pairs that simulated the no-op default are dropped.

## Screenshots — classic theme `/?s=hello`

Captured against Twenty Twenty at 1440×1100. "Before" simulates the legacy fallback by pinning the filter to false via an mu-plugin on trunk; "After" is this branch (filter no longer exists).

| Before (trunk + filter pinned false → legacy Inline) | After (this branch → Embedded) |
|---|---|
| ![before](https://github.com/user-attachments/assets/b81ab718-9884-46af-9c72-db5443a505f6) | ![after](https://github.com/user-attachments/assets/586bcb67-abb4-456a-b4c1-a1ea2a225dcf) |

## Verification

Confirmed on the live docker env that `Module_Control::get_experience()` no longer responds to the filter:

<details>
<summary>wp eval output</summary>

```text
$ wp eval 'add_filter("jetpack_search_theme_supports_embedded_experience", "__return_false"); $mc = new \Automattic\Jetpack\Search\Module_Control(); echo $mc->get_experience();'
embedded
```

</details>

Repo grep confirms zero remaining references:

```text
$ grep -rn "theme_supports_embedded_experience\|jetpack_search_theme_supports_embedded" \
    projects/packages/search projects/plugins/search projects/plugins/jetpack
(no matches)
```

## Related product discussion/links

* Linear: [SEARCH-253](https://linear.app/a8c/issue/SEARCH-253/search-blocks-drop-the-stale-embeddedinline-fallback-in-module-control)
* Original fallback: [SEARCH-202](https://linear.app/a8c/issue/SEARCH-202) / [#48941](https://github.com/Automattic/jetpack/pull/48941)
* Precondition removal: [#49117](https://github.com/Automattic/jetpack/pull/49117) — Search Blocks: Embedded experience on classic themes

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-253:

- [x] `Module_Control::get_experience()` returns `EXPERIENCE_EMBEDDED` unconditionally when the saved option is `embedded` (no theme-based downgrade).
- [x] `theme_supports_embedded_experience()` method and its `jetpack_search_theme_supports_embedded_experience` filter are deleted.
- [x] Tests that exercise the filter are removed or rewritten; a positive `saved embedded → reads back embedded` test exists (`Module_Control_Test::test_get_experience_returns_saved_value`).
- [x] Embedded experience renders correctly on both block themes (Twenty Twenty-Five) and classic themes (Twenty Twenty) — verified in a live dev env with `/?s=foo`.
- [x] Before/after screenshots attached.
- [x] Changelog entry added.

To reproduce locally:

1. On a Jetpack Search–active site, save the Embedded experience: `wp option set jetpack_search_experience embedded`.
2. Activate a classic theme (e.g. `wp theme activate twentytwenty`).
3. Visit `/?s=hello`. The page should render the Embedded block tree (search input, filter panel, results list with sort / count / load-more) wrapped in the classic theme's `<header>` / `<footer>` chrome — *not* the theme's native search results template.
4. Add `add_filter( 'jetpack_search_theme_supports_embedded_experience', '__return_false' );` to a mu-plugin and refresh. The page should still render Embedded — the filter is gone, so it has no effect.
5. Repeat steps 3–4 on a block theme (e.g. `wp theme activate twentytwentyfive`). Same Embedded render, via the `search_template_hierarchy` route.
6. Run `composer phpunit -- --testdox projects/packages/search/tests/php/Module_Control_Test.php projects/packages/search/tests/php/Search_Blocks_Test.php projects/packages/search/tests/php/REST_Controller_Test.php projects/packages/search/tests/php/Initializer_Test.php` (or `jp test php packages/search`) — all green.
