### PR TITLE
Search Blocks: add a Width control to the Search Input block

### DIFF
--- a/projects/packages/search/changelog/raven-search-input-width-control
+++ b/projects/packages/search/changelog/raven-search-input-width-control
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: added
 
 Search Blocks: add a Width control (px / %) to the Search Input block inspector, matching `core/search`.

--- a/projects/packages/search/changelog/raven-search-input-width-control
+++ b/projects/packages/search/changelog/raven-search-input-width-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: add a Width control (px / %) to the Search Input block inspector, matching `core/search`.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -29,7 +29,9 @@
 			"type": "array",
 			"default": [],
 			"items": { "type": "string" }
-		}
+		},
+		"width": { "type": "number" },
+		"widthUnit": { "type": "string" }
 	},
 	"textdomain": "jetpack-search-pkg",
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -14,10 +14,34 @@ import {
 	PanelBody,
 	TextControl,
 	ToggleControl,
+	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PostTypeScopeControl from '../../editor/post-type-control';
+
+// Width control constants mirror `core/search`'s defaults so authors get the
+// same feel across the two blocks (`packages/block-library/src/search/utils.js`).
+// `MIN_WIDTH` is the px floor for any non-percentage unit — below ~220 px the
+// field can't reliably show a useful placeholder + clear button.
+const MIN_WIDTH = 220;
+const PX_WIDTH_DEFAULT = 350;
+const PC_WIDTH_DEFAULT = 50;
+const WIDTH_UNITS = [
+	{ value: 'px', label: 'px', default: PX_WIDTH_DEFAULT },
+	{ value: '%', label: '%', default: PC_WIDTH_DEFAULT },
+];
+
+/**
+ * Whether a unit is the percentage unit. Used to clamp max=100 and to swap
+ * `MIN_WIDTH` out of the way (a 220% width isn't meaningful).
+ *
+ * @param {string} unit - The unit symbol.
+ * @return {boolean} True for '%'.
+ */
+function isPercentageUnit( unit ) {
+	return unit === '%';
+}
 
 // Mirrors the enum on `block.json::attributes.suggestionTypes.items.enum`
 // and the canonical order rendered by `suggestion-rows.js::TYPE_ORDER`.
@@ -95,10 +119,18 @@ function SearchGlyph() {
  * @return {object} Rendered element.
  */
 export default function SearchInputEdit( { attributes, setAttributes } ) {
-	const blockProps = useBlockProps();
+	// Width is opt-in: only emit the inline style when the author has set both
+	// halves of the (value, unit) pair, mirroring `render_block_core_search`'s
+	// `! empty( $width ) && ! empty( $widthUnit )` gate.
+	const width = attributes?.width;
+	const widthUnit = attributes?.widthUnit;
+	const hasWidth = width !== undefined && width !== null && !! widthUnit;
+	const wrapperStyle = hasWidth ? { width: `${ width }${ widthUnit }` } : undefined;
+	const blockProps = useBlockProps( wrapperStyle ? { style: wrapperStyle } : undefined );
 	// Per-instance id keeps the label→input association valid when the editor
 	// renders more than one Search Input on the same canvas.
 	const inputId = useId();
+	const widthInputId = useId();
 	const defaultPlaceholder = __( 'Search…', 'jetpack-search-pkg' );
 	// Match render.php: a whitespace-only placeholder falls back to the
 	// translated default in the preview so the editor mirrors the front end.
@@ -201,6 +233,53 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 							</p>
 						</fieldset>
 					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Dimensions', 'jetpack-search-pkg' ) } initialOpen={ false }>
+					{ /* Mirrors core/search's width control — UnitControl with px / %
+						units, MIN_WIDTH floor on non-percentage units, max=100 on %.
+						Switching units snaps to a sensible default (350 px ↔ 50 %)
+						so a 350 → % transition doesn't leave a meaningless 350%. */ }
+					<UnitControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Width', 'jetpack-search-pkg' ) }
+						id={ widthInputId }
+						min={ isPercentageUnit( widthUnit ) ? 0 : MIN_WIDTH }
+						max={ isPercentageUnit( widthUnit ) ? 100 : undefined }
+						step={ 1 }
+						units={ WIDTH_UNITS }
+						value={ hasWidth ? `${ width }${ widthUnit }` : '' }
+						onChange={ newValue => {
+							if ( ! newValue ) {
+								setAttributes( { width: undefined, widthUnit: undefined } );
+								return;
+							}
+							// UnitControl emits a concatenated string like `300px` — the
+							// number plus its currently-selected unit. Save BOTH halves
+							// on every keystroke; without this, `width` lands but
+							// `widthUnit` only sets through `onUnitChange` (which fires
+							// only on explicit unit-picker changes). Fall back to the
+							// existing widthUnit, then to the first unit in WIDTH_UNITS,
+							// so the very first keystroke on a fresh block persists a
+							// usable pair.
+							const parsed = parseInt( newValue, 10 );
+							const unitMatch = String( newValue ).match( /[^\d.]+$/ );
+							const unit = unitMatch?.[ 0 ] || widthUnit || WIDTH_UNITS[ 0 ].value;
+							setAttributes( {
+								width: Number.isNaN( parsed ) ? undefined : parsed,
+								widthUnit: unit,
+							} );
+						} }
+						onUnitChange={ newUnit => {
+							setAttributes( {
+								width: isPercentageUnit( newUnit ) ? PC_WIDTH_DEFAULT : PX_WIDTH_DEFAULT,
+								widthUnit: newUnit,
+							} );
+						} }
+					/>
+					<p className="components-base-control__help" style={ HELP_STYLE }>
+						{ __( 'Leave empty to use the full container width.', 'jetpack-search-pkg' ) }
+					</p>
 				</PanelBody>
 				<PanelBody title={ __( 'Post types', 'jetpack-search-pkg' ) } initialOpen={ false }>
 					<p className="components-base-control__help" style={ HELP_STYLE }>

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -125,8 +125,10 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const width = attributes?.width;
 	const widthUnit = attributes?.widthUnit;
 	const hasWidth = width !== undefined && width !== null && !! widthUnit;
+	// `useBlockProps` drops a `style: undefined` entry on its own, so no need
+	// to gate the call on `wrapperStyle` — keeps the call site to one line.
 	const wrapperStyle = hasWidth ? { width: `${ width }${ widthUnit }` } : undefined;
-	const blockProps = useBlockProps( wrapperStyle ? { style: wrapperStyle } : undefined );
+	const blockProps = useBlockProps( { style: wrapperStyle } );
 	// Per-instance id keeps the label→input association valid when the editor
 	// renders more than one Search Input on the same canvas.
 	const inputId = useId();

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -92,9 +92,29 @@ $emit_context = ! empty( $context );
 $context_json = $emit_context
 	? wp_json_encode( $context, JSON_HEX_AMP | JSON_UNESCAPED_SLASHES )
 	: '';
+
+// Mirrors `render_block_core_search()`'s width handling: both halves of the
+// (value, unit) pair must be present, then emit `width: <n><unit>;` on the
+// wrapper. The inside-wrapper's `display:flex` + `min-width:0` on the field
+// shrinks the visible text area in step; icon + clear stay at natural width.
+// `widthUnit` is allowlisted against the same units the editor offers —
+// `block.json` only types it as a free-form string, so a REST write or a
+// future migration can't smuggle an arbitrary unit into the inline style.
+$wrapper_extra_attrs = array();
+$allowed_width_units = array( 'px', '%' );
+$raw_width_unit      = (string) ( $attributes['widthUnit'] ?? '' );
+$width_unit          = in_array( $raw_width_unit, $allowed_width_units, true ) ? $raw_width_unit : '';
+$has_width           = isset( $attributes['width'] ) && '' !== $attributes['width'] && '' !== $width_unit;
+if ( $has_width ) {
+	$wrapper_extra_attrs['style'] = sprintf(
+		'width:%d%s;',
+		(int) $attributes['width'],
+		$width_unit
+	);
+}
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	<?php echo wp_kses_data( get_block_wrapper_attributes( $wrapper_extra_attrs ) ); ?>
 	data-wp-interactive="jetpack-search"
 	<?php if ( $emit_context ) : ?>
 	data-wp-context='<?php echo esc_attr( $context_json ); ?>'

--- a/projects/packages/search/tests/js/search-blocks/search-input-block-json.test.js
+++ b/projects/packages/search/tests/js/search-blocks/search-input-block-json.test.js
@@ -26,4 +26,13 @@ describe( 'search-input block.json', () => {
 			items: { type: 'string' },
 		} );
 	} );
+
+	it( 'declares opt-in width + widthUnit attributes (no defaults — matches core/search)', () => {
+		const attrs = blockJson.attributes;
+		// No defaults: the (value, unit) pair only takes effect when the
+		// author has set both halves, matching `render_block_core_search`'s
+		// `! empty( $width ) && ! empty( $widthUnit )` gate.
+		expect( attrs.width ).toEqual( { type: 'number' } );
+		expect( attrs.widthUnit ).toEqual( { type: 'string' } );
+	} );
 } );


