### PR TITLE
Jetpack CLI: parallelize `fast-build` autoloader regen + surface composer errors inline

### DIFF
--- a/tools/cli/commands/fast-build.js
+++ b/tools/cli/commands/fast-build.js
@@ -3,6 +3,7 @@ import { execa } from 'execa';
 import Listr from 'listr';
 import SilentRenderer from 'listr-silent-renderer';
 import UpdateRenderer from 'listr-update-renderer';
+import pLimit from 'p-limit';
 import { findOwnerProject } from '../helpers/classOwner.js';
 import { filterDeps, getBuildOrder, getDependencies } from '../helpers/dependencyAnalysis.js';
 import formatDuration from '../helpers/format-duration.js';
@@ -20,7 +21,7 @@ export const describe =
  *
  * @see resolveAction
  */
-const ACTION_RANK = {
+export const ACTION_RANK = {
 	skip: 0,
 	'dump-autoload': 1,
 	build: 2,
@@ -85,6 +86,12 @@ export function builder( yargs ) {
 			default: false,
 			description:
 				'Abort on the first failed project. Default is to continue and report which projects need attention at the end.',
+		} )
+		.option( 'concurrency', {
+			type: 'number',
+			default: 4,
+			description:
+				'How many `dump-autoload` actions to run in parallel. Build actions always run serially because they may have inter-project dependencies. Use 1 to force fully serial execution.',
 		} );
 }
 
