### PR TITLE
Search Blocks: focus search input + cursor at end of existing query on render (SEARCH-276)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-276-focus-input-cursor-at-end
+++ b/projects/packages/search/changelog/atlas-search-276-focus-input-cursor-at-end
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: when the overlay opens or a search page renders with an existing query, focus the search input and place the caret at the end of that query so visitors can keep typing to refine without re-positioning the cursor.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -132,6 +132,7 @@ $context_json = $emit_context
 			data-wp-bind--value="state.searchQuery"
 			data-wp-on--input="actions.onSearchInput"
 			data-wp-on--keydown="actions.onSearchKeydown"
+			data-wp-init="callbacks.initFocusInputIfHasQuery"
 		/>
 		<button
 			type="button"

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -17,7 +17,9 @@ const debounceTimers = new WeakMap();
 /**
  * Focus an input and place the cursor at the end of its current value, so
  * a visitor opening Search with a query already in flight can keep typing
- * to refine it without manually re-positioning the caret.
+ * to refine it without manually re-positioning the caret. The overlay
+ * bundle (`overlay-bootstrap/index.js`'s `openOverlay()`) carries an
+ * inlined duplicate of these three lines — when changing one, change both.
  *
  * @param {HTMLInputElement|null} input - The input to focus.
  */
@@ -26,7 +28,7 @@ function focusInputWithCursorAtEnd( input ) {
 		return;
 	}
 	input.focus();
