### PR TITLE
Image Studio: Add site context to tracking data

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-image-studio-tracking-data
+++ b/projects/plugins/jetpack/changelog/fix-image-studio-tracking-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Image Studio: Add site context to tracking data.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Extensions\ImageStudio;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Status\Visitor;
 use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -319,6 +320,52 @@ function get_asset_data_from_remote() {
 }
 
 /**
+ * Get the current site's WordPress.com blog ID for tracking.
+ *
+ * @return int The WordPress.com blog ID, or 0 when unavailable.
+ */
+function get_tracking_blog_id() {
+	$blog_id = ( new Host() )->get_wpcom_site_id();
+
+	return $blog_id ? absint( $blog_id ) : 0;
+}
+
+/**
+ * Get the current site type for Image Studio tracking.
+ *
+ * @return string The site type: simple, atomic, or jetpack.
+ */
+function get_tracking_site_type() {
+	$host = new Host();
+
+	if ( $host->is_wpcom_simple() ) {
+		return 'simple';
+	}
+
+	if ( $host->is_woa_site() ) {
+		return 'atomic';
+	}
+
+	return 'jetpack';
+}
+
+/**
+ * Check whether the current visitor should be treated as an Automattician.
+ *
+ * @return bool True when the current visitor is an Automattician.
+ */
+function is_tracking_automattician() {
+	if ( function_exists( 'wpcom_is_proxied_request' )
+		&& \wpcom_is_proxied_request()
+		&& function_exists( 'is_automattician' )
+	) {
+		return (bool) \is_automattician();
+	}
+
+	return ( new Visitor() )->is_automattician_feature_flags_only();
+}
+
+/**
  * Enqueue Image Studio script and style assets.
  *
  * @return void
@@ -361,6 +408,9 @@ function do_enqueue_assets() {
 	$image_studio_data = array(
 		'enabled'               => true,
 		'version'               => '1.0',
+		'blogId'                => get_tracking_blog_id(),
+		'siteType'              => get_tracking_site_type(),
+		'isA11n'                => is_tracking_automattician(),
 		'isDevMode'             => jetpack_is_internal_testing_environment(),
 		'canGenerateVideoClips' => image_studio_can_generate_video_clips(),
 	);

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -88,6 +88,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'jetpack_ai_enabled' );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
+		\Jetpack_Options::delete_option( array( 'id', 'blog_token' ) );
 		delete_option( 'big_sky_enable' );
 		update_option( 'siteurl', $this->saved_siteurl );
 		$GLOBALS['current_screen'] = $this->saved_screen;
@@ -208,6 +209,33 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		ImageStudio\register_plugin();
 		set_transient( ImageStudio\ASSET_TRANSIENT, $asset_data, HOUR_IN_SECONDS );
 		ImageStudio\enqueue_image_studio_admin();
+	}
+
+	/**
+	 * Get Image Studio inline script data.
+	 *
+	 * @return array|null The decoded imageStudioData array, or null if missing.
+	 */
+	private function get_image_studio_inline_data() {
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		if ( ! is_array( $inline ) ) {
+			return null;
+		}
+
+		foreach ( $inline as $line ) {
+			if ( ! is_string( $line ) || false === strpos( $line, 'imageStudioData' ) ) {
+				continue;
+			}
+
+			$matches = array();
+			if ( preg_match( '/window\.imageStudioData = (\{.*\}); \}$/', $line, $matches ) ) {
+				$data = json_decode( $matches[1], true );
+				return is_array( $data ) ? $data : null;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -517,22 +545,22 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test inline script includes isDevMode property.
+	 * Test inline script sets tracking context data.
 	 */
-	public function test_inline_script_includes_is_dev_mode() {
+	public function test_inline_script_sets_tracking_context_data() {
+		\Jetpack_Options::update_option( 'id', 1234 );
+		\Jetpack_Options::update_option( 'blog_token', 'asd.qwe.1' );
+		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
+
 		$this->enable_and_enqueue_block_editor();
 
-		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+		$data = $this->get_image_studio_inline_data();
 
-		$this->assertIsArray( $inline );
-		$found = false;
-		foreach ( $inline as $line ) {
-			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
-				$found = true;
-				$this->assertStringContainsString( '"isDevMode":', $line );
-			}
-		}
-		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+		$this->assertIsArray( $data );
+		$this->assertSame( 1234, $data['blogId'] );
+		$this->assertSame( 'jetpack', $data['siteType'] );
+		$this->assertFalse( $data['isA11n'] );
+		$this->assertArrayHasKey( 'isDevMode', $data );
 	}
 
 	/**


### PR DESCRIPTION
Part of FORNO-196

## Proposed changes
* Add Image Studio tracking context to `window.imageStudioData`:
  * `blogId`
  * `siteType` (`simple`, `atomic`, or `jetpack`)
  * `isA11n`
* Preserve the existing `isDevMode` bootstrap value.
* Update Image Studio extension tests to validate the injected tracking context.
* Add a Jetpack changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
This adds site context values to the Image Studio bootstrap data so Image Studio Tracks events can include the WordPress.com blog ID, normalised site type, and Automattician flag. However this is not new data.

## Testing instructions
* Checkout this PR `bin/jetpack-downloader test jetpack fix/image-studio-tracking-data` on your sandbox
* Checkout companion Calypso branch `fix/image-studio-tracking-data` 
* Sandbox your test site and widgets.wp.com
* Enable tracking `localStorage.debug = 'calypso:analytics*'`
* Open Image Studio
* Check your console and verify the tracking payload includes `blog_id`, `site_type`, and `is_a11n`