### PR TITLE
Search: exclude search-blocks agent docs from the mirrored package

### DIFF
--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -16,6 +16,11 @@
 /src/**/*.jsx                                            production-exclude
 /src/**/*.scss                                           production-exclude
 
+# Agent / contributor docs. The monorepo-root rules drop these by basename,
+# but those don't travel with the package when it's mirrored standalone.
+/src/**/AGENTS.md                                        production-exclude
+/src/**/CLAUDE.md                                        production-exclude
+
 # `src/widgets/js/` has no build step — `class-search-widget.php` enqueues
 # those files straight from source, so they must ship. Every other src
 # subdirectory is bundled into `/build/**` and its source is dev-only.

--- a/projects/packages/search/changelog/echo-search-gitattributes-exclude-agent-docs
+++ b/projects/packages/search/changelog/echo-search-gitattributes-exclude-agent-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: exclude the search-blocks AGENTS.md and CLAUDE.md contributor docs from the production build so they don't ship with the mirrored package.


### PR DESCRIPTION
## Why

The `src/search-blocks/` directory carries `AGENTS.md` and `CLAUDE.md` contributor docs. The monorepo-root `.gitattributes` already drops files named `AGENTS.md`/`CLAUDE.md` from the production build by basename — but those root rules don't travel with the Search package when it's mirrored to its standalone `Automattic/jetpack-search` repo. Adding package-local `production-exclude` entries keeps the published package free of these dev-only docs regardless of where it's built from.

## Proposed changes

* Add `/src/**/AGENTS.md` and `/src/**/CLAUDE.md` as `production-exclude` to `projects/packages/search/.gitattributes`.

No code or runtime behavior changes — build-config only. These files are already excluded from the monorepo build today; this makes the package self-contained.

## Related product discussion/links

* n/a — build hygiene.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `git check-attr production-exclude -- projects/packages/search/src/search-blocks/AGENTS.md projects/packages/search/src/search-blocks/CLAUDE.md` — both report `production-exclude: set`.
2. Build the package (`jp build packages/search`) and confirm neither file appears in the mirrored/vendored output (`find projects/plugins/search/jetpack_vendor/automattic/jetpack-search -iname 'AGENTS.md' -o -iname 'CLAUDE.md'` returns nothing).
