### PR TITLE
Social: modernized dashboard feedback fixes (spacing, a11y, settings copy)

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/connection-info-modern.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-info-modern.tsx
@@ -5,6 +5,7 @@ import { chevronDown, info } from '@wordpress/icons';
 import { Collapsible, Icon, IconButton, Stack, Text } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
+import { useServiceLabel } from '../services/use-service-label';
 import { XNotice } from '../services/x-notice';
 import { ConnectionName } from './connection-name';
 import { ConnectionStatus, ConnectionStatusProps } from './connection-status';
@@ -31,6 +32,8 @@ export function ModernConnectionInfo( {
 }: ConnectionInfoProps ) {
 	const [ isPanelOpen, setIsPanelOpen ] = useState( false );
 
+	const getServiceLabel = useServiceLabel();
+
 	const { canManageConnection, isUnsupported } = useSelect(
 		select => {
 			const { canUserManageConnection, getServicesBy } = select( socialStore );
@@ -54,9 +57,10 @@ export function ModernConnectionInfo( {
 	);
 
 	const toggleLabel = sprintf(
-		/* translators: %s: name of the connected social media account. */
-		__( 'Toggle details for %s', 'jetpack-publicize-pkg' ),
-		connection.display_name
+		/* translators: %1$s: name of the connected social media account. %2$s: name of the social network, e.g. Facebook. */
+		__( 'Toggle details for %1$s on %2$s', 'jetpack-publicize-pkg' ),
+		connection.display_name,
+		getServiceLabel( connection.service_name )
 	);
 
 	return (

--- a/projects/packages/publicize/_inc/components/connection-management/connection-info-modern.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-info-modern.tsx
@@ -1,6 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown, info } from '@wordpress/icons';
 import { Collapsible, Icon, IconButton, Stack, Text } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
@@ -12,13 +12,10 @@ import { ConnectionTemplateEditor } from './connection-template';
 import { Disconnect } from './disconnect';
 import { MarkAsShared } from './mark-as-shared';
 import styles from './style-modern.module.scss';
-import type { SyntheticEvent } from 'react';
 
 type ConnectionInfoProps = ConnectionStatusProps & {
 	canMarkAsShared: boolean;
 };
-
-const stopPropagation = ( event: SyntheticEvent ) => event.stopPropagation();
 
 /**
  * Connection info component
@@ -56,13 +53,21 @@ export function ModernConnectionInfo( {
 		'jetpack-publicize-pkg'
 	);
 
+	const toggleLabel = sprintf(
+		/* translators: %s: name of the connected social media account. */
+		__( 'Toggle details for %s', 'jetpack-publicize-pkg' ),
+		connection.display_name
+	);
+
 	return (
 		<Collapsible.Root open={ isPanelOpen } onOpenChange={ setIsPanelOpen }>
-			<Collapsible.Trigger
-				className={ styles[ 'connection-row' ] }
-				nativeButton={ false }
-				render={ <div /> }
-			>
+			{ /*
+			 * The row is a plain container, not the trigger: it holds the profile
+			 * name link (and, when broken, the Reconnect link), and an interactive
+			 * <a> may not be nested inside a role="button". Only the chevron is the
+			 * disclosure trigger, so the links stay siblings of the button.
+			 */ }
+			<div className={ styles[ 'connection-row' ] }>
 				<ConnectionIcon
 					serviceName={ connection.service_name }
 					label={ connection.display_name }
@@ -70,41 +75,21 @@ export function ModernConnectionInfo( {
 					size="medium"
 				/>
 				<Stack direction="column" gap="xs" className={ styles[ 'connection-name-wrapper' ] }>
-					{ /*
-					 * The profile-name link lives inside the row, which doubles as
-					 * the Collapsible.Trigger. Without stopping propagation a click
-					 * on the link would also toggle the disclosure (and an anchor
-					 * inside role="button" is invalid nesting). Mirror the
-					 * connection-status-wrap below so the link opens the profile
-					 * without toggling the panel.
-					 */ }
-					<Text
-						variant="body-lg"
-						className={ styles[ 'connection-item-name' ] }
-						onClick={ stopPropagation }
-						onKeyDown={ stopPropagation }
-						role="presentation"
-					>
+					<Text variant="body-lg" className={ styles[ 'connection-item-name' ] }>
 						<ConnectionName connection={ connection } tone="neutral" />
 					</Text>
 					{ hasStatus ? (
-						<Stack
-							direction="column"
-							gap="xs"
-							onClick={ stopPropagation }
-							onKeyDown={ stopPropagation }
-							role="presentation"
-						>
-							<ConnectionStatus connection={ connection } service={ service } />
-						</Stack>
+						<ConnectionStatus connection={ connection } service={ service } />
 					) : (
 						<Text variant="body-md" className={ styles[ 'connection-network' ] }>
 							{ service?.label }
 						</Text>
 					) }
 				</Stack>
-				<Icon className={ styles.chevron } icon={ chevronDown } />
-			</Collapsible.Trigger>
+				<Collapsible.Trigger className={ styles[ 'panel-toggle' ] } aria-label={ toggleLabel }>
+					<Icon className={ styles.chevron } icon={ chevronDown } />
+				</Collapsible.Trigger>
+			</div>
 			<Collapsible.Panel className={ styles[ 'connection-panel' ] }>
 				<div className={ styles[ 'connection-panel-inner' ] }>
 					{ canMarkAsShared && (

--- a/projects/packages/publicize/_inc/components/connection-management/connection-status.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-status.tsx
@@ -81,7 +81,7 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 								'jetpack-publicize-pkg'
 						  );
 				} )( isUnsupported, connection.status ) }
-			</span>
+			</span>{ ' ' }
 			{ ! isUnsupported && service ? (
 				<Reconnect connection={ connection } service={ service } />
 			) : (

--- a/projects/packages/publicize/_inc/components/connection-management/connection-status.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-status.tsx
@@ -81,7 +81,8 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 								'jetpack-publicize-pkg'
 						  );
 				} )( isUnsupported, connection.status ) }
-			</span>{ ' ' }
+			</span>
+			{ '\u00A0' }
 			{ ! isUnsupported && service ? (
 				<Reconnect connection={ connection } service={ service } />
 			) : (

--- a/projects/packages/publicize/_inc/components/connection-management/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-management/style-modern.module.scss
@@ -36,22 +36,36 @@
 	}
 }
 
-// Flat row that doubles as the Collapsible.Trigger. Click anywhere on the
-// row (outside of the name link / status actions) toggles the disclosure;
-// the chevron rotates 180° via `[data-panel-open]` set by Base UI. The row is
-// rendered through Collapsible.Trigger's `render` prop, so it stays a plain
-// class (it still needs the cursor/padding/focus styling Stack doesn't cover).
+// Flat row holding the connection identity. It is a plain container — only the
+// chevron (`.panel-toggle`) is the Collapsible.Trigger — so the
+// profile/Reconnect links inside don't end up nested in a role="button".
 .connection-row {
 	align-items: center;
-	cursor: var(--wpds-cursor-control, pointer);
 	display: flex;
 	gap: var(--wpds-dimension-gap-lg, 16px);
 	padding: var(--wpds-dimension-padding-lg, 16px) var(--wpds-dimension-padding-2xl, 24px);
 	width: 100%;
+}
+
+// The disclosure trigger: an unstyled button wrapping just the chevron. Base UI
+// renders a native <button>, so reset its chrome and supply the focus ring the
+// row used to carry.
+.panel-toggle {
+	align-items: center;
+	appearance: none;
+	background: none;
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm, 2px);
+	color: inherit;
+	cursor: var(--wpds-cursor-control, pointer);
+	display: inline-flex;
+	flex-shrink: 0;
+	margin: 0;
+	padding: var(--wpds-dimension-padding-xs, 4px);
 
 	&:focus-visible {
 		outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus-brand, #3858e9);
-		outline-offset: calc(var(--wpds-border-width-focus, 2px) * -1);
+		outline-offset: 0;
 	}
 }
 
@@ -82,7 +96,7 @@
 	}
 }
 
