### PR TITLE
BFP: Only use WP_User->roles if $user is a WP_User

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-only_use_as_WP_User_if_WP_User
+++ b/projects/packages/waf/changelog/fix-waf-only_use_as_WP_User_if_WP_User
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+BFP: Prevent PHP warning when username is invalid.

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -586,7 +586,8 @@ class Brute_Force_Protection {
 			$user = get_user_by( 'login', $user_login );
 		}
 
-		$this->protect_call( 'successful_login', array( 'roles' => $user->roles ) );
+		$roles = $user instanceof \WP_User ? $user->roles : array();
+		$this->protect_call( 'successful_login', array( 'roles' => $roles ) );
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -40,6 +40,18 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that log_successful_login still calls protect_call when get_user_by returns false.
+	 */
+	public function test_log_successful_login_handles_unknown_user() {
+		$this->instance->expects( $this->once() )
+			->method( 'protect_call' )
+			->with( 'successful_login', array( 'roles' => array() ) );
+
+		// 'nonexistent-user' has no corresponding DB row, so get_user_by() returns false.
+		$this->instance->log_successful_login( 'nonexistent-user' );
+	}
+
+	/**
 	 * Test that log_failed_attempt can handle null usernames.
 	 */
 	public function test_log_failed_attempt_handles_null_username() {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This prevents the following warning:
```
PHP Warning: Attempt to read property "roles" on false in /wordpress/plugins/jetpack/15.9-a.5/jetpack_vendor/automattic/jetpack-waf/src/class-brute-force-protection.php on line 589
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Third-party code might have something like this:

```
do_action( 'wp_login', 'bad_username', null );
```