### PR TITLE
Revert "Plans: recognize new Choose plan tiers"

### DIFF
--- a/projects/packages/plans/changelog/revert-48806-add-choose-plans
+++ b/projects/packages/plans/changelog/revert-48806-add-choose-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Revert Choose plan tier recognition added in #48806; the experiment is being rolled back.

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -76,9 +76,6 @@ class Current_Plan {
 				'personal-bundle-2y',
 				'personal-bundle-3y',
 				'starter-plan',
-				'wp_bundle_choose_low_yearly',
-				'wp_bundle_choose_mid_yearly',
-				'wp_bundle_choose_high_yearly',
 			),
 			'supports' => array(
 				'akismet',

--- a/projects/plugins/wpcomsh/changelog/add-choose-plan-slugs
+++ b/projects/plugins/wpcomsh/changelog/add-choose-plan-slugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Mirror Choose plan entries from wpcom

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -80,9 +80,6 @@ class WPCOM_Features {
 	private const WPCOM_HOSTING_TRIAL_BUNDLE_MONTHLY          = 'wp_bundle_hosting_trial_monthly'; // 1058
 	private const WPCOM_STAGING_PRODUCT                       = 'wp_staging_site_lifetime'; // 1060
 	private const WPCOM_HUNDRED_YEAR_BUNDLE                   = 'wp_com_hundred_year_bundle_centennially'; // 1061
-	private const WPCOM_CHOOSE_LOW_YEARLY                     = 'wp_bundle_choose_low_yearly'; // 1078
-	private const WPCOM_CHOOSE_MID_YEARLY                     = 'wp_bundle_choose_mid_yearly'; // 1079
-	private const WPCOM_CHOOSE_HIGH_YEARLY                    = 'wp_bundle_choose_high_yearly'; // 1080
 	private const JETPACK_PREMIUM                             = 'jetpack_premium'; // 2000
 	private const JETPACK_BUSINESS                            = 'jetpack_business'; // 2001
 	private const JETPACK_FREE                                = 'jetpack_free'; // 2002
@@ -252,14 +249,6 @@ class WPCOM_Features {
 	private const GOOGLE_WORKSPACE_PRODUCTS     = array( self::WP_GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY );
 	private const GSUITE_PRODUCTS               = array( self::GAPPS, self::GAPPS_UNLIMITED );
 	private const WPCOM_TITAN_MAIL_PRODUCTS     = array( self::WP_TITAN_MAIL_MONTHLY, self::WP_TITAN_MAIL_YEARLY );
-
-	// "Choose" tier plans (Choose Low / Mid / High at $12 / $24 / $36). Each
-	// tier is cumulative — a Choose High site has the entitlements of Mid and
-	// Low too, so the "tier-and-higher" groups below are what the FEATURES_MAP
-	// entries reference rather than picking individual slugs at each gate.
-	private const WPCOM_CHOOSE_PLANS           = array( self::WPCOM_CHOOSE_LOW_YEARLY, self::WPCOM_CHOOSE_MID_YEARLY, self::WPCOM_CHOOSE_HIGH_YEARLY );
-	private const WPCOM_CHOOSE_MID_AND_HIGHER  = array( self::WPCOM_CHOOSE_MID_YEARLY, self::WPCOM_CHOOSE_HIGH_YEARLY );
-	private const WPCOM_CHOOSE_HIGH_AND_HIGHER = array( self::WPCOM_CHOOSE_HIGH_YEARLY );
 
 	private const WPCOM_PERSONAL_AND_PREMIUM_PLANS = array( self::WPCOM_PERSONAL_PLANS, self::WPCOM_PREMIUM_PLANS );
 	// Unlock Business-gated features for sites with the flex-cache-site sticker via the free plan.
@@ -758,7 +747,6 @@ class WPCOM_Features {
 		self::CUSTOM_DESIGN                     => array(
 			self::WPCOM_CUSTOM_DESIGN,
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
-			self::WPCOM_CHOOSE_MID_AND_HIGHER,
 		),
 		self::CUSTOM_DOMAIN                     => array(
 			self::WPCOM_BLOGGER_AND_HIGHER_PLANS,
@@ -1048,7 +1036,6 @@ class WPCOM_Features {
 			self::WPCOM_BLOGGER_PLANS,
 			self::WPCOM_PERSONAL_PLANS,
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
-			self::WPCOM_CHOOSE_HIGH_AND_HIGHER,
 		),
 		// NO_WPCOM_BRANDING - Enable the ability to hide the WP.com branding in the site footer.
 		self::NO_WPCOM_BRANDING                 => array(
@@ -1449,7 +1436,6 @@ class WPCOM_Features {
 		// Features: Posts/Locations/Emails/File downloads/Referrers/Clicks
 		self::STATS_PAID                        => array(
 			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
-			self::WPCOM_CHOOSE_PLANS,
 			self::WP_P2_PLUS_MONTHLY,
 			self::JETPACK_STATS_PWYW,
 			self::JETPACK_STATS_MONTHLY,


### PR DESCRIPTION
Reverts #48806. The `choose` experiment is being rolled back in full across wpcom, Calypso, and
  Jetpack; we've decided not to proceed with these experimental plan tiers.
     
  ### Proposed changes:

  - Revert the Choose-tier plan recognition added in #48806:
    - **`packages/plans`** — remove the `wp_bundle_choose_low_yearly` / `wp_bundle_choose_mid_yearly` /
  `wp_bundle_choose_high_yearly` slugs from the personal-tier classification in `class-current-plan.php`.
    - **`plugins/wpcomsh`** — remove the mirrored feature gates for those slugs in
  `wpcom-features/class-wpcom-features.php` (the cumulative `STATS_PAID` / `CUSTOM_DESIGN` /  `NO_ADVERTS` entitlements and the three tier constants).
  - No other behavior changes; this restores the files to their pre-#48806 state.

  ### Other information:

  - [ ] Have you written new tests for your changes, if applicable? — N/A, pure revert; the tests added in #48806 are
  removed with it.
  - [x] Have you checked whether your changes affect cached data and added cache busting if appropriate? — No cached data affected. 
  - [x] Changelog entries added for the affected projects (`packages/plans`, `plugins/wpcomsh`).
  
  ### Jetpack product discussion

  Part of the coordinated `/choose` rollback. The wpcom plan registrations these tiers depended on are being removed; this revert keeps Jetpack/wpcomsh from referencing plan slugs that will no longer exist.

  ### Does this pull request change what data or activity we track or use?

  No. This only removes recognition of three unused experimental plan slugs. No tracking, data collection, or activity
  logging is added or changed.
  
  ### Testing instructions:
  
  - Confirm `wp_bundle_choose_*_yearly` no longer appears in `projects/packages/plans/src/class-current-plan.php` or `projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php`.
  - On an Atomic test site, verify a site **not** on a Choose plan still resolves its tier and feature entitlements
  correctly (Choose tiers were experimental and not in production use, so no live site should be affected).
  - Run the `plans` package test suite and the `wpcomsh` feature-gate tests; both should pass with the Choose cases removed.