### PR TITLE
Social: render connection & pricing gating inside the modernized dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23502,12 +23502,12 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack@5.105.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack@5.105.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2)':
     dependencies:
@@ -34059,7 +34059,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack@5.105.2)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3883,6 +3883,9 @@ importers:
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils
+      '@automattic/number-formatters':
+        specifier: workspace:*
+        version: link:../../js-packages/number-formatters
       '@automattic/popup-monitor':
         specifier: 1.0.2
         version: 1.0.2
@@ -23499,12 +23502,12 @@ snapshots:
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2)':
     dependencies:
@@ -34056,7 +34059,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack@5.105.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/projects/packages/publicize/_inc/components/services/utils.tsx
+++ b/projects/packages/publicize/_inc/components/services/utils.tsx
@@ -3,18 +3,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import { ConnectionService } from '../../types';
-import { getSocialScriptData } from '../../utils';
+import { assetUrl } from '../../utils';
 import { ServiceUiDetails } from './types';
 import { XNotice } from './x-notice';
-
-// Service-walkthrough illustrations live in `_inc/assets/` and are
-// copied verbatim into `build/assets/` by `webpack.config.js` (via
-// `CopyWebpackPlugin`). Resolving the URL at runtime — instead of via
-// `import x from './foo.webp'` — keeps both the webpack-built legacy
-// admin entry and the wp-build esbuild chassis happy without either
-// pipeline needing a binary-asset loader.
-const assetUrl = ( filename: string ) =>
-	`${ getSocialScriptData()?.assets_url ?? '' }assets/${ filename }`;
 
 const connectionsFacebook = assetUrl( 'connections-facebook.webp' );
 const connectionsInstagramBusiness = assetUrl( 'connections-instagram-business.webp' );

