### PR TITLE
CI: Skip E2E Slack notification on pull_request events

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -350,7 +350,8 @@ jobs:
       actions: read
       # actions/checkout, actions/download-artifact
       contents: read
-    if: ${{ always() && needs.e2e-tests.result != 'cancelled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+    # Skip on pull_request: PR feedback is already in the GitHub Checks UI. Mirror-repo dispatches still notify.
+    if: ${{ always() && needs.e2e-tests.result != 'cancelled' && github.event_name != 'pull_request' }}
     needs: [e2e-tests]
 
     steps:


### PR DESCRIPTION
## Proposed changes

* Skip the `slack-notification` job in the E2E Tests workflow when the workflow is triggered by a `pull_request` event.
* PR-only E2E results remain visible in the GitHub Checks UI, where they are already actionable for PR authors.
* Notifications continue to fire for `repository_dispatch` events (the path that delivers trunk, release, and scheduled runs from mirror repos), preserving the existing alerting for shared branches.

## Why

The `slack-notification` job calls the in-repo `test-results-to-slack` action with `slack_channel: ${{ vars.SLACK_E2E_CHANNEL }}` as the default channel. For `pull_request` events, the rules engine in `test-results-to-slack` cannot match any ref-name or suite-name rule (PR refs look like `123/merge`, and `suite_name` is empty for PRs), so PR failures always post to the default channel. The result is high-volume PR-specific noise mixed in with the trunk/release alerts that the channel exists for.

The smallest fix is to scope the notification job to non-PR events. The previously redundant same-repo guard (`head.repo.full_name == base.repo.full_name`) is no longer needed because `pull_request` is the only event that produces `github.event.pull_request`.

## Related product discussion/links

* pdWQjU-1A6-p2

## Testing instructions

* Push a small change in a PR against this branch (or any PR after merge) and confirm no Slack message is posted for the E2E run, while the E2E checks still appear on the PR itself.
* After merge, the next trunk push (which arrives via `repository_dispatch` from the mirror repo) should still produce a Slack notification on failure.
