### PR TITLE
fix: fix white background on notched labels in Outline style on dark themes

### DIFF
--- a/projects/packages/forms/changelog/1780096156402-forms-outline-dark-theme
+++ b/projects/packages/forms/changelog/1780096156402-forms-outline-dark-theme
@@ -1,4 +1,4 @@
-significance: patch
-type: fixed
+Significance: patch
+Type: fixed
 
 Fixed white background showing behind form labels in Outline style on dark themes.

--- a/projects/packages/forms/changelog/1780096156402-forms-outline-dark-theme
+++ b/projects/packages/forms/changelog/1780096156402-forms-outline-dark-theme
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+
+Fixed white background showing behind form labels in Outline style on dark themes.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -959,7 +959,7 @@
 	border-right: none !important;
 	border-top-right-radius: unset !important;
 	border-bottom-right-radius: unset !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: inherit;
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__notch {
@@ -972,7 +972,7 @@
 	transition: border 150ms linear;
 	border-left: none !important;
 	border-right: none !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: inherit;
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__filler {
@@ -984,7 +984,7 @@
 	border-left: none !important;
 	border-right: none !important;
 	border-radius: unset !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: inherit;
 }
 
 :where(.wp-block-jetpack-contact-form.is-style-outlined) .notched-label__trailing {
@@ -999,7 +999,7 @@
 	border-left: none !important;
 	border-top-left-radius: unset !important;
 	border-bottom-left-radius: unset !important;
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: inherit;
 }
 
 /* Preserve the background color for the checkbox multiple and radio


### PR DESCRIPTION
## What does this PR do?

Fixes #41518. The notched label parts (leading, notch, filler, trailing) in the Outline form style had `background-color` set to `var(--jetpack--contact-form--input-background)`. On dark themes like TT5 "Evening", this caused a visible white bar behind the floating label text. Changing to `inherit` lets the notch sections pick up the page background color instead.

Ran `@claude review` — pending (will update after review).

## Testing instructions

1. Create a WordPress site with the TT5 (Twenty Twenty-Five) theme active
2. Select the "Evening" color style
3. Add a Jetpack contact form block to a page
4. Set the form style to "Outline"
5. Confirm the white background behind the label text is no longer visible on the dark background

Verified locally by @smorphewA8C  — white background behind the notched label text in the Outlined style on dark themes is resolved.

## Does this pull request change what data or activity we track or use?

No — this is a CSS-only visual fix with no changes to data collection or tracking.

## Screenshots

Before:

<img width="1414" height="2580" alt="image" src="https://github.com/user-attachments/assets/79365220-bb7d-4c92-886a-cbbf674fda39" />

After:

<img width="1505" height="846" alt="image" src="https://github.com/user-attachments/assets/2c944beb-3f6b-4bd7-9499-eb7e7fbaeb9a" />
