### PR TITLE
Simple Payments: redact spay_email from public REST responses

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-simple-payments-spay-email-public-rest-leak
+++ b/projects/packages/paypal-payments/changelog/fix-simple-payments-spay-email-public-rest-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Simple Payments: strip seller PayPal email (spay_email) from public REST responses while preserving editor read/write.

--- a/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
+++ b/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
@@ -527,9 +527,9 @@ class Simple_Payments {
 	 * or read-only callers no longer see the address in collection or single-item
 	 * responses for the `jp_pay_product` post type.
 	 *
-	 * @param \WP_REST_Response $response The response object.
-	 * @param \WP_Post          $post     The product post.
-	 * @return \WP_REST_Response
+	 * @param mixed $response The response object (expected: \WP_REST_Response).
+	 * @param mixed $post     The product post (expected: \WP_Post).
+	 * @return mixed
 	 */
 	public function redact_spay_email_for_unauthorized( $response, $post ) {
 		if ( ! $response instanceof \WP_REST_Response || ! $post instanceof WP_Post ) {

--- a/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
+++ b/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
@@ -129,6 +129,7 @@ class Simple_Payments {
 	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
+		add_filter( 'rest_prepare_' . self::$post_type_product, array( $this, 'redact_spay_email_for_unauthorized' ), 10, 2 );
 	}
 
 	/**
@@ -517,6 +518,35 @@ class Simple_Payments {
 				'type'              => 'string',
 			)
 		);
+	}
+
+	/**
+	 * Strip the seller's PayPal email (`spay_email`) from REST responses when the
+	 * requester cannot edit the product. The meta stays `show_in_rest => true` so
+	 * the block editor's read/write round-trip keeps working — but unauthenticated
+	 * or read-only callers no longer see the address in collection or single-item
+	 * responses for the `jp_pay_product` post type.
+	 *
+	 * @param \WP_REST_Response $response The response object.
+	 * @param \WP_Post          $post     The product post.
+	 * @return \WP_REST_Response
+	 */
+	public function redact_spay_email_for_unauthorized( $response, $post ) {
+		if ( ! $response instanceof \WP_REST_Response || ! $post instanceof WP_Post ) {
+			return $response;
+		}
+
+		if ( current_user_can( 'edit_post', $post->ID ) ) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+		if ( isset( $data['meta']['spay_email'] ) ) {
+			unset( $data['meta']['spay_email'] );
+			$response->set_data( $data );
+		}
+
+		return $response;
 	}
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/Simple_Payments_Rest_Redaction_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Simple_Payments_Rest_Redaction_Test.php
@@ -184,10 +184,14 @@ class Simple_Payments_Rest_Redaction_Test extends BaseTestCase {
 	public function test_response_without_meta_is_unchanged() {
 		wp_set_current_user( 0 );
 
-		$response = new WP_REST_Response( array( 'id' => $this->product_id, 'title' => 'no meta' ) );
+		$payload  = array(
+			'id'    => $this->product_id,
+			'title' => 'no meta',
+		);
+		$response = new WP_REST_Response( $payload );
 		$result   = $this->simple_payments->redact_spay_email_for_unauthorized( $response, get_post( $this->product_id ) );
 
-		$this->assertSame( array( 'id' => $this->product_id, 'title' => 'no meta' ), $result->get_data() );
+		$this->assertSame( $payload, $result->get_data() );
 	}
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/Simple_Payments_Rest_Redaction_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Simple_Payments_Rest_Redaction_Test.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tests for the spay_email REST redaction filter.
+ *
+ * Guards against the SHILL-1889 regression: the seller's PayPal email
+ * must not leak through public REST responses, but must remain available
+ * to authenticated editors so the block editor's read/write round-trip
+ * keeps working (incident: 2026-04-15 misrouted Simple Payments).
+ *
+ * @package automattic/jetpack-paypal-payments
+ */
+
+namespace Automattic\Jetpack\Paypal_Payments;
+
+use WorDBless\BaseTestCase;
+use WP_REST_Response;
+
+/**
+ * Class Simple_Payments_Rest_Redaction_Test
+ */
+class Simple_Payments_Rest_Redaction_Test extends BaseTestCase {
+
+	/**
+	 * The Simple_Payments singleton.
+	 *
+	 * @var Simple_Payments
+	 */
+	private $simple_payments;
+
+	/**
+	 * A product post ID.
+	 *
+	 * @var int
+	 */
+	private $product_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Simple_Payments::$post_type_product ) ) {
+			register_post_type(
+				Simple_Payments::$post_type_product,
+				array(
+					'public'       => false,
+					'show_in_rest' => true,
+				)
+			);
+		}
+
+		$this->simple_payments = Simple_Payments::get_instance();
+
+		$this->product_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test product',
+				'post_status' => 'publish',
+				'post_type'   => Simple_Payments::$post_type_product,
+			)
+		);
+		update_post_meta( $this->product_id, 'spay_email', 'seller@example.com' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a REST response that mirrors what the default posts controller
+	 * produces for a jp_pay_product entity (with meta included).
+	 */
+	private function build_response_with_email() {
+		return new WP_REST_Response(
+			array(
+				'id'    => $this->product_id,
+				'title' => array( 'raw' => 'Test product' ),
+				'meta'  => array(
+					'spay_email'    => 'seller@example.com',
+					'spay_currency' => 'USD',
+					'spay_price'    => '9.99',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Unauthenticated callers must not see spay_email — this is the SHILL-1889 case.
+	 */
+	public function test_unauthenticated_request_strips_spay_email() {
+		wp_set_current_user( 0 );
+
+		$response = $this->simple_payments->redact_spay_email_for_unauthorized(
+			$this->build_response_with_email(),
+			get_post( $this->product_id )
+		);
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertArrayNotHasKey( 'spay_email', $data['meta'], 'spay_email must not leak to unauthenticated callers' );
+		// Sibling meta keys must survive.
+		$this->assertSame( 'USD', $data['meta']['spay_currency'] );
+		$this->assertSame( '9.99', $data['meta']['spay_price'] );
+	}
+
+	/**
+	 * Subscribers (read-only) must not see spay_email either.
+	 */
+	public function test_subscriber_request_strips_spay_email() {
+		$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'subscriber',
+				'user_pass'  => wp_hash_password( 'password' ),
+				'user_email' => 'subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber_id );
+
+		$response = $this->simple_payments->redact_spay_email_for_unauthorized(
+			$this->build_response_with_email(),
+			get_post( $this->product_id )
+		);
+
+		$data = $response->get_data();
+		$this->assertArrayNotHasKey( 'spay_email', $data['meta'] );
+	}
+
+	/**
+	 * Editors (the block-editor write path) MUST keep seeing spay_email so the
+	 * round-trip save doesn't wipe the field — this is the regression guard
+	 * for the 2026-04 incident.
+	 */
+	public function test_editor_request_preserves_spay_email() {
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'editor',
+				'user_pass'  => wp_hash_password( 'password' ),
+				'user_email' => 'editor@example.com',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $editor_id );
+
+		$response = $this->simple_payments->redact_spay_email_for_unauthorized(
+			$this->build_response_with_email(),
+			get_post( $this->product_id )
+		);
+
+		$data = $response->get_data();
+		$this->assertSame( 'seller@example.com', $data['meta']['spay_email'] );
+	}
+
+	/**
+	 * Administrators see spay_email too.
+	 */
+	public function test_admin_request_preserves_spay_email() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'admin',
+				'user_pass'  => wp_hash_password( 'password' ),
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		$response = $this->simple_payments->redact_spay_email_for_unauthorized(
+			$this->build_response_with_email(),
+			get_post( $this->product_id )
+		);
+
+		$data = $response->get_data();
+		$this->assertSame( 'seller@example.com', $data['meta']['spay_email'] );
+	}
+
+	/**
+	 * A response without a meta key must pass through untouched.
+	 */
+	public function test_response_without_meta_is_unchanged() {
+		wp_set_current_user( 0 );
+
+		$response = new WP_REST_Response( array( 'id' => $this->product_id, 'title' => 'no meta' ) );
+		$result   = $this->simple_payments->redact_spay_email_for_unauthorized( $response, get_post( $this->product_id ) );
+
+		$this->assertSame( array( 'id' => $this->product_id, 'title' => 'no meta' ), $result->get_data() );
+	}
+
+	/**
+	 * Defensive guard: non-response/non-post inputs are returned as-is.
+	 */
+	public function test_non_response_input_returned_unchanged() {
+		$not_a_response = 'string instead of response';
+		$result         = $this->simple_payments->redact_spay_email_for_unauthorized( $not_a_response, get_post( $this->product_id ) );
+
+		$this->assertSame( $not_a_response, $result );
+	}
+}


### PR DESCRIPTION
Fixes SHILL-1889 (re-fix after the 2026-04 incident — see [SHILL-1905](https://linear.app/a8c/issue/SHILL-1905) and the pfOicC-11M-p2).

## Proposed changes
* Add a `rest_prepare_jp_pay_product` filter that strips `meta.spay_email` from REST responses when the requester cannot `edit_post` on the product.
* Keep the meta registered with `show_in_rest => true` so the block editor's `getEntityRecord` / `saveEntityRecord` round-trip is untouched — preventing a repeat of the bug where the editor saved an empty `spay_email` and PayPal defaulted to `help@wordpress.com`.
* Add PHPUnit coverage for unauthenticated, subscriber, editor, and administrator callers, plus the no-meta / non-response edge cases.

### Why a different approach this time
The original fix (#48090) flipped `show_in_rest` to `false`, which also blocked editor writes — that's what caused the misrouted transactions. The follow-up proposal (passing `spay_email` through the payment-create endpoint, PR #48350 + wpcom/213528) didn't actually address the editor write path: the payment endpoint reads from the DB directly (`product.php:243`), and the leak was happening through the editor's REST fetch of the product CPT. Filtering the response at read time, gated by `edit_post` capability, redacts the email for the public without affecting the authenticated editor flow.

## Does this pull request change what data or activity we track or use?
No. This change reduces data exposure — the seller's PayPal email is no longer returned in public REST responses for the `jp_pay_product` post type.

## Testing instructions

**Automated:**
* From `projects/packages/paypal-payments/`, run `composer phpunit`. The new `Simple_Payments_Rest_Redaction_Test` suite covers the redaction matrix.


**Manual — confirm the editor round-trip is NOT broken (this is the regression we're guarding against):**
0. [Create a Jurassic Ninja instance](https://jurassic.ninja/) on that branch. **Make sure you have Jetpack complete enabled** 
<img width="300"  alt="Screenshot 2026-05-27 at 14 20 36" src="https://github.com/user-attachments/assets/61616560-733d-40a3-b882-562888d25911" />
1. Go to "My Jetpack" and connect your account
2. Open a new post in the WP block editor.
3. Top-right kebab menu → Code editor (or ⇧⌥⌘M).
4. Paste this and exit code editor:
  `<!-- wp:jetpack/simple-payments /-->`
5. The Simple Payments placeholder appears. Fill in title / price / PayPal email and Publish.
6. Reload the post in the editor → the email should still be populated in the sidebar. (This is the editor read path that the previous fix broke.)

<img width="300"  alt="Screenshot 2026-05-27 at 14 29 19" src="https://github.com/user-attachments/assets/ac5ef098-8824-4728-8545-18a9d97c700f" />


8. Edit any field (e.g., bump price), save, reload → email is still there. (This is the SHILL-1905 regression guard — without the filter being capability-aware, this is where it used to wipe.)

**Manual — confirm the original issue is fixed:**

1. On a site that has a legacy Simple Payments block configured, find the product post ID (the `jp_pay_product` CPT created when the block was saved).
2. As a logged-out visitor, `curl https://<site>/wp-json/wp/v2/jp_pay_product/<id>` and confirm `meta.spay_email` is **absent** from the response. Repeat against the list endpoint `/wp-json/wp/v2/jp_pay_product` and confirm none of the items expose the email.
3. As a subscriber (logged in but no `edit_posts` cap), repeat — `spay_email` must still be absent.


Example:
```
curl https://hyacinth-of-cattles.jurassic.ninja/wp-json/wp/v2/jp_pay_product/ 
```
Will not have spay_email. 


But the post is still saved properly. You can see it by opening the editor and filtering the **network** tab with jp_pay_product. 

Example:
<img width="711" height="575" alt="Screenshot 2026-05-27 at 14 40 23" src="https://github.com/user-attachments/assets/cfa5acf8-0c7e-4371-8837-86a237c7e424" />

Written with Claude's help.
