### PR TITLE
Search Blocks: route Restore Default through jetpack/v4 (search-package-local redo)

### DIFF
--- a/projects/packages/search/changelog/raven-search-restore-default-pkg-local
+++ b/projects/packages/search/changelog/raven-search-restore-default-pkg-local
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: route the Restore Default action through jetpack/v4 so it works on WordPress.com Simple sites.

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -131,6 +131,27 @@ class REST_Controller {
 				'permission_callback' => 'is_user_logged_in',
 			)
 		);
+		// "Restore default" for the singleton-template CPTs. Lives on
+		// jetpack/v4 (not /wp/v2/<rest_base>) so wpcom-origin can proxy it
+		// on Simple sites — the Jetpack-registered CPT controller isn't on
+		// the wpcom REST surface. The allowed `<post_type>` slugs are
+		// enforced inside the handler (single source of truth) rather than
+		// duplicated into a route-level validate_callback.
+		register_rest_route(
+			static::$namespace,
+			'/search/templates/(?P<post_type>[a-z0-9_-]+)',
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'reset_singleton_template' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'args'                => array(
+					'post_type' => array(
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -563,6 +584,61 @@ class REST_Controller {
 			'post_count'          => Search_Product_Stats::estimate_count(),
 			'post_type_breakdown' => Search_Product_Stats::get_post_type_breakdown(),
 		);
+	}
+
+	/**
+	 * Force-delete the {@see Singleton_Template_Cpt} customization for the
+	 * requested post type, backing the dashboard's "Restore default" link.
+	 * `before_delete_post` in the base class clears the option pointer +
+	 * per-request cache so the next render falls back to the bundled template.
+	 *
+	 * DELETE `jetpack/v4/search/templates/<post_type>`
+	 *
+	 * @param WP_REST_Request $request - REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function reset_singleton_template( $request ) {
+		$cpt_class = $this->resolve_singleton_template_class( $request['post_type'] );
+		if ( ! $cpt_class ) {
+			return new WP_Error(
+				'jetpack_search_template_unknown',
+				__( 'Unknown search template.', 'jetpack-search-pkg' ),
+				array( 'status' => 404 )
+			);
+		}
+		if ( ! $cpt_class::is_customized() ) {
+			return new WP_Error(
+				'jetpack_search_template_not_customized',
+				__( 'No customization to restore.', 'jetpack-search-pkg' ),
+				array( 'status' => 404 )
+			);
+		}
+		$post_id = $cpt_class::get_post_id();
+		if ( ! wp_delete_post( $post_id, true ) ) {
+			return new WP_Error(
+				'jetpack_search_template_reset_failed',
+				__( 'Failed to restore the default template.', 'jetpack-search-pkg' ),
+				array( 'status' => 500 )
+			);
+		}
+		return rest_ensure_response( array( 'deleted' => true ) );
+	}
+
+	/**
+	 * Map a CPT slug to its concrete `Singleton_Template_Cpt` subclass.
+	 * Returns null when the slug isn't one of the registered singleton-template
+	 * CPTs — the route only sanitizes the slug (via `sanitize_key`), so this
+	 * lookup is the primary "is this a known CPT?" filter, not a backup check.
+	 *
+	 * @param string $post_type Post type slug from the request.
+	 * @return class-string<Singleton_Template_Cpt>|null
+	 */
+	protected function resolve_singleton_template_class( $post_type ) {
+		$map = array(
+			Overlay_Template::POST_TYPE => Overlay_Template::class,
+			Search_Template::POST_TYPE  => Search_Template::class,
+		);
+		return $map[ $post_type ] ?? null;
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\My_Jetpack\Products\Search_Stats as Search_Product_Stats;
 use Jetpack_Options;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -228,7 +228,7 @@ class Initial_State {
 	 * before any switch, would carry a null `editorUrl` and the link would
 	 * become a no-op once the card flipped to Active without a refresh).
 	 *
-	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function get_block_template_overlay_config(): array {
 		return $this->build_singleton_template_config(
@@ -241,12 +241,12 @@ class Initial_State {
 	/**
 	 * Build the classic-theme search-template editor config exposed to the
 	 * dashboard. Counterpart of `get_block_template_overlay_config()` —
-	 * same `{enabled, editorUrl, resetRestPath, isCustomized}` shape and
-	 * the same "expose URLs before activation" rule: admins can edit the
+	 * same `{enabled, editorUrl, postType, isCustomized}` shape and the
+	 * same "expose URLs before activation" rule: admins can edit the
 	 * template from the Embedded card on any classic theme, even before
 	 * actually switching to Embedded.
 	 *
-	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function get_search_template_config(): array {
 		$is_classic = ! wp_is_block_theme();
@@ -260,28 +260,33 @@ class Initial_State {
 	/**
 	 * Shared assembly for a {@see Singleton_Template_Cpt}-backed editor
 	 * config block. Both `blockTemplateOverlay` and `searchTemplate` ship
-	 * the same `{enabled, editorUrl, resetRestPath, isCustomized}` shape
-	 * to the React dashboard. The `$enabled` and `$can_edit` flags are
+	 * the same `{enabled, editorUrl, postType, isCustomized}` shape to
+	 * the React dashboard. The `$enabled` and `$can_edit` flags are
 	 * intentionally separate: the card lights up as "active" on
-	 * `$enabled`, but the URLs surface as soon as `$can_edit` is true so
-	 * admins can pre-customize the template before activating the
-	 * experience — without forcing a page reload after the switch.
+	 * `$enabled`, but the URLs / `postType` surface as soon as `$can_edit`
+	 * is true so admins can pre-customize the template before activating
+	 * the experience — without forcing a page reload after the switch.
 	 *
-	 * The action handlers re-check `manage_options` server-side, so
-	 * omitting the URLs here is just to keep the wire payload tight for
-	 * non-admins.
+	 * `postType` (rather than a pre-built REST path) is what the dashboard
+	 * needs: the React "Restore default" handler builds the
+	 * `${wpcomOriginApiUrl}jetpack/v4/search/templates/<post_type>` URL
+	 * itself, which is how the request reaches the right route on wpcom
+	 * Simple sites (the local /wp-json/ surface there doesn't expose
+	 * Jetpack routes). The handler re-checks `manage_options` server-side,
+	 * so omitting the URLs / postType here just keeps the wire payload
+	 * tight for non-admins.
 	 *
 	 * @param bool   $enabled   Whether the CPT-backed route is currently live on the site.
-	 * @param bool   $can_edit  Whether to expose the nonce'd URLs (operator-level gate + capability).
+	 * @param bool   $can_edit  Whether to expose the editor URL + postType (operator-level gate + capability).
 	 * @param string $cpt_class Concrete `Singleton_Template_Cpt` subclass to query.
-	 * @return array{enabled: bool, editorUrl: string|null, resetRestPath: string|null, isCustomized: bool}
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function build_singleton_template_config( bool $enabled, bool $can_edit, string $cpt_class ): array {
 		return array(
-			'enabled'       => $enabled,
-			'editorUrl'     => $can_edit ? $cpt_class::get_editor_url() : null,
-			'resetRestPath' => $can_edit ? $cpt_class::get_reset_rest_path() : null,
-			'isCustomized'  => $can_edit && $cpt_class::is_customized(),
+			'enabled'      => $enabled,
+			'editorUrl'    => $can_edit ? $cpt_class::get_editor_url() : null,
+			'postType'     => $can_edit ? $cpt_class::POST_TYPE : null,
+			'isCustomized' => $can_edit && $cpt_class::is_customized(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
@@ -54,8 +54,13 @@ export default function SingletonTemplateActions( {
 	// `@automattic/jetpack-api` package — keeps this fix contained inside
 	// the Search package, so the wpcom-origin DELETE doesn't pull a
 	// monorepo-wide rebuild of every consumer of jetpack-api.
-	const wpcomOriginApiUrl = useSelect( select => select( STORE_ID ).getWpcomOriginApiUrl(), [] );
-	const apiNonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );
+	const { wpcomOriginApiUrl, apiNonce } = useSelect(
+		select => ( {
+			wpcomOriginApiUrl: select( STORE_ID ).getWpcomOriginApiUrl(),
+			apiNonce: select( STORE_ID ).getAPINonce(),
+		} ),
+		[]
+	);
 
 	const restoreLabel = __( 'Restore default', 'jetpack-search-pkg' );
 

--- a/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/singleton-template-actions.jsx
@@ -1,7 +1,6 @@
-import apiFetch from '@wordpress/api-fetch';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- ConfirmDialog is the canonical WP confirm pattern; still under the experimental flag in @wordpress/components 33.
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
@@ -13,9 +12,9 @@ import CardLink from './card-link';
  * editor flow on the PHP side. The two consumers — the experimental
  * blocks-powered Overlay (SEARCH-216) and the classic-theme Search
  * template route — share an identical shape: one config blob describing
- * the editor URL / reset REST path / isCustomized state, one "Edit …"
- * link, one "Restore default" link that opens a destructive confirm
- * dialog, and an AJAX DELETE that posts a notice on success / failure.
+ * the editor URL / postType / isCustomized state, one "Edit …" link,
+ * one "Restore default" link that opens a destructive confirm dialog,
+ * and an AJAX DELETE that posts a notice on success / failure.
  *
  * Local state (`justReset`, `isResetting`, `isResetConfirmOpen`) is
  * scoped here so two of these components can coexist on a single page
@@ -23,7 +22,7 @@ import CardLink from './card-link';
  * reset flags cross-contaminating.
  *
  * @param {object}  props                       - Props.
- * @param {object}  props.config                - The `{enabled, editorUrl, resetRestPath, isCustomized}` blob from the matching singleton-template selector.
+ * @param {object}  props.config                - The `{enabled, editorUrl, postType, isCustomized}` blob from the matching singleton-template selector.
  * @param {string}  props.editLabel             - Visible label for the "Edit …" link.
  * @param {string}  props.restoreConfirmMessage - Body copy for the destructive confirm dialog.
  * @param {string}  props.successMessage        - Notice copy posted after a successful reset.
@@ -48,6 +47,15 @@ export default function SingletonTemplateActions( {
 	const [ isResetting, setIsResetting ] = useState( false );
 	const [ isResetConfirmOpen, setResetConfirmOpen ] = useState( false );
 	const { successNotice, errorNotice } = useDispatch( STORE_ID );
+	// Read the wpcom-origin-prefixed API root + nonce from the dashboard
+	// store directly (same selectors `wrapped-dashboard.jsx` hands to
+	// `restApi.setWpcomOriginApiUrl()` / `setApiNonce()` at boot). Building
+	// the URL here — rather than delegating to a helper in the shared
+	// `@automattic/jetpack-api` package — keeps this fix contained inside
+	// the Search package, so the wpcom-origin DELETE doesn't pull a
+	// monorepo-wide rebuild of every consumer of jetpack-api.
+	const wpcomOriginApiUrl = useSelect( select => select( STORE_ID ).getWpcomOriginApiUrl(), [] );
+	const apiNonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );
 
 	const restoreLabel = __( 'Restore default', 'jetpack-search-pkg' );
 
@@ -81,15 +89,15 @@ export default function SingletonTemplateActions( {
 					// reality.
 					onClick={ () => setJustReset( false ) }
 				/>
-				{ config.resetRestPath && config.isCustomized && ! justReset && (
+				{ config.postType && config.isCustomized && ! justReset && (
 					<CardLink
 						label={ restoreLabel }
 						href="#"
 						disabled={ linksDisabled || isResetting }
 						onClick={ event => {
 							// Destructive — open the confirm dialog instead of
-							// running the AJAX delete directly. The dialog's
-							// confirm handler is the one that fires `apiFetch`.
+							// running the DELETE directly. The dialog's
+							// confirm handler is the one that fires the request.
 							event.preventDefault();
 							setResetConfirmOpen( true );
 						} }
@@ -101,18 +109,33 @@ export default function SingletonTemplateActions( {
 				onConfirm={ async () => {
 					setResetConfirmOpen( false );
 					// Defensive guard: the dialog can only open via the
-					// `isCustomized && resetRestPath` CardLink above, so
-					// `resetRestPath` is non-null in practice — avoid firing a
-					// DELETE to `undefined` if the gating logic ever shifts.
-					if ( ! config.resetRestPath ) {
+					// `isCustomized && postType` CardLink above, so `postType`
+					// is non-null in practice — avoid firing a DELETE against
+					// `undefined` if the gating logic ever shifts.
+					if ( ! config.postType || ! wpcomOriginApiUrl ) {
 						return;
 					}
 					setIsResetting( true );
 					try {
-						await apiFetch( {
-							path: config.resetRestPath,
+						// Build the URL against `wpcomOriginApiUrl` (not
+						// apiFetch's default /wp-json/ root) so the request
+						// reaches the Jetpack route on WordPress.com Simple
+						// sites, where Jetpack-registered routes are only
+						// exposed under wp-json/wpcom-origin/. The nonce
+						// header matches what the rest of the Search dashboard
+						// sends via restApi for the same reason.
+						const url = `${ wpcomOriginApiUrl }jetpack/v4/search/templates/${ encodeURIComponent(
+							config.postType
+						) }`;
+						const response = await fetch( url, {
 							method: 'DELETE',
+							credentials: 'same-origin',
+							headers: { 'X-WP-Nonce': apiNonce ?? '' },
 						} );
+						if ( ! response.ok ) {
+							const data = await response.json().catch( () => null );
+							throw new Error( data?.message || errorMessage );
+						}
 						setJustReset( true );
 						successNotice( successMessage );
 					} catch ( error ) {

--- a/projects/packages/search/src/dashboard/components/experience-selector/test/singleton-template-actions.test.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/test/singleton-template-actions.test.jsx
@@ -69,11 +69,13 @@ describe( 'SingletonTemplateActions', () => {
 				getAPINonce: () => NONCE,
 			} ) )
 		);
-		jest
-			.spyOn( global, 'fetch' )
-			.mockImplementation( () =>
-				Promise.resolve( { ok: true, status: 200, json: async () => ( { deleted: true } ) } )
-			);
+		// jsdom doesn't ship `fetch`, so jest.spyOn(global, 'fetch') has
+		// no descriptor to wrap. Assigning a jest.fn() directly is the
+		// idiomatic stand-in here.
+		// eslint-disable-next-line jest/prefer-spy-on -- see above.
+		global.fetch = jest.fn( () =>
+			Promise.resolve( { ok: true, status: 200, json: async () => ( { deleted: true } ) } )
+		);
 	} );
 
 	afterEach( () => {
@@ -147,7 +149,8 @@ describe( 'SingletonTemplateActions', () => {
 	} );
 
 	test( 'surfaces the server error message on non-OK response', async () => {
-		jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+		// eslint-disable-next-line jest/prefer-spy-on -- jsdom has no native fetch to spy on.
+		global.fetch = jest.fn( () =>
 			Promise.resolve( {
 				ok: false,
 				status: 500,
@@ -165,7 +168,8 @@ describe( 'SingletonTemplateActions', () => {
 	} );
 
 	test( 'falls back to the prop errorMessage when the response has no JSON body', async () => {
-		jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+		// eslint-disable-next-line jest/prefer-spy-on -- jsdom has no native fetch to spy on.
+		global.fetch = jest.fn( () =>
 			Promise.resolve( {
 				ok: false,
 				status: 502,

--- a/projects/packages/search/src/dashboard/components/experience-selector/test/singleton-template-actions.test.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/test/singleton-template-actions.test.jsx
@@ -1,0 +1,194 @@
+// Hoisted mocks — must precede component imports so the component file's own
+// dependency chain doesn't pull in the real @wordpress/components / ui / data
+// modules at test time.
+/* eslint-disable testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package; fireEvent is intentional. */
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	__experimentalConfirmDialog: ( { isOpen, onConfirm, onCancel, confirmButtonText, children } ) =>
+		isOpen ? (
+			<div role="dialog" aria-label="confirm">
+				<div>{ children }</div>
+				<button onClick={ onCancel }>Cancel</button>
+				<button onClick={ onConfirm }>{ confirmButtonText }</button>
+			</div>
+		) : null,
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	Stack: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+} ) );
+
+jest.mock( 'store', () => ( { STORE_ID: 'jetpack-search-singleton-template-actions-test' } ), {
+	virtual: true,
+} );
+
+/* eslint-disable import/order -- mocks above must hoist before imports */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SingletonTemplateActions from '../singleton-template-actions.jsx';
+/* eslint-enable import/order */
+
+const WPCOM_ORIGIN = 'https://example.simple/wp-json/wpcom-origin/';
+const NONCE = 'test-nonce-abc';
+
+const baseConfig = {
+	enabled: true,
+	editorUrl: 'https://example.simple/wp-admin/admin.php?page=jetpack-search&edit_overlay=1',
+	postType: 'jp_search_overlay',
+	isCustomized: true,
+};
+
+const labels = {
+	editLabel: 'Edit the Search overlay',
+	restoreConfirmMessage: 'Restore the bundled Search overlay template?',
+	successMessage: 'The Search overlay template has been restored to the bundled default.',
+	errorMessage: 'Could not restore the default Search overlay template. Try again later.',
+	linksDisabled: false,
+};
+
+describe( 'SingletonTemplateActions', () => {
+	let successNotice;
+	let errorNotice;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		successNotice = jest.fn();
+		errorNotice = jest.fn();
+		useDispatch.mockReturnValue( { successNotice, errorNotice } );
+		// Mirror the boot-time wiring in wrapped-dashboard.jsx — selectors
+		// resolve the wpcom-origin URL + nonce from the dashboard store.
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getWpcomOriginApiUrl: () => WPCOM_ORIGIN,
+				getAPINonce: () => NONCE,
+			} ) )
+		);
+		jest
+			.spyOn( global, 'fetch' )
+			.mockImplementation( () =>
+				Promise.resolve( { ok: true, status: 200, json: async () => ( { deleted: true } ) } )
+			);
+	} );
+
+	afterEach( () => {
+		delete global.fetch;
+	} );
+
+	test( 'hides the Restore default link when the singleton is not customized', () => {
+		render(
+			<SingletonTemplateActions { ...labels } config={ { ...baseConfig, isCustomized: false } } />
+		);
+		expect( screen.getByText( 'Edit the Search overlay' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Restore default' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hides the Restore default link when postType is null (non-admin / gate off)', () => {
+		render(
+			<SingletonTemplateActions { ...labels } config={ { ...baseConfig, postType: null } } />
+		);
+		expect( screen.queryByText( 'Restore default' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'opens the confirm dialog when the Restore default link is clicked', () => {
+		render( <SingletonTemplateActions { ...labels } config={ baseConfig } /> );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		fireEvent.click( screen.getByText( 'Restore default' ) );
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Restore the bundled Search overlay template?' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'DELETEs the wpcom-origin URL + nonce, fires success notice, hides the link', async () => {
+		render( <SingletonTemplateActions { ...labels } config={ baseConfig } /> );
+		fireEvent.click( screen.getByText( 'Restore default' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Restore default' } ) );
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalledTimes( 1 ) );
+		const [ url, options ] = global.fetch.mock.calls[ 0 ];
+		// The URL contract this whole PR exists to fix — wpcom-origin
+		// prefix + jetpack/v4 namespace + CPT slug, not the old
+		// `/wp/v2/<rest_base>/<id>?force=true` path.
+		expect( url ).toBe(
+			'https://example.simple/wp-json/wpcom-origin/jetpack/v4/search/templates/jp_search_overlay'
+		);
+		expect( options.method ).toBe( 'DELETE' );
+		expect( options.credentials ).toBe( 'same-origin' );
+		expect( options.headers ).toEqual( { 'X-WP-Nonce': NONCE } );
+
+		await waitFor( () => expect( successNotice ).toHaveBeenCalledWith( labels.successMessage ) );
+		await waitFor( () =>
+			expect( screen.queryByText( 'Restore default' ) ).not.toBeInTheDocument()
+		);
+		expect( errorNotice ).not.toHaveBeenCalled();
+	} );
+
+	test( 'escapes special characters in postType when building the URL', async () => {
+		render(
+			<SingletonTemplateActions
+				{ ...labels }
+				config={ { ...baseConfig, postType: 'a slug/with weird chars' } }
+			/>
+		);
+		fireEvent.click( screen.getByText( 'Restore default' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Restore default' } ) );
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalledTimes( 1 ) );
+		const [ url ] = global.fetch.mock.calls[ 0 ];
+		expect( url ).toBe(
+			'https://example.simple/wp-json/wpcom-origin/jetpack/v4/search/templates/a%20slug%2Fwith%20weird%20chars'
+		);
+	} );
+
+	test( 'surfaces the server error message on non-OK response', async () => {
+		jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+			Promise.resolve( {
+				ok: false,
+				status: 500,
+				json: async () => ( { message: 'Template is locked.' } ),
+			} )
+		);
+		render( <SingletonTemplateActions { ...labels } config={ baseConfig } /> );
+		fireEvent.click( screen.getByText( 'Restore default' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Restore default' } ) );
+
+		await waitFor( () => expect( errorNotice ).toHaveBeenCalledWith( 'Template is locked.' ) );
+		expect( successNotice ).not.toHaveBeenCalled();
+		// Failed DELETE leaves the link in place so the admin can retry.
+		expect( screen.getByText( 'Restore default' ) ).toBeInTheDocument();
+	} );
+
+	test( 'falls back to the prop errorMessage when the response has no JSON body', async () => {
+		jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+			Promise.resolve( {
+				ok: false,
+				status: 502,
+				json: () => Promise.reject( new Error( 'no body' ) ),
+			} )
+		);
+		render( <SingletonTemplateActions { ...labels } config={ baseConfig } /> );
+		fireEvent.click( screen.getByText( 'Restore default' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Restore default' } ) );
+
+		await waitFor( () => expect( errorNotice ).toHaveBeenCalledWith( labels.errorMessage ) );
+	} );
+
+	test( 'does not fire fetch when wpcomOriginApiUrl is missing', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getWpcomOriginApiUrl: () => null,
+				getAPINonce: () => NONCE,
+			} ) )
+		);
+		render( <SingletonTemplateActions { ...labels } config={ baseConfig } /> );
+		fireEvent.click( screen.getByText( 'Restore default' ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Restore default' } ) );
+		expect( global.fetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -5,7 +5,7 @@
 const singletonTemplateConfigDefault = {
 	enabled: false,
 	editorUrl: null,
-	resetRestPath: null,
+	postType: null,
 	isCustomized: false,
 };
 
@@ -31,9 +31,11 @@ const siteDataSelectors = {
 	// Editor affordances for the blocks-powered Overlay. Surface in the
 	// Overlay search card when the active experience is `overlay_blocks`
 	// (the PHP gate). Returns the whole config blob so callers can
-	// destructure `{ enabled, editorUrl, resetRestPath, isCustomized }`
-	// in one go. `resetRestPath` is the apiFetch path the "Restore
-	// default" link DELETEs to roll back the customization.
+	// destructure `{ enabled, editorUrl, postType, isCustomized }` in one
+	// go. `postType` is the CPT slug the "Restore default" handler passes
+	// into the `DELETE /jetpack/v4/search/templates/<post_type>` URL it
+	// builds against `wpcomOriginApiUrl`; null when the admin lacks the
+	// edit gate so the link is hidden in that state.
 	getBlockTemplateOverlayConfig: state =>
 		state.siteData?.blockTemplateOverlay ?? singletonTemplateConfigDefault,
 	// Same shape as `getBlockTemplateOverlayConfig`, sibling under the

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -37,7 +37,9 @@ abstract class Singleton_Template_Cpt {
 	const POST_TYPE = '';
 
 	/**
-	 * REST base — appears in `/wp/v2/<rest_base>/<id>` and `get_reset_rest_path()`.
+	 * REST base for the core CPT controller (`/wp/v2/<rest_base>`) the block
+	 * editor uses to load + save the singleton. The "Restore default" path
+	 * lives on jetpack/v4 instead, registered by `REST_Controller`.
 	 */
 	const REST_BASE = '';
 
@@ -264,20 +266,6 @@ abstract class Singleton_Template_Cpt {
 			),
 			admin_url( 'admin.php?page=jetpack-search' )
 		);
-	}
-
-	/**
-	 * REST DELETE path for "Restore default" — `/wp/v2/<rest_base>/<id>?force=true`.
-	 * `before_delete_post` keeps the option + cache in sync. Returns `null`
-	 * when no singleton exists (the React link is hidden in that state).
-	 *
-	 * @return string|null
-	 */
-	public static function get_reset_rest_path(): ?string {
-		if ( ! static::is_customized() ) {
-			return null;
-		}
-		return '/wp/v2/' . static::REST_BASE . '/' . static::get_post_id() . '?force=true';
 	}
 
 	/**

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -881,6 +881,29 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
+	 * `Overlay_Template::POST_TYPE` is the other half of the resolver
+	 * allowlist in `resolve_singleton_template_class()`; the rest of the
+	 * suite drives only the `Search_Template` slug, so a typo in the
+	 * Overlay entry of the map would slip through. Hitting the route
+	 * with the Overlay slug and getting back the stable
+	 * `jetpack_search_template_not_customized` code proves the slug
+	 * resolved to its class (otherwise it would be the
+	 * `jetpack_search_template_unknown` path).
+	 */
+	public function test_reset_singleton_template_recognizes_overlay_post_type() {
+		wp_set_current_user( $this->admin_id );
+		Overlay_Template::register_post_type();
+		delete_option( Overlay_Template::OPTION_POST_ID );
+		Overlay_Template::reset_customized_content_cache();
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Overlay_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 'jetpack_search_template_not_customized', $response->get_data()['code'] );
+	}
+
+	/**
 	 * No customization on file ⇒ the handler returns 404 with a stable error
 	 * code so the dashboard can surface a meaningful message instead of a 500.
 	 */

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -838,6 +838,146 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
+	 * DELETE /jetpack/v4/search/templates/<post_type> requires manage_options —
+	 * an editor user gets 403 from `require_admin_privilege_callback`.
+	 */
+	public function test_reset_singleton_template_unauthorized_for_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Anonymous callers get 401 from `require_admin_privilege_callback` — the
+	 * same auth matrix the rest of the controller's destructive endpoints
+	 * (`activate_plan`, `deactivate_plan`) cover.
+	 */
+	public function test_reset_singleton_template_unauthorized_for_anonymous() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * An unknown post_type slug is rejected by the handler's
+	 * `resolve_singleton_template_class()` lookup with a stable 404 + error
+	 * code, so the dashboard surfaces a sensible message instead of leaking
+	 * an upstream 500 if a future slug change drifts client/server.
+	 */
+	public function test_reset_singleton_template_rejects_unknown_post_type() {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/not_a_real_cpt' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 'jetpack_search_template_unknown', $response->get_data()['code'] );
+	}
+
+	/**
+	 * No customization on file ⇒ the handler returns 404 with a stable error
+	 * code so the dashboard can surface a meaningful message instead of a 500.
+	 */
+	public function test_reset_singleton_template_returns_404_when_not_customized() {
+		wp_set_current_user( $this->admin_id );
+		Search_Template::register_post_type();
+		delete_option( Search_Template::OPTION_POST_ID );
+		Search_Template::reset_customized_content_cache();
+
+		$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 'jetpack_search_template_not_customized', $response->get_data()['code'] );
+	}
+
+	/**
+	 * If `wp_delete_post()` itself fails (here simulated by short-circuiting
+	 * via the `pre_delete_post` filter), the handler returns a 500 with a
+	 * stable error code rather than silently claiming success. Covers the
+	 * defensive branch that exists for the wp_delete_post → false path
+	 * (post vanished mid-request, plugin veto, etc.).
+	 */
+	public function test_reset_singleton_template_returns_500_when_delete_fails() {
+		wp_set_current_user( $this->admin_id );
+		Search_Template::register_post_type();
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'will-fail-to-delete',
+			)
+		);
+		update_option( Search_Template::OPTION_POST_ID, $post_id );
+		Search_Template::reset_customized_content_cache();
+		$veto = static function () {
+			return false;
+		};
+		add_filter( 'pre_delete_post', $veto );
+		try {
+			$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 500, $response->get_status() );
+			$this->assertSame( 'jetpack_search_template_reset_failed', $response->get_data()['code'] );
+			// The post is still on disk because the filter vetoed deletion.
+			$this->assertNotNull( get_post( $post_id ) );
+		} finally {
+			remove_filter( 'pre_delete_post', $veto );
+			wp_delete_post( $post_id, true );
+			delete_option( Search_Template::OPTION_POST_ID );
+			Search_Template::reset_customized_content_cache();
+		}
+	}
+
+	/**
+	 * Happy path: an existing customization is force-deleted, the option
+	 * pointer is cleared (via `before_delete_post`), and the route returns
+	 * `{deleted: true}`. This is the wpcom-origin-reachable replacement for
+	 * the legacy `/wp/v2/<rest_base>/<id>?force=true` DELETE.
+	 */
+	public function test_reset_singleton_template_deletes_customization_and_clears_option() {
+		wp_set_current_user( $this->admin_id );
+		Search_Template::register_post_type();
+		// The cleanup hook (option pointer + per-class cache) is normally
+		// wired by `Singleton_Template_Cpt::init()`. The test bootstrap only
+		// registers the CPT, so wire the hook locally for this test and
+		// remove it in the cleanup branch to keep the global state pristine.
+		$cleanup_cb = array( Search_Template::class, 'maybe_cleanup_on_singleton_delete' );
+		add_action( 'before_delete_post', $cleanup_cb );
+		try {
+			$post_id = wp_insert_post(
+				array(
+					'post_type'    => Search_Template::POST_TYPE,
+					'post_status'  => 'publish',
+					'post_content' => 'will-be-restored',
+				)
+			);
+			update_option( Search_Template::OPTION_POST_ID, $post_id );
+			Search_Template::reset_customized_content_cache();
+			$this->assertTrue( Search_Template::is_customized() );
+
+			$request  = new WP_REST_Request( 'DELETE', '/jetpack/v4/search/templates/' . Search_Template::POST_TYPE );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertSame( array( 'deleted' => true ), $response->get_data() );
+			$this->assertSame( 0, (int) get_option( Search_Template::OPTION_POST_ID, 0 ) );
+			$this->assertNull( get_post( $post_id ) );
+		} finally {
+			remove_action( 'before_delete_post', $cleanup_cb );
+			delete_option( Search_Template::OPTION_POST_ID );
+			Search_Template::reset_customized_content_cache();
+		}
+	}
+
+	/**
 	 * Signs a request with a blog token before dispatching it.
 	 *
 	 * Ensures that these tests pass through Connection_Rest_Authentication::wp_rest_authenticate,

--- a/projects/packages/search/tests/php/Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Search_Template_Test.php
@@ -56,22 +56,20 @@ class Search_Template_Test extends Search_TestCase {
 
 	/**
 	 * No singleton on file ⇒ `get_customized_content()` returns null,
-	 * `is_customized()` is false, `get_reset_rest_path()` is null. The
-	 * shape callers depend on to fall back to the bundled template.
+	 * `is_customized()` is false. The shape callers depend on to fall
+	 * back to the bundled template.
 	 */
 	public function test_uncustomized_state_returns_nulls() {
 		$this->assertNull( Search_Template::get_customized_content() );
 		$this->assertFalse( Search_Template::is_customized() );
-		$this->assertNull( Search_Template::get_reset_rest_path() );
 		$this->assertSame( 0, Search_Template::get_post_id() );
 	}
 
 	/**
 	 * A saved customization round-trips: `get_customized_content()`
-	 * returns the post content, `is_customized()` flips true, and
-	 * `get_reset_rest_path()` resolves to the CPT's REST endpoint.
+	 * returns the post content, `is_customized()` flips true.
 	 */
-	public function test_customized_state_returns_post_content_and_reset_path() {
+	public function test_customized_state_returns_post_content() {
 		$post_id = wp_insert_post(
 			array(
 				'post_type'    => Search_Template::POST_TYPE,
@@ -90,10 +88,6 @@ class Search_Template_Test extends Search_TestCase {
 			Search_Template::get_customized_content()
 		);
 		$this->assertTrue( Search_Template::is_customized() );
-		$this->assertSame(
-			'/wp/v2/' . Search_Template::REST_BASE . '/' . $post_id . '?force=true',
-			Search_Template::get_reset_rest_path()
-		);
 	}
 
 	/**
@@ -116,7 +110,6 @@ class Search_Template_Test extends Search_TestCase {
 
 		$this->assertNull( Search_Template::get_customized_content() );
 		$this->assertFalse( Search_Template::is_customized() );
-		$this->assertNull( Search_Template::get_reset_rest_path() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes

The dashboard's "Restore default" link DELETEs the singleton-template CPT to roll back to the bundled template. It was using the auto-generated core CPT route, `/wp/v2/<rest_base>/<id>?force=true` — which **isn't reachable through wpcom-origin on WordPress.com Simple sites** because the Jetpack-registered CPT controller doesn't exist on the wpcom REST surface. Clicking "Restore default" on a Simple site failed silently.

A previous fix (#49147) addressed this by adding a `resetSearchTemplate()` helper to `@automattic/jetpack-api` and consuming it from the dashboard. That worked, but the version bump on the shared API client forced a monorepo-wide rebuild of every consumer and was reverted (#49149). **This redo keeps the entire fix inside `projects/packages/search/` — zero changes to shared packages, no cross-monorepo build impact.**

What's in the PR:

* Add a Jetpack-namespaced route — `DELETE /jetpack/v4/search/templates/<post_type>` — in `REST_Controller::register_common_rest_routes()`. The handler resolves `<post_type>` to the matching `Singleton_Template_Cpt` subclass (`Overlay_Template` / `Search_Template`), capability-checks `manage_options`, then `wp_delete_post( …, true )`. `before_delete_post` already clears the option pointer + per-class cache, so no new cleanup code.
* The React "Restore default" handler in `singleton-template-actions.jsx` no longer goes through `restApi` (and no new helper is added to the shared package). Instead it reads `wpcomOriginApiUrl` + `WP_API_nonce` from the existing search-dashboard store — the same values `wrapped-dashboard.jsx` hands to `restApi.setWpcomOriginApiUrl()` / `setApiNonce()` at boot — builds the URL inline, and calls `fetch()` directly with `X-WP-Nonce`. This is the same `fetch + nonce` pattern already used elsewhere in the search package (`instant-search/lib/api.js`, `search-blocks/store/index.js`, `search-blocks/store/suggestions-api.js`).
* Wire field rename `resetRestPath` → `postType` in `build_singleton_template_config()`: the JS builds the URL now, so the PHP side just emits the CPT slug. `isCustomized` remains the visibility gate. Drop the now-unused `get_reset_rest_path()` and its tests.
* The `/wp/v2/<rest_base>` route stays as-is — the block editor itself uses it to load/save the CPT during editing. Only the "Restore default" action moves.
* Tests: unauthorized (editor + anonymous) / unknown post_type / not-customized / wp_delete_post failure / happy-path coverage for the new route in `REST_Controller_Test`, plus updated assertions in `Search_Template_Test`.

## Related product discussion/links

* Reported by @jasper-kang — "Restore default" link on the Search dashboard does not work on WordPress.com Simple sites.
* Reverted predecessor: #49147 / revert #49149.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Self-hosted / Atomic (smoke test the new path)**

1. Activate Jetpack Search on a site with the blocks-powered Overlay or classic-theme Embedded experience enabled.
2. Open the Search dashboard, click "Edit search template" (or "Edit Overlay"), save any change in the block editor, return to the dashboard.
3. Click "Restore default" → confirm. The link should disappear, the success notice should fire, and the front-end search page should fall back to the bundled template.
4. Verify in DevTools that the request goes to `DELETE /wp-json/jetpack/v4/search/templates/jp_search_template` (or `jp_search_overlay`) and returns `{ deleted: true }`.

**WordPress.com Simple (the bug being fixed)**

1. On a Simple site that has the Search dashboard, customize the Embedded / Overlay template via the same flow.
2. Click "Restore default" → confirm.
3. Verify the request goes to `DELETE /wp-json/wpcom-origin/jetpack/v4/search/templates/<post_type>` and succeeds (previously: silent failure against the unreachable `/wp/v2/<rest_base>/...` route).
4. Reload the dashboard; "Restore default" should no longer be shown, and the front-end search page should serve the bundled template.

**Automated**

* `cd projects/packages/search && composer phpunit` — 596 passing / 1 skipped on this branch (the one pre-existing order-dependent flake in `Search_Template_Test::test_delete_singleton_cleans_up_state` also fails on clean trunk, unrelated to this PR).
* `composer phpunit -- --filter='REST_Controller_Test|Search_Template_Test'` — new route + updated template tests pass.
* eslint clean on the changed React file (the 2 remaining errors — `import/no-unresolved 'store'` and the textdomain warning — also fire on the trunk version of the same file).

## Verified end-to-end against local docker (raven)

Drove the flow in real Chromium against `https://jp-raven.jurassic.tube/wp-admin/admin.php?page=jetpack-search#/settings` with a seeded `jp_search_overlay` singleton. Playwright intercepted the network call — the DELETE landed on the new route and returned 200:

```
DELETE https://jp-raven.jurassic.tube/wp-json/jetpack/v4/search/templates/jp_search_overlay
→ 200 OK
```

The success notice fired and the "Restore default" link disappeared as soon as the response landed (the local `justReset` flag hides it client-side without waiting for a reload).

### Walkthrough

| 1. Dashboard with a customized overlay — "Restore default" link visible on the Active "Overlay search (blocks)" card | 2. Zoomed view of the link pair |
|---|---|
| ![dashboard with Restore default visible](https://github.com/user-attachments/assets/5c4c3400-f2f7-4848-9dd1-ce85ce92f2c7) | ![Edit + Restore default link pair](https://github.com/user-attachments/assets/4b228673-ab14-4bc1-a2e6-65942270d88a) |

| 3. Click "Restore default" → destructive confirm dialog | 4. After "Restore default" — success notice fired, "Restore default" link gone (only "Edit the Search overlay" remains) |
|---|---|
| ![confirm dialog: Restore the bundled Search overlay template?](https://github.com/user-attachments/assets/e6b339f3-ce10-4f68-8aaa-3bde1368a3aa) | ![success notice + link gone](https://github.com/user-attachments/assets/4c55b49c-cc27-414a-bcbd-58d0bf7556f2) |
