### PR TITLE
Search Blocks: widen blocks Overlay to match legacy on large viewports

### DIFF
--- a/projects/packages/search/changelog/nova-search-254-overlay-wide-viewport-width
+++ b/projects/packages/search/changelog/nova-search-254-overlay-wide-viewport-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: blocks-powered Overlay card now widens on viewports ≥992px, matching the legacy Instant Search overlay's wide-screen behavior.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1247,14 +1247,7 @@ class Search_Blocks {
 		padding: .5em 1em 1em;
 	}
 }
-/*
- * Wide-viewport widen: match the legacy Instant Search overlay's
- * `break-large-up` rule (`$break-lg: 992px` → `max-width: 95%`). The base
- * 1080px cap above is the comfortable reading width on tablet-class screens;
- * past 992px the card scales with the viewport so the filters + results
- * columns get breathing room on 1440 / 4K displays, matching how the
- * preact-era modal behaved.
- */
+/* Mirror legacy `$break-lg: 992px → $modal-max-width-lg: 95%` from `instant-search/components/search-results.scss`. */
 @media (min-width: 992px) {
 	.jetpack-search-block-overlay__card {
 		max-width: 95%;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1247,6 +1247,19 @@ class Search_Blocks {
 		padding: .5em 1em 1em;
 	}
 }
+/*
+ * Wide-viewport widen: match the legacy Instant Search overlay's
+ * `break-large-up` rule (`$break-lg: 992px` → `max-width: 95%`). The base
+ * 1080px cap above is the comfortable reading width on tablet-class screens;
+ * past 992px the card scales with the viewport so the filters + results
+ * columns get breathing room on 1440 / 4K displays, matching how the
+ * preact-era modal behaved.
+ */
+@media (min-width: 992px) {
+	.jetpack-search-block-overlay__card {
+		max-width: 95%;
+	}
+}
 /* Body-scroll lock while open. JS side stashes/restores scrollY on toggle. */
 body.jetpack-search-block-overlay-open {
 	position: fixed;


### PR DESCRIPTION
Fixes [SEARCH-254](https://linear.app/a8c/issue/SEARCH-254/search-blocks-widen-blocks-overlay-to-match-legacy-on-large-viewports)

## Why

On wide screens the legacy preact Instant Search overlay grew to ~95% of viewport width, so the filters + results columns had room to breathe on 1440 / 1600 / 4K monitors. The new blocks-powered Overlay capped the card at a flat **1080px regardless of viewport**, so on those same displays it sat as a narrow column with large empty backdrop gutters. This restores the legacy wide-screen behavior so the new overlay scales the same way past 992px.

## Proposed changes

* In `block_template_overlay_inline_css()`, add a `@media (min-width: 992px)` rule that sets `.jetpack-search-block-overlay__card { max-width: 95%; }`. Mirrors `$break-lg: 992px` and `$modal-max-width-lg: 95%` from the legacy `instant-search/components/search-results.scss`.
* Existing rules are untouched — the base `max-width: 1080px` still applies below 992px, and the existing `@media (max-width: 781px)` mobile full-screen treatment is preserved.

## Screenshots

Captured at 1920×1080 on the local docker env via the Jurassic Tube tunnel. The card width is reported below each shot from `getBoundingClientRect()`.

| Before (`1080px` cap) | After (`95%` → `1794px`) |
|---|---|
| ![before](https://github.com/user-attachments/assets/fb01046a-3d0e-4ce6-ae70-d41bc0e7b354) | ![after](https://github.com/user-attachments/assets/6e1588c1-4251-46d8-b90b-ae5e4f7c319d) |

## Related product discussion/links

* Linear: [SEARCH-254](https://linear.app/a8c/issue/SEARCH-254/search-blocks-widen-blocks-overlay-to-match-legacy-on-large-viewports)
* Legacy spec being matched: `projects/packages/search/src/instant-search/components/search-results.scss:3-17` (`$modal-max-width-lg: 95%` above `$break-lg: 992px`).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-254 — work through these against a site running the blocks-powered Overlay:

* [ ] On viewports ≥992px, `.jetpack-search-block-overlay__card` expands to ~95% of viewport width (matches legacy `$modal-max-width-lg`).
* [ ] Breakpoint is `992px`, matching legacy `$break-lg` so the two overlays widen at the same viewport boundary.
* [ ] On viewports 782–991px, behavior is unchanged (1080px cap; effectively viewport-minus-backdrop-padding because the cap is wider than the viewport itself).
* [ ] On viewports ≤781px, the card remains full-screen with `border-radius: 0` (existing mobile behavior preserved).
* [ ] No upper cap — confirm the card keeps scaling on a 2400px+ viewport, matching legacy.
* [ ] No regression in the filters-column / results-column layout at the wider card width — the inner blocks should absorb the extra space via the existing flex/grid layout.

To reproduce:

1. On a site with Jetpack Search active and at least a few indexed posts, set `wp option update jetpack_search_experience overlay_blocks`.
2. Visit `<site>/?s=hello` — the blocks-powered Overlay auto-opens (`?s=` URL trigger, PR #49073).
3. Resize the browser through 600px → 800px → 1000px → 1400px → 1920px → 2400px and confirm the card's rendered width tracks the table above. The DevTools inspector should show `max-width: 1080px` below 992px and `max-width: 95%` at/above 992px.
4. Compare side-by-side with the legacy preact Overlay (`wp option update jetpack_search_experience overlay`) at the same viewports — both should widen identically past 992px.
