### PR TITLE
Search Blocks: default checkbox-filter Custom Taxonomy label to the taxonomy name

### DIFF
--- a/projects/packages/search/changelog/echo-search-267-filter-checkbox-default-taxonomy-label
+++ b/projects/packages/search/changelog/echo-search-267-filter-checkbox-default-taxonomy-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: default the checkbox-filter Custom Taxonomy label to the taxonomy's display name instead of leaving it empty.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -29,7 +29,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { normalizeDisplayStyle } from '../display-style.js';
 
@@ -364,6 +364,33 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// always returns zero results. Hiding the control on those variations
 	// keeps authors from setting it by mistake.
 	const isTaxonomyFilter = attributes?.filterType === 'taxonomy';
+
+	// Default the label to the taxonomy's display name the first time we see
+	// a given custom-taxonomy slug with an empty label. The ref captures
+	// "this slug has already been labeled at least once" so a manual clear
+	// by the author is respected — only moving to a not-yet-seeded slug
+	// re-triggers the seed. Built-in variations don't pass this gate; they
+	// already get a hardcoded default via variationDefaultLabel().
+	const lastLabeledTaxonomyRef = useRef( null );
+	useEffect( () => {
+		if ( ! isCustomTaxonomy ) {
+			return;
+		}
+		if ( ! Array.isArray( taxonomies ) || ! taxonomy ) {
+			return;
+		}
+		if ( rawLabel ) {
+			lastLabeledTaxonomyRef.current = taxonomy;
+			return;
+		}
+		if ( lastLabeledTaxonomyRef.current === taxonomy ) {
+			return;
+		}
+		const match = taxonomies.find( t => t?.slug === taxonomy );
+		if ( match?.name ) {
+			setAttributes( { label: match.name } );
+		}
+	}, [ isCustomTaxonomy, taxonomies, taxonomy, rawLabel, setAttributes ] );
 
 	// Swapping the filter type via the inspector shouldn't wipe an author's
 	// custom label, but when the stored label still matches the prior

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -371,6 +371,13 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// leaving and re-entering the Custom Taxonomy variation — drops the guard
 	// so the picker can seed again. Built-in variations don't pass this gate;
 	// they already get a hardcoded default via variationDefaultLabel().
