### PR TITLE
Search Blocks: sample body computed color/bg for theme-accurate Search surfaces (SEARCH-274)

### DIFF
--- a/projects/packages/search/changelog/echo-search-274-theme-token-sampling
+++ b/projects/packages/search/changelog/echo-search-274-theme-token-sampling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: sample the active theme's body color and background at page load and feed them to the overlay card, filters popover, sort menu, and search-input suggestions surfaces — so themes that expose only positional palette slugs (wp.com Global Styles' --theme-N) still render Search surfaces in theme-accurate colors.

--- a/projects/packages/search/postcss.blocks.config.js
+++ b/projects/packages/search/postcss.blocks.config.js
@@ -1,0 +1,21 @@
+// Bundle-scoped postcss config for `src/search-blocks/` only — the front-end
+// blocks ship to themes whose `--wp--preset--color--*` (and authors'
+// `--jetpack-search-*`) variables resolve at runtime, so `preserve: true`
+// keeps the `var()` chains intact and lets the cascade pick the runtime
+// value when defined. postcss still emits a literal substitution alongside
+// each `var()`, which serves as the static fallback for browsers /
+// contexts where the variable isn't defined. The other bundles
+// (inline-search, customberg, instant-search) keep `postcss.config.js`
+// with `preserve: false` — `instant-search` in particular reads
+// calypso-color-schemes vars that aren't shipped to the runtime.
+module.exports = () => ( {
+	plugins: [
+		require( '@csstools/postcss-global-data' )( {
+			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
+		} ),
+		require( 'postcss-custom-properties' )( {
+			preserve: true,
+		} ),
+		require( 'autoprefixer' ),
+	],
+} );

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -81,7 +81,7 @@ The chain reaches each layer in order:
 1. `--jp-search-page-*` — sampled from `body`'s computed `color` / `backgroundColor` at `wp_body_open` (see `Search_Blocks::print_theme_token_sampler()`). Theme-accurate regardless of palette slug convention, so themes that emit positional slugs like wp.com Global Styles' `--wp--preset--color--theme-1`/`--theme-2` still drive Search surfaces to the right value.
 2. WP 6.1+ `--base`/`--contrast` pair.
 3. Legacy `--background`/`--foreground` pair (TT1, Kaze, many WPCOM themes).
-4. Static literal — also emitted by the PHP `:root` defaults (`print_theme_token_defaults_style()` at `wp_head` priority 1) so the custom props are always defined even when JS doesn't run.
+4. Static literal — postcss-custom-properties emits this as a separate declaration alongside the `var()` call, so the surface always has a paintable value even when no var resolves.
 
 Guard the sampler against `getComputedStyle().backgroundColor === 'rgba(0, 0, 0, 0)'` — classic themes that don't set body bg resolve to transparent, and writing that would override the PHP default and paint surfaces transparent.
 

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -135,3 +135,16 @@ Block edit components mirror the server `render.php` so the canvas preview match
 - **`previewSelected` fallback.** When a saved `defaultSort` no longer appears in `availableSortOptions` (author just unchecked it), fall back to the first visible option for the preview. The render callback already does this; the edit component has to do it too.
 - **Snap empty selections to the full set.** Persisting `availableSortOptions: []` would make the renderer fall back to "all options" while every inspector checkbox stays unchecked — invisible mismatch. The setter writes the canonical full set back instead.
 - **Per-instance IDs.** Edit components that emit `<label htmlFor=…>` use `useId()` — the editor canvas may render the same block twice, and a shared static id breaks the label→control association on the second instance.
