### PR TITLE
Create AI Podcast: limit specific-post selection to 25

### DIFF
--- a/projects/packages/podcast/changelog/add-create-ai-podcast-post-limit
+++ b/projects/packages/podcast/changelog/add-create-ai-podcast-post-limit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Create AI Podcast: Limit the "from specific posts" selection to 25 posts and surface a hint indicating the cap.

--- a/projects/packages/podcast/src/admin-pages/create-ai-podcast/index.js
+++ b/projects/packages/podcast/src/admin-pages/create-ai-podcast/index.js
@@ -342,6 +342,7 @@
 	const episodesList = root.querySelector( '[data-region="episodes-list"]' );
 
 	const selectedPostIds = new Set();
+	const maxSelectedPosts = data.maxPosts || 25;
 	let pollTimer = null;
 
 	// --- Status notice rendering -------------------------------------------------
@@ -797,10 +798,16 @@
 			checkbox.checked = selectedPostIds.has( post.id );
 			checkbox.addEventListener( 'change', () => {
 				if ( checkbox.checked ) {
+					if ( selectedPostIds.size >= maxSelectedPosts ) {
+						checkbox.checked = false;
+						setStatus( 'error', data.i18n.maxPostsReached );
+						return;
+					}
 					selectedPostIds.add( post.id );
 				} else {
 					selectedPostIds.delete( post.id );
 				}
+				refreshPostLimitState();
 			} );
 
 			const title = document.createElement( 'span' );
@@ -826,6 +833,18 @@
 			ul.appendChild( li );
 		} );
 		postsRegion.appendChild( ul );
+		refreshPostLimitState();
+	}
+
+	/**
+	 * Disable unchecked post checkboxes once the selection limit is reached so
+	 * the user can't select more than `maxSelectedPosts` posts.
+	 */
+	function refreshPostLimitState() {
+		const atLimit = selectedPostIds.size >= maxSelectedPosts;
+		postsRegion.querySelectorAll( 'input[type="checkbox"]' ).forEach( cb => {
+			cb.disabled = atLimit && ! cb.checked;
+		} );
 	}
 
 	function renderPostsLoading() {

--- a/projects/packages/podcast/src/admin-pages/create-ai-podcast/style.css
+++ b/projects/packages/podcast/src/admin-pages/create-ai-podcast/style.css
@@ -351,6 +351,12 @@
 	margin: 0;
 }
 
