### PR TITLE
Charts: add a Center layout primitive (CHARTS-212)

### DIFF
--- a/projects/js-packages/charts/changelog/add-center-layout-primitive
+++ b/projects/js-packages/charts/changelog/add-center-layout-primitive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: add an internal Center layout primitive and use it for centered chart wrappers.

--- a/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { FC, useContext, useMemo } from 'react';
 import { Chart } from 'react-google-charts';
@@ -13,6 +12,7 @@ import { GlobalChartsContext, GlobalChartsProvider, useGlobalChartsContext } fro
 import { lightenHexColor, normalizeColorToHex } from '../../utils/color-utils';
 import { resolveCssVariable } from '../../utils/resolve-css-var';
 import { sanitizeHtml } from '../../utils/sanitize-html';
+import { Center } from '../private/center';
 import { withResponsive } from '../private/with-responsive';
 import styles from './geo-chart.module.scss';
 import { GeoChartProps } from './types';
@@ -60,15 +60,13 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 
 	// Render loading placeholder
 	const loadingPlaceholder = (
-		<Stack
-			align="center"
-			justify="center"
+		<Center
 			className={ clsx( 'geo-chart', styles.container, className ) }
 			data-testid="geo-chart-loading"
 			style={ { width, height } }
 		>
 			{ renderPlaceholder ? renderPlaceholder() : __( 'Loading map', 'jetpack-charts' ) }
-		</Stack>
+		</Center>
 	);
 
 	// Google charts doesn't accept CSS variables, so we need to convert them to hex colors
@@ -149,9 +147,7 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 	);
 
 	return (
-		<Stack
-			align="center"
-			justify="center"
+		<Center
 			className={ clsx( 'geo-chart', styles.container, className ) }
 			data-testid="geo-chart"
 			style={ { width, height, backgroundColor } }
@@ -164,7 +160,7 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 				options={ options }
 				loader={ loadingPlaceholder }
 			/>
-		</Stack>
+		</Center>
 	);
 };
 

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.module.scss
@@ -7,8 +7,4 @@
 		width: 100%;
 	}
 
-	&__centering {
-		width: 100%;
-		height: 100%;
-	}
 }

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -2,7 +2,6 @@ import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
@@ -22,6 +21,7 @@ import {
 } from '../../providers';
 import { attachSubComponents, resolveFontSize } from '../../utils';
 import { getStringWidth } from '../../visx/text';
+import { Center } from '../private/center';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { ChartLayout } from '../private/chart-layout';
 import { RadialWipeAnimation } from '../private/radial-wipe-animation/';
@@ -358,12 +358,7 @@ const PieChartInternal = ( {
 						: 0;
 
 					return (
-						<Stack
-							ref={ containerRef }
-							align="center"
-							justify="center"
-							className={ styles[ 'pie-chart__centering' ] }
-						>
+						<Center ref={ containerRef }>
 							<svg
 								viewBox={ `0 0 ${ width } ${ height }` }
 								preserveAspectRatio="xMidYMid meet"
@@ -493,7 +488,7 @@ const PieChartInternal = ( {
 									{ ! allSegmentsHidden && svgChildren }
 								</Group>
 							</svg>
-						</Stack>
+						</Center>
 					);
 				} }
 			</ChartLayout>

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
@@ -5,11 +5,6 @@
 		width: 100%;
 	}
 
-	&__centering {
-		width: 100%;
-		height: 100%;
-	}
-
 	.label {
 		font-weight: var(--wpds-typography-font-weight-medium, 499);
 		font-size: var(--wpds-typography-font-size-lg, 16px);

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -3,7 +3,6 @@ import { Pie } from '@visx/shape';
 import { Text } from '@visx/text';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
@@ -21,6 +20,7 @@ import {
 	GlobalChartsContext,
 } from '../../providers';
 import { attachSubComponents } from '../../utils';
+import { Center } from '../private/center';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { ChartLayout } from '../private/chart-layout';
 import { RadialWipeAnimation } from '../private/radial-wipe-animation';
@@ -397,12 +397,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 					const innerRadius = radius * ( 1 - thickness );
 
 					return (
-						<Stack
-							ref={ containerRef }
-							align="center"
-							justify="center"
-							className={ styles[ 'pie-semi-circle-chart__centering' ] }
-						>
+						<Center ref={ containerRef }>
 							<svg
 								width={ width }
 								height={ height }
@@ -491,7 +486,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 									) }
 								</Group>
 							</svg>
-						</Stack>
+						</Center>
 					);
 				} }
 			</ChartLayout>

--- a/projects/js-packages/charts/src/charts/private/center/center.module.scss
+++ b/projects/js-packages/charts/src/charts/private/center/center.module.scss
@@ -1,0 +1,4 @@
+.center {
+	width: 100%;
+	height: 100%;
+}

--- a/projects/js-packages/charts/src/charts/private/center/center.tsx
+++ b/projects/js-packages/charts/src/charts/private/center/center.tsx
@@ -1,0 +1,33 @@
+import { Stack } from '@wordpress/ui';
+import clsx from 'clsx';
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import styles from './center.module.scss';
+
+export type CenterProps = ComponentPropsWithoutRef< typeof Stack >;
+
+/**
+ * Centers its children on both axes and fills its parent.
+ *
+ * A thin wrapper around `Stack` with `align="center"` and `justify="center"`
+ * defaults (both overridable) plus `width: 100%; height: 100%`. Reads more
+ * honestly than a `Stack` with both axes centered, and lets call sites drop
+ * ad-hoc `*__centering` classes. Forwards its ref and spreads remaining props
+ * onto the underlying `Stack`.
+ *
+ * @param props - Stack props; `align`/`justify` default to `"center"`.
+ * @param ref   - Forwarded to the underlying element.
+ * @return The centered layout element.
+ */
+export const Center = forwardRef< HTMLDivElement, CenterProps >(
+	( { align = 'center', justify = 'center', className, ...props }, ref ) => (
+		<Stack
+			ref={ ref }
+			align={ align }
+			justify={ justify }
+			className={ clsx( styles.center, className ) }
+			{ ...props }
+		/>
+	)
+);
+
+Center.displayName = 'Center';

