### PR TITLE
wpcomsh: Restore custom-fonts typekit provider json files

### DIFF
--- a/projects/plugins/wpcomsh/.gitattributes
+++ b/projects/plugins/wpcomsh/.gitattributes
@@ -52,8 +52,6 @@
 /vendor/automattic/custom-fonts/package-lock.json        production-exclude
 /vendor/automattic/custom-fonts/package.json             production-exclude
 /vendor/automattic/custom-fonts/annotations.md           production-exclude
-/vendor/automattic/custom-fonts/providers/typekit.json   production-exclude
-/vendor/automattic/custom-fonts/providers/google.json    production-exclude
 /vendor/automattic/custom-fonts/tests/**                 production-exclude
 /vendor/automattic/wc-calypso-bridge/.*                  production-exclude
 /vendor/automattic/wc-calypso-bridge/.*/**               production-exclude

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore custom-fonts typekit provider json files that shouldn't have been deleted.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
These files were removed in #49014, but turn out to actually be needed.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1779998320137539-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Install an older theme, such as TwentyTwenty, on a WoW dev site.
* Go to Appearance → Customize → Fonts. With trunk you should get an exception thrown. With this PR, it should load.