### PR TITLE
Modules/About/Debug: modernize header and footer to match my-jetpack

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -7,9 +7,9 @@ $color__back-link: #787c82;
 
 .jetpack-about__main,
 .jetpack-about__plugin {
-	background-color: colors.$white;
-	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
-	border-radius: 4px;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+	border-radius: var(--wpds-border-radius-lg, 8px);
 }
 
 .jetpack-about__main,

--- a/projects/plugins/jetpack/_inc/client/components/contextualized-connection/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/contextualized-connection/style.scss
@@ -4,9 +4,9 @@
 .jp-contextualized-connection {
 	display: flex;
 	flex-direction: column;
-	background: var(--jp-white);
-	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
-	border-radius: var(--jp-border-radius);
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+	border-radius: var(--wpds-border-radius-lg, 8px);
 
 	&__content {
 		display: flex;

--- a/projects/plugins/jetpack/_inc/client/components/footer/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/footer/style.scss
@@ -18,6 +18,8 @@
 	--jp-black: #000;
 	--font-body-extra-small: 12px;
 
+	border-top: 1px solid #e0e0e0;
+
 	&,
 	*,
 	*::before,
@@ -32,6 +34,8 @@
 		flex-wrap: wrap;
 		font-size: var(--font-body-extra-small);
 		line-height: 1.333;
+		max-width: none;
+		padding: 0 24px;
 		width: 100%;
 
 		@include breakpoints.breakpoint( "<960px" ) {

--- a/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
@@ -1,8 +1,14 @@
 @use "../../scss/variables/colors";
 
+#jp-plugin-container {
+	background-color: var(--wpds-color-bg-surface-neutral, #fcfcfc);
+	min-height: calc(100vh - 32px);
+}
+
 .jp-masthead {
-	background-color: colors.$white;
-	padding: 16px 24px;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
+	border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+	padding: var(--wpds-dimension-padding-lg, 16px) var(--wpds-dimension-padding-2xl, 24px);
 }
 
 .jp-masthead__inside-container {
@@ -10,6 +16,7 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: 8px;
+	min-height: 40px;
 }
 
 .jp-masthead__title-container {
@@ -20,6 +27,11 @@
 
 .jp-masthead__logo-link {
 	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: calc(var(--wpds-dimension-base, 4px) * 6);
+	height: calc(var(--wpds-dimension-base, 4px) * 6);
+	flex-shrink: 0;
 	outline: none;
 
 	&:focus {
@@ -29,15 +41,37 @@
 }
 
 .jp-masthead__title {
-	font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 20px;
-	font-weight: 500;
-	line-height: 1.4;
+	font-family: var(--wpds-typography-font-family-heading, -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif);
+	font-size: var(--_gcd-heading-font-size, var(--wpds-typography-font-size-lg, 15px));
+	font-weight: var(--_gcd-heading-font-weight, var(--wpds-typography-font-weight-medium, 499));
+	line-height: var(--_gcd-heading-line-height, var(--wpds-typography-line-height-sm, 1.3));
 	margin: 0;
-	color: #1e1e1e;
+	color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.jp-masthead__title-link {
+	color: #1e1e1e;
+	text-decoration: none;
+	font-weight: inherit;
+
+	&:hover,
+	&:focus {
+		color: #1e1e1e;
+		text-decoration: underline;
+	}
+}
+
+.jp-masthead__title-separator {
+	color: #757575;
+	font-weight: 400;
+	margin: 0 4px;
+}
+
+.jp-masthead__title-current {
+	font-weight: 700;
 }
 
 .jp-masthead__nav {

--- a/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
@@ -24,9 +24,9 @@
 	.jp-static-block {
 		display: block;
 		margin-top: 24px;
-		background: colors.$white;
-		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
-		border-radius: 4px;
+		background: var(--wpds-color-bg-surface-neutral-strong, #fff);
+		border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+		border-radius: var(--wpds-border-radius-lg, 8px);
 
 		.jp-static-block-body {
 			padding: 0 24px 20px;

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
@@ -95,12 +95,6 @@ class Jetpack_About_Page extends Jetpack_Admin_Page {
 		?>
 		<div class="jp-lower">
 			<h1 class="screen-reader-text"><?php esc_html_e( 'About Jetpack', 'jetpack' ); ?></h1>
-			<div class="jetpack-about__link-back">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack' ) ); ?>">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></g></svg>
-					<?php esc_html_e( 'Back to Jetpack Dashboard', 'jetpack' ); ?>
-				</a>
-			</div>
 			<div class="jetpack-about__main">
 				<div class="jetpack-about__logo">
 					<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 800 96" style="enable-background:new 0 0 800 96;" xml:space="preserve">

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -116,7 +116,8 @@ abstract class Jetpack_Admin_Page {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['page'] ) && 'jetpack_modules' === $_GET['page'] ) {
-			$args['is-wide'] = true;
+			$args['is-wide']  = true;
+			$args['show-nav'] = false;
 		}
 
 		self::wrap_ui( array( $this, 'page_render' ), $args );
@@ -259,12 +260,6 @@ abstract class Jetpack_Admin_Page {
 			? admin_url( 'admin.php?page=jetpack_about' )
 			: Redirect::get_url( 'jetpack' );
 
-		$jetpack_privacy_url = ! $connectable
-			? $jetpack_admin_url . '#/privacy'
-			: Redirect::get_url( 'a8c-privacy' );
-
-		$external_link_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" class="jp-footer__menu-item__icon" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>';
-
 		?>
 		<div id="jp-plugin-container" class="
 		<?php
@@ -276,21 +271,29 @@ abstract class Jetpack_Admin_Page {
 			<header class="jp-masthead">
 				<div class="jp-masthead__inside-container">
 					<div class="jp-masthead__title-container">
-						<a class="jp-masthead__logo-link" href="<?php echo esc_url( $jetpack_admin_url ); ?>">
+						<a class="jp-masthead__logo-link" href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/overview' ) ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" height="20" aria-label="<?php esc_attr_e( 'Jetpack logo', 'jetpack' ); ?>"><path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"></path></svg>
 						</a>
 						<h2 class="jp-masthead__title">
 							<?php
 							// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic only.
-							$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+							$page          = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+							$current_label = '';
 							if ( 'jetpack_modules' === $page ) {
-								esc_html_e( 'Modules', 'jetpack' );
+								$current_label = __( 'Modules', 'jetpack' );
 							} elseif ( 'jetpack_about' === $page ) {
-								esc_html_e( 'About', 'jetpack' );
-							} else {
-								echo 'Jetpack'; // "Jetpack" is a product name, do not translate.
+								$current_label = __( 'About', 'jetpack' );
+							} elseif ( 'jetpack-debugger' === $page ) {
+								$current_label = __( 'Debug', 'jetpack' );
 							}
 							?>
+							<?php if ( $current_label ) : ?>
+								<a class="jp-masthead__title-link" href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/overview' ) ); ?>">Jetpack</a><?php // "Jetpack" is a product name, do not translate. ?>
+								<span class="jp-masthead__title-separator" aria-hidden="true">/</span>
+								<span class="jp-masthead__title-current"><?php echo esc_html( $current_label ); ?></span>
+							<?php else : ?>
+								Jetpack<?php // "Jetpack" is a product name, do not translate. ?>
+							<?php endif; ?>
 						</h2>
 					</div>
 					<?php
@@ -369,39 +372,14 @@ abstract class Jetpack_Admin_Page {
 							</desc>
 							<path fill="#000" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"></path>
 						</svg>
-						<span class="jp-footer__module-name">
-							<a href="<?php echo esc_url( Redirect::get_url( 'jetpack' ) ); ?>" target="_blank" rel="noopener noreferrer" aria-label="Jetpack 12.2-a.0">
-								<?php esc_html_e( 'Jetpack', 'jetpack' ); ?>
-							</a>
-						</span>
+						<span class="jp-footer__module-name"><?php esc_html_e( 'Jetpack', 'jetpack' ); ?></span>
 					</div>
+					<?php if ( ! ( new Host() )->is_wpcom_platform() ) : ?>
 					<div class="jp-footer__menu">
-						<a href="<?php echo esc_url( $jetpack_about_url ); ?>" title="<?php esc_attr__( 'About Jetpack', 'jetpack' ); ?>" class="jp-footer__menu-item">
-							<?php echo esc_html__( 'About', 'jetpack' ); ?>
-						</a>
-						<a href="<?php echo esc_url( $jetpack_privacy_url ); ?>" rel="noopener noreferrer" title="<?php esc_html_e( "Automattic's Privacy Policy", 'jetpack' ); ?>" class="jp-footer__menu-item <?php echo ! $connectable ? 'is-external' : ''; ?> ?>" target="<?php echo ! $connectable ? '_blank' : '_self'; ?>">
-							<?php echo esc_html_x( 'Privacy', 'Navigation item', 'jetpack' ); ?>
-							<?php echo ! $connectable ? $external_link_icon : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</a>
-						<a href="<?php echo esc_url( Redirect::get_url( 'wpcom-tos' ) ); ?>" target="_blank" rel="noopener noreferrer" title="<?php esc_html__( 'WordPress.com Terms of Service', 'jetpack' ); ?>" class="jp-footer__menu-item is-external">
-							<?php echo esc_html_x( 'Terms', 'Navigation item', 'jetpack' ); ?>
-							<?php echo $external_link_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</a>
-						<a href="<?php echo esc_url( Redirect::get_url( 'jetpack' ) ); ?>" target="_blank" rel="noopener noreferrer" aria-label="Jetpack 12.2-a.0" class="jp-footer__menu-item is-external">
-							Version <?php echo esc_html( JETPACK__VERSION ); ?>
-							<?php echo $external_link_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</a>
-						<?php if ( is_multisite() && current_user_can( 'jetpack_network_sites_page' ) ) { ?>
-							<a href="<?php echo esc_url( network_admin_url( 'admin.php?page=jetpack' ) ); ?>" title="<?php esc_html_e( "Manage your network's Jetpack Sites.", 'jetpack' ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Network Sites', 'Navigation item', 'jetpack' ); ?></a>
-						<?php } ?>
-						<?php if ( is_multisite() && current_user_can( 'jetpack_network_settings_page' ) ) { ?>
-							<a href="<?php echo esc_url( network_admin_url( 'admin.php?page=jetpack-settings' ) ); ?>" title="<?php esc_html_e( "Manage your network's Jetpack Sites.", 'jetpack' ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Network Settings', 'Navigation item', 'jetpack' ); ?></a>
-						<?php } ?>
-						<?php if ( current_user_can( 'manage_options' ) ) { ?>
-							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack_modules' ) ); ?>" title="<?php esc_html_e( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Modules', 'Navigation item', 'jetpack' ); ?></a>
-							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack-debugger' ) ); ?>" title="<?php esc_html_e( "Test your site's compatibility with Jetpack.", 'jetpack' ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Debug', 'Navigation item', 'jetpack' ); ?></a>
-						<?php } ?>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/products' ) ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Products', 'Navigation item', 'jetpack' ); ?></a>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/help' ) ); ?>" class="jp-footer__menu-item"><?php echo esc_html_x( 'Help', 'Navigation item', 'jetpack' ); ?></a>
 					</div>
+					<?php endif; ?>
 					<a class="jp-footer__a8c-logo" href="<?php echo esc_url( $jetpack_about_url ); ?>" aria-label="<?php echo esc_attr__( 'An Automattic Airline', 'jetpack' ); ?>">
 						<svg role="img" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2" aria-labelledby="jp-automattic-byline-logo-title" height="7" class="jp-automattic-byline-logo">
 							<desc id="jp-automattic-byline-logo-title">

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
@@ -263,6 +263,11 @@ class Jetpack_Debugger {
 	 */
 	public static function jetpack_debug_admin_head() {
 
+		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons', 'jetpack-connection' ), JETPACK__VERSION . '-20121016' );
+		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
+		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
+
 		Jetpack_Admin_Page::load_wrapper_styles();
 		?>
 		<style type="text/css">
@@ -292,18 +297,17 @@ class Jetpack_Debugger {
 			}
 
 			.formbox input[type="text"], .formbox input[type="email"], .formbox input[type="url"], .formbox textarea, #debug_info_div {
-				border: 1px solid #dcdcde;
-				border-radius: 11px;
-				box-shadow: inset 0 1px 1px rgba(0,0,0,0.1);
+				border: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+				border-radius: var(--wpds-border-radius-md, 4px);
 				color: #646970;
 				font-size: 14px;
 				padding: 10px;
 				width: 97%;
 			}
 			#debug_info_div {
-				border-radius: 0;
+				border-radius: var(--wpds-border-radius-lg, 8px);
 				margin-top: 16px;
-				background: #FFF;
+				background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 				padding: 16px;
 			}
 			.formbox .contact-support input[type="submit"] {

--- a/projects/plugins/jetpack/changelog/update-old-ui-header-footer
+++ b/projects/plugins/jetpack/changelog/update-old-ui-header-footer
@@ -1,0 +1,3 @@
+Significance: patch
+Type: enhancement
+Comment: Simplify and modernize the header and footer on the Jetpack Modules, About, and Debug admin pages to match the my-jetpack design system.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -555,7 +555,13 @@ class Jetpack_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			die( '-1' );
 		}
-		Jetpack_Admin_Page::wrap_ui( array( $this, 'debugger_page' ), array( 'is-wide' => true ) );
+		Jetpack_Admin_Page::wrap_ui(
+			array( $this, 'debugger_page' ),
+			array(
+				'is-wide'  => true,
+				'show-nav' => false,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes

Simplify and modernize the header and footer on the three legacy Jetpack admin pages (`jetpack_modules`, `jetpack_about`, `jetpack-debugger`) so they align with the my-jetpack design system.

**Header**
* Dropped the Dashboard/Settings nav buttons on all three pages (`show-nav => false`).
* Logo now links to `admin.php?page=my-jetpack#/overview` (was the old jetpack dashboard).
* New breadcrumb-style title: `Jetpack / About`, `Jetpack / Modules`, `Jetpack / Debug` — the "Jetpack" part is a link back to my-jetpack, the current page is bold, with a gray `/` separator.
* Logo container sized to match admin-ui's `header-visual` slot (24×24 with the 20px SVG centered).
* Header now uses WPDS typography tokens (`--wpds-typography-font-size-lg`, `font-weight-medium`, `font-family-heading`) so the title matches admin-ui's `Text variant="heading-lg"` used on my-jetpack.
* Min-height of 40px on the inner container (matches admin-page override) and bottom border using `--wpds-color-stroke-surface-neutral-weak`.

**Footer**
* Replaced the About / Privacy / Terms / Version / Modules / Debug / Network links with just **Products** and **Help** (linking to `my-jetpack#/products` and `my-jetpack#/help`), matching the modern `JetpackFooter` pattern.
* Footer now spans full width (removed the `max-width: 68rem` constraint within `.jp-footer--static`).
* Added a thin top border matching the my-jetpack footer divider.
* Removed the now-unused `$jetpack_privacy_url` and `$external_link_icon` locals.

**Background, boxes, and shadows**
* Page background uses `--wpds-color-bg-surface-neutral` (`#fcfcfc`) — matches my-jetpack.
* Removed `box-shadow: 0 0 40px rgba(0,0,0,0.08)` from `.jetpack-about__main`, `.jetpack-about__plugin`, `.jp-contextualized-connection`, and `.jp-static-block`. Replaced with `border: 1px solid var(--wpds-color-stroke-surface-neutral-weak)` and `border-radius: var(--wpds-border-radius-lg)` — matching the `@wordpress/ui` Card pattern.
* Debugger inline formbox/`#debug_info_div` styles updated to use the same WPDS tokens; dropped the inset box-shadow.

**About page**
* Removed the redundant "Back to Jetpack Dashboard" link block — the header breadcrumb now handles that navigation.

**Debugger styles consistency**
* Debugger now also enqueues `css/jetpack-admin.min.css` so it loads the same stylesheet as the Modules/About pages — fixes the visual drift (font sizes, link styles) where the debug header looked different from the other two.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Visit `wp-admin/admin.php?page=jetpack_modules`, `wp-admin/admin.php?page=jetpack_about`, and `wp-admin/admin.php?page=jetpack-debugger`.
* Confirm on each page:
  - Header shows the green Jetpack logo (20px SVG centered in a 24px box), followed by `Jetpack / <page name>` — "Jetpack" is a link (no underline by default, underlines on hover) that navigates to `admin.php?page=my-jetpack#/overview`; the current page name is bold; the slash separator is gray.
  - No Dashboard / Settings buttons in the header on these three pages.
  - The header background is white, with a thin bottom border, and consistent 16/24 padding.
  - Page background is the off-white `#fcfcfc` (matches my-jetpack).
  - Boxes (About cards, debugger info/formboxes, `.jp-static-block` on Modules/Debug) have a 1px gray border with no drop shadow.
  - Footer is full-width with only **Products** and **Help** links + the Automattic byline; thin top border above the footer.
* On the About page, confirm the old "Back to Jetpack Dashboard" arrow link is gone (the header breadcrumb replaces it).
* Compare each header visually against `wp-admin/admin.php?page=my-jetpack` — sizes, weights, padding, and colors should match.
* Hover the "Jetpack" link in the header on all three pages — underline should appear consistently.
* Confirm the Modules page (which uses `.jp-static-block`) and Debugger page render without box-shadows; only borders.


## Before / After

Captured on a live local site (tunneled via Jurassic Tube) at 1440×900.

### Modules

| Before | After |
|---|---|
| ![before modules](https://github.com/Automattic/jetpack/raw/screenshots/update/footer-old-ui/before-modules.png) | ![after modules](https://github.com/Automattic/jetpack/raw/screenshots/update/footer-old-ui/after-modules.png) |

### About

| Before | After |
|---|---|
| ![before about](https://github.com/Automattic/jetpack/raw/screenshots/update/footer-old-ui/before-about.png) | ![after about](https://github.com/Automattic/jetpack/raw/screenshots/update/footer-old-ui/after-about.png) |

### Debug

| Before | After |
|---|---|
| ![before debugger](https://github.com/Automattic/jetpack/raw/screenshots/update/footer-old-ui/before-debugger.png) | ![after debugger](https://github.com/Automattic/jetpack/raw/screenshots/update/footer-old-ui/after-debugger.png) |