--- a/projects/js-packages/charts/src/charts/private/center/index.ts
+++ b/projects/js-packages/charts/src/charts/private/center/index.ts
@@ -1,0 +1,2 @@
+export { Center } from './center';
+export type { CenterProps } from './center';

--- a/projects/js-packages/charts/src/charts/private/center/test/center.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/center/test/center.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { Center } from '../index';
+
+describe( 'Center', () => {
+	test( 'renders its children', () => {
+		render(
+			<Center data-testid="center">
+				<span>Centered content</span>
+			</Center>
+		);
+		expect( screen.getByTestId( 'center' ) ).toHaveTextContent( 'Centered content' );
+	} );
+
+	test( 'merges a custom className with the center class', () => {
+		render(
+			<Center data-testid="center" className="custom-class">
+				child
+			</Center>
+		);
+		const el = screen.getByTestId( 'center' );
+		expect( el ).toHaveClass( 'center' );
+		expect( el ).toHaveClass( 'custom-class' );
+	} );
+
+	test( 'forwards its ref to the underlying element', () => {
+		const ref = createRef< HTMLDivElement >();
+		render( <Center ref={ ref }>child</Center> );
+		expect( ref.current ).toBeInstanceOf( HTMLElement );
+	} );
+
+	test( 'spreads arbitrary props through to the element', () => {
+		render(
+			<Center data-testid="center" style={ { width: 120 } }>
+				child
+			</Center>
+		);
+		expect( screen.getByTestId( 'center' ) ).toHaveStyle( { width: '120px' } );
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/private/center/test/center.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/center/test/center.test.tsx
@@ -37,4 +37,24 @@ describe( 'Center', () => {
 		);
 		expect( screen.getByTestId( 'center' ) ).toHaveStyle( { width: '120px' } );
 	} );
+
+	test( 'centers on both axes by default', () => {
+		render( <Center data-testid="center">child</Center> );
+		expect( screen.getByTestId( 'center' ) ).toHaveStyle( {
+			alignItems: 'center',
+			justifyContent: 'center',
+		} );
+	} );
+
+	test( 'allows overriding the align and justify defaults', () => {
+		render(
+			<Center data-testid="center" align="flex-start" justify="flex-end">
+				child
+			</Center>
+		);
+		expect( screen.getByTestId( 'center' ) ).toHaveStyle( {
+			alignItems: 'flex-start',
+			justifyContent: 'flex-end',
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
+++ b/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
@@ -1,7 +1,5 @@
 .svg-empty-state {
 	text-align: center;
-	width: 100%;
-	height: 100%;
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
 }

--- a/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.tsx
+++ b/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@wordpress/ui';
+import { Center } from '../center';
 import styles from './svg-empty-state.module.scss';
 import type { FC, ReactNode } from 'react';
 
@@ -32,9 +32,7 @@ interface SvgEmptyStateProps {
 export const SvgEmptyState: FC< SvgEmptyStateProps > = ( { x, y, width, height, children } ) => {
 	return (
 		<foreignObject x={ x - width / 2 } y={ y - height / 2 } width={ width } height={ height }>
-			<Stack align="center" justify="center" className={ styles[ 'svg-empty-state' ] }>
-				{ children }
-			</Stack>
+			<Center className={ styles[ 'svg-empty-state' ] }>{ children }</Center>
 		</foreignObject>
 	);
 };


### PR DESCRIPTION
Fixes CHARTS-212

## Why

During the Stack migration (#47981) some `<Stack align="center" justify="center">` usages were really centered, parent-filling wrappers rather than stacks — the layout intent was obscured, and two pie charts had already hand-named it with `*__centering` CSS classes (a tell that "centered box" is a recurring concept). A dedicated `<Center>` primitive states that intent directly, removes the duplicated centering/fill boilerplate, and gives the package one obvious home for it going forward.

## Proposed changes

* Add a private `Center` layout primitive (`src/charts/private/center/`) — a thin `forwardRef` wrapper around `@wordpress/ui`'s `Stack` with `align="center"`/`justify="center"` defaults (both overridable) plus `width/height: 100%`. It forwards its ref and spreads remaining props through.
* Migrate the five call sites that used `<Stack align="center" justify="center">` purely to center content: GeoChart (loading placeholder + main container), PieChart, PieSemiCircleChart, and the private SvgEmptyState.
* Drop the now-redundant `pie-chart__centering` / `pie-semi-circle-chart__centering` SCSS rules and the duplicate `width/height: 100%` in `svg-empty-state` — that fill behaviour now lives in `Center`.

Note: those `*__centering` classes only ever applied `width/height: 100%` (the centering came from `Stack`'s `align`/`justify` props), so the fill was folded into `Center` rather than deleted outright.

## Related product discussion/links

* CHARTS-212
* Pattern flagged during the Stack migration in #47981

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

From `projects/js-packages/charts`:

* `pnpm run test` — 875 tests pass (includes 4 new `Center` tests).
* `pnpm run typecheck` — clean.
* `pnpm run storybook`, then open these stories and confirm each still renders centered and fills its container, with labels and empty-state messages intact (no visual change vs. `trunk`):
  * Charts → Pie Chart → Default
  * Charts → Geo Chart → Default, Empty Data
  * Charts → Pie Semi Circle Chart → Default
  * Charts → Pie Chart → Error States (exercises the empty-state component)
