### PR TITLE
Search Blocks: render product-results body on classic themes (SEARCH-259)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-259-classic-theme-product-search
+++ b/projects/packages/search/changelog/atlas-search-259-classic-theme-product-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: render the product-results body (filters-product, results-list layout=product, WC-only filters) on classic themes when "Use Jetpack Search for product search results" is enabled.

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -636,8 +636,9 @@ class REST_Controller {
 	 */
 	protected function resolve_singleton_template_class( $post_type ) {
 		$map = array(
-			Overlay_Template::POST_TYPE => Overlay_Template::class,
-			Search_Template::POST_TYPE  => Search_Template::class,
+			Overlay_Template::POST_TYPE        => Overlay_Template::class,
+			Search_Template::POST_TYPE         => Search_Template::class,
+			Product_Search_Template::POST_TYPE => Product_Search_Template::class,
 		);
 		return $map[ $post_type ] ?? null;
 	}

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -266,19 +266,24 @@ class Initial_State {
 	 * Build the classic-theme product-search-template editor config exposed
 	 * to the dashboard. Counterpart of `get_search_template_config()` for the
 	 * WooCommerce product shim — same `{enabled, editorUrl, postType, isCustomized}`
-	 * shape. `enabled` requires the override option on as well (the shim
-	 * itself is a no-op without it), so the WC card only lights up as
-	 * "active" when the front-end render path is actually wired.
+	 * shape. `enabled` adds the override-on check on top of the Embedded +
+	 * classic gate — it signals "the front-end render path is actually
+	 * wired", distinct from "the override toggle is on" in
+	 * `jetpackSettings.override_woocommerce_search_template`. `$can_edit`
+	 * mirrors the Embedded gate too: `Product_Search_Template::init()` (in
+	 * `Search_Blocks::init()`) only registers `maybe_handle_editor_request`
+	 * on Embedded + classic, so exposing the editor URL on, say, classic +
+	 * Inline would produce a link that silently does nothing when clicked.
 	 *
 	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
 	 */
 	protected function get_product_search_template_config(): array {
-		$is_classic = ! wp_is_block_theme();
+		$is_classic          = ! wp_is_block_theme();
+		$is_classic_embedded = $is_classic
+			&& Module_Control::EXPERIENCE_EMBEDDED === $this->module_control->get_experience();
 		return $this->build_singleton_template_config(
-			$is_classic
-				&& Module_Control::EXPERIENCE_EMBEDDED === $this->module_control->get_experience()
-				&& Search_Blocks::woocommerce_search_template_override_enabled(),
-			$is_classic && current_user_can( 'manage_options' ),
+			$is_classic_embedded && Search_Blocks::woocommerce_search_template_override_enabled(),
+			$is_classic_embedded && current_user_can( 'manage_options' ),
 			Product_Search_Template::class
 		);
 	}

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -115,6 +115,14 @@ class Initial_State {
 				 * shape and same React link as `blockTemplateOverlay`.
 				 */
 				'searchTemplate'             => $this->get_search_template_config(),
+				/**
+				 * Same as `searchTemplate` but for the WooCommerce product
+				 * search shim — the `WooCommerceProductSearchControl`
+				 * surfaces this on classic themes so the "Edit the product
+				 * search template" link routes to `post.php` on the hidden
+				 * CPT instead of a useless Site Editor URL.
+				 */
+				'productSearchTemplate'      => $this->get_product_search_template_config(),
 				// Gates the WooCommerce Product Search control to stores.
 				'isWooCommerceActive'        => Search_Blocks::woocommerce_blocks_enabled(),
 				/**
@@ -251,6 +259,27 @@ class Initial_State {
 			$is_classic && Module_Control::EXPERIENCE_EMBEDDED === $this->module_control->get_experience(),
 			$is_classic && current_user_can( 'manage_options' ),
 			Search_Template::class
+		);
+	}
+
+	/**
+	 * Build the classic-theme product-search-template editor config exposed
+	 * to the dashboard. Counterpart of `get_search_template_config()` for the
+	 * WooCommerce product shim — same `{enabled, editorUrl, postType, isCustomized}`
+	 * shape. `enabled` requires the override option on as well (the shim
+	 * itself is a no-op without it), so the WC card only lights up as
+	 * "active" when the front-end render path is actually wired.
+	 *
+	 * @return array{enabled: bool, editorUrl: string|null, postType: string|null, isCustomized: bool}
+	 */
+	protected function get_product_search_template_config(): array {
+		$is_classic = ! wp_is_block_theme();
+		return $this->build_singleton_template_config(
+			$is_classic
+				&& Module_Control::EXPERIENCE_EMBEDDED === $this->module_control->get_experience()
+				&& Search_Blocks::woocommerce_search_template_override_enabled(),
+			$is_classic && current_user_can( 'manage_options' ),
+			Product_Search_Template::class
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -202,13 +202,26 @@ export default function DashboardPage( { isLoading = false } ) {
 	const showWooCommerceProductSearchControl =
 		isWooCommerceActive &&
 		( activeExperience === EXPERIENCE.EMBEDDED || activeExperience === EXPERIENCE.INLINE );
-	// Site Editor identifies plugin templates as `<stylesheet>//<slug>`;
-	// fall back to the Templates list when the stylesheet is unavailable.
-	const wooProductSearchEditUrl = activeThemeStylesheet
-		? `${ siteAdminUrl }site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
-				activeThemeStylesheet
-		  ) }%2F%2Fjetpack-search-product-results&canvas=edit`
-		: `${ siteAdminUrl }site-editor.php?p=%2Ftemplate`;
+	// Block themes get the Site Editor entry (templates resolve as
+	// `<stylesheet>//<slug>`); classic themes don't have a Site Editor at
+	// all, so route to the `Product_Search_Template` singleton-CPT editor
+	// instead. The CPT URL is nonce'd by PHP and is `null` for any visitor
+	// without `manage_options` — keep the WC control's existing
+	// `editTemplateUrl && …` guard so the link hides cleanly in that case.
+	const isBlockTheme = useSelect( select => select( STORE_ID ).isBlockTheme() );
+	const productSearchTemplate = useSelect( select =>
+		select( STORE_ID ).getProductSearchTemplateConfig()
+	);
+	let wooProductSearchEditUrl;
+	if ( isBlockTheme ) {
+		wooProductSearchEditUrl = activeThemeStylesheet
+			? `${ siteAdminUrl }site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
+					activeThemeStylesheet
+			  ) }%2F%2Fjetpack-search-product-results&canvas=edit`
+			: `${ siteAdminUrl }site-editor.php?p=%2Ftemplate`;
+	} else {
+		wooProductSearchEditUrl = productSearchTemplate.editorUrl;
+	}
 	const showAIAgentAccessGuidelinesLink =
 		! isReaderChatAvailable ||
 		! supportsSearch ||

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -108,6 +108,13 @@ const createSelectMethods = () => ( {
 	isSearchSuggestionsEnabled: jest.fn( () => false ),
 	isWooCommerceActive: jest.fn( () => false ),
 	isWooCommerceSearchTemplateOverrideEnabled: jest.fn( () => false ),
+	isBlockTheme: jest.fn( () => true ),
+	getProductSearchTemplateConfig: jest.fn( () => ( {
+		enabled: false,
+		editorUrl: null,
+		postType: null,
+		isCustomized: false,
+	} ) ),
 	getActiveExperience: jest.fn( () => 'embedded' ),
 	isTogglingInstantSearch: jest.fn( () => false ),
 	isTogglingModule: jest.fn( () => false ),

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -283,6 +283,54 @@ describe( 'DashboardPage', () => {
 		expect( mockWooCommerceProductSearchControl ).not.toHaveBeenCalled();
 	} );
 
+	test( 'routes editTemplateUrl through the Site Editor on block themes', () => {
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'getActiveExperience' ).mockImplementation( () => 'embedded' );
+		jest
+			.spyOn( mockSelectMethods, 'isWooCommerceSearchTemplateOverrideEnabled' )
+			.mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isBlockTheme' ).mockImplementation( () => true );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( mockWooCommerceProductSearchControl ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				editTemplateUrl: expect.stringContaining( 'site-editor.php' ),
+			} )
+		);
+	} );
+
+	test( 'routes editTemplateUrl through the singleton CPT on classic themes', () => {
+		// Regression guard for SEARCH-259's classic-theme fix: a classic
+		// theme has no Site Editor, so the Site Editor URL is a dead link.
+		// `dashboard-page.jsx` branches on `isBlockTheme` and routes to
+		// `Product_Search_Template`'s CPT editor URL instead.
+		const cptEditorUrl =
+			'https://example.com/wp-admin/admin.php?page=jetpack-search&jetpack_search_open_product_template_editor=1&_wpnonce=ABC';
+		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'getActiveExperience' ).mockImplementation( () => 'embedded' );
+		jest
+			.spyOn( mockSelectMethods, 'isWooCommerceSearchTemplateOverrideEnabled' )
+			.mockImplementation( () => true );
+		jest.spyOn( mockSelectMethods, 'isBlockTheme' ).mockImplementation( () => false );
+		jest.spyOn( mockSelectMethods, 'getProductSearchTemplateConfig' ).mockImplementation( () => ( {
+			enabled: true,
+			editorUrl: cptEditorUrl,
+			postType: 'jp_product_search',
+			isCustomized: false,
+		} ) );
+
+		render( <DashboardPage /> );
+		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
+
+		expect( mockWooCommerceProductSearchControl ).toHaveBeenCalledWith(
+			expect.objectContaining( { editTemplateUrl: cptEditorUrl } )
+		);
+	} );
+
 	test( 'hides WooCommerceProductSearchControl under the Overlay experience (moot — instant search intercepts)', () => {
 		jest.spyOn( mockSelectMethods, 'isSearchBlocksEnabled' ).mockImplementation( () => true );
 		jest.spyOn( mockSelectMethods, 'isWooCommerceActive' ).mockImplementation( () => true );

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -46,6 +46,13 @@ const siteDataSelectors = {
 	// instead of the FSE template editor.
 	getSearchTemplateConfig: state =>
 		state.siteData?.searchTemplate ?? singletonTemplateConfigDefault,
+	// Sibling of `getSearchTemplateConfig` for the WooCommerce product-search
+	// shim. The `WooCommerceProductSearchControl` reads this to route the
+	// "Edit the product search template" link to `post.php` on the hidden
+	// `Product_Search_Template` CPT on classic themes — the Site Editor URL
+	// the control falls back to is useless there.
+	getProductSearchTemplateConfig: state =>
+		state.siteData?.productSearchTemplate ?? singletonTemplateConfigDefault,
 	isWooCommerceActive: state => state.siteData?.isWooCommerceActive ?? false,
 	getActiveThemeStylesheet: state => state.siteData?.activeThemeStylesheet ?? '',
 	// Defaults to true so Embedded is never blocked when the flag is absent

--- a/projects/packages/search/src/dashboard/store/selectors/test/site-data.test.js
+++ b/projects/packages/search/src/dashboard/store/selectors/test/site-data.test.js
@@ -29,4 +29,34 @@ describe( 'siteDataSelectors', () => {
 		expect( siteDataSelectors.isBlockTheme( {} ) ).toBe( true );
 		expect( siteDataSelectors.isBlockTheme( { siteData: {} } ) ).toBe( true );
 	} );
+
+	test( 'returns the product search template config from siteData', () => {
+		const config = {
+			enabled: true,
+			editorUrl: 'https://example.com/wp-admin/post.php?post=42&action=edit',
+			postType: 'jp_product_search',
+			isCustomized: false,
+		};
+		expect(
+			siteDataSelectors.getProductSearchTemplateConfig( {
+				siteData: { productSearchTemplate: config },
+			} )
+		).toEqual( config );
+	} );
+
+	test( 'falls back to the singleton-template default when productSearchTemplate is missing', () => {
+		// Match `singletonTemplateConfigDefault` in site-data.js: a stale or
+		// older initial-state blob must read as "no customization, no link"
+		// instead of crashing on undefined property reads in the WC control.
+		const fallback = {
+			enabled: false,
+			editorUrl: null,
+			postType: null,
+			isCustomized: false,
+		};
+		expect( siteDataSelectors.getProductSearchTemplateConfig( {} ) ).toEqual( fallback );
+		expect( siteDataSelectors.getProductSearchTemplateConfig( { siteData: {} } ) ).toEqual(
+			fallback
+		);
+	} );
 } );

--- a/projects/packages/search/src/search-blocks/class-product-search-template.php
+++ b/projects/packages/search/src/search-blocks/class-product-search-template.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Singleton CPT + lifecycle for the classic-theme product-search template editor.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Theme-agnostic customization surface for the classic-theme product-search
+ * template via post.php — the WooCommerce-product counterpart of
+ * {@see Search_Template}. Lifecycle lives on {@see Singleton_Template_Cpt}.
+ * Seed mirrors what `Search_Blocks::get_classic_theme_product_search_body()`
+ * renders so the editor and the front end stay in lockstep.
+ */
+class Product_Search_Template extends Singleton_Template_Cpt {
+
+	const POST_TYPE          = 'jp_product_search';
+	const REST_BASE          = 'jetpack-product-search-template';
+	const OPTION_POST_ID     = 'jetpack_product_search_template_post_id';
+	const EDITOR_REQUEST_KEY = 'jetpack_search_open_product_template_editor';
+	const EDITOR_NONCE       = 'jetpack_search_product_template_editor';
+	const SEED_META_KEY      = '_jetpack_product_search_template_seeded_version';
+
+	/**
+	 * Subclass hook — CPT labels.
+	 *
+	 * @return array{name:string,singular_name:string}
+	 */
+	protected static function labels(): array {
+		return array(
+			'name'          => __( 'Product search template', 'jetpack-search-pkg' ),
+			'singular_name' => __( 'Product search template', 'jetpack-search-pkg' ),
+		);
+	}
+
+	/**
+	 * Subclass hook — default post title.
+	 *
+	 * @return string
+	 */
+	protected static function post_title(): string {
+		return __( 'Jetpack Search product template', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Subclass hook — seed `post_content`. `ensure_post_exists()` only runs
+	 * when no customization exists, so the body source resolves to the
+	 * bundled (template-part-stripped) markup.
+	 *
+	 * @return string
+	 */
+	protected static function read_seed_content(): string {
+		return Search_Blocks::get_classic_theme_product_search_body();
+	}
+
+	/**
+	 * Subclass hook — forbidden-response copy.
+	 *
+	 * @return string
+	 */
+	protected static function forbidden_message(): string {
+		return __( 'You do not have permission to customize the product search template.', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Subclass hook — create-failure copy.
+	 *
+	 * @return string
+	 */
+	protected static function create_failure_message(): string {
+		return __( 'Could not create the product search template.', 'jetpack-search-pkg' );
+	}
+}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -149,7 +149,15 @@ class Search_Blocks {
 				// Classic themes: no FSE hierarchy to prepend to, so swap the
 				// resolved template path via `template_include`. The block markup
 				// renders inside the theme's `get_header()`/`get_footer()`.
-				add_filter( 'template_include', array( static::class, 'route_classic_theme_search_template' ) );
+				//
+				// Priority 20: WooCommerce's `WC_Template_Loader::template_loader`
+				// hooks at priority 10 and rewrites the path to `archive-product.php`
+				// on product-archive requests — that includes product search. We
+				// need to run *after* WC so the override actually sticks; running
+				// at 10 (same priority, later registration) is order-of-load
+				// dependent. Higher priorities (anything > 20 used by chrome
+				// filters) aren't relevant — nothing else swaps the path.
+				add_filter( 'template_include', array( static::class, 'route_classic_theme_search_template' ), 20 );
 				// No Site Editor entry on classic themes; the `Search_Template` singleton
 				// CPT gives authors the standard block editor on a hidden post instead.
 				Search_Template::init();

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -158,9 +158,15 @@ class Search_Blocks {
 				// dependent. Higher priorities (anything > 20 used by chrome
 				// filters) aren't relevant — nothing else swaps the path.
 				add_filter( 'template_include', array( static::class, 'route_classic_theme_search_template' ), 20 );
-				// No Site Editor entry on classic themes; the `Search_Template` singleton
-				// CPT gives authors the standard block editor on a hidden post instead.
+				// No Site Editor entry on classic themes; the singleton CPTs give
+				// authors the standard block editor on hidden posts instead. Both
+				// init regardless of the WooCommerce override option so admins can
+				// pre-customize either template before activating the relevant
+				// surface — matching `Search_Template`'s "expose URLs before
+				// activation" rule. The override option still gates the actual
+				// front-end render path in `route_classic_theme_search_template()`.
 				Search_Template::init();
+				Product_Search_Template::init();
 			}
 		}
 
@@ -180,13 +186,6 @@ class Search_Blocks {
 		) {
 			add_action( 'init', array( static::class, 'register_product_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'route_woocommerce_product_search_template' ), 20 );
-			// Classic-theme product-search counterpart of `Search_Template::init()` —
-			// no Site Editor entry, so the singleton CPT gives authors the standard
-			// block editor on a hidden post. Block themes use the FSE Site Editor
-			// against `register_product_search_template()` instead.
-			if ( Module_Control::EXPERIENCE_EMBEDDED === $experience && ! static::block_templates_active() ) {
-				Product_Search_Template::init();
-			}
 		}
 
 		// Two-tier gate: register the editable template CPT + admin-init editor

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -172,6 +172,13 @@ class Search_Blocks {
 		) {
 			add_action( 'init', array( static::class, 'register_product_search_template' ) );
 			add_filter( 'search_template_hierarchy', array( static::class, 'route_woocommerce_product_search_template' ), 20 );
+			// Classic-theme product-search counterpart of `Search_Template::init()` —
+			// no Site Editor entry, so the singleton CPT gives authors the standard
+			// block editor on a hidden post. Block themes use the FSE Site Editor
+			// against `register_product_search_template()` instead.
+			if ( Module_Control::EXPERIENCE_EMBEDDED === $experience && ! static::block_templates_active() ) {
+				Product_Search_Template::init();
+			}
 		}
 
 		// Two-tier gate: register the editable template CPT + admin-init editor
@@ -423,16 +430,20 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Mirrors WooCommerce's own `ProductSearchResultsTemplate` guard so the
-	 * override only touches requests WooCommerce would itself reroute.
+	 * Whether the current request is a WooCommerce product search — a search
+	 * query scoped to the `product` post-type archive on a Woo-enabled site.
+	 *
+	 * Theme-agnostic. Block-theme-only behavior (FSE hierarchy work) gates on
+	 * {@see block_templates_active()} at the call site so this predicate also
+	 * drives the classic-theme product shim. Public because the
+	 * `classic-theme-product-search.php` shim reads it.
 	 *
 	 * @return bool
 	 */
-	protected static function is_woocommerce_product_search(): bool {
+	public static function is_woocommerce_product_search(): bool {
 		return self::woocommerce_blocks_enabled()
 			&& is_search()
-			&& is_post_type_archive( 'product' )
-			&& static::block_templates_active();
+			&& is_post_type_archive( 'product' );
 	}
 
 	/**
@@ -1450,12 +1461,24 @@ CSS;
 		if ( ! is_search() ) {
 			return $template;
 		}
-		if ( ! static::woocommerce_search_template_override_enabled() && static::is_woocommerce_product_search() ) {
+		$is_product_search = static::is_woocommerce_product_search();
+		// Override off: leave product search to WooCommerce / the theme's own
+		// archive routing — we don't impose the product shim without opt-in.
+		if ( ! static::woocommerce_search_template_override_enabled() && $is_product_search ) {
 			return $template;
 		}
-		// Bail back to the theme's template if there's no customization AND no
-		// bundled body — rendering header/footer with nothing between looks
-		// broken. A saved empty customization ('' vs null) is honored as intentional.
+		// Override on + product search: route to the product-results shim.
+		// Bail back to the theme's template if neither a customization nor a
+		// bundled body is available — rendering header/footer around an empty
+		// body looks broken.
+		if ( $is_product_search ) {
+			if ( null === Product_Search_Template::get_customized_content() && '' === static::get_classic_theme_product_search_body() ) {
+				return $template;
+			}
+			return __DIR__ . '/templates/classic-theme-product-search.php';
+		}
+		// Non-product search: same empty-body bail-out for the generic shim.
+		// A saved empty customization ('' vs null) is honored as intentional.
 		if ( null === Search_Template::get_customized_content() && '' === static::get_classic_theme_search_body() ) {
 			return $template;
 		}
@@ -1477,13 +1500,39 @@ CSS;
 		if ( null !== $customized ) {
 			return $customized;
 		}
-		$content = static::get_search_template_content();
+		return static::strip_top_level_template_parts( static::get_search_template_content() );
+	}
+
+	/**
+	 * Product-search counterpart to {@see get_classic_theme_search_body()} —
+	 * source of truth for the classic-theme product-results shim. Customized
+	 * `Product_Search_Template` CPT → bundled `jetpack-search-product-results.html`.
+	 * Public because `templates/classic-theme-product-search.php` calls it from
+	 * outside the class.
+	 *
+	 * @return string Block markup, no template-part wrappers.
+	 */
+	public static function get_classic_theme_product_search_body(): string {
+		$customized = Product_Search_Template::get_customized_content();
+		if ( null !== $customized ) {
+			return $customized;
+		}
+		return static::strip_top_level_template_parts( static::get_product_search_template_content() );
+	}
+
+	/**
+	 * Strip top-level `core/template-part` self-closing comments — classic
+	 * themes can't resolve their slugs. Non-greedy `.*?` capped by `-->` keeps
+	 * matching cleanly across template revisions and across nested attribute
+	 * payloads.
+	 *
+	 * @param string $content Block markup, possibly empty.
+	 * @return string
+	 */
+	protected static function strip_top_level_template_parts( string $content ): string {
 		if ( '' === $content ) {
 			return '';
 		}
-		// Strip the two top-level `core/template-part` self-closing comments —
-		// classic themes can't resolve their slugs. Non-greedy `.*?` capped by
-		// `-->` keeps matching cleanly across template revisions.
 		return (string) preg_replace( '#<!--\s*wp:template-part\s+.*?/-->\s*#s', '', $content );
 	}
 
@@ -1525,7 +1574,10 @@ CSS;
 	 * @return string[]
 	 */
 	public static function route_woocommerce_product_search_template( $templates ) {
-		if ( ! static::is_woocommerce_product_search() ) {
+		// FSE-hierarchy work — classic themes resolve template slugs as `{slug}.php`
+		// and there's no `jetpack-search-product-results.php`. The classic-theme
+		// equivalent runs through `route_classic_theme_search_template()` instead.
+		if ( ! static::block_templates_active() || ! static::is_woocommerce_product_search() ) {
 			return $templates;
 		}
 		$templates = array_values(

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1545,6 +1545,40 @@ CSS;
 	}
 
 	/**
+	 * Inline layout `<style>` block the classic-theme shims emit before the
+	 * Bundled block markup. Classic themes don't emit core's block-supports
+	 * Layout CSS, so two traits the bundled templates rely on collapse on
+	 * Classic themes: the inner group's 1.5rem `blockGap` vanishes (search
+	 * Input runs straight into the results row), and `alignwide` has no
+	 * Effect (content stretches edge-to-edge because `template_include`
+	 * Bypasses the theme's own content wrapper). Reapplying both, scoped to
+	 * `<main class="wp-block-group">`, restores parity without leaking
+	 * Outside the shim. Shared by both shims so a future layout tweak
+	 * Touches one place. The `<style>` `id` is unique per render — routing
+	 * Ensures only one shim runs per request, so duplicate IDs can't occur.
+	 *
+	 * Public because both `templates/classic-theme-search.php` and
+	 * `templates/classic-theme-product-search.php` call it from outside the
+	 * Class.
+	 *
+	 * @return string Inline `<style>` element ready to echo.
+	 */
+	public static function get_classic_theme_layout_style(): string {
+		return <<<'HTML'
+<style id="jetpack-search-classic-theme-layout">
+main.wp-block-group {
+	max-width: var(--wp--style--global--wide-size, 1280px);
+	margin-inline: auto;
+	padding-inline: clamp(1rem, 4vw, 2rem);
+}
+main.wp-block-group .is-layout-flow > * + * {
+	margin-block-start: var(--wp--style--block-gap, 1.5rem);
+}
+</style>
+HTML;
+	}
+
+	/**
 	 * Test override for `block_templates_active()`. Null = read the live state.
 	 *
 	 * @var bool|null

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -443,8 +443,10 @@ class Search_Blocks {
 	 *
 	 * Theme-agnostic. Block-theme-only behavior (FSE hierarchy work) gates on
 	 * {@see block_templates_active()} at the call site so this predicate also
-	 * drives the classic-theme product shim. Public because the
-	 * `classic-theme-product-search.php` shim reads it.
+	 * drives the classic-theme product shim. Public to keep the WC-gating
+	 * surface (see AGENTS.md § WooCommerce gating) discoverable from outside
+	 * the class; the in-class callers are `route_classic_theme_search_template()`
+	 * and `route_woocommerce_product_search_template()`.
 	 *
 	 * @return bool
 	 */
@@ -1546,20 +1548,20 @@ CSS;
 
 	/**
 	 * Inline layout `<style>` block the classic-theme shims emit before the
-	 * Bundled block markup. Classic themes don't emit core's block-supports
-	 * Layout CSS, so two traits the bundled templates rely on collapse on
-	 * Classic themes: the inner group's 1.5rem `blockGap` vanishes (search
-	 * Input runs straight into the results row), and `alignwide` has no
-	 * Effect (content stretches edge-to-edge because `template_include`
-	 * Bypasses the theme's own content wrapper). Reapplying both, scoped to
+	 * bundled block markup. Classic themes don't emit core's block-supports
+	 * layout CSS, so two traits the bundled templates rely on collapse on
+	 * classic themes: the inner group's 1.5rem `blockGap` vanishes (search
+	 * input runs straight into the results row), and `alignwide` has no
+	 * effect (content stretches edge-to-edge because `template_include`
+	 * bypasses the theme's own content wrapper). Reapplying both, scoped to
 	 * `<main class="wp-block-group">`, restores parity without leaking
-	 * Outside the shim. Shared by both shims so a future layout tweak
-	 * Touches one place. The `<style>` `id` is unique per render — routing
-	 * Ensures only one shim runs per request, so duplicate IDs can't occur.
+	 * outside the shim. Shared by both shims so a future layout tweak
+	 * touches one place. The `<style>` `id` is unique per render — routing
+	 * ensures only one shim runs per request, so duplicate IDs can't occur.
 	 *
 	 * Public because both `templates/classic-theme-search.php` and
 	 * `templates/classic-theme-product-search.php` call it from outside the
-	 * Class.
+	 * class.
 	 *
 	 * @return string Inline `<style>` element ready to echo.
 	 */

--- a/projects/packages/search/src/search-blocks/templates/classic-theme-product-search.php
+++ b/projects/packages/search/src/search-blocks/templates/classic-theme-product-search.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Classic-theme product-search results template for the Jetpack Search
+ * Embedded experience — WooCommerce-product counterpart of
+ * `classic-theme-search.php`.
+ *
+ * Wraps the bundled `jetpack-search-product-results.html` block markup in the
+ * active theme's `get_header()` / `get_footer()` so the block-rendered
+ * product results sit inside the theme's chrome — the classic-theme
+ * counterpart to the FSE block template fronted via
+ * `search_template_hierarchy` on block themes.
+ *
+ * Loaded via the `template_include` filter in
+ * `Search_Blocks::route_classic_theme_search_template()`; reachable only on
+ * `is_search()` with Embedded saved + classic theme + WooCommerce product
+ * search + the `jetpack_search_override_woocommerce_search_template` option on.
+ *
+ * @package automattic/jetpack-search
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+
+// Classic themes don't emit core's layout block-supports CSS — see the
+// matching note in `classic-theme-search.php` for why we reapply the inner
+// `wp-block-group` layout here.
+?>
+<style id="jetpack-search-classic-theme-layout">
+main.wp-block-group {
+	max-width: var(--wp--style--global--wide-size, 1280px);
+	margin-inline: auto;
+	padding-inline: clamp(1rem, 4vw, 2rem);
+}
+main.wp-block-group .is-layout-flow > * + * {
+	margin-block-start: var(--wp--style--block-gap, 1.5rem);
+}
+</style>
+<?php
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks renders trusted bundled markup.
+echo do_blocks( \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_product_search_body() );
+
+get_footer();

--- a/projects/packages/search/src/search-blocks/templates/classic-theme-product-search.php
+++ b/projects/packages/search/src/search-blocks/templates/classic-theme-product-search.php
@@ -24,21 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
-// Classic themes don't emit core's layout block-supports CSS — see the
-// matching note in `classic-theme-search.php` for why we reapply the inner
-// `wp-block-group` layout here.
-?>
-<style id="jetpack-search-classic-theme-layout">
-main.wp-block-group {
-	max-width: var(--wp--style--global--wide-size, 1280px);
-	margin-inline: auto;
-	padding-inline: clamp(1rem, 4vw, 2rem);
-}
-main.wp-block-group .is-layout-flow > * + * {
-	margin-block-start: var(--wp--style--block-gap, 1.5rem);
-}
-</style>
-<?php
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- bundled inline CSS, no untrusted input.
+echo \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_layout_style();
 
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks renders trusted bundled markup.
 echo do_blocks( \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_product_search_body() );

--- a/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
+++ b/projects/packages/search/src/search-blocks/templates/classic-theme-search.php
@@ -21,31 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 
-// Classic themes don't emit core's layout block-supports CSS, so two
-// layout traits the bundled `jetpack-search.html` relies on collapse on
-// classic themes:
-//
-// 1. The 1.5rem `blockGap` declared on the inner `wp-block-group`
-// vanishes — search input runs straight into the results / filters row.
-// 2. The `alignwide` class on the inner group has no effect — content
-// hugs the viewport edges and stretches edge-to-edge on wide screens
-// because `template_include` bypasses the theme's own content wrapper.
-//
-// Reapply both once, scoped to our `<main class="wp-block-group">` so the
-// rules can't leak into theme content elsewhere. CSS-variable fallbacks
-// honor a theme.json-shipping classic theme's tokens when present.
-?>
-<style id="jetpack-search-classic-theme-layout">
-main.wp-block-group {
-	max-width: var(--wp--style--global--wide-size, 1280px);
-	margin-inline: auto;
-	padding-inline: clamp(1rem, 4vw, 2rem);
-}
-main.wp-block-group .is-layout-flow > * + * {
-	margin-block-start: var(--wp--style--block-gap, 1.5rem);
-}
-</style>
-<?php
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- bundled inline CSS, no untrusted input.
+echo \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_layout_style();
 
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_blocks renders trusted bundled markup.
 echo do_blocks( \Automattic\Jetpack\Search\Search_Blocks::get_classic_theme_search_body() );

--- a/projects/packages/search/tests/php/Product_Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Product_Search_Template_Test.php
@@ -31,9 +31,9 @@ class Product_Search_Template_Test extends Search_TestCase {
 
 	/**
 	 * `Product_Search_Template` must declare distinct identifiers from the
-	 * Two sibling singleton CPTs so they don't share a singleton — the
-	 * Shared base caches by class but everything else (post-type, option,
-	 * Nonces) is keyed by class constant.
+	 * two sibling singleton CPTs so they don't share a singleton — the
+	 * shared base caches by class but everything else (post-type, option,
+	 * nonces) is keyed by class constant.
 	 */
 	public function test_subclass_constants_are_distinct_from_siblings() {
 		$this->assertNotSame( Search_Template::POST_TYPE, Product_Search_Template::POST_TYPE );
@@ -57,7 +57,7 @@ class Product_Search_Template_Test extends Search_TestCase {
 
 	/**
 	 * No singleton on file ⇒ `get_customized_content()` returns null, the
-	 * Shape callers depend on to fall back to the bundled product template.
+	 * shape callers depend on to fall back to the bundled product template.
 	 */
 	public function test_uncustomized_state_returns_nulls() {
 		$this->assertNull( Product_Search_Template::get_customized_content() );
@@ -68,7 +68,7 @@ class Product_Search_Template_Test extends Search_TestCase {
 	/**
 	 * The REST resolver must map this CPT back to its concrete class so
 	 * "Restore default" reaches the right Singleton_Template_Cpt subclass —
-	 * Without this entry, the route would 404 on the new post-type slug.
+	 * without this entry, the route would 404 on the new post-type slug.
 	 */
 	public function test_rest_controller_resolves_product_search_template() {
 		$controller = new \Automattic\Jetpack\Search\REST_Controller();
@@ -99,9 +99,9 @@ class Product_Search_Template_Test extends Search_TestCase {
 
 	/**
 	 * `Search_Blocks::get_classic_theme_product_search_body()` must prefer
-	 * A saved customization over the bundled file — the whole point of the
+	 * a saved customization over the bundled file — the whole point of the
 	 * CPT path. An empty string customization (admin saved a blank canvas)
-	 * Is honored verbatim.
+	 * is honored verbatim.
 	 */
 	public function test_classic_theme_product_search_body_prefers_customization() {
 		$post_id = wp_insert_post(

--- a/projects/packages/search/tests/php/Product_Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Product_Search_Template_Test.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Automattic\Jetpack\Search;
+
+use Automattic\Jetpack\Search\TestCase as Search_TestCase;
+
+/**
+ * Unit tests for the Product_Search_Template singleton CPT and its
+ * integration with Search_Blocks's classic-theme product-search render path.
+ *
+ * @package automattic/jetpack-search
+ */
+class Product_Search_Template_Test extends Search_TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		Product_Search_Template::register_post_type();
+		Product_Search_Template::reset_customized_content_cache();
+		delete_option( Product_Search_Template::OPTION_POST_ID );
+	}
+
+	public function tearDown(): void {
+		$post_id = (int) get_option( Product_Search_Template::OPTION_POST_ID, 0 );
+		if ( $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		delete_option( Product_Search_Template::OPTION_POST_ID );
+		Product_Search_Template::reset_customized_content_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * `Product_Search_Template` must declare distinct identifiers from the
+	 * Two sibling singleton CPTs so they don't share a singleton — the
+	 * Shared base caches by class but everything else (post-type, option,
+	 * Nonces) is keyed by class constant.
+	 */
+	public function test_subclass_constants_are_distinct_from_siblings() {
+		$this->assertNotSame( Search_Template::POST_TYPE, Product_Search_Template::POST_TYPE );
+		$this->assertNotSame( Overlay_Template::POST_TYPE, Product_Search_Template::POST_TYPE );
+		$this->assertNotSame( Search_Template::REST_BASE, Product_Search_Template::REST_BASE );
+		$this->assertNotSame( Search_Template::OPTION_POST_ID, Product_Search_Template::OPTION_POST_ID );
+		$this->assertNotSame( Search_Template::EDITOR_REQUEST_KEY, Product_Search_Template::EDITOR_REQUEST_KEY );
+		$this->assertNotSame( Search_Template::EDITOR_NONCE, Product_Search_Template::EDITOR_NONCE );
+		$this->assertSame( 'jp_product_search', Product_Search_Template::POST_TYPE );
+		$this->assertLessThanOrEqual(
+			20,
+			strlen( Product_Search_Template::POST_TYPE ),
+			'register_post_type() limits the slug to 20 chars.'
+		);
+	}
+
+	/**
+	 * No singleton on file ⇒ `get_customized_content()` returns null, the
+	 * Shape callers depend on to fall back to the bundled product template.
+	 */
+	public function test_uncustomized_state_returns_nulls() {
+		$this->assertNull( Product_Search_Template::get_customized_content() );
+		$this->assertFalse( Product_Search_Template::is_customized() );
+		$this->assertSame( 0, Product_Search_Template::get_post_id() );
+	}
+
+	/**
+	 * The REST resolver must map this CPT back to its concrete class so
+	 * "Restore default" reaches the right Singleton_Template_Cpt subclass —
+	 * Without this entry, the route would 404 on the new post-type slug.
+	 */
+	public function test_rest_controller_resolves_product_search_template() {
+		$controller = new \Automattic\Jetpack\Search\REST_Controller();
+		$ref        = new \ReflectionMethod( $controller, 'resolve_singleton_template_class' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+
+		$this->assertSame(
+			Product_Search_Template::class,
+			$ref->invoke( $controller, Product_Search_Template::POST_TYPE )
+		);
+	}
+
+	/**
+	 * The seed content for a fresh singleton is exactly what
+	 * `Search_Blocks::get_classic_theme_product_search_body()` returns —
+	 * placeholders substituted, template-part wrappers stripped — so the
+	 * editor opens populated with the same markup the front end renders.
+	 */
+	public function test_seed_content_matches_classic_theme_product_search_body() {
+		$seed = Search_Blocks::get_classic_theme_product_search_body();
+		$this->assertNotEmpty( $seed );
+		$this->assertStringNotContainsString( 'wp:template-part', $seed, 'Seed must have template-parts stripped.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/filters-product', $seed );
+		$this->assertStringContainsString( '"layout":"product"', $seed );
+	}
+
+	/**
+	 * `Search_Blocks::get_classic_theme_product_search_body()` must prefer
+	 * A saved customization over the bundled file — the whole point of the
+	 * CPT path. An empty string customization (admin saved a blank canvas)
+	 * Is honored verbatim.
+	 */
+	public function test_classic_theme_product_search_body_prefers_customization() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Product_Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:heading --><h2>CUSTOMIZED_PRODUCT</h2><!-- /wp:heading -->',
+			)
+		);
+		update_option( Product_Search_Template::OPTION_POST_ID, $post_id );
+		Product_Search_Template::reset_customized_content_cache();
+
+		$body = Search_Blocks::get_classic_theme_product_search_body();
+		$this->assertStringContainsString( 'CUSTOMIZED_PRODUCT', $body );
+		$this->assertStringNotContainsString( 'wp:jetpack-search/filters-product', $body, 'When customized, the bundled body must not be merged in.' );
+	}
+
+	/**
+	 * Class-keyed cache on the shared base must not cross-contaminate
+	 * Product_Search_Template and Search_Template lookups within a request.
+	 */
+	public function test_subclass_caches_are_isolated() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Product_Search_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => 'PRODUCT_TEMPLATE_CONTENT',
+			)
+		);
+		update_option( Product_Search_Template::OPTION_POST_ID, $post_id );
+		Product_Search_Template::reset_customized_content_cache();
+
+		$this->assertSame( 'PRODUCT_TEMPLATE_CONTENT', Product_Search_Template::get_customized_content() );
+		$this->assertNull( Search_Template::get_customized_content() );
+	}
+}

--- a/projects/packages/search/tests/php/Product_Search_Template_Test.php
+++ b/projects/packages/search/tests/php/Product_Search_Template_Test.php
@@ -42,6 +42,11 @@ class Product_Search_Template_Test extends Search_TestCase {
 		$this->assertNotSame( Search_Template::OPTION_POST_ID, Product_Search_Template::OPTION_POST_ID );
 		$this->assertNotSame( Search_Template::EDITOR_REQUEST_KEY, Product_Search_Template::EDITOR_REQUEST_KEY );
 		$this->assertNotSame( Search_Template::EDITOR_NONCE, Product_Search_Template::EDITOR_NONCE );
+		// `SEED_META_KEY` is stamped on every seeded row by the base
+		// `ensure_post_exists()`; a shared key would let a future re-seed
+		// query target the wrong subclass's posts.
+		$this->assertNotSame( Search_Template::SEED_META_KEY, Product_Search_Template::SEED_META_KEY );
+		$this->assertNotSame( Overlay_Template::SEED_META_KEY, Product_Search_Template::SEED_META_KEY );
 		$this->assertSame( 'jp_product_search', Product_Search_Template::POST_TYPE );
 		$this->assertLessThanOrEqual(
 			20,

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -946,19 +946,22 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * The classic-theme product-search singleton CPT is only meaningful when
-	 * the override is on AND the experience is Embedded AND the theme is
-	 * classic — the same gates that route product searches into our shim.
-	 * `init()` must call `Product_Search_Template::init()` in that exact slice
-	 * of the matrix and nowhere else, so the hidden CPT + before-delete cleanup
-	 * don't get registered on sites that wouldn't reach the editor anyway.
+	 * The classic-theme product-search singleton CPT lifecycle wires up on
+	 * Embedded + classic, regardless of the WooCommerce override option —
+	 * mirroring `Search_Template`'s "expose URLs before activation" rule so
+	 * admins can pre-customize the product template before flipping the
+	 * override on. The override still gates the front-end render path in
+	 * `route_classic_theme_search_template()`; it just doesn't gate the
+	 * editor surface. Block themes and non-Embedded experiences must not
+	 * wire the CPT — block themes get the Site Editor, and Inline doesn't
+	 * use the classic shim at all.
 	 *
 	 * Asserts via the `before_delete_post` hook the parent
 	 * `Singleton_Template_Cpt::init()` registers — `register_post_type` is
 	 * idempotent and `admin_init` may not be reachable without `is_admin()`,
 	 * so before-delete is the cleanest lifecycle signal to probe.
 	 */
-	public function test_init_registers_product_search_template_cpt_only_when_embedded_classic_override_on() {
+	public function test_init_registers_product_search_template_cpt_on_embedded_classic() {
 		try {
 			$cb = array( Product_Search_Template::class, 'maybe_cleanup_on_singleton_delete' );
 
@@ -974,16 +977,16 @@ class Search_Blocks_Test extends TestCase {
 				'Product_Search_Template::init() must wire before_delete_post on Embedded + classic + override on'
 			);
 
-			// Embedded + classic + override OFF → no CPT lifecycle (override is what gates it).
+			// Embedded + classic + override OFF → still wired (pre-customization affordance).
 			$this->reset_search_blocks_hooks();
 			$this->set_module_active( true );
 			Search_Blocks::set_block_templates_active_for_testing( false );
 			update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
 			delete_option( 'jetpack_search_override_woocommerce_search_template' );
 			Search_Blocks::init();
-			$this->assertFalse(
+			$this->assertNotFalse(
 				has_action( 'before_delete_post', $cb ),
-				'Product_Search_Template::init() must not wire when the override is off'
+				'Product_Search_Template::init() must wire on Embedded + classic even with the override off (pre-customization)'
 			);
 
 			// Embedded + BLOCK theme + override on → no CPT lifecycle (block themes use the Site Editor).

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -946,6 +946,77 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * The classic-theme product-search singleton CPT is only meaningful when
+	 * The override is on AND the experience is Embedded AND the theme is
+	 * Classic — the same gates that route product searches into our shim.
+	 * `init()` must call `Product_Search_Template::init()` in that exact slice
+	 * Of the matrix and nowhere else, so the hidden CPT + before-delete cleanup
+	 * Don't get registered on sites that wouldn't reach the editor anyway.
+	 *
+	 * Asserts via the `before_delete_post` hook the parent
+	 * `Singleton_Template_Cpt::init()` registers — `register_post_type` is
+	 * Idempotent and `admin_init` may not be reachable without `is_admin()`,
+	 * So before-delete is the cleanest lifecycle signal to probe.
+	 */
+	public function test_init_registers_product_search_template_cpt_only_when_embedded_classic_override_on() {
+		try {
+			$cb = array( Product_Search_Template::class, 'maybe_cleanup_on_singleton_delete' );
+
+			// Embedded + classic + override on → CPT lifecycle wired.
+			$this->reset_search_blocks_hooks();
+			$this->set_module_active( true );
+			Search_Blocks::set_block_templates_active_for_testing( false );
+			update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+			update_option( 'jetpack_search_override_woocommerce_search_template', true );
+			Search_Blocks::init();
+			$this->assertNotFalse(
+				has_action( 'before_delete_post', $cb ),
+				'Product_Search_Template::init() must wire before_delete_post on Embedded + classic + override on'
+			);
+
+			// Embedded + classic + override OFF → no CPT lifecycle (override is what gates it).
+			$this->reset_search_blocks_hooks();
+			$this->set_module_active( true );
+			Search_Blocks::set_block_templates_active_for_testing( false );
+			update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+			Search_Blocks::init();
+			$this->assertFalse(
+				has_action( 'before_delete_post', $cb ),
+				'Product_Search_Template::init() must not wire when the override is off'
+			);
+
+			// Embedded + BLOCK theme + override on → no CPT lifecycle (block themes use the Site Editor).
+			$this->reset_search_blocks_hooks();
+			$this->set_module_active( true );
+			Search_Blocks::set_block_templates_active_for_testing( true );
+			update_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY, Module_Control::EXPERIENCE_EMBEDDED );
+			update_option( 'jetpack_search_override_woocommerce_search_template', true );
+			Search_Blocks::init();
+			$this->assertFalse(
+				has_action( 'before_delete_post', $cb ),
+				'Product_Search_Template::init() must not wire on block themes — Site Editor owns that surface'
+			);
+
+			// Inline + classic + override on → no CPT lifecycle (Inline doesn't use the classic shim).
+			$this->reset_search_blocks_hooks();
+			$this->set_module_active( true );
+			Search_Blocks::set_block_templates_active_for_testing( false );
+			delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+			update_option( 'jetpack_search_override_woocommerce_search_template', true );
+			Search_Blocks::init();
+			$this->assertFalse(
+				has_action( 'before_delete_post', $cb ),
+				'Product_Search_Template::init() must not wire under the Inline experience'
+			);
+		} finally {
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+			delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+			Search_Blocks::set_block_templates_active_for_testing( null );
+		}
+	}
+
+	/**
 	 * `init()` must always register the block-level hooks AND the IA state
 	 * Seeding regardless of which experience the site has saved — admins can
 	 * Insert Search blocks anywhere blocks are configurable, and those blocks
@@ -1398,7 +1469,10 @@ class Search_Blocks_Test extends TestCase {
 		remove_filter( 'block_categories_all', array( Search_Blocks::class, 'register_block_category' ) );
 		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'prepend_search_template' ) );
 		remove_filter( 'search_template_hierarchy', array( Search_Blocks::class, 'route_woocommerce_product_search_template' ), 20 );
-		remove_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) );
+		remove_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ), 20 );
+		remove_action( 'before_delete_post', array( Product_Search_Template::class, 'maybe_cleanup_on_singleton_delete' ) );
+		remove_action( 'admin_init', array( Product_Search_Template::class, 'maybe_handle_editor_request' ) );
+		remove_action( 'init', array( Product_Search_Template::class, 'register_post_type' ), 9 );
 		remove_action( 'template_redirect', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'wp_enqueue_scripts', array( Search_Blocks::class, 'seed_interactivity_state' ) );
 		remove_action( 'enqueue_block_editor_assets', array( Search_Blocks::class, 'enqueue_editor_assets' ) );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1186,9 +1186,13 @@ class Search_Blocks_Test extends TestCase {
 
 		Search_Blocks::init();
 
-		$this->assertNotFalse(
+		// Priority 20: WC's `WC_Template_Loader::template_loader` hooks at 10
+		// And rewrites product searches to `archive-product.php`; running after
+		// WC is what makes the override actually stick on product searches.
+		$this->assertSame(
+			20,
 			has_filter( 'template_include', array( Search_Blocks::class, 'route_classic_theme_search_template' ) ),
-			'classic-theme template_include route must hook on embedded + classic theme'
+			'classic-theme template_include route must hook at priority 20 (after WC) on embedded + classic theme'
 		);
 		$this->assertFalse(
 			has_action( 'init', array( Search_Blocks::class, 'register_search_template' ) ),

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -557,7 +557,7 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The FSE hierarchy router is a strict no-op on classic themes: classic
-	 * Themes resolve template slugs as `{slug}.php` and we don't ship a
+	 * themes resolve template slugs as `{slug}.php` and we don't ship a
 	 * `jetpack-search-product-results.php` — the classic-theme equivalent
 	 * runs through `route_classic_theme_search_template()` instead.
 	 */
@@ -683,9 +683,9 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * Defensive bail-out for the product shim: if neither a customization
-	 * Nor the bundled `jetpack-search-product-results.html` produces a body,
-	 * The router must return the input template unchanged so the theme's own
-	 * Template renders instead of the shim wrapping a blank body.
+	 * nor the bundled `jetpack-search-product-results.html` produces a body,
+	 * the router must return the input template unchanged so the theme's own
+	 * template renders instead of the shim wrapping a blank body.
 	 */
 	public function test_route_classic_theme_search_template_bails_when_product_body_is_empty() {
 		update_option( 'jetpack_search_override_woocommerce_search_template', true );
@@ -797,11 +797,11 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * `get_classic_theme_product_search_body()` returns the bundled
-	 * Product-results markup with top-level `core/template-part` self-closing
-	 * Comments stripped — same contract as `get_classic_theme_search_body()`,
-	 * Product-flavored. Keeps the product-only blocks intact so the shim
-	 * Renders the WC layout (filters-product, results-list layout=product,
-	 * Filter-wc-price / filter-wc-rating / filter-wc-stock-status).
+	 * product-results markup with top-level `core/template-part` self-closing
+	 * comments stripped — same contract as `get_classic_theme_search_body()`,
+	 * product-flavored. Keeps the product-only blocks intact so the shim
+	 * renders the WC layout (filters-product, results-list layout=product,
+	 * filter-wc-price / filter-wc-rating / filter-wc-stock-status).
 	 */
 	public function test_get_classic_theme_product_search_body_strips_template_parts() {
 		$body = Search_Blocks::get_classic_theme_product_search_body();
@@ -947,16 +947,16 @@ class Search_Blocks_Test extends TestCase {
 
 	/**
 	 * The classic-theme product-search singleton CPT is only meaningful when
-	 * The override is on AND the experience is Embedded AND the theme is
-	 * Classic — the same gates that route product searches into our shim.
+	 * the override is on AND the experience is Embedded AND the theme is
+	 * classic — the same gates that route product searches into our shim.
 	 * `init()` must call `Product_Search_Template::init()` in that exact slice
-	 * Of the matrix and nowhere else, so the hidden CPT + before-delete cleanup
-	 * Don't get registered on sites that wouldn't reach the editor anyway.
+	 * of the matrix and nowhere else, so the hidden CPT + before-delete cleanup
+	 * don't get registered on sites that wouldn't reach the editor anyway.
 	 *
 	 * Asserts via the `before_delete_post` hook the parent
 	 * `Singleton_Template_Cpt::init()` registers — `register_post_type` is
-	 * Idempotent and `admin_init` may not be reachable without `is_admin()`,
-	 * So before-delete is the cleanest lifecycle signal to probe.
+	 * idempotent and `admin_init` may not be reachable without `is_admin()`,
+	 * so before-delete is the cleanest lifecycle signal to probe.
 	 */
 	public function test_init_registers_product_search_template_cpt_only_when_embedded_classic_override_on() {
 		try {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -469,7 +469,7 @@ class Search_Blocks_Test extends TestCase {
 				protected static function block_templates_active(): bool {
 					return true;
 				}
-				protected static function is_woocommerce_product_search(): bool {
+				public static function is_woocommerce_product_search(): bool {
 					return true;
 				}
 			}
@@ -499,7 +499,7 @@ class Search_Blocks_Test extends TestCase {
 				protected static function block_templates_active(): bool {
 					return true;
 				}
-				protected static function is_woocommerce_product_search(): bool {
+				public static function is_woocommerce_product_search(): bool {
 					return true;
 				}
 			}
@@ -523,7 +523,10 @@ class Search_Blocks_Test extends TestCase {
 	 */
 	public function test_route_woocommerce_product_search_template_fronts_product_slug() {
 		$anon = new class() extends Search_Blocks {
-			protected static function is_woocommerce_product_search(): bool {
+			public static function is_woocommerce_product_search(): bool {
+				return true;
+			}
+			protected static function block_templates_active(): bool {
 				return true;
 			}
 		};
@@ -541,7 +544,7 @@ class Search_Blocks_Test extends TestCase {
 	 */
 	public function test_route_woocommerce_product_search_template_noop_off_product_search() {
 		$anon = new class() extends Search_Blocks {
-			protected static function is_woocommerce_product_search(): bool {
+			public static function is_woocommerce_product_search(): bool {
 				return false;
 			}
 		};
@@ -550,6 +553,28 @@ class Search_Blocks_Test extends TestCase {
 		$result = $anon::route_woocommerce_product_search_template( $input );
 
 		$this->assertSame( $input, $result );
+	}
+
+	/**
+	 * The FSE hierarchy router is a strict no-op on classic themes: classic
+	 * Themes resolve template slugs as `{slug}.php` and we don't ship a
+	 * `jetpack-search-product-results.php` — the classic-theme equivalent
+	 * runs through `route_classic_theme_search_template()` instead.
+	 */
+	public function test_route_woocommerce_product_search_template_noop_on_classic_theme() {
+		$anon = new class() extends Search_Blocks {
+			public static function is_woocommerce_product_search(): bool {
+				return true;
+			}
+			protected static function block_templates_active(): bool {
+				return false;
+			}
+		};
+
+		$input  = array( 'product-search-results', 'search', 'index' );
+		$result = $anon::route_woocommerce_product_search_template( $input );
+
+		$this->assertSame( $input, $result, 'Hierarchy must stay untouched on classic themes.' );
 	}
 
 	/**
@@ -603,7 +628,7 @@ class Search_Blocks_Test extends TestCase {
 		delete_option( 'jetpack_search_override_woocommerce_search_template' );
 		$anon           = get_class(
 			new class() extends Search_Blocks {
-				protected static function is_woocommerce_product_search(): bool {
+				public static function is_woocommerce_product_search(): bool {
 					return true;
 				}
 			}
@@ -622,19 +647,18 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * WC-on, override-on: with the override flipped on, a product search on
-	 * A classic theme routes through the same generic shim a non-product
-	 * Search would use. There's no dedicated product-results classic-theme
-	 * Template — block themes get one via `register_block_template()`,
-	 * Classic themes share the single shim and rely on the generic blocks
-	 * For the product layout. Pins that documented behavior so an accidental
-	 * WC carve-out for the classic path doesn't slip through.
+	 * WC-on, override-on: on a classic theme the router fronts the dedicated
+	 * `classic-theme-product-search.php` shim — the product-results
+	 * counterpart of the generic shim. Pins that the override actually
+	 * delivers the product layout (filters-product, results-list layout=product,
+	 * WC-only filters) on classic themes instead of falling back to the web
+	 * search body.
 	 */
-	public function test_route_classic_theme_search_template_routes_to_shim_when_override_on() {
+	public function test_route_classic_theme_search_template_routes_to_product_shim_when_override_on() {
 		update_option( 'jetpack_search_override_woocommerce_search_template', true );
 		$anon           = get_class(
 			new class() extends Search_Blocks {
-				protected static function is_woocommerce_product_search(): bool {
+				public static function is_woocommerce_product_search(): bool {
 					return true;
 				}
 			}
@@ -646,10 +670,43 @@ class Search_Blocks_Test extends TestCase {
 			$result = $anon::route_classic_theme_search_template( '/var/www/html/wp-content/themes/twentytwentyone/search.php' );
 
 			$this->assertStringEndsWith(
-				'/src/search-blocks/templates/classic-theme-search.php',
+				'/src/search-blocks/templates/classic-theme-product-search.php',
 				$result,
-				'Classic router must route to the bundled shim on product searches when the override is on.'
+				'Classic router must front the product shim on WC product searches when the override is on.'
 			);
+			$this->assertFileExists( $result, 'Bundled product shim must exist at the routed path.' );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+			delete_option( 'jetpack_search_override_woocommerce_search_template' );
+		}
+	}
+
+	/**
+	 * Defensive bail-out for the product shim: if neither a customization
+	 * Nor the bundled `jetpack-search-product-results.html` produces a body,
+	 * The router must return the input template unchanged so the theme's own
+	 * Template renders instead of the shim wrapping a blank body.
+	 */
+	public function test_route_classic_theme_search_template_bails_when_product_body_is_empty() {
+		update_option( 'jetpack_search_override_woocommerce_search_template', true );
+		$anon           = get_class(
+			new class() extends Search_Blocks {
+				public static function is_woocommerce_product_search(): bool {
+					return true;
+				}
+				public static function get_classic_theme_product_search_body(): string {
+					return '';
+				}
+			}
+		);
+		$original_query = $GLOBALS['wp_query'] ?? null;
+		try {
+			$GLOBALS['wp_query'] = new \WP_Query( array( 's' => 'boots' ) );
+
+			$input  = '/var/www/html/wp-content/themes/twentytwentyone/search.php';
+			$result = $anon::route_classic_theme_search_template( $input );
+
+			$this->assertSame( $input, $result, 'Empty product body must bail back to the theme template.' );
 		} finally {
 			$GLOBALS['wp_query'] = $original_query;
 			delete_option( 'jetpack_search_override_woocommerce_search_template' );
@@ -736,6 +793,29 @@ class Search_Blocks_Test extends TestCase {
 			$body,
 			'Body must keep the results-list block.'
 		);
+	}
+
+	/**
+	 * `get_classic_theme_product_search_body()` returns the bundled
+	 * Product-results markup with top-level `core/template-part` self-closing
+	 * Comments stripped — same contract as `get_classic_theme_search_body()`,
+	 * Product-flavored. Keeps the product-only blocks intact so the shim
+	 * Renders the WC layout (filters-product, results-list layout=product,
+	 * Filter-wc-price / filter-wc-rating / filter-wc-stock-status).
+	 */
+	public function test_get_classic_theme_product_search_body_strips_template_parts() {
+		$body = Search_Blocks::get_classic_theme_product_search_body();
+
+		$this->assertNotEmpty( $body, 'Body must be non-empty when the bundled product template file exists.' );
+		$this->assertStringNotContainsString(
+			'wp:template-part',
+			$body,
+			'Body must not reference template-parts — those resolve only on block themes.'
+		);
+		$this->assertStringContainsString( 'wp:jetpack-search/search-input', $body, 'Search input must remain.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/filters-product', $body, 'Product filters wrapper must remain.' );
+		$this->assertStringContainsString( '"layout":"product"', $body, 'Results-list must keep the product layout.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/filter-wc-price', $body, 'WC-only price filter must remain.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-259/search-blocks-render-product-results-body-on-classic-themes-when-wc

## Why

If you run a WooCommerce store on a classic theme (one without block-template / Site Editor support — Twenty Sixteen, Storefront, most non-FSE themes) and you flip on **"Use Jetpack Search for product search results"** in the Search dashboard, a product search currently rendered the bare WooCommerce archive with a "No products were found" message — none of Jetpack Search's filtering or ranked results showed up. Shoppers got nothing useful, and the store owner had no way to tell the toggle hadn't actually taken effect.

This PR makes that toggle do what it says on classic themes too: a product search now renders the same product-results layout block themes already get — search input, ranked product results, the product-shaped sidebar filters (categories, rating, price range, stock status), and "Search powered by Jetpack" attribution.

## Proposed changes

* `is_woocommerce_product_search()` is no longer gated on `block_templates_active()` — it just describes the request (search query + product post-type archive + WC enabled). The block-theme gate moves to the FSE hierarchy filter where it actually belongs.
* New `templates/classic-theme-product-search.php` shim — the product-search sibling of the existing `classic-theme-search.php`, wrapped in the active theme's `get_header()` / `get_footer()`.
* `route_classic_theme_search_template()` branches on `is_woocommerce_product_search()` to return the product shim on a WC product search (when the override is on), and the existing generic shim otherwise. Override-off + product search still defers to WooCommerce — no regression for sites that haven't opted in.
* New `Product_Search_Template` singleton CPT — parallel to the existing `Search_Template` — gives classic-theme authors the standard block editor on a hidden post to customize the product-results template (the same pattern we already use for the web search template). Registered in the REST resolver so the dashboard's "Restore default" path works.
* Filter priority bumped to 20 so we run after `WC_Template_Loader::template_loader` (priority 10). At the same priority WC's filter overrode ours and the override silently did nothing — this is the missing piece that actually made the bug fix stick in a real env.
* Extracted `strip_top_level_template_parts()` helper — both the web and product classic-theme body methods strip top-level `<!-- wp:template-part /-->` comments the same way.
* Test coverage: WC-on/off matrix for the new path, FSE filter stays a no-op on classic themes, body parity assertions (filters-product, results-list `layout=product`, filter-wc-price are present), CPT identifiers stay distinct from the two sibling singleton CPTs.

## Related product discussion/links

* Linear: [SEARCH-259](https://linear.app/a8c/issue/SEARCH-259/search-blocks-render-product-results-body-on-classic-themes-when-wc)
* Follow-up: dashboard React surface still only carries the Site Editor URL on classic themes — the new `Product_Search_Template` CPT editor URL isn't exposed yet. Tracking separately.

## Screenshots

Classic-theme (Twenty Sixteen) + WooCommerce + Embedded experience + "Use Jetpack Search for product search results" on. Searching `?s=hat&post_type=product` against a store seeded with the WC sample products.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/1c6e6b2a-1859-48cc-800a-353e439d4761) | ![after](https://github.com/user-attachments/assets/9ce0757c-b34c-4e74-b701-d600cb2ac567) |

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-259, in checklist form:

- [ ] On a classic theme + WooCommerce + Embedded experience + "Use Jetpack Search for product search results" **on**, a product search renders the product-results template body (`filters-product`, `results-list` `layout=product`, WC-only filters: `filter-wc-price`, `filter-wc-rating`, `filter-wc-stock-status`).
- [ ] On a classic theme + override **off**, a product search still defers to WooCommerce / the theme's archive routing (no regression — you should see WC's bare archive, not the Jetpack Search blocks).
- [ ] On a block theme + override on, a product search continues to render via the existing FSE `register_block_template()` + `route_woocommerce_product_search_template()` path (no regression — the dedicated block template still wins).
- [ ] The classic-theme product-results body is editable via a hidden singleton CPT, parallel to `Search_Template` (so authors can customize on classic themes where the Site Editor isn't available). "Restore default" works through the existing `jetpack/v4/search/templates/<post_type>` REST route.
- [ ] Test coverage exercises the new classic-theme product path, including override on/off matrix and the FSE filter staying a no-op on classic themes.

### How to reproduce locally

* Activate a classic theme (e.g. Twenty Sixteen, Storefront).
* Activate Jetpack, WooCommerce (>= 6.5), and either the standalone Jetpack Search plugin or Jetpack's Search module.
* In **Jetpack Search → Experience**, pick **Embedded**.
* In the dashboard, toggle on **"Use Jetpack Search for product search results"**.
* Seed a few products (e.g. via WC's sample data importer).
* Visit `/?s=<keyword>&post_type=product` on the front end. You should see the Jetpack Search product-results layout — search input echoing your query, product cards, and the product-shaped sidebar (categories, rating, price, stock).
* Flip the toggle off and reload the same URL — you should fall back to WC's normal archive output.

### Editing the bundled template (classic theme)

* With the override on and a classic theme active, an admin-only `jp_product_search` singleton CPT is registered. Reach the editor via `Product_Search_Template::get_editor_url()` (a nonce'd `post.php` link). After saving a customization, the front end uses your edited content; "Restore default" deletes the singleton via `DELETE /wp-json/jetpack/v4/search/templates/jp_product_search`.

