### PR TITLE
Sync: Fix PHP warnings from null/undefined access in 6 modules

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-php-warnings
+++ b/projects/packages/sync/changelog/fix-sync-php-warnings
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Sync: Fix PHP warnings from undefined array keys, null property access, and deprecated null arguments across multiple sync modules.

--- a/projects/packages/sync/changelog/fix-sync-php-warnings
+++ b/projects/packages/sync/changelog/fix-sync-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sync: Fix PHP warnings from undefined array keys, null property access, and deprecated null arguments across multiple sync modules.

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -561,9 +561,12 @@ class Queue {
 		);
 
 		if ( $checkout_value ) {
-			list( $checkout_id, $timestamp ) = explode( ':', $checkout_value );
-			if ( (int) $timestamp > time() ) {
-				return $checkout_id;
+			$parts = explode( ':', $checkout_value, 2 );
+			if ( count( $parts ) === 2 ) {
+				list( $checkout_id, $timestamp ) = $parts;
+				if ( (int) $timestamp > time() ) {
+					return $checkout_id;
+				}
 			}
 		}
 

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -241,12 +241,12 @@ class Comments extends Module {
 		if ( isset( $args[1] ) ) {
 			// comment object is available.
 			$comment = $args[1];
-		} elseif ( is_numeric( $args[0] ) ) {
+		} elseif ( isset( $args[0] ) && is_numeric( $args[0] ) ) {
 			// comment_id is available.
 			$comment = get_comment( $args[0] );
 		}
 
-		if ( ! isset( $comment->comment_type ) || ! is_string( $comment->comment_type ) ) {
+		if ( ! $comment instanceof \WP_Comment ) {
 			return false;
 		}
 

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -232,6 +232,10 @@ class Comments extends Module {
 	 * @return bool or array $args Arguments passed to wp_insert_comment, deleted_comment, spammed_comment, etc.
 	 */
 	public function only_allow_white_listed_comment_types( $args ) {
+		if ( empty( $args ) ) {
+			return false;
+		}
+
 		$comment = false;
 
 		if ( isset( $args[1] ) ) {
@@ -242,10 +246,11 @@ class Comments extends Module {
 			$comment = get_comment( $args[0] );
 		}
 
-		if (
-			isset( $comment->comment_type )
-			&& ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true )
-		) {
+		if ( ! isset( $comment->comment_type ) || ! is_string( $comment->comment_type ) ) {
+			return false;
+		}
+
+		if ( ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
 			return false;
 		}
 

--- a/projects/packages/sync/src/modules/class-menus.php
+++ b/projects/packages/sync/src/modules/class-menus.php
@@ -142,7 +142,7 @@ class Menus extends Module {
 	 * @param \WP_Post $post_after  Nav menu item post object after the update.
 	 */
 	public function remove_just_added_menu_item( $nav_item_id, $post_after ) {
-		if ( ! isset( $post_after->post_type ) || 'nav_menu_item' !== $post_after->post_type ) {
+		if ( ! $post_after instanceof \WP_Post || 'nav_menu_item' !== $post_after->post_type ) {
 			return;
 		}
 		$this->nav_items_just_added = array_diff( $this->nav_items_just_added, array( $nav_item_id ) );

--- a/projects/packages/sync/src/modules/class-menus.php
+++ b/projects/packages/sync/src/modules/class-menus.php
@@ -142,7 +142,7 @@ class Menus extends Module {
 	 * @param \WP_Post $post_after  Nav menu item post object after the update.
 	 */
 	public function remove_just_added_menu_item( $nav_item_id, $post_after ) {
-		if ( 'nav_menu_item' !== $post_after->post_type ) {
+		if ( ! isset( $post_after->post_type ) || 'nav_menu_item' !== $post_after->post_type ) {
 			return;
 		}
 		$this->nav_items_just_added = array_diff( $this->nav_items_just_added, array( $nav_item_id ) );

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -181,7 +181,7 @@ class Meta extends Module {
 	private function get_prepared_meta_object( $object_type, $meta_entry ) {
 		$object_id_column = $object_type . '_id';
 
-		if ( 'post' === $object_type && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_META_LENGTH ) {
+		if ( 'post' === $object_type && isset( $meta_entry['meta_value'] ) && is_string( $meta_entry['meta_value'] ) && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_META_LENGTH ) {
 			$meta_entry['meta_value'] = '';
 		}
 

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -301,7 +301,11 @@ class Terms extends Module {
 	 * @return array|boolean False if not whitelisted, the original hook args otherwise.
 	 */
 	public function filter_blacklisted_taxonomies( $args ) {
-		$term = $args[0];
+		$term = $args[0] ?? null;
+
+		if ( ! isset( $term->taxonomy ) || ! is_string( $term->taxonomy ) ) {
+			return false;
+		}
 
 		if ( in_array( $term->taxonomy, Settings::get_setting( 'taxonomies_blacklist' ), true ) ) {
 			return false;

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -303,7 +303,7 @@ class Terms extends Module {
 	public function filter_blacklisted_taxonomies( $args ) {
 		$term = $args[0] ?? null;
 
-		if ( ! isset( $term->taxonomy ) || ! is_string( $term->taxonomy ) ) {
+		if ( ! $term instanceof \WP_Term ) {
 			return false;
 		}
 

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -192,6 +192,9 @@ class Themes extends Module {
 		}
 
 		$query_params = array();
+		if ( ! isset( $url['query'] ) ) {
+			return $redirect_url;
+		}
 		wp_parse_str( $url['query'], $query_params );
 		if (
 			! isset( $_POST['newcontent'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Missing -- 'wp_redirect' gets fired for a lot of things. We're only using $_POST['newcontent'] to limit action to redirects from theme edits, we're not doing anything with or in response to the post itself.

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -187,14 +187,11 @@ class Themes extends Module {
 		$url              = wp_parse_url( admin_url( $redirect_url ) );
 		$theme_editor_url = wp_parse_url( admin_url( 'theme-editor.php' ) );
 
-		if ( $theme_editor_url['path'] !== $url['path'] ) {
+		if ( ! isset( $url['query'] ) || $theme_editor_url['path'] !== $url['path'] ) {
 			return $redirect_url;
 		}
 
 		$query_params = array();
-		if ( ! isset( $url['query'] ) ) {
-			return $redirect_url;
-		}
 		wp_parse_str( $url['query'], $query_params );
 		if (
 			! isset( $_POST['newcontent'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Missing -- 'wp_redirect' gets fired for a lot of things. We're only using $_POST['newcontent'] to limit action to redirects from theme edits, we're not doing anything with or in response to the post itself.

--- a/projects/plugins/jetpack/changelog/fix-sync-php-warnings
+++ b/projects/plugins/jetpack/changelog/fix-sync-php-warnings
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Sync: Add regression test for malformed queue lock values.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Queue_Test.php
@@ -347,6 +347,31 @@ class Jetpack_Sync_Queue_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( 'foo' ), $other_queue->checkout( 5 )->get_item_values() );
 	}
 
+	public function test_malformed_checkout_value_treated_as_expired() {
+		global $wpdb;
+
+		$this->queue->add( 'foo' );
+
+		// Simulate a corrupted lock value (no colon separator).
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )
+				ON DUPLICATE KEY UPDATE option_value = VALUES(option_value)",
+				'jpsq_my_queue_checkout',
+				'malformed_no_colon'
+			)
+		);
+
+		// The queue should treat the malformed value as expired and not be locked.
+		$this->assertFalse( $this->queue->is_locked() );
+
+		// Checkout should succeed since the malformed lock is treated as expired.
+		$buffer = $this->queue->checkout( 5 );
+		$this->assertNotFalse( $buffer );
+		$this->assertFalse( is_wp_error( $buffer ) );
+		$this->assertEquals( array( 'foo' ), $buffer->get_item_values() );
+	}
+
 	public function test_benchmark() {
 		$this->markTestIncomplete( "We don't want to run this every time" );
 		// @phan-suppress-next-line PhanPluginUnreachableCode


### PR DESCRIPTION
Fixes SYNC-343

## Proposed changes

Fix 6 PHP warnings in the Sync package that together account for ~15% of Jetpack-related warnings on WP Cloud (p1778873257341169-slack-C05PV073SG3).

All fixes are defensive checks at system boundaries where data from WordPress hooks or the database may be null, missing, or malformed.

### 1. `class-themes.php:195` — Undefined array key `"query"` (~5000/month)

`wp_parse_url()` on a redirect URL that has no query string returns no `query` key. The code accessed `$url['query']` without checking.

**Fix:** Early return if `$url['query']` is not set — no query string means this isn't a theme editor redirect.

### 2. `class-queue.php:564` — Undefined array key `1` (~3500/month)

The sync queue lock stores `"{checkout_id}:{expires_timestamp}"` in `wp_options`. On high-traffic sites, the stored value can become malformed (missing the colon separator), likely due to a corrupted write or stale value from an older code path. `explode(':')` then returns a single-element array, and `list($id, $ts)` fails accessing index 1.

**Fix:** Validate `explode()` returns exactly 2 parts before destructuring; treat malformed values as expired locks.

### 3. `class-menus.php:145` — Attempt to read property `"post_type"` on null

The `post_updated` hook can pass a null `$post_after` if the post was deleted between hook scheduling and callback execution.

**Fix:** Guard with `isset($post_after->post_type)` before accessing.

### 4. `class-terms.php:306` — Attempt to read property `"taxonomy"` on false

The sync filter receives `$args[0]` which is expected to be a term object, but can be `false` (deleted/invalid term).

**Fix:** Guard with `isset($term->taxonomy) && is_string($term->taxonomy)`; return `false` (drop the event) if malformed — don't sync bad data.

### 5. `class-comments.php:240` — Undefined array key `0`

The whitelist filter receives `$args` which can be an empty array when a sync event is enqueued with no arguments.

**Fix:** Early return `false` on empty `$args`. Also validate `$comment->comment_type` is set and is a string before checking the whitelist — same defensive pattern as the terms fix.

### 6. `class-meta.php:184` — `strlen()` on null (deprecated in PHP 8.1+)

`$meta_entry['meta_value']` can be `NULL` in the database. `strlen(null)` triggers a deprecation warning.

**Fix:** Guard with `isset() && is_string()` before `strlen()`.

## Related product discussion/links

* p1778873257341169-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?

No. These are defensive null/type checks only — no changes to what data is synced. Malformed events that would have triggered warnings are now silently dropped (terms, comments) or treated as expired (queue lock).

## Testing instructions

* Code review