### PR TITLE
feat(premium-analytics): port layout package from next-woocommerce-analytics

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3839,6 +3839,9 @@ importers:
       '@wordpress/route':
         specifier: 0.12.0
         version: 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui':
+        specifier: 0.13.0
+        version: 0.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1

--- a/projects/packages/premium-analytics/changelog/wooa7s-1315-integrate-layout-package-into-analytics
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1315-integrate-layout-package-into-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Port the `layout` package from `next-woocommerce-analytics` as an internal package providing the `BaseLayout` primitive.

--- a/projects/packages/premium-analytics/eslint.config.mjs
+++ b/projects/packages/premium-analytics/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { makeBaseConfig, defineConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
+
+/**
+ * Soften JSDoc rules for `packages/layout/**` so the initial port can
+ * land. Temporary — backfill proper descriptions on the components and
+ * remove this override (at which point this whole file can go away).
+ */
+export default defineConfig( makeBaseConfig( import.meta.url ), {
+	files: [ 'packages/layout/**' ],
+	rules: {
+		'jsdoc/require-description': 'off',
+		'jsdoc/require-param-description': 'off',
+		'jsdoc/require-returns': 'off',
+		'jsdoc/check-indentation': 'off',
+	},
+} );

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^13.0.0",
 		"@wordpress/route": "0.12.0",
+		"@wordpress/ui": "0.13.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1"
 	},

--- a/projects/packages/premium-analytics/packages/layout/README.md
+++ b/projects/packages/premium-analytics/packages/layout/README.md
@@ -1,0 +1,33 @@
+# @jetpack-premium-analytics/layout
+
+Layout primitives for Jetpack Premium Analytics.
+
+## Overview
+
+Provides shared page-level layout components used by routes and widget hosts —
+currently a single `BaseLayout` that stacks a header above its children with
+a consistent gap.
+
+## Components
+
+### `<BaseLayout header={…}>{ … }</BaseLayout>`
+
+Renders a vertical [`Stack`](https://github.com/WordPress/gutenberg/tree/trunk/packages/ui)
+with `gap="lg"`. The `header` slot sits above the children.
+
+```tsx
+import { BaseLayout } from '@jetpack-premium-analytics/layout';
+
+<BaseLayout header={ <PageHeader /> }>
+	<WidgetGrid />
+</BaseLayout>;
+```
+
+**Props:**
+
+- `header`: `React.ReactNode` — content rendered above the children.
+- `children`: `React.ReactNode` — main page content.
+
+## Dependencies
+
+- `@wordpress/ui` — provides the `Stack` primitive.

--- a/projects/packages/premium-analytics/packages/layout/package.json
+++ b/projects/packages/premium-analytics/packages/layout/package.json
@@ -1,17 +1,13 @@
 {
-	"name": "@next-woo-analytics/layout",
-	"description": "WooCommerce Analytics layout",
-	"version": "1.0.0",
+	"name": "@automattic/jetpack-premium-analytics-layout",
+	"description": "Premium Analytics layout primitives",
+	"version": "0.1.0",
 	"private": true,
 	"type": "module",
-	"wpModule": true,
 	"main": "src/index.ts",
-	"exports": {
-		".": "./build/src/index.js"
-	},
+	"types": "src/index.ts",
+	"sideEffects": false,
 	"dependencies": {
-		"@automattic/ui": "*",
-		"@wordpress/components": "*",
-		"@wordpress/ui": "*"
+		"@wordpress/ui": "0.13.0"
 	}
 }

--- a/projects/packages/premium-analytics/packages/layout/package.json
+++ b/projects/packages/premium-analytics/packages/layout/package.json
@@ -4,8 +4,11 @@
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",
+	"wpScript": true,
 	"main": "src/index.ts",
+	"module": "build-module/index.mjs",
 	"types": "src/index.ts",
+	"wpScriptModuleExports": "./build-module/index.mjs",
 	"sideEffects": false,
 	"dependencies": {
 		"@wordpress/ui": "0.13.0"

--- a/projects/packages/premium-analytics/packages/layout/package.json
+++ b/projects/packages/premium-analytics/packages/layout/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@next-woo-analytics/layout",
+	"description": "WooCommerce Analytics layout",
+	"version": "1.0.0",
+	"private": true,
+	"type": "module",
+	"wpModule": true,
+	"main": "src/index.ts",
+	"exports": {
+		".": "./build/src/index.js"
+	},
+	"dependencies": {
+		"@automattic/ui": "*",
+		"@wordpress/components": "*",
+		"@wordpress/ui": "*"
+	}
+}

--- a/projects/packages/premium-analytics/packages/layout/src/base/base.tsx
+++ b/projects/packages/premium-analytics/packages/layout/src/base/base.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { Stack } from '@wordpress/ui';
+
+type BaseLayoutProps = {
+	header: React.ReactNode;
+	children: React.ReactNode;
+};
+
+/**
+ *
+ * @param root0
+ * @param root0.header
+ * @param root0.children
+ */
+export function BaseLayout( { header, children }: BaseLayoutProps ) {
+	return (
+		<Stack gap="lg" direction="column">
+			<>{ header }</>
+			<>{ children }</>
+		</Stack>
+	);
+}

--- a/projects/packages/premium-analytics/packages/layout/src/base/base.tsx
+++ b/projects/packages/premium-analytics/packages/layout/src/base/base.tsx
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import { Stack } from '@wordpress/ui';
+import type { ReactNode } from 'react';
 
 type BaseLayoutProps = {
-	header: React.ReactNode;
-	children: React.ReactNode;
+	header: ReactNode;
+	children: ReactNode;
 };
 
 /**

--- a/projects/packages/premium-analytics/packages/layout/src/base/index.ts
+++ b/projects/packages/premium-analytics/packages/layout/src/base/index.ts
@@ -1,0 +1,1 @@
+export { BaseLayout } from './base';

--- a/projects/packages/premium-analytics/packages/layout/src/index.ts
+++ b/projects/packages/premium-analytics/packages/layout/src/index.ts
@@ -1,0 +1,1 @@
+export { BaseLayout } from './base';

--- a/projects/packages/premium-analytics/packages/layout/tsconfig.json
+++ b/projects/packages/premium-analytics/packages/layout/tsconfig.json
@@ -1,9 +1,0 @@
-{
-	"extends": "../../tsconfig.json",
-	"compilerOptions": {
-		"outDir": "build",
-		"skipLibCheck": true
-	},
-	"include": [ "src/**/*" ],
-	"exclude": [ "build", "node_modules" ]
-}

