### PR TITLE
Shortcodes: fix [archiveorg] query parameter handling

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-archiveorg-shortcode-query-parameters
+++ b/projects/plugins/jetpack/changelog/fix-archiveorg-shortcode-query-parameters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcodes: fix [archiveorg] so query parameters such as playlist, autoplay, and poster produce valid Archive.org embed URLs.

--- a/projects/plugins/jetpack/modules/shortcodes/archiveorg.php
+++ b/projects/plugins/jetpack/modules/shortcodes/archiveorg.php
@@ -72,6 +72,10 @@ function jetpack_archiveorg_shortcode( $atts ) {
 	$id = $atts['id'];
 
 	// Allow extra query parameters to be baked into the identifier, e.g. "myitem&playlist=1" or "myitem?playlist=1".
+	// In some environments a the_content filter encodes "&" to "&amp;" before do_shortcode runs, so the
+	// parser receives "myitem&amp;playlist=1" — normalize that back before splitting. The sibling function
+	// jetpack_archiveorg_embed_to_shortcode() splits on "&amp;" for the same reason.
+	$id          = str_replace( '&amp;', '&', $id );
 	$extra_query = '';
 	if ( preg_match( '/^([^?&]*)[?&](.*)$/', $id, $id_match ) ) {
 		$id          = $id_match[1];

--- a/projects/plugins/jetpack/modules/shortcodes/archiveorg.php
+++ b/projects/plugins/jetpack/modules/shortcodes/archiveorg.php
@@ -75,11 +75,17 @@ function jetpack_archiveorg_shortcode( $atts ) {
 	// In some environments a the_content filter encodes "&" to "&amp;" before do_shortcode runs, so the
 	// parser receives "myitem&amp;playlist=1" — normalize that back before splitting. The sibling function
 	// jetpack_archiveorg_embed_to_shortcode() splits on "&amp;" for the same reason.
-	$id          = str_replace( '&amp;', '&', $id );
-	$extra_query = '';
+	$id            = str_replace( '&amp;', '&', $id );
+	$id_extra_args = array();
 	if ( preg_match( '/^([^?&]*)[?&](.*)$/', $id, $id_match ) ) {
-		$id          = $id_match[1];
-		$extra_query = $id_match[2];
+		$id = $id_match[1];
+		wp_parse_str( $id_match[2], $id_extra_args );
+	}
+
+	// Re-check after the split — an identifier that's only a query string (e.g. "?playlist=1") leaves $id empty
+	// and would otherwise produce an item-less embed URL.
+	if ( '' === $id ) {
+		return '<!-- error: missing archive.org ID -->';
 	}
 
 	if ( ! $atts['width'] ) {
@@ -94,8 +100,6 @@ function jetpack_archiveorg_shortcode( $atts ) {
 		$height = (int) $atts['height'];
 	}
 
-	$url = 'https://archive.org/embed/' . $id;
-
 	$query_args = array();
 	if ( $atts['autoplay'] ) {
 		$query_args['autoplay'] = 1;
@@ -106,11 +110,13 @@ function jetpack_archiveorg_shortcode( $atts ) {
 	if ( $atts['playlist'] ) {
 		$query_args['playlist'] = 1;
 	}
+
+	// Explicit shortcode attributes take precedence over query parameters baked into the identifier.
+	$query_args = array_merge( $id_extra_args, $query_args );
+
+	$url = 'https://archive.org/embed/' . $id;
 	if ( ! empty( $query_args ) ) {
 		$url = add_query_arg( $query_args, $url );
-	}
-	if ( '' !== $extra_query ) {
-		$url .= ( str_contains( $url, '?' ) ? '&' : '?' ) . $extra_query;
 	}
 
 	return sprintf(

--- a/projects/plugins/jetpack/modules/shortcodes/archiveorg.php
+++ b/projects/plugins/jetpack/modules/shortcodes/archiveorg.php
@@ -60,6 +60,7 @@ function jetpack_archiveorg_shortcode( $atts ) {
 			'height'   => 480,
 			'autoplay' => 0,
 			'poster'   => '',
+			'playlist' => 0,
 		),
 		$atts
 	);
@@ -69,6 +70,13 @@ function jetpack_archiveorg_shortcode( $atts ) {
 	}
 
 	$id = $atts['id'];
+
+	// Allow extra query parameters to be baked into the identifier, e.g. "myitem&playlist=1" or "myitem?playlist=1".
+	$extra_query = '';
+	if ( preg_match( '/^([^?&]*)[?&](.*)$/', $id, $id_match ) ) {
+		$id          = $id_match[1];
+		$extra_query = $id_match[2];
+	}
 
 	if ( ! $atts['width'] ) {
 		$width = absint( $content_width );
@@ -82,22 +90,29 @@ function jetpack_archiveorg_shortcode( $atts ) {
 		$height = (int) $atts['height'];
 	}
 
-	if ( $atts['autoplay'] ) {
-		$autoplay = '&autoplay=1';
-	} else {
-		$autoplay = '';
-	}
+	$url = 'https://archive.org/embed/' . $id;
 
+	$query_args = array();
+	if ( $atts['autoplay'] ) {
+		$query_args['autoplay'] = 1;
+	}
 	if ( $atts['poster'] ) {
-		$poster = '&poster=' . $atts['poster'];
-	} else {
-		$poster = '';
+		$query_args['poster'] = $atts['poster'];
+	}
+	if ( $atts['playlist'] ) {
+		$query_args['playlist'] = 1;
+	}
+	if ( ! empty( $query_args ) ) {
+		$url = add_query_arg( $query_args, $url );
+	}
+	if ( '' !== $extra_query ) {
+		$url .= ( str_contains( $url, '?' ) ? '&' : '?' ) . $extra_query;
 	}
 
 	return sprintf(
 		'<div class="embed-archiveorg" style="text-align:center;"><iframe title="%s" src="%s" width="%s" height="%s" style="border:0;" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe></div>',
 		esc_attr__( 'Archive.org', 'jetpack' ),
-		esc_url( "https://archive.org/embed/{$id}{$autoplay}{$poster}" ),
+		esc_url( $url ),
 		esc_attr( $width ),
 		esc_attr( $height )
 	);

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
@@ -52,7 +52,7 @@ class Jetpack_Shortcodes_ArchiveOrg_Test extends WP_UnitTestCase {
 	public function test_shortcode_autoplay_and_poster() {
 		$content           = "[archiveorg id='Wonderfu1958' autoplay=1 poster='http://archive.org/img.png']";
 		$shortcode_content = do_shortcode( $content );
-		$this->assertStringContainsString( 'src="https://archive.org/embed/Wonderfu1958?autoplay=1&#038;poster=http%3A%2F%2Farchive.org%2Fimg.png"', $shortcode_content );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/Wonderfu1958?autoplay=1&#038;poster=http://archive.org/img.png"', $shortcode_content );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
@@ -90,6 +90,33 @@ class Jetpack_Shortcodes_ArchiveOrg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that an identifier consisting of only a query string returns the missing-ID error
+	 * rather than producing an item-less embed URL.
+	 */
+	public function test_shortcode_returns_error_when_id_is_only_a_query_string() {
+		$this->assertEquals( '<!-- error: missing archive.org ID -->', do_shortcode( '[archiveorg ?playlist=1]' ) );
+		$this->assertEquals( '<!-- error: missing archive.org ID -->', do_shortcode( '[archiveorg &playlist=1]' ) );
+	}
+
+	/**
+	 * Verify that a query parameter supplied both via the identifier and as a shortcode attribute
+	 * appears only once in the rendered URL.
+	 */
+	public function test_shortcode_dedupes_duplicate_query_params_from_id_and_atts() {
+		$shortcode_content = do_shortcode( '[archiveorg myitem&playlist=1 playlist=1]' );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/myitem?playlist=1"', $shortcode_content );
+		$this->assertEquals( 1, substr_count( $shortcode_content, 'playlist=1' ) );
+	}
+
+	/**
+	 * Verify that a "#" fragment in the identifier stays after the query string rather than swallowing it.
+	 */
+	public function test_shortcode_places_query_before_fragment_in_id() {
+		$shortcode_content = do_shortcode( '[archiveorg myitem#frag&playlist=1]' );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/myitem?playlist=1#frag"', $shortcode_content );
+	}
+
+	/**
 	 * Verify that rendering the archiveorg-book shortcode returns an ArchiveOrg book.
 	 *
 	 * @since 4.5.0

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
@@ -105,7 +105,7 @@ class Jetpack_Shortcodes_ArchiveOrg_Test extends WP_UnitTestCase {
 	public function test_shortcode_dedupes_duplicate_query_params_from_id_and_atts() {
 		$shortcode_content = do_shortcode( '[archiveorg myitem&playlist=1 playlist=1]' );
 		$this->assertStringContainsString( 'src="https://archive.org/embed/myitem?playlist=1"', $shortcode_content );
-		$this->assertEquals( 1, substr_count( $shortcode_content, 'playlist=1' ) );
+		$this->assertSame( 1, substr_count( $shortcode_content, 'playlist=1' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
@@ -81,6 +81,15 @@ class Jetpack_Shortcodes_ArchiveOrg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that an HTML-encoded "&amp;" baked into the identifier is normalized before splitting,
+	 * matching what reaches do_shortcode in environments where the_content encodes ampersands first.
+	 */
+	public function test_shortcode_query_string_in_id_with_html_encoded_ampersand() {
+		$shortcode_content = do_shortcode( '[archiveorg sentidodelobjeto&amp;playlist=1 width=640 height=300]' );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/sentidodelobjeto?playlist=1"', $shortcode_content );
+	}
+
+	/**
 	 * Verify that rendering the archiveorg-book shortcode returns an ArchiveOrg book.
 	 *
 	 * @since 4.5.0

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_ArchiveOrg_Test.php
@@ -47,6 +47,40 @@ class Jetpack_Shortcodes_ArchiveOrg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that autoplay and poster attributes render as a proper query string.
+	 */
+	public function test_shortcode_autoplay_and_poster() {
+		$content           = "[archiveorg id='Wonderfu1958' autoplay=1 poster='http://archive.org/img.png']";
+		$shortcode_content = do_shortcode( $content );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/Wonderfu1958?autoplay=1&#038;poster=http%3A%2F%2Farchive.org%2Fimg.png"', $shortcode_content );
+	}
+
+	/**
+	 * Verify that the playlist attribute renders as a proper query parameter.
+	 */
+	public function test_shortcode_playlist_attribute() {
+		$content           = "[archiveorg id='sentidodelobjeto' playlist=1]";
+		$shortcode_content = do_shortcode( $content );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/sentidodelobjeto?playlist=1"', $shortcode_content );
+	}
+
+	/**
+	 * Verify that query parameters baked into the identifier with "&" are converted to a proper query string.
+	 */
+	public function test_shortcode_query_string_in_id_with_ampersand() {
+		$shortcode_content = do_shortcode( '[archiveorg sentidodelobjeto&playlist=1 width=640 height=300]' );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/sentidodelobjeto?playlist=1"', $shortcode_content );
+	}
+
+	/**
+	 * Verify that query parameters baked into the identifier with "?" pass through correctly.
+	 */
+	public function test_shortcode_query_string_in_id_with_question_mark() {
+		$shortcode_content = do_shortcode( '[archiveorg sentidodelobjeto?playlist=1 width=640 height=300]' );
+		$this->assertStringContainsString( 'src="https://archive.org/embed/sentidodelobjeto?playlist=1"', $shortcode_content );
+	}
+
+	/**
 	 * Verify that rendering the archiveorg-book shortcode returns an ArchiveOrg book.
 	 *
 	 * @since 4.5.0


### PR DESCRIPTION
## Proposed changes
* Build the `[archiveorg]` embed URL with `add_query_arg()` so `autoplay`, `poster`, and the newly-supported `playlist` attribute render as a proper `?key=value&key=value` query string instead of being concatenated into the URL path with stray `&` separators.
* Accept query parameters baked into the identifier (e.g. `[archiveorg myitem&playlist=1]` or `[archiveorg myitem?playlist=1]`), splitting them off the id and re-appending them with the correct separator. This keeps existing posts working — including the `?`-prefix workaround that's been shared as guidance.
* Add PHPUnit coverage for the four cases above.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. On a site with the Jetpack shortcodes module active, add a post containing each of the following shortcodes:
   - `[archiveorg sentidodelobjeto&playlist=1 width=640 height=300]`
   - `[archiveorg sentidodelobjeto?playlist=1 width=640 height=300]`
   - `[archiveorg id=sentidodelobjeto playlist=1]`
   - `[archiveorg id=Wonderfu1958 autoplay=1 poster=https://archive.org/img.png]`
2. View the rendered post and inspect each iframe's `src`:
   - For the first three, the URL should be `https://archive.org/embed/sentidodelobjeto?playlist=1` and the playlist should display on archive.org's end.
   - For the fourth, the URL should be `https://archive.org/embed/Wonderfu1958?autoplay=1&poster=...`.
3. Confirm that a plain `[archiveorg Wonderfu1958]` (no extras) still produces `https://archive.org/embed/Wonderfu1958` unchanged.
4. Optionally run the suite: `jp docker phpunit jetpack -- --filter Jetpack_Shortcodes_ArchiveOrg_Test`.