### PR DESCRIPTION
## Why

Authors who place the Search Input in a tight header or sidebar layout need to constrain its width — currently it always stretches to the container. This adds a Width control in the inspector that mirrors `core/search`'s contract (`width` + `widthUnit` attribute pair, px / % units, opt-in with no defaults), so the two blocks feel identical to author with and the saved markup is portable.

## Proposed changes

* `block.json`: new `width` (number) + `widthUnit` (string) attributes, both opt-in with no defaults — matching `core/search` and the `! empty( $width ) && ! empty( $widthUnit )` gate in `render_block_core_search`.
* `edit.js`: new **Dimensions** panel with `__experimentalUnitControl`, px / % units, `MIN_WIDTH=220` floor on px, `max=100` on %, and the canonical 350 px ↔ 50 % swap on unit change. The `onChange` handler extracts the unit suffix from the emitted string (e.g. `"300px"`) and persists both halves on every keystroke, with a fall-back chain (`current → first WIDTH_UNITS entry`) so the first keystroke on a fresh block lands a usable pair.
* `render.php`: emits `style="width:<n><unit>;"` on the block wrapper via `get_block_wrapper_attributes()`. `widthUnit` is allowlisted in PHP against the units the editor offers — `block.json` only types it as a free-form string, so a REST write or future migration can't smuggle an arbitrary unit into the inline style.

