### PR TITLE
AI Sidebar: Hide legacy toolbar when replacement is active

### DIFF
--- a/projects/plugins/jetpack/changelog/hide-legacy-ai-toolbar-with-sidebar
+++ b/projects/plugins/jetpack/changelog/hide-legacy-ai-toolbar-with-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Hide legacy block toolbar controls when Jetpack AI Sidebar content editing is enabled.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -23,7 +23,7 @@ import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 import {
 	canAIAssistantBeEnabled,
-	isJetpackAiSidebarBlockTransformationsEnabled,
+	isAiSidebarToolbarButtonEnabled,
 } from '../lib/can-ai-assistant-be-enabled';
 import { preprocessImageContent } from '../lib/preprocess-image-content';
 import { TYPE_ALT_TEXT, TYPE_CAPTION } from '../types';
@@ -234,7 +234,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ ! isJetpackAiSidebarBlockTransformationsEnabled && (
+				{ ! isAiSidebarToolbarButtonEnabled && (
 					<BlockControls { ...blockControlsProps }>
 						<AiAssistantImageExtensionToolbarDropdown
 							onRequestAltText={ () => request( TYPE_ALT_TEXT ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -23,7 +23,7 @@ import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 import {
 	canAIAssistantBeEnabled,
-	isJetpackAiSidebarBlockToolbarEnabled,
+	isJetpackAiSidebarBlockTransformationsEnabled,
 } from '../lib/can-ai-assistant-be-enabled';
 import { preprocessImageContent } from '../lib/preprocess-image-content';
 import { TYPE_ALT_TEXT, TYPE_CAPTION } from '../types';
@@ -234,7 +234,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ ! isJetpackAiSidebarBlockToolbarEnabled && (
+				{ ! isJetpackAiSidebarBlockTransformationsEnabled && (
 					<BlockControls { ...blockControlsProps }>
 						<AiAssistantImageExtensionToolbarDropdown
 							onRequestAltText={ () => request( TYPE_ALT_TEXT ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/image/with-ai-image-extension.tsx
@@ -21,7 +21,10 @@ import debugFactory from 'debug';
 import { store as seoStore } from '../../../../plugins/ai-assistant-plugin/components/seo-enhancer/store';
 import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
-import { canAIAssistantBeEnabled } from '../lib/can-ai-assistant-be-enabled';
+import {
+	canAIAssistantBeEnabled,
+	isJetpackAiSidebarBlockToolbarEnabled,
+} from '../lib/can-ai-assistant-be-enabled';
 import { preprocessImageContent } from '../lib/preprocess-image-content';
 import { TYPE_ALT_TEXT, TYPE_CAPTION } from '../types';
 import AiAssistantImageExtensionToolbarDropdown from './components/image-toolbar-dropdown';
@@ -231,16 +234,18 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		return (
 			<>
 				<BlockEdit { ...props } />
-				<BlockControls { ...blockControlsProps }>
-					<AiAssistantImageExtensionToolbarDropdown
-						onRequestAltText={ () => request( TYPE_ALT_TEXT ) }
-						onRequestCaption={ () => request( TYPE_CAPTION ) }
-						loadingAltText={ loadingAltText }
-						loadingCaption={ loadingCaption }
-						disabled={ ! hasImage }
-						wrapperRef={ wrapperRef }
-					/>
-				</BlockControls>
+				{ ! isJetpackAiSidebarBlockToolbarEnabled && (
+					<BlockControls { ...blockControlsProps }>
+						<AiAssistantImageExtensionToolbarDropdown
+							onRequestAltText={ () => request( TYPE_ALT_TEXT ) }
+							onRequestCaption={ () => request( TYPE_CAPTION ) }
+							loadingAltText={ loadingAltText }
+							loadingCaption={ loadingCaption }
+							disabled={ ! hasImage }
+							wrapperRef={ wrapperRef }
+						/>
+					</BlockControls>
+				) }
 			</>
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
@@ -10,13 +10,11 @@ import { select } from '@wordpress/data';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
-export const JETPACK_AI_SIDEBAR_BLOCK_TRANSFORMATIONS = 'ai-sidebar-block-transformations';
+export const AI_SIDEBAR_TOOLBAR_BUTTON = 'ai-sidebar-toolbar-button';
 
 // Check if the AI Assistant support is enabled.
 export const isAiAssistantSupportEnabled = getFeatureAvailability( AI_ASSISTANT_SUPPORT_NAME );
-export const isJetpackAiSidebarBlockTransformationsEnabled = getFeatureAvailability(
-	JETPACK_AI_SIDEBAR_BLOCK_TRANSFORMATIONS
-);
+export const isAiSidebarToolbarButtonEnabled = getFeatureAvailability( AI_SIDEBAR_TOOLBAR_BUTTON );
 
 /**
  * Check if it is possible to enable the AI Assistant block and its features.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
@@ -10,9 +10,13 @@ import { select } from '@wordpress/data';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
+export const JETPACK_AI_SIDEBAR_BLOCK_TOOLBAR = 'ai-sidebar-block-toolbar';
 
 // Check if the AI Assistant support is enabled.
 export const isAiAssistantSupportEnabled = getFeatureAvailability( AI_ASSISTANT_SUPPORT_NAME );
+export const isJetpackAiSidebarBlockToolbarEnabled = getFeatureAvailability(
+	JETPACK_AI_SIDEBAR_BLOCK_TOOLBAR
+);
 
 /**
  * Check if it is possible to enable the AI Assistant block and its features.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
@@ -10,12 +10,12 @@ import { select } from '@wordpress/data';
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
 
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
-export const JETPACK_AI_SIDEBAR_BLOCK_TOOLBAR = 'ai-sidebar-block-toolbar';
+export const JETPACK_AI_SIDEBAR_BLOCK_TRANSFORMATIONS = 'ai-sidebar-block-transformations';
 
 // Check if the AI Assistant support is enabled.
 export const isAiAssistantSupportEnabled = getFeatureAvailability( AI_ASSISTANT_SUPPORT_NAME );
-export const isJetpackAiSidebarBlockToolbarEnabled = getFeatureAvailability(
-	JETPACK_AI_SIDEBAR_BLOCK_TOOLBAR
+export const isJetpackAiSidebarBlockTransformationsEnabled = getFeatureAvailability(
+	JETPACK_AI_SIDEBAR_BLOCK_TRANSFORMATIONS
 );
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
@@ -22,7 +22,7 @@ import debugFactory from 'debug';
 import useAutoScroll from '../../hooks/use-auto-scroll';
 import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { mapInternalPromptTypeToBackendPromptType } from '../../lib/prompt/backend-prompt';
-import { isJetpackAiSidebarBlockToolbarEnabled } from '../lib/can-ai-assistant-be-enabled';
+import { isJetpackAiSidebarBlockTransformationsEnabled } from '../lib/can-ai-assistant-be-enabled';
 import AiAssistantInput from './components/ai-assistant-input';
 import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
 import { getBlockHandler, InlineExtensionsContext } from './get-block-handler';
@@ -562,7 +562,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					/>
 				) }
 
-				{ ! isJetpackAiSidebarBlockToolbarEnabled && (
+				{ ! isJetpackAiSidebarBlockTransformationsEnabled && (
 					<BlockControls { ...blockControlsProps }>
 						<AiAssistantExtensionToolbarDropdown
 							blockType={ blockName }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
@@ -22,7 +22,7 @@ import debugFactory from 'debug';
 import useAutoScroll from '../../hooks/use-auto-scroll';
 import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { mapInternalPromptTypeToBackendPromptType } from '../../lib/prompt/backend-prompt';
-import { isJetpackAiSidebarBlockTransformationsEnabled } from '../lib/can-ai-assistant-be-enabled';
+import { isAiSidebarToolbarButtonEnabled } from '../lib/can-ai-assistant-be-enabled';
 import AiAssistantInput from './components/ai-assistant-input';
 import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
 import { getBlockHandler, InlineExtensionsContext } from './get-block-handler';
@@ -562,7 +562,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					/>
 				) }
 
-				{ ! isJetpackAiSidebarBlockTransformationsEnabled && (
+				{ ! isAiSidebarToolbarButtonEnabled && (
 					<BlockControls { ...blockControlsProps }>
 						<AiAssistantExtensionToolbarDropdown
 							blockType={ blockName }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
@@ -22,6 +22,7 @@ import debugFactory from 'debug';
 import useAutoScroll from '../../hooks/use-auto-scroll';
 import useBlockModuleStatus from '../../hooks/use-block-module-status';
 import { mapInternalPromptTypeToBackendPromptType } from '../../lib/prompt/backend-prompt';
+import { isJetpackAiSidebarBlockToolbarEnabled } from '../lib/can-ai-assistant-be-enabled';
 import AiAssistantInput from './components/ai-assistant-input';
 import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
 import { getBlockHandler, InlineExtensionsContext } from './get-block-handler';
@@ -561,14 +562,16 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					/>
 				) }
 
-				<BlockControls { ...blockControlsProps }>
-					<AiAssistantExtensionToolbarDropdown
-						blockType={ blockName }
-						onAskAiAssistant={ handleAskAiAssistant }
-						onRequestSuggestion={ handleRequestSuggestion }
-						behavior={ behavior }
-					/>
-				</BlockControls>
+				{ ! isJetpackAiSidebarBlockToolbarEnabled && (
+					<BlockControls { ...blockControlsProps }>
+						<AiAssistantExtensionToolbarDropdown
+							blockType={ blockName }
+							onAskAiAssistant={ handleAskAiAssistant }
+							onRequestSuggestion={ handleRequestSuggestion }
+							behavior={ behavior }
+						/>
+					</BlockControls>
+				) }
 			</>
 		);
 

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -74,7 +74,7 @@
 		"ai-title-optimization-keywords-support",
 		"ai-response-feedback",
 		"ai-assistant-image-extension",
-		"ai-sidebar-block-toolbar",
+		"ai-sidebar-block-transformations",
 		"ai-seo-enhancer",
 		"ai-correct-spelling",
 		"paypal-payment-buttons",

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -74,7 +74,7 @@
 		"ai-title-optimization-keywords-support",
 		"ai-response-feedback",
 		"ai-assistant-image-extension",
-		"ai-sidebar-block-transformations",
+		"ai-sidebar-toolbar-button",
 		"ai-seo-enhancer",
 		"ai-correct-spelling",
 		"paypal-payment-buttons",

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -74,6 +74,7 @@
 		"ai-title-optimization-keywords-support",
 		"ai-response-feedback",
 		"ai-assistant-image-extension",
+		"ai-sidebar-block-toolbar",
 		"ai-seo-enhancer",
 		"ai-correct-spelling",
 		"paypal-payment-buttons",

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -17,13 +17,14 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
-const AM_ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
-const AI_SIDEBAR_ASSET_TRANSIENT = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
+const AM_ASSET_BASE_PATH                 = 'widgets.wp.com/agents-manager/';
+const AI_SIDEBAR_ASSET_TRANSIENT         = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL                  = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL                 = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL             = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL            = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID                = 'wp-orchestrator';
+const AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION = 'ai-sidebar-block-toolbar';
 
 /**
  * Initializes the Agents Manager package and registers the Jetpack AI
@@ -71,6 +72,9 @@ class Jetpack_AI_Sidebar {
 		// never fired. Priority 250 runs after both jetpack-mu-wpcom and the
 		// Agents Manager package enqueue (priority 101).
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
+
+		// Let editor JS know when the Jetpack AI Sidebar toolbar replacement is active.
+		add_action( 'jetpack_register_gutenberg_extensions', array( __CLASS__, 'register_block_toolbar_extension' ), 99 );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -383,6 +387,33 @@ class Jetpack_AI_Sidebar {
 			'enabled'  => self::is_jetpack_ai_sidebar_preview_enabled(),
 			'features' => $features,
 		);
+	}
+
+	/**
+	 * Whether Jetpack AI Sidebar content-editing block toolbar controls are active.
+	 *
+	 * @return bool
+	 */
+	public static function has_block_transformations_enabled(): bool {
+		$preview_config = self::get_jetpack_ai_sidebar_preview_config();
+
+		return self::is_post_editor()
+			&& self::has_ai_features()
+			&& true === $preview_config['enabled']
+			&& true === ( $preview_config['features']['blockTransformations'] ?? false );
+	}
+
+	/**
+	 * Register the Jetpack AI Sidebar block toolbar replacement feature.
+	 *
+	 * @return void
+	 */
+	public static function register_block_toolbar_extension(): void {
+		if ( ! self::has_block_transformations_enabled() ) {
+			return;
+		}
+
+		\Jetpack_Gutenberg::set_extension_available( AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -365,6 +365,7 @@ class Jetpack_AI_Sidebar {
 			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
 			'generateFeedback'        => self::is_generate_feedback_enabled(),
 			'blockTransformations'    => true,
+			'blockToolbarButton'      => false,
 			'optimizeTitleSuggestion' => self::is_optimize_title_suggestion_enabled(),
 			'chatHistory'             => false,
 			'supportGuides'           => false,
@@ -409,7 +410,12 @@ class Jetpack_AI_Sidebar {
 	 * @return void
 	 */
 	public static function register_block_transformations_extension(): void {
-		if ( ! self::has_block_transformations_enabled() ) {
+		$preview_config = self::get_jetpack_ai_sidebar_preview_config();
+
+		if (
+			! self::has_block_transformations_enabled()
+			|| true !== ( $preview_config['features']['blockToolbarButton'] ?? false )
+		) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -17,14 +17,14 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
-const AM_ASSET_BASE_PATH                         = 'widgets.wp.com/agents-manager/';
-const AI_SIDEBAR_ASSET_TRANSIENT                 = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL                          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL                         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL                     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL                    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID                        = 'wp-orchestrator';
-const AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION = 'ai-sidebar-block-transformations';
+const AM_ASSET_BASE_PATH                  = 'widgets.wp.com/agents-manager/';
+const AI_SIDEBAR_ASSET_TRANSIENT          = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL                   = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL                  = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL              = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL             = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID                 = 'wp-orchestrator';
+const AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION = 'ai-sidebar-toolbar-button';
 
 /**
  * Initializes the Agents Manager package and registers the Jetpack AI
@@ -73,8 +73,8 @@ class Jetpack_AI_Sidebar {
 		// Agents Manager package enqueue (priority 101).
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
 
-		// Let editor JS know when Jetpack AI Sidebar block transformations are active.
-		add_action( 'jetpack_register_gutenberg_extensions', array( __CLASS__, 'register_block_transformations_extension' ), 99 );
+		// Let editor JS know when the Jetpack AI Sidebar toolbar button replaces the legacy AI toolbar.
+		add_action( 'jetpack_register_gutenberg_extensions', array( __CLASS__, 'register_toolbar_button_extension' ), 99 );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -391,39 +391,32 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Whether Jetpack AI Sidebar block transformations are active.
+	 * Whether the Jetpack AI Sidebar toolbar button replaces the legacy AI toolbar.
 	 *
 	 * @return bool
 	 */
-	public static function has_block_transformations_enabled(): bool {
+	public static function is_toolbar_button_enabled(): bool {
 		$preview_config = self::get_jetpack_ai_sidebar_preview_config();
 
-		return self::is_post_editor()
-			&& self::has_ai_features()
-			&& true === $preview_config['enabled']
-			&& true === ( $preview_config['features']['blockTransformations'] ?? false );
+		return self::should_expose_sidebar()
+			&& true === ( $preview_config['features']['blockToolbarButton'] ?? false );
 	}
 
 	/**
-	 * Register the Jetpack AI Sidebar block transformations feature.
+	 * Register the Jetpack AI Sidebar toolbar button feature.
 	 *
 	 * @return void
 	 */
-	public static function register_block_transformations_extension(): void {
-		$preview_config = self::get_jetpack_ai_sidebar_preview_config();
-
-		if (
-			! self::has_block_transformations_enabled()
-			|| true !== ( $preview_config['features']['blockToolbarButton'] ?? false )
-		) {
+	public static function register_toolbar_button_extension(): void {
+		if ( ! self::is_toolbar_button_enabled() ) {
 			\Jetpack_Gutenberg::set_extension_unavailable(
-				AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION,
+				AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION,
 				'jetpack_ai_sidebar_feature_disabled'
 			);
 			return;
 		}
 
-		\Jetpack_Gutenberg::set_extension_available( AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION );
+		\Jetpack_Gutenberg::set_extension_available( AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -17,14 +17,14 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
-const AM_ASSET_BASE_PATH                 = 'widgets.wp.com/agents-manager/';
-const AI_SIDEBAR_ASSET_TRANSIENT         = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL                  = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL                 = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL             = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL            = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID                = 'wp-orchestrator';
-const AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION = 'ai-sidebar-block-toolbar';
+const AM_ASSET_BASE_PATH                         = 'widgets.wp.com/agents-manager/';
+const AI_SIDEBAR_ASSET_TRANSIENT                 = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL                          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL                         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL                     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL                    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID                        = 'wp-orchestrator';
+const AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION = 'ai-sidebar-block-transformations';
 
 /**
  * Initializes the Agents Manager package and registers the Jetpack AI
@@ -73,8 +73,8 @@ class Jetpack_AI_Sidebar {
 		// Agents Manager package enqueue (priority 101).
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
 
-		// Let editor JS know when the Jetpack AI Sidebar toolbar replacement is active.
-		add_action( 'jetpack_register_gutenberg_extensions', array( __CLASS__, 'register_block_toolbar_extension' ), 99 );
+		// Let editor JS know when Jetpack AI Sidebar block transformations are active.
+		add_action( 'jetpack_register_gutenberg_extensions', array( __CLASS__, 'register_block_transformations_extension' ), 99 );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -390,7 +390,7 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Whether Jetpack AI Sidebar content-editing block toolbar controls are active.
+	 * Whether Jetpack AI Sidebar block transformations are active.
 	 *
 	 * @return bool
 	 */
@@ -404,16 +404,16 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Register the Jetpack AI Sidebar block toolbar replacement feature.
+	 * Register the Jetpack AI Sidebar block transformations feature.
 	 *
 	 * @return void
 	 */
-	public static function register_block_toolbar_extension(): void {
+	public static function register_block_transformations_extension(): void {
 		if ( ! self::has_block_transformations_enabled() ) {
 			return;
 		}
 
-		\Jetpack_Gutenberg::set_extension_available( AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION );
+		\Jetpack_Gutenberg::set_extension_available( AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -416,6 +416,10 @@ class Jetpack_AI_Sidebar {
 			! self::has_block_transformations_enabled()
 			|| true !== ( $preview_config['features']['blockToolbarButton'] ?? false )
 		) {
+			\Jetpack_Gutenberg::set_extension_unavailable(
+				AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION,
+				'jetpack_ai_sidebar_feature_disabled'
+			);
 			return;
 		}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -52,6 +52,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->reset_sidebar_hooks();
+		\Jetpack_Gutenberg::reset();
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 		update_option( 'jetpack_offline_mode', '0' );
 		Status_Cache::clear();
@@ -93,6 +94,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$GLOBALS['current_screen'] = $this->saved_screen;
 		$GLOBALS['wp_scripts']     = $this->saved_wp_scripts;
 		$GLOBALS['wp_styles']      = $this->saved_wp_styles;
+		\Jetpack_Gutenberg::reset();
 		parent::tear_down();
 	}
 
@@ -109,6 +111,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ), 201 );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
+		remove_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ), 99 );
 	}
 
 	/**
@@ -190,6 +193,14 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Constants::set_constant( 'ATOMIC_CLIENT_ID', false );
 		Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', false );
 		Status_Cache::clear();
+	}
+
+	/**
+	 * Mark legacy Jetpack AI block toolbar extensions as available.
+	 */
+	private function make_legacy_block_toolbar_extensions_available() {
+		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-support' );
+		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 	}
 
 	/**
@@ -285,6 +296,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ) ),
 			'maybe_patch_jetpack_ai_sidebar_preview_data should be hooked by default.'
 		);
+		$this->assertNotFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
+			'register_block_toolbar_extension should be hooked by default.'
+		);
 	}
 
 	/**
@@ -301,6 +316,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse(
 			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
 			'enable_agents_manager_in_post_editor should not be hooked when filter is false.'
+		);
+		$this->assertFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
+			'register_block_toolbar_extension should not be hooked when filter is false.'
 		);
 	}
 
@@ -319,6 +338,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse(
 			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_in_post_editor' ) ),
 			'enable_agents_manager_in_post_editor should not be hooked on a self-hosted site.'
+		);
+		$this->assertFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
+			'register_block_toolbar_extension should not be hooked when the preview gate is false.'
 		);
 	}
 
@@ -365,6 +388,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertNotFalse(
 			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ) ),
 			'maybe_patch_jetpack_ai_sidebar_preview_data should be hooked when filter is true.'
+		);
+		$this->assertNotFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
+			'register_block_toolbar_extension should be hooked when filter is true.'
 		);
 	}
 
@@ -454,6 +481,103 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->simulate_big_sky_class();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		$this->assertFalse( $this->gate_open() );
+	}
+
+	// ──────────────────────────────────────────────────
+	// Legacy toolbar replacement tests
+	// ──────────────────────────────────────────────────
+
+	/**
+	 * Test that block transformations are active in the post editor by default.
+	 */
+	public function test_block_transformations_enabled_in_post_editor() {
+		$this->set_block_editor_screen();
+
+		$this->assertTrue( Jetpack_AI_Sidebar::has_block_transformations_enabled() );
+	}
+
+	/**
+	 * Test that the sidebar kill switch disables block transformations.
+	 */
+	public function test_block_transformations_respect_sidebar_kill_switch() {
+		$this->set_block_editor_screen();
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
+
+		$this->assertFalse( Jetpack_AI_Sidebar::has_block_transformations_enabled() );
+	}
+
+	/**
+	 * Test that the preview feature flag disables block transformations.
+	 */
+	public function test_block_transformations_respect_preview_feature_flag() {
+		$this->set_block_editor_screen();
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockTransformations'] = false;
+				return $features;
+			}
+		);
+
+		$this->assertFalse( Jetpack_AI_Sidebar::has_block_transformations_enabled() );
+	}
+
+	/**
+	 * Test that the active sidebar registers the replacement toolbar extension.
+	 */
+	public function test_register_block_toolbar_extension_marks_replacement_available() {
+		$this->set_block_editor_screen();
+		$this->make_legacy_block_toolbar_extensions_available();
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
+		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockTransformations'] = true;
+				return $features;
+			}
+		);
+
+		Jetpack_AI_Sidebar::register_block_toolbar_extension();
+
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
+	}
+
+	/**
+	 * Test that the replacement toolbar extension stays unavailable when block transformations are off.
+	 */
+	public function test_register_block_toolbar_extension_skips_when_transformations_disabled() {
+		$this->set_block_editor_screen();
+		$this->make_legacy_block_toolbar_extensions_available();
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockTransformations'] = false;
+				return $features;
+			}
+		);
+
+		Jetpack_AI_Sidebar::register_block_toolbar_extension();
+
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
+	}
+
+	/**
+	 * Test that the replacement toolbar extension stays unavailable outside the post editor.
+	 */
+	public function test_register_block_toolbar_extension_skips_page_editor() {
+		$this->set_page_block_editor_screen();
+		$this->make_legacy_block_toolbar_extensions_available();
+
+		Jetpack_AI_Sidebar::register_block_toolbar_extension();
+
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
 	}
 
 	// ──────────────────────────────────────────────────

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -111,7 +111,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ), 201 );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
-		remove_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ), 99 );
+		remove_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ), 99 );
 	}
 
 	/**
@@ -297,8 +297,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'maybe_patch_jetpack_ai_sidebar_preview_data should be hooked by default.'
 		);
 		$this->assertNotFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
-			'register_block_toolbar_extension should be hooked by default.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
+			'register_block_transformations_extension should be hooked by default.'
 		);
 	}
 
@@ -318,8 +318,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'enable_agents_manager_in_post_editor should not be hooked when filter is false.'
 		);
 		$this->assertFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
-			'register_block_toolbar_extension should not be hooked when filter is false.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
+			'register_block_transformations_extension should not be hooked when filter is false.'
 		);
 	}
 
@@ -340,8 +340,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'enable_agents_manager_in_post_editor should not be hooked on a self-hosted site.'
 		);
 		$this->assertFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
-			'register_block_toolbar_extension should not be hooked when the preview gate is false.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
+			'register_block_transformations_extension should not be hooked when the preview gate is false.'
 		);
 	}
 
@@ -390,8 +390,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'maybe_patch_jetpack_ai_sidebar_preview_data should be hooked when filter is true.'
 		);
 		$this->assertNotFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_toolbar_extension' ) ),
-			'register_block_toolbar_extension should be hooked when filter is true.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
+			'register_block_transformations_extension should be hooked when filter is true.'
 		);
 	}
 
@@ -484,7 +484,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	// ──────────────────────────────────────────────────
-	// Legacy toolbar replacement tests
+	// Sidebar block transformations tests
 	// ──────────────────────────────────────────────────
 
 	/**
@@ -523,9 +523,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the active sidebar registers the replacement toolbar extension.
+	 * Test that the active sidebar registers the block transformations feature.
 	 */
-	public function test_register_block_toolbar_extension_marks_replacement_available() {
+	public function test_register_block_transformations_extension_marks_feature_available() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
@@ -538,17 +538,17 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			}
 		);
 
-		Jetpack_AI_Sidebar::register_block_toolbar_extension();
+		Jetpack_AI_Sidebar::register_block_transformations_extension();
 
-		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
 	}
 
 	/**
-	 * Test that the replacement toolbar extension stays unavailable when block transformations are off.
+	 * Test that the block transformations feature stays unavailable when transformations are off.
 	 */
-	public function test_register_block_toolbar_extension_skips_when_transformations_disabled() {
+	public function test_register_block_transformations_extension_skips_when_transformations_disabled() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		add_filter(
@@ -559,23 +559,23 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			}
 		);
 
-		Jetpack_AI_Sidebar::register_block_toolbar_extension();
+		Jetpack_AI_Sidebar::register_block_transformations_extension();
 
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION ) );
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
 	}
 
 	/**
-	 * Test that the replacement toolbar extension stays unavailable outside the post editor.
+	 * Test that the block transformations feature stays unavailable outside the post editor.
 	 */
-	public function test_register_block_toolbar_extension_skips_page_editor() {
+	public function test_register_block_transformations_extension_skips_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 
-		Jetpack_AI_Sidebar::register_block_toolbar_extension();
+		Jetpack_AI_Sidebar::register_block_transformations_extension();
 
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TOOLBAR_EXTENSION ) );
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -534,6 +534,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
 				$features['blockTransformations'] = true;
