### PR TITLE
Search Blocks: collapse the image column in expanded results when a result has no image (SEARCH-278)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-278-collapse-empty-image-column
+++ b/projects/packages/search/changelog/atlas-search-278-collapse-empty-image-column
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: in the expanded Results List layout, hide the image column for results that have no image so the text expands to fill the row.

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.js
@@ -42,6 +42,7 @@ const SAMPLE_RESULTS = [
 		path: 'example.com/articles/first',
 		author: __( 'Sample Author', 'jetpack-search-pkg' ),
 		date: 'Apr 1, 2026',
+		hasImage: true,
 	},
 	{
 		title: __( 'Another relevant post', 'jetpack-search-pkg' ),
@@ -52,7 +53,11 @@ const SAMPLE_RESULTS = [
 		path: 'example.com/guides/another',
 		author: __( 'A. Writer, B. Editor', 'jetpack-search-pkg' ),
 		date: 'Mar 22, 2026',
+		hasImage: true,
 	},
+	// Third row demonstrates the image-less collapse — image column drops out,
+	// text fills the row. Mirrors the runtime behavior when a result's
+	// `imageUrl` is empty.
 	{
 		title: __( 'Older archived entry', 'jetpack-search-pkg' ),
 		contentSnippet: __(
@@ -263,9 +268,9 @@ function renderExpandedPreview( results ) {
 							) }
 						</div>
 					</div>
-					<a className="jetpack-search-results__image-link" tabIndex={ -1 } aria-hidden="true">
-						<span className="jetpack-search-results__image-placeholder" aria-hidden="true" />
-					</a>
+					{ result.hasImage && (
+						<a className="jetpack-search-results__image-link" tabIndex={ -1 } aria-hidden="true" />
+					) }
 				</li>
 			) ) }
 		</ul>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -322,20 +322,15 @@ if ( '' === $error_message ) {
 					<a
 						class="jetpack-search-results__image-link"
 						data-wp-bind--href="context.result.permalink"
+						data-wp-bind--hidden="!context.result.imageUrl"
 						tabindex="-1"
 						aria-hidden="true"
 					>
 						<img
 							class="jetpack-search-results__image"
 							data-wp-bind--src="context.result.imageUrl"
-							data-wp-bind--hidden="!context.result.imageUrl"
 							alt=""
 						/>
-						<span
-							class="jetpack-search-results__image-placeholder"
-							data-wp-bind--hidden="context.result.imageUrl"
-							aria-hidden="true"
-						></span>
 					</a>
 				<?php endif; ?>
 			</li>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/style.scss
@@ -195,6 +195,10 @@
 		border-radius: 4px;
 		overflow: hidden;
 		background-color: color-mix(in sRGB, currentColor 8%, transparent);
+
+		&[hidden] {
+			display: none;
+		}
 	}
 
 	.jetpack-search-results__image {
@@ -203,30 +207,6 @@
 		height: 100%;
 		aspect-ratio: 16 / 10;
 		object-fit: cover;
-
-		&[hidden] {
-			display: none;
-		}
-	}
-
-	.jetpack-search-results__image-placeholder {
-		display: block;
-		width: 100%;
-		height: 100%;
-		background-color: currentColor;
-		opacity: 0.3;
-		mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><rect x='3' y='3' width='18' height='18' rx='2'/><circle cx='8.5' cy='8.5' r='1.5'/><path d='m21 15-5-5L5 21'/></svg>");
-		mask-repeat: no-repeat;
-		mask-position: center;
-		mask-size: 32%;
-		-webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><rect x='3' y='3' width='18' height='18' rx='2'/><circle cx='8.5' cy='8.5' r='1.5'/><path d='m21 15-5-5L5 21'/></svg>");
-		-webkit-mask-repeat: no-repeat;
-		-webkit-mask-position: center;
-		-webkit-mask-size: 32%;
-
-		&[hidden] {
-			display: none;
-		}
 	}
 }
 

