### PR TITLE
Search Blocks: close gap between sidebar left border and search-input hairline (SEARCH-269)

### DIFF
--- a/projects/packages/search/changelog/nova-search-269-sidebar-border-hairline-gap
+++ b/projects/packages/search/changelog/nova-search-269-sidebar-border-hairline-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: sidebar left border now joins the search-input hairline cleanly across the embedded, blocks Overlay, and product-results templates, closing the 1.5rem gap that left the corner disconnected.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1404,51 +1404,47 @@ CSS;
 		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
-/* Sidebar-showing rules (>= 992px):
+/* Sidebar-showing rules (>= 992px). The corner-join is structural, not
+ * decorative: the columns row is pulled flush against the search-input
+ * hairline, and visual breathing room is re-added as internal column
+ * padding. Three sources of vertical gap have to be neutralised for the
+ * column's `border-left` to start *at* the hairline:
  *
- * 1. Hide the in-header filters-popover entirely so a stale
- *    `is-popover-open` class can't leak its panel into view while the
- *    sidebar is doing the filter job.
+ *   a) The outer `wp:group`'s declared `spacing.blockGap` (1.5rem in the
+ *      templates) or the theme's default block-gap (e.g. TT5 falls back
+ *      to 1.2rem when the block-layout system doesn't emit the
+ *      per-container override for templates rendered into a `<template>`
+ *      element). Both manifest as `margin-block-start` on the columns row.
  *
- * 2. Force the columns row to top-align — the block-layout default
- *    (`.is-layout-flex { align-items: center }`) vertically centers the
- *    shorter filters column inside the taller results column, dropping
- *    the sidebar's top edge well below the columns-row top. Top-aligning
- *    pins it back to the row's top so the border-left starts alongside
- *    the results column. Scoped via `:has(> filters-column)` so unrelated
- *    `wp:columns` blocks elsewhere in the template are unaffected.
+ *   b) `.is-layout-flex { align-items: center }` (theme default, also in
+ *      WordPress core), which vertically centres the shorter filters
+ *      column inside the taller results column, dropping the sidebar's
+ *      top edge below the row's top.
  *
- * 3. Bridge the outer-group `blockGap` with a 1px `::before` extending
- *    upward from the column's top edge to (just past) the hairline. The
- *    1.5rem height matches the `spacing.blockGap` declared on the outer
- *    `wp:group` in every template under `templates/`; on themes whose
- *    block-layout swallows the per-container override and falls back to
- *    a smaller `--wp--style--block-gap` (e.g. TT5's 1.2rem), the extra
- *    ~0.3rem overshoots into the search-input's vertical padding —
- *    visually neutral. */
+ *   c) Overlay-only: the `__content > .wp-block-group:first-child` rule
+ *      (SEARCH-243) gives the alignwide group a `padding: .5em 2em 2em`
+ *      to "clear the 60px header strip." But the search-input is
+ *      `position: absolute` in the overlay — it doesn't take flow space —
+ *      so the 0.5em top-pad just pushes the columns row 8px below the
+ *      card's `::before` hairline at `top: 60px`.
+ *
+ * The `.is-layout-flex` class match bumps the columns selector to
+ * specificity (0,3,0), enough to outrank any per-container `blockGap`
+ * CSS WP might emit (typically (0,1,0)). The `:has(> filters-column)`
+ * scope keeps these overrides off any unrelated `wp:columns` block. */
 @media (min-width: 992px) {
 	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
 		display: none;
 	}
-	.wp-block-columns:has(> .jetpack-search-layout__filters-column) {
+	.wp-block-columns.is-layout-flex:has(> .jetpack-search-layout__filters-column) {
 		align-items: flex-start;
+		margin-block-start: 0;
 	}
-	.jetpack-search-layout__filters-column {
-		position: relative;
+	.jetpack-search-block-overlay__content > .wp-block-group:first-child:has(.jetpack-search-layout__filters-column) {
+		padding-top: 0;
 	}
-	.jetpack-search-layout__filters-column::before {
-		content: "";
-		position: absolute;
-		left: -1px;
-		bottom: 100%;
-		width: 1px;
-		height: 1.5rem;
-		background-color: transparent;
-	}
-	@supports (background-color: color-mix(in sRGB, black 50%, white)) {
-		.jetpack-search-layout__filters-column::before {
-			background-color: color-mix(in sRGB, currentColor 15%, transparent);
-		}
+	.wp-block-columns:has(> .jetpack-search-layout__filters-column) > .wp-block-column {
+		padding-top: 0.5em;
 	}
 }
 CSS;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1390,13 +1390,6 @@ CSS;
 		flex-basis: 100% !important;
 	}
 }
