### PR TITLE
JSON API: add REST-vs-XML-RPC parity test helper and cover converted endpoints

### DIFF
--- a/projects/plugins/jetpack/changelog/add-json-api-rest-xmlrpc-parity-helper
+++ b/projects/plugins/jetpack/changelog/add-json-api-rest-xmlrpc-parity-helper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+JSON API: add a REST-vs-XML-RPC body parity test helper plus an auto-discovering coverage test for REST-enabled GET endpoints, and a context=edit (jetpack#42377) lock for /posts.

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_List_Posts_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_List_Posts_Endpoint_Test.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 
 require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
 require_once JETPACK__PLUGIN_DIR . 'json-endpoints/class.wpcom-json-api-list-posts-endpoint.php';
+require_once __DIR__ . '/trait-assert-rest-xmlrpc-parity.php';
 
 /**
  * Tests for the /sites/%s/posts/ list posts endpoint.
@@ -22,6 +23,7 @@ require_once JETPACK__PLUGIN_DIR . 'json-endpoints/class.wpcom-json-api-list-pos
 #[CoversClass( WPCOM_JSON_API_List_Posts_Endpoint::class )]
 class WPCOM_JSON_API_List_Posts_Endpoint_Test extends WP_UnitTestCase {
 	use WP_UnitTestCase_Fix;
+	use Assert_Rest_Xmlrpc_Parity;
 
 	/**
 	 * An admin user ID.
@@ -96,6 +98,8 @@ class WPCOM_JSON_API_List_Posts_Endpoint_Test extends WP_UnitTestCase {
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
+		$this->tear_down_rest_parity();
+
 		parent::tear_down();
 
 		$_SERVER = $this->pre_globals;
@@ -103,6 +107,43 @@ class WPCOM_JSON_API_List_Posts_Endpoint_Test extends WP_UnitTestCase {
 		WPCOM_JSON_API::init()->token_details = array();
 		WPCOM_JSON_API::init()->query         = array();
 		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Lock the jetpack#42377 fix: with context=edit the post content comes back identically on
+	 * both transports. If rest_callback() ever drops the user_can_richedit / comment_edit_pre
+	 * filters, the REST body re-escapes the content and this parity assertion fails.
+	 *
+	 * (Default-request parity for /posts is covered generically by
+	 * WPCOM_JSON_API_Rest_Parity_Coverage_Test; this case adds the edit-context input.)
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_rest_xmlrpc_parity_edit_context_locks_jetpack_42377() {
+		self::factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_author'  => self::$admin_user_id,
+				'post_content' => 'Café &amp; <!-- wp:paragraph --><b>x</b><!-- /wp:paragraph -->',
+			)
+		);
+
+		list( $xmlrpc, $rest ) = $this->assert_rest_parity(
+			$this->get_endpoint(),
+			array(
+				'number'  => 5,
+				'context' => 'edit',
+			)
+		);
+
+		$this->assertNotEmpty( $rest['posts'] );
+		$this->assertStringContainsString(
+			'<b>x</b>',
+			$rest['posts'][0]['content'],
+			'edit-context returns raw markup on the REST path.'
+		);
+		$this->assertSame( $xmlrpc['posts'][0]['content'], $rest['posts'][0]['content'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Auto-discovered REST-vs-XML-RPC parity coverage.
+ *
+ * Asserts that every registered GET endpoint which exposes a rest_route -- and whose only
+ * path placeholder is the site -- returns the same body via REST and XML-RPC for a default
+ * request. New conversions are covered the moment they add a rest_route; nothing per-endpoint
+ * to write here. Endpoints that need specific inputs, URL placeholders (post id / slug), or
+ * fixtures get their own bespoke parity case next to that endpoint's existing tests.
+ *
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Rest_Parity_Coverage_Test
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+require_once JETPACK__PLUGIN_DIR . 'json-endpoints.php';
+require_once __DIR__ . '/trait-assert-rest-xmlrpc-parity.php';
+
+/**
+ * Parity coverage across all REST-enabled simple GET endpoints.
+ *
+ * @covers \WPCOM_JSON_API_Endpoint::rest_callback
+ */
+#[CoversMethod( WPCOM_JSON_API_Endpoint::class, 'rest_callback' )]
+class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
+	use WP_UnitTestCase_Fix;
+	use Assert_Rest_Xmlrpc_Parity;
+
+	/**
+	 * Per-test cleanup.
+	 */
+	public function tear_down() {
+		$this->tear_down_rest_parity();
+		parent::tear_down();
+	}
+
+	/**
+	 * Every REST-enabled GET endpoint whose only path placeholder is the site returns the
+	 * same body on both transports for a default request.
+	 *
+	 * @group json-api
+	 *
+	 * @phan-suppress PhanTypeArraySuspicious -- $api->endpoints is a map of method => endpoint.
+	 */
+	#[Group( 'json-api' )]
+	public function test_simple_get_endpoints_have_rest_xmlrpc_parity() {
+		$checked = array();
+
+		foreach ( WPCOM_JSON_API::init()->endpoints as $endpoints_by_method ) {
+			$endpoint = $endpoints_by_method['GET'] ?? null;
+
+			if ( ! $endpoint instanceof WPCOM_JSON_API_Endpoint || empty( $endpoint->rest_route ) ) {
+				continue;
+			}
+
+			// Only the site placeholder: anything with a post id / slug needs a fixture-backed
+			// bespoke test, so it is out of scope for this generic default-request sweep.
+			if ( substr_count( (string) $endpoint->path, '%' ) !== 1 ) {
+				continue;
+			}
+
+			$this->assert_rest_parity( $endpoint );
+			$checked[] = $endpoint->path . ' (v' . $endpoint->max_version . ')';
+		}
+
+		$this->assertNotEmpty(
+			$checked,
+			'Expected at least one REST-enabled simple GET endpoint to be discovered and checked.'
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
@@ -32,6 +32,21 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 	use Assert_Rest_Xmlrpc_Parity;
 
 	/**
+	 * Per-test setup.
+	 *
+	 * Endpoints build links via WPCOM_JSON_API__BASE (sal/class.json-api-links.php); define it as
+	 * the sibling endpoint tests do so the sweep is runnable in isolation, not just when another
+	 * test in the run has already defined the constant.
+	 */
+	public function set_up() {
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		parent::set_up();
+	}
+
+	/**
 	 * Per-test cleanup.
 	 */
 	public function tear_down() {

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
@@ -15,6 +15,7 @@
 
 use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
@@ -32,11 +33,7 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 	use Assert_Rest_Xmlrpc_Parity;
 
 	/**
-	 * Per-test setup.
-	 *
-	 * Endpoints build links via WPCOM_JSON_API__BASE (sal/class.json-api-links.php); define it as
-	 * the sibling endpoint tests do so the sweep is runnable in isolation, not just when another
-	 * test in the run has already defined the constant.
+	 * Define WPCOM_JSON_API__BASE (endpoints build links from it) so the sweep runs in isolation.
 	 */
 	public function set_up() {
 		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
@@ -55,16 +52,14 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Every REST-enabled GET endpoint whose only path placeholder is the site returns the
-	 * same body on both transports for a default request.
+	 * One data set per REST-enabled simple GET endpoint, as [ path, version ] for the test to re-resolve.
 	 *
-	 * @group json-api
+	 * @return array
 	 *
 	 * @phan-suppress PhanTypeArraySuspicious -- $api->endpoints is a map of method => endpoint.
 	 */
-	#[Group( 'json-api' )]
-	public function test_simple_get_endpoints_have_rest_xmlrpc_parity() {
-		$checked = array();
+	public static function simple_get_endpoints_provider(): array {
+		$cases = array();
 
 		foreach ( WPCOM_JSON_API::init()->endpoints as $endpoints_by_method ) {
 			$endpoint = $endpoints_by_method['GET'] ?? null;
@@ -73,19 +68,70 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 				continue;
 			}
 
-			// Only the site placeholder: anything with a post id / slug needs a fixture-backed
-			// bespoke test, so it is out of scope for this generic default-request sweep.
+			// Only the site placeholder; a post id / slug needs a fixture-backed bespoke test.
 			if ( substr_count( (string) $endpoint->path, '%' ) !== 1 ) {
 				continue;
 			}
 
-			$this->assert_rest_parity( $endpoint );
-			$checked[] = $endpoint->path . ' (v' . $endpoint->max_version . ')';
+			$cases[ $endpoint->path . ' (v' . $endpoint->max_version . ')' ] = array(
+				$endpoint->path,
+				(string) $endpoint->max_version,
+			);
 		}
 
+		return $cases;
+	}
+
+	/**
+	 * Each endpoint returns the same body on both transports for a default request.
+	 *
+	 * @dataProvider simple_get_endpoints_provider
+	 * @group json-api
+	 *
+	 * @param string $path        Endpoint path template.
+	 * @param string $max_version Endpoint max version.
+	 */
+	#[DataProvider( 'simple_get_endpoints_provider' )]
+	#[Group( 'json-api' )]
+	public function test_endpoint_has_rest_xmlrpc_parity( string $path, string $max_version ) {
+		$this->assert_rest_parity( $this->resolve_endpoint( $path, $max_version ) );
+	}
+
+	/**
+	 * Fail if discovery finds nothing -- an empty provider would mark the parity test risky.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_sweep_discovers_endpoints() {
 		$this->assertNotEmpty(
-			$checked,
-			'Expected at least one REST-enabled simple GET endpoint to be discovered and checked.'
+			self::simple_get_endpoints_provider(),
+			'Expected at least one REST-enabled simple GET endpoint to be discovered.'
 		);
+	}
+
+	/**
+	 * Look up the registered GET endpoint for a provider case.
+	 *
+	 * @param string $path        Endpoint path template.
+	 * @param string $max_version Endpoint max version.
+	 * @return WPCOM_JSON_API_Endpoint
+	 *
+	 * @phan-suppress PhanTypeArraySuspicious -- $api->endpoints is a map of method => endpoint.
+	 */
+	private function resolve_endpoint( string $path, string $max_version ): WPCOM_JSON_API_Endpoint {
+		foreach ( WPCOM_JSON_API::init()->endpoints as $endpoints_by_method ) {
+			$endpoint = $endpoints_by_method['GET'] ?? null;
+
+			if (
+				$endpoint instanceof WPCOM_JSON_API_Endpoint
+				&& $endpoint->path === $path
+				&& (string) $endpoint->max_version === $max_version
+			) {
+				return $endpoint;
+			}
+		}
+
+		$this->fail( "GET endpoint not found in registry: {$path} (v{$max_version})" );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Rest_Parity_Coverage_Test.php
@@ -52,7 +52,8 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * One data set per REST-enabled simple GET endpoint, as [ path, version ] for the test to re-resolve.
+	 * One data set per REST-enabled simple GET endpoint. Captures the endpoint object itself --
+	 * the shared registry can be overwritten by other tests, so re-resolving by path later is unsafe.
 	 *
 	 * @return array
 	 *
@@ -73,10 +74,7 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 				continue;
 			}
 
-			$cases[ $endpoint->path . ' (v' . $endpoint->max_version . ')' ] = array(
-				$endpoint->path,
-				(string) $endpoint->max_version,
-			);
+			$cases[ $endpoint->path . ' (v' . $endpoint->max_version . ')' ] = array( $endpoint );
 		}
 
 		return $cases;
@@ -88,13 +86,12 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 	 * @dataProvider simple_get_endpoints_provider
 	 * @group json-api
 	 *
-	 * @param string $path        Endpoint path template.
-	 * @param string $max_version Endpoint max version.
+	 * @param WPCOM_JSON_API_Endpoint $endpoint The discovered endpoint.
 	 */
 	#[DataProvider( 'simple_get_endpoints_provider' )]
 	#[Group( 'json-api' )]
-	public function test_endpoint_has_rest_xmlrpc_parity( string $path, string $max_version ) {
-		$this->assert_rest_parity( $this->resolve_endpoint( $path, $max_version ) );
+	public function test_endpoint_has_rest_xmlrpc_parity( WPCOM_JSON_API_Endpoint $endpoint ) {
+		$this->assert_rest_parity( $endpoint );
 	}
 
 	/**
@@ -108,30 +105,5 @@ class WPCOM_JSON_API_Rest_Parity_Coverage_Test extends WP_UnitTestCase {
 			self::simple_get_endpoints_provider(),
 			'Expected at least one REST-enabled simple GET endpoint to be discovered.'
 		);
-	}
-
-	/**
-	 * Look up the registered GET endpoint for a provider case.
-	 *
-	 * @param string $path        Endpoint path template.
-	 * @param string $max_version Endpoint max version.
-	 * @return WPCOM_JSON_API_Endpoint
-	 *
-	 * @phan-suppress PhanTypeArraySuspicious -- $api->endpoints is a map of method => endpoint.
-	 */
-	private function resolve_endpoint( string $path, string $max_version ): WPCOM_JSON_API_Endpoint {
-		foreach ( WPCOM_JSON_API::init()->endpoints as $endpoints_by_method ) {
-			$endpoint = $endpoints_by_method['GET'] ?? null;
-
-			if (
-				$endpoint instanceof WPCOM_JSON_API_Endpoint
-				&& $endpoint->path === $path
-				&& (string) $endpoint->max_version === $max_version
-			) {
-				return $endpoint;
-			}
-		}
-
-		$this->fail( "GET endpoint not found in registry: {$path} (v{$max_version})" );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -84,8 +84,13 @@ trait Assert_Rest_Xmlrpc_Parity {
 	 *
 	 * @param WPCOM_JSON_API_Endpoint $endpoint   The endpoint under test.
 	 * @param array                   $query      Request params (number, context, type, ...).
-	 * @param array                   $url_params Route placeholder values beyond the site, in path
-	 *                                            order (post id, slug, ...).
+	 * @param array                   $url_params Route placeholder values beyond the site, as an
+	 *                                            associative map of REST param name => value, in path
+	 *                                            order (e.g. array( 'post_id' => 5 )). Must be string
+	 *                                            keyed: rest_callback() merges these as
+	 *                                            array( $path, $blog_id ) + get_url_params(), so
+	 *                                            numeric keys (0, 1) would collide with $path/$blog_id
+	 *                                            and the value would be dropped on the REST side.
 	 * @param string|null             $api_path   Concrete API path; defaults to the endpoint path
 	 *                                            with the blog id and $url_params substituted.
 	 * @return array{0: mixed, 1: mixed} [ xmlrpc_body, rest_body ] for further assertions.
@@ -94,8 +99,8 @@ trait Assert_Rest_Xmlrpc_Parity {
 		$this->prepare_rest_parity_env();
 
 		if ( null === $api_path ) {
-			// The site is always the first placeholder; any remaining placeholders (post id, slug)
-			// are filled positionally from $url_params, so multi-placeholder paths resolve too.
+			// The site is always the first placeholder; remaining placeholders (post id, slug) are
+			// filled from $url_params values in path order, so multi-placeholder paths resolve too.
 			$api_path = false === strpos( (string) $endpoint->path, '%' )
 				? $endpoint->path
 				: vsprintf( $endpoint->path, array_merge( array( $this->rest_parity_blog_id ), array_values( $url_params ) ) );

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -59,6 +59,27 @@ trait Assert_Rest_Xmlrpc_Parity {
 	private $rest_parity_server = array();
 
 	/**
+	 * Current user id before the parity env switched it, restored in tear_down.
+	 *
+	 * @var int
+	 */
+	private $rest_parity_prior_user_id;
+
+	/**
+	 * API singleton token_details before the parity env overwrote them, restored in tear_down.
+	 *
+	 * @var array
+	 */
+	private $rest_parity_prior_token_details;
+
+	/**
+	 * Jetpack blog id option before the parity env aligned it, restored in tear_down.
+	 *
+	 * @var mixed
+	 */
+	private $rest_parity_prior_blog_option;
+
+	/**
 	 * Assert that the REST dispatch of $endpoint matches its XML-RPC dispatch.
 	 *
 	 * @param WPCOM_JSON_API_Endpoint $endpoint   The endpoint under test.
@@ -121,6 +142,19 @@ trait Assert_Rest_Xmlrpc_Parity {
 		}
 
 		WPCOM_JSON_API::init()->query = array();
+
+		// Restore the global/singleton state prepare_rest_parity_env() switched, so a consumer
+		// whose tear_down() only calls this helper (e.g. the coverage sweep) does not leak it.
+		if ( isset( $this->rest_parity_blog_id ) ) {
+			wp_set_current_user( (int) $this->rest_parity_prior_user_id );
+			WPCOM_JSON_API::init()->token_details = $this->rest_parity_prior_token_details;
+
+			if ( empty( $this->rest_parity_prior_blog_option ) ) {
+				Jetpack_Options::delete_option( 'id' );
+			} else {
+				Jetpack_Options::update_option( 'id', $this->rest_parity_prior_blog_option );
+			}
+		}
 	}
 
 	/**
@@ -131,6 +165,12 @@ trait Assert_Rest_Xmlrpc_Parity {
 		if ( isset( $this->rest_parity_blog_id ) ) {
 			return;
 		}
+
+		// Capture the global/singleton state we are about to mutate so tear_down can restore it;
+		// the DB transaction rollback covers option rows, but not the API singleton or current user.
+		$this->rest_parity_prior_user_id       = get_current_user_id();
+		$this->rest_parity_prior_token_details = WPCOM_JSON_API::init()->token_details;
+		$this->rest_parity_prior_blog_option   = Jetpack_Options::get_option( 'id' );
 
 		$this->rest_parity_blog_id = (int) $GLOBALS['blog_id'];
 		$this->rest_parity_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
@@ -232,6 +272,9 @@ trait Assert_Rest_Xmlrpc_Parity {
 			Connection_Rest_Authentication::init()->reset_saved_auth_state();
 		}
 
+		// dispatch_rest_body() calls this once per assert_rest_parity(); remove before adding so a
+		// multi-endpoint test (the coverage sweep) keeps exactly one copy of the callback.
+		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
 
 		$_SERVER['HTTP_HOST']      = 'example.org';

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -292,10 +292,8 @@ trait Assert_Rest_Xmlrpc_Parity {
 		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
 
-		// rest_callback()'s signature check (Connection\Manager::verify_xml_rpc_signature) rebuilds
-		// the HMAC from these superglobals, not from the WP_REST_Request route. So the request line
-		// here is fixed and self-consistent with the signature computed below -- the actual endpoint
-		// route the request object carries is irrelevant to verification.
+		// Signature verification rebuilds the HMAC from these superglobals, not the WP_REST_Request
+		// route, so this fixed request line only has to match the signature computed below.
 		$_SERVER['HTTP_HOST']      = 'example.org';
 		$_SERVER['REQUEST_URI']    = '/jetpack/v4/test?qstest=yep';
 		$_SERVER['REQUEST_METHOD'] = 'GET';

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Reusable assertion: a JSON API endpoint's REST dispatch produces the same
+ * response body as its XML-RPC dispatch, for the same logical request.
+ *
+ * Both paths run on the Jetpack site and both end in the same `callback()`:
+ *
+ *   XML-RPC: WPCOM_JSON_API::serve()  -> adds user_can_richedit + comment_edit_pre,
+ *                                        sets $api->endpoint/path/version
+ *                                     -> process_request() -> callback()
+ *   REST:    WPCOM_JSON_API_Endpoint::rest_callback() -> the SAME setup -> callback()
+ *
+ * So the only ways the two can diverge are (1) the edit-context filter set drifting
+ * out of sync (the jetpack#42377 regression class) and (2) the REST route failing to
+ * pass through a request param the XML-RPC query carried. This assertion drives both
+ * paths over shared fixtures and compares the decoded bodies, catching exactly that.
+ *
+ * Self-contained: it creates its own admin user, aligns the Jetpack blog id, and mocks
+ * the request signature internally. A consuming WP_UnitTestCase only needs to call
+ * tear_down_rest_parity() from its tear_down().
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+
+/**
+ * Asserts REST-vs-XML-RPC body parity for a JSON API endpoint.
+ *
+ * Intended to be used only by WP_UnitTestCase subclasses; it relies on their assert*()
+ * and factory() methods. The @mixin resolves those for static analysis.
+ *
+ * @mixin \WP_UnitTestCase
+ */
+trait Assert_Rest_Xmlrpc_Parity {
+
+	/**
+	 * Blog id both dispatch paths resolve to.
+	 *
+	 * @var int
+	 */
+	private $rest_parity_blog_id;
+
+	/**
+	 * Admin user the parity request authenticates as.
+	 *
+	 * @var int
+	 */
+	private $rest_parity_user_id;
+
+	/**
+	 * Saved $_SERVER values to restore in tear_down.
+	 *
+	 * @var array
+	 */
+	private $rest_parity_server = array();
+
+	/**
+	 * Assert that the REST dispatch of $endpoint matches its XML-RPC dispatch.
+	 *
+	 * @param WPCOM_JSON_API_Endpoint $endpoint   The endpoint under test.
+	 * @param array                   $query      Request params (number, context, type, ...).
+	 * @param array                   $url_params Route placeholder values (post id, slug, ...).
+	 * @param string|null             $api_path   Concrete API path; defaults to the endpoint
+	 *                                            path with the blog id substituted.
+	 * @return array{0: mixed, 1: mixed} [ xmlrpc_body, rest_body ] for further assertions.
+	 */
+	protected function assert_rest_parity( WPCOM_JSON_API_Endpoint $endpoint, array $query = array(), array $url_params = array(), $api_path = null ) {
+		$this->prepare_rest_parity_env();
+
+		if ( null === $api_path ) {
+			$api_path = false === strpos( (string) $endpoint->path, '%' )
+				? $endpoint->path
+				: sprintf( $endpoint->path, $this->rest_parity_blog_id );
+		}
+
+		// The endpoint is actually REST-enabled and its route resolves.
+		$this->assertNotEmpty( $endpoint->rest_route, 'Endpoint declares a rest_route.' );
+		$this->assertStringContainsString(
+			ltrim( $endpoint->rest_route, '/' ),
+			$endpoint->build_rest_route(),
+			'build_rest_route() includes the declared rest_route.'
+		);
+
+		$xmlrpc = $this->dispatch_xmlrpc_body( $endpoint, $api_path, $query, $url_params );
+		$rest   = $this->dispatch_rest_body( $endpoint, $query, $url_params );
+
+		$this->assertEquals(
+			$xmlrpc,
+			$rest,
+			'REST response body diverged from the XML-RPC body for ' . $api_path
+		);
+
+		return array( $xmlrpc, $rest );
+	}
+
+	/**
+	 * Remove the filters/superglobals the parity helpers install. Call from tear_down().
+	 */
+	protected function tear_down_rest_parity() {
+		remove_all_filters( 'pre_option_jetpack_private_options' );
+		remove_filter( 'user_can_richedit', '__return_true' );
+		remove_filter( 'comment_edit_pre', array( WPCOM_JSON_API::init(), 'comment_edit_pre' ) );
+
+		unset( $_GET['token'], $_GET['timestamp'], $_GET['nonce'], $_GET['body-hash'], $_GET['signature'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		foreach ( $this->rest_parity_server as $key => $value ) {
+			if ( null === $value ) {
+				unset( $_SERVER[ $key ] );
+			} else {
+				$_SERVER[ $key ] = $value;
+			}
+		}
+		$this->rest_parity_server = array();
+
+		if ( class_exists( Connection_Rest_Authentication::class ) ) {
+			Connection_Rest_Authentication::init()->reset_saved_auth_state();
+		}
+
+		WPCOM_JSON_API::init()->query = array();
+	}
+
+	/**
+	 * Lazily set up the shared fixtures: an admin user, the blog id alignment, and the
+	 * baseline request environment. Idempotent within a single test.
+	 */
+	private function prepare_rest_parity_env() {
+		if ( isset( $this->rest_parity_blog_id ) ) {
+			return;
+		}
+
+		$this->rest_parity_blog_id = (int) $GLOBALS['blog_id'];
+		$this->rest_parity_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->rest_parity_user_id );
+
+		// rest_callback() derives the blog id from Jetpack_Options::get_option( 'id' );
+		// align it with the test blog so both dispatch paths resolve the same site.
+		Jetpack_Options::update_option( 'id', $this->rest_parity_blog_id );
+
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $this->rest_parity_blog_id );
+
+		foreach ( array( 'HTTP_HOST', 'REQUEST_URI', 'REQUEST_METHOD' ) as $key ) {
+			$this->rest_parity_server[ $key ] = $_SERVER[ $key ] ?? null;
+		}
+	}
+
+	/**
+	 * Run the endpoint the XML-RPC way: reproduce serve()'s request context + edit-context
+	 * filters, set the shared query, and invoke callback() directly.
+	 *
+	 * @param WPCOM_JSON_API_Endpoint $endpoint   Endpoint.
+	 * @param string                  $api_path   Concrete API path.
+	 * @param array                   $query      Request params.
+	 * @param array                   $url_params Route placeholder values.
+	 * @return mixed Decoded body.
+	 */
+	private function dispatch_xmlrpc_body( WPCOM_JSON_API_Endpoint $endpoint, $api_path, array $query, array $url_params ) {
+		$api        = WPCOM_JSON_API::init();
+		$api->query = $query;
+
+		// Mirror the request context both serve() and rest_callback() establish before
+		// dispatch, so version-dependent output (e.g. link URLs) matches. rest_callback()
+		// sets these at class.json-api-endpoints.php:2753-2756.
+		$api->endpoint = $endpoint;
+		$api->path     = $endpoint->path;
+		$api->version  = $endpoint->max_version;
+
+		// Mirror WPCOM_JSON_API::serve() (class.json-api.php:413-415).
+		add_filter( 'user_can_richedit', '__return_true' );
+		add_filter( 'comment_edit_pre', array( $api, 'comment_edit_pre' ) );
+
+		$args     = array_merge( array( $api_path, $this->rest_parity_blog_id ), array_values( $url_params ) );
+		$response = call_user_func_array( array( $endpoint, 'callback' ), $args );
+
+		remove_filter( 'user_can_richedit', '__return_true' );
+		remove_filter( 'comment_edit_pre', array( $api, 'comment_edit_pre' ) );
+
+		return $this->normalize_body( $response );
+	}
+
+	/**
+	 * Run the endpoint through the real rest_callback() and return its decoded body.
+	 *
+	 * @param WPCOM_JSON_API_Endpoint $endpoint   Endpoint.
+	 * @param array                   $query      Request params.
+	 * @param array                   $url_params Route placeholder values.
+	 * @return mixed Decoded body.
+	 */
+	private function dispatch_rest_body( WPCOM_JSON_API_Endpoint $endpoint, array $query, array $url_params ) {
+		// callback() reads params from $this->api->query, same source as the XML-RPC path.
+		WPCOM_JSON_API::init()->query = $query;
+
+		$this->set_up_rest_authentication();
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/' . ltrim( $endpoint->build_rest_route(), '/' ) );
+		$request->set_url_params( $url_params );
+		foreach ( $query as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response = $endpoint->rest_callback( $request );
+
+		$this->assertIsArray( $response, 'rest_callback() returns [ json, nonce, hmac ].' );
+		$this->assertCount( 3, $response, 'rest_callback() returns [ json, nonce, hmac ].' );
+
+		return json_decode( $response[0], true );
+	}
+
+	/**
+	 * Normalize a callback() return into the same decoded shape rest_callback() emits
+	 * (WP_Error -> serializable error, then a JSON round-trip so objects become arrays).
+	 *
+	 * @param mixed $response Raw callback() return.
+	 * @return mixed Decoded body.
+	 */
+	private function normalize_body( $response ) {
+		if ( is_wp_error( $response ) ) {
+			$response = WPCOM_JSON_API::serializable_error( $response );
+		}
+		return json_decode( wp_json_encode( $response, JSON_UNESCAPED_SLASHES ), true );
+	}
+
+	/**
+	 * Mock the signature/token environment so rest_callback() passes verification.
+	 * Mirrors WPCOM_JSON_API_Endpoint_Rest_Callback_Test::set_up_authentication().
+	 */
+	private function set_up_rest_authentication() {
+		if ( class_exists( Connection_Rest_Authentication::class ) ) {
+			Connection_Rest_Authentication::init()->reset_saved_auth_state();
+		}
+
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
+
+		$_SERVER['HTTP_HOST']      = 'example.org';
+		$_SERVER['REQUEST_URI']    = '/jetpack/v4/test?qstest=yep';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$_GET['token']     = 'pretend_this_is_valid:1:' . $this->rest_parity_user_id;
+		$_GET['timestamp'] = (string) time();
+		$_GET['nonce']     = 'testing123';
+
+		$_GET['signature'] = base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			hash_hmac(
+				'sha1',
+				implode(
+					"\n",
+					array(
+						$_GET['token'],
+						$_GET['timestamp'],
+						$_GET['nonce'],
+						'',
+						'GET',
+						'example.org',
+						'80',
+						'/jetpack/v4/test',
+						'qstest=yep',
+					)
+				) . "\n",
+				'secret',
+				true
+			)
+		);
+	}
+
+	/**
+	 * Provide test tokens via the jetpack_private_options option.
+	 *
+	 * @param mixed  $value       Original option value (unused).
+	 * @param string $option_name Option name (unused).
+	 * @return array
+	 */
+	public function mock_jetpack_private_options( $value, $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array(
+			'user_tokens' => array(
+				$this->rest_parity_user_id => 'pretend_this_is_valid.secret.' . $this->rest_parity_user_id,
+			),
+			'blog_token'  => 'pretend_this_is_valid_blog_token.secret_blog',
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -292,6 +292,10 @@ trait Assert_Rest_Xmlrpc_Parity {
 		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
 
+		// rest_callback()'s signature check (Connection\Manager::verify_xml_rpc_signature) rebuilds
+		// the HMAC from these superglobals, not from the WP_REST_Request route. So the request line
+		// here is fixed and self-consistent with the signature computed below -- the actual endpoint
+		// route the request object carries is irrelevant to verification.
 		$_SERVER['HTTP_HOST']      = 'example.org';
 		$_SERVER['REQUEST_URI']    = '/jetpack/v4/test?qstest=yep';
 		$_SERVER['REQUEST_METHOD'] = 'GET';

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -28,9 +28,12 @@ use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authent
  * Asserts REST-vs-XML-RPC body parity for a JSON API endpoint.
  *
  * Intended to be used only by WP_UnitTestCase subclasses; it relies on their assert*()
- * and factory() methods. The @mixin resolves those for static analysis.
+ * and factory() methods. The mixin annotation below resolves the instance assertions for
+ * static analysis; the static factory() is declared explicitly (a trait can't resolve a
+ * self:: call against the mixin).
  *
  * @mixin \WP_UnitTestCase
+ * @method static \WP_UnitTest_Factory factory()
  */
 trait Assert_Rest_Xmlrpc_Parity {
 

--- a/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
+++ b/projects/plugins/jetpack/tests/php/json-api/trait-assert-rest-xmlrpc-parity.php
@@ -84,18 +84,21 @@ trait Assert_Rest_Xmlrpc_Parity {
 	 *
 	 * @param WPCOM_JSON_API_Endpoint $endpoint   The endpoint under test.
 	 * @param array                   $query      Request params (number, context, type, ...).
-	 * @param array                   $url_params Route placeholder values (post id, slug, ...).
-	 * @param string|null             $api_path   Concrete API path; defaults to the endpoint
-	 *                                            path with the blog id substituted.
+	 * @param array                   $url_params Route placeholder values beyond the site, in path
+	 *                                            order (post id, slug, ...).
+	 * @param string|null             $api_path   Concrete API path; defaults to the endpoint path
+	 *                                            with the blog id and $url_params substituted.
 	 * @return array{0: mixed, 1: mixed} [ xmlrpc_body, rest_body ] for further assertions.
 	 */
 	protected function assert_rest_parity( WPCOM_JSON_API_Endpoint $endpoint, array $query = array(), array $url_params = array(), $api_path = null ) {
 		$this->prepare_rest_parity_env();
 
 		if ( null === $api_path ) {
+			// The site is always the first placeholder; any remaining placeholders (post id, slug)
+			// are filled positionally from $url_params, so multi-placeholder paths resolve too.
 			$api_path = false === strpos( (string) $endpoint->path, '%' )
 				? $endpoint->path
-				: sprintf( $endpoint->path, $this->rest_parity_blog_id );
+				: vsprintf( $endpoint->path, array_merge( array( $this->rest_parity_blog_id ), array_values( $url_params ) ) );
 		}
 
 		// The endpoint is actually REST-enabled and its route resolves.
@@ -224,13 +227,20 @@ trait Assert_Rest_Xmlrpc_Parity {
 	/**
 	 * Run the endpoint through the real rest_callback() and return its decoded body.
 	 *
+	 * Query params reach callback() the same way they do in production: via the shared
+	 * WPCOM_JSON_API singleton's ->query, which the real request populates by parsing the
+	 * request URL (class.json-api.php). rest_callback() itself only pulls the route placeholders
+	 * (get_url_params()) plus `language`/`http_envelope` off the WP_REST_Request, so we set the
+	 * query on the singleton and also mirror it onto the request to cover those request-read keys.
+	 * Both transports therefore read the identical ->query — this asserts callback()/rest_callback()
+	 * parity, not the URL-to-query parsing, which is shared and not REST-specific.
+	 *
 	 * @param WPCOM_JSON_API_Endpoint $endpoint   Endpoint.
 	 * @param array                   $query      Request params.
 	 * @param array                   $url_params Route placeholder values.
 	 * @return mixed Decoded body.
 	 */
 	private function dispatch_rest_body( WPCOM_JSON_API_Endpoint $endpoint, array $query, array $url_params ) {
-		// callback() reads params from $this->api->query, same source as the XML-RPC path.
 		WPCOM_JSON_API::init()->query = $query;
 
 		$this->set_up_rest_authentication();


### PR DESCRIPTION
Based on CONNECT-235.

## Proposed changes

Adds a test trait, `Assert_Rest_Xmlrpc_Parity`, that runs a JSON API endpoint through both dispatch paths a Jetpack site uses (the XML-RPC `callback()` via `serve()`, and `rest_callback()`) and checks the decoded bodies match.

Two tiers use it:

- `WPCOM_JSON_API_Rest_Parity_Coverage_Test` auto-discovers every registered GET endpoint that has a `rest_route` and whose only path placeholder is the site, and asserts default-request parity. New conversions are covered as soon as they add `rest_route`, nothing to hand-write. Today that's `/posts`, `/site`, `/users`, `/plugins`.
- A bespoke case in `WPCOM_JSON_API_List_Posts_Endpoint_Test` covers `/posts` with `context=edit`, locking the #42377 content-encoding fix.

## Why

Both paths call the same `callback()`, so they can only drift two ways: `rest_callback()` and `serve()` stop applying the same edit-context filters (what broke in jetpack#42377), or the REST route drops a query param. Nothing caught that before — the wpcom-side comparator from CONNECT-225 only samples a sliver of live traffic.

Endpoints that need specific inputs, URL placeholders (post id / slug), or fixtures get a bespoke case next to that endpoint's tests; the coverage sweep handles the simple GET ones.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

```
jetpack docker phpunit jetpack -- --filter='WPCOM_JSON_API_Rest_Parity_Coverage_Test|WPCOM_JSON_API_List_Posts_Endpoint_Test'
```

Passes: `OK (26 tests, 117 assertions)`. Test-only change, nothing tracked.


