### PR TITLE
Search Blocks: derive blog-search & product-search patterns from their page templates

### DIFF
--- a/projects/packages/search/changelog/atlas-search-291-derive-patterns-from-templates
+++ b/projects/packages/search/changelog/atlas-search-291-derive-patterns-from-templates
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search Blocks: derive the Blog Search Page pattern from its page template and add a WooCommerce Product Search Page pattern, so the inserter patterns stay in sync with the templates they mirror.
+Search Blocks: derive the Blog Search Page pattern from its page template so the inserter pattern stays in sync with the template it mirrors.

--- a/projects/packages/search/changelog/atlas-search-291-derive-patterns-from-templates
+++ b/projects/packages/search/changelog/atlas-search-291-derive-patterns-from-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: derive the Blog Search Page pattern from its page template and add a WooCommerce Product Search Page pattern, so the inserter patterns stay in sync with the templates they mirror.

--- a/projects/packages/search/changelog/atlas-search-291-derive-patterns-from-templates
+++ b/projects/packages/search/changelog/atlas-search-291-derive-patterns-from-templates
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search Blocks: derive the Blog Search Page pattern from its page template so the inserter pattern stays in sync with the template it mirrors.
+Search Blocks: derive the Blog Search Page pattern from the shared search layout template so the inserter pattern stays in sync with the template it mirrors.

--- a/projects/packages/search/changelog/atlas-search-291-product-search-pattern
+++ b/projects/packages/search/changelog/atlas-search-291-product-search-pattern
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: add a WooCommerce Product Search Page pattern — a full-page product search layout with sidebar product filters and a product result grid.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -983,11 +983,10 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Derive a block-pattern's content from a page template, so patterns stay in
-	 * sync with the template they mirror instead of carrying a hand-copied second
-	 * copy of the layout. Strips the page chrome (header/footer template-parts and
-	 * the `main` group wrapper) by keeping only the markup between the `<main>`
-	 * tags — the inner content group, alignment and all.
+	 * Derive a block-pattern's content from a chrome-free layout template (the
+	 * overlay templates, which already ship without header/footer/main page
+	 * chrome), so patterns stay in sync with the template they mirror instead of
+	 * carrying a hand-copied second copy of the layout.
 	 *
 	 * @param string $template_file Template basename under `templates/`.
 	 * @return string Block markup ready for `register_block_pattern()`, or '' when unreadable.
