### PR TITLE
My Jetpack: migrate Main CTA action button to @wordpress/ui

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { createRoot } from '@wordpress/element';
-import '@wordpress/theme/design-tokens.css';
 import { useEffect } from 'react';
 import { HashRouter, Navigate, Routes, Route, useLocation } from 'react-router';
 /**

--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createRoot } from '@wordpress/element';
+import '@wordpress/theme/design-tokens.css';
 import { useEffect } from 'react';
 import { HashRouter, Navigate, Routes, Route, useLocation } from 'react-router';
 /**

--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -80,7 +80,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	const buttonState = useMemo< Partial< SecondaryButtonProps > >( () => {
 		return {
 			variant: 'primary',
-			size: 'small',
+			size: 'compact',
 			isLoading: isBusy,
 			loadingAnnouncement: __( 'Loading…', 'jetpack-my-jetpack' ),
 			className,

--- a/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/jetpack-components';
 import { getUserConnectionUrl } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown, external, check } from '@wordpress/icons';
@@ -13,10 +12,10 @@ import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
+import SecondaryButton, { type SecondaryButtonProps } from './secondary-button';
 import styles from './style.module.scss';
-import type { SecondaryButtonProps } from './secondary-button';
 import type { AdditionalAction } from './types';
-import type { FC, ComponentProps, MouseEvent, SetStateAction } from 'react';
+import type { FC, MouseEvent, SetStateAction } from 'react';
 
 const getActionButtonId = ( productSlug: string ) => `action-button-label-${ productSlug }`;
 
@@ -46,7 +45,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	} = useProductsByOwnership();
 
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
-	const [ currentAction, setCurrentAction ] = useState< ComponentProps< typeof Button > >( {} );
+	const [ currentAction, setCurrentAction ] = useState< SecondaryButtonProps >( {} );
 	const { detail, isLoading: isProductDataLoading, isRefetching } = useProduct( slug );
 
 	const {
@@ -80,10 +79,10 @@ const ActionButton: FC< ActionButtonProps > = ( {
 
 	const buttonState = useMemo< Partial< SecondaryButtonProps > >( () => {
 		return {
-			variant: ! isBusy ? 'primary' : undefined,
-			disabled: isBusy,
+			variant: 'primary',
 			size: 'small',
-			weight: 'regular',
+			isLoading: isBusy,
+			loadingAnnouncement: __( 'Loading…', 'jetpack-my-jetpack' ),
 			className,
 		};
 	}, [ isBusy, className ] );
@@ -211,7 +210,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 
 				return {
 					...buttonState,
-					disabled: isManageDisabled || buttonState?.disabled,
+					disabled: isManageDisabled,
 					href: manageUrl,
 					variant: 'secondary',
 					label: buttonText,
@@ -424,9 +423,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 					hasAdditionalActions ? styles[ 'has-additional-actions' ] : null
 				) }
 			>
-				<Button { ...buttonState } { ...currentAction } id={ getActionButtonId( slug ) }>
-					{ currentAction.label }
-				</Button>
+				<SecondaryButton { ...buttonState } { ...currentAction } id={ getActionButtonId( slug ) } />
 				{ hasAdditionalActions && (
 					<button
 						className={ clsx(

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { Button, Link } from '@wordpress/ui';
 import type { IconType } from '@wordpress/components';
 import type { FC, MouseEvent } from 'react';
 
@@ -16,25 +16,92 @@ export type SecondaryButtonProps = {
 	iconSize?: number;
 	disabled?: boolean;
 	isLoading?: boolean;
+	loadingAnnouncement?: string;
 	className?: string;
+	id?: string;
 	'aria-labelledby'?: string;
 };
 
-// SecondaryButton component
+const variantMap = {
+	primary: 'solid',
+	secondary: 'outline',
+	tertiary: 'minimal',
+} as const;
+
+const sizeMap = {
+	normal: 'default',
+	small: 'small',
+} as const;
+
 const SecondaryButton: FC< SecondaryButtonProps > = props => {
-	const { shouldShowButton = () => true, ...buttonProps } = {
-		size: 'small' as const,
-		variant: 'secondary' as const,
-		weight: 'regular' as const,
-		label: __( 'Learn more', 'jetpack-my-jetpack' ),
-		...props,
-	};
+	const {
+		shouldShowButton = () => true,
+		size = 'small',
+		variant = 'secondary',
+		label = __( 'Learn more', 'jetpack-my-jetpack' ),
+		href,
+		onClick,
+		isExternalLink,
+		disabled,
+		isLoading,
+		loadingAnnouncement,
+		className,
+		id,
+		'aria-labelledby': ariaLabelledBy,
+	} = props;
 
 	if ( ! shouldShowButton() ) {
-		return false;
+		return null;
 	}
 
-	return <Button { ...buttonProps }>{ buttonProps.label }</Button>;
+	if ( variant === 'link' ) {
+		return (
+			<Link
+				id={ id }
+				href={ href ?? '#' }
+				openInNewTab={ isExternalLink }
+				onClick={ onClick }
+				className={ className }
+				aria-labelledby={ ariaLabelledBy }
+			>
+				{ label }
+			</Link>
+		);
+	}
+
+	const sharedProps = {
+		variant: variantMap[ variant ],
+		size: sizeMap[ size ],
+		disabled,
+		loading: isLoading,
+		loadingAnnouncement,
+		onClick,
+		className,
+		id,
+		'aria-labelledby': ariaLabelledBy,
+	};
+
+	if ( href ) {
+		return (
+			<Button
+				{ ...sharedProps }
+				nativeButton={ false }
+				render={
+					<a
+						href={ href }
+						{ ...( isExternalLink && {
+							target: '_blank',
+							rel: 'noopener noreferrer',
+						} ) }
+					/>
+				}
+			>
+				{ label }
+			</Button>
+		);
+	}
+
+	return <Button { ...sharedProps }>{ label }</Button>;
 };
 
 export default SecondaryButton;

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -4,7 +4,7 @@ import type { FC, MouseEvent } from 'react';
 
 export type SecondaryButtonProps = {
 	href?: string;
-	size?: 'normal' | 'small';
+	size?: 'normal' | 'compact';
 	variant?: 'primary' | 'secondary' | 'link' | 'tertiary';
 	label?: string;
 	shouldShowButton?: () => boolean;
@@ -26,13 +26,13 @@ const variantMap = {
 
 const sizeMap = {
 	normal: 'default',
-	small: 'small',
+	compact: 'compact',
 } as const;
 
 const SecondaryButton: FC< SecondaryButtonProps > = props => {
 	const {
 		shouldShowButton = () => true,
-		size = 'small',
+		size = 'compact',
 		variant = 'secondary',
 		label = __( 'Learn more', 'jetpack-my-jetpack' ),
 		href,

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -1,19 +1,15 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Link } from '@wordpress/ui';
-import type { IconType } from '@wordpress/components';
 import type { FC, MouseEvent } from 'react';
 
 export type SecondaryButtonProps = {
 	href?: string;
 	size?: 'normal' | 'small';
 	variant?: 'primary' | 'secondary' | 'link' | 'tertiary';
-	weight?: 'bold' | 'regular';
 	label?: string;
 	shouldShowButton?: () => boolean;
 	onClick?: ( () => void ) | ( ( e: MouseEvent< HTMLButtonElement > ) => void );
 	isExternalLink?: boolean;
-	icon?: IconType;
-	iconSize?: number;
 	disabled?: boolean;
 	isLoading?: boolean;
 	loadingAnnouncement?: string;

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -77,6 +77,10 @@ const SecondaryButton: FC< SecondaryButtonProps > = props => {
 		'aria-labelledby': ariaLabelledBy,
 	};
 
+	// @wordpress/ui's Button can't natively render as an anchor, so when we need
+	// a link we keep the Button chrome and swap the element via render={<a/>}.
+	// Revisit this once a first-class LinkButton exists upstream:
+	// https://github.com/WordPress/gutenberg/issues/77098
 	if ( href ) {
 		return (
 			<Button

--- a/projects/packages/my-jetpack/_inc/components/action-button/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/action-button/types.ts
@@ -1,10 +1,12 @@
-import type { ButtonProps } from '@automattic/jetpack-components';
 import type { IconType } from '@wordpress/components';
 
-type ProductButtonProps = Pick<
-	ButtonProps,
-	'size' | 'variant' | 'weight' | 'disabled' | 'className'
->;
+type ProductButtonProps = {
+	size?: 'normal' | 'small';
+	variant?: 'primary' | 'secondary' | 'tertiary' | 'link';
+	weight?: 'bold' | 'regular';
+	disabled?: boolean;
+	className?: string;
+};
 
 export type AdditionalAction = ProductButtonProps & {
 	label: string;

--- a/projects/packages/my-jetpack/_inc/components/action-button/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/action-button/types.ts
@@ -1,9 +1,6 @@
-import type { IconType } from '@wordpress/components';
-
 type ProductButtonProps = {
 	size?: 'normal' | 'small';
 	variant?: 'primary' | 'secondary' | 'tertiary' | 'link';
-	weight?: 'bold' | 'regular';
 	disabled?: boolean;
 	className?: string;
 };
@@ -22,8 +19,6 @@ export type SecondaryAction = ProductButtonProps & {
 	onClick: () => void;
 	positionFirst?: boolean;
 	isExternalLink?: boolean;
-	icon?: IconType;
-	iconSize?: number;
 	disabled?: boolean;
 	isLoading?: boolean;
 	className?: string;

--- a/projects/packages/my-jetpack/_inc/components/action-button/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/action-button/types.ts
@@ -1,5 +1,5 @@
 type ProductButtonProps = {
-	size?: 'normal' | 'small';
+	size?: 'normal' | 'compact';
 	variant?: 'primary' | 'secondary' | 'tertiary' | 'link';
 	disabled?: boolean;
 	className?: string;

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -29,6 +29,20 @@
 		@include jetpack-admin-page-layout;
 	}
 
+	// Defend @wordpress/ui Button against wp-admin's unlayered anchor styles
+	// when Button renders as an <a> via nativeButton={false} + render={<a/>}.
+	// @wordpress/ui's component rules live inside @layer wp-ui-components, and
+	// per CSS Cascade Layers, unlayered wp-admin rules like `a { color, …}`
+	// win over them — so the rendered anchor inherits wp-admin's blue link
+	// color and underline instead of the Button's intended foreground. We
+	// target the stable `__button` suffix that @wordpress/ui's CSS modules
+	// emit, and bump specificity with #my-jetpack-container so wp-admin's
+	// bare `a` cannot win.
+	#my-jetpack-container a[class*="__button"] {
+		color: var(--wp-ui-button-foreground-color);
+		text-decoration: none;
+	}
+
 	#my-jetpack-container {
 		height: 100%;
 

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -31,16 +31,17 @@
 
 	// Defend @wordpress/ui Button against wp-admin's unlayered anchor styles
 	// when Button renders as an <a> via nativeButton={false} + render={<a/>}.
-	// @wordpress/ui's component rules live inside @layer wp-ui-components, and
-	// per CSS Cascade Layers, unlayered wp-admin rules like `a { color, …}`
-	// win over them — so the rendered anchor inherits wp-admin's blue link
-	// color and underline instead of the Button's intended foreground. We
-	// target the stable `__button` suffix that @wordpress/ui's CSS modules
-	// emit, and bump specificity with #my-jetpack-container so wp-admin's
-	// bare `a` cannot win.
+	// @wordpress/ui's component rules live inside @layer wp-ui-components and
+	// per CSS Cascade Layers unlayered wp-admin rules like `a { color, …}`
+	// override them, so the rendered anchor inherits wp-admin's link color
+	// and underline instead of the Button's intended chrome — and worse,
+	// `is-loading { color: transparent }` also loses, so the label stays
+	// visible behind the spinner. `revert-layer` short-circuits the implicit
+	// unlayered layer entirely and falls back to the @wordpress/ui-computed
+	// value, picking up `is-loading` overrides for free.
 	#my-jetpack-container a[class*="__button"] {
-		color: var(--wp-ui-button-foreground-color);
-		text-decoration: none;
+		color: revert-layer;
+		text-decoration: revert-layer;
 	}
 
 	#my-jetpack-container {

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,5 +1,13 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 
+// Bring @wordpress/ui design tokens (--wpds-*) into :root for every My Jetpack
+// route. Without this, the @wordpress/ui Button class hooks land on elements
+// but the var() lookups for color and dimension all resolve to empty, so the
+// chrome falls through to wp-admin defaults. The JS-side equivalent gets
+// mis-detected by the WordPress dependency-extraction webpack plugin as a
+// script handle ("wp-theme/design-tokens.css") and blanks the page.
+@import "@wordpress/theme/design-tokens.css";
+
 :global {
 
 	// Apply the shared admin-page-layout mixin so the main My Jetpack page

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -31,6 +31,9 @@
 
 	// Defend @wordpress/ui Button against wp-admin's unlayered anchor styles
 	// when Button renders as an <a> via nativeButton={false} + render={<a/>}.
+	// The root cause is that @wordpress/ui has no link-button component yet, so
+	// we render a Button-as-anchor; this whole block can go once one exists:
+	// https://github.com/WordPress/gutenberg/issues/77098
 	// @wordpress/ui's component rules live inside @layer wp-ui-components and
 	// per CSS Cascade Layers unlayered wp-admin rules like `a { color, …}`
 	// override them, so the rendered anchor inherits wp-admin's link color

--- a/projects/packages/my-jetpack/changelog/update-action-button-to-wp-ui
+++ b/projects/packages/my-jetpack/changelog/update-action-button-to-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: migrate the product card main CTA to @wordpress/ui Button and surface a spinner while an action is in progress.


### PR DESCRIPTION
Fixes JETPACK-1633

## Proposed changes
* Migrates the Main CTA on every My Jetpack product card from `Button` (`@automattic/jetpack-components`) to `Button` (`@wordpress/ui`).
* Centralises the variant translation (`primary` → `solid`, `secondary` → `outline`, `tertiary` → `minimal`, `link` → `Link`) inside the `SecondaryButton` wrapper, so callers (`product-card`, `products-table-view`, any `AdditionalAction` consumer) keep their existing prop API and the chevron-coloring logic in `action-button/index.tsx` stays intact.
* Adopts the new Button's built-in `loading` + `loadingAnnouncement` so the CTA shows a spinner with a screen-reader announcement while activating, installing, or registering — addresses the "seems old" visual gap from MYJP-303.
* Inlines the legacy variant/size/weight prop shape in `action-button/types.ts`, removing the last value/type import of `@automattic/jetpack-components` Button from this surface.

## Related product discussion/links
* JETPACK-1633 (this PR), MYJP-303 (same trunk walkthrough)
* Part of JETPACK-1543 (Jetpack UI Modernization); addresses the Phase 4 wrapper called out in JETPACK-1542.

## Does this pull request change what data or activity we track or use?
No. The tracks events (`jetpack_myjetpack_${tracksIdentifier}_*_click`) and their payloads are unchanged.

## Testing instructions

1. Pull this branch and run `pnpm install && jetpack build packages/my-jetpack --deps`.
2. Boot a local Jetpack dev environment (Docker or Jurassic Ninja).
3. Open `/wp-admin/admin.php?page=my-jetpack`.
4. For each product card, confirm the primary CTA renders with the new chrome (`solid` + `brand` for primary, `outline` for secondary). Walk through products in each major status:
   * **ACTIVE**: "View" should be an outline button linking to the management URL.
   * **INACTIVE / MODULE_DISABLED / NEEDS_ACTIVATION**: "Activate" should be an outline button. Click it; a spinner should appear while `isBusy` is true (this is the new `loading` prop in action).
   * **NEEDS_PLAN / CAN_UPGRADE**: "Get plan" / "Learn more" / "Upgrade" should be solid buttons that navigate to the purchase URL.
   * **EXPIRING_SOON / EXPIRED**: "Renew my plan" / "Resume my plan" should be solid buttons.
   * **NEEDS_ATTENTION (error/warning)**: "Troubleshoot" or "Fix threats" (for protect) should render as solid buttons.
5. For a card with `additionalActions`, open the dropdown chevron next to the CTA, pick a secondary action, and confirm the chevron's color updates to match (primary → dark chevron with white arrow; non-primary → light chevron with black arrow). If the chevron's height or alignment looks off next to the new Button chrome, the fix lives in `_inc/components/action-button/style.module.scss` (`.dropdown-chevron.primary` / `.secondary`).
6. Switch to the products table view ("Card view" / "List view" toggle) and confirm the same CTAs render correctly there.
7. With VoiceOver or browser screen-reader devtools, click "Activate" on an inactive product — the loading state should be announced via `loadingAnnouncement` ("Loading…").
8. Verify any external-link CTAs (e.g., the Backup "Troubleshoot" link to `jetpack.com/support/...`) open in a new tab and carry `rel="noopener noreferrer"` on the rendered anchor.
