### PR TITLE
Forms: Align wp-build dashboard header logo and pin footer

### DIFF
--- a/projects/packages/forms/changelog/forms-dashboard-footer-logo
+++ b/projects/packages/forms/changelog/forms-dashboard-footer-logo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Dashboard: Align the header logo with the page title and pin the footer to the bottom of the viewport.
+Dashboard: Align the header logo with the page title, pin the footer to the bottom of the viewport, and keep the tabs and search controls on a single row on desktop.

--- a/projects/packages/forms/changelog/forms-dashboard-footer-logo
+++ b/projects/packages/forms/changelog/forms-dashboard-footer-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Align the header logo with the page title and pin the footer to the bottom of the viewport.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -3,7 +3,6 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { formatNumber } from '@automattic/number-formatters';
-import { Page } from '@wordpress/admin-ui';
 import {
 	Button,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -36,6 +35,7 @@ import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-
 import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
+import FormsPage from '../../src/dashboard/wp-build/components/page';
 import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import { useRenameForm } from '../../src/dashboard/wp-build/hooks/use-rename-form';
@@ -594,7 +594,7 @@ function StageInner() {
 	);
 
 	return (
-		<Page
+		<FormsPage
 			visual={ visual }
 			breadcrumbs={ breadcrumbs }
 			title={ title }
@@ -689,7 +689,7 @@ function StageInner() {
 				context="dashboard"
 			/>
 			<FormsHelpModal isOpen={ isFormsHelpModalOpen } onClose={ closeFormsHelpModal } />
-		</Page>
+		</FormsPage>
 	);
 }
 

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -6,7 +6,6 @@ import { formatNumber } from '@automattic/number-formatters';
 /**
  * WordPress dependencies
  */
-import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
@@ -28,6 +27,7 @@ import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.ts
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
+import FormsPage from '../../src/dashboard/wp-build/components/page';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
@@ -682,7 +682,7 @@ function StageInner() {
 	);
 
 	return (
-		<Page
+		<FormsPage
 			visual={ visual }
 			breadcrumbs={ breadcrumbs }
 			badges={ badges }
@@ -737,7 +737,7 @@ function StageInner() {
 				refreshIntegrations={ refreshIntegrations }
 				context="dashboard"
 			/>
-		</Page>
+		</FormsPage>
 	);
 }
 

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -9,12 +9,6 @@
 	container-type: inline-size;
 	flex-shrink: 0;
 
-	@container (width < 500px) {
-		--wp-ui-stack-justify: flex-start;
-		flex-direction: column;
-		align-items: flex-start;
-	}
-
 	> div:not(:empty) {
 		min-height: 48px;
 	}
@@ -35,4 +29,3 @@
 	margin-inline-start: 4px;
 	vertical-align: middle;
 }
-

--- a/projects/packages/forms/src/dashboard/wp-build/components/page/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/page/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import JetpackFooter from '@automattic/jetpack-components/jetpack-footer';
+import { Page } from '@wordpress/admin-ui';
+import type { ComponentProps, ReactNode } from 'react';
+
+type PageProps = ComponentProps< typeof Page >;
+
+type FormsPageProps = PageProps & {
+	children: ReactNode;
+};
+
+/**
+ * Thin chrome wrapper for the wp-build Forms dashboard routes.
+ *
+ * Mirrors the structure of `<AdminPage>` from `@automattic/jetpack-components`
+ * (`.jp-admin-page` root + `@wordpress/admin-ui` `<Page className="jp-admin-page__page">`
+ * + a trailing `<JetpackFooter>`), so the shared `jetpack-admin-page-layout-wp-build`
+ * mixin can pin the header, scroll the middle, and pin the footer. We use this
+ * local wrapper instead of `<AdminPage>` directly because the Forms routes pass
+ * `<Page>` props that `<AdminPage>` does not forward (`badges`, `ariaLabel`,
+ * `hasPadding`) and rely on `<Page>` rendering their DataViews children directly
+ * rather than inside `<AdminPage>`'s `<Container><Col>` wrap.
+ *
+ * @param props          - All `<Page>` props are forwarded through.
+ * @param props.children - Page content (rendered inside `<Page>`, above the footer).
+ * @return The Forms page chrome.
+ */
+export default function FormsPage( { children, ...pageProps }: FormsPageProps ): JSX.Element {
+	return (
+		<div className="jp-admin-page">
+			<Page className="jp-admin-page__page" { ...pageProps }>
+				{ children }
+				<JetpackFooter />
+			</Page>
+		</div>
+	);
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -459,13 +459,6 @@ export default function usePageHeaderDetails(
 		trackAction,
 	] );
 
