### PR TITLE
Search Blocks: make Singleton_Template_Cpt::init() self-healing across init priorities

### DIFF
--- a/projects/packages/search/changelog/raven-search-255-singleton-template-self-healing-init
+++ b/projects/packages/search/changelog/raven-search-255-singleton-template-self-healing-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: register singleton template CPTs synchronously when init() is invoked from inside an init action, so downstream consumers hooking Search_Blocks::init() onto init don't drop the registration.

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -110,9 +110,18 @@ abstract class Singleton_Template_Cpt {
 	 * Wire the hooks. Called from the subclass's `init()` invocation.
 	 */
 	public static function init() {
-		// Priority 9: register the CPT just before `Search_Blocks::register_blocks()`
-		// (priority 10) so the blocks exist when `do_blocks()` runs on the singleton.
-		add_action( 'init', array( static::class, 'register_post_type' ), 9 );
+		// Self-healing CPT registration: a downstream consumer may hook
+		// `Search_Blocks::init()` onto `init:N` itself, in which case queuing
+		// `register_post_type` onto `init:9` from inside that callback lands on
+		// a priority WordPress is already iterating — PHP's `foreach` snapshot
+		// drops it. Register synchronously when we're already inside (or past)
+		// `init`; queue on `init:9` otherwise to preserve the standard
+		// `plugins_loaded` → `init:9` → `register_blocks` at `init:10` ordering.
+		if ( did_action( 'init' ) || doing_action( 'init' ) ) {
+			static::register_post_type();
+		} else {
+			add_action( 'init', array( static::class, 'register_post_type' ), 9 );
+		}
 		add_action( 'admin_init', array( static::class, 'maybe_handle_editor_request' ) );
 		// `before_delete_post` fires for force-delete too, so it catches every
 		// delete path: AJAX reset, REST DELETE, post.php trash-then-delete.

--- a/projects/packages/search/tests/php/Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Search_Template_Test.php
@@ -253,4 +253,35 @@ class Search_Template_Test extends Search_TestCase {
 			array_pop( $wp_current_filter );
 		}
 	}
+
+	/**
+	 * `init()` must also register the CPT synchronously when invoked after
+	 * `init` has already fired — `did_action( 'init' )` returns non-zero
+	 * and queuing on `init:9` would be a permanent no-op.
+	 */
+	public function test_init_after_init_action_registers_cpt_synchronously() {
+		unregister_post_type( Search_Template::POST_TYPE );
+		$this->assertFalse( post_type_exists( Search_Template::POST_TYPE ) );
+
+		// Bump the action counter that `did_action()` reads, without
+		// dispatching `init` (which would re-fire every WP and plugin init
+		// callback in the suite — heavy and unrelated to what we're testing).
+		global $wp_actions;
+		$prev_count         = $wp_actions['init'] ?? 0;
+		$wp_actions['init'] = $prev_count + 1;
+		try {
+			$this->assertGreaterThan( 0, did_action( 'init' ) );
+			Search_Template::init();
+			$this->assertTrue(
+				post_type_exists( Search_Template::POST_TYPE ),
+				'register_post_type() must run inline when init() is invoked after init has fired.'
+			);
+		} finally {
+			if ( 0 === $prev_count ) {
+				unset( $wp_actions['init'] );
+			} else {
+				$wp_actions['init'] = $prev_count;
+			}
+		}
+	}
 }

--- a/projects/packages/search/tests/php/Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Search_Template_Test.php
@@ -229,4 +229,28 @@ class Search_Template_Test extends Search_TestCase {
 		$this->assertNull( Search_Template::get_customized_content() );
 		$this->assertFalse( Search_Template::is_customized() );
 	}
