### PR TITLE
React 19 audit: fix `render`/`inert` callsites in mu-wpcom & publicize

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-17270-react-19-upgrade-audit-mu-wpcom-global-styles-and-dashboard
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-17270-react-19-upgrade-audit-mu-wpcom-global-styles-and-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Global Styles: migrate the limited-styles notice mount to React 18 createRoot for React 19 compatibility.

--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-site-management-widget-iframe-inert
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-site-management-widget-iframe-inert
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOM Site Management widget: mark the iframe `inert` attribute for the upcoming React 19 migration.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/index.js
@@ -7,6 +7,10 @@ const WpcomSiteManagementWidget = ( { siteName, siteUrl, siteIconUrl, isBlockThe
 		<>
 			<div className="wpcom_site_preview_wrapper">
 				<div className="wpcom_site_preview">
+					{ /* TODO(react-19): switch `inert="true"` to bare `inert` (boolean)
+					     when Gutenberg bumps to React 19. React 18 strips boolean
+					     `inert` and warns, so the string form is the only one that
+					     renders here today. */ }
 					<iframe
 						loading="lazy"
 						title="Site Preview"

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/notices.js
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { render, useCallback, useEffect, useState } from '@wordpress/element';
+import { createRoot, useCallback, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { wpcomTrackEvent } from '../../common/tracks';
 import { useCanvas } from './use-canvas';
@@ -64,20 +64,10 @@ function GlobalStylesWarningNotice() {
  */
 function GlobalStylesViewNotice() {
 	const { canvas } = useCanvas();
-	const [ isRendered, setIsRendered ] = useState( false );
 	const { globalStylesInUse } = useGlobalStylesConfig();
 
 	useEffect( () => {
-		if ( ! globalStylesInUse ) {
-			document.querySelector( `.${ GLOBAL_STYLES_VIEW_NOTICE_SELECTOR }` )?.remove();
-			setIsRendered( false );
-			return;
-		}
-
-		if ( isRendered ) {
-			return;
-		}
-		if ( canvas !== 'view' ) {
+		if ( ! globalStylesInUse || canvas !== 'view' ) {
 			return;
 		}
 
@@ -88,15 +78,18 @@ function GlobalStylesViewNotice() {
 
 		// Insert the notice as a sibling of the save hub instead of as a child,
 		// to prevent our notice from breaking the flex styles of the hub.
-		const container = saveHub.parentNode;
 		const noticeContainer = document.createElement( 'div' );
 		noticeContainer.classList.add( GLOBAL_STYLES_VIEW_NOTICE_SELECTOR );
-		container.insertBefore( noticeContainer, saveHub );
+		saveHub.parentNode.insertBefore( noticeContainer, saveHub );
 
-		render( <GlobalStylesWarningNotice />, noticeContainer );
+		const root = createRoot( noticeContainer );
+		root.render( <GlobalStylesWarningNotice /> );
 
-		setIsRendered( true );
-	}, [ isRendered, canvas, globalStylesInUse ] );
+		return () => {
+			root.unmount();
+			noticeContainer.remove();
+		};
+	}, [ canvas, globalStylesInUse ] );
 
 	return null;
 }

--- a/projects/packages/publicize/_inc/components/connection-management/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/index.tsx
@@ -65,7 +65,13 @@ const ConnectionManagement = ( {
 	return (
 		<div
 			className={ clsx( listStyles.wrapper, className ) }
-			// @ts-expect-error inert propery is not yet in react types
+			// TODO(react-19): React 18 strips boolean `inert` and warns; the
+			// string form below is the only one that renders in React 18.
+			// When Gutenberg bumps to React 19, switch this to
+			// `inert={ disabled || undefined }` and remove the
+			// `@ts-expect-error` (which `inert` will satisfy once it lands in
+			// the stable `@types/react` HTMLAttributes interface).
+			// @ts-expect-error inert property is not yet in react types
 			inert={ disabled ? 'true' : undefined }
 		>
 			{ connections.length ? (

--- a/projects/packages/publicize/changelog/connection-management-iframe-inert
+++ b/projects/packages/publicize/changelog/connection-management-iframe-inert
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection management: mark the `inert` attribute on the wrapper for the upcoming React 19 migration.


### PR DESCRIPTION
Fixes DOTCOM-17270

## Proposed changes
React 19 upgrade audit follow-up. One real fix; two TODO markers for migrations that have to ride alongside the actual React 19 bump.

* **Global Styles (`jetpack-mu-wpcom`)** — `wpcom-global-styles/notices.js` was mounting the limited-styles notice with the legacy `render` from `@wordpress/element`, which delegates to `react-dom`'s legacy entry point removed in React 19. Migrated to `createRoot().render()` and moved teardown (`root.unmount()` + container `.remove()`) into the `useEffect` cleanup return; the `isRendered` state and the manual DOM-removal branch are gone.
* **WPCOM Site Management widget (`jetpack-mu-wpcom`)** — added a `TODO(react-19)` marker at the preview iframe's `inert="true"` attribute. **No attribute change applied** — verified that React 18.3 strips boolean `inert` and warns, so the string form is the only one that renders today.
* **Publicize** — fixed a "propery" -> "property" typo in the existing `@ts-expect-error` comment on the connection-management wrapper, and added a `TODO(react-19)` marker at the `inert` site (same React 18 reasoning as above).

### Why the inert migration was deferred
The audit recommended `inert={ disabled || undefined }` / bare `inert`, which is correct *for React 19*. Empirically (Node + `react@18.3.1` + `react-dom/server`):
```
boolean true:    <div></div>          (stripped, warns)
boolean false:   <div></div>          (stripped)
string "true":   <div inert="true">   renders
```
i.e., the boolean form would have silently broken the `disabled` UX on both surfaces. Both inert sites carry `TODO(react-19)` markers so the migration isn't lost; DOTCOM-17270 tracks the audit work end-to-end.

### Behavior change worth flagging
In the Global Styles fix, the view-canvas notice will now unmount when the canvas leaves `'view'` and remount when it returns. Previously the `isRendered` guard caused it to linger after a canvas switch — that was almost certainly unintentional.

## Related product discussion/links
* DOTCOM-17270 (React 19 upgrade audit)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Global Styles notice (site editor)
1. On a site without a premium plan, open the site editor.
2. Apply a premium global style (e.g. a non-default color palette).
3. Confirm the upgrade warning notice appears as a sibling of the `.edit-site-save-hub` in the view canvas.
4. Reset the premium styles — confirm the notice disappears cleanly (no React console warnings about unmounted roots).
5. Re-apply premium styles — confirm the notice mounts again.
6. Switch the canvas from `view` to `edit` and back — confirm the notice unmounts when leaving `view` and remounts when returning (intentional semantics change).

### WPCOM Site Management widget & Publicize (no behavioral change — code comments / typo only)
* `git diff trunk..HEAD` and confirm both inert sites carry only the TODO comment plus, in publicize, a single-character typo fix in the existing `@ts-expect-error` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)