### PR TITLE
Search Blocks: add a Search Layout wrapper block with width + theme-independent spacing/border controls

### DIFF
--- a/projects/packages/search/changelog/sage-search-285-search-layout-block
+++ b/projects/packages/search/changelog/sage-search-285-search-layout-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add a Search Layout wrapper block with a Width control and theme-independent spacing/border/dimension controls for the embedded Search template.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -30,9 +30,14 @@ Current slug shapes — match one if it fits, but new shapes are fine when nothi
 - **Filters:** `filter-{kind}` (e.g. `filter-checkbox`, `filter-date`). Visitor-facing titles read "Filter by X". Author-configured scoping (post-type bounds for the whole search experience) lives on the `search-results` block's "Search scope" inspector panel, not as a standalone filter block — same shape as core's Query Loop carrying `postType` on the block that renders the results.
 - **Filter compositions:** `filters` for the default vertical stack; layout-suffixed `filters-{layout}` for variants (e.g. `filters-popover`, `filters-product`).
 - **Results region:** `search-results` for the container; `results-{role}` for atoms inside it (`results-list`, `results-count`, `results-sort`, `results-load-more`).
+- **Page wrapper:** `layout` — the top-level `<main>` shell that frames the whole embedded Search experience (the `jetpack-search.html` / `jetpack-search-product-results.html` templates wrap their content in it). Bare role noun matching the `jetpack-search-layout__*` CSS family.
 - **Standalone:** bare role slug (`search-input`, `powered-by`, `active-filters`).
 
 Titles aim to read naturally in the inserter, not mirror the slug shape — "Sort By" not "Results Sort", "Collapsible Filters" not "Filters Popover".
+
+## Search Layout forced controls
+
+`Search_Blocks::force_search_layout_block_supports()` (hooked on `wp_theme_json_data_theme`, always-on in `init()`) injects `settings.blocks['jetpack-search/layout']` with spacing / border / dimensions enabled. This is what makes the `layout` block's margin/padding/border/min-height panels appear regardless of the active theme's `appearanceTools` opt-in — block-level `supports` alone stay gated behind the theme's global `settings.*`, and per-block theme.json settings override that gate for one block only. It's registered unconditionally (not behind the experience or `block_templates_active()`) so the controls are present in both the Site Editor and the classic-theme singleton-CPT editors. The block's own `block.json` `supports` still has to declare each capability — the theme.json settings control UI availability, the supports control serialization; both are required. Scoped to the one block, so no other `core/group` on the site changes behavior.
 
 ## Shared store / bundles
 

--- a/projects/packages/search/src/search-blocks/blocks/layout/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/layout/block.json
@@ -34,6 +34,7 @@
 		}
 	},
 	"attributes": {
+		"tagName": { "type": "string", "default": "div" },
 		"width": { "type": "number" },
 		"widthUnit": { "type": "string" }
 	},

--- a/projects/packages/search/src/search-blocks/blocks/layout/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/layout/block.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/layout",
+	"version": "0.1.0",
+	"title": "Search Layout",
+	"category": "jetpack-search",
+	"description": "Centered page wrapper for the Jetpack Search experience. Controls the search region's width, margin, padding, and border.",
+	"keywords": [ "search", "layout", "wrapper" ],
+	"supports": {
+		"html": false,
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"blockGap": true
+		},
+		"border": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		},
+		"dimensions": {
+			"minHeight": true
+		},
+		"layout": {
+			"default": { "type": "constrained" }
+		}
+	},
+	"attributes": {
+		"width": { "type": "number" },
+		"widthUnit": { "type": "string" }
+	},
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php"
+}

--- a/projects/packages/search/src/search-blocks/blocks/layout/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/layout/block.json
@@ -14,11 +14,17 @@
 			"margin": true,
 			"blockGap": true
 		},
