### PR TITLE
Search Blocks: show the loading skeleton for the initial client-side search (SEARCH-288)

### DIFF
--- a/projects/packages/search/changelog/atlas-search-288-initial-search-skeleton
+++ b/projects/packages/search/changelog/atlas-search-288-initial-search-skeleton
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: show the loading skeleton during the initial client-side search, not just the pre-hydration window, so the results and filters no longer flash empty while the first query loads.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
@@ -69,11 +69,7 @@ $in_interactive_scope = isset( $block ) && $block instanceof \WP_Block
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<?php endif; ?>
-	<?php
-	if ( $view['is_initial_loading'] ) {
-		require __DIR__ . '/../filter-skeleton-partial.php';
-	}
-	?>
+	<?php require __DIR__ . '/../filter-skeleton-partial.php'; ?>
 	<ul class="jetpack-search-filter__list">
 		<template
 			data-wp-each--item="state.filterItems"

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
@@ -45,11 +45,7 @@ $display_style = Search_Blocks::normalize_display_style( $attributes['displaySty
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<?php endif; ?>
-	<?php
-	if ( $view['is_initial_loading'] ) {
-		require __DIR__ . '/../filter-skeleton-partial.php';
-	}
-	?>
+	<?php require __DIR__ . '/../filter-skeleton-partial.php'; ?>
 	<ul class="jetpack-search-filter__list">
 		<template
 			data-wp-each--item="state.filterItems"

--- a/projects/packages/search/src/search-blocks/blocks/filter-skeleton-partial.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-skeleton-partial.php
@@ -1,11 +1,10 @@
 <?php
 /**
- * Pre-hydration skeleton list shared by filter-checkbox and filter-date
- * render.php. Included with `require __DIR__ . '/../filter-skeleton.partial.php';`
- * inside the wrapper element when `Search_Blocks::is_initial_loading()` is true.
- *
- * Visibility flips off via `state.skeletonHidden` once the first fetch
- * resolves on the client (see `actions.search()` in `store/index.js`).
+ * Skeleton list shared by the filter blocks' render.php, included inside the
+ * wrapper element. The literal `hidden` keeps it out of the pre-hydration
+ * paint unless the URL already carries a query/filter (`is_initial_loading()`);
+ * afterwards `state.skeletonHidden` drives visibility reactively, so a
+ * client-side search from a bare /search/ page re-shows it.
  *
  * @package automattic/jetpack-search
  */
@@ -14,12 +13,14 @@ namespace Automattic\Jetpack\Search;
 
 defined( 'ABSPATH' ) || exit;
 
-$rows = 4;
+$rows               = 4;
+$is_initial_loading = Search_Blocks::is_initial_loading();
 ?>
 <ul
 	class="jetpack-search-filter__list jetpack-search-filter__list--skeleton"
 	data-wp-bind--hidden="state.skeletonHidden"
 	aria-hidden="true"
+	<?php echo $is_initial_loading ? '' : 'hidden'; ?>
 >
 	<?php for ( $i = 0; $i < $rows; $i++ ) : ?>
 		<li class="jetpack-search-filter__item jetpack-search-filter__item--skeleton">

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
@@ -95,11 +95,7 @@ $display_style = Search_Blocks::normalize_display_style( $attributes['displaySty
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<?php endif; ?>
-	<?php
-	if ( $view['is_initial_loading'] ) {
-		require __DIR__ . '/../filter-skeleton-partial.php';
-	}
-	?>
+	<?php require __DIR__ . '/../filter-skeleton-partial.php'; ?>
 	<ul
 		class="jetpack-search-filter__list"
 		data-wp-bind--hidden="state.allBucketsSelected"

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
@@ -83,11 +83,7 @@ $enabled_stars = Filter_Wc_Rating::get_enabled_stars( (array) $attributes );
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<?php endif; ?>
-	<?php
-	if ( $view['is_initial_loading'] ) {
-		require __DIR__ . '/../filter-skeleton-partial.php';
-	}
-	?>
+	<?php require __DIR__ . '/../filter-skeleton-partial.php'; ?>
 	<ul class="jetpack-search-filter__list">
 		<?php foreach ( $enabled_stars as $star ) : ?>
 			<?php

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -108,11 +108,11 @@ if ( function_exists( 'wp_interactivity_state' ) ) {
 	wp_interactivity_state( 'jetpack-search', array( 'resultsLayout' => $layout ) );
 }
 
-// Pre-hydration loading state. Skeleton items below render server-side only
-// when the URL carries a query/filter that will trigger an initial fetch on
-// hydration; otherwise emitting them would freeze placeholder rows on a bare
-// /search/ page where no fetch ever fires. Once JS hydrates,
-// `data-wp-bind--hidden="state.skeletonHidden"` takes over visibility.
+// Skeleton items always render so the IA runtime can re-show them on a
+// client-side search from a bare /search/ page. The literal `hidden` keeps
+// them out of the pre-hydration paint unless the URL already carries a
+// query/filter that fires an initial fetch on hydration; afterwards
+// `data-wp-bind--hidden="state.skeletonHidden"` drives visibility reactively.
 $is_initial_loading = Search_Blocks::is_initial_loading();
 $skeleton_count     = 'compact' === $layout ? 6 : 4;
 
@@ -146,34 +146,33 @@ if ( '' === $error_message ) {
 		class="jetpack-search-results__list"
 		aria-live="polite"
 	>
-		<?php if ( $is_initial_loading ) : ?>
-			<?php for ( $i = 0; $i < $skeleton_count; $i++ ) : ?>
-				<li
-					class="jetpack-search-results__item jetpack-search-results__item--skeleton"
-					data-wp-bind--hidden="state.skeletonHidden"
-					aria-hidden="true"
-				>
-					<?php if ( 'product' === $layout ) : ?>
-						<div class="jetpack-search-skeleton jetpack-search-skeleton--product-image"></div>
-						<div class="jetpack-search-results__copy">
-							<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
-							<div class="jetpack-search-skeleton jetpack-search-skeleton--title-secondary"></div>
-						</div>
-					<?php elseif ( 'compact' === $layout ) : ?>
-						<div class="jetpack-search-results__copy">
-							<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
-						</div>
-					<?php else : ?>
-						<div class="jetpack-search-results__copy">
-							<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
-							<div class="jetpack-search-skeleton jetpack-search-skeleton--path"></div>
-							<div class="jetpack-search-skeleton jetpack-search-skeleton--meta"></div>
-						</div>
-						<div class="jetpack-search-skeleton jetpack-search-skeleton--image"></div>
-					<?php endif; ?>
-				</li>
-			<?php endfor; ?>
-		<?php endif; ?>
+		<?php for ( $i = 0; $i < $skeleton_count; $i++ ) : ?>
+			<li
+				class="jetpack-search-results__item jetpack-search-results__item--skeleton"
+				data-wp-bind--hidden="state.skeletonHidden"
+				aria-hidden="true"
+				<?php echo $is_initial_loading ? '' : 'hidden'; ?>
+			>
+				<?php if ( 'product' === $layout ) : ?>
+					<div class="jetpack-search-skeleton jetpack-search-skeleton--product-image"></div>
+					<div class="jetpack-search-results__copy">
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--title-secondary"></div>
+					</div>
+				<?php elseif ( 'compact' === $layout ) : ?>
+					<div class="jetpack-search-results__copy">
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
+					</div>
+				<?php else : ?>
+					<div class="jetpack-search-results__copy">
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--path"></div>
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--meta"></div>
+					</div>
+					<div class="jetpack-search-skeleton jetpack-search-skeleton--image"></div>
+				<?php endif; ?>
+			</li>
+		<?php endfor; ?>
 		<template
 			data-wp-each--result="state.results"
 			data-wp-key="context.result.id"

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -2135,9 +2135,6 @@ HTML;
 			'isLoadingMore'              => false,
 			'hasError'                   => false,
 
-			// One-shot pre-hydration skeleton gate; never re-flashed on re-search.
-			'skeletonHidden'             => false,
-
 			// Seeded so SSR resolves `data-wp-text` on first paint.
 			'resultsCountText'           => $is_initial_loading ? $searching_text : '',
 

--- a/projects/packages/search/src/search-blocks/store/filters-empty.js
+++ b/projects/packages/search/src/search-blocks/store/filters-empty.js
@@ -55,10 +55,8 @@ export function hasAnyActiveFilter( sharedState ) {
 }
 
 /**
- * Filters empty-state visibility. Gated like `showNoResults` (search has run,
- * not loading, no error) plus `skeletonHidden` — sidebar flashes are more
- * disorienting than results flashes, so this waits for hydration to settle.
- * Any active filter short-circuits.
+ * Filters empty-state visibility. Gated like `showNoResults` — search has run,
+ * not loading, no error. Any active filter short-circuits.
  *
  * @param {object} sharedState - Live store state.
  * @return {boolean} True when the empty state should show.
@@ -67,7 +65,7 @@ export function filtersHaveNothingToShow( sharedState ) {
 	if ( ! ( sharedState.searchQuery || sharedState.hasSearchParam ) ) {
 		return false;
 	}
-	if ( ! sharedState.skeletonHidden || sharedState.isLoading || sharedState.hasError ) {
+	if ( sharedState.isLoading || sharedState.hasError ) {
 		return false;
 	}
 	if ( hasAnyActiveFilter( sharedState ) ) {

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -590,12 +590,10 @@ const { state, actions } = store( NAMESPACE, {
 		// `computeResultsCountText()` for the lockstep logic.
 
 		/**
-		 * Skeleton visibility — shown whenever a fetch is in flight with no
-		 * results yet, so the initial client-side search gets a skeleton and
-		 * not just the pre-hydration window. A reload that already has results
-		 * keeps them (no flash). SSR can't evaluate this getter, so the
-		 * skeleton markup carries a literal `hidden` attribute off the initial
-		 * load; the IA runtime takes over after hydration.
+		 * Skeleton visibility. SSR can't evaluate a getter, so the skeleton
+		 * markup carries a literal `hidden` off the initial paint; this getter
+		 * takes over after hydration so the in-flight initial search shows the
+		 * skeleton (a reload that already has results keeps them — no flash).
 		 *
 		 * @return {boolean} True when the skeleton should be hidden.
 		 */

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -590,6 +590,20 @@ const { state, actions } = store( NAMESPACE, {
 		// `computeResultsCountText()` for the lockstep logic.
 
 		/**
+		 * Skeleton visibility — shown whenever a fetch is in flight with no
+		 * results yet, so the initial client-side search gets a skeleton and
+		 * not just the pre-hydration window. A reload that already has results
+		 * keeps them (no flash). SSR can't evaluate this getter, so the
+		 * skeleton markup carries a literal `hidden` attribute off the initial
+		 * load; the IA runtime takes over after hydration.
+		 *
+		 * @return {boolean} True when the skeleton should be hidden.
+		 */
+		get skeletonHidden() {
+			return ! ( state.isLoading && state.results.length === 0 );
+		},
+
+		/**
 		 * No-results visibility. `data-wp-bind` only evaluates simple
 		 * property paths, so derived flags must be single getters.
 		 *
@@ -1008,10 +1022,6 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken === searchToken ) {
 					state.isLoading = false;
 					state.resultsCountText = computeResultsCountText( state );
-					// One-shot: ends the pre-hydration skeleton window.
-					if ( ! state.skeletonHidden ) {
-						state.skeletonHidden = true;
-					}
 				}
 			}
 		},
@@ -1600,9 +1610,9 @@ const { state, actions } = store( NAMESPACE, {
 			if ( state.searchQuery || state.hasActiveFilters || state.hasSearchParam ) {
 				actions.dispatchInitialSearchIfNeeded();
 			} else if ( droppedAny ) {
-				// No fetch will fire — clear the spinner + skeleton.
+				// No fetch will fire — clear the spinner; `skeletonHidden`
+				// derives to true once `isLoading` is false.
 				state.isLoading = false;
-				state.skeletonHidden = true;
 			}
 		},
 

--- a/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
+++ b/projects/packages/search/src/search-blocks/store/test/filters-empty.test.js
@@ -12,7 +12,6 @@ function emptySearchedState( overrides = {} ) {
 	return {
 		searchQuery: 'test',
 		hasSearchParam: true,
-		skeletonHidden: true,
 		isLoading: false,
 		hasError: false,
 		aggregations: {},
@@ -38,12 +37,6 @@ describe( 'filtersHaveNothingToShow', () => {
 
 	it( 'is false while the search is loading', () => {
 		expect( filtersHaveNothingToShow( emptySearchedState( { isLoading: true } ) ) ).toBe( false );
-	} );
-
-	it( 'is false while the pre-hydration skeleton is up', () => {
-		expect( filtersHaveNothingToShow( emptySearchedState( { skeletonHidden: false } ) ) ).toBe(
-			false
-		);
 	} );
 
 	it( 'is false when the fetch errored', () => {

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -428,14 +428,17 @@ describe( 'syncFilterWrapperVisibility callback', () => {
 		captured.state.aggregations = {};
 		captured.state.retainedFilterOptions = {};
 		captured.state.filterConfigs = {};
-		captured.state.skeletonHidden = true;
+		// `skeletonHidden` is derived — drive it via the fetch lifecycle.
+		captured.state.isLoading = false;
+		captured.state.results = [];
 		contextRef.current = { filterKey: 'category', wrapperHidden: true };
 	} );
 
 	const run = () => captured.callbacks.syncFilterWrapperVisibility();
 
 	it( 'keeps the wrapper visible while the skeleton is still showing', () => {
-		captured.state.skeletonHidden = false;
+		captured.state.isLoading = true;
+		captured.state.results = [];
 		captured.state.aggregations = {};
 		run();
 		expect( contextRef.current.wrapperHidden ).toBe( false );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -179,12 +179,11 @@ describe( 'store actions', () => {
 		jest.restoreAllMocks();
 	} );
 
-	it( 'flips skeletonHidden once the first search resolves (success or error)', async () => {
-		// `skeletonHidden` gates the pre-hydration placeholders. Once the
-		// first fetch completes, JS owns the DOM and the skeleton must
-		// disappear for the rest of the session — both the success path
-		// and the error path of `search()` need to flip the flag.
-		state.skeletonHidden = false;
+	it( 'hides the skeleton once a search resolves (success or error)', async () => {
+		// `skeletonHidden` derives from an in-flight fetch with no results yet.
+		// Once `search()` settles — success or error — `isLoading` is false so
+		// the skeleton is hidden again. The error path clears `results`, so the
+		// derived flag must still resolve to hidden and not strand placeholders.
 		global.fetch.mockResolvedValueOnce(
 			createResponse( {
 				results: [ createResult( 'Fresh hit' ) ],
@@ -197,10 +196,6 @@ describe( 'store actions', () => {
 		expect( state.skeletonHidden ).toBe( true );
 		expect( state.isLoading ).toBe( false );
 
-		// Reset and confirm the error path also closes the skeleton —
-		// otherwise a connection failure would leave placeholders on screen
-		// indefinitely with no visible loading indicator.
-		state.skeletonHidden = false;
 		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) );
 		await runGenerator( actions.search( { syncUrl: false } ) );
 		expect( state.skeletonHidden ).toBe( true );
@@ -738,6 +733,23 @@ describe( 'store getters', () => {
 		expect( state.activeFilterCount ).toBe( 2 );
 	} );
 
+	it( 'shows the skeleton only while a fetch is in flight with no results yet', () => {
+		// The initial client-side search must surface the skeleton; a reload
+		// that already has results keeps them visible (no flash).
+		state.isLoading = false;
+		state.results = [];
+		expect( state.skeletonHidden ).toBe( true );
+
+		state.isLoading = true;
+		expect( state.skeletonHidden ).toBe( false );
+
+		state.results = [ { title: 'Fresh hit' } ];
+		expect( state.skeletonHidden ).toBe( true );
+
+		state.isLoading = false;
+		expect( state.skeletonHidden ).toBe( true );
+	} );
+
 	it( 'surfaces showNoResults for an explicit-but-empty `?s=` deep link (SEARCH-183)', () => {
 		// Empty `?s=` URL — `searchQuery` is `''` but `hasSearchParam` is true,
 		// so the initial search fires (covered by other tests). If that search
@@ -1130,14 +1142,13 @@ describe( 'store callbacks', () => {
 			fresh.state.filterConfigs = { category: { filterKey: 'category' } };
 			fresh.state.activeFilters = { foo: [ 'bar' ] };
 			fresh.state.isLoading = true;
-			fresh.state.skeletonHidden = false;
 
 			captured.callbacks.initialize();
 
 			expect( fresh.state.activeFilters ).toEqual( {} );
 			expect( search ).not.toHaveBeenCalled();
 			expect( fresh.state.isLoading ).toBe( false );
-			// Skeleton flips closed even though no fetch fires — otherwise the
+			// Skeleton derives closed once `isLoading` clears — otherwise the
 			// pre-hydration placeholders would linger forever on a deep link
 			// whose only filter keys are stale and get gated out.
 			expect( fresh.state.skeletonHidden ).toBe( true );

--- a/projects/packages/search/tests/php/Filter_Wc_Attribute_Render_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Attribute_Render_Test.php
@@ -130,22 +130,24 @@ class Filter_Wc_Attribute_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Without a URL filter param, the block has no seeded buckets and no
-	 * initial-loading signal, so it must render with the `hidden` attribute
-	 * on the wrapper and must NOT include skeleton markup.
+	 * Without a URL filter param the block has no seeded buckets and no
+	 * initial-loading signal. The skeleton still renders — the IA runtime
+	 * re-shows it on a client-side search from a bare page — but carries a
+	 * static `hidden` attribute, and the wrapper is hidden too.
 	 */
-	public function test_no_skeleton_when_not_initial_loading(): void {
+	public function test_skeleton_hidden_when_not_initial_loading(): void {
 		$this->require_interactivity_api();
 
 		$markup = $this->render( array( 'attributeTaxonomy' => 'pa_color' ) );
 
-		$this->assertStringNotContainsString( 'jetpack-search-filter__list--skeleton', $markup );
-		$this->assertStringNotContainsString( 'jetpack-search-filter__item--skeleton', $markup );
-		// Wrapper must carry the static `hidden` attribute when there are no
-		// buckets and no initial load. Match `hidden` only as a standalone
-		// attribute on the opening div (preceded by whitespace, followed by
-		// whitespace / `>` / `=`) so the assertion can't be satisfied by
-		// `data-wp-bind--hidden`, `aria-hidden`, or `wrapperHidden` substrings.
+		$this->assertStringContainsString( 'jetpack-search-filter__list--skeleton', $markup );
+		$this->assertStringContainsString( 'jetpack-search-filter__item--skeleton', $markup );
+		// The skeleton list carries a static `hidden` attribute off the initial
+		// paint. Match `hidden` only as a standalone attribute (preceded by
+		// whitespace, followed by whitespace / `>` / `=`) so the assertion can't
+		// be satisfied by `data-wp-bind--hidden` or `aria-hidden`.
+		$this->assertSame( 1, preg_match( '/<ul[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+		// The wrapper is hidden too — no buckets and no initial load.
 		$this->assertSame( 1, preg_match( '/<div[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
 	}
 
@@ -161,11 +163,13 @@ class Filter_Wc_Attribute_Render_Test extends TestCase {
 
 		$this->assertStringContainsString( 'jetpack-search-filter__list--skeleton', $markup );
 		$this->assertStringContainsString( 'jetpack-search-filter__item--skeleton', $markup );
-		// Wrapper must be visible while the skeleton is up — no static `hidden`
-		// attribute on the opening div. Matches `hidden` only as a standalone
-		// attribute so the indirect bindings (`data-wp-bind--hidden`,
-		// `aria-hidden`, `wrapperHidden`) don't false-positive.
+		// Wrapper and skeleton list must be visible while the skeleton is up —
+		// no static `hidden` attribute on the opening div or any `<ul>`. Matches
+		// `hidden` only as a standalone attribute so the indirect bindings
+		// (`data-wp-bind--hidden`, `aria-hidden`, `wrapperHidden`) don't
+		// false-positive.
 		$this->assertSame( 0, preg_match( '/<div[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+		$this->assertSame( 0, preg_match( '/<ul[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -457,11 +457,13 @@ class Results_List_Render_Test extends TestCase {
 	public function test_skeleton_items_present_but_hidden_when_not_initial_loading() {
 		$markup = $this->render();
 
-		$this->assertStringContainsString( 'jetpack-search-results__item--skeleton', $markup );
-		// Each skeleton `<li>` carries a static `hidden` attribute. Match
-		// `hidden` only as a standalone attribute so `data-wp-bind--hidden` and
-		// `aria-hidden` don't false-positive.
-		$this->assertSame( 1, preg_match( '/<li[^>]*--skeleton[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+		$total_skeletons = preg_match_all( '/jetpack-search-results__item--skeleton/', $markup );
+		$this->assertGreaterThan( 0, $total_skeletons );
+		// *Every* skeleton `<li>` carries a static `hidden` attribute, not just
+		// one. Match `hidden` only as a standalone attribute so
+		// `data-wp-bind--hidden` and `aria-hidden` don't false-positive.
+		$hidden_skeletons = preg_match_all( '/<li[^>]*--skeleton[^>]*\s+hidden(?=\s|\/|>|=)/', $markup );
+		$this->assertSame( $total_skeletons, $hidden_skeletons );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -449,6 +449,22 @@ class Results_List_Render_Test extends TestCase {
 	}
 
 	/**
+	 * Without an initial-loading signal the skeleton items still render — the
+	 * IA runtime re-shows them on a client-side search from a bare page — but
+	 * each carries a static `hidden` attribute so they stay out of the
+	 * pre-hydration paint.
+	 */
+	public function test_skeleton_items_present_but_hidden_when_not_initial_loading() {
+		$markup = $this->render();
+
+		$this->assertStringContainsString( 'jetpack-search-results__item--skeleton', $markup );
+		// Each skeleton `<li>` carries a static `hidden` attribute. Match
+		// `hidden` only as a standalone attribute so `data-wp-bind--hidden` and
+		// `aria-hidden` don't false-positive.
+		$this->assertSame( 1, preg_match( '/<li[^>]*--skeleton[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+	}
+
+	/**
 	 * Render the block with the given post-type request params seeded into
 	 * `$_GET`. Resets the `is_initial_loading()` memo around the render and
 	 * clears the params after so the auto-product-view cases stay isolated


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-288

## Why

On the block-based search experiences (embedded, blocks overlay, and the WooCommerce product overlay), a visitor who lands on a bare `/search/` page and types a query saw a mostly-empty screen while the first results loaded. The loading skeleton only ever showed during the brief pre-hydration window, so once the Interactivity API had taken over, the initial search had no loading state at all. Visitors now see the skeleton during that initial search — the same polished loading state across every block experience.

## Proposed changes

* Convert `skeletonHidden` from a stored one-shot boolean into a derived getter — `NOT (isLoading && no results yet)` — mirroring the existing `showNoResults` / `showError` idiom. Every existing `data-wp-bind--hidden="state.skeletonHidden"` binding and consumer (`syncFilterWrapperVisibility`, `filtersHaveNothingToShow`) keeps working untouched; the skeleton just becomes reactive.
* Always emit the results-list and filter skeleton markup, carrying a literal `hidden` attribute off the initial load so it stays out of the pre-hydration paint but is in the DOM for the IA runtime to re-show on a client-side search.
* A reload that already has results keeps them visible during the fetch (no skeleton flash) — the skeleton only appears when there is nothing to show yet (the true initial search).
* Remove the now-redundant PHP `skeletonHidden` seed and the two one-shot writes in the store.

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-288

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Same flow on both — bare `/search/` page, type a query, captured during the initial in-flight fetch (network throttled to hold the loading state).

| Before (empty during initial search) | After (skeleton during initial search) |
|---|---|
| ![before](https://github.com/user-attachments/assets/8015238f-45ed-4223-9a60-c97ada3f2b2c) | ![after](https://github.com/user-attachments/assets/89c4f300-0d63-4f72-9cb1-e57298c6f86e) |

## Testing instructions

Use a block theme (e.g. Twenty Twenty-Five) on a site with Jetpack Search and the **Blocks Overlay** (`overlay_blocks`) or **Embedded** experience active.

* [ ] On a bare `/search/` page, type a query and submit — the loading skeleton (results list **and** filter sidebar) appears during the initial fetch, then swaps to live results. Throttle the network or use a slow connection to see the in-flight state clearly.
* [ ] A `?s=` deep-link load is seamless: the pre-hydration skeleton hands off to the hydrated store with no flash and no regression.
* [ ] A subsequent search while results are already on screen keeps the existing results visible (no skeleton flash); `aria-busy` toggles as before.
* [ ] The error path is unaffected — the error region owns the failure case and the skeleton stays hidden.
* [ ] Behaviour is identical across the embedded, blocks overlay, and product overlay experiences.

