### PR TITLE
Search Blocks: track sidebar left-border to currentColor hairline across templates (SEARCH-268)

### DIFF
--- a/projects/packages/search/changelog/echo-search-268-sidebar-border-hairline
+++ b/projects/packages/search/changelog/echo-search-268-sidebar-border-hairline
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search Blocks: sidebar left divider now tracks the theme's text color (a soft currentColor hairline) instead of a hardcoded grey, matching the search-input underline and the existing overlay treatment across all three templates.
+Search Blocks: sidebar left divider and search-input underline now both render as a 15%-currentColor hairline (matching the overlay header hairline) instead of a hardcoded grey or a full-strength currentColor rule, so the three "hair" surfaces read as one family across the embedded, WC product-results, and blocks-overlay experiences.

--- a/projects/packages/search/changelog/echo-search-268-sidebar-border-hairline
+++ b/projects/packages/search/changelog/echo-search-268-sidebar-border-hairline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: sidebar left divider now tracks the theme's text color (a soft currentColor hairline) instead of a hardcoded grey, matching the search-input underline and the existing overlay treatment across all three templates.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -7,13 +7,22 @@
 
 .wp-block-jetpack-search-search-input {
 
+	// Bottom hairline tracks the same 15%-currentColor mix used by the sidebar
+	// left-divider and the overlay header hairline, so all three surfaces read
+	// as one family across experiences. `transparent` is the fallback on UAs
+	// without color-mix support — divider disappears rather than reverting to
+	// a hard full-strength rule.
 	.jetpack-search-input__inside-wrapper {
 		position: relative;
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
 		padding: 0.5rem 0;
-		border-bottom: 1px solid currentColor;
+		border-bottom: 1px solid transparent;
+
+		@supports (border-color: color-mix(in sRGB, black 50%, white)) {
+			border-bottom-color: color-mix(in sRGB, currentColor 15%, transparent);
+		}
 	}
 
 	.jetpack-search-input__icon {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1263,19 +1263,6 @@ class Search_Blocks {
 .jetpack-search-block-overlay__content > .wp-block-group:first-child {
 	padding: .5em 2em 2em;
 }
-/* Sidebar left divider tracks `currentColor` so the hairline stays subtle on
- * light themes and visible on dark themes. We only set color; the column
- * block's inline `border-left-width` does the rest. Scoped under the overlay
- * container so the divider remains overlay-only — the embedded / WC-product
- * page templates set their own border-left-color inline on the column. */
-.jetpack-search-block-overlay .jetpack-search-layout__filters-column {
-	border-left-color: transparent;
-}
-@supports (border-color: color-mix(in sRGB, black 50%, white)) {
-	.jetpack-search-block-overlay .jetpack-search-layout__filters-column {
-		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
-	}
-}
 @media (max-width: 781px) {
 	.jetpack-search-block-overlay {
 		padding: 0;
@@ -1408,6 +1395,20 @@ CSS;
 @media (min-width: 992px) {
 	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
 		display: none;
+	}
+}
+/* Sidebar left divider tracks `currentColor` so the hairline stays subtle on
+ * light themes and visible on dark themes, matching the search-input
+ * underline. We only set color; each template's column block sets
+ * `border-left-width: 1px` inline. Fallback to `transparent` so themes/UAs
+ * without `color-mix` support get an invisible divider rather than a hard
+ * grey rule. */
+.jetpack-search-layout__filters-column {
+	border-left-color: transparent;
+}
+@supports (border-color: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-layout__filters-column {
+		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
 CSS;

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -42,8 +42,8 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"260px","fontSize":"small","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column has-small-font-size jetpack-search-layout__filters-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:column {"width":"260px","fontSize":"small","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column has-small-font-size jetpack-search-layout__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -39,8 +39,8 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"260px","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column jetpack-search-layout__filters-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:column {"width":"260px","className":"jetpack-search-layout__filters-column","style":{"border":{"left":{"width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column jetpack-search-layout__filters-column" style="border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
 <h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->


### PR DESCRIPTION
Fixes [SEARCH-268](https://linear.app/a8c/issue/SEARCH-268/search-blocks-track-sidebar-left-border-color-to-currentcolor-hairline)

## Why

Two Search Blocks "hair" surfaces visibly disagreed with the overlay's hairline treatment across themes:

1. **Sidebar left divider** — hardcoded `#e0e0e0` on the embedded and WooCommerce product-results page templates, so on dark themes it showed as a near-white rule against a dark surface.
2. **Search-input bottom underline** — full-strength `1px solid currentColor`, which stayed strong on every theme while the sidebar (post-fix) and the overlay header hairline (`color-mix(ink 15%, surface)`, SEARCH-260) both faded to a 15% mix.

After this PR, all three surfaces — sidebar left divider, search-input bottom underline, and overlay header hairline — render as the same `color-mix(in sRGB, currentColor 15%, transparent)` hairline (with `transparent` fallback for UAs without `color-mix` support), so they read as one family across the embedded, WC product-results, and blocks-overlay experiences.

## Proposed changes

* Drop the hardcoded `border-left-color:#e0e0e0` from `jetpack-search.html` and `jetpack-search-product-results.html`; the column block keeps `border-left-width:1px`.
* Move the existing sidebar hairline CSS (`color-mix(in sRGB, currentColor 15%, transparent)`, with `transparent` fallback) out of `Search_Blocks::block_template_overlay_inline_css()` and into the shared `Search_Blocks::search_layout_inline_css()`, unscoped from `.jetpack-search-block-overlay` so all three templates pick it up.
* Replace the search-input's `border-bottom: 1px solid currentColor` with the same 15% mix on `.jetpack-search-input__inside-wrapper`, so the underline matches the sidebar/overlay hairline. The overlay's existing `border-bottom: 0` override on the in-card search-input still wins (extra `.jetpack-search-block-overlay__card` ancestor) — the overlay's `::before` header hairline keeps owning the modal's header rule.

## Screenshots

### Dark theme — before vs after (most visible)

Both hairlines (search-input underline + sidebar left divider) used to read as bright rules against a dark surface; now they both fade to the same 15% hairline.

| Before (sidebar `#e0e0e0`, search-input full currentColor) | After (both 15% currentColor hairline) |
|---|---|
| ![before](https://github.com/user-attachments/assets/0c654355-bd3b-4930-b63d-7f7fd087bc35) | ![after](https://github.com/user-attachments/assets/114b055f-becf-48b1-bcbe-a8125f08c101) |

### Light theme (Twenty Twenty-Five) — embedded `jetpack-search.html`

The search-input underline now reads as a soft hairline matching the sidebar.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/2e68a5df-d8d7-43d3-a6bb-ea53405f0e06) | ![after](https://github.com/user-attachments/assets/eb8032a0-e71d-4e80-a267-299af829bb39) |

### Light theme — WooCommerce product results `jetpack-search-product-results.html`

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/fcb029ec-677f-45b0-8641-01d99db27014) | ![after](https://github.com/user-attachments/assets/8b624952-728b-4fe5-a362-2b431eff8c1c) |

## Related product discussion/links

* [SEARCH-268](https://linear.app/a8c/issue/SEARCH-268/search-blocks-track-sidebar-left-border-color-to-currentcolor-hairline)
* Builds on [SEARCH-260](https://linear.app/a8c/issue/SEARCH-260) (overlay header hairline) and its follow-up #49184, which established the same `color-mix(currentColor 15%, transparent)` hairline pattern for the overlay.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Spin up a site with Jetpack Search active and the Embedded experience saved (`jetpack_search_experience=embedded`). For the WC template, also have WooCommerce active and `jetpack_search_override_woocommerce_search_template=1`.
2. On a **block theme with a light color scheme** (e.g. Twenty Twenty-Five default), visit `/?s=<term>` — confirm the search-input has a subtle hairline below it and the right-side filter sidebar has a matching subtle vertical divider on its left edge. The two hairlines should read as the same weight.
3. Repeat on a **WooCommerce product search**: `/?s=<term>&post_type=product` — same expectation against the product-results sidebar.
4. Switch the same theme to a **dark color scheme** (or use a dark theme entirely). Visit the same `/?s=<term>` page — both the search-input bottom rule AND the sidebar's left divider should now blend with the dark surface (soft white hairlines tracking the theme's ink), instead of one showing as a bright `#e0e0e0` rule and the other as a strong currentColor underline.
5. Open the **blocks overlay** experience (`jetpack_search_experience=overlay_blocks`, when available) and confirm: the overlay's existing header hairline is unchanged (still owned by `.jetpack-search-block-overlay__card::before`), the overlay's sidebar divider is unchanged in effect (the new shared rule supersedes the moved overlay-scoped rule), and the in-card search-input still has its border-bottom suppressed (the `border-bottom: 0` override still wins specificity).
6. In a browser without CSS `color-mix()` support (or with the `@supports` rule disabled via devtools), confirm both hairlines fall back to `transparent` — i.e. they disappear rather than reverting to the hardcoded grey or a full-strength rule.