+
+## Comments
+
+Code is the source of truth — well-named identifiers should make most code easier to read than any prose attached to it. Default to **no comment**.
+
+Narrow exceptions:
+
+- **Linting requires it** (phpcs short description, JSDoc on exports). Meet the linter's minimum, nothing more.
+- **The code is non-obvious** — a workaround, a hidden constraint, a counter-intuitive choice. Keep it short and inline next to the line(s) it explains.
+
+Do not restate what the code does. Do not narrate the flow. Do not write paragraph-long block comments for routine cascades, fallback chains, or two-declaration patterns where the source already reads clearly.
+
+If a surprise is global enough that a future agent landing in unrelated code could hit it, document it here in AGENTS.md — not as a comment in the file. The file comment risks rotting; AGENTS.md is what agents read first.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -65,13 +65,23 @@ Manual wrapper classes (set via `useBlockProps({ className })` and the matching 
 
 ## Theme tokens & `var()` chains
 
-Two things to know before touching surface colors:
+The search-blocks bundle uses its own postcss config (`postcss.blocks.config.js`) with `postcss-custom-properties` set to `preserve: true`. Every `var(--foo, fallback)` ships as two declarations: a literal substitution (the deepest fallback) followed by the full `var()` call. The browser cascade picks the var when defined and falls through to the literal otherwise — runtime theme tokens work, and there's always a static safety net.
 
-1. **`postcss-custom-properties` (`preserve: false` in `postcss.config.js`) folds every `var(--foo, fallback)` to its literal fallback at build time.** Single-argument `var(--foo)` (no fallback) is preserved through to the runtime. Empirically: `background-color: var(--wp--preset--color--base, #fff);` compiles to `background-color: #fff;`. So the long `--base → --background → #fff` chain you see across the SCSS files is **source documentation + forward-compat** for when the plugin's `preserve` flag flips — at runtime, every `var(--, fallback)` already ships its deepest literal. Anything that needs runtime token resolution has to either go through PHP-emitted inline CSS (which postcss never sees), or use single-arg `var()` against a custom property that's defined elsewhere.
+The other Search bundles (`inline-search`, `customberg`, `instant-search`) keep the shared `postcss.config.js` with `preserve: false`. `instant-search` in particular reads calypso-color-schemes vars that aren't shipped to the runtime; preserving them as `var()` would paint invalid. Don't change those bundles' config without auditing every var() usage there.
 
-2. **Themes don't always expose `--wp--preset--color--base/--contrast/--background/--foreground`.** wp.com Global Styles palette customization emits positional slugs (`--wp--preset--color--theme-1` / `--theme-2` / `--theme-N`) and binds them to `body` via a separate rule — the slug name carrying the semantic role is theme-specific. To stay theme-accurate regardless of slug convention, sample `getComputedStyle(document.body)` at `wp_body_open` and write the resolved `color` / `backgroundColor` onto `:root` as `--jp-search-page-ink` / `--jp-search-page-surface` (see `Search_Blocks::print_theme_token_sampler()`). PHP defaults for those two props are also emitted on `wp_head` priority 1 (`print_theme_token_defaults_style()`) so the props are defined even when JS doesn't run.
+Surface colors in search-blocks SCSS follow one shape:
 
-The current shape every Search surface should follow: `var(--jp-search-page-{ink|surface}, <existing --wp--preset--color--* chain>)`. The sampler wins when available; the chain is the safety net.
+```scss
+background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
+```
+
+The chain reaches each layer in order:
+
+1. `--jp-search-page-*` — sampled from `body`'s computed `color` / `backgroundColor` at `wp_body_open` (see `Search_Blocks::print_theme_token_sampler()`). Theme-accurate regardless of palette slug convention, so themes that emit positional slugs like wp.com Global Styles' `--wp--preset--color--theme-1`/`--theme-2` still drive Search surfaces to the right value.
+2. WP 6.1+ `--base`/`--contrast` pair.
+3. Legacy `--background`/`--foreground` pair (TT1, Kaze, many WPCOM themes).
+4. Static literal — also emitted by the PHP `:root` defaults (`print_theme_token_defaults_style()` at `wp_head` priority 1) so the custom props are always defined even when JS doesn't run.
 
 Guard the sampler against `getComputedStyle().backgroundColor === 'rgba(0, 0, 0, 0)'` — classic themes that don't set body bg resolve to transparent, and writing that would override the PHP default and paint surfaces transparent.
 

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -63,6 +63,18 @@ WordPress derives `.wp-block-jetpack-search-{bare-slug}` from the full block nam
 
 Manual wrapper classes (set via `useBlockProps({ className })` and the matching `get_block_wrapper_attributes()` call in `render.php`) don't have to track the slug exactly — they're just CSS hooks.
 
+## Theme tokens & `var()` chains
+
+Two things to know before touching surface colors:
+
+1. **`postcss-custom-properties` (`preserve: false` in `postcss.config.js`) folds every `var(--foo, fallback)` to its literal fallback at build time.** Single-argument `var(--foo)` (no fallback) is preserved through to the runtime. Empirically: `background-color: var(--wp--preset--color--base, #fff);` compiles to `background-color: #fff;`. So the long `--base → --background → #fff` chain you see across the SCSS files is **source documentation + forward-compat** for when the plugin's `preserve` flag flips — at runtime, every `var(--, fallback)` already ships its deepest literal. Anything that needs runtime token resolution has to either go through PHP-emitted inline CSS (which postcss never sees), or use single-arg `var()` against a custom property that's defined elsewhere.
+
+2. **Themes don't always expose `--wp--preset--color--base/--contrast/--background/--foreground`.** wp.com Global Styles palette customization emits positional slugs (`--wp--preset--color--theme-1` / `--theme-2` / `--theme-N`) and binds them to `body` via a separate rule — the slug name carrying the semantic role is theme-specific. To stay theme-accurate regardless of slug convention, sample `getComputedStyle(document.body)` at `wp_body_open` and write the resolved `color` / `backgroundColor` onto `:root` as `--jp-search-page-ink` / `--jp-search-page-surface` (see `Search_Blocks::print_theme_token_sampler()`). PHP defaults for those two props are also emitted on `wp_head` priority 1 (`print_theme_token_defaults_style()`) so the props are defined even when JS doesn't run.
+
+The current shape every Search surface should follow: `var(--jp-search-page-{ink|surface}, <existing --wp--preset--color--* chain>)`. The sampler wins when available; the chain is the safety net.
+
+Guard the sampler against `getComputedStyle().backgroundColor === 'rgba(0, 0, 0, 0)'` — classic themes that don't set body bg resolve to transparent, and writing that would override the PHP default and paint surfaces transparent.
+
 ## URL format
 
 Filters round-trip through the URL in Jetpack Search's array shape: `?<filterKey>[]=<value>`, one param per selected value. Both sides agree on this contract — `store/url-state.js` writes/reads it on the JS side, `Search_Blocks::parse_url_filters()` reads it on the PHP side.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -83,7 +83,10 @@ The chain reaches each layer in order:
 3. Legacy `--background`/`--foreground` pair (TT1, Kaze, many WPCOM themes).
 4. Static literal — postcss-custom-properties emits this as a separate declaration alongside the `var()` call, so the surface always has a paintable value even when no var resolves.
 
-Guard the sampler against `getComputedStyle().backgroundColor === 'rgba(0, 0, 0, 0)'` — classic themes that don't set body bg resolve to transparent, and writing that would override the PHP default and paint surfaces transparent.
+Two guards in the sampler against degenerate cases:
+
+- `backgroundColor === 'rgba(0, 0, 0, 0)'` / `'transparent'` — classic themes that don't set body bg resolve to transparent; the theme paints on the browser canvas instead. Skip the surface write so the SCSS chain's literal fallback wins.
+- `backgroundColor === color` — vintage frame-themes (Twenty Sixteen and similar) use `<body>` as a colored border around a lighter `.site` content wrapper, so body's resolved bg matches body's resolved color. Sampling that pair would paint same-color ink on same-color surface. Skip the surface write so the chain's literal fallback wins; ink still samples (it matches the content wrapper's text color via the cascade).
 
 ## URL format
 

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -62,9 +62,19 @@ $jetpack-search-filters-popover-collapse: 992px;
 		}
 	}
 
