### PR TITLE
Search Blocks Overlay: polarity-aware card shadow so it lifts off the scrim across color schemes

### DIFF
--- a/projects/packages/search/changelog/raven-search-289-overlay-polarity-aware-shadow
+++ b/projects/packages/search/changelog/raven-search-289-overlay-polarity-aware-shadow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks Overlay: derive the card elevation shadow from the theme ink so it lifts off the scrim on dark themes instead of melting into the page.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1261,11 +1261,9 @@ class Search_Blocks {
 	.jetpack-search-block-overlay__card {
 		--jp-search-overlay-surface: color-mix(in sRGB, var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327))) 5%, var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff))));
 		border-color: color-mix(in sRGB, var(--jp-search-overlay-ink) 20%, var(--jp-search-overlay-surface));
-		/* Tint the elevation shadow from ink so it inverts polarity with the theme
-		 * (SEARCH-289): a dark drop shadow on light cards, a soft light halo on dark
-		 * cards. A flat black shadow is invisible against the dark scrim on dark
-		 * themes, leaving the card melted into the page. The static black `box-shadow`
-		 * above stays as the no-`color-mix` fallback. */
+		/* Ink-derived shadow inverts polarity per theme (SEARCH-289): a dark drop
+		 * shadow on light cards, a soft light halo on dark — a flat black shadow is
+		 * invisible against the dark scrim. Static black above is the fallback. */
 		box-shadow: 0 8px 32px color-mix(in sRGB, var(--jp-search-overlay-ink) 22%, transparent);
 	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1261,6 +1261,12 @@ class Search_Blocks {
 	.jetpack-search-block-overlay__card {
 		--jp-search-overlay-surface: color-mix(in sRGB, var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #1d2327))) 5%, var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff))));
 		border-color: color-mix(in sRGB, var(--jp-search-overlay-ink) 20%, var(--jp-search-overlay-surface));
+		/* Tint the elevation shadow from ink so it inverts polarity with the theme
+		 * (SEARCH-289): a dark drop shadow on light cards, a soft light halo on dark
+		 * cards. A flat black shadow is invisible against the dark scrim on dark
+		 * themes, leaving the card melted into the page. The static black `box-shadow`
+		 * above stays as the no-`color-mix` fallback. */
+		box-shadow: 0 8px 32px color-mix(in sRGB, var(--jp-search-overlay-ink) 22%, transparent);
 	}
 }
 /* Single hairline over the full 60px header strip — siblings paint with a seam (SEARCH-260). */


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-289

## Why

The Search blocks overlay already carried a drop shadow, but it was a hardcoded **black** shadow painted over a fixed dark scrim. On a dark theme — where the card surface is itself dark — a black shadow is effectively invisible, so the overlay melted into the page instead of reading as a layer floating above it. This makes the card lift off the scrim on light, dark, and arbitrary themed color schemes.

## Proposed changes

* Derive the overlay card's elevation shadow from the theme ink (`--jp-search-overlay-ink`) via `color-mix`, inside the existing SEARCH-270 `@supports (color-mix)` block — so the shadow inverts polarity with the theme: a dark drop shadow on light cards, a soft light halo on dark cards.
* Keep the existing static black `box-shadow` as the no-`color-mix` fallback for older browsers.
* No change to the scrim, border, surface tint, border-radius, or the mobile full-screen behavior (shadow still suppressed at `≤781px`).

## Screenshots

**Dark theme — card edge against the scrim (cropped).** Before, the black shadow is invisible and the card edge is just a hairline; after, a soft light halo lifts the card off the scrim.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/4c67890d-1076-4a1a-bbcb-e2d3d957adb0) | ![after](https://github.com/user-attachments/assets/6e1200da-e2d9-4a2e-9405-82ef10e5a763) |

**Dark theme — full overlay.**

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/f76a9336-6685-40b6-b826-3ce6f59b0b5e) | ![after](https://github.com/user-attachments/assets/056a832e-6304-4f28-affd-0d9fd2a66dbe) |

**Light theme — after.** The polarity inverts: the light card casts a clear dark drop shadow, so it still reads as floating.

![light after](https://github.com/user-attachments/assets/0681c4f5-6f7a-463e-acdf-c90e0489228b)

## Related product discussion/links

* [SEARCH-289](https://linear.app/a8c/issue/SEARCH-289)
* Builds on [SEARCH-270](https://linear.app/a8c/issue/SEARCH-270) (card/scrim separation on dark themes), reusing the same ink-derived `color-mix` polarity pattern.

## Does this pull request change what data or activity we track or use?

No. This is a CSS-only presentation change to the overlay card shadow.

## Testing instructions

Enable the experimental blocks-powered Search overlay (`overlay_blocks` experience) on a site with a Search plan, then open the overlay (e.g. visit a search URL `/?s=test`) and check the card edge against the scrim:

* [ ] On a **light** theme, the card casts a clear dark drop shadow and reads as floating above the page (parity with or better than before).
* [ ] On a **dark** theme, the card visibly lifts off the dark scrim via a soft light halo instead of an invisible black shadow.
* [ ] The elevation tracks the theme ink, so arbitrary themed color schemes get a polarity-appropriate shadow without per-theme rules.
* [ ] Browsers without `color-mix` still get the existing static black shadow (graceful fallback).
* [ ] Mobile full-screen behavior is unchanged (no shadow at `≤781px`).
