### PR TITLE
Plugin Conflicts Guardian: confirmation probe via active_plugins injection

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-confirmation-probe
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-confirmation-probe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: on a captured fatal in activation mode, re-probe with the candidate injected into active_plugins so WP's normal bootstrap loads it at real-activation timing; downgrade to ok-inconclusive if the confirmation probe is clean.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-confirmation-probe
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-confirmation-probe
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Plugin Conflicts Guardian: on a captured fatal in activation mode, re-probe with the candidate injected into active_plugins so WP's normal bootstrap loads it at real-activation timing; downgrade to ok-inconclusive if the confirmation probe is clean.
+Plugin Conflicts Guardian: confirm captured fatals via a second probe loaded through WP's normal active-plugin bootstrap; downgrade if clean.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -32,6 +32,12 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/common/fatal-error-signature.php';
 		require_once __DIR__ . '/utils.php';
 
+		// PCG confirmation probe needs to hook `pre_option_active_plugins`
+		// before wp-settings.php reads the option, so we wire it up here
+		// (mu-plugin load time) rather than via the usual `plugins_loaded`
+		// feature loader.
+		require_once __DIR__ . '/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
+
 		// Load features that don't need any special loading considerations.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_features' ) );
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -32,10 +32,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/common/fatal-error-signature.php';
 		require_once __DIR__ . '/utils.php';
 
-		// PCG confirmation probe needs to hook `pre_option_active_plugins`
-		// before wp-settings.php reads the option, so we wire it up here
-		// (mu-plugin load time) rather than via the usual `plugins_loaded`
-		// feature loader.
+		// PCG confirmation probe wires its `pre_option_active_plugins`
+		// filter at mu-plugin time, before WP loads active plugins.
 		require_once __DIR__ . '/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
 
 		// Load features that don't need any special loading considerations.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -83,9 +83,8 @@ The probe endpoint loads candidates via a manual `require_once`, which doesn't p
 
 When the first probe captures a fatal in activation mode, the load tester fires a **confirmation probe** with `pcg_confirm=1`. An early-bootstrap hook (`probe-confirm-bootstrap.php`, required from `Jetpack_Mu_Wpcom::init()` at mu-plugin load time) hooks `pre_option_active_plugins` so the candidate is treated as already-active for that request; the probe endpoint skips its manual require and observes whether `wp_loaded` / `admin_init` complete cleanly.
 
-- Clean confirmation → downgrade to `ok-inconclusive`; log `Probe fatal downgraded after confirmation`.
-- Confirmation also fatals → keep the original verdict; block.
-- Confirmation transport error → downgrade as well — we've lost the ability to disambiguate, and keeping the block would re-introduce the false-positive class. CLI activation remains the recovery path.
+- Explicit clean `ok` confirmation → downgrade to `ok-inconclusive`; log `Probe fatal downgraded after confirmation`.
+- Anything else — confirmation fatal, transport error, or an ambiguous `ok-inconclusive` / `ok-shutdown` — keeps the original verdict and blocks. A fatal during the injected `active_plugins` load dies in `wp-settings.php` before the probe endpoint arms its shutdown handler, so it can't return as `status=fatal`; treating that ambiguity as a pass would downgrade a real fatal. We only override a captured fatal on positive clean evidence.
 
 Update mode never confirms — the candidate is already loaded by WP's normal bootstrap before the probe fires, so there's no different ordering to test against, and a fatal MUST block to let `PCG_Rollback::to_snapshot()` fire.
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -85,7 +85,7 @@ When the first probe captures a fatal in activation mode, the load tester fires 
 
 - Clean confirmation → downgrade to `ok-inconclusive`; log `Probe fatal downgraded after confirmation`.
 - Confirmation also fatals → keep the original verdict; block.
