### PR TITLE
Connectors: Disable connect/disconnect in offline mode

### DIFF
--- a/projects/packages/connection/changelog/add-connectors-card-offline-mode
+++ b/projects/packages/connection/changelog/add-connectors-card-offline-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connectors: Disable connecting and disconnecting from the Connectors card while the site is in offline mode.

--- a/projects/packages/connection/src/connectors/class-jetpack-connector.php
+++ b/projects/packages/connection/src/connectors/class-jetpack-connector.php
@@ -12,6 +12,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -146,6 +147,7 @@ class Jetpack_Connector {
 
 		$data['isConnected']          = $is_connected;
 		$data['isRegistered']         = $is_registered;
+		$data['isOfflineMode']        = ( new Status() )->is_offline_mode();
 		$data['isFirstConnection']    = ! $is_registered && ! (bool) \Jetpack_Options::get_option( 'id' );
 		$data['apiRoot']              = esc_url_raw( rest_url() );
 		$data['apiNonce']             = wp_create_nonce( 'wp_rest' );

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -154,21 +154,9 @@
 	}
 }
 
-.jetpack-connector__error {
-	color: #cc1818;
-	font-size: 13px;
-	margin-block-start: 8px;
-	padding-block: 8px;
-	padding-inline: 12px;
-	border-inline-start: 4px solid #cc1818;
-	background-color: #fcecec;
-	border-radius: 2px;
-	align-items: center;
-}
-
-.jetpack-connector__error .components-button {
-	color: #cc1818;
-	flex-shrink: 0;
+.jetpack-connector__error.components-notice {
+	margin-block: 8px 0;
+	margin-inline: 0;
 }
 
 .jetpack-connector__tos-notice {
@@ -179,16 +167,7 @@
 	color: inherit;
 }
 
-.jetpack-connector__offline-notice {
-	display: block;
-	margin-block-start: 8px;
-	padding-block: 8px;
-	padding-inline: 12px;
-	border-inline-start: 4px solid #dba617;
-	background-color: #fcf9e8;
-	border-radius: 2px;
-}
-
-.jetpack-connector__offline-notice a {
-	color: inherit;
+.jetpack-connector__offline-notice.components-notice {
+	margin-block: 8px 0;
+	margin-inline: 0;
 }

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -178,3 +178,16 @@
 .jetpack-connector__tos-notice a {
 	color: inherit;
 }
+
+.jetpack-connector__offline-notice {
+	margin-block-start: 8px;
+	padding-block: 8px;
+	padding-inline: 12px;
+	border-inline-start: 4px solid #dba617;
+	background-color: #fcf9e8;
+	border-radius: 2px;
+}
+
+.jetpack-connector__offline-notice a {
+	color: inherit;
+}

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -154,7 +154,7 @@
 	}
 }
 
-.jetpack-connector__error.components-notice {
+.jetpack-connector__notice.components-notice {
 	margin-block: 8px 0;
 	margin-inline: 0;
 }
@@ -165,9 +165,4 @@
 
 .jetpack-connector__tos-notice a {
 	color: inherit;
-}
-
-.jetpack-connector__offline-notice.components-notice {
-	margin-block: 8px 0;
-	margin-inline: 0;
 }

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -180,6 +180,7 @@
 }
 
 .jetpack-connector__offline-notice {
+	display: block;
 	margin-block-start: 8px;
 	padding-block: 8px;
 	padding-inline: 12px;

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -25,7 +25,7 @@ const ConnectorItem = connectors.__experimentalConnectorItem || connectors.Conne
 
 const { createElement, createInterpolateElement, useState, useEffect, useRef } = window.wp.element;
 const { __ } = window.wp.i18n;
-const { Button, Modal } = window.wp.components;
+const { Button, Modal, Notice } = window.wp.components;
 const HStack = window.wp.components.__experimentalHStack || window.wp.components.HStack;
 const VStack = window.wp.components.__experimentalVStack || window.wp.components.VStack;
 const Text = window.wp.components.__experimentalText || window.wp.components.Text;
@@ -180,21 +180,14 @@ function focusWhenReady( element ) {
  */
 function ErrorNotice( { message, onDismiss = null } ) {
 	return createElement(
-		HStack,
-		{ spacing: 2, className: 'jetpack-connector__error', role: 'alert' },
-		createElement( Text, { size: 13 }, message ),
-		onDismiss
-			? createElement(
-					Button,
-					{
-						variant: 'link',
-						size: 'small',
-						onClick: onDismiss,
-						'aria-label': __( 'Dismiss error', 'jetpack-connection' ),
-					},
-					__( 'Dismiss', 'jetpack-connection' )
-			  )
-			: null
+		Notice,
+		{
+			status: 'error',
+			isDismissible: Boolean( onDismiss ),
+			onRemove: onDismiss || undefined,
+			className: 'jetpack-connector__error',
+		},
+		message
 	);
 }
 
@@ -252,8 +245,12 @@ function OfflineNotice() {
 	);
 
 	return createElement(
-		Text,
-		{ variant: 'muted', size: 12, className: 'jetpack-connector__offline-notice', role: 'note' },
+		Notice,
+		{
+			status: 'warning',
+			isDismissible: false,
+			className: 'jetpack-connector__offline-notice',
+		},
 		message
 	);
 }

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -185,7 +185,7 @@ function ErrorNotice( { message, onDismiss = null } ) {
 			status: 'error',
 			isDismissible: Boolean( onDismiss ),
 			onRemove: onDismiss || undefined,
-			className: 'jetpack-connector__error',
+			className: 'jetpack-connector__notice',
 		},
 		message
 	);