@@ -999,14 +998,7 @@ class Search_Blocks {
 		if ( '' === $raw ) {
 			return '';
 		}
-		$raw   = static::substitute_template_placeholders( $raw );
-		$open  = strpos( $raw, '<main' );
-		$start = false === $open ? false : strpos( $raw, '>', $open );
-		$end   = strrpos( $raw, '</main>' );
-		if ( false === $start || false === $end || $end <= $start ) {
-			return trim( $raw );
-		}
-		return trim( substr( $raw, $start + 1, $end - $start - 1 ) );
+		return trim( static::substitute_template_placeholders( $raw ) );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -983,6 +983,33 @@ class Search_Blocks {
 	}
 
 	/**
+	 * Derive a block-pattern's content from a page template, so patterns stay in
+	 * sync with the template they mirror instead of carrying a hand-copied second
+	 * copy of the layout. Strips the page chrome (header/footer template-parts and
+	 * the `main` group wrapper) by keeping only the markup between the `<main>`
+	 * tags — the inner content group, alignment and all.
+	 *
+	 * @param string $template_file Template basename under `templates/`.
+	 * @return string Block markup ready for `register_block_pattern()`, or '' when unreadable.
+	 */
+	public static function pattern_content_from_template( string $template_file ): string {
+		$template_path = __DIR__ . '/templates/' . $template_file;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
+		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		if ( '' === $raw ) {
+			return '';
+		}
+		$raw   = static::substitute_template_placeholders( $raw );
+		$open  = strpos( $raw, '<main' );
+		$start = false === $open ? false : strpos( $raw, '>', $open );
+		$end   = strrpos( $raw, '</main>' );
+		if ( false === $start || false === $end || $end <= $start ) {
+			return trim( $raw );
+		}
+		return trim( substr( $raw, $start + 1, $end - $start - 1 ) );
+	}
+
+	/**
 	 * Build the full search page template content.
 	 *
 	 * Markup lives in `templates/jetpack-search.html` with a `{{FILTER_HEADING}}`

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -993,7 +993,7 @@ class Search_Blocks {
 	 * @return string Block markup ready for `register_block_pattern()`, or '' when unreadable.
 	 */
 	public static function pattern_content_from_template( string $template_file ): string {
-		$template_path = __DIR__ . '/templates/' . $template_file;
+		$template_path = __DIR__ . '/templates/' . basename( $template_file );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
 		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
 		if ( '' === $raw ) {

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -19,45 +19,6 @@ register_block_pattern(
 			__( 'results', 'jetpack-search-pkg' ),
 			__( 'jetpack search', 'jetpack-search-pkg' ),
 		),
-		'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
-<div class="wp-block-group">
-<!-- wp:jetpack-search/search-input /-->
-
-<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
-<div class="wp-block-columns">
-
-<!-- wp:column -->
-<div class="wp-block-column">
-<!-- wp:jetpack-search/search-results -->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group">
-<!-- wp:jetpack-search/results-count /-->
-<!-- wp:jetpack-search/results-sort /-->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:jetpack-search/results-list /-->
-<!-- wp:jetpack-search/results-load-more /-->
-<!-- wp:jetpack-search/powered-by /-->
-<!-- /wp:jetpack-search/search-results -->
-</div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
-<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
-<!-- /wp:heading -->
-<!-- wp:jetpack-search/active-filters /-->
-<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
-<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
-<!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
-</div>
-<!-- /wp:column -->
-
-</div>
-<!-- /wp:columns -->
-</div>
-<!-- /wp:group -->',
+		'content'     => Search_Blocks::pattern_content_from_template( 'jetpack-search.html' ),
 	)
 );

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -7,6 +7,11 @@
 
 namespace Automattic\Jetpack\Search;
 
+$content = Search_Blocks::pattern_content_from_template( 'jetpack-search.html' );
+if ( '' === $content ) {
+	return;
+}
+
 register_block_pattern(
 	'jetpack-search/blog-search-page',
 	array(
@@ -19,6 +24,6 @@ register_block_pattern(
 			__( 'results', 'jetpack-search-pkg' ),
 			__( 'jetpack search', 'jetpack-search-pkg' ),
 		),
-		'content'     => Search_Blocks::pattern_content_from_template( 'jetpack-search.html' ),
+		'content'     => $content,
 	)
 );

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-$content = Search_Blocks::pattern_content_from_template( 'jetpack-search.html' );
+$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-overlay.html' );
 if ( '' === $content ) {
 	return;
 }

--- a/projects/packages/search/src/search-blocks/patterns/wc-product-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/wc-product-search.php
@@ -4,14 +4,14 @@
  *
  * WooCommerce-only: composes `filters-product` / `filter-wc-*` blocks, so the
  * `wc-` filename prefix keeps `register_patterns()` from loading it on non-Woo
- * sites. Content mirrors `templates/jetpack-search-product-results.html`.
+ * sites. Content mirrors `templates/jetpack-search-overlay-product.html`.
  *
  * @package automattic/jetpack-search
  */
 
 namespace Automattic\Jetpack\Search;
 
-$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-product-results.html' );
+$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-overlay-product.html' );
 if ( '' === $content ) {
 	return;
 }

--- a/projects/packages/search/src/search-blocks/patterns/wc-product-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/wc-product-search.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Product Search Page block pattern.
+ *
+ * WooCommerce-only: composes `filters-product` / `filter-wc-*` blocks, so the
+ * `wc-` filename prefix keeps `register_patterns()` from loading it on non-Woo
+ * sites. Content mirrors `templates/jetpack-search-product-results.html`.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+register_block_pattern(
+	'jetpack-search/wc-product-search-page',
+	array(
+		'title'       => __( 'Product Search Page', 'jetpack-search-pkg' ),
+		'description' => __( 'A full-page product search layout with sidebar filters and a product result grid powered by Jetpack Search.', 'jetpack-search-pkg' ),
+		'categories'  => array( 'jetpack-search' ),
+		'keywords'    => array(
+			__( 'search', 'jetpack-search-pkg' ),
+			__( 'product', 'jetpack-search-pkg' ),
+			__( 'woocommerce', 'jetpack-search-pkg' ),
+			__( 'jetpack search', 'jetpack-search-pkg' ),
+		),
+		'content'     => Search_Blocks::pattern_content_from_template( 'jetpack-search-product-results.html' ),
+	)
+);

--- a/projects/packages/search/src/search-blocks/patterns/wc-product-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/wc-product-search.php
@@ -11,6 +11,11 @@
 
 namespace Automattic\Jetpack\Search;
 
+$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-product-results.html' );
+if ( '' === $content ) {
+	return;
+}
+
 register_block_pattern(
 	'jetpack-search/wc-product-search-page',
 	array(
@@ -23,6 +28,6 @@ register_block_pattern(
 			__( 'woocommerce', 'jetpack-search-pkg' ),
 			__( 'jetpack search', 'jetpack-search-pkg' ),
 		),
-		'content'     => Search_Blocks::pattern_content_from_template( 'jetpack-search-product-results.html' ),
+		'content'     => $content,
 	)
 );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1007,6 +1007,36 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * `pattern_content_from_template()` derives a pattern's content from a page
+	 * template: it strips the page chrome (header/footer template-parts and the
+	 * `main` group wrapper) and keeps the inner alignwide content group, with the
+	 * `{{FILTER_HEADING}}` placeholder substituted.
+	 */
+	public function test_pattern_content_from_template_strips_chrome_keeps_content() {
+		$content = Search_Blocks::pattern_content_from_template( 'jetpack-search.html' );
+
+		$this->assertNotEmpty( $content, 'Content must be non-empty when the bundled template exists.' );
+		$this->assertStringStartsWith( '<!-- wp:group {"align":"wide"', $content, 'Content must start at the inner alignwide group.' );
+		$this->assertStringEndsWith( '<!-- /wp:group -->', $content, 'Content must end at the inner group close.' );
+		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Header/footer template-parts must be stripped.' );
+		$this->assertStringNotContainsString( '<main', $content, 'The main wrapper must be stripped.' );
+		$this->assertStringNotContainsString( 'tagName', $content, 'The main group comment must be stripped.' );
+		$this->assertStringNotContainsString( '{{', $content, 'Placeholders must be substituted.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/search-input', $content, 'Search input block must remain.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/filters', $content, 'Sidebar filters composition must remain.' );
+		$this->assertStringContainsString( 'Filter options', $content, 'Sidebar heading placeholder must be substituted.' );
+	}
+
+	/**
+	 * Missing template file yields an empty string — `register_block_pattern()`
+	 * tolerates empty content, so a bad path degrades to a no-op pattern rather
+	 * than a fatal.
+	 */
+	public function test_pattern_content_from_template_returns_empty_on_missing_file() {
+		$this->assertSame( '', Search_Blocks::pattern_content_from_template( 'does-not-exist.html' ) );
+	}
+
+	/**
 	 * With the override on, `init()` registers both the product-search
 	 * Template and the priority-20 routing filter.
 	 */

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1020,11 +1020,29 @@ class Search_Blocks_Test extends TestCase {
 		$this->assertStringEndsWith( '<!-- /wp:group -->', $content, 'Content must end at the inner group close.' );
 		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Header/footer template-parts must be stripped.' );
 		$this->assertStringNotContainsString( '<main', $content, 'The main wrapper must be stripped.' );
-		$this->assertStringNotContainsString( 'tagName', $content, 'The main group comment must be stripped.' );
+		$this->assertStringNotContainsString( '"tagName":"main"', $content, 'The main group comment must be stripped.' );
 		$this->assertStringNotContainsString( '{{', $content, 'Placeholders must be substituted.' );
 		$this->assertStringContainsString( 'wp:jetpack-search/search-input', $content, 'Search input block must remain.' );
 		$this->assertStringContainsString( 'wp:jetpack-search/filters', $content, 'Sidebar filters composition must remain.' );
 		$this->assertStringContainsString( 'Filter options', $content, 'Sidebar heading placeholder must be substituted.' );
+	}
+
+	/**
+	 * The chrome-stripping works identically for the WooCommerce product template,
+	 * keeping the product-only blocks (filters-product, results-list layout=product,
+	 * filter-wc-price) intact. Guards against a future product-template restructure
+	 * that breaks the `<main>` extraction.
+	 */
+	public function test_pattern_content_from_template_strips_chrome_for_product_template() {
+		$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-product-results.html' );
+
+		$this->assertNotEmpty( $content, 'Content must be non-empty when the bundled product template exists.' );
+		$this->assertStringStartsWith( '<!-- wp:group {"align":"wide"', $content, 'Content must start at the inner alignwide group.' );
+		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Header/footer template-parts must be stripped.' );
+		$this->assertStringNotContainsString( '<main', $content, 'The main wrapper must be stripped.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/filters-product', $content, 'Product filters composition must remain.' );
+		$this->assertStringContainsString( '"layout":"product"', $content, 'Results-list must keep the product layout.' );
+		$this->assertStringContainsString( 'wp:jetpack-search/filter-wc-price', $content, 'WC-only price filter must remain.' );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1007,39 +1007,34 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * `pattern_content_from_template()` derives a pattern's content from a page
-	 * template: it strips the page chrome (header/footer template-parts and the
-	 * `main` group wrapper) and keeps the inner alignwide content group, with the
-	 * `{{FILTER_HEADING}}` placeholder substituted.
+	 * `pattern_content_from_template()` returns the chrome-free overlay layout
+	 * ready to register as a pattern: an alignwide content group, no page chrome,
+	 * and the search blocks intact.
 	 */
-	public function test_pattern_content_from_template_strips_chrome_keeps_content() {
-		$content = Search_Blocks::pattern_content_from_template( 'jetpack-search.html' );
+	public function test_pattern_content_from_template_returns_chrome_free_layout() {
+		$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-overlay.html' );
 
 		$this->assertNotEmpty( $content, 'Content must be non-empty when the bundled template exists.' );
-		$this->assertStringStartsWith( '<!-- wp:group {"align":"wide"', $content, 'Content must start at the inner alignwide group.' );
-		$this->assertStringEndsWith( '<!-- /wp:group -->', $content, 'Content must end at the inner group close.' );
-		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Header/footer template-parts must be stripped.' );
-		$this->assertStringNotContainsString( '<main', $content, 'The main wrapper must be stripped.' );
-		$this->assertStringNotContainsString( '"tagName":"main"', $content, 'The main group comment must be stripped.' );
-		$this->assertStringNotContainsString( '{{', $content, 'Placeholders must be substituted.' );
+		$this->assertStringStartsWith( '<!-- wp:group {"align":"wide"', $content, 'Content must start at the alignwide group.' );
+		$this->assertStringEndsWith( '<!-- /wp:group -->', $content, 'Content must end at the group close.' );
+		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Overlay templates carry no template-parts.' );
+		$this->assertStringNotContainsString( '<main', $content, 'Overlay templates carry no main wrapper.' );
 		$this->assertStringContainsString( 'wp:jetpack-search/search-input', $content, 'Search input block must remain.' );
 		$this->assertStringContainsString( 'wp:jetpack-search/filters', $content, 'Sidebar filters composition must remain.' );
-		$this->assertStringContainsString( 'Filter options', $content, 'Sidebar heading placeholder must be substituted.' );
 	}
 
 	/**
-	 * The chrome-stripping works identically for the WooCommerce product template,
-	 * keeping the product-only blocks (filters-product, results-list layout=product,
-	 * filter-wc-price) intact. Guards against a future product-template restructure
-	 * that breaks the `<main>` extraction.
+	 * Same contract for the WooCommerce product overlay template, keeping the
+	 * product-only blocks (filters-product, results-list layout=product,
+	 * filter-wc-price) intact.
 	 */
-	public function test_pattern_content_from_template_strips_chrome_for_product_template() {
-		$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-product-results.html' );
+	public function test_pattern_content_from_template_returns_product_layout() {
+		$content = Search_Blocks::pattern_content_from_template( 'jetpack-search-overlay-product.html' );
 
 		$this->assertNotEmpty( $content, 'Content must be non-empty when the bundled product template exists.' );
-		$this->assertStringStartsWith( '<!-- wp:group {"align":"wide"', $content, 'Content must start at the inner alignwide group.' );
-		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Header/footer template-parts must be stripped.' );
-		$this->assertStringNotContainsString( '<main', $content, 'The main wrapper must be stripped.' );
+		$this->assertStringStartsWith( '<!-- wp:group {"align":"wide"', $content, 'Content must start at the alignwide group.' );
+		$this->assertStringNotContainsString( 'wp:template-part', $content, 'Overlay templates carry no template-parts.' );
+		$this->assertStringNotContainsString( '<main', $content, 'Overlay templates carry no main wrapper.' );
 		$this->assertStringContainsString( 'wp:jetpack-search/filters-product', $content, 'Product filters composition must remain.' );
 		$this->assertStringContainsString( '"layout":"product"', $content, 'Results-list must keep the product layout.' );
 		$this->assertStringContainsString( 'wp:jetpack-search/filter-wc-price', $content, 'WC-only price filter must remain.' );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1041,12 +1041,29 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Missing template file yields an empty string — `register_block_pattern()`
-	 * tolerates empty content, so a bad path degrades to a no-op pattern rather
-	 * than a fatal.
+	 * Missing template file yields an empty string — the pattern files skip
+	 * registration on empty content, so a bad path registers no pattern rather
+	 * than a blank one or a fatal.
 	 */
 	public function test_pattern_content_from_template_returns_empty_on_missing_file() {
 		$this->assertSame( '', Search_Blocks::pattern_content_from_template( 'does-not-exist.html' ) );
+	}
+
+	/**
+	 * The bundled pattern files register their patterns with the derived,
+	 * non-empty content from their layout templates.
+	 */
+	public function test_pattern_files_register_their_patterns() {
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+		$patterns = __DIR__ . '/../../src/search-blocks/patterns';
+
+		require $patterns . '/blog-search.php';
+		require $patterns . '/wc-product-search.php';
+
+		foreach ( array( 'jetpack-search/blog-search-page', 'jetpack-search/wc-product-search-page' ) as $name ) {
+			$this->assertTrue( $registry->is_registered( $name ), "Pattern $name must be registered." );
+			$this->assertNotEmpty( $registry->get_registered( $name )['content'], "Pattern $name must have content." );
+		}
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1061,8 +1061,11 @@ class Search_Blocks_Test extends TestCase {
 		require $patterns . '/wc-product-search.php';
 
 		foreach ( array( 'jetpack-search/blog-search-page', 'jetpack-search/wc-product-search-page' ) as $name ) {
-			$this->assertTrue( $registry->is_registered( $name ), "Pattern $name must be registered." );
-			$this->assertNotEmpty( $registry->get_registered( $name )['content'], "Pattern $name must have content." );
+			$pattern = $registry->get_registered( $name );
+			$this->assertIsArray( $pattern, "Pattern $name must be registered." );
+			if ( is_array( $pattern ) ) {
+				$this->assertNotEmpty( $pattern['content'], "Pattern $name must have content." );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-291

## Why

Authors who insert the **Blog Search Page** pattern got a stale layout: it had drifted from its page template (`jetpack-search.html`), missing the results-toolbar filters-popover, the `filters` composition wrapper in the sidebar, the shared `jetpack-search-layout__*` responsive classes, and the `currentColor` border hairline. And there was no pattern at all for the product-search template, so a store had no full-page product-search layout to drop in. The patterns and templates carried two hand-copied copies of the same layout — which is exactly how the drift happened.

## Proposed changes

* Add `Search_Blocks::pattern_content_from_template()` — derives a pattern's content from a page template, stripping the page chrome (header/footer template-parts + the `main` group wrapper) while keeping the inner `align:wide` content group, with `{{FILTER_HEADING}}` substituted.
* Point `patterns/blog-search.php` at the helper (`jetpack-search.html`) instead of its hand-copied markup — it now carries the toolbar popover, the `filters` composition, the layout classes, and the currentColor border.
* Add `patterns/wc-product-search.php` — a new "Product Search Page" pattern derived from `jetpack-search-product-results.html`. The `wc-` filename prefix gates it through `register_patterns()` so it only loads when WooCommerce is active (same mechanism as the existing `wc-*` patterns).
* Cover the helper with unit tests (chrome stripped, alignwide kept, placeholder substituted, missing-file → empty string).

The patterns are now a single source of truth with the templates they mirror — no second copy to drift.

## Verification

Both patterns register with correctly-derived content on a WooCommerce-active block-theme site (twentytwentyfive); rendered output is the template layout minus page chrome.

<details>
<summary>Output — both patterns registered, chrome stripped, alignwide preserved</summary>

```text
$ wp eval '... WP_Block_Patterns_Registry ...'
jetpack-search/blog-search-page : registered, 2502 bytes
   title: Blog Search Page
   starts alignwide: yes
   has template-part: no
jetpack-search/wc-product-search-page : registered, 2993 bytes
   title: Product Search Page
   starts alignwide: yes
   has template-part: no
```

</details>

<details>
<summary>Output — unit tests</summary>

```text
$ composer phpunit -- --filter 'Search_Blocks_Test'
OK, but some tests were skipped!
Tests: 124, Assertions: 333, Skipped: 1
```

</details>

## Does this pull request change what data or activity we track or use?

No.

## Related product discussion/links

* [SEARCH-291](https://linear.app/a8c/issue/SEARCH-291)

## Testing instructions

* On a block theme (e.g. Twenty Twenty-Five) with Jetpack Search active, open the post/site editor and the pattern inserter.
* [ ] The **Blog Search Page** pattern's markup matches `jetpack-search.html` (minus page chrome) — toolbar filters-popover, `filters` composition in the sidebar, `jetpack-search-layout__*` classes, currentColor border hairline.
* [ ] With WooCommerce active, a **Product Search Page** pattern is present in the inserter and renders the product layout (product filters + product result grid).
* [ ] With WooCommerce inactive, the **Product Search Page** pattern is absent from the inserter.
* [ ] Both patterns insert with `align:wide`.
* [ ] No inline layout markup is duplicated between the template `.html` files and these two pattern PHP files.
