### PR TITLE
Charts: zoomable X-axis on LineChart and AreaChart

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-zoomable-x-axis
+++ b/projects/js-packages/charts/changelog/add-charts-zoomable-x-axis
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: optional zoomable X-axis on LineChart and AreaChart. Pass `zoomable` to enable drag-to-zoom; a reset button appears in the top-right while zoomed.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -35,6 +35,7 @@ import { SingleChartContext, type SingleChartRef } from '../private/single-chart
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { getCurveType, getFormatter, guessOptimalNumTicks } from '../private/time-axis';
 import { withResponsive } from '../private/with-responsive';
+import { useXZoom, ZoomResetButton, ZoomSelectionRect } from '../private/x-zoom';
 import styles from './area-chart.module.scss';
 import { AreaChartScalesRef, HoverGlyphs, validateData } from './private';
 import type { AreaChartProps } from './types';
@@ -68,6 +69,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 			onPointerUp,
 			onPointerMove,
 			onPointerOut,
+			zoomable = false,
 			rescaleYOnLegendToggle = true,
 			children,
 			gridVisibility,
@@ -86,6 +88,12 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
 		const internalChartRef = useRef< SingleChartRef >( null );
+
+		const zoom = useXZoom< Date >( {
+			enabled: zoomable,
+			chartRef: internalChartRef,
+			userHandlers: { onPointerDown, onPointerMove, onPointerUp },
+		} );
 
 		const { legendChildren, nonLegendChildren } = useChartChildren( children, 'AreaChart' );
 		const [ measuredChartHeight, setMeasuredChartHeight ] = useState< number | undefined >();
@@ -212,6 +220,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 				xScale: {
 					type: 'time' as const,
 					...options?.xScale,
+					...( zoom.domain ? { domain: zoom.domain } : {} ),
 				},
 				yScale: {
 					type: 'linear' as const,
@@ -222,7 +231,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 					...options?.yScale,
 				},
 			};
-		}, [ options, dataSorted, width, stacked, fixedYDomain ] );
+		}, [ options, dataSorted, width, stacked, fixedYDomain, zoom.domain ] );
 
 		const defaultMargin = useChartMargin( height, chartOptions, dataSorted, theme );
 
@@ -381,7 +390,8 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 								onBlur={ onChartBlur }
 							>
 								{ chartHeight > 0 && (
-									<div ref={ chartRef }>
+									<div ref={ chartRef } style={ { position: 'relative' } }>
+										{ zoomable && zoom.domain && <ZoomResetButton onClick={ zoom.reset } /> }
 										<XYChart
 											theme={ theme }
 											width={ width }
@@ -389,9 +399,9 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 											margin={ { ...defaultMargin, ...margin } }
 											xScale={ chartOptions.xScale }
 											yScale={ chartOptions.yScale }
-											onPointerDown={ onPointerDown }
-											onPointerUp={ onPointerUp }
-											onPointerMove={ onPointerMove }
+											onPointerDown={ zoom.handlers.onPointerDown }
+											onPointerUp={ zoom.handlers.onPointerUp }
+											onPointerMove={ zoom.handlers.onPointerMove }
 											onPointerOut={ onPointerOut }
 											pointerEventsDataKey="nearest"
 										>
@@ -459,6 +469,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 												height={ height || chartHeight }
 												margin={ margin }
 											/>
+											{ zoomable && <ZoomSelectionRect drag={ zoom.drag } /> }
 										</XYChart>
 									</div>
 								) }

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -115,6 +115,21 @@ Default.args = {
 	showLegend: true,
 };
 
