### PR TITLE
Search Blocks: drop clear-filters from default filter-container content

### DIFF
--- a/projects/packages/search/changelog/nova-search-drop-clear-filters-from-defaults
+++ b/projects/packages/search/changelog/nova-search-drop-clear-filters-from-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: drop the `jetpack-search/clear-filters` block from the default content of the `filters`, `filters-popover`, and `filters-product` containers, the two bundled patterns (`blog-search`, `compact-search`), and the three page templates (`jetpack-search.html`, `jetpack-search-overlay.html`, `jetpack-search-product-results.html`). The block remains registered and stays in each container's `allowedBlocks` so authors can add it manually.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -23,7 +23,6 @@ import { filter } from '@wordpress/icons';
 
 const TEMPLATE = [
 	[ 'jetpack-search/active-filters' ],
-	[ 'jetpack-search/clear-filters' ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'post_type' } ],

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
@@ -20,7 +20,6 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 const TEMPLATE = [
 	[ 'jetpack-search/filter-post-type', { mode: 'include', postTypes: [ 'product' ] } ],
 	[ 'jetpack-search/active-filters' ],
-	[ 'jetpack-search/clear-filters', { className: 'is-style-compact' } ],
 	[
 		'jetpack-search/filter-checkbox',
 		{ filterType: 'taxonomy', taxonomy: 'product_cat', displayStyle: 'chips' },

--- a/projects/packages/search/src/search-blocks/blocks/filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters/edit.js
@@ -10,7 +10,6 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const TEMPLATE = [
 	[ 'jetpack-search/active-filters' ],
-	[ 'jetpack-search/clear-filters', { className: 'is-style-compact' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'author' } ],

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -49,7 +49,6 @@ register_block_pattern(
 <h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
 <!-- /wp:heading -->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -30,7 +30,6 @@ register_block_pattern(
 <!-- wp:jetpack-search/search-input /-->
 <!-- wp:jetpack-search/filters-popover {"displayMode":"popover-always"} -->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -18,7 +18,6 @@
 
 <!-- wp:jetpack-search/filters-popover -->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
@@ -39,7 +38,6 @@
 <div class="wp-block-column jetpack-search-block-overlay__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:jetpack-search/filters -->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -24,7 +24,6 @@
 <!-- wp:jetpack-search/filters-popover -->
 <!-- wp:jetpack-search/filter-post-type {"mode":"include","postTypes":["product"]} /-->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters {"className":"is-style-compact"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->
@@ -51,7 +50,6 @@
 <!-- wp:jetpack-search/filters-product -->
 <!-- wp:jetpack-search/filter-post-type {"mode":"include","postTypes":["product"]} /-->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters {"className":"is-style-compact"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -23,7 +23,6 @@
 
 <!-- wp:jetpack-search/filters-popover -->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
@@ -47,7 +46,6 @@
 <!-- /wp:heading -->
 <!-- wp:jetpack-search/filters -->
 <!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/tests/js/search-blocks/filters-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-edit.test.jsx
@@ -19,7 +19,6 @@ describe( 'FiltersEdit', () => {
 		const props = InnerBlocks.mock.calls[ 0 ][ 0 ];
 		expect( props.template ).toEqual( [
 			[ 'jetpack-search/active-filters' ],
-			[ 'jetpack-search/clear-filters', { className: 'is-style-compact' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'author' } ],


### PR DESCRIPTION
## Why

The `jetpack-search/clear-filters` block is no longer wanted as part of the default child set in any filter container. Active filters can be removed individually via the `active-filters` pill region; the bulk "clear all" affordance is no longer a default UX expectation. Authors who still want it can add the block manually — it stays registered and stays in every container's `allowedBlocks`.

## Proposed changes

Removed `jetpack-search/clear-filters` from every default-content slot it currently sits in:

- **Block editor defaults** — `blocks/filters/edit.js`, `blocks/filters-popover/edit.js`, `blocks/filters-product/edit.js`. The block is removed from each `TEMPLATE` array; it stays in each `ALLOWED` array so authors can drop it in manually from the inserter.
- **Bundled patterns** — `patterns/blog-search.php`, `patterns/compact-search.php`.
- **Page templates** — `templates/jetpack-search.html`, `templates/jetpack-search-overlay.html`, `templates/jetpack-search-product-results.html`.

No change to:

- The `jetpack-search/clear-filters` block itself (block.json, render.php, edit.js, view.js, style.scss).
- The block's registration in `editor/register-blocks.js` and `editor/icons.js`.
- Existing customized templates / patterns / saved posts that already contain the block — those keep their current `clear-filters` instances.

## Does this pull request change what data or activity we track or use?

No.

## Related product discussion/links

* Follow-up to #49181 (narrow-width sidebar collapse on the page templates) — that PR added the popovers; this PR drops `clear-filters` from their default child sets.

## Testing instructions

1. On a fresh site with Jetpack Search active, open the block inserter and insert each of `jetpack-search/filters`, `jetpack-search/filters-popover`, `jetpack-search/filters-product`.
   - [ ] None of the three containers seeds a `clear-filters` child by default.
   - [ ] In the inserter inside each container, `Clear all` (the block) is still listed as an allowed inner block.
2. From the Site Editor → Templates, regenerate / re-insert the bundled `Jetpack Search Results`, `Jetpack Search Overlay`, and `Jetpack Search — Product Results` templates.
   - [ ] None of the three regenerated templates contains `clear-filters`.
3. From the Pattern inserter, insert the `Blog Search` and `Compact Search` patterns.
   - [ ] Neither inserted pattern contains `clear-filters`.
4. On a site with an existing customized `wp_template` or `jp_search_overlay` CPT that contains `clear-filters`, confirm the existing block continues to render — this PR doesn't migrate anything.

