### PR TITLE
`jetpack playground`: Use pnpm dlx instead of npx

### DIFF
--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -106,11 +106,11 @@ export async function handler( argv ) {
 		}
 
 		if ( argv.verbose ) {
-			console.log( chalk.gray( `Running: npx ${ args.join( ' ' ) }` ) );
+			console.log( chalk.gray( `Running: pnpm dlx ${ args.join( ' ' ) }` ) );
 		}
 
 		await new Promise( ( resolve, reject ) => {
-			const proc = child_process.spawn( 'npx', args, {
+			const proc = child_process.spawn( 'pnpm', [ 'dlx', ...args ], {
 				stdio: [ 'inherit', 'pipe', 'inherit' ],
 			} );
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
When running `jetpack playground boost` (or any other plugin), it gives this alert:
```
npm warn Unknown project config "jetpack-webpack-config-resolve-conditions". This will stop working in the next major version of npm.
```

This is because we've set that key in `.npmrc`, and `npm` (as of 11.2.0) warns on non-standard keys:
npm/cli#8071

Since we use `pnpm`, this PR switches the `npx` call to `pnpm dlx`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Unfortunately, there's an upstream bug with the package we're trying to run but hopefully that'll be fixed soon: WordPress/wordpress-playground#3711

Once the upstream fix is merged, try `jetpack playground boost` on this branch and it should work.