### PR TITLE
CLI: phase-level build timing summary and JSON profiling output

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -20,6 +20,7 @@ import PrefixStream from '../helpers/prefix-stream.js';
 import { allProjects, allProjectsByType } from '../helpers/projectHelpers.js';
 import promptForProject from '../helpers/promptForProject.js';
 import { chalkJetpackGreen } from '../helpers/styling.js';
+import { printTimingSummary, buildTimingJson } from '../helpers/timing-summary.js';
 
 export const command = 'build [project...]';
 export const describe = 'Builds one or more monorepo projects';
@@ -75,6 +76,11 @@ export function builder( yargs ) {
 		.option( 'no-use-uncommitted-composer-lock', {
 			type: 'boolean',
 			description: "Don't use uncommitted composer.lock files.",
+		} )
+		.option( 'timing-output', {
+			type: 'string',
+			normalize: true,
+			description: 'Write machine-readable timing data (JSON) to the given file. Implies --timing.',
 		} );
 }
 
@@ -94,6 +100,11 @@ export async function handler( argv ) {
 	}
 
 	argv.useUncommittedComposerLock = argv.useUncommittedComposerLock !== false;
+
+	// `--timing-output` writes JSON, which requires the timing data to be collected.
+	if ( argv.timingOutput ) {
+		argv.timing = true;
+	}
 
 	let dependencies = await getDependencies( process.cwd(), 'build' );
 	const listr = new Listr( [], {
@@ -222,15 +233,35 @@ export async function handler( argv ) {
 		promises: {},
 		mirrorMutex: pLimit( 1 ),
 		versions: {},
+		// When `--timing` is set, collect a flat list of phase timings to summarize at the end.
+		timings: argv.timing ? { overallStart: Date.now(), entries: [], buildOrder } : null,
 	};
 	await listr
 		.run( ctx )
-		.finally( () => {
+		.finally( async () => {
 			if ( missing.size ) {
 				console.error( '' );
 				const wrap = argv.v ? v => v : chalk.red;
 				for ( const project of missing ) {
 					console.error( wrap( `Project ${ project } was ignored as it does not exist.` ) );
+				}
+			}
+
+			// Print the timing summary (and optionally dump JSON) on both success and failure.
+			// This runs before the `.catch` below, which may call `process.exit()`.
+			if ( ctx.timings ) {
+				printTimingSummary( ctx, argv );
+				if ( argv.timingOutput ) {
+					try {
+						await fs.writeFile(
+							argv.timingOutput,
+							JSON.stringify( buildTimingJson( ctx, argv ), null, 2 ) + '\n',
+							'utf8'
+						);
+						console.log( `Timing data written to ${ argv.timingOutput }` );
+					} catch ( e ) {
+						console.error( `Failed to write timing output: ${ e.message }` );
+					}
 				}
 			}
 		} )
@@ -386,6 +417,33 @@ function createBuildTask( project, argv, title, build ) {
 						return p;
 					};
 
+					// Time a named build phase, recording its duration into ctx.timings (if enabled).
+					// Returns the wrapped function's value, and records even when it throws.
+					t.time = async ( phase, fn ) => {
+						const start = Date.now();
+						const record = ok => {
+							if ( ctx.timings ) {
+								const end = Date.now();
+								ctx.timings.entries.push( {
+									project,
+									phase,
+									start,
+									end,
+									duration: end - start,
+									ok,
+								} );
+							}
+						};
+						try {
+							const result = await fn();
+							record( true );
+							return result;
+						} catch ( e ) {
+							record( false );
+							throw e;
+						}
+					};
+
 					// Build!
 					const t0 = Date.now();
 					buildStarted = true;
@@ -395,7 +453,19 @@ function createBuildTask( project, argv, title, build ) {
 						await t.output( `\nBuild failed: ${ e.stack }\n` );
 						throw e;
 					} finally {
-						await t.setStatus( argv.timing ? formatDuration( Date.now() - t0 ) + 's' : 'complete' );
+						const dur = Date.now() - t0;
+						if ( ctx.timings ) {
+							// The authoritative per-task total (also covers the shared pnpm/changelogger tasks).
+							ctx.timings.entries.push( {
+								project,
+								phase: '_task',
+								start: t0,
+								end: t0 + dur,
+								duration: dur,
+								ok: true,
+							} );
+						}
+						await t.setStatus( argv.timing ? formatDuration( dur ) + 's' : 'complete' );
 					}
 				} );
 			} )().then(
@@ -778,11 +848,13 @@ async function buildProject( t ) {
 	if ( skipInstall ) {
 		await t.output( `Skipping composer install for CI build of non-plugin with no build script\n` );
 	} else {
-		await t.execa( 'composer', await getInstallArgs( t.project, 'composer', t.argv ), {
-			cwd: t.cwd,
-			stdio: [ 'ignore', 'inherit', 'inherit' ],
-			buffer: false,
-		} );
+		await t.time( 'install', async () =>
+			t.execa( 'composer', await getInstallArgs( t.project, 'composer', t.argv ), {
+				cwd: t.cwd,
+				stdio: [ 'ignore', 'inherit', 'inherit' ],
+				buffer: false,
+			} )
+		);
 	}
 
 	// Build.
@@ -790,11 +862,13 @@ async function buildProject( t ) {
 	if ( script === null ) {
 		await t.output( `No build scripts are defined for ${ t.project }\n` );
 	} else {
-		await t.execa( 'composer', [ 'run', '--timeout=0', script ], {
-			cwd: t.cwd,
-			stdio: [ 'ignore', 'inherit', 'inherit' ],
-			buffer: false,
-		} );
+		await t.time( 'build', async () =>
+			t.execa( 'composer', [ 'run', '--timeout=0', script ], {
+				cwd: t.cwd,
+				stdio: [ 'ignore', 'inherit', 'inherit' ],
+				buffer: false,
+			} )
+		);
 	}
 
 	// If we're not mirroring, the build is done. Mirroring has a bunch of stuff to do yet.

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -447,9 +447,13 @@ function createBuildTask( project, argv, title, build ) {
 					// Build!
 					const t0 = Date.now();
 					buildStarted = true;
+					let taskOk = true;
 					try {
 						await build( t );
 					} catch ( e ) {
+						// Record the failure so the `_task` total below (and the JSON `ok` field) reflect it,
+						// even when the failure happens outside a `t.time()`-wrapped phase (e.g. mirroring).
+						taskOk = false;
 						await t.output( `\nBuild failed: ${ e.stack }\n` );
 						throw e;
 					} finally {
@@ -462,7 +466,7 @@ function createBuildTask( project, argv, title, build ) {
 								start: t0,
 								end: t0 + dur,
 								duration: dur,
-								ok: true,
+								ok: taskOk,
 							} );
 						}
 						await t.setStatus( argv.timing ? formatDuration( dur ) + 's' : 'complete' );

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -420,19 +420,21 @@ function createBuildTask( project, argv, title, build ) {
 					// Time a named build phase, recording its duration into ctx.timings (if enabled).
 					// Returns the wrapped function's value, and records even when it throws.
 					t.time = async ( phase, fn ) => {
+						// No-op passthrough when timing is disabled, so the normal build path is untouched.
+						if ( ! ctx.timings ) {
+							return fn();
+						}
 						const start = Date.now();
 						const record = ok => {
-							if ( ctx.timings ) {
-								const end = Date.now();
-								ctx.timings.entries.push( {
-									project,
-									phase,
-									start,
-									end,
-									duration: end - start,
-									ok,
-								} );
-							}
+							const end = Date.now();
+							ctx.timings.entries.push( {
+								project,
+								phase,
+								start,
+								end,
+								duration: end - start,
+								ok,
+							} );
 						};
 						try {
 							const result = await fn();

--- a/tools/cli/helpers/timing-summary.js
+++ b/tools/cli/helpers/timing-summary.js
@@ -1,0 +1,158 @@
+import formatDuration from './format-duration.js';
+
+const DASH = '—';
+
+/**
+ * Aggregate the flat list of timing entries into per-project phase totals.
+ *
+ * @param {object} timings - The `ctx.timings` object ({ overallStart, entries, buildOrder }).
+ * @return {object} `{ rows, sumOfTotals }` where `rows` is a Map of project => { install, build, task, other, shared, ok }.
+ */
+function aggregate( timings ) {
+	const buildOrder = new Set( timings.buildOrder );
+	const rows = new Map();
+	let sumOfTotals = 0;
+
+	for ( const e of timings.entries ) {
+		let row = rows.get( e.project );
+		if ( ! row ) {
+			row = {
+				project: e.project,
+				install: null,
+				build: null,
+				task: null,
+				shared: ! buildOrder.has( e.project ),
+				ok: true,
+			};
+			rows.set( e.project, row );
+		}
+		if ( e.phase === '_task' ) {
+			row.task = ( row.task || 0 ) + e.duration;
+		} else {
+			row[ e.phase ] = ( row[ e.phase ] || 0 ) + e.duration;
+		}
+		if ( ! e.ok ) {
+			row.ok = false;
+		}
+	}
+
+	for ( const row of rows.values() ) {
+		const task = row.task || 0;
+		sumOfTotals += task;
+		// "Other" is whatever wasn't explicitly timed as install/build (changelog, mirroring, overhead).
+		row.other = Math.max( 0, task - ( row.install || 0 ) - ( row.build || 0 ) );
+	}
+
+	return { rows, sumOfTotals };
+}
+
+/**
+ * Print a human-readable phase-level timing summary table.
+ *
+ * Shared/top-level tasks (e.g. `pnpm install`) are listed first, then build projects in build
+ * order. Phases that never ran (skipped install, no build script) render as an em dash.
+ *
+ * @param {object} ctx  - Build context. Uses `ctx.timings`.
+ * @param {object} argv - Command line arguments. Uses `argv.concurrency`.
+ */
+export function printTimingSummary( ctx, argv ) {
+	if ( ! ctx.timings || ctx.timings.entries.length === 0 ) {
+		return;
+	}
+
+	const { rows, sumOfTotals } = aggregate( ctx.timings );
+	const wallClock = Date.now() - ctx.timings.overallStart;
+	const order = [ ...ctx.timings.buildOrder ];
+
+	// Shared rows first (in encounter order), then build rows in build order.
+	const sorted = [ ...rows.values() ]
+		.filter( r => r.shared )
+		.concat( order.map( p => rows.get( p ) ).filter( Boolean ) );
+
+	const fmt = ms => ( ms === null || ms === undefined ? DASH : formatDuration( ms ) + 's' );
+
+	const cols = [
+		{ label: 'Project', get: r => r.project, align: 'left' },
+		{ label: 'Install', get: r => fmt( r.install ), align: 'right' },
+		{ label: 'Build', get: r => fmt( r.build ), align: 'right' },
+		{ label: 'Other', get: r => fmt( r.other ), align: 'right' },
+		{ label: 'Total', get: r => fmt( r.task ), align: 'right' },
+	];
+
+	// Compute each column's width from its header and all cell values.
+	const widths = cols.map( c =>
+		Math.max( c.label.length, ...sorted.map( r => c.get( r ).length ) )
+	);
+
+	const pad = ( s, i ) =>
+		cols[ i ].align === 'right' ? s.padStart( widths[ i ] ) : s.padEnd( widths[ i ] );
+
+	const renderRow = cells => '  ' + cells.map( ( s, i ) => pad( s, i ) ).join( '   ' );
+
+	const header = renderRow( cols.map( c => c.label ) );
+	const sep = '  ' + '─'.repeat( header.length - 2 );
+	const concurrency = Number.isFinite( argv.concurrency ) ? argv.concurrency : 'unlimited';
+
+	const lines = [
+		'',
+		`Timing summary (concurrency: ${ concurrency })`,
+		'',
+		header,
+		sep,
+		...sorted.map( r => renderRow( cols.map( c => c.get( r ) ) ) ),
+		sep,
+	];
+
+	// Footers: align the value under the Total column.
+	const labelWidth = widths.slice( 0, -1 ).reduce( ( a, w ) => a + w, 0 ) + 3 * ( cols.length - 1 );
+	const footer = ( label, ms ) =>
+		'  ' + label.padEnd( labelWidth ) + ( formatDuration( ms ) + 's' ).padStart( widths.at( -1 ) );
+	lines.push( footer( 'Sum of per-project totals', sumOfTotals ) );
+	lines.push( footer( 'Wall-clock (overall)', wallClock ) );
+
+	console.log( lines.join( '\n' ) );
+}
+
+/**
+ * Build a machine-readable timing report suitable for JSON serialization.
+ *
+ * @param {object} ctx  - Build context. Uses `ctx.timings`.
+ * @param {object} argv - Command line arguments.
+ * @return {object} The timing report.
+ */
+export function buildTimingJson( ctx, argv ) {
+	const { rows, sumOfTotals } = aggregate( ctx.timings );
+	const finishedMs = Date.now();
+	const wallClockMs = finishedMs - ctx.timings.overallStart;
+
+	const projects = {};
+	const shared = {};
+	for ( const r of rows.values() ) {
+		if ( r.shared ) {
+			shared[ r.project ] = { totalMs: r.task ?? null, ok: r.ok };
+		} else {
+			projects[ r.project ] = {
+				installMs: r.install ?? null,
+				buildMs: r.build ?? null,
+				otherMs: r.other,
+				totalMs: r.task ?? null,
+				ok: r.ok,
+			};
+		}
+	}
+
+	return {
+		version: 1,
+		command: 'build',
+		startedAt: new Date( ctx.timings.overallStart ).toISOString(),
+		finishedAt: new Date( finishedMs ).toISOString(),
+		wallClockMs,
+		sumOfProjectTotalsMs: sumOfTotals,
+		concurrency: Number.isFinite( argv.concurrency ) ? argv.concurrency : 'unlimited',
+		production: !! argv.production,
+		forMirrors: !! argv.forMirrors,
+		projects,
+		shared,
+		raw: ctx.timings.entries,
+	};
+}

--- a/tools/cli/helpers/timing-summary.js
+++ b/tools/cli/helpers/timing-summary.js
@@ -39,8 +39,15 @@ function aggregate( timings ) {
 	for ( const row of rows.values() ) {
 		const task = row.task || 0;
 		sumOfTotals += task;
-		// "Other" is whatever wasn't explicitly timed as install/build (changelog, mirroring, overhead).
-		row.other = Math.max( 0, task - ( row.install || 0 ) - ( row.build || 0 ) );
+		// Shared tasks (pnpm/changelogger install) have no install/build phase of their own; their
+		// whole total is install work, so surface it in the Install column rather than "Other".
+		if ( row.shared ) {
+			row.install = task;
+			row.other = null;
+		} else {
+			// "Other" is whatever wasn't explicitly timed as install/build (changelog, mirroring, overhead).
+			row.other = Math.max( 0, task - ( row.install || 0 ) - ( row.build || 0 ) );
+		}
 	}
 
 	return { rows, sumOfTotals };
@@ -115,6 +122,10 @@ export function printTimingSummary( ctx, argv ) {
 
 /**
  * Build a machine-readable timing report suitable for JSON serialization.
+ *
+ * The `projects` and `shared` maps are aggregated views derived from `raw`, which is the
+ * unaggregated list of phase entries. Consumers wanting per-phase totals should read
+ * `projects`/`shared`; `raw` is for ad-hoc analysis of the individual timings.
  *
  * @param {object} ctx  - Build context. Uses `ctx.timings`.
  * @param {object} argv - Command line arguments.

--- a/tools/cli/tests/unit/helpers/timing-summary.test.js
+++ b/tools/cli/tests/unit/helpers/timing-summary.test.js
@@ -4,7 +4,7 @@ import { printTimingSummary, buildTimingJson } from '../../../helpers/timing-sum
 /**
  * Build a `ctx.timings`-shaped object from a list of phase entries.
  *
- * @param {Array}  entries    - Timing entries.
+ * @param {Array}  entries     - Timing entries.
  * @param {object} [overrides] - Overrides for overallStart/buildOrder.
  * @return {object} A `ctx` with a `timings` property.
  */
@@ -66,10 +66,12 @@ describe( 'buildTimingJson', () => {
 	} );
 
 	test( 'serializes infinite concurrency as "unlimited" and finite as a number', () => {
-		expect( buildTimingJson( makeCtx( SAMPLE_ENTRIES ), { concurrency: Infinity } ).concurrency ).toBe(
-			'unlimited'
+		expect(
+			buildTimingJson( makeCtx( SAMPLE_ENTRIES ), { concurrency: Infinity } ).concurrency
+		).toBe( 'unlimited' );
+		expect( buildTimingJson( makeCtx( SAMPLE_ENTRIES ), { concurrency: 4 } ).concurrency ).toBe(
+			4
 		);
-		expect( buildTimingJson( makeCtx( SAMPLE_ENTRIES ), { concurrency: 4 } ).concurrency ).toBe( 4 );
 	} );
 
 	test( 'passes the raw entries through untouched', () => {

--- a/tools/cli/tests/unit/helpers/timing-summary.test.js
+++ b/tools/cli/tests/unit/helpers/timing-summary.test.js
@@ -1,0 +1,139 @@
+import { jest } from '@jest/globals';
+import { printTimingSummary, buildTimingJson } from '../../../helpers/timing-summary.js';
+
+/**
+ * Build a `ctx.timings`-shaped object from a list of phase entries.
+ *
+ * @param {Array}  entries    - Timing entries.
+ * @param {object} [overrides] - Overrides for overallStart/buildOrder.
+ * @return {object} A `ctx` with a `timings` property.
+ */
+function makeCtx( entries, overrides = {} ) {
+	return {
+		timings: {
+			overallStart: 1000,
+			buildOrder: [ 'packages/foo', 'plugins/bar' ],
+			entries,
+			...overrides,
+		},
+	};
+}
+
+// A representative run: a shared pnpm install, a fully-timed project, and a project that
+// fails outside a timed phase (only the `_task` entry carries the failure).
+const SAMPLE_ENTRIES = [
+	{ project: 'pnpm install', phase: '_task', start: 1000, end: 6000, duration: 5000, ok: true },
+	{ project: 'packages/foo', phase: 'install', start: 6000, end: 8000, duration: 2000, ok: true },
+	{ project: 'packages/foo', phase: 'build', start: 8000, end: 11000, duration: 3000, ok: true },
+	{ project: 'packages/foo', phase: '_task', start: 6000, end: 11500, duration: 5500, ok: true },
+	{ project: 'plugins/bar', phase: 'install', start: 11000, end: 12000, duration: 1000, ok: true },
+	{ project: 'plugins/bar', phase: '_task', start: 11000, end: 14000, duration: 3000, ok: false },
+];
+
+describe( 'buildTimingJson', () => {
+	const argv = { concurrency: Infinity };
+
+	test( 'splits project phases into install/build/other/total', () => {
+		const json = buildTimingJson( makeCtx( SAMPLE_ENTRIES ), argv );
+		expect( json.projects[ 'packages/foo' ] ).toEqual( {
+			installMs: 2000,
+			buildMs: 3000,
+			otherMs: 500, // 5500 total - 2000 install - 3000 build
+			totalMs: 5500,
+			ok: true,
+		} );
+	} );
+
+	test( 'reports a per-task failure even when it happens outside a timed phase', () => {
+		const json = buildTimingJson( makeCtx( SAMPLE_ENTRIES ), argv );
+		// bar only has a passing `install` entry; the failure lives on its `_task` total.
+		expect( json.projects[ 'plugins/bar' ].ok ).toBe( false );
+		expect( json.projects[ 'plugins/bar' ].buildMs ).toBeNull();
+	} );
+
+	test( 'puts shared tasks in the shared bucket, not projects', () => {
+		const json = buildTimingJson( makeCtx( SAMPLE_ENTRIES ), argv );
+		expect( json.shared ).toEqual( { 'pnpm install': { totalMs: 5000, ok: true } } );
+		expect( json.projects[ 'pnpm install' ] ).toBeUndefined();
+	} );
+
+	test( 'sums every per-project total and reports wall-clock from overallStart', () => {
+		const json = buildTimingJson( makeCtx( SAMPLE_ENTRIES ), argv );
+		expect( json.sumOfProjectTotalsMs ).toBe( 13500 ); // 5000 + 5500 + 3000
+		expect( json.wallClockMs ).toBeGreaterThan( 0 );
+		expect( json.version ).toBe( 1 );
+		expect( json.command ).toBe( 'build' );
+	} );
+
+	test( 'serializes infinite concurrency as "unlimited" and finite as a number', () => {
+		expect( buildTimingJson( makeCtx( SAMPLE_ENTRIES ), { concurrency: Infinity } ).concurrency ).toBe(
+			'unlimited'
+		);
+		expect( buildTimingJson( makeCtx( SAMPLE_ENTRIES ), { concurrency: 4 } ).concurrency ).toBe( 4 );
+	} );
+
+	test( 'passes the raw entries through untouched', () => {
+		const json = buildTimingJson( makeCtx( SAMPLE_ENTRIES ), argv );
+		expect( json.raw ).toBe( SAMPLE_ENTRIES );
+	} );
+} );
+
+describe( 'printTimingSummary', () => {
+	let logSpy;
+
+	beforeEach( () => {
+		logSpy = jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		logSpy.mockRestore();
+	} );
+
+	/**
+	 * Run printTimingSummary and return everything it logged as one string.
+	 *
+	 * @param {object} ctx  - Build context.
+	 * @param {object} argv - CLI args.
+	 * @return {string} Joined console.log output.
+	 */
+	function capture( ctx, argv ) {
+		printTimingSummary( ctx, argv );
+		return logSpy.mock.calls.map( c => c[ 0 ] ).join( '\n' );
+	}
+
+	test( 'does nothing when there are no entries', () => {
+		capture( makeCtx( [] ), { concurrency: Infinity } );
+		expect( logSpy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'prints a header, a row per task, and the footer totals', () => {
+		const out = capture( makeCtx( SAMPLE_ENTRIES ), { concurrency: Infinity } );
+		expect( out ).toContain( 'Timing summary (concurrency: unlimited)' );
+		expect( out ).toMatch( /Project\s+Install\s+Build\s+Other\s+Total/ );
+		expect( out ).toContain( 'pnpm install' );
+		expect( out ).toContain( 'packages/foo' );
+		expect( out ).toContain( 'plugins/bar' );
+		expect( out ).toContain( 'Sum of per-project totals' );
+		expect( out ).toContain( 'Wall-clock (overall)' );
+	} );
+
+	test( 'shows shared install time under Install (em dash for Build/Other)', () => {
+		const out = capture( makeCtx( SAMPLE_ENTRIES ), { concurrency: Infinity } );
+		const sharedRow = out.split( '\n' ).find( l => l.includes( 'pnpm install' ) );
+		// Install populated, Build + Other are em dashes for a shared task.
+		expect( sharedRow ).toContain( '5.000s' );
+		expect( sharedRow.match( /—/g ) ).toHaveLength( 2 );
+	} );
+
+	test( 'lists shared rows before build rows, in build order', () => {
+		const out = capture( makeCtx( SAMPLE_ENTRIES ), { concurrency: Infinity } );
+		const idx = name => out.indexOf( name );
+		expect( idx( 'pnpm install' ) ).toBeLessThan( idx( 'packages/foo' ) );
+		expect( idx( 'packages/foo' ) ).toBeLessThan( idx( 'plugins/bar' ) );
+	} );
+
+	test( 'renders a finite concurrency value in the header', () => {
+		const out = capture( makeCtx( SAMPLE_ENTRIES ), { concurrency: 2 } );
+		expect( out ).toContain( 'Timing summary (concurrency: 2)' );
+	} );
+} );


### PR DESCRIPTION
This PR is introducing a new `--timing` and --timing-output <file> flags so that we can take a look at how fast things are taking to build / install etc. 

This is useful when trying to improve the performance of this process. 

## Proposed changes

Adds phase-level timing/profiling to the `jetpack build` CLI command so it's clear where build time actually goes (including across all dependencies, and split by install vs asset build).

* Extends the existing `--timing` flag to print an **end-of-run summary table** (printed even without `-v`): per-project **Install** (composer install) / **Build** (`composer run build-*`) / **Other** (changelog, mirroring, overhead) / **Total**, plus a **Sum of per-project totals** and the overall **Wall-clock** time. The header notes the concurrency so it's obvious why the sum exceeds wall-clock.
* Shared top-level tasks (`pnpm install`, `changelogger install`) get their own row, with their time shown in the **Install** column.
* Adds a new `--timing-output <file>` option that writes a versioned, machine-readable JSON report (aggregated per-project/shared timings plus a `raw` array with absolute epoch timestamps) for cross-run comparison. It implies `--timing`.
* Adds a `t.time(phase, fn)` helper that wraps the install/build phases and records durations into a `ctx.timings` collector; the authoritative per-task total is recorded in the existing task `finally`, so the shared `pnpm install`/`changelogger install` tasks get a row for free.
* The per-task total carries the real pass/fail status, so a failure that happens **outside** a timed phase (e.g. during mirroring) is still reflected in the table and in the JSON `ok` field.
* New helper `tools/cli/helpers/timing-summary.js` (`printTimingSummary()` + `buildTimingJson()`) keeps formatting out of the build orchestration and is independently testable.

All recording is gated on `--timing`; when the flag is off the build path is behaviorally unchanged. No changelog entry is needed — `tools/cli` is not a changelogger-managed project.

Note: the breakdown is at the phase granularity the CLI controls (install vs asset build per project). Finer per-asset breakdown (individual webpack/babel/sass steps) lives in each project's own build tooling and is intentionally out of scope; that time is accounted for in the `Other` column.

## Screenshots

Summary table printed at the end of `jetpack build packages/constants packages/roles packages/status --timing` (concurrency lets the per-project sum exceed wall-clock; `status` waits on its dependency `constants`):

![Timing summary table](https://raw.githubusercontent.com/Automattic/jetpack/add/jetpack-build-profiling-assets/pr-assets/timing-summary.png)

Machine-readable output written by `--timing-output ./timing.json`:

![timing.json output](https://raw.githubusercontent.com/Automattic/jetpack/add/jetpack-build-profiling-assets/pr-assets/timing-json.png)

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From the monorepo root, run a build with timing for a project and its dependencies:
  * `jetpack build packages/connection --deps --timing`
  * Confirm an end-of-run table prints with `Install` / `Build` / `Other` / `Total` columns, a `pnpm install` row (its time under `Install`), and `Sum of per-project totals` + `Wall-clock (overall)` lines.
* Confirm the table prints **without** `-v` (i.e. `--timing` alone is enough).
* Run with JSON output: `jetpack build packages/connection --deps --timing-output ./jp-timing.json`
  * Confirm `--timing` is auto-enabled, the file is written, and it contains `projects`, `shared`, `wallClockMs`, and a `raw` array.
* Run **without** `--timing` (`jetpack build packages/connection`) and confirm no summary table prints and behavior is unchanged.
* Serial sanity: add `--concurrency=1` and confirm `Sum of per-project totals` ≈ `Wall-clock (overall)`.
* Failure path: break a project's `build-development` script (e.g. set it to `exit 1`), build with `--timing`, and confirm a partial summary still prints, the failing project shows `ok: false` in the JSON, and the process exits non-zero. Restore the script afterward.
