### PR TITLE
Search Blocks: extend sidebar hairline to the bottom of the column (SEARCH-283)

### DIFF
--- a/projects/packages/search/changelog/raven-search-283-sidebar-hairline-bottom
+++ b/projects/packages/search/changelog/raven-search-283-sidebar-hairline-bottom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: stretch the filters sidebar to the full row height so its hairline divider reaches the bottom of the column instead of stopping at the end of the filter list.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -63,6 +63,10 @@ WordPress derives `.wp-block-jetpack-search-{bare-slug}` from the full block nam
 
 Manual wrapper classes (set via `useBlockProps({ className })` and the matching `get_block_wrapper_attributes()` call in `render.php`) don't have to track the slug exactly — they're just CSS hooks.
 
+## Sidebar layout: `.wp-block-columns` align-items reset
+
+The filters sidebar's `border-left` hairline (`.jetpack-search-layout__filters-column`) runs the full height of the columns row only when that row stretches its children. `search_layout_inline_css()` sets `align-items: stretch` on the row to force this, but be aware: **WP core's `wp-includes/blocks/columns/style.css` ships `.wp-block-columns { align-items: normal !important }`.** Where present (recent core, no theme override), that `!important` rule wins regardless of our selector's specificity — `align-items` on the row resolves to `normal` (which itself stretches), so our `stretch` is a redundant no-op there. It only does real work on sites where that core reset is absent or overridden, where the row would otherwise fall back to `.is-layout-flex { align-items: center }`. The upshot for testing: a stock dev env (core reset present) won't show a *difference* from this rule — to see it bite, neutralise the core reset (delete the `.wp-block-columns` align-items rule from the CSSOM) first. The overlay's bottom-edge fix is a pure `padding` move and is independent of all this.
+
 ## Theme tokens & `var()` chains
 
 The search-blocks bundle uses its own postcss config (`postcss.blocks.config.js`) with `postcss-custom-properties` set to `preserve: true`. Every `var(--foo, fallback)` ships as two declarations: a literal substitution (the deepest fallback) followed by the full `var()` call. The browser cascade picks the var when defined and falls through to the literal otherwise — runtime theme tokens work, and there's always a static safety net.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1451,51 +1451,34 @@ CSS;
 		border-left-color: color-mix(in sRGB, currentColor 15%, transparent);
 	}
 }