+				$features['blockToolbarButton']   = true;
 				return $features;
 			}
 		);
@@ -546,6 +547,26 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the block transformations feature stays unavailable until the toolbar button is released.
+	 */
+	public function test_register_block_transformations_extension_skips_when_toolbar_button_disabled() {
+		$this->set_block_editor_screen();
+		$this->make_legacy_block_toolbar_extensions_available();
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockTransformations'] = true;
+				$features['blockToolbarButton']   = false;
+				return $features;
+			}
+		);
+
+		Jetpack_AI_Sidebar::register_block_transformations_extension();
+
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
+	}
+
+	/**
 	 * Test that the block transformations feature stays unavailable when transformations are off.
 	 */
 	public function test_register_block_transformations_extension_skips_when_transformations_disabled() {
@@ -555,6 +576,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
 				$features['blockTransformations'] = false;
+				$features['blockToolbarButton']   = true;
 				return $features;
 			}
 		);
@@ -653,6 +675,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 		// generateFeedback and optimizeTitleSuggestion are in development: off outside testing environments.
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
@@ -752,6 +775,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -109,9 +109,31 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
+		remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		remove_filter( 'jetpack_gutenberg', '__return_true' );
+		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_sidebar_extension_allowlist' ) );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ), 201 );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
 		remove_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ), 99 );
