### PR TITLE
Search Blocks: style the results-sort select to match sibling toolbar surfaces

### DIFF
--- a/projects/packages/search/changelog/echo-search-290-results-sort-select-theme-colors
+++ b/projects/packages/search/changelog/echo-search-290-results-sort-select-theme-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: style the Sort By block's select control with the theme's surface and text colors instead of a stock system widget, so it matches the other search toolbar surfaces on dark and custom-palette themes.

--- a/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-sort/style.scss
@@ -14,14 +14,27 @@
 		opacity: 0.8;
 	}
 
-	// Leave the <select>'s colors / border / background to the browser:
-	// native controls render correctly on any background and stay
-	// accessible on every platform without per-OS workarounds (e.g.
-	// transparent backgrounds breaking the dropdown list on Windows).
-	// Padding is safe to nudge — it doesn't affect the dropdown chrome —
-	// and matching the clear-all button keeps the toolbar row balanced.
+	// A native <select> ignores a transparent background (the OS paints its
+	// own field chrome), so this can't use the pills' transparent treatment.
+	// Match the popover menu / suggestions surfaces instead: opaque theme
+	// tokens with a currentColor hairline. `appearance: auto` re-asserts the
+	// native control — and its theme-tracking chevron — if a theme forced it
+	// off.
 	select {
+		appearance: auto;
+		background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+		color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
+		border: 1px solid color-mix(in sRGB, currentColor 20%, transparent);
+		border-radius: 4px;
 		padding: 0.2rem 0.5rem;
+		cursor: pointer;
+
+		// The open option list is OS-painted; without explicit tokens it can
+		// fall back to system colors and go unreadable on Linux / Windows.
+		option {
+			background-color: var(--jp-search-page-surface, var(--wp--preset--color--base, var(--wp--preset--color--background, #fff)));
+			color: var(--jp-search-page-ink, var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, inherit)));
+		}
 	}
 
 	// Reset browser defaults on the radio-variant fieldset. Without this the


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-290

## Why

On a dark or custom-palette theme, the Sort By block's `<select>` was the one control in the search toolbar that stayed a stock light system widget — a white box with dark text sitting on a dark page. Now it rides the theme's surface and text colors like the other Search surfaces, so the results toolbar reads as one coherent set of controls.

## Proposed changes

* Style the `results-sort` block's native `<select>` with the standard Search theme-token chain (`--jp-search-page-surface` / `--jp-search-page-ink`) plus a `currentColor`-mix hairline border and radius, matching the popover menu and search-input suggestions surfaces.
* Apply the same opaque tokens to the `<option>` list so the open dropdown stays readable on Linux/Windows (the failure mode tracked in WOOPRD-3516).
* Use an opaque surface (not the active-filter pills' transparent treatment): a native `<select>` ignores a transparent background, so only an opaque fill actually paints across platforms. `appearance: auto` keeps the native, theme-tracking chevron — the same approach the legacy instant-search sort select already uses.

This is presentation-only — no markup, block-attribute, or JS changes. The radio and popover variants are untouched.

## Related product discussion/links

* [SEARCH-290](https://linear.app/a8c/issue/SEARCH-290)

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Sort By control on a dark theme (the `<select>` previously rendered as a stock light system widget).

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/6d3535cc-365c-44db-8a28-8ccd43ac67c3) | ![after](https://github.com/user-attachments/assets/a914cb47-0ebe-40c5-b526-65813065b700) |


## Testing instructions

1. On a site with Jetpack Search blocks, view a page/template that renders the **Sort By** block (`jetpack-search/results-sort`) in its default `select` display.
2. Use a **dark or custom-palette theme** (or a dark Global Styles variation) so the page surface isn't white.
3. Confirm against the acceptance criteria:
   - [ ] The closed sort `<select>` rides the theme surface/text colors (dark control + light text on a dark theme) with a `currentColor`-mix hairline border and radius — no stock white widget.
   - [ ] The open `<option>` list is legible on macOS, Windows, and Linux.
   - [ ] The radio variant and the popover-menu variant of the block are unchanged.
   - [ ] No markup/class/JS changes — presentation only.
