### PR TITLE
Webpack: opt-in filesystem cache + stop wiping `.cache/` on clean

### DIFF
--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -144,16 +144,22 @@ This is an object suitable for spreading some defaults into Webpack's `resolve` 
 
 * `ignored`: `[ '**/node_modules', '**/dist', '**/vendor' ]`.
 
-#### `cache`
+#### `cache( configFile )`
 
-`cache` is an object suitable for use as Webpack's `cache` setting. Opt in by setting `cache: jetpackWebpackConfig.cache` in your config. It enables Webpack's filesystem cache, scoped per consumer project:
+`cache` is a function returning an object suitable for use as Webpack's `cache` setting, enabling Webpack's filesystem cache scoped per consumer project. Opt in by spreading it into your config and passing the config's own path:
+
+```js
+cache: jetpackWebpackConfig.cache( __filename ), // or `import.meta.filename` in ESM
+```
+
+It returns:
 
 * `type`: `'filesystem'`.
-* `cacheDirectory`: `path.resolve( process.cwd(), '.cache/webpack' )`.
-* `name`: `` `jetpack-${ mode }` `` — keeps production and development caches separate.
+* `cacheDirectory`: `path.resolve( process.cwd(), '.cache/webpack', <configFile basename> )` — namespaced by the config file so a project's multiple configs (some built concurrently) don't share, and clobber, a single cache pack.
 * `store`: `'pack'`.
