### PR TITLE
Widgets: Prevent a PHP fatal when Display Posts data is malformed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widgets-prevent_php_warning_in_wordpress_post_widget
+++ b/projects/plugins/jetpack/changelog/fix-widgets-prevent_php_warning_in_wordpress_post_widget
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Widgets: Prevent a PHP warning when Display Posts data is malformed.
+Widgets: Prevent a PHP error when Display Posts data is malformed.

--- a/projects/plugins/jetpack/changelog/fix-widgets-prevent_php_warning_in_wordpress_post_widget
+++ b/projects/plugins/jetpack/changelog/fix-widgets-prevent_php_warning_in_wordpress_post_widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Widgets: Prevent a PHP warning when Display Posts data is malformed.

--- a/projects/plugins/jetpack/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget-base.php
+++ b/projects/plugins/jetpack/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget-base.php
@@ -675,7 +675,7 @@ abstract class Jetpack_Display_Posts_Widget__Base extends WP_Widget {
 		/**
 		 * If no optional data is supplied, initialize a new structure
 		 */
-		if ( ! empty( $original_data ) ) {
+		if ( ! empty( $original_data ) && is_array( $original_data ) ) {
 			$widget_data = $original_data;
 		} else {
 			$widget_data = array(


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR prevents the following a PHP fatal by ensuring the var is an array before accessing its keys:
```
PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /wordpress/plugins/jetpack/15.9-a.5/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget-base.php:700
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

There's not a clear path to reproduce this.