+
+	/**
+	 * `init()` must register the CPT synchronously when invoked from inside
+	 * an `init` callback. Adding a callback to the priority WordPress is
+	 * currently iterating leaves it stranded by PHP's `foreach` snapshot —
+	 * the regression that hid the CPT on downstream consumers hooking
+	 * `Search_Blocks::init()` onto `init`.
+	 */
+	public function test_init_during_init_action_registers_cpt_synchronously() {
+		unregister_post_type( Search_Template::POST_TYPE );
+		$this->assertFalse( post_type_exists( Search_Template::POST_TYPE ) );
+
+		global $wp_current_filter;
+		$wp_current_filter[] = 'init';
+		try {
+			Search_Template::init();
+			$this->assertTrue(
+				post_type_exists( Search_Template::POST_TYPE ),
+				'register_post_type() must run inline when init() is invoked from inside an init callback.'
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
 }


### PR DESCRIPTION
Fixes [SEARCH-255](https://linear.app/a8c/issue/SEARCH-255/search-blocks-make-singleton-template-cptinit-self-healing-across-init)

## Why

`Singleton_Template_Cpt::init()` unconditionally queues `add_action( 'init', …, 9 )` to register the singleton CPT. That's fine when the package is initialized at `plugins_loaded` (the standard Jetpack code path), because `init` hasn't dispatched yet.

It breaks the moment a downstream consumer hooks `Search_Blocks::init()` onto `init:N` itself. The wpcom site-search initializer does this at `init:9`, so the cascade `init:9 → Search_Blocks::init() → Search_Template::init() / Overlay_Template::init() → Singleton_Template_Cpt::init()` runs *while* WordPress is iterating the priority-9 callback list, and the new `add_action( 'init', …, 9 )` lands on a callback array PHP's `foreach` has already snapshotted. The callback is appended but never reached — `register_post_type` never fires, the hidden CPT doesn't exist, and the admin editor link 404s on every Atomic / WoA site that goes through that initializer.

This makes the base class composable: it now behaves correctly regardless of whether the parent invokes it before `init`, during any `init` priority, or after `init`. No wpcom-side change is required to benefit.

## Proposed changes

* `Singleton_Template_Cpt::init()` registers `register_post_type` synchronously when `did_action( 'init' )` or `doing_action( 'init' )` is already true; otherwise queues on `init:9` as before. `admin_init` and `before_delete_post` registrations are unchanged.
* Adds a PHPUnit case in `Search_Template_Test` that primes `$wp_current_filter` with `'init'` and asserts `post_type_exists()` flips true *inline* — exactly the regression scenario.
* Changelog: `patch` / `fixed`.

## Related product discussion/links

* [SEARCH-255](https://linear.app/a8c/issue/SEARCH-255/search-blocks-make-singleton-template-cptinit-self-healing-across-init)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-255 (verify against the new PHPUnit case and the Verification section below):

- [ ] `Singleton_Template_Cpt::init()` is self-healing — registers the CPT correctly whether the caller is on `plugins_loaded`, on any `init:N` priority, or after `init` has fired.
- [ ] Standard Jetpack code path (`Config::enable_search` → … → `Search_Template::init()` during `plugins_loaded`) still registers `jp_search_template` at `init:9` exactly as today.
- [ ] When called while `doing_action( 'init' )` is true, the CPT is registered synchronously and is available for the remainder of the request.
- [ ] When called after `did_action( 'init' )`, the CPT is registered synchronously.
- [ ] `register_post_type` runs exactly once per subclass on the standard path (no double-registration).
- [ ] `admin_init` and `before_delete_post` registrations remain unchanged (they're still pre-fire on every supported path).
- [ ] A PHPUnit test exercises the `doing_action( 'init' )` case for at least one subclass.

Repro for the regression (drop-in mu-plugin that simulates the wpcom hook ordering):

```php
<?php
// wp-content/mu-plugins/search-255-repro.php
add_filter( 'jetpack_search_blocks_enabled', '__return_false' );
add_action(
    'plugins_loaded',
    static function () {
        add_action(
            'init',
            static function () {
                if ( class_exists( '\\Automattic\\Jetpack\\Search\\Overlay_Template' ) ) {
                    \Automattic\Jetpack\Search\Overlay_Template::init();
                }
            },
            9
        );
    },
    99
);
```

Then `wp post-type list --fields=name | grep jp_search` should print `jp_search_overlay` with the fix applied. Reverting `class-singleton-template-cpt.php` to trunk and re-running prints nothing.

## Verification

Live wp-cli A/B on a local docker WP env with the repro mu-plugin above installed.

<details>
<summary>Before / after wp-cli output</summary>

```text
Simulation conditions:
  1. Disabled the standard initializer path:
       add_filter( 'jetpack_search_blocks_enabled', '__return_false' );
  2. Hooked Overlay_Template::init() onto init:9 directly (mirrors wpcom):
       add_action( 'plugins_loaded', fn() => add_action( 'init', fn() => Overlay_Template::init(), 9 ), 99 );

Before the fix (HEAD without changes to class-singleton-template-cpt.php):
  $ wp post-type list --fields=name | grep jp_search
  (no output — jp_search_overlay missing; regression reproduces)

After the fix:
  $ wp post-type list --fields=name | grep jp_search
  jp_search_overlay
```

</details>

<details>
<summary>PHPUnit (filtered)</summary>

```text
$ composer phpunit -- --filter "Search_Template_Test|Overlay_Template_Test|Search_Blocks_Test"
PHPUnit 12.5.27 by Sebastian Bergmann and contributors.

OK, but some tests were skipped!
Tests: 105, Assertions: 319, Skipped: 1.
```

</details>