-.connection-row[data-panel-open] {
+.panel-toggle[data-panel-open] {
 
 	.chevron {
 		rotate: 180deg;

--- a/projects/packages/publicize/_inc/components/connection-management/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-management/style-modern.module.scss
@@ -111,7 +111,11 @@
 }
 
 .connection-panel-inner {
-	padding: 0 var(--wpds-dimension-padding-2xl, 24px) var(--wpds-dimension-padding-xl, 20px);
+	// Panel keeps `overflow: hidden` for the collapse animation, so the top
+	// padding doubles as clearance for the focus ring of the first focusable
+	// child (e.g. the mark-as-shared info button) — without it the ring's top
+	// edge is clipped by the panel.
+	padding: var(--wpds-dimension-padding-xs, 4px) var(--wpds-dimension-padding-2xl, 24px) var(--wpds-dimension-padding-xl, 20px);
 }
 
 // Stack supplies the row layout (align + gap); only the trailing spacing

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-info-modern.test.jsx
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-info-modern.test.jsx
@@ -82,7 +82,7 @@ describe( 'ModernConnectionInfo', () => {
 		expect( screen.getByRole( 'button', { expanded: false } ) ).toBeInTheDocument();
 	} );
 
-	test( 'clicking the row toggles the disclosure open', async () => {
+	test( 'clicking the chevron toggle opens the disclosure', async () => {
 		const user = userEvent.setup();
 		renderInfo();
 

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/index-modern.tsx
@@ -74,11 +74,19 @@ export const ModernManageConnectionsModal = () => {
 						<Dialog.CloseIcon />
 					</Dialog.Header>
 					{ hasKeyringResult ? (
-						<ConfirmationForm
-							keyringResult={ keyringResult }
-							onComplete={ closeModal }
-							canMarkAsShared={ canMarkAsShared }
-						/>
+						/*
+						 * Wrap the confirmation form in `Dialog.Content` too, so it
+						 * picks up the same body inset the services list gets
+						 * (`0 24px 24px`). Rendered bare, the form ran edge-to-edge
+						 * and the footer buttons sat flush against the popup bottom.
+						 */
+						<Dialog.Content>
+							<ConfirmationForm
+								keyringResult={ keyringResult }
+								onComplete={ closeModal }
+								canMarkAsShared={ canMarkAsShared }
+							/>
+						</Dialog.Content>
 					) : (
 						/*
 						 * `Dialog.Content` is the library's scroll region (flex:1;

--- a/projects/packages/publicize/_inc/components/settings-tab/content-creation-card.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/content-creation-card.tsx
@@ -62,7 +62,7 @@ export default function ContentCreationCard(): JSX.Element {
 	return (
 		<Card.Root>
 			<Card.Header>
-				<Card.Title>{ __( 'Content creation', 'jetpack-publicize-pkg' ) }</Card.Title>
+				<Card.Title>{ __( 'Social Notes', 'jetpack-publicize-pkg' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
 				<Stack direction="column" gap="lg">

--- a/projects/packages/publicize/changelog/update-social-modernization-feedback
+++ b/projects/packages/publicize/changelog/update-social-modernization-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: refine connection card spacing and accessibility, add breathing room to the connection confirmation modal, and rename the Social Notes settings card.


### PR DESCRIPTION
Fixes #

This PR addresses a round of design/QA feedback on the modernized Social dashboard (the WPDS chassis behind the `rsm_jetpack_ui_modernization_social` flag), plus one shared fix and a settings copy change.

## Proposed changes
* **Connected account card – spacing:** add a space between the connection status text and the inline Reconnect/Disconnect link (was rendering as `…connection.Reconnect`). This lives in the shared `connection-status.tsx`, so it also benefits the legacy/block-editor paths.
* **Connected account card – info button focus ring:** add `padding-top` to the modern connection panel so the "mark as shared" info button's focus ring is no longer clipped by the panel's `overflow: hidden`.
* **Connection confirmation modal – breathing room:** wrap the confirmation form in `Dialog.Content` so it gets the same body inset (`0 24px 24px`) as the services-list view; previously it ran edge-to-edge and the footer buttons sat flush against the popup bottom.
* **Connection row – accessibility:** the whole row was the `Collapsible.Trigger` (`role="button"`), nesting the profile and Reconnect `<a>` links inside it (a nested-interactive-content violation). The row is now a plain container and only the chevron is the trigger — a labelled `<button>` — so the links stay siblings of the button. Clicking the chevron toggles the panel; the `stopPropagation` workaround is gone.
* **Settings page:** rename the "Content creation" card title to "Social Notes".

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Enable the Social modernization flag (`rsm_jetpack_ui_modernization_social`) and open **Jetpack → Social**.
* **Connection cards:** expand a connected account.
  * Confirm the info button next to "Mark the connection as shared" shows a complete focus ring (all four sides) when focused via keyboard.
  * Confirm only the **chevron** toggles the panel — clicking the row body does nothing — and that the chevron button is keyboard-focusable with a visible focus ring.
  * Confirm the profile name link and (for a broken connection) the Reconnect link are no longer nested inside a `role="button"` — inspect the row in DevTools; the trigger is now `<button aria-label="Toggle details for …">` with no `<a>` descendants.
  * For a broken connection, confirm there is a space in "There is an issue with this connection. Reconnect".
* **Confirmation modal:** go through **Add account** and reach the "Connection confirmation" step. Confirm the body content is inset from the edges and the Cancel/Confirm buttons have breathing room at the bottom.
* **Settings tab:** confirm the card previously titled "Content creation" now reads "Social Notes" (Social plugin only).

<img width="696" height="378" alt="Screenshot from 2026-06-01 12-55-23" src="https://github.com/user-attachments/assets/08687718-64c9-4296-9dfb-2035332097e4" />
<img width="1047" height="568" alt="Screenshot from 2026-06-01 12-37-12" src="https://github.com/user-attachments/assets/9931d030-b708-4225-9d9a-0774c34f493d" />
<img width="738" height="431" alt="Screenshot from 2026-06-01 12-29-23" src="https://github.com/user-attachments/assets/84f2ba2e-2058-47d7-982e-71c2094893d9" />
