### PR TITLE
AdminPage: stick JetpackFooter to the bottom of the viewport

### DIFF
--- a/projects/js-packages/components/changelog/stick-admin-page-footer
+++ b/projects/js-packages/components/changelog/stick-admin-page-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AdminPage: pin `JetpackFooter` to the bottom of the viewport when content is short, so every product using `AdminPage` gets a consistent sticky-footer layout.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -1,5 +1,12 @@
 .admin-page {
 	margin-left: -20px; // to neutralize the padding of #wpcontent.
+	// Fill wp-admin's content area so the JetpackFooter can sit at the
+	// bottom of the viewport when content is short. The admin-ui `Page`
+	// (`.admin-ui-page`) becomes a flex column that flex-grows inside the
+	// root, and the footer claims any leftover space via `margin-top: auto`.
+	display: flex;
+	flex-direction: column;
+	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));
 
 	@media (max-width: 782px) {
 		margin-left: -10px; // to neutralize the padding of #wpcontent.
@@ -7,6 +14,21 @@
 
 	&.background {
 		background-color: var(--jp-white);
+	}
+
+	// Normalize admin headers: implementation of admin-ui needs to
+	// comprehend old wp-admin floating containers, such as Hello Dolly
+	// (`clear: both`). Also make the Page a flex column that fills the
+	// wp-admin content area so `JetpackFooter` can stick to the bottom.
+	:global(.admin-ui-page) {
+		clear: both;
+		flex: 1 1 auto;
+		display: flex;
+		flex-direction: column;
+	}
+
+	:global(.jetpack-footer) {
+		margin-top: auto;
 	}
 
 	// Remove the admin-ui header border when tabs are present,


### PR DESCRIPTION
Part 1 of a stacked PR series extracted from #48154 (*Jetpack SEO: introduce new SEO product*).

This is the smallest, foundational piece: make the shared `AdminPage` component a flex column with `min-height: calc(100vh - --wp-admin--admin-bar--height)`, and give `.jetpack-footer` `margin-top: auto`. Every product using the shared admin shell gets a consistent sticky-footer layout instead of the footer floating up against short content.

Originally authored by @keoshi in #48154; extracted here so it can land independently and unblock the rest of the SEO product split.

## Proposed changes

- `.admin-page` becomes a flex column with a viewport-based `min-height`, fitting wp-admin's content area.
- `:global(.admin-ui-page)` flex-grows inside that column.
- `:global(.jetpack-footer)` claims any leftover vertical space via `margin-top: auto`.

## Related product discussion/links

* Extracted from #48154 — see that PR for the SEO product PRD, design, and JETH-10045 references.

## Screenshots

*Before/after screenshots showing the footer position on a short Jetpack admin page (e.g. My Jetpack landing) — to be added.*

## Testing instructions

The change affects every Jetpack admin page that uses the shared `AdminPage` shell (My Jetpack, the main Jetpack settings page, Boost, Protect, Search, Backup, Stats, etc.).

**Verify the footer sticks to the bottom on short pages:**
* Visit `wp-admin/admin.php?page=my-jetpack`. With short content, the `JetpackFooter` should sit at the bottom of the viewport, not float up against the content with empty space underneath.

**Verify the footer appears normally on long pages:**
* Visit `wp-admin/admin.php?page=jetpack#/settings` and expand all the cards. The footer should appear at the end of the content with normal scrolling — no clipping, no overlap with content above.

**Verify no visual regression on:**
* The header layout (JetpackLogo position, tabs alignment, sandbox-domain badge on dev sites)
* Any page using `AdminPage` that already rendered correctly (Boost, Protect, Search, Backup, Stats dashboards)

## Does this pull request change what data or activity we track or use?
No.