### PR TITLE
CRM: Restore legacy code used by Client Portal Pro to prevent PHP fatals

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-restore_legacy_code_used_by_extensions
+++ b/projects/plugins/crm/changelog/fix-crm-restore_legacy_code_used_by_extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Client Portal: Prevent PHP fatal when downloading PDFs.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -2827,6 +2827,34 @@ final class ZeroBSCRM {
 	}
 
 	/**
+	 * Legacy list of loaded libraries. Only used by libLoad(), which is only used by Client Portal Pro.
+	 * Note: All paths need to be prepended by ZEROBSCRM_PATH before use
+	 *
+	 * @var array
+	 */
+	private $libs = array();
+
+	/**
+	 * Load a library via include. Legacy (only used by Client Portal Pro).
+	 *
+	 * @param string $libKey Library slug.
+	 */
+	public function libLoad( $libKey = '' ) {
+
+		if (
+			isset( $this->libs[ $libKey ] ) &&
+			isset( $this->libs[ $libKey ]['include'] ) &&
+			! isset( $this->libs[ $libKey ]['loaded'] ) &&
+			file_exists( ZEROBSCRM_PATH . $this->libs[ $libKey ]['include'] )
+		) {
+			require_once ZEROBSCRM_PATH . $this->libs[ $libKey ]['include'];
+				$this->libs[ $libKey ]['loaded'] = true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Autoload files from a directory which match a regex filter
 	 */
 	public function autoload_from_directory( string $directory, string $regex_filter ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -2827,11 +2827,11 @@ final class ZeroBSCRM {
 	}
 
 	/**
-	 * Obsolete function kept for backwards compatibility.
+	 * Obsolete method kept for backwards compatibility with older versions (<2.2.5) of the Client Portal Pro extension.
 	 *
 	 * @param string $libKey Library slug.
 	 */
-	public function libLoad( $libKey = '' ) {
+	public function libLoad( $libKey = '' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return false;
 	}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -2827,30 +2827,11 @@ final class ZeroBSCRM {
 	}
 
 	/**
-	 * Legacy list of loaded libraries. Only used by libLoad(), which is only used by Client Portal Pro.
-	 * Note: All paths need to be prepended by ZEROBSCRM_PATH before use
-	 *
-	 * @var array
-	 */
-	private $libs = array();
-
-	/**
-	 * Load a library via include. Legacy (only used by Client Portal Pro).
+	 * Obsolete function kept for backwards compatibility.
 	 *
 	 * @param string $libKey Library slug.
 	 */
 	public function libLoad( $libKey = '' ) {
-
-		if (
-			isset( $this->libs[ $libKey ] ) &&
-			isset( $this->libs[ $libKey ]['include'] ) &&
-			! isset( $this->libs[ $libKey ]['loaded'] ) &&
-			file_exists( ZEROBSCRM_PATH . $this->libs[ $libKey ]['include'] )
-		) {
-			require_once ZEROBSCRM_PATH . $this->libs[ $libKey ]['include'];
-				$this->libs[ $libKey ]['loaded'] = true;
-		}
-
 		return false;
 	}
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Client Portal Pro makes a call to `libLoad()` when downloading PDFs from the Client Portal, which was removed in #47743 (and released in Jetpack CRM 6.8.0). This PR restores that method as a stub, preventing a fatal and restoring the feature.

Note that the call is completely unnecessary, as we now use class autoloading, so I'm removing it from the extension's code.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1779427815878289-slack-CL5UJ9ASE

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

With Client Portal 2.2.4 or lower:
1. Create a contact with an email.
2. Add an invoice to the contact.
3. Log into the Client Portal as the contact.
4. Try to download the invoice PDF.

In `trunk` you'll get a PHP fatal.

In the `fix/crm/restore_legacy_code_used_by_extensions` branch the PDF will download.