### PR TITLE
Search Blocks: fire empty ?s= search on blocks Overlay (SEARCH-258)

### DIFF
--- a/projects/packages/search/changelog/echo-search-258-empty-s-stuck-loading
+++ b/projects/packages/search/changelog/echo-search-258-empty-s-stuck-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: deep-linking to `/?s=` (empty value) on the blocks-powered Overlay now runs the initial search instead of latching the "Searching…" skeleton on forever.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -10,6 +10,14 @@
  */
 
 import { getSearchOwnedParamKeys } from '../store/url-state.js';
+// Side-effect import: the bootstrap calls
+// `store('jetpack-search').actions.dispatchInitialSearchIfNeeded()` after
+// hydrating the cloned subtree. Without this import the bootstrap can run
+// before the per-block view modules pull in `jetpack-search/store`, and the
+// action would still be undefined at call time. Bare specifier resolves to the
+// shared `jetpack-search/store` Script Module via `DependencyExtractionPlugin`
+// (see tools/webpack.blocks.config.js); does NOT inline the store.
+import 'jetpack-search/store';
 
 const PRIVATE_API_CONSENT =
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
@@ -93,6 +101,18 @@ function ensureHydrated() {
 			const regions = content.querySelectorAll( '[data-wp-interactive]' );
 			for ( const region of regions ) {
 				apis.render( apis.toVdom( region ), apis.getRegionRootFragment( region ) );
+			}
+			// Belt-and-suspenders trigger for the deep-link first fetch. The
+			// `data-wp-init` directive on results-list races with the IA
+			// runtime's DOMContentLoaded auto-walk for cloned regions and
+			// intermittently doesn't fire — most reliably reproducible on a
+			// bare `?s=` deep link, where the result was a "Searching…"
+			// skeleton that never cleared. The store action is idempotent
+			// (module-scope latch in `store/index.js`), so when the directive
+			// does fire, this becomes a no-op.
+			if ( typeof ia.store === 'function' ) {
+				const { actions } = ia.store( 'jetpack-search' );
+				actions?.dispatchInitialSearchIfNeeded?.();
 			}
 		} catch ( e ) {
 			// eslint-disable-next-line no-console

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -9,6 +9,12 @@
 // `ensureHydrated()` dynamically imports this; stub it so the hydration branch
 // no-ops instead of reaching for the real Interactivity runtime in jsdom.
 jest.mock( '@wordpress/interactivity', () => ( {} ), { virtual: true } );
+// The bootstrap statically depends on the shared store as a side-effect
+// import (so the runtime store registers before the bootstrap dispatches
+// `dispatchInitialSearchIfNeeded` after hydration). The store module itself
+// is exercised in `tests/js/search-blocks/store.test.js`; here it would just
+// pull in the real Interactivity API and unrelated build paths, so stub it.
+jest.mock( 'jetpack-search/store', () => ( {} ), { virtual: true } );
 
 const OVERLAY_ID = 'jetpack-search-block-overlay';
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -20,6 +20,14 @@ import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
 let initialized = false;
+// Idempotency latch for the deep-link first fetch. Either entry path — the
+// `data-wp-init` callback on the results-list block, or the overlay-bootstrap's
+// explicit invocation after hydrating the cloned overlay subtree — can flip it
+// safely; only the first one actually dispatches. The bootstrap path exists
+// because the IA private-API render of the cloned overlay regions races with
+// the runtime's auto-walk and the directive intermittently misses, leaving the
+// PHP-seeded "Searching…" spinner latched on.
+let initialSearchDispatched = false;
 
 // Module-scope abort handles so `actions.search()` can cancel the previous
 // stream — across action calls, fetch has no other way to reach them.
@@ -858,6 +866,35 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * Idempotent first-fetch dispatcher for deep-linked search URLs
+		 * (`?s=…`, `?q=…`, or a URL carrying filter params). Safe to call
+		 * from multiple entry paths — only the first invocation actually
+		 * fires `actions.search()`. The flag is per-page-load and
+		 * deliberately never cleared; subsequent visitor-initiated searches
+		 * go through the regular `actions.search()` path.
+		 *
+		 * Two callers today, by design. `callbacks.initialize` fires from
+		 * the results-list block's `data-wp-init` directive on the regular
+		 * hydration path (Embedded experience, or the Overlay when the IA
+		 * runtime's auto-walk wins the race). `overlay-bootstrap.ensureHydrated`
+		 * fires after the bootstrap clones the overlay template into the
+		 * shell and runs `apis.render()` on each region — the safety net for
+		 * the Overlay case where the directive doesn't fire reliably for the
+		 * freshly-mounted subtree.
+		 */
+		dispatchInitialSearchIfNeeded() {
+			if ( initialSearchDispatched ) {
+				return;
+			}
+			if ( ! state.searchQuery && ! state.hasActiveFilters && ! state.hasSearchParam ) {
+				return;
+			}
+			initialSearchDispatched = true;
+			// syncUrl=false: URL already carries this query; avoid a duplicate history entry.
+			actions.search( { syncUrl: false } );
+		},
+
+		/**
 		 * Run a search and replace the result list.
 		 *
 		 * @param {object}      [options]                 - Options.
@@ -1483,11 +1520,14 @@ const { state, actions } = store( NAMESPACE, {
 					state.filterLogic = gatedLogic;
 				}
 			}
+			// `hasSearchParam` catches `?s=` (empty value) — the param is
+			// present so the visitor expects a search to run, but
+			// `searchQuery` alone is `''` and indistinguishable from a
+			// URL that omits `s`. Seeded from PHP via build_initial_state().
+			// The dispatcher is idempotent so the overlay-bootstrap's
+			// belt-and-suspenders call after hydration doesn't double-fire.
 			if ( state.searchQuery || state.hasActiveFilters || state.hasSearchParam ) {
-				// `hasSearchParam` catches `?s=` (empty value) which `searchQuery`
-				// alone can't distinguish from a URL without `s`.
-				// syncUrl=false: URL already has this state; avoid a dup history entry.
-				actions.search( { syncUrl: false } );
+				actions.dispatchInitialSearchIfNeeded();
 			} else if ( droppedAny ) {
 				// No fetch will fire — clear the spinner + skeleton.
 				state.isLoading = false;

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -1176,6 +1176,56 @@ describe( 'store callbacks', () => {
 		} );
 	} );
 
+	describe( 'dispatchInitialSearchIfNeeded (SEARCH-258)', () => {
+		// The action is the shared seam between the IA-directive entry path
+		// (results-list's `data-wp-init`) and the overlay-bootstrap entry
+		// path (post-hydration explicit call). The flag is module-scoped, so
+		// each case loads a fresh module via `jest.isolateModules` rather
+		// than mutating the shared module instance — otherwise the latch from
+		// the first case would silently make every later case a no-op.
+
+		it( 'fires actions.search once on the first call and is a no-op on subsequent calls', () => {
+			jest.isolateModules( () => {
+				const fresh = require( '../../../src/search-blocks/store' );
+				const search = jest.spyOn( fresh.actions, 'search' ).mockImplementation();
+				fresh.state.searchQuery = '';
+				fresh.state.priceRange = null;
+				fresh.state.filterConfigs = {};
+				fresh.state.activeFilters = {};
+				fresh.state.hasSearchParam = true;
+
+				captured.actions.dispatchInitialSearchIfNeeded();
+				captured.actions.dispatchInitialSearchIfNeeded();
+				captured.actions.dispatchInitialSearchIfNeeded();
+
+				// The latch is what lets the IA directive AND the overlay
+				// bootstrap both call this safely after hydration — only the
+				// first invocation wins.
+				expect( search ).toHaveBeenCalledTimes( 1 );
+				expect( search ).toHaveBeenCalledWith( { syncUrl: false } );
+
+				fresh.state.hasSearchParam = false;
+			} );
+		} );
+
+		it( 'bails without dispatching when no search criteria are present', () => {
+			jest.isolateModules( () => {
+				const fresh = require( '../../../src/search-blocks/store' );
+				const search = jest.spyOn( fresh.actions, 'search' ).mockImplementation();
+				// Plain homepage: no `?s=` / `?q=`, no filters, no price range.
+				fresh.state.searchQuery = '';
+				fresh.state.priceRange = null;
+				fresh.state.filterConfigs = {};
+				fresh.state.activeFilters = {};
+				fresh.state.hasSearchParam = false;
+
+				captured.actions.dispatchInitialSearchIfNeeded();
+
+				expect( search ).not.toHaveBeenCalled();
+			} );
+		} );
+	} );
+
 	describe( 'initLoadMoreObserver', () => {
 		let originalIO;
 		let observerInstances;


### PR DESCRIPTION
Fixes [SEARCH-258](https://linear.app/a8c/issue/SEARCH-258)

## Why

Deep-linking to `https://example.com/?s=` (the search param present, value empty) on the blocks-powered Overlay opened the overlay but latched the "Searching…" skeleton on forever — no search request ever fired, no results rendered. Visitors arriving from a shared "see what we have" link were stuck staring at placeholder rows.

## Proposed changes

* Extract the deep-link first-fetch dispatch out of `callbacks.initialize` into a new idempotent `actions.dispatchInitialSearchIfNeeded`. The flag is module-scope and one-shot, so any number of callers race-safely.
* Add a belt-and-suspenders call to `dispatchInitialSearchIfNeeded` from `overlay-bootstrap.ensureHydrated` right after the cloned subtree finishes IA rendering, so the dispatch no longer depends on `data-wp-init` winning the auto-walk race for the post-DOMContentLoaded subtree (it intermittently doesn't — empty `?s=` was the worst-biased case but every query was affected).
* Pull the shared store in as a static side-effect dependency of the bootstrap (`import 'jetpack-search/store'`) so the new action is guaranteed registered before the post-hydration call.
* Two new jest cases (idempotency + bail-when-no-criteria); existing overlay-bootstrap test mock updated to stub the new store side-effect import.

## Related product discussion/links

* [SEARCH-258](https://linear.app/a8c/issue/SEARCH-258) — original report and full plan
* SEARCH-183 — the prior fix that introduced `hasSearchParam` as the empty-`?s=` signal. That fix was correct in intent (the dispatcher gates on `hasSearchParam`), but didn't address the IA-directive race that's bypassed here.

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Before / After at `/?s=` on the blocks Overlay (echo docker, 1440×900). Captured against trunk for **before**, against this PR for **after**.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/f9b732c2-bc96-4ff5-996b-328d7ef59f2d) | ![after](https://github.com/user-attachments/assets/48dab86a-ad06-4a5e-8a5c-8a8eb5383921) |

## Testing instructions

1. On a site with Jetpack Search activated, switch the experience to the experimental blocks Overlay (`Module_Control::EXPERIENCE_OVERLAY_BLOCKS`). For example via WP-CLI:
   ```
   wp option update jetpack_search_experience overlay_blocks
   ```
2. Visit `/?s=` (the search param present, value empty) on the front end.
   * **Expected:** the overlay opens, the search input is focused, one `GET https://public-api.wordpress.com/rest/v1.3/sites/<id>/search?query=&…` request fires, and results + filter facets render. The "Searching…" skeleton clears.
3. Visit `/?s=foo` — regression guard.
   * **Expected:** identical existing behaviour. Overlay opens, one search request fires, the matching results render.
4. Visit `/` (no search param) — regression guard.
   * **Expected:** overlay stays closed; no search request fires.
5. From `/?s=`, close the overlay (click X / scrim / Esc) and reopen via the theme search trigger.
   * **Expected:** the empty-query search does *not* re-fire; the overlay reopens to the previously-loaded results. The latch is per-page-load.
6. The Embedded experience (`embedded`) and the classic Instant Search Overlay (`overlay`) are out of scope — verify they're unchanged.