--- a/projects/packages/premium-analytics/packages/layout/tsconfig.json
+++ b/projects/packages/premium-analytics/packages/layout/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "build",
+		"skipLibCheck": true
+	},
+	"include": [ "src/**/*" ],
+	"exclude": [ "build", "node_modules" ]
+}


### PR DESCRIPTION
## Proposed changes

Second leaf in **M2 — Shared Packages Integration** (WOOA7S-1315): port `@next-woo-analytics/layout` into `@automattic/jetpack-premium-analytics` as an internal package. Provides a single `BaseLayout` primitive — a vertical `@wordpress/ui` `Stack` with a header slot above the children — used by analytics routes to keep page chrome consistent.

A true leaf — no internal deps, only `@wordpress/ui`. Stacked on #49189 (which sets up the `@jetpack-premium-analytics/*` tsconfig paths alias this work relies on). Sibling to #49221 (datetime port); the two don't touch the same files.

### What's in the package

| File | Purpose |
|---|---|
| `src/base/base.tsx` | `BaseLayout` component — `Stack gap="lg" direction="column"` with `header` + `children` slots |
| `src/base/index.ts`, `src/index.ts` | barrel exports |
| `README.md` | usage + props reference (new — upstream had none) |

### Monorepo adaptations

| Upstream | Here | Why |
|---|---|---|
| `name: @next-woo-analytics/layout` | `name: @automattic/jetpack-premium-analytics-layout` | Per the internal-packages convention in the parent `README.md` — the import specifier (`@jetpack-premium-analytics/layout`) comes from `wpPlugin.packageNamespace`; the `name:` field is separate and must use the `@automattic/...` form |
| `version: 1.0.0` | `version: 0.1.0` | Matches the datetime port and sibling `packages/init/` |
| `@wordpress/ui: "*"` | `@wordpress/ui: 0.13.0` | Jetpack convention — every other package pins concrete versions; the repo also sets `minimumReleaseAge: 1440` which conflicts with `"*"` |
| `@automattic/ui: "*"`, `@wordpress/components: "*"` | (dropped) | Declared upstream but never imported — only `Stack` from `@wordpress/ui` is used |
| `wpModule: true`, `exports: { ./build/src/index.js }` | `wpScript: true`, `module: "build-module/index.mjs"`, `wpScriptModuleExports: "./build-module/index.mjs"` | Upstream `wpModule: true` told CIAB's wp-build to emit a standalone script module (`build/packages/layout/index.js` + `index.asset.php`). `@wordpress/build`'s `dependency-graph.mjs` uses `wpScript` / `wpScriptModuleExports` for the same role; sibling `packages/init/` follows the same triple. Without these the package would be inlined into every consumer instead of loaded once via the script-module registry — same as upstream behavior |
| Leaf `tsconfig.json` | (deleted) | Parent already `includes: [packages/**/*]`; sibling `packages/init/` and the datetime port carry no leaf tsconfig either |
| `header: React.ReactNode` (global namespace) | `import type { ReactNode } from 'react'`; `header: ReactNode` | tsgo doesn't have a global `React` in scope under this package's config (`TS2503: Cannot find namespace 'React'`); behaviorally identical |
| No README | New README | Documents the only export, its props, and the `@wordpress/ui` `Stack` dependency — mirrors the datetime README style |