-	// Match the canonical `<AdminPage>` logo (`<JetpackLogo showText={ false }
-	// height={ 20 } />`): the admin-ui Page `visual` slot is a 24px grid cell that
-	// pins (does not center) its child to the cell top. The square viewBox
-	// (`0 0 32 32`) scales from `height`; passing `width={ 20 }` instead left
-	// `height` at its 32px default, so the logo overflowed the slot and sat ~4px
-	// below the title baseline. Sizing by `height={ 20 }` keeps the square aspect
-	// and fits the slot, aligning the logo with the title.
 	const visual = <JetpackLogo showText={ false } height={ 20 } />;
 
 	const ariaLabel = useMemo( () => {

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -459,7 +459,14 @@ export default function usePageHeaderDetails(
 		trackAction,
 	] );
 
-	const visual = <JetpackLogo showText={ false } width={ 20 } />;
+	// Match the canonical `<AdminPage>` logo (`<JetpackLogo showText={ false }
+	// height={ 20 } />`): the admin-ui Page `visual` slot is a 24px grid cell that
+	// pins (does not center) its child to the cell top. The square viewBox
+	// (`0 0 32 32`) scales from `height`; passing `width={ 20 }` instead left
+	// `height` at its 32px default, so the logo overflowed the slot and sat ~4px
+	// below the title baseline. Sizing by `height={ 20 }` keeps the square aspect
+	// and fits the slot, aligning the logo with the title.
+	const visual = <JetpackLogo showText={ false } height={ 20 } />;
 
 	const ariaLabel = useMemo( () => {
 		if ( isSingleFormScreen ) {

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -3,6 +3,7 @@
  */
 
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+@use "@wordpress/base-styles/breakpoints";
 
 body.jetpack_page_jetpack-forms-responses-wp-admin,
 body.jetpack-forms-responses {
@@ -70,6 +71,24 @@ body.jetpack-forms-responses {
 			.dataviews-footer {
 				flex: 0 0 auto;
 				min-block-size: 0;
+			}
+
+			// The layout mixin above blanket-sets `flex-direction: column` on
+			// the scrollable middle's direct children (its `> *` rule). That
+			// column is only wanted on narrow screens; the toolbar is a Stack
+			// that owns its own axis with tabs on the left and the
+			// search/settings controls on the right. Above the small breakpoint
+			// drop the mixin's forced column (back to the default row) so the
+			// two groups sit on a single line; below it the mixin's column
+			// keeps them stacked across multiple lines.
+			.jp-forms-dataviews__view-actions {
+				align-items: flex-start;
+				gap: 8px;
+
+				@media (min-width: #{ (breakpoints.$break-small + 1) }) {
+					flex-direction: unset;
+					align-items: center;
+				}
 			}
 
 			.dataviews-layout__container,

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -2,37 +2,42 @@
  * Holds shared styling for the wp-build routes.
  */
 
-/**
- * Temporary overrides to align styling of core elements with Jetpack Forms
- * designs and Commerce in a Box designs.
- *
- * To remove these overrides
- *
- * The breadcrumbs component would need to support:
- * - removing bottom margin on breadcrumb list items
- * - applying a color attribute to breadcrumb links
- *
- * The search control component would need to support:
- * - removing bottom margin on the search field
- */
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 body.jetpack_page_jetpack-forms-responses-wp-admin,
 body.jetpack-forms-responses {
 
-	.admin-ui-breadcrumbs__list li {
-		margin-bottom: 0;
+	// The wp-build dashboard mounts `@wordpress/admin-ui` 2.x chrome via the
+	// local `FormsPage` wrapper (`.jp-admin-page` root + `<Page
+	// className="jp-admin-page__page">` + `<JetpackFooter>`). The shared mixin
+	// owns the viewport-pinned layout (fixed content column, scrolling middle,
+	// pinned footer) and resets the wp-admin globals — notably `ul li {
+	// margin-bottom }` — that otherwise inflate the breadcrumb list and push the
+	// header logo below the title baseline.
+	@include jetpack-admin-page-layout-wp-build;
 
-		&:first-of-type {
-			margin-inline-start: 4px;
-		}
-
-		a {
-			color: var(--wp-components-color-foreground, #1e1e1e);
-			font-weight: 600;
-		}
+	// Match the breadcrumb link color/weight to the Jetpack Forms design. The
+	// mixin already handles the margin reset and the underline behavior; this
+	// only adds the color treatment the mixin intentionally leaves alone.
+	nav[aria-label="Breadcrumbs"] a {
+		color: var(--wp-components-color-foreground, #1e1e1e);
+		font-weight: 600;
 	}
 
 	.dataviews-search .components-base-control__field {
 		margin-bottom: 0;
 	}
-}
 
+	// Continue the layout mixin's flex chain through the DataViews surface so
+	// the table fills the bounded middle and its pagination footer pins to the
+	// bottom (mirrors Newsletter's Subscribers DataViews chain). The mixin
+	// already flexes the page's scrollable middle and its direct child; walk
+	// the rest down to `.dataviews-wrapper`.
+	.jp-admin-page:has(.dataviews-wrapper) {
+
+		.dataviews-wrapper {
+			flex: 1 1 auto;
+			min-block-size: 0;
+		}
+	}
+}

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -16,6 +16,21 @@ body.jetpack-forms-responses {
 	// header logo below the title baseline.
 	@include jetpack-admin-page-layout-wp-build;
 
+	// admin-ui's header `visual` slot is a 24px grid cell that does not center
+	// its contents, and its header content row doesn't center its items — so the
+	// JetpackLogo pins to the top and looks misaligned vs. the title. The shared
+	// <AdminPage> wrapper fixes this in its stylesheet, but the Forms wp-build
+	// dashboard uses a thin FormsPage shell that doesn't load it. Mirror the two
+	// AdminPage overrides here. (See js-packages/components admin-page style.)
+	.jp-admin-page__page > :first-child [aria-hidden="true"] {
+		place-items: center;
+	}
+
+	.jp-admin-page__page > :first-child > div:has([aria-hidden="true"]) {
+		min-block-size: 40px;
+		align-items: center;
+	}
+
 	// Match the breadcrumb link color/weight to the Jetpack Forms design. The
 	// mixin already handles the margin reset and the underline behavior; this
 	// only adds the color treatment the mixin intentionally leaves alone.

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -28,16 +28,41 @@ body.jetpack-forms-responses {
 		margin-bottom: 0;
 	}
 
-	// Continue the layout mixin's flex chain through the DataViews surface so
-	// the table fills the bounded middle and its pagination footer pins to the
-	// bottom (mirrors Newsletter's Subscribers DataViews chain). The mixin
-	// already flexes the page's scrollable middle and its direct child; walk
-	// the rest down to `.dataviews-wrapper`.
+	// DataViews owns its own internal vertical layout: `.dataviews-wrapper` is a
+	// `display: flex; flex-direction: column` surface whose toolbar, filters row
+	// and pagination footer are `flex-shrink: 0` (natural height, pinned
+	// top/bottom) while the results/empty area is the only `flex-grow: 1` child.
+	// Here `.dataviews-wrapper` is the *direct* scrollable middle of the page
+	// (`.jp-admin-page__page > :not(:first-child)`), unlike Newsletter where it
+	// sits a few wrappers deeper inside a tab panel. The layout mixin blanket-
+	// styles that middle's direct children with `flex: 1 1 auto; display: flex`
+	// to bridge `<AdminPage>`'s `Container > Col` grid — but here those "direct
+	// children" ARE the wrapper's own toolbar/results/footer, so the blanket
+	// would stretch the toolbar (its custom `jp-forms-dataviews__view-actions`
+	// class never picked up DataViews' native `flex-shrink: 0`) and push it into
+	// the middle of the page. Restore DataViews' intended per-child flex roles:
+	// the wrapper grows and scrolls, the toolbar + filters + footer stay natural
+	// height where they belong, and only the results area absorbs the leftover
+	// space so the JetpackFooter pins to the viewport bottom in every data state.
 	.jp-admin-page:has(.dataviews-wrapper) {
 
 		.dataviews-wrapper {
 			flex: 1 1 auto;
 			min-block-size: 0;
+
+			.jp-forms-dataviews__view-actions,
+			.jp-forms-dataviews-filters__container,
+			.dataviews-footer {
+				flex: 0 0 auto;
+				min-block-size: 0;
+			}
+
+			.dataviews-layout__container,
+			.dataviews-no-results,
+			.dataviews-loading {
+				flex: 1 1 auto;
+				min-block-size: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes JETPACK-1638 and JETPACK-1639 (umbrella JETPACK-1543).

## Proposed changes

The new wp-build ("alpha") Jetpack Forms dashboard (`routes/`) mounted a bare `@wordpress/admin-ui` `Page` directly, without the `.jp-admin-page` wrapper, without a `JetpackFooter`, and without ever applying the shared `jetpack-admin-page-layout-wp-build` mixin. As a result:

* **JETPACK-1638 (header logo):** wp-admin's global `ul li { margin-bottom: 6px }` inflated the breadcrumb `<ul>`, and admin-ui's header centered the logo against that inflated title block — pushing the logo below the title baseline.
* **JETPACK-1639 (footer):** the page rendered no footer and nothing pinned to the viewport bottom.

This PR brings the dashboard in line with how Newsletter integrates the shared chrome:

* Add a thin `FormsPage` wrapper (`src/dashboard/wp-build/components/page/index.tsx`) that renders the `.jp-admin-page` root div, the `@wordpress/admin-ui` `Page` with `className="jp-admin-page__page"`, and `JetpackFooter` as the last child. It forwards all of Forms' existing `Page` props.
* Point `routes/responses/stage.tsx` and `routes/forms/stage.tsx` at `FormsPage` instead of the bare `Page`.
* In the wp-build entry SCSS (`src/dashboard/wp-build/style.scss`), `@use` + `@include jetpack-admin-page-layout-wp-build` scoped to the Forms page body class (`body.jetpack_page_jetpack-forms-responses-wp-admin`), and add the DataViews flex chain so the table fills the bounded middle and its pagination/footer pin (mirrors `newsletter-page.scss`). This replaces the older, now-stale manual `.admin-ui-breadcrumbs__list li` margin reset (which targeted a pre-2.x admin-ui class hook) with the mixin's version-stable `nav[aria-label="Breadcrumbs"] li { margin: 0 }` reset.

**Why a thin shell instead of reusing the shared `AdminPage` directly:** the generic Jetpack `AdminPage` from `@automattic/jetpack-components` cannot forward the `Page` props these stages rely on (`badges`, `ariaLabel`, `hasPadding={false}`) and it hard-wraps children in `<Container fluid><Col>`, which would break the DataViews flex chain. The thin shell is the smallest faithful diff that keeps current rendering while adding the footer + layout.

**Nothing was deleted, and the legacy dashboard was not touched.** The duplicated chrome under `src/dashboard/components/page/*` is imported only by the LEGACY webpack dashboard (`src/dashboard/inbox/stage/index.js`, `src/dashboard/forms/index.tsx`); deleting it would break legacy, so it was left in place. No other packages were modified.

## Related product discussion/links

* JETPACK-1638, JETPACK-1639 (umbrella JETPACK-1543)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the package: `jp build packages/forms` (and `jp build plugins/jetpack` if your env loads Forms via the Jetpack plugin).
2. With the new wp-build dashboard enabled (the `jetpack_forms_alpha` filter defaults to `true`), go to **Jetpack → Forms** in wp-admin.
3. **Header logo (JETPACK-1638):** open a single form's responses (the breadcrumbs view, e.g. "Forms / <form name>"). The Jetpack logo in the header should be vertically centered with the breadcrumb/title text, not sitting below it.
4. **Footer (JETPACK-1639):** on the Responses list with many responses, confirm the `JetpackFooter` ("Jetpack · Products · Help · An Automattic Airline") is pinned to the bottom of the viewport and the responses list scrolls beneath it (matching the Newsletter page).
5. **Legacy regression:** set the `jetpack_forms_alpha` filter to `false` and confirm the legacy webpack dashboard renders unchanged.

### Before / after

<img width="1258" height="796" alt="image" src="https://github.com/user-attachments/assets/22aaeaac-ed11-479e-8cc6-4f8e14ad78c2" />


<img width="1261" height="797" alt="image" src="https://github.com/user-attachments/assets/60c0c832-3ebe-4ab4-9b77-bc97db276b57" />

