### PR TITLE
Reader Chat: skip asset-cache tests under SCRIPT_DEBUG

### DIFF
--- a/projects/plugins/jetpack/changelog/2026-05-26-13-39-54-517693
+++ b/projects/plugins/jetpack/changelog/2026-05-26-13-39-54-517693
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Reader Chat: skip asset-cache unit tests when SCRIPT_DEBUG is enabled

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
@@ -1108,6 +1108,10 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 	 * page loads do not retry the remote manifest on every request.
 	 */
 	public function test_enqueue_scripts_caches_asset_fetch_failure() {
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$this->markTestSkipped( 'Asset manifest transients are bypassed when SCRIPT_DEBUG is enabled.' );
+		}
+
 		$this->override_ai_features( true );
 		delete_transient( AiAssistantPlugin\READER_CHAT_ASSET_TRANSIENT );
 
@@ -1136,6 +1140,10 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 	 * version string matches what was cached.
 	 */
 	public function test_enqueue_scripts_uses_cached_asset_version() {
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$this->markTestSkipped( 'Asset manifest transients are bypassed when SCRIPT_DEBUG is enabled.' );
+		}
+
 		$this->override_ai_features( true );
 		$this->cache_asset_data( array( 'version' => 'cached-1.2.3' ) );
 


### PR DESCRIPTION
Two Reader Chat tests fail when running `jetpack docker phpunit`, but pass in CI.
The code skips caching the asset version when `SCRIPT_DEBUG` is on. Docker turns `SCRIPT_DEBUG` on, CI leaves it off — so the two tests that check caching only fail under docker.

## Proposed changes
* Skip those two tests when `SCRIPT_DEBUG` is on, same as the existing `Jetpack_AI_Sidebar_Test`. Tests only, no production code changes.

> **Follow-up to consider:** this skip-guard has to be remembered for every new cache-dependent test. A root fix would be to read `SCRIPT_DEBUG` via `Constants::is_true()` so tests can pin it and exercise the caching path directly; no guard needed and no skipped tests. `Jetpack_Test` already drives `SCRIPT_DEBUG` this way via `Constants::set_constant()`, so the pattern is established. Out of scope here.

## Does this pull request change what data or activity we track or use?

No. Test-only change.

## Testing instructions

* Run: `jetpack docker phpunit jetpack -- --filter=Jetpack_Reader_Chat_Test`
* Before: 2 failures. After: 0 failures (the two tests show as skipped).
