### PR TITLE
Search Blocks: container-query the sidebar/popover responsive flip (SEARCH-279)

### DIFF
--- a/projects/packages/search/changelog/echo-search-279-container-query-sidebar-popover-flip
+++ b/projects/packages/search/changelog/echo-search-279-container-query-sidebar-popover-flip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: drive the sidebar/popover responsive flip from a container query against the columns row; the existing @media (min-width: 992px) rules are kept as a fallback for browsers without container-query support.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -2,6 +2,68 @@
 // at the same width.
 $jetpack-search-filters-popover-collapse: 992px;
 
+// Inline-sidebar mode — the popover root becomes a block-flow region, the
+// trigger drops out of the tree, and the panel sheds its popover chrome.
+// Used by the `@media` rule below and by the editor-preview selector
+// further down — they need the same body, so it lives here as one mixin.
+@mixin filters-popover-inline-mode {
+	display: block;
+
+	.jetpack-search-filters-popover__trigger {
+		display: none;
+	}
+
+	.jetpack-search-filters-popover__panel {
+		position: static;
+		display: flex;
+		min-width: 0;
+		max-width: none;
+		padding: 0;
+		background: transparent;
+		color: inherit;
+		border: none;
+		border-radius: 0;
+		box-shadow: none;
+		z-index: auto;
+	}
+}
+
+// Popover-mode restore — explicitly re-applies the popover-chrome values
+// that inline-mode above had overridden. Used by the `@container (max-width)`
+// rule to undo `@media (min-width)` when the named container is narrower
+// than the viewport. Property values mirror the base `.__panel` block; keep
+// them in sync if the base changes.
+@mixin filters-popover-popover-mode {
+	display: inline-block;
+
+	.jetpack-search-filters-popover__trigger {
+		display: inline-flex;
+	}
+
+	.jetpack-search-filters-popover__panel {
+		position: absolute;
+		display: none;
+		min-width: 260px;
+		max-width: min(360px, 90vw);
+		padding: 12px;
+		background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
+		border: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 15%, transparent);
+		border-radius: 4px;
+		box-shadow: 0 4px 16px color-mix(in sRGB, currentColor 12%, transparent);
+		z-index: 20;
+	}
+
+	// The base `.is-popover-open .__panel { display: flex }` rule earlier in
+	// source has lower source-order than this @container block, so its
+	// `display: flex` would be lost to the `display: none` above. Restate it
+	// at higher source-order so the popover still opens on click.
+	&.is-popover-open .jetpack-search-filters-popover__panel {
+		display: flex;
+	}
+}
+
 .jetpack-search-filters-popover {
 	position: relative;
 	display: inline-block;
@@ -105,31 +167,26 @@ $jetpack-search-filters-popover-collapse: 992px;
 	}
 
 	// Responsive mode above the breakpoint: the popover becomes an inline
-	// sidebar. The trigger is taken out of the flow (its `aria-controls` is
-	// unreachable too, which is correct — the target panel is now an inline
-	// region) and the panel sheds every popover-only style.
+	// sidebar. The `@media` rule is the universal base — it fires in every
+	// browser (including legacy ones without container-query support), and
+	// drives standalone usage outside the named container declared on the
+	// shared Search templates' columns row (see
+	// `Search_Blocks::search_layout_inline_css()`). The `@container` rule
+	// then overrides `@media` via source-order cascade when the named
+	// container is in scope AND narrower than 992px — the "wide viewport,
+	// narrow container" case, which is the whole point of the change. The
+	// override has to explicitly restore popover-mode values; the cascade
+	// can't infer them.
 	&.is-mode-responsive {
 
 		@media (min-width: $jetpack-search-filters-popover-collapse) {
-			display: block;
 
-			.jetpack-search-filters-popover__trigger {
-				display: none;
-			}
+			@include filters-popover-inline-mode;
+		}
 
-			.jetpack-search-filters-popover__panel {
-				position: static;
-				display: flex;
-				min-width: 0;
-				max-width: none;
-				padding: 0;
-				background: transparent;
-				color: inherit;
-				border: none;
-				border-radius: 0;
-				box-shadow: none;
-				z-index: auto;
-			}
+		@container jetpack-search-layout (max-width: #{$jetpack-search-filters-popover-collapse - 0.02px}) {
+
+			@include filters-popover-popover-mode;
 		}
 	}
 

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -4,8 +4,10 @@ $jetpack-search-filters-popover-collapse: 992px;
 
 // Inline-sidebar mode — the popover root becomes a block-flow region, the
 // trigger drops out of the tree, and the panel sheds its popover chrome.
