### PR TITLE
Publicize: Prevent PHP warning when $post is not WP_Post

### DIFF
--- a/projects/packages/publicize/changelog/fix-publicize-prevent_php_warning_on_when_post_is_not_WP_Post
+++ b/projects/packages/publicize/changelog/fix-publicize-prevent_php_warning_on_when_post_is_not_WP_Post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Publicize: Avoid flagging a non-post for publicize

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -590,7 +590,7 @@ class Publicize extends Publicize_Base {
 	 * @param WP_Post $post Post object.
 	 */
 	public function flag_post_for_publicize( $new_status, $old_status, $post ) {
-		if ( ! $this->post_type_is_publicizeable( $post->post_type ) ) {
+		if ( ! $post instanceof \WP_Post || ! $this->post_type_is_publicizeable( $post->post_type ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR guards against trying to publicize a `$post` that isn't really a `WP_Post`, which causes this:

```
PHP Warning: Attempt to read property "post_type" on null in /wordpress/plugins/jetpack/15.9-a.5/jetpack_vendor/automattic/jetpack-publicize/src/class-publicize.php on line 593
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Third-party code with this would trigger the issue:
```
do_action( 'transition_post_status', $new_status, $old_status, null );
```