### PR TITLE
Add Smart Dictation client secret proxy for Atomic sites and enable on Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-smart-dictation-client-secret-proxy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-smart-dictation-client-secret-proxy
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Smart Dictation: Add an endpoint to proxy client secret requests.
+Smart Dictation: Add endpoints to proxy client secret requests.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-smart-dictation-client-secret-proxy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-smart-dictation-client-secret-proxy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Smart Dictation: Add an endpoint to proxy client secret requests.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * WP_REST_WPCOM_Smart_Dictation_Client_Secret file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_WPCOM_Smart_Dictation_Client_Secret.
+ *
+ * Proxies dictation client secret requests to the WPCOM platform endpoint.
+ */
+class WP_REST_WPCOM_Smart_Dictation_Client_Secret extends \WP_REST_Controller {
+
+	/**
+	 * WP_REST_WPCOM_Smart_Dictation_Client_Secret constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = '/dictation-client-secret';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_client_secret' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'session' => array(
+						'type'     => 'object',
+						'required' => true,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Proxy the client secret request to the WPCOM platform endpoint.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_client_secret( \WP_REST_Request $request ) {
+		$session = $request->get_param( 'session' );
+
+		if ( is_object( $session ) ) {
+			$session = get_object_vars( $session );
+		}
+
+		if ( ! is_array( $session ) || ! isset( $session['instructions'] ) || ! is_string( $session['instructions'] ) ) {
+			return new \WP_Error(
+				'invalid_session',
+				'The session.instructions field is required.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/dictation-client-secret',
+			'2',
+			array( 'method' => 'POST' ),
+			array(
+				'session' => array(
+					'instructions' => $session['instructions'],
+				),
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php
@@ -17,6 +17,11 @@ use Automattic\Jetpack\Connection\Client;
 class WP_REST_WPCOM_Smart_Dictation_Client_Secret extends \WP_REST_Controller {
 
 	/**
+	 * Session keys supported by the WPCOM endpoint.
+	 */
+	private const SUPPORTED_SESSION_KEYS = array( 'instructions' );
+
+	/**
 	 * WP_REST_WPCOM_Smart_Dictation_Client_Secret constructor.
 	 */
 	public function __construct() {
@@ -33,14 +38,35 @@ class WP_REST_WPCOM_Smart_Dictation_Client_Secret extends \WP_REST_Controller {
 			$this->rest_base,
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'get_client_secret' ),
+				'callback'            => array( $this, 'create_client_secret' ),
 				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
 					'session' => array(
-						'type'     => 'object',
-						'required' => true,
+						'type'              => 'object',
+						'required'          => false,
+						'validate_callback' => array( $this, 'validate_session' ),
 					),
 				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/settle',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'settle_session' ),
+				'permission_callback' => 'is_user_logged_in',
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/remaining-time',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_remaining_time' ),
+				'permission_callback' => 'is_user_logged_in',
 			)
 		);
 	}