-// Used by the `@media` rule below and by the editor-preview selector
-// further down — they need the same body, so it lives here as one mixin.
+// Used by the `@media` rule on `.is-mode-responsive` below. (The editor-
+// preview selector further down restates the panel-only portion of these
+// styles directly because it only targets `&__panel`, not the root or
+// trigger — it can't reuse the full mixin.)
 @mixin filters-popover-inline-mode {
 	display: block;
 
@@ -55,10 +57,13 @@ $jetpack-search-filters-popover-collapse: 992px;
 		z-index: 20;
 	}
 
-	// The base `.is-popover-open .__panel { display: flex }` rule earlier in
-	// source has lower source-order than this @container block, so its
-	// `display: flex` would be lost to the `display: none` above. Restate it
-	// at higher source-order so the popover still opens on click.
+	// The base `.is-popover-open .__panel { display: flex }` rule (specificity
+	// 0,3,0) already outranks this mixin's `.__panel { display: none }`
+	// (0,2,0), so the popover would open on click without this rule. The
+	// restated rule at 0,4,0 (the extra `.is-mode-responsive` class) is a
+	// belt-and-braces guarantee that survives any future specificity churn —
+	// adding a class higher up the chain wouldn't accidentally suppress the
+	// open state.
 	&.is-popover-open .jetpack-search-filters-popover__panel {
 		display: flex;
 	}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1402,6 +1402,23 @@ CSS;
 	align-items: center;
 	gap: 0.75rem;
 }
+/* Name the columns row as the layout container so the sidebar/popover flip
+ * tracks its inline-size. The `@media` rules below are the universal base —
+ * they fire in every browser (including legacy ones without container-query
+ * support) and they drive standalone usage outside the named container (no
+ * container ancestor → only `@media` applies). The `@container` rule further
+ * down overrides `@media` via source-order cascade at equal specificity when
+ * the named container is in scope AND narrower than 992px. The override has
+ * to undo `@media (min-width: 992px)`'s `popover { display: none }`
+ * explicitly: in the "wide viewport, narrow container" case `@media
+ * (min-width: 992px)` keeps firing on the viewport width and would otherwise
+ * leave the visitor with no filter UI at all. `@container (min-width: 992px)`
+ * isn't defined — container width is bounded by viewport width in practice,
+ * so the matching `@media (min-width: 992px)` already covers the wide case. */
+.wp-block-columns:has(> .jetpack-search-layout__filters-column) {
+	container-type: inline-size;
+	container-name: jetpack-search-layout;
+}
 /* Below 992px the right-column filter sidebar collapses to a popover trigger
  * docked next to results-sort. The trigger comes from the
  * `jetpack-search/filters-popover` block that ships in each template. The
@@ -1461,8 +1478,18 @@ CSS;
  * The `.is-layout-flex` class match bumps the columns selector to
  * specificity (0,3,0), enough to outrank any per-container `blockGap`
  * CSS WP might emit (typically (0,1,0)). The `:has(> filters-column)`
- * scope keeps these overrides off any unrelated `wp:columns` block. */
+ * scope keeps these overrides off any unrelated `wp:columns` block.
+ *
+ * The layout fine-tuning rules below (`align-items`, `margin-block-start`,
+ * overlay `padding-top`, column `padding-top`) target the columns row itself
+ * and its parent group — `@container` can't reach those from inside the
+ * named container, so they stay viewport-driven. Effect is harmless when the
+ * sidebar is collapsed via `@container` (align-items has no effect with one
+ * visible column; the margin/padding tightening is universally fine). */
 @media (min-width: 992px) {
+	/* Sidebar shown, popover-in-results-header hidden. The `@container
+	 * (max-width: 991.98px)` block below re-shows the popover when the
+	 * named container is narrower than the viewport. */
 	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
 		display: none;
 	}
@@ -1475,6 +1502,25 @@ CSS;
 	}
 	.wp-block-columns:has(> .jetpack-search-layout__filters-column) > .wp-block-column {
 		padding-top: 0.5em;
+	}
+}
+/* @container override: applies when the named container exists. Placed AFTER
+ * the `@media` rules so source-order cascade lets it win over them at equal
+ * specificity. In "wide viewport, narrow container" (the case the change is
+ * meant to fix), `@media (max-width: 991.98px)` doesn't fire but `@media
+ * (min-width: 992px)` does — this block undoes the latter's `popover {
+ * display: none }` via `display: inline-block` and hides the sidebar that
+ * the `@media (max-width)` rule wouldn't have hidden at this viewport. Same
+ * `!important` reasoning on `flex-basis: 100%` as the @media block. */
+@container jetpack-search-layout (max-width: 991.98px) {
+	.jetpack-search-layout__filters-column {
+		display: none;
+	}
+	.jetpack-search-layout__results-column {
+		flex-basis: 100% !important;
+	}
+	.jetpack-search-layout__results-header .jetpack-search-filters-popover {
+		display: inline-block;
 	}
 }
 CSS;


