### PR TITLE
Custom CSS: stop PHP 8 fatal on stray '}' in LESS input

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-custom-css-lessc-stray-brace-fatal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-custom-css-lessc-stray-brace-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom CSS: stop PHP 8 fatal when LESS input contains a stray closing brace.

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/preprocessors/lessc.inc.php
@@ -2527,6 +2527,11 @@ class lessc_parser {
 				$block = null; // Rector.
 			}
 
+			if ($this->env === null) {
+				$this->seek($s);
+				$this->throwError("unexpected '}'");
+			}
+
 			$hidden = false;
 			if (is_null($block->type)) {
 				$hidden = true;


### PR DESCRIPTION
Fixes p1779979261318439-slack-C04DZ8M0GHW

## Proposed changes
* `lessc` parser: when an unbalanced `}` pops the root block (leaving `env=null`), throw a parse error at that point instead of letting the next `env->` access fatal under PHP 8 (`Uncaught Error: Attempt to modify property "props" on null` and related null-property accesses at `:2382`, `:2544`, `:2688`). The thrown exception is handled by `jetpack_less_css_preprocess()`'s existing `try`/`catch`, which returns the input unchanged.
* No behavior change for valid LESS input.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Prerequisites: 
 * Add the below to tools/docker/mu-plugins/enable-custom-css-less.php to activate custom css on your local docker install:
```
<?php
add_action('plugins_loaded', function() {
    $base_path = '/usr/local/src/jetpack-monorepo/projects/packages/jetpack-mu-wpcom/src/features/custom-css';
    require_once $base_path . '/custom-css/preprocessors.php';
    require_once $base_path . '/custom-css.php';
}, 5);
```
 * In Custom CSS (Appearance → Customize → Additional CSS), select **LESS** as the preprocessor.

1. Save each of the following malformed inputs in turn. Each previously produced a PHP fatal on save under PHP 8; after this change, the save should complete cleanly and `wp-content/debug.log` should not contain `Attempt to modify property "props" on null`:
   * `}`
   * `}` followed by `color: red;`
   * `}` followed by `a { color: red; }`
   * Two valid rules with an extra `}` between them, e.g.
     ```less
     a { color: red; }
     }
     b { color: blue; }
     ```
   * A realistic typo:
     ```less
     }

     p.wp-block-paragraph { text-decoration: underline; color: blue; }
     ```
   The downstream `csstidy`/`safecss` sanitizer will still discard the malformed CSS so the rule won't take visual effect — that is unchanged and expected.
2. Save valid LESS, e.g. `a { color: red; b { color: blue; } }`, and confirm it compiles to `a { color: red; }` and `a b { color: blue; }` as before.