### PR TITLE
Search Blocks: strip post_type alias on close so product searches reset cleanly

### DIFF
--- a/projects/packages/search/changelog/search-293-overlay-close-strip-post-type
+++ b/projects/packages/search/changelog/search-293-overlay-close-strip-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: strip the scalar `post_type` alias when closing the blocks Overlay so a product-scoped search resets the URL cleanly instead of leaving `?post_type=…` behind.

--- a/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
+++ b/projects/packages/search/src/search-blocks/overlay-bootstrap/test/index.test.js
@@ -254,6 +254,15 @@ describe( 'overlay-bootstrap close URL behavior', () => {
 		expect( console ).toHaveErrored();
 	} );
 
+	it( 'strips the scalar post_type alias on a product search close', async () => {
+		await closeFrom( '/?s=shirt&post_type=product' );
+
+		const params = new URLSearchParams( window.location.search );
+		expect( params.has( 's' ) ).toBe( false );
+		expect( params.has( 'post_type' ) ).toBe( false );
+		expect( console ).toHaveErrored();
+	} );
+
 	it( 'preserves non-search params and the hash', async () => {
 		await closeFrom( '/page/?s=hello&utm_source=twitter#anchor' );
 

--- a/projects/packages/search/src/search-blocks/store/test/url-state.test.js
+++ b/projects/packages/search/src/search-blocks/store/test/url-state.test.js
@@ -1,0 +1,39 @@
+import { getSearchOwnedParamKeys } from '../url-state';
+
+/**
+ * Wrap a query string in `URLSearchParams` for the function under test.
+ *
+ * @param {string} query - Query string without the leading `?`.
+ * @return {URLSearchParams} Parsed params.
+ */
+function params( query ) {
+	return new URLSearchParams( query );
+}
+
+describe( 'getSearchOwnedParamKeys', () => {
+	it( 'claims reserved params', () => {
+		const owned = getSearchOwnedParamKeys(
+			params( 's=shirt&orderby=newest&min_price=5&max_price=50' )
+		);
+		expect( owned.sort() ).toEqual( [ 'max_price', 'min_price', 'orderby', 's' ] );
+	} );
+
+	it( 'claims array-shaped filter and query_type params', () => {
+		const owned = getSearchOwnedParamKeys( params( 'category[]=news&query_type_category=and' ) );
+		expect( owned.sort() ).toEqual( [ 'category[]', 'query_type_category' ] );
+	} );
+
+	it( 'claims the scalar post_type alias the writer never emits', () => {
+		const owned = getSearchOwnedParamKeys( params( 's=shirt&post_type=product' ) );
+		expect( owned.sort() ).toEqual( [ 'post_type', 's' ] );
+	} );
+
+	it( 'leaves unrelated third-party params alone', () => {
+		const owned = getSearchOwnedParamKeys( params( 's=shirt&utm_source=twitter&page_id=12' ) );
+		expect( owned ).toEqual( [ 's' ] );
+	} );
+
+	it( 'returns an empty array when no search params are present', () => {
+		expect( getSearchOwnedParamKeys( params( 'utm_source=twitter' ) ) ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -30,6 +30,11 @@ const RESERVED_PARAMS = new Set( [ 's', 'q', 'orderby', 'min_price', 'max_price'
 // WooCommerce's `product-filter-attribute` convention.
 const QUERY_TYPE_PREFIX = 'query_type_';
 
+// Scalar params Search *reads* but never *writes* (`urlParamsToState` consumes
+// them; `stateToUrlParams` emits the array form instead). Listed so the close
+// stripper can clear them — the writer-shape detection alone would miss them.
+const READ_ALIAS_PARAMS = new Set( [ 'post_type' ] );
+
 /**
  * Parse `min_price`/`max_price` into a finite non-negative number or null.
  *
@@ -262,15 +267,15 @@ export function urlParamsToState(
 /**
  * Identify URL params owned by Search Blocks state. Used when leaving the
  * search experience (overlay close) to clear the URL the same way legacy
- * Instant Search's `restorePreviousHref()` does. The bootstrap layer can't
- * reach into `filterConfigs`, so we identify filter params by the URL shapes
- * the writer (`stateToUrlParams`) emits — array-suffixed and `query_type_`-
- * prefixed — which covers every key the store can have round-tripped.
+ * Instant Search's `restorePreviousHref()` does — strip everything Search
+ * reads, not only what it writes. We identify those params by the reserved
+ * set, the URL shapes the writer (`stateToUrlParams`) emits — array-suffixed
+ * and `query_type_`-prefixed — and the read-only scalar aliases the reader
+ * consumes (`post_type`), which together cover every key the store round-trips.
  *
  * Static filter scalars are not stripped here: they share `?key=value` shape
  * with arbitrary non-search params and the bootstrap has no filter registry to
- * disambiguate. The reserved set + array shape + query_type prefix is what
- * legacy strips for the default close path.
+ * disambiguate.
  *
  * @param {URLSearchParams} params - URL params to scan.
  * @return {string[]} Unique keys present in `params` that Search owns.
@@ -280,6 +285,7 @@ export function getSearchOwnedParamKeys( params ) {
 	for ( const rawKey of params.keys() ) {
 		if (
 			RESERVED_PARAMS.has( rawKey ) ||
+			READ_ALIAS_PARAMS.has( rawKey ) ||
 			rawKey.startsWith( QUERY_TYPE_PREFIX ) ||
 			rawKey.endsWith( '[]' )
 		) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-293

## Why

On a WooCommerce store, a product search opens the blocks-powered Search Overlay over a URL like `/?s=shirt&post_type=product`. Closing the overlay is supposed to drop the visitor back on a clean page, but it only stripped `s` and left `/?post_type=product` behind — so the shopper landed on a bare product archive with a stale, search-owned param still in the address bar. Closing now clears every param Search controls, returning the visitor to the page root.

## Proposed changes

* `getSearchOwnedParamKeys()` decided what to strip on close by matching only the URL shapes the *writer* emits: reserved keys (`s`, `q`, `orderby`, `min_price`, `max_price`), `query_type_`-prefixed overrides, and `[]`-suffixed filters. Scalar `post_type` is a **read-only alias** — the store reads `?post_type=product` into `activeFilters.post_types` but only ever writes the array form `post_types[]` — so it matched none of those patterns and survived the close.
* Add a small `READ_ALIAS_PARAMS` set (`post_type`) and include it in the ownership test, so the close stripper clears what Search *reads*, not only what it writes. This mirrors legacy Instant Search's `restorePreviousHref()`, which builds its strip-set from the full filter-key universe (`getFilterKeys()` + `getStaticFilterKeys()` + `s` + `sort`).
* Out of scope (unchanged): the writer still emits only `post_types[]`; the `post_type`→`post_types` read-alias parsing is untouched; static-filter scalars (`?filter_id=value`) are still left alone (the bootstrap has no filter registry to disambiguate them from third-party params).

## Verification

Exercised live in a local docker env (Twenty Twenty-Five + WooCommerce, experience = Overlay blocks) by opening the product overlay on `/?s=shirt&post_type=product` and clicking **Close search**.

<details>
<summary>Live before/after</summary>

```text
URL on open:        /?s=shirt&post_type=product

BEFORE (trunk) close strips: ["s"]              → leftover URL: /?post_type=product
AFTER  (fix)   close strips: ["s","post_type"]  → leftover URL: /   (reloads to root)
```

Confirmed in the browser after the fix — closing the overlay navigates to `http://localhost:18090/` with an empty query string (`URLSearchParams.has('s') === false`, `URLSearchParams.has('post_type') === false`).

</details>

Covered by tests: a new unit suite for `getSearchOwnedParamKeys` (`store/test/url-state.test.js`) and a new `/?s=shirt&post_type=product` close case in `overlay-bootstrap/test/index.test.js`. Full search-blocks suite: 78 passing.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a WooCommerce store with the search experience set to **Overlay (blocks-powered)** and the product-search override on:

* [ ] Open a product search so the overlay appears over `/?s=<term>&post_type=product`.
* [ ] Close the overlay (Close button or Escape). The page reloads to the site root (`/`) with **no** `s` and **no** `post_type` left in the URL — not `/?post_type=product`.
* [ ] Regression — non-product search: open the overlay on `/?s=<term>`, close it, and confirm it still strips `s` and reloads as before.
* [ ] Regression — filters: open on `/?s=<term>&category[]=news&query_type_category=and`, close, and confirm the array filter and `query_type_` params are still stripped.
* [ ] Regression — unrelated params: open on `/page/?s=<term>&utm_source=x#anchor`, close, and confirm `utm_source` and the `#anchor` survive while `s` is removed.