+.jetpack-create-ai-podcast__field-hint {
+	margin: 4px 0 0;
+	font-size: 12px;
+	color: #646970;
+}
+
 /* --- Posts picker --------------------------------------------------------- */
 
 .jetpack-create-ai-podcast__posts {

--- a/projects/packages/podcast/src/class-create-ai-podcast-page.php
+++ b/projects/packages/podcast/src/class-create-ai-podcast-page.php
@@ -33,6 +33,11 @@ class Create_AI_Podcast_Page {
 	const STYLE_HANDLE      = 'jetpack-create-ai-podcast';
 	const EPISODES_PER_PAGE = 5;
 
+	/**
+	 * Maximum number of posts that can be selected when generating from specific posts.
+	 */
+	const MAX_SELECTED_POSTS = 25;
+
 	const POST_PUBLISH_PROMO_SCRIPT_HANDLE    = 'jetpack-post-publish-podcast-promo';
 	const POST_PUBLISH_PROMO_DISMISSED_OPTION = 'jetpack_posts_to_podcast_post_publish_promo_dismissed';
 	const POST_PUBLISH_PROMO_MIN_POSTS        = 5;
@@ -342,7 +347,10 @@ class Create_AI_Podcast_Page {
 	 * @return array<string, mixed>
 	 */
 	private static function build_localized_data(): array {
+		$max_posts = self::MAX_SELECTED_POSTS;
+
 		return array(
+			'maxPosts'  => $max_posts,
 			'endpoints' => array(
 				'enqueue'  => '/wpcom/v2/posts-to-podcast',
 				'job'      => '/wpcom/v2/posts-to-podcast/jobs/',
@@ -404,6 +412,8 @@ class Create_AI_Podcast_Page {
 				'noPostsFound'        => __( 'No posts match.', 'jetpack-podcast' ),
 				'loadingPosts'        => __( 'Loading posts…', 'jetpack-podcast' ),
 				'pickPosts'           => __( 'Select at least one post to continue.', 'jetpack-podcast' ),
+				// translators: %d: maximum number of posts that can be selected.
+				'maxPostsReached'     => sprintf( __( 'You can select up to %d posts.', 'jetpack-podcast' ), $max_posts ),
 				'upgradeCta'          => __( 'Upgrade plan', 'jetpack-podcast' ),
 				'episodesTitle'       => __( 'Generated podcasts', 'jetpack-podcast' ),
 				'episodesEmpty'       => __( 'No generated podcasts yet.', 'jetpack-podcast' ),
@@ -804,6 +814,17 @@ class Create_AI_Podcast_Page {
 								id="jetpack-create-ai-podcast-posts-search"
 								placeholder="<?php echo esc_attr__( 'Type to filter…', 'jetpack-podcast' ); ?>"
 							>
+							<p class="jetpack-create-ai-podcast__field-hint">
+								<?php
+								echo esc_html(
+									sprintf(
+										/* translators: %d: maximum number of posts that can be selected. */
+										__( 'You can choose up to %d posts.', 'jetpack-podcast' ),
+										self::MAX_SELECTED_POSTS
+									)
+								);
+								?>
+							</p>
 							<div class="jetpack-create-ai-podcast__posts" data-region="posts"></div>
 						</div>
 

--- a/projects/packages/podcast/src/endpoints/class-posts-to-podcast-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-posts-to-podcast-endpoint.php
@@ -88,7 +88,8 @@ class Posts_To_Podcast_Endpoint extends WP_REST_Controller {
 							'type'        => 'array',
 							'required'    => false,
 							'items'       => array( 'type' => 'integer' ),
-							'description' => __( 'Explicit list of published post IDs to draw from. Required when window is omitted.', 'jetpack-podcast' ),
+							'maxItems'    => 25,
+							'description' => __( 'Explicit list of published post IDs to draw from (up to 25). Required when window is omitted.', 'jetpack-podcast' ),
 						),
 						'length'      => array(
 							'type'        => 'string',


### PR DESCRIPTION
Fixes #

## Proposed changes
* Cap the "From specific posts" selection in the Create AI Podcast page at **25 posts**, with a single source of truth (`Create_AI_Podcast_Page::MAX_SELECTED_POSTS`) passed to the front end as `maxPosts`.
* Surface a hint under the post search field: *"You can choose up to 25 posts."*
* Enforce the cap in the post picker JS: selecting a 26th post is blocked (checkbox reverts) and unchecked checkboxes are disabled once the limit is reached. The limit holds across searches since selections persist.
* Show an error notice (*"You can select up to 25 posts."*) if a user attempts to exceed the limit.
* Add a server-side guard: `maxItems => 25` on the `postIds` REST schema so the cap is enforced even if the UI is bypassed.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with the Create AI Podcast page available, go to the Create AI Podcast admin page (Media → Create AI Podcast).
* Select the **From specific posts** source option.
* Confirm the hint *"You can choose up to 25 posts."* appears under the search field.
* Search for and select posts. After selecting 25 posts, confirm the remaining unchecked checkboxes become disabled.
* Try to select a 26th post (e.g. via an already-rendered checkbox) and confirm it is blocked and an error notice appears.
* Deselect a post and confirm the checkboxes become enabled again.
* (Optional) Send a `POST` to `/wpcom/v2/posts-to-podcast` with a `postIds` array of more than 25 integers and confirm the REST API rejects it with a validation error.
