### PR TITLE
Search Blocks: polish no-results, error, and filters-empty messages (SEARCH-275)

### DIFF
--- a/projects/packages/search/changelog/nova-search-275-empty-state-polish
+++ b/projects/packages/search/changelog/nova-search-275-empty-state-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: polish the no-results, error, and filters-empty messages with a consistent muted-scale typography across the overlay; the no-results copy now adapts when filters are active.

--- a/projects/packages/search/changelog/nova-search-275-empty-state-polish
+++ b/projects/packages/search/changelog/nova-search-275-empty-state-polish
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
 Search Blocks: polish the no-results, error, and filters-empty messages with a consistent muted-scale typography across the overlay; the no-results copy now adapts when filters are active.

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/style.scss
@@ -12,6 +12,11 @@
 
 .jetpack-search-filters-product__empty {
 	margin: 0;
+	// Size + line-height match `results-list` no-results/error so every
+	// muted-message region in the overlay shares one visual scale. See
+	// the sibling `filters/style.scss` for the same pattern.
+	font-size: 0.875rem;
+	line-height: 1.5;
 	opacity: 0.6;
 
 	&[hidden] {

--- a/projects/packages/search/src/search-blocks/blocks/filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters/style.scss
@@ -9,6 +9,12 @@
 
 .jetpack-search-filters__empty {
 	margin: 0;
+	// Size + line-height match `results-list` no-results/error so every
+	// muted-message region in the overlay shares one visual scale. `rem`
+	// (not `em`) anchors to the root font-size — see `results-list/style.scss`
+	// for the rationale. `opacity: 0.6` keeps parity with `__path` / `__meta`.
+	font-size: 0.875rem;
+	line-height: 1.5;
 	opacity: 0.6;
 
 	&[hidden] {

--- a/projects/packages/search/src/search-blocks/blocks/results-list/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack-search/results-list",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"title": "Results List",
 	"category": "jetpack-search",
 	"description": "Renders search results, plus the empty-state and error messages for the same region. Powered by Jetpack Search.",
@@ -14,6 +14,7 @@
 		},
 		"autoProductView": { "type": "boolean", "default": true },
 		"noResultsMessage": { "type": "string", "default": "" },
+		"noResultsWithFiltersMessage": { "type": "string", "default": "" },
 		"errorMessage": { "type": "string", "default": "" }
 	},
 	"supports": {

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
@@ -128,7 +128,13 @@ export default function ResultsListEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps( {
 		className: `jetpack-search-results--${ layout }`,
 	} );
+	// Defaults mirror render.php so the inspector placeholder matches what
+	// visitors actually see when the field is left empty.
 	const noResultsDefault = __( 'No results found. Try a different search.', 'jetpack-search-pkg' );
+	const noResultsWithFiltersDefault = __(
+		'No results match these filters. Try clearing some, or searching for something else.',
+		'jetpack-search-pkg'
+	);
 	const errorDefault = __( 'Something went wrong. Please try again.', 'jetpack-search-pkg' );
 	return (
 		<>
@@ -164,6 +170,18 @@ export default function ResultsListEdit( { attributes, setAttributes } ) {
 						onChange={ value => setAttributes( { noResultsMessage: value } ) }
 						help={ __(
 							'Shown when a search returns nothing. Leave empty for the default.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'No-results message (when filters are active)', 'jetpack-search-pkg' ) }
+						value={ attributes?.noResultsWithFiltersMessage || '' }
+						placeholder={ noResultsWithFiltersDefault }
+						onChange={ value => setAttributes( { noResultsWithFiltersMessage: value } ) }
+						help={ __(
+							'Shown when active filters return zero results. Leave empty for the default.',
 							'jetpack-search-pkg'
 						) }
 					/>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -117,6 +117,14 @@ if ( '' === $no_results_message ) {
 	$no_results_message = __( 'No results found. Try a different search.', 'jetpack-search-pkg' );
 }
 
+// Filter-aware variant — shown when `state.hasActiveFilters` is true. Both
+// variants live in the markup so the store's existing reactive getter picks
+// which `<p>` is visible without a store-side message-resolution branch.
+$no_results_with_filters_message = trim( (string) ( $attrs['noResultsWithFiltersMessage'] ?? '' ) );
+if ( '' === $no_results_with_filters_message ) {
+	$no_results_with_filters_message = __( 'No results match these filters. Try clearing some, or searching for something else.', 'jetpack-search-pkg' );
+}
+
 $error_message = trim( (string) ( $attrs['errorMessage'] ?? '' ) );
 if ( '' === $error_message ) {
 	$error_message = __( 'Something went wrong. Please try again.', 'jetpack-search-pkg' );
@@ -338,7 +346,8 @@ if ( '' === $error_message ) {
 		data-wp-bind--hidden="!state.showNoResults"
 		hidden
 	>
-		<p><?php echo esc_html( $no_results_message ); ?></p>
+		<p data-wp-bind--hidden="state.hasActiveFilters"><?php echo esc_html( $no_results_message ); ?></p>
+		<p data-wp-bind--hidden="!state.hasActiveFilters"><?php echo esc_html( $no_results_with_filters_message ); ?></p>
 	</div>
 	<div
 		class="jetpack-search-results__error"

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -344,8 +344,17 @@ if ( '' === $error_message ) {
 	<div
 		class="jetpack-search-results__no-results"
 		data-wp-bind--hidden="!state.showNoResults"
+		role="status"
 		hidden
 	>
+		<?php
+		// Both `<p>` variants render without an initial `hidden` attribute —
+		// the outer wrapper's `hidden` covers them on the SSR path, and the IA
+		// runtime resolves the inner `data-wp-bind--hidden` atomically when it
+		// reveals the region. Don't remove the outer `hidden` without also
+		// adding initial `hidden` to one of the variants, or both messages
+		// will flash briefly on hydration.
+		?>
 		<p data-wp-bind--hidden="state.hasActiveFilters"><?php echo esc_html( $no_results_message ); ?></p>
 		<p data-wp-bind--hidden="!state.hasActiveFilters"><?php echo esc_html( $no_results_with_filters_message ); ?></p>
 	</div>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/style.scss
@@ -41,6 +41,52 @@
 		padding: 0;
 	}
 
+	// Empty/error regions share a centered presentation with reserved vertical
+	// space so the message reads as intentional in the overlay's wide results
+	// column instead of clinging to the top-left edge. Visual treatment matches
+	// the package's other muted-text regions (`__meta`, `__path`, the filter
+	// empty states): plain `<p>` with `opacity: 0.6`, no icon or heading — the
+	// package doesn't use either elsewhere. The `&[hidden]` rule on the inner
+	// `<p>` is load-bearing for no-results specifically: two `<p>` variants
+	// live inside one region and toggle via
+	// `data-wp-bind--hidden="state.hasActiveFilters"` to swap the copy when
+	// filters are active. Without it, the inactive variant would still take a
+	// line of vertical space.
+	.jetpack-search-results__no-results,
+	.jetpack-search-results__error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		gap: 0.25rem;
+		min-height: 12rem;
+		margin: 0;
+		padding: 2rem 1rem;
+		opacity: 0.6;
+
+		&[hidden] {
+			display: none;
+		}
+
+		p {
+			max-width: 36ch;
+			margin: 0;
+			// `rem` (not `em`) so the size is anchored to the root font-size
+			// rather than the theme's body font, which on themes like
+			// Twenty Twenty-Five is large enough that a relative `0.875em`
+			// still reads as the primary body size. ~14px is comparable to
+			// the package's other muted-text regions (`__path` 0.8125rem,
+			// `__meta` 0.9rem).
+			font-size: 0.875rem;
+			line-height: 1.5;
+
+			&[hidden] {
+				display: none;
+			}
+		}
+	}
+
 	.jetpack-search-results__item {
 		display: flex;
 		align-items: flex-start;

--- a/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
@@ -214,6 +214,7 @@ describe( 'ResultsListEdit', () => {
 				attributes={ {
 					layout: 'expanded',
 					noResultsMessage: 'Try a broader query.',
+					noResultsWithFiltersMessage: 'Clear a filter to see results.',
 					errorMessage: 'Search is offline right now.',
 				} }
 				setAttributes={ jest.fn() }
@@ -224,6 +225,7 @@ describe( 'ResultsListEdit', () => {
 		// the empty and error copy live in the Inspector controls only.
 		expect( screen.getByText( 'First sample result' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Try a broader query.' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Clear a filter to see results.' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Search is offline right now.' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
@@ -160,10 +160,13 @@ describe( 'ResultsListEdit', () => {
 		expect( setAttributes ).toHaveBeenCalledWith( { autoProductView: false } );
 	} );
 
-	it( 'exposes message controls for the empty and error states in the inspector', () => {
+	it( 'exposes message controls for the empty, filtered-empty, and error states in the inspector', () => {
 		render( <ResultsListEdit attributes={ {} } setAttributes={ jest.fn() } /> );
 
 		expect( screen.getByRole( 'textbox', { name: 'No-results message' } ) ).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'textbox', { name: 'No-results message (when filters are active)' } )
+		).toBeInTheDocument();
 		expect( screen.getByRole( 'textbox', { name: 'Error message' } ) ).toBeInTheDocument();
 	} );
 
@@ -176,6 +179,20 @@ describe( 'ResultsListEdit', () => {
 			target: { value: 'Try a broader query.' },
 		} );
 		expect( setAttributes ).toHaveBeenCalledWith( { noResultsMessage: 'Try a broader query.' } );
+	} );
+
+	it( 'updates the noResultsWithFiltersMessage attribute when the filtered-empty control changes', () => {
+		const setAttributes = jest.fn();
+		render( <ResultsListEdit attributes={ {} } setAttributes={ setAttributes } /> );
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- @testing-library/user-event isn't a dep of the search package; results-sort-edit.test.jsx uses fireEvent for the same reason.
+		fireEvent.change(
+			screen.getByRole( 'textbox', { name: 'No-results message (when filters are active)' } ),
+			{ target: { value: 'Try removing a filter.' } }
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			noResultsWithFiltersMessage: 'Try removing a filter.',
+		} );
 	} );
 
 	it( 'updates the errorMessage attribute when the error control changes', () => {


### PR DESCRIPTION
Fixes [SEARCH-275](https://linear.app/a8c/issue/SEARCH-275/search-blocks-polish-no-results-and-error-empty-states-icon-heading)

## Why

The Search Blocks overlay rendered "No results found. Try a different search." as a bare `<p>` in the upper-left corner of the wide results column, and the error state looked identical — both read as unintentional and undercut the rest of the polished overlay. This PR centers both regions inside reserved vertical space and uses the package's existing muted-text scale (`0.875rem`, `opacity: 0.6`) so every "nothing to show here" message in the overlay reads as the same intentional system. When filters are active and produce zero results, the copy adapts to acknowledge the filters instead of just nudging the user to a different query.

## Proposed changes

- Restructure the no-results region in `results-list` to render two `<p>` variants, each gated by `data-wp-bind--hidden="state.hasActiveFilters"`, so a search with active filters returning zero results shows filter-aware copy and the standard variant otherwise.
- Add a new editor-overridable `noResultsWithFiltersMessage` block attribute (alongside the existing `noResultsMessage` and `errorMessage`), with an inspector `TextControl`. PHP fills the localized default on empty/whitespace via the same `trim()` fallback the other two messages use.
- Add SCSS for `.jetpack-search-results__no-results` and `.jetpack-search-results__error` so they share a centered presentation (`min-height: 12rem`, `flex` + `text-align: center`, `opacity: 0.6`, `max-width: 36ch`). `font-size: 0.875rem` keeps the copy comparable to the package's other muted-text regions (`__path` 0.8125rem, `__meta` 0.9rem) — without this, the theme's body font cascaded through and the message read as primary copy on themes like Twenty Twenty-Five.
- Apply the same `font-size` + `line-height` to `.jetpack-search-filters__empty` and `.jetpack-search-filters-product__empty` so the sidebar "No filters available" message lines up with the new typography scale (per in-PR review feedback).
- No store changes — `state.hasActiveFilters`, `state.showNoResults`, and `state.showError` all already existed and stay as-is.
- Unit test added for the new `noResultsWithFiltersMessage` inspector control.
- Block version bumped to `0.3.0`.

## Screenshots

### No-results, no filters

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/97b2c807-05f4-45ca-83f7-68eebcb89645) | ![after](https://github.com/user-attachments/assets/87cd8b28-d977-45e9-8294-176e736ab798) |

### No-results, active filters

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/78cbb895-c7e3-4efc-9ee2-f0fce57a924a) | ![after](https://github.com/user-attachments/assets/ba45c98c-64ef-4edb-94c7-00549dfd285d) |

(The trunk "before" still shows the standard copy regardless of filter state — there was no filter-aware variant on trunk.)

### Error state

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/c3658166-5441-4e21-a2dd-4a565119bea2) | ![after](https://github.com/user-attachments/assets/6865536d-fd95-4b97-b886-8feea9cd5da9) |

## Related product discussion/links

* Linear: [SEARCH-275](https://linear.app/a8c/issue/SEARCH-275/search-blocks-polish-no-results-and-error-empty-states-icon-heading)

## Does this pull request change what data or activity we track or use?

No — this is presentational polish only. No data, tracking, or telemetry changes.

## Testing instructions

Set up: enable the Search Blocks Overlay experience on a local site with Jetpack Search active and some indexed content + facets.

- [ ] **No-results, no filters**: visit `/?s=asdfasdf` (a query with no matches). Confirm the "No results found. Try a different search." message renders centered horizontally and vertically inside the results column with reserved vertical space, muted (~14px), and is **not** clinging to the top-left edge.
- [ ] **No-results, active filters**: visit `/?s=zzzzzz&category[]=block` (or any query + active filter that returns zero results). Confirm the message swaps to "No results match these filters. Try clearing some, or searching for something else." Remove the filter chip and confirm the copy reverts to the standard "No results found. Try a different search." variant.
- [ ] **Error state**: simulate a network failure (DevTools → Network conditions → block `*public-api.wordpress.com*`) and re-run a search. Confirm "Something went wrong. Please try again." renders with the same centered treatment as the no-results region, and the wrapper still carries `role="alert"` for screen readers.
- [ ] **Filters-empty alignment**: pick a query that returns hits but no facet buckets (or any state that surfaces the sidebar "No filters available" copy). Confirm that copy now matches the new typography scale (`0.875rem`, opacity 0.6) rather than the larger inherited body size.
- [ ] **Editor override**: in the block editor, edit the Results List block; the Inspector now has three message fields (no-results, no-results with filters, error). Set custom strings for each, then confirm each surfaces on the front end in the corresponding state.
- [ ] **Loading + skeleton regression**: refresh the search page and watch the pre-hydration window. The skeleton items should still render and the empty/error regions should stay hidden until `state.isLoading` resolves.
- [ ] **Embedded experience**: confirm the same polish on a page using the standard `jetpack-search.html` block template, not just the modal overlay.