@@ -95,7 +102,7 @@ export function builder( yargs ) {
  * @param {string} b - Second action.
  * @return {string} The winning action.
  */
-function resolveAction( a, b ) {
+export function resolveAction( a, b ) {
 	return ( ACTION_RANK[ a ] ?? 0 ) >= ( ACTION_RANK[ b ] ?? 0 ) ? a : b;
 }
 
@@ -106,7 +113,7 @@ function resolveAction( a, b ) {
  * @param {string}             project - Project slug.
  * @param {string}             action  - Proposed action.
  */
-function mergeAction( plan, project, action ) {
+export function mergeAction( plan, project, action ) {
 	const existing = plan.get( project );
 	plan.set( project, existing ? resolveAction( existing, action ) : action );
 }
@@ -121,7 +128,7 @@ function mergeAction( plan, project, action ) {
  * @param {string} slug - Project slug.
  * @return {boolean} Whether the project owns a runtime classmap.
  */
-function ownsRuntimeClassmap( slug ) {
+export function ownsRuntimeClassmap( slug ) {
 	return slug.startsWith( 'plugins/' );
 }
 
@@ -233,9 +240,14 @@ async function planFromLogScan( deps, scan, cwd, skipSet ) {
  */
 async function runAction( slug, action, argv ) {
 	const cwd = projectDir( slug );
-	const stdio = [ 'ignore', argv.v ? 'inherit' : 'pipe', argv.v ? 'inherit' : 'pipe' ];
 	if ( action === 'dump-autoload' ) {
-		await execa( 'composer', [ 'dump-autoload' ], { cwd, stdio, buffer: false } );
+		// Buffer stdout/stderr when not verbose so we can surface composer's actual
+		// error output if the command fails (otherwise the user just sees "exit code 1").
+		const stdio = argv.v ? 'inherit' : 'pipe';
+		await execa( 'composer', [ 'dump-autoload', '--no-interaction' ], {
+			cwd,
+			stdio,
+		} );
 		return;
 	}
 	if ( action === 'build' ) {
@@ -243,6 +255,42 @@ async function runAction( slug, action, argv ) {
 		return;
 	}
 	throw new Error( `Unknown action: ${ action }` );
+}
+
+/**
+ * Pull the most informative chunk out of an execa error for inline display.
+ *
+ * Composer's stderr is usually a wall of help text; the actually-useful lines
+ * are above it. We try stderr first (composer puts diagnostics there), then
+ * stdout, then the bare exit message.
+ *
+ * @param {Error}  error - execa error.
+ * @param {number} [n]   - Max number of lines to include.
+ * @return {string} Compact, multi-line snippet suitable for printing under a task title.
+ */
+export function summarizeExecError( error, n = 6 ) {
+	const pickFirst = text => {
+		if ( ! text ) {
+			return '';
+		}
+		const lines = text
+			.split( '\n' )
+			.map( s => s.replace( /\s+$/, '' ) )
+			.filter( s => s.length > 0 );
+		// Strip composer's "dump-autoload [-o|...] ..." usage trailer that follows real errors.
+		const cutAt = lines.findIndex( s => /^dump-autoload\s+\[/i.test( s ) );
+		const trimmed = cutAt >= 0 ? lines.slice( 0, cutAt ) : lines;
+		return trimmed.slice( 0, n ).join( '\n' );
+	};
+	const fromStderr = pickFirst( error.stderr );
+	if ( fromStderr ) {
+		return fromStderr;
+	}
+	const fromStdout = pickFirst( error.stdout );
+	if ( fromStdout ) {
+		return fromStdout;
+	}
+	return error.shortMessage || error.message || 'Unknown error';
 }
 
 /**
@@ -395,26 +443,38 @@ export async function handler( argv ) {
 
 	const t0 = Date.now();
 	const failures = [];
+
+	// dump-autoload actions are independent per plugin (each plugin has its own
+	// vendor/composer/jetpack_autoload_classmap.php), so they can run in parallel.
+	// `build` actions stay serial because Listr-internal topological ordering
+	// guarantees a dependency package's build emits before a dependent plugin's
+	// build starts. Mixed plans are run serial to be safe.
+	const allDumpAutoload = ordered.every( o => o.action === 'dump-autoload' );
+	const concurrency = Math.max( 1, argv.concurrency || 1 );
+	const limit = pLimit( allDumpAutoload ? concurrency : 1 );
+
 	const tasks = ordered.map( ( { slug, action } ) => ( {
 		title: `${ chalk.bold( slug ) } ${ chalk.grey( `[${ action }]` ) }`,
-		task: async ( _ctx, task ) => {
-			const startedAt = Date.now();
-			try {
-				await runAction( slug, action, argv );
-				task.title += chalk.grey( ` (${ formatDuration( Date.now() - startedAt ) }s)` );
-				const sha = await currentHead( cwd );
-				await writeStamp( slug, sha, cwd );
-			} catch ( e ) {
-				const message = e.shortMessage || e.message;
-				failures.push( { slug, action, message } );
-				throw new Error( `[${ slug }] ${ action } failed: ${ message }` );
-			}
-		},
+		task: ( _ctx, task ) =>
+			limit( async () => {
+				const startedAt = Date.now();
+				try {
+					await runAction( slug, action, argv );
+					task.title += chalk.grey( ` (${ formatDuration( Date.now() - startedAt ) }s)` );
+					const sha = await currentHead( cwd );
+					await writeStamp( slug, sha, cwd );
+				} catch ( e ) {
+					const detail = summarizeExecError( e );
+					failures.push( { slug, action, message: detail } );
+					throw new Error( `[${ slug }] ${ action } failed:\n${ detail }` );
+				}
+			} ),
 	} ) );
 
 	const listr = new Listr( tasks, {
 		renderer: argv.v ? SilentRenderer : UpdateRenderer,
-		concurrent: false,
+		// When parallelism is on, ask Listr to schedule everything at once and let pLimit gate.
+		concurrent: allDumpAutoload && concurrency > 1,
 		exitOnError: !! argv.stopOnError,
 	} );
 

--- a/tools/cli/tests/unit/commands/fast-build.test.js
+++ b/tools/cli/tests/unit/commands/fast-build.test.js
@@ -1,0 +1,94 @@
+import {
+	ACTION_RANK,
+	mergeAction,
+	ownsRuntimeClassmap,
+	resolveAction,
+	summarizeExecError,
+} from '../../../commands/fast-build.js';
+
+describe( 'fast-build.resolveAction', () => {
+	test( 'higher-rank action wins', () => {
+		expect( resolveAction( 'dump-autoload', 'build' ) ).toBe( 'build' );
+		expect( resolveAction( 'build', 'dump-autoload' ) ).toBe( 'build' );
+	} );
+
+	test( 'equal ranks pick the first argument', () => {
+		expect( resolveAction( 'dump-autoload', 'dump-autoload' ) ).toBe( 'dump-autoload' );
+		expect( resolveAction( 'build', 'build' ) ).toBe( 'build' );
+	} );
+
+	test( 'unknown actions rank as 0 (skip)', () => {
+		expect( resolveAction( 'mystery', 'dump-autoload' ) ).toBe( 'dump-autoload' );
+		expect( resolveAction( 'mystery', 'skip' ) ).toBe( 'mystery' );
+	} );
+
+	test( 'ACTION_RANK is strictly ordered', () => {
+		expect( ACTION_RANK.skip ).toBeLessThan( ACTION_RANK[ 'dump-autoload' ] );
+		expect( ACTION_RANK[ 'dump-autoload' ] ).toBeLessThan( ACTION_RANK.build );
+	} );
+} );
+
+describe( 'fast-build.mergeAction', () => {
+	test( 'sets a fresh entry when the project is absent', () => {
+		const plan = new Map();
+		mergeAction( plan, 'plugins/jetpack', 'dump-autoload' );
+		expect( plan.get( 'plugins/jetpack' ) ).toBe( 'dump-autoload' );
+	} );
+
+	test( 'upgrades to the higher-rank action when one already exists', () => {
+		const plan = new Map( [ [ 'plugins/jetpack', 'dump-autoload' ] ] );
+		mergeAction( plan, 'plugins/jetpack', 'build' );
+		expect( plan.get( 'plugins/jetpack' ) ).toBe( 'build' );
+	} );
+
+	test( 'does not downgrade when the lower-rank action is provided second', () => {
+		const plan = new Map( [ [ 'plugins/jetpack', 'build' ] ] );
+		mergeAction( plan, 'plugins/jetpack', 'dump-autoload' );
+		expect( plan.get( 'plugins/jetpack' ) ).toBe( 'build' );
+	} );
+} );
+
+describe( 'fast-build.ownsRuntimeClassmap', () => {
+	test( 'plugins own a runtime classmap', () => {
+		expect( ownsRuntimeClassmap( 'plugins/jetpack' ) ).toBe( true );
+		expect( ownsRuntimeClassmap( 'plugins/mu-wpcom-plugin' ) ).toBe( true );
+	} );
+
+	test( 'packages do not own a runtime classmap', () => {
+		expect( ownsRuntimeClassmap( 'packages/connection' ) ).toBe( false );
+		expect( ownsRuntimeClassmap( 'js-packages/components' ) ).toBe( false );
+		expect( ownsRuntimeClassmap( 'monorepo' ) ).toBe( false );
+	} );
+} );
+
+describe( 'fast-build.summarizeExecError', () => {
+	test( 'extracts the meaningful lines from composer stderr', () => {
+		const err = {
+			stderr:
+				'Generating autoload files\n\nIn ClassMapGenerator.php line 137:\n  Could not scan for classes inside "jetpack_vendor/automattic/foo/src/"\n  which does not appear to be a file nor a folder\n\ndump-autoload [-o|--optimize] [-a|--classmap-authoritative] ...\n',
+			stdout: '',
+			shortMessage: 'Command failed with exit code 1',
+		};
+		const summary = summarizeExecError( err );
+		expect( summary ).toContain( 'Could not scan for classes' );
+		expect( summary ).toContain( 'ClassMapGenerator.php' );
+		// Composer's "dump-autoload [-o|...]" usage trailer should be stripped.
+		expect( summary ).not.toContain( 'dump-autoload [-o' );
+	} );
+
+	test( 'falls back to stdout when stderr is empty', () => {
+		const err = { stderr: '', stdout: 'first line\nsecond line\n', message: 'whatever' };
+		expect( summarizeExecError( err ) ).toBe( 'first line\nsecond line' );
+	} );
+
+	test( 'falls back to shortMessage when no output is captured', () => {
+		const err = { stderr: '', stdout: '', shortMessage: 'Command failed' };
+		expect( summarizeExecError( err ) ).toBe( 'Command failed' );
+	} );
+
+	test( 'caps the result at N lines', () => {
+		const big = Array.from( { length: 30 }, ( _, i ) => `line ${ i }` ).join( '\n' );
+		const err = { stderr: big, stdout: '', message: '' };
+		expect( summarizeExecError( err, 4 ).split( '\n' ) ).toHaveLength( 4 );
+	} );
+} );


### PR DESCRIPTION
Fixes # N/A

Stacks on #49173 (the `jetpack fast-build` command). Merge that first.

## Proposed changes

Three quality-of-life improvements to `jetpack fast-build`:

### 1. Parallelize `dump-autoload` actions (the headline win)

The original fast-build PR ran `composer dump-autoload` sequentially across every dependent plugin. In testing that took ~31s for 13 plugins (~2.4s each, mostly composer startup + classmap I/O). Each plugin has its own `vendor/composer/jetpack_autoload_classmap.php` — they're independent, no file-locking concerns — so they parallelize trivially.

* New `--concurrency N` flag (default **4**, mirroring the pattern in `jetpack build`).
* When **every** planned action is `dump-autoload`, run them through `pLimit(N)`. With concurrency 4 on the demo case, the same 13-plugin regen should drop to roughly the **slowest 3–4 plugins added end-to-end**, i.e. **~6–10s wall-clock** vs. 31s serial. Use `--concurrency 1` to restore strictly serial behavior.
* When the plan contains any `build` action, execution stays serial. `composer run build-*` for a package can emit files that a dependent plugin's build consumes (via the workspace `jetpack_vendor/` symlinks), so the topological ordering matters. Pure `dump-autoload` runs (the common case) get the speedup; mixed runs stay safe.

### 2. Surface composer's actual error inline

Previously a failed `dump-autoload` task printed the unhelpful `Command failed with exit code 1: composer dump-autoload`. That sent reviewers (and me) hunting for the real diagnostic. Now:

* `composer dump-autoload` runs with `--no-interaction` and buffers stdout/stderr when not in verbose mode.
* On failure, a new `summarizeExecError()` helper pulls the meaningful prefix from `stderr` (with a fallback chain to `stdout` → `shortMessage`) and strips composer's noisy "dump-autoload [-o|--optimize] …" usage trailer that follows real error messages.
* Both the per-task failure line and the end-of-run "Failed projects" summary now show the actual root cause. For the known `plugins/mu-wpcom-plugin` case it now looks like:

  ```
  plugins/mu-wpcom-plugin  [dump-autoload]
    Generating autoload files
    In ClassMapGenerator.php line 137:
    Could not scan for classes inside "jetpack_vendor/automattic/jetpack-subscribers-dashboard/src/"
    which does not appear to be a file nor a folder
  ```

### 3. Unit tests for the planner logic

Adds a new suite at `tools/cli/tests/unit/commands/fast-build.test.js` covering the previously-untested helpers:

* `resolveAction` — higher rank wins, ties favor the first argument, unknown actions rank as 0.
* `mergeAction` — sets fresh, upgrades on conflict, doesn't downgrade.
* `ownsRuntimeClassmap` — plugins yes, packages no.
* `summarizeExecError` — extracts composer's diagnostic from stderr, strips the usage trailer, falls back through stdout → shortMessage, respects the N-lines cap.

Test count goes from 169 → 182.

The four helpers above are now `export`ed from `fast-build.js`. They're still internal in spirit (no other file imports them), but the export surface gives tests something to grab.

## Related product discussion/links

Stacked on #49173.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Unit tests

```
cd tools/cli && NODE_OPTIONS=--experimental-vm-modules pnpm test
```

Expect 182 tests passing (16 new in `tests/unit/commands/fast-build.test.js`).

### Concurrency flag in `--help`

```
node tools/cli/bin/jetpack.js fast-build --help
```

`--concurrency` should appear with default 4.

### End-to-end parallel speedup (requires Jetpack docker dev environment)

1. From a branch with a stale autoloader classmap (e.g. anything that adds a new PHP class without rebuilding), confirm `curl http://localhost` returns HTTP 500 and `jp-tail` shows the `Class "..." not found` fatal.
2. Run `time node tools/cli/bin/jetpack.js fast-build --skip plugins/mu-wpcom-plugin --skip plugins/wpcomsh`. Note the wall-clock.
3. Re-run the steps to recreate the fatal, then run `time node tools/cli/bin/jetpack.js fast-build --concurrency 1 --skip plugins/mu-wpcom-plugin --skip plugins/wpcomsh`. Compare.
4. Expected: the default (concurrency 4) run is ~3–4× faster than `--concurrency 1`.

### Verify the improved error output

1. Run `node tools/cli/bin/jetpack.js fast-build` on a branch where `plugins/mu-wpcom-plugin` (or any plugin with a stale `autoload.classmap` referencing a missing vendor dir) fails its `dump-autoload`.
2. The per-task error and the end-of-run "Failed projects" section should show the actual `ClassMapGenerator.php line 137` message rather than just `exit code 1`.