-/* Sidebar-showing rules (>= 992px). The corner-join is structural, not
- * decorative: the columns row is pulled flush against the search-input
- * hairline, and visual breathing room is re-added as internal column
- * padding. Three sources of vertical gap have to be neutralised for the
- * column's `border-left` to start *at* the hairline:
+/* Sidebar-showing rules (>= 992px). The corner-join is structural: the
+ * columns row is pulled flush to the search-input hairline and breathing
+ * room re-added as internal column padding, so the filters column's
+ * `border-left` runs the row's full height — hairline (top) to end-of-div
+ * (bottom). Three vertical gaps are neutralised:
  *
- *   a) The outer `wp:group`'s declared `spacing.blockGap` (1.5rem in the
- *      templates) or the theme's default block-gap (e.g. TT5 falls back
- *      to 1.2rem when the block-layout system doesn't emit the
- *      per-container override for templates rendered into a `<template>`
- *      element). Both manifest as `margin-block-start` on the columns row.
+ *   a) `margin-block-start` on the row (outer group's `spacing.blockGap` or
+ *      the theme's default block-gap) — zeroed.
  *
- *   b) `.is-layout-flex { align-items: center }` (theme default, also in
- *      WordPress core), which vertically centres the shorter filters
- *      column inside the taller results column, dropping the sidebar's
- *      top edge below the row's top. We override to `stretch` rather than
- *      `flex-start` so the column also grows to the full row height — the
- *      `border-left` then reaches the bottom of the div, not just the
- *      bottom of the (shorter) filter list. The column is flow layout, so
- *      its content stays top-aligned regardless.
+ *   b) `.is-layout-flex { align-items: center }` (theme/core default), which
+ *      centres the shorter filters column and drops its top edge. Overridden
+ *      to `stretch` (not `flex-start`) so the column also grows to full row
+ *      height; it's flow layout, so its content stays top-aligned regardless.
  *
- *   c) Overlay-only: the `__content > .wp-block-group:first-child` rule
- *      (SEARCH-243) gives the alignwide group a `padding: .5em 2em 2em`
- *      to "clear the 60px header strip." But the search-input is
- *      `position: absolute` in the overlay — it doesn't take flow space —
- *      so the 0.5em top-pad just pushes the columns row 8px below the
- *      card's `::before` hairline at `top: 60px`. The matching 2em
- *      *bottom*-pad sits below the columns row, inside the group but
- *      outside the columns, so the stretched column — and its
- *      `border-left` — stops 2em short of the card's bottom edge. Zero
- *      both on the group and re-add the 2em as `padding-bottom` on the
- *      columns themselves (overlay-scoped) so the divider runs to the card
- *      edge while the powered-by row keeps its breathing room.
+ *   c) Overlay-only: SEARCH-243's `padding: .5em 2em 2em` on the alignwide
+ *      group sits outside the columns, so the stretched column stops 0.5em
+ *      below the `::before` hairline (top) and 2em short of the card edge
+ *      (bottom). Zeroed on the group and re-added as column `padding-top` /
+ *      `padding-bottom` so the divider reaches both edges while content keeps
+ *      its breathing room.
  *
- * The `.is-layout-flex` class match bumps the columns selector to
- * specificity (0,3,0), enough to outrank any per-container `blockGap`
- * CSS WP might emit (typically (0,1,0)). The `:has(> filters-column)`
- * scope keeps these overrides off any unrelated `wp:columns` block.
- *
- * The layout fine-tuning rules below (`align-items`, `margin-block-start`,
- * overlay `padding-top`, column `padding-top`) target the columns row itself
- * and its parent group — `@container` can't reach those from inside the
- * named container, so they stay viewport-driven. Effect is harmless when the
- * sidebar is collapsed via `@container` (align-items has no effect with one
- * visible column; the margin/padding tightening is universally fine). */
+ * `.is-layout-flex` bumps the columns selector to (0,3,0) to outrank
+ * per-container `blockGap` CSS; `:has(> filters-column)` scopes it to our
+ * rows. These target the row/group, which `@container` can't reach from
+ * inside the named container, so they stay viewport-driven — harmless when
+ * the sidebar collapses below 992px. (b) is also a no-op wherever WP core's
+ * `.wp-block-columns { align-items: normal !important }` is present; see
+ * AGENTS.md. */
 @media (min-width: 992px) {
 	/* Sidebar shown, popover-in-results-header hidden. The `@container
 	 * (max-width: 991.98px)` block below re-shows the popover when the

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1466,7 +1466,11 @@ CSS;
  *   b) `.is-layout-flex { align-items: center }` (theme default, also in
  *      WordPress core), which vertically centres the shorter filters
  *      column inside the taller results column, dropping the sidebar's
- *      top edge below the row's top.
+ *      top edge below the row's top. We override to `stretch` rather than
+ *      `flex-start` so the column also grows to the full row height — the
+ *      `border-left` then reaches the bottom of the div, not just the
+ *      bottom of the (shorter) filter list. The column is flow layout, so
+ *      its content stays top-aligned regardless.
  *
  *   c) Overlay-only: the `__content > .wp-block-group:first-child` rule
  *      (SEARCH-243) gives the alignwide group a `padding: .5em 2em 2em`
@@ -1494,7 +1498,7 @@ CSS;
 		display: none;
 	}
 	.wp-block-columns.is-layout-flex:has(> .jetpack-search-layout__filters-column) {
-		align-items: flex-start;
+		align-items: stretch;
 		margin-block-start: 0;
 	}
 	.jetpack-search-block-overlay__content > .wp-block-group:first-child:has(.jetpack-search-layout__filters-column) {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1156,6 +1156,14 @@ class Search_Blocks {
 	max-width: 1080px;
 	--jp-search-overlay-surface: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
 	--jp-search-overlay-ink: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327)));
+	/* Single source for the content group's inset. The corner-join in
+	 * search_layout_inline_css() zeroes the block-start/block-end of this
+	 * padding on the group and re-adds the same tokens on the columns, so the
+	 * sidebar hairline reaches both card edges — keep them as var()s so the
+	 * two sites can't drift. */
+	--jp-search-overlay-content-pad-block-start: 0.5em;
+	--jp-search-overlay-content-pad-inline: 2em;
+	--jp-search-overlay-content-pad-block-end: 2em;
 	background: var(--jp-search-overlay-surface);
 	color: var(--jp-search-overlay-ink);
 	border: 1px solid rgba(128, 128, 128, 0.25);
@@ -1290,7 +1298,7 @@ class Search_Blocks {
 }
 /* Top padding clears the absolutely-positioned 60px header strip (SEARCH-243). */
 .jetpack-search-block-overlay__content > .wp-block-group:first-child {
-	padding: .5em 2em 2em;
+	padding: var(--jp-search-overlay-content-pad-block-start) var(--jp-search-overlay-content-pad-inline) var(--jp-search-overlay-content-pad-block-end);
 }
 @media (max-width: 781px) {
 	.jetpack-search-block-overlay {
@@ -1301,9 +1309,8 @@ class Search_Blocks {
 		border: 0;
 		border-radius: 0;
 		box-shadow: none;
-	}
-	.jetpack-search-block-overlay__content > .wp-block-group:first-child {
-		padding: .5em 1em 1em;
+		--jp-search-overlay-content-pad-inline: 1em;
+		--jp-search-overlay-content-pad-block-end: 1em;
 	}
 }
 /* Mirror legacy `$break-lg: 992px → $modal-max-width-lg: 95%` from `instant-search/components/search-results.scss`. */
@@ -1465,12 +1472,13 @@ CSS;
  *      to `stretch` (not `flex-start`) so the column also grows to full row
  *      height; it's flow layout, so its content stays top-aligned regardless.
  *
- *   c) Overlay-only: SEARCH-243's `padding: .5em 2em 2em` on the alignwide
- *      group sits outside the columns, so the stretched column stops 0.5em
- *      below the `::before` hairline (top) and 2em short of the card edge
- *      (bottom). Zeroed on the group and re-added as column `padding-top` /
- *      `padding-bottom` so the divider reaches both edges while content keeps
- *      its breathing room.
+ *   c) Overlay-only: SEARCH-243's content-group inset sits outside the
+ *      columns, so the stretched column stops short of the card edges (below
+ *      the `::before` hairline at the top, and short of the bottom). Zeroed
+ *      on the group's block axis and re-added on the columns, both sides
+ *      reading the same `--jp-search-overlay-content-pad-*` tokens the group
+ *      itself uses — so the divider reaches both edges while content keeps
+ *      its breathing room, and the two sites can't drift.
  *
  * `.is-layout-flex` bumps the columns selector to (0,3,0) to outrank
  * per-container `blockGap` CSS; `:has(> filters-column)` scopes it to our
