### PR TITLE
Search Blocks: product-search edit/restore link follows the active experience; mark pre-GA surfaces Beta

### DIFF
--- a/projects/packages/search/changelog/echo-search-292-product-search-edit-restore-link
+++ b/projects/packages/search/changelog/echo-search-292-product-search-edit-restore-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: the product-search edit link now follows the active experience — "Edit the product Search overlay" for Overlay (blocks), "Edit the product search template" otherwise — and pairs with a Restore default that acts on the matching template. The product-search toggle and the Embedded experience are now marked Beta.

--- a/projects/packages/search/src/dashboard/components/experience-selector/constants.js
+++ b/projects/packages/search/src/dashboard/components/experience-selector/constants.js
@@ -19,13 +19,14 @@ export const EXPERIENCE = Object.freeze( {
 } );
 
 /**
- * Display order on the dashboard. Embedded leads (RECOMMENDED), then the
+ * Display order on the dashboard. Embedded leads (BETA), then the
  * preact Overlay (the mature choice), then the blocks-powered Overlay
  * (BETA) as a sibling — both overlays are first-class peers, not
  * predecessor/successor. Theme search, then Off, follow.
  *
- * The BETA card intentionally sits *after* the preact one so the visual
- * hierarchy doesn't push site owners toward the not-yet-mature path.
+ * The blocks-powered Overlay card intentionally sits *after* the preact
+ * one so the visual hierarchy doesn't push site owners toward the
+ * not-yet-mature path.
  *
  * `OVERLAY_BLOCKS` is filtered out at render time on sites where the
  * `jetpack_search_overlay_block_template_enabled` server flag is pinned

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -120,7 +120,6 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 		activeThemeStylesheet,
 		isBlockTheme,
 		blockTemplateOverlay,
-		productOverlayTemplate,
 		searchTemplate,
 	} = useSelect(
 		select => ( {
@@ -129,7 +128,6 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 			activeThemeStylesheet: select( STORE_ID ).getActiveThemeStylesheet(),
 			isBlockTheme: select( STORE_ID ).isBlockTheme(),
 			blockTemplateOverlay: select( STORE_ID ).getBlockTemplateOverlayConfig(),
-			productOverlayTemplate: select( STORE_ID ).getProductOverlayTemplateConfig(),
 			searchTemplate: select( STORE_ID ).getSearchTemplateConfig(),
 		} ),
 		[]
@@ -258,30 +256,10 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 				/>
 			) }
 			{ /*
-			   The product overlay is a Woo-only variant rendered on a product
-			   search; its editor only surfaces on Woo stores (the PHP gate
-			   nulls `editorUrl` off Woo), so render the second action group
-			   conditionally rather than as a perpetually-muted link.
+			   The product-overlay variant's "Edit … / Restore default" lives on
+			   the WooCommerce product-search toggle in Settings (gated by the
+			   override), not here — keeping it on the card too would duplicate it.
 			*/ }
