### PR TITLE
Jetpack CLI: `fast-build` command (autoloader recovery, parallel, watch, seed, verify, log-path, skip list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ phpcs.xml
 # This file indicates we're in draft mode, which reduces checks
 .jetpack-draft
 
+# Per-project last-built SHA stamps, used by `jetpack fast-build` to scope incremental work.
+/.jetpack-cli/
+
 # VS Code setting files
 *.code-workspace
 /.vscode/settings.json

--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -9,6 +9,7 @@ import * as dependenciesCommand from './commands/dependencies.js';
 import { dockerDefine } from './commands/docker.js';
 import { docsDefine } from './commands/docs.js';
 import { draftDefine } from './commands/draft.js';
+import * as fastBuildCommand from './commands/fast-build.js';
 import { generateDefine } from './commands/generate.js';
 import * as installCommand from './commands/install.js';
 import * as noopCommand from './commands/noop.js';
@@ -46,6 +47,7 @@ export async function cli() {
 	argv = dockerDefine( argv );
 	argv = docsDefine( argv );
 	argv = draftDefine( argv );
+	argv.command( fastBuildCommand );
 	argv = generateDefine( argv );
 	argv.command( installCommand );
 	argv.command( noopCommand );

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -14,6 +14,7 @@ import pLimit from 'p-limit';
 import { getDependencies, filterDeps, getBuildOrder } from '../helpers/dependencyAnalysis.js';
 import formatDuration from '../helpers/format-duration.js';
 import { getInstallArgs, projectDir } from '../helpers/install.js';
+import { currentHead, writeStamp } from '../helpers/lastBuilt.js';
 import { listProjectFiles } from '../helpers/list-project-files.js';
 import { coerceConcurrency } from '../helpers/normalizeArgv.js';
 import PrefixStream from '../helpers/prefix-stream.js';
@@ -790,8 +791,15 @@ async function buildProject( t ) {
 		} );
 	}
 
-	// If we're not mirroring, the build is done. Mirroring has a bunch of stuff to do yet.
+	// Stamp the project as built at the current HEAD so `jetpack fast-build` has a baseline.
+	// Only meaningful outside of mirror/CI builds, where the working tree is ephemeral.
 	if ( ! t.argv.forMirrors ) {
+		try {
+			const sha = await currentHead();
+			await writeStamp( t.project, sha );
+		} catch {
+			// Stamping is best-effort; never fail a build over it.
+		}
 		return;
 	}
 

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -1,3 +1,5 @@
+import fs from 'fs/promises';
+import path from 'path';
 import chalk from 'chalk';
 import { execa } from 'execa';
 import Listr from 'listr';