## Related product discussion/links

* Width control derived from `core/search` (`packages/block-library/src/search/edit.js`, `index.php`).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- [ ] In the editor, insert a Search Input block. Open the **Dimensions** panel in the inspector. Set Width = `300` → the input narrows to 300 px in the canvas. Save + view on the front end → renders at 300 px.
- [ ] Switch the unit picker to `%`: value snaps to `50` (`PC_WIDTH_DEFAULT`); typing `75` renders the input at 75 % of the container.
- [ ] Switch back to `px`: value snaps to `350` (`PX_WIDTH_DEFAULT`).
- [ ] Clear the field. Both `width` and `widthUnit` reset to `undefined`; the block renders at full container width on the front end.
- [ ] Front-end DOM inspection: a configured value emits `style="width:<n><unit>;"` on `.wp-block-jetpack-search-search-input`. An unconfigured one omits the style attribute entirely.
- [ ] Non-`px` / non-`%` units delivered via REST or a migration are silently dropped by `render.php`'s allowlist (no inline style emitted, no console errors).

## Screenshots

Captured against the local docker WP at 1680×900 with `<!-- wp:jetpack-search/search-input {"width":300,"widthUnit":"px"} /-->` on a page. Trunk drops the unknown attributes; this branch applies them.

### Editor — block selected, Settings sidebar open

| Before (trunk — no Dimensions panel) | After (this branch — Dimensions panel + Width=300 px) |
|---|---|
| ![before](https://github.com/user-attachments/assets/d4fbc649-ff4b-422a-8164-e65d0a940a6a) | ![after](https://github.com/user-attachments/assets/d30e6e6e-9a05-41fc-ab27-5fa6cb635dea) |

### Front-end render

| Before (trunk — full-container width) | After (this branch — 300 px) |
|---|---|
| ![before](https://github.com/user-attachments/assets/1554223c-d235-4fac-be50-cfdfba7fa9a4) | ![after](https://github.com/user-attachments/assets/21ae7ba0-b447-40c2-a156-72d29628584b) |

---

> Scope note: this PR was trimmed to width-only. The earlier form-wrap work (so a standalone Search Input degrades to `/?s=…`) lives in [SEARCH-271](https://linear.app/a8c/issue/SEARCH-271/search-blocks-wrap-search-input-in-a-form-so-it-works-standalone) for a separate PR.
