### PR TITLE
Pinterest block: Prevent PHP warning when url attribute is malformed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-pinterest-php_warning_on_malformed_block_attributes
+++ b/projects/plugins/jetpack/changelog/fix-pinterest-php_warning_on_malformed_block_attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Pinterest block: Prevent PHP warning when block attributes are malformed.

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
@@ -231,7 +231,7 @@ function load_assets( $attr, $content ) {
 	if ( Blocks::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {
-		$url  = $attr['url'];
+		$url  = $attr['url'] ?? '';
 		$type = pin_type( $url );
 
 		if ( ! $type ) {

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
@@ -228,10 +228,11 @@ function load_assets( $attr, $content ) {
 	if ( ! Request::is_frontend() ) {
 		return $content;
 	}
+	$attr['url'] = $attr['url'] ?? '';
 	if ( Blocks::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {
-		$url  = $attr['url'] ?? '';
+		$url  = $attr['url'];
 		$type = pin_type( $url );
 
 		if ( ! $type ) {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR guards against a missing `url` key that is causing these:
```
PHP Warning: Undefined array key "url" in /wordpress/plugins/jetpack/15.9-a.5/extensions/blocks/pinterest/pinterest.php on line 144

PHP Warning: Undefined array key "url" in /wordpress/plugins/jetpack/15.9-a.5/extensions/blocks/pinterest/pinterest.php on line 202

PHP Warning: Undefined array key "url" in /wordpress/plugins/jetpack/15.9-a.5/extensions/blocks/pinterest/pinterest.php on line 207

PHP Warning: Undefined array key "url" in /wordpress/plugins/jetpack/15.9-a.5/extensions/blocks/pinterest/pinterest.php on line 208

PHP Warning: Undefined array key "url" in /wordpress/plugins/jetpack/15.9-a.5/extensions/blocks/pinterest/pinterest.php on line 234
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Presumably one could reproduce it by manually editing a block.