### PR TITLE
Podcast: align readiness notices with settings field labels

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-owner-email-copy
+++ b/projects/packages/podcast/changelog/fix-podcast-owner-email-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: align the distribution readiness notices with their settings field labels so it's clear which field each one refers to.

--- a/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
@@ -35,11 +35,11 @@ export const getValidationIssues = ( settings: PodcastSettings | undefined ): st
 		);
 	}
 	if ( ! settings.podcasting_talent_name ) {
-		issues.push( __( 'Set the host or talent name.', 'jetpack-podcast' ) );
+		issues.push( __( 'Set the host, artist, or producer name.', 'jetpack-podcast' ) );
 	}
 	if ( ! settings.podcasting_email ) {
 		issues.push(
-			__( 'Add an owner email so podcast directories can reach you.', 'jetpack-podcast' )
+			__( 'Add an owner email address so podcast directories can reach you.', 'jetpack-podcast' )
 		);
 	}
 	if ( ! settings.podcasting_category_1 ) {

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -352,7 +352,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							type="email"
-							label={ __( 'Email address', 'jetpack-podcast' ) }
+							label={ __( 'Owner email address', 'jetpack-podcast' ) }
 							help={ __(
 								'Included in your feed so podcast directories can verify ownership. Most require it for submission.',
 								'jetpack-podcast'


### PR DESCRIPTION
Fixes PODS-165/podcast-settings-hostowner-field-copy-is-confusing

## Summary

Change some of the copy around the email address in Podcast settings.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

1. Go to Podcast ⇢ Settings
2. Make sure the copy looks correct and better unified