### PR TITLE
Search Blocks: align rating-star colors + opaque-surface var() chains (SEARCH-272)

### DIFF
--- a/projects/packages/search/changelog/echo-search-272-css-theme-tokens
+++ b/projects/packages/search/changelog/echo-search-272-css-theme-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: unify rating-star color contract and align suggestions / price-slider surfaces with the 3-tier theme-token fallback chain.

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/style.scss
@@ -30,7 +30,11 @@
 	width: 14px;
 	height: 14px;
 	border-radius: 50%;
-	background: var(--wp--preset--color--background, #fff);
+	// 3-tier `--base → --background → #fff` fallback chain matches
+	// `filters-popover` / `results-sort` / search-input suggestions, so the
+	// thumb stays an opaque puck across block themes, classic themes with
+	// partial theme.json, and pre-theme.json classic themes.
+	background: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 	border: 2px solid currentColor;
 	margin: 0;
 	padding: 0;
@@ -225,12 +229,12 @@
 
 			&::-webkit-slider-thumb {
 				background: var(--range-color);
-				border-color: var(--wp--preset--color--background, #fff);
+				border-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 			}
 
 			&::-moz-range-thumb {
 				background: var(--range-color);
-				border-color: var(--wp--preset--color--background, #fff);
+				border-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 			}
 		}
 	}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
@@ -70,19 +70,22 @@
 
 	// Stars are inline-rendered text glyphs (★) styled with color so the
 	// markup stays SVG-free and survives WP's content-export pipeline.
-	// Matches WC's color cues — gold for filled, muted gray for empty —
-	// without pulling in WC's icon asset.
+	// Filled stars share the `--jetpack-search-rating-color` author override
+	// with the per-result product-rating widget (`results-list/style.scss`),
+	// so retinting one retints both. Empty stars mute against the theme's
+	// foreground via `color-mix` instead of pinning to a fixed grey — that
+	// keeps the track readable on dark themes.
 	.jetpack-search-filter-rating__star {
 		display: inline-block;
 		font-size: 1.05em;
 		line-height: 1;
 
 		&.is-filled {
-			color: #f0b800;
+			color: var(--jetpack-search-rating-color, #f7b500);
 		}
 
 		&.is-empty {
-			color: #c8c8c8;
+			color: color-mix(in sRGB, currentColor 25%, transparent);
 		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -101,15 +101,17 @@
 		max-height: 60vh;
 		overflow-y: auto;
 		overscroll-behavior: contain;
-		// Fallbacks keep the surface opaque on themes that don't define the
-		// `base` / `contrast` tokens — without them the rule resolves to
-		// nothing and the panel paints transparent, letting whatever sits
-		// behind it (results rows, filter labels) bleed through.
-		background: var(--wp--preset--color--base, #fff);
+		// `background-color` longhand + 3-tier `--base → --background → #fff`
+		// fallback chain matches `filters-popover` / `results-sort`. The
+		// shorthand `background:` collapses to `transparent` on themes that
+		// emit neither token, letting result-card content bleed through behind
+		// the dropdown.
+		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 		// The dropdown owns its surface, so pin the ink color too — otherwise
 		// the option text inherits a low-contrast theme accent from the
-		// surrounding page (e.g. a muted header link color).
-		color: var(--wp--preset--color--contrast, currentColor);
+		// surrounding page (e.g. a muted header link color). 3-tier fallback
+		// chain mirrors the popover panel's `--contrast → --foreground → inherit`.
+		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
 		// Reset the inherited theme base size so option text tracks the
 		// other block surfaces (sort menu, filters popover) at 1rem instead
 		// of the host theme's oversized default.


### PR DESCRIPTION
Fixes [SEARCH-272](https://linear.app/a8c/issue/SEARCH-272/search-blocks-replace-hardcoded-css-values-with-theme-tokens-rating)

## Why

Audit of `projects/packages/search/src/search-blocks/blocks/**/*.scss` for hardcoded values that drift from the package's theme-aware conventions. The package is already mostly theme-aware (`color-mix(currentColor, …)` accents, `var(--wp--style--block-gap, …)` gaps, surface tokens with fallback chains), but two pockets stuck out:

1. **`filter-wc-rating` star colors were hardcoded** (`#f0b800` filled, `#c8c8c8` empty) while the visually identical star widget in `results-list` already used `var(--jetpack-search-rating-color, #f7b500)` for filled and `color-mix(in sRGB, currentColor 25%, transparent)` for the empty track. Two yellows on the same page; flat grey empty stars regardless of theme.
2. **The `search-input` suggestions dropdown and the `filter-wc-price` slider thumb** still used the older `var(--…, #fff)` 2-tier fallback, instead of the 3-tier `--base → --background → #fff` chain that #49180 (SEARCH-263) established for `filters-popover` and `results-sort`.

## Proposed changes

* `filter-wc-rating/style.scss` — filled stars switch to `var(--jetpack-search-rating-color, #f7b500)`, matching the per-result product-rating widget. Empty stars switch to `color-mix(in sRGB, currentColor 25%, transparent)` so the track mutes against the theme foreground.
* `search-input/style.scss` — suggestions dropdown surface uses the longhand `background-color` with `--base → --background → #fff`, ink color uses `--contrast → --foreground → inherit`. Same idiom as `filters-popover` / `results-sort`.
* `filter-wc-price/style.scss` — slider thumb background + focus-thumb border-color both use `--base → --background → #fff`.
* Changelog entry (significance: patch, type: changed).

## What actually changes at runtime

The search package's `postcss.config.js` runs `postcss-custom-properties` with `preserve: false`, which folds every `var(--foo, fallback)` to its literal fallback at build time. Verified directly against the built CSS — the compiled `filters-popover.css` already ships `background-color: #fff;`, not the var() chain. Implication for this PR:

* **`filter-wc-rating` empty stars — real runtime change.** `color-mix(currentColor, …)` passes through postcss intact, so on dark themes the empty stars now mute against the inherited foreground instead of pinning to flat `#c8c8c8`. See the dark-theme screenshot below.
* **`filter-wc-rating` filled stars — small runtime change.** Source declares `var(--jetpack-search-rating-color, #f7b500)`; postcss collapses it to `#f7b500` literal. The author-override property doesn't fire (same caveat as the existing `results-list/style.scss:410` declaration). What does change: the filled-star yellow swaps from `#f0b800` to `#f7b500`, aligning with the per-result product rating widget rendered alongside it.
* **`search-input` suggestions + `filter-wc-price` thumb — source consistency, byte-identical compiled output.** Both `var(--base, #fff)` and `var(--base, var(--background, #fff))` postcss-fold to literal `#fff`. Keeping the 3-tier chain in source for forward-compat with the `preserve: false` removal that's annotated as the intended direction in the postcss.config.js comment, and to match the SEARCH-263 precedent.

## Screenshots

Captured against `twentytwentyfive` via the per-agent local docker env at 1440×900. Light-theme delta on the filled-star hue is subtle; the dark-wrap screenshot is the load-bearing one for the empty-star currentColor mix.

### Filter card on a light theme

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/6cde2cd2-4be6-4e72-ab1c-19de6976806c) | ![after](https://github.com/user-attachments/assets/14491469-cd63-4414-a63d-f09ecdfef345) |

### Filter card on a dark wrap (`color: #fff` on the block container — simulates dark-theme inheritance)

| Before | After |
|---|---|
| ![before-dark](https://github.com/user-attachments/assets/fd651e52-7b43-4485-a32f-ec0d26398c01) | ![after-dark](https://github.com/user-attachments/assets/dc37f425-e471-43fa-93dd-5290cc5ac7c4) |

The empty stars in the **before** dark image read as a fixed light-grey pinned at `#c8c8c8` — they ignore the wrapper's white foreground. In the **after** dark image the same stars become a translucent white at 25% — they read as a muted state of the theme's own foreground, the same way the per-result rating widget's track already does.

## Related product discussion/links

* Linear: [SEARCH-272](https://linear.app/a8c/issue/SEARCH-272/search-blocks-replace-hardcoded-css-values-with-theme-tokens-rating)
* Prior in this series: #49180 (SEARCH-263 surface fallback chain), #49184 (SEARCH-260 overlay tokens follow-up), #49179 (SEARCH-260 overlay tokens).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Pull the branch and rebuild the matrix: `pnpm jetpack build packages/my-jetpack && pnpm jetpack build plugins/jetpack && pnpm jetpack build packages/search && pnpm jetpack build plugins/search`.
2. On a local site with WooCommerce active and at least one product:
   - [ ] Insert a `jetpack-search/search-results` block on a page containing a `filter-wc-rating` child block, publish, view on the front end. Confirm the filled stars match the yellow of `results-list`'s rating widget on the same page (both render at `#f7b500`).
   - [ ] On a dark style (or wrap the filter in a container with `color: #fff; background: #1a1a1a;`), confirm the empty stars now mute against the wrapper foreground via `color-mix` instead of staying a flat `#c8c8c8`.
3. Surface-fallback alignment (compiled to `#fff` literal on every theme today — no visible regression, just source consistency):
   - [ ] Open the search-input autocomplete suggestions; confirm the dropdown remains opaque against varied page content.
   - [ ] On a product search page, drag and focus a price slider thumb; confirm the thumb fill is opaque and the focus-ring border is visible.
4. Confirm no compiled-CSS regression on the unchanged surfaces (`filters-popover`, `results-sort`, `active-filters` pills).
