### PR TITLE
Newsletter: fire jetpack_newsletter_tab_view on initial mount + dedupe StrictMode

### DIFF
--- a/projects/packages/newsletter/_inc/components/newsletter-page.tsx
+++ b/projects/packages/newsletter/_inc/components/newsletter-page.tsx
@@ -1,6 +1,5 @@
-import analytics from '@automattic/jetpack-analytics';
 import AdminPage from '@automattic/jetpack-components/admin-page';
-import { getSiteData, getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteData } from '@automattic/jetpack-script-data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
@@ -88,12 +87,6 @@ export default function NewsletterPage( {
 			if ( next !== 'subscribers' && next !== 'settings' ) {
 				return;
 			}
-			if ( next !== activeTab ) {
-				analytics.tracks.recordEvent( 'jetpack_newsletter_tab_view', {
-					site_type: getSiteType(),
-					tab: next,
-				} );
-			}
 			navigate( {
 				search: {
 					tab: next === 'settings' ? 'settings' : undefined,
@@ -102,7 +95,7 @@ export default function NewsletterPage( {
 				},
 			} as unknown as Parameters< typeof navigate >[ 0 ] );
 		},
-		[ activeTab, navigate ]
+		[ navigate ]
 	);
 
 	const contentClass = contentHasPadding

--- a/projects/packages/newsletter/changelog/fix-newsletter-tab-view-on-mount
+++ b/projects/packages/newsletter/changelog/fix-newsletter-tab-view-on-mount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter dashboard now records a `jetpack_newsletter_tab_view` Tracks event on initial page load (matching its tab-switch behavior).

--- a/projects/packages/newsletter/routes/dashboard/stage.tsx
+++ b/projects/packages/newsletter/routes/dashboard/stage.tsx
@@ -1,8 +1,8 @@
 import analytics from '@automattic/jetpack-analytics';
 import useConnection from '@automattic/jetpack-connection/use-connection';
-import { getSiteData } from '@automattic/jetpack-script-data';
+import { getSiteData, getSiteType } from '@automattic/jetpack-script-data';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useSearch } from '@wordpress/route';
 import { Tabs } from '@wordpress/ui';
 import NewsletterPage, { type NewsletterTab } from '../../_inc/components/newsletter-page';
@@ -88,6 +88,25 @@ const Stage = () => {
 			analytics.initialize( tracksUserData.userid, tracksUserData.username );
 		}
 	}, [] );
