### PR TITLE
Admin UI: Hide WordPress core admin notices on Jetpack admin pages

### DIFF
--- a/projects/packages/admin-ui/changelog/centralize-core-notice-suppression
+++ b/projects/packages/admin-ui/changelog/centralize-core-notice-suppression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Hide WordPress core admin notices on Jetpack admin pages.

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.8.6';
+	const PACKAGE_VERSION = '0.8.7';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.
@@ -200,7 +200,48 @@ class Admin_Menu {
 		 * We know all pages will be under Jetpack top level menu page, so we can hardcode the first part of the string.
 		 * Using get_plugin_page_hookname here won't work because the top level page is not registered yet.
 		 */
-		return 'jetpack_page_' . $menu_slug;
+		$hook = 'jetpack_page_' . $menu_slug;
+
+		// Hide WordPress core admin notices on this Jetpack page. The load-<hook>
+		// action only fires when the matching screen is being rendered, so this
+		// stays scoped to Jetpack pages and reaches every page registered here.
+		add_action( 'load-' . $hook, array( __CLASS__, 'hide_core_admin_notices' ) );
+		add_action( 'load-' . $hook . '-network', array( __CLASS__, 'hide_core_admin_notices' ) );
+
+		return $hook;
+	}
+
+	/**
+	 * Queues an inline style that hides WordPress core admin notices on the current Jetpack page.
+	 *
+	 * Hooked from the page's load-<hook> action so it only runs on Jetpack screens.
+	 *
+	 * @return void
+	 */
+	public static function hide_core_admin_notices() {
+		add_action( 'admin_print_styles', array( __CLASS__, 'print_hide_core_admin_notices_style' ) );
+	}
+
+	/**
+	 * Prints the inline style that hides WordPress core admin notices.
+	 *
+	 * We only target direct children of #wpbody-content (where core renders notices via the
+	 * admin_notices / all_admin_notices hooks). This intentionally leaves JITMs untouched —
+	 * they output `.jetpack-jitm-message`, not `.notice` — and leaves in-app/React notices
+	 * untouched, since those render deeper inside `.wrap`. An inline style is used (rather than
+	 * an enqueued build asset) so it also works on older Jetpack pages that ship no stylesheet.
+	 *
+	 * @return void
+	 */
+	public static function print_hide_core_admin_notices_style() {
+		?>
+		<style id="jetpack-admin-ui-hide-core-notices">
+			#wpbody-content > .notice,
+			#wpbody-content > .update-nag,
+			#wpbody-content > .updated,
+			#wpbody-content > .error { display: none !important; }
+		</style>
+		<?php
 	}
 
 	/**

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.8.7';
+	const PACKAGE_VERSION = '0.8.6';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -190,6 +190,57 @@ class Admin_Menu_Test extends TestCase {
 	}
 
 	/**
+	 * Adding a menu registers the load hooks that hide core admin notices.
+	 *
+	 * @return void
+	 */
+	public function test_add_menu_registers_hide_core_admin_notices_hooks() {
+		$hook = Admin_Menu::add_menu( 'Test', 'Test', 'edit_posts', 'notices_menu', '__return_null' );
+
+		$this->assertSame( 'jetpack_page_notices_menu', $hook );
+		$this->assertNotFalse(
+			has_action( 'load-' . $hook, array( Admin_Menu::class, 'hide_core_admin_notices' ) ),
+			'Expected the load hook to hide core admin notices to be registered.'
+		);
+		$this->assertNotFalse(
+			has_action( 'load-' . $hook . '-network', array( Admin_Menu::class, 'hide_core_admin_notices' ) ),
+			'Expected the network-admin load hook to hide core admin notices to be registered.'
+		);
+	}
+
+	/**
+	 * Calling hide_core_admin_notices queues the inline style printer.
+	 *
+	 * @return void
+	 */
+	public function test_hide_core_admin_notices_queues_inline_style() {
+		Admin_Menu::hide_core_admin_notices();
+
+		$this->assertNotFalse(
+			has_action( 'admin_print_styles', array( Admin_Menu::class, 'print_hide_core_admin_notices_style' ) ),
+			'Expected the inline style printer to be hooked to admin_print_styles.'
+		);
+
+		remove_action( 'admin_print_styles', array( Admin_Menu::class, 'print_hide_core_admin_notices_style' ) );
+	}
+
+	/**
+	 * The printed style targets only direct-child core notices, leaving JITMs untouched.
+	 *
+	 * @return void
+	 */
+	public function test_print_hide_core_admin_notices_style_output() {
+		ob_start();
+		Admin_Menu::print_hide_core_admin_notices_style();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="jetpack-admin-ui-hide-core-notices"', $output );
+		$this->assertStringContainsString( '#wpbody-content > .notice', $output );
+		// JITMs render as `.jetpack-jitm-message`; the selector must not match them.
+		$this->assertStringNotContainsString( 'jetpack-jitm-message', $output );
+	}
+
+	/**
 	 * Tests that the first registered menu item is returned correctly.
 	 *
 	 * @return void


### PR DESCRIPTION
## Proposed changes

Centralizes suppression of WordPress core admin notices across all Jetpack standalone admin pages via a single, JITM-safe mechanism in the shared `Admin_UI` package.

* `Admin_Menu::add_menu()` now registers a `load-<hook>` (and `-network`) action for each page it registers. Since virtually every Jetpack standalone admin page (My Jetpack, Protect, Newsletter, Backup, Beta, Activity Log, Social, Search, VideoPress, Forms, etc.) registers through `add_menu()`, this reaches them all from one place.
* On those screens, an inline `<style id="jetpack-admin-ui-hide-core-notices">` hides core admin notices that core renders as **direct children** of `#wpbody-content` — `.notice`, `.update-nag`, `.updated`, `.error`.
* An **inline** style is used (not an enqueued build asset) so it also works on older Jetpack pages that ship no modern stylesheet (e.g. the old Newsletter page, the old Protect UI), with no webpack/asset dependency.

### JITM is intentionally left untouched

JITMs (Just In Time Messages) register on the same `admin_notices` hook, but they output `<div class="jetpack-jitm-message">`, **not** a `.notice`. The direct-child `.notice` selector therefore hides core notices while leaving JITM fully intact. This is why the CSS approach is used instead of `remove_all_actions( 'admin_notices' )` (the approach some pages use), which would also kill JITM. In-app/React notices that render deeper inside `.wrap` are likewise unaffected.

### Intentional scope note (please don't flag as missing)

This PR deliberately does **not** touch Backup, Forms, Scan, or Stats:

* Backup and Forms keep their existing bespoke `remove_all_actions( ... )` calls. Removing those would re-enable JITM on those pages, which is explicitly not wanted. The centralized CSS additionally covers the gaps (e.g. Backup's non-modernized state) for **core** notices, on top of those bespoke removals.
* Stats registers via a raw `add_menu_page` (not `Admin_Menu`) and is out of scope this round.
* No JITM package code or behavior is changed anywhere.

## Related product discussion/links

* Linear: JETPACK-1543 (umbrella) — sub-issues JETPACK-1640, JETPACK-1651, JETPACK-1657, JETPACK-1662, JETPACK-1668, ACTLOG-73.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Add a temporary core notice. Drop a tiny mu-plugin (or paste into `0-sandbox.php`):
   ```php
   add_action( 'admin_notices', function () {
       echo '<div class="notice notice-warning"><p>TEST CORE NOTICE</p></div>';
   } );
   ```
2. Visit a **non-Jetpack** admin page (e.g. **Plugins**) — the "TEST CORE NOTICE" should be **visible** (suppression is scoped to Jetpack pages).
3. Visit a Jetpack admin page registered via `Admin_Menu` (e.g. **Jetpack → Newsletter**, **Jetpack → Social**) — the "TEST CORE NOTICE" should be **gone**, and an inline `<style id="jetpack-admin-ui-hide-core-notices">` should be present in the page source.
4. Confirm JITM (`.jetpack-jitm-message`) still renders where it normally would — the selector does not match it. (Verified locally by injecting a `.jetpack-jitm-message` as a direct child of `#wpbody-content` on a Jetpack page; it stayed visible while the core notice was hidden.)
5. Remove the temporary notice afterward.


### Automated checks run locally

* `jetpack build packages/admin-ui` — pass
* `jetpack test php packages/admin-ui` — pass (added focused tests for the load-hook registration, the inline-style queueing, and the style output / JITM-safe selector)
* `jetpack phan packages/admin-ui` — 0 issues
* phpcs on changed files — clean
