### PR TITLE
Search Blocks: strip search params + reload page when closing the blocks Overlay

### DIFF
--- a/projects/packages/search/changelog/atlas-search-256-overlay-close-strip-url
+++ b/projects/packages/search/changelog/atlas-search-256-overlay-close-strip-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: closing the blocks-powered Overlay now strips the search/filter params from the URL and reloads, matching the legacy Instant Search overlay.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -9,6 +9,8 @@
  * `privateApis`. Subsequent opens just toggle the `hidden` attribute.
  */
 
+import { getSearchOwnedParamKeys } from '../store/url-state.js';
+
 const PRIVATE_API_CONSENT =
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
 
@@ -127,11 +129,42 @@ async function openOverlay( triggerEl ) {
 }
 
 /**
- * Hide the overlay and restore focus to the element that opened it.
+ * Strip every Search-owned param from the current URL and `replaceState` the
+ * cleaned URL. Returns true when at least one key was actually removed.
+ *
+ * @return {boolean} Whether the URL was changed.
+ */
+function stripSearchParamsFromUrl() {
+	const params = new URLSearchParams( window.location.search );
+	const ownedKeys = getSearchOwnedParamKeys( params );
+	if ( ownedKeys.length === 0 ) {
+		return false;
+	}
+	for ( const key of ownedKeys ) {
+		params.delete( key );
+	}
+	const search = params.toString();
+	const newUrl = window.location.pathname + ( search ? `?${ search }` : '' ) + window.location.hash;
+	window.history.replaceState( {}, '', newUrl );
+	return true;
+}
+
+/**
+ * Hide the overlay and restore focus to the element that opened it. When the
+ * URL carried search/filter state, also strip those params and reload the
+ * page so the visitor lands on the underlying page rather than WP's default
+ * search-results template — matches legacy Instant Search's
+ * `restorePreviousHref()` close path.
  */
 function closeOverlay() {
 	const overlay = getOverlay();
 	if ( ! overlay || ! isOpen( overlay ) ) {
+		return;
+	}
+	if ( stripSearchParamsFromUrl() ) {
+		// Reload swaps in the no-search-params version of the page (e.g. home),
+		// so we skip the local DOM-restore work — it's about to be replaced.
+		window.location.reload();
 		return;
 	}
 	overlay.setAttribute( 'hidden', '' );

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -72,6 +72,13 @@ async function loadBootstrap() {
 
 const isOpen = () => ! document.getElementById( OVERLAY_ID ).hasAttribute( 'hidden' );
 
+// jsdom locks `window.location.reload` (non-configurable, non-writable, on the
+// instance — not the prototype), and `window.location` itself can't be
+// redefined. Invoking `reload()` emits a "Not implemented: navigation to
+// another Document" `console.error`. Reload-path tests assert
+// `expect( console ).toHaveErrored()` as evidence the call fired — that doubles
+// as the declaration that satisfies the jest-console strict guard.
+
 afterEach( () => {
 	setReadyState( 'complete' );
 	setUrl( '/' );
@@ -139,13 +146,17 @@ describe( 'overlay-bootstrap click dismissal', () => {
 	 * Render the full overlay, open it via the URL trigger, and stub
 	 * `window.scrollTo` (which `closeOverlay` calls when restoring scroll
 	 * position). jsdom doesn't implement scrollTo and the close-path tests
-	 * would otherwise trip `@wordpress/jest-console`'s strict error guard.
+	 * would otherwise trip the jest-console strict error guard.
+	 *
+	 * @param {string} [initialUrl] - Path+query to load the bootstrap against.
+	 *                              Defaults to `?s=hello` so the overlay opens
+	 *                              via the URL trigger.
 	 */
-	async function setUpOpenOverlay() {
+	async function setUpOpenOverlay( initialUrl = '/?s=hello' ) {
 		window.scrollTo = () => {};
 		setReadyState( 'complete' );
 		renderOverlayShell( { full: true } );
-		setUrl( '/?s=hello' );
+		setUrl( initialUrl );
 		await loadBootstrap();
 	}
 
@@ -155,7 +166,10 @@ describe( 'overlay-bootstrap click dismissal', () => {
 		const closeBtn = document.querySelector( '.jetpack-search-block-overlay__close' );
 		closeBtn.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 
-		expect( isOpen() ).toBe( false );
+		// `?s=hello` was present, so the close path reloads and the DOM-hide
+		// branch is skipped. We can't observe `hidden` here because
+		// `closeOverlay()` returns immediately after `reload()`.
+		expect( console ).toHaveErrored();
 	} );
 
 	it( 'closes when the scrim (outside the card) is clicked', async () => {
@@ -165,7 +179,7 @@ describe( 'overlay-bootstrap click dismissal', () => {
 			.getElementById( OVERLAY_ID )
 			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 
-		expect( isOpen() ).toBe( false );
+		expect( console ).toHaveErrored();
 	} );
 
 	it( 'stays open when a click target inside the card is detached mid-bubble', async () => {
@@ -193,5 +207,84 @@ describe( 'overlay-bootstrap click dismissal', () => {
 			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 
 		expect( isOpen() ).toBe( true );
+	} );
+} );
+
+describe( 'overlay-bootstrap close URL behavior', () => {
+	beforeEach( () => {
+		window.scrollTo = () => {};
+	} );
+
+	/**
+	 * Open the overlay against the given URL and trigger a close-button click.
+	 *
+	 * @param {string} initialUrl - Path+query to start at.
+	 * @return {Promise<void>}
+	 */
+	async function closeFrom( initialUrl ) {
+		setReadyState( 'complete' );
+		renderOverlayShell( { full: true } );
+		setUrl( initialUrl );
+		await loadBootstrap();
+		document
+			.querySelector( '.jetpack-search-block-overlay__close' )
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+	}
+
+	it( 'strips ?s= and reloads when closing from a searched URL', async () => {
+		await closeFrom( '/?s=hello' );
+
+		expect( window.location.search ).toBe( '' );
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'strips array-shaped filter params alongside the search query', async () => {
+		await closeFrom( '/?s=hello&category[]=news&category[]=blog&query_type_category=and' );
+
+		const params = new URLSearchParams( window.location.search );
+		expect( params.has( 's' ) ).toBe( false );
+		expect( params.has( 'category[]' ) ).toBe( false );
+		expect( params.has( 'query_type_category' ) ).toBe( false );
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'preserves non-search params and the hash', async () => {
+		await closeFrom( '/page/?s=hello&utm_source=twitter#anchor' );
+
+		const params = new URLSearchParams( window.location.search );
+		expect( params.has( 's' ) ).toBe( false );
+		expect( params.get( 'utm_source' ) ).toBe( 'twitter' );
+		expect( window.location.pathname ).toBe( '/page/' );
+		expect( window.location.hash ).toBe( '#anchor' );
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'does not reload when closing with no search params (manual trigger close)', async () => {
+		// No `?s=`/`?q=` means the URL-trigger doesn't auto-open. Simulate an
+		// open by removing `hidden` directly, then close — verifies the
+		// no-strip → no-reload branch end-to-end.
+		setReadyState( 'complete' );
+		renderOverlayShell( { full: true } );
+		setUrl( '/' );
+		await loadBootstrap();
+		document.getElementById( OVERLAY_ID ).removeAttribute( 'hidden' );
+
+		document
+			.querySelector( '.jetpack-search-block-overlay__close' )
+			.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+
+		// No params to strip → no reload, overlay hides via the DOM path.
+		expect( isOpen() ).toBe( false );
+	} );
+
+	it( 'reloads on Escape close when the URL carried search params', async () => {
+		setReadyState( 'complete' );
+		renderOverlayShell( { full: true } );
+		setUrl( '/?s=hello' );
+		await loadBootstrap();
+
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ) );
+
+		expect( console ).toHaveErrored();
 	} );
 } );

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -241,6 +241,36 @@ export function urlParamsToState(
 }
 
 /**
+ * Identify URL params owned by Search Blocks state. Used when leaving the
+ * search experience (overlay close) to clear the URL the same way legacy
+ * Instant Search's `restorePreviousHref()` does. The bootstrap layer can't
+ * reach into `filterConfigs`, so we identify filter params by the URL shapes
+ * the writer (`stateToUrlParams`) emits — array-suffixed and `query_type_`-
+ * prefixed — which covers every key the store can have round-tripped.
+ *
+ * Static filter scalars are not stripped here: they share `?key=value` shape
+ * with arbitrary non-search params and the bootstrap has no filter registry to
+ * disambiguate. The reserved set + array shape + query_type prefix is what
+ * legacy strips for the default close path.
+ *
+ * @param {URLSearchParams} params - URL params to scan.
+ * @return {string[]} Unique keys present in `params` that Search owns.
+ */
+export function getSearchOwnedParamKeys( params ) {
+	const owned = new Set();
+	for ( const rawKey of params.keys() ) {
+		if (
+			RESERVED_PARAMS.has( rawKey ) ||
+			rawKey.startsWith( QUERY_TYPE_PREFIX ) ||
+			rawKey.endsWith( '[]' )
+		) {
+			owned.add( rawKey );
+		}
+	}
+	return Array.from( owned );
+}
+
+/**
  * Sync state into the browser URL via `replaceState` so debounced typing
  * doesn't pile up history entries. Back navigates to the page before search.
  *


### PR DESCRIPTION
Fixes [SEARCH-256](https://linear.app/a8c/issue/SEARCH-256/search-blocks-strip-search-params-reload-page-when-closing-the-blocks)

## Why

A site visitor who opens the Search Blocks Overlay, types a query, and then dismisses the overlay currently lands on a URL that still says `?s=keyword&filter[]=value`, with WordPress's default search-results template rendered underneath. They've effectively been navigated somewhere they didn't ask to go. The legacy Instant Search overlay solves this by stripping the search/filter params and reloading the page on close, so closing the overlay feels like backing out. The new `overlay_blocks` experience now behaves the same way.

## Proposed changes

* `closeOverlay()` in `overlay-bootstrap/index.js` now strips every Search-owned URL param (`s`, `q`, `orderby`, `min_price`, `max_price`, array-shaped filter keys, and `query_type_*` overrides) via `history.replaceState`, then calls `window.location.reload()` so the underlying page repaints from a clean URL.
* If no Search-owned params were present (overlay opened from a clean URL), the original DOM-hide path runs and nothing reloads — matches the legacy behavior.
* New `getSearchOwnedParamKeys()` helper in `store/url-state.js` derives the strip set from the same `RESERVED_PARAMS` + `QUERY_TYPE_PREFIX` constants the URL *writer* uses, keeping the bootstrap dependency-light and the writer/reader symmetric.
* Unit tests cover every close path (X button, scrim, Escape), the strip set (search, filters, `query_type_*`), preservation of non-Search params + hash, and the no-strip → no-reload branch.

## Real-screen before / after

Captured against the per-agent docker WP env (overlay_blocks experience enabled via `jetpack_search_overlay_block_template_enabled` filter, anonymous visitor) at 1440×900. Visiting `/?s=hello&category[]=news&category[]=blog` opens the overlay; clicking the X close button is what differs.

| Stage | Before (trunk) | After (this PR) |
|---|---|---|
| Overlay open at searched URL | ![before-1](https://github.com/user-attachments/assets/90d617cb-37d5-4eed-a8f9-c4314d4c1d9e) | ![after-1](https://github.com/user-attachments/assets/79892eee-4313-446d-bb51-81abea1f761c) |
| After clicking close | ![before-2](https://github.com/user-attachments/assets/a1e4a283-afc5-4f02-bbce-773c88508eb9) | ![after-2](https://github.com/user-attachments/assets/288760a0-d32b-48ae-9e6f-8925a9ec540d) |

The meaningful diff is the "after close" row — on trunk the page underneath remains WP's default search-results template and the URL still says `?s=hello…`; with this PR the visitor lands back on the home page with a clean URL.

<details>
<summary>Verification (Playwright, anonymous visitor)</summary>

```
trunk (before)
  url_before_close: https://jp-atlas.jurassic.tube/?s=hello&category[]=news&category[]=blog
  url_after_close:  https://jp-atlas.jurassic.tube/?s=hello&category[]=news&category[]=blog
  overlay visible_before_close: true
  overlay visible_after_close:  false   ← overlay hides, but URL is unchanged

atlas/search-256 (after)
  url_before_close: https://jp-atlas.jurassic.tube/?s=hello&category[]=news&category[]=blog
  url_after_close:  https://jp-atlas.jurassic.tube/
  overlay visible_before_close: true
  overlay visible_after_close:  false   ← overlay hides, URL stripped, page reloaded
```

</details>

## Related product discussion/links

* Linear: [SEARCH-256](https://linear.app/a8c/issue/SEARCH-256/search-blocks-strip-search-params-reload-page-when-closing-the-blocks)
* Legacy reference: `restorePreviousHref()` in `projects/packages/search/src/instant-search/lib/query-string.js`

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Prereq: enable the experimental overlay_blocks experience via a mu-plugin:

```php
add_filter( 'jetpack_search_overlay_block_template_enabled', '__return_true' );
```

Verify each acceptance criterion below — all should pass with this PR and fail on trunk for everything except the no-search-params close.

* [ ] Open the overlay (header search trigger or visit `/?s=keyword`), type a query, and click X. URL clears of `s`/`q`/`orderby`/`min_price`/`max_price`/filter params **and** the page reloads onto the underlying page (e.g. home).
* [ ] Same flow with array-shaped filters in the URL (`/?s=keyword&category[]=news&query_type_category=and`) → all filter keys + `query_type_*` are stripped, page reloads.
* [ ] Same flow but close via scrim click — same result.
* [ ] Same flow but close via Escape — same result.
* [ ] Open the overlay from a clean URL (no `?s=` / `?q=`) — close without searching → overlay just hides, **no** reload, URL unchanged. (Matches legacy + previous behavior.)
* [ ] Non-Search query params (e.g. `utm_source=twitter`) and the hash fragment survive a close+reload — they're not in the Search-owned set.
* [ ] Existing close-path regressions don't fire: clicking a search suggestion does **not** dismiss the overlay (the SEARCH-249 fix); clicking inside the overlay card does not dismiss.
* [ ] Side-by-side against the legacy Instant Search overlay on the same site: close behavior matches.
