### PR TITLE
Boost: fix double header logo on log viewer & remove TanStack debugger

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1273,9 +1273,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.90.8
         version: 5.90.8(react@18.3.1)
-      '@tanstack/react-query-devtools':
-        specifier: 5.90.2
-        version: 5.90.2(@tanstack/react-query@5.90.8(react@18.3.1))(react@18.3.1)
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260225.1
         version: 7.0.0-dev.20260225.1

--- a/projects/js-packages/react-data-sync-client/changelog/fix-gate-react-query-devtools
+++ b/projects/js-packages/react-data-sync-client/changelog/fix-gate-react-query-devtools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove the React Query devtools from DataSyncProvider so the TanStack debugger no longer renders in consuming apps.

--- a/projects/js-packages/react-data-sync-client/package.json
+++ b/projects/js-packages/react-data-sync-client/package.json
@@ -34,7 +34,6 @@
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@tanstack/react-query": "5.90.8",
-		"@tanstack/react-query-devtools": "5.90.2",
 		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"jest": "30.4.2",
 		"react": "18.3.1",

--- a/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
+++ b/projects/js-packages/react-data-sync-client/src/DataSyncHooks.ts
@@ -8,7 +8,6 @@ import {
 	useMutation,
 	QueryClientProvider,
 } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createElement, useCallback, useEffect, useState } from 'react';
 import { z } from 'zod';
 import { DataSync } from './DataSync';
