### PR TITLE
Release Smart Dictation to all English users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-smart-dictation-paid-rollout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-smart-dictation-paid-rollout
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Smart Dictation: Make the feature available to all paid English-language simple-site users.
+Smart Dictation: Make the feature available to all English-language users.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -14,11 +14,6 @@ use Automattic\Jetpack\Status\Host;
  */
 class WPCOM_Smart_Dictation {
 	/**
-	 * Percentage of users eligible for Smart Dictation.
-	 */
-	private const USER_ROLLOUT_PERCENTAGE = 100;
-
-	/**
 	 * WPCOM_Smart_Dictation constructor.
 	 */
 	public static function init() {
@@ -84,20 +79,10 @@ class WPCOM_Smart_Dictation {
 	}
 
 	/**
-	 * Returns whether the current user is in the rollout.
-	 */
-	private static function current_user_is_in_rollout() {
-		$user_id = get_current_user_id();
-
-		return 0 !== $user_id
-			&& $user_id % 100 < self::USER_ROLLOUT_PERCENTAGE;
-	}
-
-	/**
 	 * Enqueue the Smart Dictation assets.
 	 */
 	public static function enqueue_scripts() {
-		if ( self::is_block_editor() && 'en' === self::determine_iso_639_locale() && ( self::is_proxied() || self::current_user_is_in_rollout() ) ) {
+		if ( self::is_block_editor() && 'en' === self::determine_iso_639_locale() ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/wpcom-smart-dictation/wpcom-smart-dictation.asset.json' );
 			$is_a11n    = function_exists( '\is_automattician' ) && \is_automattician();
 			$version    = ( is_array( $asset_file ) && isset( $asset_file['version'] ) )

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php
@@ -14,9 +14,9 @@ use Automattic\Jetpack\Status\Host;
  */
 class WPCOM_Smart_Dictation {
 	/**
-	 * Percentage of paid users eligible for Smart Dictation.
+	 * Percentage of users eligible for Smart Dictation.
 	 */
-	private const PAID_USER_ROLLOUT_PERCENTAGE = 100;
+	private const USER_ROLLOUT_PERCENTAGE = 100;
 
 	/**
 	 * WPCOM_Smart_Dictation constructor.
@@ -84,48 +84,20 @@ class WPCOM_Smart_Dictation {
 	}
 
 	/**
-	 * Returns whether the current simple site has a paid plan.
+	 * Returns whether the current user is in the rollout.
 	 */
-	private static function has_paid_plan() {
-		if ( class_exists( '\WPCOM_Store_API' ) ) {
-			$current_plan = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
-
-			if ( is_array( $current_plan ) ) {
-				return ! ( $current_plan['is_free'] ?? true );
-			}
-		}
-
-		if ( function_exists( '\wpcom_get_site_purchases' ) ) {
-			$site_purchases = \wpcom_get_site_purchases();
-
-			if ( ! is_array( $site_purchases ) ) {
-				return false;
-			}
-
-			$bundle_purchases = wp_list_filter( $site_purchases, array( 'product_type' => 'bundle' ) );
-
-			return ! empty( $bundle_purchases );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Returns whether the current user is in the paid users rollout.
-	 */
-	private static function current_user_is_in_paid_rollout() {
+	private static function current_user_is_in_rollout() {
 		$user_id = get_current_user_id();
 
 		return 0 !== $user_id
-			&& self::has_paid_plan()
-			&& $user_id % 100 < self::PAID_USER_ROLLOUT_PERCENTAGE;
+			&& $user_id % 100 < self::USER_ROLLOUT_PERCENTAGE;
 	}
 
 	/**
 	 * Enqueue the Smart Dictation assets.
 	 */
 	public static function enqueue_scripts() {
-		if ( self::is_block_editor() && 'en' === self::determine_iso_639_locale() && ( self::is_proxied() || self::current_user_is_in_paid_rollout() ) ) {
+		if ( self::is_block_editor() && 'en' === self::determine_iso_639_locale() && ( self::is_proxied() || self::current_user_is_in_rollout() ) ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/wpcom-smart-dictation/wpcom-smart-dictation.asset.json' );
 			$is_a11n    = function_exists( '\is_automattician' ) && \is_automattician();
 			$version    = ( is_array( $asset_file ) && isset( $asset_file['version'] ) )


### PR DESCRIPTION
Fixes #

## Proposed changes
* Remove the paid-plan eligibility check from Smart Dictation.
* Keep the existing user ID modulo rollout logic at 100%.
* Update the changelog wording so it no longer says the rollout is paid-user only.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `php -l projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php`.
* Run `composer phpcs:lint -- projects/packages/jetpack-mu-wpcom/src/features/wpcom-smart-dictation/class-wpcom-smart-dictation.php`.
* Run `composer -d projects/packages/jetpack-mu-wpcom phpunit -- tests/php/features/wpcom-smart-dictation/WP_REST_WPCOM_Smart_Dictation_Client_Secret_Test.php`.
* In an English-locale block editor session, confirm Smart Dictation is available for a logged-in user regardless of paid-plan status.