### PR TITLE
Content Guidelines AI: update injection selectors for latest Gutenberg

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/inject.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/inject.js
@@ -100,13 +100,21 @@ function getBlockNameFromModal( modal ) {
 }
 
 function runAll() {
-	// Header button.
+	// Header button — placed at the top of the guidelines content, above the
+	// list. The wp-admin Page header only renders an actions slot when the
+	// gutenberg page passes `actions` to <Page> (it does not), so there is no
+	// header-actions container to target.
 	inject(
 		'header',
 		() => {
-			const actionsSlot = document.querySelector( '.admin-ui-page__header-actions' );
-			return actionsSlot
-				? { parent: actionsSlot, className: 'jetpack-content-guidelines-ai__header-container' }
+			const content = document.querySelector( '.guidelines__content' );
+			const list = content?.querySelector( '.guidelines__list' );
+			return content
+				? {
+						parent: content,
+						before: list,
+						className: 'jetpack-content-guidelines-ai__header-container',
+				  }
 				: null;
 		},
 		SuggestAllButton
@@ -116,7 +124,7 @@ function runAll() {
 	inject(
 		'upgrade-notice',
 		() => {
-			const list = document.querySelector( '.content-guidelines__list' );
+			const list = document.querySelector( '.guidelines__list' );
 			return list
 				? {
 						parent: list.parentElement,
@@ -132,7 +140,7 @@ function runAll() {
 	inject(
 		'banner',
 		() => {
-			const list = document.querySelector( '.content-guidelines__list' );
+			const list = document.querySelector( '.guidelines__list' );
 			return list
 				? {
 						parent: list.parentElement,
@@ -144,29 +152,30 @@ function runAll() {
 		EmptyStateBanner
 	);
 
-	// Per-section injections.
+	// Per-section injections. Sections are matched by the stable `data-slug`
+	// attribute on each `.guidelines__list-item`. The per-section form is
+	// always present in the DOM (the CollapsibleCard keeps its content mounted
+	// while collapsed).
 	for ( const slug of VALID_SECTIONS ) {
-		const form = document.getElementById( `content-guidelines-${ slug }` );
+		const item = document.querySelector( `.guidelines__list-item[data-slug="${ slug }"]` );
+		const form = item?.querySelector( 'form' );
 		if ( ! form ) {
 			continue;
 		}
 
-		// Badge in accordion header.
+		// Badge in the accordion header (the section's heading element).
 		inject(
 			`badge-${ slug }`,
 			() => {
-				const accordion = form.closest( '.content-guidelines__accordion' );
-				const trigger = accordion?.querySelector( '.content-guidelines__accordion-trigger' );
-				const hStack = trigger?.firstElementChild;
-				if ( ! hStack ) {
-					return null;
-				}
-				return {
-					parent: hStack,
-					before: hStack.lastElementChild,
-					className: 'jetpack-content-guidelines-ai__badge-container',
-					tag: 'span',
-				};
+				const heading = item.querySelector( 'h1, h2, h3, h4, h5, h6' );
+				const titleStack = heading?.firstElementChild ?? heading;
+				return titleStack
+					? {
+							parent: titleStack,
+							className: 'jetpack-content-guidelines-ai__badge-container',
+							tag: 'span',
+					  }
+					: null;
 			},
 			SuggestionBadge,
 			{ slug }
@@ -189,11 +198,12 @@ function runAll() {
 			{ slug }
 		);
 
-		// Per-section generate button next to save.
+		// Per-section generate button next to the Save button (the form's
+		// primary submit button lives in an HStack with the Clear button).
 		inject(
 			`button-${ slug }`,
 			() => {
-				const saveButton = form.querySelector( '.save-button' );
+				const saveButton = form.querySelector( 'button[type="submit"]' );
 				const hStack = saveButton?.parentElement;
 				return hStack
 					? {

--- a/projects/plugins/jetpack/changelog/update-content-guidelines-ai-gutenberg-selectors
+++ b/projects/plugins/jetpack/changelog/update-content-guidelines-ai-gutenberg-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Content Guidelines AI: update DOM selectors to match the latest Gutenberg Guidelines markup so the AI UI injects correctly.


### PR DESCRIPTION
### Proposed changes

Stacked on top of #47959.

The Gutenberg Guidelines page markup changed in ways that silently broke the Content Guidelines AI UI injection — the JS bundle loads (HTTP 200, no console error) but **zero** components render, because every DOM anchor the injector looks for no longer exists:

- `content-guidelines__*` classes were renamed to `guidelines__*` (Gutenberg #77223).
- The accordion was refactored to `CollapsibleCard` (Gutenberg #77903), which emits **hashed CSS-module class names** and **removed the per-section element `id`**.
- The wp-admin Page header (#77088) moved to CSS modules; it also renders no `header-actions` slot because the Guidelines page passes no `actions` to `<Page>`.

This PR updates `_inc/content-guidelines-ai/lib/inject.js` to anchor on stable selectors:

- **Per-section badge / actions / generate-button** key off the new `data-slug` attribute on `.guidelines__list-item`, then use semantic anchors within the section (`form`, the `type="submit"` button's HStack, the form's top VStack).
- **Banner / upgrade notice** use the renamed `.guidelines__list`.
- **Header "Suggest all" button** moves to the top of `.guidelines__content` (above the list), since there is no header-actions slot to target.
- **Block-guideline modal** selectors are unchanged (those classes were not renamed).

#### Dependency

Requires the Gutenberg-side hook: **WordPress/gutenberg#78676** (`data-slug` on the guideline list items). Until that ships in the bundled Gutenberg, the per-section injections will no-op.

### Testing instructions

1. Build the plugin and apply the Gutenberg branch from WordPress/gutenberg#78676 (or patch the attribute in).
2. Enable the `gutenberg-guidelines` experiment.
3. Visit `wp-admin/options-general.php?page=guidelines-wp-admin&enable_ai_generation=true`.
4. Confirm the AI UI now renders: the "Suggest all" button above the list, per-section badges/actions/generate buttons, and the block-guideline modal buttons.

#### Verification done

- Validated all 15 injection anchors resolve against the live Guidelines DOM (with the `data-slug` attribute simulated), and a marker-insertion test placed every component at the correct spot.
- Full in-browser render of the built bundle was not reproducible locally due to an unrelated workspace build-env issue (`@automattic/jetpack-ai-client` / `jetpack-components` build artifacts); CI/sandbox builds it normally.