-		"border": {
+		"__experimentalBorder": {
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		},
 		"dimensions": {
 			"minHeight": true

--- a/projects/packages/search/src/search-blocks/blocks/layout/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/layout/edit.js
@@ -31,13 +31,10 @@ const WIDTH_UNITS = [
 	{ value: '%', label: '%', default: PC_WIDTH_DEFAULT },
 ];
 
-const HELP_STYLE = {
-	marginTop: 8,
-	marginBottom: 0,
-	fontSize: 12,
-	fontStyle: 'normal',
-	color: 'rgb(117, 117, 117)',
-};
+// Only the top gap after the UnitControl — color, font-size, and font-style
+// come from the `components-base-control__help` class (which also tracks WP's
+// dark color scheme; a hardcoded color here would override it).
+const HELP_STYLE = { marginTop: 8 };
 
 /**
  * Whether a unit is the percentage unit. Used to clamp max=100 and to drop the
@@ -77,10 +74,14 @@ export default function LayoutEdit( { attributes, setAttributes } ) {
 		layout: usedLayout,
 		renderAppender: InnerBlocks.ButtonBlockAppender,
 	} );
+	// Render the saved semantic tag so the preview matches render.php; the
+	// templates set `main`, ad-hoc insertions default to `div` (no second
+	// `<main>` landmark). Capitalized binding so JSX treats it as the element.
+	const TagName = attributes?.tagName || 'div';
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Dimensions', 'jetpack-search-pkg' ) } initialOpen={ false }>
+				<PanelBody title={ __( 'Width', 'jetpack-search-pkg' ) } initialOpen={ false }>
 					{ /* UnitControl with px / % units, MIN_WIDTH floor on non-percentage
 						units, max=100 on %. Switching units snaps to a sensible default
 						so a px → % transition doesn't leave a meaningless 1100%. */ }
@@ -124,7 +125,7 @@ export default function LayoutEdit( { attributes, setAttributes } ) {
 					</p>
 				</PanelBody>
 			</InspectorControls>
-			<main { ...innerBlocksProps } />
+			<TagName { ...innerBlocksProps } />
 		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/layout/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/layout/edit.js
@@ -1,0 +1,132 @@
+/**
+ * Editor preview for jetpack-search/layout.
+ *
+ * Group-like wrapper that frames the whole Search experience. Renders a
+ * constrained-layout InnerBlocks region so alignwide/alignfull children
+ * behave, and exposes a Width control (centered max-width) in the inspector.
+ * Spacing, border, and dimensions come from block supports — forced on for
+ * this block regardless of theme via a `wp_theme_json_data_theme` filter (see
+ * Search_Blocks::force_search_layout_block_supports()).
+ */
+import {
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+// Width defaults sized for a page region rather than a single field: a typical
+// content cap in px, a full-bleed default in %. `MIN_WIDTH` floors px so the
+// search columns never collapse below a usable width.
+const MIN_WIDTH = 320;
+const PX_WIDTH_DEFAULT = 1100;
+const PC_WIDTH_DEFAULT = 100;
+const WIDTH_UNITS = [
+	{ value: 'px', label: 'px', default: PX_WIDTH_DEFAULT },
+	{ value: '%', label: '%', default: PC_WIDTH_DEFAULT },
+];
+
+const HELP_STYLE = {
+	marginTop: 8,
+	marginBottom: 0,
+	fontSize: 12,
+	fontStyle: 'normal',
+	color: 'rgb(117, 117, 117)',
+};
+
+/**
+ * Whether a unit is the percentage unit. Used to clamp max=100 and to drop the
+ * `MIN_WIDTH` floor (a 320% width isn't meaningful).
+ *
+ * @param {string} unit - The unit symbol.
+ * @return {boolean} True for '%'.
+ */
+function isPercentageUnit( unit ) {
+	return unit === '%';
+}
+
+/**
+ * Edit component for the layout block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function LayoutEdit( { attributes, setAttributes } ) {
+	// Width is opt-in: only emit the inline style when the author has set both
+	// halves of the (value, unit) pair. The render emits a centered max-width,
+	// so the editor preview mirrors it with the same logical centering.
+	const width = attributes?.width;
+	const widthUnit = attributes?.widthUnit;
+	const hasWidth = width !== undefined && width !== null && !! widthUnit;
+	const wrapperStyle = hasWidth
+		? { maxWidth: `${ width }${ widthUnit }`, marginLeft: 'auto', marginRight: 'auto' }
+		: undefined;
+	const blockProps = useBlockProps( { style: wrapperStyle } );
+	// Mirror core/group: fall back to constrained so alignwide/full children
+	// center even on a freshly-inserted block whose layout attr is still unset.
+	const layout = attributes?.layout;
+	const usedLayout = layout?.type ? layout : { type: 'constrained' };
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		layout: usedLayout,
+		renderAppender: InnerBlocks.ButtonBlockAppender,
+	} );
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Dimensions', 'jetpack-search-pkg' ) } initialOpen={ false }>
+					{ /* UnitControl with px / % units, MIN_WIDTH floor on non-percentage
+						units, max=100 on %. Switching units snaps to a sensible default
+						so a px → % transition doesn't leave a meaningless 1100%. */ }
+					<UnitControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Width', 'jetpack-search-pkg' ) }
+						min={ isPercentageUnit( widthUnit ) ? 0 : MIN_WIDTH }
+						max={ isPercentageUnit( widthUnit ) ? 100 : undefined }
+						step={ 1 }
+						units={ WIDTH_UNITS }
+						value={ hasWidth ? `${ width }${ widthUnit }` : '' }
+						onChange={ newValue => {
+							if ( ! newValue ) {
+								setAttributes( { width: undefined, widthUnit: undefined } );
+								return;
+							}
+							// UnitControl emits a concatenated string like `900px`. Save
+							// BOTH halves on every keystroke; without this, `width` lands
+							// but `widthUnit` only sets through `onUnitChange` (which fires
+							// only on explicit unit-picker changes). Fall back to the
+							// existing unit, then the first in WIDTH_UNITS, so the very
+							// first keystroke on a fresh block persists a usable pair.
+							const parsed = parseInt( newValue, 10 );
+							const unitMatch = String( newValue ).match( /[^\d.]+$/ );
+							const unit = unitMatch?.[ 0 ] || widthUnit || WIDTH_UNITS[ 0 ].value;
+							setAttributes( {
+								width: Number.isNaN( parsed ) ? undefined : parsed,
+								widthUnit: unit,
+							} );
+						} }
+						onUnitChange={ newUnit => {
+							setAttributes( {
+								width: isPercentageUnit( newUnit ) ? PC_WIDTH_DEFAULT : PX_WIDTH_DEFAULT,
+								widthUnit: newUnit,
+							} );
+						} }
+					/>
+					<p className="components-base-control__help" style={ HELP_STYLE }>
+						{ __( 'Leave empty to use the full container width.', 'jetpack-search-pkg' ) }
+					</p>
+				</PanelBody>
+			</InspectorControls>
+			<main { ...innerBlocksProps } />
+		</>
+	);
+}
+
+export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/blocks/layout/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/layout/render.php
@@ -3,16 +3,26 @@
  * Search Layout block render.
  *
  * Group-like wrapper that frames the whole embedded Search experience: emits