@@ -318,7 +320,6 @@ export function summarizeExecError( error, n = 6 ) {
  * @param {object} argv - Argv.
  */
 async function runBuildScriptIfAny( slug, cwd, argv ) {
-	const fs = await import( 'fs/promises' );
 	let composerJson;
 	try {
 		composerJson = JSON.parse(
@@ -339,6 +340,29 @@ async function runBuildScriptIfAny( slug, cwd, argv ) {
 		stdio: [ 'ignore', argv.v ? 'inherit' : 'pipe', argv.v ? 'inherit' : 'pipe' ],
 		buffer: false,
 	} );
+}
+
+/**
+ * Read the persistent skip list at `.jetpack-cli/skip.txt`. One project slug per
+ * line, blank lines and `#`-prefixed comments ignored.
+ *
+ * @param {string} cwd - Monorepo root.
+ * @return {Promise<string[]>} Slugs to skip.
+ */
+async function readSkipFile( cwd ) {
+	const file = path.join( cwd, '.jetpack-cli/skip.txt' );
+	try {
+		const data = await fs.readFile( file, { encoding: 'utf8' } );
+		return data
+			.split( '\n' )
+			.map( s => s.trim() )
+			.filter( s => s.length > 0 && ! s.startsWith( '#' ) );
+	} catch ( e ) {
+		if ( e.code === 'ENOENT' ) {
+			return [];
+		}
+		throw e;
+	}
 }
 
 /**
@@ -481,6 +505,19 @@ export async function handler( argv ) {
 	const deps = await getDependencies( cwd, 'build' );
 
 	const skipSet = new Set( argv.skip || [] );
+	const persistentSkip = await readSkipFile( cwd );
+	for ( const slug of persistentSkip ) {
+		skipSet.add( slug );
+	}
+	if ( persistentSkip.length ) {
+		console.log(
+			chalk.grey(
+				`Honoring ${
+					persistentSkip.length
+				} entry(s) from .jetpack-cli/skip.txt: ${ persistentSkip.join( ', ' ) }`
+			)
+		);
+	}
 	const targets =
 		argv.project && argv.project.length ? new Set( argv.project ) : new Set( deps.keys() );
 	for ( const slug of skipSet ) {

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -97,6 +97,12 @@ export function builder( yargs ) {
 			default: 4,
 			description:
 				'How many `dump-autoload` actions to run in parallel. Build actions always run serially because they may have inter-project dependencies. Use 1 to force fully serial execution.',
+		} )
+		.option( 'seed', {
+			type: 'boolean',
+			default: false,
+			description:
+				'Stamp every project (or those named as positionals) at the current HEAD without running anything, so future runs have a baseline. Useful for first-time setup without doing a full `jetpack build`.',
 		} );
 }
 
@@ -336,6 +342,33 @@ async function runBuildScriptIfAny( slug, cwd, argv ) {
 }
 
 /**
+ * Stamp every target project at the current HEAD without running any work.
+ *
+ * Used by `--seed`. Writes the `build` stamp (which implies the `autoload`
+ * stamp), so future runs of fast-build will diff against the seeded SHA.
+ *
+ * @param {Set<string>} targets - Project slugs to seed.
+ * @param {string}      cwd     - Monorepo root.
+ */
+async function seedStamps( targets, cwd ) {
+	const sha = await currentHead( cwd );
+	const slugs = [ ...targets ].filter( s => s !== 'monorepo' ).sort();
+	if ( slugs.length === 0 ) {
+		console.log( chalk.yellow( 'No projects to seed.' ) );
+		return;
+	}
+	await Promise.all( slugs.map( slug => writeStamp( slug, sha, 'build', cwd ) ) );
+	console.log(
+		chalkJetpackGreen(
+			`Seeded ${ slugs.length } project(s) at ${ sha.substring(
+				0,
+				10
+			) }. Future fast-builds will diff from this SHA.`
+		)
+	);
+}
+
+/**
  * Convert a plan map to a topologically-ordered list of (slug, action) pairs.
  *
  * Reuses dependencyAnalysis.getBuildOrder for ordering so that a package builds
@@ -398,6 +431,11 @@ export async function handler( argv ) {
 		argv.project && argv.project.length ? new Set( argv.project ) : new Set( deps.keys() );
 	for ( const slug of skipSet ) {
 		targets.delete( slug );
+	}
+
+	if ( argv.seed ) {
+		await seedStamps( targets, cwd );
+		return;
 	}
 
 	// Signal 1 — log scan.

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -1,0 +1,574 @@
+import chalk from 'chalk';
+import { execa } from 'execa';
+import Listr from 'listr';
+import SilentRenderer from 'listr-silent-renderer';
+import UpdateRenderer from 'listr-update-renderer';
+import { findOwnerProject } from '../helpers/classOwner.js';
+import { filterDeps, getBuildOrder, getDependencies } from '../helpers/dependencyAnalysis.js';
+import formatDuration from '../helpers/format-duration.js';
+import { projectDir } from '../helpers/install.js';
+import { currentHead, inspectProjectChanges, readStamp, writeStamp } from '../helpers/lastBuilt.js';
+import { scanForMissingSymbols } from '../helpers/logScan.js';
+import { chalkJetpackGreen } from '../helpers/styling.js';
+
+export const command = 'fast-build [project...]';
+export const describe =
+	'Restore the local dev site by doing only the targeted rebuild work the diff actually needs (autoloader regen + minimal builds).';
+
+/**
+ * Action ranking — higher wins when two signals disagree about a project.
+ *
+ * @see resolveAction
+ */
+const ACTION_RANK = {
+	skip: 0,
+	'dump-autoload': 1,
+	build: 2,
+};
+
+/**
+ * Options definition for fast-build.
+ *
+ * @param {object} yargs - Yargs instance.
+ * @return {object} Yargs.
+ */
+export function builder( yargs ) {
+	return yargs
+		.positional( 'project', {
+			describe:
+				'Restrict to specific projects (e.g. plugins/jetpack). Default: every project with a last-built stamp.',
+			type: 'string',
+		} )
+		.option( 'url', {
+			type: 'string',
+			default: 'http://localhost',
+			description: 'URL to curl when verifying the fix.',
+		} )
+		.option( 'verify', {
+			type: 'boolean',
+			default: true,
+			description: 'After fixes, curl --url and re-scan the docker debug.log for new fatals.',
+		} )
+		.option( 'since', {
+			type: 'string',
+			description:
+				'Override per-project last-built stamps and diff every project against this git ref instead.',
+		} )
+		.option( 'dry-run', {
+			type: 'boolean',
+			description: 'Print the planned actions without executing.',
+		} )
+		.option( 'autoload-only', {
+			type: 'boolean',
+			description:
+				'Skip JS rebuilds entirely — Signal 1 + PHP-only changes. Use when you only care about clearing the class-not-found fatal.',
+		} )
+		.option( 'log-scan', {
+			type: 'boolean',
+			default: true,
+			description:
+				'Scan the docker debug.log for class-not-found fatals (Signal 1). Use --no-log-scan to skip.',
+		} )
+		.option( 'lines', {
+			type: 'number',
+			default: 500,
+			description: 'How many lines of debug.log to scan.',
+		} )
+		.option( 'skip', {
+			type: 'array',
+			default: [],
+			description:
+				'Exclude one or more projects from the plan (repeatable). Useful when a project needs a full `jetpack build` instead.',
+		} )
+		.option( 'stop-on-error', {
+			type: 'boolean',
+			default: false,
+			description:
+				'Abort on the first failed project. Default is to continue and report which projects need attention at the end.',
+		} );
+}
+
+/**
+ * Pick the higher-priority of two actions for the same project.
+ *
+ * @param {string} a - First action.
+ * @param {string} b - Second action.
+ * @return {string} The winning action.
+ */
+function resolveAction( a, b ) {
+	return ( ACTION_RANK[ a ] ?? 0 ) >= ( ACTION_RANK[ b ] ?? 0 ) ? a : b;
+}
+
+/**
+ * Merge an action into a plan map, keeping the higher-priority action.
+ *
+ * @param {Map<string,string>} plan    - Plan being built.
+ * @param {string}             project - Project slug.
+ * @param {string}             action  - Proposed action.
+ */
+function mergeAction( plan, project, action ) {
+	const existing = plan.get( project );
+	plan.set( project, existing ? resolveAction( existing, action ) : action );
+}
+
+/**
+ * Project slugs that own a runtime jetpack-autoloader classmap (i.e. anything
+ * with its own vendor/composer/jetpack_autoload_classmap.php).
+ *
+ * In practice this is `projects/plugins/*`, since packages are consumed by
+ * plugins and don't ship their own runtime classmap.
+ *
+ * @param {string} slug - Project slug.
+ * @return {boolean} Whether the project owns a runtime classmap.
+ */
+function ownsRuntimeClassmap( slug ) {
+	return slug.startsWith( 'plugins/' );
+}
+
+/**
+ * Build the action plan from the source-drift signal (Signal 2).
+ *
+ * fast-build intentionally caps automatic work at cheap actions:
+ * `dump-autoload` for PHP / composer-autoload-block changes, and `build` for
+ * JS / asset source changes.
+ *
+ * When a project's `require` (composer) or `dependencies` (npm) block changed,
+ * we don't auto-install — installs belong to `jetpack build`. Such projects
+ * are returned separately so the caller can warn instead.
+ *
+ * @param {Map<string,Set<string>>} deps         - Dependency map (slug → Set of deps).
+ * @param {Iterable<string>}        targets      - Projects to consider.
+ * @param {string|null}             since        - Override base ref, or null to use per-project stamps.
+ * @param {boolean}                 autoloadOnly - When true, also downgrade `build` to `dump-autoload`.
+ * @param {string}                  cwd          - Monorepo root.
+ * @return {Promise<object>} Object with `plan` (Map of slug → action) and `heavy` (Array of {slug, reason} for projects whose changes need a full `jetpack build` instead).
+ */
+async function planFromSourceDrift( deps, targets, since, autoloadOnly, cwd ) {
+	const plan = new Map();
+	const heavy = [];
+	for ( const slug of targets ) {
+		if ( slug === 'monorepo' ) {
+			continue;
+		}
+		const base = since || ( await readStamp( slug, cwd ) );
+		if ( ! base ) {
+			// No stamp and no override → this project has never been recorded as built
+			// by fast-build; skip silently (the user can run `jetpack build` first to seed).
+			continue;
+		}
+		const buckets = await inspectProjectChanges( slug, base, cwd );
+		if ( buckets.missing ) {
+			heavy.push( { slug, reason: 'last-built SHA is no longer reachable in git' } );
+			continue;
+		}
+		if ( buckets.none ) {
+			continue;
+		}
+		if ( buckets.composerRequire ) {
+			heavy.push( { slug, reason: 'composer require/require-dev/extra.dependencies changed' } );
+			continue;
+		}
+		if ( buckets.jsDeps ) {
+			heavy.push( { slug, reason: 'package.json dependencies or scripts changed' } );
+			continue;
+		}
+		if ( buckets.jsSources ) {
+			mergeAction( plan, slug, autoloadOnly ? 'dump-autoload' : 'build' );
+		} else if ( buckets.phpAutoload ) {
+			mergeAction( plan, slug, 'dump-autoload' );
+		}
+	}
+	return { plan, heavy };
+}
+
+/**
+ * Build the action plan from the docker debug.log signal (Signal 1).
+ *
+ * For each missing class FQN, find the owning project and the plugins that
+ * consume it transitively; schedule `dump-autoload` on each plugin (and on the
+ * owner itself for symmetry).
+ *
+ * @param {Map<string,Set<string>>} deps    - Dependency map.
+ * @param {object}                  scan    - Output of scanForMissingSymbols.
+ * @param {string}                  cwd     - Monorepo root.
+ * @param {Set<string>}             skipSet - Projects to exclude from the plan and the diagnostic.
+ * @return {Promise<object>} Object with `plan` (Map of slug → action) and `resolved` (Array of {fqn, owner, plugins}).
+ */
+async function planFromLogScan( deps, scan, cwd, skipSet ) {
+	const plan = new Map();
+	const resolved = [];
+	if ( ! scan.missing.length ) {
+		return { plan, resolved };
+	}
+	for ( const fqn of scan.missing ) {
+		const owner = await findOwnerProject( fqn, cwd );
+		if ( ! owner ) {
+			resolved.push( { fqn, owner: null, plugins: [] } );
+			continue;
+		}
+		// Find every dependent that owns its own runtime classmap.
+		const dependents = filterDeps( deps, [ owner ], { dependents: true } );
+		let consumers = [ ...dependents.keys() ].filter( ownsRuntimeClassmap );
+		// Always regenerate in the owner too, in case it's a plugin itself.
+		if ( ownsRuntimeClassmap( owner ) && ! consumers.includes( owner ) ) {
+			consumers.push( owner );
+		}
+		if ( skipSet && skipSet.size ) {
+			consumers = consumers.filter( slug => ! skipSet.has( slug ) );
+		}
+		for ( const slug of consumers ) {
+			mergeAction( plan, slug, 'dump-autoload' );
+		}
+		resolved.push( { fqn, owner, plugins: consumers } );
+	}
+	return { plan, resolved };
+}
+
+/**
+ * Execute a single planned action for one project.
+ *
+ * @param {string} slug   - Project slug.
+ * @param {string} action - Action to run.
+ * @param {object} argv   - Argv.
+ */
+async function runAction( slug, action, argv ) {
+	const cwd = projectDir( slug );
+	const stdio = [ 'ignore', argv.v ? 'inherit' : 'pipe', argv.v ? 'inherit' : 'pipe' ];
+	if ( action === 'dump-autoload' ) {
+		await execa( 'composer', [ 'dump-autoload' ], { cwd, stdio, buffer: false } );
+		return;
+	}
+	if ( action === 'build' ) {
+		await runBuildScriptIfAny( slug, cwd, argv );
+		return;
+	}
+	throw new Error( `Unknown action: ${ action }` );
+}
+
+/**
+ * Run a project's composer build-development (or build-production) script when present.
+ *
+ * @param {string} slug - Project slug (for diagnostics).
+ * @param {string} cwd  - Project directory.
+ * @param {object} argv - Argv.
+ */
+async function runBuildScriptIfAny( slug, cwd, argv ) {
+	const fs = await import( 'fs/promises' );
+	let composerJson;
+	try {
+		composerJson = JSON.parse(
+			await fs.readFile( `${ cwd }/composer.json`, { encoding: 'utf8' } )
+		);
+	} catch {
+		return;
+	}
+	const candidates = argv.production
+		? [ 'build-production', 'build-development' ]
+		: [ 'build-development', 'build-production' ];
+	const script = candidates.find( s => composerJson.scripts?.[ s ] );
+	if ( ! script ) {
+		return;
+	}
+	await execa( 'composer', [ 'run', '--timeout=0', script ], {
+		cwd,
+		stdio: [ 'ignore', argv.v ? 'inherit' : 'pipe', argv.v ? 'inherit' : 'pipe' ],
+		buffer: false,
+	} );
+}
+
+/**
+ * Convert a plan map to a topologically-ordered list of (slug, action) pairs.
+ *
+ * Reuses dependencyAnalysis.getBuildOrder for ordering so that a package builds
+ * before any plugin that depends on it.
+ *
+ * @param {Map<string,Set<string>>} deps - Full dependency map.
+ * @param {Map<string,string>}      plan - Plan map.
+ * @return {Array<{ slug: string, action: string }>} Ordered work items.
+ */
+function orderPlan( deps, plan ) {
+	if ( plan.size === 0 ) {
+		return [];
+	}
+	const slugs = [ ...plan.keys() ];
+	const filtered = filterDeps( deps, slugs );
+	// Clone so getBuildOrder can mutate.
+	const clone = new Map();
+	for ( const [ k, v ] of filtered ) {
+		clone.set( k, new Set( v ) );
+	}
+	const order = getBuildOrder( clone ).flat();
+	return order
+		.filter( slug => plan.has( slug ) )
+		.map( slug => ( { slug, action: plan.get( slug ) } ) );
+}
+
+/**
+ * Verify the site by curling --url and re-scanning the log for fatals.
+ *
+ * @param {object} argv - Argv.
+ * @return {Promise<{ status: number|null, missing: string[] }>} Verification result.
+ */
+async function verify( argv ) {
+	let status = null;
+	try {
+		const { stdout } = await execa(
+			'curl',
+			[ '-sS', '-o', '/dev/null', '-w', '%{http_code}', argv.url ],
+			{ reject: false }
+		);
+		status = parseInt( stdout, 10 );
+	} catch {
+		// Leave status null — caller decides how strict to be.
+	}
+	const scan = await scanForMissingSymbols( { lines: argv.lines } );
+	return { status, missing: scan.missing };
+}
+
+/**
+ * Handle the fast-build command.
+ *
+ * @param {object} argv - Argv.
+ */
+export async function handler( argv ) {
+	const cwd = process.cwd();
+	const deps = await getDependencies( cwd, 'build' );
+
+	const skipSet = new Set( argv.skip || [] );
+	const targets =
+		argv.project && argv.project.length ? new Set( argv.project ) : new Set( deps.keys() );
+	for ( const slug of skipSet ) {
+		targets.delete( slug );
+	}
+
+	// Signal 1 — log scan.
+	let logScan = { container: null, missing: [] };
+	let logPlan = new Map();
+	let logResolved = [];
+	if ( argv.logScan ) {
+		logScan = await scanForMissingSymbols( { lines: argv.lines } );
+		( { plan: logPlan, resolved: logResolved } = await planFromLogScan(
+			deps,
+			logScan,
+			cwd,
+			skipSet
+		) );
+		// Honor the explicit project filter too (--skip is already applied inside planFromLogScan).
+		if ( argv.project && argv.project.length ) {
+			for ( const slug of [ ...logPlan.keys() ] ) {
+				if ( ! targets.has( slug ) ) {
+					logPlan.delete( slug );
+				}
+			}
+		}
+	}
+
+	// Signal 2 — source drift.
+	const { plan: driftPlan, heavy } = await planFromSourceDrift(
+		deps,
+		targets,
+		argv.since || null,
+		!! argv.autoloadOnly,
+		cwd
+	);
+
+	// Merge.
+	const plan = new Map();
+	for ( const [ slug, action ] of logPlan ) {
+		mergeAction( plan, slug, action );
+	}
+	for ( const [ slug, action ] of driftPlan ) {
+		mergeAction( plan, slug, action );
+	}
+
+	const ordered = orderPlan( deps, plan );
+
+	printPlanHeader( logScan, logResolved, ordered, heavy, argv );
+
+	if ( ordered.length === 0 ) {
+		console.log( chalkJetpackGreen( 'Nothing to do.' ) );
+		return;
+	}
+	if ( argv.dryRun ) {
+		return;
+	}
+
+	const t0 = Date.now();
+	const failures = [];
+	const tasks = ordered.map( ( { slug, action } ) => ( {
+		title: `${ chalk.bold( slug ) } ${ chalk.grey( `[${ action }]` ) }`,
+		task: async ( _ctx, task ) => {
+			const startedAt = Date.now();
+			try {
+				await runAction( slug, action, argv );
+				task.title += chalk.grey( ` (${ formatDuration( Date.now() - startedAt ) }s)` );
+				const sha = await currentHead( cwd );
+				await writeStamp( slug, sha, cwd );
+			} catch ( e ) {
+				const message = e.shortMessage || e.message;
+				failures.push( { slug, action, message } );
+				throw new Error( `[${ slug }] ${ action } failed: ${ message }` );
+			}
+		},
+	} ) );
+
+	const listr = new Listr( tasks, {
+		renderer: argv.v ? SilentRenderer : UpdateRenderer,
+		concurrent: false,
+		exitOnError: !! argv.stopOnError,
+	} );
+
+	await listr.run().catch( err => {
+		// With exitOnError: false, listr resolves and we report below. With
+		// stopOnError: true, the run rejects and we abort.
+		if ( argv.stopOnError ) {
+			console.error( chalk.red( err.message ) );
+			process.exit( err.exitCode || 1 );
+		}
+	} );
+
+	const total = ordered.length;
+	const succeeded = total - failures.length;
+	if ( failures.length === 0 ) {
+		console.log( chalkJetpackGreen( `Done in ${ formatDuration( Date.now() - t0 ) }s.` ) );
+	} else {
+		console.log(
+			chalk.yellow(
+				`Done in ${ formatDuration( Date.now() - t0 ) }s with ${
+					failures.length
+				} failure(s) (${ succeeded } succeeded).`
+			)
+		);
+		printFailures( failures );
+	}
+
+	if ( argv.verify ) {
+		const result = await verify( argv );
+		printVerifyResult( result, argv );
+	}
+
+	if ( failures.length > 0 && ! argv.stopOnError ) {
+		// Exit non-zero so scripts/aliases can detect partial failure, but only after reporting.
+		process.exit( 1 );
+	}
+}
+
+/**
+ * Print a digestible summary of failed projects with a suggested next step.
+ *
+ * @param {Array<{ slug: string, action: string, message: string }>} failures - Failed tasks.
+ */
+function printFailures( failures ) {
+	console.log( chalk.bold( '\nFailed projects:' ) );
+	for ( const { slug, action, message } of failures ) {
+		console.log( `  ${ chalk.red( slug ) }  ${ chalk.grey( `[${ action }]` ) }` );
+		const compact = message.split( '\n' ).slice( 0, 4 ).join( '\n    ' );
+		console.log( `    ${ chalk.grey( compact ) }` );
+	}
+	const slugList = failures.map( f => f.slug ).join( ' ' );
+	const skipArgs = failures.map( f => `--skip ${ f.slug }` ).join( ' ' );
+	console.log(
+		chalk.yellow(
+			`\nNext steps: run \`jetpack build ${ slugList }\` (composer install + build) ` +
+				`to fix these, or re-run with \`${ skipArgs }\` to ignore them.`
+		)
+	);
+}
+
+/**
+ * Pretty-print the resolved plan before execution.
+ *
+ * @param {object}                                                        logScan     - scanForMissingSymbols result.
+ * @param {Array<{ fqn: string, owner: string|null, plugins: string[] }>} logResolved - Resolved log-scan info.
+ * @param {Array<{ slug: string, action: string }>}                       ordered     - Final ordered plan.
+ * @param {Array<{ slug: string, reason: string }>}                       heavy       - Projects that need full `jetpack build`.
+ * @param {object}                                                        argv        - Argv.
+ */
+function printPlanHeader( logScan, logResolved, ordered, heavy, argv ) {
+	if ( logScan.container ) {
+		console.log( chalk.grey( `Scanned debug.log in ${ logScan.container }.` ) );
+	} else if ( argv.logScan ) {
+		console.log( chalk.grey( 'No running Jetpack dev container detected — skipping log scan.' ) );
+	}
+	if ( logResolved.length ) {
+		console.log( chalk.bold( '\nMissing symbols in debug.log:' ) );
+		for ( const r of logResolved ) {
+			if ( r.owner ) {
+				console.log(
+					`  ${ chalk.yellow( r.fqn ) }  →  owner ${ chalk.cyan( r.owner ) }, regen in: ${
+						r.plugins.map( p => chalk.cyan( p ) ).join( ', ' ) || chalk.grey( 'none' )
+					}`
+				);
+			} else {
+				console.log(
+					`  ${ chalk.yellow( r.fqn ) }  →  ${ chalk.red(
+						'owner not found'
+					) } (you may need to run a full jetpack build)`
+				);
+			}
+		}
+	}
+	if ( heavy.length ) {
+		console.log(
+			chalk.bold(
+				`\nSkipping ${ heavy.length } project(s) whose dependency manifests changed — run \`jetpack build\` for these:`
+			)
+		);
+		for ( const { slug, reason } of heavy ) {
+			console.log( `  ${ chalk.cyan( slug ) }  ${ chalk.grey( `(${ reason })` ) }` );
+		}
+		console.log(
+			chalk.grey(
+				'  e.g. ' +
+					chalk.bold(
+						`jetpack build ${ heavy
+							.map( h => h.slug )
+							.slice( 0, 3 )
+							.join( ' ' ) }`
+					)
+			)
+		);
+	}
+	if ( ordered.length === 0 ) {
+		return;
+	}
+	console.log( chalk.bold( `\nPlanned actions (${ ordered.length }):` ) );
+	for ( const { slug, action } of ordered ) {
+		console.log( `  ${ chalk.cyan( slug ) }  ${ chalk.grey( `[${ action }]` ) }` );
+	}
+	console.log( '' );
+}
+
+/**
+ * Print the result of the post-fix verification step.
+ *
+ * @param {object} result - { status, missing }.
+ * @param {object} argv   - Argv.
+ */
+function printVerifyResult( result, argv ) {
+	const { status, missing } = result;
+	if ( status === null ) {
+		console.log( chalk.yellow( `Verify: could not curl ${ argv.url } (is the site running?).` ) );
+	} else if ( status >= 500 ) {
+		console.log( chalk.red( `Verify: ${ argv.url } returned HTTP ${ status }.` ) );
+	} else {
+		console.log( chalk.green( `Verify: ${ argv.url } → HTTP ${ status }.` ) );
+	}
+	if ( missing.length ) {
+		console.log(
+			chalk.red(
+				`Verify: debug.log still shows missing symbols: ${ missing
+					.slice( 0, 3 )
+					.map( m => chalk.yellow( m ) )
+					.join( ', ' ) }${ missing.length > 3 ? ', ...' : '' }`
+			)
+		);
+		console.log(
+			chalk.yellow(
+				'You may need a full `jetpack build <plugin>` if a transitive change is involved.'
+			)
+		);
+	} else if ( argv.logScan ) {
+		console.log( chalk.green( 'Verify: no class-not-found fatals in debug.log.' ) );
+	}
+}

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -121,6 +121,13 @@ export function builder( yargs ) {
 			type: 'number',
 			default: 3,
 			description: 'In --watch mode, seconds between log scans.',
+		} )
+		.option( 'production', {
+			alias: 'p',
+			type: 'boolean',
+			default: false,
+			description:
+				'Select the `build-production` composer script for `build` actions instead of `build-development`. Mirrors `jetpack build --production`.',
 		} );
 }
 

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -396,12 +396,17 @@ function orderPlan( deps, plan ) {
 }
 
 /**
- * Verify the site by curling --url and re-scanning the log for fatals.
+ * Verify the site by curling --url, re-scanning the log for fatals, and
+ * (when targeted FQNs are provided) confirming each is now present in at
+ * least one regenerated plugin classmap.
  *
- * @param {object} argv - Argv.
- * @return {Promise<{ status: number|null, missing: string[] }>} Verification result.
+ * @param {object}   argv               - Argv.
+ * @param {object}   options            - Verification options.
+ * @param {string[]} [options.expected] - FQNs we tried to resolve via Signal 1.
+ * @param {string}   [options.cwd]      - Monorepo root.
+ * @return {Promise<object>} Verification result with `status`, `missing`, and `expected`.
  */
