### PR TITLE
CLI: incremental build cache (--cache) + composer install fast-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ npm-debug.log
 phpcs.xml
 .phpunit.cache
 .phpunit.result.cache
+# Build-cache manifests written by `jetpack build --cache`.
+**/.cache/build/
 
 ## Things for Docker compose
 /tools/docker/data/*

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -121,7 +121,10 @@ export async function handler( argv ) {
 		argv.useUncommittedComposerLock = ! process.env.CI && ! argv.forMirrors;
 	}
 
-	let dependencies = await getDependencies( process.cwd(), 'build' );
+	// Keep the full, unfiltered graph around: the build cache fingerprints the whole graph so a
+	// project's fingerprint is stable whether it's built alone or via `--deps`.
+	const fullDependencies = await getDependencies( process.cwd(), 'build' );
+	let dependencies = fullDependencies;
 	const listr = new Listr( [], {
 		renderer: argv.v ? SilentRenderer : UpdateRenderer,
 		concurrent: argv.concurrency > 1,
@@ -184,7 +187,7 @@ export async function handler( argv ) {
 	// (they do extra work a skip would break) and in CI (no persistent cache between runs).
 	const cacheEnabled = !! argv.cache && ! argv.forMirrors && ! process.env.CI;
 	const cacheFingerprints = cacheEnabled
-		? await computeFingerprints( buildOrder, dependencies, argv, execa )
+		? await computeFingerprints( fullDependencies, argv, execa )
 		: null;
 
 	// Avoid a node warning about too many event listeners.

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -20,6 +20,7 @@ import PrefixStream from '../helpers/prefix-stream.js';
 import { allProjects, allProjectsByType } from '../helpers/projectHelpers.js';
 import promptForProject from '../helpers/promptForProject.js';
 import { chalkJetpackGreen } from '../helpers/styling.js';
+import { printTimingSummary, buildTimingJson } from '../helpers/timing-summary.js';
 
 export const command = 'build [project...]';
 export const describe = 'Builds one or more monorepo projects';
@@ -70,6 +71,11 @@ export function builder( yargs ) {
 		.option( 'timing', {
 			type: 'boolean',
 			description: 'Output timing information.',
+		} )
+		.option( 'timing-output', {
+			type: 'string',
+			normalize: true,
+			description: 'Write machine-readable timing data (JSON) to the given file. Implies --timing.',
 		} );
 }
 
@@ -86,6 +92,11 @@ export async function handler( argv ) {
 	} catch ( e ) {
 		console.error( e.message );
 		process.exit( 1 );
+	}
+
+	// `--timing-output` writes JSON, which requires the timing data to be collected.
+	if ( argv.timingOutput ) {
+		argv.timing = true;
 	}
 
 	let dependencies = await getDependencies( process.cwd(), 'build' );
@@ -215,15 +226,35 @@ export async function handler( argv ) {
 		promises: {},
 		mirrorMutex: pLimit( 1 ),
 		versions: {},
+		// When `--timing` is set, collect a flat list of phase timings to summarize at the end.
+		timings: argv.timing ? { overallStart: Date.now(), entries: [], buildOrder } : null,
 	};
 	await listr
 		.run( ctx )
-		.finally( () => {
+		.finally( async () => {
 			if ( missing.size ) {
 				console.error( '' );
 				const wrap = argv.v ? v => v : chalk.red;
 				for ( const project of missing ) {
 					console.error( wrap( `Project ${ project } was ignored as it does not exist.` ) );
+				}
+			}
+
+			// Print the timing summary (and optionally dump JSON) on both success and failure.
+			// This runs before the `.catch` below, which may call `process.exit()`.
+			if ( ctx.timings ) {
+				printTimingSummary( ctx, argv );
+				if ( argv.timingOutput ) {
+					try {
+						await fs.writeFile(
+							argv.timingOutput,
+							JSON.stringify( buildTimingJson( ctx, argv ), null, 2 ) + '\n',
+							'utf8'
+						);
+						console.log( `Timing data written to ${ argv.timingOutput }` );
+					} catch ( e ) {
+						console.error( `Failed to write timing output: ${ e.message }` );
+					}
 				}
 			}
 		} )
@@ -379,6 +410,33 @@ function createBuildTask( project, argv, title, build ) {
 						return p;
 					};
 
+					// Time a named build phase, recording its duration into ctx.timings (if enabled).
+					// Returns the wrapped function's value, and records even when it throws.
+					t.time = async ( phase, fn ) => {
+						const start = Date.now();
+						const record = ok => {
+							if ( ctx.timings ) {
+								const end = Date.now();
+								ctx.timings.entries.push( {
+									project,
+									phase,
+									start,
+									end,
+									duration: end - start,
+									ok,
+								} );
+							}
+						};
+						try {
+							const result = await fn();
+							record( true );
+							return result;
+						} catch ( e ) {
+							record( false );
+							throw e;
+						}
+					};
+
 					// Build!
 					const t0 = Date.now();
 					buildStarted = true;
@@ -388,7 +446,19 @@ function createBuildTask( project, argv, title, build ) {
 						await t.output( `\nBuild failed: ${ e.stack }\n` );
 						throw e;
 					} finally {
-						await t.setStatus( argv.timing ? formatDuration( Date.now() - t0 ) + 's' : 'complete' );
+						const dur = Date.now() - t0;
+						if ( ctx.timings ) {
+							// The authoritative per-task total (also covers the shared pnpm/changelogger tasks).
+							ctx.timings.entries.push( {
+								project,
+								phase: '_task',
+								start: t0,
+								end: t0 + dur,
+								duration: dur,
+								ok: true,
+							} );
+						}
+						await t.setStatus( argv.timing ? formatDuration( dur ) + 's' : 'complete' );
 					}
 				} );
 			} )().then(
@@ -771,11 +841,13 @@ async function buildProject( t ) {
 	if ( skipInstall ) {
 		await t.output( `Skipping composer install for CI build of non-plugin with no build script\n` );
 	} else {
-		await t.execa( 'composer', await getInstallArgs( t.project, 'composer', t.argv ), {
-			cwd: t.cwd,
-			stdio: [ 'ignore', 'inherit', 'inherit' ],
-			buffer: false,
-		} );
+		await t.time( 'install', async () =>
+			t.execa( 'composer', await getInstallArgs( t.project, 'composer', t.argv ), {
+				cwd: t.cwd,
+				stdio: [ 'ignore', 'inherit', 'inherit' ],
+				buffer: false,
+			} )
+		);
 	}
 
 	// Build.
@@ -783,11 +855,13 @@ async function buildProject( t ) {
 	if ( script === null ) {
 		await t.output( `No build scripts are defined for ${ t.project }\n` );
 	} else {
-		await t.execa( 'composer', [ 'run', '--timeout=0', script ], {
-			cwd: t.cwd,
-			stdio: [ 'ignore', 'inherit', 'inherit' ],
-			buffer: false,
-		} );
+		await t.time( 'build', async () =>
+			t.execa( 'composer', [ 'run', '--timeout=0', script ], {
+				cwd: t.cwd,
+				stdio: [ 'ignore', 'inherit', 'inherit' ],
+				buffer: false,
+			} )
+		);
 	}
 
 	// If we're not mirroring, the build is done. Mirroring has a bunch of stuff to do yet.

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -11,6 +11,7 @@ import ListrState from 'listr/lib/state.js';
 import SilentRenderer from 'listr-silent-renderer';
 import UpdateRenderer from 'listr-update-renderer';
 import pLimit from 'p-limit';
+import { computeFingerprints, canSkip, writeManifest } from '../helpers/build-cache.js';
 import { getDependencies, filterDeps, getBuildOrder } from '../helpers/dependencyAnalysis.js';
 import formatDuration from '../helpers/format-duration.js';
 import { getInstallArgs, projectDir } from '../helpers/install.js';
@@ -76,6 +77,20 @@ export function builder( yargs ) {
 			type: 'string',
 			normalize: true,
 			description: 'Write machine-readable timing data (JSON) to the given file. Implies --timing.',
+		} )
+		.option( 'cache', {
+			type: 'boolean',
+			description:
+				'Skip building projects whose inputs are unchanged since their last successful build. Ignored with --for-mirrors and in CI.',
+		} )
+		.option( 'force', {
+			type: 'boolean',
+			description: 'With --cache, rebuild every project but refresh the cache fingerprints.',
+		} )
+		.option( 'use-uncommitted-composer-lock', {
+			type: 'boolean',
+			description:
+				'Run `composer install` from an existing (uncommitted) composer.lock when it is valid, instead of the slower `composer update`. Defaults to true for local builds.',
 		} );
 }
 
@@ -97,6 +112,13 @@ export async function handler( argv ) {
 	// `--timing-output` writes JSON, which requires the timing data to be collected.
 	if ( argv.timingOutput ) {
 		argv.timing = true;
+	}
+
+	// Phase 2: by default, local (non-CI, non-mirror) builds reuse a valid on-disk composer.lock via
+	// `composer install` instead of the much slower `composer update`. CI/mirrors keep `update` for
+	// reproducibility. `getInstallArgs` already honors `argv.useUncommittedComposerLock`.
+	if ( argv.useUncommittedComposerLock === undefined ) {
+		argv.useUncommittedComposerLock = ! process.env.CI && ! argv.forMirrors;
 	}
 
 	let dependencies = await getDependencies( process.cwd(), 'build' );
@@ -157,6 +179,13 @@ export async function handler( argv ) {
 		bodeps.set( k, new Set( v ) );
 	}
 	const buildOrder = getBuildOrder( bodeps ).flat();
+
+	// Phase 1: compute per-project input fingerprints for the skip cache. Disabled for mirror builds
+	// (they do extra work a skip would break) and in CI (no persistent cache between runs).
+	const cacheEnabled = !! argv.cache && ! argv.forMirrors && ! process.env.CI;
+	const cacheFingerprints = cacheEnabled
+		? await computeFingerprints( buildOrder, dependencies, argv, execa )
+		: null;
 
 	// Avoid a node warning about too many event listeners.
 	if ( argv.v ) {
@@ -228,6 +257,10 @@ export async function handler( argv ) {
 		versions: {},
 		// When `--timing` is set, collect a flat list of phase timings to summarize at the end.
 		timings: argv.timing ? { overallStart: Date.now(), entries: [], buildOrder } : null,
+		// Phase 1 skip cache: per-project fingerprints and a tally of cached vs built projects.
+		cache: cacheEnabled
+			? { force: !! argv.force, fingerprints: cacheFingerprints, cached: 0, built: 0 }
+			: null,
 	};
 	await listr
 		.run( ctx )
@@ -256,6 +289,13 @@ export async function handler( argv ) {
 						console.error( `Failed to write timing output: ${ e.message }` );
 					}
 				}
+			}
+
+			// Phase 1: report how many projects were skipped via the cache.
+			if ( ctx.cache ) {
+				console.log(
+					chalkJetpackGreen( `Cache: ${ ctx.cache.cached } skipped, ${ ctx.cache.built } built.` )
+				);
 			}
 		} )
 		.catch( err => {
@@ -683,6 +723,17 @@ async function checkCollisions( basedir ) {
  * @param {object} t - Task object.
  */
 async function buildProject( t ) {
+	// Phase 1: skip the whole project (install + build) when its inputs are unchanged and the
+	// outputs it produced last time are still present. `--force` rebuilds but still refreshes below.
+	if ( t.ctx.cache && ! t.argv.forMirrors ) {
+		const fp = t.ctx.cache.fingerprints.get( t.project );
+		if ( fp && ! t.ctx.cache.force && ( await canSkip( t.project, fp, t.argv ) ) ) {
+			t.ctx.cache.cached++;
+			await t.setStatus( 'cached' );
+			return;
+		}
+	}
+
 	await t.setStatus( 'installing' );
 
 	let composerJson = JSON.parse(
@@ -866,6 +917,14 @@ async function buildProject( t ) {
 
 	// If we're not mirroring, the build is done. Mirroring has a bunch of stuff to do yet.
 	if ( ! t.argv.forMirrors ) {
+		// Phase 1: record this successful build so the next run can skip it.
+		if ( t.ctx.cache ) {
+			t.ctx.cache.built++;
+			const fp = t.ctx.cache.fingerprints.get( t.project );
+			if ( fp ) {
+				await writeManifest( t.project, fp, t.argv );
+			}
+		}
 		return;
 	}
 

--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -51,6 +51,10 @@ infrastructureFileSets.e2e = {
 	},
 };
 
+// The set of files whose change invalidates every project's build (reused by the build cache to
+// derive a "tool version": editing build infrastructure busts all cached builds).
+export const infrastructureBuildFiles = infrastructureFileSets.build;
+
 // Files to ignore for --git-changed.
 const ignoreFiles = [ '**/*.md', '**/*.txt' ];
 

--- a/tools/cli/helpers/build-cache.js
+++ b/tools/cli/helpers/build-cache.js
@@ -1,0 +1,296 @@
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import { infrastructureBuildFiles } from '../commands/dependencies.js';
+import { projectDir } from './install.js';
+
+// Bump to invalidate every cached build when the fingerprint algorithm or manifest format changes.
+export const SCHEMA_VERSION = 1;
+
+// Candidate build-output directories checked for presence before trusting a cache hit.
+// If `jetpack clean` (or a manual `rm`) removed any that were present at build time, we rebuild.
+const OUTPUT_DIRS = [ 'vendor', 'jetpack_vendor', 'build' ];
+
+/**
+ * Whether a path is irrelevant to a build for caching purposes.
+ *
+ * Mirrors the `--git-changed` convention in dependencies.js (docs/changelogs don't affect builds)
+ * and excludes our own cache dir so writing a manifest never invalidates the next fingerprint.
+ *
+ * @param {string} path - Repo-relative path.
+ * @return {boolean} True to ignore.
+ */
+function isIgnoredInput( path ) {
+	return /\.(?:md|txt)$/i.test( path ) || path.includes( '/.cache/' );
+}
+
+/**
+ * Extract a `projects/<type>/<name>` slug from a repo-relative path, or null.
+ *
+ * @param {string} path - Repo-relative path.
+ * @return {string|null} Project slug.
+ */
+function slugOf( path ) {
+	const m = path.match( /^projects\/([^/]+\/[^/]+)\// );
+	return m ? m[ 1 ] : null;
+}
+
+/**
+ * Hash the working-tree contents of a set of files in a single `git hash-object` call.
+ *
+ * @param {Function}      execa - execa function.
+ * @param {Array<string>} paths - Repo-relative paths (must exist on disk).
+ * @return {Promise<Map<string,string>>} path -> blob sha.
+ */
+async function hashWorkingTree( execa, paths ) {
+	const out = new Map();
+	if ( ! paths.length ) {
+		return out;
+	}
+	const { stdout } = await execa( 'git', [ 'hash-object', '--stdin-paths' ], {
+		cwd: process.cwd(),
+		input: paths.join( '\n' ),
+	} );
+	const hashes = stdout.split( '\n' );
+	paths.forEach( ( p, i ) => out.set( p, hashes[ i ] ) );
+	return out;
+}
+
+/**
+ * Compute the "tool version" component: a hash of the build-infrastructure files' current contents.
+ *
+ * Editing any of these (build.js, install.js, pnpm-lock.yaml, …) invalidates every project's cache,
+ * matching the `infrastructureFileSets.build` semantics used by `--git-changed`.
+ *
+ * @param {Function} execa - execa function.
+ * @return {Promise<string>} Hex digest.
+ */
+export async function buildToolVersion( execa ) {
+	const files = [ ...infrastructureBuildFiles ].sort();
+	// Only hash files that exist (a set entry may reference a not-yet-present path).
+	const existing = [];
+	for ( const f of files ) {
+		if (
+			await fs.access( f ).then(
+				() => true,
+				() => false
+			)
+		) {
+			existing.push( f );
+		}
+	}
+	const hashes = await hashWorkingTree( execa, existing );
+	const h = crypto.createHash( 'sha256' );
+	for ( const f of existing ) {
+		h.update( `${ f }:${ hashes.get( f ) }\n` );
+	}
+	return h.digest( 'hex' );
+}
+
+/**
+ * Collect git state for fingerprinting in a small, fixed number of subprocesses (not per-project).
+ *
+ * @param {Function} execa - execa function.
+ * @return {Promise<{committed: Map<string,string[]>, dirty: Map<string,string[]>}>} Per-project committed and dirty-overlay lines.
+ */
+export async function collectGitState( execa ) {
+	const committed = new Map();
+	const dirty = new Map();
+
+	// 1. All committed blobs with their SHAs (one process; SHAs are git's content hashes).
+	const { stdout: lsf } = await execa( 'git', [ 'ls-files', '-s' ], { cwd: process.cwd() } );
+	for ( const line of lsf.split( '\n' ) ) {
+		if ( ! line ) {
+			continue;
+		}
+		const tab = line.indexOf( '\t' );
+		const sha = line.slice( 0, tab ).split( ' ' )[ 1 ];
+		const path = line.slice( tab + 1 );
+		const slug = slugOf( path );
+		if ( ! slug || isIgnoredInput( path ) ) {
+			continue;
+		}
+		if ( ! committed.has( slug ) ) {
+			committed.set( slug, [] );
+		}
+		committed.get( slug ).push( `${ sha }\t${ path }` );
+	}
+
+	// 2. Uncommitted changes (modified/added/untracked/deleted) overlaid with working-tree hashes.
+	const { stdout: st } = await execa( 'git', [ 'status', '--porcelain', '--no-renames' ], {
+		cwd: process.cwd(),
+	} );
+	const dirtyPaths = [];
+	for ( const line of st.split( '\n' ) ) {
+		if ( ! line ) {
+			continue;
+		}
+		const path = line.slice( 3 );
+		// Skip untracked directories (porcelain ends them with '/'), ignored inputs, non-projects.
+		if ( path.endsWith( '/' ) || isIgnoredInput( path ) || ! slugOf( path ) ) {
+			continue;
+		}
+		dirtyPaths.push( path );
+	}
+	const existing = [];
+	for ( const p of dirtyPaths ) {
+		if (
+			await fs.access( p ).then(
+				() => true,
+				() => false
+			)
+		) {
+			existing.push( p );
+		}
+	}
+	const wtHashes = await hashWorkingTree( execa, existing );
+	for ( const path of dirtyPaths ) {
+		const slug = slugOf( path );
+		if ( ! dirty.has( slug ) ) {
+			dirty.set( slug, [] );
+		}
+		dirty.get( slug ).push( `${ wtHashes.get( path ) || 'gone' } ${ path }` );
+	}
+
+	return { committed, dirty };
+}
+
+/**
+ * Combine collected state into a per-project fingerprint map (pure; no I/O).
+ *
+ * Walks `buildOrder` (topologically sorted) so each project's dependencies already have a
+ * fingerprint, and folds those in — a change to a dependency cascades to all its dependents.
+ *
+ * @param {object}               o              - Inputs.
+ * @param {string[]}             o.buildOrder   - Project slugs in build order.
+ * @param {Map<string,Set>}      o.dependencies - slug -> set of dependency slugs.
+ * @param {string}               o.mode         - 'production' or 'development'.
+ * @param {string}               o.toolVersion  - Tool-version hash.
+ * @param {Map<string,string[]>} o.committed    - Per-project committed lines.
+ * @param {Map<string,string[]>} o.dirty        - Per-project dirty overlay lines.
+ * @return {Map<string,string>} slug -> fingerprint hex.
+ */
+export function fingerprintProjects( {
+	buildOrder,
+	dependencies,
+	mode,
+	toolVersion,
+	committed,
+	dirty,
+} ) {
+	const fps = new Map();
+	for ( const slug of buildOrder ) {
+		const files = ( committed.get( slug ) || [] ).slice().sort();
+		const changes = ( dirty.get( slug ) || [] ).slice().sort();
+		const deps = [ ...( dependencies.get( slug ) || [] ) ]
+			.filter( d => fps.has( d ) )
+			.sort()
+			.map( d => `${ d }:${ fps.get( d ) }` );
+		const h = crypto.createHash( 'sha256' );
+		h.update( JSON.stringify( { v: SCHEMA_VERSION, mode, toolVersion, files, changes, deps } ) );
+		fps.set( slug, h.digest( 'hex' ) );
+	}
+	return fps;
+}
+
+/**
+ * Compute fingerprints for every project in `buildOrder`.
+ *
+ * @param {string[]}        buildOrder   - Project slugs in build order.
+ * @param {Map<string,Set>} dependencies - Dependency map.
+ * @param {object}          argv         - Argv (uses .production).
+ * @param {Function}        execa        - execa function.
+ * @return {Promise<Map<string,string>>} slug -> fingerprint.
+ */
+export async function computeFingerprints( buildOrder, dependencies, argv, execa ) {
+	const [ toolVersion, { committed, dirty } ] = await Promise.all( [
+		buildToolVersion( execa ),
+		collectGitState( execa ),
+	] );
+	return fingerprintProjects( {
+		buildOrder,
+		dependencies,
+		mode: argv.production ? 'production' : 'development',
+		toolVersion,
+		committed,
+		dirty,
+	} );
+}
+
+const manifestPath = project => projectDir( project, '.cache/build/manifest.json' );
+
+/**
+ * Read a project's build manifest, or null if absent/unreadable.
+ *
+ * @param {string} project - Slug.
+ * @return {Promise<object|null>} Manifest.
+ */
+export async function readManifest( project ) {
+	try {
+		return JSON.parse( await fs.readFile( manifestPath( project ), 'utf8' ) );
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Which of the candidate output dirs currently exist for a project.
+ *
+ * @param {string} project - Slug.
+ * @return {Promise<string[]>} Present output dir names.
+ */
+async function presentOutputs( project ) {
+	const present = [];
+	for ( const dir of OUTPUT_DIRS ) {
+		if (
+			await fs.access( projectDir( project, dir ) ).then(
+				() => true,
+				() => false
+			)
+		) {
+			present.push( dir );
+		}
+	}
+	return present;
+}
+
+/**
+ * Whether a project can be skipped: manifest matches the current fingerprint/mode and every output
+ * recorded at build time still exists on disk.
+ *
+ * @param {string} project - Slug.
+ * @param {string} fp      - Current fingerprint.
+ * @param {object} argv    - Argv (uses .production).
+ * @return {Promise<boolean>} True to skip.
+ */
+export async function canSkip( project, fp, argv ) {
+	const mode = argv.production ? 'production' : 'development';
+	const m = await readManifest( project );
+	if ( ! m || m.schemaVersion !== SCHEMA_VERSION || m.inputHash !== fp || m.mode !== mode ) {
+		return false;
+	}
+	const present = new Set( await presentOutputs( project ) );
+	return ( m.outputs || [] ).every( o => present.has( o ) );
+}
+
+/**
+ * Record a successful build so the next run can skip it.
+ *
+ * @param {string} project - Slug.
+ * @param {string} fp      - Fingerprint that was just built.
+ * @param {object} argv    - Argv (uses .production).
+ */
+export async function writeManifest( project, fp, argv ) {
+	const manifest = {
+		schemaVersion: SCHEMA_VERSION,
+		inputHash: fp,
+		mode: argv.production ? 'production' : 'development',
+		outputs: await presentOutputs( project ),
+		builtAt: new Date().toISOString(),
+	};
+	await fs.mkdir( projectDir( project, '.cache/build' ), { recursive: true } );
+	await fs.writeFile(
+		manifestPath( project ),
+		JSON.stringify( manifest, null, '\t' ) + '\n',
+		'utf8'
+	);
+}

--- a/tools/cli/helpers/build-cache.js
+++ b/tools/cli/helpers/build-cache.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs/promises';
 import { infrastructureBuildFiles } from '../commands/dependencies.js';
+import { getBuildOrder } from './dependencyAnalysis.js';
 import { projectDir } from './install.js';
 
 // Bump to invalidate every cached build when the fingerprint algorithm or manifest format changes.
@@ -193,15 +194,25 @@ export function fingerprintProjects( {
 }
 
 /**
- * Compute fingerprints for every project in `buildOrder`.
+ * Compute fingerprints for every project in the dependency graph.
  *
- * @param {string[]}        buildOrder   - Project slugs in build order.
- * @param {Map<string,Set>} dependencies - Dependency map.
+ * Always fingerprints the FULL graph (not just the projects being built) so a given project's
+ * fingerprint folds in its complete transitive dependencies and is therefore identical whether it
+ * is built alone or with `--deps`. This keeps cache hits consistent across different invocations.
+ *
+ * @param {Map<string,Set>} dependencies - Full (unfiltered) dependency map.
  * @param {object}          argv         - Argv (uses .production).
  * @param {Function}        execa        - execa function.
  * @return {Promise<Map<string,string>>} slug -> fingerprint.
  */
-export async function computeFingerprints( buildOrder, dependencies, argv, execa ) {
+export async function computeFingerprints( dependencies, argv, execa ) {
+	// getBuildOrder mutates its input, so hand it a clone.
+	const clone = new Map();
+	for ( const [ slug, deps ] of dependencies ) {
+		clone.set( slug, new Set( deps ) );
+	}
+	const buildOrder = getBuildOrder( clone ).flat();
+
 	const [ toolVersion, { committed, dirty } ] = await Promise.all( [
 		buildToolVersion( execa ),
 		collectGitState( execa ),

--- a/tools/cli/helpers/timing-summary.js
+++ b/tools/cli/helpers/timing-summary.js
@@ -1,0 +1,158 @@
+import formatDuration from './format-duration.js';
+
+const DASH = '—';
+
+/**
+ * Aggregate the flat list of timing entries into per-project phase totals.
+ *
+ * @param {object} timings - The `ctx.timings` object ({ overallStart, entries, buildOrder }).
+ * @return {object} `{ rows, sumOfTotals }` where `rows` is a Map of project => { install, build, task, other, shared, ok }.
+ */
+function aggregate( timings ) {
+	const buildOrder = new Set( timings.buildOrder );
+	const rows = new Map();
+	let sumOfTotals = 0;
+
+	for ( const e of timings.entries ) {
+		let row = rows.get( e.project );
+		if ( ! row ) {
+			row = {
+				project: e.project,
+				install: null,
+				build: null,
+				task: null,
+				shared: ! buildOrder.has( e.project ),
+				ok: true,
+			};
+			rows.set( e.project, row );
+		}
+		if ( e.phase === '_task' ) {
+			row.task = ( row.task || 0 ) + e.duration;
+		} else {
+			row[ e.phase ] = ( row[ e.phase ] || 0 ) + e.duration;
+		}
+		if ( ! e.ok ) {
+			row.ok = false;
+		}
+	}
+
+	for ( const row of rows.values() ) {
+		const task = row.task || 0;
+		sumOfTotals += task;
+		// "Other" is whatever wasn't explicitly timed as install/build (changelog, mirroring, overhead).
+		row.other = Math.max( 0, task - ( row.install || 0 ) - ( row.build || 0 ) );
+	}
+
+	return { rows, sumOfTotals };
+}
+
+/**
+ * Print a human-readable phase-level timing summary table.
+ *
+ * Shared/top-level tasks (e.g. `pnpm install`) are listed first, then build projects in build
+ * order. Phases that never ran (skipped install, no build script) render as an em dash.
+ *
+ * @param {object} ctx  - Build context. Uses `ctx.timings`.
+ * @param {object} argv - Command line arguments. Uses `argv.concurrency`.
+ */
+export function printTimingSummary( ctx, argv ) {
+	if ( ! ctx.timings || ctx.timings.entries.length === 0 ) {
+		return;
+	}
+
+	const { rows, sumOfTotals } = aggregate( ctx.timings );
+	const wallClock = Date.now() - ctx.timings.overallStart;
+	const order = [ ...ctx.timings.buildOrder ];
+
+	// Shared rows first (in encounter order), then build rows in build order.
+	const sorted = [ ...rows.values() ]
+		.filter( r => r.shared )
+		.concat( order.map( p => rows.get( p ) ).filter( Boolean ) );
+
+	const fmt = ms => ( ms === null || ms === undefined ? DASH : formatDuration( ms ) + 's' );
+
+	const cols = [
+		{ label: 'Project', get: r => r.project, align: 'left' },
+		{ label: 'Install', get: r => fmt( r.install ), align: 'right' },
+		{ label: 'Build', get: r => fmt( r.build ), align: 'right' },
+		{ label: 'Other', get: r => fmt( r.other ), align: 'right' },
+		{ label: 'Total', get: r => fmt( r.task ), align: 'right' },
+	];
+
+	// Compute each column's width from its header and all cell values.
+	const widths = cols.map( c =>
+		Math.max( c.label.length, ...sorted.map( r => c.get( r ).length ) )
+	);
+
+	const pad = ( s, i ) =>
+		cols[ i ].align === 'right' ? s.padStart( widths[ i ] ) : s.padEnd( widths[ i ] );
+
+	const renderRow = cells => '  ' + cells.map( ( s, i ) => pad( s, i ) ).join( '   ' );
+
+	const header = renderRow( cols.map( c => c.label ) );
+	const sep = '  ' + '─'.repeat( header.length - 2 );
+	const concurrency = Number.isFinite( argv.concurrency ) ? argv.concurrency : 'unlimited';
+
+	const lines = [
+		'',
+		`Timing summary (concurrency: ${ concurrency })`,
+		'',
+		header,
+		sep,
+		...sorted.map( r => renderRow( cols.map( c => c.get( r ) ) ) ),
+		sep,
+	];
+
+	// Footers: align the value under the Total column.
+	const labelWidth = widths.slice( 0, -1 ).reduce( ( a, w ) => a + w, 0 ) + 3 * ( cols.length - 1 );
+	const footer = ( label, ms ) =>
+		'  ' + label.padEnd( labelWidth ) + ( formatDuration( ms ) + 's' ).padStart( widths.at( -1 ) );
+	lines.push( footer( 'Sum of per-project totals', sumOfTotals ) );
+	lines.push( footer( 'Wall-clock (overall)', wallClock ) );
+
+	console.log( lines.join( '\n' ) );
+}
+
+/**
+ * Build a machine-readable timing report suitable for JSON serialization.
+ *
+ * @param {object} ctx  - Build context. Uses `ctx.timings`.
+ * @param {object} argv - Command line arguments.
+ * @return {object} The timing report.
+ */
+export function buildTimingJson( ctx, argv ) {
+	const { rows, sumOfTotals } = aggregate( ctx.timings );
+	const finishedMs = Date.now();
+	const wallClockMs = finishedMs - ctx.timings.overallStart;
+
+	const projects = {};
+	const shared = {};
+	for ( const r of rows.values() ) {
+		if ( r.shared ) {
+			shared[ r.project ] = { totalMs: r.task ?? null, ok: r.ok };
+		} else {
+			projects[ r.project ] = {
+				installMs: r.install ?? null,
+				buildMs: r.build ?? null,
+				otherMs: r.other,
+				totalMs: r.task ?? null,
+				ok: r.ok,
+			};
+		}
+	}
+
+	return {
+		version: 1,
+		command: 'build',
+		startedAt: new Date( ctx.timings.overallStart ).toISOString(),
+		finishedAt: new Date( finishedMs ).toISOString(),
+		wallClockMs,
+		sumOfProjectTotalsMs: sumOfTotals,
+		concurrency: Number.isFinite( argv.concurrency ) ? argv.concurrency : 'unlimited',
+		production: !! argv.production,
+		forMirrors: !! argv.forMirrors,
+		projects,
+		shared,
+		raw: ctx.timings.entries,
+	};
+}

--- a/tools/cli/tests/unit/helpers/build-cache.test.js
+++ b/tools/cli/tests/unit/helpers/build-cache.test.js
@@ -1,0 +1,102 @@
+import { fingerprintProjects } from '../../../helpers/build-cache.js';
+
+// A tiny graph: B depends on A; C is independent.
+const baseInputs = () => ( {
+	buildOrder: [ 'packages/a', 'packages/b', 'packages/c' ],
+	dependencies: new Map( [
+		[ 'packages/a', new Set() ],
+		[ 'packages/b', new Set( [ 'packages/a' ] ) ],
+		[ 'packages/c', new Set() ],
+	] ),
+	mode: 'development',
+	toolVersion: 'tool-v1',
+	committed: new Map( [
+		[ 'packages/a', [ 'sha-a1\tprojects/packages/a/src/x.php' ] ],
+		[ 'packages/b', [ 'sha-b1\tprojects/packages/b/src/y.php' ] ],
+		[ 'packages/c', [ 'sha-c1\tprojects/packages/c/src/z.php' ] ],
+	] ),
+	dirty: new Map(),
+} );
+
+describe( 'build-cache fingerprintProjects', () => {
+	test( 'is deterministic for identical inputs', () => {
+		const a = fingerprintProjects( baseInputs() );
+		const b = fingerprintProjects( baseInputs() );
+		expect( [ ...a ] ).toEqual( [ ...b ] );
+	} );
+
+	test( 'produces a distinct fingerprint per project', () => {
+		const fps = fingerprintProjects( baseInputs() );
+		const values = [ ...fps.values() ];
+		expect( new Set( values ).size ).toBe( 3 );
+	} );
+
+	test( 'changing a source file invalidates that project but not unrelated siblings', () => {
+		const before = fingerprintProjects( baseInputs() );
+		const changed = baseInputs();
+		changed.committed.set( 'packages/a', [ 'sha-a2\tprojects/packages/a/src/x.php' ] );
+		const after = fingerprintProjects( changed );
+
+		expect( after.get( 'packages/a' ) ).not.toBe( before.get( 'packages/a' ) );
+		// C is independent of A — unchanged.
+		expect( after.get( 'packages/c' ) ).toBe( before.get( 'packages/c' ) );
+	} );
+
+	test( 'a dependency change cascades to its dependents', () => {
+		const before = fingerprintProjects( baseInputs() );
+		const changed = baseInputs();
+		changed.committed.set( 'packages/a', [ 'sha-a2\tprojects/packages/a/src/x.php' ] );
+		const after = fingerprintProjects( changed );
+
+		// B depends on A, so B's fingerprint must change even though B's own files did not.
+		expect( after.get( 'packages/b' ) ).not.toBe( before.get( 'packages/b' ) );
+	} );
+
+	test( 'an uncommitted (dirty) change invalidates the project', () => {
+		const before = fingerprintProjects( baseInputs() );
+		const changed = baseInputs();
+		changed.dirty.set( 'packages/c', [ 'wt-hash projects/packages/c/src/z.php' ] );
+		const after = fingerprintProjects( changed );
+
+		expect( after.get( 'packages/c' ) ).not.toBe( before.get( 'packages/c' ) );
+	} );
+
+	test( 'production and development modes yield different fingerprints', () => {
+		const dev = fingerprintProjects( baseInputs() );
+		const prodInputs = baseInputs();
+		prodInputs.mode = 'production';
+		const prod = fingerprintProjects( prodInputs );
+
+		for ( const slug of dev.keys() ) {
+			expect( prod.get( slug ) ).not.toBe( dev.get( slug ) );
+		}
+	} );
+
+	test( 'a tool-version change invalidates every project', () => {
+		const before = fingerprintProjects( baseInputs() );
+		const changed = baseInputs();
+		changed.toolVersion = 'tool-v2';
+		const after = fingerprintProjects( changed );
+
+		for ( const slug of before.keys() ) {
+			expect( after.get( slug ) ).not.toBe( before.get( slug ) );
+		}
+	} );
+
+	test( 'file ordering within a project does not affect the fingerprint', () => {
+		const ordered = baseInputs();
+		ordered.committed.set( 'packages/a', [
+			'sha-1\tprojects/packages/a/a.php',
+			'sha-2\tprojects/packages/a/b.php',
+		] );
+		const reversed = baseInputs();
+		reversed.committed.set( 'packages/a', [
+			'sha-2\tprojects/packages/a/b.php',
+			'sha-1\tprojects/packages/a/a.php',
+		] );
+
+		expect( fingerprintProjects( ordered ).get( 'packages/a' ) ).toBe(
+			fingerprintProjects( reversed ).get( 'packages/a' )
+		);
+	} );
+} );

--- a/tools/cli/tests/unit/helpers/build-cache.test.js
+++ b/tools/cli/tests/unit/helpers/build-cache.test.js
@@ -83,6 +83,17 @@ describe( 'build-cache fingerprintProjects', () => {
 		}
 	} );
 
+	test( 'omitting a dependency from the order changes the dependent fingerprint (why the full graph must be fingerprinted)', () => {
+		// B depends on A. With A present (full graph), B folds A's fingerprint in.
+		const withDep = fingerprintProjects( baseInputs() );
+		// Simulate the old bug: build a subset that omits the dependency A.
+		const inputsNoDep = baseInputs();
+		inputsNoDep.buildOrder = [ 'packages/b', 'packages/c' ];
+		const withoutDep = fingerprintProjects( inputsNoDep );
+		// B's fingerprint differs — so fingerprints are only stable if the FULL graph is always used.
+		expect( withoutDep.get( 'packages/b' ) ).not.toBe( withDep.get( 'packages/b' ) );
+	} );
+
 	test( 'file ordering within a project does not affect the fingerprint', () => {
 		const ordered = baseInputs();
 		ordered.committed.set( 'packages/a', [


### PR DESCRIPTION
Fixes # N/A

Stacked on #49288 (build `--timing` summary), which is set as the base so this diff shows only the cache work. The `--timing` summary is reused to display per-project `cached` rows.

## Proposed changes

Makes repeated `jetpack build` runs dramatically faster by (1) skipping projects whose inputs are unchanged and (2) avoiding the slow `composer update` on every build. Profiling showed a full build spends most of its ~4 min in per-package `composer` work that re-runs even when nothing changed.

**Phase 1 — `--cache` (opt-in) project skip cache**
* New `--cache` flag: before building a project, compute a content fingerprint of its inputs; if it matches the last successful build and the outputs it produced are still on disk, skip **both** the composer install and the asset build for that project.
* Fingerprint (new helper `tools/cli/helpers/build-cache.js`) combines, per project: committed file blob SHAs + an overlay of uncommitted/working-tree changes, the build mode (dev/prod), a "tool version" hash of the build-infrastructure files (reused `infrastructureFileSets.build` from `dependencies.js` — editing build tooling busts the whole cache), and the fingerprints of the project's dependencies. Because fingerprints fold in dependency fingerprints, a change to a low-level package cascades to all its dependents while unrelated siblings stay cached.
* Collected in a fixed number of git calls (`git ls-files -s` + `git status`), not per-project — a spike showed per-project enumeration was a ~30s subprocess storm, while the single-shot approach fingerprints the whole monorepo in ~1s.
* Manifests are stored at `<project>/.cache/build/manifest.json` (gitignored) and record the expected output dirs; if `jetpack clean` (or a manual delete) removed any, the project rebuilds. `--force` rebuilds everything but refreshes the manifests.
* Hard-disabled with `--for-mirrors` and in CI (no persistent cache between CI runs; mirror builds do extra work a skip would break). When off, the build path is unchanged.
* End-of-run line: `Cache: N skipped, M built.`

**Phase 2 — composer install fast-path (default for local builds)**
* Packages don't commit `composer.lock`, so the build ran `composer update` (full dependency resolution, ~15–27s/package) every time. There was already a dormant fast path in `getInstallArgs` that runs `composer install` from a valid on-disk lock; this PR enables it by default for local (non-CI, non-mirror) builds via `--use-uncommitted-composer-lock` (default true). CI/mirrors keep `composer update` for reproducibility. No change to `install.js` logic.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Measured on this branch (build `packages/connection --deps`, ~28 projects):

* **Phase 2:** `jetpack build packages/status --timing` → install ~1.4s; `jetpack build packages/status --timing --no-use-uncommitted-composer-lock` → install ~14.5s (the old `composer update`).
* **Phase 1 warm rebuild:** `jetpack build packages/connection --deps --cache --timing` twice. First run builds (`Cache: 0 skipped, 28 built`); second run with no changes → ~1.8s, `Cache: 28 skipped, 0 built`, every project row shows `cached`.
* **Invalidation cascade:** edit a file in `projects/packages/status/` (a widely-depended-on package), re-run with `--cache` → `status` and its dependents rebuild, unrelated projects stay cached (`Cache: 23 skipped, 5 built`). Revert the edit.
* **Output tripwire:** `rm -rf projects/packages/status/vendor` then `jetpack build packages/status --cache` → it rebuilds despite a matching fingerprint (missing output).
* **CI guard:** `CI=true jetpack build packages/status --cache` → no `Cache:` line (cache disabled).
* **No regression:** `jetpack build packages/status` (no flags) builds normally.
* Unit tests: `cd tools/cli && NODE_OPTIONS=--experimental-vm-modules pnpm jest --testMatch='<rootDir>/tests/unit/**/*.test.js'` (145 pass, incl. new `build-cache.test.js`).
