### PR TITLE
Protect: remove TanStack debugger & fix Firewall NaN stat

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5911,9 +5911,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.90.8
         version: 5.90.8(react@18.3.1)
-      '@tanstack/react-query-devtools':
-        specifier: 5.90.2
-        version: 5.90.2(@tanstack/react-query@5.90.8(react@18.3.1))(react@18.3.1)
       '@wordpress/api-fetch':
         specifier: 7.46.0
         version: 7.46.0

--- a/projects/plugins/protect/README.md
+++ b/projects/plugins/protect/README.md
@@ -25,12 +25,6 @@ Be aware that a request to the server will be made in all admin pages! Use it on
 
 Run `pnpm run storybook:dev` in `projects/js-packages/storybook` to get started.
 
-### React Query Browser Tools
-
-This project also includes [React Query Devtools](https://tanstack.com/query/latest/docs/framework/react/devtools).
-
-Whenever the application is running in development mode (i.e. via `jetpack watch`), the tools will be available in the plugin via a floating icon in the bottom right corner.
-
 ## Contribute
 
 Please refer to the [Contribute](https://github.com/Automattic/jetpack/blob/trunk/readme.md#contribute) section in the README.md file at the root of the repository.

--- a/projects/plugins/protect/changelog/fix-firewall-nan-stat
+++ b/projects/plugins/protect/changelog/fix-firewall-nan-stat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Firewall: show 0 instead of NaN on the stat cards when there are no blocked requests.

--- a/projects/plugins/protect/changelog/fix-remove-tanstack-debugger
+++ b/projects/plugins/protect/changelog/fix-remove-tanstack-debugger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removed the React Query Devtools (TanStack debugger).

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -32,7 +32,6 @@
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-scan": "workspace:*",
 		"@tanstack/react-query": "5.90.8",
-		"@tanstack/react-query-devtools": "5.90.2",
 		"@wordpress/api-fetch": "7.46.0",
 		"@wordpress/components": "33.1.0",
 		"@wordpress/data": "10.46.0",

--- a/projects/plugins/protect/src/js/index.tsx
+++ b/projects/plugins/protect/src/js/index.tsx
@@ -1,6 +1,5 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import * as WPElement from '@wordpress/element';
 import { useEffect } from 'react';
 import { HashRouter, Routes, Route, useLocation, Navigate } from 'react-router';
@@ -89,7 +88,6 @@ function render() {
 					</ModalProvider>
 				</NoticeProvider>
 			</ThemeProvider>
-			<ReactQueryDevtools initialIsOpen={ false } />
 		</QueryClientProvider>
 	);
 	WPElement.createRoot( container ).render( component );

--- a/projects/plugins/protect/src/js/routes/firewall/firewall-statcards.jsx
+++ b/projects/plugins/protect/src/js/routes/firewall/firewall-statcards.jsx
@@ -19,9 +19,8 @@ const FirewallStatCards = () => {
 	const isSupportedWafFeatureEnabled = wafSupported
 		? isWafModuleEnabled
 		: isBruteForceModuleEnabled;
-	const { currentDay: currentDayBlockCount, thirtyDays: thirtyDayBlockCounts } = stats
-		? stats.blockedRequests
-		: { currentDay: 0, thirtyDays: 0 };
+	const { currentDay: currentDayBlockCount, thirtyDays: thirtyDayBlockCounts } =
+		stats?.blockedRequests || { currentDay: 0, thirtyDays: 0 };
 	const isFeatureDisabled = ! isSupportedWafFeatureEnabled || ! hasPlan;
 
 	const defaultArgs = useMemo(


### PR DESCRIPTION
Fixes #

## Proposed changes

Two Protect bugs from the Jetpack UI Modernization walkthrough ([JETPACK-1543](https://linear.app/a8c/issue/JETPACK-1543/jetpack-ui-modernization)).

**[JETPACK-1658](https://linear.app/a8c/issue/JETPACK-1658/protect-remove-tanstack-debugger) — Remove TanStack debugger**
* Protect rendered its own `<ReactQueryDevtools>` unconditionally in `src/js/index.tsx`, so the floating TanStack debugger showed up in the admin UI. (Unlike Boost in #49280, Protect does not use the shared `DataSyncProvider` — this was a separate, local instance.)
* Removed the import and render, dropped the now-unused `@tanstack/react-query-devtools` dependency, and removed the corresponding README section.

**[PROTECT-170](https://linear.app/a8c/issue/PROTECT-170/protect-firewall-tab-shows-nan-error) — Firewall tab shows NaN**
* On the Firewall stat cards, when the WAF is enabled but the site has no *required* plan, the PHP endpoint returns `blockedRequests: false`. The JS destructured that `false` into `undefined`, and `StatCard`'s `formatNumber(undefined)` rendered `"NaN"`.
* `firewall-statcards.jsx` now falls back to `{ currentDay: 0, thirtyDays: 0 }` when `blockedRequests` is falsy, so the cards show **0** (as confirmed by the Protect team in the issue). Minimal, local change — no PHP or shared `StatCard` changes.

### Not included

[JETPACK-1660](https://linear.app/a8c/issue/JETPACK-1660/protect-prevent-icon-wrapping-on-settings-page) (external-link icon wrapping on the Settings page) is intentionally **not** in this PR. The arrow comes from the upstream `@wordpress/ui` `Link` component (`openInNewTab` renders a `display: inline-block` `.link-icon`), so the proper fix belongs upstream rather than as a local CSS hack. Findings left on the issue.

## Related product discussion/links

* [JETPACK-1658](https://linear.app/a8c/issue/JETPACK-1658/protect-remove-tanstack-debugger)
* [PROTECT-170](https://linear.app/a8c/issue/PROTECT-170/protect-firewall-tab-shows-nan-error)
* Precedent for the debugger removal: #49280 (Boost)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Protect (`jetpack build plugins/protect`) and open the Jetpack Protect admin UI.
* Confirm the **TanStack Query debugger** no longer appears anywhere (including local/dev builds).
* Go to the **Firewall** tab. On a site where the WAF is on but without the required plan (the case that previously showed `NaN`), confirm the block-count stat cards now read **0** instead of `NaN`. Verify normal sites with real block counts still show their numbers.
