### PR TITLE
Search Blocks: fire TrainTracks render/interact events from the blocks search path (SEARCH-281)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-281-traintracks-blocks-tracking
+++ b/projects/packages/search/changelog/atlas-search-281-traintracks-blocks-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: fire the TrainTracks render/interact analytics events from the blocks search path (embedded and overlay), matching Instant Search, so result impressions and clicks feed the search-relevance pipeline.

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -1071,4 +1071,14 @@ class Helper {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		return isset( $_GET['disable_tracking'] ) && $_GET['disable_tracking'];
 	}
+
+	/**
+	 * Enqueue the WordPress.com Tracks library that drains `window._tkq` and
+	 * sends the queued events. Shared by Instant Search and the Search blocks so
+	 * the handle, src, and cache-busting version live in one place. Callers own
+	 * the decision of whether to load it (e.g. the `is_tracking_disabled()` gate).
+	 */
+	public static function enqueue_tracks_script() {
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+	}
 }

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -155,7 +155,7 @@ class Instant_Search extends Classic_Search {
 	 * Loads scripts for Tracks analytics library
 	 */
 	public function load_and_initialize_tracks() {
-		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+		Helper::enqueue_tracks_script();
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -102,6 +102,12 @@ $features      = $resolve_layout( $layout );
 $wrapper_class = 'jetpack-search-results--' . $features['modifier'];
 $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class ) );
 
+// Hand the resolved layout to the store so the TrainTracks `ui_algo` matches
+// what visitors actually see. Deep-merges onto the global seed.
+if ( function_exists( 'wp_interactivity_state' ) ) {
+	wp_interactivity_state( 'jetpack-search', array( 'resultsLayout' => $layout ) );
+}
+
 // Pre-hydration loading state. Skeleton items below render server-side only
 // when the URL carries a query/filter that will trigger an initial fetch on
 // hydration; otherwise emitting them would freeze placeholder rows on a bare
