### PR TITLE
Charts: rescale AreaChart Y-axis on legend toggle by default

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-area-rescale-y-on-legend-toggle
+++ b/projects/js-packages/charts/changelog/add-charts-area-rescale-y-on-legend-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: AreaChart Y-axis now rescales to the visible series when interactive legends toggle items off. Pass `rescaleYOnLegendToggle={ false }` to restore the previous pinned-extent behavior.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -68,6 +68,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 			onPointerUp,
 			onPointerMove,
 			onPointerOut,
+			rescaleYOnLegendToggle = true,
 			children,
 			gridVisibility,
 			gap = 'md',
@@ -136,12 +137,14 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		} );
 
 		// Computed from the full data set (ignoring legend visibility) so the y-axis stays
-		// fixed when series are toggled off — otherwise visx auto-fits to the remaining data
-		// and the chart appears to rescale. Skipped for non-default stack offsets, which
-		// reshape the y-extent (`expand` → [0,1], `wiggle`/`silhouette` → centred around
-		// zero) — letting visx derive the domain is correct there.
+		// fixed when series are toggled off - otherwise visx auto-fits to the remaining
+		// data and the chart's baseline appears to move. Opt-in via
+		// `rescaleYOnLegendToggle={ false }`. Skipped for non-default stack offsets,
+		// which reshape the y-extent (`expand` -> [0,1], `wiggle`/`silhouette` -> centred
+		// around zero); letting visx derive the domain is correct there.
 		const fixedYDomain = useMemo< [ number, number ] | undefined >( () => {
 			if (
+				rescaleYOnLegendToggle ||
 				! legendInteractive ||
 				! dataSorted.length ||
 				! dataSorted[ 0 ].data.length ||
@@ -184,7 +187,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 			}
 			if ( max === -Infinity ) return undefined;
 			return [ Math.min( 0, min ), max ];
-		}, [ dataSorted, stacked, stackOffset, legendInteractive ] );
+		}, [ dataSorted, stacked, stackOffset, legendInteractive, rescaleYOnLegendToggle ] );
 
 		const chartOptions = useMemo( () => {
 			const formatter = options?.axis?.x?.tickFormat || getFormatter( dataSorted );

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -211,6 +211,37 @@ Animation.args = {
 	legendInteractive: true,
 };
 
+export const RescaleYOnLegendToggle: StoryObj< typeof AreaChart > = {
+	name: 'Y-axis rescales when legends toggle (default)',
+	render: args => (
+		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
+			<div>
+				<h4>rescaleYOnLegendToggle: true (default)</h4>
+				<AreaChart { ...args } rescaleYOnLegendToggle />
+			</div>
+			<div>
+				<h4>rescaleYOnLegendToggle: false (pinned)</h4>
+				<AreaChart { ...args } rescaleYOnLegendToggle={ false } />
+			</div>
+		</div>
+	),
+	args: {
+		...areaChartStoryArgs,
+		showLegend: true,
+		legend: { interactive: true },
+		width: 480,
+		height: 280,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Click legend items to toggle series. The left chart rescales the Y axis to the visible series; the right chart pins the Y axis to the full data extent so the baseline stays put.',
+			},
+		},
+	},
+};
+
 export const WithCompositionLegend: StoryObj< typeof AreaChart > = {
 	render: args => {
 		const legend = extractLegendConfig( args );

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -240,7 +240,7 @@ describe( 'AreaChart', () => {
 			expect( keyboardCall![ 0 ].tooltipData?.nearestDatum?.key ).not.toBe( 'Series A' );
 		} );
 
-		test( 'y-axis domain stays fixed across legend toggles', async () => {
+		test( 'y-axis rescales across legend toggles by default', async () => {
 			const user = userEvent.setup();
 			const ref = createRef< SingleChartRef >();
 			render(
@@ -248,8 +248,39 @@ describe( 'AreaChart', () => {
 					<AreaChartUnresponsive
 						{ ...defaultProps }
 						showLegend
-						chartId="test-interactive-domain"
+						chartId="test-interactive-domain-rescale"
 						legend={ { interactive: true } }
+						ref={ ref }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const initialDomain = (
+				ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined
+			 )?.domain();
+			expect( initialDomain ).toBeDefined();
+
+			await user.click( screen.getByText( 'Series A' ) );
+
+			const afterToggleDomain = (
+				ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined
+			 )?.domain();
+			// Hiding Series A drops the upper bound; visx should refit.
+			expect( afterToggleDomain ).toBeDefined();
+			expect( afterToggleDomain![ 1 ] ).toBeLessThan( initialDomain![ 1 ] );
+		} );
+
+		test( 'y-axis stays pinned when rescaleYOnLegendToggle is false', async () => {
+			const user = userEvent.setup();
+			const ref = createRef< SingleChartRef >();
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						{ ...defaultProps }
+						showLegend
+						chartId="test-interactive-domain-pin"
+						legend={ { interactive: true } }
+						rescaleYOnLegendToggle={ false }
 						ref={ ref }
 					/>
 				</GlobalChartsProvider>

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -270,6 +270,40 @@ describe( 'AreaChart', () => {
 			expect( afterToggleDomain![ 1 ] ).toBeLessThan( initialDomain![ 1 ] );
 		} );
 
+		test( 'y-axis stays pinned for unstacked area when rescaleYOnLegendToggle is false', async () => {
+			// Exercises the non-stacked branch of fixedYDomain, which scans the
+			// raw min/max across all series rather than summing stack columns.
+			const user = userEvent.setup();
+			const ref = createRef< SingleChartRef >();
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						{ ...defaultProps }
+						showLegend
+						chartId="test-interactive-domain-pin-unstacked"
+						legend={ { interactive: true } }
+						stacked={ false }
+						rescaleYOnLegendToggle={ false }
+						ref={ ref }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const initialDomain = (
+				ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined
+			 )?.domain();
+			expect( initialDomain ).toBeDefined();
+			// defaultProps has values up to 20; pinned-unstacked should cover the max.
+			expect( initialDomain![ 1 ] ).toBeGreaterThanOrEqual( 20 );
+
+			await user.click( screen.getByText( 'Series A' ) );
+
+			const afterToggleDomain = (
+				ref.current?.getScales()?.yScale as { domain: () => number[] } | undefined
+			 )?.domain();
+			expect( afterToggleDomain ).toEqual( initialDomain );
+		} );
+
 		test( 'y-axis stays pinned when rescaleYOnLegendToggle is false', async () => {
 			const user = userEvent.setup();
 			const ref = createRef< SingleChartRef >();

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -299,7 +299,11 @@ describe( 'AreaChart', () => {
 			expect( afterToggleDomain ).toEqual( initialDomain );
 		} );
 
-		test( 'supports negative stacked values without clipping', () => {
+		test( 'supports negative stacked values without clipping (with pinned Y)', () => {
+			// The mixed-sign full-extent pin only kicks in when the consumer
+			// opts into pinned-Y behavior; visx's natural domain derivation for
+			// a `stackOffset: 'none'` stack does not extend below zero for
+			// purely-negative series, which is what this test guards against.
 			const ref = createRef< SingleChartRef >();
 			render(
 				<GlobalChartsProvider>
@@ -309,6 +313,7 @@ describe( 'AreaChart', () => {
 						chartId="test-interactive-negative"
 						showLegend
 						legend={ { interactive: true } }
+						rescaleYOnLegendToggle={ false }
 						data={ [
 							{
 								label: 'Pos',

--- a/projects/js-packages/charts/src/charts/area-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/area-chart/types.ts
@@ -47,5 +47,14 @@ export interface AreaChartProps extends BaseChartProps< SeriesData[] > {
 	 * @default false when stacked, true when overlapping
 	 */
 	withStroke?: boolean;
+	/**
+	 * When using an interactive legend, controls whether the Y axis rescales
+	 * to fit only the visible series. Defaults to `true`, matching the
+	 * intuitive default for LineChart and BarChart. Set to `false` to pin
+	 * the Y axis to the full data extent so toggling legend items off does
+	 * not move the chart's baseline.
+	 * @default true
+	 */
+	rescaleYOnLegendToggle?: boolean;
 	children?: ReactNode;
 }


### PR DESCRIPTION
## Proposed changes

Adds a new `rescaleYOnLegendToggle?: boolean` prop on `AreaChartProps`, defaulting to `true`. When interactive legends toggle a series off, visx now refits the Y axis to the visible series, matching the natural default for `LineChart` and `BarChart`.

Consumers that depend on the previous pinned-extent behavior can opt back in via `rescaleYOnLegendToggle={ false }`. The existing `fixedYDomain` computation is preserved behind the flag.

* Side-by-side Storybook story comparing both behaviors.
* Existing pin test renamed and updated to expect the rescaling default.
* Adds opt-in tests for the pinned-Y branches: stacked, unstacked, and mixed-sign-stack.

This is split out of #49167 so the zoom feature and the Y-axis change can be reviewed and shipped independently.

## Related product discussion/links

* (none)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run Storybook: `cd projects/js-packages/storybook && pnpm run storybook:dev`.
2. Open *JS Packages / Charts Library / Charts / Area Chart / Y-axis rescales when legends toggle (default)*.
3. Two charts render side by side with interactive legends. Click any legend item.
   * Left chart (`rescaleYOnLegendToggle: true`, default): Y axis refits to the visible series.
   * Right chart (`rescaleYOnLegendToggle={ false }`): Y axis stays pinned to the full data extent.
4. Run unit tests:
   ```
   cd projects/js-packages/charts
   TZ=UTC npx jest --config=tests/jest.config.cjs src/charts/area-chart
   ```