@@ -249,7 +249,7 @@ function OfflineNotice() {
 		{
 			status: 'warning',
 			isDismissible: false,
-			className: 'jetpack-connector__offline-notice',
+			className: 'jetpack-connector__notice',
 		},
 		message
 	);

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -51,6 +51,7 @@ const CONNECTOR_LOGO = data.connectorLogoUrl
 	: null;
 const ssoStatus = data.ssoStatus ?? null;
 const isFirstConnection = Boolean( data.isFirstConnection );
+const isOfflineMode = Boolean( data.isOfflineMode );
 
 /**
  * Start the Jetpack connection flow: register the site (if needed),
@@ -230,6 +231,34 @@ function TosNotice() {
 }
 
 /**
+ * Notice explaining that connection management is disabled while the
+ * site is in Jetpack's offline mode.
+ *
+ * @return {object} React element.
+ */
+function OfflineNotice() {
+	const message = createInterpolateElement(
+		__(
+			'Your site is in <link>offline mode</link>, so connecting and disconnecting are disabled.',
+			'jetpack-connection'
+		),
+		{
+			link: createElement( 'a', {
+				href: 'https://jetpack.com/support/offline-mode/',
+				target: '_blank',
+				rel: 'noopener noreferrer',
+			} ),
+		}
+	);
+
+	return createElement(
+		Text,
+		{ variant: 'muted', size: 12, className: 'jetpack-connector__offline-notice', role: 'note' },
+		message
+	);
+}
+
+/**
  * Status badge with a BEM modifier for different connection states.
  *
  * @param {object} props          - Component props.
@@ -396,7 +425,7 @@ function ConnectPrompt( { onConnect, isConnecting, isDisconnecting } ) {
 				size: 'small',
 				onClick: onConnect,
 				isBusy: isConnecting,
-				disabled: isConnecting || isDisconnecting,
+				disabled: isConnecting || isDisconnecting || isOfflineMode,
 				className: 'jetpack-connector__inline-action',
 			},
 			isConnecting
@@ -525,6 +554,9 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 	const disconnectAccountRef = useRef( null );
 
 	const executeDisconnect = async () => {
+		if ( isOfflineMode ) {
+			return;
+		}
 		setPendingConfirm( null );
 		setIsDisconnecting( true );
 		setActionError( null );
@@ -571,6 +603,9 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 	};
 
 	const executeUnlinkUser = async () => {
+		if ( isOfflineMode ) {
+			return;
+		}
 		setPendingConfirm( null );
 		setIsUnlinking( true );
 		setActionError( null );
@@ -633,6 +668,9 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 		VStack,
 		{ spacing: 5 },
 
+		// Offline mode notice (connecting/disconnecting disabled).
+		isOfflineMode ? createElement( OfflineNotice ) : null,
+
 		// Current user info + unlink action (only when the viewing admin is linked).
 		currentUser
 			? createElement( UserSection, {
@@ -649,7 +687,7 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 										ref: disconnectAccountRef,
 										variant: 'link',
 										isDestructive: true,
-										disabled: isUnlinking || isDisconnecting,
+										disabled: isUnlinking || isDisconnecting || isOfflineMode,
 										onClick: handleUnlinkUser,
 										className: 'jetpack-connector__inline-action',
 									},
@@ -717,7 +755,7 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 							isDestructive: true,
 							size: 'compact',
 							isBusy: isDisconnecting,
-							disabled: isDisconnecting || isUnlinking,
+							disabled: isDisconnecting || isUnlinking || isOfflineMode,
 							onClick: handleDisconnect,
 							className: 'jetpack-connector__disconnect-site',
 						},
@@ -786,6 +824,9 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 	}, [] );
 
 	const handleConnect = async () => {
+		if ( isOfflineMode ) {
+			return;
+		}
 		setIsConnecting( true );
 		setConnectError( null );
 
@@ -847,7 +888,7 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 				size: 'compact',
 				onClick: handleConnect,
 				isBusy: isConnecting,
-				disabled: isConnecting,
+				disabled: isConnecting || isOfflineMode,
 			},
 			isConnecting
 				? __( 'Connecting…', 'jetpack-connection' )
@@ -878,7 +919,10 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 					onDismiss: () => setConnectError( null ),
 			  } )
 			: null,
-		isFirstConnection && ! isConnected && ! isSiteRegistered ? createElement( TosNotice ) : null
+		isOfflineMode && ! isConnected && ! isSiteRegistered ? createElement( OfflineNotice ) : null,
+		isFirstConnection && ! isOfflineMode && ! isConnected && ! isSiteRegistered
+			? createElement( TosNotice )
+			: null
 	);
 }
 

--- a/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Status\Cache as StatusCache;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -95,6 +96,9 @@ class Jetpack_Connector_Test extends TestCase {
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 		wp_set_current_user( 0 );
+
+		remove_all_filters( 'jetpack_offline_mode' );
+		StatusCache::clear();
 	}
 
 	/* ── init() ────────────────────────────────────────────────── */
