### PR TITLE
Search Blocks: track theme button palette for active-filter pills on classic themes

### DIFF
--- a/projects/packages/search/changelog/nova-search-282-active-filter-pills-theme-button
+++ b/projects/packages/search/changelog/nova-search-282-active-filter-pills-theme-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: active-filter pills now track the theme's button palette on classic themes instead of falling back to WordPress core's default button color.

--- a/projects/packages/search/changelog/nova-search-282-active-filter-pills-theme-button
+++ b/projects/packages/search/changelog/nova-search-282-active-filter-pills-theme-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Search Blocks: active-filter pills now track the theme's button palette on classic themes instead of falling back to WordPress core's default button color.
+Search Blocks: render active-filter pills as theme-tracking outline chips (matching the filter chips) instead of solid buttons, and give the Load More button the overlay's ghost styling inside the blocks Overlay, so both read correctly on classic themes and against the light overlay card.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -11,6 +11,16 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
+// Each pill carries `wp-block-button__link` so it inherits the theme's core
+// button palette — including on classic themes, whose block CSS styles
+// `.wp-block-button__link` but never the newer `.wp-element-button` class.
+// Without the older class a pill falls through to WordPress core's
+// `#32373c` classic-theme button default instead of the theme's own color,
+// so it stops tracking the theme (and stops matching the Load More button,
+// which already carries the class). That class is only styled when the core
+// Button block's stylesheet is on the page, so pull it in explicitly.
+wp_enqueue_style( 'wp-block-button' );
+
 // First-paint FOUC guard: emit `hidden` on the wrapper when the seeded state
 // has no active filters, so the "Active filters:" heading doesn't briefly
 // render before hydration and push siblings ~30px down — `data-wp-bind--hidden`
@@ -67,7 +77,7 @@ $in_interactive_scope = isset( $block ) && $block instanceof \WP_Block
 			<li>
 				<button
 					type="button"
-					class="wp-element-button jetpack-search-active-filters__pill"
+					class="wp-element-button wp-block-button__link jetpack-search-active-filters__pill"
 					data-wp-on--click="actions.onRemovePill"
 					data-wp-bind--aria-label="context.pill.ariaLabel"
 				>

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -11,16 +11,6 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-// Each pill carries `wp-block-button__link` so it inherits the theme's core
-// button palette — including on classic themes, whose block CSS styles
-// `.wp-block-button__link` but never the newer `.wp-element-button` class.
-// Without the older class a pill falls through to WordPress core's
-// `#32373c` classic-theme button default instead of the theme's own color,
-// so it stops tracking the theme (and stops matching the Load More button,
-// which already carries the class). That class is only styled when the core
-// Button block's stylesheet is on the page, so pull it in explicitly.
-wp_enqueue_style( 'wp-block-button' );
-
 // First-paint FOUC guard: emit `hidden` on the wrapper when the seeded state
 // has no active filters, so the "Active filters:" heading doesn't briefly
 // render before hydration and push siblings ~30px down — `data-wp-bind--hidden`
@@ -77,7 +67,7 @@ $in_interactive_scope = isset( $block ) && $block instanceof \WP_Block
 			<li>
 				<button
 					type="button"
-					class="wp-element-button wp-block-button__link jetpack-search-active-filters__pill"
+					class="jetpack-search-active-filters__pill"
 					data-wp-on--click="actions.onRemovePill"
 					data-wp-bind--aria-label="context.pill.ariaLabel"
 				>

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -26,9 +26,13 @@
 		padding: 0;
 	}
 
-	// Pills carry `wp-element-button` so they adopt the active theme's
-	// button palette (theme.json → styles.elements.button). We only
-	// override what we need — pill shape, spacing, and remove-icon weight.
+	// Pills carry `wp-block-button__link` + `wp-element-button` so they adopt
+	// the active theme's button palette on both block themes (theme.json →
+	// styles.elements.button) and classic themes (whose block CSS styles
+	// `.wp-block-button__link`) — mirroring the Load More button's class set.
+	// These two-class rules (0,2,0) outrank the core/theme single-class button
+	// rules, so we keep the pill shape, spacing, and remove-icon weight while
+	// the theme drives the colors.
 	.jetpack-search-active-filters__pill {
 		display: inline-flex;
 		align-items: center;

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -26,22 +26,52 @@
 		padding: 0;
 	}
 
