### PR TITLE
Write: Allow dragging an image file into a post

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-2172-add-ability-to-drag-image-into-post
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-2172-add-ability-to-drag-image-into-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Allow dragging an image file directly into a post to insert it, no image block needed first.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1175,6 +1175,39 @@
 	pointer-events: none;
 }
 
+/* Horizontal drop indicator on the block where a dragged image will land.
+   `--before` draws above the block; `--after` draws below. */
+.bw-content .bw-drop-target--before,
+.bw-content .bw-drop-target--after {
+	position: relative;
+}
+
+.bw-content .bw-drop-target--before::before,
+.bw-content .bw-drop-target--after::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	height: 3px;
+	background: var(--studio-blue-50, #1d4fc4);
+	border-radius: 2px;
+	pointer-events: none;
+}
+
+.bw-content .bw-drop-target--before::before {
+	top: -2px;
+}
+
+.bw-content .bw-drop-target--after::after {
+	bottom: -2px;
+}
+
+/* Pre-upload placeholder figure: dim the locally-previewed image while
+   the upload is in flight, then snap back once the real URL is in place. */
+.bw-content .bw-image-figure.bw-image-uploading img {
+	opacity: 0.5;
+}
+
 .bw-content p {
 	font-size: inherit;
 	line-height: inherit;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2896,7 +2896,11 @@ function uploadAndInsertImage( file ) {
 	if ( ! content ) return;
 
 	const figure = document.createElement( 'figure' );
-	figure.className = 'bw-image-figure bw-image-uploading';
+	// Apply size-large up-front so the placeholder renders at the same
+	// 75% width the figure will land at after upload. Without it the
+	// locally-previewed image renders at its natural pixel size and
+	// snaps narrower the moment the swap runs.
+	figure.className = 'bw-image-figure bw-image-uploading size-large';
 	const img = document.createElement( 'img' );
 	const localUrl = URL.createObjectURL( file );
 	img.src = localUrl;
@@ -5459,5 +5463,45 @@ window.addEventListener( 'pageshow', event => {
 window.addEventListener( 'pagehide', () => {
 	if ( autosaveTimer ) {
 		clearInterval( autosaveTimer );
+	}
+} );
+
+// File-drop safety net: .bw-content has min-height:60vh but doesn't
+// fill the rest of the viewport, and a long post can extend below the
+// viewport entirely. A file dropped outside .bw-content would otherwise
+// be opened by the browser. Catch file drags at the window level so
+// dropping anywhere on the Write page inserts at the end of the post
+// instead of navigating away from the editor.
+window.addEventListener( 'dragover', event => {
+	if ( ! event.dataTransfer?.types?.includes( 'Files' ) ) return;
+	event.preventDefault();
+	event.dataTransfer.dropEffect = 'copy';
+} );
+
+window.addEventListener( 'drop', event => {
+	if ( ! event.dataTransfer?.types?.includes( 'Files' ) ) return;
+	// The editor (.bw-content) and the image-modal overlay each have
+	// their own data-wp-on--drop handlers; those fire on the inner
+	// target first and bubble up to here. Only handle drops that
+	// landed outside both.
+	const target = event.target;
+	if (
+		target instanceof Element &&
+		( target.closest( '.bw-content' ) || target.closest( '.bw-image-overlay:not([hidden])' ) )
+	) {
+		return;
+	}
+	event.preventDefault();
+
+	const images = Array.from( event.dataTransfer.files || [] ).filter( f =>
+		f.type.startsWith( 'image/' )
+	);
+	if ( ! images.length ) return;
+
+	const content = getContent();
+	if ( ! content ) return;
+	placeCursorAtEnd( content );
+	for ( const file of images ) {
+		uploadAndInsertImage( file );
 	}
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5482,12 +5482,17 @@ window.addEventListener( 'drop', event => {
 	if ( ! event.dataTransfer?.types?.includes( 'Files' ) ) return;
 	// The editor (.bw-content) and the image-modal overlay each have
 	// their own data-wp-on--drop handlers; those fire on the inner
-	// target first and bubble up to here. Only handle drops that
-	// landed outside both.
-	const target = event.target;
+	// target first and bubble up to here. Check via composedPath rather
+	// than target.closest because the editor handler removes the empty
+	// <p> that was the drop target (insertMediaBlock collapses an empty
+	// trailing paragraph into the figure), leaving event.target detached
+	// and breaking ancestor lookups. composedPath is snapshotted at
+	// dispatch time and stays valid through the mutation.
+	const path = event.composedPath();
 	if (
-		target instanceof Element &&
-		( target.closest( '.bw-content' ) || target.closest( '.bw-image-overlay:not([hidden])' ) )
+		path.some(
+			el => el instanceof Element && el.matches?.( '.bw-content, .bw-image-overlay:not([hidden])' )
+		)
 	) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -2785,6 +2785,7 @@ function placeCaretAtPoint( x, y ) {
 		}
 	} else if ( document.caretRangeFromPoint ) {
 		range = document.caretRangeFromPoint( x, y );
+		range?.collapse( true );
 	}
 
 	if ( ! range || ! content.contains( range.startContainer ) ) {
@@ -2906,11 +2907,22 @@ function uploadAndInsertImage( file ) {
 	if ( p ) {
 		placeCursorAt( p );
 	}
-	pushToUndoHistory();
+	// Deliberately do NOT push undo history here: the placeholder figure's
+	// img.src is a blob: URL that gets revoked when the upload completes.
+	// Capturing the placeholder in an undo snapshot would let Cmd+Z restore
+	// a dead blob URL, which would then serialize into the saved post. The
+	// undo snapshot is pushed inside the swap below, after the real URL
+	// and wp-image-{id} class are in place.
 
 	const swap = ( async () => {
 		try {
 			const media = await uploadMedia( file );
+			// If the figure was removed during the upload (e.g. by undo or
+			// manual delete), skip the DOM swap. The upload still lives in
+			// the media library, which is harmless.
+			if ( ! content.contains( figure ) ) {
+				return;
+			}
 			// Tag the figure with the media-library id+size so the
 			// save-time serializer produces a real <!-- wp:image --> block.
 			img.src = media.source_url;
@@ -2925,8 +2937,11 @@ function uploadAndInsertImage( file ) {
 			stripRuntimeFigureControls( figure );
 			addDeleteButtons();
 			await applyMediaSizeToFigure( figure, 'large' );
+			pushToUndoHistory();
 		} catch ( err ) {
-			figure.remove();
+			if ( content.contains( figure ) ) {
+				figure.remove();
+			}
 			state.message = ( i18n.uploadFailed || 'Upload failed: %s' ).replace( '%s', err.message );
 			setTimeout( () => {
 				state.message = '';

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1972,6 +1972,23 @@ function resetUploadZone() {
 }
 
 /**
+ * POST a file to the media REST endpoint. Returns the media response.
+ * No side effects on state or DOM — callers handle the result.
+ *
+ * @param {File} file - The file to upload.
+ * @return {Promise<Object>} The media library response.
+ */
+async function uploadMedia( file ) {
+	const formData = new FormData();
+	formData.append( 'file', file );
+	return await window.wp.apiFetch( {
+		path: state.mediaPath,
+		method: 'POST',
+		body: formData,
+	} );
+}
+
+/**
  * Upload a file to the media library and update state with the result.
  *
  * @param {File} file - The file to upload.
@@ -1988,15 +2005,8 @@ async function uploadFileToMedia( file ) {
 		if ( saving ) saving.style.display = '';
 	}
 
-	const formData = new FormData();
-	formData.append( 'file', file );
-
 	try {
-		const media = await window.wp.apiFetch( {
-			path: state.mediaPath,
-			method: 'POST',
-			body: formData,
-		} );
+		const media = await uploadMedia( file );
 		state.isUploading = false;
 		if ( zone ) zone.classList.remove( 'bw-uploading' );
 
@@ -2749,6 +2759,183 @@ function insertMediaBlock( mediaEl ) {
 
 	ensureBlockStructure();
 	return p;
+}
+
+/**
+ * Place the caret at the (x, y) viewport coordinates inside the editor.
+ * Uses the standard `caretPositionFromPoint`, falling back to the
+ * WebKit/Chromium-prefixed `caretRangeFromPoint`. Returns true if the
+ * caret was placed inside the editor; false otherwise.
+ *
+ * @param {number} x - Viewport X coordinate.
+ * @param {number} y - Viewport Y coordinate.
+ * @return {boolean} Whether the caret was placed inside the editor.
+ */
+function placeCaretAtPoint( x, y ) {
+	const content = getContent();
+	if ( ! content ) return false;
+
+	let range = null;
+	if ( document.caretPositionFromPoint ) {
+		const pos = document.caretPositionFromPoint( x, y );
+		if ( pos && pos.offsetNode ) {
+			range = document.createRange();
+			range.setStart( pos.offsetNode, pos.offset );
+			range.collapse( true );
+		}
+	} else if ( document.caretRangeFromPoint ) {
+		range = document.caretRangeFromPoint( x, y );
+	}
+
+	if ( ! range || ! content.contains( range.startContainer ) ) {
+		return false;
+	}
+
+	const sel = window.getSelection();
+	sel.removeAllRanges();
+	sel.addRange( range );
+	return true;
+}
+
+// Currently highlighted drop-target block, so dragover can move the
+// indicator between blocks without re-querying every frame.
+let currentDropTarget = null;
+
+/**
+ * Show a visual indicator on the block where a dragged image will land.
+ * The indicator is a class on the block element itself (a top-level
+ * child of .bw-content-inner) so the CSS can position a horizontal line
+ * at the insertion point — under the target block, or above the first
+ * block if the drag is near the top edge.
+ *
+ * @param {number} x - Viewport X coordinate.
+ * @param {number} y - Viewport Y coordinate.
+ */
+function updateDropIndicator( x, y ) {
+	const content = getContent();
+	if ( ! content ) return;
+
+	let target = null;
+	let position = 'after';
+
+	if ( document.caretPositionFromPoint || document.caretRangeFromPoint ) {
+		let node = null;
+		if ( document.caretPositionFromPoint ) {
+			const pos = document.caretPositionFromPoint( x, y );
+			node = pos?.offsetNode || null;
+		} else {
+			const range = document.caretRangeFromPoint( x, y );
+			node = range?.startContainer || null;
+		}
+		// Walk up to the direct child of .bw-content-inner.
+		while ( node && node !== content && node.parentNode !== content ) {
+			node = node.parentNode;
+		}
+		if ( node && node.parentNode === content ) {
+			target = node;
+		}
+	}
+
+	// Fallback: pick the block closest to the y-coordinate, or the
+	// last block if the drag is below all content. Lets the indicator
+	// stay visible when hovering over the empty area below the post.
+	if ( ! target ) {
+		const blocks = Array.from( content.children );
+		for ( const block of blocks ) {
+			const rect = block.getBoundingClientRect();
+			if ( y < rect.top ) {
+				target = block;
+				position = 'before';
+				break;
+			}
+			target = block;
+		}
+	}
+
+	if ( ! target ) return;
+	if ( currentDropTarget === target ) {
+		// Position may have flipped on the same block — keep both states
+		// consistent by clearing the other one.
+		target.classList.toggle( 'bw-drop-target--before', position === 'before' );
+		target.classList.toggle( 'bw-drop-target--after', position === 'after' );
+		return;
+	}
+
+	clearDropIndicator();
+	target.classList.add(
+		position === 'before' ? 'bw-drop-target--before' : 'bw-drop-target--after'
+	);
+	currentDropTarget = target;
+}
+
+/**
+ * Remove the drop-target indicator from whichever block currently has it.
+ */
+function clearDropIndicator() {
+	if ( currentDropTarget ) {
+		currentDropTarget.classList.remove( 'bw-drop-target--before', 'bw-drop-target--after' );
+		currentDropTarget = null;
+	}
+}
+
+/**
+ * Upload an image file and insert it at the current caret position.
+ * Inserts a placeholder figure immediately (using a local object URL)
+ * so the user gets feedback while the upload is in flight, then
+ * replaces the placeholder with the media-library URL and ID once
+ * uploaded.
+ *
+ * The whole upload+swap is registered via trackMediaSizeSwap so
+ * savePost waits for it before serializing the editor.
+ *
+ * @param {File} file - The image file to upload.
+ */
+function uploadAndInsertImage( file ) {
+	const content = getContent();
+	if ( ! content ) return;
+
+	const figure = document.createElement( 'figure' );
+	figure.className = 'bw-image-figure bw-image-uploading';
+	const img = document.createElement( 'img' );
+	const localUrl = URL.createObjectURL( file );
+	img.src = localUrl;
+	img.alt = '';
+	figure.appendChild( img );
+
+	const p = insertMediaBlock( figure );
+	if ( p ) {
+		placeCursorAt( p );
+	}
+	pushToUndoHistory();
+
+	const swap = ( async () => {
+		try {
+			const media = await uploadMedia( file );
+			// Tag the figure with the media-library id+size so the
+			// save-time serializer produces a real <!-- wp:image --> block.
+			img.src = media.source_url;
+			img.alt = media.alt_text || '';
+			img.className = 'wp-image-' + media.id;
+			figure.className = 'bw-image-figure size-large';
+			mediaSizesCache.set( media.id, media.media_details?.sizes || null );
+			// The figure was decorated by addDeleteButtons() before upload,
+			// so it's missing the Size button (that branch is gated on
+			// getMediaIdFromImg). Strip and re-decorate now that the
+			// wp-image-{id} class is in place.
+			stripRuntimeFigureControls( figure );
+			addDeleteButtons();
+			await applyMediaSizeToFigure( figure, 'large' );
+		} catch ( err ) {
+			figure.remove();
+			state.message = ( i18n.uploadFailed || 'Upload failed: %s' ).replace( '%s', err.message );
+			setTimeout( () => {
+				state.message = '';
+			}, 3000 );
+		} finally {
+			URL.revokeObjectURL( localUrl );
+		}
+	} )();
+	trackMediaSizeSwap( swap );
 }
 
 // --- Inline category meta helpers ---
@@ -4173,6 +4360,50 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 			await uploadFileToMedia( file );
+		},
+
+		handleEditorDragOver( event ) {
+			// Only react to file drags, not text/selection drags inside
+			// the editor (which we want to leave to the browser default).
+			if ( ! event.dataTransfer?.types?.includes( 'Files' ) ) return;
+			event.preventDefault();
+			event.dataTransfer.dropEffect = 'copy';
+			updateDropIndicator( event.clientX, event.clientY );
+		},
+
+		handleEditorDragLeave( event ) {
+			// dragleave fires when the pointer crosses any child element
+			// boundary; only clear the visual state when the drag truly
+			// leaves the editor wrapper.
+			if ( event.relatedTarget && event.currentTarget.contains( event.relatedTarget ) ) {
+				return;
+			}
+			clearDropIndicator();
+		},
+
+		handleEditorDrop( event ) {
+			if ( ! event.dataTransfer?.types?.includes( 'Files' ) ) return;
+			event.preventDefault();
+			clearDropIndicator();
+
+			const images = Array.from( event.dataTransfer.files || [] ).filter( f =>
+				f.type.startsWith( 'image/' )
+			);
+			if ( ! images.length ) return;
+
+			// Place the caret at the drop point once before inserting.
+			// Each insertMediaBlock leaves the caret in the trailing
+			// paragraph, so subsequent figures naturally stack below.
+			// If the drop lands outside the editable area, fall back to
+			// the end of the content.
+			const content = getContent();
+			if ( content && ! placeCaretAtPoint( event.clientX, event.clientY ) ) {
+				placeCursorAtEnd( content );
+			}
+
+			for ( const file of images ) {
+				uploadAndInsertImage( file );
+			}
 		},
 
 		// --- Slash commands ---

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1130,6 +1130,9 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--input="actions.repairStructure"
 				data-wp-on--keydown="actions.handleKeyDown"
 				data-wp-on--beforeinput="actions.handleBeforeInput"
+				data-wp-on--dragover="actions.handleEditorDragOver"
+				data-wp-on--dragleave="actions.handleEditorDragLeave"
+				data-wp-on--drop="actions.handleEditorDrop"
 				data-placeholder="<?php echo esc_attr__( 'Tell your story...', 'jetpack-mu-wpcom' ); ?>"
 			><div
 				class="bw-content-inner"


### PR DESCRIPTION
Fixes RSM-2172.

## Proposed changes
* Wire `dragover` / `dragleave` / `drop` handlers on `.bw-content` so an image file dropped anywhere on the post is uploaded and inserted at the drop position, matching Gutenberg. Previously you had to open the `/image` modal first.
* `placeCaretAtPoint` (cross-browser via `caretPositionFromPoint` / `caretRangeFromPoint`) puts the caret at the drop coordinates so the figure lands between blocks. Drops outside the editable area fall back to appending at the end.
* A horizontal indicator (`.bw-drop-target--before` / `--after`) draws under (or above) the target block during the drag so the user can see where the image will land.
* `uploadAndInsertImage` shows a local-URL placeholder immediately and then swaps in the `wp-image-{id}` + `size-large` classes after upload completes. The swap is registered via `trackMediaSizeSwap` so `savePost` waits for it before serializing.
* The placeholder figure is stripped and re-decorated after upload so it picks up the Size / Alt / Caption / Delete controls (the Size button is gated on `getMediaIdFromImg`, which is empty until upload finishes).
* Multi-file drops insert each image at the drop point in file order; non-image files in a mixed batch are silently ignored.
* `uploadFileToMedia` (the modal path) is refactored to share a tiny `uploadMedia` helper with the new path so both use the same REST call.
* The undo snapshot is pushed only after the upload swap resolves, so Cmd/Ctrl+Z never restores a revoked blob URL. If the user undoes mid-upload, the swap detects the detached figure and silently bails instead of mutating an orphaned node.

## Related product discussion/links
* RSM-2172

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Make sure you have the Write editor available (`/wp-admin/admin.php?page=write`).
2. From your file browser, drag a PNG/JPG onto the post body — anywhere on the editor surface, not just into a modal.
3. While dragging, confirm a horizontal indicator appears on the block where the image will land. Move between blocks and confirm it tracks.
4. Release. The image should appear at the drop position (with a brief faded placeholder while it uploads), and once uploaded should expose the same Size / Alt / Caption / Delete controls as an image inserted via `/image`.
5. Save the draft, then open the post in the block editor and confirm it appears as a real `<!-- wp:image -->` block with the right media ID and size.
6. Try dropping multiple image files at once — they should insert in file order at the drop point.
7. Try dropping a non-image file (e.g. a PDF) — nothing should insert, and the browser should not navigate away.
8. Try dropping in the empty area below all content — the image should append at the end.
9. Confirm the existing `/image` modal flow still works (slash command → modal → drag into upload zone → Insert image).
10. Drop an image and press Cmd/Ctrl+Z — the figure should be removed.
11. Drop an image, wait for the upload to finish, type some additional text after it, then press Cmd/Ctrl+Z. Confirm the figure remains with the real `http://...` URL on the `<img>` (not a `blob:` URL) and the `wp-image-{id}` class is intact. Save and re-open in the block editor to confirm the saved post has a proper `wp:image` block.