@@ -176,6 +180,32 @@ class Jetpack_Connector_Test extends TestCase {
 		$this->assertArrayNotHasKey( 'currentUser', $data );
 		$this->assertArrayNotHasKey( 'connectionOwner', $data );
 		$this->assertArrayNotHasKey( 'ssoStatus', $data );
+	}
+
+	/* ── get_connector_data() — offline mode ───────────────────── */
+
+	/**
+	 * Test that isOfflineMode is false when the site is not in offline mode.
+	 */
+	public function test_get_connector_data_offline_mode_false_by_default() {
+		StatusCache::clear();
+
+		$data = Jetpack_Connector::get_connector_data( array() );
+
+		$this->assertArrayHasKey( 'isOfflineMode', $data );
+		$this->assertFalse( $data['isOfflineMode'] );
+	}
+
+	/**
+	 * Test that isOfflineMode is true when the site is in offline mode.
+	 */
+	public function test_get_connector_data_offline_mode_true_when_offline() {
+		StatusCache::clear();
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+
+		$data = Jetpack_Connector::get_connector_data( array() );
+
+		$this->assertTrue( $data['isOfflineMode'] );
 	}
 
 	/**


### PR DESCRIPTION
Closes: CONNECT-239

## Proposed changes

Disable the ability to connect/disconnect (change connection status) from the WP core **Settings → Connectors** card while the site is in Jetpack's offline mode.

* `Jetpack_Connector::get_connector_data()` now passes an `isOfflineMode` flag to the connectors script module (via `Status::is_offline_mode()`).
* `connectors-card.js` disables all state-changing actions when offline — top-level **Connect**, **Connect account**, **Disconnect site**, and **Disconnect account** — with defense-in-depth guards in the corresponding handlers.
* A new `OfflineNotice` (with matching styles) explains why the actions are unavailable and links to the [offline mode support doc](https://jetpack.com/support/offline-mode/). The ToS notice is suppressed while offline.
* Added unit tests covering the new `isOfflineMode` field.

This is a UX fix scoped to the new Connectors card. The connect paths were already blocked server-side (the `jetpack_connect`/`jetpack_connect_user` capabilities return `do_not_allow` in offline mode), so previously a user clicking Connect just hit an opaque error. The global `jetpack_disconnect` capability and the `disconnect_site_wpcom()` token-protection escape hatch are intentionally left untouched.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Enable Jetpack offline mode (e.g. add `define( 'JETPACK_DEV_DEBUG', true );` to `wp-config.php`, or add a `jetpack_offline_mode` filter returning `true`). Or, test on a local site (http://local) which auto-enables offline mode. 
* Go to **Settings → Connectors** (requires WordPress 7.0+ or the Gutenberg plugin's Connectors page).
* On a non-connected site: confirm the **Connect** button is disabled and an offline-mode notice is shown.
* On a connected site: expand the Jetpack card and confirm **Connect account**, **Disconnect account**, and **Disconnect site** are all disabled, with the offline-mode notice shown in the expanded panel.
* Disable offline mode and confirm the buttons become enabled again and behave as before.
