### PR TITLE
Social: pre-release hardening for the modernized dashboard (save-failure notices, pricing copy, test gaps)

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/index.tsx
@@ -29,7 +29,11 @@ const ConnectionManagement = ( {
 	const listStyles = isModernized ? modernStyles : styles;
 	const { refresh } = useSocialMediaConnections();
 
-	const { connections, deletingConnections, updatingConnections } = useSelect( select => {
+	const {
+		connections: rawConnections,
+		deletingConnections,
+		updatingConnections,
+	} = useSelect( select => {
 		const { getConnections, getDeletingConnections, getUpdatingConnections } = select( store );
 
 		return {
@@ -39,7 +43,9 @@ const ConnectionManagement = ( {
 		};
 	}, [] );
 
-	connections.sort( ( a, b ) => {
+	// Copy before sorting — `getConnections()` returns the store's array and
+	// `Array.prototype.sort` mutates in place.
+	const connections = [ ...rawConnections ].sort( ( a, b ) => {
 		if ( a.service_name === b.service_name ) {
 			return a.connection_id.localeCompare( b.connection_id );
 		}

--- a/projects/packages/publicize/_inc/components/connection-management/tests/pageObjects/PanelPage.js
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/pageObjects/PanelPage.js
@@ -49,6 +49,11 @@ export class Panel {
 		await userEvent.click( screen.getByRole( 'button', { name: 'Yes' } ) );
 	}
 
+	async cancelDisconnect() {
+		await this.disconnect();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+	}
+
 	async toggleMarkAsShared() {
 		await userEvent.click( this.markAsSharedToggle );
 	}

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/disconnect.test.js
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/disconnect.test.js
@@ -25,6 +25,18 @@ describe( 'Disconnecting a connection', () => {
 		expect( stubDeleteConnectionById ).toHaveBeenCalledWith( { connectionId: '2' } );
 	} );
 
+	test( 'cancelling the confirmation should not disconnect', async () => {
+		const { stubDeleteConnectionById } = setup();
+		const management = getManagementPageObject();
+
+		const facebookPanel = management.connectionPanels[ 0 ];
+
+		await facebookPanel.open();
+		await facebookPanel.cancelDisconnect();
+
+		expect( stubDeleteConnectionById ).not.toHaveBeenCalled();
+	} );
+
 	test( 'panel is disabled while updating', async () => {
 		setup( { getDeletingConnections: [ '2' ] } );
 		const management = getManagementPageObject();

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Dialog, Link, Text, Tooltip } from '@wordpress/ui';
 import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
 import { store } from '../../social-store';
@@ -14,7 +14,7 @@ import styles from './style-modern.module.scss';
 // ternary: interpolating translatable strings inside JSX expressions can break
 // the way our build extracts/bundles them for translation.
 const CONFIRMATION_TITLE = () => __( 'Connection confirmation', 'jetpack-publicize-pkg' );
-const MANAGE_TITLE = () => _x( 'Manage Jetpack Social connections', '', 'jetpack-publicize-pkg' );
+const MANAGE_TITLE = () => __( 'Manage Jetpack Social connections', 'jetpack-publicize-pkg' );
 
 export const ModernManageConnectionsModal = () => {
 	const { keyringResult } = useSelect( select => {

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
@@ -10,12 +10,6 @@ import { ModernServicesList } from '../services/services-list-modern';
 import { ConfirmationForm } from './confirmation-form';
 import styles from './style-modern.module.scss';
 
-// Split the two titles into constants rather than picking them inline with a
-// ternary: interpolating translatable strings inside JSX expressions can break
-// the way our build extracts/bundles them for translation.
-const CONFIRMATION_TITLE = () => __( 'Connection confirmation', 'jetpack-publicize-pkg' );
-const MANAGE_TITLE = () => __( 'Manage Jetpack Social connections', 'jetpack-publicize-pkg' );
-
 export const ModernManageConnectionsModal = () => {
 	const { keyringResult } = useSelect( select => {
 		const { getKeyringResult } = select( store );
@@ -48,7 +42,13 @@ export const ModernManageConnectionsModal = () => {
 
 	const hasKeyringResult = Boolean( keyringResult?.ID );
 
-	const title = hasKeyringResult ? CONFIRMATION_TITLE() : MANAGE_TITLE();
+	// Hold each title in its own variable and select with the ternary afterwards.
+	// Picking inline (`cond ? __( 'A' ) : __( 'B' )`) lets the minifier fold both
+	// branches into a single `__( cond ? 'A' : 'B' )` call, which the i18n string
+	// extraction can no longer read.
+	const confirmationTitle = __( 'Connection confirmation', 'jetpack-publicize-pkg' );
+	const manageTitle = __( 'Manage Jetpack Social connections', 'jetpack-publicize-pkg' );
+	const title = hasKeyringResult ? confirmationTitle : manageTitle;
 
 	const canMarkAsShared = useUserCanShareConnection();
 

--- a/projects/packages/publicize/_inc/components/services/connect-form.tsx
+++ b/projects/packages/publicize/_inc/components/services/connect-form.tsx
@@ -125,9 +125,14 @@ export function ConnectForm( {
 							return __( 'Connecting…', 'jetpack-publicize-pkg' );
 						}
 
-						return hasConnections
-							? __( 'Connect more', 'jetpack-publicize-pkg' )
-							: __( 'Connect', 'jetpack-publicize-pkg' );
+						// Hold each label in its own variable and select with the
+						// ternary afterwards. Picking inline (`cond ? __( 'A' ) :
+						// __( 'B' )`) lets the minifier fold both branches into one
+						// `__( cond ? 'A' : 'B' )` call, which the i18n string
+						// extraction can no longer read.
+						const connectMoreLabel = __( 'Connect more', 'jetpack-publicize-pkg' );
+						const connectLabel = __( 'Connect', 'jetpack-publicize-pkg' );
+						return hasConnections ? connectMoreLabel : connectLabel;
 					} )( buttonLabel ) }
 				</Button>
 			</div>

--- a/projects/packages/publicize/_inc/components/services/connect-form.tsx
+++ b/projects/packages/publicize/_inc/components/services/connect-form.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useIsModernized } from '../../hooks/use-is-modernized';
@@ -126,7 +126,7 @@ export function ConnectForm( {
 						}
 
 						return hasConnections
-							? _x( 'Connect more', '', 'jetpack-publicize-pkg' )
+							? __( 'Connect more', 'jetpack-publicize-pkg' )
 							: __( 'Connect', 'jetpack-publicize-pkg' );
 					} )( buttonLabel ) }
 				</Button>

--- a/projects/packages/publicize/_inc/components/settings-tab/default-share-message-card.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/default-share-message-card.tsx
@@ -2,7 +2,7 @@ import { useDebounce } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Card } from '@wordpress/ui';
+import { Card, Stack, Text } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import { MessageTemplateEditor } from '../message-template-editor';
 
@@ -68,7 +68,15 @@ export default function DefaultShareMessageCard(): JSX.Element {
 				<Card.Title>{ __( 'Default share message', 'jetpack-publicize-pkg' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<MessageTemplateEditor value={ draft } onChange={ onChange } />
+				<Stack direction="column" gap="md">
+					<Text variant="body-sm">
+						{ __(
+							'Set a default message format used when sharing posts to social networks. Use placeholders to insert post details automatically.',
+							'jetpack-publicize-pkg'
+						) }
+					</Text>
+					<MessageTemplateEditor value={ draft } onChange={ onChange } />
+				</Stack>
 			</Card.Content>
 		</Card.Root>
 	);

--- a/projects/packages/publicize/_inc/components/settings-tab/test/cards.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/cards.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createReduxStore, RegistryProvider, createRegistry } from '@wordpress/data';
+import ContentCreationCard from '../content-creation-card';
+import CustomizeLinksCard from '../customize-links-card';
+import CustomizeMediaCard from '../customize-media-card';
+
+// `@wordpress/jest-console` augments the global jest matchers at runtime, but
+// the package typecheck doesn't pick up its types — declare the one we use.
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace jest {
+		interface Matchers< R > {
+			toHaveErrored(): R;
+		}
+	}
+}
+
+const SOCIAL_STORE = 'jetpack-social';
+
+// The cards import the real social store only for its `store` descriptor,
+// which we swap for a lightweight stand-in registered below so the test
+// can spy on the action creators the toggles dispatch.
+jest.mock( '../../../social-store', () => ( { store: 'jetpack-social' } ) );
+
+// The media card mounts the heavy template-picker tree behind its toggle;
+// stub it so the test isolates the toggle → dispatch behavior.
+jest.mock( '../../social-image-generator/template-picker/modal', () => () => (
+	<div data-testid="template-picker-modal" />
+) );
+
+// Action-creator spies, shared across the per-test registry. They double as
+// thunk-style action creators: returning a plain object keeps @wordpress/data
+// happy when the bound dispatch runs them.
+const actionSpies = {
+	updateSocialImageGeneratorConfig: jest.fn( () => ( { type: 'NOOP' } ) ),
+	updateUtmSettings: jest.fn( () => ( { type: 'NOOP' } ) ),
+	toggleSocialNotes: jest.fn( () => ( { type: 'NOOP' } ) ),
+	updateSocialNotesConfig: jest.fn( () => ( { type: 'NOOP' } ) ),
+};
+
+let registry: ReturnType< typeof createRegistry >;
+
+/**
+ * Build a registry whose social store exposes `getSocialSettings` /
+ * `isSavingSiteSettings` reading the supplied state and the spied action
+ * creators above, then render `ui` inside it.
+ *
+ * @param ui         - The card element under test.
+ * @param settings   - Partial social settings the cards read.
+ * @param [isSaving] - Whether a site save is in flight (drives `disabled`).
+ * @return The Testing Library render result.
+ */
+function renderCard( ui: JSX.Element, settings: Record< string, unknown >, isSaving = false ) {
+	registry = createRegistry();
+
+	const store = createReduxStore( SOCIAL_STORE, {
+		reducer: ( state = {} ) => state,
+		actions: actionSpies,
+		selectors: {
+			getSocialSettings: () => settings,
+			isSavingSiteSettings: () => isSaving,
+		},
+	} );
+
+	registry.register( store );
+
+	return render( <RegistryProvider value={ registry }>{ ui }</RegistryProvider> );
+}
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'CustomizeMediaCard', () => {
+	it( 'toggling the SIG control dispatches updateSocialImageGeneratorConfig with the new enabled value', async () => {
+		renderCard( <CustomizeMediaCard />, { socialImageGenerator: { enabled: false } } );
+
+		await userEvent.click( screen.getByLabelText( 'Enable Social Image Generator' ) );
+
+		expect( actionSpies.updateSocialImageGeneratorConfig ).toHaveBeenCalledWith( {
+			enabled: true,
+		} );
+	} );
+
+	it( 'disables the toggle while a save is in flight', () => {
+		renderCard( <CustomizeMediaCard />, { socialImageGenerator: { enabled: true } }, true );
+
+		expect( screen.getByLabelText( 'Enable Social Image Generator' ) ).toBeDisabled();
+	} );
+
+	it( 'reveals the template picker only when SIG is enabled', () => {
+		const { unmount } = renderCard( <CustomizeMediaCard />, {
+			socialImageGenerator: { enabled: false },
+		} );
+		expect( screen.queryByTestId( 'template-picker-modal' ) ).not.toBeInTheDocument();
+		unmount();
+
+		renderCard( <CustomizeMediaCard />, { socialImageGenerator: { enabled: true } } );
+		expect( screen.getByTestId( 'template-picker-modal' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'CustomizeLinksCard', () => {
+	it( 'toggling the UTM control dispatches updateUtmSettings with the new enabled value', async () => {
+		renderCard( <CustomizeLinksCard />, { utmSettings: { enabled: false } } );
+
+		await userEvent.click( screen.getByLabelText( 'Append UTM parameters to shared URLs' ) );
+
+		expect( actionSpies.updateUtmSettings ).toHaveBeenCalledWith( { enabled: true } );
+	} );
+
+	it( 'reflects the saved enabled state and disables while saving', () => {
+		renderCard( <CustomizeLinksCard />, { utmSettings: { enabled: true } }, true );
+
+		const toggle = screen.getByLabelText( 'Append UTM parameters to shared URLs' );
+		expect( toggle ).toBeChecked();
+		expect( toggle ).toBeDisabled();
+	} );
+} );
+
+describe( 'ContentCreationCard', () => {
+	const notesSettings = ( overrides = {} ) => ( {
+		socialNotes: { enabled: false, config: {}, ...overrides },
+	} );
+
+	it( 'toggling Social Notes dispatches toggleSocialNotes with the new value', async () => {
+		renderCard( <ContentCreationCard />, notesSettings() );
+
+		await userEvent.click( screen.getByLabelText( 'Enable Social Notes' ) );
+
+		expect( actionSpies.toggleSocialNotes ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'shows the nested options only when Social Notes is enabled, and the append-link toggle dispatches the config update', async () => {
+		renderCard(
+			<ContentCreationCard />,
+			notesSettings( { enabled: true, config: { append_link: true } } )
+		);
+
+		// The append-link toggle is only rendered while Social Notes is on.
+		await userEvent.click( screen.getByLabelText( 'Append post link' ) );
+
+		expect( actionSpies.updateSocialNotesConfig ).toHaveBeenCalledWith( { append_link: false } );
+
+		// The "Create a note" link renders an <a> through @wordpress/ui's
+		// Button, which logs a Base UI nativeButton notice. It's incidental to
+		// the behavior under test; acknowledge it so jest-console stays happy.
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'hides the nested options while Social Notes is off', () => {
+		renderCard( <ContentCreationCard />, notesSettings( { enabled: false } ) );
+
+		expect( screen.queryByLabelText( 'Append post link' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -106,7 +106,12 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 								) }
 							</Stack>
 							<span className="jetpack-social-gate__price-legend">
-								{ __( 'per month, billed yearly', 'jetpack-publicize-pkg' ) }
+								{ introPrice != null
+									? __(
+											'per month for the first year, then billed yearly',
+											'jetpack-publicize-pkg'
+									  )
+									: __( 'per month, billed yearly', 'jetpack-publicize-pkg' ) }
 							</span>
 						</div>
 					) }
@@ -116,9 +121,9 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 						gap="sm"
 						render={ <ul /> }
 					>
-						{ PAID_FEATURES.map( ( feature, index ) => (
+						{ PAID_FEATURES.map( feature => (
 							<Stack
-								key={ index }
+								key={ feature }
 								className="jetpack-social-gate__feature"
 								direction="row"
 								align="center"

--- a/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
@@ -5,6 +5,8 @@ import PricingGate from '../pricing-gate';
 const mockSetShowPricingPage = jest.fn();
 const mockUpdateSocialModuleSettings = jest.fn( () => Promise.resolve() );
 
+let mockProductInfo = { currencyCode: 'USD', v1: { price: 10, introOffer: null } };
+
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		setShowPricingPage: mockSetShowPricingPage,
@@ -17,7 +19,7 @@ jest.mock( '@automattic/jetpack-script-data', () => ( {
 } ) );
 jest.mock( '../../../hooks/use-product-info', () => ( {
 	__esModule: true,
-	default: () => [ { currencyCode: 'USD', v1: { price: 10, introOffer: null } } ],
+	default: () => [ mockProductInfo ],
 } ) );
 jest.mock( '../../../utils', () => ( {
 	getSocialScriptData: () => ( { is_publicize_enabled: true } ),
@@ -29,6 +31,7 @@ describe( 'PricingGate', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockUpdateSocialModuleSettings.mockReturnValue( Promise.resolve() );
+		mockProductInfo = { currencyCode: 'USD', v1: { price: 10, introOffer: null } };
 	} );
 
 	it( 'dismisses the pricing page on "Start for free"', async () => {
@@ -47,5 +50,18 @@ describe( 'PricingGate', () => {
 		render( <PricingGate onDismiss={ jest.fn() } /> );
 		// $10/mo formatting — assert the amount is present in the document.
 		expect( screen.getByText( /\$10/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the discounted intro price, the struck-through original, and the intro legend', () => {
+		mockProductInfo = { currencyCode: 'USD', v1: { price: 10, introOffer: 5 } };
+		render( <PricingGate onDismiss={ jest.fn() } /> );
+		// Discounted intro price is shown prominently.
+		expect( screen.getByText( /\$5/ ) ).toBeInTheDocument();
+		// Original price is still rendered (struck through).
+		expect( screen.getByText( /\$10/ ) ).toBeInTheDocument();
+		// Legend reflects the intro-offer wording.
+		expect(
+			screen.getByText( /per month for the first year, then billed yearly/i )
+		).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/social-gate/test/use-social-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/use-social-gate.test.tsx
@@ -60,6 +60,11 @@ describe( 'useSocialGate', () => {
 		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBeNull();
 	} );
 
+	it( 'returns null when connected and free but the pricing nudge should not show', () => {
+		mockState( { paid: false, showPricingPage: false, jetpackSite: true } );
+		expect( renderHook( () => useSocialGate() ).result.current.gate ).toBeNull();
+	} );
+
 	it( 'returns null after dismissPricing is called', () => {
 		mockState( { paid: false, showPricingPage: true, jetpackSite: true } );
 		const { result } = renderHook( () => useSocialGate() );

--- a/projects/packages/publicize/_inc/social-store/actions/social-image-generator.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/social-image-generator.ts
@@ -1,4 +1,6 @@
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { SIG_SETTINGS_KEY } from '../constants';
 import { SocialImageGeneratorConfig } from '../types';
 
@@ -12,7 +14,21 @@ import { SocialImageGeneratorConfig } from '../types';
 export function updateSocialImageGeneratorConfig( data: Partial< SocialImageGeneratorConfig > ) {
 	return async function ( { registry } ) {
 		const { saveSite } = registry.dispatch( coreStore );
+		const { getLastEntitySaveError } = registry.select( coreStore );
+		const { createErrorNotice } = registry.dispatch( noticesStore );
 
 		await saveSite( { [ SIG_SETTINGS_KEY ]: data } );
+
+		const lastError = getLastEntitySaveError( 'root', 'site' );
+		if ( lastError ) {
+			let message: string = __(
+				'There was an error saving the social image settings.',
+				'jetpack-publicize-pkg'
+			);
+			if ( lastError?.message ) {
+				message += ' ' + lastError.message;
+			}
+			createErrorNotice( message, { type: 'snackbar' } );
+		}
 	};
 }

--- a/projects/packages/publicize/_inc/social-store/actions/social-notes.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/social-notes.ts
@@ -1,8 +1,26 @@
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { SOCIAL_NOTES_CONFIG_KEY, SOCIAL_NOTES_ENABLED_KEY } from '../constants';
 import { SocialNotesConfig } from '../types';
 import type { store } from '../index';
 import type { ThunkArgs } from '@wordpress/data';
+
+/**
+ * Surfaces an error notice if the most recent site save failed.
+ *
+ * @param registry - The data registry passed to the thunk.
+ * @param message  - The user-facing error message to show on failure.
+ */
+function noticeOnSaveError( registry, message: string ) {
+	const lastError = registry.select( coreStore ).getLastEntitySaveError( 'root', 'site' );
+	if ( lastError ) {
+		const { createErrorNotice } = registry.dispatch( noticesStore );
+		createErrorNotice( lastError?.message ? `${ message } ${ lastError.message }` : message, {
+			type: 'snackbar',
+		} );
+	}
+}
 
 /**
  * Sets the Social Notes enabled status.
@@ -16,6 +34,11 @@ export function toggleSocialNotes( isEnabled: boolean ) {
 		const { saveSite } = registry.dispatch( coreStore );
 
 		await saveSite( { [ SOCIAL_NOTES_ENABLED_KEY ]: isEnabled } );
+
+		noticeOnSaveError(
+			registry,
+			__( 'There was an error saving the Social Notes setting.', 'jetpack-publicize-pkg' )
+		);
 	};
 }
 
@@ -33,5 +56,10 @@ export function updateSocialNotesConfig( data: Partial< SocialNotesConfig > ) {
 		const { saveSite } = registry.dispatch( coreStore );
 
 		await saveSite( { [ SOCIAL_NOTES_CONFIG_KEY ]: { ...prevConfig, ...data } } );
+
+		noticeOnSaveError(
+			registry,
+			__( 'There was an error saving the Social Notes settings.', 'jetpack-publicize-pkg' )
+		);
 	};
 }

--- a/projects/packages/publicize/_inc/social-store/actions/social-settings.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/social-settings.ts
@@ -1,4 +1,6 @@
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { MESSAGE_TEMPLATE_KEY, SHOW_PRICING_PAGE_KEY } from '../constants';
 
 /**
@@ -24,7 +26,21 @@ export function setShowPricingPage( isEnabled: boolean ) {
 export function setMessageTemplate( value: string ) {
 	return async function ( { registry } ) {
 		const { saveSite } = registry.dispatch( coreStore );
+		const { getLastEntitySaveError } = registry.select( coreStore );
+		const { createErrorNotice } = registry.dispatch( noticesStore );
 
 		await saveSite( { [ MESSAGE_TEMPLATE_KEY ]: value } );
+
+		const lastError = getLastEntitySaveError( 'root', 'site' );
+		if ( lastError ) {
+			let message: string = __(
+				'There was an error saving the default share message.',
+				'jetpack-publicize-pkg'
+			);
+			if ( lastError?.message ) {
+				message += ' ' + lastError.message;
+			}
+			createErrorNotice( message, { type: 'snackbar' } );
+		}
 	};
 }

--- a/projects/packages/publicize/_inc/social-store/actions/test/save-error-notices.test.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/test/save-error-notices.test.ts
@@ -1,0 +1,100 @@
+import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
+import { updateSocialImageGeneratorConfig } from '../social-image-generator';
+import { toggleSocialNotes, updateSocialNotesConfig } from '../social-notes';
+import { setMessageTemplate } from '../social-settings';
+import { updateUtmSettings } from '../utm-settings';
+
+// Each save thunk surfaces a snackbar error notice when the most recent
+// `saveSite` left a `getLastEntitySaveError( 'root', 'site' )`. These tests
+// drive that branch through a stub registry so no network/core-data state is
+// involved.
+
+const saveSite = jest.fn();
+const getLastEntitySaveError = jest.fn();
+const createErrorNotice = jest.fn();
+
+/**
+ * Build the stub registry the thunks receive. `saveSite` resolves immediately;
+ * `getLastEntitySaveError` returns whatever the test queued.
+ *
+ * @return The thunk argument object.
+ */
+function makeThunkArgs() {
+	const registry = {
+		dispatch: ( store: unknown ) => {
+			if ( store === coreStore ) {
+				return { saveSite };
+			}
+			if ( store === noticesStore ) {
+				return { createErrorNotice };
+			}
+			return {};
+		},
+		select: ( store: unknown ) => {
+			if ( store === coreStore ) {
+				return { getLastEntitySaveError };
+			}
+			return {};
+		},
+	};
+
+	// `updateSocialNotesConfig` also reads previous config off the store select.
+	const select = {
+		getSocialSettings: () => ( { socialNotes: { config: { append_link: true } } } ),
+	};
+
+	return { registry, select };
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	saveSite.mockResolvedValue( undefined );
+} );
+
+describe( 'site-save thunks surface an error notice on save failure', () => {
+	const cases: Array< [ string, () => ( args: unknown ) => Promise< void > ] > = [
+		[
+			'updateSocialImageGeneratorConfig',
+			() => updateSocialImageGeneratorConfig( { enabled: true } ),
+		],
+		[ 'updateUtmSettings', () => updateUtmSettings( { enabled: true } ) ],
+		[ 'toggleSocialNotes', () => toggleSocialNotes( true ) ],
+		[ 'updateSocialNotesConfig', () => updateSocialNotesConfig( { append_link: false } ) ],
+		[ 'setMessageTemplate', () => setMessageTemplate( 'Hello {title}' ) ],
+	];
+
+	it.each( cases )( '%s shows a snackbar notice when the save errors', async ( _name, make ) => {
+		getLastEntitySaveError.mockReturnValue( { message: 'Network down' } );
+
+		await make()( makeThunkArgs() );
+
+		expect( saveSite ).toHaveBeenCalledTimes( 1 );
+		expect( getLastEntitySaveError ).toHaveBeenCalledWith( 'root', 'site' );
+		expect( createErrorNotice ).toHaveBeenCalledTimes( 1 );
+
+		const [ message, options ] = createErrorNotice.mock.calls[ 0 ];
+		// The error detail is appended to the per-thunk message.
+		expect( message ).toContain( 'Network down' );
+		expect( options ).toEqual( { type: 'snackbar' } );
+	} );
+
+	it.each( cases )( '%s shows no notice when the save succeeds', async ( _name, make ) => {
+		getLastEntitySaveError.mockReturnValue( undefined );
+
+		await make()( makeThunkArgs() );
+
+		expect( saveSite ).toHaveBeenCalledTimes( 1 );
+		expect( createErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to the base message when the error carries no detail', async () => {
+		getLastEntitySaveError.mockReturnValue( {} );
+
+		await updateUtmSettings( { enabled: false } )( makeThunkArgs() );
+
+		expect( createErrorNotice ).toHaveBeenCalledTimes( 1 );
+		const [ message ] = createErrorNotice.mock.calls[ 0 ];
+		expect( message ).toBe( 'There was an error saving the link tracking settings.' );
+	} );
+} );

--- a/projects/packages/publicize/_inc/social-store/actions/utm-settings.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/utm-settings.ts
@@ -1,4 +1,6 @@
 import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { UTM_ENABLED_KEY } from '../constants';
 import { UtmSettingsConfig } from '../types';
 
@@ -12,7 +14,21 @@ import { UtmSettingsConfig } from '../types';
 export function updateUtmSettings( data: Partial< UtmSettingsConfig > ) {
 	return async function ( { registry } ) {
 		const { saveSite } = registry.dispatch( coreStore );
+		const { getLastEntitySaveError } = registry.select( coreStore );
+		const { createErrorNotice } = registry.dispatch( noticesStore );
 
 		await saveSite( { [ UTM_ENABLED_KEY ]: data } );
+
+		const lastError = getLastEntitySaveError( 'root', 'site' );
+		if ( lastError ) {
+			let message: string = __(
+				'There was an error saving the link tracking settings.',
+				'jetpack-publicize-pkg'
+			);
+			if ( lastError?.message ) {
+				message += ' ' + lastError.message;
+			}
+			createErrorNotice( message, { type: 'snackbar' } );
+		}
 	};
 }

--- a/projects/packages/publicize/_inc/social-store/test/resolvers.test.ts
+++ b/projects/packages/publicize/_inc/social-store/test/resolvers.test.ts
@@ -1,0 +1,116 @@
+import { getScriptData, isSimpleSite } from '@automattic/jetpack-script-data';
+import apiFetch from '@wordpress/api-fetch';
+import { getTrafficReferrers } from '../resolvers';
+import type { TrafficInterval } from '../types';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: jest.fn(),
+	isSimpleSite: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockGetScriptData = getScriptData as jest.Mock;
+const mockIsSimpleSite = isSimpleSite as jest.Mock;
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * Run the `getTrafficReferrers` resolver thunk against a stub dispatch and
+ * return the dispatched action creators so assertions can inspect the
+ * fetch/receive/error sequence.
+ *
+ * @param interval - Number of days the chart should cover.
+ * @return The dispatch spy.
+ */
+async function runResolver( interval: TrafficInterval = 30 ) {
+	const dispatch = jest.fn();
+	await getTrafficReferrers( interval )( { dispatch } );
+	return dispatch;
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockIsSimpleSite.mockReturnValue( false );
+} );
+
+describe( 'getTrafficReferrers resolver', () => {
+	it( 'dispatches the error action when the site has no wpcom blog ID', async () => {
+		mockGetScriptData.mockReturnValue( { site: {} } );
+
+		const dispatch = await runResolver( 30 );
+
+		// Loading was flagged first…
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'FETCH_TRAFFIC_REFERRERS', interval: 30 } )
+		);
+		// …then the error action, with no network request made.
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS_ERROR', interval: 30 } )
+		);
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'dispatches the error action when the referrers fetch rejects', async () => {
+		mockGetScriptData.mockReturnValue( { site: { wpcom: { blog_id: 123 } } } );
+		mockApiFetch.mockRejectedValue( new Error( 'boom' ) );
+
+		const dispatch = await runResolver( 7 );
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'FETCH_TRAFFIC_REFERRERS', interval: 7 } )
+		);
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS_ERROR', interval: 7 } )
+		);
+		// The success action must not fire on a rejected fetch.
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS' } )
+		);
+	} );
+
+	it( 'targets the Jetpack stats-app route with the real blog ID and stores the payload', async () => {
+		mockGetScriptData.mockReturnValue( { site: { wpcom: { blog_id: 123 } } } );
+		const days = { '2026-05-01': { groups: [] } };
+		mockApiFetch.mockResolvedValue( { days } );
+
+		const dispatch = await runResolver( 30 );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( '/jetpack/v4/stats-app/sites/123/stats/referrers' ),
+			} )
+		);
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS', interval: 30, days } )
+		);
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS_ERROR' } )
+		);
+	} );
+
+	it( 'reads the public REST namespace on Simple sites', async () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockGetScriptData.mockReturnValue( { site: { wpcom: { blog_id: 456 } } } );
+		mockApiFetch.mockResolvedValue( { days: {} } );
+
+		await runResolver( 30 );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: expect.stringContaining( '/rest/v1.1/sites/456/stats/referrers' ),
+			} )
+		);
+	} );
+
+	it( 'defaults a missing payload to an empty day map', async () => {
+		mockGetScriptData.mockReturnValue( { site: { wpcom: { blog_id: 123 } } } );
+		mockApiFetch.mockResolvedValue( {} );
+
+		const dispatch = await runResolver( 30 );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS', interval: 30, days: {} } )
+		);
+	} );
+} );

--- a/projects/packages/publicize/changelog/fix-social-dashboard-pre-release-gaps
+++ b/projects/packages/publicize/changelog/fix-social-dashboard-pre-release-gaps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: surface an error notice when saving dashboard settings fails, and show the "first year" caveat on the upgrade screen's intro-offer price.

--- a/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
+++ b/projects/packages/publicize/tests/php/Social_Admin_Page_Test.php
@@ -177,6 +177,31 @@ class Social_Admin_Page_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Kill switch: when the modernization filter is forced false, the wp-build
+	 * dashboard is inactive even if the chassis render function is defined, so
+	 * the legacy admin script IS enqueued (legacy fallback).
+	 */
+	public function test_enqueue_loads_legacy_script_when_kill_switch_engaged() {
+		add_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_false' );
+		// Define the wp-build render fn in the GLOBAL namespace (via fixture) so
+		// is_wp_build_dashboard_active()'s function_exists() check passes. The
+		// kill switch must still win, gating the dashboard off despite a loaded
+		// chassis.
+		require_once __DIR__ . '/fixtures/wp-build-render-fn.php';
+
+		Social_Admin_Page::init()->enqueue_admin_scripts();
+
+		$this->assertTrue(
+			wp_script_is( 'social-admin-page', 'enqueued' ),
+			'Legacy script should be enqueued when the modernization kill switch is engaged.'
+		);
+
+		wp_dequeue_script( 'social-admin-page' );
+		wp_deregister_script( 'social-admin-page' );
+		remove_filter( Social_Admin_Page::MODERNIZATION_FILTER, '__return_false' );
+	}
+
+	/**
 	 * It rejects plan refresh when the nonce is missing or invalid.
 	 */
 	public function test_admin_init_rejects_plan_refresh_without_valid_nonce() {


### PR DESCRIPTION
Fixes #

## Proposed changes

Pre-release hardening for the modernized Jetpack Social dashboard, ahead of flipping `rsm_jetpack_ui_modernization_social` on by default (#48867). This is the follow-up to a whole-feature audit of the gated dashboard; it closes the gaps that audit surfaced. Branched off `trunk` and independent of the flag flip.

User-facing fixes:
* **Save failures are no longer silent.** The Settings-tab saves (Social Image Generator, link UTM parameters, Social Notes, default share message) `await` a core-data `saveSite` that never rejects — on failure they previously left the UI desynced with no feedback. They now surface a snackbar error notice via `getLastEntitySaveError( 'root', 'site' )`, matching the existing `scheduled-shares` pattern. (Shared thunks, so this fixes the legacy surface too.)
* **PricingGate intro-offer copy.** When an intro offer is present, the upgrade screen now shows the "for the first year, then billed yearly" caveat instead of a flat "billed yearly" legend, so the discounted price isn't read as the perpetual price (restores legacy `PricingPage` behavior).
* **Restored** the default-share-message card description that was dropped from the legacy `MessageTemplateSection`.

Cleanups:
* Copy the connections array before sorting (no in-place mutation of the `useSelect` result); drop two empty `_x()` contexts.

Test coverage for now-default paths:
* Disconnect **cancel** path (confirm/disabled were already covered).
* social-gate: connected + free with the pricing nudge suppressed → no gate; PricingGate intro-offer rendering.
* traffic-stats **resolver** error path (missing blog id / apiFetch rejection), Jetpack vs Simple-site routes, empty-payload default.
* Settings-tab cards: toggle → store-action wiring and save-failure notices (thunk-level).
* `Social_Admin_Page`: kill switch keeps the legacy script enqueued even when the wp-build render fn is defined.

> [!NOTE]
> The audit also flagged that the **default-on flip itself** lacks a "no-filter → modernized" test. That assertion belongs with the flip in #48867 (this branch is off `trunk`, where `is_modernized()` still defaults to `false`), so it is intentionally not added here.

## Related product discussion/links
* Follow-up to the pre-release audit of the modernized Social dashboard (#48824 / #48829 / #49260 / #48867).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack build packages/publicize` (or run the test suites directly).
* **Automated:**
  * `pnpm jetpack test js packages/publicize` — full JS suite green (incl. the new `social-gate`, `settings-tab/test/cards`, `social-store/test/resolvers`, `social-store/actions/test/save-error-notices`, and disconnect cancel tests).
  * `pnpm jetpack test php packages/publicize` — incl. the new `Social_Admin_Page` kill-switch test.
* **Manual — save-failure notice:** On the modernized Settings tab, throttle/block the REST `saveSite` request (e.g. DevTools offline) and toggle Social Image Generator / UTM / Social Notes, or edit the default share message. Confirm a snackbar error notice appears (previously the toggle silently reverted with no message).
* **Manual — pricing copy:** On a free Jetpack self-hosted site with an active intro offer, open the Social dashboard pricing gate and confirm the legend reads "per month for the first year, then billed yearly" under the discounted price.