+	}
+
+	/**
+	 * Limit Jetpack Gutenberg availability checks to the sidebar extension under test.
+	 *
+	 * @return array
+	 */
+	public static function get_sidebar_extension_allowlist() {
+		return array( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION );
+	}
+
+	/**
+	 * Enable Jetpack Gutenberg availability checks for the sidebar extension under test.
+	 */
+	private function enable_sidebar_extension_availability_checks() {
+		add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		add_filter( 'jetpack_gutenberg', '__return_true' );
+		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_sidebar_extension_allowlist' ) );
+		Status_Cache::clear();
 	}
 
 	/**
@@ -528,6 +550,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_block_transformations_extension_marks_feature_available() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
+		$this->enable_sidebar_extension_availability_checks();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
 		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
 		add_filter(
@@ -544,6 +567,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
+		$this->assertTrue( \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ]['available'] );
 	}
 
 	/**
@@ -552,6 +576,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_block_transformations_extension_skips_when_toolbar_button_disabled() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
+		$this->enable_sidebar_extension_availability_checks();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
@@ -564,6 +589,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Jetpack_AI_Sidebar::register_block_transformations_extension();
 
 		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
+		$availability = \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ];
+		$this->assertFalse( $availability['available'] );
+		$this->assertSame( 'jetpack_ai_sidebar_feature_disabled', $availability['unavailable_reason'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -114,7 +114,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_sidebar_extension_allowlist' ) );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ), 201 );
 		remove_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ), 250 );
-		remove_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ), 99 );
+		remove_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ), 99 );
 	}
 
 	/**
@@ -123,7 +123,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public static function get_sidebar_extension_allowlist() {
-		return array( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION );
+		return array( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION );
 	}
 
 	/**
@@ -319,8 +319,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'maybe_patch_jetpack_ai_sidebar_preview_data should be hooked by default.'
 		);
 		$this->assertNotFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
-			'register_block_transformations_extension should be hooked by default.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should be hooked by default.'
 		);
 	}
 
@@ -340,8 +340,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'enable_agents_manager_in_post_editor should not be hooked when filter is false.'
 		);
 		$this->assertFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
-			'register_block_transformations_extension should not be hooked when filter is false.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should not be hooked when filter is false.'
 		);
 	}
 
@@ -362,8 +362,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'enable_agents_manager_in_post_editor should not be hooked on a self-hosted site.'
 		);
 		$this->assertFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
-			'register_block_transformations_extension should not be hooked when the preview gate is false.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
 		);
 	}
 
@@ -412,8 +412,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 			'maybe_patch_jetpack_ai_sidebar_preview_data should be hooked when filter is true.'
 		);
 		$this->assertNotFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_block_transformations_extension' ) ),
-			'register_block_transformations_extension should be hooked when filter is true.'
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should be hooked when filter is true.'
 		);
 	}
 
@@ -506,48 +506,55 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	// ──────────────────────────────────────────────────
-	// Sidebar block transformations tests
+	// Sidebar toolbar button tests
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that block transformations are active in the post editor by default.
+	 * Test that the toolbar button stays disabled until its preview feature is released.
 	 */
