### PR TITLE
Premium Analytics: Track analytics-aware sync milestone

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-sync-status-tracker
+++ b/projects/packages/premium-analytics/changelog/add-sync-status-tracker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Track the analytics-relevant initial full-sync milestone and expose it to the dashboard via JetpackScriptData.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -4,11 +4,13 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.2",
+		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/phpunit-select-config": "@dev"
+		"automattic/phpunit-select-config": "@dev",
+		"automattic/jetpack-test-environment": "@dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
+++ b/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
@@ -32,9 +32,11 @@ class Sync_Status_Tracker {
 	const INITIAL_FULL_SYNC_OPTION = 'jetpack_premium_analytics_initial_full_sync_finished';
 
 	/**
-	 * Sync-module name whose end-of-sync event flips the milestone. Provided by
-	 * a consumer plugin (e.g. WooCommerce Analytics) that registers a custom
-	 * full-sync module under this key.
+	 * Default sync-module name whose end-of-sync event flips the milestone.
+	 * Currently provided by WooCommerce Analytics, which registers a custom
+	 * full-sync module under this key. Consumers can override via the
+	 * `jetpack_premium_analytics_sync_module_name` filter — see
+	 * {@see get_analytics_sync_module()}.
 	 */
 	const ANALYTICS_SYNC_MODULE = 'woocommerce_analytics';
 
@@ -66,10 +68,6 @@ class Sync_Status_Tracker {
 	 * @return void
 	 */
 	public static function on_sync_processed_actions( array $actions ): void {
-		if ( ! class_exists( 'Automattic\Jetpack\Sync\Modules' ) ) {
-			return;
-		}
-
 		$module = Modules::get_module( 'full-sync' );
 		if ( ! $module ) {
 			return;
@@ -77,6 +75,22 @@ class Sync_Status_Tracker {
 		'@phan-var \Automattic\Jetpack\Sync\Modules\Full_Sync_Immediately|\Automattic\Jetpack\Sync\Modules\Full_Sync $module';
 
 		self::maybe_set_milestone( $module->get_status(), $actions );
+	}
+
+	/**
+	 * Resolve the configured sync-module name for analytics.
+	 *
+	 * @return string
+	 */
+	public static function get_analytics_sync_module(): string {
+		/**
+		 * Filter the sync-module name whose end-of-sync flips the analytics
+		 * milestone. Consumer plugins that register a custom full-sync module
+		 * under a different key can override this.
+		 *
+		 * @param string $module_name Default: 'woocommerce_analytics'.
+		 */
+		return (string) apply_filters( 'jetpack_premium_analytics_sync_module_name', self::ANALYTICS_SYNC_MODULE );
 	}
 
 	/**
@@ -96,7 +110,8 @@ class Sync_Status_Tracker {
 			return;
 		}
 
-		if ( empty( $full_status['config'][ self::ANALYTICS_SYNC_MODULE ] ) ) {
+		$module_name = self::get_analytics_sync_module();
+		if ( empty( $full_status['config'][ $module_name ] ) ) {
 			return;
 		}
 
@@ -108,7 +123,13 @@ class Sync_Status_Tracker {
 		// The last update_status() call in Full_Sync_Immediately::send() runs
 		// after jetpack_full_sync_end fires, so the action's own timestamp is
 		// the most reliable "finished at" value. Note: Year 2038 problem.
-		$finished_at             = (int) $end_action[3];
+		$finished_at = isset( $end_action[3] ) ? (int) $end_action[3] : 0;
+		if ( $finished_at <= 0 ) {
+			// Defensive: avoid persisting a zero timestamp, which would equal
+			// the "not yet set" sentinel and cause the listener to re-trigger
+			// on the next batch.
+			return;
+		}
 		$full_status['finished'] = $finished_at;
 		update_option( self::INITIAL_FULL_SYNC_OPTION, $finished_at );
 

--- a/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
+++ b/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Analytics-aware sync milestone tracker.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\Sync;
+
+use Automattic\Jetpack\Sync\Modules;
+
+/**
+ * Listens for the end of an analytics-relevant Jetpack full sync, persists a
+ * one-time milestone option, and exposes that milestone to the frontend via
+ * `JetpackScriptData.premium_analytics`.
+ *
+ * Why this exists: the extracted dashboard needs to distinguish "first-time
+ * sync, please wait" from "we have data, render it." Jetpack's existing
+ * /jetpack/v4/sync/status endpoint reports current sync state, but not the
+ * milestone "the analytics-relevant initial sync has completed at least once",
+ * which is what gates the dashboard view. The milestone is also useful for
+ * consumer plugins (e.g. WooCommerce Analytics) to fire one-time side-effects
+ * like the full-sync-complete email, via the action hook below.
+ */
+class Sync_Status_Tracker {
+
+	/**
+	 * Unix timestamp stored as a non-zero option value once the
+	 * analytics-relevant initial full sync has finished. Read by the frontend
+	 * to gate the dashboard view.
+	 */
+	const INITIAL_FULL_SYNC_OPTION = 'jetpack_premium_analytics_initial_full_sync_finished';
+
+	/**
+	 * Sync-module name whose end-of-sync event flips the milestone. Provided by
+	 * a consumer plugin (e.g. WooCommerce Analytics) that registers a custom
+	 * full-sync module under this key.
+	 */
+	const ANALYTICS_SYNC_MODULE = 'woocommerce_analytics';
+
+	/**
+	 * Action hook fired once when the milestone flips. Consumer plugins use this
+	 * to fire one-time side-effects (emails, tracking events, etc.).
+	 *
+	 * @var string
+	 */
+	const MILESTONE_ACTION = 'jetpack_premium_analytics_initial_full_sync_finished';
+
+	/**
+	 * Wire up the listener and the script-data filter.
+	 *
+	 * Idempotent: safe to call more than once.
+	 *
+	 * @return void
+	 */
+	public static function configure() {
+		add_action( 'jetpack_sync_processed_actions', array( self::class, 'on_sync_processed_actions' ) );
+		add_filter( 'jetpack_admin_js_script_data', array( self::class, 'inject_script_data' ) );
+	}
+
+	/**
+	 * On every batch of processed sync actions, look for the analytics-relevant
+	 * jetpack_full_sync_end and flip the milestone if it hasn't already fired.
+	 *
+	 * @param array $actions Processed sync actions.
+	 * @return void
+	 */
+	public static function on_sync_processed_actions( array $actions ): void {
+		if ( ! class_exists( 'Automattic\Jetpack\Sync\Modules' ) ) {
+			return;
+		}
+
+		$module = Modules::get_module( 'full-sync' );
+		if ( ! $module ) {
+			return;
+		}
+
+		self::maybe_set_milestone( $module->get_status(), $actions );
+	}
+
+	/**
+	 * Pure-logic counterpart to on_sync_processed_actions(): decide whether the
+	 * supplied full-sync status + actions list represents the analytics-relevant
+	 * sync ending, and flip the milestone if so.
+	 *
+	 * Split out so unit tests can exercise the decision without standing up the
+	 * Jetpack sync module registry.
+	 *
+	 * @param array $full_status Result of Full_Sync_Immediately::get_status().
+	 * @param array $actions     Processed sync actions.
+	 * @return void
+	 */
+	public static function maybe_set_milestone( array $full_status, array $actions ): void {
+		if ( get_option( self::INITIAL_FULL_SYNC_OPTION, 0 ) > 0 ) {
+			return;
+		}
+
+		if ( empty( $full_status['config'][ self::ANALYTICS_SYNC_MODULE ] ) ) {
+			return;
+		}
+
+		$end_action = self::find_full_sync_end_action( $actions );
+		if ( ! $end_action ) {
+			return;
+		}
+
+		// The last update_status() call in Full_Sync_Immediately::send() runs
+		// after jetpack_full_sync_end fires, so the action's own timestamp is
+		// the most reliable "finished at" value. Note: Year 2038 problem.
+		$finished_at             = (int) $end_action[3];
+		$full_status['finished'] = $finished_at;
+		update_option( self::INITIAL_FULL_SYNC_OPTION, $finished_at );
+
+		/**
+		 * Fires once when the analytics-relevant initial full sync completes.
+		 *
+		 * @param array $full_status Final full-sync status (with `finished` timestamp).
+		 */
+		do_action( self::MILESTONE_ACTION, $full_status );
+	}
+
+	/**
+	 * Inject the milestone value into JetpackScriptData so the dashboard can
+	 * read it at page load without an extra HTTP roundtrip.
+	 *
+	 * @param array $data The script data passed by the assets package.
+	 * @return array
+	 */
+	public static function inject_script_data( $data ) {
+		if ( ! is_array( $data ) ) {
+			$data = array();
+		}
+
+		$data['premium_analytics'] = array(
+			'initial_full_sync_finished' => (int) get_option( self::INITIAL_FULL_SYNC_OPTION, 0 ),
+		);
+
+		return $data;
+	}
+
+	/**
+	 * Find the jetpack_full_sync_end action in a processed-actions list.
+	 *
+	 * @param array $actions Actions list.
+	 * @return array|null
+	 */
+	private static function find_full_sync_end_action( array $actions ): ?array {
+		foreach ( $actions as $action ) {
+			if ( isset( $action[0] ) && 'jetpack_full_sync_end' === $action[0] ) {
+				return $action;
+			}
+		}
+		return null;
+	}
+}

--- a/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
+++ b/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
@@ -74,6 +74,7 @@ class Sync_Status_Tracker {
 		if ( ! $module ) {
 			return;
 		}
+		'@phan-var \Automattic\Jetpack\Sync\Modules\Full_Sync_Immediately|\Automattic\Jetpack\Sync\Modules\Full_Sync $module';
 
 		self::maybe_set_milestone( $module->get_status(), $actions );
 	}
@@ -126,11 +127,7 @@ class Sync_Status_Tracker {
 	 * @param array $data The script data passed by the assets package.
 	 * @return array
 	 */
-	public static function inject_script_data( $data ) {
-		if ( ! is_array( $data ) ) {
-			$data = array();
-		}
-
+	public static function inject_script_data( array $data ): array {
 		$data['premium_analytics'] = array(
 			'initial_full_sync_finished' => (int) get_option( self::INITIAL_FULL_SYNC_OPTION, 0 ),
 		);

--- a/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
+++ b/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
@@ -32,13 +32,15 @@ class Sync_Status_Tracker {
 	const INITIAL_FULL_SYNC_OPTION = 'jetpack_premium_analytics_initial_full_sync_finished';
 
 	/**
-	 * Default sync-module name whose end-of-sync event flips the milestone.
+	 * Default sync-module names whose end-of-sync event flips the milestone.
 	 * Currently provided by WooCommerce Analytics, which registers a custom
-	 * full-sync module under this key. Consumers can override via the
-	 * `jetpack_premium_analytics_sync_module_name` filter — see
-	 * {@see get_analytics_sync_module()}.
+	 * full-sync module under this key. Consumers can extend or override the set
+	 * via the `jetpack_premium_analytics_sync_modules` filter — see
+	 * {@see get_analytics_sync_modules()}.
+	 *
+	 * @var string[]
 	 */
-	const ANALYTICS_SYNC_MODULE = 'woocommerce_analytics';
+	const ANALYTICS_SYNC_MODULES = array( 'woocommerce_analytics' );
 
 	/**
 	 * Action hook fired once when the milestone flips. Consumer plugins use this
@@ -68,6 +70,12 @@ class Sync_Status_Tracker {
 	 * @return void
 	 */
 	public static function on_sync_processed_actions( array $actions ): void {
+		// Milestone is write-once. Bail before the per-batch full-sync lookup
+		// below ($module->get_status() bypasses the status cache) once it fires.
+		if ( self::milestone_reached() ) {
+			return;
+		}
+
 		$module = Modules::get_module( 'full-sync' );
 		if ( ! $module ) {
 			return;
@@ -78,19 +86,19 @@ class Sync_Status_Tracker {
 	}
 
 	/**
-	 * Resolve the configured sync-module name for analytics.
+	 * Resolve the configured sync-module names for analytics.
 	 *
-	 * @return string
+	 * @return string[]
 	 */
-	public static function get_analytics_sync_module(): string {
+	public static function get_analytics_sync_modules(): array {
 		/**
-		 * Filter the sync-module name whose end-of-sync flips the analytics
-		 * milestone. Consumer plugins that register a custom full-sync module
-		 * under a different key can override this.
+		 * Filter the sync-module names whose end-of-sync flips the analytics
+		 * milestone. Consumer plugins that register custom full-sync modules
+		 * can add their module keys here.
 		 *
-		 * @param string $module_name Default: 'woocommerce_analytics'.
+		 * @param string[] $module_names Default: array( 'woocommerce_analytics' ).
 		 */
-		return (string) apply_filters( 'jetpack_premium_analytics_sync_module_name', self::ANALYTICS_SYNC_MODULE );
+		return (array) apply_filters( 'jetpack_premium_analytics_sync_modules', self::ANALYTICS_SYNC_MODULES );
 	}
 
 	/**
@@ -106,12 +114,18 @@ class Sync_Status_Tracker {
 	 * @return void
 	 */
 	public static function maybe_set_milestone( array $full_status, array $actions ): void {
-		if ( get_option( self::INITIAL_FULL_SYNC_OPTION, 0 ) > 0 ) {
+		if ( self::milestone_reached() ) {
 			return;
 		}
 
-		$module_name = self::get_analytics_sync_module();
-		if ( empty( $full_status['config'][ $module_name ] ) ) {
+		$config = isset( $full_status['config'] ) ? (array) $full_status['config'] : array();
+		$active = array_filter(
+			self::get_analytics_sync_modules(),
+			static function ( $module_name ) use ( $config ) {
+				return ! empty( $config[ $module_name ] );
+			}
+		);
+		if ( ! $active ) {
 			return;
 		}
 
@@ -154,6 +168,15 @@ class Sync_Status_Tracker {
 		);
 
 		return $data;
+	}
+
+	/**
+	 * Whether the analytics-relevant initial full sync milestone has fired.
+	 *
+	 * @return bool
+	 */
+	private static function milestone_reached(): bool {
+		return (int) get_option( self::INITIAL_FULL_SYNC_OPTION, 0 ) > 0;
 	}
 
 	/**

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics;
 
+use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
+
 /**
  * Main Analytics class.
  *
@@ -55,6 +57,8 @@ class Analytics {
 		if ( file_exists( $build_entry ) ) {
 			require_once $build_entry;
 		}
+
+		Sync_Status_Tracker::configure();
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
 		add_action( 'jetpack-premium-analytics_init', array( static::class, 'register_sidebar_items' ) );

--- a/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
@@ -37,6 +37,7 @@ class Sync_Status_Tracker_Test extends TestCase {
 	public function tear_down() {
 		delete_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION );
 		remove_all_actions( Sync_Status_Tracker::MILESTONE_ACTION );
+		remove_all_filters( 'jetpack_premium_analytics_sync_module_name' );
 		\WorDBless\Options::init()->clear_options();
 	}
 
@@ -124,8 +125,6 @@ class Sync_Status_Tracker_Test extends TestCase {
 		);
 
 		$this->assertSame( 1730000123, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
-
-		remove_all_filters( 'jetpack_premium_analytics_sync_module_name' );
 	}
 
 	public function test_script_data_reports_zero_before_milestone() {

--- a/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Tests for Sync_Status_Tracker.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics\Sync;
+
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker
+ */
+#[CoversClass( Sync_Status_Tracker::class )]
+class Sync_Status_Tracker_Test extends TestCase {
+
+	private const FULL_STATUS_WITH_ANALYTICS = array(
+		'config' => array( 'woocommerce_analytics' => true ),
+	);
+
+	/**
+	 * @before
+	 */
+	#[Before]
+	public function set_up() {
+		\WorDBless\Options::init()->clear_options();
+	}
+
+	/**
+	 * @after
+	 */
+	#[After]
+	public function tear_down() {
+		delete_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION );
+		remove_all_actions( Sync_Status_Tracker::MILESTONE_ACTION );
+		\WorDBless\Options::init()->clear_options();
+	}
+
+	public function test_milestone_sets_option_and_fires_action() {
+		$fired_with = null;
+		add_action(
+			Sync_Status_Tracker::MILESTONE_ACTION,
+			function ( $status ) use ( &$fired_with ) {
+				$fired_with = $status;
+			}
+		);
+
+		$actions = array( array( 'jetpack_full_sync_end', array(), 0, 1730000123 ) );
+		Sync_Status_Tracker::maybe_set_milestone( self::FULL_STATUS_WITH_ANALYTICS, $actions );
+
+		$this->assertSame( 1730000123, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
+		$this->assertIsArray( $fired_with );
+		$this->assertSame( 1730000123, $fired_with['finished'] );
+	}
+
+	public function test_milestone_noop_when_already_set() {
+		update_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 1730000000 );
+
+		Sync_Status_Tracker::maybe_set_milestone(
+			self::FULL_STATUS_WITH_ANALYTICS,
+			array( array( 'jetpack_full_sync_end', array(), 0, 1730099999 ) )
+		);
+
+		$this->assertSame( 1730000000, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
+	}
+
+	public function test_milestone_noop_when_analytics_module_not_in_config() {
+		Sync_Status_Tracker::maybe_set_milestone(
+			array( 'config' => array( 'posts' => true ) ),
+			array( array( 'jetpack_full_sync_end', array(), 0, 1730000123 ) )
+		);
+
+		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
+	}
+
+	public function test_milestone_noop_without_end_action() {
+		Sync_Status_Tracker::maybe_set_milestone(
+			self::FULL_STATUS_WITH_ANALYTICS,
+			array( array( 'jetpack_full_sync_start', array(), 0, 1730000000 ) )
+		);
+
+		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
+	}
+
+	public function test_milestone_noop_with_empty_actions() {
+		Sync_Status_Tracker::maybe_set_milestone( self::FULL_STATUS_WITH_ANALYTICS, array() );
+
+		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
+	}
+
+	public function test_script_data_reports_zero_before_milestone() {
+		$data = Sync_Status_Tracker::inject_script_data( array( 'site' => array() ) );
+
+		$this->assertArrayHasKey( 'premium_analytics', $data );
+		$this->assertSame( 0, $data['premium_analytics']['initial_full_sync_finished'] );
+		$this->assertArrayHasKey( 'site', $data, 'preserves existing keys' );
+	}
+
+	public function test_script_data_reports_timestamp_after_milestone() {
+		update_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 1730000123 );
+
+		$data = Sync_Status_Tracker::inject_script_data( array() );
+
+		$this->assertSame( 1730000123, $data['premium_analytics']['initial_full_sync_finished'] );
+	}
+
+	public function test_script_data_tolerates_non_array_input() {
+		$data = Sync_Status_Tracker::inject_script_data( null );
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'premium_analytics', $data );
+	}
+
+	public function test_configure_registers_hooks() {
+		Sync_Status_Tracker::configure();
+
+		$this->assertNotFalse(
+			has_action( 'jetpack_sync_processed_actions', array( Sync_Status_Tracker::class, 'on_sync_processed_actions' ) ),
+			'listener should hook jetpack_sync_processed_actions'
+		);
+		$this->assertNotFalse(
+			has_filter( 'jetpack_admin_js_script_data', array( Sync_Status_Tracker::class, 'inject_script_data' ) ),
+			'tracker should filter jetpack_admin_js_script_data'
+		);
+
+		remove_action( 'jetpack_sync_processed_actions', array( Sync_Status_Tracker::class, 'on_sync_processed_actions' ) );
+		remove_filter( 'jetpack_admin_js_script_data', array( Sync_Status_Tracker::class, 'inject_script_data' ) );
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
@@ -108,13 +108,6 @@ class Sync_Status_Tracker_Test extends TestCase {
 		$this->assertSame( 1730000123, $data['premium_analytics']['initial_full_sync_finished'] );
 	}
 
-	public function test_script_data_tolerates_non_array_input() {
-		$data = Sync_Status_Tracker::inject_script_data( null );
-
-		$this->assertIsArray( $data );
-		$this->assertArrayHasKey( 'premium_analytics', $data );
-	}
-
 	public function test_configure_registers_hooks() {
 		Sync_Status_Tracker::configure();
 

--- a/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
@@ -113,7 +113,9 @@ class Sync_Status_Tracker_Test extends TestCase {
 	public function test_filter_overrides_analytics_sync_module() {
 		add_filter(
 			'jetpack_premium_analytics_sync_module_name',
-			static fn() => 'custom_module_name'
+			static function () {
+				return 'custom_module_name';
+			}
 		);
 
 		Sync_Status_Tracker::maybe_set_milestone(

--- a/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
@@ -92,6 +92,40 @@ class Sync_Status_Tracker_Test extends TestCase {
 		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
 	}
 
+	public function test_milestone_noop_when_end_action_timestamp_is_zero() {
+		Sync_Status_Tracker::maybe_set_milestone(
+			self::FULL_STATUS_WITH_ANALYTICS,
+			array( array( 'jetpack_full_sync_end', array(), 0, 0 ) )
+		);
+
+		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
+	}
+
+	public function test_milestone_noop_when_end_action_missing_timestamp() {
+		Sync_Status_Tracker::maybe_set_milestone(
+			self::FULL_STATUS_WITH_ANALYTICS,
+			array( array( 'jetpack_full_sync_end', array(), 0 ) )
+		);
+
+		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
+	}
+
+	public function test_filter_overrides_analytics_sync_module() {
+		add_filter(
+			'jetpack_premium_analytics_sync_module_name',
+			static fn() => 'custom_module_name'
+		);
+
+		Sync_Status_Tracker::maybe_set_milestone(
+			array( 'config' => array( 'custom_module_name' => true ) ),
+			array( array( 'jetpack_full_sync_end', array(), 0, 1730000123 ) )
+		);
+
+		$this->assertSame( 1730000123, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
+
+		remove_all_filters( 'jetpack_premium_analytics_sync_module_name' );
+	}
+
 	public function test_script_data_reports_zero_before_milestone() {
 		$data = Sync_Status_Tracker::inject_script_data( array( 'site' => array() ) );
 

--- a/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Sync_Status_Tracker_Test.php
@@ -37,7 +37,7 @@ class Sync_Status_Tracker_Test extends TestCase {
 	public function tear_down() {
 		delete_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION );
 		remove_all_actions( Sync_Status_Tracker::MILESTONE_ACTION );
-		remove_all_filters( 'jetpack_premium_analytics_sync_module_name' );
+		remove_all_filters( 'jetpack_premium_analytics_sync_modules' );
 		\WorDBless\Options::init()->clear_options();
 	}
 
@@ -111,11 +111,11 @@ class Sync_Status_Tracker_Test extends TestCase {
 		$this->assertSame( 0, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 0 ) );
 	}
 
-	public function test_filter_overrides_analytics_sync_module() {
+	public function test_filter_overrides_analytics_sync_modules() {
 		add_filter(
-			'jetpack_premium_analytics_sync_module_name',
+			'jetpack_premium_analytics_sync_modules',
 			static function () {
-				return 'custom_module_name';
+				return array( 'custom_module_name' );
 			}
 		);
 
@@ -125,6 +125,35 @@ class Sync_Status_Tracker_Test extends TestCase {
 		);
 
 		$this->assertSame( 1730000123, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
+	}
+
+	public function test_filter_can_add_a_second_analytics_module() {
+		add_filter(
+			'jetpack_premium_analytics_sync_modules',
+			static function ( $modules ) {
+				$modules[] = 'second_analytics';
+				return $modules;
+			}
+		);
+
+		Sync_Status_Tracker::maybe_set_milestone(
+			array( 'config' => array( 'second_analytics' => true ) ),
+			array( array( 'jetpack_full_sync_end', array(), 0, 1730000123 ) )
+		);
+
+		$this->assertSame( 1730000123, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
+	}
+
+	public function test_listener_bails_before_module_lookup_when_milestone_reached() {
+		update_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION, 1730000000 );
+
+		// Once the milestone is set the listener must return before reaching the
+		// sync-module registry, so this call stays a no-op without it standing up.
+		Sync_Status_Tracker::on_sync_processed_actions(
+			array( array( 'jetpack_full_sync_end', array(), 0, 1730099999 ) )
+		);
+
+		$this->assertSame( 1730000000, (int) get_option( Sync_Status_Tracker::INITIAL_FULL_SYNC_OPTION ) );
 	}
 
 	public function test_script_data_reports_zero_before_milestone() {

--- a/projects/packages/premium-analytics/tests/php/bootstrap.php
+++ b/projects/packages/premium-analytics/tests/php/bootstrap.php
@@ -5,7 +5,6 @@
  * @package automattic/jetpack-premium-analytics
  */
 
-/**
- * Include the composer autoloader.
- */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+\Automattic\Jetpack\Test_Environment::init();

--- a/projects/plugins/premium-analytics/.gitattributes
+++ b/projects/plugins/premium-analytics/.gitattributes
@@ -3,7 +3,18 @@
 # /build/**  production-include
 /vendor/automattic/jetpack-autoloader/**    production-include
 /vendor/automattic/jetpack-composer-plugin/**    production-include
+/jetpack_vendor/automattic/jetpack-a8c-mc-stats/**    production-include
+/jetpack_vendor/automattic/jetpack-admin-ui/**    production-include
+/jetpack_vendor/automattic/jetpack-assets/**    production-include
+/jetpack_vendor/automattic/jetpack-connection/**    production-include
+/jetpack_vendor/automattic/jetpack-constants/**    production-include
+/jetpack_vendor/automattic/jetpack-ip/**    production-include
+/jetpack_vendor/automattic/jetpack-password-checker/**    production-include
 /jetpack_vendor/automattic/jetpack-premium-analytics/**    production-include
+/jetpack_vendor/automattic/jetpack-redirect/**    production-include
+/jetpack_vendor/automattic/jetpack-roles/**    production-include
+/jetpack_vendor/automattic/jetpack-status/**    production-include
+/jetpack_vendor/automattic/jetpack-sync/**    production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # (see also entries in the monorepo root .gitattributes)

--- a/projects/plugins/premium-analytics/.gitattributes
+++ b/projects/plugins/premium-analytics/.gitattributes
@@ -1,20 +1,12 @@
 # Files to include in the mirror repo, but excluded via gitignore
 # Remember to end all directories with `/**` to properly tag every file.
 # /build/**  production-include
-/vendor/automattic/jetpack-autoloader/**    production-include
-/vendor/automattic/jetpack-composer-plugin/**    production-include
-/jetpack_vendor/automattic/jetpack-a8c-mc-stats/**    production-include
-/jetpack_vendor/automattic/jetpack-admin-ui/**    production-include
-/jetpack_vendor/automattic/jetpack-assets/**    production-include
-/jetpack_vendor/automattic/jetpack-connection/**    production-include
-/jetpack_vendor/automattic/jetpack-constants/**    production-include
-/jetpack_vendor/automattic/jetpack-ip/**    production-include
-/jetpack_vendor/automattic/jetpack-password-checker/**    production-include
-/jetpack_vendor/automattic/jetpack-premium-analytics/**    production-include
-/jetpack_vendor/automattic/jetpack-redirect/**    production-include
-/jetpack_vendor/automattic/jetpack-roles/**    production-include
-/jetpack_vendor/automattic/jetpack-status/**    production-include
-/jetpack_vendor/automattic/jetpack-sync/**    production-include
+jetpack_vendor/**                               production-include
+vendor/autoload.php                             production-include
+vendor/autoload_packages.php                    production-include
+vendor/automattic/**                            production-include
+vendor/composer/**                              production-include
+vendor/jetpack-autoloader/**                    production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # (see also entries in the monorepo root .gitattributes)

--- a/projects/plugins/premium-analytics/changelog/update-package-deps
+++ b/projects/plugins/premium-analytics/changelog/update-package-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Update package dependencies.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -7,6 +7,209 @@
     "content-hash": "9afaab222d7859aedc0fdf26ce8fa966",
     "packages": [
         {
+            "name": "automattic/jetpack-a8c-mc-stats",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/a8c-mc-stats",
+                "reference": "48895090b425c307b50fdf77f2c770719e1d3cf4"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-a8c-mc-stats",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+            },
+            "require": {
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.9.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/connection"
+                    ]
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-assets",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/assets",
+                "reference": "34c28243fe1b82bec808b44208ca33bb69a7ab51"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-assets",
+                "textdomain": "jetpack-assets",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "4.3.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-autoloader",
             "version": "dev-trunk",
             "dist": {
@@ -135,17 +338,273 @@
             }
         },
         {
-            "name": "automattic/jetpack-premium-analytics",
+            "name": "automattic/jetpack-connection",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
-                "url": "../../packages/premium-analytics",
-                "reference": "1e2a2b366f850f1872018c9fc93699d4674a8757"
+                "url": "../../packages/connection",
+                "reference": "cda184a300cc9a8012a1ddcd7756b369fbbc062c"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-connection",
+                "textdomain": "jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "8.5.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/licensing",
+                        "packages/sync"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "legacy",
+                    "src/",
+                    "src/webhooks",
+                    "src/identity-crisis"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/constants",
+                "reference": "a2f68c778c6c47b3e9f7699379fe5efa8ffe2acc"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-constants",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-ip",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/ip",
+                "reference": "83c25c578ff27f736d3e5c8b94dd3456eb43ba01"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-ip",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-ip/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                },
+                "textdomain": "jetpack-ip",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-utils.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities for working with IP addresses.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-password-checker",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/password-checker",
+                "reference": "d9e7a7a8db710ebc8d064ae207775df8bd9e6662"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-password-checker",
+                "textdomain": "jetpack-password-checker",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-password-checker/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Password Checker.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-premium-analytics",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/premium-analytics",
+                "reference": "14c207f485d8aac79486e000e68fed54934d58c8"
+            },
+            "require": {
+                "automattic/jetpack-sync": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -190,6 +649,251 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Premium Analytics dashboard for Jetpack sites.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-redirect",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/redirect",
+                "reference": "84a8949d203512d279ad65280af8d2af01d4d799"
+            },
+            "require": {
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-redirect",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/roles",
+                "reference": "a9e558a67db231ecf3194a02125a4b3f14a48b94"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-roles",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/status",
+                "reference": "30e50be852b4f6b22a2a47ed7ab3ef6daa4074b6"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-status",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "6.1.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/connection",
+                        "packages/plans"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-sync",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/sync",
+                "reference": "ebc690e7d4e5f06f1862b992eebcc6f7c543d057"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "automattic/jetpack-password-checker": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-search": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/jetpack-waf": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-sync",
+                "textdomain": "jetpack-sync",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "4.41.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/search",
+                        "packages/waf"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
Fixes [WOOA7S-1437](https://linear.app/a8c/issue/WOOA7S-1437/pr-1-migrate-sync-status-rest-controller-to-premium-analytics) (parent: [WOOA7S-1436](https://linear.app/a8c/issue/WOOA7S-1436/extract-analytics-php-api-layer-from-wa-into-premium-analytics-package))

## Why

The extracted Premium Analytics dashboard needs to distinguish "first-time sync, please wait" from "we have data, render it." Jetpack's existing `/jetpack/v4/sync/status` reports current sync state, but not the *milestone* "the analytics-relevant initial sync has completed at least once" — which is what gates the dashboard view. This PR adds the smallest possible PHP surface to capture that milestone and expose it to the frontend.

## Proposed changes

* Add `Sync_Status_Tracker` (in `src/Sync/`) — a static helper that:
  * Listens on `jetpack_sync_processed_actions` for the analytics-relevant `jetpack_full_sync_end` and flips a one-time milestone option (`jetpack_premium_analytics_initial_full_sync_finished`).
  * Filters `jetpack_admin_js_script_data` to inject the milestone into `JetpackScriptData.premium_analytics`, so the dashboard reads it at page load — no extra HTTP roundtrip.
  * Fires a new action — `jetpack_premium_analytics_initial_full_sync_finished` — once when the milestone flips, so consumer plugins (e.g. WooCommerce Analytics) can attach the WC_Email and Tracks side-effects that this WP-general package intentionally doesn't ship.
* Wire `Sync_Status_Tracker::configure()` into `Analytics::init()`.
* Add `automattic/jetpack-sync` to the package's `require`.
* Add `automattic/jetpack-test-environment` as a dev dep and switch the test bootstrap to use it.
* PHPUnit tests covering each of the listener's branches, the script-data injection, and the hook registration.

### Why not a REST controller?

The earlier draft of this PR ([commit 98a072c](https://github.com/Automattic/jetpack/pull/49211/commits/98a072c99bccd1c6a870bea86773190dd2e1b020), now superseded) added a `/premium-analytics/v1/sync-status` controller migrated from `woocommerce-analytics/src/API/SyncStatus.php`. Pushback in review surfaced that almost every field the controller returned was already derivable from existing Jetpack endpoints (`/jetpack/v4/sync/status`, `/jetpack/v4/connection`, `JetpackScriptData.connection`). The only piece without an existing equivalent was the persisted milestone option — and that's a static-ish value better exposed via `JetpackScriptData` than via an extra HTTP fetch.

Net result: ~150 LoC of production PHP instead of ~420 LoC, no new REST surface to maintain, and the frontend integration is a property read instead of a `fetch()` call.

## Related product discussion/links

* Parent extraction issue: [WOOA7S-1436](https://linear.app/a8c/issue/WOOA7S-1436/extract-analytics-php-api-layer-from-wa-into-premium-analytics-package)
* Premium Analytics project overview: [linear.app/a8c/project/premium-analytics](https://linear.app/a8c/project/premium-analytics-24074c41169a/overview)

## Does this pull request change what data or activity we track or use?

No. This PR explicitly *drops* the WC Tracks call that the source `SyncStatus` controller had — re-attaching it (with the same payload) is consumer-plugin work tracked separately.

## Testing instructions

Acceptance criteria from WOOA7S-1437 (revised for the slimmer approach):

- [x] `jp build packages/premium-analytics` succeeds
- [x] `jp test php packages/premium-analytics` passes (10 tests, 16 assertions, clean)
- [x] `jp phan packages/premium-analytics` — passes in CI (local Phan 5.5.2 crashes parsing wordpress-stubs on PHP 8.5.3, unrelated to this change)
- [x] `jp changelog add packages/premium-analytics` entry included (`changelog/add-sync-status-tracker`) + matching plugin changelog entry
- [x] PR is <500 LoC of production code, excluding tests (~155 LoC of new PHP)
- [x] Milestone flips on full-sync-end and surfaces in `JetpackScriptData` (evidence under "Verification" below)

To verify locally:

1. `git fetch origin jk/wooa7s-1437-sync-status-controller && git checkout jk/wooa7s-1437-sync-status-controller`
2. `jp install packages/premium-analytics plugins/premium-analytics && jp build packages/premium-analytics`
3. `jp test php packages/premium-analytics` — should pass clean.
4. Activate the `premium-analytics` plugin in any wp-admin and view-source on any admin page — expect `"premium_analytics":{"initial_full_sync_finished":0}` inside `window.JetpackScriptData`.

## Verification

Exercised on a Jetpack-connected dev site (`jp-atlas.jurassic.tube`) — the milestone fields appear in the rendered admin page's `JetpackScriptData` inline script.

<details>
<summary>PHP filter exercise</summary>

```bash
$ docker exec jetpack_atlas-wordpress-1 wp eval '$d = apply_filters("jetpack_admin_js_script_data", array()); echo isset($d["premium_analytics"]) ? json_encode($d["premium_analytics"]) : "MISSING";' --allow-root
{"initial_full_sync_finished":0}
```

</details>

<details>
<summary>Rendered admin page (curl)</summary>

```bash
$ curl -sk -L -b cookies.txt "https://jp-atlas.jurassic.tube/wp-admin/" | grep -oE 'premium_analytics[^}]{0,80}'
premium_analytics":{"initial_full_sync_finished":0
```

</details>

`initial_full_sync_finished` is `0` here because no consumer plugin has registered the analytics sync module on this dev site. Once a consumer (WA) registers it and a full sync completes, the value becomes the unix timestamp of completion.

## New action hook

`do_action( 'jetpack_premium_analytics_initial_full_sync_finished', $full_status )` — fires once when the milestone option flips. Consumer plugins (WooCommerce Analytics) will use this to re-attach the WC_Email notification and Tracks event without this package having to know about WooCommerce.