+	/* stylelint-disable declaration-block-no-duplicate-properties --
+	 * Two declarations are intentional (SEARCH-274): the first compiles to
+	 * a literal via postcss-custom-properties, the second is preserved to
+	 * runtime and reads `--jp-search-page-surface` — the sampled body bg
+	 * (see `class-search-blocks.php::print_theme_token_sampler`). Badge
+	 * text uses the surface color so it stays readable on top of the
+	 * foreground-mixed badge background — the "opposite-of-foreground"
+	 * cue inverts polarity per theme. */
 	&__badge-count {
 		color: var(--wp--preset--color--background, #fff);
+		color: var(--jp-search-page-surface);
 	}
+	/* stylelint-enable declaration-block-no-duplicate-properties */
 
 	// Panel base — popover form. Collapsed by default; visibility is driven
 	// by `.is-popover-open` on the root (toggled by the Interactivity store
@@ -88,8 +98,16 @@ $jetpack-search-filters-popover-collapse: 992px;
 		// shorthand `background:` collapses to `transparent` on themes that
 		// don't define `--wp--preset--color--base` (classic themes, block
 		// themes without the token), letting result-card content bleed through.
+		// Two declarations apply to each of `background-color` and `color` —
+		// postcss folds the chain above to its literal fallback, single-arg
+		// `var()` below is preserved to runtime where `--jp-search-page-*`
+		// (set on `:root` by the PHP defaults and the body sampler) wins.
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
+		background-color: var(--jp-search-page-surface);
+		color: var(--jp-search-page-ink);
 		// Reset the inherited theme base size so popover body text tracks the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. Rem-based children (filter title, count pill)

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -62,19 +62,13 @@ $jetpack-search-filters-popover-collapse: 992px;
 		}
 	}
 