-	public function test_block_transformations_enabled_in_post_editor() {
+	public function test_toolbar_button_disabled_by_default() {
 		$this->set_block_editor_screen();
 
-		$this->assertTrue( Jetpack_AI_Sidebar::has_block_transformations_enabled() );
+		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
 	}
 
 	/**
-	 * Test that the sidebar kill switch disables block transformations.
+	 * Test that the preview feature flag activates the toolbar button.
 	 */
-	public function test_block_transformations_respect_sidebar_kill_switch() {
-		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
-
-		$this->assertFalse( Jetpack_AI_Sidebar::has_block_transformations_enabled() );
-	}
-
-	/**
-	 * Test that the preview feature flag disables block transformations.
-	 */
-	public function test_block_transformations_respect_preview_feature_flag() {
+	public function test_toolbar_button_enabled_by_preview_feature_flag() {
 		$this->set_block_editor_screen();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
-				$features['blockTransformations'] = false;
+				$features['blockToolbarButton'] = true;
 				return $features;
 			}
 		);
 
-		$this->assertFalse( Jetpack_AI_Sidebar::has_block_transformations_enabled() );
+		$this->assertTrue( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
 	}
 
 	/**
-	 * Test that the active sidebar registers the block transformations feature.
+	 * Test that the sidebar kill switch disables the toolbar button.
 	 */
-	public function test_register_block_transformations_extension_marks_feature_available() {
+	public function test_toolbar_button_respects_sidebar_kill_switch() {
+		$this->set_block_editor_screen();
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockToolbarButton'] = true;
+				return $features;
+			}
+		);
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
+
+		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
+	}
+
+	/**
+	 * Test that the active sidebar registers the toolbar button feature.
+	 */
+	public function test_register_toolbar_button_extension_marks_feature_available() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
@@ -556,76 +563,59 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
-				$features['blockTransformations'] = true;
-				$features['blockToolbarButton']   = true;
+				$features['blockToolbarButton'] = true;
 				return $features;
 			}
 		);
 