@@ -1495,10 +1503,10 @@ CSS;
 		padding-bottom: 0;
 	}
 	.wp-block-columns:has(> .jetpack-search-layout__filters-column) > .wp-block-column {
-		padding-top: 0.5em;
+		padding-top: var(--jp-search-overlay-content-pad-block-start, 0.5em);
 	}
 	.jetpack-search-block-overlay__content .wp-block-columns:has(> .jetpack-search-layout__filters-column) > .wp-block-column {
-		padding-bottom: 2em;
+		padding-bottom: var(--jp-search-overlay-content-pad-block-end, 2em);
 	}
 }
 /* @container override: applies when the named container exists. Placed AFTER

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1477,7 +1477,13 @@ CSS;
  *      to "clear the 60px header strip." But the search-input is
  *      `position: absolute` in the overlay — it doesn't take flow space —
  *      so the 0.5em top-pad just pushes the columns row 8px below the
- *      card's `::before` hairline at `top: 60px`.
+ *      card's `::before` hairline at `top: 60px`. The matching 2em
+ *      *bottom*-pad sits below the columns row, inside the group but
+ *      outside the columns, so the stretched column — and its
+ *      `border-left` — stops 2em short of the card's bottom edge. Zero
+ *      both on the group and re-add the 2em as `padding-bottom` on the
+ *      columns themselves (overlay-scoped) so the divider runs to the card
+ *      edge while the powered-by row keeps its breathing room.
  *
  * The `.is-layout-flex` class match bumps the columns selector to
  * specificity (0,3,0), enough to outrank any per-container `blockGap`
@@ -1503,9 +1509,13 @@ CSS;
 	}
 	.jetpack-search-block-overlay__content > .wp-block-group:first-child:has(.jetpack-search-layout__filters-column) {
 		padding-top: 0;
+		padding-bottom: 0;
 	}
 	.wp-block-columns:has(> .jetpack-search-layout__filters-column) > .wp-block-column {
 		padding-top: 0.5em;
+	}
+	.jetpack-search-block-overlay__content .wp-block-columns:has(> .jetpack-search-layout__filters-column) > .wp-block-column {
+		padding-bottom: 2em;
 	}
 }
 /* @container override: applies when the named container exists. Placed AFTER


### PR DESCRIPTION
Fixes [SEARCH-283](https://linear.app/a8c/issue/SEARCH-283/search-blocks-extend-sidebar-hairline-to-the-bottom-of-the-column)

## Why

[#49206](https://github.com/Automattic/jetpack/pull/49206) (SEARCH-269) closed the gap at the **top** of the filters-sidebar hairline so it meets the search-input underline. The **bottom** was still short: the sidebar divider stopped where the filter list ended (embedded/product) or `2em` above the card edge (overlay), leaving a stub of empty space. The hairline should run the full height — reaching the end of the div / the card's bottom edge — across every template.

## Proposed changes

* **All templates:** in `Search_Blocks::search_layout_inline_css()`, change the columns-row override from `align-items: flex-start` to `align-items: stretch` (scoped to `>= 992px`, on `.wp-block-columns.is-layout-flex:has(> .jetpack-search-layout__filters-column)`). `stretch` keeps the top pinned to the row top (preserving the SEARCH-269 corner-join) **and** grows the column to the full row height, so its `border-left` reaches the bottom. The column is flow layout, so its content stays top-aligned.
* **Overlay only:** the `.jetpack-search-block-overlay__content > .wp-block-group:first-child` group carries `padding: .5em 2em 2em` (SEARCH-243). That `2em` bottom-pad sits below the columns row but *inside* the group, so even a stretched column stops `2em` short of the card edge. Zero the group's `padding-bottom` in the sidebar case and re-add the `2em` as `padding-bottom` on the columns themselves (overlay-scoped) — the divider now runs to the card edge while the powered-by row keeps its breathing room. The inset values are defined once as `--jp-search-overlay-content-pad-*` tokens on the card and read by both the group's `padding` and the column re-adds, so the two sites can't drift.

One shared rule set covers all five templates (`jetpack-search.html`, the overlay, product-results, and the two classic-theme PHP templates that reuse the same block markup).

## Root-cause note for reviewers

The `align-items` change only changes behavior on sites where alignment on the columns row is author-controlled. WordPress core's `wp-includes/blocks/columns/style.css` ships `.wp-block-columns { align-items: normal !important }`, which (where present) neutralizes both the old `flex-start` and the new `stretch` and resolves to `normal` → stretch anyway — so the column already fills the row there. On environments where that core reset is absent or overridden (the case the issue's screenshot shows), `flex-start` won and the column was short; `stretch` (specificity 0,3,0) outranks the `.is-layout-flex { align-items: center }` default and fixes it. No-op where core already stretches, a fix where it doesn't, and it can't regress the top corner-join either way. The overlay bottom-padding move is a pure padding change and applies regardless of the core reset.

## Screenshots

Sidebar divider emphasized (3px red) for visibility — the shipped hairline is the usual subtle 15%-`currentColor` stroke.

**Embedded** — captured at `/?s=the` (TT5), with WP core's `.wp-block-columns` reset neutralized to reproduce the buggy case:

| Before (`flex-start` — column 1037px short) | After (`stretch` — flush to bottom) |
|---|---|
| ![before](https://github.com/user-attachments/assets/b059b826-5470-45b1-8370-2f342c3963b1) | ![after](https://github.com/user-attachments/assets/c93d8140-8887-4f99-894d-2a5c17800847) |

**Blocks Overlay** — captured at `/?s=the` (TT5), scrolled to the card bottom:

| Before (border stops 2em above card edge) | After (border reaches card edge) |
|---|---|
| ![before](https://github.com/user-attachments/assets/cfe87671-400c-4457-ade0-b183f190a1ee) | ![after](https://github.com/user-attachments/assets/e6d9be13-758c-446c-8170-c22dec1f965b) |

Measured border-to-bottom gap:

| State | Embedded (results col = 2157px) | Overlay (content bottom) |
|---|---|---|
| Before | filters col 1037px → 1120px gap | 44px (2em) gap |
| After | filters col 2157px → 0px gap | 0px gap |

## Related product discussion/links

* [SEARCH-283](https://linear.app/a8c/issue/SEARCH-283/search-blocks-extend-sidebar-hairline-to-the-bottom-of-the-column)
* Builds on [#49206](https://github.com/Automattic/jetpack/pull/49206) (SEARCH-269), [#49192](https://github.com/Automattic/jetpack/pull/49192) (SEARCH-268)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with Jetpack Search, run a search that returns many results (so the results column is taller than the filter list) at a viewport `>= 992px`. Test both the **Embedded** experience (`jetpack_search_experience = embedded`) and the **Blocks Overlay** (`overlay_blocks`).
* [ ] The filters-sidebar `border-left` runs from the search-input hairline (top) to the bottom of the columns row — Embedded, Overlay, and Product-results templates, plus the classic-theme variants.
* [ ] In the Blocks Overlay, the divider reaches the card's bottom edge (no 2em stub), and the "Search powered by Jetpack" row keeps its bottom breathing room.
* [ ] The top corner-join from SEARCH-269 is preserved (no regression at the top).
* [ ] Sidebar content (heading + filter list) stays top-aligned.
* [ ] No effect below 992px, where the sidebar is collapsed via the existing `@container` rule.