@@ -172,7 +178,10 @@ if ( '' === $error_message ) {
 			data-wp-each--result="state.results"
 			data-wp-key="context.result.id"
 		>
-			<li class="jetpack-search-results__item">
+			<li
+				class="jetpack-search-results__item"
+				data-wp-on--click="actions.recordResultInteract"
+			>
 				<?php if ( $features['show_image'] && 'product' === $layout ) : ?>
 					<a
 						class="jetpack-search-results__product-image-link"

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -44,11 +44,10 @@ if ( function_exists( 'wp_interactivity_state' ) && ( ! empty( $scope['include']
 
 // Load the WordPress.com Tracks consumer (drains `window._tkq`) so the
 // TrainTracks render/interact events the store pushes actually get sent.
-// Same handle + src as instant search's `load_and_initialize_tracks()`;
-// enqueuing here loads it exactly on pages where the Search blocks render,
+// Enqueuing here loads it exactly on pages where the Search blocks render,
 // across all blocks experiences. Skipped when tracking is suppressed.
 if ( ! Search_Blocks::is_tracking_disabled() ) {
-	wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+	Helper::enqueue_tracks_script();
 }
 
 $panel_content = $content; // @phan-suppress-current-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -42,6 +42,15 @@ if ( function_exists( 'wp_interactivity_state' ) && ( ! empty( $scope['include']
 	wp_interactivity_state( 'jetpack-search', array( 'staticPostTypes' => $scope ) );
 }
 
+// Load the WordPress.com Tracks consumer (drains `window._tkq`) so the
+// TrainTracks render/interact events the store pushes actually get sent.
+// Same handle + src as instant search's `load_and_initialize_tracks()`;
+// enqueuing here loads it exactly on pages where the Search blocks render,
+// across all blocks experiences. Skipped when tracking is suppressed.
+if ( ! Search_Blocks::is_tracking_disabled() ) {
+	wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+}
+
 $panel_content = $content; // @phan-suppress-current-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
 
 if ( Search_Blocks::is_free_plan() && false === strpos( $panel_content, 'wp-block-jetpack-search-powered-by' ) ) {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1978,6 +1978,11 @@ HTML;
 			'nonce'                      => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
 			'isPrivateSite'              => $is_private,
 			'isWpcom'                    => $is_wpcom,
+			// TrainTracks gate, mirroring instant search's `disableTracking`
+			// (Helper::get_search_options): suppresses `_tkq` pushes for
+			// `?disable_tracking=1` crawlers/QA and the filter override.
+			'disableTracking'            => ( class_exists( Helper::class ) && Helper::is_tracking_disabled() )
+				|| apply_filters( 'jetpack_instant_search_disable_tracking', false ),
 			// Threaded through url-state so `?orderby=price_asc` round-trips on Woo only.
 			'isWooCommerceBlocksEnabled' => self::woocommerce_blocks_enabled(),
 			'homeUrl'                    => function_exists( 'home_url' ) ? home_url() : '',

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -234,6 +234,20 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Whether TrainTracks analytics are suppressed for this request. Mirrors
+	 * instant search (Helper::get_search_options): the `?disable_tracking=1`
+	 * crawler/QA param plus the `jetpack_instant_search_disable_tracking`
+	 * operator filter. Gates both the `_tkq` pushes (seeded into
+	 * `state.disableTracking`) and whether the Tracks consumer script loads.
+	 *
+	 * @return bool
+	 */
+	public static function is_tracking_disabled(): bool {
+		return ( class_exists( Helper::class ) && Helper::is_tracking_disabled() )
+			|| apply_filters( 'jetpack_instant_search_disable_tracking', false );
+	}
+
+	/**
 	 * Short-circuit the main front-end search query when the blocks own results
 	 * (see AGENTS.md § Search experiences). Registered only when
 	 * `owns_search_results()` is true and off `is_admin()`.
@@ -1981,8 +1995,7 @@ HTML;
 			// TrainTracks gate, mirroring instant search's `disableTracking`
 			// (Helper::get_search_options): suppresses `_tkq` pushes for
 			// `?disable_tracking=1` crawlers/QA and the filter override.
-			'disableTracking'            => ( class_exists( Helper::class ) && Helper::is_tracking_disabled() )
-				|| apply_filters( 'jetpack_instant_search_disable_tracking', false ),
+			'disableTracking'            => static::is_tracking_disabled(),
 			// Threaded through url-state so `?orderby=price_asc` round-trips on Woo only.
 			'isWooCommerceBlocksEnabled' => self::woocommerce_blocks_enabled(),
 			'homeUrl'                    => function_exists( 'home_url' ) ? home_url() : '',

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -539,6 +539,9 @@ function trainTracksProps( railcar, uiPosition ) {
  * @param {Array<object>} results - Normalized results just added to the list.
  */
 function recordResultRenders( results ) {
+	if ( state.disableTracking ) {
+		return;
+	}
 	for ( const result of results ) {
 		if ( result.railcar ) {
 			recordTrainTracksRender( trainTracksProps( result.railcar, result.index ) );
@@ -556,6 +559,11 @@ const { state, actions } = store( NAMESPACE, {
 		// Drives the TrainTracks `ui_algo`; default keeps a valid value on pages
 		// where the seed hasn't landed.
 		resultsLayout: 'expanded',
+
+		// Suppresses TrainTracks `_tkq` pushes. PHP-seeded from
+		// `?disable_tracking=1` + the `jetpack_instant_search_disable_tracking`
+		// filter, mirroring instant search. Default off so a missing seed tracks.
+		disableTracking: false,
 
 		// Roving-tabindex active descendant for the sort menu. `null` /
 		// unknown-key = menu hasn't been keyboard-engaged; the currently
@@ -1051,6 +1059,9 @@ const { state, actions } = store( NAMESPACE, {
 		 * reuses the result's stamped index so it matches its render event.
 		 */
 		recordResultInteract() {
+			if ( state.disableTracking ) {
+				return;
+			}
 			const { result } = getContext();
 			if ( result?.railcar ) {
 				recordTrainTracksInteract( {
@@ -1546,7 +1557,9 @@ const { state, actions } = store( NAMESPACE, {
 				return;
 			}
 			initialized = true;
-			identifySite( state.siteId );
+			if ( ! state.disableTracking ) {
+				identifySite( state.siteId );
+			}
 			// PHP seed; `formatDate()` reads from module scope rather than threading per-call.
 			setSeededDateFormat( state.dateFormat );
 			window.addEventListener( 'popstate', actions.handlePopState );

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -16,6 +16,7 @@ import {
 	getSortMenuOptionKeysFromItem,
 	getSortMenuOptionKeysFromTrigger,
 } from './results-sort-menu-dom';
+import { identifySite, recordTrainTracksInteract, recordTrainTracksRender } from './tracks';
 import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
@@ -494,11 +495,67 @@ function* fetchResults( pageHandle ) {
 	return yield response.json();
 }
 
+const UI_ALGO_VARIANT = { compact: 'minimal', expanded: 'expanded', product: 'product' };
+
+/**
+ * UI-algo identifier for TrainTracks. Kept identical to instant search so blocks
+ * impressions land in the same relevance bucket; the blocks `compact` layout maps
+ * to instant search's `minimal`.
+ *
+ * @return {string} `jetpack-instant-search-ui/v1-{minimal|expanded|product}`.
+ */
+function trainTracksUiAlgo() {
+	const variant = UI_ALGO_VARIANT[ state.resultsLayout ] ?? 'expanded';
+	return `jetpack-instant-search-ui/v1-${ variant }`;
+}
+
+/**
+ * Build the TrainTracks payload from a result's server-assigned railcar. Shape
+ * matches instant search's `getCommonTrainTracksProps()` exactly.
+ *
+ * @param {object} railcar    - Per-result railcar from the search API.
+ * @param {number} uiPosition - Absolute position of the result in the list.
+ * @return {object} TrainTracks event properties.
+ */
+function trainTracksProps( railcar, uiPosition ) {
+	return {
+		fetch_algo: railcar.fetch_algo,
+		fetch_position: railcar.fetch_position,
+		fetch_query: railcar.fetch_query,
+		railcar: railcar.railcar,
+		rec_blog_id: railcar.rec_blog_id,
+		rec_post_id: railcar.rec_post_id,
+		session_id: railcar.session_id,
+		ui_algo: trainTracksUiAlgo(),
+		ui_position: uiPosition,
+	};
+}
+
+/**
+ * Fire one TrainTracks render (impression) event per result that carries a
+ * railcar. `ui_position` reads the absolute index stamped on each result so it
+ * matches the interact event fired on click.
+ *
+ * @param {Array<object>} results - Normalized results just added to the list.
+ */
+function recordResultRenders( results ) {
+	for ( const result of results ) {
+		if ( result.railcar ) {
+			recordTrainTracksRender( trainTracksProps( result.railcar, result.index ) );
+		}
+	}
+}
+
 const { state, actions } = store( NAMESPACE, {
 	state: {
 		// Mutually exclusive popovers — only one open at a time.
 		isFilterPopoverOpen: false,
 		isSortPopoverOpen: false,
+
+		// Resolved results-list layout, seeded per-page by results-list/render.php.
+		// Drives the TrainTracks `ui_algo`; default keeps a valid value on pages
+		// where the seed hasn't landed.
+		resultsLayout: 'expanded',
 
 		// Roving-tabindex active descendant for the sort menu. `null` /
 		// unknown-key = menu hasn't been keyboard-engaged; the currently
@@ -908,9 +965,11 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken !== searchToken ) {
 					return;
 				}
-				state.results = ( data.results ?? [] ).map( r =>
-					normalizeResult( r, state.locale, state.searchQuery )
-				);
+				state.results = ( data.results ?? [] ).map( ( r, i ) => ( {
+					...normalizeResult( r, state.locale, state.searchQuery ),
+					index: i,
+				} ) );
+				recordResultRenders( state.results );
 				state.totalResults = data.total ?? 0;
 				state.pageHandle = data.page_handle ?? null;
 				state.aggregations = remapAggregationsToFilterKeys(
@@ -967,12 +1026,13 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken !== searchToken ) {
 					return;
 				}
-				state.results = [
-					...state.results,
-					...( data.results ?? [] ).map( r =>
-						normalizeResult( r, state.locale, state.searchQuery )
-					),
-				];
+				const offset = state.results.length;
+				const appended = ( data.results ?? [] ).map( ( r, i ) => ( {
+					...normalizeResult( r, state.locale, state.searchQuery ),
+					index: offset + i,
+				} ) );
+				state.results = [ ...state.results, ...appended ];
+				recordResultRenders( appended );
 				state.pageHandle = data.page_handle ?? null;
 			} catch {
 				if ( myToken === searchToken ) {
@@ -982,6 +1042,21 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken === searchToken ) {
 					state.isLoadingMore = false;
 				}
+			}
+		},
+
+		/**
+		 * Fires a TrainTracks interact event when a visitor clicks a result.
+		 * Mirrors instant search's `action: 'click'` payload; `ui_position`
+		 * reuses the result's stamped index so it matches its render event.
+		 */
+		recordResultInteract() {
+			const { result } = getContext();
+			if ( result?.railcar ) {
+				recordTrainTracksInteract( {
+					...trainTracksProps( result.railcar, result.index ),
+					action: 'click',
+				} );
 			}
 		},
 
@@ -1471,6 +1546,7 @@ const { state, actions } = store( NAMESPACE, {
 				return;
 			}
 			initialized = true;
+			identifySite( state.siteId );
 			// PHP seed; `formatDate()` reads from module scope rather than threading per-call.
 			setSeededDateFormat( state.dateFormat );
 			window.addEventListener( 'popstate', actions.handlePopState );

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -379,6 +379,10 @@ export function normalizeResult( raw, locale = 'en-US', searchQuery = '' ) {
 	const matchHint = hasQuery ? deriveMatchHint( highlight, titlePieces ) : '';
 	return {
 		id: String( raw?.result_id ?? fields.post_id ?? permalink ),
+		// Server-assigned TrainTracks payload (fetch_algo, railcar, session_id…).
+		// The search API attaches it per-result; carried through so the relevance
+		// events in store/index.js can read it off `context.result`.
+		railcar: raw?.railcar ?? null,
 		title: plainTitle,
 		titlePieces,
 		hasTitlePieces: titlePieces.length > 0,

--- a/projects/packages/search/src/search-blocks/store/tracks.js
+++ b/projects/packages/search/src/search-blocks/store/tracks.js
@@ -1,0 +1,51 @@
+/**
+ * TrainTracks analytics for the Search Blocks path. Mirrors the relevant slice
+ * of `instant-search/lib/tracks.js` (render + interact only) so blocks
+ * engagement feeds the same search-relevance pipeline, but stays free of the
+ * calypso dependencies that bundle pulls in — the blocks view bundle is
+ * size-guarded (see AGENTS.md § Shared store / bundles).
+ *
+ * Events are pushed onto `window._tkq`; the WordPress.com stats script flushes
+ * the queue if/when it loads, and the push is a harmless no-op otherwise —
+ * exactly how instant search behaves.
+ */
+
+const globalProperties = {};
+
+/**
+ * Associates the current site with events fired in the future.
+ *
+ * @param {number|string} siteId - Current site identifier.
+ */
+export function identifySite( siteId ) {
+	globalProperties.blog_id = siteId;
+}
+
+/**
+ * Fires a general event to Tracks.
+ *
+ * @param {string} eventName  - Name of the event.
+ * @param {object} properties - Event properties.
+ */
+function recordEvent( eventName, properties ) {
+	window._tkq = window._tkq || [];
+	window._tkq.push( [ 'recordEvent', eventName, { ...globalProperties, ...properties } ] );
+}
+
+/**
+ * Fires a TrainTracks render event to Tracks.
+ *
+ * @param {object} properties - Event properties.
+ */
+export function recordTrainTracksRender( properties ) {
+	recordEvent( 'jetpack_instant_search_traintracks_render', properties );
+}
+
+/**
+ * Fires a TrainTracks interaction event to Tracks.
+ *
+ * @param {object} properties - Event properties.
+ */
+export function recordTrainTracksInteract( properties ) {
+	recordEvent( 'jetpack_instant_search_traintracks_interact', properties );
+}

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -563,6 +563,7 @@ describe( 'normalizeResult', () => {
 		const r = normalizeResult( {} );
 		expect( r ).toEqual( {
 			id: '',
+			railcar: null,
 			title: '',
 			titlePieces: [],
 			hasTitlePieces: false,
@@ -823,6 +824,24 @@ describe( 'normalizeResult', () => {
 		} );
 		expect( r.matchHint ).toBe( '' );
 		expect( r.matchHintIsComments ).toBe( false );
+	} );
+
+	it( 'carries the server railcar through for TrainTracks', () => {
+		const railcar = {
+			railcar: 'axtafgiOICSM',
+			fetch_algo: 'jetpack:search/1-score_default',
+			fetch_position: 0,
+			fetch_query: 'hello',
+			rec_blog_id: 1,
+			rec_post_id: 12,
+			session_id: 'p5G3vV',
+		};
+		const r = normalizeResult( { railcar, fields: { post_id: 12 } } );
+		expect( r.railcar ).toEqual( railcar );
+	} );
+
+	it( 'railcar is null when the API result omits it', () => {
+		expect( normalizeResult( { fields: { post_id: 12 } } ).railcar ).toBeNull();
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -1477,6 +1477,7 @@ describe( 'TrainTracks relevance events', () => {
 			retainedFilterOptions: {},
 			results: [],
 			resultsLayout: 'expanded',
+			disableTracking: false,
 			locale: 'en-US',
 			isLoading: false,
 			isLoadingMore: false,
@@ -1545,6 +1546,42 @@ describe( 'TrainTracks relevance events', () => {
 
 		const render = window._tkq.find( e => e[ 1 ] === 'jetpack_instant_search_traintracks_render' );
 		expect( render[ 2 ].ui_algo ).toBe( 'jetpack-instant-search-ui/v1-minimal' );
+	} );
+
+	it( 'maps the product layout to the product ui_algo', async () => {
+		state.resultsLayout = 'product';
+		global.fetch.mockResolvedValueOnce(
+			createResponse( { results: [ railcarResult( 'Only', 0 ) ], total: 1, page_handle: null } )
+		);
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		const render = window._tkq.find( e => e[ 1 ] === 'jetpack_instant_search_traintracks_render' );
+		expect( render[ 2 ].ui_algo ).toBe( 'jetpack-instant-search-ui/v1-product' );
+	} );
+
+	it( 'fires no render events when tracking is disabled', async () => {
+		state.disableTracking = true;
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ railcarResult( 'First', 0 ), railcarResult( 'Second', 1 ) ],
+				total: 2,
+				page_handle: null,
+			} )
+		);
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		expect(
+			window._tkq.filter( e => e[ 1 ] === 'jetpack_instant_search_traintracks_render' )
+		).toHaveLength( 0 );
+	} );
+
+	it( 'fires no interact event when tracking is disabled', () => {
+		state.disableTracking = true;
+		captured.context = { result: { index: 0, railcar: { railcar: 'rc-x' } } };
+		actions.recordResultInteract();
+		expect(
+			window._tkq.filter( e => e[ 1 ] === 'jetpack_instant_search_traintracks_interact' )
+		).toHaveLength( 0 );
 	} );
 
 	it( 'fires no event for results lacking a railcar', async () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -1433,3 +1433,178 @@ describe( 'handlePopState gating', () => {
 		expect( state.hasSearchParam ).toBe( true );
 	} );
 } );
+
+describe( 'TrainTracks relevance events', () => {
+	/**
+	 * Raw API result carrying a railcar, as the search API returns it.
+	 *
+	 * @param {string} title - Result title.
+	 * @param {number} pos   - Server fetch_position.
+	 * @return {object} Raw search result with railcar.
+	 */
+	function railcarResult( title, pos ) {
+		return {
+			...createResult( title ),
+			railcar: {
+				railcar: `rc-${ pos }`,
+				fetch_algo: 'jetpack:search/1-score_default',
+				fetch_position: pos,
+				fetch_query: 'boots',
+				rec_blog_id: 1,
+				rec_post_id: 100 + pos,
+				session_id: 'sess-1',
+			},
+		};
+	}
+
+	beforeEach( () => {
+		Object.assign( actions, originalActions );
+		Object.assign( state, {
+			siteId: 123,
+			searchQuery: 'boots',
+			sortOrder: 'relevance',
+			pageHandle: null,
+			isPrivateSite: false,
+			isWpcom: false,
+			apiRoot: 'https://example.com/wp-json/',
+			homeUrl: 'https://example.com',
+			nonce: '',
+			activeFilters: {},
+			filterConfigs: {},
+			priceRange: null,
+			staticFilterSelections: {},
+			staticPostTypes: null,
+			retainedFilterOptions: {},
+			results: [],
+			resultsLayout: 'expanded',
+			locale: 'en-US',
+			isLoading: false,
+			isLoadingMore: false,
+			hasError: false,
+			totalResults: 0,
+			aggregations: {},
+			strings: {},
+		} );
+		Object.defineProperty( global, 'fetch', {
+			configurable: true,
+			writable: true,
+			value: jest.fn(),
+		} );
+		window._tkq = [];
+		captured.context = {};
+	} );
+
+	afterEach( () => {
+		if ( originalFetch ) {
+			Object.defineProperty( global, 'fetch', {
+				configurable: true,
+				writable: true,
+				value: originalFetch,
+			} );
+		} else {
+			delete global.fetch;
+		}
+		jest.restoreAllMocks();
+	} );
+
+	it( 'fires one render event per result with absolute ui_position and the instant-search ui_algo', async () => {
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ railcarResult( 'First', 0 ), railcarResult( 'Second', 1 ) ],
+				total: 2,
+				page_handle: null,
+				aggregations: {},
+			} )
+		);
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		const renders = window._tkq.filter(
+			e => e[ 1 ] === 'jetpack_instant_search_traintracks_render'
+		);
+		expect( renders ).toHaveLength( 2 );
+		expect( renders[ 0 ][ 2 ] ).toMatchObject( {
+			fetch_algo: 'jetpack:search/1-score_default',
+			fetch_position: 0,
+			fetch_query: 'boots',
+			railcar: 'rc-0',
+			rec_blog_id: 1,
+			rec_post_id: 100,
+			session_id: 'sess-1',
+			ui_algo: 'jetpack-instant-search-ui/v1-expanded',
+			ui_position: 0,
+		} );
+		expect( renders[ 1 ][ 2 ] ).toMatchObject( { railcar: 'rc-1', ui_position: 1 } );
+	} );
+
+	it( 'maps the compact layout to the minimal ui_algo', async () => {
+		state.resultsLayout = 'compact';
+		global.fetch.mockResolvedValueOnce(
+			createResponse( { results: [ railcarResult( 'Only', 0 ) ], total: 1, page_handle: null } )
+		);
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		const render = window._tkq.find( e => e[ 1 ] === 'jetpack_instant_search_traintracks_render' );
+		expect( render[ 2 ].ui_algo ).toBe( 'jetpack-instant-search-ui/v1-minimal' );
+	} );
+
+	it( 'fires no event for results lacking a railcar', async () => {
+		global.fetch.mockResolvedValueOnce(
+			createResponse( { results: [ createResult( 'No railcar' ) ], total: 1, page_handle: null } )
+		);
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		expect(
+			window._tkq.filter( e => e[ 1 ] === 'jetpack_instant_search_traintracks_render' )
+		).toHaveLength( 0 );
+	} );
+
+	it( 'offsets ui_position by the existing list length on loadMore', async () => {
+		// One result already on the page (ui_position 0); the next page's
+		// result must report ui_position 1, not 0.
+		state.results = [ { id: 'a', title: 'Already here', index: 0, railcar: null } ];
+		state.pageHandle = 'page-2';
+		global.fetch.mockResolvedValueOnce(
+			createResponse( { results: [ railcarResult( 'Page two', 1 ) ], page_handle: null } )
+		);
+		await runGenerator( actions.loadMore() );
+
+		const render = window._tkq.find( e => e[ 1 ] === 'jetpack_instant_search_traintracks_render' );
+		expect( render[ 2 ].ui_position ).toBe( 1 );
+	} );
+
+	it( 'fires an interact event with action:click reading the clicked result context', () => {
+		captured.context = {
+			result: {
+				index: 3,
+				railcar: {
+					railcar: 'rc-click',
+					fetch_algo: 'jetpack:search/1-score_default',
+					fetch_position: 3,
+					fetch_query: 'boots',
+					rec_blog_id: 1,
+					rec_post_id: 103,
+					session_id: 'sess-1',
+				},
+			},
+		};
+		actions.recordResultInteract();
+
+		const interact = window._tkq.find(
+			e => e[ 1 ] === 'jetpack_instant_search_traintracks_interact'
+		);
+		expect( interact[ 2 ] ).toMatchObject( {
+			railcar: 'rc-click',
+			ui_position: 3,
+			ui_algo: 'jetpack-instant-search-ui/v1-expanded',
+			action: 'click',
+		} );
+	} );
+
+	it( 'fires no interact event when the clicked result has no railcar', () => {
+		captured.context = { result: { index: 0, railcar: null } };
+		actions.recordResultInteract();
+		expect(
+			window._tkq.filter( e => e[ 1 ] === 'jetpack_instant_search_traintracks_interact' )
+		).toHaveLength( 0 );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/tracks.test.js
+++ b/projects/packages/search/tests/js/search-blocks/tracks.test.js
@@ -1,0 +1,41 @@
+import {
+	identifySite,
+	recordTrainTracksInteract,
+	recordTrainTracksRender,
+} from '../../../src/search-blocks/store/tracks';
+
+describe( 'search-blocks tracks', () => {
+	beforeEach( () => {
+		delete window._tkq;
+	} );
+
+	it( 'lazily creates window._tkq and records a render event under the instant-search name', () => {
+		recordTrainTracksRender( { railcar: 'abc', ui_position: 0 } );
+		expect( window._tkq[ 0 ][ 0 ] ).toBe( 'recordEvent' );
+		expect( window._tkq[ 0 ][ 1 ] ).toBe( 'jetpack_instant_search_traintracks_render' );
+		expect( window._tkq[ 0 ][ 2 ] ).toMatchObject( { railcar: 'abc', ui_position: 0 } );
+	} );
+
+	it( 'records an interact event under the instant-search name', () => {
+		recordTrainTracksInteract( { railcar: 'abc', action: 'click' } );
+		expect( window._tkq[ 0 ][ 1 ] ).toBe( 'jetpack_instant_search_traintracks_interact' );
+		expect( window._tkq[ 0 ][ 2 ] ).toMatchObject( { railcar: 'abc', action: 'click' } );
+	} );
+
+	it( 'merges blog_id from identifySite into every event', () => {
+		identifySite( 12345 );
+		recordTrainTracksRender( { railcar: 'xyz', ui_position: 2 } );
+		expect( window._tkq[ 0 ][ 2 ] ).toMatchObject( {
+			blog_id: 12345,
+			railcar: 'xyz',
+			ui_position: 2,
+		} );
+	} );
+
+	it( 'appends to an existing queue rather than replacing it', () => {
+		window._tkq = [ [ 'recordEvent', 'pre_existing', {} ] ];
+		recordTrainTracksRender( { railcar: 'abc' } );
+		expect( window._tkq ).toHaveLength( 2 );
+		expect( window._tkq[ 1 ][ 1 ] ).toBe( 'jetpack_instant_search_traintracks_render' );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-281

## Why

Jetpack Instant Search fires two TrainTracks events — a `render` (one impression per result shown) and an `interact` (`action: 'click'` on a result). They carry each result's server-assigned `railcar` data, and they're the signals the search backend uses to learn which results visitors actually engage with. The blocks-driven search experiences (`embedded` and `overlay_blocks`) rendered results without firing any of this, so every impression and click on a blocks-rendered result was invisible to the relevance pipeline. This wires the same two events into the blocks path with a payload identical to Instant Search, so blocks engagement feeds the exact same pipeline.

## Proposed changes

* New `search-blocks/store/tracks.js` — a standalone (no calypso deps) helper that pushes `jetpack_instant_search_traintracks_render` / `_interact` onto `window._tkq`, mirroring `instant-search/lib/tracks.js`.
* `normalizeResult()` now carries the per-result `railcar` through (the search API already attaches it; the blocks path was discarding it).
* `store/index.js` fires one `render` event per result shown — from `search()` (first page) and `loadMore()` (appended pages, with absolute `ui_position`) — and a new `recordResultInteract` action fires the `interact` event on result click. `ui_algo` is built from the resolved results-list layout (`compact` → `minimal`, matching Instant Search) and `blog_id` is set from the seeded `siteId`.
* `results-list/render.php` wires `data-wp-on--click="actions.recordResultInteract"` onto each result item and seeds the resolved layout into the store.
* `search-results/render.php` enqueues the WordPress.com Tracks consumer (`//stats.wp.com/w.js`, same handle as instant search's `load_and_initialize_tracks()`) so the queued `_tkq` events actually send — it's the container block present in every blocks experience. Gated by a shared `Search_Blocks::is_tracking_disabled()` predicate that also backs the `disableTracking` seed.

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-281

## Does this pull request change what data or activity we track or use?

Yes. It extends the existing `jetpack_instant_search_traintracks_render` and `jetpack_instant_search_traintracks_interact` Tracks events to the blocks search surface (`embedded` and `overlay_blocks`). No new event names or properties are introduced — the payload (railcar fields, `ui_algo`, `ui_position`, `blog_id`) is identical to what Instant Search already sends; the events simply now fire from a surface that previously fired nothing. Added the **[Status] Needs Privacy Updates** label. The blocks path also honors the same `disable_tracking` suppression gate as instant search (`?disable_tracking=1` + the `jetpack_instant_search_disable_tracking` filter), so QA/crawler traffic and filter overrides fire no events.

## Verification

This change is not user-visible — it fires analytics events to `window._tkq`, with no UI change. Because the local env is in Offline Mode (the WPCOM search proxy that supplies `railcar` is unavailable), it was verified in a real browser against the built bundle by stubbing only the network response to the exact WPCOM v1.3 shape (results carrying `railcar`), then reading `window._tkq`. Also covered by unit tests (`tracks.test.js`, `store.test.js`, `result-utils.test.js`).

<details>
<summary>Render events (2 results shown, embedded experience)</summary>

```json
[
  { "event": "jetpack_instant_search_traintracks_render",
    "blog_id": 254381802, "fetch_algo": "jetpack:search/1-score_default",
    "fetch_position": 0, "fetch_query": "test", "railcar": "rc-abc-0",
    "rec_blog_id": 1, "rec_post_id": 11, "session_id": "sess-xyz",
    "ui_algo": "jetpack-instant-search-ui/v1-expanded", "ui_position": 0 },
  { "event": "jetpack_instant_search_traintracks_render",
    "railcar": "rc-abc-1", "ui_position": 1,
    "ui_algo": "jetpack-instant-search-ui/v1-expanded" }
]
```

</details>

<details>
<summary>Interact event (click on the first result)</summary>

```json
{ "event": "jetpack_instant_search_traintracks_interact",
  "blog_id": 254381802, "fetch_algo": "jetpack:search/1-score_default",
  "fetch_position": 0, "fetch_query": "test", "railcar": "rc-abc-0",
  "rec_blog_id": 1, "rec_post_id": 11, "session_id": "sess-xyz",
  "ui_algo": "jetpack-instant-search-ui/v1-expanded", "ui_position": 0,
  "action": "click" }
```

</details>

## Testing instructions

On a site connected to WordPress.com with Jetpack Search and a blocks search experience (`embedded` or `overlay_blocks`), open the browser console and run a search, then verify against `window._tkq`:

* [ ] Each result shown pushes one `jetpack_instant_search_traintracks_render`, payload identical to Instant Search (`fetch_algo`, `fetch_position`, `fetch_query`, `railcar`, `rec_blog_id`, `rec_post_id`, `session_id`, `ui_algo=jetpack-instant-search-ui/v1-{minimal|expanded|product}`, `ui_position`).
* [ ] Clicking a result pushes `jetpack_instant_search_traintracks_interact` with the same payload + `action: 'click'`.
* [ ] `blog_id` is set on every event.
* [ ] `ui_position` is absolute across paginated (load-more) results and matches between a result's render and interact events.
* [ ] Results lacking a railcar fire nothing.
* [ ] No other analytics events are introduced.


