### PR TITLE
Story block: Prevent PHP warnings that sometimes occur when trying to render a video with no poster

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-story-prevent_php_warnings
+++ b/projects/plugins/jetpack/changelog/fix-story-prevent_php_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Story block: Prevent PHP warning when handling an invalid media type.

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -356,7 +356,7 @@ function render_static_slide( $media_files ) {
 
 	// if no "static" media was found for the thumbnail try to render a video tag without poster.
 	if ( empty( $media_template ) ) {
-		$media_template = render_video( $media_files[0] );
+		$media_template = render_video( reset( $media_files ) );
 	}
 
 	return sprintf(

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -168,8 +168,8 @@ function enrich_video_meta( $media_file ) {
 	return array_merge(
 		$media_file,
 		array(
-			'width'   => absint( ! empty( $video_meta['width'] ) ? $video_meta['width'] : $media_file['width'] ),
-			'height'  => absint( ! empty( $video_meta['height'] ) ? $video_meta['height'] : $media_file['height'] ),
+			'width'   => absint( ! empty( $video_meta['width'] ) ? $video_meta['width'] : ( $media_file['width'] ?? 0 ) ),
+			'height'  => absint( ! empty( $video_meta['height'] ) ? $video_meta['height'] : ( $media_file['height'] ?? 0 ) ),
 			'alt'     => ! empty( $video_meta['videopress']['description'] ) ? $video_meta['videopress']['description'] : $media_file['alt'],
 			'url'     => $video_url,
 			'title'   => get_the_title( $attachment_id ),

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -356,6 +356,7 @@ function render_static_slide( $media_files ) {
 
 	// if no "static" media was found for the thumbnail try to render a video tag without poster.
 	if ( empty( $media_template ) ) {
+		// enrich_media_files() may return an array with no zero-index, so use reset()
 		$media_template = render_video( reset( $media_files ) );
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -170,7 +170,7 @@ function enrich_video_meta( $media_file ) {
 		array(
 			'width'   => absint( ! empty( $video_meta['width'] ) ? $video_meta['width'] : ( $media_file['width'] ?? 0 ) ),
 			'height'  => absint( ! empty( $video_meta['height'] ) ? $video_meta['height'] : ( $media_file['height'] ?? 0 ) ),
-			'alt'     => ! empty( $video_meta['videopress']['description'] ) ? $video_meta['videopress']['description'] : $media_file['alt'],
+			'alt'     => ! empty( $video_meta['videopress']['description'] ) ? $video_meta['videopress']['description'] : ( $media_file['alt'] ?? '' ),
 			'url'     => $video_url,
 			'title'   => get_the_title( $attachment_id ),
 			'caption' => wp_get_attachment_caption( $attachment_id ),


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This handles the below PHP warning:
```
PHP Warning: Undefined array key 0 in /wordpress/plugins/jetpack/15.9-a.5/extensions/blocks/story/story.php on line 359
```

As best I can tell, if `enrich_media_files()` runs across a media file that is neither an image or video, it'll set the array item value to `null`, and those values are filtered by `array_filter()` but not reindexed.

Later down the chain it then tries to use the 0-index of the array as a fallback, but said index doesn't exist. With this PR we use `reset()` instead of `[0]`.

I also handled these with a fallback `0` value:
```
PHP Warning: Undefined array key "width" in /wordpress/plugins/jetpack/15.9-a.3/extensions/blocks/story/story.php on line 171
PHP Warning: Undefined array key "height" in /wordpress/plugins/jetpack/15.9-a.3/extensions/blocks/story/story.php on line 172
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

I'm not sure how to get to this state...perhaps manually editing the block?