Two structural files touched at the parent level:

- **`package.json`**: adds `@wordpress/ui: 0.13.0` so the leaf's `Stack` import resolves. `packages/layout/` is **not** a pnpm workspace member (the root `pnpm-workspace.yaml` glob `projects/*/*` doesn't reach in two levels), so the leaf's own dep declarations are decorative — only the parent's matter to pnpm. Same pattern as the datetime port adds `date-fns` / `@date-fns/tz` here.
- **`eslint.config.mjs`** (new — *temporary*): softens `jsdoc/require-*` for `packages/layout/**` so the initial port can land with the upstream JSDoc style. Mirrors the override #49221 introduced for `packages/datetime/**`. Backfill proper JSDoc on `BaseLayout` and delete this config file entirely in a follow-up.

### What's intentionally not here

- **No `link:` dep on the parent yet.** The parent README documents the pattern (`@jetpack-premium-analytics/layout: link:packages/layout`), but `eslint-plugin-package-json`'s `valid-dependencies` rule rejects `link:` URLs by default. Since no route or sibling package imports `layout` yet, the wiring isn't load-bearing — wp-build's `packages/*` autodiscovery is enough for the package to exist. The first consumer PR will need to resolve the lint conflict (same blocker the datetime port called out).
- **No tests.** The upstream package ships no tests; not adding speculative ones here.
- **No JSDoc backfill.** Out of scope for the port commit — tracked by the comment in `eslint.config.mjs`.

## Related product discussion/links

- WOOA7S-1315
- Stacked on #49189 (WOOA7S-1320)
- Sibling port: #49221 (datetime, WOOA7S-1312) — same conventions, but datetime is bundled (no `wpScript`) while layout is a script module (`wpScript: true`), matching each upstream package's role

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires Node 24 (repo `engineStrict`).

```bash
pnpm install
cd projects/packages/premium-analytics
pnpm typecheck   # tsgo --noEmit — passes
pnpm build       # wp-build — passes (~300ms); emits build/modules/layout/index.min.{js,asset.php}
pnpm exec eslint --flag v10_config_lookup_from_file --max-warnings=0 packages/layout/   # clean
```

**Confirm the script module is registered:**

```bash
grep -A2 '@jetpack-premium-analytics/layout' build/modules/registry.php
# →   'id' => '@jetpack-premium-analytics/layout',
#     'path' => 'layout/index',
#     'asset' => 'layout/index.min.asset.php',
```

**Optional smoke import**, to confirm the path alias works through the typechecker:

1. Edit `routes/dashboard/stage.tsx`:
   ```ts
   import { BaseLayout } from '@jetpack-premium-analytics/layout';
   void BaseLayout;
   ```
2. `pnpm typecheck` — resolves and passes.
3. Revert the edit.

**Optional — build-time resolution via `link:`** (confirms wp-build tracks the package as a module dependency once a consumer imports it):

1. Add to `projects/packages/premium-analytics/package.json` `dependencies`: `"@jetpack-premium-analytics/layout": "link:packages/layout"` (the `valid-dependencies` lint rejects `link:` — relax it for the temp edit).
2. Import + reference a `layout` export in `routes/dashboard/stage.tsx`.
3. `pnpm install && pnpm build` → `build/routes/dashboard/content.min.asset.php` lists the dependency under `module_dependencies`.
4. Revert the edits + `pnpm install`.

> **Note:** the `@jetpack-premium-analytics/layout` specifier is a temporary bridge inherited from the source repo. Once name-based identity (WordPress/gutenberg#78822, mirrored monorepo-wide by #48089) lands, the specifier becomes the package's own `name` (`@automattic/jetpack-premium-analytics-layout`) and the bare-scope alias/`link:` drop out — so long term there's no `@jetpack-premium-analytics/...` to maintain. The package README already uses the canonical `@automattic/jetpack-premium-analytics-layout` name.
