### PR TITLE
Search Blocks: drop the filters-popover responsive display mode; block is always a popover (SEARCH-280)

### DIFF
--- a/projects/packages/search/changelog/echo-search-280-drop-filters-popover-responsive-mode
+++ b/projects/packages/search/changelog/echo-search-280-drop-filters-popover-responsive-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: drop the filters-popover responsive display mode; the block is always a popover.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/block.json
@@ -5,12 +5,8 @@
 	"version": "0.1.0",
 	"title": "Collapsible Filters",
 	"category": "jetpack-search",
-	"description": "Tucks the filters behind a compact button that opens them in a popover. Can also show them inline on wider screens. Powered by Jetpack Search.",
+	"description": "Tucks the filters behind a compact button that opens them in a popover. Powered by Jetpack Search.",
 	"attributes": {
-		"displayMode": {
-			"type": "string",
-			"default": "popover-always"
-		},
 		"interactiveScope": {
 			"type": "boolean",
 			"default": true

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -1,22 +1,14 @@
 /**
  * Editor preview for jetpack-search/filters-popover.
  *
- * Two display modes share this block. In `popover-always` (default) the trigger button
- * renders as a non-interactive preview of the front-end control, and a block-toolbar
- * button toggles whether the panel is expanded in the canvas — so authors can edit the
- * panel contents when expanded or the surrounding template parts when collapsed. The
- * trigger itself stays inert because clicking it would select the block (and pop the
- * settings sidebar) without giving the author a way to collapse the panel afterwards.
- * `responsive` renders children inline, mirroring the ≥992px front-end appearance;
- * runtime visibility on the front end stays class-driven by the Interactivity store.
+ * The trigger button renders as a non-interactive preview of the front-end control, and a
+ * block-toolbar button toggles whether the panel is expanded in the canvas — so authors can
+ * edit the panel contents when expanded or the surrounding template parts when collapsed. The
+ * trigger itself stays inert because clicking it would select the block (and pop the settings
+ * sidebar) without giving the author a way to collapse the panel afterwards.
  */
-import {
-	BlockControls,
-	InnerBlocks,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
-import { PanelBody, SelectControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { BlockControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { filter } from '@wordpress/icons';
@@ -34,28 +26,12 @@ const ALLOWED = [
 	'jetpack-search/clear-filters',
 ];
 
-const DISPLAY_MODE_OPTIONS = [
-	{
-		value: 'popover-always',
-		label: __( 'Always collapsed (popover)', 'jetpack-search-pkg' ),
-	},
-	{
-		value: 'responsive',
-		label: __( 'Inline on desktop, popover on mobile', 'jetpack-search-pkg' ),
-	},
-];
-
 /**
  * Edit component for the filters-popover block.
  *
- * @param {object}   props               - Block props.
- * @param {object}   props.attributes    - Block attributes.
- * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
-	const displayMode = attributes?.displayMode === 'responsive' ? 'responsive' : 'popover-always';
-	const isResponsive = displayMode === 'responsive';
+export default function FiltersPopoverEdit() {
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
 	// Split into a top-level if/else so Terser doesn't collapse two __() calls
 	// into `__( cond ? 'a' : 'b' )` — the post-build i18n validator requires a
@@ -67,9 +43,8 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps( {
 		className: [
 			'jetpack-search-filters-popover',
-			`is-mode-${ displayMode }`,
 			'is-editor-preview',
-			! isResponsive && isPopoverOpen && 'is-popover-open',
+			isPopoverOpen && 'is-popover-open',
 		]
 			.filter( Boolean )
 			.join( ' ' ),
@@ -77,57 +52,37 @@ export default function FiltersPopoverEdit( { attributes, setAttributes } ) {
 
 	return (
 		<>
-			{ ! isResponsive && (
-				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton
-							icon={ filter }
-							label={ togglePanelLabel }
-							isPressed={ isPopoverOpen }
-							onClick={ () => setIsPopoverOpen( open => ! open ) }
-						/>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Display mode', 'jetpack-search-pkg' ) }
-						value={ displayMode }
-						options={ DISPLAY_MODE_OPTIONS }
-						onChange={ value => setAttributes( { displayMode: value } ) }
-						help={ __(
-							'Responsive shows the filters inline on wider screens and collapses them to a popover button on narrow ones.',
-							'jetpack-search-pkg'
-						) }
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ filter }
+						label={ togglePanelLabel }
+						isPressed={ isPopoverOpen }
+						onClick={ () => setIsPopoverOpen( open => ! open ) }
 					/>
-				</PanelBody>
-			</InspectorControls>
+				</ToolbarGroup>
+			</BlockControls>
 			<div { ...blockProps }>
-				{ ! isResponsive && (
-					<button
-						type="button"
-						className="jetpack-search-filters-popover__trigger"
-						aria-expanded="false"
-						disabled
+				<button
+					type="button"
+					className="jetpack-search-filters-popover__trigger"
+					aria-expanded="false"
+					disabled
+				>
+					<svg
+						className="jetpack-search-filters-popover__icon"
+						width={ 18 }
+						height={ 18 }
+						viewBox="0 0 24 24"
+						aria-hidden="true"
+						focusable="false"
 					>
-						<svg
-							className="jetpack-search-filters-popover__icon"
-							width={ 18 }
-							height={ 18 }
-							viewBox="0 0 24 24"
-							aria-hidden="true"
-							focusable="false"
-						>
-							<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z" />
-						</svg>
-						<span className="screen-reader-text">
-							{ __( 'Filter results', 'jetpack-search-pkg' ) }
-						</span>
-					</button>
-				) }
+						<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z" />
+					</svg>
+					<span className="screen-reader-text">
+						{ __( 'Filter results', 'jetpack-search-pkg' ) }
+					</span>
+				</button>
 				<div
 					className="jetpack-search-filters-popover__panel"
 					role="region"

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/render.php
@@ -14,18 +14,9 @@ namespace Automattic\Jetpack\Search;
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
-
-// `popover-always` (default) keeps the trigger+popover at every viewport.
-// `responsive` renders inline ≥992px and collapses to the popover trigger below.
-// Any unknown value falls back to `popover-always` so a serialised typo can't
-// end up with no styling.
-$display_mode  = isset( $attributes['displayMode'] ) && 'responsive' === $attributes['displayMode']
-	? 'responsive'
-	: 'popover-always';
-$wrapper_class = 'jetpack-search-filters-popover is-mode-' . $display_mode;
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => $wrapper_class ) ) ); ?>
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filters-popover' ) ) ); ?>
 	data-wp-interactive="jetpack-search"
 	data-jetpack-search-popover-root
 	data-wp-class--is-popover-open="state.isFilterPopoverOpen"

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/style.scss
@@ -1,74 +1,3 @@
-// Match Instant Search's $break-lg so the two Search experiences flip layouts
-// at the same width.
-$jetpack-search-filters-popover-collapse: 992px;
-
-// Inline-sidebar mode — the popover root becomes a block-flow region, the
-// trigger drops out of the tree, and the panel sheds its popover chrome.
-// Used by the `@media` rule on `.is-mode-responsive` below. (The editor-
-// preview selector further down restates the panel-only portion of these
-// styles directly because it only targets `&__panel`, not the root or
-// trigger — it can't reuse the full mixin.)
-@mixin filters-popover-inline-mode {
-	display: block;
-
-	.jetpack-search-filters-popover__trigger {
-		display: none;
-	}
-
-	.jetpack-search-filters-popover__panel {
-		position: static;
-		display: flex;
-		min-width: 0;
-		max-width: none;
-		padding: 0;
-		background: transparent;
-		color: inherit;
-		border: none;
-		border-radius: 0;
-		box-shadow: none;
-		z-index: auto;
-	}
-}
-
-// Popover-mode restore — explicitly re-applies the popover-chrome values
-// that inline-mode above had overridden. Used by the `@container (max-width)`
-// rule to undo `@media (min-width)` when the named container is narrower
-// than the viewport. Property values mirror the base `.__panel` block; keep
-// them in sync if the base changes.
-@mixin filters-popover-popover-mode {
-	display: inline-block;
-
-	.jetpack-search-filters-popover__trigger {
-		display: inline-flex;
-	}
-
-	.jetpack-search-filters-popover__panel {
-		position: absolute;
-		display: none;
-		min-width: 260px;
-		max-width: min(360px, 90vw);
-		padding: 12px;
-		background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
-		color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
-		border: 1px solid;
-		border-color: color-mix(in sRGB, currentColor 15%, transparent);
-		border-radius: 4px;
-		box-shadow: 0 4px 16px color-mix(in sRGB, currentColor 12%, transparent);
-		z-index: 20;
-	}
-
-	// The base `.is-popover-open .__panel { display: flex }` rule (specificity
-	// 0,3,0) already outranks this mixin's `.__panel { display: none }`
-	// (0,2,0), so the popover would open on click without this rule. The
-	// restated rule at 0,4,0 (the extra `.is-mode-responsive` class) is a
-	// belt-and-braces guarantee that survives any future specificity churn —
-	// adding a class higher up the chain wouldn't accidentally suppress the
-	// open state.
-	&.is-popover-open .jetpack-search-filters-popover__panel {
-		display: flex;
-	}
-}
-
 .jetpack-search-filters-popover {
 	position: relative;
 	display: inline-block;
@@ -171,36 +100,11 @@ $jetpack-search-filters-popover-collapse: 992px;
 		display: flex;
 	}
 
-	// Responsive mode above the breakpoint: the popover becomes an inline
-	// sidebar. The `@media` rule is the universal base — it fires in every
-	// browser (including legacy ones without container-query support), and
-	// drives standalone usage outside the named container declared on the
-	// shared Search templates' columns row (see
-	// `Search_Blocks::search_layout_inline_css()`). The `@container` rule
-	// then overrides `@media` via source-order cascade when the named
-	// container is in scope AND narrower than 992px — the "wide viewport,
-	// narrow container" case, which is the whole point of the change. The
-	// override has to explicitly restore popover-mode values; the cascade
-	// can't infer them.
-	&.is-mode-responsive {
-
-		@media (min-width: $jetpack-search-filters-popover-collapse) {
-
-			@include filters-popover-inline-mode;
-		}
-
-		@container jetpack-search-layout (max-width: #{$jetpack-search-filters-popover-collapse - 0.02px}) {
-
-			@include filters-popover-popover-mode;
-		}
-	}
-
 	// Editor preview renders the panel inline (no floating popover) so authors
-	// can edit it. `responsive` mode always shows it; `popover-always` shows it
-	// only when the trigger has been toggled open (mirrors the front-end
-	// `.is-popover-open` hook, but driven by editor-local React state).
-	&.is-mode-responsive.is-editor-preview &__panel,
-	&.is-mode-popover-always.is-editor-preview.is-popover-open &__panel {
+	// can edit it — shown only when the trigger has been toggled open (mirrors
+	// the front-end `.is-popover-open` hook, but driven by editor-local React
+	// state).
+	&.is-editor-preview.is-popover-open &__panel {
 		position: static;
 		display: flex;
 		min-width: 0;

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -28,7 +28,7 @@ register_block_pattern(
 <!-- wp:group {"className":"jetpack-search-compact-toolbar","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 <div class="wp-block-group jetpack-search-compact-toolbar">
 <!-- wp:jetpack-search/search-input /-->
-<!-- wp:jetpack-search/filters-popover {"displayMode":"popover-always"} -->
+<!-- wp:jetpack-search/filters-popover -->
 <!-- wp:jetpack-search/active-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -5,17 +5,12 @@ import FiltersPopoverEdit from '../../../src/search-blocks/blocks/filters-popove
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: props => ( { ...props, className: props?.className } ),
 	InnerBlocks: () => <div data-testid="filters-popover-inner-blocks" />,
-	InspectorControls: ( { children } ) => (
-		<div data-testid="filters-popover-inspector">{ children }</div>
-	),
 	BlockControls: ( { children } ) => (
 		<div data-testid="filters-popover-block-controls">{ children }</div>
 	),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
-	PanelBody: ( { children } ) => <div>{ children }</div>,
-	SelectControl: ( { label } ) => <span data-testid="filters-popover-mode-select">{ label }</span>,
 	ToolbarGroup: ( { children } ) => <div>{ children }</div>,
 	ToolbarButton: ( { label, isPressed, onClick } ) => (
 		<button type="button" onClick={ onClick } aria-pressed={ isPressed ? 'true' : 'false' }>
@@ -32,71 +27,37 @@ jest.mock( '@wordpress/i18n', () => ( {
 	__: text => text,
 } ) );
 
-const renderEdit = ( attributes = {} ) =>
-	render( <FiltersPopoverEdit attributes={ attributes } setAttributes={ jest.fn() } /> );
-
 describe( 'FiltersPopoverEdit', () => {
-	describe( 'default (popover-always) mode', () => {
-		// In popover-always mode the trigger button is a non-interactive preview
-		// of the front-end control. A block-toolbar button is the actual toggle
-		// in the editor — clicking the inline trigger would select the block and
-		// open the settings sidebar without a way to collapse the panel again.
-		// Front-end visibility is class-driven by the Interactivity store and
-		// covered by `Filters_Popover_Render_Test` on the PHP side.
-		it( 'renders the disabled preview trigger and a toolbar toggle in the closed state', () => {
-			renderEdit();
+	// The trigger button is a non-interactive preview of the front-end control.
+	// A block-toolbar button is the actual toggle in the editor — clicking the
+	// inline trigger would select the block and open the settings sidebar without
+	// a way to collapse the panel again. Front-end visibility is class-driven by
+	// the Interactivity store and covered by `Filters_Popover_Render_Test` on the
+	// PHP side.
+	it( 'renders the disabled preview trigger and a toolbar toggle in the closed state', () => {
+		render( <FiltersPopoverEdit /> );
 
-			const trigger = screen.getByRole( 'button', { name: 'Filter results' } );
-			expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
-			expect( trigger ).toBeDisabled();
+		const trigger = screen.getByRole( 'button', { name: 'Filter results' } );
+		expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( trigger ).toBeDisabled();
 
-			const toolbarToggle = screen.getByRole( 'button', { name: 'Show filter panel' } );
-			expect( toolbarToggle ).toHaveAttribute( 'aria-pressed', 'false' );
+		const toolbarToggle = screen.getByRole( 'button', { name: 'Show filter panel' } );
+		expect( toolbarToggle ).toHaveAttribute( 'aria-pressed', 'false' );
 
-			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
-			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
-		} );
-
-		it( 'toggles the panel open and closed when the toolbar button is clicked', async () => {
-			const user = userEvent.setup();
-			renderEdit();
-
-			await user.click( screen.getByRole( 'button', { name: 'Show filter panel' } ) );
-			const opened = screen.getByRole( 'button', { name: 'Hide filter panel' } );
-			expect( opened ).toHaveAttribute( 'aria-pressed', 'true' );
-
-			await user.click( opened );
-			const closed = screen.getByRole( 'button', { name: 'Show filter panel' } );
-			expect( closed ).toHaveAttribute( 'aria-pressed', 'false' );
-		} );
-
-		it( 'falls back to popover-always for an unknown displayMode value', () => {
-			renderEdit( { displayMode: 'something-else' } );
-			expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'button', { name: 'Show filter panel' } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
-		} );
+		expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
 	} );
 
-	describe( 'responsive mode', () => {
-		it( 'renders an inline labelled region with no trigger or toolbar toggle', () => {
-			renderEdit( { displayMode: 'responsive' } );
-			expect( screen.queryByRole( 'button', { name: 'Filter results' } ) ).not.toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'button', { name: 'Show filter panel' } )
-			).not.toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'button', { name: 'Hide filter panel' } )
-			).not.toBeInTheDocument();
-			expect( screen.getByRole( 'region', { name: 'Search filters' } ) ).toBeInTheDocument();
-			expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
-		} );
-	} );
+	it( 'toggles the panel open and closed when the toolbar button is clicked', async () => {
+		const user = userEvent.setup();
+		render( <FiltersPopoverEdit /> );
 
-	it( 'exposes the display-mode select in the inspector', () => {
-		renderEdit();
-		expect( screen.getByTestId( 'filters-popover-mode-select' ) ).toHaveTextContent(
-			'Display mode'
-		);
+		await user.click( screen.getByRole( 'button', { name: 'Show filter panel' } ) );
+		const opened = screen.getByRole( 'button', { name: 'Hide filter panel' } );
+		expect( opened ).toHaveAttribute( 'aria-pressed', 'true' );
+
+		await user.click( opened );
+		const closed = screen.getByRole( 'button', { name: 'Show filter panel' } );
+		expect( closed ).toHaveAttribute( 'aria-pressed', 'false' );
 	} );
 } );

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -90,8 +90,7 @@ class Filters_Popover_Render_Test extends TestCase {
 	/**
 	 * The panel must NOT carry the `hidden` HTML attribute or `role="dialog"` —
 	 * class-driven visibility via `.is-popover-open` keeps sighted and AT users
-	 * in sync. Regression guard for PR feedback by Copilot on
-	 * filters-popover/style.scss.
+	 * in sync.
 	 */
 	public function test_panel_has_no_hidden_attribute_or_dialog_role() {
 		$markup = $this->render();
@@ -111,8 +110,7 @@ class Filters_Popover_Render_Test extends TestCase {
 	/**
 	 * The panel must expose a labelled landmark (`role="region"` +
 	 * `aria-label="Search filters"`) so AT users navigating by landmarks can
-	 * find the filter controls. Regression guard for PR feedback by claude[bot]
-	 * on filters-popover.
+	 * find the filter controls.
 	 */
 	public function test_panel_exposes_search_filters_landmark() {
 		$markup = $this->render();

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -31,12 +31,6 @@ class Filters_Popover_Render_Test extends TestCase {
 		\register_block_type(
 			'jetpack-search/filters-popover',
 			array(
-				'attributes'      => array(
-					'displayMode' => array(
-						'type'    => 'string',
-						'default' => 'popover-always',
-					),
-				),
 				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 				'render_callback' => static function ( $attributes, $content ) {
 					ob_start();
@@ -71,97 +65,66 @@ class Filters_Popover_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Missing `displayMode` (block.json default takes over) must paint the
-	 * popover-always mode class so the block stays collapsed by default.
+	 * The block renders as a popover at every viewport — no `is-mode-*` display
+	 * mode class survives now that the responsive mode is gone.
 	 */
-	public function test_missing_display_mode_renders_as_popover_always() {
+	public function test_renders_without_a_display_mode_class() {
 		$markup = $this->render();
-		$this->assertStringContainsString( 'is-mode-popover-always', $markup );
-		$this->assertStringNotContainsString( 'is-mode-responsive', $markup );
+		$this->assertStringContainsString( 'jetpack-search-filters-popover', $markup );
+		$this->assertStringNotContainsString( 'is-mode-', $markup );
 	}
 
 	/**
-	 * Explicit `popover-always` must paint the popover-only mode class so the
-	 * responsive desktop CSS path stays off.
+	 * The trigger button + panel scaffolding must render so the Interactivity
+	 * bindings (`data-wp-on--*`, `data-wp-class--*`) drive the runtime popover
+	 * toggle.
 	 */
-	public function test_popover_always_renders_popover_mode_class() {
-		$markup = $this->render( array( 'displayMode' => 'popover-always' ) );
-		$this->assertStringContainsString( 'is-mode-popover-always', $markup );
-		$this->assertStringNotContainsString( 'is-mode-responsive', $markup );
-	}
-
-	/**
-	 * An unknown / malformed `displayMode` value must fall back to popover-always
-	 * so a serialised typo can't end up with no styling applied.
-	 */
-	public function test_unknown_display_mode_falls_back_to_popover_always() {
-		$markup = $this->render( array( 'displayMode' => 'something-else' ) );
-		$this->assertStringContainsString( 'is-mode-popover-always', $markup );
-		$this->assertStringNotContainsString( 'is-mode-responsive', $markup );
-		$this->assertStringNotContainsString( 'is-mode-something-else', $markup );
-	}
-
-	/**
-	 * The trigger button + panel scaffolding must render in every mode — CSS
-	 * and `.is-popover-open` toggle visibility, the markup itself doesn't
-	 * change. Confirms the Interactivity bindings (`data-wp-on--*`,
-	 * `data-wp-class--*`) are emitted so the runtime popover toggle keeps
-	 * working below the breakpoint and in always-collapsed mode.
-	 */
-	public function test_trigger_and_panel_scaffolding_always_render() {
-		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
-			$markup = $this->render( array( 'displayMode' => $mode ) );
-			$this->assertStringContainsString( 'jetpack-search-filters-popover__trigger', $markup, "mode=$mode" );
-			$this->assertStringContainsString( 'jetpack-search-filters-popover__panel', $markup, "mode=$mode" );
-			$this->assertStringContainsString( 'data-wp-on--click="actions.toggleFilterPopover"', $markup, "mode=$mode" );
-			$this->assertStringContainsString( 'data-wp-class--is-popover-open="state.isFilterPopoverOpen"', $markup, "mode=$mode" );
-		}
+	public function test_trigger_and_panel_scaffolding_render() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'jetpack-search-filters-popover__trigger', $markup );
+		$this->assertStringContainsString( 'jetpack-search-filters-popover__panel', $markup );
+		$this->assertStringContainsString( 'data-wp-on--click="actions.toggleFilterPopover"', $markup );
+		$this->assertStringContainsString( 'data-wp-class--is-popover-open="state.isFilterPopoverOpen"', $markup );
 	}
 
 	/**
 	 * The panel must NOT carry the `hidden` HTML attribute or `role="dialog"` —
-	 * those were the source of the original a11y bug, where responsive mode at
-	 * ≥992px kept the panel `hidden` from screen readers even though CSS
-	 * overrode the visual `display`. Class-driven visibility via
-	 * `.is-popover-open` keeps sighted and AT users in sync. Regression guard
-	 * for PR feedback by Copilot on filters-popover/style.scss.
+	 * class-driven visibility via `.is-popover-open` keeps sighted and AT users
+	 * in sync. Regression guard for PR feedback by Copilot on
+	 * filters-popover/style.scss.
 	 */
 	public function test_panel_has_no_hidden_attribute_or_dialog_role() {
-		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
-			$markup = $this->render( array( 'displayMode' => $mode ) );
-			$this->assertSame(
-				0,
-				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*\bhidden\b[^>]*>/', $markup ),
-				"mode=$mode: panel must not carry the hidden attribute"
-			);
-			$this->assertSame(
-				0,
-				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="dialog"[^>]*>/', $markup ),
-				"mode=$mode: panel must not carry role=\"dialog\""
-			);
-			$this->assertStringNotContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup, "mode=$mode" );
-		}
+		$markup = $this->render();
+		$this->assertSame(
+			0,
+			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*\bhidden\b[^>]*>/', $markup ),
+			'panel must not carry the hidden attribute'
+		);
+		$this->assertSame(
+			0,
+			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="dialog"[^>]*>/', $markup ),
+			'panel must not carry role="dialog"'
+		);
+		$this->assertStringNotContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup );
 	}
 
 	/**
 	 * The panel must expose a labelled landmark (`role="region"` +
 	 * `aria-label="Search filters"`) so AT users navigating by landmarks can
-	 * find the filter controls in both the inline-sidebar and popover forms.
-	 * Regression guard for PR feedback by claude[bot] on filters-popover.
+	 * find the filter controls. Regression guard for PR feedback by claude[bot]
+	 * on filters-popover.
 	 */
 	public function test_panel_exposes_search_filters_landmark() {
-		foreach ( array( 'responsive', 'popover-always' ) as $mode ) {
-			$markup = $this->render( array( 'displayMode' => $mode ) );
-			$this->assertSame(
-				1,
-				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="region"[^>]*>/', $markup ),
-				"mode=$mode: panel must carry role=\"region\""
-			);
-			$this->assertSame(
-				1,
-				preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*aria-label="Search filters"[^>]*>/', $markup ),
-				"mode=$mode: panel must carry aria-label=\"Search filters\""
-			);
-		}
+		$markup = $this->render();
+		$this->assertSame(
+			1,
+			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="region"[^>]*>/', $markup ),
+			'panel must carry role="region"'
+		);
+		$this->assertSame(
+			1,
+			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*aria-label="Search filters"[^>]*>/', $markup ),
+			'panel must carry aria-label="Search filters"'
+		);
 	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-280/search-blocks-drop-the-filters-popover-responsive-display-mode-block

## Why

The Collapsible Filters block shipped two author-facing display modes — "Always collapsed (popover)" and a "responsive" mode that rendered filters inline on wide screens and collapsed them to a popover button on narrow ones. The page and overlay templates already own that wide-vs-narrow flip at the layout level (a real filter sidebar on wide screens, the popover trigger on narrow ones) via the shared `jetpack-search-layout` container query. The block-local responsive mode was a redundant second system that doubled the maintenance surface and gave authors a confusing choice. This reduces the block to a single, predictable behaviour: it is always a popover.

## Proposed changes

* Remove the `displayMode` block attribute and its "Display mode" inspector control.
* Remove the front-end/editor `is-mode-*` handling: the `render.php` wrapper class, and the `style.scss` `@media`/`@container` responsive rules plus the two mode mixins.
* Drop the now-defunct `{"displayMode":"popover-always"}` attribute from the compact-search pattern.
* Update the JS + PHP tests to the single-mode behaviour; assert no `is-mode-*` class is ever emitted.

The template/overlay sidebar↔popover **layout** flip (`Search_Blocks::search_layout_inline_css()`, the `jetpack-search-layout` container query) is a separate system and is left untouched.

## Screenshots

The user-visible change is in the editor: selecting the **Collapsible Filters** block no longer shows the "Display mode" control. Captured at 1440×900 with the same block in the same post; only the Search build differs (`trunk` vs this branch).

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/a1fe9554-3729-492d-88ec-7d2fa01c867f) | ![after](https://github.com/user-attachments/assets/80edb5fa-293c-41eb-9f37-2ced6c838c30) |

The block inspector's "Settings → Display mode" dropdown (and its help text) is gone; only the default **Advanced** panel remains. The block description also drops the "Can also show them inline on wider screens" sentence.

The front end is intentionally **not** shown as a before/after: no shipped template or pattern used the `responsive` mode, so the front-end of every shipped search experience is byte-identical before and after — see Verification for the rendered-markup proof.

## Verification

Built the four-layer matrix and exercised the block end-to-end in the local docker env (`overlay_blocks` experience, `filters-popover` registered). The block renders as a popover with no display-mode class, the template-level responsive flip is preserved, the editor no longer ships the "Display mode" control, and both test suites pass.

<details>
<summary>Front-end: block wrapper carries no <code>is-mode-*</code> class; template flip preserved</summary>

```text
$ curl -s "http://localhost:18110/?s=shirt" | grep wrapper
class="jetpack-search-filters-popover wp-block-jetpack-search-filters-popover" data-wp-interactive="jetpack-search" ...

$ curl -s "http://localhost:18110/?s=shirt" | grep -c 'is-mode-'
0

# template-level layout flip still present (out of scope, preserved):
$ curl -s "http://localhost:18110/?s=shirt" | grep -c '@container jetpack-search-layout'
1
```

</details>

<details>
<summary>Editor: "Display mode" control removed from the built editor bundle</summary>

```text
$ grep -rl "Display mode" projects/packages/search/build/    -> (no match)
$ grep -rl "Inline on desktop" projects/packages/search/build/ -> (no match)
```

</details>

<details>
<summary>Tests</summary>

```text
$ npx jest tests/js/search-blocks/filters-popover-edit.test.jsx
Tests:       2 passed, 2 total

$ composer phpunit -- --filter Filters_Popover_Render_Test
OK (4 tests, 11 assertions)
```

</details>

## Related product discussion/links

* [SEARCH-280](https://linear.app/a8c/issue/SEARCH-280/search-blocks-drop-the-filters-popover-responsive-display-mode-block)
* Reverts the author-facing responsive mode added in [SEARCH-225](https://linear.app/a8c/issue/SEARCH-225/search-blocks-make-filters-popover-a-responsive-container-sidebar); the template-level flip from SEARCH-262/264/265/279 is unaffected.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Acceptance criteria from SEARCH-280:

* [ ] The block renders as a popover trigger + panel at all viewports; no inline-sidebar mode.
* [ ] No `displayMode` attribute and no `is-mode-*` classes in rendered markup or the editor canvas.
* [ ] No "Display mode" setting in the block inspector.
* [ ] The page/overlay templates still collapse the sidebar to the popover trigger on narrow widths (layout flip unaffected).
* [ ] JS + PHP tests pass; size-limit unaffected.

To verify locally:

* Build Search: `jp build packages/search` (and the matrix if testing in a live env).
* In the Site Editor, open a search template (e.g. `jetpack-search-overlay`) and select the **Collapsible Filters** block — confirm the inspector has no "Display mode" control.
* On the front end, run a search and confirm the filters surface as a popover button. Resize the window: the template's filter sidebar still collapses to the popover trigger below ~992px (this flip is template-level and unchanged).

