### PR TITLE
VideoPress: fix doubled post-connection redirect URL in modernized dashboard

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-connection-redirect-uri
+++ b/projects/packages/videopress/changelog/fix-videopress-connection-redirect-uri
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the post-connection redirect so the modernized dashboard returns users to the VideoPress page instead of a 404

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/index.tsx
@@ -3,21 +3,12 @@ import ConnectScreen from './connect-screen';
 import PricingUpsell from './pricing-upsell';
 import type { ReactNode } from 'react';
 
+// Path *relative* to wp-admin, not an absolute URL: the connection REST
+// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
+// absolute URL would be appended onto the wp-admin base, producing a doubled,
+// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
+// legacy dashboard, which passed the relative `adminUri` from its initial state.
 const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
-
-/**
- * After connecting, return the user to the VideoPress dashboard — the same
- * redirect the legacy dashboard's connection flow used.
- *
- * @return The absolute VideoPress admin URL, or undefined when the admin URL isn't in the inlined initial state (e.g. tests).
- */
-function getRedirectUri(): string | undefined {
-	const adminUrl =
-		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
-			? JPVIDEOPRESS_INITIAL_STATE?.siteData?.adminUrl
-			: undefined;
-	return adminUrl ? `${ adminUrl }${ VIDEOPRESS_ADMIN_PAGE }` : undefined;
-}
 
 /**
  * Gates the whole dashboard behind a WordPress.com connection. VideoPress
@@ -50,7 +41,7 @@ export default function ConnectionGate( { children }: { children: ReactNode } ) 
 		handleRegisterSite,
 	} = useConnection( {
 		from: 'jetpack-videopress',
-		redirectUri: getRedirectUri(),
+		redirectUri: VIDEOPRESS_ADMIN_PAGE,
 	} );
 
 	const canPerformAction = isRegistered && hasConnectedOwner && isUserConnected;

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/index.tsx
@@ -1,14 +1,8 @@
 import useConnection from '@automattic/jetpack-connection/use-connection';
+import { VIDEOPRESS_ADMIN_PAGE } from '../../utils/constants';
 import ConnectScreen from './connect-screen';
 import PricingUpsell from './pricing-upsell';
 import type { ReactNode } from 'react';
-
-// Path *relative* to wp-admin, not an absolute URL: the connection REST
-// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
-// absolute URL would be appended onto the wp-admin base, producing a doubled,
-// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
-// legacy dashboard, which passed the relative `adminUri` from its initial state.
-const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
 
 /**
  * Gates the whole dashboard behind a WordPress.com connection. VideoPress

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
@@ -12,6 +12,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import './style.scss';
 
+// Path *relative* to wp-admin, not an absolute URL: the connection REST
+// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
+// absolute URL would be appended onto the wp-admin base, producing a doubled,
+// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
+// legacy dashboard, which passed the relative `adminUri` from its initial state.
 const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
 
 /**
@@ -31,9 +36,8 @@ export default function PricingUpsell() {
 	const state =
 		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined' ? JPVIDEOPRESS_INITIAL_STATE : undefined;
 	const pricing = state?.pricing;
-	const adminUrl = state?.siteData?.adminUrl ?? '';
 	const siteSuffix = state?.jetpackStatus?.calypsoSlug ?? '';
-	const redirectUrl = adminUrl ? `${ adminUrl }${ VIDEOPRESS_ADMIN_PAGE }` : '';
+	const redirectUrl = VIDEOPRESS_ADMIN_PAGE;
 
 	// These hooks must run unconditionally (Rules of Hooks) and therefore precede
 	// the `! pricing` guard below, which the gate already makes unreachable in

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
@@ -10,14 +10,8 @@ import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use
 import useConnection from '@automattic/jetpack-connection/use-connection';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
+import { VIDEOPRESS_ADMIN_PAGE } from '../../utils/constants';
 import './style.scss';
-
-// Path *relative* to wp-admin, not an absolute URL: the connection REST
-// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
-// absolute URL would be appended onto the wp-admin base, producing a doubled,
-// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
-// legacy dashboard, which passed the relative `adminUri` from its initial state.
-const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
 
 /**
  * Pre-connection upsell shown when the site isn't registered yet. A port of the

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/test/pricing-upsell.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/test/pricing-upsell.test.tsx
@@ -89,7 +89,9 @@ describe( 'PricingUpsell', () => {
 		expect( mockCheckoutWorkflow ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				productSlug: 'jetpack_videopress',
-				redirectUrl: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+				// Relative to wp-admin; the REST endpoint makes it absolute via
+				// `admin_url()`. An absolute URL here would be doubled and 404.
+				redirectUrl: 'admin.php?page=jetpack-videopress',
 				siteSuffix: 'example.com',
 				from: 'jetpack-videopress',
 			} )

--- a/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
@@ -14,6 +14,13 @@ import type { ReactElement } from 'react';
 // against the same funnel.
 const UPGRADE_CLICK_EVENT = 'jetpack_videopress_upgrade_trigger_link_click';
 
+// Path *relative* to wp-admin, not an absolute URL: the connection REST
+// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
+// absolute URL would be appended onto the wp-admin base, producing a doubled,
+// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
+// legacy dashboard, which passed the relative `adminUri` from its initial state.
+const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
+
 /**
  * Read the inlined initial state, guarding for environments (tests, the
  * legacy page) where the `var JPVIDEOPRESS_INITIAL_STATE` is absent.
@@ -50,11 +57,10 @@ function getInitialState() {
  */
 export default function FreeTierNotice(): ReactElement {
 	const state = getInitialState();
-	const adminUrl = state?.siteData?.adminUrl ?? '';
 
 	const { run } = useProductCheckoutWorkflow( {
 		productSlug: state?.product?.slug ?? '',
-		redirectUrl: adminUrl ? `${ adminUrl }admin.php?page=jetpack-videopress` : '',
+		redirectUrl: VIDEOPRESS_ADMIN_PAGE,
 		useBlogIdSuffix: true,
 		from: 'jetpack-videopress',
 	} );

--- a/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
@@ -7,19 +7,13 @@ import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
+import { VIDEOPRESS_ADMIN_PAGE } from '../../utils/constants';
 import type { ReactElement } from 'react';
 
 // Tracks event recorded when the upgrade CTA is clicked. Carried over verbatim
 // from the legacy dashboard's `UpgradeTrigger` so both dashboards report
 // against the same funnel.
 const UPGRADE_CLICK_EVENT = 'jetpack_videopress_upgrade_trigger_link_click';
-
-// Path *relative* to wp-admin, not an absolute URL: the connection REST
-// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
-// absolute URL would be appended onto the wp-admin base, producing a doubled,
-// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
-// legacy dashboard, which passed the relative `adminUri` from its initial state.
-const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';
 
 /**
  * Read the inlined initial state, guarding for environments (tests, the

--- a/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/test/free-tier-notice.test.tsx
@@ -47,7 +47,9 @@ describe( 'FreeTierNotice', () => {
 
 		expect( mockedCheckoutWorkflow ).toHaveBeenCalledWith( {
 			productSlug: 'jetpack_videopress',
-			redirectUrl: 'https://example.com/wp-admin/admin.php?page=jetpack-videopress',
+			// Relative to wp-admin; the REST endpoint makes it absolute via
+			// `admin_url()`. An absolute URL here would be doubled and 404.
+			redirectUrl: 'admin.php?page=jetpack-videopress',
 			useBlogIdSuffix: true,
 			from: 'jetpack-videopress',
 		} );

--- a/projects/packages/videopress/src/dashboard/utils/constants.ts
+++ b/projects/packages/videopress/src/dashboard/utils/constants.ts
@@ -1,0 +1,6 @@
+// Path *relative* to wp-admin, not an absolute URL: the connection REST
+// endpoint resolves it server-side with `admin_url( $redirect_uri )`. An
+// absolute URL would be appended onto the wp-admin base, producing a doubled,
+// broken redirect (`…/wp-admin/https:/…/wp-admin/…`) that 404s. Matches the
+// legacy dashboard, which passed the relative `adminUri` from its initial state.
+export const VIDEOPRESS_ADMIN_PAGE = 'admin.php?page=jetpack-videopress';

--- a/projects/plugins/jetpack/changelog/fix-videopress-connection-redirect-uri
+++ b/projects/plugins/jetpack/changelog/fix-videopress-connection-redirect-uri
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: fix the post-connection redirect so the modernized dashboard returns users to the VideoPress page instead of a 404

--- a/projects/plugins/videopress/changelog/fix-videopress-connection-redirect-uri
+++ b/projects/plugins/videopress/changelog/fix-videopress-connection-redirect-uri
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the post-connection redirect so the modernized dashboard returns users to the VideoPress page instead of a 404


### PR DESCRIPTION
Fixes #

Follow-up to the VideoPress dashboard modernization. Caught by @keoshi while reviewing #49023 (the flag flip): after connecting from the modernized VideoPress page, the user lands on a frontend 404 instead of returning to the dashboard.

## Proposed changes
* Fix the post-connection redirect in the modernized VideoPress dashboard. The connection gate, the pre-connection pricing upsell, and the free-tier upgrade notice each built an **absolute** redirect URL (`${adminUrl}admin.php?page=jetpack-videopress`) and handed it to the connection/checkout hooks.
* The connection REST endpoint (`Connection\REST_Connector`) resolves `redirect_uri` with `admin_url( $redirect_uri )`, which *prepends* the wp-admin base. An absolute URL therefore gets doubled into a broken redirect — e.g. `https://site/wp-admin/https:/site/wp-admin/admin.php?page=jetpack-videopress` (note the collapsed `https:/`) — which 404s.
* Pass the **relative** path `admin.php?page=jetpack-videopress` instead, matching what the legacy dashboard passed (`adminUri`), and let `admin_url()` resolve it server-side.
* Updated the two Jest tests that asserted the old absolute URL to assert the relative path; they serve as the regression coverage.

## Related product discussion/links
* Reported in https://github.com/Automattic/jetpack/pull/49023#pullrequestreview (review by @keoshi)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with VideoPress (or Jetpack VideoPress) active and the modernized dashboard enabled, **disconnect** the site/user from WordPress.com.
* Go to **VideoPress** in wp-admin (`wp-admin/admin.php?page=jetpack-videopress`); the connection gate (or pricing upsell) renders.
* Click **Connect** (or **Start for free** / **Get VideoPress**) and complete the WordPress.com connection.
* Confirm you are returned to the VideoPress dashboard (`admin.php?page=jetpack-videopress`) and **not** to a doubled-URL 404 on the site frontend.
* Also exercise the free-tier **Upgrade** notice on the Overview tab and confirm the checkout flow returns to the VideoPress page.
