### PR TITLE
Forms: Preserve selected phone country flag

### DIFF
--- a/projects/packages/forms/changelog/fix-phone-response-country-flags
+++ b/projects/packages/forms/changelog/fix-phone-response-country-flags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix phone response country flags for submitted numbers with shared dialing prefixes.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1195,6 +1195,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					id="<?php echo esc_attr( $id ); ?>"
 					name="<?php echo esc_attr( $id ); ?>"
 					data-wp-bind--value='context.fullPhoneNumber' />
+				<input type="hidden"
+					id="<?php echo esc_attr( $id ); ?>-country-code"
+					name="<?php echo esc_attr( $id ); ?>-country-code"
+					data-wp-bind--value='context.phoneCountryCode' />
 		</div>
 		<?php
 		$input = ob_get_clean();

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -274,8 +274,7 @@ class Feedback_Field {
 			return $this->value;
 		}
 
-		// Try to extract country code from phone number prefix.
-		$country_code = $this->get_country_code_from_phone( $this->value );
+		$country_code = $this->get_phone_country_code( $this->value );
 
 		if ( ! empty( $country_code ) ) {
 			$flag = self::country_code_to_emoji_flag( $country_code );
@@ -285,6 +284,25 @@ class Feedback_Field {
 		}
 
 		return $this->value;
+	}
+
+	/**
+	 * Get the phone country code from saved metadata, falling back to the phone number prefix.
+	 *
+	 * @param string $phone_number The phone number with country prefix (e.g., "+49 123456789").
+	 *
+	 * @return string|null The ISO country code (e.g., "DE") or null if not found.
+	 */
+	private function get_phone_country_code( $phone_number ) {
+		$country_code = $this->get_meta_key_value( 'countryCode' );
+		if ( is_string( $country_code ) ) {
+			$country_code = strtoupper( $country_code );
+			if ( preg_match( '/^[A-Z]{2}$/', $country_code ) ) {
+				return $country_code;
+			}
+		}
+
+		return $this->get_country_code_from_phone( $phone_number );
 	}
 
 	/**
@@ -542,7 +560,7 @@ class Feedback_Field {
 		}
 
 		$raw_phone    = preg_replace( '/[^\d+]/', '', $this->value );
-		$country_code = $this->get_country_code_from_phone( $this->value );
+		$country_code = $this->get_phone_country_code( $this->value );
 		$flag_prefix  = '';
 
 		if ( ! empty( $country_code ) ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -2076,9 +2076,11 @@ class Feedback {
 	 *
 	 * @param Contact_Form_Field $field The field object.
 	 * @param string             $type  The field type.
+	 * @param array              $post_data The post data from the form submission.
+	 * @param string             $field_id The field ID.
 	 * @return array Metadata array for the field.
 	 */