+
+	// Record a tab-view event on initial mount and whenever the active tab
+	// changes. The `lastTrackedTab` ref dedupes React 18 StrictMode's
+	// dev-only mount/cleanup/remount cycle — refs persist across the
+	// simulated remount, so the second setup invocation finds the current
+	// tab already recorded and bails out. Lives here (not in
+	// `NewsletterPage.onTabChange`) so it also fires on first page render,
+	// not just on user-initiated tab clicks.
+	const lastTrackedTab = useRef< NewsletterTab | null >( null );
+	useEffect( () => {
+		if ( lastTrackedTab.current === activeTab ) {
+			return;
+		}
+		lastTrackedTab.current = activeTab;
+		analytics.tracks.recordEvent( 'jetpack_newsletter_tab_view', {
+			site_type: getSiteType(),
+			tab: activeTab,
+		} );
+	}, [ activeTab ] );
 
 	return (
 		<QueryClientProvider client={ queryClient }>

--- a/projects/packages/newsletter/tests/newsletter-page.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-page.test.tsx
@@ -1,17 +1,16 @@
 // The `newsletter-page.tsx` shell is the surface that two routed tabs share —
 // the active-tab indicator slides between Subscribers and Settings because the
-// `Tabs.Root` mounts once. We're exercising three contracts this PR cares about:
+// `Tabs.Root` mounts once. Tab-view analytics are owned by the route stage
+// (covered in `stage.test.tsx`), so this file's contracts are navigation-only:
 //
-// 1. flipping to a different tab fires `jetpack_newsletter_tab_view` with
-//    `{ site_type, tab }` and routes the visitor via `useNavigate` with the
+// 1. flipping to a different tab routes the visitor via `useNavigate` with the
 //    subscriber-detail params cleared.
-// 2. clicking the already-active tab is a no-op (no event, no navigate).
+// 2. clicking the already-active tab still navigates so the URL stays
+//    canonical (`?tab=undefined` clears stale params).
 // 3. when `subscriberManagementEnabled` is false the tab nav doesn't render
 //    so Settings-only hosts never see a phantom Subscribers tab.
 
-const mockRecordEvent = jest.fn();
 const mockNavigate = jest.fn();
-const mockGetSiteType = jest.fn( () => 'jetpack' );
 const mockGetSiteData = jest.fn( () => ( {
 	rest_root: 'https://example.com/wp-json/',
 	rest_nonce: 'test-nonce',
@@ -28,15 +27,7 @@ const mockTabsOnValueChange: { current: ( ( value: string | null ) => void ) | n
 	current: null,
 };
 
-jest.mock( '@automattic/jetpack-analytics', () => ( {
-	__esModule: true,
-	default: {
-		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
-	},
-} ) );
-
 jest.mock( '@automattic/jetpack-script-data', () => ( {
-	getSiteType: () => mockGetSiteType(),
 	getSiteData: () => mockGetSiteData(),
 } ) );
 
@@ -109,10 +100,7 @@ import { render, screen } from '@testing-library/react';
 import NewsletterPage from '../_inc/components/newsletter-page';
 
 beforeEach( () => {
-	mockRecordEvent.mockReset();
 	mockNavigate.mockReset();
-	mockGetSiteType.mockReset();
-	mockGetSiteType.mockReturnValue( 'jetpack' );
 	mockGetSiteData.mockClear();
 	mockAdminPageProps.mockClear();
 	mockGetNewsletterScriptData.mockReset();
@@ -121,26 +109,6 @@ beforeEach( () => {
 } );
 
 describe( 'NewsletterPage tab navigation', () => {
-	it( 'records jetpack_newsletter_tab_view with site_type + tab when switching tabs', async () => {
-		render(
-			<NewsletterPage activeTab="subscribers">
-				<div>panel body</div>
-			</NewsletterPage>
-		);
-
-		// The Tabs.Tab mock renders the tab as a button; click "Settings" to flip.
-		const settingsTab = screen
-			.getAllByRole( 'tab' )
-			.find( tab => tab.getAttribute( 'data-tab-value' ) === 'settings' );
-		settingsTab?.click();
-
-		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
-		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_newsletter_tab_view', {
-			site_type: 'jetpack',
-			tab: 'settings',
-		} );
-	} );
-
 	it( 'navigates to ?tab=settings and clears subscriber-detail params on switch', () => {
 		render(
 			<NewsletterPage activeTab="subscribers">
@@ -178,7 +146,7 @@ describe( 'NewsletterPage tab navigation', () => {
 		expect( navArg.search.tab ).toBeUndefined();
 	} );
 
-	it( 'does not fire analytics or navigate when clicking the active tab', () => {
+	it( 'still navigates when clicking the active tab so the URL stays canonical', () => {
 		render(
 			<NewsletterPage activeTab="subscribers">
 				<div>panel body</div>
@@ -190,10 +158,12 @@ describe( 'NewsletterPage tab navigation', () => {
 			.find( tab => tab.getAttribute( 'data-tab-value' ) === 'subscribers' )
 			?.click();
 
-		expect( mockRecordEvent ).not.toHaveBeenCalled();
-		// `navigate` is still invoked so the URL stays canonical (?tab=undefined
-		// clears stale params), but no analytics event fires — that's the contract
-		// the same-tab guard protects.
+		// Clicking the active tab still runs the navigate(?tab=undefined) call so
+		// stale `subscriber`/`u` params get cleared. No analytics fire from this
+		// surface; the route stage owns the tab-view event and dedupes on its end.
+		expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+		const navArg = mockNavigate.mock.calls[ 0 ][ 0 ] as { search: Record< string, unknown > };
+		expect( navArg.search.tab ).toBeUndefined();
 	} );
 
 	it( 'ignores unknown tab values from the underlying Tabs primitive', () => {
@@ -206,12 +176,11 @@ describe( 'NewsletterPage tab navigation', () => {
 		// Drive `onValueChange` directly with garbage values that the underlying
 		// `Tabs.Root` can emit (e.g. `null` while clearing focus, or a
 		// stale value from a third-party panel). The shell must short-circuit
-		// before either analytics or navigation runs.
+		// before navigation runs.
 		expect( mockTabsOnValueChange.current ).not.toBeNull();
 		mockTabsOnValueChange.current?.( null );
 		mockTabsOnValueChange.current?.( 'gibberish' );
 
-		expect( mockRecordEvent ).not.toHaveBeenCalled();
 		expect( mockNavigate ).not.toHaveBeenCalled();
 	} );
 

--- a/projects/packages/newsletter/tests/stage.test.tsx
+++ b/projects/packages/newsletter/tests/stage.test.tsx
@@ -1,0 +1,181 @@
+// The Newsletter dashboard route stage owns the `jetpack_newsletter_tab_view`
+// Tracks event. Two contracts matter:
+//
+// 1. The event fires once on initial mount carrying the landing tab (so a
+//    visitor who deep-links to `?tab=settings` is counted as a Settings view),
+//    and once per subsequent active-tab change.
+// 2. React 18 StrictMode's dev-only mount/cleanup/remount cycle MUST NOT
+//    produce a duplicate fire. The implementation guards this with a `useRef`
+//    keyed on the last tracked tab — refs persist across the simulated
+//    remount, so the second `useEffect` setup finds the active tab already
+//    recorded and bails out.
+
+const mockRecordEvent = jest.fn();
+const mockInitialize = jest.fn();
+const mockSearch = jest.fn< { tab?: string }, [] >();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: ( ...args: unknown[] ) => mockInitialize( ...args ),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getSiteData: () => ( { admin_url: 'https://example.com/wp-admin/' } ),
+	getSiteType: () => 'jetpack',
+} ) );
+
+jest.mock( '@automattic/jetpack-connection/use-connection', () => ( {
+	__esModule: true,
+	default: () => ( {
+		isRegistered: false,
+		hasConnectedOwner: false,
+		isUserConnected: false,
+		siteIsRegistering: false,
+		userIsConnecting: false,
+		handleRegisterSite: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+} ) );
+
+// QueryClientProvider has no behavior relevant to this test; render children
+// directly so we don't have to spin up a real `QueryClient`.
+jest.mock( '@tanstack/react-query', () => ( {
+	QueryClientProvider: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	Tabs: {
+		Panel: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+	},
+} ) );
+
+// SubscribersBody is a render-prop component; the Stage passes a function
+// that builds the panels. The mock invokes it with empty slot data so the
+// downstream render path is exercised without any data-views machinery.
+jest.mock( '../_inc/subscribers/components/subscribers-body', () => ( {
+	__esModule: true,
+	default: ( {
+		children,
+	}: {
+		children: ( ctx: { body: React.ReactNode; actions: React.ReactNode } ) => React.ReactNode;
+	} ) => <>{ children( { body: null, actions: null } ) }</>,
+} ) );
+
+jest.mock( '../_inc/subscribers/components/connection-gate', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( '../_inc/subscribers/lib/query-client', () => ( {
+	queryClient: {},
+} ) );
+
+jest.mock( '../src/settings/newsletter-settings', () => ( {
+	NewsletterSettingsBody: () => null,
+} ) );
+
+jest.mock( '../src/settings/script-data', () => ( {
+	getNewsletterScriptData: () => ( {
+		subscriberManagementEnabled: true,
+		tracksUserData: { userid: 1, username: 'tester' },
+	} ),
+} ) );
+
+// NewsletterPage's render output is irrelevant for the analytics contract;
+// reduce it to a children passthrough so the test doesn't depend on the
+// shell's tab nav, AdminPage wiring, or SCSS imports.
+jest.mock( '../_inc/components/newsletter-page', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
+
+// SCSS side-effect imports — no-op in jest.
+jest.mock( '../src/settings/style.scss', () => ( {} ), { virtual: true } );
+jest.mock( '../routes/dashboard/route.scss', () => ( {} ), { virtual: true } );
+
+// Imports must come after the jest.mock factories above.
+import { render } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { stage as Stage } from '../routes/dashboard/stage';
+
+beforeEach( () => {
+	mockRecordEvent.mockReset();
+	mockInitialize.mockReset();
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+} );
+
+describe( 'Newsletter dashboard Stage analytics', () => {
+	it( 'records jetpack_newsletter_tab_view once on initial mount with the landing tab', () => {
+		render( <Stage /> );
+
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_newsletter_tab_view', {
+			site_type: 'jetpack',
+			tab: 'subscribers',
+		} );
+	} );
+
+	it( 'records the Settings tab when the route deep-links to ?tab=settings', () => {
+		mockSearch.mockReturnValue( { tab: 'settings' } );
+
+		render( <Stage /> );
+
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_newsletter_tab_view', {
+			site_type: 'jetpack',
+			tab: 'settings',
+		} );
+	} );
+
+	it( 'records again with the new tab when the active tab flips', () => {
+		const { rerender } = render( <Stage /> );
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+
+		// Simulate the route flipping `?tab=settings`; useSearch's next return
+		// drives the activeTab dep and re-runs the tab-view effect.
+		mockSearch.mockReturnValue( { tab: 'settings' } );
+		rerender( <Stage /> );
+
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 2 );
+		expect( mockRecordEvent ).toHaveBeenLastCalledWith( 'jetpack_newsletter_tab_view', {
+			site_type: 'jetpack',
+			tab: 'settings',
+		} );
+	} );
+
+	it( 'does not re-fire when re-rendered with the same active tab', () => {
+		const { rerender } = render( <Stage /> );
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+
+		// Re-render without touching mockSearch — activeTab stays 'subscribers'.
+		rerender( <Stage /> );
+
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'dedupes React 18 StrictMode mount/cleanup/remount so only one event fires', () => {
+		render(
+			<StrictMode>
+				<Stage />
+			</StrictMode>
+		);
+
+		// Without the `useRef` dedupe, StrictMode dev-mode would run the
+		// useEffect setup twice on mount and we'd see 2 calls here.
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'initializes analytics once on mount with the tracks user data', () => {
+		render( <Stage /> );
+
+		expect( mockInitialize ).toHaveBeenCalledTimes( 1 );
+		expect( mockInitialize ).toHaveBeenCalledWith( 1, 'tester' );
+	} );
+} );


### PR DESCRIPTION
Fixes #

## Proposed changes

* Hoists the `jetpack_newsletter_tab_view` Tracks event into the Newsletter dashboard's route stage (`routes/dashboard/stage.tsx`) so it fires on initial page load as well as on tab switches. Previously the event lived inside `NewsletterPage.onTabChange`, so a visitor deep-linking to `?page=jetpack-newsletter` (or `?tab=settings`) never produced an initial view event.
* Implements the fire via `useEffect` keyed on `[ activeTab ]`, calling `analytics.tracks.recordEvent` directly (not the `useAnalytics()` hook). The hook's `recordEvent` is a `useCallback` over connection state that churns through several identities during initial mount and would re-fire the effect spuriously.
* Adds a `useRef` dedupe to handle React 18 StrictMode's dev-only mount/cleanup/remount cycle — refs persist across the simulated remount, so the second `useEffect` setup finds the active tab already recorded and bails. Production isn't affected; the ref is harmless defense in depth.
* Drops the now-redundant analytics call (and its `if (next !== activeTab)` guard) from `NewsletterPage.onTabChange`. The page-level test loses its tab-view assertion; a new `stage.test.tsx` covers the mount/change/StrictMode-dedupe contracts at the route level.

## Related product discussion/links

* Mirrors the same fix on Social (#49240). Identifying the StrictMode double-fire on Social surfaced the missing initial-mount fire on Newsletter at the same time.

## Does this pull request change what data or activity we track or use?

Yes — same event name, same payload (`{ site_type, tab }`), but now fires once on initial mount in addition to tab clicks. No new event types, no new properties.

* Before: `jetpack_newsletter_tab_view` only on user-initiated tab switches.
* After: `jetpack_newsletter_tab_view` on every dashboard view (with the landing tab) plus every subsequent tab switch.

Net effect for analysts: tab-view counts on the Newsletter dashboard will increase to reflect total visits rather than just intra-session tab navigation.

## Testing instructions

* Pull this branch and `pnpm jetpack build packages/newsletter`.
* Hard-reload `wp-admin/admin.php?page=jetpack-newsletter` on a Jetpack-connected site with subscriber management enabled.
* Open DevTools → Network panel, filter for `pixel.wp.com/t.gif`.
* Confirm exactly **one** `jetpack_newsletter_tab_view` request fires on the initial Subscribers render, with `tab=subscribers` and `site_type=jetpack` in the query string.
* Click the **Settings** tab. Confirm exactly **one** more `jetpack_newsletter_tab_view` request fires with `tab=settings`.
* Click back to **Subscribers**. Confirm exactly **one** more with `tab=subscribers`.
* Click the same tab again — confirm **no** request fires (the active tab didn't change).
* Visit `wp-admin/admin.php?page=jetpack-newsletter&p=/&tab=settings` directly. Confirm exactly **one** request fires on initial load with `tab=settings`.

**Settings-only host (subscriber management disabled):**

* Filter `jetpack_wp_admin_subscriber_management_enabled` to `false` (e.g. via Code Snippets).
* Hard-reload the Newsletter dashboard. Confirm one `jetpack_newsletter_tab_view` fires with `tab=settings`. No tab nav renders (matching trunk behavior).

**Tests:**

* `pnpm jetpack test js packages/newsletter` — all 31 tests pass, including the new 6-test `stage.test.tsx` and the trimmed `newsletter-page.test.tsx` (tab-view assertion moved to the stage test).
