### PR TITLE
My Jetpack: hide Help footer Useful links when they aren't reachable

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
@@ -2,6 +2,7 @@ import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
 import { useCallback } from 'react';
+import { isJetpackPluginActive } from '../../../utils/is-jetpack-plugin-active';
 import styles from './styles.module.scss';
 import { useHelpTracking } from './use-help-tracking';
 
@@ -25,6 +26,12 @@ export function HelpFooter() {
 		trackHelpRequest( 'documentation', 'clicked_debug_information_link' );
 	}, [ trackHelpRequest ] );
 
+	// These links target wp-admin pages (the Jetpack modules list and the
+	// Debugger) that are only registered by the Jetpack plugin. My Jetpack also
+	// runs inside other standalone plugins where those pages don't exist, so only
+	// surface the links when the Jetpack plugin is active to avoid dead-ends.
+	const isJetpackActive = isJetpackPluginActive();
+
 	return (
 		<div className={ styles.footer }>
 			{ /* Needed to show different background colour */ }
@@ -46,30 +53,32 @@ export function HelpFooter() {
 						{ __( 'Learn more about us', 'jetpack-my-jetpack' ) }
 					</Link>
 
-					<nav
-						className={ styles[ 'footer-nav' ] }
-						aria-label={ __( 'Useful links', 'jetpack-my-jetpack' ) }
-					>
-						<h4>{ __( 'Useful links', 'jetpack-my-jetpack' ) }</h4>
-						<ul>
-							<li>
-								<Link
-									href={ getAdminUrl( 'admin.php?page=jetpack_modules' ) }
-									onClick={ handleAllModulesClick }
-								>
-									{ __( 'All Jetpack modules', 'jetpack-my-jetpack' ) }
-								</Link>
-							</li>
-							<li>
-								<Link
-									href={ getAdminUrl( 'admin.php?page=jetpack-debugger' ) }
-									onClick={ handleDebugInfoClick }
-								>
-									{ __( 'Debug information', 'jetpack-my-jetpack' ) }
-								</Link>
-							</li>
-						</ul>
-					</nav>
+					{ isJetpackActive && (
+						<nav
+							className={ styles[ 'footer-nav' ] }
+							aria-label={ __( 'Useful links', 'jetpack-my-jetpack' ) }
+						>
+							<h4>{ __( 'Useful links', 'jetpack-my-jetpack' ) }</h4>
+							<ul>
+								<li>
+									<Link
+										href={ getAdminUrl( 'admin.php?page=jetpack_modules' ) }
+										onClick={ handleAllModulesClick }
+									>
+										{ __( 'All Jetpack modules', 'jetpack-my-jetpack' ) }
+									</Link>
+								</li>
+								<li>
+									<Link
+										href={ getAdminUrl( 'admin.php?page=jetpack-debugger' ) }
+										onClick={ handleDebugInfoClick }
+									>
+										{ __( 'Debug information', 'jetpack-my-jetpack' ) }
+									</Link>
+								</li>
+							</ul>
+						</nav>
+					) }
 				</section>
 			</div>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
@@ -1,4 +1,4 @@
-import { getAdminUrl } from '@automattic/jetpack-script-data';
+import { currentUserCan, getAdminUrl } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
 import { useCallback } from 'react';
@@ -27,10 +27,13 @@ export function HelpFooter() {
 	}, [ trackHelpRequest ] );
 
 	// These links target wp-admin pages (the Jetpack modules list and the
-	// Debugger) that are only registered by the Jetpack plugin. My Jetpack also
-	// runs inside other standalone plugins where those pages don't exist, so only
-	// surface the links when the Jetpack plugin is active to avoid dead-ends.
-	const isJetpackActive = isJetpackPluginActive();
+	// Debugger) that only exist, and are only reachable, under two conditions:
+	// the Jetpack plugin is active (My Jetpack also runs inside other standalone
+	// plugins where these pages aren't registered), and the current user can
+	// manage options (both pages require it, but the Help tab is also shown to
+	// non-admins like editors). Guard on both to avoid links that dead-end on a
+	// "you are not allowed to access this page" screen.
+	const showUsefulLinks = isJetpackPluginActive() && currentUserCan( 'manage_options' );
 
 	return (
 		<div className={ styles.footer }>
@@ -53,7 +56,7 @@ export function HelpFooter() {
 						{ __( 'Learn more about us', 'jetpack-my-jetpack' ) }
 					</Link>
 
-					{ isJetpackActive && (
+					{ showUsefulLinks && (
 						<nav
 							className={ styles[ 'footer-nav' ] }
 							aria-label={ __( 'Useful links', 'jetpack-my-jetpack' ) }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-useful-links
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-useful-links
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-My Jetpack: only show the Help section's Useful links (All Jetpack modules, Debug information) when the Jetpack plugin is active, to avoid linking to wp-admin pages that don't exist in other standalone plugins.
+My Jetpack: only show the Help section's Useful links (All Jetpack modules, Debug information) when the Jetpack plugin is active and the user can manage options, to avoid dead-end links for editors or inside other standalone plugins.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-useful-links
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-useful-links
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-My Jetpack: modernize the Help section's Useful links by migrating them to the @wordpress/ui Link component, and only show them when the Jetpack plugin is active to avoid dead links.
+My Jetpack: only show the Help section's Useful links (All Jetpack modules, Debug information) when the Jetpack plugin is active, to avoid linking to wp-admin pages that don't exist in other standalone plugins.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-useful-links
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-useful-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: modernize the Help section's Useful links by migrating them to the @wordpress/ui Link component, and only show them when the Jetpack plugin is active to avoid dead links.


### PR DESCRIPTION
Fixes #

## Proposed changes
* My Jetpack → Help tab footer: only render the **Useful links** `<nav>` (*All Jetpack modules*, *Debug information*) when **both** (1) the Jetpack plugin is active and (2) the current user can `manage_options`. Both links target wp-admin pages registered only by the Jetpack plugin (`admin.php?page=jetpack_modules`, `admin.php?page=jetpack-debugger`), and both are gated on `manage_options` (the modules page via `jetpack_manage_modules`, which maps to `manage_options`). My Jetpack also ships inside other standalone plugins (Boost, Protect, Social, …) where those pages don't exist, **and** the Help tab is shown to non-admins such as editors who can't reach them — so without these guards the links dead-end on a "you are not allowed to access this page" screen. The existing `onClick` Tracks handlers are preserved.

> [!NOTE]
> The `@wordpress/ui` `Link`/`Text` modernization of this footer landed separately in #49238 and is already on `trunk`. After rebasing, the diff here is **only** the reachability guard — the link component swap is no longer part of this PR.

## Related product discussion/links
* JETPACK-1632 (parent: JETPACK-1543 — Jetpack UI Modernization)

## Does this pull request change what data or activity we track or use?
No. The existing `clicked_all_jetpack_modules_link` and `clicked_debug_information_link` Tracks events are unchanged. They simply won't fire in contexts where the links are now hidden (Jetpack plugin inactive, or the user can't `manage_options`).

## Testing instructions
* On a site **with the Jetpack plugin active**, logged in as an **administrator**: open **Jetpack → My Jetpack → Help** and scroll to the footer. Confirm the **Useful links** section shows *All Jetpack modules* and *Debug information*, and that each navigates (same tab) to the modules list (`admin.php?page=jetpack_modules`) and the Jetpack Debugger (`admin.php?page=jetpack-debugger`).
* On the same site, logged in as an **editor** (or any non-admin): open the Help tab footer and confirm the **Useful links** section is **not** shown. (Previously these links appeared but dead-ended on a "you are not allowed to access this page" screen.)
* In a context **without the Jetpack plugin active** (e.g. My Jetpack rendered inside a standalone plugin such as Boost/Protect): open the Help tab footer and confirm the **Useful links** section is not shown — no dead links.
* Regression: confirm the "Learn more about us" link and the rest of the Help footer are unchanged for all roles.