-- Confirmation transport error → keep the original verdict (uncertainty doesn't downgrade).
+- Confirmation transport error → downgrade as well — we've lost the ability to disambiguate, and keeping the block would re-introduce the false-positive class. CLI activation remains the recovery path.
 
 Update mode never confirms — the candidate is already loaded by WP's normal bootstrap before the probe fires, so there's no different ordering to test against, and a fatal MUST block to let `PCG_Rollback::to_snapshot()` fire.
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -77,6 +77,18 @@ Two independent filters:
 
 Atomic and some managed hosts sandbox web-PHP so `proc_open` can't find/exec a CLI binary (`open_basedir` + restricted exec). A separate HTTP request is isolated from the admin request: if the plugin fatals, the probe 500s but the parent sees JSON via the shutdown handler, and the admin page keeps rendering.
 
+## Confirmation probe (activation mode)
+
+The probe endpoint loads candidates via a manual `require_once`, which doesn't perfectly match the timing of a real activation page-load (where the candidate is in `active_plugins` from the start, loaded by `wp-settings.php` before `plugins_loaded` fires). Some captured fatals are timing artifacts that wouldn't happen on a real activation.
+
+When the first probe captures a fatal in activation mode, the load tester fires a **confirmation probe** with `pcg_confirm=1`. An early-bootstrap hook (`probe-confirm-bootstrap.php`, required from `Jetpack_Mu_Wpcom::init()` at mu-plugin load time) hooks `pre_option_active_plugins` so the candidate is treated as already-active for that request; the probe endpoint skips its manual require and observes whether `wp_loaded` / `admin_init` complete cleanly.
+
+- Clean confirmation → downgrade to `ok-inconclusive`; log `Probe fatal downgraded after confirmation`.
+- Confirmation also fatals → keep the original verdict; block.
+- Confirmation transport error → keep the original verdict (uncertainty doesn't downgrade).
+
+Update mode never confirms — the candidate is already loaded by WP's normal bootstrap before the probe fires, so there's no different ordering to test against, and a fatal MUST block to let `PCG_Rollback::to_snapshot()` fire.
+
 ## Percentage rollout
 
 `PCG_Rollout` narrows `pcg_guard_activation` / `pcg_guard_updates` per blog. Default is **0%** — PCG is off everywhere until the operator opts in:

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -118,13 +118,27 @@ class PCG_Load_Tester {
 		}
 
 		// Activation-mode captured fatal: re-probe via WP's normal
-		// active-plugin bootstrap to confirm. Clean confirmation →
-		// downgrade. Update mode never confirms — fatals must block so
-		// `PCG_Rollback::to_snapshot()` can fire.
+		// active-plugin bootstrap to confirm. Block only when the
+		// confirmation also captures a fatal. Clean confirmation OR
+		// confirmation transport failure → downgrade (we either have
+		// positive evidence the plugin loads cleanly, or we've lost
+		// the ability to disambiguate — keeping the block in the
+		// latter case would re-introduce the false positives the
+		// confirmation is meant to eliminate). Update mode never
+		// confirms — fatals must block so PCG_Rollback can fire.
 		if ( null !== $verdict ) {
 			if ( self::MODE_ACTIVATION === $mode ) {
 				$confirmation = $this->confirm_via_normal_load( $plugin_mains );
-				if ( null !== $confirmation && ! $this->is_block( $confirmation ) ) {
+				if ( null === $confirmation ) {
+					return $this->downgrade_after_confirmation(
+						$verdict,
+						array(
+							'status' => 'error',
+							'reason' => 'Confirmation probe transport failure; treating original fatal as inconclusive.',
+						)
+					);
+				}
+				if ( ! $this->is_block( $confirmation ) ) {
 					return $this->downgrade_after_confirmation( $verdict, $confirmation );
 				}
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -119,7 +119,7 @@ class PCG_Load_Tester {
 		}
 
 		if ( ! empty( $blocking ) ) {
-			$verdict = $blocking['front'] ?? $blocking['admin'];
+			$verdict = $this->is_block( $front_result ) ? $front_result : $admin_result;
 
 			// Confirm each blocking surface via WP's normal active-plugin
 			// bootstrap; downgrade only when EVERY one comes back an explicit

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -117,14 +117,10 @@ class PCG_Load_Tester {
 			$verdict = $admin_result;
 		}
 
-		// Activation-mode captured fatal: re-probe via WP's normal active-
-		// plugin bootstrap to disambiguate "probe-only loading-order
-		// artifact" from "real fatal." A clean confirmation downgrades
-		// the verdict; a confirming fatal keeps it. Update mode never
-		// confirms — the candidate is already loaded by WP's bootstrap
-		// before the probe fires, so there's no different ordering to
-		// test against, and an update fatal MUST block to let
-		// `PCG_Rollback::to_snapshot()` fire.
+		// Activation-mode captured fatal: re-probe via WP's normal
+		// active-plugin bootstrap to confirm. Clean confirmation →
+		// downgrade. Update mode never confirms — fatals must block so
+		// `PCG_Rollback::to_snapshot()` can fire.
 		if ( null !== $verdict && self::MODE_ACTIVATION === $mode ) {
 			$confirmation = $this->confirm_via_normal_load( $plugin_mains );
 			if ( null !== $confirmation && ! $this->is_block( $confirmation ) ) {
@@ -150,15 +146,9 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Fire a confirmation probe pair with `pcg_confirm=1`. The probe
-	 * endpoint will skip its manual `require_once` because the early
-	 * bootstrap (`probe-confirm-bootstrap.php`) injected the candidates
-	 * into `active_plugins`, so WP's normal bootstrap has already loaded
-	 * them at real-activation timing.
-	 *
-	 * Returns null if the confirmation probe itself failed to round-trip
-	 * (transport exception, both responses unusable). The caller treats
-	 * that as "don't downgrade" — uncertainty keeps the original verdict.
+	 * Fire a confirmation probe pair with `pcg_confirm=1`. Returns null
+	 * on transport failure — the caller keeps the original verdict on
+	 * uncertainty.
 	 *
 	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.
 	 * @return array|null Verdict (most-blocking of front/admin), or null on transport failure.
@@ -197,9 +187,8 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Build the downgraded verdict after a clean confirmation probe.
-	 * Preserves the original captured-fatal context so logstash can
-	 * still see which candidate triggered the downgrade.
+	 * Downgraded verdict after a clean confirmation. Preserves the
+	 * original captured-fatal context for log attribution.
 	 *
 	 * @param array $verdict      Original captured-fatal verdict.
 	 * @param array $confirmation Clean confirmation-probe verdict.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -110,11 +110,30 @@ class PCG_Load_Tester {
 		// fatal/throwable wins; an inconclusive `error` from one probe must
 		// not shadow a real fatal from the other. Front-end is the canonical
 		// "site works" signal when neither probe captured a fatal.
+		$verdict = null;
 		if ( $this->is_block( $front_result ) ) {
-			return $front_result;
+			$verdict = $front_result;
+		} elseif ( $this->is_block( $admin_result ) ) {
+			$verdict = $admin_result;
 		}
-		if ( $this->is_block( $admin_result ) ) {
-			return $admin_result;
+
+		// Activation-mode captured fatal: re-probe via WP's normal active-
+		// plugin bootstrap to disambiguate "probe-only loading-order
+		// artifact" from "real fatal." A clean confirmation downgrades
+		// the verdict; a confirming fatal keeps it. Update mode never
+		// confirms — the candidate is already loaded by WP's bootstrap
+		// before the probe fires, so there's no different ordering to
+		// test against, and an update fatal MUST block to let
+		// `PCG_Rollback::to_snapshot()` fire.
+		if ( null !== $verdict && self::MODE_ACTIVATION === $mode ) {
+			$confirmation = $this->confirm_via_normal_load( $plugin_mains );
+			if ( null !== $confirmation && ! $this->is_block( $confirmation ) ) {
+				return $this->downgrade_after_confirmation( $verdict, $confirmation );
+			}
+			return $verdict;
+		}
+		if ( null !== $verdict ) {
+			return $verdict;
 		}
 
 		// Neither probe blocked. Log if either verdict was a transport-level
@@ -128,6 +147,85 @@ class PCG_Load_Tester {
 		}
 
 		return $front_result;
+	}
+
+	/**
+	 * Fire a confirmation probe pair with `pcg_confirm=1`. The probe
+	 * endpoint will skip its manual `require_once` because the early
+	 * bootstrap (`probe-confirm-bootstrap.php`) injected the candidates
+	 * into `active_plugins`, so WP's normal bootstrap has already loaded
+	 * them at real-activation timing.
+	 *
+	 * Returns null if the confirmation probe itself failed to round-trip
+	 * (transport exception, both responses unusable). The caller treats
+	 * that as "don't downgrade" — uncertainty keeps the original verdict.
+	 *
+	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.
+	 * @return array|null Verdict (most-blocking of front/admin), or null on transport failure.
+	 */
+	protected function confirm_via_normal_load( array $plugin_mains ) {
+		$front = $this->prepare_probe( $plugin_mains, home_url( '/' ), false, self::MODE_ACTIVATION, true );
+		$admin = $this->prepare_probe( $plugin_mains, admin_url( 'index.php' ), true, self::MODE_ACTIVATION, true );
+
+		try {
+			$responses = \WpOrg\Requests\Requests::request_multiple(
+				array(
+					'front' => $front['request'],
+					'admin' => $admin['request'],
+				),
+				array(
+					'timeout'   => self::PROBE_TIMEOUT,
+					'redirects' => 5,
+				)
+			);
+		} catch ( \Throwable $t ) {
+			return null;
+		} finally {
+			delete_transient( self::transient_key( $front['token'] ) );
+			delete_transient( self::transient_key( $admin['token'] ) );
+		}
+
+		$front_result = $this->parse_response( $responses['front'] );
+		$admin_result = $this->parse_response( $responses['admin'] );
+		if ( $this->is_block( $front_result ) ) {
+			return $front_result;
+		}
+		if ( $this->is_block( $admin_result ) ) {
+			return $admin_result;
+		}
+		return $front_result;
+	}
+
+	/**
+	 * Build the downgraded verdict after a clean confirmation probe.
+	 * Preserves the original captured-fatal context so logstash can
+	 * still see which candidate triggered the downgrade.
+	 *
+	 * @param array $verdict      Original captured-fatal verdict.
+	 * @param array $confirmation Clean confirmation-probe verdict.
+	 * @return array
+	 */
+	protected function downgrade_after_confirmation( array $verdict, array $confirmation ) {
+		pcg_log_event(
+			'Probe fatal downgraded after confirmation',
+			array(
+				'plugin'  => isset( $verdict['plugin'] ) ? $this->relative_basenames( array( (string) $verdict['plugin'] ) )[0] : '',
+				'status'  => (string) ( $verdict['status'] ?? '' ),
+				'reason'  => (string) ( $verdict['message'] ?? $verdict['reason'] ?? '' ),
+				'file'    => isset( $verdict['file'] ) ? basename( (string) $verdict['file'] ) : '',
+				'confirm' => (string) ( $confirmation['status'] ?? '' ),
+			)
+		);
+		$out = array(
+			'status'  => 'ok-inconclusive',
+			'reason'  => 'Captured fatal did not reproduce when the candidate was loaded via WP\'s normal active-plugin bootstrap; downgrading to allow.',
+			'message' => (string) ( $verdict['message'] ?? '' ),
+			'file'    => (string) ( $verdict['file'] ?? '' ),
+		);
+		if ( '' !== (string) ( $verdict['plugin'] ?? '' ) ) {
+			$out['plugin'] = (string) $verdict['plugin'];
+		}
+		return $out;
 	}
 
 	/**
@@ -254,10 +352,11 @@ class PCG_Load_Tester {
 	 * @param string   $mode         Probe mode constant.
 	 * @return array{plugins:string[],mode:string}
 	 */
-	public static function build_probe_payload( array $plugin_mains, $mode = self::MODE_ACTIVATION ) {
+	public static function build_probe_payload( array $plugin_mains, $mode = self::MODE_ACTIVATION, $is_confirm = false ) {
 		return array(
 			'plugins' => array_values( array_map( static fn( $p ) => (string) $p, $plugin_mains ) ),
 			'mode'    => self::MODE_UPDATE === $mode ? self::MODE_UPDATE : self::MODE_ACTIVATION,
+			'confirm' => (bool) $is_confirm,
 		);
 	}
 
@@ -271,14 +370,17 @@ class PCG_Load_Tester {
 	 * @param string   $mode         Probe mode constant.
 	 * @return array{token:string,request:array}
 	 */
-	protected function prepare_probe( array $plugin_mains, $base_url, $is_admin, $mode = self::MODE_ACTIVATION ) {
+	protected function prepare_probe( array $plugin_mains, $base_url, $is_admin, $mode = self::MODE_ACTIVATION, $is_confirm = false ) {
 		$token = wp_generate_password( 32, false );
-		set_transient( self::transient_key( $token ), self::build_probe_payload( $plugin_mains, $mode ), self::TOKEN_LIFETIME );
+		set_transient( self::transient_key( $token ), self::build_probe_payload( $plugin_mains, $mode, $is_confirm ), self::TOKEN_LIFETIME );
 
 		$query   = array(
 			'pcg_probe' => '1',
 			'token'     => $token,
 		);
+		if ( $is_confirm ) {
+			$query['pcg_confirm'] = '1';
+		}
 		$headers = array();
 		$options = array();
 		if ( $is_admin ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -118,14 +118,18 @@ class PCG_Load_Tester {
 		}
 
 		// Activation-mode captured fatal: re-probe via WP's normal
-		// active-plugin bootstrap to confirm. Block only when the
-		// confirmation also captures a fatal. Clean confirmation OR
-		// confirmation transport failure → downgrade (we either have
-		// positive evidence the plugin loads cleanly, or we've lost
-		// the ability to disambiguate — keeping the block in the
-		// latter case would re-introduce the false positives the
-		// confirmation is meant to eliminate). Update mode never
-		// confirms — fatals must block so PCG_Rollback can fire.
+		// active-plugin bootstrap to confirm, and downgrade ONLY on an
+		// explicit clean `ok` verdict (see is_clean_confirmation). Any
+		// other confirmation result — transport failure, ok-inconclusive,
+		// ok-shutdown, error — keeps the original captured fatal. A fatal
+		// during the active_plugins-driven load dies in wp-settings.php,
+		// before the probe endpoint registers its shutdown handler, so it
+		// can never come back as status=fatal; it surfaces as a bare 500 /
+		// ok-inconclusive / transport error. Treating that ambiguity as a
+		// pass would downgrade a real fatal, so we trust the genuine fatal
+		// the first probe captured unless the confirmation produces
+		// positive clean evidence. Update mode never confirms — fatals
+		// must block so PCG_Rollback can fire.
 		if ( null !== $verdict ) {
 			if ( self::MODE_ACTIVATION === $mode ) {
 				// Re-probe only the surface that captured. The other surface
@@ -133,16 +137,7 @@ class PCG_Load_Tester {
 				// adds cost without changing the outcome.
 				$surface      = $this->is_block( $front_result ) ? 'front' : 'admin';
 				$confirmation = $this->confirm_via_normal_load( $plugin_mains, $surface );
-				if ( null === $confirmation ) {
-					return $this->downgrade_after_confirmation(
-						$verdict,
-						array(
-							'status' => 'error',
-							'reason' => 'Confirmation probe transport failure; treating original fatal as inconclusive.',
-						)
-					);
-				}
-				if ( ! $this->is_block( $confirmation ) ) {
+				if ( $this->is_clean_confirmation( $confirmation ) ) {
 					return $this->downgrade_after_confirmation( $verdict, $confirmation );
 				}
 			}
@@ -191,6 +186,25 @@ class PCG_Load_Tester {
 		}
 
 		return $this->parse_response( $responses[ $surface ] );
+	}
+
+	/**
+	 * Whether a confirmation-probe verdict is an explicit clean load. Only
+	 * status=`ok` qualifies — the probe endpoint emits it from
+	 * wp_loaded/admin_init once the candidate loaded via the real
+	 * active_plugins path and the whole bootstrap completed without a
+	 * captured fatal. This is the sole result that downgrades a captured
+	 * fatal: a fatal during the active_plugins-driven load dies in
+	 * wp-settings.php before the endpoint registers its shutdown handler,
+	 * so it can never return as status=`fatal` — it comes back as a 500 /
+	 * `ok-inconclusive` / transport error (null), none of which we trust
+	 * to override a genuine captured fatal.
+	 *
+	 * @param array|null $confirmation Confirmation verdict, or null on transport failure.
+	 * @return bool
+	 */
+	protected function is_clean_confirmation( $confirmation ) {
+		return is_array( $confirmation ) && 'ok' === (string) ( $confirmation['status'] ?? '' );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -107,38 +107,37 @@ class PCG_Load_Tester {
 		$front_result = $this->parse_response( $responses['front'] );
 		$admin_result = $this->parse_response( $responses['admin'] );
 
-		// fatal/throwable wins; an inconclusive `error` from one probe must
-		// not shadow a real fatal from the other. Front-end is the canonical
-		// "site works" signal when neither probe captured a fatal.
-		$verdict = null;
+		// Every surface that captured a fatal. An admin-only fatal still
+		// crashes the site, so both must be confirmed. Front-end is the
+		// canonical verdict when both block.
+		$blocking = array();
 		if ( $this->is_block( $front_result ) ) {
-			$verdict = $front_result;
-		} elseif ( $this->is_block( $admin_result ) ) {
-			$verdict = $admin_result;
+			$blocking['front'] = $front_result;
+		}
+		if ( $this->is_block( $admin_result ) ) {
+			$blocking['admin'] = $admin_result;
 		}
 
-		// Activation-mode captured fatal: re-probe via WP's normal
-		// active-plugin bootstrap to confirm, and downgrade ONLY on an
-		// explicit clean `ok` verdict (see is_clean_confirmation). Any
-		// other confirmation result — transport failure, ok-inconclusive,
-		// ok-shutdown, error — keeps the original captured fatal. A fatal
-		// during the active_plugins-driven load dies in wp-settings.php,
-		// before the probe endpoint registers its shutdown handler, so it
-		// can never come back as status=fatal; it surfaces as a bare 500 /
-		// ok-inconclusive / transport error. Treating that ambiguity as a
-		// pass would downgrade a real fatal, so we trust the genuine fatal
-		// the first probe captured unless the confirmation produces
-		// positive clean evidence. Update mode never confirms — fatals
-		// must block so PCG_Rollback can fire.
-		if ( null !== $verdict ) {
+		if ( ! empty( $blocking ) ) {
+			$verdict = $blocking['front'] ?? $blocking['admin'];
+
+			// Confirm each blocking surface via WP's normal active-plugin
+			// bootstrap; downgrade only when EVERY one comes back an explicit
+			// clean `ok`. Anything else keeps the captured fatal (see
+			// is_clean_confirmation). Update mode never confirms — fatals must
+			// block so PCG_Rollback can fire.
 			if ( self::MODE_ACTIVATION === $mode ) {
-				// Re-probe only the surface that captured. The other surface
-				// already returned a non-fatal response, so re-running it
-				// adds cost without changing the outcome.
-				$surface      = $this->is_block( $front_result ) ? 'front' : 'admin';
-				$confirmation = $this->confirm_via_normal_load( $plugin_mains, $surface );
-				if ( $this->is_clean_confirmation( $confirmation ) ) {
-					return $this->downgrade_after_confirmation( $verdict, $confirmation );
+				$clean_confirmation = null;
+				foreach ( array_keys( $blocking ) as $surface ) {
+					$confirmation = $this->confirm_via_normal_load( $plugin_mains, $surface );
+					if ( ! $this->is_clean_confirmation( $confirmation ) ) {
+						$clean_confirmation = null;
+						break;
+					}
+					$clean_confirmation = $confirmation;
+				}
+				if ( null !== $clean_confirmation ) {
+					return $this->downgrade_after_confirmation( $verdict, $clean_confirmation );
 				}
 			}
 			return $verdict;

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -128,7 +128,11 @@ class PCG_Load_Tester {
 		// confirms — fatals must block so PCG_Rollback can fire.
 		if ( null !== $verdict ) {
 			if ( self::MODE_ACTIVATION === $mode ) {
-				$confirmation = $this->confirm_via_normal_load( $plugin_mains );
+				// Re-probe only the surface that captured. The other surface
+				// already returned a non-fatal response, so re-running it
+				// adds cost without changing the outcome.
+				$surface      = $this->is_block( $front_result ) ? 'front' : 'admin';
+				$confirmation = $this->confirm_via_normal_load( $plugin_mains, $surface );
 				if ( null === $confirmation ) {
 					return $this->downgrade_after_confirmation(
 						$verdict,
@@ -159,23 +163,22 @@ class PCG_Load_Tester {
 	}
 
 	/**
-	 * Fire a confirmation probe pair with `pcg_confirm=1`. Returns null
-	 * on transport failure — the caller keeps the original verdict on
-	 * uncertainty.
+	 * Fire a confirmation probe for a single surface with `pcg_confirm=1`.
+	 * Returns null on transport failure — the caller keeps the original
+	 * verdict on uncertainty.
 	 *
 	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.
-	 * @return array|null Verdict (most-blocking of front/admin), or null on transport failure.
+	 * @param string   $surface      Which surface to re-probe: `front` or `admin`.
+	 * @return array|null Parsed verdict, or null on transport failure.
 	 */
-	protected function confirm_via_normal_load( array $plugin_mains ) {
-		$front = $this->prepare_probe( $plugin_mains, home_url( '/' ), false, self::MODE_ACTIVATION, true );
-		$admin = $this->prepare_probe( $plugin_mains, admin_url( 'index.php' ), true, self::MODE_ACTIVATION, true );
+	protected function confirm_via_normal_load( array $plugin_mains, $surface = 'front' ) {
+		$is_admin = 'admin' === $surface;
+		$base_url = $is_admin ? admin_url( 'index.php' ) : home_url( '/' );
+		$probe    = $this->prepare_probe( $plugin_mains, $base_url, $is_admin, self::MODE_ACTIVATION, true );
 
 		try {
 			$responses = \WpOrg\Requests\Requests::request_multiple(
-				array(
-					'front' => $front['request'],
-					'admin' => $admin['request'],
-				),
+				array( $surface => $probe['request'] ),
 				array(
 					'timeout'   => self::PROBE_TIMEOUT,
 					'redirects' => 5,
@@ -184,19 +187,10 @@ class PCG_Load_Tester {
 		} catch ( \Throwable $t ) {
 			return null;
 		} finally {
-			delete_transient( self::transient_key( $front['token'] ) );
-			delete_transient( self::transient_key( $admin['token'] ) );
+			delete_transient( self::transient_key( $probe['token'] ) );
 		}
 
-		$front_result = $this->parse_response( $responses['front'] );
-		$admin_result = $this->parse_response( $responses['admin'] );
-		if ( $this->is_block( $front_result ) ) {
-			return $front_result;
-		}
-		if ( $this->is_block( $admin_result ) ) {
-			return $admin_result;
-		}
-		return $front_result;
+		return $this->parse_response( $responses[ $surface ] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -121,14 +121,13 @@ class PCG_Load_Tester {
 		// active-plugin bootstrap to confirm. Clean confirmation →
 		// downgrade. Update mode never confirms — fatals must block so
 		// `PCG_Rollback::to_snapshot()` can fire.
-		if ( null !== $verdict && self::MODE_ACTIVATION === $mode ) {
-			$confirmation = $this->confirm_via_normal_load( $plugin_mains );
-			if ( null !== $confirmation && ! $this->is_block( $confirmation ) ) {
-				return $this->downgrade_after_confirmation( $verdict, $confirmation );
-			}
-			return $verdict;
-		}
 		if ( null !== $verdict ) {
+			if ( self::MODE_ACTIVATION === $mode ) {
+				$confirmation = $this->confirm_via_normal_load( $plugin_mains );
+				if ( null !== $confirmation && ! $this->is_block( $confirmation ) ) {
+					return $this->downgrade_after_confirmation( $verdict, $confirmation );
+				}
+			}
 			return $verdict;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-load-tester.php
@@ -339,7 +339,8 @@ class PCG_Load_Tester {
 	 * @internal
 	 * @param string[] $plugin_mains Absolute paths to plugin main PHP files.
 	 * @param string   $mode         Probe mode constant.
-	 * @return array{plugins:string[],mode:string}
+	 * @param bool     $is_confirm   Whether this payload is for a confirmation probe.
+	 * @return array{plugins:string[],mode:string,confirm:bool}
 	 */
 	public static function build_probe_payload( array $plugin_mains, $mode = self::MODE_ACTIVATION, $is_confirm = false ) {
 		return array(
@@ -357,6 +358,7 @@ class PCG_Load_Tester {
 	 * @param string   $base_url     Front-end or admin base URL.
 	 * @param bool     $is_admin     Adds `pcg_admin=1` and forwards auth cookies.
 	 * @param string   $mode         Probe mode constant.
+	 * @param bool     $is_confirm   Adds `pcg_confirm=1` so the early bootstrap injects candidates into active_plugins.
 	 * @return array{token:string,request:array}
 	 */
 	protected function prepare_probe( array $plugin_mains, $base_url, $is_admin, $mode = self::MODE_ACTIVATION, $is_confirm = false ) {
@@ -367,11 +369,11 @@ class PCG_Load_Tester {
 			'pcg_probe' => '1',
 			'token'     => $token,
 		);
+		$headers = array();
+		$options = array();
 		if ( $is_confirm ) {
 			$query['pcg_confirm'] = '1';
 		}
-		$headers = array();
-		$options = array();
 		if ( $is_admin ) {
 			$query['pcg_admin'] = '1';
 			$cookie_header      = $this->collect_auth_cookie_header();

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -21,12 +21,14 @@ function pcg_confirm_maybe_register_hook() {
 		return;
 	}
 
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- only used as a literal flag comparison; no sanitization needed.
-	if ( '1' !== ( $_GET['pcg_probe'] ?? '' ) || '1' !== ( $_GET['pcg_confirm'] ?? '' ) ) {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- token (validated below) is the nonce.
+	$probe_flag   = sanitize_text_field( wp_unslash( $_GET['pcg_probe'] ?? '' ) );
+	$confirm_flag = sanitize_text_field( wp_unslash( $_GET['pcg_confirm'] ?? '' ) );
+	$raw_token    = sanitize_text_field( wp_unslash( $_GET['token'] ?? '' ) );
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	if ( '1' !== $probe_flag || '1' !== $confirm_flag ) {
 		return;
 	}
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- validated via regex on the next line.
-	$raw_token = (string) wp_unslash( $_GET['token'] ?? '' );
 	// Length is locked to what wp_generate_password( 32, false ) emits;
 	// the transient lookup is still the real gate, but anchoring length
 	// here rules out truncation / accidental-collision noise.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -7,8 +7,6 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-require_once __DIR__ . '/class-pcg-load-tester.php';
-
 pcg_confirm_maybe_register_hook();
 
 /**
@@ -23,18 +21,18 @@ function pcg_confirm_maybe_register_hook() {
 		return;
 	}
 
-	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- token is the nonce, validated below.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- only used as a literal flag comparison; no sanitization needed.
 	if ( '1' !== ( $_GET['pcg_probe'] ?? '' ) || '1' !== ( $_GET['pcg_confirm'] ?? '' ) ) {
 		return;
 	}
-	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- validated via regex on the next line.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- validated via regex on the next line.
 	$raw_token = (string) wp_unslash( $_GET['token'] ?? '' );
 	$token     = preg_match( '/^[A-Za-z0-9]+$/', $raw_token ) ? $raw_token : '';
-	// phpcs:enable
 	if ( '' === $token ) {
 		return;
 	}
 
+	require_once __DIR__ . '/class-pcg-load-tester.php';
 	$payload = get_transient( PCG_Load_Tester::transient_key( $token ) );
 	if ( ! is_array( $payload ) || true !== ( $payload['confirm'] ?? false ) ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -1,13 +1,8 @@
 <?php
 /**
- * Early-bootstrap hook for the PCG confirmation probe.
- *
- * Confirmation probes carry `pcg_confirm=1` on the URL. To load the
- * candidates via WP's normal active-plugin flow (rather than the manual
- * require_once in probe-endpoint.php), we hook `pre_option_active_plugins`
- * BEFORE wp-settings.php reads the option. That means this file must be
- * required at mu-plugin load time — too late if it waits for
- * `plugins_loaded`.
+ * Early-bootstrap hook for the PCG confirmation probe. Must load at
+ * mu-plugin time — `pre_option_active_plugins` has to be registered
+ * before wp-settings.php reads `active_plugins`.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -17,10 +12,17 @@ require_once __DIR__ . '/class-pcg-load-tester.php';
 pcg_confirm_maybe_register_hook();
 
 /**
- * Validate the request and, if it's a valid confirmation probe,
- * register the `pre_option_active_plugins` filter to inject candidates.
+ * Validate the request and register the `pre_option_active_plugins`
+ * filter when this is a valid confirmation probe.
  */
 function pcg_confirm_maybe_register_hook() {
+	// Bail if `plugins_loaded` already fired — we're loaded too late for
+	// the active-plugin injection to take effect (dev path where
+	// jetpack-mu-wpcom runs as a regular plugin, not a mu-plugin).
+	if ( did_action( 'plugins_loaded' ) ) {
+		return;
+	}
+
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- token is the nonce, validated below.
 	if ( '1' !== ( $_GET['pcg_probe'] ?? '' ) || '1' !== ( $_GET['pcg_confirm'] ?? '' ) ) {
 		return;
@@ -50,13 +52,8 @@ function pcg_confirm_maybe_register_hook() {
 	add_filter(
 		'pre_option_active_plugins',
 		static function ( $value ) use ( $plugin_mains ) {
-			// `false` means "let WP read the real option." Merge our
-			// candidates onto whatever WP would have returned.
-			$existing = false === $value ? get_option( 'active_plugins', array() ) : (array) $value;
-			$basenames = array();
-			foreach ( $plugin_mains as $main ) {
-				$basenames[] = plugin_basename( (string) $main );
-			}
+			$existing  = false === $value ? get_option( 'active_plugins', array() ) : (array) $value;
+			$basenames = array_map( 'plugin_basename', $plugin_mains );
 			return array_values( array_unique( array_merge( $existing, $basenames ) ) );
 		}
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -21,43 +21,87 @@ function pcg_confirm_maybe_register_hook() {
 		return;
 	}
 
-	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- token (validated below) is the nonce.
-	$probe_flag   = sanitize_text_field( wp_unslash( $_GET['pcg_probe'] ?? '' ) );
-	$confirm_flag = sanitize_text_field( wp_unslash( $_GET['pcg_confirm'] ?? '' ) );
-	$raw_token    = sanitize_text_field( wp_unslash( $_GET['token'] ?? '' ) );
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- token (validated by `pcg_confirm_validate_request`) is the nonce.
+	$plugin_mains = pcg_confirm_validate_request( $_GET );
 	// phpcs:enable WordPress.Security.NonceVerification.Recommended
-	if ( '1' !== $probe_flag || '1' !== $confirm_flag ) {
-		return;
-	}
-	// Length is locked to what wp_generate_password( 32, false ) emits;
-	// the transient lookup is still the real gate, but anchoring length
-	// here rules out truncation / accidental-collision noise.
-	$token = preg_match( '/^[A-Za-z0-9]{32}$/', $raw_token ) ? $raw_token : '';
-	if ( '' === $token ) {
-		return;
-	}
-
-	require_once __DIR__ . '/class-pcg-load-tester.php';
-	$payload = get_transient( PCG_Load_Tester::transient_key( $token ) );
-	if ( ! is_array( $payload ) || true !== ( $payload['confirm'] ?? false ) ) {
-		return;
-	}
-	$plugin_mains = is_array( $payload['plugins'] ?? null ) ? array_values(
-		array_filter(
-			array_map( static fn( $p ) => (string) $p, $payload['plugins'] ),
-			static fn( $p ) => '' !== $p
-		)
-	) : array();
 	if ( empty( $plugin_mains ) ) {
 		return;
 	}
 
 	// Only single-site active_plugins is hooked; pre_option_active_sitewide_plugins
 	// would need the same treatment if PCG ever guards network activations.
-	add_filter(
-		'pre_option_active_plugins',
-		static fn( $value ) => pcg_confirm_inject_active_plugins( $value, $plugin_mains )
-	);
+	pcg_confirm_plugin_mains( $plugin_mains );
+	add_filter( 'pre_option_active_plugins', 'pcg_confirm_filter_active_plugins' );
+}
+
+/**
+ * Pure validation: returns the plugin-main list iff $request is a valid
+ * confirmation probe (correct flags, well-formed token, matching
+ * transient with `confirm === true`, non-empty plugins). Empty array
+ * otherwise. Extracted from the entry hook for unit testability.
+ *
+ * @internal
+ * @param array $request Request array (typically `$_GET`).
+ * @return string[] Plugin main absolute paths, or empty on any failure.
+ */
+function pcg_confirm_validate_request( array $request ) {
+	$probe_flag   = sanitize_text_field( wp_unslash( $request['pcg_probe'] ?? '' ) );
+	$confirm_flag = sanitize_text_field( wp_unslash( $request['pcg_confirm'] ?? '' ) );
+	$raw_token    = sanitize_text_field( wp_unslash( $request['token'] ?? '' ) );
+	if ( '1' !== $probe_flag || '1' !== $confirm_flag ) {
+		return array();
+	}
+	// Length is locked to what wp_generate_password( 32, false ) emits;
+	// the transient lookup is still the real gate, but anchoring length
+	// here rules out truncation / accidental-collision noise.
+	$token = preg_match( '/^[A-Za-z0-9]{32}$/', $raw_token ) ? $raw_token : '';
+	if ( '' === $token ) {
+		return array();
+	}
+
+	require_once __DIR__ . '/class-pcg-load-tester.php';
+	$payload = get_transient( PCG_Load_Tester::transient_key( $token ) );
+	// During a mixed-version deploy a pre-deploy transient may lack the
+	// `confirm` key; strict `true ===` keeps that case on the safe side
+	// (no injection — the probe endpoint will manually require as before).
+	if ( ! is_array( $payload ) || true !== ( $payload['confirm'] ?? false ) ) {
+		return array();
+	}
+	return is_array( $payload['plugins'] ?? null ) ? array_values(
+		array_filter(
+			array_map( static fn( $p ) => (string) $p, $payload['plugins'] ),
+			static fn( $p ) => '' !== $p
+		)
+	) : array();
+}
+
+/**
+ * Stash for the plugin-mains list the active_plugins filter needs.
+ * Using a named function + static container (instead of an anonymous
+ * closure) keeps the filter callback removable via `remove_filter`.
+ *
+ * @internal
+ * @param array|null $set Optional — replace the stashed list.
+ * @return string[]
+ */
+function pcg_confirm_plugin_mains( ?array $set = null ) {
+	static $mains = array();
+	if ( is_array( $set ) ) {
+		$mains = $set;
+	}
+	return $mains;
+}
+
+/**
+ * Named filter callback for `pre_option_active_plugins`. Delegates to
+ * `pcg_confirm_inject_active_plugins` with the stashed candidate list.
+ *
+ * @internal
+ * @param mixed $value Existing filter value.
+ * @return string[]
+ */
+function pcg_confirm_filter_active_plugins( $value ) {
+	return pcg_confirm_inject_active_plugins( $value, pcg_confirm_plugin_mains() );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Early-bootstrap hook for the PCG confirmation probe.
+ *
+ * Confirmation probes carry `pcg_confirm=1` on the URL. To load the
+ * candidates via WP's normal active-plugin flow (rather than the manual
+ * require_once in probe-endpoint.php), we hook `pre_option_active_plugins`
+ * BEFORE wp-settings.php reads the option. That means this file must be
+ * required at mu-plugin load time — too late if it waits for
+ * `plugins_loaded`.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+require_once __DIR__ . '/class-pcg-load-tester.php';
+
+pcg_confirm_maybe_register_hook();
+
+/**
+ * Validate the request and, if it's a valid confirmation probe,
+ * register the `pre_option_active_plugins` filter to inject candidates.
+ */
+function pcg_confirm_maybe_register_hook() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- token is the nonce, validated below.
+	if ( '1' !== ( $_GET['pcg_probe'] ?? '' ) || '1' !== ( $_GET['pcg_confirm'] ?? '' ) ) {
+		return;
+	}
+	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- validated via regex on the next line.
+	$raw_token = (string) wp_unslash( $_GET['token'] ?? '' );
+	$token     = preg_match( '/^[A-Za-z0-9]+$/', $raw_token ) ? $raw_token : '';
+	// phpcs:enable
+	if ( '' === $token ) {
+		return;
+	}
+
+	$payload = get_transient( PCG_Load_Tester::transient_key( $token ) );
+	if ( ! is_array( $payload ) || true !== ( $payload['confirm'] ?? false ) ) {
+		return;
+	}
+	$plugin_mains = is_array( $payload['plugins'] ?? null ) ? array_values(
+		array_filter(
+			array_map( static fn( $p ) => (string) $p, $payload['plugins'] ),
+			static fn( $p ) => '' !== $p
+		)
+	) : array();
+	if ( empty( $plugin_mains ) ) {
+		return;
+	}
+
+	add_filter(
+		'pre_option_active_plugins',
+		static function ( $value ) use ( $plugin_mains ) {
+			// `false` means "let WP read the real option." Merge our
+			// candidates onto whatever WP would have returned.
+			$existing = false === $value ? get_option( 'active_plugins', array() ) : (array) $value;
+			$basenames = array();
+			foreach ( $plugin_mains as $main ) {
+				$basenames[] = plugin_basename( (string) $main );
+			}
+			return array_values( array_unique( array_merge( $existing, $basenames ) ) );
+		}
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -27,7 +27,10 @@ function pcg_confirm_maybe_register_hook() {
 	}
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- validated via regex on the next line.
 	$raw_token = (string) wp_unslash( $_GET['token'] ?? '' );
-	$token     = preg_match( '/^[A-Za-z0-9]+$/', $raw_token ) ? $raw_token : '';
+	// Length is locked to what wp_generate_password( 32, false ) emits;
+	// the transient lookup is still the real gate, but anchoring length
+	// here rules out truncation / accidental-collision noise.
+	$token = preg_match( '/^[A-Za-z0-9]{32}$/', $raw_token ) ? $raw_token : '';
 	if ( '' === $token ) {
 		return;
 	}
@@ -47,12 +50,33 @@ function pcg_confirm_maybe_register_hook() {
 		return;
 	}
 
+	// Only single-site active_plugins is hooked; pre_option_active_sitewide_plugins
+	// would need the same treatment if PCG ever guards network activations.
 	add_filter(
 		'pre_option_active_plugins',
-		static function ( $value ) use ( $plugin_mains ) {
-			$existing  = false === $value ? get_option( 'active_plugins', array() ) : (array) $value;
-			$basenames = array_map( 'plugin_basename', $plugin_mains );
-			return array_values( array_unique( array_merge( $existing, $basenames ) ) );
-		}
+		static fn( $value ) => pcg_confirm_inject_active_plugins( $value, $plugin_mains )
 	);
+}
+
+/**
+ * Merge confirmation-probe candidates into the `active_plugins` option
+ * value. When $value is false, read the cached option without going
+ * through `get_option()` — `get_option()` re-fires the same
+ * `pre_option_active_plugins` filter, which would recurse forever.
+ *
+ * @internal Exposed for unit tests.
+ * @param mixed    $value         Existing filter value (false = "let WP read the option").
+ * @param string[] $plugin_mains  Absolute paths to candidate plugin main files.
+ * @return string[] Merged active_plugins list of basenames.
+ */
+function pcg_confirm_inject_active_plugins( $value, array $plugin_mains ) {
+	if ( false === $value ) {
+		$alloptions = wp_load_alloptions();
+		$raw        = $alloptions['active_plugins'] ?? array();
+		$existing   = is_array( $raw ) ? $raw : (array) maybe_unserialize( $raw );
+	} else {
+		$existing = (array) $value;
+	}
+	$basenames = array_map( 'plugin_basename', $plugin_mains );
+	return array_values( array_unique( array_merge( $existing, $basenames ) ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php
@@ -30,8 +30,10 @@ function pcg_confirm_maybe_register_hook() {
 
 	// Only single-site active_plugins is hooked; pre_option_active_sitewide_plugins
 	// would need the same treatment if PCG ever guards network activations.
-	pcg_confirm_plugin_mains( $plugin_mains );
-	add_filter( 'pre_option_active_plugins', 'pcg_confirm_filter_active_plugins' );
+	add_filter(
+		'pre_option_active_plugins',
+		static fn( $value ) => pcg_confirm_inject_active_plugins( $value, $plugin_mains )
+	);
 }
 
 /**
@@ -73,35 +75,6 @@ function pcg_confirm_validate_request( array $request ) {
 			static fn( $p ) => '' !== $p
 		)
 	) : array();
-}
-
-/**
- * Stash for the plugin-mains list the active_plugins filter needs.
- * Using a named function + static container (instead of an anonymous
- * closure) keeps the filter callback removable via `remove_filter`.
- *
- * @internal
- * @param array|null $set Optional — replace the stashed list.
- * @return string[]
- */
-function pcg_confirm_plugin_mains( ?array $set = null ) {
-	static $mains = array();
-	if ( is_array( $set ) ) {
-		$mains = $set;
-	}
-	return $mains;
-}
-
-/**
- * Named filter callback for `pre_option_active_plugins`. Delegates to
- * `pcg_confirm_inject_active_plugins` with the stashed candidate list.
- *
- * @internal
- * @param mixed $value Existing filter value.
- * @return string[]
- */
-function pcg_confirm_filter_active_plugins( $value ) {
-	return pcg_confirm_inject_active_plugins( $value, pcg_confirm_plugin_mains() );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
@@ -105,7 +105,14 @@ function pcg_maybe_handle_probe() {
 	// Activation: load each plugin to exercise its load path. Update: skip;
 	// re-requiring an already-loaded plugin would fatal with
 	// "Cannot redeclare". The shutdown handler catches either way.
-	if ( PCG_Load_Tester::MODE_ACTIVATION === $mode ) {
+	//
+	// Confirmation probes also skip the manual require: the
+	// `probe-confirm-bootstrap.php` early hook injected the candidates
+	// into `active_plugins`, so wp-settings.php has already loaded them
+	// via WP's normal flow — at real-activation timing. We just observe
+	// whether wp_loaded/admin_init fires cleanly.
+	$is_confirm = true === ( $payload['confirm'] ?? false );
+	if ( PCG_Load_Tester::MODE_ACTIVATION === $mode && ! $is_confirm ) {
 		foreach ( $plugin_mains as $plugin_main ) {
 			try {
 				require_once $plugin_main;

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/probe-endpoint.php
@@ -102,15 +102,10 @@ function pcg_maybe_handle_probe() {
 
 	register_shutdown_function( 'pcg_probe_shutdown' );
 
-	// Activation: load each plugin to exercise its load path. Update: skip;
-	// re-requiring an already-loaded plugin would fatal with
-	// "Cannot redeclare". The shutdown handler catches either way.
-	//
-	// Confirmation probes also skip the manual require: the
-	// `probe-confirm-bootstrap.php` early hook injected the candidates
-	// into `active_plugins`, so wp-settings.php has already loaded them
-	// via WP's normal flow — at real-activation timing. We just observe
-	// whether wp_loaded/admin_init fires cleanly.
+	// Activation: load each candidate. Update: skip (already loaded by
+	// WP's bootstrap; re-requiring would fatal). Confirmation probes
+	// also skip — the early hook injected them into active_plugins so
+	// wp-settings.php loaded them at real-activation timing.
 	$is_confirm = true === ( $payload['confirm'] ?? false );
 	if ( PCG_Load_Tester::MODE_ACTIVATION === $mode && ! $is_confirm ) {
 		foreach ( $plugin_mains as $plugin_main ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -18,6 +18,7 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian
 // isn't set. Loading the file in tests is safe and gives us access to
 // helpers like `pcg_probe_already_emitted()` for unit testing.
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/probe-endpoint.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/activation-guard.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/update-guard.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/class-pcg-snapshot.php';
@@ -325,6 +326,66 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertSame( 'ok-inconclusive', $out['status'] );
 		$this->assertArrayNotHasKey( 'plugin', $out );
+	}
+
+	/**
+	 * When the `pre_option_active_plugins` filter passes `false` (meaning
+	 * "let WP read the option"), the injector must read the alloptions
+	 * cache directly instead of calling `get_option` — otherwise it
+	 * would re-enter the same filter and recurse forever.
+	 */
+	public function test_confirm_inject_active_plugins_merges_without_recursion() {
+		// Seed the alloptions cache so wp_load_alloptions() returns the
+		// existing active-plugin list.
+		update_option( 'active_plugins', array( 'akismet/akismet.php' ) );
+		wp_cache_delete( 'alloptions', 'options' );
+
+		$plugin_mains = array( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' );
+
+		// Counter to detect recursion: every time the filter fires, bump.
+		// If the injector calls get_option, the filter re-fires.
+		$fire_count = 0;
+		$counter    = static function ( $value ) use ( &$fire_count ) {
+			++$fire_count;
+			return $value;
+		};
+		add_filter( 'pre_option_active_plugins', $counter, 1 );
+
+		$merged = pcg_confirm_inject_active_plugins( false, $plugin_mains );
+
+		remove_filter( 'pre_option_active_plugins', $counter, 1 );
+		delete_option( 'active_plugins' );
+
+		$this->assertContains( 'akismet/akismet.php', $merged );
+		$this->assertContains( 'woocommerce/woocommerce.php', $merged );
+		// Injector itself must not have re-fired the filter while
+		// resolving existing active plugins.
+		$this->assertSame( 0, $fire_count, 'pcg_confirm_inject_active_plugins must not call get_option on active_plugins' );
+	}
+
+	/**
+	 * When the filter already has a list (someone hooked at higher
+	 * priority), the injector merges onto that list rather than the DB
+	 * value, so other filters compose cleanly.
+	 */
+	public function test_confirm_inject_active_plugins_respects_filtered_value() {
+		$merged = pcg_confirm_inject_active_plugins(
+			array( 'a/a.php', 'b/b.php' ),
+			array( WP_PLUGIN_DIR . '/c/c.php' )
+		);
+		$this->assertSame( array( 'a/a.php', 'b/b.php', 'c/c.php' ), $merged );
+	}
+
+	/**
+	 * Duplicate basenames (a candidate already in active_plugins) appear
+	 * only once in the merged list.
+	 */
+	public function test_confirm_inject_active_plugins_dedupes_candidates() {
+		$merged = pcg_confirm_inject_active_plugins(
+			array( 'foo/foo.php' ),
+			array( WP_PLUGIN_DIR . '/foo/foo.php' )
+		);
+		$this->assertSame( array( 'foo/foo.php' ), $merged );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -389,6 +389,142 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Scenarios for `pcg_confirm_validate_request` bail paths.
+	 *
+	 * @return array<string,array{0:array<string,string>}>
+	 */
+	public static function provide_confirm_validate_bail_requests(): array {
+		$valid_token = str_repeat( 'a', 32 );
+		return array(
+			'empty request'         => array( array() ),
+			'pcg_probe missing'     => array(
+				array(
+					'pcg_confirm' => '1',
+					'token'       => $valid_token,
+				),
+			),
+			'pcg_confirm missing'   => array(
+				array(
+					'pcg_probe' => '1',
+					'token'     => $valid_token,
+				),
+			),
+			'pcg_probe wrong value' => array(
+				array(
+					'pcg_probe'   => '0',
+					'pcg_confirm' => '1',
+					'token'       => $valid_token,
+				),
+			),
+			'token wrong length'    => array(
+				array(
+					'pcg_probe'   => '1',
+					'pcg_confirm' => '1',
+					'token'       => 'short',
+				),
+			),
+			'token disallowed char' => array(
+				array(
+					'pcg_probe'   => '1',
+					'pcg_confirm' => '1',
+					'token'       => str_repeat( 'a', 31 ) . '!',
+				),
+			),
+			'token missing'         => array(
+				array(
+					'pcg_probe'   => '1',
+					'pcg_confirm' => '1',
+				),
+			),
+		);
+	}
+
+	/**
+	 * `pcg_confirm_validate_request` returns an empty array — and therefore
+	 * `pcg_confirm_maybe_register_hook` would not register the filter — for
+	 * malformed requests: missing flags, wrong values, or tokens that don't
+	 * match the `wp_generate_password( 32, false )` shape.
+	 *
+	 * @param array $request Faux $_GET payload.
+	 * @dataProvider provide_confirm_validate_bail_requests
+	 */
+	#[DataProvider( 'provide_confirm_validate_bail_requests' )]
+	public function test_confirm_validate_request_bails_on_malformed_input( array $request ) {
+		$this->assertSame( array(), pcg_confirm_validate_request( $request ) );
+	}
+
+	/**
+	 * Even with valid flags and a well-formed token, missing transient
+	 * (token never set, or expired) keeps the validator on the bail path.
+	 */
+	public function test_confirm_validate_request_bails_when_transient_missing() {
+		$this->assertSame(
+			array(),
+			pcg_confirm_validate_request(
+				array(
+					'pcg_probe'   => '1',
+					'pcg_confirm' => '1',
+					'token'       => str_repeat( 'a', 32 ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * A transient written by a pre-confirmation-feature deploy (no
+	 * `confirm` key, or `confirm => false`) must bail — strict `true ===`
+	 * keeps mixed-version deploys on the safe side, so the probe endpoint
+	 * still manually requires the candidate as before.
+	 */
+	public function test_confirm_validate_request_bails_when_payload_confirm_flag_unset() {
+		$token = str_repeat( 'b', 32 );
+		set_transient(
+			PCG_Load_Tester::transient_key( $token ),
+			array(
+				'plugins' => array( '/abs/foo/foo.php' ),
+				'mode'    => 'activation',
+			),
+			60
+		);
+		$out = pcg_confirm_validate_request(
+			array(
+				'pcg_probe'   => '1',
+				'pcg_confirm' => '1',
+				'token'       => $token,
+			)
+		);
+		delete_transient( PCG_Load_Tester::transient_key( $token ) );
+		$this->assertSame( array(), $out );
+	}
+
+	/**
+	 * Happy path: flags + format + matching transient with `confirm =>
+	 * true` returns the candidate list ready for the
+	 * `pre_option_active_plugins` injection.
+	 */
+	public function test_confirm_validate_request_returns_plugins_on_valid_payload() {
+		$token = str_repeat( 'c', 32 );
+		set_transient(
+			PCG_Load_Tester::transient_key( $token ),
+			PCG_Load_Tester::build_probe_payload(
+				array( '/abs/foo/foo.php', '/abs/bar/bar.php' ),
+				PCG_Load_Tester::MODE_ACTIVATION,
+				true
+			),
+			60
+		);
+		$out = pcg_confirm_validate_request(
+			array(
+				'pcg_probe'   => '1',
+				'pcg_confirm' => '1',
+				'token'       => $token,
+			)
+		);
+		delete_transient( PCG_Load_Tester::transient_key( $token ) );
+		$this->assertSame( array( '/abs/foo/foo.php', '/abs/bar/bar.php' ), $out );
+	}
+
+	/**
 	 * Unknown mode strings fall back to activation rather than poisoning
 	 * the transient with a value the endpoint will reject.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -239,6 +239,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 			array(
 				'plugins' => array( '/abs/foo/foo.php' ),
 				'mode'    => 'activation',
+				'confirm' => false,
 			),
 			$default
 		);
@@ -248,9 +249,19 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 			array(
 				'plugins' => array( '/abs/foo/foo.php', '/abs/bar/bar.php' ),
 				'mode'    => 'update',
+				'confirm' => false,
 			),
 			$update
 		);
+	}
+
+	/**
+	 * `build_probe_payload` carries the `confirm` flag so the early
+	 * bootstrap and probe endpoint can branch on confirmation-mode.
+	 */
+	public function test_build_probe_payload_carries_confirm_flag() {
+		$payload = PCG_Load_Tester::build_probe_payload( array( '/abs/foo/foo.php' ), PCG_Load_Tester::MODE_ACTIVATION, true );
+		$this->assertTrue( $payload['confirm'] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -265,6 +265,69 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * `prepare_probe` adds `pcg_confirm=1` to the loopback URL when
+	 * `$is_confirm` is true, so the early-bootstrap hook and the probe
+	 * endpoint can both detect the confirmation path.
+	 */
+	public function test_prepare_probe_includes_pcg_confirm_query_when_confirming() {
+		$tester = new PCG_Load_Tester();
+		$ref    = new \ReflectionMethod( PCG_Load_Tester::class, 'prepare_probe' );
+		$probe  = $ref->invoke( $tester, array( '/abs/foo/foo.php' ), 'https://example.test/', false, PCG_Load_Tester::MODE_ACTIVATION, true );
+
+		$this->assertStringContainsString( 'pcg_confirm=1', (string) $probe['request']['url'] );
+		$this->assertStringContainsString( 'pcg_probe=1', (string) $probe['request']['url'] );
+
+		// Non-confirm probes must NOT carry the flag — that would route
+		// the request through the early-bootstrap injection path
+		// inadvertently.
+		$normal = $ref->invoke( $tester, array( '/abs/foo/foo.php' ), 'https://example.test/', false );
+		$this->assertStringNotContainsString( 'pcg_confirm', (string) $normal['request']['url'] );
+	}
+
+	/**
+	 * `downgrade_after_confirmation` rewrites the captured-fatal verdict
+	 * as `ok-inconclusive` while preserving the original `plugin`,
+	 * `message`, and `file` so logstash can still attribute the
+	 * downgrade to a specific candidate.
+	 */
+	public function test_downgrade_after_confirmation_preserves_attribution() {
+		$tester  = new PCG_Load_Tester();
+		$ref     = new \ReflectionMethod( PCG_Load_Tester::class, 'downgrade_after_confirmation' );
+		$verdict = array(
+			'status'  => 'fatal',
+			'plugin'  => '/abs/foo/foo.php',
+			'message' => 'Class "Foo\\Bar" not found',
+			'file'    => '/abs/foo/inc/missing.php',
+		);
+		$out = $ref->invoke( $tester, $verdict, array( 'status' => 'ok' ) );
+
+		$this->assertSame( 'ok-inconclusive', $out['status'] );
+		$this->assertSame( '/abs/foo/foo.php', $out['plugin'] );
+		$this->assertSame( 'Class "Foo\\Bar" not found', $out['message'] );
+		$this->assertSame( '/abs/foo/inc/missing.php', $out['file'] );
+		$this->assertNotEmpty( $out['reason'] );
+	}
+
+	/**
+	 * Downgrade omits the `plugin` key when the original verdict didn't
+	 * carry one (e.g. shutdown-classify fatal without explicit
+	 * attribution).
+	 */
+	public function test_downgrade_after_confirmation_omits_plugin_when_unset() {
+		$tester  = new PCG_Load_Tester();
+		$ref     = new \ReflectionMethod( PCG_Load_Tester::class, 'downgrade_after_confirmation' );
+		$verdict = array(
+			'status'  => 'fatal',
+			'message' => 'engine death',
+			'file'    => '/abs/foo/foo.php',
+		);
+		$out = $ref->invoke( $tester, $verdict, array( 'status' => 'ok' ) );
+
+		$this->assertSame( 'ok-inconclusive', $out['status'] );
+		$this->assertArrayNotHasKey( 'plugin', $out );
+	}
+
+	/**
 	 * Unknown mode strings fall back to activation rather than poisoning
 	 * the transient with a value the endpoint will reject.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -299,7 +299,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 			'message' => 'Class "Foo\\Bar" not found',
 			'file'    => '/abs/foo/inc/missing.php',
 		);
-		$out = $ref->invoke( $tester, $verdict, array( 'status' => 'ok' ) );
+		$out     = $ref->invoke( $tester, $verdict, array( 'status' => 'ok' ) );
 
 		$this->assertSame( 'ok-inconclusive', $out['status'] );
 		$this->assertSame( '/abs/foo/foo.php', $out['plugin'] );
@@ -321,7 +321,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 			'message' => 'engine death',
 			'file'    => '/abs/foo/foo.php',
 		);
-		$out = $ref->invoke( $tester, $verdict, array( 'status' => 'ok' ) );
+		$out     = $ref->invoke( $tester, $verdict, array( 'status' => 'ok' ) );
 
 		$this->assertSame( 'ok-inconclusive', $out['status'] );
 		$this->assertArrayNotHasKey( 'plugin', $out );


### PR DESCRIPTION
## Summary

Replaces the string-matching sibling-load heuristic (scoped out of the closed #49158) with a structural confirmation-probe mechanism. When the first probe captures a fatal in activation mode, fire a second probe with the candidate injected into `active_plugins` via `pre_option_active_plugins` — so WP's normal `wp-settings.php` bootstrap loads it at real-activation timing rather than via the probe endpoint's manual `require_once`.

- **Clean confirmation** → downgrade to `ok-inconclusive`; log `Probe fatal downgraded after confirmation`.
- **Confirmation also fatals** → keep the original verdict; block.
- **Confirmation transport error** → downgrade as well — uncertainty in activation mode defaults to allow, since keeping the block would re-introduce the false-positive class. CLI activation remains the recovery path.

Update mode never confirms — the candidate is already loaded by WP's normal bootstrap before the probe fires, and an update fatal MUST block so `PCG_Rollback::to_snapshot()` can fire.

## Why this design

The previous attempt (#49158) downgraded based on PHP error-message wording (`Failed opening required`, `Class \"X\" not found`). If PHP ever rewords those, we'd regress to over-blocking — exactly the false-positive class this work was meant to remove.

The confirmation probe asks the *underlying behavioural question* directly: \"if WP loaded this plugin via its real bootstrap, would it still fatal?\" If no, the first capture was a loading-order artifact and we allow. If yes, it's a real bug and we block.

## What changed

- **`probe-confirm-bootstrap.php`** (new) — required from `Jetpack_Mu_Wpcom::init()` at mu-plugin load time (before `wp-settings.php` reads `active_plugins`). Validates `pcg_probe=1&pcg_confirm=1&token=…`, reads the transient, and hooks `pre_option_active_plugins` to merge in the candidates as `plugin_basename(...)` entries.
- **`class-jetpack-mu-wpcom.php`** — one new `require_once` line.
- **`probe-endpoint.php`** — skips the manual `require_once` loop when payload carries `confirm = true`.
- **`class-pcg-load-tester.php`** — `build_probe_payload` and `prepare_probe` thread an `\$is_confirm` flag; new `confirm_via_normal_load()` fires the second probe pair; `downgrade_after_confirmation()` builds the downgraded verdict and logs the event.

## Testing instructions

1. `cd projects/packages/jetpack-mu-wpcom && composer phpunit -- --filter build_probe_payload` — confirms the `confirm` flag round-trips through the payload.
2. Manual smoke (activation only): on a probe-eligible site, install a plugin whose entry file fatals **at probe timing but works on real activation** (e.g. references a constant only defined by another plugin's `init` callback). The first probe captures a fatal; the confirmation probe should come back clean; the activation should proceed and Logstash should record `Probe fatal downgraded after confirmation`.
3. Repeat with a plugin that genuinely fatals (broken `require` of a non-existent file). The first probe captures; the confirmation also captures; the activation should be blocked as before.

## Does this pull request change what data or activity we track or use?

Adds a new Logstash event `Probe fatal downgraded after confirmation` on the existing `atomic_pcg` feature bucket. Payload shape mirrors other PCG events (mode, plugin basename, captured-fatal context); no new user data. The transient payload schema gains a `confirm: bool` field.

## Open follow-ups

- Defensive guard for dev/test path: when jetpack-mu-wpcom loads as a regular plugin (not mu-plugin), `Jetpack_Mu_Wpcom::init()` runs too late for `pre_option_active_plugins` to fire. Considering a `did_action('plugins_loaded')` bail in `probe-confirm-bootstrap.php` to make this explicit.
- Additional unit tests for `downgrade_after_confirmation` verdict shape and `prepare_probe` URL output with `pcg_confirm=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