--- a/projects/packages/publicize/_inc/components/social-gate/connection-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/connection-gate.tsx
@@ -1,8 +1,84 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, Card } from '@wordpress/ui';
+import { assetUrl } from '../../utils';
+import './style.scss';
+
 /**
- * Placeholder — implemented in a later task.
+ * Disconnected-state gate for the modernization chassis. Replaces the legacy
+ * `ConnectionScreen` with a native `@wordpress/ui` card; the illustration loads via the
+ * runtime `assetUrl()` URL (no esbuild asset import). The "Get Started" CTA runs the
+ * standard site-registration flow via `useConnection().handleRegisterSite`.
  *
- * @return Placeholder element.
+ * @return The connection gate.
  */
 export default function ConnectionGate(): JSX.Element {
-	return <div>connection-gate</div>;
+	const { handleRegisterSite, siteIsRegistering, userIsConnecting, registrationError } =
+		useConnection( {
+			from: 'jetpack-social',
+			// MUST stay relative — an absolute URL doubles server-side and 404s.
+			redirectUri: 'admin.php?page=jetpack-social',
+		} );
+
+	const isLoading = siteIsRegistering || userIsConnecting;
+
+	const onGetStarted = useCallback( () => {
+		handleRegisterSite();
+	}, [ handleRegisterSite ] );
+
+	return (
+		<div className="jetpack-social-gate">
+			<Card.Root className="jetpack-social-gate__card">
+				<Card.Content>
+					<img
+						className="jetpack-social-gate__illustration"
+						src={ assetUrl( 'illustration.webp' ) }
+						alt=""
+					/>
+					<h2 className="jetpack-social-gate__title">
+						{ /* "Jetpack Social" is a product name, do not translate. */ }
+						Jetpack Social
+					</h2>
+					<p className="jetpack-social-gate__subtitle">
+						{ __(
+							'Share your posts with your social media network and increase your site’s traffic.',
+							'jetpack-publicize-pkg'
+						) }
+					</p>
+					{ registrationError && (
+						<p className="jetpack-social-gate__error" role="alert">
+							{ __( 'An error occurred. Please try again.', 'jetpack-publicize-pkg' ) }
+						</p>
+					) }
+					<Button
+						variant="solid"
+						onClick={ onGetStarted }
+						loading={ isLoading }
+						disabled={ isLoading }
+					>
+						{ __( 'Get Started', 'jetpack-publicize-pkg' ) }
+					</Button>
+					<p className="jetpack-social-gate__tos">
+						{ createInterpolateElement(
+							__(
+								'By clicking “Get Started”, you agree to our <tosLink>Terms of Service</tosLink>.',
+								'jetpack-publicize-pkg'
+							),
+							{
+								tosLink: (
+									<a
+										href={ getRedirectUrl( 'wpcom-tos' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							}
+						) }
+					</p>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	);
 }

--- a/projects/packages/publicize/_inc/components/social-gate/connection-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/connection-gate.tsx
@@ -56,6 +56,7 @@ export default function ConnectionGate(): JSX.Element {
 						variant="solid"
 						onClick={ onGetStarted }
 						loading={ isLoading }
+						loadingAnnouncement={ __( 'Registering…', 'jetpack-publicize-pkg' ) }
 						disabled={ isLoading }
 					>
 						{ __( 'Get Started', 'jetpack-publicize-pkg' ) }

--- a/projects/packages/publicize/_inc/components/social-gate/connection-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/connection-gate.tsx
@@ -1,0 +1,8 @@
+/**
+ * Placeholder — implemented in a later task.
+ *
+ * @return Placeholder element.
+ */
+export default function ConnectionGate(): JSX.Element {
+	return <div>connection-gate</div>;
+}

--- a/projects/packages/publicize/_inc/components/social-gate/index.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/index.tsx
@@ -1,46 +1,34 @@
-import useConnection from '@automattic/jetpack-connection/use-connection';
-import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
-import { useSelect } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
-import { store as socialStore } from '../../social-store';
-import { hasSocialPaidFeatures } from '../../utils';
 import ConnectionGate from './connection-gate';
 import PricingGate from './pricing-gate';
+import type { SocialGateType } from './use-social-gate';
 import type { ReactNode } from 'react';
 
 /**
- * Client-side gate for the modernization chassis. Renders the connection gate
- * (disconnected) or the pricing gate (free Jetpack, nudge not dismissed) in place of
- * the Overview/Settings tabs; otherwise renders the tabs unchanged. Replaces the former
- * PHP `should_preempt_to_legacy()` fallback so the flag never loads legacy code.
+ * Presentational gate switch for the modernization chassis. The decision lives in
+ * `useSocialGate()` (owned by `SocialPage`); this component just renders the matching
+ * gate, or the children (the Overview/Settings tabs) on the happy path.
  *
- * @param props          - Component props.
- * @param props.children - The tab block to render on the happy path.
+ * @param props                  - Component props.
+ * @param props.gate             - Which gate to show, or null for the tabs.
+ * @param props.onDismissPricing - Dismiss handler passed to the pricing gate.
+ * @param props.children         - The tab block rendered on the happy path.
  * @return The gate or the children.
  */
-export default function SocialGate( { children }: { children: ReactNode } ): JSX.Element {
-	const { isRegistered, isUserConnected } = useConnection();
-
-	const showPricingPage = useSelect(
-		select => select( socialStore ).getSocialSettings().showPricingPage,
-		[]
-	);
-
-	const [ pricingDismissed, setPricingDismissed ] = useState( false );
-
-	const dismissPricing = useCallback( () => setPricingDismissed( true ), [] );
-
-	if ( ! isRegistered || ! isUserConnected ) {
+export default function SocialGate( {
+	gate,
+	onDismissPricing,
+	children,
+}: {
+	gate: SocialGateType;
+	onDismissPricing: () => void;
+	children: ReactNode;
+} ): JSX.Element {
+	if ( gate === 'connection' ) {
 		return <ConnectionGate />;
 	}
 
-	if (
-		isJetpackSelfHostedSite() &&
-		! hasSocialPaidFeatures() &&
-		showPricingPage &&
-		! pricingDismissed
-	) {
-		return <PricingGate onDismiss={ dismissPricing } />;
+	if ( gate === 'pricing' ) {
+		return <PricingGate onDismiss={ onDismissPricing } />;
 	}
 
 	return <>{ children }</>;

--- a/projects/packages/publicize/_inc/components/social-gate/index.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/index.tsx
@@ -1,0 +1,47 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { store as socialStore } from '../../social-store';
+import { hasSocialPaidFeatures } from '../../utils';
+import ConnectionGate from './connection-gate';
+import PricingGate from './pricing-gate';
+import type { ReactNode } from 'react';
+
+/**
+ * Client-side gate for the modernization chassis. Renders the connection gate
+ * (disconnected) or the pricing gate (free Jetpack, nudge not dismissed) in place of
+ * the Overview/Settings tabs; otherwise renders the tabs unchanged. Replaces the former
+ * PHP `should_preempt_to_legacy()` fallback so the flag never loads legacy code.
+ *
+ * @param props          - Component props.
+ * @param props.children - The tab block to render on the happy path.
+ * @return The gate or the children.
+ */
+export default function SocialGate( { children }: { children: ReactNode } ): JSX.Element {
+	const { isRegistered, isUserConnected } = useConnection();
+
+	const showPricingPage = useSelect(
+		select => select( socialStore ).getSocialSettings().showPricingPage,
+		[]
+	);
+
+	const [ pricingDismissed, setPricingDismissed ] = useState( false );
+
+	const dismissPricing = useCallback( () => setPricingDismissed( true ), [] );
+
+	if ( ! isRegistered || ! isUserConnected ) {
+		return <ConnectionGate />;
+	}
+
+	if (
+		isJetpackSelfHostedSite() &&
+		! hasSocialPaidFeatures() &&
+		showPricingPage &&
+		! pricingDismissed
+	) {
+		return <PricingGate onDismiss={ dismissPricing } />;
+	}
+
+	return <>{ children }</>;
+}

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -3,10 +3,22 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { Icon, check } from '@wordpress/icons';
 import { Button, Card } from '@wordpress/ui';
 import useProductInfo from '../../hooks/use-product-info';
 import { store as socialStore } from '../../social-store';
 import { getRefreshPlanQuery, getSocialScriptData } from '../../utils';
+
+const PAID_FEATURES = [
+	__( 'Schedule posts in advance', 'jetpack-publicize-pkg' ),
+	__( 'Customize each post per network', 'jetpack-publicize-pkg' ),
+	__( 'Automatically generate social images', 'jetpack-publicize-pkg' ),
+	__(
+		'Share to Facebook, Instagram, LinkedIn, Mastodon, Tumblr, Threads, Bluesky, and Nextdoor',
+		'jetpack-publicize-pkg'
+	),
+	__( 'Priority support', 'jetpack-publicize-pkg' ),
+];
 
 /**
  * Free-plan upsell gate for the modernization chassis. A compact native
@@ -22,6 +34,20 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 	const [ productInfo ] = useProductInfo();
 	const blogID = getScriptData().site.wpcom.blog_id;
 	const siteSuffix = getScriptData().site.suffix;
+
+	const currency = productInfo?.currencyCode ?? 'USD';
+	const monthlyPrice = productInfo?.v1?.price ?? null;
+	const introPrice = productInfo?.v1?.introOffer ?? null;
+
+	const formatPrice = useCallback(
+		( amount: number ) =>
+			new Intl.NumberFormat( undefined, {
+				style: 'currency',
+				currency,
+				maximumFractionDigits: 0,
+			} ).format( amount ),
+		[ currency ]
+	);
 
 	const { setShowPricingPage, updateSocialModuleSettings } = useDispatch( socialStore );
 	const isEnabling = useSelect(
@@ -52,8 +78,6 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 		onDismiss();
 	}, [ isSocialEnabled, updateSocialModuleSettings, setShowPricingPage, onDismiss ] );
 
-	const price = productInfo?.v1?.introOffer ?? productInfo?.v1?.price;
-
 	return (
 		<div className="jetpack-social-gate">
 			<Card.Root className="jetpack-social-gate__card">
@@ -62,13 +86,36 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 						{ __( 'Write once, post everywhere', 'jetpack-publicize-pkg' ) }
 					</h2>
 					<p className="jetpack-social-gate__subtitle">
-						{ price != null
+						{ monthlyPrice != null
 							? __(
 									'Unlock scheduling, custom images, and more with a paid plan.',
 									'jetpack-publicize-pkg'
 							  )
 							: __( 'Unlock the full power of Jetpack Social.', 'jetpack-publicize-pkg' ) }
 					</p>
+					{ monthlyPrice != null && (
+						<div className="jetpack-social-gate__price">
+							<span className="jetpack-social-gate__price-amount">
+								{ formatPrice( introPrice ?? monthlyPrice ) }
+							</span>
+							{ introPrice != null && (
+								<span className="jetpack-social-gate__price-was">
+									{ formatPrice( monthlyPrice ) }
+								</span>
+							) }
+							<span className="jetpack-social-gate__price-legend">
+								{ __( 'per month, billed yearly', 'jetpack-publicize-pkg' ) }
+							</span>
+						</div>
+					) }
+					<ul className="jetpack-social-gate__features">
+						{ PAID_FEATURES.map( feature => (
+							<li key={ feature } className="jetpack-social-gate__feature">
+								<Icon icon={ check } />
+								<span>{ feature }</span>
+							</li>
+						) ) }
+					</ul>
 					<Button variant="solid" onClick={ onGetSocial }>
 						{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
 					</Button>

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -31,6 +31,10 @@ const PAID_FEATURES = [
  * @param props.onDismiss - Called after the nudge is dismissed.
  * @return The pricing gate.
  */
+// TODO: Replace this bespoke card with the shared `PricingCard`
+// (`@automattic/jetpack-components`) once it and the related pricing components
+// are refactored onto `@wordpress/ui`. Recreated here because reworking those
+// shared components affects every consumer and is out of scope for this work.
 export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } ): JSX.Element {
 	const [ productInfo ] = useProductInfo();
 	const blogID = getScriptData().site.wpcom.blog_id;

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -116,24 +116,26 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 							</li>
 						) ) }
 					</ul>
-					<Button variant="solid" onClick={ onGetSocial }>
-						{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
-					</Button>
-					<Button
-						variant="outline"
-						onClick={ onStartForFree }
-						loading={ isEnabling }
-						loadingAnnouncement={ __( 'Please wait…', 'jetpack-publicize-pkg' ) }
-						disabled={ isEnabling }
-					>
-						{ isEnabling
-							? __( 'Please wait…', 'jetpack-publicize-pkg' )
-							: _x(
-									'Start for free',
-									'Pricing page CTA for Social admin page',
-									'jetpack-publicize-pkg'
-							  ) }
-					</Button>
+					<div className="jetpack-social-gate__actions">
+						<Button variant="solid" onClick={ onGetSocial }>
+							{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
+						</Button>
+						<Button
+							variant="outline"
+							onClick={ onStartForFree }
+							loading={ isEnabling }
+							loadingAnnouncement={ __( 'Please wait…', 'jetpack-publicize-pkg' ) }
+							disabled={ isEnabling }
+						>
+							{ isEnabling
+								? __( 'Please wait…', 'jetpack-publicize-pkg' )
+								: _x(
+										'Start for free',
+										'Pricing page CTA for Social admin page',
+										'jetpack-publicize-pkg'
+								  ) }
+						</Button>
+					</div>
 				</Card.Content>
 			</Card.Root>
 		</div>

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -109,8 +109,8 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 						</div>
 					) }
 					<ul className="jetpack-social-gate__features">
-						{ PAID_FEATURES.map( feature => (
-							<li key={ feature } className="jetpack-social-gate__feature">
+						{ PAID_FEATURES.map( ( feature, index ) => (
+							<li key={ index } className="jetpack-social-gate__feature">
 								<Icon icon={ check } />
 								<span>{ feature }</span>
 							</li>

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -1,10 +1,91 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __, _x } from '@wordpress/i18n';
+import { Button, Card } from '@wordpress/ui';
+import useProductInfo from '../../hooks/use-product-info';
+import { store as socialStore } from '../../social-store';
+import { getRefreshPlanQuery, getSocialScriptData } from '../../utils';
+
 /**
- * Placeholder — implemented in a later task.
+ * Free-plan upsell gate for the modernization chassis. A compact native
+ * `@wordpress/ui` replacement for the legacy two-column `PricingTable`: it surfaces the
+ * paid price (from `useProductInfo`) with an upgrade CTA, plus a "Start for free" action
+ * that enables the Social module and dismisses the nudge.
  *
  * @param props           - Component props.
- * @param props.onDismiss - Dismiss handler.
- * @return Placeholder element.
+ * @param props.onDismiss - Called after the nudge is dismissed.
+ * @return The pricing gate.
  */
 export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } ): JSX.Element {
-	return <button onClick={ onDismiss }>pricing-gate</button>;
+	const [ productInfo ] = useProductInfo();
+	const blogID = getScriptData().site.wpcom.blog_id;
+	const siteSuffix = getScriptData().site.suffix;
+
+	const { setShowPricingPage, updateSocialModuleSettings } = useDispatch( socialStore );
+	const isEnabling = useSelect(
+		select => select( socialStore ).isSavingSocialModuleSettings(),
+		[]
+	);
+	const { is_publicize_enabled: isSocialEnabled } = getSocialScriptData();
+
+	const onGetSocial = useCallback( () => {
+		window.location.href = getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
+			site: blogID ? blogID.toString() : siteSuffix,
+			query: getRefreshPlanQuery(),
+		} );
+	}, [ blogID, siteSuffix ] );
+
+	const onStartForFree = useCallback( async () => {
+		if ( ! isSocialEnabled ) {
+			await updateSocialModuleSettings( { publicize: true } );
+		}
+		setShowPricingPage( false );
+		if ( ! isSocialEnabled ) {
+			window.location.reload();
+			return;
+		}
+		onDismiss();
+	}, [ isSocialEnabled, updateSocialModuleSettings, setShowPricingPage, onDismiss ] );
+
+	const price = productInfo?.v1?.introOffer ?? productInfo?.v1?.price;
+
+	return (
+		<div className="jetpack-social-gate">
+			<Card.Root className="jetpack-social-gate__card">
+				<Card.Content>
+					<h2 className="jetpack-social-gate__title">
+						{ __( 'Write once, post everywhere', 'jetpack-publicize-pkg' ) }
+					</h2>
+					<p className="jetpack-social-gate__subtitle">
+						{ price != null
+							? __(
+									'Unlock scheduling, custom images, and more with a paid plan.',
+									'jetpack-publicize-pkg'
+							  )
+							: __( 'Unlock the full power of Jetpack Social.', 'jetpack-publicize-pkg' ) }
+					</p>
+					<Button variant="solid" onClick={ onGetSocial }>
+						{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
+					</Button>
+					<Button
+						variant="outline"
+						onClick={ onStartForFree }
+						loading={ isEnabling }
+						loadingAnnouncement={ __( 'Please wait…', 'jetpack-publicize-pkg' ) }
+						disabled={ isEnabling }
+					>
+						{ isEnabling
+							? __( 'Please wait…', 'jetpack-publicize-pkg' )
+							: _x(
+									'Start for free',
+									'Pricing page CTA for Social admin page',
+									'jetpack-publicize-pkg'
+							  ) }
+					</Button>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	);
 }

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -28,6 +28,9 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 		select => select( socialStore ).isSavingSocialModuleSettings(),
 		[]
 	);
+	// Snapshot from page-load script data (not a live store value); the
+	// `! isSocialEnabled` branch in onStartForFree reloads the page, matching
+	// the legacy pricing page's behaviour.
 	const { is_publicize_enabled: isSocialEnabled } = getSocialScriptData();
 
 	const onGetSocial = useCallback( () => {

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -1,0 +1,10 @@
+/**
+ * Placeholder — implemented in a later task.
+ *
+ * @param props           - Component props.
+ * @param props.onDismiss - Dismiss handler.
+ * @return Placeholder element.
+ */
+export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } ): JSX.Element {
+	return <button onClick={ onDismiss }>pricing-gate</button>;
+}

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -1,10 +1,11 @@
 import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
 import { getScriptData } from '@automattic/jetpack-script-data';
+import { formatCurrency } from '@automattic/number-formatters';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { Button, Card } from '@wordpress/ui';
+import { Button, Card, Stack, Text } from '@wordpress/ui';
 import useProductInfo from '../../hooks/use-product-info';
 import { store as socialStore } from '../../social-store';
 import { getRefreshPlanQuery, getSocialScriptData } from '../../utils';
@@ -39,13 +40,10 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 	const monthlyPrice = productInfo?.v1?.price ?? null;
 	const introPrice = productInfo?.v1?.introOffer ?? null;
 
+	// Drop the trailing `.00` the currency would otherwise add, but keep cents
+	// when the price isn't a whole unit.
 	const formatPrice = useCallback(
-		( amount: number ) =>
-			new Intl.NumberFormat( undefined, {
-				style: 'currency',
-				currency,
-				maximumFractionDigits: 0,
-			} ).format( amount ),
+		( amount: number ) => formatCurrency( amount, currency, { stripZeros: true } ),
 		[ currency ]
 	);
 
@@ -95,28 +93,40 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 					</p>
 					{ monthlyPrice != null && (
 						<div className="jetpack-social-gate__price">
-							<span className="jetpack-social-gate__price-amount">
-								{ formatPrice( introPrice ?? monthlyPrice ) }
-							</span>
-							{ introPrice != null && (
-								<span className="jetpack-social-gate__price-was">
-									{ formatPrice( monthlyPrice ) }
-								</span>
-							) }
+							<Stack direction="row" justify="center" align="baseline" gap="sm">
+								<Text variant="heading-2xl">{ formatPrice( introPrice ?? monthlyPrice ) }</Text>
+								{ introPrice != null && (
+									<Text className="jetpack-social-gate__price-was">
+										{ formatPrice( monthlyPrice ) }
+									</Text>
+								) }
+							</Stack>
 							<span className="jetpack-social-gate__price-legend">
 								{ __( 'per month, billed yearly', 'jetpack-publicize-pkg' ) }
 							</span>
 						</div>
 					) }
-					<ul className="jetpack-social-gate__features">
+					<Stack
+						className="jetpack-social-gate__features"
+						direction="column"
+						gap="sm"
+						render={ <ul /> }
+					>
 						{ PAID_FEATURES.map( ( feature, index ) => (
-							<li key={ index } className="jetpack-social-gate__feature">
+							<Stack
+								key={ index }
+								className="jetpack-social-gate__feature"
+								direction="row"
+								align="center"
+								gap="sm"
+								render={ <li /> }
+							>
 								<Icon icon={ check } />
 								<span>{ feature }</span>
-							</li>
+							</Stack>
 						) ) }
-					</ul>
-					<div className="jetpack-social-gate__actions">
+					</Stack>
+					<Stack className="jetpack-social-gate__actions" direction="row" justify="center" gap="md">
 						<Button variant="solid" onClick={ onGetSocial }>
 							{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
 						</Button>
@@ -135,7 +145,7 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 										'jetpack-publicize-pkg'
 								  ) }
 						</Button>
-					</div>
+					</Stack>
 				</Card.Content>
 			</Card.Root>
 		</div>

--- a/projects/packages/publicize/_inc/components/social-gate/style.scss
+++ b/projects/packages/publicize/_inc/components/social-gate/style.scss
@@ -33,4 +33,40 @@
 		font-size: 12px;
 		color: var(--wpds-color-fg-content-neutral, #50575e);
 	}
+
+	&__price {
+		margin-bottom: 16px;
+	}
+
+	&__price-amount {
+		font-size: 28px;
+		font-weight: 600;
+	}
+
+	&__price-was {
+		margin-inline-start: 8px;
+		text-decoration: line-through;
+		color: var(--wpds-color-fg-content-neutral, #50575e);
+	}
+
+	&__price-legend {
+		display: block;
+		font-size: 12px;
+		color: var(--wpds-color-fg-content-neutral, #50575e);
+	}
+
+	&__features {
+		list-style: none;
+		margin: 0 0 24px;
+		padding: 0;
+		text-align: start;
+		display: inline-block;
+	}
+
+	&__feature {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 8px;
+	}
 }

--- a/projects/packages/publicize/_inc/components/social-gate/style.scss
+++ b/projects/packages/publicize/_inc/components/social-gate/style.scss
@@ -1,0 +1,36 @@
+.jetpack-social-gate {
+	display: flex;
+	justify-content: center;
+	padding: 32px 16px;
+
+	&__card {
+		max-width: 480px;
+		text-align: center;
+	}
+
+	&__illustration {
+		max-width: 200px;
+		height: auto;
+		margin-bottom: 16px;
+	}
+
+	&__title {
+		margin: 0 0 8px;
+	}
+
+	&__subtitle {
+		margin: 0 0 24px;
+		color: var(--wpds-color-fg-content-neutral, #50575e);
+	}
+
+	&__error {
+		color: var(--wpds-color-fg-content-error, #d63638);
+		margin-bottom: 16px;
+	}
+
+	&__tos {
+		margin-top: 16px;
+		font-size: 12px;
+		color: var(--wpds-color-fg-content-neutral, #50575e);
+	}
+}

--- a/projects/packages/publicize/_inc/components/social-gate/style.scss
+++ b/projects/packages/publicize/_inc/components/social-gate/style.scss
@@ -38,13 +38,7 @@
 		margin-bottom: 16px;
 	}
 
-	&__price-amount {
-		font-size: 28px;
-		font-weight: 600;
-	}
-
 	&__price-was {
-		margin-inline-start: 8px;
 		text-decoration: line-through;
 		color: var(--wpds-color-fg-content-neutral, #50575e);
 	}
@@ -56,23 +50,17 @@
 	}
 
 	&__features {
+		// `Stack` sets `display: flex` from a `@layer`; this unlayered rule wins,
+		// keeping the list shrink-wrapped and centered, rows left-aligned.
+		display: inline-flex;
 		list-style: none;
 		margin: 0 0 24px;
 		padding: 0;
 		text-align: start;
-		display: inline-block;
 	}
 
-	&__feature {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		margin-bottom: 8px;
-	}
-
-	&__actions {
-		display: flex;
-		justify-content: center;
-		gap: 12px;
+	&__feature svg {
+		// Keep the checkmark from shrinking when a feature label wraps to two lines.
+		flex-shrink: 0;
 	}
 }

--- a/projects/packages/publicize/_inc/components/social-gate/style.scss
+++ b/projects/packages/publicize/_inc/components/social-gate/style.scss
@@ -69,4 +69,10 @@
 		gap: 8px;
 		margin-bottom: 8px;
 	}
+
+	&__actions {
+		display: flex;
+		justify-content: center;
+		gap: 12px;
+	}
 }

--- a/projects/packages/publicize/_inc/components/social-gate/test/connection-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/connection-gate.test.tsx
@@ -1,0 +1,36 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import ConnectionGate from '../connection-gate';
+
+jest.mock( '@automattic/jetpack-connection/use-connection', () => jest.fn() );
+jest.mock( '../../../utils', () => ( { assetUrl: ( f: string ) => `assets/${ f }` } ) );
+
+describe( 'ConnectionGate', () => {
+	it( 'calls handleRegisterSite when the CTA is clicked', async () => {
+		const handleRegisterSite = jest.fn();
+		( useConnection as jest.Mock ).mockReturnValue( {
+			handleRegisterSite,
+			siteIsRegistering: false,
+			userIsConnecting: false,
+			registrationError: null,
+		} );
+
+		const user = userEvent.setup();
+		render( <ConnectionGate /> );
+		await user.click( screen.getByRole( 'button', { name: /get started/i } ) );
+		expect( handleRegisterSite ).toHaveBeenCalled();
+	} );
+
+	it( 'shows an error message on registration error', () => {
+		( useConnection as jest.Mock ).mockReturnValue( {
+			handleRegisterSite: jest.fn(),
+			siteIsRegistering: false,
+			userIsConnecting: false,
+			registrationError: true,
+		} );
+
+		render( <ConnectionGate /> );
+		expect( screen.getByText( /an error occurred/i ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/social-gate/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/index.test.tsx
@@ -1,78 +1,31 @@
-import useConnection from '@automattic/jetpack-connection/use-connection';
-import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
 import { render, screen } from '@testing-library/react';
-import { useSelect } from '@wordpress/data';
 import SocialGate from '..';
-import { hasSocialPaidFeatures } from '../../../utils';
 
-jest.mock( '@automattic/jetpack-connection/use-connection', () => jest.fn() );
-jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn(), useDispatch: () => ( {} ) } ) );
-jest.mock( '@automattic/jetpack-script-data', () => ( { isJetpackSelfHostedSite: jest.fn() } ) );
-jest.mock( '../../../utils', () => ( { hasSocialPaidFeatures: jest.fn() } ) );
-// Avoid registering the real @wordpress/data store (which the mocked data module
-// cannot do): SocialGate only needs the store symbol passed to the mocked useSelect.
-jest.mock( '../../../social-store', () => ( { store: {} } ) );
 jest.mock( '../connection-gate', () => () => <div>connection-gate</div> );
 jest.mock( '../pricing-gate', () => () => <div>pricing-gate</div> );
 
-const mockState = ( {
-	isRegistered = true,
-	isUserConnected = true,
-	showPricingPage = false,
-	paid = true,
-	jetpackSite = true,
-} ) => {
-	( useConnection as jest.Mock ).mockReturnValue( { isRegistered, isUserConnected } );
-	( useSelect as jest.Mock ).mockReturnValue( showPricingPage );
-	( hasSocialPaidFeatures as jest.Mock ).mockReturnValue( paid );
-	( isJetpackSelfHostedSite as jest.Mock ).mockReturnValue( jetpackSite );
-};
-
-describe( 'SocialGate', () => {
-	it( 'renders ConnectionGate when not registered', () => {
-		mockState( { isRegistered: false } );
+describe( 'SocialGate (presentational)', () => {
+	it( 'renders ConnectionGate when gate="connection"', () => {
 		render(
-			<SocialGate>
+			<SocialGate gate="connection" onDismissPricing={ jest.fn() }>
 				<div>tabs</div>
 			</SocialGate>
 		);
 		expect( screen.getByText( 'connection-gate' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders ConnectionGate when user not connected', () => {
-		mockState( { isUserConnected: false } );
+	it( 'renders PricingGate when gate="pricing"', () => {
 		render(
-			<SocialGate>
-				<div>tabs</div>
-			</SocialGate>
-		);
-		expect( screen.getByText( 'connection-gate' ) ).toBeInTheDocument();
-	} );
-
-	it( 'renders PricingGate when connected, free, and pricing not dismissed', () => {
-		mockState( { paid: false, showPricingPage: true, jetpackSite: true } );
-		render(
-			<SocialGate>
+			<SocialGate gate="pricing" onDismissPricing={ jest.fn() }>
 				<div>tabs</div>
 			</SocialGate>
 		);
 		expect( screen.getByText( 'pricing-gate' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders children on a WPcom (non-Jetpack) site even when pricing would show', () => {
-		mockState( { paid: false, showPricingPage: true, jetpackSite: false } );
+	it( 'renders children when gate is null', () => {
 		render(
-			<SocialGate>
-				<div>tabs</div>
-			</SocialGate>
-		);
-		expect( screen.getByText( 'tabs' ) ).toBeInTheDocument();
-	} );
-
-	it( 'renders children (tabs) on the happy path', () => {
-		mockState( {} );
-		render(
-			<SocialGate>
+			<SocialGate gate={ null } onDismissPricing={ jest.fn() }>
 				<div>tabs</div>
 			</SocialGate>
 		);

--- a/projects/packages/publicize/_inc/components/social-gate/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/index.test.tsx
@@ -1,0 +1,71 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import SocialGate from '..';
+import { hasSocialPaidFeatures } from '../../../utils';
+
+jest.mock( '@automattic/jetpack-connection/use-connection', () => jest.fn() );
+jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn(), useDispatch: () => ( {} ) } ) );
+jest.mock( '@automattic/jetpack-script-data', () => ( { isJetpackSelfHostedSite: jest.fn() } ) );
+jest.mock( '../../../utils', () => ( { hasSocialPaidFeatures: jest.fn() } ) );
+// Avoid registering the real @wordpress/data store (which the mocked data module
+// cannot do): SocialGate only needs the store symbol passed to the mocked useSelect.
+jest.mock( '../../../social-store', () => ( { store: {} } ) );
+jest.mock( '../connection-gate', () => () => <div>connection-gate</div> );
+jest.mock( '../pricing-gate', () => () => <div>pricing-gate</div> );
+
+const mockState = ( {
+	isRegistered = true,
+	isUserConnected = true,
+	showPricingPage = false,
+	paid = true,
+	jetpackSite = true,
+} ) => {
+	( useConnection as jest.Mock ).mockReturnValue( { isRegistered, isUserConnected } );
+	( useSelect as jest.Mock ).mockReturnValue( showPricingPage );
+	( hasSocialPaidFeatures as jest.Mock ).mockReturnValue( paid );
+	( isJetpackSelfHostedSite as jest.Mock ).mockReturnValue( jetpackSite );
+};
+
+describe( 'SocialGate', () => {
+	it( 'renders ConnectionGate when not registered', () => {
+		mockState( { isRegistered: false } );
+		render(
+			<SocialGate>
+				<div>tabs</div>
+			</SocialGate>
+		);
+		expect( screen.getByText( 'connection-gate' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders ConnectionGate when user not connected', () => {
+		mockState( { isUserConnected: false } );
+		render(
+			<SocialGate>
+				<div>tabs</div>
+			</SocialGate>
+		);
+		expect( screen.getByText( 'connection-gate' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders PricingGate when connected, free, and pricing not dismissed', () => {
+		mockState( { paid: false, showPricingPage: true, jetpackSite: true } );
+		render(
+			<SocialGate>
+				<div>tabs</div>
+			</SocialGate>
+		);
+		expect( screen.getByText( 'pricing-gate' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders children (tabs) on the happy path', () => {
+		mockState( {} );
+		render(
+			<SocialGate>
+				<div>tabs</div>
+			</SocialGate>
+		);
+		expect( screen.getByText( 'tabs' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/social-gate/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/index.test.tsx
@@ -59,6 +59,16 @@ describe( 'SocialGate', () => {
 		expect( screen.getByText( 'pricing-gate' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders children on a WPcom (non-Jetpack) site even when pricing would show', () => {
+		mockState( { paid: false, showPricingPage: true, jetpackSite: false } );
+		render(
+			<SocialGate>
+				<div>tabs</div>
+			</SocialGate>
+		);
+		expect( screen.getByText( 'tabs' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders children (tabs) on the happy path', () => {
 		mockState( {} );
 		render(

--- a/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
@@ -42,4 +42,10 @@ describe( 'PricingGate', () => {
 		render( <PricingGate onDismiss={ jest.fn() } /> );
 		expect( screen.getByRole( 'button', { name: /get social/i } ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the formatted price', () => {
+		render( <PricingGate onDismiss={ jest.fn() } /> );
+		// $10/mo formatting — assert the amount is present in the document.
+		expect( screen.getByText( /\$10/ ) ).toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PricingGate from '../pricing-gate';
+
+const mockSetShowPricingPage = jest.fn();
+const mockUpdateSocialModuleSettings = jest.fn( () => Promise.resolve() );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setShowPricingPage: mockSetShowPricingPage,
+		updateSocialModuleSettings: mockUpdateSocialModuleSettings,
+	} ),
+	useSelect: () => false,
+} ) );
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: () => ( { site: { wpcom: { blog_id: 1 }, suffix: 'example.com' } } ),
+} ) );
+jest.mock( '../../../hooks/use-product-info', () => ( {
+	__esModule: true,
+	default: () => [ { currencyCode: 'USD', v1: { price: 10, introOffer: null } } ],
+} ) );
+jest.mock( '../../../utils', () => ( {
+	getSocialScriptData: () => ( { is_publicize_enabled: true } ),
+	getRefreshPlanQuery: () => '',
+} ) );
+jest.mock( '../../../social-store', () => ( { store: {} } ) );
+
+describe( 'PricingGate', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUpdateSocialModuleSettings.mockReturnValue( Promise.resolve() );
+	} );
+
+	it( 'dismisses the pricing page on "Start for free"', async () => {
+		const user = userEvent.setup();
+		render( <PricingGate onDismiss={ jest.fn() } /> );
+		await user.click( screen.getByRole( 'button', { name: /start for free/i } ) );
+		expect( mockSetShowPricingPage ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'renders the upgrade CTA', () => {
+		render( <PricingGate onDismiss={ jest.fn() } /> );
+		expect( screen.getByRole( 'button', { name: /get social/i } ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/social-gate/test/use-social-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/use-social-gate.test.tsx
@@ -1,5 +1,5 @@
 import useConnection from '@automattic/jetpack-connection/use-connection';
-import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { isJetpackSelfHostedSite, isSimpleSite } from '@automattic/jetpack-script-data';
 import { renderHook, act } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { hasSocialPaidFeatures } from '../../../utils';
@@ -7,7 +7,10 @@ import useSocialGate from '../use-social-gate';
 
 jest.mock( '@automattic/jetpack-connection/use-connection', () => jest.fn() );
 jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn(), useDispatch: () => ( {} ) } ) );
-jest.mock( '@automattic/jetpack-script-data', () => ( { isJetpackSelfHostedSite: jest.fn() } ) );
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isJetpackSelfHostedSite: jest.fn(),
+	isSimpleSite: jest.fn(),
+} ) );
 jest.mock( '../../../utils', () => ( { hasSocialPaidFeatures: jest.fn() } ) );
 jest.mock( '../../../social-store', () => ( { store: {} } ) );
 
@@ -17,11 +20,13 @@ const mockState = ( {
 	showPricingPage = false,
 	paid = true,
 	jetpackSite = true,
+	simple = false,
 } ) => {
 	( useConnection as jest.Mock ).mockReturnValue( { isRegistered, isUserConnected } );
 	( useSelect as jest.Mock ).mockReturnValue( showPricingPage );
 	( hasSocialPaidFeatures as jest.Mock ).mockReturnValue( paid );
 	( isJetpackSelfHostedSite as jest.Mock ).mockReturnValue( jetpackSite );
+	( isSimpleSite as jest.Mock ).mockReturnValue( simple );
 };
 
 describe( 'useSocialGate', () => {
@@ -42,6 +47,11 @@ describe( 'useSocialGate', () => {
 
 	it( 'returns null on a WPcom (non-Jetpack) site even when pricing would show', () => {
 		mockState( { paid: false, showPricingPage: true, jetpackSite: false } );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBeNull();
+	} );
+
+	it( 'never gates on a WPCOM Simple site, even when disconnected', () => {
+		mockState( { isRegistered: false, isUserConnected: false, simple: true } );
 		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBeNull();
 	} );
 

--- a/projects/packages/publicize/_inc/components/social-gate/test/use-social-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/use-social-gate.test.tsx
@@ -1,0 +1,60 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { renderHook, act } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import { hasSocialPaidFeatures } from '../../../utils';
+import useSocialGate from '../use-social-gate';
+
+jest.mock( '@automattic/jetpack-connection/use-connection', () => jest.fn() );
+jest.mock( '@wordpress/data', () => ( { useSelect: jest.fn(), useDispatch: () => ( {} ) } ) );
+jest.mock( '@automattic/jetpack-script-data', () => ( { isJetpackSelfHostedSite: jest.fn() } ) );
+jest.mock( '../../../utils', () => ( { hasSocialPaidFeatures: jest.fn() } ) );
+jest.mock( '../../../social-store', () => ( { store: {} } ) );
+
+const mockState = ( {
+	isRegistered = true,
+	isUserConnected = true,
+	showPricingPage = false,
+	paid = true,
+	jetpackSite = true,
+} ) => {
+	( useConnection as jest.Mock ).mockReturnValue( { isRegistered, isUserConnected } );
+	( useSelect as jest.Mock ).mockReturnValue( showPricingPage );
+	( hasSocialPaidFeatures as jest.Mock ).mockReturnValue( paid );
+	( isJetpackSelfHostedSite as jest.Mock ).mockReturnValue( jetpackSite );
+};
+
+describe( 'useSocialGate', () => {
+	it( 'returns "connection" when not registered', () => {
+		mockState( { isRegistered: false } );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBe( 'connection' );
+	} );
+
+	it( 'returns "connection" when user not connected', () => {
+		mockState( { isUserConnected: false } );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBe( 'connection' );
+	} );
+
+	it( 'returns "pricing" when connected, jetpack, free, nudge not dismissed', () => {
+		mockState( { paid: false, showPricingPage: true, jetpackSite: true } );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBe( 'pricing' );
+	} );
+
+	it( 'returns null on a WPcom (non-Jetpack) site even when pricing would show', () => {
+		mockState( { paid: false, showPricingPage: true, jetpackSite: false } );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBeNull();
+	} );
+
+	it( 'returns null on the happy path', () => {
+		mockState( {} );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBeNull();
+	} );
+
+	it( 'returns null after dismissPricing is called', () => {
+		mockState( { paid: false, showPricingPage: true, jetpackSite: true } );
+		const { result } = renderHook( () => useSocialGate() );
+		expect( result.current.gate ).toBe( 'pricing' );
+		act( () => result.current.dismissPricing() );
+		expect( result.current.gate ).toBeNull();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/social-gate/use-social-gate.ts
+++ b/projects/packages/publicize/_inc/components/social-gate/use-social-gate.ts
@@ -1,5 +1,5 @@
 import useConnection from '@automattic/jetpack-connection/use-connection';
-import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { isJetpackSelfHostedSite, isSimpleSite } from '@automattic/jetpack-script-data';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
@@ -31,7 +31,9 @@ export default function useSocialGate(): {
 
 	let gate: SocialGateType = null;
 
-	if ( ! isRegistered || ! isUserConnected ) {
+	// WPCOM Simple sites have no Jetpack connection to establish, so the connection
+	// gate never applies there (mirrors the legacy admin page's `! isSimple` guard).
+	if ( ! isSimpleSite() && ( ! isRegistered || ! isUserConnected ) ) {
 		gate = 'connection';
 	} else if (
 		isJetpackSelfHostedSite() &&

--- a/projects/packages/publicize/_inc/components/social-gate/use-social-gate.ts
+++ b/projects/packages/publicize/_inc/components/social-gate/use-social-gate.ts
@@ -1,0 +1,46 @@
+import useConnection from '@automattic/jetpack-connection/use-connection';
+import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { store as socialStore } from '../../social-store';
+import { hasSocialPaidFeatures } from '../../utils';
+
+export type SocialGateType = 'connection' | 'pricing' | null;
+
+/**
+ * Decides which gate (if any) the modernized Social dashboard should show.
+ * Owned by `SocialPage` so the gate decision is shared between the page-header
+ * actions (suppressed while gated) and the gate body. Returns `null` for the
+ * happy path (render the tabs).
+ *
+ * @return The current gate type and a callback to dismiss the pricing gate.
+ */
+export default function useSocialGate(): {
+	gate: SocialGateType;
+	dismissPricing: () => void;
+} {
+	const { isRegistered, isUserConnected } = useConnection();
+
+	const showPricingPage = useSelect(
+		select => select( socialStore ).getSocialSettings().showPricingPage,
+		[]
+	);
+
+	const [ pricingDismissed, setPricingDismissed ] = useState( false );
+	const dismissPricing = useCallback( () => setPricingDismissed( true ), [] );
+
+	let gate: SocialGateType = null;
+
+	if ( ! isRegistered || ! isUserConnected ) {
+		gate = 'connection';
+	} else if (
+		isJetpackSelfHostedSite() &&
+		! hasSocialPaidFeatures() &&
+		showPricingPage &&
+		! pricingDismissed
+	) {
+		gate = 'pricing';
+	}
+
+	return { gate, dismissPricing };
+}

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from '@wordpress/route';
 import { Tabs, Tooltip } from '@wordpress/ui';
 import { ModernizationProvider } from '../hooks/use-is-modernized';
 import SocialGate from './social-gate';
+import useSocialGate from './social-gate/use-social-gate';
 // Define the `--color-facebook`, `--color-twitter`, ... custom properties
 // that `SocialServiceIcon` (and friends) consume to paint per-service
 // brand colours. The legacy `social-admin-page` webpack bundle inlines
@@ -52,6 +53,9 @@ const SUBTITLES: Record< SocialTab, () => string > = {
 export default function SocialPage( { activeTab, actions, children }: Props ): JSX.Element {
 	const navigate = useNavigate();
 
+	const { gate, dismissPricing } = useSocialGate();
+	const headerActions = gate === null ? actions : null;
+
 	// Keep the route at `/` and toggle tabs via a `?tab=` search param so the
 	// `Tabs.Root` mounts once and the active-tab indicator can animate.
 	const onTabChange = useCallback(
@@ -76,9 +80,9 @@ export default function SocialPage( { activeTab, actions, children }: Props ): J
 					apiNonce={ getSiteData()?.rest_nonce }
 					title={ PRODUCT_NAME }
 					subTitle={ SUBTITLES[ activeTab ]() }
-					actions={ actions }
+					actions={ headerActions }
 				>
-					<SocialGate>
+					<SocialGate gate={ gate } onDismissPricing={ dismissPricing }>
 						<Tabs.Root
 							className="jetpack-social-tabs"
 							value={ activeTab }

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Tabs, Tooltip } from '@wordpress/ui';
 import { ModernizationProvider } from '../hooks/use-is-modernized';
+import SocialGate from './social-gate';
 // Define the `--color-facebook`, `--color-twitter`, ... custom properties
 // that `SocialServiceIcon` (and friends) consume to paint per-service
 // brand colours. The legacy `social-admin-page` webpack bundle inlines
@@ -77,21 +78,27 @@ export default function SocialPage( { activeTab, actions, children }: Props ): J
 					subTitle={ SUBTITLES[ activeTab ]() }
 					actions={ actions }
 				>
-					<Tabs.Root
-						className="jetpack-social-tabs"
-						value={ activeTab }
-						onValueChange={ onTabChange }
-					>
-						<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
-							<Tabs.List variant="minimal">
-								<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-publicize-pkg' ) }</Tabs.Tab>
-								<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-publicize-pkg' ) }</Tabs.Tab>
-							</Tabs.List>
-						</div>
-						<div className="jetpack-social-page__content jetpack-social-page__content--padded">
-							{ children }
-						</div>
-					</Tabs.Root>
+					<SocialGate>
+						<Tabs.Root
+							className="jetpack-social-tabs"
+							value={ activeTab }
+							onValueChange={ onTabChange }
+						>
+							<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
+								<Tabs.List variant="minimal">
+									<Tabs.Tab value="overview">
+										{ __( 'Overview', 'jetpack-publicize-pkg' ) }
+									</Tabs.Tab>
+									<Tabs.Tab value="settings">
+										{ __( 'Settings', 'jetpack-publicize-pkg' ) }
+									</Tabs.Tab>
+								</Tabs.List>
+							</div>
+							<div className="jetpack-social-page__content jetpack-social-page__content--padded">
+								{ children }
+							</div>
+						</Tabs.Root>
+					</SocialGate>
 				</AdminPage>
 			</Tooltip.Provider>
 		</ModernizationProvider>

--- a/projects/packages/publicize/_inc/utils/script-data.ts
+++ b/projects/packages/publicize/_inc/utils/script-data.ts
@@ -44,3 +44,17 @@ export function getRefreshPlanQuery() {
 
 	return `${ baseQuery }&_wpnonce=${ encodeURIComponent( nonce ) }`;
 }
+
+/**
+ * Resolve a runtime URL for a file in the package's `assets/` build directory.
+ *
+ * Assets in `_inc/assets/` are copied verbatim to `build/assets/` by both the
+ * webpack (legacy) and wp-build (chassis) pipelines. Resolving the URL at runtime
+ * — instead of `import x from './foo.webp'` — keeps esbuild happy (no binary loader).
+ *
+ * @param filename - The file name within the assets directory.
+ * @return The absolute URL to the asset.
+ */
+export function assetUrl( filename: string ): string {
+	return `${ getSocialScriptData()?.assets_url ?? '' }assets/${ filename }`;
+}

--- a/projects/packages/publicize/changelog/add-social-modernization-connection-pricing-gating
+++ b/projects/packages/publicize/changelog/add-social-modernization-connection-pricing-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: render connection and pricing gating inside the modernized dashboard (behind the rsm_jetpack_ui_modernization_social flag), so it no longer falls back to the legacy UI.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -48,6 +48,7 @@
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
+		"@automattic/number-formatters": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/social-previews": "workspace:*",
 		"@automattic/ui": "1.0.2",

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -39,13 +39,11 @@ const AddAccountAction = () => {
  * active-tab indicator slides between Overview and Settings instead of
  * remounting on each route hop.
  *
- * `ConnectionScreen` (site not connected) and `PricingPage` (free
- * Jetpack, not dismissed) pre-empt the chassis at the PHP layer: when
- * either condition holds, `Social_Admin_Page` routes the menu callback
- * to the legacy `SocialAdminPage` shell so those flows render exactly
- * as they do today. The chassis therefore renders only on the happy
- * path — connected + paid/dismissed — and stays free of the
- * jetpack-connection bundle's asset imports.
+ * When the site is disconnected, or on the free plan with the pricing
+ * nudge not yet dismissed, the client-side `SocialGate` (rendered inside
+ * `SocialPage`) shows the connection or pricing gate in place of these
+ * tabs — so the modernized dashboard handles those states itself instead
+ * of falling back to the legacy admin page.
  *
  * @return Stage content.
  */

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
@@ -78,15 +79,6 @@ class Social_Admin_Page {
 	 */
 	public static function maybe_load_wp_build() {
 		if ( ! self::is_modernized() || ! self::is_social_admin_request() ) {
-			return;
-		}
-
-		// The chassis pre-empts to the legacy `SocialAdminPage` when the
-		// site isn't connected or the free-plan pricing nudge should
-		// show, so those flows render exactly as they do today and the
-		// wp-build bundle stays free of the jetpack-connection asset
-		// imports that the chassis would otherwise have to handle.
-		if ( self::should_preempt_to_legacy() ) {
 			return;
 		}
 
@@ -176,15 +168,20 @@ class Social_Admin_Page {
 		//
 		// Gate on `is_wp_build_dashboard_active()` (not `is_modernized()` alone) so
 		// this mirrors the exact decision `add_menu()` made when choosing the menu
-		// callback. When modernization is on but the page preempts to the legacy
-		// callback (e.g. free plan pricing nudge, or site not connected), the
-		// wp-build render function is never loaded — so we must still enqueue the
-		// legacy bundle here, or the legacy `#jetpack-social-root` div renders with
-		// no script to mount it.
+		// callback: when modernization is on AND the wp-build render function is defined
+		// (i.e. the chassis was actually loaded), skip the legacy bundle entirely.
 		if ( self::is_wp_build_dashboard_active() ) {
 			// wp-build manages its own enqueue pipeline. The legacy script,
 			// localized config, and media-library bootstrap are intentionally
-			// skipped for the wp-build dashboard.
+			// skipped here.
+			//
+			// The chassis reads site-connection state via `useConnection()`, whose
+			// store has no REST resolver — it must be hydrated inline. The wp-build
+			// boot registers a classic `…-prerequisites` script that loads before the
+			// chassis module, so attach the connection initial state there.
+			if ( wp_script_is( 'jetpack-social-dashboard-wp-admin-prerequisites', 'registered' ) ) {
+				Connection_Initial_State::render_script( 'jetpack-social-dashboard-wp-admin-prerequisites' );
+			}
 			return;
 		}
 
@@ -272,49 +269,14 @@ class Social_Admin_Page {
 	 * menu callback) and `enqueue_admin_scripts()` (which decides whether to skip
 	 * the legacy bundle). `maybe_load_wp_build()` only loads the wp-build entry —
 	 * and therefore only defines its render function — when modernization is on AND
-	 * the request is not preempted to the legacy flow (`should_preempt_to_legacy()`).
-	 * Checking `function_exists()` here captures both conditions in one place, so
-	 * the callback and the enqueue gate can never diverge and leave an empty
-	 * `#jetpack-social-root`.
+	 * we are on the Social admin page. Checking `function_exists()` here captures
+	 * both conditions in one place, so the callback and the enqueue gate can never
+	 * diverge and leave an empty `#jetpack-social-root`.
 	 *
 	 * @return bool
 	 */
 	private static function is_wp_build_dashboard_active() {
 		return self::is_modernized() && function_exists( 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page' );
-	}
-
-	/**
-	 * Returns true when the chassis should defer to the legacy admin page.
-	 *
-	 * The legacy `SocialAdminPage` short-circuits its body with
-	 * `ConnectionScreen` (site not connected) or `PricingPage` (free
-	 * plan, pricing nudge not dismissed). Those components pull in
-	 * `@automattic/jetpack-connection`'s disconnect-dialog assets
-	 * (.jpg / .webp / .svg) and `@use "@wordpress/theme/design-tokens.css"`
-	 * in transitive SCSS — none of which the wp-build esbuild pipeline
-	 * loads out of the box. Detecting those same states server-side here
-	 * lets the chassis stay slim while preserving today's "pre-empt the
-	 * tabs" behaviour: when either holds we fall through to the legacy
-	 * menu callback and the user sees the existing flow.
-	 *
-	 * @return bool
-	 */
-	private static function should_preempt_to_legacy() {
-		if ( ! ( new Host() )->is_wpcom_platform() && ! ( new Connection_Manager() )->is_connected() ) {
-			return true;
-		}
-
-		if (
-			class_exists( '\\Automattic\\Jetpack\\Publicize\\Jetpack_Social_Settings\\Settings' )
-			&& \Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings::should_show_pricing_page()
-		) {
-			$publicize = Publicize_Script_Data::publicize();
-			if ( $publicize && ! $publicize->has_paid_features() ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-social-admin-page.php
+++ b/projects/packages/publicize/src/class-social-admin-page.php
@@ -119,7 +119,7 @@ class Social_Admin_Page {
 			return;
 		}
 
-		$callback = self::is_modernized() && function_exists( 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page' )
+		$callback = self::is_wp_build_dashboard_active()
 			? 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page'
 			: array( $this, 'render' );
 
@@ -173,7 +173,15 @@ class Social_Admin_Page {
 	public function enqueue_admin_scripts() {
 		// This callback is registered via `load-{$page_suffix}` in `add_menu()`,
 		// so it only fires on the Social admin page — no need to re-check the page here.
-		if ( self::is_modernized() ) {
+		//
+		// Gate on `is_wp_build_dashboard_active()` (not `is_modernized()` alone) so
+		// this mirrors the exact decision `add_menu()` made when choosing the menu
+		// callback. When modernization is on but the page preempts to the legacy
+		// callback (e.g. free plan pricing nudge, or site not connected), the
+		// wp-build render function is never loaded — so we must still enqueue the
+		// legacy bundle here, or the legacy `#jetpack-social-root` div renders with
+		// no script to mount it.
+		if ( self::is_wp_build_dashboard_active() ) {
 			// wp-build manages its own enqueue pipeline. The legacy script,
 			// localized config, and media-library bootstrap are intentionally
 			// skipped for the wp-build dashboard.
@@ -255,6 +263,24 @@ class Social_Admin_Page {
 	 */
 	private static function is_modernized() {
 		return (bool) apply_filters( self::MODERNIZATION_FILTER, false );
+	}
+
+	/**
+	 * Returns true when the wp-build dashboard is the page that will actually render.
+	 *
+	 * This is the single source of truth shared by `add_menu()` (which picks the
+	 * menu callback) and `enqueue_admin_scripts()` (which decides whether to skip
+	 * the legacy bundle). `maybe_load_wp_build()` only loads the wp-build entry —
+	 * and therefore only defines its render function — when modernization is on AND
+	 * the request is not preempted to the legacy flow (`should_preempt_to_legacy()`).
+	 * Checking `function_exists()` here captures both conditions in one place, so
+	 * the callback and the enqueue gate can never diverge and leave an empty
+	 * `#jetpack-social-root`.
+	 *
+	 * @return bool
+	 */
+	private static function is_wp_build_dashboard_active() {
+		return self::is_modernized() && function_exists( 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page' );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
+++ b/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
@@ -140,6 +140,34 @@ class Social_Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
+	 * When modernization is on but the page preempts to the legacy callback
+	 * (e.g. free plan / not connected), the wp-build render function is never
+	 * loaded. The legacy `social-admin-page` script must still be enqueued, or
+	 * the legacy `#jetpack-social-root` div renders with nothing to mount it.
+	 */
+	public function test_enqueue_falls_back_to_legacy_script_when_wp_build_render_fn_missing() {
+		add_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_true' );
+
+		// Mirrors the preempt-to-legacy path: load_wp_build() is skipped, so the
+		// wp-build render function is never defined.
+		$this->assertFalse(
+			function_exists( 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page' ),
+			'Test relies on the wp-build render function being absent.'
+		);
+
+		Social_Admin_Page::init()->enqueue_admin_scripts();
+
+		$this->assertTrue(
+			wp_script_is( 'social-admin-page', 'enqueued' ),
+			'Legacy Social admin script should be enqueued when modernization is on but the page renders the legacy callback.'
+		);
+
+		remove_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_true' );
+		wp_dequeue_script( 'social-admin-page' );
+		wp_deregister_script( 'social-admin-page' );
+	}
+
+	/**
 	 * It rejects plan refresh when the nonce is missing or invalid.
 	 */
 	public function test_admin_init_rejects_plan_refresh_without_valid_nonce() {

--- a/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
+++ b/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
@@ -140,31 +140,40 @@ class Social_Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
-	 * When modernization is on but the page preempts to the legacy callback
-	 * (e.g. free plan / not connected), the wp-build render function is never
-	 * loaded. The legacy `social-admin-page` script must still be enqueued, or
-	 * the legacy `#jetpack-social-root` div renders with nothing to mount it.
+	 * When modernization is OFF, the legacy admin script is enqueued.
 	 */
-	public function test_enqueue_falls_back_to_legacy_script_when_wp_build_render_fn_missing() {
-		add_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_true' );
-
-		// Mirrors the preempt-to-legacy path: load_wp_build() is skipped, so the
-		// wp-build render function is never defined.
-		$this->assertFalse(
-			function_exists( 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page' ),
-			'Test relies on the wp-build render function being absent.'
-		);
-
+	public function test_enqueue_loads_legacy_script_when_not_modernized() {
 		Social_Admin_Page::init()->enqueue_admin_scripts();
 
 		$this->assertTrue(
 			wp_script_is( 'social-admin-page', 'enqueued' ),
-			'Legacy Social admin script should be enqueued when modernization is on but the page renders the legacy callback.'
+			'Legacy Social admin script should be enqueued when modernization is off.'
+		);
+
+		wp_dequeue_script( 'social-admin-page' );
+		wp_deregister_script( 'social-admin-page' );
+	}
+
+	/**
+	 * When modernization is ON, the legacy admin script is NOT enqueued
+	 * (the wp-build chassis owns its own enqueue pipeline).
+	 */
+	public function test_enqueue_skips_legacy_script_when_modernized() {
+		add_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_true' );
+		// Define the wp-build render fn in the GLOBAL namespace (via fixture) so
+		// is_wp_build_dashboard_active()'s function_exists() check passes. A function
+		// declared inline in this namespaced test file would land in
+		// Automattic\Jetpack\Publicize, which function_exists() (global) won't find.
+		require_once __DIR__ . '/fixtures/wp-build-render-fn.php';
+
+		Social_Admin_Page::init()->enqueue_admin_scripts();
+
+		$this->assertFalse(
+			wp_script_is( 'social-admin-page', 'enqueued' ),
+			'Legacy script should not be enqueued when the wp-build chassis is active.'
 		);
 
 		remove_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_true' );
-		wp_dequeue_script( 'social-admin-page' );
-		wp_deregister_script( 'social-admin-page' );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/fixtures/wp-build-render-fn.php
+++ b/projects/packages/publicize/tests/php/fixtures/wp-build-render-fn.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Test fixture: defines the wp-build chassis render function in the GLOBAL namespace
+ * so Social_Admin_Page::is_wp_build_dashboard_active() detects a "loaded" chassis.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+if ( ! function_exists( 'jetpack_social_jetpack_social_dashboard_wp_admin_render_page' ) ) {
+	/**
+	 * Stand-in for the auto-generated wp-build render function.
+	 *
+	 * @return void
+	 */
+	function jetpack_social_jetpack_social_dashboard_wp_admin_render_page() {}
+}


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

Behind the `rsm_jetpack_ui_modernization_social` feature flag, the modernized Social dashboard (the wp-build "chassis") no longer falls back to the legacy React admin for the disconnected / free-plan states. Those states are now rendered inside the chassis with `@wordpress/ui`.

* **PHP** (`Social_Admin_Page`): removed `should_preempt_to_legacy()` — the wp-build dashboard now loads whenever modernization is on and we're on the Social page. The `jetpack-connection` store is hydrated for the chassis via `Connection_Initial_State::render_script()` on the prerequisites handle (the store has no REST resolver). Kept `is_wp_build_dashboard_active()` so the menu-callback and asset-enqueue decisions stay in lock-step (this also fixes an empty `#jetpack-social-root` that could occur on the old preempt path).
* **JS** (`_inc/components/social-gate/`): new client-side gating.
  * `useSocialGate()` hook — single source of truth for the gate decision (connection → pricing → tabs), owned by `SocialPage`.
  * `ConnectionGate` — native connect screen (illustration via the runtime `assetUrl()` pattern, "Get Started" → `useConnection().handleRegisterSite`, ToS link).
  * `PricingGate` — compact upsell with price (from `useProductInfo()`) and a paid-feature list; "Get Social" (checkout) / "Start for free" CTAs.
  * `SocialPage` renders the gate in place of the Overview/Settings tabs and suppresses the header "Add account" action while gated (subtitle unchanged).
* Extracted a shared `assetUrl()` helper to `_inc/utils/script-data.ts`.
* Tests: PHP `Social_Admin_Page_Test` updated for the removed preempt; Jest coverage for `useSocialGate` (decision matrix incl. dismiss + WPcom guard), the presentational `SocialGate`, `ConnectionGate`, and `PricingGate`.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

All changes are gated behind the `rsm_jetpack_ui_modernization_social` filter and the flag-off path is unchanged.

1. Enable the flag (e.g. via Code Snippets or an mu-plugin): `add_filter( 'rsm_jetpack_ui_modernization_social', '__return_true' );`
2. Go to **Jetpack → Social**. On a connected, paid (or pricing-dismissed) site you should see the modernized Overview/Settings tabs — unchanged by this PR.
3. **ConnectionGate** — to preview the disconnected state without disconnecting, temporarily force the JS connection status off:
   ```php
   add_filter( 'jetpack_connection_status', function ( $s ) {
       $s['isRegistered'] = false; $s['isUserConnected'] = false; return $s;
   } );
   ```
   The Social page should render the connection gate (illustration, "Get Started", ToS link) in place of the tabs, with no "Add account" header button and no empty `#jetpack-social-root`.
4. **PricingGate** — to preview the connected-but-free state, force connection on and drop the paid feature:
   ```php
   add_filter( 'jetpack_connection_status', fn( $s ) => array_merge( $s, [ 'isRegistered' => true, 'isUserConnected' => true ] ) );
   add_filter( 'jetpack_admin_js_script_data', function ( $d ) {
       $d['site']['plan']['features']['active'] = array_values( array_diff(
           $d['site']['plan']['features']['active'] ?? [], [ 'social-enhanced-publishing' ] ) );
       $d['social']['settings']['showPricingPage'] = true;
       return $d;
   }, 99 );
   ```
   The Social page should render the pricing gate (title, feature list, "Get Social" / "Start for free"). Note: the price only renders when `/my-jetpack/v1/site/products` returns data, so it may be absent on a mock-connected local site.
5. Remove the temporary filters; confirm the dashboard returns to its normal state.
6. Disable the flag; confirm the legacy Social admin renders exactly as before.

Automated: `jetpack test php packages/publicize` and `jetpack test js packages/publicize` (gate suites under `_inc/components/social-gate/`).

<img width="411" height="897" alt="Screenshot from 2026-05-28 22-11-51" src="https://github.com/user-attachments/assets/ad2a8121-3636-46d4-98bd-87a2e94d15e2" />
<img width="411" height="897" alt="Screenshot from 2026-05-28 22-11-40" src="https://github.com/user-attachments/assets/51e3fdf9-f937-4051-a001-7f2f7729b3bf" />
<img width="2379" height="1246" alt="Screenshot from 2026-05-28 22-11-19" src="https://github.com/user-attachments/assets/741a1960-ee69-4470-9440-e24629eb72e6" />
<img width="2379" height="1246" alt="Screenshot from 2026-05-28 22-09-50" src="https://github.com/user-attachments/assets/637fa003-73ef-4795-85df-b5d0717fd5f2" />