-		Jetpack_AI_Sidebar::register_block_transformations_extension();
+		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
-		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
-		$this->assertTrue( \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ]['available'] );
+		$this->assertTrue( \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ]['available'] );
 	}
 
 	/**
-	 * Test that the block transformations feature stays unavailable until the toolbar button is released.
+	 * Test that the toolbar button feature stays unavailable until the preview feature is released.
 	 */
-	public function test_register_block_transformations_extension_skips_when_toolbar_button_disabled() {
+	public function test_register_toolbar_button_extension_skips_when_toolbar_button_disabled() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
-				$features['blockTransformations'] = true;
-				$features['blockToolbarButton']   = false;
+				$features['blockToolbarButton'] = false;
 				return $features;
 			}
 		);
 
-		Jetpack_AI_Sidebar::register_block_transformations_extension();
+		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
-		$availability = \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ];
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
+		$availability = \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ];
 		$this->assertFalse( $availability['available'] );
 		$this->assertSame( 'jetpack_ai_sidebar_feature_disabled', $availability['unavailable_reason'] );
 	}
 
 	/**
-	 * Test that the block transformations feature stays unavailable when transformations are off.
+	 * Test that the toolbar button feature stays unavailable outside the post editor.
 	 */
-	public function test_register_block_transformations_extension_skips_when_transformations_disabled() {
-		$this->set_block_editor_screen();
+	public function test_register_toolbar_button_extension_skips_page_editor() {
+		$this->set_page_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
-				$features['blockTransformations'] = false;
-				$features['blockToolbarButton']   = true;
+				$features['blockToolbarButton'] = true;
 				return $features;
 			}
 		);
 
