### PR TITLE
Search Blocks Overlay: continuous header hairline + theme-aware close-button hover (SEARCH-260)

### DIFF
--- a/projects/packages/search/changelog/raven-search-260-overlay-border-gap
+++ b/projects/packages/search/changelog/raven-search-260-overlay-border-gap
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Search Blocks: fix the visible seam in the blocks-powered Overlay's header underline at the close-button boundary.
+Search Blocks: fix the visible seam in the blocks-powered Overlay's header underline at the close-button boundary, and bind the close button's hover surface to the resolved theme tokens so the X stays visible across themes.

--- a/projects/packages/search/changelog/raven-search-260-overlay-border-gap
+++ b/projects/packages/search/changelog/raven-search-260-overlay-border-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: fix the visible seam in the blocks-powered Overlay's header underline at the close-button boundary.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1135,13 +1135,7 @@ class Search_Blocks {
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 	padding-top: 60px;
 }
-/* Single hairline under the 60px header strip — drawn on the card so the line
- * spans the search-input block AND the close button as one continuous element.
- * Two separate `border-bottom`s on the sibling `div` + `button` (SEARCH-260)
- * painted with a visible seam at the boundary because browsers apply different
- * paint defaults to the two element types. `@supports` + `transparent` default
- * keeps pre-color-mix browsers (~Chrome <111, FF <113, Safari <16.2) graceful;
- * same convention as `_chip.scss`. */
+/* Single hairline over the full 60px header strip — siblings paint with a seam (SEARCH-260). */
 .jetpack-search-block-overlay__card::before {
 	content: "";
 	position: absolute;
@@ -1154,7 +1148,7 @@ class Search_Blocks {
 }
 @supports (background: color-mix(in sRGB, black 50%, white)) {
 	.jetpack-search-block-overlay__card::before {
-		background: color-mix(in sRGB, currentColor 15%, transparent);
+		background: color-mix(in sRGB, var(--jp-search-overlay-ink) 15%, var(--jp-search-overlay-surface));
 	}
 }
 .jetpack-search-block-overlay__close {
@@ -1171,13 +1165,7 @@ class Search_Blocks {
 	cursor: pointer;
 	color: inherit;
 }
-/* Hover / focus surface is an opaque ink-over-surface mix rather than a
- * `color-mix(currentColor, transparent)` wash. The wash form (a) collapsed
- * to full-opacity ink on Safari <16.4 (a `color-mix` × `transparent` bug)
- * which made the X icon disappear into the hover background, and (b) was
- * too subtle at 8% to read as a real interactive affordance. Binding to the
- * card's resolved `--jp-search-overlay-ink` / `--jp-search-overlay-surface`
- * tokens keeps the affordance theme-aware on every variation. */
+/* Opaque ink-over-surface mix — `color-mix(currentColor, transparent)` collapses to full-opacity ink on Safari <16.4 and swallows the X icon. */
 @supports (background: color-mix(in sRGB, black 50%, white)) {
 	.jetpack-search-block-overlay__close:hover,
 	.jetpack-search-block-overlay__close:focus-visible {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1135,6 +1135,28 @@ class Search_Blocks {
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 	padding-top: 60px;
 }
+/* Single hairline under the 60px header strip — drawn on the card so the line
+ * spans the search-input block AND the close button as one continuous element.
+ * Two separate `border-bottom`s on the sibling `div` + `button` (SEARCH-260)
+ * painted with a visible seam at the boundary because browsers apply different
+ * paint defaults to the two element types. `@supports` + `transparent` default
+ * keeps pre-color-mix browsers (~Chrome <111, FF <113, Safari <16.2) graceful;
+ * same convention as `_chip.scss`. */
+.jetpack-search-block-overlay__card::before {
+	content: "";
+	position: absolute;
+	top: 60px;
+	left: 0;
+	right: 0;
+	height: 1px;
+	background: transparent;
+	pointer-events: none;
+}
+@supports (background: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-block-overlay__card::before {
+		background: color-mix(in sRGB, currentColor 15%, transparent);
+	}
+}
 .jetpack-search-block-overlay__close {
 	position: absolute;
 	top: 0;
@@ -1146,17 +1168,8 @@ class Search_Blocks {
 	justify-content: center;
 	background: transparent;
 	border: 0;
-	border-bottom: 1px solid transparent;
 	cursor: pointer;
 	color: inherit;
-}
-/* `@supports` + `transparent` defaults: pre-color-mix browsers (~Chrome <111,
- * FF <113, Safari <16.2) get a graceful no-affordance state instead of stark
- * full-opacity `currentColor`. Same convention as `_chip.scss`. */
-@supports (border-color: color-mix(in sRGB, black 50%, white)) {
-	.jetpack-search-block-overlay__close {
-		border-bottom-color: color-mix(in sRGB, currentColor 15%, transparent);
-	}
 }
 @supports (background: color-mix(in sRGB, black 50%, white)) {
 	.jetpack-search-block-overlay__close:hover,
@@ -1170,7 +1183,8 @@ class Search_Blocks {
 }
 /* Promote the first child (search-input) to a 60px header strip flush with
  * the close button, matching the legacy `__box` header. Suppress the input
- * block's own border-bottom — the header strip's border handles separation. */
+ * block's own border-bottom — the card's `::before` hairline handles the
+ * separator across the whole strip. */
 .jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input {
 	position: absolute;
 	top: 0;
@@ -1179,12 +1193,6 @@ class Search_Blocks {
 	height: 60px;
 	margin: 0;
 	padding: 0;
-	border-bottom: 1px solid transparent;
-}
-@supports (border-color: color-mix(in sRGB, black 50%, white)) {
-	.jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input {
-		border-bottom-color: color-mix(in sRGB, currentColor 15%, transparent);
-	}
 }
 .jetpack-search-block-overlay__card .wp-block-jetpack-search-search-input .jetpack-search-input__inside-wrapper {
 	height: 100%;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1171,10 +1171,17 @@ class Search_Blocks {
 	cursor: pointer;
 	color: inherit;
 }
+/* Hover / focus surface is an opaque ink-over-surface mix rather than a
+ * `color-mix(currentColor, transparent)` wash. The wash form (a) collapsed
+ * to full-opacity ink on Safari <16.4 (a `color-mix` × `transparent` bug)
+ * which made the X icon disappear into the hover background, and (b) was
+ * too subtle at 8% to read as a real interactive affordance. Binding to the
+ * card's resolved `--jp-search-overlay-ink` / `--jp-search-overlay-surface`
+ * tokens keeps the affordance theme-aware on every variation. */
 @supports (background: color-mix(in sRGB, black 50%, white)) {
 	.jetpack-search-block-overlay__close:hover,
 	.jetpack-search-block-overlay__close:focus-visible {
-		background: color-mix(in sRGB, currentColor 8%, transparent);
+		background: color-mix(in sRGB, var(--jp-search-overlay-ink) 14%, var(--jp-search-overlay-surface));
 	}
 }
 .jetpack-search-block-overlay__close svg {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1097,7 +1097,7 @@ class Search_Blocks {
 	 * Kaze, many WPCOM themes). #49125's hardcoded `#fff` resurrected the
 	 * white-on-white bug on legacy themes; the chain fixes it. Hoisted onto
 	 * two custom props so in-card surfaces (suggestions panel) share one source.
-	 * Hairlines use `color-mix(currentColor)`.
+	 * Hairlines use `color-mix(--jp-search-overlay-ink, --jp-search-overlay-surface)`.
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
Fixes [SEARCH-260](https://linear.app/a8c/issue/SEARCH-260/search-blocks-overlay-fix-bottom-border-gap-at-close-button)

## Why

The blocks-powered Overlay's header strip (search icon + input + "clear" + X close) had a visible 1px seam right above the close button — the hairline below the input didn't connect to the hairline below the X. Same area: hovering the X visually swallowed the icon on Safari <16.4 because `color-mix(currentColor, transparent)` collapsed the hover surface to full-opacity ink. Both issues live in the same ~15 lines of inline CSS, so they're bundled.

## Proposed changes

- Replace the two sibling `border-bottom` rules on `.wp-block-jetpack-search-search-input` (right: 60px) and `.jetpack-search-block-overlay__close` (right: 0) with a single `.jetpack-search-block-overlay__card::before` hairline at `top: 60px; left: 0; right: 0; height: 1px`. One element draws the line, so there is no seam.
- Bind the close button's hover / focus-visible surface to the card's own `--jp-search-overlay-ink` / `--jp-search-overlay-surface` tokens via an opaque ink-over-surface `color-mix` (14% ink). No `transparent` keyword, so the Safari <16.4 `color-mix(..., transparent)` quirk that paints the hover surface as full-opacity ink is sidestepped, and the affordance is visibly stronger than the prior 8% wash.
- Keep the `.__inside-wrapper { border-bottom: 0 }` reset — the base `style.scss` border still needs to be suppressed in the overlay context.
- Plus a changelog entry under `packages/search`.

## Screenshots

Dark theme (the surface the bug was reported against):

| Before | After |
|---|---|
| ![before dark](https://github.com/user-attachments/assets/79358864-ead2-44c5-b516-7398a1df42bf) | ![after dark](https://github.com/user-attachments/assets/16e50d04-234d-4b56-9858-b27ee365b300) |

Dark theme, hovering the X:

| Before | After |
|---|---|
| ![before dark hover](https://github.com/user-attachments/assets/b4bf9590-6620-4b17-9a14-6de04383c80e) | ![after dark hover](https://github.com/user-attachments/assets/2af627c5-4be0-43e9-981b-0fb074a7837b) |

Light theme (default Twenty Twenty-Five), for completeness:

| Before | After |
|---|---|
| ![before light](https://github.com/user-attachments/assets/270683fd-4b61-4e4c-b7e9-cd17ba9fbe9c) | ![after light](https://github.com/user-attachments/assets/e05d3b54-af0b-4dd2-b254-b16533d42b79) |
| ![before light hover](https://github.com/user-attachments/assets/59d12404-f9c6-4185-85c9-a15d8a97fe6c) | ![after light hover](https://github.com/user-attachments/assets/1672c361-b88a-444a-879d-a90ad1065e61) |

Full-overlay context shot, after-state:

![after dark full](https://github.com/user-attachments/assets/144010da-f264-4752-bd7e-235c1ef46a74)

## Related product discussion/links

* Linear: [SEARCH-260](https://linear.app/a8c/issue/SEARCH-260/search-blocks-overlay-fix-bottom-border-gap-at-close-button)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-260:

- [ ] The hairline under the overlay header row is **one unbroken line** from the card's left edge to its right edge — no visible seam at the close-button boundary.
- [ ] The hairline still uses the established theming: `color-mix` against the card's resolved ink token, with a `transparent` fallback for pre-color-mix browsers (Chrome <111, Firefox <113, Safari <16.2).
- [ ] No regressions on the narrow viewport (`max-width: 781px`) full-screen layout or the `min-width: 992px` wide layout.
- [ ] No regressions to non-overlay search experiences (theme `inline`, `embedded`, legacy `overlay`). The fix is scoped to the `overlay_blocks` inline CSS only.
- [ ] Hovering the X close button shows a clear theme-aware background tint, and the X icon stays fully visible (does not blend into the hover surface) on both light and dark theme variations.

Repro steps:

1. On a site with Jetpack Search activated and the Experience set to **Overlay (Blocks)** (`Module_Control::EXPERIENCE_OVERLAY_BLOCKS`), open the front-end and trigger a search (e.g. `/?s=hello`).
2. The overlay opens with the header strip pinned to the top: search icon + input + "clear" + X.
3. Confirm the bottom hairline of the header is **continuous from edge to edge**, including under "clear" and under the X.
4. Hover the X. Confirm a visible theme-toned background appears under the X and the X icon stays sharp.
5. Try a dark theme variation. Repeat 3–4.
6. Resize to narrow (<781px) and wide (>992px). The hairline should remain continuous in both layouts.
7. Switch the Experience back to `overlay` (legacy) and `inline` — confirm those surfaces are unchanged.