@@ -31,12 +30,7 @@ export function invalidateQuery( key: string ) {
  * @see https://tanstack.com/query/v5/docs/react/reference/QueryClientProvider
  */
 export function DataSyncProvider( props: { children: ReactNode } ) {
-	return createElement(
-		QueryClientProvider,
-		{ client: queryClient },
-		props.children,
-		createElement( ReactQueryDevtools )
-	);
+	return createElement( QueryClientProvider, { client: queryClient }, props.children );
 }
 
 /**

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.module.scss
@@ -59,26 +59,11 @@
 				color: var(--gray-60);
 				font-weight: 400;
 			}
-
-			label {
-				display: block;
-				font-size: 16px;
-				line-height: 1.5;
-
-				&:not(:last-child) {
-					margin-bottom: 8px;
-				}
-			}
 		}
 
 		.button {
 			margin-top: 16px;
 		}
-	}
-
-	.see-logs-link {
-		font-size: 16px;
-		line-height: 1.5;
 	}
 
 	.logging-toggle {

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/meta/meta.tsx
@@ -6,7 +6,6 @@ import Lightning from '$svg/lightning';
 import styles from './meta.module.scss';
 import { useEffect, useState } from 'react';
 import { usePageCache, useClearPageCacheAction } from '$lib/stores/page-cache';
-import { Link } from 'react-router';
 import clsx from 'clsx';
 import { useMutationNotice } from '$features/ui';
 import { useDataSyncSubset } from '@automattic/jetpack-react-data-sync-client';
@@ -129,13 +128,9 @@ const Meta = () => {
 					{ __( 'Activate logging to track all your cache events.', 'jetpack-boost' ) }
 				</label>
 				{ logging && (
-					<Link
-						onClick={ handleSeeLogsClick }
-						className={ styles[ 'see-logs-link' ] }
-						to="/cache-debug-log"
-					>
+					<WPLink href="#/cache-debug-log" onClick={ handleSeeLogsClick }>
 						{ __( 'See Logs', 'jetpack-boost' ) }
-					</Link>
+					</WPLink>
 				) }
 				<div className={ styles.clearfix } />
 			</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.module.scss
@@ -1,36 +1,36 @@
 @use "$css/main/variables";
 
-.breadcrumbs :global(.admin-ui-breadcrumbs__list) {
-	min-height: auto;
+.breadcrumbs {
+	display: flex;
+	align-items: center;
+	list-style: none;
+	padding: 0;
+	margin: 0;
 
 	li {
 		display: flex;
 		align-items: center;
 		margin-bottom: 0;
+		flex-shrink: 0;
 	}
+
+	li:last-child {
+		flex-shrink: 1;
+		min-width: 0;
+	}
+}
+
+.separator {
+	color: var(--wpds-color-stroke-surface-neutral);
+	margin: 0 var(--wpds-dimension-gap-sm);
+	user-select: none;
 }
 
 .breadcrumb-current {
-	display: inline;
-	font-size: inherit;
-	font-weight: inherit;
-	line-height: inherit;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	margin: 0;
-}
-
-.breadcrumb-link {
-	display: inline-flex;
-	align-items: center;
-	gap: 8px;
-	color: inherit;
-	text-decoration: none;
-
-	&:hover,
-	&:focus,
-	&:active {
-		color: inherit;
-		text-decoration: underline;
-	}
 }
 
 .header {

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -1,18 +1,29 @@
+import { Button } from '@wordpress/components';
+import { check, copy } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
-import styles from './cache-debug-log.module.scss';
-import clsx from 'clsx';
-import { CopyToClipboard, JetpackLogo } from '@automattic/jetpack-components';
-import { useDebugLog } from '$features/page-cache/lib/stores';
+import { Link, Text } from '@wordpress/ui';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
+import clsx from 'clsx';
+import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
+import { useDebugLog } from '$features/page-cache/lib/stores';
 import { recordBoostEvent } from '$lib/utils/analytics';
-import {
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
+import styles from './cache-debug-log.module.scss';
 
 const CacheDebugLog = () => {
 	const [ { data: debugLog } ] = useDebugLog();
 	const navigate = useNavigate();
+	const [ hasCopied, setHasCopied ] = useState( false );
+	const copyTimer = useRef< ReturnType< typeof setTimeout > | undefined >();
+
+	useEffect( () => {
+		// Clear the "Copied!" reset timer on unmount.
+		return () => {
+			if ( copyTimer.current ) {
+				clearTimeout( copyTimer.current );
+			}
+		};
+	}, [] );
 
 	const handleBack = ( e: React.MouseEvent ) => {
 		e.preventDefault();
@@ -23,27 +34,39 @@ const CacheDebugLog = () => {
 		navigate( '/' );
 	};
 
+	const handleCopy = () => {
+		navigator.clipboard.writeText( debugLog || '' );
+		setHasCopied( true );
+		if ( copyTimer.current ) {
+			clearTimeout( copyTimer.current );
+		}
+		copyTimer.current = setTimeout( () => setHasCopied( false ), 3000 );
+	};
+
+	// Kept as a variable (and reused as the aria-label) so the minifier can't
+	// collapse the two `__()` calls into `__( cond ? a : b, … )`, which breaks
+	// the i18n string extraction in production builds.
+	const copyLabel = __( 'Copy to clipboard', 'jetpack-boost' );
+
 	const breadcrumbs = (
-		<nav aria-label={ __( 'Breadcrumbs', 'jetpack-boost' ) } className={ styles.breadcrumbs }>
-			<HStack
-				as="ul"
-				className="admin-ui-breadcrumbs__list"
-				spacing={ 0 }
-				justify="flex-start"
-				alignment="center"
-			>
+		<nav aria-label={ __( 'Breadcrumbs', 'jetpack-boost' ) }>
+			<ul className={ styles.breadcrumbs }>
 				<li>
-					<a href="#/" onClick={ handleBack } className={ styles[ 'breadcrumb-link' ] }>
-						<JetpackLogo showText={ false } height={ 20 } />
-						{ 'Boost' /** "Boost" is a product name, do not translate. */ }
-					</a>
+					<Text variant="body-lg">
+						<Link tone="neutral" href="#/" onClick={ handleBack }>
+							{ 'Boost' /** "Boost" is a product name, do not translate. */ }
+						</Link>
+					</Text>
+					<Text variant="body-lg" aria-hidden="true" className={ styles.separator }>
+						/
+					</Text>
 				</li>
 				<li>
-					<h1 className={ styles[ 'breadcrumb-current' ] }>
+					<Text variant="heading-lg" className={ styles[ 'breadcrumb-current' ] }>
 						{ __( 'Cache debug log', 'jetpack-boost' ) }
-					</h1>
+					</Text>
 				</li>
-			</HStack>
+			</ul>
 		</nav>
 	);
 