+* `buildDependencies.config`: `[ configFile ]` — so the cache invalidates when your config file changes. (`name` is left unset; Webpack's default already namespaces by `mode`, keeping production and development caches separate.)
 
-The cache invalidates on Webpack version change. If you need invalidation on your own config-file changes, extend the object with `buildDependencies: { config: [ require.resolve( './webpack.config.js' ) ] }`. To force-invalidate manually, delete the project's `.cache/webpack/` directory.
+The cache also invalidates on Webpack version change. It is disabled (returns `undefined`) when `process.env.CI` is set, since CI runs don't preserve the cache between builds. To force-invalidate manually, delete the project's `.cache/webpack/` directory.
 
 #### `DevServer( options )`
 

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -146,7 +146,7 @@ This is an object suitable for spreading some defaults into Webpack's `resolve` 
 
 #### `cache( configFile )`
 
-`cache` is a function returning an object suitable for use as Webpack's `cache` setting, enabling Webpack's filesystem cache scoped per consumer project. Opt in by spreading it into your config and passing the config's own path:
+`cache` is a function returning an object suitable for use as Webpack's [`cache`](https://webpack.js.org/configuration/cache/) setting, enabling Webpack's filesystem cache scoped per consumer project.
 
 ```js
 cache: jetpackWebpackConfig.cache( __filename ), // or `import.meta.filename` in ESM
@@ -157,7 +157,7 @@ It returns:
 * `type`: `'filesystem'`.
 * `cacheDirectory`: `path.resolve( process.cwd(), '.cache/webpack', <configFile basename> )` — namespaced by the config file so a project's multiple configs (some built concurrently) don't share, and clobber, a single cache pack.
 * `store`: `'pack'`.
-* `buildDependencies.config`: `[ configFile ]` — so the cache invalidates when your config file changes. (`name` is left unset; Webpack's default already namespaces by `mode`, keeping production and development caches separate.)
+* `buildDependencies.config`: `[ configFile ]` — so the cache invalidates when your config file changes.
 
 The cache also invalidates on Webpack version change. It is disabled (returns `undefined`) when `process.env.CI` is set, since CI runs don't preserve the cache between builds. To force-invalidate manually, delete the project's `.cache/webpack/` directory.
 

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -144,6 +144,17 @@ This is an object suitable for spreading some defaults into Webpack's `resolve` 
 
 * `ignored`: `[ '**/node_modules', '**/dist', '**/vendor' ]`.
 
+#### `cache`
+
+`cache` is an object suitable for use as Webpack's `cache` setting. Opt in by setting `cache: jetpackWebpackConfig.cache` in your config. It enables Webpack's filesystem cache, scoped per consumer project:
+
+* `type`: `'filesystem'`.
+* `cacheDirectory`: `path.resolve( process.cwd(), '.cache/webpack' )`.
+* `name`: `` `jetpack-${ mode }` `` — keeps production and development caches separate.
+* `store`: `'pack'`.
+
+The cache invalidates on Webpack version change. If you need invalidation on your own config-file changes, extend the object with `buildDependencies: { config: [ require.resolve( './webpack.config.js' ) ] }`. To force-invalidate manually, delete the project's `.cache/webpack/` directory.
+
 #### `DevServer( options )`
 
 Creates a webpack `devServer` configuration for Hot Module Replacement (HMR). Returns `undefined` when not running `webpack serve`, so you can use it directly without conditional checks. Requires `webpack-dev-server` as a dev dependency.

--- a/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
+++ b/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Export a `cache` config that consumers can opt in to via `cache: jetpackWebpackConfig.cache` for filesystem-backed webpack caching at `.cache/webpack/`.
+Export a `cache( configFile )` helper that consumers can opt in to via `cache: jetpackWebpackConfig.cache( __filename )` for filesystem-backed webpack caching at `.cache/webpack/`.

--- a/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
+++ b/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
@@ -1,3 +1,4 @@
-Significance: patch
+Significance: minor
 Type: added
-Comment: Export a `cache( configFile )` helper that consumers can opt in to via `cache: jetpackWebpackConfig.cache( __filename )` for filesystem-backed webpack caching at `.cache/webpack/`. Internal build tooling; no user-facing effect.
+
+Add webpack cache setup function.

--- a/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
+++ b/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Export a `cache` config that consumers can opt in to via `cache: jetpackWebpackConfig.cache` for filesystem-backed webpack caching at `.cache/webpack/`.

--- a/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
+++ b/projects/js-packages/webpack-config/changelog/add-filesystem-cache-export
@@ -1,4 +1,3 @@
-Significance: minor
+Significance: patch
 Type: added
-
-Export a `cache( configFile )` helper that consumers can opt in to via `cache: jetpackWebpackConfig.cache( __filename )` for filesystem-backed webpack caching at `.cache/webpack/`.
+Comment: Export a `cache( configFile )` helper that consumers can opt in to via `cache: jetpackWebpackConfig.cache( __filename )` for filesystem-backed webpack caching at `.cache/webpack/`. Internal build tooling; no user-facing effect.

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -91,9 +91,13 @@ const watchOptions = {
 	ignored: [ '**/node_modules', '**/dist', '**/vendor' ],
 };
 
-// Opt-in filesystem cache; see the readme. Takes the consumer's config path so the cache
-// invalidates when that config changes and is namespaced per config file (so a project's
-// multiple, possibly concurrent, configs don't share one pack). Disabled under CI.
+/**
+ * Generate filesystem cache configuration.
+ *
+ * @param {string} configFile - Config file being processed, for proper invalidation.
+ *                            Generally, you'll pass `__filename` or `import.meta.filename`.
+ * @return {object|undefined} Cache configuration. Returns undefined in CI.
+ */
 const cache = configFile => {
 	if ( process.env.CI ) {
 		return undefined;
@@ -103,6 +107,7 @@ const cache = configFile => {
 		cacheDirectory: path.resolve(
 			process.cwd(),
 			'.cache/webpack',
+			// Split cache on config filename to avoid collisions with parallel builds (e.g. plugins/jetpack).
 			path.basename( configFile, path.extname( configFile ) )
 		),
 		store: 'pack',

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -91,6 +91,24 @@ const watchOptions = {
 	ignored: [ '**/node_modules', '**/dist', '**/vendor' ],
 };
 
+// Filesystem cache rooted at the consumer's project directory. Opt-in: consumers
+// pass `cache: jetpackWebpackConfig.cache` in their webpack config. Mode-namespacing
+// keeps production and development caches separate. The `babel` cache is unaffected;
+// it still lives at .cache/babel via the TranspileRule defaults.
+//
+// To invalidate the cache after upgrading webpack-config or changing your own
+// webpack config, delete `.cache/webpack/` in the project. (We deliberately don't
+// list config files in `buildDependencies.config` from here — the consumer's config
+// path isn't known to this module. Consumers can extend this object with their own
+// `buildDependencies.config: [ require.resolve('./webpack.config.js') ]` if they
+// want config-change invalidation.)
+const cache = {
+	type: 'filesystem',
+	cacheDirectory: path.resolve( process.cwd(), '.cache/webpack' ),
+	name: `jetpack-${ mode }`,
+	store: 'pack',
+};
+
 /****** Plugins ******/
 
 const DefinePlugin = defines => [
@@ -281,6 +299,7 @@ module.exports = {
 	CssMinimizerPlugin,
 	resolve,
 	watchOptions,
+	cache,
 	DevServer,
 	// Plugins.
 	StandardPlugins,

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -91,22 +91,25 @@ const watchOptions = {
 	ignored: [ '**/node_modules', '**/dist', '**/vendor' ],
 };
 
-// Filesystem cache rooted at the consumer's project directory. Opt-in: consumers
-// pass `cache: jetpackWebpackConfig.cache` in their webpack config. Mode-namespacing
-// keeps production and development caches separate. The `babel` cache is unaffected;
-// it still lives at .cache/babel via the TranspileRule defaults.
-//
-// To invalidate the cache after upgrading webpack-config or changing your own
-// webpack config, delete `.cache/webpack/` in the project. (We deliberately don't
-// list config files in `buildDependencies.config` from here — the consumer's config
-// path isn't known to this module. Consumers can extend this object with their own
-// `buildDependencies.config: [ require.resolve('./webpack.config.js') ]` if they
-// want config-change invalidation.)
-const cache = {
-	type: 'filesystem',
-	cacheDirectory: path.resolve( process.cwd(), '.cache/webpack' ),
-	name: `jetpack-${ mode }`,
-	store: 'pack',
+// Opt-in filesystem cache; see the readme. Takes the consumer's config path so the cache
+// invalidates when that config changes and is namespaced per config file (so a project's
+// multiple, possibly concurrent, configs don't share one pack). Disabled under CI.
+const cache = configFile => {
+	if ( process.env.CI ) {
+		return undefined;
+	}
+	return {
+		type: 'filesystem',
+		cacheDirectory: path.resolve(
+			process.cwd(),
+			'.cache/webpack',
+			path.basename( configFile, path.extname( configFile ) )
+		),
+		store: 'pack',
+		buildDependencies: {
+			config: [ configFile ],
+		},
+	};
 };
 
 /****** Plugins ******/

--- a/projects/packages/blaze/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/blaze/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/blaze/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/blaze/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"build": "pnpm run clean && webpack",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
-		"clean": "rm -rf build/ .cache/",
+		"clean": "rm -rf build/",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},

--- a/projects/packages/classic-theme-helper/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/classic-theme-helper/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/classic-theme-helper/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/classic-theme-helper/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -19,7 +19,7 @@
 		"build-js": "webpack --config webpack.config.js",
 		"build-production": "pnpm run clean && pnpm run build-production-js && pnpm run validate",
 		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm run build-js",
-		"clean": "rm -rf dist/ .cache/",
+		"clean": "rm -rf dist/",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},

--- a/projects/packages/forms/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/forms/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/forms/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/forms/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -25,7 +25,7 @@
 		"build:strip-unminified-prod": "strip-unminified-prod",
 		"build:wp-build": "wp-build",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run build:strip-unminified-prod && pnpm run validate",
-		"clean": "rm -rf dist/ build/ .cache/",
+		"clean": "rm -rf dist/ build/",
 		"extract-icons": "node tools/extract-icons.mjs",
 		"generate-icons": "pnpm run extract-icons && pnpm run rasterize-icons",
 		"module:build": "webpack --config ./tools/webpack.config.modules.js",

--- a/projects/packages/masterbar/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/masterbar/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/masterbar/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/masterbar/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -19,7 +19,7 @@
 		"build-js": "webpack --config tools/webpack.config.js",
 		"build-production": "pnpm run clean && pnpm run build-production-js && pnpm run validate",
 		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm run build-js",
-		"clean": "rm -rf dist/ .cache/",
+		"clean": "rm -rf dist/",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
 		"watch": "pnpm run build && pnpm webpack watch --config tools/webpack.config.js"
 	},

--- a/projects/packages/paypal-payments/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/paypal-payments/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/paypal-payments/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/paypal-payments/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"build": "pnpm run clean && webpack --config ./webpack.config.blocks.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm build",
-		"clean": "rm -rf dist/ .cache/",
+		"clean": "rm -rf dist/",
 		"test:js": "jest --config=jest.config.js",
 		"watch": "webpack --watch --config ./webpack.config.blocks.js"
 	},

--- a/projects/packages/podcast/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/podcast/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/podcast/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/podcast/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -22,7 +22,7 @@
 		"build:strip-unminified-prod": "strip-unminified-prod",
 		"build:wp-build": "wp-build",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run clean && concurrently 'pnpm:build:blocks' 'pnpm:build:wp-build' && pnpm run build:strip-unminified-prod && pnpm run build:boot-asset",
-		"clean": "rm -rf build/ dist/ .cache/",
+		"clean": "rm -rf build/ dist/",
 		"watch": "concurrently 'pnpm:build:blocks --watch' 'pnpm:watch:wp-build'",
 		"watch:wp-build": "wp-build --watch"
 	},

--- a/projects/packages/search/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/search/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/search/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/search/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -26,7 +26,7 @@
 		"build-inline": "webpack --config ./tools/webpack.inline.config.js",
 		"build-instant": "webpack --config ./tools/webpack.instant.config.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
-		"clean": "rm -rf build/ .cache/",
+		"clean": "rm -rf build/",
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "concurrently 'pnpm:test-scripts' 'pnpm:test-url-tests' 'pnpm:test-size'",
 		"test-coverage": "pnpm:test-scripts --coverage && pnpm:test-url-tests --coverage",

--- a/projects/packages/yoast-promo/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/yoast-promo/changelog/preserve-cache-dir-on-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/yoast-promo/changelog/preserve-cache-dir-on-clean
+++ b/projects/packages/yoast-promo/changelog/preserve-cache-dir-on-clean
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans. Internal-only; no effect on the published package.
 
-Build: stop wiping `.cache/` on `pnpm clean` so persistent build caches (babel, webpack) survive cleans.

--- a/projects/packages/yoast-promo/package.json
+++ b/projects/packages/yoast-promo/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"build": "pnpm run clean && webpack",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
-		"clean": "rm -rf build/ .cache/",
+		"clean": "rm -rf build/",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},

--- a/projects/plugins/jetpack/changelog/enable-webpack-filesystem-cache
+++ b/projects/plugins/jetpack/changelog/enable-webpack-filesystem-cache
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: other
 
 Build: enable webpack's filesystem cache for the main, extensions, and widget-visibility bundles. Reduces local incremental rebuild time substantially after the first build; no effect on production output.

--- a/projects/plugins/jetpack/changelog/enable-webpack-filesystem-cache
+++ b/projects/plugins/jetpack/changelog/enable-webpack-filesystem-cache
@@ -1,4 +1,3 @@
 Significance: patch
 Type: other
-
-Build: enable webpack's filesystem cache for the main, extensions, and widget-visibility bundles. Reduces local incremental rebuild time substantially after the first build; no effect on production output.
+Comment: Build: enable webpack's filesystem cache for the main, extensions, and widget-visibility bundles to speed up local incremental rebuilds. Internal-only; no effect on production output.

--- a/projects/plugins/jetpack/changelog/enable-webpack-filesystem-cache
+++ b/projects/plugins/jetpack/changelog/enable-webpack-filesystem-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: enable webpack's filesystem cache for the main, extensions, and widget-visibility bundles. Reduces local incremental rebuild time substantially after the first build; no effect on production output.

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -107,6 +107,7 @@ const editorNoPostEditorScript = [
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
+	cache: jetpackWebpackConfig.cache,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '../_inc/blocks' ),

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -107,7 +107,7 @@ const editorNoPostEditorScript = [
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
-	cache: jetpackWebpackConfig.cache,
+	cache: jetpackWebpackConfig.cache( __filename ),
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '../_inc/blocks' ),

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -7,7 +7,7 @@ const StaticSiteGeneratorPlugin = require( './static-site-generator-webpack-plug
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
-	cache: jetpackWebpackConfig.cache,
+	cache: jetpackWebpackConfig.cache( __filename ),
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '../_inc/build' ),

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -7,6 +7,7 @@ const StaticSiteGeneratorPlugin = require( './static-site-generator-webpack-plug
 const sharedWebpackConfig = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
+	cache: jetpackWebpackConfig.cache,
 	output: {
 		...jetpackWebpackConfig.output,
 		path: path.join( __dirname, '../_inc/build' ),

--- a/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
+++ b/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
@@ -5,7 +5,7 @@ const { definePaletteColorsAsStaticVariables } = require( './webpack.helpers' );
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
-	cache: jetpackWebpackConfig.cache,
+	cache: jetpackWebpackConfig.cache( __filename ),
 	entry: {
 		index: {
 			import: path.join( __dirname, '../modules/widget-visibility/editor/index.jsx' ),

--- a/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
+++ b/projects/plugins/jetpack/tools/webpack.config.widget-visibility.js
@@ -5,6 +5,7 @@ const { definePaletteColorsAsStaticVariables } = require( './webpack.helpers' );
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
+	cache: jetpackWebpackConfig.cache,
 	entry: {
 		index: {
 			import: path.join( __dirname, '../modules/widget-visibility/editor/index.jsx' ),


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

Follow-up to #49173. Opt-in webpack filesystem cache + stops several `clean` scripts from wiping `.cache/`.

The fast-build PR can detect "this project's JS sources changed since last build" via per-project SHA stamps, but the actual rebuild for those projects still pays full webpack cold-start cost (~60–90s on `plugins/jetpack`'s three concurrent bundles). Webpack's filesystem cache cuts incremental rebuilds to ~5–10s.

This PR ships the foundation plus the highest-impact adoption:

* **`@automattic/jetpack-webpack-config`** now exports a `cache( configFile )` helper. Consumers opt in by spreading `cache: jetpackWebpackConfig.cache( __filename )` into their config. It returns `{ type: 'filesystem', cacheDirectory: path.resolve( process.cwd(), '.cache/webpack', <configFile basename> ), store: 'pack', buildDependencies: { config: [ configFile ] } }`:
  * Passing the config's own path means the cache invalidates automatically when that config changes (`buildDependencies.config`), and is namespaced per config file so a project's multiple — possibly concurrently built — configs don't share, and clobber, a single pack.
  * `name` is left unset: webpack's default already namespaces by `mode`, keeping production and development caches separate.
  * Returns `undefined` when `process.env.CI` is set, since CI doesn't preserve the cache between builds.
  * README has a new section documenting it.
* **`plugins/jetpack`** opts in across all three of its webpack configs (`tools/webpack.config.js`, `webpack.config.extensions.js`, `webpack.config.widget-visibility.js`) by passing `cache: jetpackWebpackConfig.cache( __filename )`. After the first cold build, subsequent rebuilds are cache-hit and dramatically faster.
* **`clean` script audit:** eight packages (blaze, classic-theme-helper, forms, masterbar, paypal-payments, podcast, search, yoast-promo) had `clean` scripts of the form `rm -rf <build-output>/ .cache/`. The `.cache/` wipe pre-dated this PR; per git archaeology it traces back to #21814 with no stated rationale (that PR also deleted `vendor`/`node_modules`, so it reads as an overzealous cleanup that was then copy-pasted around). Removed it from all eight so persistent build caches survive `clean`. Build-output dirs (`dist/`, `build/`) are still wiped as before.

Note this **does** change the babel cache's lifetime in those eight packages: `.cache/babel/` was previously deleted on every `clean`, and now persists. Per @anomiex's experiment on this PR, dev and production builds of the eight packages from this branch produced output identical to trunk, so persisting the cache appears safe.

Other webpack-config consumers can opt in incrementally by passing `cache: jetpackWebpackConfig.cache( __filename )` to their config — no required follow-up.

### Why opt-in rather than always-on

If we forced `cache: ...` from inside webpack-config, every consumer would inherit it whether or not they're ready. Opt-in keeps each project's webpack config explicit about what it's doing, lets risky bundles (e.g. anything generating dynamic entry points) decide for themselves, and gives reviewers a single grep target.

### Other information

- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links

Follows up on #49173 (the `jetpack fast-build` CLI command).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Verify the cache export

```
node -e "const { cache } = require('./projects/js-packages/webpack-config/src/webpack'); console.log( cache('/some/project/tools/webpack.config.js') );"
```

Expected: an object with `type: 'filesystem'`, `store: 'pack'`, a `cacheDirectory` ending in `.cache/webpack/webpack.config` (namespaced by the config file's basename), and `buildDependencies.config` containing the path you passed. Run it again with `CI=true` set and it should print `undefined` instead.

### Verify the cache works end-to-end on `plugins/jetpack`

1. `cd projects/plugins/jetpack && rm -rf .cache/webpack` — start from a clean cache.
2. Time the first build: `time pnpm run build-widget-visibility` (smallest bundle; or `build-development` for all). Note duration (cold).
3. Without changing anything, time it again. Should be substantially faster — webpack reports `[cached] … modules` (locally: ~800ms → ~95ms for widget-visibility).
4. `ls .cache/webpack/` shows a populated, per-config-namespaced cache, e.g. `.cache/webpack/webpack.config.widget-visibility/default-development/`.

### Verify `clean` no longer wipes `.cache/`

For any of the 8 packages (e.g. `projects/packages/forms`):

1. Create a probe: `mkdir -p .cache/babel && touch .cache/babel/probe`.
2. `pnpm run clean`, then check `.cache/babel/probe` still exists. The build-output dirs (`dist/`, `build/`) should be gone.

### Verify no regression elsewhere

* `node --check projects/plugins/jetpack/tools/webpack.config.js` — no errors (also for `.extensions.js` and `.widget-visibility.js`).
* A full `jetpack build plugins/jetpack` should still produce correct output. The cache only affects build time, not output.
