### PR TITLE
Plugin Conflicts Guardian: percentage rollout gate by blog ID

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-rollout-gate
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-rollout-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Plugin Conflicts Guardian: add percentage rollout gate by blog ID (default 0%).

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -77,6 +77,16 @@ Two independent filters:
 
 Atomic and some managed hosts sandbox web-PHP so `proc_open` can't find/exec a CLI binary (`open_basedir` + restricted exec). A separate HTTP request is isolated from the admin request: if the plugin fatals, the probe 500s but the parent sees JSON via the shutdown handler, and the admin page keeps rendering.
 
+## Percentage rollout
+
+`PCG_Rollout` narrows `pcg_guard_activation` / `pcg_guard_updates` per blog. Default is **0%** — PCG is off everywhere until the operator opts in:
+
+```php
+add_filter( 'pcg_rollout_percentage', fn () => 10 ); // 10% cohort
+```
+
+Bucketing is `crc32(blog_id) % 100`, so ramping from 10% → 50% strictly adds blogs (no reshuffling between tiers). The gate only narrows — emergency-override filters at priority > 100 on `pcg_guard_activation` / `pcg_guard_updates` can still re-enable or disable a blog.
+
 ## Limitations
 
 - Only catches errors hit while `require`-ing the main file and during `plugins_loaded` / `init` / `admin_init` callbacks. Errors that surface only on later hooks (e.g. `template_redirect`, REST) are invisible.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Percentage-based rollout gate for the Plugin Conflicts Guardian.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Percentage rollout gate for PCG.
+ */
+class PCG_Rollout {
+
+	const DEFAULT_PERCENTAGE = 0;
+
+	/**
+	 * Priority 100 leaves room for emergency overrides at higher priorities.
+	 */
+	public static function init() {
+		add_filter( 'pcg_guard_activation', array( __CLASS__, 'gate' ), 100 );
+		add_filter( 'pcg_guard_updates', array( __CLASS__, 'gate' ), 100 );
+	}
+
+	/**
+	 * Only narrows.
+	 *
+	 * @param bool $enabled Previous filter value.
+	 * @return bool
+	 */
+	public static function gate( $enabled ) {
+		if ( ! $enabled ) {
+			return $enabled;
+		}
+		return self::is_enabled_for_blog( get_current_blog_id() );
+	}
+
+	/**
+	 * On single-site, `get_current_blog_id()` is always 1, so the site is
+	 * wholly in or wholly out at any given percentage.
+	 *
+	 * @param int $blog_id Blog ID under test.
+	 * @return bool
+	 */
+	public static function is_enabled_for_blog( $blog_id ) {
+		$blog_id = (int) $blog_id;
+		if ( $blog_id <= 0 ) {
+			return false;
+		}
+
+		$percentage = (int) apply_filters( 'pcg_rollout_percentage', self::DEFAULT_PERCENTAGE );
+		if ( $percentage <= 0 ) {
+			return false;
+		}
+		if ( $percentage >= 100 ) {
+			return true;
+		}
+
+		return self::blog_bucket( $blog_id ) < $percentage;
+	}
+
+	/**
+	 * `abs()` on the modulo result (not raw `crc32`) — 32-bit PHP returns
+	 * a signed int and `abs(PHP_INT_MIN)` overflows.
+	 *
+	 * @internal Exposed for tests.
+	 * @param int $blog_id Blog ID.
+	 * @return int
+	 */
+	public static function blog_bucket( $blog_id ) {
+		return abs( crc32( (string) (int) $blog_id ) % 100 );
+	}
+}
+
+PCG_Rollout::init();

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php
@@ -12,6 +12,7 @@
  */
 require_once __DIR__ . '/pcg-log.php';
 require_once __DIR__ . '/class-pcg-load-tester.php';
+require_once __DIR__ . '/class-pcg-rollout.php';
 
 // Probe endpoint must answer front-end requests, so it's not gated on is_admin().
 require_once __DIR__ . '/probe-endpoint.php';

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/pcg-log.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/class-pcg-load-tester.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/class-pcg-rollout.php';
 // probe-endpoint.php registers a shutdown handler and reads $_GET on
 // require; the entry function `pcg_maybe_handle_probe()` is the one
 // that does that work, and it bails immediately when `$_GET['pcg_probe']`
@@ -53,6 +54,18 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		remove_all_filters( 'pcg_guard_activation' );
 		remove_all_filters( 'pcg_guard_updates' );
 		remove_all_filters( 'pcg_backup_root' );
+		remove_all_filters( 'pcg_rollout_percentage' );
+		// PCG_Rollout::init() registers itself on require_once. We tear
+		// the gate callbacks down by name (not via remove_all_filters,
+		// which would also drop any test-local pcg_guard_* filters set
+		// up above) and then re-add via init() so every test starts
+		// with exactly one copy of the gate at priority 100. Without
+		// this, calling init() unconditionally in tear_down would stack
+		// the same callback N times across the suite — harmless
+		// functionally but wasteful and noisy in some test envs.
+		remove_filter( 'pcg_guard_activation', array( 'PCG_Rollout', 'gate' ), 100 );
+		remove_filter( 'pcg_guard_updates', array( 'PCG_Rollout', 'gate' ), 100 );
+		PCG_Rollout::init();
 		parent::tear_down();
 	}
 
