### PR TITLE
Search Blocks: unify responsive layout under a shared .jetpack-search-layout__* namespace

### DIFF
--- a/projects/packages/search/changelog/echo-search-265-layout-namespace-unify
+++ b/projects/packages/search/changelog/echo-search-265-layout-namespace-unify
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: unify the three search-results templates' responsive layout under a shared `.jetpack-search-layout__*` class namespace, collapsing the duplicate sidebar-collapse rules from `block_template_overlay_inline_css()` and `search_page_inline_css()` into a single `search_layout_inline_css()` helper. Pure refactor — no behavior change.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1084,6 +1084,11 @@ class Search_Blocks {
 		wp_enqueue_style( 'jetpack-search-block-overlay' );
 		wp_add_inline_style( 'jetpack-search-block-overlay', static::block_template_overlay_inline_css() );
 
+		// Shared responsive layout CSS (narrow-width sidebar collapse +
+		// in-header popover toggle). Same rules ship to the embedded /
+		// WC-product page templates via `enqueue_search_page_assets()`.
+		static::enqueue_search_layout_style();
+
 		// Render here (during `wp_enqueue_scripts`) so view-module enqueues
 		// from `do_blocks()` land before the importmap prints — see
 		// AGENTS.md § Hydration & SSR seeding.
@@ -1095,7 +1100,9 @@ class Search_Blocks {
 	/**
 	 * Inline CSS for the overlay modal chrome. Block content brings its own
 	 * theme styling; this is just the scrim, centered card, 60px header strip,
-	 * close button, animation, and scroll lock.
+	 * close button, mobile padding tweaks, and scroll lock. The responsive
+	 * sidebar-collapse + in-header popover rules shared with the page
+	 * templates live in `search_layout_inline_css()`.
 	 *
 	 * Surface/ink follow a two-step token fallback: newer `base`/`contrast`
 	 * (TT2/TT3/TT5-family) first, then legacy `background`/`foreground` (TT1,
@@ -1242,33 +1249,16 @@ class Search_Blocks {
 .jetpack-search-block-overlay__content > .wp-block-group:first-child {
 	padding: .5em 2em 2em;
 }
-/* Force flex-row for the "Found N results" + sort row — `wp:group` inline
- * layout (`justifyContent: space-between`) doesn't always emit the core
- * flex-layout class in this context. */
-.jetpack-search-block-overlay__results-header {
-	display: flex;
-	flex-wrap: nowrap;
-	justify-content: space-between;
-	align-items: center;
-}
-/* Right-side controls cluster: sort + filters-popover trigger. Without this
- * the three `__results-header` children get spread evenly by the parent's
- * `space-between`; nesting sort + popover here pins them as one block on the
- * trailing edge. */
-.jetpack-search-block-overlay__results-header-controls {
-	display: flex;
-	flex-wrap: nowrap;
-	align-items: center;
-	gap: 0.75rem;
-}
 /* Sidebar left divider tracks `currentColor` so the hairline stays subtle on
  * light themes and visible on dark themes. We only set color; the column
- * block's inline `border-left-width` does the rest. */
-.jetpack-search-block-overlay__filters-column {
+ * block's inline `border-left-width` does the rest. Scoped under the overlay
+ * container so the divider remains overlay-only — the embedded / WC-product
+ * page templates set their own border-left-color inline on the column. */
+.jetpack-search-block-overlay .jetpack-search-layout__filters-column {
 	border-left-color: transparent;
 }
 @supports (border-color: color-mix(in sRGB, black 50%, white)) {
-	.jetpack-search-block-overlay__filters-column {
+	.jetpack-search-block-overlay .jetpack-search-layout__filters-column {
 		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
@@ -1285,34 +1275,10 @@ class Search_Blocks {
 		padding: .5em 1em 1em;
 	}
 }
-/* Below 992px the right-column filter sidebar collapses to a popover trigger
- * docked next to results-sort. Mirrors the legacy Instant Search overlay UX
- * (`.jetpack-instant-search__search-results-secondary { display: none }` below
- * `$break-lg`). The trigger comes from the `jetpack-search/filters-popover`
- * block that ships in the default overlay template. */
-@media (max-width: 991.98px) {
-	.jetpack-search-block-overlay__filters-column {
-		display: none;
-	}
-	/* The right column's 260px width is set via inline `flex-basis`, so the
-	 * results column needs `!important` to claim the full row. Parent `gap`
-	 * doesn't need zeroing — flexbox removes `display: none` children from
-	 * the layout entirely, so there is no sibling for a gap rule to apply
-	 * against. The selector is scoped to the named outer column so nested
-	 * `wp-block-column`s inside result-card templates aren't affected. */
-	.jetpack-search-block-overlay__results-column {
-		flex-basis: 100% !important;
-	}
-}
 /* Mirror legacy `$break-lg: 992px → $modal-max-width-lg: 95%` from `instant-search/components/search-results.scss`. */
 @media (min-width: 992px) {
 	.jetpack-search-block-overlay__card {
 		max-width: 95%;
-	}
-	/* Sidebar is showing; hide the in-header popover entirely so a stale
-	 * `is-popover-open` class can't leak its panel into view. */
-	.jetpack-search-block-overlay__results-header .jetpack-search-filters-popover {
-		display: none;
 	}
 }
 /* Body-scroll lock while open. JS side stashes/restores scrollY on toggle. */
@@ -1327,39 +1293,53 @@ CSS;
 	}
 
 	/**
-	 * Register + enqueue the inline CSS that drives the narrow-width sidebar
-	 * collapse on the page templates (`jetpack-search.html`,
-	 * `jetpack-search-product-results.html`). Self-gates on `is_search()` so it
-	 * only fires when one of those templates is actually about to render —
-	 * non-search requests skip the work entirely.
-	 *
-	 * Lives next to `block_template_overlay_inline_css()` rather than in the
-	 * `search-results` block stylesheet because the rules target the page
-	 * templates' outer columns + results-header, none of which the block owns.
+	 * Register + enqueue the shared responsive layout CSS on the embedded /
+	 * WC-product page templates (`jetpack-search.html`,
+	 * `jetpack-search-product-results.html`). Self-gates on `is_search()` so
+	 * non-search requests skip the work entirely; the overlay path enqueues
+	 * the same handle unconditionally from its own asset hook.
 	 */
 	public static function enqueue_search_page_assets() {
 		if ( ! is_search() ) {
 			return;
 		}
-		// No src — this handle exists only as a target for `wp_add_inline_style`.
-		// Version tracks the package so a release bust cache-invalidates any
-		// reusing site's inline-style cache.
-		wp_register_style( 'jetpack-search-page', false, array(), Package::VERSION );
-		wp_enqueue_style( 'jetpack-search-page' );
-		wp_add_inline_style( 'jetpack-search-page', static::search_page_inline_css() );
+		static::enqueue_search_layout_style();
 	}
 
 	/**
-	 * Inline CSS for the embedded / product-search page templates. Mirrors the
-	 * narrow-width sidebar-collapse pattern from
-	 * `block_template_overlay_inline_css()` (the overlay's equivalent) but
-	 * scoped to the page templates' own `__results-page__*` class hierarchy so
-	 * the two sets of rules don't overlap and the overlay's CSS stays
-	 * untouched.
+	 * Register + enqueue the inline CSS that drives the shared responsive
+	 * layout pattern across all three Search Blocks templates — narrow-width
+	 * sidebar collapse and in-header popover toggle. Called from both the
+	 * overlay enqueue path and the page-template enqueue path; the style
+	 * handle is idempotent under repeat enqueue calls.
+	 */
+	public static function enqueue_search_layout_style() {
+		// No src — this handle exists only as a target for `wp_add_inline_style`.
+		// Version tracks the package so a release bust cache-invalidates any
+		// reusing site's inline-style cache.
+		wp_register_style( 'jetpack-search-layout', false, array(), Package::VERSION );
+		wp_enqueue_style( 'jetpack-search-layout' );
+		wp_add_inline_style( 'jetpack-search-layout', static::search_layout_inline_css() );
+	}
+
+	/**
+	 * Inline CSS for the responsive search-results layout shared across the
+	 * overlay, embedded (`jetpack-search.html`), and WC product
+	 * (`jetpack-search-product-results.html`) templates.
+	 *
+	 * Below 992px the right-column filter sidebar collapses to a popover
+	 * trigger docked next to results-sort; at >= 992px the sidebar is the
+	 * sole filter UI and the in-header popover is hidden so the two don't
+	 * double up. Same breakpoint as the legacy Instant Search overlay
+	 * (`.jetpack-instant-search__search-results-secondary { display: none }`
+	 * below `$break-lg`). Lives next to `block_template_overlay_inline_css()`
+	 * (which keeps overlay-only chrome) because the rules target the
+	 * templates' outer columns + results-header, none of which any single
+	 * block owns.
 	 *
 	 * @return string
 	 */
-	protected static function search_page_inline_css(): string {
+	protected static function search_layout_inline_css(): string {
 		return <<<'CSS'
 /* The block group already carries `layout.type:flex` which makes the WordPress
  * block-layout system emit `display:flex` / `flex-wrap:nowrap` /
@@ -1367,7 +1347,7 @@ CSS;
  * from block-layout CSS being present); the operative net-new rule is
  * `align-items: center`, which centers `results-count` against the controls
  * cluster. */
-.jetpack-search-results-page__results-header {
+.jetpack-search-layout__results-header {
 	display: flex;
 	flex-wrap: nowrap;
 	justify-content: space-between;
@@ -1377,33 +1357,34 @@ CSS;
  * the three `__results-header` children get spread evenly by the parent's
  * `space-between`; nesting sort + popover here pins them as one block on the
  * trailing edge. */
-.jetpack-search-results-page__results-header-controls {
+.jetpack-search-layout__results-header-controls {
 	display: flex;
 	flex-wrap: nowrap;
 	align-items: center;
 	gap: 0.75rem;
 }
 /* Below 992px the right-column filter sidebar collapses to a popover trigger
- * docked next to results-sort. Same breakpoint and rationale as the overlay.
- * The selector is scoped to the named outer column so nested
- * `wp-block-column`s inside result-card templates aren't affected. */
+ * docked next to results-sort. The trigger comes from the
+ * `jetpack-search/filters-popover` block that ships in each template. The
+ * selector is scoped to the named outer column so nested `wp-block-column`s
+ * inside result-card templates aren't affected. */
 @media (max-width: 991.98px) {
-	.jetpack-search-results-page__filters-column {
+	.jetpack-search-layout__filters-column {
 		display: none;
 	}
 	/* `!important` defends against the parent `wp:columns` block-layout CSS
 	 * that pins `.wp-block-column` to its inline `flex-basis` (or to an even
-	 * split when no width is set). Mirrors the overlay equivalent. Once the
-	 * filter column is `display:none`, the results column has to be able to
-	 * claim the full row at any specificity. */
-	.jetpack-search-results-page__results-column {
+	 * split when no width is set). Once the filter column is `display:none`,
+	 * the results column has to be able to claim the full row at any
+	 * specificity. */
+	.jetpack-search-layout__results-column {
 		flex-basis: 100% !important;
 	}
 }
 /* Sidebar is showing; hide the in-header popover entirely so a stale
  * `is-popover-open` class can't leak its panel into view. */
 @media (min-width: 992px) {
-	.jetpack-search-results-page__results-header .jetpack-search-filters-popover {
+	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
 		display: none;
 	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1310,14 +1310,22 @@ CSS;
 	 * Register + enqueue the inline CSS that drives the shared responsive
 	 * layout pattern across all three Search Blocks templates — narrow-width
 	 * sidebar collapse and in-header popover toggle. Called from both the
-	 * overlay enqueue path and the page-template enqueue path; the style
-	 * handle is idempotent under repeat enqueue calls.
+	 * overlay enqueue path and the page-template enqueue path.
+	 *
+	 * `wp_register_style` / `wp_enqueue_style` are idempotent, but
+	 * `wp_add_inline_style` is **not** — it appends to an internal array on
+	 * every call, so a second invocation would double the inline payload.
+	 * The `wp_style_is( …, 'enqueued' )` short-circuit makes the helper safe
+	 * to call from multiple sites in one request.
 	 */
 	public static function enqueue_search_layout_style() {
 		// No src — this handle exists only as a target for `wp_add_inline_style`.
 		// Version tracks the package so a release bust cache-invalidates any
 		// reusing site's inline-style cache.
 		wp_register_style( 'jetpack-search-layout', false, array(), Package::VERSION );
+		if ( wp_style_is( 'jetpack-search-layout', 'enqueued' ) ) {
+			return;
+		}
 		wp_enqueue_style( 'jetpack-search-layout' );
 		wp_add_inline_style( 'jetpack-search-layout', static::search_layout_inline_css() );
 	}

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-overlay.html
@@ -5,15 +5,15 @@
 <!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
 <div class="wp-block-columns">
 
-<!-- wp:column {"className":"jetpack-search-block-overlay__results-column"} -->
-<div class="wp-block-column jetpack-search-block-overlay__results-column">
+<!-- wp:column {"className":"jetpack-search-layout__results-column"} -->
+<div class="wp-block-column jetpack-search-layout__results-column">
 <!-- wp:jetpack-search/search-results -->
-<!-- wp:group {"className":"jetpack-search-block-overlay__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group jetpack-search-block-overlay__results-header">
+<!-- wp:group {"className":"jetpack-search-layout__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group jetpack-search-layout__results-header">
 <!-- wp:jetpack-search/results-count /-->
 
-<!-- wp:group {"className":"jetpack-search-block-overlay__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group jetpack-search-block-overlay__results-header-controls">
+<!-- wp:group {"className":"jetpack-search-layout__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group jetpack-search-layout__results-header-controls">
 <!-- wp:jetpack-search/results-sort /-->
 
 <!-- wp:jetpack-search/filters-popover -->
@@ -35,8 +35,8 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"260px","className":"jetpack-search-block-overlay__filters-column","style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column jetpack-search-block-overlay__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:column {"width":"260px","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column jetpack-search-layout__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:jetpack-search/filters -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/clear-filters /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -10,15 +10,15 @@
 <!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
 <div class="wp-block-columns">
 
-<!-- wp:column {"className":"jetpack-search-results-page__results-column"} -->
-<div class="wp-block-column jetpack-search-results-page__results-column">
+<!-- wp:column {"className":"jetpack-search-layout__results-column"} -->
+<div class="wp-block-column jetpack-search-layout__results-column">
 <!-- wp:jetpack-search/search-results -->
-<!-- wp:group {"className":"jetpack-search-results-page__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group jetpack-search-results-page__results-header">
+<!-- wp:group {"className":"jetpack-search-layout__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group jetpack-search-layout__results-header">
 <!-- wp:jetpack-search/results-count /-->
 
-<!-- wp:group {"className":"jetpack-search-results-page__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group jetpack-search-results-page__results-header-controls">
+<!-- wp:group {"className":"jetpack-search-layout__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group jetpack-search-layout__results-header-controls">
 <!-- wp:jetpack-search/results-sort /-->
 
 <!-- wp:jetpack-search/filters-popover -->
@@ -43,8 +43,8 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"260px","fontSize":"small","className":"jetpack-search-results-page__filters-column","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column has-small-font-size jetpack-search-results-page__filters-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:column {"width":"260px","fontSize":"small","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column has-small-font-size jetpack-search-layout__filters-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -10,15 +10,15 @@
 <!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
 <div class="wp-block-columns">
 
-<!-- wp:column {"className":"jetpack-search-results-page__results-column"} -->
-<div class="wp-block-column jetpack-search-results-page__results-column">
+<!-- wp:column {"className":"jetpack-search-layout__results-column"} -->
+<div class="wp-block-column jetpack-search-layout__results-column">
 <!-- wp:jetpack-search/search-results -->
-<!-- wp:group {"className":"jetpack-search-results-page__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group jetpack-search-results-page__results-header">
+<!-- wp:group {"className":"jetpack-search-layout__results-header","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group jetpack-search-layout__results-header">
 <!-- wp:jetpack-search/results-count /-->
 
-<!-- wp:group {"className":"jetpack-search-results-page__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group jetpack-search-results-page__results-header-controls">
+<!-- wp:group {"className":"jetpack-search-layout__results-header-controls","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group jetpack-search-layout__results-header-controls">
 <!-- wp:jetpack-search/results-sort /-->
 
 <!-- wp:jetpack-search/filters-popover -->
@@ -40,8 +40,8 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"260px","className":"jetpack-search-results-page__filters-column","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column jetpack-search-results-page__filters-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:column {"width":"260px","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column jetpack-search-layout__filters-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->

--- a/projects/plugins/search/changelog/echo-search-265-layout-namespace-unify
+++ b/projects/plugins/search/changelog/echo-search-265-layout-namespace-unify
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: unify the three search-results templates' responsive layout under a shared `.jetpack-search-layout__*` class namespace, collapsing the duplicate sidebar-collapse rules from `block_template_overlay_inline_css()` and `search_page_inline_css()` into a single `search_layout_inline_css()` helper. Pure refactor — no behavior change.


### PR DESCRIPTION
Fixes [SEARCH-265](https://linear.app/a8c/issue/SEARCH-265/search-blocks-unify-responsive-layout-under-a-shared-jetpack-search)

## Why

[#49177](https://github.com/Automattic/jetpack/pull/49177) (overlay) and [#49181](https://github.com/Automattic/jetpack/pull/49181) (embedded + WC product page templates) each shipped the same narrow-width sidebar-collapse + in-header `filters-popover` pattern — two parallel class prefixes (`__block-overlay__*`, `__results-page__*`) and two sibling inline-CSS PHP functions (`block_template_overlay_inline_css()`, `search_page_inline_css()`) carrying nearly identical rules. Adding a fourth template would have meant copy-pasting a third time.

This collapses both into one shared `.jetpack-search-layout__*` namespace and one canonical helper (`search_layout_inline_css()`) enqueued by both contexts via a single `enqueue_search_layout_style()`. `block_template_overlay_inline_css()` shrinks to genuinely overlay-only chrome (scrim, card, close, search-header strip, mobile padding tweaks, scroll lock, 95% card cap at ≥992px) plus the scoped `.jetpack-search-block-overlay .jetpack-search-layout__filters-column` divider styling.

Pure refactor — no behavior change.

## Proposed changes

* **`class-search-blocks.php`** — delete `search_page_inline_css()`; add `search_layout_inline_css()` (shared rules under `.jetpack-search-layout__*`) and `enqueue_search_layout_style()` (single enqueue path, idempotent style handle `jetpack-search-layout`); `enqueue_search_page_assets()` now just calls the shared helper after its `is_search()` gate; the overlay's asset-enqueue path also calls the shared helper so both contexts ship the same rules.
* **`block_template_overlay_inline_css()`** — drop the rules targeting `__results-header`, `__results-header-controls`, the `@media (max-width: 991.98px)` block, and the in-header popover hide inside `@media (min-width: 992px)`. The 95% card cap at ≥992px stays. The filters-column hairline divider becomes a descendant selector (`.jetpack-search-block-overlay .jetpack-search-layout__filters-column`) so it remains overlay-only — the embedded / WC-product page columns set their own `border-left-color` inline.
* **Three template files** — `jetpack-search-overlay.html`, `jetpack-search.html`, `jetpack-search-product-results.html`: rename the four layout-region classes (`results-column`, `filters-column`, `results-header`, `results-header-controls`) onto the shared namespace.
* Net: **+90 / -101 lines.**

## Screenshots

Captured live in the `echo` docker env on Twenty Twenty-Five at four (experience × viewport) tuples. **All four PNG pairs are SHA-256 identical between trunk and this branch** — strongest possible no-regression check.

### Overlay (`overlay_blocks` experience, `?s=test`)

| | Before (trunk) | After (this branch) |
|---|---|---|
| Wide (1400×900) | ![before-overlay-wide](https://github.com/user-attachments/assets/53c93747-0368-43b5-a88f-bd0a5dc284e4) | ![after-overlay-wide](https://github.com/user-attachments/assets/52b782c5-8e1e-43f5-a1fd-7089e1fca2d3) |
| Narrow (911×900) | ![before-overlay-narrow](https://github.com/user-attachments/assets/c9b52d78-c024-4da3-b287-45bfe5923944) | ![after-overlay-narrow](https://github.com/user-attachments/assets/8b8fa381-9378-44eb-b88c-0e4701ec115a) |

### Embedded (`embedded` experience, `?s=test`)

| | Before (trunk) | After (this branch) |
|---|---|---|
| Wide (1400×900) | ![before-embedded-wide](https://github.com/user-attachments/assets/3f867de0-2318-4dd2-a6fd-5fadd39dace8) | ![after-embedded-wide](https://github.com/user-attachments/assets/af13d8bc-bc10-46fd-8baa-02d568f89a74) |
| Narrow (911×900) | ![before-embedded-narrow](https://github.com/user-attachments/assets/7054ebcb-e884-43a6-b941-ed7a272dc86d) | ![after-embedded-narrow](https://github.com/user-attachments/assets/53f5baac-cdf0-450a-b181-485ecf644a5f) |

### WC product (`embedded` + `jetpack_search_override_woocommerce_search_template=1`, `?s=hat&post_type=product`)

| | Before (trunk) | After (this branch) |
|---|---|---|
| Wide (1400×900) | ![before-wc-product-wide](https://github.com/user-attachments/assets/318ef3ac-cfd1-4ed0-85d2-c804a0d8c01d) | ![after-wc-product-wide](https://github.com/user-attachments/assets/e6936c95-9eac-4ab2-8e92-0f7699c4ae94) |
| Narrow (911×900) | ![before-wc-product-narrow](https://github.com/user-attachments/assets/0ed50814-aaad-4c65-8b45-592104246b60) | ![after-wc-product-narrow](https://github.com/user-attachments/assets/aa3d282d-af11-47a0-9cc3-bc9fda9598b2) |

### `getComputedStyle()` probes — identical across trunk vs. branch

Probed selectors target the **named outer column** + the **in-header popover** at each viewport. Trunk probes use the pre-refactor class names (`__block-overlay__*` / `__results-page__*`); branch probes use the new `__layout__*` names. Same elements, identical computed values.

| Experience | Viewport | `filters-column` `display` | `results-column` `flex-basis` | in-header popover `display` |
|---|---|---|---|---|
| Overlay    | 1400px | `block` | `0px` (sidebar at 260px) | `none` |
| Overlay    | 911px  | `none`  | `100%`                   | `block` |
| Embedded   | 1400px | `block` | `0px` (sidebar at 260px) | `none` |
| Embedded   | 911px  | `none`  | `100%`                   | `block` |
| WC product | 1400px | `block` | `0px` (sidebar at 260px) | `none` |
| WC product | 911px  | `none`  | `100%`                   | `block` |

## Related product discussion/links

* [SEARCH-265](https://linear.app/a8c/issue/SEARCH-265/search-blocks-unify-responsive-layout-under-a-shared-jetpack-search)
* Pattern sources — [#49177](https://github.com/Automattic/jetpack/pull/49177) (overlay), [#49181](https://github.com/Automattic/jetpack/pull/49181) (page templates)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-265 — verify against the screenshots above and against a local docker env:

* [ ] Grep clean — neither `jetpack-search-block-overlay__{results-column,filters-column,results-header,results-header-controls}` nor `jetpack-search-results-page__{results-column,filters-column,results-header,results-header-controls}` appears anywhere in `projects/packages/search` or `projects/plugins/search`.
* [ ] `search_page_inline_css()` is gone; `search_layout_inline_css()` + `enqueue_search_layout_style()` exist and are called from both the overlay enqueue path and `enqueue_search_page_assets()`.
* [ ] `block_template_overlay_inline_css()` no longer contains the responsive media-query block or the `__results-header*` declarations — only scrim / card / close / search-header / mobile padding / 95% cap / scroll lock remain, plus the scoped `.jetpack-search-block-overlay .jetpack-search-layout__filters-column` divider rule.
* [ ] All three templates render with the new `.jetpack-search-layout__*` classes.
* [ ] **Overlay** (`wp option update jetpack_search_experience overlay_blocks` + `wp post list --post_type=jp_search_overlay --field=ID | xargs -I{} wp post delete {} --force`, then visit `/?s=test`):
  * `>=992px`: sidebar visible (260px right column), in-header `filters-popover` hidden.
  * `<992px`: sidebar hidden, results column claims full row, in-header popover trigger visible next to `results-sort`, panel opens on click.
* [ ] **Embedded** (`wp option update jetpack_search_experience embedded` + delete any customized `wp_template` named `jetpack-search`, then visit `/?s=hello`): same narrow / wide swap.
* [ ] **WC product** (requires WooCommerce active + `wp option update jetpack_search_override_woocommerce_search_template 1`, visit `/?s=hat&post_type=product`): same swap; popover surfaces `filter-wc-rating`, `filter-wc-price`, `filter-wc-stock-status` alongside the category/brand checkboxes.
* [ ] Both `<style id="jetpack-search-block-overlay-inline-css">` and `<style id="jetpack-search-layout-inline-css">` ship together in the overlay render; only `<style id="jetpack-search-layout-inline-css">` ships in the page-template render.
