### PR TITLE
Search Blocks: route Restore Default through jetpack/v4 (fix Simple sites)

### DIFF
--- a/projects/js-packages/api/changelog/raven-search-restore-default-jetpack-v4
+++ b/projects/js-packages/api/changelog/raven-search-restore-default-jetpack-v4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add resetSearchTemplate( postType ) for the search dashboard's Restore Default action, routed via wpcom-origin so it reaches Simple sites.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -545,6 +545,13 @@ function JetpackRestApiClient( root, nonce ) {
 			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/pricing`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
+		resetSearchTemplate: postType =>
+			deleteRequest(
+				`${ wpcomOriginApiUrl }jetpack/v4/search/templates/${ encodeURIComponent( postType ) }`,
+				getParams
+			)
+				.then( checkStatus )
+				.then( parseJsonResponse ),
 		fetchMigrationStatus: () =>
 			getRequest( `${ apiRoot }jetpack/v4/migration/status`, getParams )
 				.then( checkStatus )
@@ -596,6 +603,20 @@ function JetpackRestApiClient( root, nonce ) {
 	 */
 	function postRequest( route, params, body ) {
 		return fetch( route, Object.assign( {}, params, body ) ).catch( catchNetworkErrors );
+	}
+
+	/**
+	 * Generate a DELETE request promise for the route. Inherits the same
+	 * credentials + X-WP-Nonce headers as GET requests; DELETE carries no body.
+	 *
+	 * @param {string} route  - the route
+	 * @param {object} params - the params (typically `getParams`)
+	 * @return {Promise<Response>} - the http response promise
+	 */
+	function deleteRequest( route, params ) {
+		return fetch( route, Object.assign( {}, params, { method: 'delete' } ) ).catch(
+			catchNetworkErrors
+		);
 	}
 
 	/**

--- a/projects/packages/search/changelog/raven-search-restore-default-jetpack-v4
+++ b/projects/packages/search/changelog/raven-search-restore-default-jetpack-v4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: route the Restore Default action through jetpack/v4 so it works on WordPress.com Simple sites.

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\My_Jetpack\Products\Search_Stats as Search_Product_Stats;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -129,6 +130,27 @@ class REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'product_pricing' ),
 				'permission_callback' => 'is_user_logged_in',
+			)
+		);
+		// "Restore default" for the singleton-template CPTs. Lives on
+		// jetpack/v4 (not /wp/v2/<rest_base>) so wpcom-origin can proxy it
+		// on Simple sites — the Jetpack-registered CPT controller isn't on
+		// the wpcom REST surface. The allowed `<post_type>` slugs are
+		// enforced inside the handler (single source of truth) rather than
+		// duplicated into a route-level validate_callback.
+		register_rest_route(
+			static::$namespace,
+			'/search/templates/(?P<post_type>[a-z0-9_-]+)',
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'reset_singleton_template' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'args'                => array(
+					'post_type' => array(
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
 			)
 		);
 	}
@@ -563,6 +585,60 @@ class REST_Controller {
 			'post_count'          => Search_Product_Stats::estimate_count(),
 			'post_type_breakdown' => Search_Product_Stats::get_post_type_breakdown(),
 		);
+	}
+
+	/**
+	 * Force-delete the {@see Singleton_Template_Cpt} customization for the
+	 * requested post type, backing the dashboard's "Restore default" link.
+	 * `before_delete_post` in the base class clears the option pointer +
+	 * per-request cache so the next render falls back to the bundled template.
+	 *
+	 * DELETE `jetpack/v4/search/templates/<post_type>`
+	 *
+	 * @param WP_REST_Request $request - REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function reset_singleton_template( $request ) {
+		$cpt_class = $this->resolve_singleton_template_class( $request['post_type'] );
+		if ( ! $cpt_class ) {
+			return new WP_Error(
+				'jetpack_search_template_unknown',
+				__( 'Unknown search template.', 'jetpack-search-pkg' ),
+				array( 'status' => 404 )
+			);
+		}
+		if ( ! $cpt_class::is_customized() ) {
+			return new WP_Error(
+				'jetpack_search_template_not_customized',
+				__( 'No customization to restore.', 'jetpack-search-pkg' ),
+				array( 'status' => 404 )
+			);
+		}
+		if ( ! wp_delete_post( $cpt_class::get_post_id(), true ) ) {
+			return new WP_Error(
+				'jetpack_search_template_reset_failed',
+				__( 'Failed to restore the default template.', 'jetpack-search-pkg' ),
+				array( 'status' => 500 )
+			);
+		}
+		return rest_ensure_response( array( 'deleted' => true ) );
+	}
+
+	/**
+	 * Map a CPT slug to its concrete `Singleton_Template_Cpt` subclass.
+	 * Returns null when the slug isn't one of the registered singleton-template
+	 * CPTs — the route's `validate_callback` already filters those, this is a
+	 * defense-in-depth check that also keeps the mapping in one place.
+	 *
+	 * @param string $post_type Post type slug from the request.
+	 * @return class-string<Singleton_Template_Cpt>|null
+	 */
+	protected function resolve_singleton_template_class( $post_type ) {
+		$map = array(
+			Overlay_Template::POST_TYPE => Overlay_Template::class,
+			Search_Template::POST_TYPE  => Search_Template::class,
+		);
+		return $map[ $post_type ] ?? null;
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -614,7 +614,8 @@ class REST_Controller {
 				array( 'status' => 404 )
 			);
 		}
-		if ( ! wp_delete_post( $cpt_class::get_post_id(), true ) ) {
+		$post_id = $cpt_class::get_post_id();
+		if ( ! wp_delete_post( $post_id, true ) ) {
 			return new WP_Error(
 				'jetpack_search_template_reset_failed',
 				__( 'Failed to restore the default template.', 'jetpack-search-pkg' ),
@@ -627,8 +628,8 @@ class REST_Controller {
 	/**
 	 * Map a CPT slug to its concrete `Singleton_Template_Cpt` subclass.
 	 * Returns null when the slug isn't one of the registered singleton-template
-	 * CPTs — the route's `validate_callback` already filters those, this is a
-	 * defense-in-depth check that also keeps the mapping in one place.
+	 * CPTs — the route only sanitizes the slug (via `sanitize_key`), so this
+	 * lookup is the primary "is this a known CPT?" filter, not a backup check.
 	 *
 	 * @param string $post_type Post type slug from the request.
 	 * @return class-string<Singleton_Template_Cpt>|null

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -228,7 +228,7 @@ class Initial_State {
 	 * before any switch, would carry a null `editorUrl` and the link would
 	 * become a no-op once the card flipped to Active without a refresh).
 	 *
-	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function get_block_template_overlay_config(): array {
 		return $this->build_singleton_template_config(
@@ -241,12 +241,12 @@ class Initial_State {
 	/**
 	 * Build the classic-theme search-template editor config exposed to the
 	 * dashboard. Counterpart of `get_block_template_overlay_config()` —
-	 * same `{enabled, editorUrl, resetRestPath, isCustomized}` shape and
+	 * same `{enabled, editorUrl, postType, isCustomized}` shape and
 	 * the same "expose URLs before activation" rule: admins can edit the
 	 * template from the Embedded card on any classic theme, even before
 	 * actually switching to Embedded.
 	 *
-	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function get_search_template_config(): array {
 		$is_classic = ! wp_is_block_theme();
@@ -260,28 +260,33 @@ class Initial_State {
 	/**
 	 * Shared assembly for a {@see Singleton_Template_Cpt}-backed editor
 	 * config block. Both `blockTemplateOverlay` and `searchTemplate` ship
-	 * the same `{enabled, editorUrl, resetRestPath, isCustomized}` shape
-	 * to the React dashboard. The `$enabled` and `$can_edit` flags are
+	 * the same `{enabled, editorUrl, postType, isCustomized}` shape to
+	 * the React dashboard. The `$enabled` and `$can_edit` flags are
 	 * intentionally separate: the card lights up as "active" on
-	 * `$enabled`, but the URLs surface as soon as `$can_edit` is true so
-	 * admins can pre-customize the template before activating the
-	 * experience — without forcing a page reload after the switch.
+	 * `$enabled`, but the URLs / `postType` surface as soon as `$can_edit`
+	 * is true so admins can pre-customize the template before activating
+	 * the experience — without forcing a page reload after the switch.
 	 *
-	 * The action handlers re-check `manage_options` server-side, so
-	 * omitting the URLs here is just to keep the wire payload tight for
-	 * non-admins.
+	 * `postType` (rather than a pre-built REST path) is what the dashboard
+	 * needs: the JS `restApi.resetSearchTemplate(postType)` call builds the
+	 * `${wpcomOriginApiUrl}jetpack/v4/search/templates/<post_type>` URL,
+	 * which is how the request reaches the right route on wpcom Simple
+	 * sites (the local /wp-json/ surface there doesn't expose Jetpack
+	 * routes). The action handlers re-check `manage_options` server-side,
+	 * so omitting the URLs / postType here just keeps the wire payload
+	 * tight for non-admins.
 	 *
 	 * @param bool   $enabled   Whether the CPT-backed route is currently live on the site.
-	 * @param bool   $can_edit  Whether to expose the nonce'd URLs (operator-level gate + capability).
+	 * @param bool   $can_edit  Whether to expose the editor URL + postType (operator-level gate + capability).
 	 * @param string $cpt_class Concrete `Singleton_Template_Cpt` subclass to query.
-	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function build_singleton_template_config( bool $enabled, bool $can_edit, string $cpt_class ): array {
 		return array(
-			'enabled'       => $enabled,
-			'editorUrl'     => $can_edit ? $cpt_class::get_editor_url() : null,
-			'resetRestPath' => $can_edit ? $cpt_class::get_reset_rest_path() : null,
-			'isCustomized'  => $can_edit && $cpt_class::is_customized(),
+			'enabled'      => $enabled,
+			'editorUrl'    => $can_edit ? $cpt_class::get_editor_url() : null,
+			'postType'     => $can_edit ? $cpt_class::POST_TYPE : null,
+			'isCustomized' => $can_edit && $cpt_class::is_customized(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
@@ -1,4 +1,4 @@
-import apiFetch from '@wordpress/api-fetch';
+import restApi from '@automattic/jetpack-api';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -23,7 +23,7 @@ import CardLink from './card-link';
  * reset flags cross-contaminating.
  *
  * @param {object}  props                       - Props.
- * @param {object}  props.config                - The `{enabled, editorUrl, resetRestPath, isCustomized}` blob from the matching singleton-template selector.
+ * @param {object}  props.config                - The `{enabled, editorUrl, postType, isCustomized}` blob from the matching singleton-template selector.
  * @param {string}  props.editLabel             - Visible label for the "Edit …" link.
  * @param {string}  props.restoreConfirmMessage - Body copy for the destructive confirm dialog.
  * @param {string}  props.successMessage        - Notice copy posted after a successful reset.
@@ -81,7 +81,7 @@ export default function SingletonTemplateActions( {
 					// reality.
 					onClick={ () => setJustReset( false ) }
 				/>
-				{ config.resetRestPath && config.isCustomized && ! justReset && (
+				{ config.postType && config.isCustomized && ! justReset && (
 					<CardLink
 						label={ restoreLabel }
 						href="#"
@@ -89,7 +89,7 @@ export default function SingletonTemplateActions( {
 						onClick={ event => {
 							// Destructive — open the confirm dialog instead of
 							// running the AJAX delete directly. The dialog's
-							// confirm handler is the one that fires `apiFetch`.
+							// confirm handler is the one that fires the request.
 							event.preventDefault();
 							setResetConfirmOpen( true );
 						} }
@@ -101,18 +101,21 @@ export default function SingletonTemplateActions( {
 				onConfirm={ async () => {
 					setResetConfirmOpen( false );
 					// Defensive guard: the dialog can only open via the
-					// `isCustomized && resetRestPath` CardLink above, so
-					// `resetRestPath` is non-null in practice — avoid firing a
-					// DELETE to `undefined` if the gating logic ever shifts.
-					if ( ! config.resetRestPath ) {
+					// `isCustomized && postType` CardLink above, so `postType`
+					// is non-null in practice — avoid firing a DELETE against
+					// `undefined` if the gating logic ever shifts.
+					if ( ! config.postType ) {
 						return;
 					}
 					setIsResetting( true );
 					try {
-						await apiFetch( {
-							path: config.resetRestPath,
-							method: 'DELETE',
-						} );
+						// `restApi` (not `apiFetch`) so the call resolves
+						// against the wpcom-origin-prefixed root the dashboard
+						// configures in `wrapped-dashboard.jsx` — that's what
+						// makes the DELETE reachable on WordPress.com Simple
+						// sites, where the local /wp-json/ surface doesn't
+						// expose Jetpack-registered routes.
+						await restApi.resetSearchTemplate( config.postType );
 						setJustReset( true );
 						successNotice( successMessage );
 					} catch ( error ) {

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -5,7 +5,7 @@
 const singletonTemplateConfigDefault = {
 	enabled: false,
 	editorUrl: null,
-	resetRestPath: null,
+	postType: null,
 	isCustomized: false,
 };
 
@@ -31,9 +31,10 @@ const siteDataSelectors = {
 	// Editor affordances for the blocks-powered Overlay. Surface in the
 	// Overlay search card when the active experience is `overlay_blocks`
 	// (the PHP gate). Returns the whole config blob so callers can
-	// destructure `{ enabled, editorUrl, resetRestPath, isCustomized }`
-	// in one go. `resetRestPath` is the apiFetch path the "Restore
-	// default" link DELETEs to roll back the customization.
+	// destructure `{ enabled, editorUrl, postType, isCustomized }` in one
+	// go. `postType` is the CPT slug the "Restore default" link passes to
+	// `restApi.resetSearchTemplate()`; it's null when the admin lacks the
+	// edit gate so the link is hidden in that state.
 	getBlockTemplateOverlayConfig: state =>
 		state.siteData?.blockTemplateOverlay ?? singletonTemplateConfigDefault,
 	// Same shape as `getBlockTemplateOverlayConfig`, sibling under the

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -38,8 +38,8 @@ abstract class Singleton_Template_Cpt {
 
 	/**
 	 * REST base for the core CPT controller (`/wp/v2/<rest_base>`) the block
-	 * editor uses to load + save the singleton. Distinct from the "Restore
-	 * default" path, which lives on jetpack/v4 — see {@see get_reset_rest_path()}.
+	 * editor uses to load + save the singleton. The "Restore default" path
+	 * lives on jetpack/v4 instead, registered by `REST_Controller`.
 	 */
 	const REST_BASE = '';
 
@@ -266,25 +266,6 @@ abstract class Singleton_Template_Cpt {
 			),
 			admin_url( 'admin.php?page=jetpack-search' )
 		);
-	}
-
-	/**
-	 * REST DELETE path for "Restore default" — `/jetpack/v4/search/templates/<post_type>`.
-	 * Routed through the package's Jetpack-namespaced controller (see
-	 * {@see REST_Controller::reset_singleton_template()}) so the call works
-	 * over wpcom-origin on Simple sites; the equivalent `/wp/v2/<rest_base>/<id>`
-	 * isn't reachable there because the Jetpack-registered CPT controller isn't
-	 * on the wpcom REST surface. `before_delete_post` keeps the option + cache
-	 * in sync. Returns `null` when no singleton exists (the React link is hidden
-	 * in that state).
-	 *
-	 * @return string|null
-	 */
-	public static function get_reset_rest_path(): ?string {
-		if ( ! static::is_customized() ) {
-			return null;
-		}
-		return '/jetpack/v4/search/templates/' . static::POST_TYPE;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -37,7 +37,9 @@ abstract class Singleton_Template_Cpt {
 	const POST_TYPE = '';
 
 	/**
-	 * REST base — appears in `/wp/v2/<rest_base>/<id>` and `get_reset_rest_path()`.
+	 * REST base for the core CPT controller (`/wp/v2/<rest_base>`) the block
+	 * editor uses to load + save the singleton. Distinct from the "Restore
+	 * default" path, which lives on jetpack/v4 — see {@see get_reset_rest_path()}.
 	 */
 	const REST_BASE = '';
 
@@ -267,9 +269,14 @@ abstract class Singleton_Template_Cpt {
 	}
 
 	/**
-	 * REST DELETE path for "Restore default" — `/wp/v2/<rest_base>/<id>?force=true`.
-	 * `before_delete_post` keeps the option + cache in sync. Returns `null`
-	 * when no singleton exists (the React link is hidden in that state).
+	 * REST DELETE path for "Restore default" — `/jetpack/v4/search/templates/<post_type>`.
+	 * Routed through the package's Jetpack-namespaced controller (see
+	 * {@see REST_Controller::reset_singleton_template()}) so the call works
+	 * over wpcom-origin on Simple sites; the equivalent `/wp/v2/<rest_base>/<id>`
+	 * isn't reachable there because the Jetpack-registered CPT controller isn't
+	 * on the wpcom REST surface. `before_delete_post` keeps the option + cache
+	 * in sync. Returns `null` when no singleton exists (the React link is hidden
+	 * in that state).
 	 *
 	 * @return string|null
 	 */
@@ -277,7 +284,7 @@ abstract class Singleton_Template_Cpt {
 		if ( ! static::is_customized() ) {
 			return null;
 		}
-		return '/wp/v2/' . static::REST_BASE . '/' . static::get_post_id() . '?force=true';
+		return '/jetpack/v4/search/templates/' . static::POST_TYPE;
 	}
 
 	/**

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -898,6 +898,45 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
+	 * If `wp_delete_post()` itself fails (here simulated by short-circuiting
+	 * via the `pre_delete_post` filter), the handler returns a 500 with a
+	 * stable error code rather than silently claiming success. Covers the
+	 * defensive branch that exists for the wp_delete_post → false path
+	 * (post vanished mid-request, plugin veto, etc.).
+	 */
+	public function test_reset_singleton_template_returns_500_when_delete_fails() {
+		wp_set_current_user( $this->admin_id );
+		Search_Template::register_post_type();
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'will-fail-to-delete',
+			)
+		);
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		Search_Template::reset_customized_content_cache();
+		$veto = static function () {
+			return false;
+		};
+		add_filter( 'pre_delete_post', $veto );
+		try {
+			$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 500, $response->get_status() );
+			$this->assertSame( 'jetpack_search_template_reset_failed', $response->get_data()['code'] );
+			// The post is still on disk because the filter vetoed deletion.
+			$this->assertNotNull( get_post( $post_id ) );
+		} finally {
+			remove_filter( 'pre_delete_post', $veto );
+			wp_delete_post( $post_id, true );
+			delete_option( Search_Template::OPTION_POST_ID );
+			Search_Template::reset_customized_content_cache();
+		}
+	}
+
+	/**
 	 * Happy path: an existing customization is force-deleted, the option
 	 * pointer is cleared (via `before_delete_post`), and the route returns
 	 * `{deleted: true}`. This is the wpcom-origin-reachable replacement for

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -851,6 +851,20 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
+	 * Anonymous callers get 401 from `require_admin_privilege_callback` — the
+	 * same auth matrix the rest of the controller's destructive endpoints
+	 * (`activate_plan`, `deactivate_plan`) cover.
+	 */
+	public function test_reset_singleton_template_unauthorized_for_anonymous() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * An unknown post_type slug is rejected by the handler's
 	 * `resolve_singleton_template_class()` lookup with a stable 404 + error
 	 * code, so the dashboard surfaces a sensible message instead of leaking

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -838,6 +838,93 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
+	 * DELETE /jetpack/v4/search/templates/<post_type> requires manage_options —
+	 * an editor user gets 403 from `require_admin_privilege_callback`.
+	 */
+	public function test_reset_singleton_template_unauthorized_for_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * An unknown post_type slug is rejected by the handler's
+	 * `resolve_singleton_template_class()` lookup with a stable 404 + error
+	 * code, so the dashboard surfaces a sensible message instead of leaking
+	 * an upstream 500 if a future slug change drifts client/server.
+	 */
+	public function test_reset_singleton_template_rejects_unknown_post_type() {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/not_a_real_cpt' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 'jetpack_search_template_unknown', $response->get_data()['code'] );
+	}
+
+	/**
+	 * No customization on file ⇒ the handler returns 404 with a stable error
+	 * code so the dashboard can surface a meaningful message instead of a 500.
+	 */
+	public function test_reset_singleton_template_returns_404_when_not_customized() {
+		wp_set_current_user( $this->admin_id );
+		Search_Template::register_post_type();
+		delete_option( Search_Template::OPTION_POST_ID );
+		Search_Template::reset_customized_content_cache();
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 'jetpack_search_template_not_customized', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Happy path: an existing customization is force-deleted, the option
+	 * pointer is cleared (via `before_delete_post`), and the route returns
+	 * `{deleted: true}`. This is the wpcom-origin-reachable replacement for
+	 * the legacy `/wp/v2/<rest_base>/<id>?force=true` DELETE.
+	 */
+	public function test_reset_singleton_template_deletes_customization_and_clears_option() {
+		wp_set_current_user( $this->admin_id );
+		Search_Template::register_post_type();
+		// The cleanup hook (option pointer + per-class cache) is normally
+		// wired by `Singleton_Template_Cpt::init()`. The test bootstrap only
+		// registers the CPT, so wire the hook locally for this test and
+		// remove it in the cleanup branch to keep the global state pristine.
+		$cleanup_cb = array( Search_Template::class, 'maybe_cleanup_on_singleton_delete' );
+		add_action( 'before_delete_post', $cleanup_cb );
+		try {
+			$post_id = wp_insert_post(
+				array(
+					'post_type'    => Search_Template::POST_TYPE,
+					'post_status'  => 'publish',
+					'post_content' => 'will-be-restored',
+				)
+			);
+			update_option( Search_Template::OPTION_POST_ID, $post_id );
+			Search_Template::reset_customized_content_cache();
+			$this->assertTrue( Search_Template::is_customized() );
+
+			$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertSame( array( 'deleted' => true ), $response->get_data() );
+			$this->assertSame( 0, (int) get_option( Search_Template::OPTION_POST_ID, 0 ) );
+			$this->assertNull( get_post( $post_id ) );
+		} finally {
+			remove_action( 'before_delete_post', $cleanup_cb );
+			delete_option( Search_Template::OPTION_POST_ID );
+			Search_Template::reset_customized_content_cache();
+		}
+	}
+
+	/**
 	 * Signs a request with a blog token before dispatching it.
 	 *
 	 * Ensures that these tests pass through Connection_Rest_Authentication::wp_rest_authenticate,

--- a/projects/packages/search/tests/php/Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Search_Template_Test.php
@@ -56,22 +56,20 @@ class Search_Template_Test extends Search_TestCase {
 
 	/**
 	 * No singleton on file ⇒ `get_customized_content()` returns null,
-	 * `is_customized()` is false, `get_reset_rest_path()` is null. The
-	 * shape callers depend on to fall back to the bundled template.
+	 * `is_customized()` is false. The shape callers depend on to fall
+	 * back to the bundled template.
 	 */
 	public function test_uncustomized_state_returns_nulls() {
 		$this->assertNull( Search_Template::get_customized_content() );
 		$this->assertFalse( Search_Template::is_customized() );
-		$this->assertNull( Search_Template::get_reset_rest_path() );
 		$this->assertSame( 0, Search_Template::get_post_id() );
 	}
 
 	/**
 	 * A saved customization round-trips: `get_customized_content()`
-	 * returns the post content, `is_customized()` flips true, and
-	 * `get_reset_rest_path()` resolves to the jetpack/v4 reset route.
+	 * returns the post content, `is_customized()` flips true.
 	 */
-	public function test_customized_state_returns_post_content_and_reset_path() {
+	public function test_customized_state_returns_post_content() {
 		$post_id = wp_insert_post(
 			array(
 				'post_type'    => Search_Template::POST_TYPE,
@@ -90,10 +88,6 @@ class Search_Template_Test extends Search_TestCase {
 			Search_Template::get_customized_content()
 		);
 		$this->assertTrue( Search_Template::is_customized() );
-		$this->assertSame(
-			'/jetpack/v4/search/templates/' . Search_Template::POST_TYPE,
-			Search_Template::get_reset_rest_path()
-		);
 	}
 
 	/**
@@ -116,7 +110,6 @@ class Search_Template_Test extends Search_TestCase {
 
 		$this->assertNull( Search_Template::get_customized_content() );
 		$this->assertFalse( Search_Template::is_customized() );
-		$this->assertNull( Search_Template::get_reset_rest_path() );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Search_Template_Test.php
@@ -69,7 +69,7 @@ class Search_Template_Test extends Search_TestCase {
 	/**
 	 * A saved customization round-trips: `get_customized_content()`
 	 * returns the post content, `is_customized()` flips true, and
-	 * `get_reset_rest_path()` resolves to the CPT's REST endpoint.
+	 * `get_reset_rest_path()` resolves to the jetpack/v4 reset route.
 	 */
 	public function test_customized_state_returns_post_content_and_reset_path() {
 		$post_id = wp_insert_post(
@@ -91,7 +91,7 @@ class Search_Template_Test extends Search_TestCase {
 		);
 		$this->assertTrue( Search_Template::is_customized() );
 		$this->assertSame(
-			'/wp/v2/' . Search_Template::REST_BASE . '/' . $post_id . '?force=true',
+			'/jetpack/v4/search/templates/' . Search_Template::POST_TYPE,
 			Search_Template::get_reset_rest_path()
 		);
 	}


### PR DESCRIPTION
## Proposed changes

The dashboard's "Restore default" link DELETEs the singleton-template CPT to roll back to the bundled template. It was using the auto-generated core CPT route, `/wp/v2/<rest_base>/<id>?force=true` — which **isn't reachable through wpcom-origin on WordPress.com Simple sites** because the Jetpack-registered CPT controller doesn't exist on the wpcom REST surface. Clicking "Restore default" on a Simple site failed silently.

* Add a Jetpack-namespaced route — `DELETE /jetpack/v4/search/templates/<post_type>` — in `REST_Controller::register_common_rest_routes()`. The handler resolves `<post_type>` to the matching `Singleton_Template_Cpt` subclass (`Overlay_Template` / `Search_Template`), capability-checks `manage_options`, then `wp_delete_post( …, true )`. `before_delete_post` already clears the option pointer + per-class cache, so no new cleanup code.
* `Singleton_Template_Cpt::get_reset_rest_path()` now returns `/jetpack/v4/search/templates/<post_type>` instead of the old core path. The React link DELETEs through the new endpoint, and apiFetch routes the request through `wpcom-origin` on Simple sites the same way the rest of the Search dashboard already does.
* The `/wp/v2/<rest_base>` route stays as-is — the block editor itself uses it to load/save the CPT during editing. Only the "Restore default" action moves.
* Tests: unauthorized / unknown post_type / not-customized / happy-path coverage for the new route, plus updated reset-path assertion in `Search_Template_Test`.

## Related product discussion/links

* Reported by @jasper-kang — "Restore default" link on the Search dashboard does not work on WordPress.com Simple sites.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Self-hosted / Atomic (smoke test the new path)**

1. Activate Jetpack Search on a site with the blocks-powered Overlay or classic-theme Embedded experience enabled.
2. Open the Search dashboard, click "Edit search template" (or "Edit Overlay"), save any change in the block editor, return to the dashboard.
3. Click "Restore default" → confirm. The link should disappear, the success notice should fire, and the front-end search page should fall back to the bundled template.
4. Verify in DevTools that the request goes to `DELETE /wp-json/jetpack/v4/search/templates/jp_search_template` (or `jp_search_overlay`) and returns `{ deleted: true }`.

**WordPress.com Simple (the bug being fixed)**

1. On a Simple site that has the Search dashboard, customize the Embedded / Overlay template via the same flow.
2. Click "Restore default" → confirm.
3. Verify the request goes to `DELETE /wp-json/wpcom-origin/jetpack/v4/search/templates/<post_type>` and succeeds (previously: silent failure against the unreachable `/wp/v2/<rest_base>/...` route).
4. Reload the dashboard; "Restore default" should no longer be shown, and the front-end search page should serve the bundled template.

**Automated**

* `cd projects/packages/search && composer phpunit -- --filter='REST_Controller_Test|Search_Template_Test'` — 57 / 57 passing.
* `composer phpunit` (full search suite) — 595 / 595 passing.