-		Jetpack_AI_Sidebar::register_block_transformations_extension();
+		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
-		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
-		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
-	}
-
-	/**
-	 * Test that the block transformations feature stays unavailable outside the post editor.
-	 */
-	public function test_register_block_transformations_extension_skips_page_editor() {
-		$this->set_page_block_editor_screen();
-		$this->make_legacy_block_toolbar_extensions_available();
-
-		Jetpack_AI_Sidebar::register_block_transformations_extension();
-
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_BLOCK_TRANSFORMATIONS_EXTENSION ) );
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( \Jetpack_Gutenberg::is_available( 'ai-assistant-image-extension' ) );
 	}


### PR DESCRIPTION
Part of FORNO-335

## Proposed changes

* Hide the legacy Jetpack AI Assistant block toolbar extensions when Jetpack AI Sidebar block transformations are active.

## Related product discussion/links

* Companion Calypso branch: `jetpack-sidebar/add-big-sky-toolbar-button`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Install Jetpack Beta on a Jurassic Ninja site and choose this branch
* Enable the extension:
  * In `~/htdocs/wp-content/plugins/jetpack-dev/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.phpL538`, edit  [this](https://github.com/Automattic/jetpack/blob/a7b6d55a65685e40ac139a531085122e4b51cd70/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php#L538) `'blockToolbarButton'      => true`
* Select paragraph block
* Confirm the legacy Jetpack AI Assistant toolbar button is not shown.
* Open a non-post editor surface, such as the page editor, and confirm the legacy toolbar controls are not suppressed by this branch.
