### PR TITLE
PCG: add force-override controls on the block notice

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-force-override
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-pcg-force-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Plugin Conflicts Guardian: add force-override controls on the block notice — "Activate anyway" / "Retry without check" for one-shot bypass and a 10-minute bypass toggle for repeated retries.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -87,6 +87,15 @@ add_filter( 'pcg_rollout_percentage', fn () => 10 ); // 10% cohort
 
 Bucketing is `crc32(blog_id) % 100`, so ramping from 10% → 50% strictly adds blogs (no reshuffling between tiers). The gate only narrows — emergency-override filters at priority > 100 on `pcg_guard_activation` / `pcg_guard_updates` can still re-enable or disable a blog.
 
+## Force override
+
+The activation block notice and the post-update notice both expose two opt-out controls for site admins who want to push through a verdict they disagree with:
+
+- **Activate anyway / Retry without check** — re-runs the original activate / upgrade action with `pcg_force=1`. The current request's own admin nonce is still required; PCG just steps out of the way.
+- **Disable check for 10 minutes** — sets a user-scoped transient (`pcg_force_bypass_<user_id>`) that lets the same user retry without re-confirming. Both guards consult `pcg_force_override_active()` and return early.
+
+Every override is logged to logstash via `pcg_log_event( 'Force override used' )` / `'Force bypass enabled'` so we can see who is bypassing and why.
+
 ## Limitations
 
 - Only catches errors hit while `require`-ing the main file and during `plugins_loaded` / `init` / `admin_init` callbacks. Errors that surface only on later hooks (e.g. `template_redirect`, REST) are invisible.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -89,12 +89,17 @@ Bucketing is `crc32(blog_id) % 100`, so ramping from 10% → 50% strictly adds b
 
 ## Force override
 
-The activation block notice and the post-update notice both expose two opt-out controls for site admins who want to push through a verdict they disagree with:
+The activation, update, and install block notices each expose opt-out controls so an admin who disagrees with a verdict can still push through:
 
-- **Activate anyway / Retry without check** — re-runs the original activate / upgrade action with `pcg_force=1`. The current request's own admin nonce is still required; PCG just steps out of the way.
-- **Disable check for 10 minutes** — sets a user-scoped transient (`pcg_force_bypass_<user_id>`) that lets the same user retry without re-confirming. Both guards consult `pcg_force_override_active()` and return early.
+- **One-shot retry** — re-runs the original action with `pcg_force=1` on the URL. The action's own admin nonce still has to validate; PCG just steps out of the way for that one request.
+  - Activation notice: `Activate <Name> anyway` (one per blocked plugin) — replays `plugins.php?action=activate&plugin=<basename>`.
+  - Update notice: `Update <Name> anyway` — replays `update.php?action=upgrade-plugin&plugin=<basename>`.
+  - Install notice: **no one-shot retry.** `Plugin_Upgrader::install()` doesn't populate `hook_extra['plugin']`; even with a slug recovered from the source basename, the .org `install-plugin` URL can't replay an uploaded zip and can't reliably resolve .org-search installs whose canonical slug differs from the extracted folder name. Operators flip the bypass and re-trigger from Add Plugin themselves.
+- **Time-boxed bypass** — `Disable checks for 10 minutes` sets a user-scoped transient (`pcg_force_bypass_<user_id>`) consumed by `pcg_force_override_active( $cap )`. The activation guard, the syntax-only install/update gate, and the post-update health check + rollback all short-circuit while the transient is live, so a user who turns this on isn't quietly rolled back behind their back.
 