-	/* stylelint-disable declaration-block-no-duplicate-properties --
-	 * Two declarations are intentional (SEARCH-274): the first compiles to
-	 * a literal via postcss-custom-properties, the second is preserved to
-	 * runtime and reads `--jp-search-page-surface` — the sampled body bg
-	 * (see `class-search-blocks.php::print_theme_token_sampler`). Badge
-	 * text uses the surface color so it stays readable on top of the
-	 * foreground-mixed badge background — the "opposite-of-foreground"
-	 * cue inverts polarity per theme. */
+	// Badge text reads the page surface so it inverts polarity on top of the
+	// foreground-mixed badge background.
 	&__badge-count {
 		color: var(--wp--preset--color--background, #fff);
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		color: var(--jp-search-page-surface);
 	}
-	/* stylelint-enable declaration-block-no-duplicate-properties */
 
 	// Panel base — popover form. Collapsed by default; visibility is driven
 	// by `.is-popover-open` on the root (toggled by the Interactivity store
@@ -93,15 +87,8 @@ $jetpack-search-filters-popover-collapse: 992px;
 		flex-direction: column;
 		gap: 1rem;
 		padding: 12px;
-		// `background-color` (longhand) + the same fallback chain the overlay
-		// card and suggestions panel use (class-search-blocks.php). The
-		// shorthand `background:` collapses to `transparent` on themes that
-		// don't define `--wp--preset--color--base` (classic themes, block
-		// themes without the token), letting result-card content bleed through.
-		// Two declarations apply to each of `background-color` and `color` —
-		// postcss folds the chain above to its literal fallback, single-arg
-		// `var()` below is preserved to runtime where `--jp-search-page-*`
-		// (set on `:root` by the PHP defaults and the body sampler) wins.
+		// `background-color` longhand (not shorthand) — `background:` collapses
+		// to `transparent` when the var resolves to nothing.
 		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 		// stylelint-disable-next-line declaration-block-no-duplicate-properties

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -65,9 +65,7 @@ $jetpack-search-filters-popover-collapse: 992px;
 	// Badge text reads the page surface so it inverts polarity on top of the
 	// foreground-mixed badge background.
 	&__badge-count {
-		color: var(--wp--preset--color--background, #fff);
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		color: var(--jp-search-page-surface);
+		color: var(--jp-search-page-surface, var(--wp--preset--color--background, #fff));
 	}
 
 	// Panel base — popover form. Collapsed by default; visibility is driven
@@ -89,12 +87,8 @@ $jetpack-search-filters-popover-collapse: 992px;
 		padding: 12px;
 		// `background-color` longhand (not shorthand) — `background:` collapses
 		// to `transparent` when the var resolves to nothing.
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
-		background-color: var(--jp-search-page-surface);
-		color: var(--jp-search-page-ink);
+		background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
 		// Reset the inherited theme base size so popover body text tracks the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. Rem-based children (filter title, count pill)

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
@@ -151,12 +151,8 @@
 		display: flex;
 		flex-direction: column;
 		padding: 4px;
-		// See the matching note in filters-popover/style.scss: the shorthand
-		// drops to `transparent` on themes that don't define
-		// `--wp--preset--color--base`, so use the longhand with the same
-		// fallback chain the overlay card and suggestions panel use.
-		// Two-declaration sampled-token pattern — see filters-popover for the
-		// rationale (SEARCH-274).
+		// `background-color` longhand (not shorthand) — `background:` collapses
+		// to `transparent` when the var resolves to nothing.
 		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 		// stylelint-disable-next-line declaration-block-no-duplicate-properties

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
@@ -155,8 +155,14 @@
 		// drops to `transparent` on themes that don't define
 		// `--wp--preset--color--base`, so use the longhand with the same
 		// fallback chain the overlay card and suggestions panel use.
+		// Two-declaration sampled-token pattern — see filters-popover for the
+		// rationale (SEARCH-274).
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
+		background-color: var(--jp-search-page-surface);
+		color: var(--jp-search-page-ink);
 		// Reset the inherited theme base size so menu items track the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. `font: inherit` on menu items picks this up.

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
@@ -153,12 +153,8 @@
 		padding: 4px;
 		// `background-color` longhand (not shorthand) — `background:` collapses
 		// to `transparent` when the var resolves to nothing.
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
-		background-color: var(--jp-search-page-surface);
-		color: var(--jp-search-page-ink);
+		background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
 		// Reset the inherited theme base size so menu items track the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. `font: inherit` on menu items picks this up.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -103,12 +103,8 @@
 		overscroll-behavior: contain;
 		// `background-color` longhand (not shorthand) — `background:` collapses
 		// to `transparent` when the var resolves to nothing.
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
-		// stylelint-disable-next-line declaration-block-no-duplicate-properties
-		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
-		background-color: var(--jp-search-page-surface);
-		color: var(--jp-search-page-ink);
+		background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
 		// Reset the inherited theme base size so option text tracks the
 		// other block surfaces (sort menu, filters popover) at 1rem instead
 		// of the host theme's oversized default.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -101,19 +101,10 @@
 		max-height: 60vh;
 		overflow-y: auto;
 		overscroll-behavior: contain;
-		// `background-color` longhand + 3-tier `--base → --background → #fff`
-		// fallback chain matches `filters-popover` / `results-sort`. The
-		// shorthand `background:` collapses to `transparent` on themes that
-		// emit neither token, letting result-card content bleed through behind
-		// the dropdown.
-		// Two-declaration sampled-token pattern — see filters-popover for the
-		// rationale (SEARCH-274).
+		// `background-color` longhand (not shorthand) — `background:` collapses
+		// to `transparent` when the var resolves to nothing.
 		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
-		// The dropdown owns its surface, so pin the ink color too — otherwise
-		// the option text inherits a low-contrast theme accent from the
-		// surrounding page (e.g. a muted header link color). 3-tier fallback
-		// chain mirrors the popover panel's `--contrast → --foreground → inherit`.
 		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
 		background-color: var(--jp-search-page-surface);

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -106,12 +106,18 @@
 		// shorthand `background:` collapses to `transparent` on themes that
 		// emit neither token, letting result-card content bleed through behind
 		// the dropdown.
+		// Two-declaration sampled-token pattern — see filters-popover for the
+		// rationale (SEARCH-274).
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		background-color: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
 		// The dropdown owns its surface, so pin the ink color too — otherwise
 		// the option text inherits a low-contrast theme accent from the
 		// surrounding page (e.g. a muted header link color). 3-tier fallback
 		// chain mirrors the popover panel's `--contrast → --foreground → inherit`.
+		// stylelint-disable-next-line declaration-block-no-duplicate-properties
 		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit));
+		background-color: var(--jp-search-page-surface);
+		color: var(--jp-search-page-ink);
 		// Reset the inherited theme base size so option text tracks the
 		// other block surfaces (sort menu, filters popover) at 1rem instead
 		// of the host theme's oversized default.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1101,17 +1101,17 @@ class Search_Blocks {
 	/**
 	 * Print the body-sampler `<script>` that sets `--jp-search-page-ink` /
 	 * `--jp-search-page-surface` on `:root` from the body's resolved `color` /
-	 * `backgroundColor`. Surface is skipped
-	 * when bg resolves to `transparent` — classic themes without an explicit
-	 * `body { background-color }` paint on the browser canvas, where the PHP
-	 * default already matches. See AGENTS.md § Theme tokens & `var()` chains.
+	 * `backgroundColor`. Skips writing surface when bg is transparent (the
+	 * theme paints on the browser canvas) or when bg equals ink (vintage
+	 * frame-themes like Twenty Sixteen use body as a colored border around a
+	 * lighter `.site` content wrapper). See AGENTS.md § Theme tokens.
 	 */
 	public static function print_theme_token_sampler(): void {
 		if ( is_admin() ) {
 			return;
 		}
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded JS string, no dynamic content.
-		echo "<script id='jetpack-search-theme-token-sampler'>(function(){try{var c=getComputedStyle(document.body),r=document.documentElement;if(c.color){r.style.setProperty('--jp-search-page-ink',c.color);}if(c.backgroundColor&&c.backgroundColor!=='rgba(0, 0, 0, 0)'&&c.backgroundColor!=='transparent'){r.style.setProperty('--jp-search-page-surface',c.backgroundColor);}}catch(e){}})();</script>";
+		echo "<script id='jetpack-search-theme-token-sampler'>(function(){try{var c=getComputedStyle(document.body),r=document.documentElement,ink=c.color,bg=c.backgroundColor;if(ink){r.style.setProperty('--jp-search-page-ink',ink);}if(bg&&bg!==ink&&bg!=='rgba(0, 0, 0, 0)'&&bg!=='transparent'){r.style.setProperty('--jp-search-page-surface',bg);}}catch(e){}})();</script>";
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -125,8 +125,6 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
-		// Priority 1 so `:root` defaults are defined before any block CSS reads them.
-		add_action( 'wp_head', array( static::class, 'print_theme_token_defaults_style' ), 1 );
 		add_action( 'wp_body_open', array( static::class, 'print_theme_token_sampler' ) );
 		// Relativize `jetpack-search/*` Script Module URLs whose host matches
 		// the site canonical so the rendered `<script type="module">` is
@@ -1101,21 +1099,9 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Print the `:root` defaults for `--jp-search-page-ink` /
-	 * `--jp-search-page-surface`. `print_theme_token_sampler()` overrides
-	 * these once `<body>` exists. See AGENTS.md § Theme tokens & `var()` chains.
-	 */
-	public static function print_theme_token_defaults_style(): void {
-		if ( is_admin() ) {
-			return;
-		}
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS string, no dynamic content.
-		echo "<style id='jetpack-search-theme-token-defaults'>:root{--jp-search-page-ink:var(--wp--preset--color--contrast,var(--wp--preset--color--foreground,#1d2327));--jp-search-page-surface:var(--wp--preset--color--base,var(--wp--preset--color--background,#fff))}</style>";
-	}
-
-	/**
-	 * Print the body-sampler `<script>` that overrides the `:root` defaults
-	 * with the body's resolved `color` / `backgroundColor`. Surface is skipped
+	 * Print the body-sampler `<script>` that sets `--jp-search-page-ink` /
+	 * `--jp-search-page-surface` on `:root` from the body's resolved `color` /
+	 * `backgroundColor`. Surface is skipped
 	 * when bg resolves to `transparent` — classic themes without an explicit
 	 * `body { background-color }` paint on the browser canvas, where the PHP
 	 * default already matches. See AGENTS.md § Theme tokens & `var()` chains.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1221,10 +1221,17 @@ class Search_Blocks {
  * mix used for the header `::before`. Both auto-invert polarity per theme, so
  * dark themes get a card that visibly layers above the scrim without losing
  * the themed surface color. The static `rgba(128,128,128,.25)` border + the
- * un-tinted token chain stay as the fallback for browsers without `color-mix`. */
+ * un-tinted token chain stay as the fallback for browsers without `color-mix`.
+ *
+ * The tint inputs read `--jp-search-page-*` first (theme-accurate values
+ * from the JS body sampler, SEARCH-274), then fall back to the
+ * `--wp--preset--color--*` chain so themes that don't expose
+ * `--base`/`--contrast` (wp.com Global Styles palettes that emit
+ * positional `--theme-N` slugs) still drive the tint from the page's
+ * actual surface and ink rather than the literal fallbacks. */
 @supports (background: color-mix(in sRGB, black 50%, white)) {
 	.jetpack-search-block-overlay__card {
-		--jp-search-overlay-surface: color-mix(in sRGB, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327)) 5%, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		--jp-search-overlay-surface: color-mix(in sRGB, var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327))) 5%, var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff))));
 		border-color: color-mix(in sRGB, var(--jp-search-overlay-ink) 20%, var(--jp-search-overlay-surface));
 	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -125,6 +125,14 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