-	// Pills carry `wp-block-button__link` + `wp-element-button` so they adopt
-	// the active theme's button palette on both block themes (theme.json →
-	// styles.elements.button) and classic themes (whose block CSS styles
-	// `.wp-block-button__link`) — mirroring the Load More button's class set.
-	// These two-class rules (0,2,0) outrank the core/theme single-class button
-	// rules, so we keep the pill shape, spacing, and remove-icon weight while
-	// the theme drives the colors.
+	// Active-filter pills are selected-filter tokens, so they mirror the
+	// checkbox filter chips (`_chip.scss`): a `currentColor` outline that tracks
+	// the inherited theme ink. `currentColor` resolves to the page ink on the
+	// search page and to the overlay card's ink inside the blocks Overlay, so
+	// the pills stay readable and consistent on every theme and surface —
+	// without leaning on the core button palette, which on classic themes fell
+	// through to WordPress's `#32373c` default and rendered as a heavy solid
+	// pill (with a clashing theme-accent hover) against the light overlay card.
 	.jetpack-search-active-filters__pill {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
+		border: 1px solid currentColor;
 		border-radius: 12px;
 		padding: 0.2rem 0.6rem;
+		// Reset the host theme's `button` typography (classic themes like Twenty
+		// Sixteen uppercase + letter-space + restyle the font of bare buttons) so
+		// the label reads in the inherited body font, mixed-case, like the
+		// surrounding Search UI rather than a theme CTA.
+		font: inherit;
 		font-size: 0.8rem;
 		line-height: 1.2;
+		text-transform: none;
+		letter-spacing: normal;
+		color: inherit;
+		background: transparent;
 		cursor: pointer;
+		transition:
+			background-color 0.2s ease,
+			border-color 0.2s ease;
+
+		@supports (border-color: color-mix(in sRGB, black 50%, white)) {
+			background: color-mix(in sRGB, currentColor 14%, transparent);
+			border-color: color-mix(in sRGB, currentColor 38%, transparent);
+		}
+
+		&:hover,
+		&:focus-visible {
+			background: transparent;
+			border-color: currentColor;
+
+			@supports (background: color-mix(in sRGB, black 50%, white)) {
+				background: color-mix(in sRGB, currentColor 24%, transparent);
+				border-color: color-mix(in sRGB, currentColor 52%, transparent);
+			}
+		}
 	}
 
 	.jetpack-search-active-filters__pill-remove {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1230,6 +1230,23 @@ class Search_Blocks {
 .jetpack-search-block-overlay__card button[aria-expanded="true"] {
 	color: var(--jp-search-overlay-ink);
 }
+/* Load More is a solid theme `core/button` on the search page, which is right
+ * there. Inside the overlay card it sits on the resolved card surface, where the
+ * theme's solid button background (and its accent `:hover`, e.g. Twenty Sixteen's
+ * #007acc) reads as a heavy slab that clashes with the card's otherwise
+ * `currentColor`-ghost controls (close, sort/filter triggers, active-filter
+ * pills). Card-scoped (0,2,0 / 0,2,1) so it only restyles the in-overlay button
+ * to the same ghost affordance — the page button is untouched. */
+.jetpack-search-block-overlay__card .jetpack-search-load-more__button {
+	background: transparent;
+	border: 1px solid;
+	border-color: color-mix(in sRGB, currentColor 20%, transparent);
+	color: var(--jp-search-overlay-ink);
+}
+.jetpack-search-block-overlay__card .jetpack-search-load-more__button:hover:not(:disabled),
+.jetpack-search-block-overlay__card .jetpack-search-load-more__button:focus-visible {
+	background: color-mix(in sRGB, currentColor 8%, transparent);
+}
 /* Promote the first child (search-input) to a 60px header strip flush with
  * the close button, matching the legacy `__box` header. Suppress the input
  * block's own border-bottom — the card's `::before` hairline handles the


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-282

## Why
In the Search Blocks experiences, the **active-filter pills** and the **Load More** button didn't read correctly across themes and surfaces:

- On a classic theme like **Twenty Sixteen** (no `--wp--preset--color--*` tokens), the pills carried only `wp-element-button`, which classic themes never style, so they fell through to WordPress core's `#32373c` default — not the theme.
- Inside the blocks **Overlay**, the pills (and the Load More button) rendered as solid, theme-colored slabs against the overlay's light card, and their theme-accent hover (e.g. Twenty Sixteen's `#007acc`) clashed with the card — while every other overlay control (close, sort/filter triggers, filter chips) uses a subtle `currentColor` ghost treatment.

This makes the pills and the in-overlay button track the theme and the surface they sit on.

## Proposed changes
* **Active-filter pills → theme-tracking outline chips.** They're selected-filter tokens, so they now mirror the checkbox filter chips (`_chip.scss`): a `currentColor` border + `color-mix` fill. `currentColor` resolves to the page ink on the search page and to the overlay card's ink inside the Overlay, so they stay readable and on-theme on every theme and surface — no dependence on the core button palette (which was also stylesheet-source-order fragile). Host-theme button typography (classic themes uppercase / restyle bare `<button>`s) is reset so the label stays mixed-case body text.
* **Load More button** stays a solid theme-button CTA on the search page, but inside the Overlay card it adopts the same `currentColor`-ghost affordance as the card's other controls. Card-scoped (`.jetpack-search-block-overlay__card …`), so the page button is untouched.

## Screenshots
All affected interfaces, before → after, on a classic theme (**Twenty Sixteen**) and a block theme (**Twenty Twenty-Five**).

### Active-filter pills — search page (embedded)
| Theme | Before | After |
|---|---|---|
| Twenty Sixteen | ![](https://github.com/user-attachments/assets/8031f62b-ba19-4c84-aa75-d5c82fabab14) | ![](https://github.com/user-attachments/assets/f7fcbf02-903a-4bce-a7ee-a5c6919cd5f4) |
| Twenty Twenty-Five | ![](https://github.com/user-attachments/assets/0fd7d8f1-191e-494c-88d9-b3eaa0a19cc0) | ![](https://github.com/user-attachments/assets/4cc16812-aa37-4e63-9aca-202725232bd1) |

### Pills + Load More — blocks Overlay (resting)
| Theme | Before | After |
|---|---|---|
| Twenty Sixteen | ![](https://github.com/user-attachments/assets/2bce24ea-65d4-4524-a32d-bc355a4c971e) | ![](https://github.com/user-attachments/assets/887d1e3b-677e-438c-8e70-cec9ebe26b2f) |
| Twenty Twenty-Five | ![](https://github.com/user-attachments/assets/bb44ac5b-48cc-4c7e-8e69-d5dd46189690) | ![](https://github.com/user-attachments/assets/c12b5221-925e-44a2-9500-a3a1f7e7b080) |

### Load More + pills — blocks Overlay (hover, Twenty Sixteen)
Before the Load More hovered to a bright `#007acc` slab; after it's a subtle `currentColor` ghost matching the close and Sort controls.

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/7a979683-5406-4b92-89eb-d5f1e4b0ee2d) | ![](https://github.com/user-attachments/assets/858b9792-6f6c-4f1f-8e10-1454c106b20d) |

## Related product discussion/links
* [SEARCH-282](https://linear.app/a8c/issue/SEARCH-282)

## Does this pull request change what data or activity we track or use?
No. CSS / markup-class / stylesheet-scope changes only.

## Testing instructions
On a site running a blocks-powered Search experience with an active **classic** theme such as **Twenty Sixteen**:

* [ ] **Embedded:** run a search with results, apply a filter, and confirm the **Active filters:** pills render as outline chips in the theme's text color (mixed-case, body font), with a subtle `currentColor` hover — not a solid `#32373c` slab.
* [ ] **Embedded:** the **Load more results** button stays a solid theme button.
* [ ] **overlay_blocks:** open the Overlay, apply a filter, and confirm the pills and the **Load more results** button are subtle `currentColor` ghosts that match the close (×) button and Sort control — no heavy dark slab, no clashing accent-blue hover.
* [ ] Switch to a block theme (**Twenty Twenty-Five**) and confirm both surfaces still look correct in both experiences.
* [ ] Pills and button hover states track the theme/surface ink on both light and dark themes (no invisible text, no clashing fixed color).
