### PR TITLE
Search Blocks Overlay: separate card from scrim on dark themes (SEARCH-270)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-270-overlay-dark-theme-separation
+++ b/projects/packages/search/changelog/atlas-search-270-overlay-dark-theme-separation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks Overlay: separate the modal card from the dim scrim on dark themes by tinting the resolved surface and painting a token-aware hairline border, so the card visibly layers above the page behind it.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1143,9 +1143,22 @@ class Search_Blocks {
 	--jp-search-overlay-ink: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327));
 	background: var(--jp-search-overlay-surface);
 	color: var(--jp-search-overlay-ink);
+	border: 1px solid rgba(128, 128, 128, 0.25);
 	border-radius: 4px;
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 	padding-top: 60px;
+}
+/* Token-aware card / scrim separation (SEARCH-270): tint the resolved surface
+ * ~5% toward ink and paint the hairline border with the same ink-over-surface
+ * mix used for the header `::before`. Both auto-invert polarity per theme, so
+ * dark themes get a card that visibly layers above the scrim without losing
+ * the themed surface color. The static `rgba(128,128,128,.25)` border + the
+ * un-tinted token chain stay as the fallback for browsers without `color-mix`. */
+@supports (background: color-mix(in sRGB, black 50%, white)) {
+	.jetpack-search-block-overlay__card {
+		--jp-search-overlay-surface: color-mix(in sRGB, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327)) 5%, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		border-color: color-mix(in sRGB, var(--jp-search-overlay-ink) 20%, var(--jp-search-overlay-surface));
+	}
 }
 /* Single hairline over the full 60px header strip — siblings paint with a seam (SEARCH-260). */
 .jetpack-search-block-overlay__card::before {
@@ -1269,6 +1282,7 @@ class Search_Blocks {
 	}
 	.jetpack-search-block-overlay__card {
 		min-height: 100vh;
+		border: 0;
 		border-radius: 0;
 		box-shadow: none;
 	}

--- a/projects/plugins/search/changelog/atlas-search-270-overlay-dark-theme-separation
+++ b/projects/plugins/search/changelog/atlas-search-270-overlay-dark-theme-separation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks Overlay: separate the modal card from the dim scrim on dark themes by tinting the resolved surface and painting a token-aware hairline border, so the card visibly layers above the page behind it.


### PR DESCRIPTION
Fixes [SEARCH-270](https://linear.app/a8c/issue/SEARCH-270/search-blocks-overlay-separate-card-from-scrim-on-dark-themes-hairline)

## Why

When a visitor opens the blocks-powered Search Overlay on a dark block theme, the modal card barely separates from the dimmed page behind it — the card surface and the scrim read at the same density, so the dialog feels like a single dark plane instead of a layered card. Light themes don't show the bug because the existing drop shadow naturally pops against a light surface. This PR brings the same "card sitting on top" cue to dark themes while still respecting `--wp--preset--color--*` tokens, so themed surfaces stay themed.

## Proposed changes

* `.jetpack-search-block-overlay__card` now paints a 1px hairline border. The static fallback is a neutral `rgba(128, 128, 128, 0.25)`; inside an `@supports (background: color-mix(...))` gate the `border-color` switches to `color-mix(in sRGB, var(--jp-search-overlay-ink) 20%, var(--jp-search-overlay-surface))` — same recipe as the header `::before` separator, bumped slightly for the outer edge. Polarity inverts per theme.
* Inside the same `@supports` block, `--jp-search-overlay-surface` is tinted ~5% toward ink via `color-mix`. All in-card surfaces (suggestions panel, header hairline, close-button hover) read the same custom prop, so they shift together — no internal mismatch.
* On `max-width: 781px` the card resets `border: 0` alongside the existing `border-radius: 0; box-shadow: none` — a full-bleed card has no scrim to separate from.

## Screenshots

Captured at 1440×900 against the local docker overlay (`/?s=hello`). The "theme" axis is simulated by injecting `--wp--preset--color--base` + `--wp--preset--color--contrast` at `:root`, which is the exact code path the fix targets.

### Dark theme — bug vs fix

| Before | After |
|---|---|
| ![before-dark](https://github.com/user-attachments/assets/f942aecb-48a9-4a12-8938-4670b31b3431) | ![after-dark](https://github.com/user-attachments/assets/df60d23a-fad2-49c1-a22e-d3e01f3d319f) |

### Light theme — no regression

| Before | After |
|---|---|
| ![before-light](https://github.com/user-attachments/assets/804d56a3-52db-436e-9a68-fadf151c7c82) | ![after-light](https://github.com/user-attachments/assets/c5d1d3cc-0c88-4716-8ffa-2c13e481e90e) |

## Related product discussion/links

* [SEARCH-270](https://linear.app/a8c/issue/SEARCH-270/search-blocks-overlay-separate-card-from-scrim-on-dark-themes-hairline)
* Related recent overlay work: [#49184](https://github.com/Automattic/jetpack/pull/49184) (SEARCH-260 follow-up — keep the static-fallback leg alive on classic themes), [#49180](https://github.com/Automattic/jetpack/pull/49180) (3-tier `base` → `background` → `#fff` fallback chain).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-270:

- [ ] On a dark block theme (e.g. Twenty Twenty-Five dark style variation, or any theme that resolves `--wp--preset--color--base` to a dark value), open the Blocks-powered Search Overlay (Jetpack → Search → Experience: "Overlay (blocks-powered)", then visit `?s=hello` on the site front-end). The card has a visible edge / subtle surface tint that separates it from the dim page behind it.
- [ ] On a light block theme, the existing layered appearance is preserved — no visible regression to the card edge or surface tone.
- [ ] On a classic / legacy theme that doesn't define `--wp--preset--color--*`, the card still has a visible edge against the scrim (the static `rgba(128, 128, 128, 0.25)` fallback path).
- [ ] On a mobile viewport (≤ 781px), the card stays full-bleed with no stray border — `border-radius: 0` + `box-shadow: none` + `border: 0`.
- [ ] In-card surfaces stay consistent with the card surface: open the search-input suggestions, hover the close button, look at the hairline under the 60px header strip — they all read the same tinted surface.
- [ ] No regression to SEARCH-260: on fieldguide or similar legacy themes that lack `--wp--preset--color--*`, the header hairline still paints and in-overlay buttons still have a visible hover affordance.
