### PR TITLE
Tiled Gallery: Remove forced gray background on images

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-background-color
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: Remove the forced gray background on images that made transparent areas appear gray.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -126,10 +126,6 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 		box-shadow: 0 0 0 2px  var(--wp-admin-theme-color);
 	}
 
-	> img {
-		background-color: rgba(0, 0, 0, 0.1);
-	}
-
 	> a,
 	> a > img,
 	> img {


### PR DESCRIPTION
## Proposed changes:

Remove the static `background-color: rgba(0, 0, 0, 0.1)` applied to all `> img` elements inside `.tiled-gallery__item` on the frontend.

This rule applies a permanent semi-transparent gray background to every image in the Tiled Gallery block. For images with transparency (PNG, WebP) or rounded corners, this gray background bleeds through and cannot be overridden by users — even with custom CSS on Simple sites.

### Before this change

```css
.tiled-gallery__item > img {
    background-color: rgba(0, 0, 0, 0.1); /* #0000001a */
}
```

Any image with transparent areas shows a gray rectangle behind it.

### After this change

The background-color declaration is removed. Transparent images render correctly.

### Context

- The editor-side equivalent was already addressed in #45344, which moved the placeholder animation behind an `is-loading` class so it only shows while images load.
- The frontend `view.scss` was not updated at the same time — it still applies the static gray background permanently.
- This was reported via customer support (EDI-156 / Zendesk #10538365) and confirmed reproducible on any site using the Tiled Gallery block with transparent images.

### Other information:

- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Add a Tiled Gallery block to a post.
2. Upload PNG or WebP images that have transparent areas (e.g., a phone mockup with rounded corners on a transparent background).
3. Publish and view the post on the frontend.
4. **Before fix:** A gray background appears behind transparent areas.
5. **After fix:** Images render with correct transparency — no gray background.