### PR TITLE
My Jetpack: Allow admins to disconnect site without connecting their account

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -123,7 +123,9 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const isConnectionOwner = userConnectionData.currentUser?.isMaster;
 	const shouldPreventDialog = isWoASite() && isConnectionOwner;
 	const allowDisconnect =
-		( currentUserCan( 'manage_options' ) || isUserConnected ) && ! shouldPreventDialog;
+		( currentUserCan( 'manage_options' ) || isUserConnected ) &&
+		! shouldPreventDialog &&
+		! ( isWoASite() && ! isUserConnected );
 
 	return (
 		<section className={ styles[ 'connection-status-card' ] }>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -123,9 +123,7 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const isConnectionOwner = userConnectionData.currentUser?.isMaster;
 	const shouldPreventDialog = isWoASite() && isConnectionOwner;
 	const allowDisconnect =
-		( currentUserCan( 'manage_options' ) || isUserConnected ) &&
-		isUserConnected &&
-		! shouldPreventDialog;
+		( currentUserCan( 'manage_options' ) || isUserConnected ) && ! shouldPreventDialog;
 
 	return (
 		<section className={ styles[ 'connection-status-card' ] }>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/styles.module.scss
@@ -110,8 +110,8 @@ $myjetpack-connection-avatar-overlap: 8px;
 				background: transparent;
 			}
 
-			&:focus,
-			&:active {
+			&:focus:not(:disabled),
+			&:active:not(:disabled) {
 				color: var(--jp-black);
 				outline: none;
 				box-shadow: none;

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -396,4 +396,64 @@ describe( 'ConnectionStatusCard', () => {
 			).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'When an admin is not connected but site is registered', () => {
+		const setup = () => {
+			global.JetpackScriptData.user.current_user.capabilities = { manage_options: true };
+
+			setConnectionStore( {
+				isRegistered: true,
+				isUserConnected: false,
+				hasConnectedOwner: false,
+				userConnectionData: adminUserConnectionData,
+			} );
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
+		};
+
+		afterEach( () => {
+			global.JetpackScriptData.user.current_user.capabilities = {};
+		} );
+
+		it( 'enables the manage connection button so admins can disconnect the site', () => {
+			setup();
+			const button = screen.getByRole( 'button', { name: /Site connected/ } );
+			expect( button ).toBeEnabled();
+		} );
+
+		it( 'still shows the connect account prompt', () => {
+			setup();
+			expect(
+				screen.getByText( 'Connect your account to unlock all the features.' )
+			).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Connect my account' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'When a non-admin is not connected and site is registered', () => {
+		const setup = () => {
+			global.JetpackScriptData.user.current_user.capabilities = {};
+
+			setConnectionStore( {
+				isRegistered: true,
+				isUserConnected: false,
+				hasConnectedOwner: true,
+				userConnectionData: nonAdminUserConnectionData,
+			} );
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
+		};
+
+		it( 'disables the manage connection button for non-admins', () => {
+			setup();
+			const button = screen.getByRole( 'button', { name: /Site connected/ } );
+			expect( button ).toBeDisabled();
+		} );
+	} );
 } );

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -456,4 +456,35 @@ describe( 'ConnectionStatusCard', () => {
 			expect( button ).toBeDisabled();
 		} );
 	} );
+
+	describe( 'When on WoA site and admin is not connected', () => {
+		const setup = () => {
+			global.JetpackScriptData.site.host = 'woa';
+			global.JetpackScriptData.user.current_user.capabilities = { manage_options: true };
+
+			setConnectionStore( {
+				isRegistered: true,
+				isUserConnected: false,
+				hasConnectedOwner: false,
+				userConnectionData: adminUserConnectionData,
+			} );
+
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
+		};
+
+		afterEach( () => {
+			global.JetpackScriptData.site.host = 'standard';
+			global.JetpackScriptData.user.current_user.capabilities = {};
+		} );
+
+		it( 'disables the manage connection button since WoA sites cannot be disconnected', () => {
+			setup();
+			const button = screen.getByRole( 'button', { name: /Site connected/ } );
+			expect( button ).toBeDisabled();
+		} );
+	} );
 } );

--- a/projects/packages/my-jetpack/changelog/fix-admin-disconnect-without-user-connection
+++ b/projects/packages/my-jetpack/changelog/fix-admin-disconnect-without-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Allow admins to access the disconnect dialog without connecting their account first.


### PR DESCRIPTION
## Proposed changes

* Fix the `allowDisconnect` gate in `ConnectionStatusCard` to allow admins (`manage_options` capability) to open the Manage Connection dialog even when their WordPress.com account is not connected.
* Previously the logic was `(currentUserCan('manage_options') || isUserConnected) && isUserConnected && !shouldPreventDialog`, which simplified to just `isUserConnected && !shouldPreventDialog` — making the `manage_options` check redundant.
* Now the logic is `(currentUserCan('manage_options') || isUserConnected) && !shouldPreventDialog`, so admins can reach the "Disconnect Jetpack" option without connecting first.
* No changes needed in `ManageConnectionDialog` — it already correctly shows only "Disconnect Jetpack" when the user isn't connected (hiding "Transfer ownership" and "Disconnect my user account").

## Other information

* Server-side permissions (`jetpack_disconnect` → `manage_options`) already support this flow.
* Added tests covering admin-not-connected (button enabled) and non-admin-not-connected (button disabled) scenarios.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Set up a Jetpack site with the site connected but the current admin's WordPress.com account **not** connected.
2. Go to **Jetpack → My Jetpack**.
3. In the Connection section, verify the "Site connected" button is clickable (has a chevron icon).
4. Click it and confirm the Manage Connection dialog opens with only the "Disconnect Jetpack" option visible.
5. Cancel the dialog.
6. Verify the "Connect my account" link is still shown below the status label.
7. Also verify that for a **non-admin** user who is not connected, the "Site connected" button remains disabled (no chevron).


Made with [Cursor](https://cursor.com)