### PR TITLE
My Jetpack: rebuild Help tab footer card with @wordpress/ui Card and Link

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
@@ -1,6 +1,6 @@
 import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
+import { Link, Text } from '@wordpress/ui';
 import { useCallback } from 'react';
 import styles from './styles.module.scss';
 import { useHelpTracking } from './use-help-tracking';
@@ -31,12 +31,12 @@ export function HelpFooter() {
 			<div className={ styles[ 'footer-inner' ] }>
 				<section>
 					<h3>{ __( 'Real humans. Real support.', 'jetpack-my-jetpack' ) }</h3>
-					<p className={ styles.description }>
+					<Text variant="body-md" render={ <p /> } className={ styles.description }>
 						{ __(
 							'We are the people behind WordPress.com, WooCommerce, Jetpack, Simplenote, and more. We believe in making the web a better place.',
 							'jetpack-my-jetpack'
 						) }
-					</p>
+					</Text>
 					<Link
 						openInNewTab
 						className={ styles[ 'footer-learn-more' ] }
@@ -53,20 +53,20 @@ export function HelpFooter() {
 						<h4>{ __( 'Useful links', 'jetpack-my-jetpack' ) }</h4>
 						<ul>
 							<li>
-								<a
+								<Link
 									href={ getAdminUrl( 'admin.php?page=jetpack_modules' ) }
 									onClick={ handleAllModulesClick }
 								>
 									{ __( 'All Jetpack modules', 'jetpack-my-jetpack' ) }
-								</a>
+								</Link>
 							</li>
 							<li>
-								<a
+								<Link
 									href={ getAdminUrl( 'admin.php?page=jetpack-debugger' ) }
 									onClick={ handleDebugInfoClick }
 								>
 									{ __( 'Debug information', 'jetpack-my-jetpack' ) }
-								</a>
+								</Link>
 							</li>
 						</ul>
 					</nav>

--- a/projects/packages/my-jetpack/changelog/fix-help-section
+++ b/projects/packages/my-jetpack/changelog/fix-help-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: use @wordpress/ui Link and Text components in the Help tab footer for consistent typography.


### PR DESCRIPTION
Before:
<img width="1209" height="1308" alt="Screenshot 2026-05-28 at 9 34 47 AM" src="https://github.com/user-attachments/assets/564a570e-e8c9-4bc9-a87c-1debd4030e28" />

After:
<img width="1367" height="1178" alt="Screenshot 2026-05-28 at 9 34 33 AM" src="https://github.com/user-attachments/assets/ceb4b275-5fe0-480e-80c3-b2dff187627a" />


## Proposed changes

Refresh the **Help** tab footer in My Jetpack (\"Real humans. Real support.\" section) so it matches the rest of the page's component library:

* Wrap the section in a `Card.Root` / `Card.Content` from `@wordpress/ui` — flat, bordered, no drop shadow — instead of the manual nested `<div>` / `<div>` / `<section>` with custom flex-center + full-bleed background.
* Replace the two plain `<a>` tags under **Useful links** with `<Link>` from `@wordpress/ui` (same component the \"Learn more about us\" link already uses), so the two admin links pick up consistent color, size, and styling.
* Restore the original `h3` typography (1.25rem / weight 500) inside the card.
* Drop the now-dead `:global(.components-external-link__icon)` rule — the `@wordpress/ui` `Link` emits a different hashed class, so the rule never matched.
* Simplify the SCSS: no more \`.footer-inner\` wrapper, no more 1288px breakpoint dropping inline padding to 0; the Card brings its own padding so the section reads cleanly at every width.

URLs and tracks are unchanged — \`getAdminUrl( 'admin.php?page=jetpack_modules' )\` / \`getAdminUrl( 'admin.php?page=jetpack-debugger' )\` and the existing \`useHelpTracking\` calls (\`clicked_all_jetpack_modules_link\`, \`clicked_debug_information_link\`, \`clicked_learn_more_about_us\`).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to **Jetpack → My Jetpack → Help** in wp-admin.
2. Scroll to the **\"Real humans. Real support.\"** section at the bottom.
3. Confirm:
   * The section is a single bordered card with consistent padding — no nested-card / nested-container look.
   * **All Jetpack modules** and **Debug information** render in the same WordPress blue / weight / size as **Learn more about us** above them.
   * Heading **\"Real humans. Real support.\"** is the same size as before this PR (1.25rem, medium weight).
   * Resize from ~1440 px down to ~600 px — card keeps its border and internal padding at every width, no edge-crowding under 1288 px.
4. Click each of the three links:
   * **Learn more about us** → opens \`https://automattic.com/about/\` in a new tab with the \`↗\` arrow.
   * **All Jetpack modules** → \`admin.php?page=jetpack_modules\` (legacy modules list).
   * **Debug information** → \`admin.php?page=jetpack-debugger\`.
5. Optional: with Tracks debug enabled, confirm \`clicked_all_jetpack_modules_link\`, \`clicked_debug_information_link\`, and \`clicked_learn_more_about_us\` events still fire on click.

Screenshots for design review will be attached below.