### PR TITLE
Search Blocks Overlay: collapse sidebar at narrow widths + filters-popover trigger

### DIFF
--- a/projects/packages/search/changelog/nova-search-262-overlay-narrow-sidebar-collapse
+++ b/projects/packages/search/changelog/nova-search-262-overlay-narrow-sidebar-collapse
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks Overlay: collapse the filter sidebar below 992px and dock a `filters-popover` trigger next to Sort By, matching the legacy Instant Search overlay UX.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1267,11 +1267,12 @@ class Search_Blocks {
 		display: none;
 	}
 	/* The right column's 260px width is set via inline `flex-basis`, so the
-	 * results column needs `!important` to claim the full row. */
-	.jetpack-search-block-overlay .wp-block-columns {
-		gap: 0;
-	}
-	.jetpack-search-block-overlay .wp-block-column:not(.jetpack-search-block-overlay__filters-column) {
+	 * results column needs `!important` to claim the full row. Parent `gap`
+	 * doesn't need zeroing — flexbox removes `display: none` children from
+	 * the layout entirely, so there is no sibling for a gap rule to apply
+	 * against. The selector is scoped to the named outer column so nested
+	 * `wp-block-column`s inside result-card templates aren't affected. */
+	.jetpack-search-block-overlay__results-column {
 		flex-basis: 100% !important;
 	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1223,6 +1223,16 @@ class Search_Blocks {
 	justify-content: space-between;
 	align-items: center;
 }
+/* Right-side controls cluster: sort + filters-popover trigger. Without this
+ * the three `__results-header` children get spread evenly by the parent's
+ * `space-between`; nesting sort + popover here pins them as one block on the
+ * trailing edge. */
+.jetpack-search-block-overlay__results-header-controls {
+	display: flex;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: 0.75rem;
+}
 /* Sidebar left divider tracks `currentColor` so the hairline stays subtle on
  * light themes and visible on dark themes. We only set color; the column
  * block's inline `border-left-width` does the rest. */
@@ -1247,10 +1257,33 @@ class Search_Blocks {
 		padding: .5em 1em 1em;
 	}
 }
+/* Below 992px the right-column filter sidebar collapses to a popover trigger
+ * docked next to results-sort. Mirrors the legacy Instant Search overlay UX
+ * (`.jetpack-instant-search__search-results-secondary { display: none }` below
+ * `$break-lg`). The trigger comes from the `jetpack-search/filters-popover`
+ * block that ships in the default overlay template. */
+@media (max-width: 991.98px) {
+	.jetpack-search-block-overlay__filters-column {
+		display: none;
+	}
+	/* The right column's 260px width is set via inline `flex-basis`, so the
+	 * results column needs `!important` to claim the full row. */
+	.jetpack-search-block-overlay .wp-block-columns {
+		gap: 0;
+	}
+	.jetpack-search-block-overlay .wp-block-column:not(.jetpack-search-block-overlay__filters-column) {
+		flex-basis: 100% !important;
+	}
+}
 /* Mirror legacy `$break-lg: 992px → $modal-max-width-lg: 95%` from `instant-search/components/search-results.scss`. */
 @media (min-width: 992px) {
 	.jetpack-search-block-overlay__card {
 		max-width: 95%;
+	}
+	/* Sidebar is showing; hide the in-header popover entirely so a stale
+	 * `is-popover-open` class can't leak its panel into view. */
+	.jetpack-search-block-overlay__results-header .jetpack-search-filters-popover {
+		display: none;
 	}
 }
 /* Body-scroll lock while open. JS side stashes/restores scrollY on toggle. */

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -113,6 +113,20 @@ function ensureHydrated() {
 			if ( typeof ia.store === 'function' ) {
 				const { actions } = ia.store( 'jetpack-search' );
 				actions?.dispatchInitialSearchIfNeeded?.();
+				// Reset popover state when crossing into the wide breakpoint:
+				// the overlay's CSS hides `.jetpack-search-filters-popover` at
+				// ≥992px (the sidebar handles filters at that width), but the
+				// store still carries `isFilterPopoverOpen: true` from a prior
+				// narrow-mode open. Without this, resizing wide → narrow makes
+				// the panel pop in without any user interaction.
+				if ( typeof window.matchMedia === 'function' ) {
+					const wideMedia = window.matchMedia( '(min-width: 992px)' );
+					wideMedia.addEventListener( 'change', e => {
+						if ( e.matches ) {
+							actions?.closeAllPopovers?.();
+						}
+					} );
+				}
 			}
 		} catch ( e ) {
 			// eslint-disable-next-line no-console

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -11,7 +11,20 @@
 <!-- wp:group {"className":"jetpack-search-block-overlay__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group jetpack-search-block-overlay__results-header">
 <!-- wp:jetpack-search/results-count /-->
+
+<!-- wp:group {"className":"jetpack-search-block-overlay__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group jetpack-search-block-overlay__results-header-controls">
 <!-- wp:jetpack-search/results-sort /-->
+
+<!-- wp:jetpack-search/filters-popover {"displayMode":"popover-always"} -->
+<!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/clear-filters /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
+<!-- /wp:jetpack-search/filters-popover -->
+</div>
+<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -5,8 +5,8 @@
 <!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
 <div class="wp-block-columns">
 
-<!-- wp:column -->
-<div class="wp-block-column">
+<!-- wp:column {"className":"jetpack-search-block-overlay__results-column"} -->
+<div class="wp-block-column jetpack-search-block-overlay__results-column">
 <!-- wp:jetpack-search/search-results -->
 <!-- wp:group {"className":"jetpack-search-block-overlay__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group jetpack-search-block-overlay__results-header">
@@ -16,7 +16,7 @@
 <div class="wp-block-group jetpack-search-block-overlay__results-header-controls">
 <!-- wp:jetpack-search/results-sort /-->
 
-<!-- wp:jetpack-search/filters-popover {"displayMode":"popover-always"} -->
+<!-- wp:jetpack-search/filters-popover -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->

--- a/projects/plugins/search/changelog/nova-search-262-overlay-narrow-sidebar-collapse
+++ b/projects/plugins/search/changelog/nova-search-262-overlay-narrow-sidebar-collapse
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks Overlay: collapse the filter sidebar below 992px and dock a `filters-popover` trigger next to Sort By, matching the legacy Instant Search overlay UX.


### PR DESCRIPTION
Fixes [SEARCH-262](https://linear.app/a8c/issue/SEARCH-262/search-blocks-collapse-overlay-blocks-sidebar-at-narrow-widths-surface)

## Why

On narrow viewports the new blocks-powered Search Overlay (`overlay_blocks`, Beta) kept its 260px filter sidebar visible at every width, eating ~30% of the result column on phones and small windows — while the legacy preact Instant Search overlay has long collapsed its sidebar below 992px. This PR brings the blocks overlay to UX parity: the sidebar hides at <992px, results take the full width, and a `jetpack-search/filters-popover` trigger appears next to **Sort by** so visitors can still reach the filters.

## Proposed changes
* Add a `jetpack-search/filters-popover` (mode `popover-always`) to the default overlay template, nested with `results-sort` in a right-side controls cluster inside `.jetpack-search-block-overlay__results-header`.
* Hide `.jetpack-search-block-overlay__filters-column` at `<992px` via overlay-scoped inline CSS, and let the results column claim the full row.
* Hide the in-header `filters-popover` at `>=992px` so the sidebar remains the sole filter UI at wide widths and a stale `is-popover-open` class can't leak its panel into view.
* The `filters-popover` block itself stays generic — no new `displayMode`. The overlay is the natural owner of "sidebar is my preferred wide-mode UI" coordination.

## Screenshots

Captured at `?s=test` on the local docker env at three viewport widths.

| Viewport | Before | After |
|---|---|---|
| 1400×900 (wide ≥ 992px) | ![before-wide](https://github.com/user-attachments/assets/f972b997-535f-4dd6-9586-bc2328764e6e) | ![after-wide](https://github.com/user-attachments/assets/6c4b86db-dd07-4b95-8e8e-09694a08ca31) |
| 900×900 (narrow < 992px) | ![before-narrow](https://github.com/user-attachments/assets/962153da-237e-4c7c-98db-02525cc3aff5) | ![after-narrow](https://github.com/user-attachments/assets/579b9858-1c72-44a3-8712-37b0353e4319) |
| 480×800 (mobile) | ![before-mobile](https://github.com/user-attachments/assets/0eb91581-54ee-4bca-a53c-681cc2613a87) | ![after-mobile](https://github.com/user-attachments/assets/80d897e2-1af8-44b3-8dbb-c25d41d17d1e) |

Popover open at 900px (clicking the trigger right of Sort by):

![after-narrow-popover-open](https://github.com/user-attachments/assets/002563ac-84ba-4fe5-9ff6-66c83e1af703)

## Related product discussion/links
* [SEARCH-262](https://linear.app/a8c/issue/SEARCH-262/search-blocks-collapse-overlay-blocks-sidebar-at-narrow-widths-surface)
* SEARCH-225 introduced the `responsive` `displayMode` on `filters-popover` that this work composes on top of.

## Does this pull request change what data or activity we track or use?

No — purely a front-end layout change in the overlay template + overlay-scoped CSS. No new requests, fields, or events.

## Testing instructions

Acceptance criteria from SEARCH-262 — verify each against the screenshots above and against your local env:

* [ ] At viewport `>= 992px`, the overlay shows the 260px right-column sidebar; no filter-popover trigger is visible; no popover panel renders inline.
* [ ] At viewport `< 992px`, the sidebar column is hidden, the results column expands to full width, and the `.jetpack-search-filters-popover__trigger` button appears at the right end of `.jetpack-search-block-overlay__results-header` (after `results-sort`).
* [ ] Clicking the trigger opens the popover panel anchored to the trigger; clicking outside / pressing Escape closes it.
* [ ] The active-filter count badge on the trigger updates as filters are selected.
* [ ] Selecting / clearing filters inside the popover reflects in the result list (same store as the sidebar — no parity bug).
* [ ] A user editing the overlay template via the `jp_search_overlay` CPT can move or remove the `filters-popover` block without breaking the sidebar behavior.
* [ ] Crossing the 992px boundary doesn't shift focus, drop store state, or leave the popover panel orphaned on screen.

To reproduce locally:

1. Activate the experimental blocks Overlay: `wp option update jetpack_search_experience overlay_blocks` (and ensure no customized `jp_search_overlay` post exists, or delete it so the bundled template seeds the editor).
2. Visit any front-end URL with `?s=<query>` to auto-open the overlay (or click your theme's search trigger).
3. Resize the browser across 992px and confirm the sidebar↔trigger swap above.
4. Click the trigger to open the popover, toggle filters, and watch results update.