-/* Sidebar is showing; hide the in-header popover entirely so a stale
- * `is-popover-open` class can't leak its panel into view. */
-@media (min-width: 992px) {
-	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
-		display: none;
-	}
-}
 /* Sidebar left divider tracks `currentColor` so the hairline stays subtle on
  * light themes and visible on dark themes, matching the search-input
  * underline. We only set color; each template's column block sets
@@ -1411,30 +1404,32 @@ CSS;
 		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
-/* Visually join the sidebar's left divider to the search-input hairline.
- * Two cooperating rules, both scoped to >= 992px (below that, the sidebar
- * is `display: none`):
+/* Sidebar-showing rules (>= 992px):
  *
- * 1. Force the columns row to top-align — the block-layout default
+ * 1. Hide the in-header filters-popover entirely so a stale
+ *    `is-popover-open` class can't leak its panel into view while the
+ *    sidebar is doing the filter job.
+ *
+ * 2. Force the columns row to top-align — the block-layout default
  *    (`.is-layout-flex { align-items: center }`) vertically centers the
  *    shorter filters column inside the taller results column, dropping
  *    the sidebar's top edge well below the columns-row top. Top-aligning
- *    pins it back to the row's top so the border-left starts at a
- *    predictable y, alongside the results column.
+ *    pins it back to the row's top so the border-left starts alongside
+ *    the results column. Scoped via `:has(> filters-column)` so unrelated
+ *    `wp:columns` blocks elsewhere in the template are unaffected.
  *
- * 2. Bridge the outer-group `blockGap` with a 1px `::before` extending
+ * 3. Bridge the outer-group `blockGap` with a 1px `::before` extending
  *    upward from the column's top edge to (just past) the hairline. The
  *    1.5rem height matches the `spacing.blockGap` declared on the outer
  *    `wp:group` in every template under `templates/`; on themes whose
- *    block-layout system swallows the per-container override and falls
- *    back to a smaller `--wp--style--block-gap` (e.g. TT5's 1.2rem), the
- *    extra ~0.3rem overshoots into the search-input's vertical padding
- *    — invisible against the hairline-colored padding area.
- *
- * The `:has()` selector caps the alignment override to columns rows that
- * actually contain our filter sidebar, so unrelated `wp:columns` blocks
- * elsewhere in the template are unaffected. */
+ *    block-layout swallows the per-container override and falls back to
+ *    a smaller `--wp--style--block-gap` (e.g. TT5's 1.2rem), the extra
+ *    ~0.3rem overshoots into the search-input's vertical padding —
+ *    visually neutral. */
 @media (min-width: 992px) {
+	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
+		display: none;
+	}
 	.wp-block-columns:has(> .jetpack-search-layout__filters-column) {
 		align-items: flex-start;
 	}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1411,16 +1411,49 @@ CSS;
 		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
-/* Pull the filters column up by the outer-group `blockGap` so its left
- * border meets the search-input hairline; matching `padding-top` keeps the
- * sidebar's visible content aligned with the results column. The 1.5rem
- * literal mirrors the `spacing.blockGap` set on the outer `wp:group` in
- * every template under `templates/` — if that gap changes, this must too.
- * Scoped to >= 992px because below that the sidebar is `display: none`. */
+/* Visually join the sidebar's left divider to the search-input hairline.
+ * Two cooperating rules, both scoped to >= 992px (below that, the sidebar
+ * is `display: none`):
+ *
+ * 1. Force the columns row to top-align — the block-layout default
+ *    (`.is-layout-flex { align-items: center }`) vertically centers the
+ *    shorter filters column inside the taller results column, dropping
+ *    the sidebar's top edge well below the columns-row top. Top-aligning
+ *    pins it back to the row's top so the border-left starts at a
+ *    predictable y, alongside the results column.
+ *
+ * 2. Bridge the outer-group `blockGap` with a 1px `::before` extending
+ *    upward from the column's top edge to (just past) the hairline. The
+ *    1.5rem height matches the `spacing.blockGap` declared on the outer
+ *    `wp:group` in every template under `templates/`; on themes whose
+ *    block-layout system swallows the per-container override and falls
+ *    back to a smaller `--wp--style--block-gap` (e.g. TT5's 1.2rem), the
+ *    extra ~0.3rem overshoots into the search-input's vertical padding
+ *    — invisible against the hairline-colored padding area.
+ *
+ * The `:has()` selector caps the alignment override to columns rows that
+ * actually contain our filter sidebar, so unrelated `wp:columns` blocks
+ * elsewhere in the template are unaffected. */
 @media (min-width: 992px) {
+	.wp-block-columns:has(> .jetpack-search-layout__filters-column) {
+		align-items: flex-start;
+	}
 	.jetpack-search-layout__filters-column {
-		margin-top: -1.5rem;
-		padding-top: 1.5rem;
+		position: relative;
+	}
+	.jetpack-search-layout__filters-column::before {
+		content: "";
+		position: absolute;
+		left: -1px;
+		bottom: 100%;
+		width: 1px;
+		height: 1.5rem;
+		background-color: transparent;
+	}
+	@supports (background-color: color-mix(in sRGB, black 50%, white)) {
+		.jetpack-search-layout__filters-column::before {
+			background-color: color-mix(in sRGB, currentColor 15%, transparent);
+		}
 	}
 }
 CSS;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1411,6 +1411,18 @@ CSS;
 		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
+/* Pull the filters column up by the outer-group `blockGap` so its left
+ * border meets the search-input hairline; matching `padding-top` keeps the
+ * sidebar's visible content aligned with the results column. The 1.5rem
+ * literal mirrors the `spacing.blockGap` set on the outer `wp:group` in
+ * every template under `templates/` — if that gap changes, this must too.
+ * Scoped to >= 992px because below that the sidebar is `display: none`. */
+@media (min-width: 992px) {
+	.jetpack-search-layout__filters-column {
+		margin-top: -1.5rem;
+		padding-top: 1.5rem;
+	}
+}
 CSS;
 	}
 