+		// Front-end theme-token sampler — see `print_theme_token_defaults_style()`
+		// for the rationale. PHP defaults at `wp_head` priority 1 so the `:root`
+		// properties exist before any block CSS reads them; JS at `wp_body_open`
+		// overrides those defaults with the resolved body computed color/bg so
+		// themes that emit positional palette slugs (wp.com `--theme-N`) still
+		// drive every Search surface to a theme-accurate value.
+		add_action( 'wp_head', array( static::class, 'print_theme_token_defaults_style' ), 1 );
+		add_action( 'wp_body_open', array( static::class, 'print_theme_token_sampler' ) );
 		// Relativize `jetpack-search/*` Script Module URLs whose host matches
 		// the site canonical so the rendered `<script type="module">` is
 		// same-origin with the page. ES modules go through CORS even without
@@ -1098,18 +1106,67 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Print the `:root` defaults for the two Search-wide theme tokens read by
+	 * the overlay card and the popover / sort / suggestions surfaces. PHP
+	 * layer of the two-layer story documented at `print_theme_token_sampler()`.
+	 *
+	 * Defaults track the existing `--wp--preset--color--*` chain so themes
+	 * that follow the WP 6.1+ semantic-slug convention (`base` / `contrast`)
+	 * or the legacy `background` / `foreground` pair Just Work without the JS
+	 * sampler. The JS sampler then overrides these with the resolved body
+	 * computed values for themes that use positional palette slugs (wp.com
+	 * Global Styles emits `--theme-N`).
+	 */
+	public static function print_theme_token_defaults_style(): void {
+		if ( is_admin() ) {
+			return;
+		}
+		echo "<style id='jetpack-search-theme-token-defaults'>:root{--jp-search-page-ink:var(--wp--preset--color--contrast,var(--wp--preset--color--foreground,#1d2327));--jp-search-page-surface:var(--wp--preset--color--base,var(--wp--preset--color--background,#fff))}</style>";
+	}
+
+	/**
+	 * Print the inline `<script>` that samples the body's computed `color` and
+	 * `background-color` and overrides `--jp-search-page-ink` /
+	 * `--jp-search-page-surface` on `:root`. Hooked on `wp_body_open` so the
+	 * `<body>` already exists (computed styles are resolvable) but before any
+	 * block paints.
+	 *
+	 * Why sample at runtime: the existing `var(--wp--preset--color--base, …)`
+	 * chains static-match the WP 6.1+ semantic slug convention. Themes that
+	 * customize the palette through the wp.com Global Styles editor emit
+	 * positional slugs (`--theme-1` / `--theme-2`) and bind them to body via
+	 * a separate rule (`body { color: var(--wp--preset--color--theme-2); }`).
+	 * The slug name is opaque to a static chain; the *resolved* value isn't —
+	 * `getComputedStyle` returns it regardless of which slug the theme used.
+	 *
+	 * Carriers: every Search surface that reads `--jp-search-page-*` then
+	 * matches the theme — overlay card (see `block_template_overlay_inline_css`),
+	 * `filters-popover __panel`, `results-sort __menu`, `search-input __suggestions`.
+	 *
+	 * Themes that omit `wp_body_open()` (very old classic themes) fall back
+	 * to the PHP-emitted defaults — same behavior as today, no regression.
+	 */
+	public static function print_theme_token_sampler(): void {
+		if ( is_admin() ) {
+			return;
+		}
+		echo "<script id='jetpack-search-theme-token-sampler'>(function(){try{var c=getComputedStyle(document.body),r=document.documentElement;r.style.setProperty('--jp-search-page-ink',c.color);r.style.setProperty('--jp-search-page-surface',c.backgroundColor);}catch(e){}})();</script>";
+	}
+
+	/**
 	 * Inline CSS for the overlay modal chrome. Block content brings its own
 	 * theme styling; this is just the scrim, centered card, 60px header strip,
 	 * close button, mobile padding tweaks, and scroll lock. The responsive
 	 * sidebar-collapse + in-header popover rules shared with the page
 	 * templates live in `search_layout_inline_css()`.
 	 *
-	 * Surface/ink follow a two-step token fallback: newer `base`/`contrast`
-	 * (TT2/TT3/TT5-family) first, then legacy `background`/`foreground` (TT1,
-	 * Kaze, many WPCOM themes). #49125's hardcoded `#fff` resurrected the
-	 * white-on-white bug on legacy themes; the chain fixes it. Hoisted onto
-	 * two custom props so in-card surfaces (suggestions panel) share one source.
-	 * Hairlines use `color-mix(--jp-search-overlay-ink, --jp-search-overlay-surface)`.
+	 * Surface/ink read `--jp-search-page-*` first (theme-accurate values from
+	 * the JS sampler), then fall back to the WP 6.1+ semantic-slug chain
+	 * (`base`/`contrast`), then the legacy `background`/`foreground` pair
+	 * (TT1, Kaze, many WPCOM themes), then literals. The chain wins on
+	 * JS-disabled clients and very old themes that omit `wp_body_open()`.
+	 * Hoisted onto two custom props so in-card surfaces (suggestions panel)
+	 * share one source. Hairlines use `color-mix(--jp-search-overlay-ink, --jp-search-overlay-surface)`.
 	 *
 	 * @return string
 	 */
