### PR TITLE
Search Blocks: keep filters-popover and results-sort panels opaque on themes without --wp--preset--color--base

### DIFF
--- a/projects/packages/search/changelog/nova-search-263-popover-theme-token-fallback
+++ b/projects/packages/search/changelog/nova-search-263-popover-theme-token-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: filters-popover panel and results-sort menu now render a solid background on themes that don't define `--wp--preset--color--base`, instead of going transparent and letting result-card content bleed through.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -83,10 +83,13 @@ $jetpack-search-filters-popover-collapse: 992px;
 		flex-direction: column;
 		gap: 1rem;
 		padding: 12px;
-		background: var(--wp--preset--color--base);
-		// The panel owns its surface, so don't inherit a low-contrast body
-		// accent color from the surrounding page.
-		color: var(--wp--preset--color--contrast);
+		// `background-color` (longhand) + the same fallback chain the overlay
+		// card and suggestions panel use (class-search-blocks.php). The
+		// shorthand `background:` collapses to `transparent` on themes that
+		// don't define `--wp--preset--color--base` (classic themes, block
+		// themes without the token), letting result-card content bleed through.
+		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
+		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
 		// Reset the inherited theme base size so popover body text tracks the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. Rem-based children (filter title, count pill)

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
@@ -151,10 +151,12 @@
 		display: flex;
 		flex-direction: column;
 		padding: 4px;
-		background: var(--wp--preset--color--base);
-		// The menu owns its surface, so don't inherit a low-contrast body
-		// accent color from the surrounding page.
-		color: var(--wp--preset--color--contrast);
+		// See the matching note in filters-popover/style.scss: the shorthand
+		// drops to `transparent` on themes that don't define
+		// `--wp--preset--color--base`, so use the longhand with the same
+		// fallback chain the overlay card and suggestions panel use.
+		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
+		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
 		// Reset the inherited theme base size so menu items track the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. `font: inherit` on menu items picks this up.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-263

## Why

On the blocks-powered Search Overlay (`overlay_blocks` experience), opening the `jetpack-search/filters-popover` panel — or the `jetpack-search/results-sort` menu — shows result-card content (text, featured-image placeholders) bleeding through behind the panel on themes that don't define `--wp--preset--color--base`. Two of the four overlay surface elements already use a defensive CSS-variable fallback chain; these two were missed, so on any classic theme and on block themes without that token the panel surface collapses to `transparent`.

## Proposed changes

- `projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss` — replace `background:` shorthand with the `background-color:` longhand and add the `--base → --background → #fff` fallback chain to both `background-color` and `color`. Matches the pattern already used by `class-search-blocks.php:1110-1111` (overlay card) and `class-search-blocks.php:1208-1211` (suggestions panel).
- `projects/packages/search/src/search-blocks/blocks/results-sort/style.scss` — same two substitutions on the popover sort menu, which has the identical anti-pattern and the same symptom.

Verified live in the nova docker env at viewport 911×1015 with Twenty Sixteen (classic theme) active and `jetpack_search_experience=overlay_blocks`. `getComputedStyle(panel).backgroundColor` goes from `rgba(0, 0, 0, 0)` (trunk) → `rgb(255, 255, 255)` (with this fix).

## Screenshots

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/cad4b81a-c9a7-4595-a9f4-10ebd72fddc0) | ![after](https://github.com/user-attachments/assets/94effd6c-b086-4450-b5ea-627a41505d56) |

The "before" image shows the result-card image placeholders visible through the open filters-popover panel — the exact symptom from the issue. The "after" image shows the same panel rendering a solid white surface.

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-263

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Local docker env (or any WP install) with Jetpack Search active.
2. Activate a classic theme that does **not** define `--wp--preset--color--base` — e.g. `wp theme activate twentysixteen` (or `twentytwentyone`).
3. Set the search experience to `overlay_blocks`: `wp option update jetpack_search_experience overlay_blocks`.
4. From the front end, run a query that returns at least one result — e.g. `/?s=hello`.
5. With the overlay open, click the filters-popover trigger in the results header.

Expected — verify all four:

- [ ] The opened popover panel renders a **solid** surface (default `#fff` via the fallback chain); no result-card content is visible behind it.
- [ ] The `results-sort` menu (also opened from the results header) likewise renders a solid surface.
- [ ] On a block theme that **does** define `--wp--preset--color--base` (Twenty Twenty-Five), both panels still inherit the theme's base color — no regression.
- [ ] On widescreen ≥992px (`is-mode-responsive` branch), the filters popover continues to render as the inline sidebar with a transparent background — that override is still in effect.
