### PR TITLE
Docker CLI: scope parallel .env handling to type=dev, exclude e2e

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -344,6 +344,21 @@ export const applyUpdateEnv = ( filePath, conflicts ) => {
 };
 
 /**
+ * Whether the hybrid tools/docker/.env parallel-instance machinery (reading keys as a base
+ * layer, conflict warnings, append-on-`up --name` persistence) applies to this invocation.
+ *
+ * Scoped to `up` on `type === 'dev'`. The e2e flow runs `docker --type e2e --name t1 up`,
+ * which sets argv.name but manages its own fixed ports and project name — it must neither
+ * read parallel keys from nor write them to the shared .env. Keeping the gate here (rather
+ * than only inline at the call sites) mirrors resolveDevCloneSource being "correct on its
+ * own terms" and makes the e2e exclusion unit-testable.
+ *
+ * @param {object} argv - Yargs argv.
+ * @return {boolean} true when parallel-env reads/writes should run.
+ */
+export const shouldManageParallelEnv = argv => argv.type === 'dev' && argv._[ 1 ] === 'up';
+
+/**
  * Decides which source instance to clone the DB from when bringing up a dev container, if any.
  *
  * Purely argv-driven; whether the chosen source is actually running is checked by the caller.
@@ -810,7 +825,10 @@ const defaultDockerCmdHandler = async argv => {
 	// surface conflicts as warnings (or rewrite when --update-env is set), and persist
 	// parallel-instance keys after a successful `up --name`. See tools/docker/README.md
 	// § "Parallel development environments" for the full precedence + semantics.
-	if ( argv._[ 1 ] === 'up' ) {
+	// Scoped via shouldManageParallelEnv (`up` + `type === 'dev'`): the e2e flow runs with a
+	// fixed `--name t1` and manages its own ports, so it must neither read parallel keys from
+	// nor write them to the shared tools/docker/.env.
+	if ( shouldManageParallelEnv( argv ) ) {
 		const flagSnapshot = snapshotFlagArgv( argv );
 		const fileEnv = readEnvFile();
 		augmentArgvFromEnvFile( argv, fileEnv );
@@ -901,7 +919,9 @@ const defaultDockerCmdHandler = async argv => {
 	// Persist parallel-instance config to .env on `up --name`. Idempotent: only appends
 	// keys that aren't already in the file (Strategy B). Skipped for the primary
 	// `jetpack_dev` flow (no --name) so the main checkout's .env is never written to.
-	if ( argv._[ 1 ] === 'up' && argv.name ) {
+	// Also skipped for non-dev types: the e2e flow always passes `--name t1`, but it
+	// must not write COMPOSE_PROJECT_NAME/PORT_* into the shared tools/docker/.env.
+	if ( shouldManageParallelEnv( argv ) && argv.name ) {
 		const written = persistParallelEnv( envOpts );
 		if ( written.length ) {
 			console.log(

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -37,6 +37,7 @@ const {
 	detectEnvConflicts,
 	persistParallelEnv,
 	applyUpdateEnv,
+	shouldManageParallelEnv,
 	PARALLEL_ENV_KEYS,
 } = await import( '../../../commands/docker.js' );
 
@@ -194,6 +195,34 @@ describe( 'resolveDevCloneSource', () => {
 
 	test( 'returns null when target would be the same as source (--name dev)', () => {
 		expect( resolveDevCloneSource( { type: 'dev', name: 'dev', clone: true } ) ).toBeNull();
+	} );
+} );
+
+describe( 'shouldManageParallelEnv', () => {
+	test( 'true for `up` on the default dev type', () => {
+		expect( shouldManageParallelEnv( { type: 'dev', _: [ 'docker', 'up' ] } ) ).toBe( true );
+	} );
+
+	test( 'true for `up --name` on dev', () => {
+		expect(
+			shouldManageParallelEnv( { type: 'dev', name: 'feature', _: [ 'docker', 'up' ] } )
+		).toBe( true );
+	} );
+
+	// Regression: the e2e framework runs `docker --type e2e --name t1 up -d`. Before the
+	// type gate, that --name leaked COMPOSE_PROJECT_NAME/PORT_* into the shared
+	// tools/docker/.env of a plain checkout. See PR #48643 review follow-up.
+	test( 'false for the e2e flow (--type e2e --name t1 up)', () => {
+		expect( shouldManageParallelEnv( { type: 'e2e', name: 't1', _: [ 'docker', 'up' ] } ) ).toBe(
+			false
+		);
+	} );
+
+	test( 'false for non-up commands on dev', () => {
+		expect( shouldManageParallelEnv( { type: 'dev', _: [ 'docker', 'down' ] } ) ).toBe( false );
+		expect(
+			shouldManageParallelEnv( { type: 'dev', name: 'feature', _: [ 'docker', 'clean' ] } )
+		).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
Fixes # <!-- no ticket; follow-up to a review comment on #48643 -->

## Proposed changes

Follow-up to a bug report on the merged parallel-environments follow-up PR: [#48643 (comment)](https://github.com/Automattic/jetpack/pull/48643#issuecomment-4535501465) — @anomiex hit it while running the Jetpack E2Es locally:

> I ran into a bug that seems related to this PR: while trying to run the Jetpack E2Es locally, it decided it wanted to write a `COMPOSE_PROJECT_NAME` to `tools/docker/.env` in my non-worktree checkout.

### Root cause

The hybrid `tools/docker/.env` machinery added in #48643 (read parallel-instance keys as a base layer, conflict warnings, and append-on-`up --name` persistence) gated its **read** block on `argv._[1] === 'up'` and its **persist** block on `argv._[1] === 'up' && argv.name` — but **neither checked `argv.type === 'dev'`**.

The E2E framework runs the CLI as `pnpm jetpack docker --type e2e --name t1 up -d` ([`tools/e2e-commons/bin/e2e-env.sh`](https://github.com/Automattic/jetpack/blob/trunk/tools/e2e-commons/bin/e2e-env.sh#L20)), which always sets `--name t1`. So running the E2Es in a plain checkout tripped the persist gate and appended `COMPOSE_PROJECT_NAME=jetpack_t1` plus the `PORT_*` keys to `tools/docker/.env`.

That pollution then **cascades**: docker compose reads `tools/docker/.env` (`env_file` in `docker-compose.yml`), and so does the CLI's `augmentArgvFromEnvFile`. A subsequent bare `jetpack docker up` (`type=dev`) reads the polluted `.env`, infers `argv.name = 't1'`, and silently brings the **dev** container up as `jetpack_t1` on the E2E ports — quietly hijacking the main dev environment.

### Fix

Add an exported predicate and gate both blocks through it:

```js
export const shouldManageParallelEnv = argv => argv.type === 'dev' && argv._[ 1 ] === 'up';
```

- Read/conflict block → `if ( shouldManageParallelEnv( argv ) )`
- Persist block → `if ( shouldManageParallelEnv( argv ) && argv.name )`

This mirrors the existing design intent — `resolveDevCloneSource` already returns `null` for non-dev "on its own terms" — and keeps the gate in one testable place. The result:

- **E2E no longer writes** parallel keys to the shared `.env` (the reported bug).
- **E2E no longer reads** parallel keys from `.env`; it uses its own `8889` default (`tools/e2e-commons/config/local.cjs`), restoring pre-#48643 behavior.
- The cascade that hijacked a subsequent dev `up` is eliminated at the source.
- The `buildEnv`/process-env path is untouched, so **E2E's own container behavior is unchanged**.

## Related product discussion/links

* Comment that prompted this: [#48643 (comment)](https://github.com/Automattic/jetpack/pull/48643#issuecomment-4535501465)
* Parent feature PRs: [#48153](https://github.com/Automattic/jetpack/pull/48153), [#48643](https://github.com/Automattic/jetpack/pull/48643)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Unit tests

From `tools/cli`:

```sh
pnpm test
```

Expected: **156 passed, 3 skipped**. New `shouldManageParallelEnv` describe block covers four cases, including the regression: `{ type: 'e2e', name: 't1', _: [ 'docker', 'up' ] }` → `false`.

### Manual — the reported bug

1. In a **plain (non-worktree) checkout**, note your current `tools/docker/.env`:
   ```sh
   cat tools/docker/.env
   ```
2. Spin up the E2E environment (this is what failed before):
   ```sh
   pnpm jetpack docker --type e2e --name t1 up -d
   ```
3. Confirm `tools/docker/.env` is **unchanged** — no `COMPOSE_PROJECT_NAME` / `PORT_*` lines were appended:
   ```sh
   cat tools/docker/.env
   ```
4. Confirm a subsequent bare dev `up` still targets `jetpack_dev` (not `jetpack_t1`):
   ```sh
   pnpm jetpack docker up -d
   docker ps --format '{{.Names}}' | grep jetpack_
   ```

### Regression — dev parallel flow still works

The `dev` parallel-instance flow (`jetpack docker up --name <slug> ...`) is unaffected: it still reads `.env` as a base layer, warns on conflicts, and appends parallel keys. See the testing instructions on #48643 for the full two-instance smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