@@ -1139,8 +1196,8 @@ class Search_Blocks {
 	position: relative;
 	width: 100%;
 	max-width: 1080px;
-	--jp-search-overlay-surface: var(--wp--preset--color--base, var(--wp--preset--color--background, #fff));
-	--jp-search-overlay-ink: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327));
+	--jp-search-overlay-surface: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+	--jp-search-overlay-ink: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327)));
 	background: var(--jp-search-overlay-surface);
 	color: var(--jp-search-overlay-ink);
 	border: 1px solid rgba(128, 128, 128, 0.25);

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1265,6 +1265,7 @@ class Search_Blocks {
 	height: 100%;
 	font-size: 18px;
 	line-height: 1;
+	margin: 0;
 	padding: 0;
 	background: transparent;
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1121,6 +1121,7 @@ class Search_Blocks {
 		if ( is_admin() ) {
 			return;
 		}
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS string, no dynamic content.
 		echo "<style id='jetpack-search-theme-token-defaults'>:root{--jp-search-page-ink:var(--wp--preset--color--contrast,var(--wp--preset--color--foreground,#1d2327));--jp-search-page-surface:var(--wp--preset--color--base,var(--wp--preset--color--background,#fff))}</style>";
 	}
 
@@ -1145,12 +1146,22 @@ class Search_Blocks {
 	 *
 	 * Themes that omit `wp_body_open()` (very old classic themes) fall back
 	 * to the PHP-emitted defaults — same behavior as today, no regression.
+	 *
+	 * Transparent-body guard: classic themes that don't explicitly set
+	 * `body { background-color }` resolve `getComputedStyle(body).backgroundColor`
+	 * to `rgba(0, 0, 0, 0)` even though the page visually paints on the
+	 * browser canvas (white). Writing that transparent string onto
+	 * `--jp-search-page-surface` would override the PHP default and make
+	 * Search surfaces transparent. The conditional keeps the PHP default
+	 * (literal `#fff`) intact for those themes — visually they were already
+	 * rendering on a white canvas, so the literal matches.
 	 */
 	public static function print_theme_token_sampler(): void {
 		if ( is_admin() ) {
 			return;
 		}
-		echo "<script id='jetpack-search-theme-token-sampler'>(function(){try{var c=getComputedStyle(document.body),r=document.documentElement;r.style.setProperty('--jp-search-page-ink',c.color);r.style.setProperty('--jp-search-page-surface',c.backgroundColor);}catch(e){}})();</script>";
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded JS string, no dynamic content.
+		echo "<script id='jetpack-search-theme-token-sampler'>(function(){try{var c=getComputedStyle(document.body),r=document.documentElement;if(c.color){r.style.setProperty('--jp-search-page-ink',c.color);}if(c.backgroundColor&&c.backgroundColor!=='rgba(0, 0, 0, 0)'&&c.backgroundColor!=='transparent'){r.style.setProperty('--jp-search-page-surface',c.backgroundColor);}}catch(e){}})();</script>";
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -125,12 +125,7 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
-		// Front-end theme-token sampler — see `print_theme_token_defaults_style()`
-		// for the rationale. PHP defaults at `wp_head` priority 1 so the `:root`
-		// properties exist before any block CSS reads them; JS at `wp_body_open`
-		// overrides those defaults with the resolved body computed color/bg so
-		// themes that emit positional palette slugs (wp.com `--theme-N`) still
-		// drive every Search surface to a theme-accurate value.
+		// Priority 1 so `:root` defaults are defined before any block CSS reads them.
 		add_action( 'wp_head', array( static::class, 'print_theme_token_defaults_style' ), 1 );
 		add_action( 'wp_body_open', array( static::class, 'print_theme_token_sampler' ) );
 		// Relativize `jetpack-search/*` Script Module URLs whose host matches
@@ -1106,16 +1101,9 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Print the `:root` defaults for the two Search-wide theme tokens read by
-	 * the overlay card and the popover / sort / suggestions surfaces. PHP
-	 * layer of the two-layer story documented at `print_theme_token_sampler()`.
-	 *
-	 * Defaults track the existing `--wp--preset--color--*` chain so themes
-	 * that follow the WP 6.1+ semantic-slug convention (`base` / `contrast`)
-	 * or the legacy `background` / `foreground` pair Just Work without the JS
-	 * sampler. The JS sampler then overrides these with the resolved body
-	 * computed values for themes that use positional palette slugs (wp.com
-	 * Global Styles emits `--theme-N`).
+	 * Print the `:root` defaults for `--jp-search-page-ink` /
+	 * `--jp-search-page-surface`. `print_theme_token_sampler()` overrides
+	 * these once `<body>` exists. See AGENTS.md § Theme tokens & `var()` chains.
 	 */
 	public static function print_theme_token_defaults_style(): void {
 		if ( is_admin() ) {
@@ -1126,35 +1114,11 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Print the inline `<script>` that samples the body's computed `color` and
-	 * `background-color` and overrides `--jp-search-page-ink` /
-	 * `--jp-search-page-surface` on `:root`. Hooked on `wp_body_open` so the
-	 * `<body>` already exists (computed styles are resolvable) but before any
-	 * block paints.
-	 *
-	 * Why sample at runtime: the existing `var(--wp--preset--color--base, …)`
-	 * chains static-match the WP 6.1+ semantic slug convention. Themes that
-	 * customize the palette through the wp.com Global Styles editor emit
-	 * positional slugs (`--theme-1` / `--theme-2`) and bind them to body via
-	 * a separate rule (`body { color: var(--wp--preset--color--theme-2); }`).
-	 * The slug name is opaque to a static chain; the *resolved* value isn't —
-	 * `getComputedStyle` returns it regardless of which slug the theme used.
-	 *
-	 * Carriers: every Search surface that reads `--jp-search-page-*` then
-	 * matches the theme — overlay card (see `block_template_overlay_inline_css`),
-	 * `filters-popover __panel`, `results-sort __menu`, `search-input __suggestions`.
-	 *
-	 * Themes that omit `wp_body_open()` (very old classic themes) fall back
-	 * to the PHP-emitted defaults — same behavior as today, no regression.
-	 *
-	 * Transparent-body guard: classic themes that don't explicitly set
-	 * `body { background-color }` resolve `getComputedStyle(body).backgroundColor`
-	 * to `rgba(0, 0, 0, 0)` even though the page visually paints on the
-	 * browser canvas (white). Writing that transparent string onto
-	 * `--jp-search-page-surface` would override the PHP default and make
-	 * Search surfaces transparent. The conditional keeps the PHP default
-	 * (literal `#fff`) intact for those themes — visually they were already
-	 * rendering on a white canvas, so the literal matches.
+	 * Print the body-sampler `<script>` that overrides the `:root` defaults
+	 * with the body's resolved `color` / `backgroundColor`. Surface is skipped
+	 * when bg resolves to `transparent` — classic themes without an explicit
+	 * `body { background-color }` paint on the browser canvas, where the PHP
+	 * default already matches. See AGENTS.md § Theme tokens & `var()` chains.
 	 */
 	public static function print_theme_token_sampler(): void {
 		if ( is_admin() ) {
@@ -1171,13 +1135,10 @@ class Search_Blocks {
 	 * sidebar-collapse + in-header popover rules shared with the page
 	 * templates live in `search_layout_inline_css()`.
 	 *
-	 * Surface/ink read `--jp-search-page-*` first (theme-accurate values from
-	 * the JS sampler), then fall back to the WP 6.1+ semantic-slug chain
-	 * (`base`/`contrast`), then the legacy `background`/`foreground` pair
-	 * (TT1, Kaze, many WPCOM themes), then literals. The chain wins on
-	 * JS-disabled clients and very old themes that omit `wp_body_open()`.
-	 * Hoisted onto two custom props so in-card surfaces (suggestions panel)
-	 * share one source. Hairlines use `color-mix(--jp-search-overlay-ink, --jp-search-overlay-surface)`.
+	 * Surface/ink hoist `--jp-search-page-*` (with the legacy
+	 * `--wp--preset--color--*` chain as fallback — see AGENTS.md § Theme
+	 * tokens) onto two custom props so in-card surfaces share one source.
+	 * Hairlines use `color-mix(--jp-search-overlay-ink, --jp-search-overlay-surface)`.
 	 *
 	 * @return string
 	 */
@@ -1221,14 +1182,7 @@ class Search_Blocks {
  * mix used for the header `::before`. Both auto-invert polarity per theme, so
  * dark themes get a card that visibly layers above the scrim without losing
  * the themed surface color. The static `rgba(128,128,128,.25)` border + the
- * un-tinted token chain stay as the fallback for browsers without `color-mix`.
- *
- * The tint inputs read `--jp-search-page-*` first (theme-accurate values
- * from the JS body sampler, SEARCH-274), then fall back to the
- * `--wp--preset--color--*` chain so themes that don't expose
- * `--base`/`--contrast` (wp.com Global Styles palettes that emit
- * positional `--theme-N` slugs) still drive the tint from the page's
- * actual surface and ink rather than the literal fallbacks. */
+ * un-tinted token chain stay as the fallback for browsers without `color-mix`. */
 @supports (background: color-mix(in sRGB, black 50%, white)) {
 	.jetpack-search-block-overlay__card {
 		--jp-search-overlay-surface: color-mix(in sRGB, var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327))) 5%, var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff))));

--- a/projects/packages/search/tools/webpack.blocks.config.js
+++ b/projects/packages/search/tools/webpack.blocks.config.js
@@ -96,7 +96,7 @@ module.exports = {
 					{
 						loader: 'postcss-loader',
 						options: {
-							postcssOptions: { config: path.join( __dirname, '../postcss.config.js' ) },
+							postcssOptions: { config: path.join( __dirname, '../postcss.blocks.config.js' ) },
 						},
 					},
 					{ loader: 'sass-loader', options: { api: 'modern-compiler' } },


### PR DESCRIPTION
Fixes [SEARCH-274](https://linear.app/a8c/issue/SEARCH-274/search-blocks-sample-body-computed-colorbackground-for-theme-accurate)

## Why

When a visitor opens a Search Blocks surface (overlay card, filters-popover panel, results-sort menu, search-input suggestions dropdown) on a theme that customizes its palette through wp.com Global Styles, the surface's text and background drift from the rest of the page — often dark slate text on bright white, while the page itself reads as themed (e.g. blue text on near-white). Live reproduction: [`https://kangzj4.wordpress.com/?s=hello`](https://kangzj4.wordpress.com/?s=hello) (theme `pubprimarium`, body paints `#0044cc` on `#f7f7f7`; the overlay card paints `#1d2327` on `#fff`).

Root cause: the existing `var(--wp--preset--color--base, …)` chain across Search Blocks reads slug names statically. Themes customized through the wp.com Global Styles palette editor emit positional palette slugs (`--theme-1` / `--theme-2`) and bind them to body via a separate rule. The chain can't reach those slugs because slug names are arbitrary and positional, not semantic.

This PR samples the body's *computed* `color` and `background-color` at `wp_body_open`, writes them onto `:root`, and has every Search surface read those resolved values first. Theme-agnostic by construction — works regardless of which palette slug the theme used.

## Proposed changes

* `class-search-blocks.php` — two new methods:
  * `print_theme_token_defaults_style()` hooked on `wp_head` priority 1 emits a `:root { --jp-search-page-ink: …; --jp-search-page-surface: …; }` rule whose values track the existing 3-tier `--wp--preset--color--*` chain. Keeps the props defined even when the JS sampler doesn't run (no-JS clients, very old classic themes that omit `wp_body_open()`) — same behavior as today, no regression.
  * `print_theme_token_sampler()` hooked on `wp_body_open` emits a small inline `<script>` that calls `getComputedStyle(document.body)` and overrides `--jp-search-page-ink` / `--jp-search-page-surface` on `:root` with the *resolved* body color and background-color. Runs once, ~150 bytes, fires before any block paints.
* Overlay card inline CSS (`class-search-blocks.php:1142-1143`) — `--jp-search-overlay-surface` / `--jp-search-overlay-ink` now read `--jp-search-page-*` first, with the existing chain as the deepest fallback. Composes cleanly with #49207 (SEARCH-270)'s `color-mix` tint recipe — that PR's algorithm becomes correct on these themes once the inputs are theme-accurate.
* Three SCSS files — `filters-popover/style.scss`, `results-sort/style.scss`, `search-input/style.scss` — each adds a second pair of declarations for `background-color` / `color` after the existing chain. Postcss-custom-properties (`preserve: false` in the package's `postcss.config.js`) folds the chain to a literal at build; the single-arg `var()` declarations are preserved to runtime. The PHP `:root` defaults guarantee the props are defined, so the later declaration wins via the cascade. `// stylelint-disable-next-line declaration-block-no-duplicate-properties` silences the duplicate-property warning where it surfaces — the two-declaration pattern is the point.
* `filters-popover` badge-count text color — picks up the same `--jp-search-page-surface` so it inverts polarity per theme on top of the foreground-mixed badge background.
* Changelog entry (`patch` / `changed`).

## Screenshots

Captured against the local docker `overlay_blocks` experience at 1440×900 on a search URL (`/?s=hello`). The "theme-N" axis is simulated by injecting `--wp--preset--color--theme-1` (= `#f7f7f7`), `--theme-2` (= `#0044cc`) and `body { background-color: var(--theme-1) !important; color: var(--theme-2) !important; }` into the page's `<head>` before any block paints — that's the exact shape `pubprimarium` ships.

### Theme-N theme (kangzj4-shape) — bug vs fix

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/echo/search-274-theme-token-sampling/before-overlay-themeN.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/echo/search-274-theme-token-sampling/after-overlay-themeN.png) |

The **before** card paints `#1d2327` text on `#fff` surface (the literal fallback bottom of the chain). The **after** card paints `#0044cc` text on `#f7f7f7` surface (the sampled body values), matching the page's theme exactly.

### TT5 default — no regression

| Before (trunk) | After |
|---|---|
| ![before-tt5](https://github.com/Automattic/jetpack/raw/screenshots/echo/search-274-theme-token-sampling/before-overlay-tt5.png) | ![after-tt5](https://github.com/Automattic/jetpack/raw/screenshots/echo/search-274-theme-token-sampling/after-overlay-tt5.png) |

Identical — TT5 exposes `--wp--preset--color--base/--contrast`, so the existing chain already resolved correctly, and the sampler just writes the same values onto `:root`. No visible delta.

## Verification

Computed-style evidence captured at the same time as the screenshots:

<details>
<summary>Resolved values (theme-N simulation)</summary>

```text
BEFORE (trunk):
  body.color           = rgb(0, 68, 204)
  body.background      = rgb(247, 247, 247)
  card.color           = rgb(17, 17, 17)     ← drifts from body
  card.background      = rgb(255, 255, 255)  ← drifts from body
  --jp-search-page-ink = ""                  ← property not defined (feature absent on trunk)
  --jp-search-page-surface = ""

AFTER (this branch):
  body.color           = rgb(0, 68, 204)
  body.background      = rgb(247, 247, 247)
  card.color           = rgb(0, 68, 204)     ← matches body ✓
  card.background      = rgb(247, 247, 247)  ← matches body ✓
  --jp-search-page-ink = rgb(0, 68, 204)
  --jp-search-page-surface = rgb(247, 247, 247)
```

</details>

<details>
<summary>Resolved values (TT5 default — regression check)</summary>

```text
BEFORE (trunk):
  body.color           = rgb(17, 17, 17)
  body.background      = rgb(255, 255, 255)
  card.color           = rgb(17, 17, 17)     ← matches body (TT5 exposes --base/--contrast)
  card.background      = rgb(255, 255, 255)  ← matches body

AFTER (this branch):
  body.color           = rgb(17, 17, 17)
  body.background      = rgb(255, 255, 255)
  card.color           = rgb(17, 17, 17)     ← matches body (now via sampled values)
  card.background      = rgb(255, 255, 255)  ← matches body
```

</details>

## Related product discussion/links

* [SEARCH-274](https://linear.app/a8c/issue/SEARCH-274/search-blocks-sample-body-computed-colorbackground-for-theme-accurate)
* Layers with PR #49207 (SEARCH-270): that PR tints the resolved card surface 5% toward ink for dark-theme card-on-scrim separation — once SEARCH-274 lands, those inputs become theme-accurate.
* Prior surface-token PRs in the same series: #49180 (SEARCH-263 — 3-tier `base → background → #fff` chain), #49184 (SEARCH-260 overlay legacy-tokens follow-up), #49179 (SEARCH-260 overlay-shell tokens), #49208 (SEARCH-272 — rating + suggestions/price-slider chain alignment).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-274:

- [ ] New `Search_Blocks` PHP method emits a `:root` inline CSS rule defining `--jp-search-page-ink` and `--jp-search-page-surface` with the existing 3-tier chains as their default values. Hooked via `add_action( 'wp_head', …, 1 )`.
- [ ] New `wp_body_open` hook emits a small inline `<script>` that calls `getComputedStyle(document.body)` and writes the resolved `color` / `backgroundColor` onto `:root` as `--jp-search-page-ink` / `--jp-search-page-surface`.
- [ ] Overlay shell inline CSS reads the new tokens first; the existing 3-tier chain stays as the deepest fallback inside `var(... , <chain>)` so a JS-disabled client still gets the current behavior.
- [ ] `filters-popover/style.scss`, `results-sort/style.scss`, `search-input/style.scss` update their surface `background-color` / `color` declarations to single-argument `var(--jp-search-page-surface)` / `var(--jp-search-page-ink)`. The existing chain declaration stays *above* the new one in source so the cascade still has a safe default for the (unlikely) case where `--jp-search-page-*` isn't defined.
- [ ] `https://kangzj4.wordpress.com/?s=hello`-style test (or any block theme that paints body via positional palette slugs): overlay card surface visually tracks the page's body bg, and ink matches the body color.
- [ ] TT5 default (light) and TT5 dark style variation: no regression — both still render with the theme's resolved ink/surface, just sampled from `body` instead of from the slug chain.
- [ ] Classic theme without `theme.json`: card falls through to the PHP-emitted defaults via the inline `:root` rule. Same behavior as today.
- [ ] JS-disabled client: `:root` defaults from the PHP-emitted rule apply. Same behavior as today.
- [ ] Editor (block editor / site editor preview): no impact — the JS runs on the front-end only (gated by `! is_admin()` in both new methods).
- [ ] Changelog entry created.

Repro steps for the bug + fix:

1. Pull the branch, rebuild: `pnpm jetpack build packages/my-jetpack && pnpm jetpack build plugins/jetpack && pnpm jetpack build packages/search && pnpm jetpack build plugins/search`.
2. On a site with WordPress' Global Styles palette editor used to define a custom palette (which emits `--theme-1` / `--theme-2` / `--theme-N`) — or simulate it by adding to your test site's customizer:
   ```css
   :root {
     --wp--preset--color--theme-1: #f7f7f7;
     --wp--preset--color--theme-2: #0044cc;
   }
   body {
     background-color: var(--wp--preset--color--theme-1);
     color: var(--wp--preset--color--theme-2);
   }
   ```
3. Set `wp option update jetpack_search_experience overlay_blocks`.
4. Visit `/?s=hello`. The overlay modal card should now render `#0044cc` text on `#f7f7f7` surface — same colors as the page body, regardless of the slug names.
