### PR TITLE
Blogging Prompts: default the v3 endpoint order to desc

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -432,7 +432,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 		$args['page']             = $parent_args['page'];
 		$args['per_page']         = $parent_args['per_page'];
 		$args['order']            = $parent_args['order'];
-		$args['order']['default'] = 'asc';
+		$args['order']['default'] = 'desc';
 		$args['orderby']          = $parent_args['orderby'];
 		$args['search']           = $parent_args['search'];
 

--- a/projects/plugins/jetpack/changelog/update-default-blogging-prompt-order
+++ b/projects/plugins/jetpack/changelog/update-default-blogging-prompt-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blogging Prompts: changed the default sort order of the wpcom/v3 endpoint to descending (newest prompts first).


### PR DESCRIPTION
Newest prompts first by default. The `order` query param still wins, so existing callers passing `order=asc` are unaffected.

Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update the order so that older version mobile apps that don't pass the order see the newest prompts

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