- * `$content` (the serialized inner block markup) inside a `<main>`, with the
- * block-wrapper attrs derived from the spacing / border / dimensions / layout
- * supports. Adds an optional author Width control on top of those.
+ * `$content` (the serialized inner block markup) inside the configured tag,
+ * with the block-wrapper attrs derived from the spacing / border / dimensions
+ * / layout supports. Adds an optional author Width control on top of those.
  *
  * @package automattic/jetpack-search
+ *
+ * @phan-file-suppress PhanUndeclaredGlobalVariable -- WP supplies $attributes and $content at block render.
  */
 
 namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// The search templates set tagName to `main` so the search page gets its
+// landmark. Inserted anywhere else the block defaults to a plain `div`, so it
+// can't introduce a second `<main>` landmark inside the theme's own. Allowlist
+// the saved value against the same tags core/group offers.
+$allowed_tags = array( 'div', 'main', 'header', 'footer', 'section', 'article', 'aside' );
+$raw_tag      = (string) ( $attributes['tagName'] ?? 'div' );
+$tag_name     = in_array( $raw_tag, $allowed_tags, true ) ? $raw_tag : 'div';
 
 // `widthUnit` is allowlisted against the units the editor offers — block.json
 // types it as a free-form string, so a REST write or a future migration can't
@@ -32,10 +42,12 @@ if ( $has_width ) {
 		$width_unit
 	);
 }
