### PR TITLE
Search Blocks: surface filters empty state in embedded & overlay templates

### DIFF
--- a/projects/packages/search/changelog/atlas-search-257-filters-empty-state-in-templates
+++ b/projects/packages/search/changelog/atlas-search-257-filters-empty-state-in-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: surface the "No filters available" empty state in the embedded and overlay templates by wrapping their sidebar filters in the jetpack-search/filters block.

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -24,11 +24,13 @@
 
 <!-- wp:column {"width":"260px","className":"jetpack-search-block-overlay__filters-column","style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
 <div class="wp-block-column jetpack-search-block-overlay__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:jetpack-search/filters -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
+<!-- /wp:jetpack-search/filters -->
 </div>
 <!-- /wp:column -->
 

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -32,11 +32,13 @@
 <!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->
+<!-- wp:jetpack-search/filters -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
+<!-- /wp:jetpack-search/filters -->
 </div>
 <!-- /wp:column -->
 


### PR DESCRIPTION
Fixes [SEARCH-257](https://linear.app/a8c/issue/SEARCH-257/search-blocks-surface-filters-empty-state-in-embedded-and-overlay)

## Why

On the embedded search page and blocks-powered Overlay, when the configured facets resolve to nothing (no categories, no tags, only a single post type, or a query that returns zero hits) the sidebar showed a "Filter options" heading with empty space below it. Visitors couldn't tell whether the page was still loading, broken, or just had nothing to filter. They now see a clear "No filters available" message under the heading instead.

## Proposed changes

* Wrap the sidebar filters in `templates/jetpack-search.html` (embedded experience) with `<!-- wp:jetpack-search/filters -->`, matching how `templates/jetpack-search-product-results.html` already uses `<!-- wp:jetpack-search/filters-product -->`.
* Wrap the sidebar filters in `templates/jetpack-search-overlay.html` (blocks-powered Overlay) the same way.
* The `jetpack-search/filters` container already ships the "No filters available" empty state (added in [SEARCH-238 / #49089](https://github.com/Automattic/jetpack/pull/49089)); this PR just wires the two remaining bundled templates into it.

## Related product discussion/links

* Linear: [SEARCH-257](https://linear.app/a8c/issue/SEARCH-257/search-blocks-surface-filters-empty-state-in-embedded-and-overlay)
* Predecessor that built the empty-state machinery: [SEARCH-238 / #49089](https://github.com/Automattic/jetpack/pull/49089)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Use a site with no taxonomies seeded (or a search query that returns zero hits) so the aggregations come back empty. The empty state fires when there's an active search, no error, and every configured filter returns no buckets / retained options / selections.

- [ ] On `jetpack-search.html` (set `jetpack_search_experience` to `embedded`), visit the search page with a query — confirm the "No filters available" message appears under the filter heading instead of an empty column.
- [ ] On `jetpack-search-overlay.html` (set `jetpack_search_experience` to `overlay_blocks`), open the blocks Overlay with a query that returns no facets — confirm the same "No filters available" message appears in the overlay's filters column.
- [ ] On a site with real facets to show, confirm the sidebar still renders the filter buckets exactly as before and the "No filters available" paragraph stays hidden (no regression in the happy path).
- [ ] On a site that customized either template via the Search_Template CPT, confirm the customized markup wins and the behavior is unchanged.

### Screenshots

Captured on the local docker env at https://jp-atlas.jurassic.tube/?s=hello with the `/jetpack/v4/search` REST response forced empty so the empty state fires.

**Embedded experience (`jetpack-search.html`):**

| Before (trunk) | After (this PR) |
|---|---|
| ![before-embedded](https://github.com/user-attachments/assets/fe7676f1-d076-4ae7-aa45-98a9ffc8e379) | ![after-embedded](https://github.com/user-attachments/assets/03d4ffc1-b389-4f50-9164-b144a68b98d3) |

**Blocks-powered Overlay (`jetpack-search-overlay.html`):**

| Before (trunk) | After (this PR) |
|---|---|
| ![before-overlay](https://github.com/user-attachments/assets/cf4b7c5e-6550-4de1-aa05-f695ece57f3f) | ![after-overlay](https://github.com/user-attachments/assets/75c64f11-a68d-43f1-afa0-1962b493e0f6) |