-	const len = input.value?.length ?? 0;
+	const len = input.value.length;
 	// `setSelectionRange` throws on input types that don't support text
 	// selection. `type="search"` does, but the guard keeps things safe
 	// if the input shape ever changes.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -1,4 +1,4 @@
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, getElement } from '@wordpress/interactivity';
 import 'jetpack-search/store';
 import {
 	clearSuggestionsContext,
@@ -13,6 +13,29 @@ const SEARCH_DEBOUNCE_MS = 300;
 // Per-input debounce keyed on the element so two inputs (header + sidebar)
 // don't reset each other; WeakMap lets GC reclaim when the input goes away.
 const debounceTimers = new WeakMap();
+
+/**
+ * Focus an input and place the cursor at the end of its current value, so
+ * a visitor opening Search with a query already in flight can keep typing
+ * to refine it without manually re-positioning the caret.
+ *
+ * @param {HTMLInputElement|null} input - The input to focus.
+ */
+function focusInputWithCursorAtEnd( input ) {
+	if ( ! input ) {
+		return;
+	}
+	input.focus();
+	const len = input.value?.length ?? 0;
+	// `setSelectionRange` throws on input types that don't support text
+	// selection. `type="search"` does, but the guard keeps things safe
+	// if the input shape ever changes.
+	try {
+		input.setSelectionRange( len, len );
+	} catch {
+		/* noop */
+	}
+}
 
 /**
  * Start/restart the debounced search. `staticPostTypes` is captured
@@ -91,6 +114,35 @@ store( NAMESPACE, {
 			// Read scope before yield — `getContext()` needs the element context.
 			const staticPostTypes = readPostTypeScope();
 			yield actions.search( { staticPostTypes } );
+		},
+	},
+	callbacks: {
+		/**
+		 * `data-wp-init` lifecycle hook on the search input. On mount,
+		 * place focus into the input with the cursor at the end of any
+		 * pre-existing query so a visitor landing on a search page (or
+		 * reopening the overlay) can keep typing without re-positioning
+		 * the caret.
+		 *
+		 * Skips when the input sits inside a `[hidden]` subtree — the
+		 * overlay-template's clone fires this during hydration while the
+		 * overlay shell still has the `hidden` attribute; `openOverlay()`
+		 * stays authoritative for the overlay's focus moment.
+		 *
+		 * Skips when no query has been entered — auto-focusing an empty
+		 * search page would steal focus from screen-reader / keyboard
+		 * users who'd prefer to land on the page heading first.
+		 */
+		initFocusInputIfHasQuery() {
+			const input = getElement()?.ref;
+			if ( ! input || input.closest( '[hidden]' ) !== null ) {
+				return;
+			}
+			const { state } = store( NAMESPACE );
+			if ( ! state.searchQuery ) {
+				return;
+			}
+			focusInputWithCursorAtEnd( input );
 		},
 	},
 } );

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -162,8 +162,9 @@ async function openOverlay( triggerEl ) {
 		// Drop the caret at the end of any pre-existing query so the
 		// visitor can keep typing to refine without hitting `End`. Mirrors
 		// `focusInputWithCursorAtEnd()` in the search-input view bundle;
-		// inlined here to avoid a cross-bundle import for ~3 lines.
-		const len = input.value?.length ?? 0;
+		// inlined here to avoid a cross-bundle import for ~3 lines. When
+		// changing this block, change the sibling helper too.
+		const len = input.value.length;
 		try {
 			input.setSelectionRange( len, len );
 		} catch {

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/index.js
@@ -159,6 +159,16 @@ async function openOverlay( triggerEl ) {
 	const input = overlay.querySelector( 'input[type="search"]' );
 	if ( input ) {
 		input.focus();
+		// Drop the caret at the end of any pre-existing query so the
+		// visitor can keep typing to refine without hitting `End`. Mirrors
+		// `focusInputWithCursorAtEnd()` in the search-input view bundle;
+		// inlined here to avoid a cross-bundle import for ~3 lines.
+		const len = input.value?.length ?? 0;
+		try {
+			input.setSelectionRange( len, len );
+		} catch {
+			/* noop */
+		}
 	}
 }
 

--- a/projects/packages/search/tests/js/search-blocks/search-input-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/search-input-view.test.js
@@ -1,0 +1,125 @@
+// `@wordpress/interactivity` is an externalized dep — mock virtually so the
+// view.js file can be required and its actions/callbacks captured. Mirrors the
+// pattern in filter-wc-price-view.test.js / results-sort-view.test.js.
+const captured = {
+	state: {},
+	actions: {},
+	callbacks: {},
+};
+const elementRef = { current: { ref: null } };
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const descriptors = Object.getOwnPropertyDescriptors( config.state || {} );
+				for ( const key of Object.keys( descriptors ) ) {
+					const descriptor = descriptors[ key ];
+					if ( typeof descriptor.get === 'function' ) {
+						Object.defineProperty( captured.state, key, descriptor );
+					} else {
+						captured.state[ key ] = descriptor.value;
+					}
+				}
+				Object.assign( captured.actions, config.actions || {} );
+				Object.assign( captured.callbacks, config.callbacks || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+		getContext: () => null,
+		getElement: () => elementRef.current,
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '../../../src/search-blocks/store', () => ( {} ), { virtual: true } );
+jest.mock( '../../../src/search-blocks/blocks/search-input/style.scss', () => ( {} ), {
+	virtual: true,
+} );
+jest.mock( '../../../src/search-blocks/blocks/search-input/suggestions', () => ( {
+	clearSuggestionsContext: jest.fn(),
+	handleInputForSuggestions: jest.fn(),
+	handleKeydownForSuggestions: jest.fn().mockReturnValue( false ),
+} ) );
+
+require( '../../../src/search-blocks/blocks/search-input/view' );
+
+/**
+ * Mount a `<input type="search">` with the given value, optionally inside a
+ * `[hidden]` wrapper that mimics the overlay shell during hydration.
+ *
+ * @param {{value?: string, hidden?: boolean}} [opts] - Initial state.
+ * @return {HTMLInputElement} The input.
+ */
+function mountInput( { value = '', hidden = false } = {} ) {
+	document.body.innerHTML = '';
+	const wrapper = document.createElement( 'div' );
+	if ( hidden ) {
+		wrapper.setAttribute( 'hidden', '' );
+	}
+	const input = document.createElement( 'input' );
+	input.type = 'search';
+	input.value = value;
+	wrapper.appendChild( input );
+	document.body.appendChild( wrapper );
+	return input;
+}
+
+describe( 'search-input view — initFocusInputIfHasQuery callback', () => {
+	beforeEach( () => {
+		captured.state.searchQuery = '';
+		elementRef.current = { ref: null };
+	} );
+
+	it( 'focuses the input and places the cursor at the end when a query exists', () => {
+		const input = mountInput( { value: 'hello' } );
+		elementRef.current = { ref: input };
+		captured.state.searchQuery = 'hello';
+
+		captured.callbacks.initFocusInputIfHasQuery();
+
+		expect( input ).toHaveFocus();
+		expect( input.selectionStart ).toBe( 5 );
+		expect( input.selectionEnd ).toBe( 5 );
+	} );
+
+	it( 'leaves focus alone when the query is empty', () => {
+		const input = mountInput( { value: '' } );
+		elementRef.current = { ref: input };
+		captured.state.searchQuery = '';
+
+		captured.callbacks.initFocusInputIfHasQuery();
+
+		expect( input ).not.toHaveFocus();
+	} );
+
+	it( 'no-ops when the input is inside a hidden wrapper (e.g. overlay template clone)', () => {
+		const input = mountInput( { value: 'hello', hidden: true } );
+		elementRef.current = { ref: input };
+		captured.state.searchQuery = 'hello';
+
+		captured.callbacks.initFocusInputIfHasQuery();
+
+		expect( input ).not.toHaveFocus();
+	} );
+
+	it( 'no-ops when getElement returns no ref', () => {
+		elementRef.current = { ref: null };
+		captured.state.searchQuery = 'hello';
+
+		expect( () => captured.callbacks.initFocusInputIfHasQuery() ).not.toThrow();
+	} );
+
+	it( 'tolerates input types that reject setSelectionRange', () => {
+		const input = mountInput( { value: 'hello' } );
+		input.setSelectionRange = () => {
+			throw new Error( 'unsupported' );
+		};
+		elementRef.current = { ref: input };
+		captured.state.searchQuery = 'hello';
+
+		expect( () => captured.callbacks.initFocusInputIfHasQuery() ).not.toThrow();
+		expect( input ).toHaveFocus();
+	} );
+} );


### PR DESCRIPTION
Fixes [SEARCH-276](https://linear.app/a8c/issue/SEARCH-276/search-blocks-focus-search-input-with-cursor-at-end-of-existing-query)

## Why

When a visitor opens the Jetpack Search overlay, or lands on a Search-Blocks-driven results page (`overlay_blocks`, `embedded`, or the WooCommerce product-search-result template) with a query already in flight, the cursor either lands at position 0 of the input or the input never gets focused at all. To refine the search they have to manually click at the end of the value or press `End` — friction every time someone iterates on a search. This PR makes the search input grab focus and place the caret at the end of the existing phrase on every render of those three experiences, so a visitor can keep typing immediately.

Empty-query renders deliberately leave focus alone — avoids stealing focus from screen-reader / keyboard users who'd rather hear the page heading first.

## Proposed changes

* New `focusInputWithCursorAtEnd()` helper in `projects/packages/search/src/search-blocks/blocks/search-input/view.js`: focuses the input and applies `setSelectionRange(len, len)` inside a try/catch.
* New `callbacks.initFocusInputIfHasQuery` lifecycle hook (wired via `data-wp-init` in `search-input/render.php`) covers the **embedded** and **product-search-result** templates. The callback no-ops when the input sits inside a `[hidden]` subtree (skips the overlay-template clone during hydration) and when `state.searchQuery` is empty.
* `overlay-bootstrap/index.js` now positions the caret immediately after its existing `input.focus()` call — `openOverlay()` stays authoritative for the overlay's focus moment.
* Jest coverage for the four branches of the new callback (happy path, empty query, hidden parent, missing ref) plus a `setSelectionRange`-throws tolerance test.

## Real-screen before / after

Captured at 1440×900 via the local atlas docker. Red focus-ring and caret marker are CSS-injected by the capture script to make the otherwise-invisible cursor position visible in static PNGs.

### Overlay (`overlay_blocks` experience, `/?s=hello`)

| Before — caret at position 0 (start of `hello`) | After — caret at position 5 (end of `hello`) |
|---|---|
| ![before-overlay](https://github.com/user-attachments/assets/e66e1dd6-6763-41de-b940-e476c9c6f60f) | ![after-overlay](https://github.com/user-attachments/assets/ccde5565-d695-4431-bb7c-3c43dead5c0f) |

### Embedded (`embedded` experience, `/?s=jetpack`)

| Before — input not focused (caret marker not drawn) | After — input focused, caret at position 7 (end of `jetpack`) |
|---|---|
| ![before-embedded](https://github.com/user-attachments/assets/73202108-7b8d-4ba6-b220-4b8ba9c1e7f0) | ![after-embedded](https://github.com/user-attachments/assets/4584efa6-bd02-435d-89a5-790c37e4b7e0) |

### Product search result (`embedded` experience + `post_type=product`, `/?s=bag&post_type=product`)

| Before — input not focused | After — input focused, caret at position 3 (end of `bag`) |
|---|---|
| ![before-product](https://github.com/user-attachments/assets/776c8cfa-0922-4cc9-b239-61de289aec62) | ![after-product](https://github.com/user-attachments/assets/9185a003-d39e-48fc-b03b-d91406ee770e) |

## Verification

Live-evaluated `document.activeElement` + `selectionStart`/`selectionEnd` from each captured page (atlas docker, twentytwentyfive theme):

<details>
<summary>JS state at screenshot time</summary>

```text
BEFORE (trunk)
  /?s=hello (overlay_blocks):       active=INPUT.jetpack-search-input__field  value="hello"   sel=[0,0]
  /?s=jetpack (embedded):            active=BODY                              input="jetpack" focused=false
  /?s=bag&post_type=product:         active=BODY                              input="bag"     focused=false

AFTER (atlas/search-276-focus-input-cursor-at-end)
  /?s=hello (overlay_blocks):       active=INPUT.jetpack-search-input__field  value="hello"   sel=[5,5]
  /?s=jetpack (embedded):            active=INPUT.jetpack-search-input__field  value="jetpack" sel=[7,7]
  /?s=bag&post_type=product:         active=INPUT.jetpack-search-input__field  value="bag"     sel=[3,3]
```

Empty-query guard (no auto-focus):

```text
/?s= (embedded, empty query):       active=BODY  inputs[0].focused=false
```

Hidden-template guard — the overlay-template clone's `data-wp-init` skips its focus on hydration because the wrapper still has `[hidden]`; `openOverlay()` keeps exclusive authority over the overlay's focus moment.

</details>

Jest (run from `projects/packages/search/`):

```
PASS tests/js/search-blocks/search-input-view.test.js
  search-input view — initFocusInputIfHasQuery callback
    ✓ focuses the input and places the cursor at the end when a query exists
    ✓ leaves focus alone when the query is empty
    ✓ no-ops when the input is inside a hidden wrapper (e.g. overlay template clone)
    ✓ no-ops when getElement returns no ref
    ✓ tolerates input types that reject setSelectionRange
```

## Related product discussion/links

* [SEARCH-276](https://linear.app/a8c/issue/SEARCH-276/search-blocks-focus-search-input-with-cursor-at-end-of-existing-query)

## Does this pull request change what data or activity we track or use?

No — purely a client-side focus / caret-positioning change.

## Testing instructions

1. On a site running Jetpack Search with the **`overlay_blocks`** experience:
   * Navigate to a URL with `?s=<query>` (e.g. `/?s=hello`). The overlay should auto-open with the search input focused and the caret at the end of `<query>`.
   * From any page, type something into a core Search block and submit → the overlay opens with focus + caret at the end of what you typed.
   * Close the overlay and reopen it; focus + caret-at-end should fire on every reopen.
2. Switch the site to the **`embedded`** experience (`wp option update jetpack_search_experience embedded`):
   * Navigate to `/?s=<query>`. The embedded search page renders inline; the search input should receive focus on page load with the caret at the end of `<query>`.
   * Navigate to `/?s=` (empty `s` param). The search input should **not** be auto-focused — `document.activeElement` stays on the page body / heading so screen readers land on the heading first.
3. On a WooCommerce site (still on `embedded`), navigate to `/?s=<query>&post_type=product`:
   * The product-search-result template renders; the search input at the top of the page should receive focus with the caret at the end of `<query>`.
4. Accessibility sanity: on the embedded search page with an empty query, a screen reader should announce the page heading first (no focus stolen by the input).

Out of scope: legacy preact Instant Search (`projects/packages/search/src/instant-search/components/search-box.jsx`) has the same bug but is on a separate deprecation track.
