### PR TITLE
Plugin Conflicts Guardian: defer require + milestone tracking + sibling-load downgrade

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-sibling-load
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-sibling-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: defer probe require_once to wp_loaded:1 so dependency shims load before the candidate; add milestone-based shutdown attribution; downgrade captured fatals that look like sibling-load flakes to ok-inconclusive in activation mode only.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-sibling-load
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-sibling-load
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Plugin Conflicts Guardian: defer probe require_once to wp_loaded:1 so dependency shims load before the candidate; add milestone-based shutdown attribution; downgrade captured fatals that look like sibling-load flakes to ok-inconclusive in activation mode only.
+Plugin Conflicts Guardian: defer probe require to wp_loaded:1, add milestone-based shutdown attribution, and downgrade sibling-load flakes to ok-inconclusive (activation mode only).

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -80,7 +80,7 @@ Atomic and some managed hosts sandbox web-PHP so `proc_open` can't find/exec a C
 ## Limitations
 
 - Only catches errors hit while `require`-ing the main file and during `plugins_loaded` / `init` / `admin_init` callbacks. Errors that surface only on later hooks (e.g. `template_redirect`, REST) are invisible.
-- The probe endpoint is wired up via jetpack-mu-wpcom's `load_features()` at `plugins_loaded` priority 10, so plugin callbacks registered for `plugins_loaded` at priority < 10 will have already fired before the plugin under test is `require`d. Fatals from those earlier-priority callbacks are missed. Hooking the probe handler earlier would require splitting it out of `load_features()`.
+- The probe endpoint is wired up via jetpack-mu-wpcom's `load_features()` at `plugins_loaded` priority 10, and the candidate `require_once` is then deferred to `wp_loaded:1`. Plugin callbacks registered for `muplugins_loaded`, `plugins_loaded` (any priority), or `init` (lower than `wp_loaded`) fire on the probe request before the candidate is loaded — i.e. those callbacks run from already-active plugins, not from the candidate. The candidate's own `plugins_loaded`/`init` callbacks never run in the probe context (we require it after both hooks have fired). This matches the real-activation shape — a real Activate click doesn't fire the newly-activated plugin's `plugins_loaded` until the next request — but fatals that only surface in those candidate-side callbacks won't be caught here either.
 - Other active plugins are live during the probe, so cross-plugin conflicts CAN surface (a full SHORTINIT sandbox would avoid that, but isn't portable here).
 
 ## Update flow (syntax-only, pre-install)

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -111,10 +111,36 @@ class PCG_Load_Tester {
 		// not shadow a real fatal from the other. Front-end is the canonical
 		// "site works" signal when neither probe captured a fatal.
 		if ( $this->is_block( $front_result ) ) {
-			return $front_result;
+			$verdict = $front_result;
+		} elseif ( $this->is_block( $admin_result ) ) {
+			$verdict = $admin_result;
+		} else {
+			$verdict = $front_result;
 		}
-		if ( $this->is_block( $admin_result ) ) {
-			return $admin_result;
+
+		// Sibling-load flake: captured fatal where the candidate's entry
+		// file loaded but a sibling under its own directory failed to
+		// require or autoload. Logstash on production data shows the same
+		// `(blog, file)` combinations reproducing for hours, so a retry
+		// can't help — downgrade to `ok-inconclusive` on the first match.
+		// CLI activation remains the recovery path.
+		//
+		// Restricted to MODE_ACTIVATION: the post-update healthcheck has
+		// already installed new files over the live plugin and needs every
+		// captured fatal to block so `PCG_Rollback::to_snapshot()` can
+		// fire. Silently allowing an update fatal would leave the site
+		// running broken new files with no recovery path.
+		if ( self::MODE_ACTIVATION === $mode && $this->is_sibling_load_flake( $verdict, $plugin_mains ) ) {
+			$this->log_sibling_load_flake_downgrade( $mode, $plugin_mains, $verdict );
+			return $this->downgrade_to_inconclusive(
+				$verdict,
+				'Probe reported a file-not-found / autoload miss against the plugin\'s own directory; allowing activation. CLI activation is unaffected.'
+			);
+		}
+
+		// A captured fatal that wasn't downgraded blocks; skip anomaly logging.
+		if ( $this->is_block( $verdict ) ) {
+			return $verdict;
 		}
 
 		// Neither probe blocked. Log if either verdict was a transport-level
@@ -127,7 +153,207 @@ class PCG_Load_Tester {
 			$this->log_probe_anomaly( $mode, $plugin_mains, $front_result, $admin_result );
 		}
 
-		return $front_result;
+		return $verdict;
+	}
+
+	/**
+	 * Build an `ok-inconclusive` downgrade verdict that preserves the
+	 * captured-fatal context (`plugin`, `message`, `file`) so downstream
+	 * readers (logstash, snapshot preservation) can still see which
+	 * candidate triggered the downgrade and why.
+	 *
+	 * @param array  $verdict Original blocking verdict.
+	 * @param string $reason  Human-readable reason for the downgrade.
+	 * @return array
+	 */
+	protected function downgrade_to_inconclusive( array $verdict, $reason ) {
+		$out = array(
+			'status'  => 'ok-inconclusive',
+			'reason'  => (string) $reason,
+			'message' => (string) ( $verdict['message'] ?? '' ),
+			'file'    => (string) ( $verdict['file'] ?? '' ),
+		);
+		if ( '' !== (string) ( $verdict['plugin'] ?? '' ) ) {
+			$out['plugin'] = (string) $verdict['plugin'];
+		}
+		return $out;
+	}
+
+	/**
+	 * Whether a verdict looks like a sibling-load flake — a fatal/throwable
+	 * where the candidate plugin's entry file loaded but a sibling under
+	 * its own directory failed to require or autoload. Logstash on the
+	 * production data shows the same `(blog, file)` failing for hours, so
+	 * a retry can't help; the signature is stable enough to downgrade-to-
+	 * allow on regardless of the underlying cause.
+	 *
+	 * Exposed for unit tests.
+	 *
+	 * @internal
+	 * @param array    $result       Probe verdict.
+	 * @param string[] $plugin_mains Absolute paths to the candidate plugins' main files.
+	 * @return bool
+	 */
+	public function is_sibling_load_flake( array $result, array $plugin_mains ) {
+		$status = (string) ( $result['status'] ?? '' );
+		if ( 'fatal' !== $status && 'throwable' !== $status ) {
+			return false;
+		}
+
+		// For the throwable arm, restrict to PHP engine error classes
+		// (`\Error` and its built-in subclasses). A hand-thrown
+		// `\RuntimeException` from a plugin's self-check that happens to
+		// contain class-not-found-shaped wording must NOT be downgraded —
+		// the plugin is asking to abort, and silently allowing the
+		// activation would deliver a half-loaded plugin to production.
+		// `classify_shutdown` verdicts (`fatal`) never carry a `class` key.
+		if ( 'throwable' === $status ) {
+			$captured_class = (string) ( $result['class'] ?? '' );
+			if ( ! self::is_php_engine_error_class( $captured_class ) ) {
+				return false;
+			}
+		}
+
+		$message = (string) ( $result['message'] ?? '' );
+
+		// Anchor the class-not-found check to PHP's canonical wording —
+		// `Class "Foo\Bar" not found` (PHP 8+) or `Class 'Foo' not found`
+		// (legacy). A loose `str_contains` on 'Class ' / ' not found'
+		// would over-match decorated error messages or wrapped fatals
+		// that mention either substring incidentally, and silently
+		// downgrade real bugs to ok-inconclusive.
+		$looks_like_class_not_found   = (bool) preg_match( '/\bClass\s+["\'][^"\']+["\']\s+not found\b/', $message );
+		$looks_like_missing_file_open = str_contains( $message, 'Failed opening required' )
+			|| str_contains( $message, 'failed to open stream: No such file or directory' );
+		if ( ! $looks_like_missing_file_open && ! $looks_like_class_not_found ) {
+			return false;
+		}
+
+		$captured_file = (string) ( $result['file'] ?? '' );
+		if ( $this->path_inside_candidate( $captured_file, $plugin_mains ) ) {
+			return true;
+		}
+
+		// Fall back to the message body ONLY for the file-open arm: those
+		// messages carry the missing path verbatim, so a substring match
+		// against a candidate's dir is a meaningful signal. The
+		// class-not-found arm requires the captured `file` to live inside
+		// a candidate — its message has no path to match on, and pulling
+		// other text in (autoloader stack traces, wrapped errors) is the
+		// over-match vector we want to avoid.
+		if ( ! $looks_like_missing_file_open ) {
+			return false;
+		}
+		return $this->message_references_candidate_path( $message, $plugin_mains );
+	}
+
+	/**
+	 * Whether an absolute path lies inside one of the candidate plugins'
+	 * own directories (or equals a candidate's main file). Flat-file
+	 * plugins are skipped because their dirname is `WP_PLUGIN_DIR`, which
+	 * would prefix-match every other plugin's files.
+	 *
+	 * @param string   $path         Absolute path to test.
+	 * @param string[] $plugin_mains Absolute paths to the candidate plugins' main files.
+	 * @return bool
+	 */
+	protected function path_inside_candidate( $path, array $plugin_mains ) {
+		if ( '' === (string) $path ) {
+			return false;
+		}
+		$plugins_root = untrailingslashit( WP_PLUGIN_DIR );
+		foreach ( $plugin_mains as $main ) {
+			$dir = untrailingslashit( dirname( (string) $main ) );
+			if ( $plugins_root === $dir ) {
+				continue;
+			}
+			if ( $path === $main || str_starts_with( $path, $dir . '/' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether a `Failed opening required` message body mentions a path
+	 * inside one of the candidate plugins' directories. Only safe for
+	 * messages that PHP composes with the failing path verbatim — see
+	 * `is_sibling_load_flake` for why we don't use this on autoloader
+	 * misses.
+	 *
+	 * @param string   $message      Verdict message.
+	 * @param string[] $plugin_mains Absolute paths to the candidate plugins' main files.
+	 * @return bool
+	 */
+	protected function message_references_candidate_path( $message, array $plugin_mains ) {
+		$plugins_root = untrailingslashit( WP_PLUGIN_DIR );
+		foreach ( $plugin_mains as $main ) {
+			$dir = untrailingslashit( dirname( (string) $main ) );
+			if ( $plugins_root === $dir ) {
+				continue;
+			}
+			if ( str_contains( $message, $dir . '/' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Log a sibling-load flake downgrade so we can measure how often the
+	 * downgrade path triggers and on which plugins. Sampled on the same
+	 * `atomic_plugin_conflicts_guardian` feature bucket.
+	 *
+	 * @param string   $mode         Probe mode constant.
+	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.
+	 * @param array    $verdict      Original blocking verdict.
+	 * @return void
+	 */
+	protected function log_sibling_load_flake_downgrade( $mode, array $plugin_mains, array $verdict ) {
+		$attributed = (string) ( $verdict['plugin'] ?? '' );
+		pcg_log_event(
+			'Sibling-load flake downgrade',
+			array(
+				'mode'    => $mode,
+				'plugins' => $this->relative_basenames( $plugin_mains ),
+				'plugin'  => '' !== $attributed ? $this->relative_basenames( array( $attributed ) )[0] : '',
+				'status'  => (string) ( $verdict['status'] ?? '' ),
+				'reason'  => (string) ( $verdict['message'] ?? $verdict['reason'] ?? '' ),
+				'file'    => isset( $verdict['file'] ) ? basename( (string) $verdict['file'] ) : '',
+			)
+		);
+	}
+
+	/**
+	 * Whether a captured throwable's class name is one of PHP's built-in
+	 * engine error classes (i.e. one that the engine raises directly,
+	 * rather than something user code could throw to signal intent).
+	 *
+	 * Used by `is_sibling_load_flake` to ensure we only downgrade fatals
+	 * that PHP itself produced — a plugin hand-throwing a
+	 * `RuntimeException` with class-not-found-shaped wording must keep
+	 * blocking.
+	 *
+	 * @internal Exposed for tests.
+	 * @param string $class_name Captured `class` value from the verdict.
+	 * @return bool
+	 */
+	public static function is_php_engine_error_class( $class_name ) {
+		// Subclasses created by user code (e.g. `class MyError extends Error {}`)
+		// are intentionally NOT matched — those carry the same
+		// "user is asking to abort" semantics as a hand-thrown Exception.
+		static $engine_errors = array(
+			'Error'               => true,
+			'TypeError'           => true,
+			'ParseError'          => true,
+			'ValueError'          => true,
+			'ArgumentCountError'  => true,
+			'ArithmeticError'     => true,
+			'DivisionByZeroError' => true,
+			'AssertionError'      => true,
+			'UnhandledMatchError' => true,
+		);
+		return isset( $engine_errors[ ltrim( (string) $class_name, '\\' ) ] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -226,6 +226,13 @@ class PCG_Load_Tester {
 		// installed `set_error_handler` that rewrites messages can
 		// defeat the match; we'd then keep the verdict as fatal (no
 		// downgrade), which is the safer failure mode.
+		// `Failed opening required` and `failed to open stream: No such
+		// file or directory` are the verbatim strings the PHP engine
+		// emits — they're not localised and they're stable across
+		// PHP 7/8. If PHP ever rewords either, the substring match here
+		// would silently break and verdicts would stay as fatal (the
+		// safer failure mode), so we'd notice via the `Sibling-load
+		// flake downgrade` event rate dropping to zero.
 		$looks_like_class_not_found   = (bool) preg_match( '/\bClass\s+["\'][^"\']+["\']\s+not found\b/', $message );
 		$looks_like_missing_file_open = str_contains( $message, 'Failed opening required' )
 			|| str_contains( $message, 'failed to open stream: No such file or directory' );
@@ -264,12 +271,22 @@ class PCG_Load_Tester {
 	protected function path_inside_candidate( $path, array $plugin_mains ) {
 		// We compare the raw paths PHP gives us (`error_get_last`'s
 		// `file`, the candidate's main as WP saw it) without `realpath`.
-		// If `WP_PLUGIN_DIR` resolves to a symlink and the captured
-		// `file` was emitted via the resolved path, this match would
-		// miss — but that's the same shape WP itself uses internally
-		// when comparing plugin paths, so the activation guard and PCG
-		// stay consistent. Resolving here would risk diverging from
-		// WP's view of the same plugin.
+		// This is correct on Atomic + standard hosts where
+		// `WP_PLUGIN_DIR` and plugin install paths are direct (no
+		// symlinks), and matches WP's own internal comparison shape
+		// (e.g. `is_plugin_active`) so the activation guard, the
+		// post-update healthcheck, and PCG agree on which plugin file
+		// is which.
+		//
+		// Symlink caveat for future maintainers: if a host installs
+		// plugins under a symlinked tree (e.g. `WP_PLUGIN_DIR` →
+		// `/var/www/.../plugins-real/`), PHP's error_get_last() often
+		// reports the realpath-resolved `file` while `$plugin_main`
+		// (built from `WP_PLUGIN_DIR`) is the symlink path. This
+		// matcher would silently fail to attribute the fatal to the
+		// candidate. If symlinked layouts become a thing, replace this
+		// with a realpath-of-both comparison (and update the
+		// `message_references_candidate_path` sibling helper too).
 		if ( '' === (string) $path ) {
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -218,10 +218,14 @@ class PCG_Load_Tester {
 
 		// Anchor the class-not-found check to PHP's canonical wording —
 		// `Class "Foo\Bar" not found` (PHP 8+) or `Class 'Foo' not found`
-		// (legacy). A loose `str_contains` on 'Class ' / ' not found'
-		// would over-match decorated error messages or wrapped fatals
-		// that mention either substring incidentally, and silently
-		// downgrade real bugs to ok-inconclusive.
+		// (legacy). PHP engine error messages are not localised — they
+		// are always emitted in English — so matching English wording is
+		// the language-agnostic choice; a loose `str_contains` on
+		// `Class ` / ` not found` would over-match decorated messages or
+		// wrapped fatals and silently downgrade real bugs. A user-
+		// installed `set_error_handler` that rewrites messages can
+		// defeat the match; we'd then keep the verdict as fatal (no
+		// downgrade), which is the safer failure mode.
 		$looks_like_class_not_found   = (bool) preg_match( '/\bClass\s+["\'][^"\']+["\']\s+not found\b/', $message );
 		$looks_like_missing_file_open = str_contains( $message, 'Failed opening required' )
 			|| str_contains( $message, 'failed to open stream: No such file or directory' );
@@ -258,6 +262,14 @@ class PCG_Load_Tester {
 	 * @return bool
 	 */
 	protected function path_inside_candidate( $path, array $plugin_mains ) {
+		// We compare the raw paths PHP gives us (`error_get_last`'s
+		// `file`, the candidate's main as WP saw it) without `realpath`.
+		// If `WP_PLUGIN_DIR` resolves to a symlink and the captured
+		// `file` was emitted via the resolved path, this match would
+		// miss — but that's the same shape WP itself uses internally
+		// when comparing plugin paths, so the activation guard and PCG
+		// stay consistent. Resolving here would risk diverging from
+		// WP's view of the same plugin.
 		if ( '' === (string) $path ) {
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -118,18 +118,9 @@ class PCG_Load_Tester {
 			$verdict = $front_result;
 		}
 
-		// Sibling-load flake: captured fatal where the candidate's entry
-		// file loaded but a sibling under its own directory failed to
-		// require or autoload. Logstash on production data shows the same
-		// `(blog, file)` combinations reproducing for hours, so a retry
-		// can't help — downgrade to `ok-inconclusive` on the first match.
-		// CLI activation remains the recovery path.
-		//
-		// Restricted to MODE_ACTIVATION: the post-update healthcheck has
-		// already installed new files over the live plugin and needs every
-		// captured fatal to block so `PCG_Rollback::to_snapshot()` can
-		// fire. Silently allowing an update fatal would leave the site
-		// running broken new files with no recovery path.
+		// Sibling-load flakes are stable across retries — downgrade to
+		// ok-inconclusive on first match. Activation only: update mode
+		// must still block so PCG_Rollback can fire on broken updates.
 		if ( self::MODE_ACTIVATION === $mode && $this->is_sibling_load_flake( $verdict, $plugin_mains ) ) {
 			$this->log_sibling_load_flake_downgrade( $mode, $plugin_mains, $verdict );
 			return $this->downgrade_to_inconclusive(
@@ -157,10 +148,8 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Build an `ok-inconclusive` downgrade verdict that preserves the
-	 * captured-fatal context (`plugin`, `message`, `file`) so downstream
-	 * readers (logstash, snapshot preservation) can still see which
-	 * candidate triggered the downgrade and why.
+	 * Downgrade to `ok-inconclusive`, preserving the captured-fatal
+	 * context so logstash can still attribute the downgrade.
 	 *
 	 * @param array  $verdict Original blocking verdict.
 	 * @param string $reason  Human-readable reason for the downgrade.
@@ -180,16 +169,11 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Whether a verdict looks like a sibling-load flake — a fatal/throwable
-	 * where the candidate plugin's entry file loaded but a sibling under
-	 * its own directory failed to require or autoload. Logstash on the
-	 * production data shows the same `(blog, file)` failing for hours, so
-	 * a retry can't help; the signature is stable enough to downgrade-to-
-	 * allow on regardless of the underlying cause.
+	 * Whether a verdict is a fatal/throwable where the candidate's entry
+	 * file loaded but a sibling under its own directory failed to
+	 * require or autoload.
 	 *
-	 * Exposed for unit tests.
-	 *
-	 * @internal
+	 * @internal Exposed for unit tests.
 	 * @param array    $result       Probe verdict.
 	 * @param string[] $plugin_mains Absolute paths to the candidate plugins' main files.
 	 * @return bool
@@ -200,13 +184,9 @@ class PCG_Load_Tester {
 			return false;
 		}
 
-		// For the throwable arm, restrict to PHP engine error classes
-		// (`\Error` and its built-in subclasses). A hand-thrown
-		// `\RuntimeException` from a plugin's self-check that happens to
-		// contain class-not-found-shaped wording must NOT be downgraded —
-		// the plugin is asking to abort, and silently allowing the
-		// activation would deliver a half-loaded plugin to production.
-		// `classify_shutdown` verdicts (`fatal`) never carry a `class` key.
+		// Throwables: only downgrade engine errors. A hand-thrown
+		// RuntimeException with similar wording is asking to abort and
+		// must keep blocking. `classify_shutdown` fatals carry no `class`.
 		if ( 'throwable' === $status ) {
 			$captured_class = (string) ( $result['class'] ?? '' );
 			if ( ! self::is_php_engine_error_class( $captured_class ) ) {
@@ -216,23 +196,10 @@ class PCG_Load_Tester {
 
 		$message = (string) ( $result['message'] ?? '' );
 
-		// Anchor the class-not-found check to PHP's canonical wording —
-		// `Class "Foo\Bar" not found` (PHP 8+) or `Class 'Foo' not found`
-		// (legacy). PHP engine error messages are not localised — they
-		// are always emitted in English — so matching English wording is
-		// the language-agnostic choice; a loose `str_contains` on
-		// `Class ` / ` not found` would over-match decorated messages or
-		// wrapped fatals and silently downgrade real bugs. A user-
-		// installed `set_error_handler` that rewrites messages can
-		// defeat the match; we'd then keep the verdict as fatal (no
-		// downgrade), which is the safer failure mode.
-		// `Failed opening required` and `failed to open stream: No such
-		// file or directory` are the verbatim strings the PHP engine
-		// emits — they're not localised and they're stable across
-		// PHP 7/8. If PHP ever rewords either, the substring match here
-		// would silently break and verdicts would stay as fatal (the
-		// safer failure mode), so we'd notice via the `Sibling-load
-		// flake downgrade` event rate dropping to zero.
+		// Anchor on the verbatim engine wording (English-only, stable
+		// across PHP 7/8). If PHP ever rewords either, the match breaks
+		// silently — verdicts stay as fatal, the safer failure mode,
+		// and the `Sibling-load flake downgrade` event rate drops.
 		$looks_like_class_not_found   = (bool) preg_match( '/\bClass\s+["\'][^"\']+["\']\s+not found\b/', $message );
 		$looks_like_missing_file_open = str_contains( $message, 'Failed opening required' )
 			|| str_contains( $message, 'failed to open stream: No such file or directory' );
@@ -245,13 +212,10 @@ class PCG_Load_Tester {
 			return true;
 		}
 
-		// Fall back to the message body ONLY for the file-open arm: those
-		// messages carry the missing path verbatim, so a substring match
-		// against a candidate's dir is a meaningful signal. The
-		// class-not-found arm requires the captured `file` to live inside
-		// a candidate — its message has no path to match on, and pulling
-		// other text in (autoloader stack traces, wrapped errors) is the
-		// over-match vector we want to avoid.
+		// Message-body fallback is safe for the file-open arm only — the
+		// message carries the missing path verbatim. Class-not-found
+		// messages don't, and matching their text risks over-matching
+		// autoloader traces and silently downgrading real bugs.
 		if ( ! $looks_like_missing_file_open ) {
 			return false;
 		}
@@ -259,34 +223,19 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Whether an absolute path lies inside one of the candidate plugins'
-	 * own directories (or equals a candidate's main file). Flat-file
-	 * plugins are skipped because their dirname is `WP_PLUGIN_DIR`, which
-	 * would prefix-match every other plugin's files.
+	 * Whether an absolute path lies inside a candidate plugin's directory
+	 * (or equals its main file). Flat-file plugins are skipped because
+	 * their dirname is `WP_PLUGIN_DIR` itself.
+	 *
+	 * Paths are compared raw (no `realpath`) to match WP's own shape.
+	 * Symlinked plugin trees would need realpath-of-both on both this
+	 * and `message_references_candidate_path`.
 	 *
 	 * @param string   $path         Absolute path to test.
 	 * @param string[] $plugin_mains Absolute paths to the candidate plugins' main files.
 	 * @return bool
 	 */
 	protected function path_inside_candidate( $path, array $plugin_mains ) {
-		// We compare the raw paths PHP gives us (`error_get_last`'s
-		// `file`, the candidate's main as WP saw it) without `realpath`.
-		// This is correct on Atomic + standard hosts where
-		// `WP_PLUGIN_DIR` and plugin install paths are direct (no
-		// symlinks), and matches WP's own internal comparison shape
-		// (e.g. `is_plugin_active`) so the activation guard, the
-		// post-update healthcheck, and PCG agree on which plugin file
-		// is which.
-		//
-		// Symlink caveat for future maintainers: if a host installs
-		// plugins under a symlinked tree (e.g. `WP_PLUGIN_DIR` →
-		// `/var/www/.../plugins-real/`), PHP's error_get_last() often
-		// reports the realpath-resolved `file` while `$plugin_main`
-		// (built from `WP_PLUGIN_DIR`) is the symlink path. This
-		// matcher would silently fail to attribute the fatal to the
-		// candidate. If symlinked layouts become a thing, replace this
-		// with a realpath-of-both comparison (and update the
-		// `message_references_candidate_path` sibling helper too).
 		if ( '' === (string) $path ) {
 			return false;
 		}
@@ -304,11 +253,9 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Whether a `Failed opening required` message body mentions a path
-	 * inside one of the candidate plugins' directories. Only safe for
-	 * messages that PHP composes with the failing path verbatim — see
-	 * `is_sibling_load_flake` for why we don't use this on autoloader
-	 * misses.
+	 * Whether a `Failed opening required` message mentions a path inside
+	 * a candidate's directory. Only safe for messages PHP composes with
+	 * the failing path verbatim.
 	 *
 	 * @param string   $message      Verdict message.
 	 * @param string[] $plugin_mains Absolute paths to the candidate plugins' main files.
@@ -329,9 +276,7 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Log a sibling-load flake downgrade so we can measure how often the
-	 * downgrade path triggers and on which plugins. Sampled on the same
-	 * `atomic_plugin_conflicts_guardian` feature bucket.
+	 * Log a sibling-load flake downgrade so we can measure the rate.
 	 *
 	 * @param string   $mode         Probe mode constant.
 	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.
@@ -354,23 +299,16 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Whether a captured throwable's class name is one of PHP's built-in
-	 * engine error classes (i.e. one that the engine raises directly,
-	 * rather than something user code could throw to signal intent).
-	 *
-	 * Used by `is_sibling_load_flake` to ensure we only downgrade fatals
-	 * that PHP itself produced — a plugin hand-throwing a
-	 * `RuntimeException` with class-not-found-shaped wording must keep
-	 * blocking.
+	 * Whether a class name is one of PHP's built-in engine error classes.
+	 * User-defined subclasses are intentionally NOT matched — those
+	 * carry the same "asking to abort" semantics as a hand-thrown
+	 * exception.
 	 *
 	 * @internal Exposed for tests.
 	 * @param string $class_name Captured `class` value from the verdict.
 	 * @return bool
 	 */
 	public static function is_php_engine_error_class( $class_name ) {
-		// Subclasses created by user code (e.g. `class MyError extends Error {}`)
-		// are intentionally NOT matched — those carry the same
-		// "user is asking to abort" semantics as a hand-thrown Exception.
 		static $engine_errors = array(
 			'Error'               => true,
 			'TypeError'           => true,

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
@@ -102,26 +102,15 @@ function pcg_maybe_handle_probe() {
 
 	register_shutdown_function( 'pcg_probe_shutdown' );
 
-	// Activation: load each plugin to exercise its load path. Deferred to
-	// `wp_loaded` (priority 1) so dependency shims registered later in the
-	// bootstrap — Action Scheduler's `as_*` functions, WC constants like
-	// `WC_ADMIN_ABSPATH`, plugin singletons set up during `init` — are
-	// available when we require the candidate. The original design ran
-	// the require inline at `plugins_loaded:10`, which captured real PHP
-	// fatals against undefined functions/constants that wouldn't fire
-	// on a real activation page-load. Trade-off: the candidate's own
-	// `plugins_loaded` callbacks are never invoked in the probe context
-	// (we require it after that hook has finished), but a real activation
-	// click also doesn't fire the new plugin's `plugins_loaded` until the
-	// next request, so the probe still matches the real activation shape.
+	// Activation: load each candidate to exercise its load path. Deferred
+	// to `wp_loaded:1` so dependency shims (Action Scheduler's `as_*`, WC
+	// constants like `WC_ADMIN_ABSPATH`, init-time singletons) are in
+	// place — running inline at `plugins_loaded:10` captured fatals
+	// against undefined functions that wouldn't fire on a real activation.
 	//
-	// Update: skip; re-requiring an already-loaded plugin would fatal with
-	// "Cannot redeclare". The shutdown handler catches either way.
+	// Update mode skips this: the new files are already loaded by WP's
+	// bootstrap and re-requiring would fatal with "Cannot redeclare."
 	if ( PCG_Load_Tester::MODE_ACTIVATION === $mode ) {
-		// Default milestone is `pre-require`; the shutdown handler reads
-		// this to distinguish "bootstrap exited before our require even
-		// ran" (a different probe issue, not a candidate fault) from
-		// "candidate's main file exited during load" (treat as throwable).
 		pcg_probe_load_milestone( array( 'state' => 'pre-require' ) );
 		add_action(
 			'wp_loaded',
@@ -146,10 +135,8 @@ function pcg_maybe_handle_probe() {
 								'line'    => $t->getLine(),
 							)
 						);
-						// `pcg_probe_respond` normally exits, but its
-						// re-entry guard can short-circuit silently;
-						// stop processing the rest of the batch either
-						// way so a captured throwable always wins.
+						// `pcg_probe_respond` may return silently via the
+						// re-entry guard; stop the batch regardless.
 						return;
 					}
 				}
@@ -158,17 +145,12 @@ function pcg_maybe_handle_probe() {
 			1
 		);
 	} else {
-		// Update mode doesn't require anything — the new plugin files are
-		// already loaded by WP's normal bootstrap. Mark the milestone as
-		// `required` so the shutdown handler treats `ok-shutdown` /
-		// captured fatals normally (no candidate-load attribution).
+		// Update mode: nothing to require; skip candidate-load attribution.
 		pcg_probe_load_milestone( array( 'state' => 'required' ) );
 	}
 
-	// Admin probe: defer the verdict to admin_init so admin-time hook fatals
-	// surface (admin_init fires after wp_loaded in admin, so the require has
-	// already happened by then). Front-end probe: emit on wp_loaded once
-	// init has fired and the require + any wp_loaded callbacks have run.
+	// Admin probe: emit on admin_init so admin-time hook fatals surface.
+	// Front-end probe: emit on wp_loaded once init has fired.
 	$is_admin_probe = '1' === sanitize_text_field( wp_unslash( $_GET['pcg_admin'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- token already validated above.
 	add_action( $is_admin_probe ? 'admin_init' : 'wp_loaded', 'pcg_probe_emit_ok', PHP_INT_MAX );
 }
@@ -183,31 +165,16 @@ function pcg_probe_emit_ok() {
 /**
  * Shutdown handler: always emits a JSON verdict.
  *
- * On a captured engine fatal, emits status=fatal. Otherwise the
- * candidate-load milestone is consulted:
- *
- * - `in-require` → emit a synthetic `throwable` against the in-flight
- *   candidate. The plugin called `exit`/`die`/`wp_die` from its main
- *   file; a real activation would abort the same way, so attributing
- *   it to that plugin is correct.
- * - `pre-require` → emit `error`. The deferred `wp_loaded` callback
- *   never ran (an earlier plugin exited during `init`), so the probe
- *   learned nothing about the candidate.
- * - `required` (or default) → emit the classify_shutdown verdict
- *   (`fatal` or `ok-shutdown`).
- *
- * The re-entry guard at the top is what keeps a single probe request
- * from emitting two verdicts: `wp_send_json` → `exit` fires this
- * handler again on the shutdown phase, and we must not over-write.
+ * Captured engine fatal → `fatal`. Otherwise dispatch on the
+ * candidate-load milestone:
+ *   - `in-require` → synthetic `throwable` against the in-flight candidate.
+ *   - `pre-require` → `error` (bootstrap exited before our require ran).
+ *   - `required` → classify_shutdown verdict (`fatal` / `ok-shutdown`).
  */
 function pcg_probe_shutdown() {
-	// Check-only (no `true` arg): `pcg_probe_respond` is the single
-	// canonical marker. If we marked here, the very next call to
-	// `pcg_probe_respond` would observe the flag and bail without
-	// emitting — and the shutdown verdict would be lost. The role of
-	// this guard is to bail when respond has *already* emitted (the
-	// throwable catch in the require loop, or the post-exit shutdown
-	// re-entry), not to claim ownership preemptively.
+	// Check-only: `pcg_probe_respond` is the single canonical marker.
+	// Marking here would make the next respond call bail and lose the
+	// shutdown verdict.
 	if ( pcg_probe_already_emitted() ) {
 		return;
 	}
@@ -250,11 +217,8 @@ function pcg_probe_shutdown() {
 }
 
 /**
- * Track the candidate-load milestone so the shutdown handler can decide
- * whether a missing wp_loaded/admin_init verdict reflects a candidate's
- * mid-load exit (treat as throwable), a pre-require bootstrap abort
- * (treat as error), or a normal post-require clean exit (treat as
- * ok-shutdown via classify_shutdown).
+ * Track the candidate-load milestone so the shutdown handler can
+ * attribute a missing verdict.
  *
  * @internal
  * @param array|null $set Optional partial state to merge in (`state` and/or `plugin`).

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
@@ -102,30 +102,73 @@ function pcg_maybe_handle_probe() {
 
 	register_shutdown_function( 'pcg_probe_shutdown' );
 
-	// Activation: load each plugin to exercise its load path. Update: skip;
-	// re-requiring an already-loaded plugin would fatal with
+	// Activation: load each plugin to exercise its load path. Deferred to
+	// `wp_loaded` (priority 1) so dependency shims registered later in the
+	// bootstrap — Action Scheduler's `as_*` functions, WC constants like
+	// `WC_ADMIN_ABSPATH`, plugin singletons set up during `init` — are
+	// available when we require the candidate. The original design ran
+	// the require inline at `plugins_loaded:10`, which captured real PHP
+	// fatals against undefined functions/constants that wouldn't fire
+	// on a real activation page-load. Trade-off: the candidate's own
+	// `plugins_loaded` callbacks are never invoked in the probe context
+	// (we require it after that hook has finished), but a real activation
+	// click also doesn't fire the new plugin's `plugins_loaded` until the
+	// next request, so the probe still matches the real activation shape.
+	//
+	// Update: skip; re-requiring an already-loaded plugin would fatal with
 	// "Cannot redeclare". The shutdown handler catches either way.
 	if ( PCG_Load_Tester::MODE_ACTIVATION === $mode ) {
-		foreach ( $plugin_mains as $plugin_main ) {
-			try {
-				require_once $plugin_main;
-			} catch ( \Throwable $t ) {
-				pcg_probe_respond(
-					array(
-						'status'  => 'throwable',
-						'plugin'  => $plugin_main,
-						'class'   => get_class( $t ),
-						'message' => $t->getMessage(),
-						'file'    => $t->getFile(),
-						'line'    => $t->getLine(),
-					)
-				);
-			}
-		}
+		// Default milestone is `pre-require`; the shutdown handler reads
+		// this to distinguish "bootstrap exited before our require even
+		// ran" (a different probe issue, not a candidate fault) from
+		// "candidate's main file exited during load" (treat as throwable).
+		pcg_probe_load_milestone( array( 'state' => 'pre-require' ) );
+		add_action(
+			'wp_loaded',
+			static function () use ( $plugin_mains ) {
+				foreach ( $plugin_mains as $plugin_main ) {
+					pcg_probe_load_milestone(
+						array(
+							'state'  => 'in-require',
+							'plugin' => $plugin_main,
+						)
+					);
+					try {
+						require_once $plugin_main;
+					} catch ( \Throwable $t ) {
+						pcg_probe_respond(
+							array(
+								'status'  => 'throwable',
+								'plugin'  => $plugin_main,
+								'class'   => get_class( $t ),
+								'message' => $t->getMessage(),
+								'file'    => $t->getFile(),
+								'line'    => $t->getLine(),
+							)
+						);
+						// `pcg_probe_respond` normally exits, but its
+						// re-entry guard can short-circuit silently;
+						// stop processing the rest of the batch either
+						// way so a captured throwable always wins.
+						return;
+					}
+				}
+				pcg_probe_load_milestone( array( 'state' => 'required' ) );
+			},
+			1
+		);
+	} else {
+		// Update mode doesn't require anything — the new plugin files are
+		// already loaded by WP's normal bootstrap. Mark the milestone as
+		// `required` so the shutdown handler treats `ok-shutdown` /
+		// captured fatals normally (no candidate-load attribution).
+		pcg_probe_load_milestone( array( 'state' => 'required' ) );
 	}
 
-	// Admin probe: defer until admin_init has fired so admin-time hook fatals
-	// surface. Front-end probe: emit on wp_loaded once init has fired.
+	// Admin probe: defer the verdict to admin_init so admin-time hook fatals
+	// surface (admin_init fires after wp_loaded in admin, so the require has
+	// already happened by then). Front-end probe: emit on wp_loaded once
+	// init has fired and the require + any wp_loaded callbacks have run.
 	$is_admin_probe = '1' === sanitize_text_field( wp_unslash( $_GET['pcg_admin'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- token already validated above.
 	add_action( $is_admin_probe ? 'admin_init' : 'wp_loaded', 'pcg_probe_emit_ok', PHP_INT_MAX );
 }
@@ -140,17 +183,22 @@ function pcg_probe_emit_ok() {
 /**
  * Shutdown handler: always emits a JSON verdict.
  *
- * On a captured engine fatal, emits status=fatal. On any other shutdown
- * — including a plugin that called `exit`/`die` cleanly during init —
- * emits status=ok-shutdown so the client can distinguish "bootstrap
- * died silently" (previously seen as "marker present, no JSON body"
- * — historically the biggest false-positive class) from a real
- * captured fatal.
+ * On a captured engine fatal, emits status=fatal. Otherwise the
+ * candidate-load milestone is consulted:
  *
- * Returning silently on re-entry preserves the original verdict.
- * `wp_send_json` calls `exit`, which fires this handler again on the
- * shutdown phase; without the guard the second pass would over-write
- * the response that was just sent.
+ * - `in-require` → emit a synthetic `throwable` against the in-flight
+ *   candidate. The plugin called `exit`/`die`/`wp_die` from its main
+ *   file; a real activation would abort the same way, so attributing
+ *   it to that plugin is correct.
+ * - `pre-require` → emit `error`. The deferred `wp_loaded` callback
+ *   never ran (an earlier plugin exited during `init`), so the probe
+ *   learned nothing about the candidate.
+ * - `required` (or default) → emit the classify_shutdown verdict
+ *   (`fatal` or `ok-shutdown`).
+ *
+ * The re-entry guard at the top is what keeps a single probe request
+ * from emitting two verdicts: `wp_send_json` → `exit` fires this
+ * handler again on the shutdown phase, and we must not over-write.
  */
 function pcg_probe_shutdown() {
 	// Check-only (no `true` arg): `pcg_probe_respond` is the single
@@ -163,7 +211,64 @@ function pcg_probe_shutdown() {
 	if ( pcg_probe_already_emitted() ) {
 		return;
 	}
-	pcg_probe_respond( PCG_Load_Tester::classify_shutdown( error_get_last() ) );
+
+	$verdict = PCG_Load_Tester::classify_shutdown( error_get_last() );
+	if ( 'fatal' === ( $verdict['status'] ?? '' ) ) {
+		pcg_probe_respond( $verdict );
+		return;
+	}
+
+	$milestone = pcg_probe_load_milestone();
+	$state     = (string) ( $milestone['state'] ?? 'required' );
+
+	if ( 'in-require' === $state ) {
+		$plugin_main = (string) ( $milestone['plugin'] ?? '' );
+		pcg_probe_respond(
+			array(
+				'status'  => 'throwable',
+				'plugin'  => $plugin_main,
+				'class'   => 'PCG_Probe_Load_Exit',
+				'message' => 'Candidate plugin terminated the request during load (exit/die/wp_die before returning). Real activation would abort the same way.',
+				'file'    => $plugin_main,
+				'line'    => 0,
+			)
+		);
+		return;
+	}
+
+	if ( 'pre-require' === $state ) {
+		pcg_probe_respond(
+			array(
+				'status' => 'error',
+				'reason' => 'Probe bootstrap exited before the candidate plugin could be loaded; verdict is inconclusive.',
+			)
+		);
+		return;
+	}
+
+	pcg_probe_respond( $verdict );
+}
+
+/**
+ * Track the candidate-load milestone so the shutdown handler can decide
+ * whether a missing wp_loaded/admin_init verdict reflects a candidate's
+ * mid-load exit (treat as throwable), a pre-require bootstrap abort
+ * (treat as error), or a normal post-require clean exit (treat as
+ * ok-shutdown via classify_shutdown).
+ *
+ * @internal
+ * @param array|null $set Optional partial state to merge in (`state` and/or `plugin`).
+ * @return array{state:string,plugin:string}
+ */
+function pcg_probe_load_milestone( $set = null ) {
+	static $milestone = array(
+		'state'  => 'required',
+		'plugin' => '',
+	);
+	if ( is_array( $set ) ) {
+		$milestone = array_merge( $milestone, $set );
+	}
+	return $milestone;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -603,7 +603,6 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	public function test_is_anomalous_allow_flags_ok_shutdown() {
 		$tester = new PCG_Load_Tester();
 		$ref    = new \ReflectionMethod( PCG_Load_Tester::class, 'is_anomalous_allow' );
-		$ref->setAccessible( true );
 		$this->assertTrue( $ref->invoke( $tester, array( 'status' => 'ok-shutdown' ) ) );
 		$this->assertTrue( $ref->invoke( $tester, array( 'status' => 'ok-inconclusive' ) ) );
 		$this->assertTrue( $ref->invoke( $tester, array( 'status' => 'error' ) ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -548,6 +548,54 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * `Failed opening required` arm: when the captured `file` is OUTSIDE
+	 * every candidate directory but the message itself names a path
+	 * inside one of them, the message-body fallback must still classify
+	 * the verdict as a sibling-load flake. This is the path where Plugin
+	 * A's main file failed to `require` a file inside Plugin A's own
+	 * subdirectory but PHP reported the caller's file (e.g. wrapped via
+	 * an external loader). Without this fallback, the downgrade would
+	 * miss it and we'd block on a known-flaky signature.
+	 */
+	public function test_is_sibling_load_flake_uses_message_fallback_for_failed_require() {
+		$tester = new PCG_Load_Tester();
+		$plugin = WP_PLUGIN_DIR . '/some-plugin/some-plugin.php';
+		$result = array(
+			'status'  => 'fatal',
+			'message' => "Failed opening required '" . WP_PLUGIN_DIR . "/some-plugin/inc/missing.php' (include_path='.')",
+			// File is outside every candidate dir — would-be Plugin Loader
+			// or composer autoloader path, not the candidate itself.
+			'file'    => '/var/www/html/wp-includes/some-loader.php',
+		);
+		$this->assertTrue(
+			$tester->is_sibling_load_flake( $result, array( $plugin ) ),
+			'Failed-opening-required arm should fall back to message-body path match when captured file is outside the candidate.'
+		);
+	}
+
+	/**
+	 * Class-not-found arm does NOT use the message-body fallback —
+	 * autoloader stack traces and wrapped errors frequently include
+	 * unrelated paths, and matching them silently downgrades real bugs.
+	 * The arm requires the captured `file` to live inside a candidate.
+	 */
+	public function test_is_sibling_load_flake_does_not_use_message_fallback_for_class_not_found() {
+		$tester = new PCG_Load_Tester();
+		$plugin = WP_PLUGIN_DIR . '/some-plugin/some-plugin.php';
+		$result = array(
+			'status'  => 'fatal',
+			// Message references the candidate dir, but the captured file
+			// is in someone else's autoloader.
+			'message' => 'Uncaught Error: Class "SomePlugin\\Helper" not found in ' . WP_PLUGIN_DIR . '/some-plugin/loader.php',
+			'file'    => '/var/www/html/wp-includes/PHPMailer/SMTP.php',
+		);
+		$this->assertFalse(
+			$tester->is_sibling_load_flake( $result, array( $plugin ) ),
+			'Class-not-found arm must require captured file inside candidate; message-body fallback would over-match autoloader traces.'
+		);
+	}
+
+	/**
 	 * `is_anomalous_allow` flags `ok-shutdown` (PR 2's always-emit
 	 * verdict) so the rate of silent-bootstrap-exit appears in
 	 * `Probe anomaly allowed`. Sanity-checked here via Reflection.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -438,12 +438,129 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		$this->assertFalse( pcg_probe_already_emitted(), 'fresh check should be false' );
 		$this->assertFalse( pcg_probe_already_emitted(), 'check-only must not mark — second check still false' );
 
-		// Mark: returns false on the marking call (flag was just set).
 		$this->assertFalse( pcg_probe_already_emitted( true ), 'marking call returns false because flag was previously unset' );
 
-		// Subsequent reads (with or without mark arg) see the flag.
 		$this->assertTrue( pcg_probe_already_emitted(), 'post-mark check returns true' );
 		$this->assertTrue( pcg_probe_already_emitted( true ), 'post-mark marking call returns true' );
+	}
+
+	/**
+	 * `is_php_engine_error_class` matches built-in engine errors but
+	 * not user-defined subclasses or hand-thrown exceptions. The strict
+	 * gate keeps the sibling-load downgrade from silently allowing a
+	 * plugin that hand-threw a RuntimeException with class-not-found-
+	 * shaped wording.
+	 */
+	public function test_is_php_engine_error_class_recognises_engine_classes() {
+		$this->assertTrue( PCG_Load_Tester::is_php_engine_error_class( 'Error' ) );
+		$this->assertTrue( PCG_Load_Tester::is_php_engine_error_class( '\\TypeError' ) );
+		$this->assertTrue( PCG_Load_Tester::is_php_engine_error_class( 'ParseError' ) );
+		$this->assertTrue( PCG_Load_Tester::is_php_engine_error_class( 'DivisionByZeroError' ) );
+		$this->assertFalse( PCG_Load_Tester::is_php_engine_error_class( 'RuntimeException' ) );
+		$this->assertFalse( PCG_Load_Tester::is_php_engine_error_class( 'LogicException' ) );
+		$this->assertFalse( PCG_Load_Tester::is_php_engine_error_class( 'MyCustomError' ) );
+		$this->assertFalse( PCG_Load_Tester::is_php_engine_error_class( '' ) );
+	}
+
+	/**
+	 * Sibling-load flake: captured fatal where the candidate's entry
+	 * file loaded but a sibling under its own directory failed to
+	 * require. `Failed opening required` with the captured `file`
+	 * inside one of the candidate dirs is the canonical signature.
+	 */
+	public function test_is_sibling_load_flake_detects_failed_require_inside_candidate_dir() {
+		$tester = new PCG_Load_Tester();
+		$plugin = WP_PLUGIN_DIR . '/some-plugin/some-plugin.php';
+		$result = array(
+			'status'  => 'fatal',
+			'message' => "Failed opening required '" . WP_PLUGIN_DIR . "/some-plugin/inc/missing.php' (include_path='.')",
+			'file'    => WP_PLUGIN_DIR . '/some-plugin/some-plugin.php',
+		);
+		$this->assertTrue( $tester->is_sibling_load_flake( $result, array( $plugin ) ) );
+	}
+
+	/**
+	 * `Class "Foo\Bar" not found` inside one of the candidate plugins'
+	 * own directories also counts as a sibling-load flake — autoloader
+	 * couldn't find a sibling class it should have been able to load.
+	 */
+	public function test_is_sibling_load_flake_detects_class_not_found_for_candidate() {
+		$tester = new PCG_Load_Tester();
+		$plugin = WP_PLUGIN_DIR . '/some-plugin/some-plugin.php';
+		$result = array(
+			'status'  => 'fatal',
+			'message' => 'Uncaught Error: Class "SomePlugin\\Helper" not found',
+			'file'    => WP_PLUGIN_DIR . '/some-plugin/includes/loader.php',
+		);
+		$this->assertTrue( $tester->is_sibling_load_flake( $result, array( $plugin ) ) );
+	}
+
+	/**
+	 * A hand-thrown `\RuntimeException` whose message happens to match
+	 * the class-not-found wording must NOT be downgraded — the plugin
+	 * is asking to abort, and silently allowing the activation would
+	 * deliver a half-loaded plugin.
+	 */
+	public function test_is_sibling_load_flake_rejects_non_engine_throwable() {
+		$tester = new PCG_Load_Tester();
+		$plugin = WP_PLUGIN_DIR . '/some-plugin/some-plugin.php';
+		$result = array(
+			'status'  => 'throwable',
+			'class'   => 'RuntimeException',
+			'message' => 'Class "SomePlugin\\Required" not found',
+			'file'    => WP_PLUGIN_DIR . '/some-plugin/loader.php',
+			'plugin'  => $plugin,
+		);
+		$this->assertFalse( $tester->is_sibling_load_flake( $result, array( $plugin ) ) );
+	}
+
+	/**
+	 * Captured file outside any candidate plugin dir → not a sibling-
+	 * load flake. A class-not-found in a third-party autoloader's path
+	 * shouldn't be silenced by association.
+	 */
+	public function test_is_sibling_load_flake_rejects_when_file_outside_candidate() {
+		$tester = new PCG_Load_Tester();
+		$plugin = WP_PLUGIN_DIR . '/some-plugin/some-plugin.php';
+		$result = array(
+			'status'  => 'fatal',
+			'message' => 'Uncaught Error: Class "SomePlugin\\Helper" not found',
+			'file'    => '/some/random/place/autoloader.php',
+		);
+		$this->assertFalse( $tester->is_sibling_load_flake( $result, array( $plugin ) ) );
+	}
+
+	/**
+	 * Flat-file plugins (e.g. `hello.php` at WP_PLUGIN_DIR root) must
+	 * not act as a prefix that matches every other plugin's files —
+	 * their dir is `WP_PLUGIN_DIR` itself, which would swallow the
+	 * whole plugins tree.
+	 */
+	public function test_is_sibling_load_flake_skips_flat_file_plugin() {
+		$tester = new PCG_Load_Tester();
+		$flat   = WP_PLUGIN_DIR . '/hello.php';
+		$result = array(
+			'status'  => 'fatal',
+			'message' => "Failed opening required '" . WP_PLUGIN_DIR . "/other-plugin/missing.php'",
+			'file'    => WP_PLUGIN_DIR . '/other-plugin/main.php',
+		);
+		$this->assertFalse( $tester->is_sibling_load_flake( $result, array( $flat ) ) );
+	}
+
+	/**
+	 * `is_anomalous_allow` flags `ok-shutdown` (PR 2's always-emit
+	 * verdict) so the rate of silent-bootstrap-exit appears in
+	 * `Probe anomaly allowed`. Sanity-checked here via Reflection.
+	 */
+	public function test_is_anomalous_allow_flags_ok_shutdown() {
+		$tester = new PCG_Load_Tester();
+		$ref    = new \ReflectionMethod( PCG_Load_Tester::class, 'is_anomalous_allow' );
+		$ref->setAccessible( true );
+		$this->assertTrue( $ref->invoke( $tester, array( 'status' => 'ok-shutdown' ) ) );
+		$this->assertTrue( $ref->invoke( $tester, array( 'status' => 'ok-inconclusive' ) ) );
+		$this->assertTrue( $ref->invoke( $tester, array( 'status' => 'error' ) ) );
+		$this->assertFalse( $ref->invoke( $tester, array( 'status' => 'ok' ) ) );
+		$this->assertFalse( $ref->invoke( $tester, array( 'status' => 'fatal' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Stacks on **#49157** (shutdown handler always emits a verdict), which itself stacks on **#49156** (only block on a captured fatal). This is the third PR in the split and addresses the remaining ~3% of update-rollback false positives (the sibling-load class) while tightening shutdown-handler attribution.

Three independent-but-coupled changes:

### 1. Defer probe \`require_once\` to \`wp_loaded:1\`

Today the probe \`require_once\`s each candidate inline at \`plugins_loaded:10\`. Dependency shims registered later in the bootstrap — Action Scheduler's \`as_*\` functions, \`WC_ADMIN_ABSPATH\`, plugin singletons set up during \`init\` — aren't available yet, so the probe captures real PHP fatals against undefined functions/constants that wouldn't fire on a real activation page-load.

After this PR the require runs in a \`wp_loaded:1\` callback. Trade-off: the candidate's own \`plugins_loaded\` callbacks are never invoked in the probe (we require it after that hook). A real activation click also doesn't fire the new plugin's \`plugins_loaded\` until the next request, so the probe still matches the real activation shape.

### 2. Milestone-based shutdown attribution

\`pcg_probe_load_milestone()\` tracks where in the require lifecycle the bootstrap died:

| State | Meaning | Shutdown emits |
|---|---|---|
| \`pre-require\` | wp_loaded callback never ran — earlier plugin's init aborted | \`status=error\` (inconclusive) |
| \`in-require:\$plugin\` | Candidate is mid-load when shutdown fired | \`status=throwable\` against that plugin |
| \`required\` | Candidate loaded cleanly | \`classify_shutdown\` (fatal / ok-shutdown) |

This re-attributes silent \`exit\`/\`die\` during candidate load as a throwable against that candidate (real activation would abort the same way), and avoids falsely greenlighting a probe whose bootstrap died before our require ran.

### 3. Sibling-load downgrade

\`PCG_Load_Tester::is_sibling_load_flake()\` matches captured fatals where the candidate's entry file loaded but a sibling under its own directory failed to require/autoload. Logstash data shows the same \`(blog, file)\` reproducing for hours, so a retry can't help — downgrade to \`ok-inconclusive\` on first match. CLI activation remains the recovery path.

Gated by:
- \`MODE_ACTIVATION\` only — post-update healthcheck has already overwritten plugin files and needs every captured fatal to block so \`PCG_Rollback::to_snapshot()\` can fire.
- Engine-error classes only on throwables (\`\\Error\` and built-in subclasses) — a hand-thrown \`RuntimeException\` keeps blocking.
- Flat-file plugins skipped in path matching (their dir is \`WP_PLUGIN_DIR\` itself).

Logged as \`Sibling-load flake downgrade\`.

## Testing instructions

1. \`cd projects/packages/jetpack-mu-wpcom && composer phpunit -- --filter is_sibling_load_flake\` — five cases must pass: matches inside candidate dir for both \`Failed opening required\` and class-not-found, rejects non-engine throwable, rejects captured file outside candidate, skips flat-file plugin, and the message-body fallback for the failed-require arm.
2. \`composer phpunit -- --filter is_php_engine_error_class\` — confirms strict engine-class matching (rejects \`RuntimeException\`, custom subclasses, empty string).
3. \`composer phpunit -- --filter is_anomalous_allow_flags_ok_shutdown\` — confirms the always-emit verdict from PR 2 surfaces in \`Probe anomaly allowed\`.
4. Manual smoke (activation only): on a probe-eligible site, deliberately install a plugin whose entry file requires a missing sibling under its own dir; activation probe should log \`Sibling-load flake downgrade\` and let the activation proceed. Repeat the same scenario via the post-update healthcheck path — that path must still block and roll back (unchanged behavior).

## Does this pull request change what data or activity we track or use?

Adds a new Logstash event \`Sibling-load flake downgrade\` on the existing \`atomic_pcg\` feature bucket; payload mirrors the existing \`Probe anomaly allowed\` event (blog ID, candidate file, captured fatal reason). \`pcg_probe_load_milestone()\` state lives in per-request process memory only and is not transmitted. No new user data is collected.

## Test plan

- [x] PHPUnit (56/56 pass):
  - \`is_sibling_load_flake\` matches \`Failed opening required\` inside candidate dir.
  - \`is_sibling_load_flake\` matches class-not-found inside candidate dir.
  - \`is_sibling_load_flake\` rejects non-engine throwable (RuntimeException).
  - \`is_sibling_load_flake\` rejects captured file outside candidate.
  - \`is_sibling_load_flake\` skips flat-file plugin.
  - \`is_php_engine_error_class\` matches Error/TypeError/ParseError/… but rejects RuntimeException, custom subclasses, empty string.
  - \`is_anomalous_allow\` flags \`ok-shutdown\` so PR 2's verdict shows up in \`Probe anomaly allowed\`.
- [x] PHPCS clean on touched files.

## Risk

This is the **highest-risk** PR in the split. The require timing change can shift what's loaded when the candidate runs; downstream plugins that depend on something defined later in \`plugins_loaded\` may behave differently in the probe than they did before. The milestone tracking is new state; the sibling-load downgrade is new policy. Reviewing these together with the data table from #49156's description is recommended.

## Stacking

Depends on #49157 (which depends on #49156). Will rebase onto \`trunk\` once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)