-	public static function get_field_meta( $field, $type ) {
+	public static function get_field_meta( $field, $type, $post_data = array(), $field_id = '' ) {
 		$meta = array();
 
 		if ( $type === 'rating' ) {
@@ -2086,6 +2088,24 @@ class Feedback {
 			$max               = $field->get_attribute( 'max' );
 			$meta['iconStyle'] = ! empty( $icon_style ) ? $icon_style : 'stars';
 			$meta['maxRating'] = is_numeric( $max ) && (int) $max > 0 ? (int) $max : 5;
+		}
+
+		if (
+			in_array( $type, array( 'phone', 'telephone' ), true )
+			&& $field->get_attribute( 'showcountryselector' )
+			&& ! empty( $field_id )
+		) {
+			$country_code_key = $field_id . '-country-code';
+			if (
+				isset( $post_data[ $country_code_key ] )
+				&& ! is_array( $post_data[ $country_code_key ] )
+			) {
+				$country_code = sanitize_text_field( wp_unslash( $post_data[ $country_code_key ] ) );
+				$country_code = strtoupper( $country_code );
+				if ( preg_match( '/^[A-Z]{2}$/', $country_code ) ) {
+					$meta['countryCode'] = $country_code;
+				}
+			}
 		}
 
 		return $meta;
@@ -2116,7 +2136,7 @@ class Feedback {
 			$label = wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			$key   = $i . '_' . $label;
 
-			$meta = self::get_field_meta( $field, $type );
+			$meta = self::get_field_meta( $field, $type, $post_data, $field_id );
 
 			// Process radio fields to detect and extract "Other" option metadata
 			if ( $type === 'radio' ) {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-phone/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-phone/index.tsx
@@ -15,26 +15,27 @@ type PhoneDisplayInfo = {
 
 type FieldPhoneProps = {
 	phone: string;
+	countryCode?: string;
 };
 
 /**
  * Renders a phone number with country flag and international formatting.
  * The libphonenumber-js library is loaded asynchronously to avoid bloating the main bundle.
  *
- * @param {FieldPhoneProps} props       - Component props.
- * @param {string}          props.phone - The phone number string to display.
+ * @param {FieldPhoneProps} props - Component props.
  * @return {JSX.Element} The rendered phone field.
  */
-const FieldPhone = ( { phone }: FieldPhoneProps ) => {
+const FieldPhone = ( { phone, countryCode: selectedCountryCode }: FieldPhoneProps ) => {
 	const [ displayInfo, setDisplayInfo ] = useState< PhoneDisplayInfo >( {
 		formattedNumber: phone,
+		countryCode: selectedCountryCode,
 	} );
 
 	useEffect( () => {
 		let cancelled = false;
 
 		// Reset to raw phone value immediately when phone changes
-		setDisplayInfo( { formattedNumber: phone, countryCode: undefined } );
+		setDisplayInfo( { formattedNumber: phone, countryCode: selectedCountryCode } );
 
 		const formatPhone = async () => {
 			try {
@@ -47,7 +48,7 @@ const FieldPhone = ( { phone }: FieldPhoneProps ) => {
 				if ( phoneNumber ) {
 					setDisplayInfo( {
 						formattedNumber: phoneNumber.formatInternational(),
-						countryCode: phoneNumber.country,
+						countryCode: selectedCountryCode ?? phoneNumber.country,
 					} );
 				}
 			} catch {
@@ -60,7 +61,7 @@ const FieldPhone = ( { phone }: FieldPhoneProps ) => {
 		return () => {
 			cancelled = true;
 		};
-	}, [ phone ] );
+	}, [ phone, selectedCountryCode ] );
 
 	const { formattedNumber, countryCode } = displayInfo;
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -102,7 +102,9 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 
 		// Phone numbers
 		if ( fieldType === 'phone' || fieldType === 'telephone' ) {
-			return <FieldPhone phone={ stringValue } />;
+			const countryCode =
+				typeof field.meta?.countryCode === 'string' ? field.meta.countryCode : undefined;
+			return <FieldPhone phone={ stringValue } countryCode={ countryCode } />;
 		}
 
 		if ( fieldType === 'url' && /^https?:\/\//.test( stringValue ) ) {

--- a/projects/packages/forms/tests/js/dashboard/components/response-view/field-phone/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/response-view/field-phone/index.test.jsx
@@ -93,6 +93,20 @@ describe( 'FieldPhone', () => {
 			} );
 		} );
 
+		it( 'prefers provided country code over parsed country', async () => {
+			mockParsePhoneNumber.mockReturnValue( {
+				formatInternational: () => '+1 555 123 4567',
+				country: 'US',
+			} );
+
+			render( <FieldPhone phone="+15551234567" countryCode="CA" /> );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'link' ) ).toHaveTextContent( '+1 555 123 4567' );
+				expect( screen.getByTestId( 'flag' ) ).toHaveAttribute( 'data-country', 'CA' );
+			} );
+		} );
+
 		it( 'does not display Flag when country cannot be determined', async () => {
 			mockParsePhoneNumber.mockReturnValue( {
 				formatInternational: () => '+14155551234',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1942,9 +1942,11 @@ class Contact_Form_Test extends BaseTestCase {
 		// Get label.
 		$label = $this->getFirstElement( $wrapper_div, 'label' );
 
-		// Inputs. (0 is the comboxbox search input, 1 is the visible input and 2 is the hidden, actual, input)
-		$visible_input = $this->getFirstElement( $wrapper_div, 'input', 1 );
-		$input         = $this->getFirstElement( $wrapper_div, 'input', 2 );
+		// Inputs. (0 is the comboxbox search input, 1 is the visible input,
+		// 2 is the hidden phone value, and 3 is the hidden country code).
+		$visible_input      = $this->getFirstElement( $wrapper_div, 'input', 1 );
+		$input              = $this->getFirstElement( $wrapper_div, 'input', 2 );
+		$country_code_input = $this->getFirstElement( $wrapper_div, 'input', 3 );
 
 		// Label matches for matches input ID.
 		$this->assertEquals(
@@ -1965,6 +1967,21 @@ class Contact_Form_Test extends BaseTestCase {
 
 		$this->assertEquals( 'hidden', $input->getAttribute( 'type' ), 'Type doesn\'t match' );
 		$this->assertEquals( $input->getAttribute( 'value' ), $attributes['default'], 'value and default doesn\'t match' );
+		$this->assertEquals(
+			'hidden',
+			$country_code_input->getAttribute( 'type' ),
+			'Country code input type doesn\'t match'
+		);
+		$this->assertEquals(
+			$attributes['id'] . '-country-code',
+			$country_code_input->getAttribute( 'name' ),
+			'Country code input name doesn\'t match'
+		);
+		$this->assertEquals(
+			'context.phoneCountryCode',
+			$country_code_input->getAttribute( 'data-wp-bind--value' ),
+			'Country code binding doesn\'t match'
+		);
 
 		$this->assertEquals(
 			'jetpack-field__input-element',

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -402,6 +402,20 @@ class Feedback_Field_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test phone field with saved country code metadata uses the selected country flag.
+	 */
+	public function test_phone_field_prefers_country_code_meta_for_flag() {
+		$field = new Feedback_Field(
+			'phone_key',
+			'Phone',
+			'+1 555 123 4567',
+			'phone',
+			array( 'countryCode' => 'CA' )
+		);
+		$this->assertEquals( '🇨🇦 +1 555 123 4567', $field->get_render_value( 'web' ) );
+	}
+
+	/**
 	 * Test phone field with German number displays flag.
 	 */
 	public function test_phone_field_with_german_number_displays_flag() {
@@ -760,6 +774,24 @@ class Feedback_Field_Test extends BaseTestCase {
 		$field  = new Feedback_Field( 'k', 'Phone', '+1 555 123 4567', 'phone' );
 		$result = $field->get_render_value( 'email_html' );
 
+		$this->assertStringContainsString( 'tel:', $result );
+		$this->assertStringContainsString( '+1 555 123 4567', $result );
+	}
+
+	/**
+	 * Test email_html phone field uses saved country code metadata for the flag.
+	 */
+	public function test_email_html_phone_field_prefers_country_code_meta_for_flag() {
+		$field  = new Feedback_Field(
+			'k',
+			'Phone',
+			'+1 555 123 4567',
+			'phone',
+			array( 'countryCode' => 'CA' )
+		);
+		$result = $field->get_render_value( 'email_html' );
+
+		$this->assertStringContainsString( '🇨🇦', $result );
 		$this->assertStringContainsString( 'tel:', $result );
 		$this->assertStringContainsString( '+1 555 123 4567', $result );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Fields_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Fields_Test.php
@@ -669,6 +669,41 @@ class Feedback_Fields_Test extends BaseTestCase {
 		$this->assertEquals( $default_expected, $default );
 	}
 
+	public function test_phone_country_code_meta_is_stored_for_country_selector() {
+		$test_phone = '+1 555 123 4567';
+		$form_id    = Utility::get_form_id();
+		$_post_data = Utility::get_post_request(
+			array(
+				'phone'              => $test_phone,
+				'phone-country-code' => 'ca',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title' => 'Test Form',
+			),
+			"[contact-field label='Phone' type='telephone' showcountryselector='1' /]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form );
+		$fields   = $response->get_fields();
+		$field    = reset( $fields );
+
+		$this->assertInstanceOf( Feedback_Field::class, $field );
+		$this->assertSame( $test_phone, $field->get_value() );
+		$this->assertSame( array( 'countryCode' => 'CA' ), $field->get_meta() );
+
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+		$saved_fields     = $saved_response->get_fields();
+		$saved_field      = reset( $saved_fields );
+
+		$this->assertInstanceOf( Feedback_Field::class, $saved_field );
+		$this->assertSame( array( 'countryCode' => 'CA' ), $saved_field->get_meta() );
+	}
+
 	public function test_get_field_by_id_and_value_by_id_new_submission() {
 		$form_id    = Utility::get_form_id();
 		$_post_data = Utility::get_post_request(


### PR DESCRIPTION
Fixes #

## Proposed changes
* Preserve the selected phone country code when a form with the country selector is submitted.
* Use the saved country code metadata when rendering phone flags in web, email, and Forms dashboard response views.
* Add PHP and JS test coverage for shared dialing prefixes such as US/Canada.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Create a form with a phone field and country selector enabled.
* Submit a phone number using a country that shares a dialing prefix with another country, such as Canada with `+1`.
* Confirm the response displays the selected country flag in the confirmation summary, email rendering, and Forms dashboard response view.
* Confirm existing phone-number formatting still works for numbers without saved country metadata.

Local checks run:
* `git diff --check`
* `corepack pnpm --dir projects/packages/forms run test tests/js/dashboard/components/response-view/field-phone/index.test.jsx`
* `corepack pnpm --dir projects/packages/forms run typecheck`

Not run locally:
* `jp test php packages/forms` - this Codex host does not have `php`, `composer`, or `docker` available, and the local pre-push hook fails at `env: php: No such file or directory`.