-			{ experience === EXPERIENCE.OVERLAY_BLOCKS && productOverlayTemplate.editorUrl && (
-				<SingletonTemplateActions
-					config={ productOverlayTemplate }
-					editLabel={ __( 'Edit the product Search overlay', 'jetpack-search-pkg' ) }
-					restoreConfirmMessage={ __(
-						'Restore the bundled product Search overlay template? Your customizations will be deleted.',
-						'jetpack-search-pkg'
-					) }
-					successMessage={ __(
-						'The product Search overlay template has been restored to the bundled default.',
-						'jetpack-search-pkg'
-					) }
-					errorMessage={ __(
-						'Could not restore the product Search overlay template.',
-						'jetpack-search-pkg'
-					) }
-					linksDisabled={ linksDisabled }
-				/>
-			) }
 			{ experience === EXPERIENCE.OVERLAY && (
 				<Stack
 					direction="row"

--- a/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
+++ b/projects/packages/search/src/dashboard/components/experience-selector/experience-option.jsx
@@ -138,8 +138,7 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 	const [ isConfirmOpen, setConfirmOpen ] = useState( false );
 
 	const isActive = active === experience;
-	const isRecommended = experience === EXPERIENCE.EMBEDDED;
-	const isBeta = experience === EXPERIENCE.OVERLAY_BLOCKS;
+	const isBeta = experience === EXPERIENCE.OVERLAY_BLOCKS || experience === EXPERIENCE.EMBEDDED;
 	const linksDisabled = isUpdating || ! isActive;
 
 	const Preview = PREVIEWS[ experience ];
@@ -183,9 +182,6 @@ export default function ExperienceOption( { experience, disabled = false } ) {
 					<h3 id={ titleId } className="jp-search-experience-option__title">
 						{ getCardTitle( experience ) }
 					</h3>
-					{ isRecommended && (
-						<Badge intent="informational">{ __( 'Recommended', 'jetpack-search-pkg' ) }</Badge>
-					) }
 					{ isBeta && <Badge intent="informational">{ __( 'Beta', 'jetpack-search-pkg' ) }</Badge> }
 				</Stack>
 				<CardCopy experience={ experience } />

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -215,23 +215,58 @@ export default function DashboardPage( { isLoading = false } ) {
 	const productOverlayTemplate = useSelect( select =>
 		select( STORE_ID ).getProductOverlayTemplateConfig()
 	);
-	// The Overlay edits its product template via the singleton CPT (post.php, any
-	// theme); Embedded/Inline edit the product-results page template — Site Editor
-	// on block themes, the Product_Search_Template CPT on classic themes. CPT URLs
-	// are null for non-admins, so the control's `editTemplateUrl && …` guard hides
-	// the link.
+	// The edit affordance follows the active experience. Overlay (blocks) edits its
+	// product template via the singleton CPT (post.php, any theme) and gets a
+	// "Restore default". Embedded/Inline edit the product-results page template —
+	// the Site Editor on block themes (which owns its own revert, so no restore
+	// link there), the Product_Search_Template singleton CPT on classic themes.
+	// Singleton editor URLs are null for non-admins, so `SingletonTemplateActions`
+	// disables the link in that state.
 	const isProductOverlayExperience = activeExperience === EXPERIENCE.OVERLAY_BLOCKS;
-	let wooProductSearchEditUrl;
+	let wooProductTemplate;
 	if ( isProductOverlayExperience ) {
-		wooProductSearchEditUrl = productOverlayTemplate.editorUrl;
+		wooProductTemplate = {
+			templateConfig: productOverlayTemplate,
+			editTemplateUrl: null,
+			editLabel: __( 'Edit the product Search overlay', 'jetpack-search-pkg' ),
+			restoreConfirmMessage: __(
+				'Restore the bundled product Search overlay template? Your customizations will be deleted.',
+				'jetpack-search-pkg'
+			),
+			successMessage: __(
+				'The product Search overlay template has been restored to the bundled default.',
+				'jetpack-search-pkg'
+			),
+			errorMessage: __(
+				'Could not restore the product Search overlay template.',
+				'jetpack-search-pkg'
+			),
+		};
 	} else if ( isBlockTheme ) {
-		wooProductSearchEditUrl = activeThemeStylesheet
-			? `${ siteAdminUrl }site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
-					activeThemeStylesheet
-			  ) }%2F%2Fjetpack-search-product-results&canvas=edit`
-			: `${ siteAdminUrl }site-editor.php?p=%2Ftemplate`;
+		wooProductTemplate = {
+			templateConfig: null,
+			editTemplateUrl: activeThemeStylesheet
+				? `${ siteAdminUrl }site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
+						activeThemeStylesheet
+				  ) }%2F%2Fjetpack-search-product-results&canvas=edit`
+				: `${ siteAdminUrl }site-editor.php?p=%2Ftemplate`,
+			editLabel: __( 'Edit the product search template', 'jetpack-search-pkg' ),
+		};
 	} else {
-		wooProductSearchEditUrl = productSearchTemplate.editorUrl;
+		wooProductTemplate = {
+			templateConfig: productSearchTemplate,
+			editTemplateUrl: null,
+			editLabel: __( 'Edit the product search template', 'jetpack-search-pkg' ),
+			restoreConfirmMessage: __(
+				'Restore the bundled product search template? Your customizations will be deleted.',
+				'jetpack-search-pkg'
+			),
+			successMessage: __(
+				'The product search template has been restored to the bundled default.',
+				'jetpack-search-pkg'
+			),
+			errorMessage: __( 'Could not restore the product search template.', 'jetpack-search-pkg' ),
+		};
 	}
 	const showAIAgentAccessGuidelinesLink =
 		! isReaderChatAvailable ||
@@ -397,7 +432,12 @@ export default function DashboardPage( { isLoading = false } ) {
 																isEnabled={ isWooCommerceSearchTemplateOverrideEnabled }
 																isSaving={ isSavingEitherOption }
 																updateOptions={ updateOptions }
-																editTemplateUrl={ wooProductSearchEditUrl }
+																templateConfig={ wooProductTemplate.templateConfig }
+																editTemplateUrl={ wooProductTemplate.editTemplateUrl }
+																editLabel={ wooProductTemplate.editLabel }
+																restoreConfirmMessage={ wooProductTemplate.restoreConfirmMessage }
+																successMessage={ wooProductTemplate.successMessage }
+																errorMessage={ wooProductTemplate.errorMessage }
 															/>
 														</div>
 													) }

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -308,7 +308,7 @@ describe( 'DashboardPage', () => {
 		);
 	} );
 
-	test( 'routes editTemplateUrl through the singleton CPT on classic themes', () => {
+	test( 'routes templateConfig through the singleton CPT on classic themes', () => {
 		// Regression guard for SEARCH-259's classic-theme fix: a classic
 		// theme has no Site Editor, so the Site Editor URL is a dead link.
 		// `dashboard-page.jsx` branches on `isBlockTheme` and routes to
@@ -333,7 +333,11 @@ describe( 'DashboardPage', () => {
 		fireEvent.click( screen.getByRole( 'tab', { name: /settings/i } ) );
 
 		expect( mockWooCommerceProductSearchControl ).toHaveBeenCalledWith(
-			expect.objectContaining( { editTemplateUrl: cptEditorUrl } )
+			expect.objectContaining( {
+				templateConfig: expect.objectContaining( { editorUrl: cptEditorUrl } ),
+				editTemplateUrl: null,
+				editLabel: 'Edit the product search template',
+			} )
 		);
 	} );
 
@@ -349,7 +353,7 @@ describe( 'DashboardPage', () => {
 		expect( mockWooCommerceProductSearchControl ).not.toHaveBeenCalled();
 	} );
 
-	test( 'renders WooCommerceProductSearchControl for the blocks Overlay experience and routes editTemplateUrl to the product overlay CPT', () => {
+	test( 'renders WooCommerceProductSearchControl for the blocks Overlay experience and routes templateConfig to the product overlay CPT', () => {
 		// SEARCH-287: the blocks Overlay now reads the same
 		// `override_woocommerce_search_template` option, so the toggle surfaces
 		// here too — with the edit link pointed at the product overlay CPT
@@ -379,7 +383,11 @@ describe( 'DashboardPage', () => {
 
 		expect( screen.getByTestId( 'woocommerce-product-search-control' ) ).toBeInTheDocument();
 		expect( mockWooCommerceProductSearchControl ).toHaveBeenCalledWith(
-			expect.objectContaining( { editTemplateUrl: overlayCptEditorUrl } )
+			expect.objectContaining( {
+				templateConfig: expect.objectContaining( { editorUrl: overlayCptEditorUrl } ),
+				editTemplateUrl: null,
+				editLabel: 'Edit the product Search overlay',
+			} )
 		);
 	} );
 

--- a/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/index.jsx
@@ -1,9 +1,10 @@
 import analytics from '@automattic/jetpack-analytics';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Badge, Stack } from '@wordpress/ui';
+import { Badge } from '@wordpress/ui';
 import { useCallback } from 'react';
 import SingletonTemplateActions from '../experience-selector/singleton-template-actions';
+import './style.scss';
 
 const WOOCOMMERCE_PRODUCT_SEARCH_DESCRIPTION = __(
 	"Render product searches through Jetpack Search's filtered results page instead of WooCommerce's default product search template.",
@@ -56,17 +57,19 @@ export default function WooCommerceProductSearchControl( {
 	return (
 		<div className="jp-form-search-settings-group__toggle is-woocommerce-product-search jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
-				<Stack direction="row" gap="sm" align="center">
-					<ToggleControl
-						checked={ !! isEnabled }
-						disabled={ isSaving }
-						onChange={ toggle }
-						className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
-						label={ __( 'Use Jetpack Search for product search results', 'jetpack-search-pkg' ) }
-						__nextHasNoMarginBottom={ true }
-					/>
-					<Badge intent="informational">{ __( 'Beta', 'jetpack-search-pkg' ) }</Badge>
-				</Stack>
+				<ToggleControl
+					checked={ !! isEnabled }
+					disabled={ isSaving }
+					onChange={ toggle }
+					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
+					label={
+						<span className="jp-form-search-settings-group__toggle-label-with-badge">
+							{ __( 'Use Jetpack Search for product search results', 'jetpack-search-pkg' ) }
+							<Badge intent="informational">{ __( 'Beta', 'jetpack-search-pkg' ) }</Badge>
+						</span>
+					}
+					__nextHasNoMarginBottom={ true }
+				/>
 			</div>
 			<div className="jp-search-dashboard-row">
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">

--- a/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/index.jsx
@@ -1,7 +1,9 @@
 import analytics from '@automattic/jetpack-analytics';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge, Stack } from '@wordpress/ui';
 import { useCallback } from 'react';
+import SingletonTemplateActions from '../experience-selector/singleton-template-actions';
 
 const WOOCOMMERCE_PRODUCT_SEARCH_DESCRIPTION = __(
 	"Render product searches through Jetpack Search's filtered results page instead of WooCommerce's default product search template.",
@@ -11,18 +13,36 @@ const WOOCOMMERCE_PRODUCT_SEARCH_DESCRIPTION = __(
 /**
  * Opt-in toggle for the `override_woocommerce_search_template` setting.
  *
- * @param {object}   props                 - Component properties.
- * @param {boolean}  props.isEnabled       - Whether the override is enabled.
- * @param {boolean}  props.isSaving        - Whether settings are being saved.
- * @param {Function} props.updateOptions   - Function to update settings.
- * @param {string}   props.editTemplateUrl - Site Editor URL for the product-search template.
+ * The edit affordance follows the active experience. Overlay (blocks) and
+ * classic-theme Embedded/Inline route through a singleton CPT, so they get the
+ * `SingletonTemplateActions` "Edit … →" + "Restore default" pair. Block-theme
+ * Embedded/Inline edits its product-results page template in the Site Editor,
+ * which owns its own revert — so that arm is a plain external link with no
+ * restore. The parent decides which arm applies and passes `templateConfig`
+ * (singleton) or `editTemplateUrl` (Site Editor) accordingly.
+ *
+ * @param {object}      props                       - Component properties.
+ * @param {boolean}     props.isEnabled             - Whether the override is enabled.
+ * @param {boolean}     props.isSaving              - Whether settings are being saved.
+ * @param {Function}    props.updateOptions         - Function to update settings.
+ * @param {object|null} props.templateConfig        - Singleton-template `{editorUrl, postType, isCustomized}` blob for the active mode, or null when the target is the Site Editor.
+ * @param {string}      props.editTemplateUrl       - Site Editor URL — used only when `templateConfig` is null.
+ * @param {string}      props.editLabel             - Visible label for the "Edit …" link.
+ * @param {string}      props.restoreConfirmMessage - Confirm-dialog body for "Restore default".
+ * @param {string}      props.successMessage        - Notice posted after a successful reset.
+ * @param {string}      props.errorMessage          - Notice posted when a reset fails.
  * @return {import('react').Component} WooCommerce product search settings component.
  */
 export default function WooCommerceProductSearchControl( {
 	isEnabled,
 	isSaving,
 	updateOptions,
+	templateConfig,
 	editTemplateUrl,
+	editLabel,
+	restoreConfirmMessage,
+	successMessage,
+	errorMessage,
 } ) {
 	const toggle = useCallback( () => {
 		const newOption = { override_woocommerce_search_template: ! isEnabled };
@@ -36,25 +56,36 @@ export default function WooCommerceProductSearchControl( {
 	return (
 		<div className="jp-form-search-settings-group__toggle is-woocommerce-product-search jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
-				<ToggleControl
-					checked={ !! isEnabled }
-					disabled={ isSaving }
-					onChange={ toggle }
-					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
-					label={ __( 'Use Jetpack Search for product search results', 'jetpack-search-pkg' ) }
-					__nextHasNoMarginBottom={ true }
-				/>
+				<Stack direction="row" gap="sm" align="center">
+					<ToggleControl
+						checked={ !! isEnabled }
+						disabled={ isSaving }
+						onChange={ toggle }
+						className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
+						label={ __( 'Use Jetpack Search for product search results', 'jetpack-search-pkg' ) }
+						__nextHasNoMarginBottom={ true }
+					/>
+					<Badge intent="informational">{ __( 'Beta', 'jetpack-search-pkg' ) }</Badge>
+				</Stack>
 			</div>
 			<div className="jp-search-dashboard-row">
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ WOOCOMMERCE_PRODUCT_SEARCH_DESCRIPTION }
 					</p>
-					{ isEnabled && editTemplateUrl && (
+					{ isEnabled && templateConfig && (
+						<SingletonTemplateActions
+							config={ templateConfig }
+							editLabel={ editLabel }
+							restoreConfirmMessage={ restoreConfirmMessage }
+							successMessage={ successMessage }
+							errorMessage={ errorMessage }
+							linksDisabled={ isSaving }
+						/>
+					) }
+					{ isEnabled && ! templateConfig && editTemplateUrl && (
 						<p className="jp-form-search-settings-group__toggle-explanation">
-							<ExternalLink href={ editTemplateUrl }>
-								{ __( 'Edit the product search template', 'jetpack-search-pkg' ) }
-							</ExternalLink>
+							<ExternalLink href={ editTemplateUrl }>{ editLabel }</ExternalLink>
 						</p>
 					) }
 				</div>

--- a/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/style.scss
+++ b/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/style.scss
@@ -1,0 +1,6 @@
+.jp-form-search-settings-group__toggle-label-with-badge {
+	display: inline-flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+}

--- a/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/woocommerce-product-search-control/test/index.test.jsx
@@ -11,16 +11,29 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 
 jest.mock( '@wordpress/components', () => ( {
 	__esModule: true,
+	// `label` is a JSX node (text + Badge), so render it as a child of a
+	// wrapping <label> — the accessible name resolves from the label's text
+	// content. Passing a JSX node to `aria-label` would stringify to
+	// "[object Object]" and break the name-based queries below.
 	ToggleControl: ( { checked, disabled, label, onChange } ) => (
-		<input
-			type="checkbox"
-			checked={ !! checked }
-			disabled={ !! disabled }
-			aria-label={ label }
-			onChange={ event => onChange( event.target.checked ) }
-		/>
+		<label htmlFor="mock-toggle-control">
+			<input
+				id="mock-toggle-control"
+				type="checkbox"
+				checked={ !! checked }
+				disabled={ !! disabled }
+				onChange={ event => onChange( event.target.checked ) }
+			/>
+			{ label }
+		</label>
 	),
 	ExternalLink: ( { href, children } ) => <a href={ href }>{ children }</a>,
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Badge: ( { children } ) => <span>{ children }</span>,
+	Stack: ( { children } ) => <div>{ children }</div>,
 } ) );
 
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -86,6 +99,12 @@ describe( 'WooCommerceProductSearchControl', () => {
 		} );
 	} );
 
+	test( 'marks the toggle with a Beta badge', () => {
+		render( <WooCommerceProductSearchControl { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
+	} );
+
 	test( 'disables the toggle while saving', () => {
 		render( <WooCommerceProductSearchControl { ...defaultProps } isSaving /> );
 
@@ -94,15 +113,25 @@ describe( 'WooCommerceProductSearchControl', () => {
 
 	test( 'shows the edit-template link only when enabled', () => {
 		const url = 'https://example.com/wp-admin/site-editor.php?p=x';
+		const editLabel = 'Edit the product search template';
 		const { rerender } = render(
-			<WooCommerceProductSearchControl { ...defaultProps } editTemplateUrl={ url } />
+			<WooCommerceProductSearchControl
+				{ ...defaultProps }
+				editTemplateUrl={ url }
+				editLabel={ editLabel }
+			/>
 		);
 		expect(
 			screen.queryByRole( 'link', { name: /edit the product search template/i } )
 		).not.toBeInTheDocument();
 
 		rerender(
-			<WooCommerceProductSearchControl { ...defaultProps } isEnabled editTemplateUrl={ url } />
+			<WooCommerceProductSearchControl
+				{ ...defaultProps }
+				isEnabled
+				editTemplateUrl={ url }
+				editLabel={ editLabel }
+			/>
 		);
 		expect(
 			screen.getByRole( 'link', { name: /edit the product search template/i } )

--- a/projects/packages/search/tests/js/dashboard/experience-selector/experience-option.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/experience-selector/experience-option.test.jsx
@@ -41,9 +41,9 @@ describe( '<ExperienceOption>', () => {
 		).toBeInTheDocument();
 	} );
 
-	test( 'shows RECOMMENDED badge only on Embedded', () => {
+	test( 'shows BETA badge on Embedded, not on the legacy Overlay', () => {
 		const { rerender } = renderWith( baseSettings, { experience: 'embedded' } );
-		expect( screen.getByText( 'Recommended' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Beta' ) ).toBeInTheDocument();
 
 		const registry2 = createRegistry();
 		const store2 = createReduxStore( STORE_ID, {
@@ -56,7 +56,7 @@ describe( '<ExperienceOption>', () => {
 				<ExperienceOption experience="overlay" />
 			</RegistryProvider>
 		);
-		expect( screen.queryByText( 'Recommended' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Beta' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows ACTIVE badge on the active card and no commit button', () => {

--- a/projects/plugins/search/changelog/echo-search-292-product-search-edit-restore-link
+++ b/projects/plugins/search/changelog/echo-search-292-product-search-edit-restore-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search Blocks: the product-search edit link now follows the active experience — "Edit the product Search overlay" for Overlay (blocks), "Edit the product search template" otherwise — and pairs with a Restore default that acts on the matching template. The product-search toggle and the Embedded experience are now marked Beta.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-292

## Why

In the Search dashboard Settings tab, the **"Use Jetpack Search for product search results"** toggle showed a single hard-coded link — *"Edit the product search template"* — regardless of which search experience was active, and gave admins no way to revert a customized template. When the active experience is **Overlay (blocks)** the product search actually renders the *product Search overlay* template, so the label pointed at the wrong thing. Now the link follows the active experience and pairs with a **Restore default** that acts on the matching template. The product-search toggle and the Embedded experience are also marked **Beta** to reflect their pre-GA status.

## Proposed changes

* The product-search edit link now follows the active experience:
  * **Overlay (blocks)** → "Edit the product Search overlay →" (singleton-CPT editor) + **Restore default**.
  * **Embedded / Theme search on a classic theme** → "Edit the product search template →" (singleton-CPT editor) + **Restore default**.
  * **Embedded / Theme search on a block theme** → "Edit the product search template ↗" (Site Editor; the editor owns its own revert, so no Restore default).
* **Restore default** issues `DELETE jetpack/v4/search/templates/{postType}` against the template that matches the active mode, reusing the existing `SingletonTemplateActions` component.
* Added a **Beta** badge beside the "Use Jetpack Search for product search results" toggle.
* Changed the **Embedded search** experience card badge from **Recommended** to **Beta**.
* Removed the now-duplicate "Edit the product Search overlay" / Restore default from the **Overlay (blocks)** card — the Settings toggle owns that affordance (the card keeps its general "Edit the Search overlay").

## Screenshots

### Product-search toggle (Overlay blocks mode)

| Before | After |
|---|---|
| ![control before](https://github.com/user-attachments/assets/e9b8f3a1-3711-4afb-a92c-d71c7e537c3a) | ![control after](https://github.com/user-attachments/assets/9d9c1c65-246a-4665-8362-f0177466bcd9) |

Before: no badge, link mislabeled "Edit the product search template" while in Overlay mode, no restore. After: "Beta" badge, correct "Edit the product Search overlay →" with a Restore default once customized.

### Embedded experience card

| Before | After |
|---|---|
| ![card before](https://github.com/user-attachments/assets/fce41abf-335b-4648-8ef6-ea939b5cccba) | ![card after](https://github.com/user-attachments/assets/2d22ed52-706f-4c2f-b2b3-913cede6f4ee) |

### Per-mode link, Restore default, and off-state

| State | Screenshot |
|---|---|
| Embedded / Theme search, **classic** theme → card-link "Edit the product search template →" | ![classic](https://github.com/user-attachments/assets/44fd83b4-0294-400c-aff9-66a331f3d474) |
| Overlay (blocks), template customized → "Restore default →" appears | ![restore link](https://github.com/user-attachments/assets/06882cd9-1de1-45e8-ad2d-8784b452d0e2) |
| "Restore default" confirm dialog (mode-specific copy) | ![restore dialog](https://github.com/user-attachments/assets/10db1668-eeae-493b-a641-02a36076628c) |
| Override **off** → Beta badge stays, no edit/restore link | ![off](https://github.com/user-attachments/assets/deca4d04-a1c5-4b3d-a348-6caf37f49816) |

## Related product discussion/links

* SEARCH-292 — https://linear.app/a8c/issue/SEARCH-292

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a WooCommerce-active site with Jetpack Search Blocks enabled, open **Jetpack → Search → Settings** and enable the "Use Jetpack Search for product search results" toggle, then verify each acceptance criterion:

* [ ] Override ON + **Overlay (blocks)** active: link reads "Edit the product Search overlay →"; "Restore default" appears once the overlay template is customized and reverts the **product overlay** template.
* [ ] Override ON + **Embedded / Theme search** on a **classic** theme: link reads "Edit the product search template →"; "Restore default" reverts the **product search** template.
* [ ] Override ON + **Embedded / Theme search** on a **block** theme: link reads "Edit the product search template ↗", opens the Site Editor product-results template; no Restore default.
* [ ] "Restore default" hits `DELETE jetpack/v4/search/templates/{postType}` for the template matching the active mode, shows the success notice, and hides itself after success.
* [ ] A **Beta** badge shows beside the "Use Jetpack Search for product search results" toggle.
* [ ] The **Embedded search** card shows **Beta** (not Recommended); the Overlay (blocks) card still shows **Beta**.
* [ ] No edit/restore link renders when the override is OFF.

### Product-template overtake — unchanged, verified across experiences

This change is **admin-React only** (dashboard components + changelog); it touches no server-side override/routing code, so the product-template overtake is byte-identical to trunk. Verified on a WooCommerce store against `/?s=hair&post_type=product`:

<details>
<summary>Front-end overtake results</summary>

| Experience | Override ON | Override OFF |
|---|---|---|
| Embedded | Jetpack Search blocks take over the product results page (`wp-block-jetpack-search`, no WC default loop) | WC default product loop returns |
| Overlay (blocks) | Jetpack Search overlay paints over the product archive | overlay still present (the override selects the product vs. general overlay variant) |
| Theme search (inline) | theme-rendered results, ES-backed (no blocks markup, by design) | theme default |

The toggle itself was driven through the UI (ON → OFF → ON): it persists `override_woocommerce_search_template` via `POST /jetpack/v4/search/settings`, and the edit/restore links correctly appear/disappear with the toggle state.

</details>
