### PR TITLE
Agents Manager: Allow overriding variant and sectionName parameters

### DIFF
--- a/projects/packages/agents-manager/changelog/agents-manager-allow-overriding-variant-sectionname
+++ b/projects/packages/agents-manager/changelog/agents-manager-allow-overriding-variant-sectionname
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: Allow overriding variant and sectionName through filters

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -172,7 +172,7 @@ class Agents_Manager {
 		}
 
 		// Determine which variant to load (null = don't load).
-		$variant = $this->get_variant();
+		$variant = apply_filters( 'agents_manager_variant', $this->get_variant() );
 		if ( null === $variant ) {
 			return;
 		}
@@ -273,7 +273,7 @@ class Agents_Manager {
 			'agentProviders'       => $agent_providers,
 			'useUnifiedExperience' => $use_unified_experience,
 			'isDevMode'            => self::is_dev_mode(),
-			'sectionName'          => $variant,
+			'sectionName'          => apply_filters( 'agents_manager_section_name', $variant ),
 			'currentUser'          => $this->get_current_user_data(),
 			'site'                 => $this->get_current_site(),
 			'helpCenterUrl'        => self::HELP_CENTER_URL,


### PR DESCRIPTION
Related to WOOAI-501.

## Proposed changes

Some consumers of the Agents Manager package require customized `variant` and `sectionName` values. This PR allows this customization through two new filters:
- `agents_manager_variant`
- `agents_manager_section_name`

## Related product discussion/links

See Linear issue.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

See the WooAI PR.