### PR TITLE
PricingCard: migrate CTA to @wordpress/ui Button

### DIFF
--- a/projects/js-packages/components/changelog/pricing-card-cta-wp-ui-button
+++ b/projects/js-packages/components/changelog/pricing-card-cta-wp-ui-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PricingCard: render the CTA with the @wordpress/ui Button (solid variant) so it shows correct button styling instead of unstyled text.

--- a/projects/js-packages/components/components/pricing-card/index.tsx
+++ b/projects/js-packages/components/components/pricing-card/index.tsx
@@ -1,6 +1,6 @@
 import { getCurrencyObject } from '@automattic/number-formatters';
-import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import LoadingPlaceholder from '../loading-placeholder/index.tsx';
 import TermsOfService from '../terms-of-service/index.tsx';
 import type { PricingCardProps } from './types.ts';
@@ -113,8 +113,8 @@ const PricingCard: FC< PricingCardProps > = ( {
 					) }
 					<div className="jp-components__pricing-card__cta">
 						<Button
+							variant="solid"
 							className="jp-components__pricing-card__button"
-							label={ props.ctaText }
 							onClick={ props.onCtaClick }
 						>
 							{ props.ctaText }

--- a/projects/js-packages/components/components/pricing-card/style.scss
+++ b/projects/js-packages/components/components/pricing-card/style.scss
@@ -87,13 +87,24 @@
 	}
 
 	&__button {
+		// Full-width CTA; the @wordpress/ui Button owns the rest of its chrome
+		// (fill, padding, radius) via its `solid` variant.
 		width: 100%;
-		height: auto;
-		font-size: 18px;
-		padding: 14px 24px;
 		margin: 24px 0 32px;
-		justify-content: center;
-		align-items: center;
+
+		// Bump the font one step up from the Button default (md/13px) to lg
+		// (15px) for a more prominent hero CTA. No exact 18px token exists
+		// (the scale jumps 15px -> 20px). We must set the Button's own
+		// `--wp-ui-button-font-size` knob rather than `font-size` directly:
+		// @wordpress/ui ships an unlayered "global-CSS-defense" rule
+		// (`font-size: var(--_gcd-button-font-size)`) that outranks our
+		// unlayered class on source order, so a plain `font-size` here is
+		// ignored. The knob feeds both that defense and the layered rule.
+
+		// NOTE: `--wp-ui-button-font-size` is an *internal* @wordpress/ui
+		// variable (not a public API). Re-check this still exists / is named
+		// the same whenever @wordpress/ui is upgraded.
+		--wp-ui-button-font-size: var(--wpds-typography-font-size-lg);
 	}
 
 	&__info,

--- a/projects/js-packages/components/components/pricing-card/style.scss
+++ b/projects/js-packages/components/components/pricing-card/style.scss
@@ -92,19 +92,6 @@
 		width: 100%;
 		margin: 24px 0 32px;
 
-		// Bump the font one step up from the Button default (md/13px) to lg
-		// (15px) for a more prominent hero CTA. No exact 18px token exists
-		// (the scale jumps 15px -> 20px). We must set the Button's own
-		// `--wp-ui-button-font-size` knob rather than `font-size` directly:
-		// @wordpress/ui ships an unlayered "global-CSS-defense" rule
-		// (`font-size: var(--_gcd-button-font-size)`) that outranks our
-		// unlayered class on source order, so a plain `font-size` here is
-		// ignored. The knob feeds both that defense and the layered rule.
-
-		// NOTE: `--wp-ui-button-font-size` is an *internal* @wordpress/ui
-		// variable (not a public API). Re-check this still exists / is named
-		// the same whenever @wordpress/ui is upgraded.
-		--wp-ui-button-font-size: var(--wpds-typography-font-size-lg);
 	}
 
 	&__info,


### PR DESCRIPTION
## Proposed changes

Fixes the `PricingCard` CTA button, which has been rendering as **borderless plain text** (no fill/border) on trunk since #47317.

**Root cause:** The shared `PricingCard` CTA was a variant-less `@wordpress/components` `Button` whose filled appearance came entirely from a SCSS override (`background: var(--jp-black); color: var(--jp-white) !important; border-radius`). #47317 ("remove Jetpack color overrides on core components") stripped that override, but the `Button` had no `variant` to fall back on — so it collapsed to unstyled text. This affected **every** consumer of `PricingCard`: Jetpack Backup (no-backup-capabilities pricing page), Search upsell, Connection required-plan screen, starter-plugin, and classic-theme-helper-plugin. (A full revert of #47317 was opened the same day on `revert-47317-update/jp-components-core-colors` but never merged.)

**This change:**
* Migrates the CTA from `@wordpress/components` `Button` → `@wordpress/ui` `Button` with `variant="solid"`, so it carries its own WPDS chrome (fill, padding, radius, centering) instead of depending on a brand-color SCSS override. This is aligned with the [Jetpack UI Modernization](https://github.com/Automattic/jetpack/issues/48160) direction.
* Drops the `label` prop (not a `@wordpress/ui` Button prop; redundant with the visible children text).
* Reduces `.jp-components__pricing-card__button` SCSS to structural-only rules: `width: 100%` (full-width CTA) + `margin`.

### Note on the CTA font size
The original button used a hardcoded `font-size: 18px`. **There is no exact 18px WPDS token** — the typography scale jumps from `lg` (15px) to `xl` (20px). We chose the **`lg` token (15px)**, which reads better here than the Button default (`md`/13px) while staying token-pure.

It is set via the Button's internal `--wp-ui-button-font-size` knob rather than a plain `font-size` declaration. `@wordpress/ui` ships an **unlayered "global-CSS-defense"** rule (`font-size: var(--_gcd-button-font-size)`) to protect itself from wp-admin's `forms.css`; because cascade layers always lose to unlayered styles, a plain `font-size` on our class is overridden. Setting the custom property the defense bridges from is the documented escape hatch.

⚠️ **`--wp-ui-button-font-size` is an *internal* `@wordpress/ui` variable** (not public API). Whoever next bumps `@wordpress/ui` should re-check it still exists / is named the same. There's a code comment to this effect in `style.scss`.

## Related product discussion/links
* Regression source: #47317
* Umbrella: [#48160 — Jetpack UI Modernization](https://github.com/Automattic/jetpack/issues/48160)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a site **without** a Backup plan, go to **Jetpack → Backup**. The upsell/pricing page ("Secure your site with a Backup subscription") should show a **filled** "Get VaultPress Backup" CTA — not plain text.
* Confirm the CTA is full-width within the pricing card and its label is slightly larger than body text (15px).
* Spot-check other `PricingCard` consumers render the same filled CTA: **Search** upsell page, and the **Connection required-plan** screen.
* The CTA color is now the WPDS brand `solid` color (no longer the old Jetpack black) — this is the intended migration direction.
