### PR TITLE
Search Blocks Overlay: restore hairline + in-overlay button hover on legacy themes (SEARCH-260)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-260-fieldguide-button-hover
+++ b/projects/packages/search/changelog/atlas-search-260-fieldguide-button-hover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks Overlay: restore header hairline + button-hover affordances on themes without --wp--preset--color--base / --contrast tokens (fieldguide and other legacy themes).

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1128,7 +1128,7 @@ class Search_Blocks {
 	width: 100%;
 	max-width: 1080px;
 	--jp-search-overlay-surface: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
-	--jp-search-overlay-ink: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
+	--jp-search-overlay-ink: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327));
 	background: var(--jp-search-overlay-surface);
 	color: var(--jp-search-overlay-ink);
 	border-radius: 4px;
@@ -1175,6 +1175,20 @@ class Search_Blocks {
 .jetpack-search-block-overlay__close svg {
 	width: 24px;
 	height: 24px;
+}
+/* Pin in-overlay button `color` against host-theme `button:hover|:focus` overrides
+ * (fieldguide and similar legacy themes flip button color to a brand accent on hover).
+ * Our block-level rules set `color: inherit` at (0,1,0); a stray `button:hover` rule
+ * at (0,1,1) outranks it on `:hover`, and the `color-mix(currentColor X%, …)` hover
+ * affordances on the filters-popover trigger, results-sort trigger, suggestions
+ * options, etc. then resolve against the host's hover color (often white-on-white).
+ * Card-scoped `:hover|:focus|[aria-expanded=true]` lands at (0,2,1) — beats the
+ * theme rule without escalating to `!important`. */
+.jetpack-search-block-overlay__card button:hover,
+.jetpack-search-block-overlay__card button:focus,
+.jetpack-search-block-overlay__card button:focus-visible,
+.jetpack-search-block-overlay__card button[aria-expanded="true"] {
+	color: var(--jp-search-overlay-ink);
 }
 /* Promote the first child (search-input) to a 60px header strip flush with
  * the close button, matching the legacy `__box` header. Suppress the input


### PR DESCRIPTION
Fixes the regression on themes without `--wp--preset--color--base` / `--contrast` tokens (Automattic's Fieldguide and other classic themes) where the overlay's header hairline disappears and every button-hover affordance inside the overlay (filters-popover trigger, results-sort trigger, suggestion options) becomes invisible.

## Why

On Fieldguide, opening the Search Blocks Overlay shows: no hairline under the 60px header strip, no hover wash on the close `×`, no hover wash on the "Filter results" trigger, no hover wash on "Sort by", and no hover highlight on suggestion rows. The overlay otherwise paints correctly. Two distinct root causes — both unique to themes that don't expose the newer WordPress preset color tokens.

## Proposed changes

* Replace `inherit` with `#1d2327` as the terminal fallback of `--jp-search-overlay-ink`. The previous `var(--contrast, var(--foreground, inherit))` chain looked harmless but is a custom-property gotcha: inside `var()`, `inherit` doesn't fall back to the parent's `color` — it inherits the same (undefined) custom property from the parent, so the token ends up with an invalid value. Every downstream `color-mix(in sRGB, var(--jp-search-overlay-ink) X%, …)` then drops at computed-value time, exposing the base `background: transparent` on the card `::before` hairline and the close-button `:hover`. The new fallback mirrors the `--surface` chain (which already ends in literal `#fff`) and matches the WP default ink.
* Pin `color: var(--jp-search-overlay-ink)` on `.jetpack-search-block-overlay__card button:hover|:focus|:focus-visible|[aria-expanded="true"]`. Fieldguide and similar legacy themes ship a `button:hover { color }` rule at specificity (0,1,1) that outranks each block's `color: inherit` base rule at (0,1,0); on hover `currentColor` flips to the theme's accent (typically white), so the `color-mix(currentColor 6–14%, transparent)` washes used by the filters-popover trigger, the results-sort trigger, the suggestion rows, and other in-overlay buttons all became invisible (6% white over the white card surface). The new card-scoped rule lands at (0,2,1) — beats the host-theme `button:hover` without `!important` — and only applies inside the overlay card, so the embedded experience keeps the host theme's button colors.

## Related product discussion/links

* [SEARCH-260](https://linear.app/a8c/issue/SEARCH-260/) — Search Blocks Overlay header hairline regression on legacy themes
* Follow-up to #49179 (initial SEARCH-260 fix)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Smoke-check on a block theme first: open the Search Blocks Overlay on TT3 (or any theme exposing `--wp--preset--color--contrast`). The hairline, close hover, filter trigger hover, and sort trigger hover should look identical to trunk — the new rules are no-ops when the host theme already pins `color` correctly on hover.
2. Repro on a legacy theme (locally: switch to `twentytwentyone` or any theme that does not define `--wp--preset--color--contrast`; remotely: PCYsg-4l-p2 after `#49179` lands).
   * Before this PR: 1px hairline at `top: 60px` is missing; hovering `×`, "Filter results", and "Sort by" produces no visible affordance; suggestion rows do not highlight on hover.
   * After this PR: hairline paints as a faint dark line; each button gets a subtle ink-over-surface wash on hover; suggestion rows highlight.
3. Sanity-check that buttons *outside* the overlay (e.g. the same filters-popover trigger in the embedded experience on `?s=…`) still pick up the host theme's button colors — the new rule is `__card`-scoped, so embedded usage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)