### PR TITLE
Base styles: stop admin-page-layout flex chain at the boot stage so inspectors render beside the page

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -162,7 +162,18 @@ $jp-breakpoint-mobile: 782px;
 	// a `display: block` div); `:has()` targets the whole chain regardless
 	// of depth. `min-width: 0` + `min-height: 0` let flex items shrink on
 	// both axes (defaults to content size which can cause overflow).
-	#wpbody-content :has(.jp-admin-page) {
+	// `:not(:has(.boot-layout__stage))` stops the chain at the boot stage. A
+	// `@wordpress/boot` dashboard mounts <AdminPage> inside `.boot-layout__stage`,
+	// and the containers above it — `.boot-layout`, `.boot-layout__surfaces`
+	// (boot's stage|inspector flex ROW), and boot's `display: contents`
+	// theme-provider wrapper — own that side-by-side layout. Flex-columning them
+	// would stack the inspector below the page and collapse boot's surfaces gap.
+	// Those ancestors all *contain* `.boot-layout__stage`, so the guard drops
+	// them while still flexing the stage (and anything below it) that the
+	// footer-pin chain needs. On non-boot pages nothing matches
+	// `.boot-layout__stage`, so the guard is always true and behavior is
+	// unchanged.
+	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage)) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;

--- a/projects/js-packages/base-styles/changelog/fix-newsletter-boot-inspector-layout
+++ b/projects/js-packages/base-styles/changelog/fix-newsletter-boot-inspector-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop the admin-page-layout flex chain at the boot stage so a @wordpress/boot dashboard's inspector renders beside the page instead of below it


### PR DESCRIPTION
Fixes #

## Proposed changes
The shared `jetpack-admin-page-layout` mixin pins the footer of a Jetpack admin page by flex-columning every ancestor of `<AdminPage>` via `#wpbody-content :has(.jp-admin-page)`. That assumes the admin page sits at the top of the `#wpbody-content` column.

In a `@wordpress/boot` dashboard the admin page is mounted **inside** `.boot-layout__stage`, alongside a `.boot-layout__inspector` side panel. The `:has()` rule overshot the stage and flipped two containers boot owns:
* `.boot-layout__surfaces` — boot's stage|inspector flex **row** → forced to `column`, so the inspector stacked **below** the page content (e.g. the Newsletter Subscribers DataViews) instead of beside it.
* boot's `display: contents` theme-provider wrapper → promoted to `display: flex`, which swallowed boot's 8px surfaces gap.

* Add a `:not(:has(.boot-layout__stage))` guard to that rule so the flex chain **stops at the boot stage**. Every container above the stage *contains* `.boot-layout__stage`, so the guard drops them — they keep boot's defaults (side-by-side row with the gap). The stage and everything below it are still flexed, so the footer-pin chain is intact.
* Pages with no boot stage never match `.boot-layout__stage`, so the guard is always-true and behavior is unchanged for the existing standalone-dashboard consumers.

This fixes the Newsletter Subscribers tab (where the "View" detail panel rendered below the DataViews) and pre-emptively covers any other boot dashboard that combines this mixin with an inspector.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the Newsletter package (or any `@wordpress/boot` dashboard using `jetpack-admin-page-layout`): `jetpack build packages/newsletter`.
* In wp-admin go to **Jetpack → Newsletter** and open the **Subscribers** tab (requires a connected site + user).
* Click the **View** row action on a subscriber.
* Confirm the subscriber detail panel opens as a **right-hand sidebar beside** the DataViews table (~400px wide, top-aligned, with a small gap between table and panel) — not stacked below it.
* Confirm the DataViews pagination footer is still pinned to the bottom of the viewport, both with and without the panel open.
* Sanity-check an existing non-boot consumer of the mixin (e.g. My Jetpack, Protect) still lays out and pins its footer as before.
