### PR TITLE
Sitemaps: link Atomic sites to Site Visibility settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -380,6 +380,16 @@ export function isSiteVisibleToSearchEngines( state ) {
 }
 
 /**
+ * Returns true if the site is hosted on WordPress.com Atomic.
+ *
+ * @param {object} state - Global state tree
+ * @return {boolean} Whether the site is a WordPress.com Atomic site.
+ */
+export function isWpcomAtomic( state ) {
+	return state.jetpack.initialState.siteData?.isWpcomAtomic ?? false;
+}
+
+/**
  * Returns the site's boost speed scores from the last time it was checked
  *
  * @param {object} state - Global state tree

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/test/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/test/reducer.js
@@ -1,0 +1,31 @@
+import { isWpcomAtomic } from '../reducer';
+
+describe( 'Initial state reducer selectors', () => {
+	describe( 'isWpcomAtomic', () => {
+		it( 'returns whether the site is hosted on WordPress.com Atomic', () => {
+			const state = {
+				jetpack: {
+					initialState: {
+						siteData: {
+							isWpcomAtomic: true,
+						},
+					},
+				},
+			};
+
+			expect( isWpcomAtomic( state ) ).toBe( true );
+		} );
+
+		it( 'defaults to false', () => {
+			const state = {
+				jetpack: {
+					initialState: {
+						siteData: {},
+					},
+				},
+			};
+
+			expect( isWpcomAtomic( state ) ).toBe( false );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/traffic/sitemaps.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/sitemaps.jsx
@@ -11,7 +11,12 @@ import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
-import { getSiteAdminUrl, isSiteVisibleToSearchEngines } from 'state/initial-state';
+import {
+	getSiteAdminUrl,
+	getSiteRawUrl,
+	isSiteVisibleToSearchEngines,
+	isWpcomAtomic,
+} from 'state/initial-state';
 
 export class Sitemaps extends Component {
 	renderSitemapRow = ( sitemap, sitemapTrack ) => {
@@ -45,6 +50,19 @@ export class Sitemaps extends Component {
 			'is-warning':
 				! this.props.isSiteVisibleToSearchEngines && this.props.getOptionValue( 'sitemaps' ),
 		} );
+		let searchEngineVisibilitySettingsUrl = this.props.siteAdminUrl + 'options-reading.php';
+		let searchEngineVisibilitySettingsText = __(
+			'Search engines can’t access your site at the moment. If you’d like to make your site accessible, check your <a>Reading settings</a> and switch "Search Engine Visibility" on.',
+			'jetpack'
+		);
+
+		if ( this.props.isWpcomAtomic ) {
+			searchEngineVisibilitySettingsUrl = `https://wordpress.com/sites/${ this.props.siteRawUrl }/settings/site-visibility`;
+			searchEngineVisibilitySettingsText = __(
+				'Search engines can’t access your site at the moment. If you’d like to make your site accessible, check your <a>Site Visibility settings</a> and make your site public.',
+				'jetpack'
+			);
+		}
 
 		return (
 			<SettingsCard { ...this.props } module="sitemaps" hideButton>
@@ -85,15 +103,9 @@ export class Sitemaps extends Component {
 						)
 					) : (
 						<p className={ searchEngineVisibilityClasses }>
-							{ createInterpolateElement(
-								__(
-									'Search engines can’t access your site at the moment. If you’d like to make your site accessible, check your <a>Reading settings</a> and switch "Search Engine Visibility" on.',
-									'jetpack'
-								),
-								{
-									a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />,
-								}
-							) }
+							{ createInterpolateElement( searchEngineVisibilitySettingsText, {
+								a: <a href={ searchEngineVisibilitySettingsUrl } />,
+							} ) }
 						</p>
 					) }
 				</SettingsGroup>
@@ -105,6 +117,8 @@ export class Sitemaps extends Component {
 export default connect( state => {
 	return {
 		isSiteVisibleToSearchEngines: isSiteVisibleToSearchEngines( state ),
+		isWpcomAtomic: isWpcomAtomic( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
+		siteRawUrl: getSiteRawUrl( state ),
 	};
 } )( withModuleSettingsFormHelpers( Sitemaps ) );

--- a/projects/plugins/jetpack/_inc/client/traffic/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/traffic/test/component.js
@@ -1,0 +1,52 @@
+import { render, screen } from 'test/test-utils';
+import { Sitemaps } from '../sitemaps';
+
+jest.mock( 'components/settings-card', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'components/settings-group', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'components/module-toggle', () => ( {
+	ModuleToggle: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+describe( 'Sitemaps', () => {
+	const defaultProps = {
+		getModule: () => ( {
+			extra: {
+				sitemap_url: 'https://example.com/sitemap.xml',
+				news_sitemap_url: 'https://example.com/news-sitemap.xml',
+			},
+		} ),
+		getOptionValue: () => true,
+		isSavingAnyOption: () => false,
+		isSiteVisibleToSearchEngines: false,
+		isWpcomAtomic: false,
+		siteAdminUrl: 'https://example.com/wp-admin/',
+		siteRawUrl: 'example.com',
+		toggleModuleNow: jest.fn(),
+	};
+
+	it( 'links non-Atomic sites to Reading settings', () => {
+		render( <Sitemaps { ...defaultProps } /> );
+
+		expect( screen.getByRole( 'link', { name: 'Reading settings' } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/wp-admin/options-reading.php'
+		);
+	} );
+
+	it( 'links WordPress.com Atomic sites to Site Visibility settings', () => {
+		render( <Sitemaps { ...defaultProps } isWpcomAtomic /> );
+
+		expect( screen.getByRole( 'link', { name: 'Site Visibility settings' } ) ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/sites/example.com/settings/site-visibility'
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -176,6 +176,7 @@ class Jetpack_Redux_State_Helper {
 					: '',
 				'representativeImage'        => self::get_site_image(),
 				'siteVisibleToSearchEngines' => '1' == get_option( 'blog_public' ), // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				'isWpcomAtomic'              => ( new Host() )->is_woa_site(),
 				/**
 				 * Whether promotions are visible or not.
 				 *

--- a/projects/plugins/jetpack/changelog/fix-sitemaps-site-visibility-link
+++ b/projects/plugins/jetpack/changelog/fix-sitemaps-site-visibility-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sitemaps: Link WordPress.com Atomic sites to Site Visibility settings.


### PR DESCRIPTION
## Proposed changes

When a site is not visible to search engines, the Jetpack Sitemaps settings currently point users to wp-admin Reading settings. That is correct for regular Jetpack sites, but WordPress.com Atomic sites manage this setting in the WordPress.com Site Visibility screen instead.

This PR:

- Adds an Atomic-site flag to the Jetpack admin initial state.
- Adds a frontend selector for that flag.
- Keeps the existing Reading settings link for non-Atomic sites.
- Links Atomic sites to `https://wordpress.com/sites/{site}/settings/site-visibility` and updates the link text to “Site Visibility settings”.

## Testing instructions

Code-level checks run locally:

- `git diff --check`
- `node --check projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js`

Manual testing still needed:

1. Load this branch on a WordPress.com Atomic test site where search engines are discouraged or the site is not public.
2. Go to Jetpack > Settings > Traffic > Sitemaps.
3. Confirm the search-engine visibility warning links to the WordPress.com Site Visibility settings page.
4. On a non-Atomic Jetpack site, confirm the same warning still links to wp-admin Reading settings.

I was not able to run full Jetpack lint/tests or manually verify on an Atomic site from this lightweight shadow checkout.

## Does this pull request change what data or activity we track or use?

No.
