### PR TITLE
Social: track Overview/Settings tab switches on the modernized dashboard

### DIFF
--- a/projects/packages/publicize/changelog/add-social-dashboard-tab-view-event
+++ b/projects/packages/publicize/changelog/add-social-dashboard-tab-view-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Track Overview/Settings tab switches on the Social dashboard via a `jetpack_social_tab_view` Tracks event.

--- a/projects/packages/publicize/routes/dashboard/package.json
+++ b/projects/packages/publicize/routes/dashboard/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/charts": "workspace:*",
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@tanstack/react-query": "5.90.8",

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -1,5 +1,8 @@
+import analytics from '@automattic/jetpack-analytics';
+import { getScriptData } from '@automattic/jetpack-script-data';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSearch } from '@wordpress/route';
 import { Button, Tabs } from '@wordpress/ui';
@@ -58,6 +61,30 @@ const Stage = () => {
 	const activeTab: SocialTab = search.tab === 'settings' ? 'settings' : 'overview';
 
 	const actions = activeTab === 'overview' ? <AddAccountAction /> : null;
+
+	// Initialize analytics once per mount so subsequent `recordEvent` calls
+	// queue with a user identity attached. Mirrors the Newsletter chassis.
+	useEffect( () => {
+		const wpcomUser = getScriptData()?.user?.current_user?.wpcom;
+		if ( wpcomUser?.ID && wpcomUser?.login ) {
+			analytics.initialize( wpcomUser.ID, wpcomUser.login );
+		}
+	}, [] );
+
+	// Record a tab-view event on initial mount and whenever the active tab
+	// changes. The `lastTrackedTab` ref dedupes React 18 StrictMode's
+	// dev-only mount/cleanup/remount cycle — refs persist across the
+	// simulated remount, so the second setup invocation finds the current
+	// tab already recorded and bails out. Production sees one fire per tab
+	// change either way.
+	const lastTrackedTab = useRef< SocialTab | null >( null );
+	useEffect( () => {
+		if ( lastTrackedTab.current === activeTab ) {
+			return;
+		}
+		lastTrackedTab.current = activeTab;
+		analytics.tracks.recordEvent( 'jetpack_social_tab_view', { tab: activeTab } );
+	}, [ activeTab ] );
 
 	return (
 		<QueryClientProvider client={ queryClient }>


### PR DESCRIPTION
Fixes #

## Proposed changes

* Adds a `jetpack_social_tab_view` Tracks event, fired from the wp-build chassis stage in a `useEffect` keyed on the active tab. Lets us measure how users move between the Overview and Settings tabs on the modernized Social dashboard.
* Pulls `@automattic/jetpack-shared-extension-utils` into the `routes/dashboard` route bundle so the chassis can call `useAnalytics()`.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

Yes — adds one new Tracks event:

* `jetpack_social_tab_view`
  * Property `tab`: either `"overview"` or `"settings"`.
  * Fires once per active-tab change while the modernized Social dashboard is rendered (chassis only — the legacy single-page admin shell is unaffected).
  * No PII; identifies the active tab only.

## Testing instructions

The chassis is currently gated behind a filter on trunk, so it needs to be enabled first.

* In a Jetpack/Social environment, add `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_true' );` (e.g. via Code Snippets).
* Visit **Jetpack > Social** in wp-admin. You should land on the modernized chassis (Overview tab).
* Open DevTools → Network panel and filter for `pixel.wp.com/t.gif`.
* Confirm one `jetpack_social_tab_view` request fires on the initial Overview render, with `tab=overview` in the query string.
* Click the **Settings** tab. Confirm another `jetpack_social_tab_view` request fires with `tab=settings`.
* Switch back to **Overview**. Confirm another `jetpack_social_tab_view` request fires with `tab=overview`.