--- a/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
@@ -89,10 +89,25 @@ describe( 'ResultsListEdit', () => {
 
 		expect( screen.getByText( 'First sample result' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Apr 1, 2026' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Ada Lovelace' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Grace Hopper' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Katherine Johnson' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Sample Author' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'A. Writer, B. Editor' ) ).not.toBeInTheDocument();
 	} );
+
+	// SAMPLE_RESULTS has three rows: the first two carry hasImage:true, the
+	// third demonstrates the runtime collapse when imageUrl is empty. We count
+	// `__image-link` elements directly because the element is aria-hidden by
+	// design (it's a decorative click-target for sighted users); there's no
+	// role or accessible name to query against via Testing Library.
+	/* eslint-disable testing-library/no-container, testing-library/no-node-access -- see comment above. */
+	it( 'renders the image-link column only for sample rows that have an image in the expanded preview', () => {
+		const { container } = render(
+			<ResultsListEdit attributes={ { layout: 'expanded' } } setAttributes={ jest.fn() } />
+		);
+
+		expect( container.querySelectorAll( '.jetpack-search-results__image-link' ) ).toHaveLength( 2 );
+		expect( screen.getByText( 'Older archived entry' ) ).toBeInTheDocument();
+	} );
+	/* eslint-enable testing-library/no-container, testing-library/no-node-access */
 
 	it( 'renders the layout picker in the inspector', () => {
 		render( <ResultsListEdit attributes={ { layout: 'expanded' } } setAttributes={ jest.fn() } /> );


### PR DESCRIPTION
Fixes [SEARCH-278](https://linear.app/a8c/issue/SEARCH-278/search-blocks-collapse-the-image-column-in-expanded-results-when-a)

## Why

For sites that mix image-rich and image-less content — blogs with untriaged featured images, documentation, plain-text posts — the **expanded** Results List today reserves a fixed ~30%-wide image slot on every row, and fills it with an empty picture-frame placeholder when the result has no image. The visitor reads a squeezed text column next to a meaningless box.

After this change, an expanded result with no image renders no image column at all and the text expands to fill the row. Rows that *do* have an image render unchanged.

## Proposed changes

* `render.php` — Move `data-wp-bind--hidden="!context.result.imageUrl"` from the `<img>` up to the parent `<a class="…__image-link">` so the whole flex item drops out of layout when there's no image. Remove the now-unreachable `<span class="…__image-placeholder">`.
* `style.scss` — Add the explicit `&[hidden] { display: none; }` override on `.jetpack-search-results__image-link` (mirrors the override pattern already on sibling elements; needed because the rule's `display: block` outranks the UA `[hidden]` rule). Drop the dead `.jetpack-search-results__image-placeholder` block.
* `edit.js` — Mirror the runtime behavior in the editor canvas: the third sample row ("Older archived entry") now renders without the image column, demonstrating the collapse so authors see what visitors will see.
* Scoped to expanded layout only. `compact` (no image column at all) and `product` (image-on-top grid card; placeholder is a legitimate hero stand-in) are untouched.

## Real-screen before / after

Captured at 1440×900 via the local docker env at `http://localhost:18080`.

| | Before (trunk) | After |
|---|---|---|
| Mixed list — `?s=block` | ![before-mixed](https://github.com/user-attachments/assets/800483aa-609a-40ef-ba0b-55303260b1c9) | ![after-mixed](https://github.com/user-attachments/assets/dcde9883-f9fd-4fd8-8bc6-d51d7e97604c) |
| Mostly no-image — `?s=lorem` | ![before-lorem](https://github.com/user-attachments/assets/b074fd45-d646-4e69-8d90-4b311935b85b) | ![after-lorem](https://github.com/user-attachments/assets/ca63e2c9-6988-4749-9a1e-b20c9f402177) |
| Editor canvas | ![before-editor](https://github.com/user-attachments/assets/1c2ba8d4-5bbd-40e6-b969-95197b2e313c) | ![after-editor](https://github.com/user-attachments/assets/78f14652-4491-4bbe-b48f-c8f2698a3f5c) |

DOM measurements on the after state confirm the row reclaims exactly the image-link's slot (~200px + 24px gap):

| query | row | image present | `.__copy` width |
|---|---|---|---|
| `?s=lorem` | Lorem Ipsum | no | **855 px** (full row) |
| `?s=lorem` | Block: Columns | yes | 631 px (200px image + 24px gap reserved) |
| editor | Older archived entry | no | **417 px** (full row) |
| editor | First sample result | yes | 268 px |

## Related product discussion/links

* [SEARCH-278](https://linear.app/a8c/issue/SEARCH-278/search-blocks-collapse-the-image-column-in-expanded-results-when-a)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with a mix of posts with and without featured images, set the Search experience to `embedded` or `overlay_blocks` (anything that paints the embedded blocks). On a page with the Results List block in the **expanded** layout, search for a query that returns both kinds of results.
   * [ ] Each result with a featured image renders the 200px image on the right (unchanged from trunk).
   * [ ] Each result with no featured image renders no image column — the text snippet expands to the full row width.
   * [ ] The inter-row gap is unaffected; a mixed list reads cleanly.
2. Search for a query whose results have **no** featured images at all (e.g. plain-text pages).
   * [ ] Every row is full-width text. No empty placeholder boxes anywhere.
3. Switch the Results List layout in the editor between `compact`, `expanded`, and `product`.
   * [ ] `compact` is unchanged (already no image column).
   * [ ] `expanded` editor canvas: the third sample row ("Older archived entry") renders without the image column; the first two rows show the image-column stand-in. (Mirrors what visitors will see.)
   * [ ] `product` is unchanged — the image-on-top placeholder hero still appears for products without an image (on a Woo site, or with `set_woocommerce_blocks_enabled_for_testing( true )`).
4. Confirm before/after via the screenshots above.
