### PR TITLE
Jetpack Media Extractor: Add WooCommerce product gallery support

### DIFF
--- a/projects/packages/post-media/changelog/2026-05-26-18-19-52-600879
+++ b/projects/packages/post-media/changelog/2026-05-26-18-19-52-600879
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooCommerce: Include product gallery images when extracting post media.

--- a/projects/packages/post-media/src/class-images.php
+++ b/projects/packages/post-media/src/class-images.php
@@ -180,6 +180,19 @@ class Images {
 		}
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
+		// WooCommerce stores product gallery image IDs in the `_product_image_gallery`
+		// postmeta rather than in post_content, so get_post_galleries() does not see them.
+		// Append them as a synthetic gallery in the same `ids` shape the loop below expects.
+		if ( 'product' === $post->post_type ) {
+			$wc_gallery_ids = get_post_meta( $post->ID, '_product_image_gallery', true );
+			if ( ! empty( $wc_gallery_ids ) ) {
+				$galleries[] = array(
+					'ids'  => $wc_gallery_ids,
+					'size' => 'full',
+				);
+			}
+		}
+
 		foreach ( $galleries as $gallery ) {
 			if ( ! empty( $gallery['ids'] ) ) {
 				$image_ids  = explode( ',', $gallery['ids'] );

--- a/projects/packages/post-media/tests/php/ImagesTest.php
+++ b/projects/packages/post-media/tests/php/ImagesTest.php
@@ -321,6 +321,81 @@ class ImagesTest extends BaseTestCase {
 	}
 
 	/**
+	 * Test if WooCommerce product gallery images are extracted from product meta.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_from_gallery_includes_woocommerce_product_gallery_images() {
+		$img_dimensions = array(
+			'width'  => 300,
+			'height' => 250,
+		);
+		$alt_text       = 'An image in a WooCommerce product gallery';
+
+		$post_id  = $this->create_post(
+			array(
+				'post_type' => 'product',
+			)
+		);
+		$img_urls = array();
+
+		foreach ( array( 'product-gallery-image.jpg', 'product-gallery-image-2.jpg' ) as $img_name ) {
+			$attachment_id = $this->create_attachment(
+				$img_name,
+				$post_id,
+				array(
+					'post_mime_type' => 'image/jpeg',
+				)
+			);
+			wp_update_attachment_metadata( $attachment_id, $img_dimensions );
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+
+			$img_urls[ $attachment_id ] = wp_get_attachment_url( $attachment_id );
+		}
+
+		update_post_meta( $post_id, '_product_image_gallery', implode( ',', array_keys( $img_urls ) ) );
+
+		$images = Images::from_gallery( $post_id );
+
+		$this->assertCount( 2, $images );
+		$img_urls = array_values( $img_urls );
+		$this->assertEquals( $img_urls[0], $images[0]['src'] );
+		$this->assertEquals( 300, $images[0]['src_width'] );
+		$this->assertEquals( 250, $images[0]['src_height'] );
+		$this->assertEquals( $alt_text, $images[0]['alt_text'] );
+		$this->assertEquals( $img_urls[1], $images[1]['src'] );
+		$this->assertEquals( 300, $images[1]['src_width'] );
+		$this->assertEquals( 250, $images[1]['src_height'] );
+	}
+
+	/**
+	 * Test if WooCommerce product gallery meta is ignored for non-product posts.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_from_gallery_ignores_woocommerce_product_gallery_meta_for_non_products() {
+		$post_id       = $this->create_post();
+		$attachment_id = $this->create_attachment(
+			'post-gallery-image.jpg',
+			$post_id,
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'width'  => 300,
+				'height' => 250,
+			)
+		);
+		update_post_meta( $post_id, '_product_image_gallery', (string) $attachment_id );
+
+		$this->assertEmpty( Images::from_gallery( $post_id ) );
+	}
+
+	/**
 	 * @author scotchfield
 	 * @author Alda Vigdís <alda.vigdis@automattic.com>
 	 * @since jetpack-3.2


### PR DESCRIPTION
We recently noted that Jetpack Search was not indexing all the images for WooCommerce products. It turns out that is because we have not been supporting the `_product_image_gallery` in the media extractor. Since WooCommerce is a very commonly used plugin, and this is part of WC Core, it makes sense to extract these. 

## Proposed changes
* Include WooCommerce product gallery images from `_product_image_gallery` when extracting galleries for `product` posts.
* Add tests for WooCommerce product gallery extraction and for ignoring that meta on non-product posts.
* Add a post-media changelog entry.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `pnpm jetpack test php packages/post-media`.
* Run `composer phpcs:lint projects/packages/post-media/src/class-images.php projects/packages/post-media/tests/php/ImagesTest.php`.
* Run `composer phpcs:compatibility projects/packages/post-media/src/class-images.php projects/packages/post-media/tests/php/ImagesTest.php`.