-Every override is logged to logstash via `pcg_log_event( 'Force override used' )` / `'Force bypass enabled'` so we can see who is bypassing and why.
+Capabilities are checked per surface: `activate_plugins` for the activation guard, `update_plugins` for the install/update gate and the healthcheck. The shared bypass-set handler accepts either cap.
+
+Every override is logged via `pcg_log_event( 'Force override used' )` (`source: pcg_force_flag` for one-shot, `bypass_transient` for the 10-min window) and `'Force bypass enabled'` when the transient is set.
 
 ## Limitations
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -4,8 +4,8 @@ Pre-flight plugin-activation check. When an admin clicks Activate (or finishes a
 
 Two independent filters:
 
-- `pcg_guard_activation` — enables the activation probe and the syntax-only install/update gate. Defaults `true`.
-- `pcg_guard_updates` — enables the post-update health check + rollback flow. Defaults `true`.
+- `pcg_guard_activation` — enables the activation probe. Defaults `true`.
+- `pcg_guard_updates` — enables the syntax-only install/update gate and the post-update health check + rollback flow. Defaults `true`.
 
 ## Files
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -21,6 +21,9 @@ function pcg_guard_maybe_block_activation() {
 	if ( ! current_user_can( 'activate_plugins' ) ) {
 		return;
 	}
+	if ( pcg_force_override_active() ) {
+		return;
+	}
 
 	// Bulk-action submissions from the bottom dropdown send `action=-1`
 	// and the real action in `action2`.
@@ -273,6 +276,22 @@ function pcg_guard_render_block_notice() {
 				<li>
 					<?php if ( '' !== (string) $plugin ) : ?>
 						<code><?php echo esc_html( $plugin ); ?></code> — <?php echo esc_html( $reason ); ?>
+						<?php
+						$retry_url = wp_nonce_url(
+							add_query_arg(
+								array(
+									'action'    => 'activate',
+									'plugin'    => $plugin,
+									'pcg_force' => '1',
+								),
+								self_admin_url( 'plugins.php' )
+							),
+							'activate-plugin_' . $plugin
+						);
+						?>
+						<a href="<?php echo esc_url( $retry_url ); ?>" class="button button-secondary" style="margin-inline-start:8px;">
+							<?php esc_html_e( 'Activate anyway', 'jetpack-mu-wpcom' ); ?>
+						</a>
 					<?php else : ?>
 						<?php echo esc_html( $reason ); ?>
 					<?php endif; ?>
@@ -280,6 +299,10 @@ function pcg_guard_render_block_notice() {
 			<?php endforeach; ?>
 		</ul>
 		<p><?php esc_html_e( 'No plugins were activated to prevent a site crash. Investigate the error before trying again.', 'jetpack-mu-wpcom' ); ?></p>
+		<p>
+			<?php pcg_force_render_bypass_form(); ?>
+			<span class="description"><?php esc_html_e( 'Skips PCG checks for activations and updates while the bypass is active.', 'jetpack-mu-wpcom' ); ?></span>
+		</p>
 	</div>
 	<?php
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -31,7 +31,7 @@ function pcg_guard_maybe_block_activation() {
 	if ( ! in_array( $action, array( 'activate', 'activate-plugin', 'activate-selected' ), true ) ) {
 		return;
 	}
-	if ( pcg_force_override_active() ) {
+	if ( pcg_force_override_active( 'activate_plugins' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -274,9 +274,8 @@ function pcg_guard_render_block_notice() {
 		<ul style="list-style:disc;padding-inline-start:24px;">
 			<?php foreach ( $messages as $plugin => $reason ) : ?>
 				<li>
-					<?php if ( '' !== (string) $plugin ) : ?>
-						<code><?php echo esc_html( $plugin ); ?></code> — <?php echo esc_html( $reason ); ?>
-						<?php
+					<?php
+					if ( '' !== (string) $plugin ) {
 						$retry_url = wp_nonce_url(
 							add_query_arg(
 								array(
@@ -288,20 +287,23 @@ function pcg_guard_render_block_notice() {
 							),
 							'activate-plugin_' . $plugin
 						);
-						?>
-						<a href="<?php echo esc_url( $retry_url ); ?>" class="button button-secondary" style="margin-inline-start:8px;">
-							<?php esc_html_e( 'Activate anyway', 'jetpack-mu-wpcom' ); ?>
-						</a>
-					<?php else : ?>
-						<?php echo esc_html( $reason ); ?>
-					<?php endif; ?>
+						printf(
+							'<code>%1$s</code> — %2$s <a href="%3$s" class="button button-link" style="margin-inline-start:6px;">%4$s</a>',
+							esc_html( $plugin ),
+							esc_html( $reason ),
+							esc_url( $retry_url ),
+							esc_html__( 'Activate anyway', 'jetpack-mu-wpcom' )
+						);
+					} else {
+						echo esc_html( $reason );
+					}
+					?>
 				</li>
 			<?php endforeach; ?>
 		</ul>
-		<p><?php esc_html_e( 'No plugins were activated to prevent a site crash. Investigate the error before trying again.', 'jetpack-mu-wpcom' ); ?></p>
-		<p>
+		<p style="margin-block-end:0;">
+			<?php esc_html_e( 'No plugins were activated to prevent a site crash. Investigate the error before trying again, or:', 'jetpack-mu-wpcom' ); ?>
 			<?php pcg_force_render_bypass_form(); ?>
-			<span class="description"><?php esc_html_e( 'Skips PCG checks for activations and updates while the bypass is active.', 'jetpack-mu-wpcom' ); ?></span>
 		</p>
 	</div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -21,9 +21,6 @@ function pcg_guard_maybe_block_activation() {
 	if ( ! current_user_can( 'activate_plugins' ) ) {
 		return;
 	}
-	if ( pcg_force_override_active() ) {
-		return;
-	}
 
 	// Bulk-action submissions from the bottom dropdown send `action=-1`
 	// and the real action in `action2`.
@@ -32,6 +29,9 @@ function pcg_guard_maybe_block_activation() {
 		$action = sanitize_text_field( wp_unslash( $_REQUEST['action2'] ?? '' ) );
 	}
 	if ( ! in_array( $action, array( 'activate', 'activate-plugin', 'activate-selected' ), true ) ) {
+		return;
+	}
+	if ( pcg_force_override_active() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -254,6 +254,25 @@ function pcg_guard_format_block_reason( $result ) {
 }
 
 /**
+ * Look up a plugin's human-readable Name header. Returns '' when the
+ * file is unreadable or the header is empty.
+ *
+ * @param string $basename Plugin basename (e.g. "akismet/akismet.php").
+ * @return string
+ */
+function pcg_guard_plugin_display_name( $basename ) {
+	$path = WP_PLUGIN_DIR . '/' . ltrim( $basename, '/' );
+	if ( ! is_file( $path ) ) {
+		return '';
+	}
+	if ( ! function_exists( 'get_plugin_data' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	$data = get_plugin_data( $path, false, false );
+	return isset( $data['Name'] ) ? (string) $data['Name'] : '';
+}
+
+/**
  * Render the admin notice. Messages are pulled from a per-user transient
  * set by the guard before the redirect.
  */
@@ -289,7 +308,7 @@ function pcg_guard_render_block_notice() {
 				if ( '' === (string) $plugin ) {
 					continue;
 				}
-				$retry_url = wp_nonce_url(
+				$retry_url   = wp_nonce_url(
 					add_query_arg(
 						array(
 							'action'    => 'activate',
@@ -300,15 +319,20 @@ function pcg_guard_render_block_notice() {
 					),
 					'activate-plugin_' . $plugin
 				);
+				$plugin_name = pcg_guard_plugin_display_name( $plugin );
 				?>
 				<li>
 					<a href="<?php echo esc_url( $retry_url ); ?>" class="button-link">
 						<?php
-						printf(
-							/* translators: %s: plugin basename, e.g. "akismet/akismet.php". */
-							esc_html__( 'Activate %s anyway', 'jetpack-mu-wpcom' ),
-							'<code>' . esc_html( $plugin ) . '</code>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $plugin is escaped above.
-						);
+						if ( '' !== $plugin_name ) {
+							printf(
+								/* translators: %s: plugin display name. */
+								esc_html__( 'Activate %s anyway', 'jetpack-mu-wpcom' ),
+								esc_html( $plugin_name )
+							);
+						} else {
+							esc_html_e( 'Activate anyway', 'jetpack-mu-wpcom' );
+						}
 						?>
 					</a>
 				</li>

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/activation-guard.php
@@ -274,37 +274,47 @@ function pcg_guard_render_block_notice() {
 		<ul style="list-style:disc;padding-inline-start:24px;">
 			<?php foreach ( $messages as $plugin => $reason ) : ?>
 				<li>
-					<?php
-					if ( '' !== (string) $plugin ) {
-						$retry_url = wp_nonce_url(
-							add_query_arg(
-								array(
-									'action'    => 'activate',
-									'plugin'    => $plugin,
-									'pcg_force' => '1',
-								),
-								self_admin_url( 'plugins.php' )
-							),
-							'activate-plugin_' . $plugin
-						);
-						printf(
-							'<code>%1$s</code> — %2$s <a href="%3$s" class="button button-link" style="margin-inline-start:6px;">%4$s</a>',
-							esc_html( $plugin ),
-							esc_html( $reason ),
-							esc_url( $retry_url ),
-							esc_html__( 'Activate anyway', 'jetpack-mu-wpcom' )
-						);
-					} else {
-						echo esc_html( $reason );
-					}
-					?>
+					<?php if ( '' !== (string) $plugin ) : ?>
+						<code><?php echo esc_html( $plugin ); ?></code> — <?php echo esc_html( $reason ); ?>
+					<?php else : ?>
+						<?php echo esc_html( $reason ); ?>
+					<?php endif; ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>
-		<p style="margin-block-end:0;">
-			<?php esc_html_e( 'No plugins were activated to prevent a site crash. Investigate the error before trying again, or:', 'jetpack-mu-wpcom' ); ?>
-			<?php pcg_force_render_bypass_form(); ?>
-		</p>
+		<p><?php esc_html_e( 'No plugins were activated to prevent a site crash. Investigate the error before trying again, or:', 'jetpack-mu-wpcom' ); ?></p>
+		<ul style="list-style:disc;padding-inline-start:24px;margin-block-end:0;">
+			<?php foreach ( $messages as $plugin => $reason ) : ?>
+				<?php
+				if ( '' === (string) $plugin ) {
+					continue;
+				}
+				$retry_url = wp_nonce_url(
+					add_query_arg(
+						array(
+							'action'    => 'activate',
+							'plugin'    => $plugin,
+							'pcg_force' => '1',
+						),
+						self_admin_url( 'plugins.php' )
+					),
+					'activate-plugin_' . $plugin
+				);
+				?>
+				<li>
+					<a href="<?php echo esc_url( $retry_url ); ?>" class="button-link">
+						<?php
+						printf(
+							/* translators: %s: plugin basename, e.g. "akismet/akismet.php". */
+							esc_html__( 'Activate %s anyway', 'jetpack-mu-wpcom' ),
+							'<code>' . esc_html( $plugin ) . '</code>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $plugin is escaped above.
+						);
+						?>
+					</a>
+				</li>
+			<?php endforeach; ?>
+			<li><?php pcg_force_render_bypass_form(); ?></li>
+		</ul>
 	</div>
 	<?php
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Force-override controls for the activation / update guards.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+add_action( 'admin_post_pcg_force_set_bypass', 'pcg_force_handle_set_bypass' );
+
+const PCG_FORCE_BYPASS_TTL = 600;
+
+/**
+ * True when the current request is allowed to skip PCG checks, either
+ * via an explicit `pcg_force=1` flag on the current action's nonce or
+ * a short-lived per-user bypass transient.
+ *
+ * @return bool
+ */
+function pcg_force_override_active() {
+	if ( ! is_user_logged_in() || ! current_user_can( 'activate_plugins' ) ) {
+		return false;
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- the surrounding action's own nonce gates the request; pcg_force is just a hint.
+	$force = sanitize_text_field( wp_unslash( $_REQUEST['pcg_force'] ?? '' ) );
+	if ( '1' === $force ) {
+		pcg_log_event( 'Force override used', array( 'source' => 'pcg_force_flag' ) );
+		return true;
+	}
+
+	if ( get_transient( pcg_force_bypass_key() ) ) {
+		pcg_log_event( 'Force override used', array( 'source' => 'bypass_transient' ) );
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Per-user transient key for the time-boxed bypass.
+ *
+ * @return string
+ */
+function pcg_force_bypass_key() {
+	return 'pcg_force_bypass_' . get_current_user_id();
+}
+
+/**
+ * Admin-post handler — sets the bypass transient and redirects back.
+ */
+function pcg_force_handle_set_bypass() {
+	if ( ! current_user_can( 'activate_plugins' ) ) {
+		wp_die( esc_html__( 'You do not have permission to do that.', 'jetpack-mu-wpcom' ), 403 );
+	}
+	check_admin_referer( 'pcg_force_set_bypass' );
+
+	set_transient( pcg_force_bypass_key(), 1, PCG_FORCE_BYPASS_TTL );
+	pcg_log_event( 'Force bypass enabled', array( 'ttl' => PCG_FORCE_BYPASS_TTL ) );
+
+	$redirect = isset( $_REQUEST['_wp_http_referer'] )
+		? wp_validate_redirect( esc_url_raw( wp_unslash( $_REQUEST['_wp_http_referer'] ) ), self_admin_url( 'plugins.php' ) )
+		: self_admin_url( 'plugins.php' );
+	wp_safe_redirect( add_query_arg( 'pcg_bypass_enabled', '1', $redirect ) );
+	exit;
+}
+
+/**
+ * Render the inline "Disable check for 10 minutes" form. Posts to
+ * admin-post.php so the handler can set the transient and redirect.
+ */
+function pcg_force_render_bypass_form() {
+	?>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;margin-inline-end:8px;">
+		<input type="hidden" name="action" value="pcg_force_set_bypass" />
+		<?php wp_nonce_field( 'pcg_force_set_bypass' ); ?>
+		<button type="submit" class="button">
+			<?php esc_html_e( 'Disable check for 10 minutes', 'jetpack-mu-wpcom' ); ?>
+		</button>
+	</form>
+	<?php
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -14,10 +14,11 @@ const PCG_FORCE_BYPASS_TTL = 600;
  * via an explicit `pcg_force=1` flag on the current action's nonce or
  * a short-lived per-user bypass transient.
  *
+ * @param string $cap Capability the caller requires (e.g. `activate_plugins`, `update_plugins`).
  * @return bool
  */
-function pcg_force_override_active() {
-	if ( ! is_user_logged_in() || ! current_user_can( 'activate_plugins' ) ) {
+function pcg_force_override_active( $cap = 'activate_plugins' ) {
+	if ( ! is_user_logged_in() || ! current_user_can( $cap ) ) {
 		return false;
 	}
 
@@ -51,7 +52,7 @@ function pcg_force_bypass_key() {
  * @return never
  */
 function pcg_force_handle_set_bypass(): never {
-	if ( ! current_user_can( 'activate_plugins' ) ) {
+	if ( ! current_user_can( 'activate_plugins' ) && ! current_user_can( 'update_plugins' ) ) {
 		wp_die( esc_html__( 'You do not have permission to do that.', 'jetpack-mu-wpcom' ), 403 );
 	}
 	check_admin_referer( 'pcg_force_set_bypass' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -76,7 +76,7 @@ function pcg_force_render_bypass_form() {
 		<input type="hidden" name="action" value="pcg_force_set_bypass" />
 		<?php wp_nonce_field( 'pcg_force_set_bypass' ); ?>
 		<button type="submit" class="button-link">
-			<?php esc_html_e( 'disable PCG checks for 10 minutes', 'jetpack-mu-wpcom' ); ?>
+			<?php esc_html_e( 'Disable checks for 10 minutes', 'jetpack-mu-wpcom' ); ?>
 		</button>
 	</form>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -72,11 +72,11 @@ function pcg_force_handle_set_bypass(): never {
  */
 function pcg_force_render_bypass_form() {
 	?>
-	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;margin-inline-end:8px;">
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline;">
 		<input type="hidden" name="action" value="pcg_force_set_bypass" />
 		<?php wp_nonce_field( 'pcg_force_set_bypass' ); ?>
-		<button type="submit" class="button">
-			<?php esc_html_e( 'Disable check for 10 minutes', 'jetpack-mu-wpcom' ); ?>
+		<button type="submit" class="button-link">
+			<?php esc_html_e( 'disable PCG checks for 10 minutes', 'jetpack-mu-wpcom' ); ?>
 		</button>
 	</form>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -47,8 +47,10 @@ function pcg_force_bypass_key() {
 
 /**
  * Admin-post handler — sets the bypass transient and redirects back.
+ *
+ * @return never
  */
-function pcg_force_handle_set_bypass() {
+function pcg_force_handle_set_bypass(): never {
 	if ( ! current_user_can( 'activate_plugins' ) ) {
 		wp_die( esc_html__( 'You do not have permission to do that.', 'jetpack-mu-wpcom' ), 403 );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -52,7 +52,12 @@ function pcg_force_bypass_key() {
  * @return never
  */
 function pcg_force_handle_set_bypass(): never {
-	if ( ! current_user_can( 'activate_plugins' ) && ! current_user_can( 'update_plugins' ) ) {
+	if (
+		! current_user_can( 'activate_plugins' )
+		&& ! current_user_can( 'update_plugins' )
+		&& ! current_user_can( 'install_plugins' )
+		&& ! current_user_can( 'upload_plugins' )
+	) {
 		wp_die( esc_html__( 'You do not have permission to do that.', 'jetpack-mu-wpcom' ), 403 );
 	}
 	check_admin_referer( 'pcg_force_set_bypass' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/force-override.php
@@ -17,7 +17,7 @@ const PCG_FORCE_BYPASS_TTL = 600;
  * @param string $cap Capability the caller requires (e.g. `activate_plugins`, `update_plugins`).
  * @return bool
  */
-function pcg_force_override_active( $cap = 'activate_plugins' ) {
+function pcg_force_override_active( $cap ) {
 	if ( ! is_user_logged_in() || ! current_user_can( $cap ) ) {
 		return false;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php
@@ -13,6 +13,7 @@
 require_once __DIR__ . '/pcg-log.php';
 require_once __DIR__ . '/class-pcg-load-tester.php';
 require_once __DIR__ . '/class-pcg-rollout.php';
+require_once __DIR__ . '/force-override.php';
 
 // Probe endpoint must answer front-end requests, so it's not gated on is_admin().
 require_once __DIR__ . '/probe-endpoint.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -33,7 +33,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	if ( is_wp_error( $source ) ) {
 		return $source;
 	}
-	if ( ! apply_filters( 'pcg_guard_activation', true ) ) {
+	if ( ! apply_filters( 'pcg_guard_updates', true ) ) {
 		return $source;
 	}
 	$type   = $hook_extra['type'] ?? '';
@@ -62,7 +62,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	$first = $scan['errors'][0];
 
 	pcg_update_guard_log_blocked( $action, $hook_extra, $scan, (string) $source );
-	pcg_update_guard_stash_retry_context( $action, $hook_extra );
+	pcg_update_guard_stash_retry_context( $action, $hook_extra, (string) $source );
 
 	return new WP_Error(
 		'pcg_update_parse_error',
@@ -117,13 +117,18 @@ function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan, 
  *
  * @param string $action     `install` or `update`.
  * @param array  $hook_extra Hook payload from `upgrader_source_selection`.
+ * @param string $source     Extracted package directory — fallback slug source on installs,
+ *                           since `Plugin_Upgrader::install()` doesn't populate `hook_extra['plugin']`.
  * @return void
  */
-function pcg_update_guard_stash_retry_context( $action, array $hook_extra ) {
+function pcg_update_guard_stash_retry_context( $action, array $hook_extra, $source = '' ) {
 	if ( ! is_user_logged_in() || ! current_user_can( 'update_plugins' ) ) {
 		return;
 	}
 	$slug = (string) ( $hook_extra['plugin'] ?? '' );
+	if ( '' === $slug && '' !== $source ) {
+		$slug = basename( untrailingslashit( $source ) );
+	}
 	if ( '' === $slug ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -168,13 +168,25 @@ function pcg_update_guard_render_retry_notice() {
 	);
 	?>
 	<div class="notice notice-warning">
-		<p style="margin-block-end:0;">
-			<strong><?php esc_html_e( 'WordPress.com blocked the last plugin update because the package failed PCG checks.', 'jetpack-mu-wpcom' ); ?></strong>
-			<code><?php echo esc_html( $slug ); ?></code> —
-			<a href="<?php echo esc_url( $retry ); ?>" class="button-link"><?php esc_html_e( 'retry without check', 'jetpack-mu-wpcom' ); ?></a>
-			<?php esc_html_e( 'or', 'jetpack-mu-wpcom' ); ?>
-			<?php pcg_force_render_bypass_form(); ?>.
+		<p>
+			<strong><?php esc_html_e( 'WordPress.com blocked the last plugin update because the package failed PCG checks:', 'jetpack-mu-wpcom' ); ?></strong>
+			<code><?php echo esc_html( $slug ); ?></code>.
+			<?php esc_html_e( 'Try one of these overrides:', 'jetpack-mu-wpcom' ); ?>
 		</p>
+		<ul style="list-style:disc;padding-inline-start:24px;margin-block-end:0;">
+			<li>
+				<a href="<?php echo esc_url( $retry ); ?>" class="button-link">
+					<?php
+					printf(
+						/* translators: %s: plugin slug. */
+						esc_html__( 'Retry %s without check', 'jetpack-mu-wpcom' ),
+						'<code>' . esc_html( $slug ) . '</code>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $slug is escaped above.
+					);
+					?>
+				</a>
+			</li>
+			<li><?php pcg_force_render_bypass_form(); ?></li>
+		</ul>
 	</div>
 	<?php
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -157,44 +157,60 @@ function pcg_update_guard_render_retry_notice() {
 	}
 	delete_transient( $key );
 
-	$slug   = (string) $ctx['slug'];
-	$action = 'install' === ( $ctx['action'] ?? '' ) ? 'install-plugin' : 'upgrade-plugin';
-	$nonce  = 'install-plugin' === $action ? 'install-plugin_' . $slug : 'upgrade-plugin_' . $slug;
-	$retry  = wp_nonce_url(
-		add_query_arg(
-			array(
-				'action'    => $action,
-				'plugin'    => $slug,
-				'pcg_force' => '1',
+	$slug      = (string) $ctx['slug'];
+	$is_update = 'install' !== ( $ctx['action'] ?? '' );
+	// One-shot retry only makes sense for updates: the original update
+	// request is replay-safe (the .org zip URL is reproducible). Installs
+	// from an uploaded zip aren't — there's no zip to replay — and even
+	// .org installs would need the user back on the Add Plugin page, so
+	// we only surface the bypass-then-retry path for installs.
+	if ( $is_update ) {
+		$retry = wp_nonce_url(
+			add_query_arg(
+				array(
+					'action'    => 'upgrade-plugin',
+					'plugin'    => $slug,
+					'pcg_force' => '1',
+				),
+				self_admin_url( 'update.php' )
 			),
-			self_admin_url( 'update.php' )
-		),
-		$nonce
-	);
+			'upgrade-plugin_' . $slug
+		);
+	}
 	?>
 	<div class="notice notice-warning">
 		<p>
-			<strong><?php esc_html_e( 'WordPress.com blocked the last plugin update because the package failed PCG checks:', 'jetpack-mu-wpcom' ); ?></strong>
+			<strong>
+				<?php
+				if ( $is_update ) {
+					esc_html_e( 'WordPress.com blocked the last plugin update because the package failed PCG checks:', 'jetpack-mu-wpcom' );
+				} else {
+					esc_html_e( 'WordPress.com blocked the last plugin install because the package failed PCG checks:', 'jetpack-mu-wpcom' );
+				}
+				?>
+			</strong>
 			<code><?php echo esc_html( $slug ); ?></code>.
 			<?php esc_html_e( 'Try one of these overrides:', 'jetpack-mu-wpcom' ); ?>
 		</p>
 		<ul style="list-style:disc;padding-inline-start:24px;margin-block-end:0;">
-			<?php $plugin_name = function_exists( 'pcg_guard_plugin_display_name' ) ? pcg_guard_plugin_display_name( $slug ) : ''; ?>
-			<li>
-				<a href="<?php echo esc_url( $retry ); ?>" class="button-link">
-					<?php
-					if ( '' !== $plugin_name ) {
-						printf(
-							/* translators: %s: plugin display name. */
-							esc_html__( 'Retry %s without check', 'jetpack-mu-wpcom' ),
-							esc_html( $plugin_name )
-						);
-					} else {
-						esc_html_e( 'Retry without check', 'jetpack-mu-wpcom' );
-					}
-					?>
-				</a>
-			</li>
+			<?php if ( $is_update ) : ?>
+				<?php $plugin_name = function_exists( 'pcg_guard_plugin_display_name' ) ? pcg_guard_plugin_display_name( $slug ) : ''; ?>
+				<li>
+					<a href="<?php echo esc_url( $retry ); ?>" class="button-link">
+						<?php
+						if ( '' !== $plugin_name ) {
+							printf(
+								/* translators: %s: plugin display name. */
+								esc_html__( 'Update %s anyway', 'jetpack-mu-wpcom' ),
+								esc_html( $plugin_name )
+							);
+						} else {
+							esc_html_e( 'Update anyway', 'jetpack-mu-wpcom' );
+						}
+						?>
+					</a>
+				</li>
+			<?php endif; ?>
 			<li><?php pcg_force_render_bypass_form(); ?></li>
 		</ul>
 	</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -41,7 +41,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	if ( 'plugin' !== $type || ! in_array( $action, array( 'install', 'update' ), true ) ) {
 		return $source;
 	}
-	if ( pcg_force_override_active() ) {
+	if ( pcg_force_override_active( 'update_plugins' ) ) {
 		return $source;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -174,14 +174,19 @@ function pcg_update_guard_render_retry_notice() {
 			<?php esc_html_e( 'Try one of these overrides:', 'jetpack-mu-wpcom' ); ?>
 		</p>
 		<ul style="list-style:disc;padding-inline-start:24px;margin-block-end:0;">
+			<?php $plugin_name = function_exists( 'pcg_guard_plugin_display_name' ) ? pcg_guard_plugin_display_name( $slug ) : ''; ?>
 			<li>
 				<a href="<?php echo esc_url( $retry ); ?>" class="button-link">
 					<?php
-					printf(
-						/* translators: %s: plugin slug. */
-						esc_html__( 'Retry %s without check', 'jetpack-mu-wpcom' ),
-						'<code>' . esc_html( $slug ) . '</code>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $slug is escaped above.
-					);
+					if ( '' !== $plugin_name ) {
+						printf(
+							/* translators: %s: plugin display name. */
+							esc_html__( 'Retry %s without check', 'jetpack-mu-wpcom' ),
+							esc_html( $plugin_name )
+						);
+					} else {
+						esc_html_e( 'Retry without check', 'jetpack-mu-wpcom' );
+					}
 					?>
 				</a>
 			</li>

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -168,16 +168,12 @@ function pcg_update_guard_render_retry_notice() {
 	);
 	?>
 	<div class="notice notice-warning">
-		<p>
+		<p style="margin-block-end:0;">
 			<strong><?php esc_html_e( 'WordPress.com blocked the last plugin update because the package failed PCG checks.', 'jetpack-mu-wpcom' ); ?></strong>
-			<?php echo ' '; ?>
-			<code><?php echo esc_html( $slug ); ?></code>
-		</p>
-		<p>
-			<a href="<?php echo esc_url( $retry ); ?>" class="button button-secondary" style="margin-inline-end:8px;">
-				<?php esc_html_e( 'Retry without check', 'jetpack-mu-wpcom' ); ?>
-			</a>
-			<?php pcg_force_render_bypass_form(); ?>
+			<code><?php echo esc_html( $slug ); ?></code> —
+			<a href="<?php echo esc_url( $retry ); ?>" class="button-link"><?php esc_html_e( 'retry without check', 'jetpack-mu-wpcom' ); ?></a>
+			<?php esc_html_e( 'or', 'jetpack-mu-wpcom' ); ?>
+			<?php pcg_force_render_bypass_form(); ?>.
 		</p>
 	</div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -7,6 +7,7 @@
  */
 
 add_filter( 'upgrader_source_selection', 'pcg_update_guard_check', 99, 4 );
+add_action( 'admin_notices', 'pcg_update_guard_render_retry_notice' );
 
 /**
  * Wall-clock budget (seconds) for scanning a package for parse errors.
@@ -40,6 +41,9 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	if ( 'plugin' !== $type || ! in_array( $action, array( 'install', 'update' ), true ) ) {
 		return $source;
 	}
+	if ( pcg_force_override_active() ) {
+		return $source;
+	}
 
 	$scan = pcg_update_guard_scan_for_parse_errors( (string) $source );
 
@@ -58,6 +62,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	$first = $scan['errors'][0];
 
 	pcg_update_guard_log_blocked( $action, $hook_extra, $scan, (string) $source );
+	pcg_update_guard_stash_retry_context( $action, $hook_extra );
 
 	return new WP_Error(
 		'pcg_update_parse_error',
@@ -103,6 +108,79 @@ function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan, 
 			'error_count' => count( $scan['errors'] ),
 		)
 	);
+}
+
+/**
+ * Stash the slug/action of a blocked install or update so the next admin
+ * page render can offer a force-retry button. Only logged-in users with
+ * `update_plugins` get a stash (the only callers who'll see the notice).
+ *
+ * @param string $action     `install` or `update`.
+ * @param array  $hook_extra Hook payload from `upgrader_source_selection`.
+ * @return void
+ */
+function pcg_update_guard_stash_retry_context( $action, array $hook_extra ) {
+	if ( ! is_user_logged_in() || ! current_user_can( 'update_plugins' ) ) {
+		return;
+	}
+	$slug = (string) ( $hook_extra['plugin'] ?? '' );
+	if ( '' === $slug ) {
+		return;
+	}
+	set_transient(
+		'pcg_update_blocked_' . get_current_user_id(),
+		array(
+			'slug'   => $slug,
+			'action' => (string) $action,
+		),
+		5 * MINUTE_IN_SECONDS
+	);
+}
+
+/**
+ * Render an admin notice that offers force-retry options after an update
+ * block. The transient is set by the upgrader filter; we consume it here.
+ */
+function pcg_update_guard_render_retry_notice() {
+	if ( ! is_user_logged_in() || ! current_user_can( 'update_plugins' ) ) {
+		return;
+	}
+	$key = 'pcg_update_blocked_' . get_current_user_id();
+	$ctx = get_transient( $key );
+	if ( ! is_array( $ctx ) || empty( $ctx['slug'] ) ) {
+		return;
+	}
+	delete_transient( $key );
+
+	$slug   = (string) $ctx['slug'];
+	$action = 'install' === ( $ctx['action'] ?? '' ) ? 'install-plugin' : 'upgrade-plugin';
+	$nonce  = 'install-plugin' === $action ? 'install-plugin_' . $slug : 'upgrade-plugin_' . $slug;
+	$retry  = wp_nonce_url(
+		add_query_arg(
+			array(
+				'action'    => $action,
+				'plugin'    => $slug,
+				'pcg_force' => '1',
+			),
+			self_admin_url( 'update.php' )
+		),
+		$nonce
+	);
+	?>
+	<div class="notice notice-warning">
+		<p>
+			<strong><?php esc_html_e( 'WordPress.com blocked the last plugin update because the package failed PCG checks.', 'jetpack-mu-wpcom' ); ?></strong>
+			<?php echo ' '; ?>
+			<code><?php echo esc_html( $slug ); ?></code>
+		</p>
+		<p>
+			<a href="<?php echo esc_url( $retry ); ?>" class="button button-secondary" style="margin-inline-end:8px;">
+				<?php esc_html_e( 'Retry without check', 'jetpack-mu-wpcom' ); ?>
+			</a>
+			<?php pcg_force_render_bypass_form(); ?>
+		</p>
+	</div>
+	<?php
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -18,6 +18,19 @@ add_action( 'admin_notices', 'pcg_update_guard_render_retry_notice' );
 const PCG_UPDATE_GUARD_BUDGET_SECONDS = 8.0;
 
 /**
+ * Capability that gates the update guard for a given upgrader action.
+ * `install` → `install_plugins`; everything else (i.e. `update`) → `update_plugins`.
+ * Stock WP roles bundle both on administrator, but a custom role plugin
+ * could split them — derive the cap from the action so we honor that.
+ *
+ * @param string $action `install` or `update`.
+ * @return string
+ */
+function pcg_update_guard_cap_for_action( $action ) {
+	return 'install' === $action ? 'install_plugins' : 'update_plugins';
+}
+
+/**
  * Filter callback. Returns a WP_Error (aborts the install/update) when
  * the extracted source contains any PHP parse errors.
  *
@@ -41,7 +54,7 @@ function pcg_update_guard_check( $source, $remote_source, $upgrader, $hook_extra
 	if ( 'plugin' !== $type || ! in_array( $action, array( 'install', 'update' ), true ) ) {
 		return $source;
 	}
-	if ( pcg_force_override_active( 'update_plugins' ) ) {
+	if ( pcg_force_override_active( pcg_update_guard_cap_for_action( $action ) ) ) {
 		return $source;
 	}
 
@@ -122,7 +135,7 @@ function pcg_update_guard_log_blocked( $action, array $hook_extra, array $scan, 
  * @return void
  */
 function pcg_update_guard_stash_retry_context( $action, array $hook_extra, $source = '' ) {
-	if ( ! is_user_logged_in() || ! current_user_can( 'update_plugins' ) ) {
+	if ( ! is_user_logged_in() || ! current_user_can( pcg_update_guard_cap_for_action( $action ) ) ) {
 		return;
 	}
 	$slug = (string) ( $hook_extra['plugin'] ?? '' );
@@ -147,7 +160,7 @@ function pcg_update_guard_stash_retry_context( $action, array $hook_extra, $sour
  * block. The transient is set by the upgrader filter; we consume it here.
  */
 function pcg_update_guard_render_retry_notice() {
-	if ( ! is_user_logged_in() || ! current_user_can( 'update_plugins' ) ) {
+	if ( ! is_user_logged_in() ) {
 		return;
 	}
 	$key = 'pcg_update_blocked_' . get_current_user_id();
@@ -155,10 +168,14 @@ function pcg_update_guard_render_retry_notice() {
 	if ( ! is_array( $ctx ) || empty( $ctx['slug'] ) ) {
 		return;
 	}
+	$action = (string) ( $ctx['action'] ?? '' );
+	if ( ! current_user_can( pcg_update_guard_cap_for_action( $action ) ) ) {
+		return;
+	}
 	delete_transient( $key );
 
 	$slug      = (string) $ctx['slug'];
-	$is_update = 'install' !== ( $ctx['action'] ?? '' );
+	$is_update = 'install' !== $action;
 	// One-shot retry only makes sense for updates: the original update
 	// request is replay-safe (the .org zip URL is reproducible). Installs
 	// from an uploaded zip aren't — there's no zip to replay — and even

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-guard.php
@@ -164,8 +164,8 @@ function pcg_update_guard_render_retry_notice() {
 	// from an uploaded zip aren't — there's no zip to replay — and even
 	// .org installs would need the user back on the Add Plugin page, so
 	// we only surface the bypass-then-retry path for installs.
-	if ( $is_update ) {
-		$retry = wp_nonce_url(
+	$retry = $is_update
+		? wp_nonce_url(
 			add_query_arg(
 				array(
 					'action'    => 'upgrade-plugin',
@@ -175,8 +175,8 @@ function pcg_update_guard_render_retry_notice() {
 				self_admin_url( 'update.php' )
 			),
 			'upgrade-plugin_' . $slug
-		);
-	}
+		)
+		: '';
 	?>
 	<div class="notice notice-warning">
 		<p>

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/update-healthcheck.php
@@ -29,6 +29,9 @@ function pcg_healthcheck_capture_snapshot( $return, $hook_extra ) {
 	if ( ! apply_filters( 'pcg_guard_updates', true ) ) {
 		return $return;
 	}
+	if ( pcg_force_override_active( 'update_plugins' ) ) {
+		return $return;
+	}
 	if ( ! pcg_healthcheck_is_plugin_pre_install_update( $hook_extra ) ) {
 		return $return;
 	}
@@ -67,6 +70,9 @@ function pcg_healthcheck_capture_snapshot( $return, $hook_extra ) {
  */
 function pcg_healthcheck_after_update( $upgrader, $hook_extra ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $upgrader is the WP-Upgrader-supplied argument; we accept it for the action signature.
 	if ( ! apply_filters( 'pcg_guard_updates', true ) ) {
+		return;
+	}
+	if ( pcg_force_override_active( 'update_plugins' ) ) {
 		return;
 	}
 	if ( ! pcg_healthcheck_is_plugin_update( $hook_extra ) ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/pcg-log.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/class-pcg-load-tester.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/class-pcg-rollout.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/plugin-conflicts-guardian/force-override.php';
 // probe-endpoint.php registers a shutdown handler and reads $_GET on
 // require; the entry function `pcg_maybe_handle_probe()` is the one
 // that does that work, and it bails immediately when `$_GET['pcg_probe']`

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -730,7 +730,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 * The filter returns the source unchanged when the guard is disabled.
 	 */
 	public function test_update_guard_check_passthrough_when_disabled() {
-		add_filter( 'pcg_guard_activation', '__return_false' );
+		add_filter( 'pcg_guard_updates', '__return_false' );
 
 		$dir = $this->make_tmp_dir();
 		file_put_contents( $dir . '/bad.php', "<?php function ( {\n" );
@@ -752,7 +752,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 * Non-plugin extensions (themes, core) are not inspected.
 	 */
 	public function test_update_guard_check_ignores_non_plugin_types() {
-		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_guard_updates', '__return_true' );
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
@@ -775,7 +775,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 * Actions other than install/update are not inspected.
 	 */
 	public function test_update_guard_check_ignores_unrelated_actions() {
-		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_guard_updates', '__return_true' );
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
@@ -798,7 +798,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 * Clean plugin packages pass through untouched.
 	 */
 	public function test_update_guard_check_allows_clean_plugin_package() {
-		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_guard_updates', '__return_true' );
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();
@@ -821,7 +821,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	 * Packages with parse errors are rejected with a descriptive WP_Error.
 	 */
 	public function test_update_guard_check_blocks_plugin_with_parse_error() {
-		add_filter( 'pcg_guard_activation', '__return_true' );
+		add_filter( 'pcg_guard_updates', '__return_true' );
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 
 		$dir = $this->make_tmp_dir();


### PR DESCRIPTION
## Summary

Adds opt-out controls on the PCG block notices so an admin who disagrees with a verdict can still push through:

- **One-shot retry** — `Activate <Name> anyway` on the activation notice and `Update <Name> anyway` on the post-block update notice. Re-fires the original action with `pcg_force=1`; the action's own admin nonce still has to validate, PCG just steps out of the way for that request. **No retry on installs** — `Plugin_Upgrader::install()` doesn't populate `hook_extra['plugin']`, the `install-plugin` URL can't replay an uploaded zip, and even .org installs can't be reliably reconstructed from `basename( source )`, so the install notice shows only the bypass form.
- **Time-boxed bypass** — `Disable checks for 10 minutes` sets a per-user transient (`pcg_force_bypass_<user_id>`). The activation guard, the syntax-only install/update gate, **and the post-update healthcheck + rollback** all consult `pcg_force_override_active( $cap )` and return early while the transient is live, so a user who explicitly opts out isn't snapshotted, probed, and rolled back behind their back.

Capabilities are checked per surface (`activate_plugins` for activation, `update_plugins` / `install_plugins` for the update/install gate, `update_plugins` for the healthcheck). Both paths are logged to logstash (`Force override used` with `source: pcg_force_flag` / `bypass_transient`, `Force bypass enabled`).

> Depends on #49388 to re-add the `require_once` for `plugin-conflicts-guardian.php` in `load_features()` — without that the feature stays unreachable and these controls don't run. Split into its own PR so we can land force-override review here and ramp the boot back on deliberately.

## Files

- `force-override.php` (new) — `pcg_force_override_active( $cap )`, the `admin_post_pcg_force_set_bypass` handler, and the shared bypass-button renderer.
- `activation-guard.php` — short-circuits when override is active; block notice grows per-row "Activate anyway" links + bypass form.
- `update-guard.php` — short-circuits when override is active; on block, stashes slug+action in a transient (with `basename( source )` fallback for installs) and renders a follow-up admin notice. Retry button only renders for `update`; install gets bypass only. Cap derived per `$action` via `pcg_update_guard_cap_for_action()` so an `install` is gated on `install_plugins` and `update` on `update_plugins`.
- `update-healthcheck.php` — short-circuits both `pcg_healthcheck_capture_snapshot()` and `pcg_healthcheck_after_update()` when override is active. Without this, the bypass would still let pre-update snapshots happen and PCG could roll the update back.
- `plugin-conflicts-guardian.php` — wires up `force-override.php`.
- README — new "Force override" section.

## Does this pull request change what data or activity we track or use?

No new external data flows. The bypass transient stores a single boolean keyed by `user_id`; the update-retry transient stores the plugin slug + action (install/update) the user just tried. Both auto-expire. Logstash entries record source (`pcg_force_flag` / `bypass_transient`) and TTL — no plugin file paths or user content.

## Testing instructions

1. Enable PCG on the test site — by default the rollout is 0%, so both guards are off. Either ramp the rollout to 100%:

   ```php
   // wp-content/mu-plugins/pcg-on.php
   <?php
   add_filter( 'pcg_rollout_percentage', fn () => 100 );
   ```

   …or skip the bucket math and force the gates directly (priority > 100 so it runs after `PCG_Rollout::gate`):

   ```php
   add_filter( 'pcg_guard_activation', '__return_true', 200 );
   add_filter( 'pcg_guard_updates',    '__return_true', 200 );
   ```

2. Install a deliberately-fatal plugin (e.g. `pcg-fatal-tester`) and try to activate it → block notice appears with the per-row override action and the bypass form.
3. Click **Activate <Name> anyway** → activation proceeds (note the `pcg_force=1` in the URL); confirm logstash shows `Force override used` with `source: pcg_force_flag`.
4. Reload, trigger another block, click **Disable checks for 10 minutes** → redirected back, `pcg_bypass_enabled=1` flag set; subsequent activations / updates skip PCG entirely; logstash shows `Force bypass enabled` then `Force override used` with `source: bypass_transient`.
5. Trigger an update block (package with a parse error). After WP shows the upgrader error, navigate to plugins.php → notice appears with `Update <Name> anyway` + bypass form. Verify `Update <Name> anyway` re-fires the update successfully.
6. Trigger an install block (zip with a parse error → Add Plugin → Upload Plugin). Notice should appear with **only** the bypass form (no retry button). Flip bypass, re-upload — install proceeds.
7. Healthcheck override: with the 10-min bypass active, push an update that would normally trip the post-update probe (e.g. plugin that fatals on `init`). Update should complete and stay applied — no rollback, no `Update rolled back` logstash event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)