@@ -51,38 +77,118 @@ class WP_REST_WPCOM_Smart_Dictation_Client_Secret extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request The request sent to the API.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public function get_client_secret( \WP_REST_Request $request ) {
+	public function create_client_secret( \WP_REST_Request $request ) {
 		$session = $request->get_param( 'session' );
+		$payload = array();
+
+		if ( $request->has_param( 'session' ) ) {
+			$validation = $this->validate_session( $session );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+
+			if ( is_object( $session ) ) {
+				$session = get_object_vars( $session );
+			}
+
+			$payload['session'] = $session;
+		}
+
+		return $this->proxy_wpcom_request( '/dictation-client-secret', 'POST', $payload );
+	}
+
+	/**
+	 * Proxy the current session settlement request to the WPCOM platform endpoint.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function settle_session() {
+		return $this->proxy_wpcom_request( '/dictation-client-secret/settle', 'POST' );
+	}
+
+	/**
+	 * Proxy the remaining dictation time request to the WPCOM platform endpoint.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_remaining_time() {
+		return $this->proxy_wpcom_request( '/dictation-client-secret/remaining-time' );
+	}
+
+	/**
+	 * Validate optional session data.
+	 *
+	 * @param mixed $session Session data.
+	 * @return true|\WP_Error
+	 */
+	public function validate_session( $session ) {
+		if ( null === $session ) {
+			return true;
+		}
 
 		if ( is_object( $session ) ) {
 			$session = get_object_vars( $session );
 		}
 
-		if ( ! is_array( $session ) || ! isset( $session['instructions'] ) || ! is_string( $session['instructions'] ) ) {
-			return new \WP_Error(
-				'invalid_session',
-				'The session.instructions field is required.',
-				array( 'status' => 400 )
-			);
+		if ( ! is_array( $session ) ) {
+			return new \WP_Error( 'rest_invalid_param', 'session must be an object.' );
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
-			'/dictation-client-secret',
-			'2',
-			array( 'method' => 'POST' ),
-			array(
-				'session' => array(
-					'instructions' => $session['instructions'],
-				),
-			)
-		);
+		$unsupported_keys = array_diff( array_keys( $session ), self::SUPPORTED_SESSION_KEYS );
+		if ( ! empty( $unsupported_keys ) ) {
+			return new \WP_Error( 'rest_invalid_param', 'session contains unsupported fields.' );
+		}
+
+		if ( isset( $session['instructions'] ) && ! is_string( $session['instructions'] ) ) {
+			return new \WP_Error( 'rest_invalid_param', 'session.instructions must be a string.' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Proxy a request to the WPCOM platform endpoint.
+	 *
+	 * @param string     $path   The WPCOM endpoint path.
+	 * @param string     $method The request method.
+	 * @param array|null $data   Optional request body data.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	private function proxy_wpcom_request( $path, $method = 'GET', $data = null ) {
+		$request_args = array( 'method' => $method );
+
+		if ( null === $data ) {
+			$body = Client::wpcom_json_api_request_as_user(
+				$path,
+				'2',
+				$request_args
+			);
+		} else {
+			$body = Client::wpcom_json_api_request_as_user(
+				$path,
+				'2',
+				$request_args,
+				$data
+			);
+		}
 
 		if ( is_wp_error( $body ) ) {
 			return $body;
 		}
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
+		$status   = wp_remote_retrieve_response_code( $body );
 
-		return rest_ensure_response( $response );
+		return new \WP_REST_Response( $response, $status ? $status : 200 );
+	}
+
+	/**
+	 * Backwards-compatible alias for the original callback name.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_client_secret( \WP_REST_Request $request ) {
+		return $this->create_client_secret( $request );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php
@@ -5,7 +5,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-namespace A8C\FSE;
+namespace A8C\WPCOM_DICTATION;
 
 use Automattic\Jetpack\Connection\Client;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -5,7 +5,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-namespace A8C\FSE;
+namespace A8C\WPCOM_DICTATION;
 
 use Automattic\Jetpack\Status\Host;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -125,10 +125,6 @@ class WPCOM_Smart_Dictation {
 	 * Enqueue the Smart Dictation assets.
 	 */
 	public static function enqueue_scripts() {
-		if ( ! ( new Host() )->is_wpcom_simple() ) {
-			return;
-		}
-
 		if ( self::is_block_editor() && 'en' === self::determine_iso_639_locale() && ( self::is_proxied() || self::current_user_is_in_paid_rollout() ) ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/wpcom-smart-dictation/wpcom-smart-dictation.asset.json' );
 			$is_a11n    = function_exists( '\is_automattician' ) && \is_automattician();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -23,6 +23,20 @@ class WPCOM_Smart_Dictation {
 	 */
 	public static function init() {
 		add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_scripts' ), 100 );
+		add_action( 'rest_api_init', array( self::class, 'register_rest_api' ) );
+	}
+
+	/**
+	 * Register the Smart Dictation endpoints.
+	 */
+	public static function register_rest_api() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		require_once __DIR__ . '/class-wp-rest-wpcom-smart-dictation-client-secret.php';
+		$controller = new WP_REST_WPCOM_Smart_Dictation_Client_Secret();
+		$controller->register_rest_route();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php
@@ -5,7 +5,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-namespace A8C\FSE;
+namespace A8C\WPCOM_DICTATION;
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -15,7 +15,7 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-smart-dictation/cla
 /**
  * Class WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test
  *
- * @covers \A8C\FSE\WP_REST_WPCOM_Smart_Dictation_Client_Secret
+ * @covers \A8C\WPCOM_DICTATION\WP_REST_WPCOM_Smart_Dictation_Client_Secret
  */
 #[CoversClass( WP_REST_WPCOM_Smart_Dictation_Client_Secret::class )]
 class WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test extends \WorDBless\BaseTestCase {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * WP_REST_WPCOM_Smart_Dictation_Client_Secret Tests File
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php';
+
+/**
+ * Class WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test
+ *
+ * @covers \A8C\FSE\WP_REST_WPCOM_Smart_Dictation_Client_Secret
+ */
+#[CoversClass( WP_REST_WPCOM_Smart_Dictation_Client_Secret::class )]
+class WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * The controller instance.
+	 *
+	 * @var WP_REST_WPCOM_Smart_Dictation_Client_Secret
+	 */
+	private $controller;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->controller = new WP_REST_WPCOM_Smart_Dictation_Client_Secret();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that the constructor sets the correct namespace.
+	 */
+	public function test_constructor_sets_correct_namespace() {
+		$reflection = new \ReflectionClass( $this->controller );
+		$property   = $reflection->getProperty( 'namespace' );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
+
+		$this->assertEquals( 'wpcom/v2', $property->getValue( $this->controller ) );
+	}
+
+	/**
+	 * Tests that the constructor sets the correct rest_base.
+	 */
+	public function test_constructor_sets_correct_rest_base() {
+		$reflection = new \ReflectionClass( $this->controller );
+		$property   = $reflection->getProperty( 'rest_base' );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
+
+		$this->assertEquals( '/dictation-client-secret', $property->getValue( $this->controller ) );
+	}
+
+	/**
+	 * Tests that register_rest_route registers the expected route.
+	 */
+	public function test_register_rest_route_registers_route() {
+		$this->controller->register_rest_route();
+
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/wpcom/v2/dictation-client-secret', $routes );
+	}
+
+	/**
+	 * Tests that the POST endpoint requires authentication.
+	 */
+	public function test_post_endpoint_requires_authentication() {
+		$this->controller->register_rest_route();
+
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/wpcom/v2/dictation-client-secret'];
+
+		$post_endpoint = null;
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['methods']['POST'] ) && $endpoint['methods']['POST'] ) {
+				$post_endpoint = $endpoint;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $post_endpoint );
+		$this->assertEquals( 'is_user_logged_in', $post_endpoint['permission_callback'] );
+	}
+
+	/**
+	 * Tests that the endpoint validates session instructions.
+	 */
+	public function test_get_client_secret_requires_session_instructions() {
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/dictation-client-secret' );
+		$request->set_param( 'session', array() );
+
+		$response = $this->controller->get_client_secret( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'invalid_session', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Tests that the endpoint validates object session instructions.
+	 */
+	public function test_get_client_secret_requires_object_session_instructions() {
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/dictation-client-secret' );
+		$request->set_param( 'session', (object) array() );
+
+		$response = $this->controller->get_client_secret( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'invalid_session', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Tests that the controller extends WP_REST_Controller.
+	 */
+	public function test_controller_extends_wp_rest_controller() {
+		$this->assertInstanceOf( \WP_REST_Controller::class, $this->controller );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php
@@ -72,63 +72,84 @@ class WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Tests that register_rest_route registers the expected route.
+	 * Tests that register_rest_route registers the expected routes.
 	 */
-	public function test_register_rest_route_registers_route() {
+	public function test_register_rest_route_registers_routes() {
 		$this->controller->register_rest_route();
 
 		$routes = rest_get_server()->get_routes();
 
 		$this->assertArrayHasKey( '/wpcom/v2/dictation-client-secret', $routes );
+		$this->assertArrayHasKey( '/wpcom/v2/dictation-client-secret/settle', $routes );
+		$this->assertArrayHasKey( '/wpcom/v2/dictation-client-secret/remaining-time', $routes );
 	}
 
 	/**
-	 * Tests that the POST endpoint requires authentication.
+	 * Tests that the endpoints require authentication.
 	 */
-	public function test_post_endpoint_requires_authentication() {
+	public function test_endpoints_require_authentication() {
 		$this->controller->register_rest_route();
 
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/wpcom/v2/dictation-client-secret'];
+		$routes             = rest_get_server()->get_routes();
+		$expected_endpoints = array(
+			'/wpcom/v2/dictation-client-secret'        => 'POST',
+			'/wpcom/v2/dictation-client-secret/settle' => 'POST',
+			'/wpcom/v2/dictation-client-secret/remaining-time' => 'GET',
+		);
 
-		$post_endpoint = null;
-		foreach ( $route_data as $endpoint ) {
-			if ( isset( $endpoint['methods']['POST'] ) && $endpoint['methods']['POST'] ) {
-				$post_endpoint = $endpoint;
-				break;
+		foreach ( $expected_endpoints as $route => $method ) {
+			$route_endpoint = null;
+			foreach ( $routes[ $route ] as $endpoint ) {
+				if ( isset( $endpoint['methods'][ $method ] ) && $endpoint['methods'][ $method ] ) {
+					$route_endpoint = $endpoint;
+					break;
+				}
 			}
+
+			$this->assertNotNull( $route_endpoint );
+			$this->assertEquals( 'is_user_logged_in', $route_endpoint['permission_callback'] );
 		}
-
-		$this->assertNotNull( $post_endpoint );
-		$this->assertEquals( 'is_user_logged_in', $post_endpoint['permission_callback'] );
 	}
 
 	/**
-	 * Tests that the endpoint validates session instructions.
+	 * Tests that the endpoint allows optional session instructions.
 	 */
-	public function test_get_client_secret_requires_session_instructions() {
-		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/dictation-client-secret' );
-		$request->set_param( 'session', array() );
-
-		$response = $this->controller->get_client_secret( $request );
-
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertSame( 'invalid_session', $response->get_error_code() );
-		$this->assertSame( 400, $response->get_error_data()['status'] );
+	public function test_validate_session_allows_optional_instructions() {
+		$this->assertTrue( $this->controller->validate_session( null ) );
+		$this->assertTrue( $this->controller->validate_session( array() ) );
+		$this->assertTrue( $this->controller->validate_session( array( 'instructions' => 'Write clearly.' ) ) );
 	}
 
 	/**
-	 * Tests that the endpoint validates object session instructions.
+	 * Tests that the endpoint rejects unsupported session fields.
 	 */
-	public function test_get_client_secret_requires_object_session_instructions() {
+	public function test_create_client_secret_rejects_unsupported_session_fields() {
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/dictation-client-secret' );
-		$request->set_param( 'session', (object) array() );
+		$request->set_param(
+			'session',
+			array(
+				'instructions' => 'Write clearly.',
+				'voice'        => 'alloy',
+			)
+		);
 
-		$response = $this->controller->get_client_secret( $request );
+		$response = $this->controller->create_client_secret( $request );
 
 		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertSame( 'invalid_session', $response->get_error_code() );
-		$this->assertSame( 400, $response->get_error_data()['status'] );
+		$this->assertSame( 'rest_invalid_param', $response->get_error_code() );
+	}
+
+	/**
+	 * Tests that the endpoint rejects invalid session instructions.
+	 */
+	public function test_create_client_secret_rejects_non_string_session_instructions() {
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/dictation-client-secret' );
+		$request->set_param( 'session', array( 'instructions' => array() ) );
+
+		$response = $this->controller->create_client_secret( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'rest_invalid_param', $response->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
* Add a `wpcom/v2/dictation-client-secret` REST proxy for the Smart Dictation app request.
* Validate `session.instructions` before forwarding the request to the WPCOM API v2 `/dictation-client-secret` endpoint.
* Add focused REST controller coverage and a jetpack-mu-wpcom changelog entry.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No. This adds a proxy for an existing Smart Dictation client secret request and does not add tracking.

## Testing instructions
* Run `composer -d projects/packages/jetpack-mu-wpcom phpunit -- tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php`.
* Run `composer phpcs:lint -- projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wp-rest-wpcom-smart-dictation-client-secret.php projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php`.
* Confirm the Smart Dictation app can POST to `/wp-json/wpcom/v2/dictation-client-secret` with `session.instructions` in the body.