### PR DESCRIPTION
Fixes [SEARCH-279](https://linear.app/a8c/issue/SEARCH-279/search-blocks-container-query-the-sidebarpopover-responsive-flip)

## Why
Search Blocks decides between the filter sidebar (wide) and the collapsible-popover trigger (narrow) by querying the viewport with `@media (min-width: 992px)`. When the Search experience is embedded in a wrapper narrower than the viewport — a page-builder column, a narrow theme template part, an iframed canvas — the layout still picked the sidebar UI on a wide screen and produced a cramped 260px column. Drive the flip from the columns row's own inline-size with a container query so the layout adapts to its actual surroundings.

## Proposed changes
* Declare a named container `jetpack-search-layout` on `.wp-block-columns:has(> .jetpack-search-layout__filters-column)` — the columns row that wraps the results column and the filters column.
* Split the responsive flip into two paths:
  * `@container jetpack-search-layout (...)` — primary; fires on the columns row's inline-size.
  * `@media (...)` gated by `@supports not (container-type: inline-size)` — fallback for browsers without container-query support.
* The `@supports not` gate is what makes this work in the new "wide viewport, narrow container" case. Without it the wide-viewport `@media` would keep hiding the popover trigger (`display: none`) and the visitor would have no filter UI at all — the exact bug the change is meant to fix.
* The wide-mode layout fine-tuning rules in `class-search-blocks.php` (align-items, margin-block-start, overlay padding, column padding) stay viewport-driven — they target the columns row itself and its parent group, neither of which `@container` can reach from inside the named container declared on the row. They're harmless when the sidebar is collapsed via `@container`.
* Apply the same `@supports not` + `@container` split to the standalone `filters-popover/style.scss` `.is-mode-responsive` rule, so the standalone "popover → inline sidebar" promotion follows container width when the block is dropped inside the named container, and falls back to viewport width otherwise.

## Screenshots

The new behaviour the change unlocks — same viewport (1440 × 900), same wrapper-constrained columns row (~640px). On `trunk` the legacy `@media` still keys on the viewport, so the sidebar is forced into a cramped layout. With this change the `@container` rule sees the narrow container and flips to the popover trigger.

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/3fe88a4b-b47a-42ad-9903-f79157f93ad4) | ![after](https://github.com/user-attachments/assets/41b3c848-5466-4388-b8d3-eb84209d2172) |

Regression check — standard viewport sizes are visually unchanged.

| Wide viewport (1440px) | Narrow viewport (700px) |
|---|---|
| ![wide](https://github.com/user-attachments/assets/16985854-cdac-467a-abe9-9cab0666d2d2) | ![narrow](https://github.com/user-attachments/assets/0c55f400-198c-403f-8d8e-01a857cdfe53) |

## Related product discussion/links
* [SEARCH-279](https://linear.app/a8c/issue/SEARCH-279/search-blocks-container-query-the-sidebarpopover-responsive-flip)
* Natural follow-up to [SEARCH-225](https://linear.app/a8c/issue/SEARCH-225) (make filters-popover a responsive container) and [SEARCH-265](https://linear.app/a8c/issue/SEARCH-265) (unify responsive layout under `.jetpack-search-layout__*`).

## Does this pull request change what data or activity we track or use?
No — CSS-only behavioural change to a responsive layout flip.

## Testing instructions
Tested against all three Search Blocks templates (embedded `jetpack-search.html`, Search Blocks overlay, and the WooCommerce product-results template).

* [ ] Spin up a Search-enabled WP env and pick any of the three Search Blocks experiences (`overlay_blocks`, `embedded`, or the WooCommerce variant — the layout CSS is shared).
* [ ] Visit `/?s=hello` (or `/shop?s=hello` for the product template). At a wide viewport (≥ 992px) the sidebar shows on the right and the popover trigger in the results header is hidden — no visible change from `trunk`.
* [ ] Resize the browser below 992px. The sidebar disappears and the popover trigger appears next to the Sort By dropdown — no visible change from `trunk`.
* [ ] **The new behaviour** — at a wide viewport (e.g. 1400px), use devtools to constrain the search experience's wrapper to ~640px (e.g. force a `max-width` on the `.alignwide` group, or test inside a page-builder column narrower than 992px). On `trunk` the sidebar is forced into a cramped 260px column squeezed against the results. On this branch the `@container` query sees the narrow container, hides the sidebar, and shows the popover trigger instead.
* [ ] Confirm the popover trigger is interactive: click it and the filter panel pops out with Category / Tag / Post Type rows.
* [ ] Standalone `filters-popover` block in `.is-mode-responsive` mode, placed inside a custom block composition outside the Search templates (so no named container is in scope), still follows viewport width — same as today.