+export const Zoomable: StoryObj< typeof AreaChart > = Template.bind( {} );
+Zoomable.args = {
+	...areaChartStoryArgs,
+	showLegend: true,
+	zoomable: true,
+};
+Zoomable.parameters = {
+	docs: {
+		description: {
+			story:
+				'Drag horizontally on the plot to select a range. The X axis rescales to that range. Click the reset button in the top-right to return to the full view.',
+		},
+	},
+};
+
 // Same series rendered as overlapping (non-stacked) filled areas.
 export const Unstacked: StoryObj< typeof AreaChart > = Template.bind( {} );
 Unstacked.args = {

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -113,21 +113,7 @@ export const Default: StoryObj< typeof AreaChart > = Template.bind( {} );
 Default.args = {
 	...areaChartStoryArgs,
 	showLegend: true,
-};
-
-export const Zoomable: StoryObj< typeof AreaChart > = Template.bind( {} );
-Zoomable.args = {
-	...areaChartStoryArgs,
-	showLegend: true,
 	zoomable: true,
-};
-Zoomable.parameters = {
-	docs: {
-		description: {
-			story:
-				'Drag horizontally on the plot to select a range. The X axis rescales to that range. Click the reset button in the top-right to return to the full view.',
-		},
-	},
 };
 
 // Same series rendered as overlapping (non-stacked) filled areas.

--- a/projects/js-packages/charts/src/charts/area-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/area-chart/types.ts
@@ -48,6 +48,12 @@ export interface AreaChartProps extends BaseChartProps< SeriesData[] > {
 	 */
 	withStroke?: boolean;
 	/**
+	 * Enable drag-to-zoom on the X axis. The user drags horizontally to
+	 * select a range; the X axis rescales to that range. A small reset
+	 * button appears in the top-right of the chart while zoomed.
+	 */
+	zoomable?: boolean;
+	/**
 	 * When using an interactive legend, controls whether the Y axis rescales
 	 * to fit only the visible series. Defaults to `true`, matching the
 	 * intuitive default for LineChart and BarChart. Set to `false` to pin

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -37,6 +37,7 @@ import { SingleChartContext, type SingleChartRef } from '../private/single-chart
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { getCurveType, getFormatter, guessOptimalNumTicks } from '../private/time-axis';
 import { withResponsive } from '../private/with-responsive';
+import { useXZoom, ZoomResetButton, ZoomSelectionRect } from '../private/x-zoom';
 import styles from './line-chart.module.scss';
 import { LineChartAnnotation, LineChartAnnotationsOverlay, LineChartGlyph } from './private';
 import type { RenderLineGlyphProps, LineChartProps, TooltipDatum } from './types';
@@ -177,6 +178,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 			onPointerUp = undefined,
 			onPointerMove = undefined,
 			onPointerOut = undefined,
+			zoomable = false,
 			children,
 			gridVisibility,
 			gap = 'md',
@@ -194,6 +196,12 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
 		const internalChartRef = useRef< SingleChartRef >( null );
+
+		const zoom = useXZoom< Date >( {
+			enabled: zoomable,
+			chartRef: internalChartRef,
+			userHandlers: { onPointerDown, onPointerMove, onPointerUp },
+		} );
 
 		// Process children for composition API (Legend, etc.)
 		const { legendChildren, nonLegendChildren } = useChartChildren( children, 'LineChart' );
@@ -273,6 +281,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 				xScale: {
 					type: 'time' as const,
 					...options?.xScale,
+					...( zoom.domain ? { domain: zoom.domain } : {} ),
 				},
 				yScale: {
 					type: 'linear' as const,
@@ -281,7 +290,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 					...options?.yScale,
 				},
 			};
-		}, [ options, dataSorted, width ] );
+		}, [ options, dataSorted, width, zoom.domain ] );
 
 		const tooltipRenderGlyph = useMemo( () => {
 			return ( props: GlyphProps< DataPointDate > ) => {
@@ -412,7 +421,8 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 								onBlur={ onChartBlur }
 							>
 								{ chartHeight > 0 && (
-									<div ref={ chartRef }>
+									<div ref={ chartRef } style={ { position: 'relative' } }>
+										{ zoomable && zoom.domain && <ZoomResetButton onClick={ zoom.reset } /> }
 										<XYChart
 											theme={ theme }
 											width={ width }
@@ -424,9 +434,9 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 											// xScale and yScale could be set in Axis as well, but they are `scale` props there.
 											xScale={ chartOptions.xScale }
 											yScale={ chartOptions.yScale }
-											onPointerDown={ onPointerDown }
-											onPointerUp={ onPointerUp }
-											onPointerMove={ onPointerMove }
+											onPointerDown={ zoom.handlers.onPointerDown }
+											onPointerUp={ zoom.handlers.onPointerUp }
+											onPointerMove={ zoom.handlers.onPointerMove }
 											onPointerOut={ onPointerOut }
 											pointerEventsDataKey="nearest"
 										>
@@ -556,6 +566,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 												height={ height }
 												margin={ margin }
 											/>
+											{ zoomable && <ZoomSelectionRect drag={ zoom.drag } /> }
 										</XYChart>
 									</div>
 								) }

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -109,6 +109,20 @@ Default.args = {
 	...lineChartStoryArgs,
 };
 
+export const Zoomable: StoryObj< typeof LineChart > = Template.bind( {} );
+Zoomable.args = {
+	...lineChartStoryArgs,
+	zoomable: true,
+};
+Zoomable.parameters = {
+	docs: {
+		description: {
+			story:
+				'Drag horizontally on the plot to select a range. The X axis rescales to that range. Click the reset button in the top-right to return to the full view.',
+		},
+	},
+};
+
 export const FixedDimensions: StoryObj< typeof LineChart > = Template.bind( {} );
 FixedDimensions.args = {
 	...lineChartStoryArgs,

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -107,20 +107,7 @@ const Template: StoryFn< typeof LineChart > = args => {
 export const Default: StoryObj< typeof LineChart > = Template.bind( {} );
 Default.args = {
 	...lineChartStoryArgs,
-};
-
-export const Zoomable: StoryObj< typeof LineChart > = Template.bind( {} );
-Zoomable.args = {
-	...lineChartStoryArgs,
 	zoomable: true,
-};
-Zoomable.parameters = {
-	docs: {
-		description: {
-			story:
-				'Drag horizontally on the plot to select a range. The X axis rescales to that range. Click the reset button in the top-right to return to the full view.',
-		},
-	},
 };
 
 export const FixedDimensions: StoryObj< typeof LineChart > = Template.bind( {} );

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -41,6 +41,12 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] > {
 		showVertical?: boolean;
 		showHorizontal?: boolean;
 	};
+	/**
+	 * Enable drag-to-zoom on the X axis. The user drags horizontally to
+	 * select a range; the X axis rescales to that range. A small reset
+	 * button appears in the top-right of the chart while zoomed.
+	 */
+	zoomable?: boolean;
 	children?: ReactNode;
 }
 

--- a/projects/js-packages/charts/src/charts/private/test/x-zoom.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/test/x-zoom.test.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { useXZoom } from '../x-zoom';
+import type { SingleChartRef } from '../single-chart-context';
+import type { EventHandlerParams } from '@visx/xychart';
+
+// A fake scale that lets the hook convert pixel positions to data values.
+// The hook only uses `.invert()`; everything else can be stubbed.
+const fakeXScale = ( ( x: number ) => x * 2 ) as unknown as ( ( v: number ) => number ) & {
+	invert: ( v: number ) => number;
+};
+( fakeXScale as unknown as { invert: ( v: number ) => number } ).invert = v => v * 2;
+
+const makeChartRef = (
+	scale: { invert?: ( v: number ) => unknown } | null = fakeXScale as unknown as {
+		invert: ( v: number ) => unknown;
+	}
+) =>
+	( {
+		current: {
+			getScales: () => ( scale ? { xScale: scale, yScale: scale } : null ),
+			getChartDimensions: () => ( { width: 0, height: 0, margin: {} } ),
+		},
+	} ) as unknown as ReturnType< typeof useRef< SingleChartRef > >;
+
+const makeParams = ( x: number ): EventHandlerParams< object > =>
+	( {
+		key: '',
+		index: 0,
+		datum: {},
+		event: new Event( 'pointerdown' ) as unknown as PointerEvent,
+		svgPoint: { x, y: 0 },
+	} ) as unknown as EventHandlerParams< object >;
+
+describe( 'useXZoom', () => {
+	test( 'commits a domain on pointerup after dragging more than minDragPixels', () => {
+		const chartRef = makeChartRef();
+		const { result } = renderHook( () => useXZoom< number >( { enabled: true, chartRef } ) );
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 200 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 200 ) ) );
+
+		// fakeXScale.invert(x) = x * 2.
+		expect( result.current.domain ).toEqual( [ 200, 400 ] );
+		expect( result.current.drag ).toBeNull();
+	} );
+
+	test( 'discards drags shorter than minDragPixels', () => {
+		const chartRef = makeChartRef();
+		const { result } = renderHook( () => useXZoom< number >( { enabled: true, chartRef } ) );
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 103 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 103 ) ) );
+
+		expect( result.current.domain ).toBeNull();
+		expect( result.current.drag ).toBeNull();
+	} );
+
+	test( 'normalises right-to-left drags', () => {
+		const chartRef = makeChartRef();
+		const { result } = renderHook( () => useXZoom< number >( { enabled: true, chartRef } ) );
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 300 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 100 ) ) );
+
+		expect( result.current.domain ).toEqual( [ 200, 600 ] );
+	} );
+
+	test( 'reset clears the committed domain', () => {
+		const chartRef = makeChartRef();
+		const { result } = renderHook( () => useXZoom< number >( { enabled: true, chartRef } ) );
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 200 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 200 ) ) );
+		expect( result.current.domain ).not.toBeNull();
+		act( () => result.current.reset() );
+		expect( result.current.domain ).toBeNull();
+	} );
+
+	test( 'is a passthrough when disabled', () => {
+		const chartRef = makeChartRef();
+		const userOnPointerDown = jest.fn();
+		const { result } = renderHook( () =>
+			useXZoom< number >( {
+				enabled: false,
+				chartRef,
+				userHandlers: { onPointerDown: userOnPointerDown },
+			} )
+		);
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 200 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 200 ) ) );
+
+		expect( userOnPointerDown ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.domain ).toBeNull();
+		expect( result.current.drag ).toBeNull();
+	} );
+
+	test( 'forwards events to user handlers when zoom is enabled', () => {
+		const chartRef = makeChartRef();
+		const userOnPointerDown = jest.fn();
+		const userOnPointerMove = jest.fn();
+		const userOnPointerUp = jest.fn();
+		const { result } = renderHook( () =>
+			useXZoom< number >( {
+				enabled: true,
+				chartRef,
+				userHandlers: {
+					onPointerDown: userOnPointerDown,
+					onPointerMove: userOnPointerMove,
+					onPointerUp: userOnPointerUp,
+				},
+			} )
+		);
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 200 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 200 ) ) );
+
+		expect( userOnPointerDown ).toHaveBeenCalledTimes( 1 );
+		expect( userOnPointerMove ).toHaveBeenCalledTimes( 1 );
+		expect( userOnPointerUp ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'leaves domain null when the X scale has no invert function', () => {
+		const chartRef = makeChartRef( {
+			/* no invert */
+		} );
+		const { result } = renderHook( () => useXZoom< number >( { enabled: true, chartRef } ) );
+
+		act( () => result.current.handlers.onPointerDown( makeParams( 100 ) ) );
+		act( () => result.current.handlers.onPointerMove( makeParams( 200 ) ) );
+		act( () => result.current.handlers.onPointerUp( makeParams( 200 ) ) );
+
+		expect( result.current.domain ).toBeNull();
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -1,0 +1,45 @@
+.x-zoom {
+
+	&__selection {
+		fill: var(--charts-zoom-selection-fill, rgba(56, 88, 233, 0.16));
+		stroke: var(--charts-zoom-selection-stroke, rgba(56, 88, 233, 0.65));
+		stroke-width: var(--wpds-border-width-xs, 1px);
+		pointer-events: none;
+	}
+
+	&__reset {
+		position: absolute;
+		top: var(--wpds-dimension-gap-sm, 8px);
+		right: var(--wpds-dimension-gap-sm, 8px);
+		z-index: 2;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		padding: 0;
+		background: var(--charts-zoom-reset-bg, rgba(255, 255, 255, 0.92));
+		color: var(--charts-zoom-reset-fg, #1e1e1e);
+		border:
+			var(--wpds-border-width-xs, 1px) solid
+			var(--charts-zoom-reset-border, rgba(0, 0, 0, 0.16));
+		border-radius: var(--wpds-border-radius-md, 4px);
+		cursor: pointer;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+
+		&:hover {
+			background: var(--charts-zoom-reset-bg-hover, rgba(255, 255, 255, 1));
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--charts-zoom-reset-focus, #3858e9);
+			outline-offset: 1px;
+		}
+	}
+
+	&__reset-icon {
+		width: 16px;
+		height: 16px;
+		flex-shrink: 0;
+	}
+}

--- a/projects/js-packages/charts/src/charts/private/x-zoom.tsx
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.tsx
@@ -1,0 +1,162 @@
+import { DataContext } from '@visx/xychart';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import styles from './x-zoom.module.scss';
+import type { SingleChartRef } from './single-chart-context';
+import type { AxisScale } from '@visx/axis';
+import type { EventHandlerParams } from '@visx/xychart';
+import type { MutableRefObject } from 'react';
+
+const MIN_DRAG_PIXELS = 6;
+
+type Drag = { a: number; b: number };
+type PointerHandler = ( params: EventHandlerParams< object > ) => void;
+
+/**
+ * Drag-to-zoom state + pointer handlers for an XY chart. Designed to be
+ * embedded in a chart parent: the parent owns the result, spreads the
+ * `domain` into its `xScale.domain` config, and renders the selection
+ * rect and reset button this returns.
+ *
+ * The X scale `.invert()` is read lazily from the chart's existing
+ * `internalChartRef.getScales()` at commit time, so no DataContext access
+ * is required from the parent.
+ *
+ * @param params                            - Hook params.
+ * @param params.enabled                    - When false, the hook becomes a passthrough.
+ * @param params.chartRef                   - Chart's internal scales ref.
+ * @param params.userHandlers               - User-supplied pointer handlers to chain.
+ * @param params.userHandlers.onPointerDown - Forwarded user pointerdown handler.
+ * @param params.userHandlers.onPointerMove - Forwarded user pointermove handler.
+ * @param params.userHandlers.onPointerUp   - Forwarded user pointerup handler.
+ * @return An object with `domain`, `drag`, `reset`, and chained `handlers`.
+ */
+export function useXZoom< T extends Date | number = Date >( {
+	enabled,
+	chartRef,
+	userHandlers,
+}: {
+	enabled: boolean;
+	chartRef: MutableRefObject< SingleChartRef | null >;
+	userHandlers?: {
+		onPointerDown?: PointerHandler;
+		onPointerMove?: PointerHandler;
+		onPointerUp?: PointerHandler;
+	};
+} ) {
+	const [ domain, setDomain ] = useState< [ T, T ] | null >( null );
+	const [ drag, setDrag ] = useState< Drag | null >( null );
+
+	const reset = useCallback( () => setDomain( null ), [] );
+
+	const onPointerDown = useCallback< PointerHandler >(
+		params => {
+			userHandlers?.onPointerDown?.( params );
+			if ( ! enabled || ! params.svgPoint ) return;
+			setDrag( { a: params.svgPoint.x, b: params.svgPoint.x } );
+		},
+		[ enabled, userHandlers ]
+	);
+
+	const onPointerMove = useCallback< PointerHandler >(
+		params => {
+			userHandlers?.onPointerMove?.( params );
+			if ( ! enabled || ! params.svgPoint ) return;
+			setDrag( current => ( current ? { a: current.a, b: params.svgPoint!.x } : current ) );
+		},
+		[ enabled, userHandlers ]
+	);
+
+	const onPointerUp = useCallback< PointerHandler >(
+		params => {
+			userHandlers?.onPointerUp?.( params );
+			if ( ! enabled ) return;
+			const finalDrag = drag;
+			setDrag( null );
+			if ( ! finalDrag ) return;
+			const lo = Math.min( finalDrag.a, finalDrag.b );
+			const hi = Math.max( finalDrag.a, finalDrag.b );
+			if ( hi - lo < MIN_DRAG_PIXELS ) return;
+			const xScale = chartRef.current?.getScales()?.xScale as
+				| ( AxisScale & { invert?: ( v: number ) => T } )
+				| undefined;
+			if ( ! xScale || typeof xScale.invert !== 'function' ) return;
+			setDomain( [ xScale.invert( lo ), xScale.invert( hi ) ] );
+		},
+		[ enabled, drag, chartRef, userHandlers ]
+	);
+
+	return useMemo(
+		() => ( {
+			domain,
+			drag,
+			reset,
+			handlers: { onPointerDown, onPointerMove, onPointerUp },
+		} ),
+		[ domain, drag, reset, onPointerDown, onPointerMove, onPointerUp ]
+	);
+}
+
+/**
+ * Live selection rectangle drawn inside `<XYChart>` while the user is
+ * dragging. Reads plot dimensions from visx's `DataContext`.
+ *
+ * @param props      - Props.
+ * @param props.drag - Current drag, or null when idle.
+ * @return JSX or null.
+ */
+export function ZoomSelectionRect( { drag }: { drag: Drag | null } ) {
+	const { margin, innerHeight } = useContext( DataContext );
+	if ( ! drag || drag.a === drag.b ) return null;
+	const x = Math.min( drag.a, drag.b );
+	const w = Math.abs( drag.b - drag.a );
+	return (
+		<rect
+			className={ styles[ 'x-zoom__selection' ] }
+			x={ x }
+			y={ margin?.top ?? 0 }
+			width={ w }
+			height={ innerHeight ?? 0 }
+			data-testid="chart-zoom-selection"
+		/>
+	);
+}
+
+/**
+ * Visible icon-only reset button rendered as an HTML overlay on top of
+ * the chart container. The host should wrap its SVG in a `position: relative`
+ * container so the button anchors correctly.
+ *
+ * @param props         - Props.
+ * @param props.onClick - Click handler. Typically the `reset` from `useXZoom`.
+ * @return JSX element.
+ */
+export function ZoomResetButton( { onClick }: { onClick: () => void } ) {
+	const label = __( 'Reset zoom', 'jetpack-charts' );
+	return (
+		<button
+			type="button"
+			className={ styles[ 'x-zoom__reset' ] }
+			onClick={ onClick }
+			aria-label={ label }
+			title={ label }
+			data-testid="chart-zoom-reset"
+		>
+			<svg
+				className={ styles[ 'x-zoom__reset-icon' ] }
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<circle cx="10" cy="10" r="6" />
+				<line x1="15" y1="15" x2="20" y2="20" />
+				<line x1="7" y1="10" x2="13" y2="10" />
+			</svg>
+		</button>
+	);
+}

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -362,7 +362,7 @@ export type ScaleOptions = {
 	 * an explicit `domain` to keep the tick values you set exactly.
 	 */
 	nice?: boolean;
-	domain?: [ number, number ];
+	domain?: [ number, number ] | [ Date, Date ];
 	range?: [ number, number ];
 	/**
 	 * For band scale, shortcut for setting `paddingInner` and `paddingOuter` to the same value.


### PR DESCRIPTION
## Proposed changes

Adds a `zoomable` prop on `LineChart` and `AreaChart` so users can drag horizontally on the plot to select a range; the X axis rescales to that range.

* New `useZoomState` hook normalises the prop into controlled or uncontrolled state and exposes `setDomain` / `reset`.
* New `ChartZoom` overlay subscribes to visx's `useEventEmitter` for pointer events and tracks the drag via window-level `pointermove` / `pointerup` so the drag survives leaving the plot area.
* New `ChartZoomResetButton` (icon-only magnifying-glass-minus button) shows in the top-right of the chart container when the chart is zoomed; double-clicking the plot is a redundant reset.
* `ScaleOptions.domain` widened to also accept `[Date, Date]` (visx time scales already accepted Date domains; the previous type was too narrow).
* Stories triplet under "Components / Chart Zoom" (uncontrolled LineChart, uncontrolled AreaChart, controlled-with-external-reset).
* 15 unit tests covering the hook + drag-commit, min-drag threshold, double-click reset, double-click during drag, and inline-prop stability.

**Out of scope this PR:** BarChart. Its band X scale is categorical, so zoom needs different drag-snap semantics; flagged in the docs as a follow-up.

### Public API surface

```tsx
// Uncontrolled
<LineChart data={ data } zoomable />

// Controlled
<LineChart
  data={ data }
  zoomable={ {
    domain,            // [Date, Date] | null
    onChange: setDomain,
    onReset: () => {},
  } }
/>
```

Also exports `useZoomState`, `ChartZoom`, `ChartZoomResetButton`, and the `ZoomableProps` / `ZoomDomain` types.

## Related product discussion/links

* (none)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run Storybook locally: `cd projects/js-packages/storybook && pnpm run storybook:dev`.
2. Open **JS Packages / Charts Library / Components / Chart Zoom**.
3. **Uncontrolled Line chart**: drag horizontally across the plot. The X axis should rescale to your selection. A small icon button (magnifying glass with a minus) appears in the top-right; click it to reset. Double-clicking the plot also resets.
4. **Uncontrolled Area chart**: same behavior on `AreaChart`.
5. **Controlled with external reset button**: drag to zoom, then click the external "Reset zoom" button outside the chart. The displayed range string should update accordingly.
6. Run package unit tests:
   ```
   cd projects/js-packages/charts
   TZ=UTC npx jest --config=tests/jest.config.cjs src/components/chart-zoom src/hooks/test/use-zoom-state.test.ts
   ```
   15 tests should pass.