-async function verify( argv ) {
+async function verify( argv, { expected = [], cwd = process.cwd() } = {} ) {
 	let status = null;
 	try {
 		const { stdout } = await execa(
@@ -414,7 +419,56 @@ async function verify( argv ) {
 		// Leave status null — caller decides how strict to be.
 	}
 	const scan = await scanForMissingSymbols( { lines: argv.lines } );
-	return { status, missing: scan.missing };
+	const expectedReport = expected.length ? await checkClassmaps( expected, cwd ) : [];
+	return { status, missing: scan.missing, expected: expectedReport };
+}
+
+/**
+ * For each FQN, check whether at least one plugin's
+ * `vendor/composer/jetpack_autoload_classmap.php` now lists it.
+ *
+ * Classmap entries look like `'Namespace\\ClassName' => $vendorDir . '/…'`.
+ * We grep for the FQN as a quoted key (with the standard PHP single-backslash
+ * encoding inside single quotes).
+ *
+ * @param {string[]} fqns - FQNs to check.
+ * @param {string}   cwd  - Monorepo root.
+ * @return {Promise<Array<{ fqn: string, resolvedIn: string[] }>>} Per-FQN report.
+ */
+async function checkClassmaps( fqns, cwd ) {
+	const report = [];
+	for ( const fqn of fqns ) {
+		// Inside a single-quoted PHP string, `\` is a literal backslash. The classmap
+		// file stores `'A\\B\\C'`, which is `A\B\C` after PHP string escaping. We
+		// already get `A\B\C` (with single backslashes) from the log parser.
+		const needle = fqn
+			.replace( /\\/g, '\\\\' ) // escape for grep's fixed-string mode below
+			.replace( /'/g, "\\'" );
+		const { stdout } = await execa(
+			'git',
+			[
+				'grep',
+				'-l',
+				'--no-index',
+				'-F',
+				`'${ needle }'`,
+				'projects/plugins/*/vendor/composer/jetpack_autoload_classmap.php',
+			],
+			{ cwd, reject: false }
+		);
+		const resolvedIn = stdout
+			.split( '\n' )
+			.filter( Boolean )
+			.map(
+				line =>
+					line.match(
+						/^projects\/(plugins\/[^/]+)\/vendor\/composer\/jetpack_autoload_classmap\.php$/
+					)?.[ 1 ] || null
+			)
+			.filter( Boolean );
+		report.push( { fqn, resolvedIn } );
+	}
+	return report;
 }
 
 /**
@@ -554,7 +608,8 @@ export async function handler( argv ) {
 	}
 
 	if ( argv.verify ) {
-		const result = await verify( argv );
+		const expected = logResolved.filter( r => r.owner ).map( r => r.fqn );
+		const result = await verify( argv, { expected, cwd } );
 		printVerifyResult( result, argv );
 	}
 
@@ -657,13 +712,33 @@ function printPlanHeader( logScan, logResolved, ordered, heavy, argv ) {
  * @param {object} argv   - Argv.
  */
 function printVerifyResult( result, argv ) {
-	const { status, missing } = result;
+	const { status, missing, expected = [] } = result;
 	if ( status === null ) {
 		console.log( chalk.yellow( `Verify: could not curl ${ argv.url } (is the site running?).` ) );
 	} else if ( status >= 500 ) {
 		console.log( chalk.red( `Verify: ${ argv.url } returned HTTP ${ status }.` ) );
 	} else {
 		console.log( chalk.green( `Verify: ${ argv.url } → HTTP ${ status }.` ) );
+	}
+	if ( expected.length ) {
+		const resolved = expected.filter( e => e.resolvedIn.length > 0 );
+		const stillMissing = expected.filter( e => e.resolvedIn.length === 0 );
+		if ( resolved.length ) {
+			console.log(
+				chalk.green(
+					`Verify: ${ resolved.length }/${ expected.length } targeted class(es) now resolve in their plugin classmaps.`
+				)
+			);
+		}
+		for ( const e of stillMissing ) {
+			console.log(
+				chalk.red(
+					`Verify: ${ chalk.yellow(
+						e.fqn
+					) } is still not in any plugin classmap — dump-autoload may have failed.`
+				)
+			);
+		}
 	}
 	if ( missing.length ) {
 		console.log(

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -105,6 +105,11 @@ export function builder( yargs ) {
 			default: false,
 			description:
 				'Stamp every project (or those named as positionals) at the current HEAD without running anything, so future runs have a baseline. Useful for first-time setup without doing a full `jetpack build`.',
+		} )
+		.option( 'log-path', {
+			type: 'string',
+			description:
+				'Read debug.log from this host-side path instead of the docker container (also honors $JETPACK_FASTBUILD_LOG). Use for wp-env / Playground / custom local setups.',
 		} );
 }
 
@@ -442,7 +447,7 @@ async function verify( argv, { expected = [], cwd = process.cwd() } = {} ) {
 	} catch {
 		// Leave status null — caller decides how strict to be.
 	}
-	const scan = await scanForMissingSymbols( { lines: argv.lines } );
+	const scan = await scanForMissingSymbols( { lines: argv.lines, logPath: argv.logPath } );
 	const expectedReport = expected.length ? await checkClassmaps( expected, cwd ) : [];
 	return { status, missing: scan.missing, expected: expectedReport };
 }
@@ -534,7 +539,7 @@ export async function handler( argv ) {
 	let logPlan = new Map();
 	let logResolved = [];
 	if ( argv.logScan ) {
-		logScan = await scanForMissingSymbols( { lines: argv.lines } );
+		logScan = await scanForMissingSymbols( { lines: argv.lines, logPath: argv.logPath } );
 		( { plan: logPlan, resolved: logResolved } = await planFromLogScan(
 			deps,
 			logScan,
@@ -688,15 +693,19 @@ function printFailures( failures ) {
  * @param {object}                                                        argv        - Argv.
  */
 function printPlanHeader( logScan, logResolved, ordered, heavy, argv ) {
-	if ( logScan.container ) {
+	if ( logScan.source && logScan.source.startsWith( 'docker:' ) ) {
 		console.log( chalk.grey( `Scanned debug.log in ${ logScan.container }.` ) );
+	} else if ( logScan.source ) {
+		console.log( chalk.grey( `Scanned debug.log from ${ logScan.source }.` ) );
 	} else if ( argv.logScan ) {
 		console.log( chalk.grey( 'No running Jetpack dev container detected — skipping log scan.' ) );
 		console.log(
 			chalk.grey(
 				`  Tip: ${ chalk.bold(
 					'jetpack docker up -d'
-				) } starts the dev environment so Signal 1 can read its debug.log.`
+				) } starts the dev environment, or pass ${ chalk.bold(
+					'--log-path /path/to/debug.log'
+				) } to read a host-side log file (e.g. wp-env / Playground / custom setups).`
 			)
 		);
 	}

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -655,6 +655,13 @@ function printPlanHeader( logScan, logResolved, ordered, heavy, argv ) {
 		console.log( chalk.grey( `Scanned debug.log in ${ logScan.container }.` ) );
 	} else if ( argv.logScan ) {
 		console.log( chalk.grey( 'No running Jetpack dev container detected — skipping log scan.' ) );
+		console.log(
+			chalk.grey(
+				`  Tip: ${ chalk.bold(
+					'jetpack docker up -d'
+				) } starts the dev environment so Signal 1 can read its debug.log.`
+			)
+		);
 	}
 	if ( logResolved.length ) {
 		console.log( chalk.bold( '\nMissing symbols in debug.log:' ) );

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -110,6 +110,17 @@ export function builder( yargs ) {
 			type: 'string',
 			description:
 				'Read debug.log from this host-side path instead of the docker container (also honors $JETPACK_FASTBUILD_LOG). Use for wp-env / Playground / custom local setups.',
+		} )
+		.option( 'watch', {
+			type: 'boolean',
+			default: false,
+			description:
+				'Stay running, re-scan the debug.log every few seconds, and auto-fix on each new class-not-found fatal. Ctrl-C to exit.',
+		} )
+		.option( 'watch-interval', {
+			type: 'number',
+			default: 3,
+			description: 'In --watch mode, seconds between log scans.',
 		} );
 }
 
@@ -348,6 +359,110 @@ async function runBuildScriptIfAny( slug, cwd, argv ) {
 }
 
 /**
+ * Watch loop: poll the debug.log for new class-not-found fatals and re-run a
+ * Signal-1-only pass each time the set of missing symbols changes.
+ *
+ * Stays alive until SIGINT (Ctrl-C). Source-drift planning is skipped here on
+ * purpose — `--watch` is for reacting to fatals while you're developing, not
+ * for ambient rebuilds.
+ *
+ * @param {object}      argv    - Argv.
+ * @param {Map}         deps    - Dependency map.
+ * @param {Set<string>} skipSet - Projects to ignore.
+ * @param {string}      cwd     - Monorepo root.
+ */
+async function runWatchLoop( argv, deps, skipSet, cwd ) {
+	const intervalMs = Math.max( 500, ( argv.watchInterval || 3 ) * 1000 );
+	console.log(
+		chalkJetpackGreen( `Watching debug.log every ${ intervalMs / 1000 }s. Ctrl-C to exit.` )
+	);
+	let lastSignature = '';
+	let busy = false;
+	let stopped = false;
+	const stop = () => {
+		stopped = true;
+		console.log( chalk.grey( '\nStopping watch.' ) );
+	};
+	process.once( 'SIGINT', stop );
+	process.once( 'SIGTERM', stop );
+
+	while ( ! stopped ) {
+		if ( ! busy ) {
+			busy = true;
+			try {
+				const scan = await scanForMissingSymbols( {
+					lines: argv.lines,
+					logPath: argv.logPath,
+				} );
+				const signature = scan.missing.join( '|' );
+				if ( signature && signature !== lastSignature ) {
+					console.log(
+						chalk.bold(
+							`\n[${ new Date().toLocaleTimeString() }] Detected ${
+								scan.missing.length
+							} missing symbol(s):`
+						)
+					);
+					for ( const fqn of scan.missing ) {
+						console.log( `  ${ chalk.yellow( fqn ) }` );
+					}
+					const { plan, resolved } = await planFromLogScan( deps, scan, cwd, skipSet );
+					await runPlanOnce( plan, resolved, argv, cwd );
+					lastSignature = signature;
+				}
+			} catch ( e ) {
+				console.log( chalk.red( `Watch loop error: ${ e.message }` ) );
+			}
+			busy = false;
+		}
+		await new Promise( resolve => setTimeout( resolve, intervalMs ) );
+	}
+}
+
+/**
+ * Execute a single plan (used by --watch). Reuses runAction + stamping; skips
+ * the headline planning printouts and the final exit code.
+ *
+ * @param {Map<string,string>} plan     - Slug → action.
+ * @param {Array}              resolved - Signal-1 resolution info for the verify step.
+ * @param {object}             argv     - Argv.
+ * @param {string}             cwd      - Monorepo root.
+ */
+async function runPlanOnce( plan, resolved, argv, cwd ) {
+	const deps = await getDependencies( cwd, 'build' );
+	const ordered = orderPlan( deps, plan );
+	if ( ordered.length === 0 ) {
+		console.log( chalk.grey( '  Nothing to do.' ) );
+		return;
+	}
+	const concurrency = Math.max( 1, argv.concurrency || 1 );
+	const allDumpAutoload = ordered.every( o => o.action === 'dump-autoload' );
+	const limit = pLimit( allDumpAutoload ? concurrency : 1 );
+	await Promise.all(
+		ordered.map( ( { slug, action } ) =>
+			limit( async () => {
+				const t0 = Date.now();
+				try {
+					await runAction( slug, action, argv );
+					const sha = await currentHead( cwd );
+					await writeStamp( slug, sha, action === 'build' ? 'build' : 'autoload', cwd );
+					console.log(
+						chalk.green( `  ✓ ${ slug } [${ action }] (${ formatDuration( Date.now() - t0 ) }s)` )
+					);
+				} catch ( e ) {
+					console.log( chalk.red( `  ✖ ${ slug } [${ action }]: ${ summarizeExecError( e ) }` ) );
+				}
+			} )
+		)
+	);
+	if ( argv.verify ) {
+		const expected = resolved.filter( r => r.owner ).map( r => r.fqn );
+		const result = await verify( argv, { expected, cwd } );
+		printVerifyResult( result, argv );
+	}
+}
+
+/**
  * Read the persistent skip list at `.jetpack-cli/skip.txt`. One project slug per
  * line, blank lines and `#`-prefixed comments ignored.
  *
@@ -531,6 +646,11 @@ export async function handler( argv ) {
 
 	if ( argv.seed ) {
 		await seedStamps( targets, cwd );
+		return;
+	}
+
+	if ( argv.watch ) {
+		await runWatchLoop( argv, deps, skipSet, cwd );
 		return;
 	}
 

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -3,6 +3,7 @@ import { execa } from 'execa';
 import Listr from 'listr';
 import SilentRenderer from 'listr-silent-renderer';
 import UpdateRenderer from 'listr-update-renderer';
+import pLimit from 'p-limit';
 import { findOwnerProject } from '../helpers/classOwner.js';
 import { filterDeps, getBuildOrder, getDependencies } from '../helpers/dependencyAnalysis.js';
 import formatDuration from '../helpers/format-duration.js';
@@ -20,7 +21,7 @@ export const describe =
  *
  * @see resolveAction
  */
-const ACTION_RANK = {
+export const ACTION_RANK = {
 	skip: 0,
 	'dump-autoload': 1,
 	build: 2,
@@ -85,6 +86,12 @@ export function builder( yargs ) {
 			default: false,
 			description:
 				'Abort on the first failed project. Default is to continue and report which projects need attention at the end.',
+		} )
+		.option( 'concurrency', {
+			type: 'number',
+			default: 4,
+			description:
+				'How many `dump-autoload` actions to run in parallel. Build actions always run serially because they may have inter-project dependencies. Use 1 to force fully serial execution.',
 		} );
 }
 
@@ -95,7 +102,7 @@ export function builder( yargs ) {
  * @param {string} b - Second action.
  * @return {string} The winning action.
  */
-function resolveAction( a, b ) {
+export function resolveAction( a, b ) {
 	return ( ACTION_RANK[ a ] ?? 0 ) >= ( ACTION_RANK[ b ] ?? 0 ) ? a : b;
 }
 
@@ -106,7 +113,7 @@ function resolveAction( a, b ) {
  * @param {string}             project - Project slug.
  * @param {string}             action  - Proposed action.
  */
-function mergeAction( plan, project, action ) {
+export function mergeAction( plan, project, action ) {
 	const existing = plan.get( project );
 	plan.set( project, existing ? resolveAction( existing, action ) : action );
 }
@@ -121,7 +128,7 @@ function mergeAction( plan, project, action ) {
  * @param {string} slug - Project slug.
  * @return {boolean} Whether the project owns a runtime classmap.
  */
-function ownsRuntimeClassmap( slug ) {
+export function ownsRuntimeClassmap( slug ) {
 	return slug.startsWith( 'plugins/' );
 }
 
@@ -233,9 +240,14 @@ async function planFromLogScan( deps, scan, cwd, skipSet ) {
  */
 async function runAction( slug, action, argv ) {
 	const cwd = projectDir( slug );
-	const stdio = [ 'ignore', argv.v ? 'inherit' : 'pipe', argv.v ? 'inherit' : 'pipe' ];
 	if ( action === 'dump-autoload' ) {
-		await execa( 'composer', [ 'dump-autoload' ], { cwd, stdio, buffer: false } );
+		// Buffer stdout/stderr when not verbose so we can surface composer's actual
+		// error output if the command fails (otherwise the user just sees "exit code 1").
+		const stdio = argv.v ? 'inherit' : 'pipe';
+		await execa( 'composer', [ 'dump-autoload', '--no-interaction' ], {
+			cwd,
+			stdio,
+		} );
 		return;
 	}
 	if ( action === 'build' ) {
@@ -243,6 +255,42 @@ async function runAction( slug, action, argv ) {
 		return;
 	}
 	throw new Error( `Unknown action: ${ action }` );
+}
+
+/**
+ * Pull the most informative chunk out of an execa error for inline display.
+ *
+ * Composer's stderr is usually a wall of help text; the actually-useful lines
+ * are above it. We try stderr first (composer puts diagnostics there), then
+ * stdout, then the bare exit message.
+ *
+ * @param {Error}  error - execa error.
+ * @param {number} [n]   - Max number of lines to include.
+ * @return {string} Compact, multi-line snippet suitable for printing under a task title.
+ */
+export function summarizeExecError( error, n = 6 ) {
+	const pickFirst = text => {
+		if ( ! text ) {
+			return '';
+		}
+		const lines = text
+			.split( '\n' )
+			.map( s => s.replace( /\s+$/, '' ) )
+			.filter( s => s.length > 0 );
+		// Strip composer's "dump-autoload [-o|...] ..." usage trailer that follows real errors.
+		const cutAt = lines.findIndex( s => /^dump-autoload\s+\[/i.test( s ) );
+		const trimmed = cutAt >= 0 ? lines.slice( 0, cutAt ) : lines;
+		return trimmed.slice( 0, n ).join( '\n' );
+	};
+	const fromStderr = pickFirst( error.stderr );
+	if ( fromStderr ) {
+		return fromStderr;
+	}
+	const fromStdout = pickFirst( error.stdout );
+	if ( fromStdout ) {
+		return fromStdout;
+	}
+	return error.shortMessage || error.message || 'Unknown error';
 }
 
 /**
@@ -395,26 +443,38 @@ export async function handler( argv ) {
 
 	const t0 = Date.now();
 	const failures = [];
+
+	// dump-autoload actions are independent per plugin (each plugin has its own
+	// vendor/composer/jetpack_autoload_classmap.php), so they can run in parallel.
+	// `build` actions stay serial because Listr-internal topological ordering
+	// guarantees a dependency package's build emits before a dependent plugin's
+	// build starts. Mixed plans are run serial to be safe.
+	const allDumpAutoload = ordered.every( o => o.action === 'dump-autoload' );
+	const concurrency = Math.max( 1, argv.concurrency || 1 );
+	const limit = pLimit( allDumpAutoload ? concurrency : 1 );
+
 	const tasks = ordered.map( ( { slug, action } ) => ( {
 		title: `${ chalk.bold( slug ) } ${ chalk.grey( `[${ action }]` ) }`,
-		task: async ( _ctx, task ) => {
-			const startedAt = Date.now();
-			try {
-				await runAction( slug, action, argv );
-				task.title += chalk.grey( ` (${ formatDuration( Date.now() - startedAt ) }s)` );
-				const sha = await currentHead( cwd );
-				await writeStamp( slug, sha, cwd );
-			} catch ( e ) {
-				const message = e.shortMessage || e.message;
-				failures.push( { slug, action, message } );
-				throw new Error( `[${ slug }] ${ action } failed: ${ message }` );
-			}
-		},
+		task: ( _ctx, task ) =>
+			limit( async () => {
+				const startedAt = Date.now();
+				try {
+					await runAction( slug, action, argv );
+					task.title += chalk.grey( ` (${ formatDuration( Date.now() - startedAt ) }s)` );
+					const sha = await currentHead( cwd );
+					await writeStamp( slug, sha, cwd );
+				} catch ( e ) {
+					const detail = summarizeExecError( e );
+					failures.push( { slug, action, message: detail } );
+					throw new Error( `[${ slug }] ${ action } failed:\n${ detail }` );
+				}
+			} ),
 	} ) );
 
 	const listr = new Listr( tasks, {
 		renderer: argv.v ? SilentRenderer : UpdateRenderer,
-		concurrent: false,
+		// When parallelism is on, ask Listr to schedule everything at once and let pLimit gate.
+		concurrent: allDumpAutoload && concurrency > 1,
 		exitOnError: !! argv.stopOnError,
 	} );
 

--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -8,7 +8,12 @@ import { findOwnerProject } from '../helpers/classOwner.js';
 import { filterDeps, getBuildOrder, getDependencies } from '../helpers/dependencyAnalysis.js';
 import formatDuration from '../helpers/format-duration.js';
 import { projectDir } from '../helpers/install.js';
-import { currentHead, inspectProjectChanges, readStamp, writeStamp } from '../helpers/lastBuilt.js';
+import {
+	currentHead,
+	inspectProjectChanges,
+	readStamps,
+	writeStamp,
+} from '../helpers/lastBuilt.js';
 import { scanForMissingSymbols } from '../helpers/logScan.js';
 import { chalkJetpackGreen } from '../helpers/styling.js';
 
@@ -157,13 +162,19 @@ async function planFromSourceDrift( deps, targets, since, autoloadOnly, cwd ) {
 		if ( slug === 'monorepo' ) {
 			continue;
 		}
-		const base = since || ( await readStamp( slug, cwd ) );
-		if ( ! base ) {
-			// No stamp and no override → this project has never been recorded as built
-			// by fast-build; skip silently (the user can run `jetpack build` first to seed).
-			continue;
+		let baselines;
+		if ( since ) {
+			baselines = { sinceBuild: since, sinceAutoload: since };
+		} else {
+			const stamps = await readStamps( slug, cwd );
+			if ( ! stamps.build ) {
+				// No build stamp → this project has never been recorded as built by us; skip
+				// silently. The user can `jetpack fast-build --seed` to bootstrap.
+				continue;
+			}
+			baselines = { sinceBuild: stamps.build, sinceAutoload: stamps.autoload || stamps.build };
 		}
-		const buckets = await inspectProjectChanges( slug, base, cwd );
+		const buckets = await inspectProjectChanges( slug, baselines, cwd );
 		if ( buckets.missing ) {
 			heavy.push( { slug, reason: 'last-built SHA is no longer reachable in git' } );
 			continue;
@@ -462,7 +473,9 @@ export async function handler( argv ) {
 					await runAction( slug, action, argv );
 					task.title += chalk.grey( ` (${ formatDuration( Date.now() - startedAt ) }s)` );
 					const sha = await currentHead( cwd );
-					await writeStamp( slug, sha, cwd );
+					// `build` updates both build + autoload stamps; `dump-autoload`
+					// only advances the autoload stamp so we don't claim JS is fresh.
+					await writeStamp( slug, sha, action === 'build' ? 'build' : 'autoload', cwd );
 				} catch ( e ) {
 					const detail = summarizeExecError( e );
 					failures.push( { slug, action, message: detail } );

--- a/tools/cli/helpers/classOwner.js
+++ b/tools/cli/helpers/classOwner.js
@@ -1,0 +1,141 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { execa } from 'execa';
+import { glob } from 'glob';
+
+let psr4CachePromise = null;
+
+/**
+ * Build (and cache) the map of PSR-4 namespace prefix → owning project slug.
+ *
+ * Sourced from every `projects/{plugins,packages}/* /composer.json`'s
+ * `autoload.psr-4` and `autoload-dev.psr-4` sections.
+ *
+ * @param {string} [cwd] - Monorepo root.
+ * @return {Promise<Array<{ prefix: string, slug: string }>>} Entries sorted by prefix length (longest first).
+ */
+async function loadPsr4Map( cwd = process.cwd() ) {
+	if ( ! psr4CachePromise ) {
+		psr4CachePromise = ( async () => {
+			const entries = [];
+			const files = await glob( 'projects/*/*/composer.json', { cwd } );
+			for ( const file of files ) {
+				const slug = file.substring( 9, file.length - '/composer.json'.length );
+				let json;
+				try {
+					json = JSON.parse( await fs.readFile( path.join( cwd, file ), { encoding: 'utf8' } ) );
+				} catch {
+					continue;
+				}
+				const sections = [ json.autoload?.[ 'psr-4' ], json[ 'autoload-dev' ]?.[ 'psr-4' ] ];
+				for ( const section of sections ) {
+					if ( ! section ) {
+						continue;
+					}
+					for ( const prefix of Object.keys( section ) ) {
+						if ( prefix ) {
+							entries.push( { prefix: prefix.replace( /^\\+/, '' ), slug } );
+						}
+					}
+				}
+			}
+			entries.sort( ( a, b ) => b.prefix.length - a.prefix.length );
+			return entries;
+		} )();
+	}
+	return psr4CachePromise;
+}
+
+/**
+ * Reset the cached PSR-4 map. Test-only.
+ */
+export function _resetCache() {
+	psr4CachePromise = null;
+}
+
+/**
+ * Resolve a class/interface/trait FQN to its owning project slug.
+ *
+ * Tries PSR-4 prefix matching first (longest prefix wins), then falls back to a
+ * `git grep` for the short name across `projects/`.
+ *
+ * @param {string} fqn   - Fully-qualified name, e.g. "Automattic\\Jetpack\\Foo\\Bar".
+ * @param {string} [cwd] - Monorepo root.
+ * @return {Promise<string|null>} Project slug (e.g. "packages/foo"), or null if not resolved.
+ */
+export async function findOwnerProject( fqn, cwd = process.cwd() ) {
+	const normalized = fqn.replace( /^\\+/, '' );
+	const map = await loadPsr4Map( cwd );
+	for ( const { prefix, slug } of map ) {
+		if ( normalized === prefix.replace( /\\$/, '' ) || normalized.startsWith( prefix ) ) {
+			return slug;
+		}
+	}
+
+	// Fallback: grep the source tree. Most Jetpack packages use classmap autoload
+	// rather than PSR-4, so this is the main code path in practice.
+	const shortName = normalized.split( '\\' ).pop();
+	if ( ! shortName || ! /^[A-Za-z_][A-Za-z0-9_]*$/.test( shortName ) ) {
+		return null;
+	}
+	// `--untracked` so we find class files that exist on disk but haven't been added yet,
+	// which is the exact branch-switch / new-file scenario the user hits in practice.
+	let grepStdout;
+	try {
+		grepStdout = (
+			await execa(
+				'git',
+				[
+					'grep',
+					'--untracked',
+					'-l',
+					'--',
+					`\\(class\\|interface\\|trait\\)\\s\\+${ shortName }\\b`,
+					'projects/',
+				],
+				{ cwd, reject: false }
+			)
+		).stdout;
+	} catch {
+		return null;
+	}
+	const namespace = normalized.split( '\\' ).slice( 0, -1 ).join( '\\' );
+	const candidates = grepStdout.split( '\n' ).filter( Boolean );
+
+	// If we have a namespace, verify each candidate declares the same namespace
+	// before accepting it — multiple packages can declare classes with the same short name.
+	for ( const candidate of candidates ) {
+		const slug = candidate.match( /^projects\/([^/]+\/[^/]+)\// )?.[ 1 ];
+		if ( ! slug ) {
+			continue;
+		}
+		if ( ! namespace ) {
+			return slug;
+		}
+		const fileNs = await readNamespace( path.join( cwd, candidate ) );
+		if ( fileNs === namespace ) {
+			return slug;
+		}
+	}
+	// Namespace-verified match wasn't found; if there's only one candidate, fall back to it.
+	if ( candidates.length === 1 ) {
+		return candidates[ 0 ].match( /^projects\/([^/]+\/[^/]+)\// )?.[ 1 ] || null;
+	}
+	return null;
+}
+
+/**
+ * Read the `namespace X\Y\Z` declaration from a PHP file, if any.
+ *
+ * @param {string} file - Absolute path to the PHP file.
+ * @return {Promise<string|null>} The namespace string, or null when none is declared.
+ */
+async function readNamespace( file ) {
+	try {
+		const data = await fs.readFile( file, { encoding: 'utf8' } );
+		const m = data.match( /^\s*namespace\s+([^\s;{]+)\s*[;{]/m );
+		return m ? m[ 1 ].replace( /^\\+/, '' ) : null;
+	} catch {
+		return null;
+	}
+}

--- a/tools/cli/helpers/classOwner.js
+++ b/tools/cli/helpers/classOwner.js
@@ -102,26 +102,63 @@ export async function findOwnerProject( fqn, cwd = process.cwd() ) {
 	const namespace = normalized.split( '\\' ).slice( 0, -1 ).join( '\\' );
 	const candidates = grepStdout.split( '\n' ).filter( Boolean );
 
-	// If we have a namespace, verify each candidate declares the same namespace
-	// before accepting it — multiple packages can declare classes with the same short name.
+	// Phase 1: namespace-verified match. Multiple packages can declare classes
+	// with the same short name (e.g. "Manager"), so when we have a namespace,
+	// only accept candidates whose `namespace X\Y;` declaration matches.
 	for ( const candidate of candidates ) {
 		const slug = candidate.match( /^projects\/([^/]+\/[^/]+)\// )?.[ 1 ];
 		if ( ! slug ) {
 			continue;
 		}
 		if ( ! namespace ) {
-			return slug;
+			// No namespace to verify — bail out of phase 1, let phase 2 handle it.
+			break;
 		}
 		const fileNs = await readNamespace( path.join( cwd, candidate ) );
 		if ( fileNs === namespace ) {
 			return slug;
 		}
 	}
-	// Namespace-verified match wasn't found; if there's only one candidate, fall back to it.
-	if ( candidates.length === 1 ) {
+
+	// Phase 2: no namespace-verified match. Restrict candidates to files that
+	// look like real class definitions (Jetpack's class-<short>.php convention,
+	// or files under a src/, classes/, lib/, or legacy/ directory). This filters
+	// out test fixtures, README excerpts, and incidental "class Foo" mentions.
+	const plausible = candidates.filter( looksLikeClassFile );
+	if ( plausible.length === 1 ) {
+		return plausible[ 0 ].match( /^projects\/([^/]+\/[^/]+)\// )?.[ 1 ] || null;
+	}
+	if ( ! namespace && candidates.length === 1 ) {
+		// FQN had no namespace and exactly one candidate exists — accept it.
 		return candidates[ 0 ].match( /^projects\/([^/]+\/[^/]+)\// )?.[ 1 ] || null;
 	}
 	return null;
+}
+
+/**
+ * Heuristic: does this file path look like a class definition (vs. a test
+ * fixture, README, or arbitrary mention of "class X" in a comment or string)?
+ *
+ * @param {string} file - Repo-relative path returned by `git grep`.
+ * @return {boolean} True when the path matches a Jetpack class-file convention.
+ */
+function looksLikeClassFile( file ) {
+	if ( /\/(tests|test|__tests__|fixtures|stubs)\//i.test( file ) ) {
+		return false;
+	}
+	if ( /\/class-[a-z0-9-]+\.php$/i.test( file ) ) {
+		return true;
+	}
+	// PSR-4-style same-name file (Manager.php for class Manager). Looser than
+	// strict PSR-4 but catches the convention.
+	if ( /\/[A-Z][A-Za-z0-9_]*\.php$/.test( file ) ) {
+		return true;
+	}
+	// Inside a conventional source directory.
+	if ( /\/(src|classes|lib|legacy)\//i.test( file ) ) {
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/tools/cli/helpers/lastBuilt.js
+++ b/tools/cli/helpers/lastBuilt.js
@@ -1,0 +1,325 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { execa } from 'execa';
+
+const STAMP_DIR = '.jetpack-cli/last-built';
+
+/**
+ * Resolve the absolute directory where per-project last-built SHAs are stored.
+ *
+ * @param {string} [cwd] - Monorepo root.
+ * @return {string} Absolute path to the stamp directory.
+ */
+export function stampDir( cwd = process.cwd() ) {
+	return path.resolve( cwd, STAMP_DIR );
+}
+
+/**
+ * Path to a project's last-built stamp file.
+ *
+ * @param {string} slug  - Project slug (e.g. "plugins/jetpack").
+ * @param {string} [cwd] - Monorepo root.
+ * @return {string} Absolute path.
+ */
+function stampPath( slug, cwd = process.cwd() ) {
+	const safe = slug.replace( /\//g, '__' );
+	return path.join( stampDir( cwd ), `${ safe }.sha` );
+}
+
+/**
+ * Read the last-built SHA for a project, if any.
+ *
+ * @param {string} slug  - Project slug.
+ * @param {string} [cwd] - Monorepo root.
+ * @return {Promise<string|null>} The SHA, or null if no stamp exists.
+ */
+export async function readStamp( slug, cwd = process.cwd() ) {
+	try {
+		const data = await fs.readFile( stampPath( slug, cwd ), { encoding: 'utf8' } );
+		const sha = data.trim();
+		return sha || null;
+	} catch ( e ) {
+		if ( e.code === 'ENOENT' ) {
+			return null;
+		}
+		throw e;
+	}
+}
+
+/**
+ * Write the last-built SHA for a project.
+ *
+ * @param {string} slug  - Project slug.
+ * @param {string} sha   - Git SHA to record.
+ * @param {string} [cwd] - Monorepo root.
+ */
+export async function writeStamp( slug, sha, cwd = process.cwd() ) {
+	const file = stampPath( slug, cwd );
+	await fs.mkdir( path.dirname( file ), { recursive: true } );
+	await fs.writeFile( file, sha + '\n', { encoding: 'utf8' } );
+}
+
+/**
+ * Resolve the current HEAD SHA of the monorepo.
+ *
+ * @param {string} [cwd] - Monorepo root.
+ * @return {Promise<string>} The SHA.
+ */
+export async function currentHead( cwd = process.cwd() ) {
+	const { stdout } = await execa( 'git', [ 'rev-parse', 'HEAD' ], { cwd } );
+	return stdout.trim();
+}
+
+/**
+ * Get files changed for a project between two refs.
+ *
+ * If `since` is null, returns null (caller treats as "no stamp, needs full build").
+ * If `since` equals current HEAD, returns an empty array.
+ *
+ * @param {string}      slug  - Project slug.
+ * @param {string|null} since - Base ref (a SHA), or null.
+ * @param {string}      [cwd] - Monorepo root.
+ * @return {Promise<string[]|null>} Changed file paths (repo-relative), or null when no baseline exists.
+ */
+export async function getChangedFiles( slug, since, cwd = process.cwd() ) {
+	if ( ! since ) {
+		return null;
+	}
+	const projectPath = slug === 'monorepo' ? '.' : `projects/${ slug }`;
+	try {
+		const { stdout } = await execa(
+			'git',
+			[
+				'-c',
+				'core.quotepath=off',
+				'diff',
+				'--no-renames',
+				'--name-only',
+				since,
+				'HEAD',
+				'--',
+				projectPath,
+			],
+			{ cwd }
+		);
+		return stdout.split( '\n' ).filter( Boolean );
+	} catch ( e ) {
+		// Stale SHA (e.g. branch was rebased) — caller should treat as "needs full build".
+		if ( /unknown revision|bad object|ambiguous argument/i.test( e.stderr || e.message || '' ) ) {
+			return null;
+		}
+		throw e;
+	}
+}
+
+/**
+ * Bucket changed files into work categories for a project (sync, no JSON-aware diff).
+ *
+ * Treats any composer.json/package.json change as a deps change. Prefer
+ * inspectProjectChanges() for planning; this helper exists for tests and
+ * for callers that don't have a `since` ref.
+ *
+ * @param {string[]} files - Changed files (repo-relative).
+ * @return {object} Bucket flags (booleans): composerRequire, phpAutoload, jsDeps, jsSources, other, none.
+ */
+export function classifyChanges( files ) {
+	const out = {
+		composerRequire: false,
+		phpAutoload: false,
+		jsDeps: false,
+		jsSources: false,
+		other: false,
+		none: false,
+	};
+	if ( ! files || files.length === 0 ) {
+		out.none = true;
+		return out;
+	}
+	for ( const file of files ) {
+		const base = path.basename( file );
+		if ( base === 'composer.json' || base === 'composer.lock' ) {
+			out.composerRequire = true;
+		} else if ( base === 'package.json' ) {
+			out.jsDeps = true;
+		} else if ( /\.php$/i.test( file ) ) {
+			out.phpAutoload = true;
+		} else if ( /\.(jsx?|tsx?|mjs|cjs|s?css|less)$/i.test( file ) ) {
+			out.jsSources = true;
+		} else if ( /webpack(\.config)?\.(js|cjs|mjs|ts)$/i.test( base ) ) {
+			out.jsSources = true;
+		} else if ( /\.(json|svg|png|jpg|gif|woff2?|ttf)$/i.test( file ) ) {
+			// Asset-ish — treat as JS source so bundlers re-emit.
+			out.jsSources = true;
+		} else {
+			out.other = true;
+		}
+	}
+	return out;
+}
+
+/**
+ * Read a file's contents at a specific git ref, returning null if it didn't exist there.
+ *
+ * @param {string} ref  - Git ref.
+ * @param {string} file - Repo-relative file path.
+ * @param {string} cwd  - Repo root.
+ * @return {Promise<string|null>} File contents, or null when missing at ref.
+ */
+async function readAtRef( ref, file, cwd ) {
+	try {
+		const { stdout } = await execa( 'git', [ 'show', `${ ref }:${ file }` ], { cwd } );
+		return stdout;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Compare two values for deep structural equality after canonical-JSON serialization.
+ *
+ * @param {unknown} a - First value.
+ * @param {unknown} b - Second value.
+ * @return {boolean} Whether the two values serialize identically with sorted keys.
+ */
+function deepEqualJson( a, b ) {
+	const canon = v => JSON.stringify( v, Object.keys( v || {} ).sort() );
+	return canon( a ) === canon( b );
+}
+
+/**
+ * Decide whether a composer.json change touched anything that affects autoload/install.
+ *
+ * Only the `require`, `require-dev`, `autoload`, `autoload-dev`, and
+ * `extra.dependencies` blocks matter for runtime — a `version` or
+ * description-only bump should not trigger `composer install`.
+ *
+ * @param {string} file  - Repo-relative path to composer.json.
+ * @param {string} since - Base ref.
+ * @param {string} cwd   - Repo root.
+ * @return {Promise<{ requireChanged: boolean, autoloadChanged: boolean }>} Diff verdict.
+ */
+async function composerJsonDiff( file, since, cwd ) {
+	const [ oldRaw, newRaw ] = await Promise.all( [
+		readAtRef( since, file, cwd ),
+		fs.readFile( path.join( cwd, file ), { encoding: 'utf8' } ).catch( () => null ),
+	] );
+	// If we can't read one side, be conservative and treat as changed.
+	if ( ! oldRaw || ! newRaw ) {
+		return { requireChanged: true, autoloadChanged: true };
+	}
+	let oldJson, newJson;
+	try {
+		oldJson = JSON.parse( oldRaw );
+		newJson = JSON.parse( newRaw );
+	} catch {
+		return { requireChanged: true, autoloadChanged: true };
+	}
+	const requireChanged =
+		! deepEqualJson( oldJson.require, newJson.require ) ||
+		! deepEqualJson( oldJson[ 'require-dev' ], newJson[ 'require-dev' ] ) ||
+		! deepEqualJson( oldJson.extra?.dependencies, newJson.extra?.dependencies );
+	const autoloadChanged =
+		! deepEqualJson( oldJson.autoload, newJson.autoload ) ||
+		! deepEqualJson( oldJson[ 'autoload-dev' ], newJson[ 'autoload-dev' ] );
+	return { requireChanged, autoloadChanged };
+}
+
+/**
+ * Decide whether a package.json change touched anything that affects pnpm install.
+ *
+ * Only the dependency blocks and `scripts` matter; `version` bumps don't.
+ *
+ * @param {string} file  - Repo-relative path to package.json.
+ * @param {string} since - Base ref.
+ * @param {string} cwd   - Repo root.
+ * @return {Promise<boolean>} Whether `pnpm install` is warranted.
+ */
+async function packageJsonDepsChanged( file, since, cwd ) {
+	const [ oldRaw, newRaw ] = await Promise.all( [
+		readAtRef( since, file, cwd ),
+		fs.readFile( path.join( cwd, file ), { encoding: 'utf8' } ).catch( () => null ),
+	] );
+	if ( ! oldRaw || ! newRaw ) {
+		return true;
+	}
+	let oldJson, newJson;
+	try {
+		oldJson = JSON.parse( oldRaw );
+		newJson = JSON.parse( newRaw );
+	} catch {
+		return true;
+	}
+	const blocks = [ 'dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies' ];
+	for ( const block of blocks ) {
+		if ( ! deepEqualJson( oldJson[ block ], newJson[ block ] ) ) {
+			return true;
+		}
+	}
+	return ! deepEqualJson( oldJson.scripts, newJson.scripts );
+}
+
+/**
+ * Async, JSON-aware variant of classifyChanges.
+ *
+ * Inspects composer.json / package.json contents at `since` vs. HEAD so that
+ * a pure version bump no longer triggers a full install. The remaining file
+ * patterns are bucketed identically to classifyChanges().
+ *
+ * @param {string} slug  - Project slug.
+ * @param {string} since - Base ref (a SHA or symbolic ref).
+ * @param {string} [cwd] - Monorepo root.
+ * @return {Promise<object>} Bucket flags (booleans): composerRequire, phpAutoload, jsDeps, jsSources, other, none, missing. `missing: true` indicates the base ref is unreachable.
+ */
+export async function inspectProjectChanges( slug, since, cwd = process.cwd() ) {
+	const out = {
+		composerRequire: false,
+		phpAutoload: false,
+		jsDeps: false,
+		jsSources: false,
+		other: false,
+		none: false,
+		missing: false,
+	};
+	const files = await getChangedFiles( slug, since, cwd );
+	if ( files === null ) {
+		out.missing = true;
+		return out;
+	}
+	if ( files.length === 0 ) {
+		out.none = true;
+		return out;
+	}
+	for ( const file of files ) {
+		const base = path.basename( file );
+		if ( base === 'composer.json' ) {
+			const diff = await composerJsonDiff( file, since, cwd );
+			out.composerRequire = out.composerRequire || diff.requireChanged;
+			// An autoload-block change is fixed by dump-autoload, no install needed.
+			out.phpAutoload = out.phpAutoload || diff.autoloadChanged;
+		} else if ( base === 'composer.lock' ) {
+			out.composerRequire = true;
+		} else if ( base === 'package.json' ) {
+			out.jsDeps = out.jsDeps || ( await packageJsonDepsChanged( file, since, cwd ) );
+		} else if ( /\.php$/i.test( file ) ) {
+			out.phpAutoload = true;
+		} else if ( /\.(jsx?|tsx?|mjs|cjs|s?css|less)$/i.test( file ) ) {
+			out.jsSources = true;
+		} else if ( /webpack(\.config)?\.(js|cjs|mjs|ts)$/i.test( base ) ) {
+			out.jsSources = true;
+		} else if ( /\.(json|svg|png|jpg|gif|woff2?|ttf)$/i.test( file ) ) {
+			out.jsSources = true;
+		} else {
+			out.other = true;
+		}
+	}
+	if (
+		! out.composerRequire &&
+		! out.phpAutoload &&
+		! out.jsDeps &&
+		! out.jsSources &&
+		! out.other
+	) {
+		out.none = true;
+	}
+	return out;
+}

--- a/tools/cli/helpers/lastBuilt.js
+++ b/tools/cli/helpers/lastBuilt.js
@@ -15,27 +15,34 @@ export function stampDir( cwd = process.cwd() ) {
 }
 
 /**
- * Path to a project's last-built stamp file.
+ * Path to a project's stamp file for a given kind.
+ *
+ * Two kinds are tracked independently:
+ * - `build`: project was fully built at this SHA (JS + PHP autoload).
+ * - `autoload`: project's autoloader classmap was regenerated at this SHA (PHP only).
+ *
+ * Tracking them separately prevents a cheap `dump-autoload` from making future
+ * runs blind to stale JS bundles that were never rebuilt.
  *
  * @param {string} slug  - Project slug (e.g. "plugins/jetpack").
+ * @param {string} kind  - "build" or "autoload".
  * @param {string} [cwd] - Monorepo root.
  * @return {string} Absolute path.
  */
-function stampPath( slug, cwd = process.cwd() ) {
+function stampPath( slug, kind, cwd = process.cwd() ) {
 	const safe = slug.replace( /\//g, '__' );
-	return path.join( stampDir( cwd ), `${ safe }.sha` );
+	return path.join( stampDir( cwd ), `${ safe }.${ kind }.sha` );
 }
 
 /**
- * Read the last-built SHA for a project, if any.
+ * Read a single stamp SHA, returning null when missing.
  *
- * @param {string} slug  - Project slug.
- * @param {string} [cwd] - Monorepo root.
+ * @param {string} file - Absolute stamp path.
  * @return {Promise<string|null>} The SHA, or null if no stamp exists.
  */
-export async function readStamp( slug, cwd = process.cwd() ) {
+async function readSha( file ) {
 	try {
-		const data = await fs.readFile( stampPath( slug, cwd ), { encoding: 'utf8' } );
+		const data = await fs.readFile( file, { encoding: 'utf8' } );
 		const sha = data.trim();
 		return sha || null;
 	} catch ( e ) {
@@ -47,16 +54,46 @@ export async function readStamp( slug, cwd = process.cwd() ) {
 }
 
 /**
- * Write the last-built SHA for a project.
+ * Read both stamp kinds for a project.
+ *
+ * @param {string} slug  - Project slug.
+ * @param {string} [cwd] - Monorepo root.
+ * @return {Promise<{ build: string|null, autoload: string|null }>} Both SHAs.
+ */
+export async function readStamps( slug, cwd = process.cwd() ) {
+	const [ build, autoload ] = await Promise.all( [
+		readSha( stampPath( slug, 'build', cwd ) ),
+		readSha( stampPath( slug, 'autoload', cwd ) ),
+	] );
+	return { build, autoload };
+}
+
+/**
+ * Write a stamp of the given kind.
+ *
+ * `writeStamp(slug, sha, 'build')` also updates the autoload stamp, since a
+ * full build implies the autoloader was regenerated as part of it.
+ * `writeStamp(slug, sha, 'autoload')` only updates the autoload stamp.
  *
  * @param {string} slug  - Project slug.
  * @param {string} sha   - Git SHA to record.
+ * @param {string} kind  - "build" or "autoload".
  * @param {string} [cwd] - Monorepo root.
  */
-export async function writeStamp( slug, sha, cwd = process.cwd() ) {
-	const file = stampPath( slug, cwd );
-	await fs.mkdir( path.dirname( file ), { recursive: true } );
-	await fs.writeFile( file, sha + '\n', { encoding: 'utf8' } );
+export async function writeStamp( slug, sha, kind, cwd = process.cwd() ) {
+	if ( kind !== 'build' && kind !== 'autoload' ) {
+		throw new Error( `Unknown stamp kind: ${ kind }` );
+	}
+	await fs.mkdir( stampDir( cwd ), { recursive: true } );
+	const writes = [
+		fs.writeFile( stampPath( slug, 'autoload', cwd ), sha + '\n', { encoding: 'utf8' } ),
+	];
+	if ( kind === 'build' ) {
+		writes.push(
+			fs.writeFile( stampPath( slug, 'build', cwd ), sha + '\n', { encoding: 'utf8' } )
+		);
+	}
+	await Promise.all( writes );
 }
 
 /**
@@ -259,18 +296,15 @@ async function packageJsonDepsChanged( file, since, cwd ) {
 }
 
 /**
- * Async, JSON-aware variant of classifyChanges.
+ * Bucket one set of changed files. Pure helper, no IO besides the JSON-aware
+ * composer.json / package.json checks.
  *
- * Inspects composer.json / package.json contents at `since` vs. HEAD so that
- * a pure version bump no longer triggers a full install. The remaining file
- * patterns are bucketed identically to classifyChanges().
- *
- * @param {string} slug  - Project slug.
- * @param {string} since - Base ref (a SHA or symbolic ref).
- * @param {string} [cwd] - Monorepo root.
- * @return {Promise<object>} Bucket flags (booleans): composerRequire, phpAutoload, jsDeps, jsSources, other, none, missing. `missing: true` indicates the base ref is unreachable.
+ * @param {string[]} files - Changed file paths.
+ * @param {string}   since - Base ref used to derive `files` (needed for JSON diffs).
+ * @param {string}   cwd   - Monorepo root.
+ * @return {Promise<object>} Same shape as classifyChanges (no `missing` field).
  */
-export async function inspectProjectChanges( slug, since, cwd = process.cwd() ) {
+async function bucketFiles( files, since, cwd ) {
 	const out = {
 		composerRequire: false,
 		phpAutoload: false,
@@ -278,13 +312,7 @@ export async function inspectProjectChanges( slug, since, cwd = process.cwd() ) 
 		jsSources: false,
 		other: false,
 		none: false,
-		missing: false,
 	};
-	const files = await getChangedFiles( slug, since, cwd );
-	if ( files === null ) {
-		out.missing = true;
-		return out;
-	}
 	if ( files.length === 0 ) {
 		out.none = true;
 		return out;
@@ -312,6 +340,75 @@ export async function inspectProjectChanges( slug, since, cwd = process.cwd() ) 
 			out.other = true;
 		}
 	}
+	if (
+		! out.composerRequire &&
+		! out.phpAutoload &&
+		! out.jsDeps &&
+		! out.jsSources &&
+		! out.other
+	) {
+		out.none = true;
+	}
+	return out;
+}
+
+/**
+ * Async, JSON-aware variant of classifyChanges.
+ *
+ * Accepts both a build baseline and an autoload baseline (typically the same
+ * SHA for fresh-built projects, or different SHAs when a previous fast-build
+ * regenerated the autoloader but didn't rebuild JS). The autoload-only buckets
+ * (`phpAutoload`) are derived from `sinceAutoload`; everything else from
+ * `sinceBuild`. When the two baselines are equal the function makes one git
+ * diff call.
+ *
+ * @param {string} slug      - Project slug.
+ * @param {object} baselines - `{ sinceBuild, sinceAutoload }` (each a SHA or null).
+ * @param {string} [cwd]     - Monorepo root.
+ * @return {Promise<object>} Bucket flags (booleans): composerRequire, phpAutoload, jsDeps, jsSources, other, none, missing. `missing: true` indicates the build baseline is unreachable.
+ */
+export async function inspectProjectChanges( slug, baselines, cwd = process.cwd() ) {
+	const out = {
+		composerRequire: false,
+		phpAutoload: false,
+		jsDeps: false,
+		jsSources: false,
+		other: false,
+		none: false,
+		missing: false,
+	};
+	const { sinceBuild, sinceAutoload } = baselines;
+	if ( ! sinceBuild ) {
+		// No build baseline → caller treats as "skip" (no stamp = never built by us).
+		out.missing = true;
+		return out;
+	}
+	const filesBuild = await getChangedFiles( slug, sinceBuild, cwd );
+	if ( filesBuild === null ) {
+		out.missing = true;
+		return out;
+	}
+	const baseAutoload = sinceAutoload || sinceBuild;
+	let filesAutoload = filesBuild;
+	if ( baseAutoload !== sinceBuild ) {
+		const fromAutoload = await getChangedFiles( slug, baseAutoload, cwd );
+		if ( fromAutoload !== null ) {
+			filesAutoload = fromAutoload;
+		}
+	}
+	const buckBuild = await bucketFiles( filesBuild, sinceBuild, cwd );
+	const buckAutoload =
+		filesAutoload === filesBuild
+			? buckBuild
+			: await bucketFiles( filesAutoload, baseAutoload, cwd );
+
+	// jsSources / jsDeps / composerRequire / other / none come from the build baseline.
+	out.composerRequire = buckBuild.composerRequire;
+	out.jsDeps = buckBuild.jsDeps;
+	out.jsSources = buckBuild.jsSources;
+	out.other = buckBuild.other;
+	// phpAutoload is what's changed since the autoloader was last regenerated.
+	out.phpAutoload = buckAutoload.phpAutoload;
 	if (
 		! out.composerRequire &&
 		! out.phpAutoload &&

--- a/tools/cli/helpers/logScan.js
+++ b/tools/cli/helpers/logScan.js
@@ -1,3 +1,4 @@
+import fs from 'fs/promises';
 import { execa } from 'execa';
 
 const DEBUG_LOG = '/var/www/html/wp-content/debug.log';
@@ -42,17 +43,34 @@ export async function findWordPressContainer() {
 }
 
 /**
- * Read the tail of the WordPress debug.log inside the container.
+ * Read the tail of the WordPress debug.log.
+ *
+ * Resolution order:
+ * 1. Explicit `logPath` option (or `JETPACK_FASTBUILD_LOG` env var) → host-side file.
+ * 2. Explicit `container` option → `docker exec`.
+ * 3. Auto-detected Jetpack dev container → `docker exec`.
+ * 4. Nothing available → returns `{ container: null, log: '' }`.
  *
  * @param {object} [options]           - Options.
  * @param {string} [options.container] - Container name (auto-detected when omitted).
+ * @param {string} [options.logPath]   - Host-side path to debug.log (overrides docker).
  * @param {number} [options.lines]     - Number of trailing lines to read.
- * @return {Promise<{ container: string|null, log: string }>} Tail contents (empty string when unavailable).
+ * @return {Promise<{ container: string|null, source: string, log: string }>} Tail contents and where they came from.
  */
-export async function readDebugLogTail( { container, lines = 500 } = {} ) {
+export async function readDebugLogTail( { container, logPath, lines = 500 } = {} ) {
+	const effectiveLogPath = logPath || process.env.JETPACK_FASTBUILD_LOG || '';
+	if ( effectiveLogPath ) {
+		try {
+			const data = await fs.readFile( effectiveLogPath, { encoding: 'utf8' } );
+			const tail = data.split( '\n' ).slice( -lines ).join( '\n' );
+			return { container: null, source: effectiveLogPath, log: tail };
+		} catch {
+			return { container: null, source: effectiveLogPath, log: '' };
+		}
+	}
 	const name = container || ( await findWordPressContainer() );
 	if ( ! name ) {
-		return { container: null, log: '' };
+		return { container: null, source: '', log: '' };
 	}
 	try {
 		const { stdout } = await execa(
@@ -60,9 +78,9 @@ export async function readDebugLogTail( { container, lines = 500 } = {} ) {
 			[ 'exec', name, 'tail', '-n', String( lines ), DEBUG_LOG ],
 			{ reject: false }
 		);
-		return { container: name, log: stdout || '' };
+		return { container: name, source: `docker:${ name }`, log: stdout || '' };
 	} catch {
-		return { container: name, log: '' };
+		return { container: name, source: `docker:${ name }`, log: '' };
 	}
 }
 
@@ -107,6 +125,6 @@ export function extractMissingSymbols( log ) {
  * @return {Promise<{ container: string|null, missing: string[] }>} Result.
  */
 export async function scanForMissingSymbols( options = {} ) {
-	const { container, log } = await readDebugLogTail( options );
-	return { container, missing: extractMissingSymbols( log ) };
+	const { container, source, log } = await readDebugLogTail( options );
+	return { container, source, missing: extractMissingSymbols( log ) };
 }

--- a/tools/cli/helpers/logScan.js
+++ b/tools/cli/helpers/logScan.js
@@ -1,0 +1,112 @@
+import { execa } from 'execa';
+
+const DEBUG_LOG = '/var/www/html/wp-content/debug.log';
+
+const FATAL_PATTERNS = [
+	// PHP 7+ Throwable-style errors thrown when autoloader can't find a symbol.
+	/Uncaught\s+Error:\s+Class\s+["']([^"']+)["']\s+not\s+found/g,
+	/Uncaught\s+Error:\s+Interface\s+["']([^"']+)["']\s+not\s+found/g,
+	/Uncaught\s+Error:\s+Trait\s+["']([^"']+)["']\s+not\s+found/g,
+	// PHP < 8 phrasing (still appears in dev logs).
+	/Fatal\s+error:\s+Class\s+["']?([^"'\s]+)["']?\s+not\s+found/g,
+];
+
+/**
+ * Find the running Jetpack dev WordPress container, if any.
+ *
+ * @return {Promise<string|null>} Container name, or null if none running.
+ */
+export async function findWordPressContainer() {
+	try {
+		const { stdout } = await execa(
+			'docker',
+			[
+				'ps',
+				'--filter',
+				'name=jetpack_dev[_-]wordpress',
+				'--filter',
+				'status=running',
+				'--format',
+				'{{.Names}}',
+			],
+			{ reject: false }
+		);
+		const first = stdout
+			.split( '\n' )
+			.map( s => s.trim() )
+			.filter( Boolean )[ 0 ];
+		return first || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Read the tail of the WordPress debug.log inside the container.
+ *
+ * @param {object} [options]           - Options.
+ * @param {string} [options.container] - Container name (auto-detected when omitted).
+ * @param {number} [options.lines]     - Number of trailing lines to read.
+ * @return {Promise<{ container: string|null, log: string }>} Tail contents (empty string when unavailable).
+ */
+export async function readDebugLogTail( { container, lines = 500 } = {} ) {
+	const name = container || ( await findWordPressContainer() );
+	if ( ! name ) {
+		return { container: null, log: '' };
+	}
+	try {
+		const { stdout } = await execa(
+			'docker',
+			[ 'exec', name, 'tail', '-n', String( lines ), DEBUG_LOG ],
+			{ reject: false }
+		);
+		return { container: name, log: stdout || '' };
+	} catch {
+		return { container: name, log: '' };
+	}
+}
+
+/**
+ * Extract the fully-qualified names of classes/interfaces/traits that the
+ * autoloader couldn't resolve, newest occurrences first.
+ *
+ * @param {string} log - debug.log contents.
+ * @return {string[]} Unique FQN strings, ordered from newest to oldest in the log.
+ */
+export function extractMissingSymbols( log ) {
+	if ( ! log ) {
+		return [];
+	}
+	const hits = [];
+	for ( const pattern of FATAL_PATTERNS ) {
+		pattern.lastIndex = 0;
+		let m;
+		while ( ( m = pattern.exec( log ) ) !== null ) {
+			hits.push( { index: m.index, fqn: m[ 1 ].replace( /^\\+/, '' ) } );
+		}
+	}
+	// Newest first: higher index in the log == later in time (tail is append-only).
+	hits.sort( ( a, b ) => b.index - a.index );
+	const seen = new Set();
+	const unique = [];
+	for ( const h of hits ) {
+		if ( ! seen.has( h.fqn ) ) {
+			seen.add( h.fqn );
+			unique.push( h.fqn );
+		}
+	}
+	return unique;
+}
+
+/**
+ * Convenience: read the log and return missing-symbol FQNs in one call.
+ *
+ * @param {object} [options]           - Same options as readDebugLogTail.
+ * @param {string} [options.container] - Container name (auto-detected when omitted).
+ * @param {number} [options.lines]     - Number of trailing lines to read.
+ * @return {Promise<{ container: string|null, missing: string[] }>} Result.
+ */
+export async function scanForMissingSymbols( options = {} ) {
+	const { container, log } = await readDebugLogTail( options );
+	return { container, missing: extractMissingSymbols( log ) };
+}

--- a/tools/cli/tests/unit/commands/fast-build.test.js
+++ b/tools/cli/tests/unit/commands/fast-build.test.js
@@ -1,0 +1,94 @@
+import {
+	ACTION_RANK,
+	mergeAction,
+	ownsRuntimeClassmap,
+	resolveAction,
+	summarizeExecError,
+} from '../../../commands/fast-build.js';
+
+describe( 'fast-build.resolveAction', () => {
+	test( 'higher-rank action wins', () => {
+		expect( resolveAction( 'dump-autoload', 'build' ) ).toBe( 'build' );
+		expect( resolveAction( 'build', 'dump-autoload' ) ).toBe( 'build' );
+	} );
+
+	test( 'equal ranks pick the first argument', () => {
+		expect( resolveAction( 'dump-autoload', 'dump-autoload' ) ).toBe( 'dump-autoload' );
+		expect( resolveAction( 'build', 'build' ) ).toBe( 'build' );
+	} );
+
+	test( 'unknown actions rank as 0 (skip)', () => {
+		expect( resolveAction( 'mystery', 'dump-autoload' ) ).toBe( 'dump-autoload' );
+		expect( resolveAction( 'mystery', 'skip' ) ).toBe( 'mystery' );
+	} );
+
+	test( 'ACTION_RANK is strictly ordered', () => {
+		expect( ACTION_RANK.skip ).toBeLessThan( ACTION_RANK[ 'dump-autoload' ] );
+		expect( ACTION_RANK[ 'dump-autoload' ] ).toBeLessThan( ACTION_RANK.build );
+	} );
+} );
+
+describe( 'fast-build.mergeAction', () => {
+	test( 'sets a fresh entry when the project is absent', () => {
+		const plan = new Map();
+		mergeAction( plan, 'plugins/jetpack', 'dump-autoload' );
+		expect( plan.get( 'plugins/jetpack' ) ).toBe( 'dump-autoload' );
+	} );
+
+	test( 'upgrades to the higher-rank action when one already exists', () => {
+		const plan = new Map( [ [ 'plugins/jetpack', 'dump-autoload' ] ] );
+		mergeAction( plan, 'plugins/jetpack', 'build' );
+		expect( plan.get( 'plugins/jetpack' ) ).toBe( 'build' );
+	} );
+
+	test( 'does not downgrade when the lower-rank action is provided second', () => {
+		const plan = new Map( [ [ 'plugins/jetpack', 'build' ] ] );
+		mergeAction( plan, 'plugins/jetpack', 'dump-autoload' );
+		expect( plan.get( 'plugins/jetpack' ) ).toBe( 'build' );
+	} );
+} );
+
+describe( 'fast-build.ownsRuntimeClassmap', () => {
+	test( 'plugins own a runtime classmap', () => {
+		expect( ownsRuntimeClassmap( 'plugins/jetpack' ) ).toBe( true );
+		expect( ownsRuntimeClassmap( 'plugins/mu-wpcom-plugin' ) ).toBe( true );
+	} );
+
+	test( 'packages do not own a runtime classmap', () => {
+		expect( ownsRuntimeClassmap( 'packages/connection' ) ).toBe( false );
+		expect( ownsRuntimeClassmap( 'js-packages/components' ) ).toBe( false );
+		expect( ownsRuntimeClassmap( 'monorepo' ) ).toBe( false );
+	} );
+} );
+
+describe( 'fast-build.summarizeExecError', () => {
+	test( 'extracts the meaningful lines from composer stderr', () => {
+		const err = {
+			stderr:
+				'Generating autoload files\n\nIn ClassMapGenerator.php line 137:\n  Could not scan for classes inside "jetpack_vendor/automattic/foo/src/"\n  which does not appear to be a file nor a folder\n\ndump-autoload [-o|--optimize] [-a|--classmap-authoritative] ...\n',
+			stdout: '',
+			shortMessage: 'Command failed with exit code 1',
+		};
+		const summary = summarizeExecError( err );
+		expect( summary ).toContain( 'Could not scan for classes' );
+		expect( summary ).toContain( 'ClassMapGenerator.php' );
+		// Composer's "dump-autoload [-o|...]" usage trailer should be stripped.
+		expect( summary ).not.toContain( 'dump-autoload [-o' );
+	} );
+
+	test( 'falls back to stdout when stderr is empty', () => {
+		const err = { stderr: '', stdout: 'first line\nsecond line\n', message: 'whatever' };
+		expect( summarizeExecError( err ) ).toBe( 'first line\nsecond line' );
+	} );
+
+	test( 'falls back to shortMessage when no output is captured', () => {
+		const err = { stderr: '', stdout: '', shortMessage: 'Command failed' };
+		expect( summarizeExecError( err ) ).toBe( 'Command failed' );
+	} );
+
+	test( 'caps the result at N lines', () => {
+		const big = Array.from( { length: 30 }, ( _, i ) => `line ${ i }` ).join( '\n' );
+		const err = { stderr: big, stdout: '', message: '' };
+		expect( summarizeExecError( err, 4 ).split( '\n' ) ).toHaveLength( 4 );
+	} );
+} );

--- a/tools/cli/tests/unit/helpers/lastBuilt.test.js
+++ b/tools/cli/tests/unit/helpers/lastBuilt.test.js
@@ -1,0 +1,66 @@
+import { classifyChanges } from '../../../helpers/lastBuilt.js';
+
+describe( 'lastBuilt.classifyChanges', () => {
+	test( 'empty/null file list marks none', () => {
+		expect( classifyChanges( [] ).none ).toBe( true );
+		expect( classifyChanges( null ).none ).toBe( true );
+	} );
+
+	test( 'php-only change → phpAutoload', () => {
+		const buckets = classifyChanges( [ 'projects/packages/foo/src/Foo.php' ] );
+		expect( buckets.phpAutoload ).toBe( true );
+		expect( buckets.composerRequire ).toBe( false );
+		expect( buckets.jsSources ).toBe( false );
+	} );
+
+	test( 'composer.json change → composerRequire', () => {
+		const buckets = classifyChanges( [ 'projects/packages/foo/composer.json' ] );
+		expect( buckets.composerRequire ).toBe( true );
+	} );
+
+	test( 'composer.lock change → composerRequire', () => {
+		const buckets = classifyChanges( [ 'projects/plugins/jetpack/composer.lock' ] );
+		expect( buckets.composerRequire ).toBe( true );
+	} );
+
+	test( 'package.json change → jsDeps', () => {
+		const buckets = classifyChanges( [ 'projects/js-packages/foo/package.json' ] );
+		expect( buckets.jsDeps ).toBe( true );
+	} );
+
+	test( 'JS/TS/SCSS source → jsSources', () => {
+		const buckets = classifyChanges( [
+			'projects/packages/foo/src/index.ts',
+			'projects/packages/foo/src/style.scss',
+			'projects/packages/foo/src/component.jsx',
+		] );
+		expect( buckets.jsSources ).toBe( true );
+		expect( buckets.phpAutoload ).toBe( false );
+	} );
+
+	test( 'mixed PHP and JS sources set both flags', () => {
+		const buckets = classifyChanges( [
+			'projects/plugins/jetpack/_inc/lib/foo.php',
+			'projects/plugins/jetpack/_inc/client/index.tsx',
+		] );
+		expect( buckets.phpAutoload ).toBe( true );
+		expect( buckets.jsSources ).toBe( true );
+	} );
+
+	test( 'docs/markdown changes → other only', () => {
+		const buckets = classifyChanges( [
+			'projects/packages/foo/README.md',
+			'projects/packages/foo/CHANGELOG.md',
+		] );
+		expect( buckets.other ).toBe( true );
+		expect( buckets.phpAutoload ).toBe( false );
+		expect( buckets.composerRequire ).toBe( false );
+		expect( buckets.jsSources ).toBe( false );
+		expect( buckets.jsDeps ).toBe( false );
+	} );
+
+	test( 'webpack config change → jsSources', () => {
+		const buckets = classifyChanges( [ 'projects/plugins/jetpack/webpack.config.js' ] );
+		expect( buckets.jsSources ).toBe( true );
+	} );
+} );

--- a/tools/cli/tests/unit/helpers/logScan.test.js
+++ b/tools/cli/tests/unit/helpers/logScan.test.js
@@ -1,0 +1,59 @@
+import { extractMissingSymbols } from '../../../helpers/logScan.js';
+
+describe( 'logScan.extractMissingSymbols', () => {
+	test( 'returns empty array for empty input', () => {
+		expect( extractMissingSymbols( '' ) ).toEqual( [] );
+		expect( extractMissingSymbols( null ) ).toEqual( [] );
+	} );
+
+	test( 'extracts FQN from PHP 8 "Class not found" fatal', () => {
+		const log = `[28-May-2026 14:32:01 UTC] PHP Fatal error:  Uncaught Error: Class "Automattic\\Jetpack\\Foo\\Bar" not found in /var/www/html/wp-content/plugins/jetpack/jetpack.php:42`;
+		expect( extractMissingSymbols( log ) ).toEqual( [ 'Automattic\\Jetpack\\Foo\\Bar' ] );
+	} );
+
+	test( 'extracts Interface and Trait fatals as well', () => {
+		const log = [
+			`PHP Fatal error:  Uncaught Error: Interface "A\\B\\IFoo" not found in /x.php:1`,
+			`PHP Fatal error:  Uncaught Error: Trait "A\\B\\TBar" not found in /x.php:1`,
+		].join( '\n' );
+		const result = extractMissingSymbols( log );
+		expect( result.sort() ).toEqual( [ 'A\\B\\IFoo', 'A\\B\\TBar' ].sort() );
+	} );
+
+	test( 'extracts PHP 7 phrasing without quotes', () => {
+		const log = `PHP Fatal error: Class Automattic\\Jetpack\\Old\\Thing not found in /x.php:1`;
+		expect( extractMissingSymbols( log ) ).toEqual( [ 'Automattic\\Jetpack\\Old\\Thing' ] );
+	} );
+
+	test( 'strips leading backslash', () => {
+		const log = `PHP Fatal error:  Uncaught Error: Class "\\Automattic\\Jetpack\\X" not found in /x.php:1`;
+		expect( extractMissingSymbols( log ) ).toEqual( [ 'Automattic\\Jetpack\\X' ] );
+	} );
+
+	test( 'deduplicates repeated FQNs', () => {
+		const log = [
+			`PHP Fatal error: Uncaught Error: Class "X\\Y\\Z" not found in /a.php:1`,
+			`PHP Fatal error: Uncaught Error: Class "X\\Y\\Z" not found in /b.php:2`,
+		].join( '\n' );
+		expect( extractMissingSymbols( log ) ).toEqual( [ 'X\\Y\\Z' ] );
+	} );
+
+	test( 'returns newest fatal first when multiple distinct FQNs appear', () => {
+		const log = [
+			`[01] PHP Fatal error: Uncaught Error: Class "A\\First" not found in /a.php:1`,
+			`some other log line`,
+			`[02] PHP Fatal error: Uncaught Error: Class "A\\Second" not found in /a.php:1`,
+		].join( '\n' );
+		// The later occurrence ("Second") has a higher index — should be first in the result.
+		expect( extractMissingSymbols( log ) ).toEqual( [ 'A\\Second', 'A\\First' ] );
+	} );
+
+	test( 'ignores unrelated error messages', () => {
+		const log = [
+			`PHP Notice:  Undefined index: foo in /x.php on line 1`,
+			`PHP Warning:  count(): Parameter must be an array in /x.php on line 1`,
+			`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to f() must be of the type string`,
+		].join( '\n' );
+		expect( extractMissingSymbols( log ) ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

Adds a new `jetpack fast-build` CLI command that restores a broken local dev site by doing only the targeted rebuild work the diff actually needs — typically `composer dump-autoload` in a handful of plugins, completing in seconds rather than the ~2 minutes that `jetpack build jetpack` takes today.

The classic pain point this addresses: after `git switch` or rebasing on `trunk`, a class added by another branch isn't in the jetpack-autoloader classmap, so localhost throws a PHP fatal. The usual fix is `jetpack build <plugin>`, of which ~60–90s is webpack bundling that's completely irrelevant to a stale-classmap fatal.

The command combines two independent signals:

* **Log scan (Signal 1):** reads `/var/www/html/wp-content/debug.log` from the running Jetpack docker container (or a host-side path via `--log-path` / `JETPACK_FASTBUILD_LOG`), extracts `Class/Interface/Trait not found` fatals, resolves each FQN to its owning project (PSR-4 prefix match first, then a namespace-aware, plausibility-filtered `git grep --untracked` fallback — since 91 of 96 monorepo projects use classmap autoload rather than PSR-4), and runs `composer dump-autoload` on every plugin that transitively depends on the owner.
* **Source drift (Signal 2):** diffs each project against per-project stamps and buckets the diff JSON-aware (so a `composer.json`/`package.json` version-bump-only commit doesn't trigger a heavy install). PHP-only changes → `dump-autoload`; JS/asset source changes → project `build`; `require`/`dependencies` block changes → surfaced as "run `jetpack build` for these" instead of auto-installed.

### Two-stamp model (correctness)

Each project now has two independent stamps: `last-built/<slug>.build.sha` (full build, JS + PHP) and `last-built/<slug>.autoload.sha` (autoloader regen only). `dump-autoload` advances the `autoload` stamp without claiming the JS bundle is fresh. Without this split, a `dump-autoload`-only action would have marked the project as fully built, hiding any stale JS bundles from future runs.

### Parallelism + helpful failure output

* **Parallel `dump-autoload`.** Each plugin's `vendor/composer/jetpack_autoload_classmap.php` is independent, so plans consisting entirely of `dump-autoload` actions run through `pLimit`. `--concurrency N` (default 4). Expected wall-clock for a 13-plugin regen: ~6–10s with the default vs. ~31s serial. Mixed plans with `build` actions stay serial.
* **Continue-on-error is the default.** A single failing project doesn't abort the rest of the plan. End-of-run summary lists failures with copy-pasteable suggestions (`jetpack build …` to fix root cause, or `--skip …` to ignore on next run). `--stop-on-error` restores fail-fast.
* **Real composer errors surface inline.** A `summarizeExecError()` helper extracts the actual `ClassMapGenerator.php line 137: Could not scan for classes …` from buffered stderr, stripping composer's noisy "dump-autoload [-o|...]" usage trailer.

### Flag inventory

| Flag | Purpose |
| --- | --- |
| `--seed` | Stamp every project at HEAD without building — first-time bootstrap. |
| `--dry-run` | Print the plan, don't execute. |
| `--autoload-only` | Cap Signal 2 to `dump-autoload`, never `build`. |
| `--since <ref>` | Override per-project stamps; diff every project against this ref. |
| `--log-scan` / `--no-log-scan` | Toggle Signal 1. |
| `--log-path <path>` (or `$JETPACK_FASTBUILD_LOG`) | Read debug.log from a host file instead of docker; for wp-env / Playground / custom setups. |
| `--lines N` | How much of debug.log to scan (default 500). |
| `--skip <project>` (repeatable) | Pre-exclude known-bad projects. |
| `--concurrency N` | Parallel limit for `dump-autoload` (default 4). |
| `--stop-on-error` | Fail-fast instead of continue-on-error. |
| `--watch` / `--watch-interval N` | Stay running; re-scan log every N seconds and auto-fix on each new fatal. |
| `--production` / `-p` | Use `build-production` script for `build` actions (mirrors `jetpack build`). |
| `--verify` / `--no-verify` | After fixes, curl `--url` AND grep each plugin's regenerated classmap to confirm the targeted FQNs now resolve. |
| `--url <url>` | URL for the verify-step curl (default `http://localhost`). |

Plus `.jetpack-cli/skip.txt` — a persistent skip list (one slug per line, `#` comments allowed) merged into `--skip`. Saves typing the same `--skip plugins/mu-wpcom-plugin --skip plugins/wpcomsh` flags every run.

### Files of interest

* `tools/cli/commands/fast-build.js` — the new command (planner + parallel runner + watch loop + reporter).
* `tools/cli/helpers/logScan.js` — debug.log tail via docker exec or host path, missing-symbol extraction.
* `tools/cli/helpers/classOwner.js` — FQN → owning-project resolution. PSR-4 match → namespace-verified grep → plausibility-filtered grep (skips test fixtures / READMEs / arbitrary "class Foo" mentions).
* `tools/cli/helpers/lastBuilt.js` — per-project two-stamp model + JSON-aware change classification.
* `tools/cli/commands/build.js` — writes a `build` stamp on each successful (non-mirror) build.
* `tools/cli/cliRouter.js` — registers the new command.
* `.gitignore` — ignores `.jetpack-cli/`.
* `tools/cli/tests/unit/helpers/{logScan,lastBuilt}.test.js` + `tools/cli/tests/unit/commands/fast-build.test.js` — **182 tests passing** (16 new).

No `projects/*` are touched, so no changelogger entry is needed. `tools/cli` is a private workspace package.

### Commit layout

The PR is 11 commits:
1. `add fast-build command` — the foundation.
2. `parallelize + surface composer errors inline + planner tests` — done as part of the original ship.
3. `split stamp into build/autoload` — fixes the stale-JS-blindness bug.
4. `--seed` — first-time bootstrap.
5. `--verify confirms targeted classes now resolve` — checks plugin classmaps, not just "no new fatals".
6. `hint at jetpack docker up -d` — friendlier error when no container.
7. `persistent skip list` — `.jetpack-cli/skip.txt`.
8. `--log-path` — non-docker setups.
9. `--watch` — auto-fix loop.
10. `--production` — mirror jetpack build.
11. `tighten classOwner git-grep fallback` — defends against short-name collisions across packages.

Reviewable as a sequence; each commit is self-contained.

## Related product discussion/links

N/A — internal developer ergonomics improvement.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Prerequisites: Jetpack docker dev environment running (`jetpack docker up -d`), or a writable host path you can use via `--log-path`.

### First-time bootstrap

1. From a clean `trunk`: `node tools/cli/bin/jetpack.js fast-build --seed`. Expect: `Seeded N project(s) at <sha>. …` and a populated `.jetpack-cli/last-built/` directory with `*.build.sha` and `*.autoload.sha` files.
2. Run `node tools/cli/bin/jetpack.js fast-build --dry-run --no-log-scan` immediately after. Expect: `Nothing to do.`

### Autoloader fatal recovery + verify

1. Reproduce a fatal: add a new PHP class under `projects/packages/connection/src/`, reference it from the bottom of `projects/packages/connection/actions.php` with `new \Automattic\Jetpack\Connection\My_New_Class();`, then `curl http://localhost`. Expect HTTP 500; `jp-tail` shows `Fatal error: Uncaught Error: Class "..." not found`.
2. Run `node tools/cli/bin/jetpack.js fast-build`. Expect:
   * Parsed missing class + owner project printed.
   * `composer dump-autoload` planned for each dependent plugin.
   * Parallel execution (default concurrency 4); per-task durations.
   * `Verify: N/N targeted class(es) now resolve in their plugin classmaps.`
   * `Verify: http://localhost → HTTP 200.`
   * Wall-clock under 15s with default concurrency.
3. Revert the test edits.

### Continue-on-error + composer's real diagnostic

1. On a branch where `plugins/mu-wpcom-plugin`'s classmap references a missing vendor dir, `node tools/cli/bin/jetpack.js fast-build`.
2. Expect: the failing plugin shows the actual `ClassMapGenerator.php line 137` error inline, the run continues through remaining plugins, and the end-of-run summary suggests `jetpack build plugins/mu-wpcom-plugin` or `--skip plugins/mu-wpcom-plugin`.

### Persistent skip list

1. `echo plugins/mu-wpcom-plugin > .jetpack-cli/skip.txt`.
2. Run `node tools/cli/bin/jetpack.js fast-build`. Expect the "Honoring N entry(s) from .jetpack-cli/skip.txt: …" notice and mu-wpcom-plugin absent from the plan.

### Watch mode

1. `node tools/cli/bin/jetpack.js fast-build --watch`. Expect "Watching debug.log every 3s. Ctrl-C to exit."
2. Trigger a fatal in another terminal (reload localhost on a stale-class branch). Expect the watcher to print the missing symbol(s) and the fix actions, then return to watching. Ctrl-C exits cleanly.

### Non-docker fallback

1. `node tools/cli/bin/jetpack.js fast-build --log-path /path/to/host/debug.log --dry-run`. Expect "Scanned debug.log from /path/to/host/debug.log." instead of the docker variant.

### Stamp split: stale-JS bug fix

1. From a `--seed`-stamped state, switch to a branch that adds JS source files but no PHP fatals. Run `node tools/cli/bin/jetpack.js fast-build --no-log-scan`. Expect Signal 2 to detect `jsSources` and plan `[build]` for the affected project (not silently skip it).
2. After a `dump-autoload`-only fix completes (Signal 1 fatal recovery), inspect `.jetpack-cli/last-built/`: only `*.autoload.sha` advanced for those plugins; `*.build.sha` is unchanged. A subsequent run will still detect JS drift.

### Parallelism comparison

1. Reproduce the fatal, then `time node tools/cli/bin/jetpack.js fast-build` (default concurrency 4) and `time node tools/cli/bin/jetpack.js fast-build --concurrency 1`. Default should be ~3–4× faster.

### Source-drift planning

1. `node tools/cli/bin/jetpack.js fast-build --dry-run --no-log-scan --since HEAD~5` — should produce a plan with `dump-autoload`/`build` actions for projects with PHP/JS changes and a "Skipping N project(s)…" section for projects whose `require`/`dependencies` blocks changed.

### Unit tests

* `cd tools/cli && NODE_OPTIONS=--experimental-vm-modules pnpm test` — all 182 tests should pass.
