### PR TITLE
My Jetpack: render Overview connection & Help footers full-width

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -2,6 +2,17 @@
 
 .my-jetpack-screen {
 
+	// `@wordpress/admin-ui`'s <Page> paints its own light-gray (#fcfcfc)
+	// surface on `.jp-admin-page__page`, which spans the whole page — including
+	// below the white footer band, leaving a gray sliver between the band and
+	// the pinned JetpackFooter. We want the gray to come only from the tab
+	// content (which already backs the cards with #fcfcfc), so clear the page
+	// surface here: below the footer band the page then reads white, flush with
+	// the band.
+	:global(.jp-admin-page__page) {
+		background-color: var(--jp-white);
+	}
+
 	:global(.jp-admin-page-header) {
 		padding-inline: 0.5rem;
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/content.tsx
@@ -2,9 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import { FullWidthSeparator } from '../full-width-separator';
 import { HelpCards } from './cards';
-import { HelpFooter } from './footer';
 import styles from './styles.module.scss';
 import { useHelpTracking } from './use-help-tracking';
 
@@ -46,8 +44,6 @@ export function HelpContent() {
 				</span>
 			</Button>
 			<HelpCards />
-			<FullWidthSeparator />
-			<HelpFooter />
 		</section>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
@@ -58,8 +58,12 @@
 
 	@include parent.full-width-container;
 
-	@media ( max-width: 1288px ) {
-		padding-inline: 0;
+	// Match `.tab-content-wrapper`'s gutter so the footer content stays aligned
+	// with the cards above. (The previous `padding-inline: 0` relied on the
+	// wrapper's padding, which no longer applies now the footer renders outside
+	// `.my-jetpack-tab-panel-inner`.)
+	@media ( max-width: gb.$break-medium ) {
+		padding-inline: 1.5rem;
 	}
 }
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
@@ -1,14 +1,12 @@
-import { Col, Container } from '@automattic/jetpack-components';
 import { currentUserCan } from '@automattic/jetpack-script-data';
-import ConnectionsSection from '../../connections-section';
-import PlansSection from '../../plans-section';
 import ProductCardsSection from '../../product-cards-section';
-import { FullWidthSeparator } from '../full-width-separator';
 import { A4AUpsell } from './a4a-upsell';
 import styles from './styles.module.scss';
 
 /**
- * The Overview content component.
+ * The Overview content component. The full-width footer band (Plans +
+ * Connection) lives in `OverviewFooter`, rendered by `TabContent` outside the
+ * centered inner container so its background spans the full width.
  *
  * @return The rendered component.
  */
@@ -24,21 +22,6 @@ export function OverviewContent() {
 					<A4AUpsell />
 				</div>
 			) : null }
-
-			<FullWidthSeparator />
-			<div className={ styles.footer }>
-				{ /* Needed to show different background colour */ }
-				<div className={ styles[ 'footer-inner' ] }>
-					<Container horizontalSpacing={ 0 } className={ styles[ 'footer-container' ] }>
-						<Col sm={ 4 } md={ 4 } lg={ 6 }>
-							<PlansSection />
-						</Col>
-						<Col sm={ 4 } md={ 4 } lg={ 6 }>
-							<ConnectionsSection />
-						</Col>
-					</Container>
-				</div>
-			</div>
 		</div>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/footer.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/footer.tsx
@@ -1,0 +1,31 @@
+import { Col, Container } from '@automattic/jetpack-components';
+import ConnectionsSection from '../../connections-section';
+import PlansSection from '../../plans-section';
+import styles from './styles.module.scss';
+
+/**
+ * The Overview footer band — a full-width white strip holding the Plans and
+ * Connection columns. Rendered by `TabContent` as a direct child of the
+ * full-width tab content (outside the centered `.my-jetpack-tab-panel-inner`)
+ * so its background spans edge-to-edge while `.footer-inner` re-centers the
+ * columns.
+ *
+ * @return The rendered overview footer.
+ */
+export function OverviewFooter() {
+	return (
+		<div className={ styles.footer }>
+			{ /* Needed to show different background colour */ }
+			<div className={ styles[ 'footer-inner' ] }>
+				<Container horizontalSpacing={ 0 } className={ styles[ 'footer-container' ] }>
+					<Col sm={ 4 } md={ 4 } lg={ 6 }>
+						<PlansSection />
+					</Col>
+					<Col sm={ 4 } md={ 4 } lg={ 6 }>
+						<ConnectionsSection />
+					</Col>
+				</Container>
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
@@ -1,6 +1,9 @@
 import clsx from 'clsx';
+import { FullWidthSeparator } from './full-width-separator';
 import { HelpContent } from './help/content';
+import { HelpFooter } from './help/footer';
 import { OverviewContent } from './overview/content';
+import { OverviewFooter } from './overview/footer';
 import { ProductsContent } from './products/content';
 import styles from './styles.module.scss';
 import { MyJetpackSection } from './types';
@@ -16,6 +19,15 @@ const componentMap: Record< MyJetpackSection, ComponentType > = {
 	help: HelpContent,
 };
 
+// Footers are full-width white bands: `TabContent` renders them as direct
+// children of the full-width tab content (outside the centered
+// `.my-jetpack-tab-panel-inner`) so their background can span edge-to-edge,
+// while each footer's `.footer-inner` re-centers its content.
+const footerMap: Partial< Record< MyJetpackSection, ComponentType > > = {
+	overview: OverviewFooter,
+	help: HelpFooter,
+};
+
 /**
  * The tab content component.
  *
@@ -25,16 +37,25 @@ const componentMap: Record< MyJetpackSection, ComponentType > = {
  */
 export function TabContent( { name }: TabContentProps ) {
 	const ContentComponent = componentMap[ name ];
+	const FooterComponent = footerMap[ name ];
 
 	if ( ! ContentComponent ) {
 		return null;
 	}
 
 	return (
-		<div className={ styles[ 'my-jetpack-tab-panel-inner' ] }>
-			<div className={ clsx( styles[ 'tab-content-wrapper' ] ) }>
-				<ContentComponent />
+		<>
+			<div className={ styles[ 'my-jetpack-tab-panel-inner' ] }>
+				<div className={ clsx( styles[ 'tab-content-wrapper' ] ) }>
+					<ContentComponent />
+				</div>
 			</div>
-		</div>
+			{ FooterComponent && (
+				<>
+					<FullWidthSeparator />
+					<FooterComponent />
+				</>
+			) }
+		</>
 	);
 }

--- a/projects/packages/my-jetpack/changelog/fix-regression-my-jetpack-footer
+++ b/projects/packages/my-jetpack/changelog/fix-regression-my-jetpack-footer
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: render the Overview connection and Help footers full-width, and keep the gray page surface scoped to the tab content so the area below the footer reads white instead of leaving a gray gap above the page footer
+My Jetpack: render the Overview and Help footers full-width and remove the gray gap below them.

--- a/projects/packages/my-jetpack/changelog/fix-regression-my-jetpack-footer
+++ b/projects/packages/my-jetpack/changelog/fix-regression-my-jetpack-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: render the Overview connection and Help footers full-width by lifting them out of the centered content container

--- a/projects/packages/my-jetpack/changelog/fix-regression-my-jetpack-footer
+++ b/projects/packages/my-jetpack/changelog/fix-regression-my-jetpack-footer
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: render the Overview connection and Help footers full-width by lifting them out of the centered content container
+My Jetpack: render the Overview connection and Help footers full-width, and keep the gray page surface scoped to the tab content so the area below the footer reads white instead of leaving a gray gap above the page footer


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="1242" height="571" alt="Screenshot 2026-05-29 at 9 37 55 AM" src="https://github.com/user-attachments/assets/3fd75b1f-fb7c-46c5-92ba-c99bf2cc8b9a" /> | <img width="1141" height="517" alt="Screenshot 2026-05-29 at 12 15 17 PM" src="https://github.com/user-attachments/assets/d56e5d36-66df-48ee-a224-79e73e26f520" /> |



## Proposed changes
* Fix the My Jetpack **Overview** "Connection" footer band (and the **Help** tab footer) not spanning the full page width. Both were authored as full-width white strips (with their own background colour) but were rendered *inside* the centered, `--max-container-width` content container (`.my-jetpack-tab-panel-inner`), so their backgrounds were clipped to the container width instead of going edge-to-edge.
* Move the footers up the hierarchy so they render as direct children of the full-width tab content — the same approach `FullWidthSeparator` already uses. `TabContent` now owns a `footerMap` and renders each tab's footer (preceded by a full-width separator) outside the constrained inner container.
* Extract the Overview footer band (Plans + Connection columns) into a dedicated `OverviewFooter` component; remove the now-redundant separator/footer markup from `OverviewContent` and `HelpContent`.
* Scope the gray page surface to the tab content. `@wordpress/admin-ui`'s `<Page>` paints its own `#fcfcfc` surface on `.jp-admin-page__page`, which spans the whole page and showed below the white footer band as a gray gap above the pinned `JetpackFooter`. Clearing it on the page node (scoped to the My Jetpack screen) leaves the gray coming only from the tab content (which already backs the cards), so below the footer band the page reads white — flush with the band.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to **My Jetpack** (`wp-admin/admin.php?page=my-jetpack`) on a connected site.
* On the **Overview** tab, scroll to the bottom "Connection" / "Plans" footer:
  * **Before:** the footer's white background stops at ~1040px and is centered, leaving the page background showing on either side.
  * **After:** the footer's white background spans the full width of the content area, with the Plans/Connection columns still centered within it.
* Switch to the **Help** tab and confirm its footer band ("Real humans. Real support.") also spans full width, and that the area below it reads white down to the page footer (no gray gap above "An Automattic Airline").
* Resize the browser down to mobile widths and confirm the footer content stays centered/padded and nothing overflows horizontally.