@@ -55,15 +78,15 @@ const CacheDebugLog = () => {
 						<div id="jp-admin-notices" className="jetpack-boost-jitm-card" />
 						<header className={ styles.header }>
 							<h3>{ __( 'Jetpack Boost Cache Log Viewer', 'jetpack-boost' ) }</h3>
-							<CopyToClipboard
-								buttonStyle="icon-text"
-								className={ styles[ 'copy-button' ] }
-								textToCopy={ debugLog || '' }
+							<Button
 								variant="link"
-								weight="regular"
+								className={ styles[ 'copy-button' ] }
+								icon={ hasCopied ? check : copy }
+								onClick={ handleCopy }
+								aria-label={ copyLabel }
 							>
-								{ __( 'Copy to clipboard', 'jetpack-boost' ) }
-							</CopyToClipboard>
+								{ hasCopied ? __( 'Copied!', 'jetpack-boost' ) : copyLabel }
+							</Button>
 						</header>
 
 						<pre className={ styles[ 'log-text' ] }>{ debugLog }</pre>

--- a/projects/plugins/boost/changelog/fix-boost-ui-modernization-followups
+++ b/projects/plugins/boost/changelog/fix-boost-ui-modernization-followups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cache debug log: remove the duplicate Jetpack logo and restyle the header breadcrumbs to match the design system, and modernize the "Copy to clipboard" and "See Logs" links. The TanStack Query debugger no longer renders.


### PR DESCRIPTION
Fixes #

## Proposed changes

Two Boost sub-issues from the Jetpack UI Modernization umbrella ([JETPACK-1543](https://linear.app/a8c/issue/JETPACK-1543/jetpack-ui-modernization)), plus a couple of adjacent link cleanups surfaced while fixing them.

**[JETPACK-1652](https://linear.app/a8c/issue/JETPACK-1652/boost-remove-tanstack-debugger) — Remove TanStack debugger**
* `DataSyncProvider` (in `@automattic/jetpack-react-data-sync-client`) rendered the React Query devtools unconditionally, so the floating TanStack debugger showed up in Boost. Boost is the only consumer of this provider.
* Removed the devtools render entirely and dropped the now-unused `@tanstack/react-query-devtools` devDependency. (Removed outright rather than dev-gated: `jetpack build` produces a development-mode bundle, where a `NODE_ENV` gate would still render it.)

**[JETPACK-1653](https://linear.app/a8c/issue/JETPACK-1653/boost-see-logs-view-shows-double-header-logo) — "See logs" view shows double header logo**
* The cache log viewer rendered two Jetpack logos: the admin-ui `Page` masthead logo plus a second one baked into the page's custom breadcrumb. Removed the duplicate.
* Rebuilt the breadcrumb trail with `@wordpress/ui` `Text`/`Link` primitives so it reads **"Boost / Cache debug log"** with a separator and the correct design-system typography. (The design-system `Breadcrumbs` component can't be dropped in directly because it relies on `@wordpress/route`, while Boost navigates via `react-router`'s hash router and needs the analytics `onClick`.)

**Adjacent link cleanups** (both looked out of place next to the modernized UI)
* "Copy to clipboard" in the log viewer now uses `@wordpress/components` `Button` instead of the legacy `@automattic/jetpack-components` `CopyToClipboard` (which renders the old RNA `Button`), keeping the "Copied!" feedback.
* "See Logs" now uses the `@wordpress/ui` `Link` instead of a raw `react-router` link.

## Related product discussion/links

* [JETPACK-1543 — Jetpack UI Modernization](https://linear.app/a8c/issue/JETPACK-1543/jetpack-ui-modernization)

## Does this pull request change what data or activity we track or use?

No. The existing `back_button_clicked` and `page_cache_see_logs_clicked` Tracks events are preserved.

## Testing instructions

* Build Boost (`jetpack build plugins/boost`) and load the Jetpack Boost admin page.
* Enable **Page Cache**, expand its options, and turn on **Logging**.
* Confirm the **See Logs** link renders as a design-system link (not a plain blue anchor) and navigates to the log viewer.
* On the log viewer:
  * Confirm there is a **single** Jetpack logo in the header (not two).
  * Confirm the breadcrumb reads **"Boost / Cache debug log"** — with the `/` separator and consistent font sizing.
  * Confirm **Copy to clipboard** copies the log and flips to "Copied!" briefly, with design-system button styling.
* Confirm the **TanStack Query debugger** no longer appears anywhere in the Boost UI (including local/dev builds).
