### PR TITLE
VideoPress: Prepare types for React 19

### DIFF
--- a/projects/packages/videopress/changelog/react-19-type-prep
+++ b/projects/packages/videopress/changelog/react-19-type-prep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Internal: Prepare types for React 19.

--- a/projects/packages/videopress/src/client/admin/components/video-card/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/test/index.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * VideoCard forwards a DOM ref from VideoThumbnail to PublishFirstVideoPopover's
+ * `anchor` prop, so the popover can position itself relative to the thumbnail.
+ *
+ * Re-implementing VideoThumbnail as a plain function component on React 18 would
+ * silently break this wire — React strips `ref` from function-component props.
+ * This test fails in that scenario.
+ */
+import { render } from '@testing-library/react';
+import { VideoCard } from '../index';
+import type { PublishFirstVideoPopoverProps } from '../../publish-first-video-popover/types';
+
+let lastPopoverProps: PublishFirstVideoPopoverProps | undefined;
+
+jest.mock( '../../publish-first-video-popover', () => ( {
+	__esModule: true,
+	default: ( props: PublishFirstVideoPopoverProps ) => {
+		lastPopoverProps = props;
+		return null;
+	},
+} ) );
+
+jest.mock( '../../../hooks/use-permission', () => ( {
+	usePermission: () => ( { canPerformAction: true } ),
+} ) );
+
+beforeEach( () => {
+	lastPopoverProps = undefined;
+} );
+
+describe( 'VideoCard ref forwarding', () => {
+	it( 'passes the thumbnail DOM element to PublishFirstVideoPopover via the anchor prop', () => {
+		render(
+			<VideoCard
+				id={ 42 }
+				title="Test"
+				duration={ 1000 }
+				plays={ 0 }
+				thumbnail="https://example.com/thumb.jpg"
+				editable={ false }
+				showQuickActions={ false }
+			/>
+		);
+
+		expect( lastPopoverProps?.id ).toBe( 42 );
+		expect( lastPopoverProps?.anchor ).toBeInstanceOf( HTMLElement );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -39,7 +39,7 @@ import './style.scss';
  */
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
 import type { PosterDataProps, PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
-import type { MutableRefObject, ReactElement } from 'react';
+import type { ReactElement, RefObject } from 'react';
 
 const MIN_LOOP_DURATION = 3 * 1000;
 const MAX_LOOP_DURATION = 10 * 1000;
@@ -206,12 +206,10 @@ export function PosterDropdown( {
  * Return the (content) Window object of the iframe,
  * given the iframe's ref.
  *
- * @param {MutableRefObject< HTMLDivElement >} iFrameRef - iframe ref
+ * @param {RefObject< HTMLDivElement >} iFrameRef - iframe ref
  * @return {Window | null} Window object of the iframe
  */
-export const getIframeWindowFromRef = (
-	iFrameRef: MutableRefObject< HTMLDivElement >
-): Window | null => {
+export const getIframeWindowFromRef = ( iFrameRef: RefObject< HTMLDivElement > ): Window | null => {
 	const iFrame: HTMLIFrameElement = iFrameRef?.current?.querySelector(
 		'iframe.components-sandbox'
 	);

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -44,13 +44,34 @@ import PosterPanel from './components/poster-panel';
 import PrivacyAndRatingPanel from './components/privacy-and-rating-panel';
 import ReplaceControl from './components/replace-control';
 import TracksControl from './components/tracks-control';
-import VideoPressUploader from './components/videopress-uploader';
+import VideoPressUploaderRaw from './components/videopress-uploader';
 import { description, title } from '.';
 /**
  * Types
  */
 import type { VideoBlockAttributes } from './types';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
+
+type PlaceholderWrapperProps = {
+	children?: ReactNode;
+	className?: string;
+	disableInstructions?: boolean;
+	errorMessage?: string;
+	instructions?: ReactNode;
+	onNoticeRemove?: ( ...args: unknown[] ) => unknown;
+};
+
+type VideoPressUploaderProps = {
+	attributes: VideoBlockAttributes;
+	setAttributes: ( attrs: Partial< VideoBlockAttributes > ) => void;
+	handleDoneUpload: ( newVideoData: VideoBlockAttributes ) => void;
+	fileToUpload: File | null;
+	isReplacing?: boolean;
+	onReplaceCancel: () => void;
+	isActive: boolean;
+};
+
+const VideoPressUploader = VideoPressUploaderRaw as ComponentType< VideoPressUploaderProps >;
 
 import './editor.scss';
 
@@ -96,7 +117,7 @@ export const PlaceholderWrapper = withNotices( function ( {
 			{ children }
 		</Placeholder>
 	);
-} );
+} ) as ComponentType< PlaceholderWrapperProps >;
 
 /**
  * VideoPress block Edit react components

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -12,7 +12,7 @@ import { isAllowedOrigin } from '../../../lib/videopress-allowed-origins';
  * Types
  */
 import type { PlayerStateProp, UseVideoPlayerOptions, UseVideoPlayer } from './types';
-import type { MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 
 const debug = debugFactory( 'videopress:use-video-player' );
 
@@ -20,12 +20,10 @@ const debug = debugFactory( 'videopress:use-video-player' );
  * Return the (content) Window object of the iframe,
  * given the iframe's ref.
  *
- * @param {MutableRefObject< HTMLDivElement >} iFrameRef - iframe ref
+ * @param {RefObject< HTMLDivElement >} iFrameRef - iframe ref
  * @return {Window | null} Window object of the iframe
  */
-export const getIframeWindowFromRef = (
-	iFrameRef: MutableRefObject< HTMLDivElement >
-): Window | null => {
+export const getIframeWindowFromRef = ( iFrameRef: RefObject< HTMLDivElement > ): Window | null => {
 	const iFrame: HTMLIFrameElement = iFrameRef?.current?.querySelector(
 		'iframe.components-sandbox'
 	);
@@ -35,13 +33,13 @@ export const getIframeWindowFromRef = (
 /**
  * Custom hook to set the player ready to use:
  *
- * @param {MutableRefObject< HTMLDivElement >} iFrameRef           - useRef of the sandbox wrapper.
- * @param {boolean}                            isRequestingPreview - Whether the preview is being requested.
- * @param {UseVideoPlayerOptions}              options             - Options object.
+ * @param {RefObject< HTMLDivElement >} iFrameRef           - useRef of the sandbox wrapper.
+ * @param {boolean}                     isRequestingPreview - Whether the preview is being requested.
+ * @param {UseVideoPlayerOptions}       options             - Options object.
  * @return {UseVideoPlayer}                                     playerIsReady and playerState
  */
 const useVideoPlayer = (
-	iFrameRef: MutableRefObject< HTMLDivElement >,
+	iFrameRef: RefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
 	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/test/index.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/test/index.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import useVideoPlayer, { getIframeWindowFromRef } from '../index';
-import type { MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 
 jest.mock( 'debug', () => () => jest.fn() );
 jest.mock( '@wordpress/compose', () => ( {
@@ -12,9 +12,9 @@ jest.mock( '@wordpress/compose', () => ( {
  * is the real jsdom `window`, so event listeners added by the hook fire when
  * we dispatch on `window`.
  *
- * @return {MutableRefObject<HTMLDivElement>} The constructed ref.
+ * @return {RefObject< HTMLDivElement >} The constructed ref.
  */
-function createIframeRef(): MutableRefObject< HTMLDivElement > {
+function createIframeRef(): RefObject< HTMLDivElement > {
 	const wrapper = document.createElement( 'div' );
 	const iframe = document.createElement( 'iframe' );
 	iframe.className = 'components-sandbox';
@@ -24,13 +24,13 @@ function createIframeRef(): MutableRefObject< HTMLDivElement > {
 	} );
 	wrapper.appendChild( iframe );
 	document.body.appendChild( wrapper );
-	return { current: wrapper } as MutableRefObject< HTMLDivElement >;
+	return { current: wrapper } as RefObject< HTMLDivElement >;
 }
 
 describe( 'getIframeWindowFromRef', () => {
 	it( 'returns undefined when the wrapper contains no sandbox iframe', () => {
 		const wrapper = document.createElement( 'div' );
-		const ref = { current: wrapper } as MutableRefObject< HTMLDivElement >;
+		const ref = { current: wrapper } as RefObject< HTMLDivElement >;
 		expect( getIframeWindowFromRef( ref ) ).toBeUndefined();
 	} );
 
@@ -44,7 +44,7 @@ describe( 'getIframeWindowFromRef', () => {
 			configurable: true,
 		} );
 		wrapper.appendChild( iframe );
-		const ref = { current: wrapper } as MutableRefObject< HTMLDivElement >;
+		const ref = { current: wrapper } as RefObject< HTMLDivElement >;
 		expect( getIframeWindowFromRef( ref ) ).toBe( mockContentWindow );
 	} );
 } );
@@ -70,7 +70,7 @@ function dispatchPlayerMessage( {
 }
 
 describe( 'useVideoPlayer — listenEventsHandler guards', () => {
-	let iFrameRef: MutableRefObject< HTMLDivElement >;
+	let iFrameRef: RefObject< HTMLDivElement >;
 
 	beforeEach( () => {
 		iFrameRef = createIframeRef();


### PR DESCRIPTION
Fixes #

## Proposed changes
* Swap `MutableRefObject` for `RefObject` in `use-video-player` (hook + test) and `poster-panel`. `MutableRefObject` is deprecated in React 19's types; `RefObject` is the unified replacement. Runtime behavior is unchanged — production code already null-checks `.current`.
* Narrow the `withNotices` HOC outputs to `ComponentType< Record< string, unknown > >` for `PlaceholderWrapper` (defined in `edit.tsx`) and `VideoPressUploader` (imported into `edit.tsx`). Under React 19's stricter JSX element type, `withNotices` returns a union including a `(props, ref) => Element` render-function arm that JSX rejects; narrowing strips that arm without changing runtime behavior.
* Add `video-card/test/index.test.tsx` covering the ref wire from `VideoCard` → `VideoThumbnail` → `PublishFirstVideoPopover.anchor`. The test mocks `PublishFirstVideoPopover`, renders `VideoCard`, and asserts the captured `anchor` prop is an `HTMLElement`. Verified to fail when the underlying `forwardRef` is removed on React 18.

## Related product discussion/links
* React 19 upgrade announcement for WordPress: https://make.wordpress.org/core/2026/05/27/react-19-upgrade-in-wordpress/
* Upstream tracker: https://github.com/WordPress/gutenberg/issues/71336
* React 19 upgrade guide: https://react.dev/blog/2024/04/25/react-19-upgrade-guide

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

To verify the type-level fix:

* Temporarily bump `@types/react` and `@types/react-dom` to `19.2.3` in `projects/packages/videopress/package.json`, then `pnpm install --strict-peer-dependencies=false`.
* Run `pnpm exec tsgo --noEmit` in `projects/packages/videopress`. Confirm the three TS2786 errors in `src/client/block-editor/blocks/video/edit.tsx` (lines around `VideoPressUploader` and `PlaceholderWrapper`) are gone.
* Restore the type pins to `18.3.28` / `18.3.7` and `pnpm install` to clean up.

To verify nothing regressed at runtime:

* `pnpm test` in `projects/packages/videopress` — all 290 tests pass (290 = 289 prior + 1 new).
* Build the VideoPress package and load the VideoPress dashboard. After uploading a first video, confirm the "Publish your new video" popover appears anchored to the newly-uploaded video's thumbnail (this exercises the `VideoCard` → `VideoThumbnail` → popover-anchor ref wire that the new test guards).
* Open the VideoPress block in the editor. Trigger an upload (`VideoPressUploader`) and the placeholder-wrapped error/loading states (`PlaceholderWrapper`, e.g. by waiting for a preview to fail to generate). Both should render normally.

Note: `forwardRef` is intentionally left in place — removing it (the eventual React 19 idiom) cannot be done while WordPress core still ships React 18. The follow-up codemod should run once WP 7.1 / Gutenberg 23.3+ is the runtime target.