@@ -805,6 +818,8 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_update_guard_check_blocks_plugin_with_parse_error() {
 		add_filter( 'pcg_guard_activation', '__return_true' );
+		// Bump the rollout to 100% so the gate doesn't veto this test.
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
 		file_put_contents( $dir . '/plugin.php', "<?php function ( {\n" );
@@ -917,5 +932,86 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 			}
 		}
 		rmdir( $dir );
+	}
+
+	/**
+	 * Rollout default is 0% — no blog is in the cohort.
+	 */
+	public function test_rollout_default_is_zero_percent() {
+		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( 1 ) );
+		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( 99999 ) );
+	}
+
+	/**
+	 * 100% includes every positive blog ID.
+	 */
+	public function test_rollout_full_includes_every_blog() {
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+		$this->assertTrue( PCG_Rollout::is_enabled_for_blog( 1 ) );
+		$this->assertTrue( PCG_Rollout::is_enabled_for_blog( 240190614 ) );
+	}
+
+	/**
+	 * Invalid or non-positive blog IDs are never enabled, even at 100%.
+	 */
+	public function test_rollout_rejects_non_positive_blog_ids() {
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( 0 ) );
+		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( -1 ) );
+	}
+
+	/**
+	 * Bucketing must be deterministic — the same blog ID stays in the
+	 * same bucket across calls. (Ramping from 10% to 50% should
+	 * strictly add blogs, never reshuffle them.)
+	 */
+	public function test_rollout_blog_bucket_is_deterministic() {
+		$this->assertSame(
+			PCG_Rollout::blog_bucket( 7777 ),
+			PCG_Rollout::blog_bucket( 7777 )
+		);
+		$this->assertNotSame(
+			PCG_Rollout::blog_bucket( 1 ),
+			PCG_Rollout::blog_bucket( 2 )
+		);
+	}
+
+	/**
+	 * Bucket is always in [0, 100). On 32-bit PHP `crc32` returns a
+	 * signed int and `abs(PHP_INT_MIN)` overflows — taking the modulo
+	 * before `abs()` is the 32-bit-safe ordering.
+	 */
+	public function test_rollout_blog_bucket_is_non_negative() {
+		foreach ( array( 1, 2, 100, 999999, 2147483647 ) as $blog_id ) {
+			$bucket = PCG_Rollout::blog_bucket( $blog_id );
+			$this->assertGreaterThanOrEqual( 0, $bucket, "blog_id=$blog_id" );
+			$this->assertLessThan( 100, $bucket, "blog_id=$blog_id" );
+		}
+	}
+
+	/**
+	 * The gate wired through `pcg_guard_activation` / `pcg_guard_updates`
+	 * returns false when the rollout would exclude the current blog,
+	 * regardless of any earlier filter that said true.
+	 */
+	public function test_rollout_gate_narrows_pcg_guard_filters() {
+		// Default percentage is 0; gate must veto.
+		$this->assertFalse( apply_filters( 'pcg_guard_activation', true ) );
+		$this->assertFalse( apply_filters( 'pcg_guard_updates', true ) );
+
+		// At 100% the gate passes through.
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+		$this->assertTrue( apply_filters( 'pcg_guard_activation', true ) );
+		$this->assertTrue( apply_filters( 'pcg_guard_updates', true ) );
+	}
+
+	/**
+	 * The gate only narrows — if an earlier filter returned false, the
+	 * gate must not flip it back to true.
+	 */
+	public function test_rollout_gate_only_narrows() {
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+		add_filter( 'pcg_guard_activation', static fn() => false, 1 );
+		$this->assertFalse( apply_filters( 'pcg_guard_activation', true ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -752,6 +752,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_update_guard_check_ignores_non_plugin_types() {
 		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
 		file_put_contents( $dir . '/bad.php', "<?php function ( {\n" );
@@ -774,6 +775,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_update_guard_check_ignores_unrelated_actions() {
 		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
 		file_put_contents( $dir . '/bad.php', "<?php function ( {\n" );
@@ -796,6 +798,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_update_guard_check_allows_clean_plugin_package() {
 		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
 		file_put_contents( $dir . '/plugin.php', "<?php\n// Plugin Name: PCG Ok\n" );
@@ -818,7 +821,6 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_update_guard_check_blocks_plugin_with_parse_error() {
 		add_filter( 'pcg_guard_activation', '__return_true' );
-		// Bump the rollout to 100% so the gate doesn't veto this test.
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();


### PR DESCRIPTION
## Summary

Adds \`PCG_Rollout\`, a percentage-based gate that narrows the existing \`pcg_guard_activation\` / \`pcg_guard_updates\` filters by blog ID. Re-enabling PCG after the #49108 disable becomes a config change instead of a deploy.

- Default 0% (off everywhere).
- \`pcg_rollout_percentage\` filter controls the cohort.
- Bucketing is \`abs( crc32(blog_id) % 100 )\` — stable, so ramping strictly adds blogs.
- Gate runs at priority 100, only narrows.

Final PR in the split. Stacks on **#49158** → **#49157** → **#49156**.

## Testing instructions

\`cd projects/packages/jetpack-mu-wpcom && composer phpunit -- --filter rollout\` — covers default-off, 100%, deterministic bucketing, 32-bit safety, and gate semantics.

## Does this pull request change what data or activity we track or use?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)