### PR TITLE
Search Blocks: use the price slider variation in the product-results template

### DIFF
--- a/projects/packages/search/changelog/nova-search-277-price-slider-in-template
+++ b/projects/packages/search/changelog/nova-search-277-price-slider-in-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: use the price slider variation of filter-wc-price in the product-results template so visitors get a draggable range with paired inputs instead of two flat number inputs.

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
@@ -29,7 +29,7 @@ const TEMPLATE = [
 		{ filterType: 'taxonomy', taxonomy: 'product_brand', displayStyle: 'chips' },
 	],
 	[ 'jetpack-search/filter-wc-rating', { enabledStars: [ 4 ] } ],
-	[ 'jetpack-search/filter-wc-price' ],
+	[ 'jetpack-search/filter-wc-price', { showSlider: true } ],
 	[ 'jetpack-search/filter-wc-stock-status' ],
 ];
 

--- a/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-product/edit.js
@@ -29,7 +29,7 @@ const TEMPLATE = [
 		{ filterType: 'taxonomy', taxonomy: 'product_brand', displayStyle: 'chips' },
 	],
 	[ 'jetpack-search/filter-wc-rating', { enabledStars: [ 4 ] } ],
-	[ 'jetpack-search/filter-wc-price', { showSlider: true } ],
+	[ 'jetpack-search/filter-wc-price', { showSlider: true, autoBounds: true } ],
 	[ 'jetpack-search/filter-wc-stock-status' ],
 ];
 

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -27,7 +27,7 @@
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->
-<!-- wp:jetpack-search/filter-wc-price {"showSlider":true} /-->
+<!-- wp:jetpack-search/filter-wc-price {"showSlider":true,"autoBounds":true} /-->
 <!-- wp:jetpack-search/filter-wc-stock-status /-->
 <!-- /wp:jetpack-search/filters-popover -->
 </div>
@@ -53,7 +53,7 @@
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->
-<!-- wp:jetpack-search/filter-wc-price {"showSlider":true} /-->
+<!-- wp:jetpack-search/filter-wc-price {"showSlider":true,"autoBounds":true} /-->
 <!-- wp:jetpack-search/filter-wc-stock-status /-->
 <!-- /wp:jetpack-search/filters-product -->
 </div>

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -27,7 +27,7 @@
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->
-<!-- wp:jetpack-search/filter-wc-price /-->
+<!-- wp:jetpack-search/filter-wc-price {"showSlider":true} /-->
 <!-- wp:jetpack-search/filter-wc-stock-status /-->
 <!-- /wp:jetpack-search/filters-popover -->
 </div>
@@ -53,7 +53,7 @@
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_brand","displayStyle":"chips"} /-->
 <!-- wp:jetpack-search/filter-wc-rating {"enabledStars":[4]} /-->
-<!-- wp:jetpack-search/filter-wc-price /-->
+<!-- wp:jetpack-search/filter-wc-price {"showSlider":true} /-->
 <!-- wp:jetpack-search/filter-wc-stock-status /-->
 <!-- /wp:jetpack-search/filters-product -->
 </div>


### PR DESCRIPTION
Fixes [SEARCH-277](https://linear.app/a8c/issue/SEARCH-277/search-blocks-use-the-price-slider-variation-in-the-product-results)

## Why

The Search Blocks plugin already ships a registered `slider` variation of `filter-wc-price` (`showSlider: true, autoBounds: true`) — a draggable range with paired min/max number inputs, modeled on WooCommerce Blocks' price slider. But the product-results page template inserts the block bare, which falls back to the default `filter` variation: two flat number inputs joined by an em-dash.

Shoppers expect a slider on Woo product search. We have the slider code; we just weren't reaching for it in the template we ship.

## Proposed changes

* `projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html`: switch both `filter-wc-price` placements (the `filters-popover` in the results header and the `filters-product` sidebar) from the bare default to `{"showSlider":true}`.
* `projects/packages/search/src/search-blocks/blocks/filters-product/edit.js`: mirror the same default-child for the `filters-product` editor composition so an author inserting the sidebar via the inserter gets the same default content as the shipped page template.

The block's registered `isDefault` variation in `block.json` stays as `filter`, so the bare inserter still gives the number-input form — only the shipped product-results template opts into the slider.

## Related product discussion/links

* [SEARCH-277](https://linear.app/a8c/issue/SEARCH-277/search-blocks-use-the-price-slider-variation-in-the-product-results) — issue with full background and acceptance criteria.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Pre-reqs: a site with WooCommerce active, the Search Blocks `embedded` experience enabled, and a handful of products with varying prices.

- [ ] Visit `/?s=<query>&post_type=product` at a wide viewport. The right-hand sidebar's **Price** filter renders as a draggable slider track with two handles, paired with `$ Min` / `$ Max` number inputs below.
- [ ] Narrow the viewport (≤ ~780 px). The sidebar collapses; the header's "Filter results" popover opens an inline panel that also shows the slider + paired inputs under **Price**.
- [ ] Drag a slider handle. The URL updates with `min_price` / `max_price`; the results list narrows; reloading the same URL restores the same selected range (autoBounds + URL state round-trip).
- [ ] In the editor, insert a `Jetpack Search → Sidebar (Product)` block on a page. The inserted default child for **Filter by Price** is the slider variation (showSlider toggle on in the inspector by default).
- [ ] In the inserter, dropping a standalone `Filter by Price` block still gives the default number-input variation (the block's registered `isDefault` is unchanged).
- [ ] Non-product templates (blog search page, compact search pattern) are untouched — no price filter appears.
- [ ] On a site without WooCommerce, the product-results template doesn't load (WC-only gate). No regressions on the standard blog template.

## Screenshots

Captured against the local docker WP with `?s=hat&post_type=product`. Trunk shows the bare `filter-wc-price` (two number inputs); this branch shows the slider variation.

### Sidebar (1440×1100)

| Before (trunk — number inputs only) | After (this branch — slider + paired inputs) |
|---|---|
| ![before](https://github.com/user-attachments/assets/f5317eeb-7a9e-4a28-bce7-2cdd1a5b9552) | ![after](https://github.com/user-attachments/assets/ce0641ed-47ff-430d-b7b2-2b7b19a8108b) |

### Filters popover (720×1100)

| Before (trunk — number inputs only) | After (this branch — slider + paired inputs) |
|---|---|
| ![before](https://github.com/user-attachments/assets/8d8d6aa0-1077-4bd2-9072-8fc8489d31cc) | ![after](https://github.com/user-attachments/assets/20e73ee5-bc00-45b2-80d2-ca15f89d8a57) |