+	//
+	// Both refs reset whenever the component unmounts (Code/Visual editor
+	// toggle, certain undo sequences). That means a saved post whose `label`
+	// is the empty string re-seeds on the next editor open — by design,
+	// since `labelHelp` already tells authors a label is required for the
+	// front-end heading to render. There's no "persistently empty" custom
+	// taxonomy label state.
 	const manuallyClearedTaxonomyRef = useRef( null );
 	const previousCustomTaxonomyStateRef = useRef( {
 		isCustomTaxonomy,

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -365,14 +365,37 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// keeps authors from setting it by mistake.
 	const isTaxonomyFilter = attributes?.filterType === 'taxonomy';
 
-	// Default the label to the taxonomy's display name the first time we see
-	// a given custom-taxonomy slug with an empty label. The ref captures
-	// "this slug has already been labeled at least once" so a manual clear
-	// by the author is respected — only moving to a not-yet-seeded slug
-	// re-triggers the seed. Built-in variations don't pass this gate; they
-	// already get a hardcoded default via variationDefaultLabel().
-	const lastLabeledTaxonomyRef = useRef( null );
+	// Default the label to the taxonomy's display name when the current
+	// custom-taxonomy selection has an empty label, except immediately after
+	// the author manually clears that same slug. Changing the slug — or
+	// leaving and re-entering the Custom Taxonomy variation — drops the guard
+	// so the picker can seed again. Built-in variations don't pass this gate;
+	// they already get a hardcoded default via variationDefaultLabel().
+	const manuallyClearedTaxonomyRef = useRef( null );
+	const previousCustomTaxonomyStateRef = useRef( {
+		isCustomTaxonomy,
+		taxonomy,
+		rawLabel,
+	} );
 	useEffect( () => {
+		const previous = previousCustomTaxonomyStateRef.current;
+		if ( previous.isCustomTaxonomy !== isCustomTaxonomy || previous.taxonomy !== taxonomy ) {
+			manuallyClearedTaxonomyRef.current = null;
+		}
+		if (
+			isCustomTaxonomy &&
+			previous.isCustomTaxonomy &&
+			previous.taxonomy === taxonomy &&
+			previous.rawLabel &&
+			! rawLabel
+		) {
+			manuallyClearedTaxonomyRef.current = taxonomy;
+		}
+		previousCustomTaxonomyStateRef.current = {
+			isCustomTaxonomy,
+			taxonomy,
+			rawLabel,
+		};
 		if ( ! isCustomTaxonomy ) {
 			return;
 		}
@@ -380,10 +403,9 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 			return;
 		}
 		if ( rawLabel ) {
-			lastLabeledTaxonomyRef.current = taxonomy;
 			return;
 		}
-		if ( lastLabeledTaxonomyRef.current === taxonomy ) {
+		if ( manuallyClearedTaxonomyRef.current === taxonomy ) {
 			return;
 		}
 		const match = taxonomies.find( t => t?.slug === taxonomy );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -543,6 +543,29 @@ describe( 'FilterCheckboxEdit custom taxonomy label seeding', () => {
 		);
 		expect( setAttributes ).not.toHaveBeenCalled();
 	} );
+
+	it( 'seeds again when returning to Custom Taxonomy with the same cleared slug', () => {
+		const setAttributes = jest.fn();
+		const { rerender } = render(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'genre', label: 'Genre' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		rerender(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'author', taxonomy: 'genre', label: '' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		rerender(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'genre', label: '' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { label: 'Genre' } );
+	} );
 } );
 
 describe( 'normalizeQueryType', () => {

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -544,6 +544,26 @@ describe( 'FilterCheckboxEdit custom taxonomy label seeding', () => {
 		expect( setAttributes ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does not overwrite an existing label when switching to a different custom taxonomy slug', () => {
+		// Simulates: author had `genre` with label "Pick a genre", then picks
+		// `mood`. The label must stay "Pick a genre" — the slug change alone
+		// is not enough to overwrite an author-typed value.
+		const setAttributes = jest.fn();
+		const { rerender } = render(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'genre', label: 'Pick a genre' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		rerender(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'mood', label: 'Pick a genre' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
 	it( 'seeds again when returning to Custom Taxonomy with the same cleared slug', () => {
 		const setAttributes = jest.fn();
 		const { rerender } = render(

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -460,6 +460,91 @@ describe( 'FilterCheckboxEdit custom taxonomy picker', () => {
 	} );
 } );
 
+describe( 'FilterCheckboxEdit custom taxonomy label seeding', () => {
+	const useSelectMock = jest.requireMock( '@wordpress/data' ).useSelect;
+
+	const taxonomyEntities = [
+		{ slug: 'genre', name: 'Genre', visibility: { public: true } },
+		{ slug: 'mood', name: 'Mood', visibility: { public: true } },
+	];
+
+	beforeEach( () => {
+		globalThis.JetpackSearchBlocksConfig = {
+			supportedCustomTaxonomies: [ 'genre', 'mood' ],
+			customTaxonomyMap: {},
+		};
+		useSelectMock.mockImplementation( () => taxonomyEntities );
+	} );
+
+	afterEach( () => {
+		delete globalThis.JetpackSearchBlocksConfig;
+		useSelectMock.mockReset();
+		useSelectMock.mockImplementation( () => null );
+	} );
+
+	it( 'seeds label from the taxonomy display name when a custom taxonomy is picked with an empty label', () => {
+		const setAttributes = jest.fn();
+		render(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'genre', label: '' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { label: 'Genre' } );
+	} );
+
+	it( 'does not overwrite an author-provided label when the taxonomy is set', () => {
+		const setAttributes = jest.fn();
+		render(
+			<FilterCheckboxEdit
+				attributes={ {
+					filterType: 'taxonomy',
+					taxonomy: 'genre',
+					label: 'Pick a genre',
+				} }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips seeding when no taxonomy has been picked yet', () => {
+		const setAttributes = jest.fn();
+		render(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: '', label: '' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves built-in variations alone (they keep their hardcoded defaults)', () => {
+		const setAttributes = jest.fn();
+		render(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'category', label: '' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not seed before the taxonomies list has loaded', () => {
+		// Simulate the in-flight state: core-data returns null until the
+		// /wp/v2/taxonomies request resolves.
+		useSelectMock.mockImplementation( () => null );
+		const setAttributes = jest.fn();
+		render(
+			<FilterCheckboxEdit
+				attributes={ { filterType: 'taxonomy', taxonomy: 'genre', label: '' } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+} );
+
 describe( 'normalizeQueryType', () => {
 	it( 'defaults to `or` for missing or unknown values', () => {
 		expect( normalizeQueryType() ).toBe( 'or' );

--- a/projects/plugins/search/changelog/echo-search-267-filter-checkbox-default-taxonomy-label
+++ b/projects/plugins/search/changelog/echo-search-267-filter-checkbox-default-taxonomy-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: default the checkbox-filter Custom Taxonomy label to the taxonomy's display name instead of leaving it empty.


### PR DESCRIPTION
## Why

In the Search Filter (Checkbox) block's **Custom Taxonomy** variation, picking a taxonomy from the dropdown leaves the **Label** field empty until the author types one in by hand. Every other variation — Category, Tag, Post Type, Author, the three WooCommerce product taxonomies — ships a hardcoded default label via `variationDefaultLabel()`. The custom-taxonomy path is the only one that lands empty, and an empty label suppresses the filter's heading entirely on the front end (`render.php` skips the `<h3>` when the label is `''`). Filling that gap removes one manual step and matches the rest of the block.

After this change, when the editor sees a custom-taxonomy slug selected with no label, it seeds the label from the taxonomy's display name (the same string the picker dropdown already renders). The author can edit or clear it freely — manual values are never overwritten. A manual clear suppresses only the immediate re-seed for that same in-memory slug selection; changing slugs, round-tripping through another variation, or reopening a saved block with an empty label re-seeds as expected.

## Proposed changes

* `projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js`: add a `useEffect` (keyed on `isCustomTaxonomy`, `taxonomies`, `taxonomy`, `rawLabel`) that defaults `label` to the picked taxonomy's `name` when the label is empty. `useRef` state tracks when the current slug was manually cleared so the block does not immediately re-seed that same in-memory selection, but it does re-seed after slug changes, variation round-trips, and remounts. An inline comment documents the intentional remount behavior for existing saved blocks with empty labels.
* `projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js`: add focused unit coverage for the seeding ACs, including auto-seed on empty label, preserving author labels, no-seed without a slug, no-seed for built-in variations, no-seed before the `taxonomies` REST request resolves, preserving a held label across custom taxonomy slug changes, and re-seeding after a `Custom → Author → Custom` round trip.
* No PHP changes — `Filter_Checkbox::default_label()` keeps returning `''` for custom taxonomies. The existing "don't fall back to `get_taxonomy()->labels`" guarantee for product variations stands.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/SEARCH-267

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Editor canvas + inspector for a Custom Taxonomy filter pointed at a registered `genre` taxonomy with `label: ""` saved. Captured on echo's docker WP via Playwright at 1440×900.

| Before (trunk) | After (this PR) |
|---|---|
| <img src="https://github.com/user-attachments/assets/9a44d6ef-9a6f-4972-8941-ca62c6e2b188"> | <img src="https://github.com/user-attachments/assets/65ab2923-c24b-4b42-9dde-292a758987ee"> |

The Label input populates with "Genres" (the taxonomy's display name) instead of staying empty. The canvas heading follows.

## Testing instructions

Acceptance criteria from SEARCH-267 — work through each against the editor:

- [ ] In the editor, switch the variation to **Custom Taxonomy** and pick a taxonomy from the dropdown. The **Label** input pre-populates with that taxonomy's display name (e.g. `genre` → "Genres"). Verified only when the current label is empty.
- [ ] Type a custom label (e.g. "Pick a genre"). Switch the taxonomy to a different custom slug. The label stays "Pick a genre" — author-typed values are never overwritten.
- [ ] Clear the label, then pick a different (or the same) taxonomy. The label auto-fills again with the new taxonomy's display name.
- [ ] Switch *into* the Custom Taxonomy variation from Post Type / Author when the prior taxonomy slug was custom (e.g. set the block to Custom→`genre`, switch to Post Type, switch back). The label lands populated (matching the preserved slug), not empty.
- [ ] Switch between Category / Tag / Post Type / Author / product variations. Each shows its existing hardcoded default label via `variationDefaultLabel()` — no behavior change.
- [ ] Save the post and view it on the front end. The persisted label is what renders. `class-filter-checkbox.php` is **not** modified.
- [ ] Existing posts that saved an empty label on a Custom Taxonomy checkbox-filter: opening them in the editor populates the label from the taxonomy display name (the same useEffect mounts on existing saves).

Unit tests: `pnpm jest tests/js/search-blocks/filter-checkbox-edit.test.js` from `projects/packages/search/`.