### PR TITLE
Instagram Gallery Block: Prevent PHP warnings when cached object is malformed

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -73,8 +73,9 @@ class Jetpack_Instagram_Gallery_Helper {
 		$cached_gallery = get_transient( $transient_key );
 		if ( $cached_gallery ) {
 			$decoded_cached_gallery = json_decode( $cached_gallery );
-			// `images` can be an array of images or a string 'ERROR'.
-			$cached_count = is_array( $decoded_cached_gallery->images ) ? count( $decoded_cached_gallery->images ) : 0;
+			// Assuming the json_decode succeeds, `images` can be an array of images or a string 'ERROR'.
+			$cached_images = isset( $decoded_cached_gallery->images ) ? $decoded_cached_gallery->images : null;
+			$cached_count  = is_array( $cached_images ) ? count( $cached_images ) : 0;
 			if ( $cached_count >= $count ) {
 				return $decoded_cached_gallery;
 			}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -74,7 +74,7 @@ class Jetpack_Instagram_Gallery_Helper {
 		if ( $cached_gallery ) {
 			$decoded_cached_gallery = json_decode( $cached_gallery );
 			// Assuming the json_decode succeeds, `images` can be an array of images or a string 'ERROR'.
-			$cached_images = isset( $decoded_cached_gallery->images ) ? $decoded_cached_gallery->images : null;
+			$cached_images = $decoded_cached_gallery->images ?? null;
 			$cached_count  = is_array( $cached_images ) ? count( $cached_images ) : 0;
 			if ( $cached_count >= $count ) {
 				return $decoded_cached_gallery;

--- a/projects/plugins/jetpack/changelog/fix-instagram-gallery-prevent_php_warnings
+++ b/projects/plugins/jetpack/changelog/fix-instagram-gallery-prevent_php_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Instagram Gallery Block: Prevent PHP warnings when cached object is malformed.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
If the gallery finds a cached gallery object it tries to use it. However, if it's missing the `images` property (which should be an array or string per the code comments) it gives this warning:
```
Warning: Undefined property: stdClass::$images in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/sun/_inc/lib/class-jetpack-instagram-gallery-helper.php on line 77
```

This PR handles malformed content more gracefully in the following scenarios:
* the transient fails to decode
* the `image` property doesn't exist (the original report)

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1779984006966649-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*