-?>
-<main <?php echo wp_kses_data( get_block_wrapper_attributes( $wrapper_extra_attrs ) ); ?>>
-	<?php
-	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
-	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
-	?>
-</main>
+
+printf(
+	'<%1$s %2$s>',
+	esc_html( $tag_name ),
+	wp_kses_data( get_block_wrapper_attributes( $wrapper_extra_attrs ) )
+);
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+echo $content;
+echo '</' . esc_html( $tag_name ) . '>';

--- a/projects/packages/search/src/search-blocks/blocks/layout/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/layout/render.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Search Layout block render.
+ *
+ * Group-like wrapper that frames the whole embedded Search experience: emits
+ * `$content` (the serialized inner block markup) inside a `<main>`, with the
+ * block-wrapper attrs derived from the spacing / border / dimensions / layout
+ * supports. Adds an optional author Width control on top of those.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// `widthUnit` is allowlisted against the units the editor offers — block.json
+// types it as a free-form string, so a REST write or a future migration can't
+// smuggle an arbitrary unit into the inline style. A set (value, unit) pair
+// caps the region with a centered max-width. Physical `margin-left/right:auto`
+// (not the logical `margin-inline`, which `safecss_filter_attr` strips) — both
+// sides auto centers in LTR and RTL alike.
+$wrapper_extra_attrs = array();
+$allowed_width_units = array( 'px', '%' );
+$raw_width_unit      = (string) ( $attributes['widthUnit'] ?? '' );
+$width_unit          = in_array( $raw_width_unit, $allowed_width_units, true ) ? $raw_width_unit : '';
+$has_width           = isset( $attributes['width'] ) && '' !== $attributes['width'] && '' !== $width_unit;
+if ( $has_width ) {
+	$wrapper_extra_attrs['style'] = sprintf(
+		'max-width:%d%s;margin-left:auto;margin-right:auto;',
+		(int) $attributes['width'],
+		$width_unit
+	);
+}
+?>
+<main <?php echo wp_kses_data( get_block_wrapper_attributes( $wrapper_extra_attrs ) ); ?>>
+	<?php
+	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+	?>
+</main>

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -232,25 +232,28 @@ class Search_Blocks {
 	 * @return \WP_Theme_JSON_Data Updated theme JSON data.
 	 */
 	public static function force_search_layout_block_supports( $theme_json_data ) {
-		$data = $theme_json_data->get_data();
-		if ( ! isset( $data['settings']['blocks'] ) ) {
-			$data['settings']['blocks'] = array();
-		}
-		$data['settings']['blocks']['jetpack-search/layout'] = array(
-			'spacing'    => array(
-				'padding'  => true,
-				'margin'   => true,
-				'blockGap' => true,
-			),
-			'border'     => array(
-				'color'  => true,
-				'radius' => true,
-				'style'  => true,
-				'width'  => true,
-			),
-			'dimensions' => array(
-				'minHeight' => true,
-			),
+		$data     = $theme_json_data->get_data();
+		$existing = $data['settings']['blocks']['jetpack-search/layout'] ?? array();
+		// Merge rather than overwrite so a theme that pre-configures other
+		// settings for this block (e.g. typography) keeps them.
+		$data['settings']['blocks']['jetpack-search/layout'] = array_replace_recursive(
+			$existing,
+			array(
+				'spacing'    => array(
+					'padding'  => true,
+					'margin'   => true,
+					'blockGap' => true,
+				),
+				'border'     => array(
+					'color'  => true,
+					'radius' => true,
+					'style'  => true,
+					'width'  => true,
+				),
+				'dimensions' => array(
+					'minHeight' => true,
+				),
+			)
 		);
 		$theme_json_class                                    = get_class( $theme_json_data );
 		return new $theme_json_class( $data, 'theme' );

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -137,6 +137,11 @@ class Search_Blocks {
 		// Both hooks needed; see AGENTS.md § Hydration & SSR seeding.
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
+		// Force the Search Layout block's dimension controls on regardless of the
+		// active theme's appearanceTools opt-in (see AGENTS.md § Search Layout
+		// forced controls). Always-on: the block is editable in the Site Editor
+		// on block themes and in the singleton-CPT editors on classic themes.
+		add_filter( 'wp_theme_json_data_theme', array( static::class, 'force_search_layout_block_supports' ) );
 
 		$experience = ( new Module_Control() )->get_experience();
 
@@ -211,6 +216,44 @@ class Search_Blocks {
 			add_action( 'wp_enqueue_scripts', array( static::class, 'enqueue_block_template_overlay_assets' ) );
 			add_action( 'wp_footer', array( static::class, 'print_block_template_overlay' ) );
 		}
+	}
+
+	/**
+	 * Force the Search Layout block's dimension controls on regardless of theme.
+	 *
+	 * The `jetpack-search/layout` block frames the embedded Search experience and
+	 * needs reliable width / spacing / border / min-height controls. Block-level
+	 * supports only surface when the active theme opts into the matching
+	 * `appearanceTools` / `settings.*` flags, so themes that don't would hide
+	 * them. Enabling the settings per-block leaves every other block — including
+	 * `core/group` — untouched.
+	 *
+	 * @param \WP_Theme_JSON_Data $theme_json_data Theme JSON data object.
+	 * @return \WP_Theme_JSON_Data Updated theme JSON data.
+	 */
+	public static function force_search_layout_block_supports( $theme_json_data ) {
+		$data = $theme_json_data->get_data();
+		if ( ! isset( $data['settings']['blocks'] ) ) {
+			$data['settings']['blocks'] = array();
+		}
+		$data['settings']['blocks']['jetpack-search/layout'] = array(
+			'spacing'    => array(
+				'padding'  => true,
+				'margin'   => true,
+				'blockGap' => true,
+			),
+			'border'     => array(
+				'color'  => true,
+				'radius' => true,
+				'style'  => true,
+				'width'  => true,
+			),
+			'dimensions' => array(
+				'minHeight' => true,
+			),
+		);
+		$theme_json_class                                    = get_class( $theme_json_data );
+		return new $theme_json_class( $data, 'theme' );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/editor/icons.js
+++ b/projects/packages/search/src/search-blocks/editor/icons.js
@@ -44,6 +44,7 @@ import {
 	search,
 	starFilled,
 	store,
+	stretchWide,
 	swatch,
 	tag,
 	tool,
@@ -70,6 +71,7 @@ const BLOCK_ICONS = {
 	'jetpack-search/filters': greened( filter ),
 	'jetpack-search/filters-popover': greened( funnel ),
 	'jetpack-search/filters-product': greened( store ),
+	'jetpack-search/layout': greened( stretchWide ),
 	'jetpack-search/active-filters': greened( pin ),
 	'jetpack-search/clear-filters': greened( reset ),
 	// The "Powered by Jetpack Search" block advertises Jetpack ownership in

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -31,6 +31,7 @@ import FilterWcStockStatusEdit from '../blocks/filter-wc-stock-status/edit';
 import FiltersEdit, { save as filtersSave } from '../blocks/filters/edit';
 import FiltersPopoverEdit, { save as filtersPopoverSave } from '../blocks/filters-popover/edit';
 import FiltersProductEdit, { save as filtersProductSave } from '../blocks/filters-product/edit';
+import LayoutEdit, { save as layoutSave } from '../blocks/layout/edit';
 import PoweredByEdit from '../blocks/powered-by/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
 import ResultsListEdit from '../blocks/results-list/edit';
@@ -67,6 +68,7 @@ const BLOCKS = [
 	[ 'jetpack-search/filter-wc-price', FilterWcPriceEdit ],
 	[ 'jetpack-search/filter-wc-stock-status', FilterWcStockStatusEdit ],
 	[ 'jetpack-search/filters-product', FiltersProductEdit, filtersProductSave ],
+	[ 'jetpack-search/layout', LayoutEdit, layoutSave ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -1,7 +1,6 @@
 <!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+<!-- wp:jetpack-search/layout {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
 <div class="wp-block-group alignwide">
@@ -62,7 +61,6 @@
 </div>
 <!-- /wp:group -->
 
-</main>
-<!-- /wp:group -->
+<!-- /wp:jetpack-search/layout -->
 
 <!-- wp:template-part {"slug":"{{FOOTER_SLUG}}"} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-product-results.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
-<!-- wp:jetpack-search/layout {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:jetpack-search/layout {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
 <div class="wp-block-group alignwide">

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
-<!-- wp:jetpack-search/layout {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:jetpack-search/layout {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
 <div class="wp-block-group alignwide">

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -1,7 +1,6 @@
 <!-- wp:template-part {"slug":"{{HEADER_SLUG}}"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+<!-- wp:jetpack-search/layout {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
 <div class="wp-block-group alignwide">
@@ -58,7 +57,6 @@
 </div>
 <!-- /wp:group -->
 
-</main>
-<!-- /wp:group -->
+<!-- /wp:jetpack-search/layout -->
 
 <!-- wp:template-part {"slug":"{{FOOTER_SLUG}}"} /-->

--- a/projects/packages/search/tests/js/search-blocks/layout-block-json.test.js
+++ b/projects/packages/search/tests/js/search-blocks/layout-block-json.test.js
@@ -1,0 +1,43 @@
+// Guards the layout block.json contract. The width attributes are part of the
+// public API (posts saved against one shape must keep rendering if defaults
+// drift), and the dimension supports must stay declared — the forced-controls
+// theme.json filter (Search_Blocks::force_search_layout_block_supports) only
+// surfaces the UI; the block.json supports are what let the block serialize
+// the values.
+
+import blockJson from '../../../src/search-blocks/blocks/layout/block.json';
+
+describe( 'layout block.json', () => {
+	it( 'declares opt-in width + widthUnit attributes (no defaults)', () => {
+		const attrs = blockJson.attributes;
+		// No defaults: the (value, unit) pair only takes effect when the author
+		// has set both halves, matching the render.php gate.
+		expect( attrs.width ).toEqual( { type: 'number' } );
+		expect( attrs.widthUnit ).toEqual( { type: 'string' } );
+	} );
+
+	it( 'declares spacing, border, dimensions, and constrained layout supports', () => {
+		const supports = blockJson.supports;
+		expect( supports.spacing ).toEqual( {
+			padding: true,
+			margin: true,
+			blockGap: true,
+		} );
+		expect( supports.border ).toEqual( {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+		} );
+		expect( supports.dimensions ).toEqual( { minHeight: true } );
+		expect( supports.layout ).toEqual( { default: { type: 'constrained' } } );
+	} );
+
+	it( 'is a dynamic block with no front-end script/style bundle', () => {
+		// Pure layout chrome: styles emit inline via supports + render.php, so it
+		// ships no view module or stylesheet (no webpack entry without view.js).
+		expect( blockJson.render ).toBe( 'file:./render.php' );
+		expect( blockJson.viewScriptModule ).toBeUndefined();
+		expect( blockJson.style ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/layout-block-json.test.js
+++ b/projects/packages/search/tests/js/search-blocks/layout-block-json.test.js
@@ -16,6 +16,12 @@ describe( 'layout block.json', () => {
 		expect( attrs.widthUnit ).toEqual( { type: 'string' } );
 	} );
 
+	it( 'defaults tagName to div so ad-hoc insertions add no second <main> landmark', () => {
+		// The templates set tagName="main" explicitly; everywhere else the block
+		// is a plain div, avoiding a duplicate-main ARIA landmark violation.
+		expect( blockJson.attributes.tagName ).toEqual( { type: 'string', default: 'div' } );
+	} );
+
 	it( 'declares spacing, border, dimensions, and constrained layout supports', () => {
 		const supports = blockJson.supports;
 		expect( supports.spacing ).toEqual( {

--- a/projects/packages/search/tests/js/search-blocks/layout-block-json.test.js
+++ b/projects/packages/search/tests/js/search-blocks/layout-block-json.test.js
@@ -23,12 +23,17 @@ describe( 'layout block.json', () => {
 			margin: true,
 			blockGap: true,
 		} );
-		expect( supports.border ).toEqual( {
+		// Border support uses the `__experimentalBorder` key, not `border` — WP's
+		// PHP border-support serialization (wp_apply_border_support) only reads
+		// the experimental key, so `border` would render no border on the front
+		// end. Matches core/group.
+		expect( supports.__experimentalBorder ).toMatchObject( {
 			color: true,
 			radius: true,
 			style: true,
 			width: true,
 		} );
+		expect( supports.border ).toBeUndefined();
 		expect( supports.dimensions ).toEqual( { minHeight: true } );
 		expect( supports.layout ).toEqual( { default: { type: 'constrained' } } );
 	} );


### PR DESCRIPTION
Fixes SEARCH-285 — https://linear.app/a8c/issue/SEARCH-285

## Why

When the embedded Search experience takes over the search page, its template wraps everything in a stock `core/group`. An author editing that template had no reliable way to control the search region's width, and margin/padding/border controls only appeared if the active theme opted into `appearanceTools`. This adds an explicit Width control (cap + center the whole region) and margin/padding/border/min-height controls that are always present, regardless of theme.

## Proposed changes

* New `jetpack-search/layout` block ("Search Layout") — a constrained-layout `<main>` wrapper that frames the embedded Search experience, replacing the templates' stock `core/group`.
* Explicit **Width** control (px/% `UnitControl`) mirroring the Search Input width control (#49210); emits a centered `max-width` on the region.
* Spacing / border / dimensions inspector panels **forced on regardless of the active theme** via a per-block `wp_theme_json_data_theme` filter scoped to just `jetpack-search/layout` — no other `core/group` on the site is affected.
* Swapped the wrapper in both `jetpack-search.html` and `jetpack-search-product-results.html`; the constrained layout, `margin-top` preset, and all inner blocks are preserved.

## Related product discussion/links

* Linear: SEARCH-285 — https://linear.app/a8c/issue/SEARCH-285
* Follows the Search Input Width control: #49210

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Front-end demo (TwentyTwentyFive) of the new Width control on the `jetpack-search/layout` block. "Before" has no width set (region fills the available content width); "after" sets Width = 480px, so the bordered region caps and centers. Border + padding are theme-independent controls now forced on for this block.

| Before — no width | After — Width 480px (capped + centered) |
|---|---|
| ![before](https://github.com/user-attachments/assets/f33e3618-7c25-432d-93cf-c66893b6cecc) | ![after](https://github.com/user-attachments/assets/88093b54-76f3-4931-8886-9b49b3494be1) |

### Editor — layout controls on the Search Layout block

Selecting the block exposes the new controls. **Settings** tab: the **Layout** panel (constrained content/wide width) and the custom **Width** control. **Styles** tab: **Dimensions** (padding / margin / block spacing / min-height) and **Border** — forced on for this block regardless of the theme's appearanceTools.

| Settings — Layout + Width | Styles — Dimensions + Border |
|---|---|
| ![editor settings](https://github.com/user-attachments/assets/fc0e0cd3-5735-415f-b755-b46327620b69) | ![editor styles](https://github.com/user-attachments/assets/7aaa408e-060b-46b1-b22d-ad3dc13c025e) |

## Testing instructions

Acceptance criteria (from SEARCH-285):

* [ ] Selecting the Search Layout wrapper in the Site Editor shows a **Width** control (px/%) that applies a centered `max-width` on the front end.
* [ ] Margin, padding, and **border** controls appear on the wrapper on any block theme regardless of `appearanceTools`, and in the classic-theme singleton-CPT editor.
* [ ] Forced settings are scoped to `jetpack-search/layout` only — other `core/group` blocks on the site are unaffected.
* [ ] `alignwide`/`alignfull` inner children still behave (constrained layout preserved).
* [ ] Both templates render correctly when no width/spacing is set.
* [ ] block.json attribute test added and passing.

Steps:

1. Activate Jetpack Search, set the experience to **Embedded** (block theme active).
2. **Appearance → Editor → Templates → Jetpack Search** (`jetpack-search`). Select the outermost **Search Layout** block.
3. In the inspector confirm a **Dimensions → Width** control plus **Spacing** (margin/padding), **Border**, and **min-height** controls. Set Width to e.g. `720px` and some padding.
4. View the search page on the front end (`/?s=test`) — confirm the region caps at the chosen width and centers, and any `alignwide` content still spans wide.
5. Optionally switch to a theme that does not enable `appearanceTools` and confirm the controls still appear on this block, while a normal `core/group` elsewhere is unchanged.