### PR DESCRIPTION
Fixes [SEARCH-269](https://linear.app/a8c/issue/SEARCH-269/search-blocks-close-gap-between-sidebar-left-border-and-search-input)

## Why

In the Search Blocks templates, the filter sidebar's vertical left border didn't visually connect to the horizontal hairline under the search input — there was a ~1.5rem gap at the top-left corner of the sidebar. [SEARCH-268 (#49192)](https://github.com/Automattic/jetpack/pull/49192) recently unified the *color* of those two strokes; this PR closes the *positional* gap so the hairline and sidebar divider read as one continuous corner.

The three templates all wrap the search input and the columns row in an outer `wp:group` with `spacing.blockGap: 1.5rem`. WP's flow layout turns that into a 1.5rem `margin-block-start` on the columns row, so the filters column's top edge — and the start of its `border-left` — sits 1.5rem below the search-input hairline.

## Proposed changes

* In `Search_Blocks::search_layout_inline_css()` add a `≥ 992px` rule that pulls `.jetpack-search-layout__filters-column` up by `1.5rem` (matching the outer-group `blockGap`) with `padding-top` compensation so the sidebar's heading / filter list stay vertically aligned with the results column. Below 992px the existing `display: none` collapse rule continues to own the layout.

## Screenshots

### Blocks Overlay

| Before | After |
|---|---|
| ![before-overlay](https://github.com/user-attachments/assets/c3515b94-75b3-414e-b1d7-dd42c1e0e5a0) | ![after-overlay](https://github.com/user-attachments/assets/2f2cb197-bc05-4451-a274-6a9fee18a047) |

### Embedded search template

| Before | After |
|---|---|
| ![before-embedded](https://github.com/user-attachments/assets/1a15a193-952e-4392-965d-1722037b6690) | ![after-embedded](https://github.com/user-attachments/assets/cd00d895-e539-4f32-8fde-5d9e4688b183) |

The product-results template (`jetpack-search-product-results.html`) shares the same `.jetpack-search-layout__filters-column` class and outer-group `blockGap`, so the same fix applies; not separately screenshotted.

## Related product discussion/links

* Linear: [SEARCH-269](https://linear.app/a8c/issue/SEARCH-269/search-blocks-close-gap-between-sidebar-left-border-and-search-input)
* Prior color-unification work: [SEARCH-268 / #49192](https://github.com/Automattic/jetpack/pull/49192)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- [ ] On the blocks Overlay (`jetpack_search_experience = overlay_blocks`), open the overlay on any search page (e.g. `/?s=hello`) and confirm the sidebar's vertical left border meets the search-input hairline cleanly — no gap above the sidebar.
- [ ] On the embedded search template (`jetpack_search_experience = embedded`), navigate to `/?s=hello` and confirm the same — sidebar border touches the hairline; `Filter options` heading remains aligned with the `Sort by` row in the results column.
- [ ] On a WooCommerce product-results page (when WC is active), confirm the same on the product-results template.
- [ ] Confirm the sidebar's `<h2>` heading + filter list haven't shifted downward — content alignment with the results-column body is preserved.
- [ ] Resize below 992px and confirm the sidebar still collapses to the existing in-header filters-popover trigger (no regression to the responsive behaviour).
- [ ] Verify on both a light theme and a dark theme that the hairline + sidebar divider render with the same 15%-currentColor mix (SEARCH-268's color tracking still applies).
