### PR TITLE
Search Blocks: add theme-tracking focus ring to active-filter pills (SEARCH-282 follow-up)

### DIFF
--- a/projects/packages/search/changelog/nova-search-282-pill-focus-ring
+++ b/projects/packages/search/changelog/nova-search-282-pill-focus-ring
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: give active-filter pills a theme-tracking keyboard focus ring, matching the checkbox filter chips.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -72,6 +72,19 @@
 				border-color: color-mix(in sRGB, currentColor 52%, transparent);
 			}
 		}
+
+		// Keyboard focus ring, matching `_chip.scss`: a solid `currentColor` ring
+		// for UAs without color-mix, upgraded to a translucent one where
+		// supported. Replaces the native outline so the ring tracks the theme ink
+		// and stays consistent with the filter chips regardless of UA defaults.
+		&:focus-visible {
+			outline: none;
+			box-shadow: 0 0 0 2px currentColor;
+
+			@supports (box-shadow: 0 0 0 2px color-mix(in sRGB, black 50%, white)) {
+				box-shadow: 0 0 0 2px color-mix(in sRGB, currentColor 28%, transparent);
+			}
+		}
 	}
 
 	.jetpack-search-active-filters__pill-remove {

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -55,7 +55,8 @@
 		cursor: pointer;
 		transition:
 			background-color 0.2s ease,
-			border-color 0.2s ease;
+			border-color 0.2s ease,
+			box-shadow 0.2s ease;
 
 		@supports (border-color: color-mix(in sRGB, black 50%, white)) {
 			background: color-mix(in sRGB, currentColor 14%, transparent);


### PR DESCRIPTION
Follow-up to #49255 (SEARCH-282).

## Why
#49255 reworked the Search Blocks active-filter pills into `currentColor` outline chips that mirror the checkbox filter chips (`_chip.scss`) — but it merged before the focus-ring polish landed, so the pills are missing the one keyboard affordance the chips have. The filter chips carry an explicit `currentColor` `:focus-visible` ring; the pills currently fall back to the UA's native `outline` (a generic blue in Chrome), which diverges from the chips and would disappear entirely if `outline` is ever reset upstream. (Flagged by `@claude`'s review on #49255.)

## Proposed changes
* Add a `:focus-visible` ring to `.jetpack-search-active-filters__pill`, matching `_chip.scss`: a solid `currentColor` ring for UAs without `color-mix`, upgraded to a translucent `currentColor 28%` ring where supported, replacing the native outline so the ring tracks the theme/overlay ink.

## Screenshots
Keyboard focus on the first pill (`:focus-visible`), before → after. Before: the browser's generic blue outline. After: a `currentColor` ring that tracks the theme ink and matches the filter chips.

| Theme | Before (native outline) | After (currentColor ring) |
|---|---|---|
| Twenty Sixteen | ![](https://github.com/user-attachments/assets/241868d0-6d84-4601-86c6-beeea74ad014) | ![](https://github.com/user-attachments/assets/ead63ad0-c7b9-4908-921e-e79b856717f4) |
| Twenty Twenty-Five | ![](https://github.com/user-attachments/assets/246ca891-b20a-40ee-8a10-37382ad508ea) | ![](https://github.com/user-attachments/assets/f89761e4-1d02-452b-a908-61d39ec1ec9d) |

## Verification
Forced `:focus-visible` on a pill via CDP and read the computed style on each theme:

<details>
<summary>Computed focus style (before → after)</summary>

```
Twenty Sixteen
  before:  box-shadow: none;  outline-style: auto   (browser default blue outline)
  after:   box-shadow: color(srgb .1019 .1019 .1019 / .28) 0 0 0 2px;  outline-style: none   // currentColor 28% = theme ink #1a1a1a

Twenty Twenty-Five
  before:  box-shadow: none;  outline-style: auto
  after:   box-shadow: color(srgb .0667 .0667 .0667 / .28) 0 0 0 2px;  outline-style: none   // currentColor 28% = theme ink #111
```

</details>

## Related product discussion/links
* [SEARCH-282](https://linear.app/a8c/issue/SEARCH-282)
* Follows #49255

## Does this pull request change what data or activity we track or use?
No. CSS-only change.

## Testing instructions
* [ ] On a blocks-powered Search experience, Tab to an active-filter pill and confirm it shows a `currentColor` focus ring that matches the checkbox filter chips' ring (not just the browser default outline).
* [ ] Confirm the ring tracks the theme ink on both a classic theme (Twenty Sixteen) and a block theme (Twenty Twenty-Five), and inside the blocks Overlay.
