### PR TITLE
Search Blocks: toggle filters-popover panel in editor via toolbar (SEARCH-261)

### DIFF
--- a/projects/packages/search/changelog/echo-search-261-filters-popover-editor-toggle
+++ b/projects/packages/search/changelog/echo-search-261-filters-popover-editor-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: the Collapsible Filters block's trigger button now toggles the panel in the editor too, so authors can close the popover and edit surrounding template parts without it crowding the canvas.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -59,6 +59,13 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 	const displayMode = attributes?.displayMode === 'responsive' ? 'responsive' : 'popover-always';
 	const isResponsive = displayMode === 'responsive';
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
+	// Split into a top-level if/else so Terser doesn't collapse two __() calls
+	// into `__( cond ? 'a' : 'b' )` — the post-build i18n validator requires a
+	// string literal as the first argument.
+	let togglePanelLabel = __( 'Show filter panel', 'jetpack-search-pkg' );
+	if ( isPopoverOpen ) {
+		togglePanelLabel = __( 'Hide filter panel', 'jetpack-search-pkg' );
+	}
 	const blockProps = useBlockProps( {
 		className: [
 			'jetpack-search-filters-popover',
@@ -77,11 +84,7 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 					<ToolbarGroup>
 						<ToolbarButton
 							icon={ filter }
-							label={
-								isPopoverOpen
-									? __( 'Hide filter panel', 'jetpack-search-pkg' )
-									: __( 'Show filter panel', 'jetpack-search-pkg' )
-							}
+							label={ togglePanelLabel }
 							isPressed={ isPopoverOpen }
 							onClick={ () => setIsPopoverOpen( open => ! open ) }
 						/>

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -1,14 +1,25 @@
 /**
  * Editor preview for jetpack-search/filters-popover.
  *
- * Two display modes share this block. `popover-always` (default) shows the trigger button
- * to signal the runtime collapse, but children still render inline so authors can edit them.
- * `responsive` renders children inline, mirroring the ≥992px front-end appearance; CSS swaps
- * in the trigger + popover below. Runtime visibility is class-driven.
+ * Two display modes share this block. In `popover-always` (default) the trigger button
+ * renders as a non-interactive preview of the front-end control, and a block-toolbar
+ * button toggles whether the panel is expanded in the canvas — so authors can edit the
+ * panel contents when expanded or the surrounding template parts when collapsed. The
+ * trigger itself stays inert because clicking it would select the block (and pop the
+ * settings sidebar) without giving the author a way to collapse the panel afterwards.
+ * `responsive` renders children inline, mirroring the ≥992px front-end appearance;
+ * runtime visibility on the front end stays class-driven by the Interactivity store.
  */
-import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import {
+	BlockControls,
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, SelectControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { filter } from '@wordpress/icons';
 
 const TEMPLATE = [
 	[ 'jetpack-search/active-filters' ],
@@ -47,12 +58,36 @@ const DISPLAY_MODE_OPTIONS = [
 export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 	const displayMode = attributes?.displayMode === 'responsive' ? 'responsive' : 'popover-always';
 	const isResponsive = displayMode === 'responsive';
+	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
 	const blockProps = useBlockProps( {
-		className: `jetpack-search-filters-popover is-mode-${ displayMode } is-editor-preview`,
+		className: [
+			'jetpack-search-filters-popover',
+			`is-mode-${ displayMode }`,
+			'is-editor-preview',
+			! isResponsive && isPopoverOpen && 'is-popover-open',
+		]
+			.filter( Boolean )
+			.join( ' ' ),
 	} );
 
 	return (
 		<>
+			{ ! isResponsive && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							icon={ filter }
+							label={
+								isPopoverOpen
+									? __( 'Hide filter panel', 'jetpack-search-pkg' )
+									: __( 'Show filter panel', 'jetpack-search-pkg' )
+							}
+							isPressed={ isPopoverOpen }
+							onClick={ () => setIsPopoverOpen( open => ! open ) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
 					<SelectControl

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -131,11 +131,12 @@ $jetpack-search-filters-popover-collapse: 992px;
 		}
 	}
 
-	// Editor preview always shows children inline regardless of `displayMode`
-	// so authors can edit them. The popover-always trigger button still
-	// renders to signal the runtime collapse, but the panel doesn't hide
-	// behind it in the canvas.
-	&.is-editor-preview &__panel {
+	// Editor preview renders the panel inline (no floating popover) so authors
+	// can edit it. `responsive` mode always shows it; `popover-always` shows it
+	// only when the trigger has been toggled open (mirrors the front-end
+	// `.is-popover-open` hook, but driven by editor-local React state).
+	&.is-mode-responsive.is-editor-preview &__panel,
+	&.is-mode-popover-always.is-editor-preview.is-popover-open &__panel {
 		position: static;
 		display: flex;
 		min-width: 0;

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import FiltersPopoverEdit from '../../../src/search-blocks/blocks/filters-popover/edit';
 
 jest.mock( '@wordpress/block-editor', () => ( {
@@ -7,11 +8,24 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	InspectorControls: ( { children } ) => (
 		<div data-testid="filters-popover-inspector">{ children }</div>
 	),
+	BlockControls: ( { children } ) => (
+		<div data-testid="filters-popover-block-controls">{ children }</div>
+	),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
 	PanelBody: ( { children } ) => <div>{ children }</div>,
 	SelectControl: ( { label } ) => <span data-testid="filters-popover-mode-select">{ label }</span>,
+	ToolbarGroup: ( { children } ) => <div>{ children }</div>,
+	ToolbarButton: ( { label, isPressed, onClick } ) => (
+		<button type="button" onClick={ onClick } aria-pressed={ isPressed ? 'true' : 'false' }>
+			{ label }
+		</button>
+	),
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	filter: 'filter-icon',
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
@@ -23,32 +37,57 @@ const renderEdit = ( attributes = {} ) =>
 
 describe( 'FiltersPopoverEdit', () => {
 	describe( 'default (popover-always) mode', () => {
-		// In popover-always mode the editor still renders children inline so
-		// authors can edit them; the visual collapse is signalled by the
-		// trigger button being present alongside. Front-end visibility is
-		// class-driven by the Interactivity store — covered by
-		// `Filters_Popover_Render_Test` on the PHP side.
-		it( 'renders the disabled trigger alongside the labelled inline region when no displayMode is set', () => {
+		// In popover-always mode the trigger button is a non-interactive preview
+		// of the front-end control. A block-toolbar button is the actual toggle
+		// in the editor — clicking the inline trigger would select the block and
+		// open the settings sidebar without a way to collapse the panel again.
+		// Front-end visibility is class-driven by the Interactivity store and
+		// covered by `Filters_Popover_Render_Test` on the PHP side.
+		it( 'renders the disabled preview trigger and a toolbar toggle in the closed state', () => {
 			renderEdit();
 
 			const trigger = screen.getByRole( 'button', { name: 'Filter results' } );
 			expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
 			expect( trigger ).toBeDisabled();
+
+			const toolbarToggle = screen.getByRole( 'button', { name: 'Show filter panel' } );
+			expect( toolbarToggle ).toHaveAttribute( 'aria-pressed', 'false' );
+
 			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
+		} );
+
+		it( 'toggles the panel open and closed when the toolbar button is clicked', async () => {
+			const user = userEvent.setup();
+			renderEdit();
+
+			await user.click( screen.getByRole( 'button', { name: 'Show filter panel' } ) );
+			const opened = screen.getByRole( 'button', { name: 'Hide filter panel' } );
+			expect( opened ).toHaveAttribute( 'aria-pressed', 'true' );
+
+			await user.click( opened );
+			const closed = screen.getByRole( 'button', { name: 'Show filter panel' } );
+			expect( closed ).toHaveAttribute( 'aria-pressed', 'false' );
 		} );
 
 		it( 'falls back to popover-always for an unknown displayMode value', () => {
 			renderEdit( { displayMode: 'something-else' } );
 			expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Show filter panel' } ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'responsive mode', () => {
-		it( 'renders an inline labelled region with no trigger', () => {
+		it( 'renders an inline labelled region with no trigger or toolbar toggle', () => {
 			renderEdit( { displayMode: 'responsive' } );
 			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: 'Show filter panel' } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: 'Hide filter panel' } )
+			).not.toBeInTheDocument();
 			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
 			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 		} );


### PR DESCRIPTION
Fixes [SEARCH-261](https://linear.app/a8c/issue/SEARCH-261/search-blocks-make-filters-popover-trigger-toggle-the-panel-in-editor)

## Why

In the editor, the trigger button on the `jetpack-search/filters-popover` block was hardcoded `disabled` and the panel rendered inline alongside it. The inner blocks (filter checkboxes, active filters, clear filters) were editable, but the always-expanded panel permanently inflated the block in the canvas and crowded sibling template parts — the author couldn't easily click into anything next to the popover. After this change, the panel can be collapsed from the canvas so authors can edit the popover when they want it and edit everything else when they don't.

## Proposed changes
* Add a `BlockControls` toolbar button on `jetpack-search/filters-popover` (popover-always mode only) that toggles whether the panel is expanded inline in the canvas — defaulting to **closed** so the block doesn't inflate by default.
* Drive editor-side panel visibility from the same `.is-popover-open` CSS hook the Interactivity store already uses on the front end (`style.scss`); the inline trigger button stays a non-interactive preview of the visitor-facing control.
* No `render.php` / `view.js` / Interactivity store changes — front-end markup and behavior are unchanged.

The toolbar button (rather than re-wiring the inline trigger) is the right surface because clicking a button inside a block selects the block and pops the settings sidebar — which gives no way to *collapse* the panel afterwards. The toolbar belongs to the selected block, so the action is reachable in both states.

## Related product discussion/links
* Linear: [SEARCH-261](https://linear.app/a8c/issue/SEARCH-261/search-blocks-make-filters-popover-trigger-toggle-the-panel-in-editor)

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Editor view of a page containing a single `jetpack-search/filters-popover` block (popover-always mode), block selected.

| Before (trunk) | After (closed, default) | After (open, via toolbar) |
|---|---|---|
| ![before](https://github.com/user-attachments/assets/61364de1-3dcf-47b5-ac1a-e7d661868e42) | ![after-closed](https://github.com/user-attachments/assets/33342cf5-0557-4050-8d90-e534e4c3585d) | ![after-open](https://github.com/user-attachments/assets/30cf99ed-d7b8-44b5-9e39-9d648d61687f) |

Before: panel is always inline in the canvas, no way to collapse.
After-closed: panel is hidden by default; the new toolbar button is unpressed.
After-open: clicking the toolbar button toggles the panel back inline (button shown pressed); a second click collapses it.

## Testing instructions

Acceptance criteria from SEARCH-261:

- [ ] In editor with `popover-always` mode, on first render: panel is hidden, the inline trigger stays as a disabled preview of the front-end control.
- [ ] Selecting the block reveals a toolbar button (filter icon) that opens the panel inline so inner blocks become editable; the toolbar button reads as pressed (`aria-pressed="true"`).
- [ ] Clicking the toolbar button again collapses the panel; sibling template parts become selectable/editable without obstruction.
- [ ] `responsive` mode editor behavior is unchanged (children render inline, no trigger, no toolbar toggle).
- [ ] Frontend HTML and behavior are unchanged — `render.php`, `view.js`, and the Interactivity store were not touched.

Manual steps:

1. Create / open a draft post/page in the block editor.
2. Insert the **Collapsible Filters** block (`jetpack-search/filters-popover`). Confirm the panel does not render inline by default; you should see only the small disabled filter trigger preview.
3. Click the block to select it. In the block toolbar, click the new filter-icon button labelled **Show filter panel**. The panel should expand inline (Active filters, Clear filters, CATEGORY, TAG, POST TYPE) so inner blocks can be edited.
4. Click the toolbar button again (now labelled **Hide filter panel**). The panel should collapse and the surrounding template parts should be selectable again.
5. In the block sidebar, switch **Display mode** to **Inline on desktop, popover on mobile** (responsive). Confirm the panel renders inline as before and no toolbar toggle is shown.
6. On the front end of a search page using this block, confirm the popover still opens/closes via the visitor-facing trigger button (i.e. the front-end behavior is unchanged).
