### PR TITLE
Remove `jetpack-webpack-config-resolve-conditions` from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# @automattic/jetpack-webpack-config looks for this.
-jetpack-webpack-config-resolve-conditions=jetpack:src

--- a/projects/js-packages/image-guide/changelog/remove-npmrc-jetpack-webpack-config-resolve-conditions
+++ b/projects/js-packages/image-guide/changelog/remove-npmrc-jetpack-webpack-config-resolve-conditions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove use of `process.env.npm_config_jetpack_webpack_config_resolve_conditions`, just hard-code the relevant value.
+
+

--- a/projects/js-packages/image-guide/rollup.config.js
+++ b/projects/js-packages/image-guide/rollup.config.js
@@ -12,9 +12,7 @@ import sveltePreprocess from 'svelte-preprocess';
 
 const production = process.env.NODE_ENV === 'production';
 
-const exportConditions = process.env.npm_config_jetpack_webpack_config_resolve_conditions
-	? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
-	: [];
+const exportConditions = [ 'jetpack:src' ];
 
 /**
  *

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -136,7 +136,7 @@ This provides an instance of [css-minimizer-webpack-plugin](https://www.npmjs.co
 This is an object suitable for spreading some defaults into Webpack's `resolve` setting.
 
 * For `extensions`, we add `.jsx`, `.ts`, and `.tsx` to Webpack's defaults.
-* If `npm_config_jetpack_webpack_config_resolve_conditions` is set in the environment (e.g. by setting `jetpack-webpack-config-resolve-conditions` in `.npmrc`), [`conditionNames`](https://webpack.js.org/configuration/resolve/#resolveconditionnames) will be set to add the values (comma-separated) to Webpack's defaults.
+* [`conditionNames`](https://webpack.js.org/configuration/resolve/#resolveconditionnames) will be set to add "jetpack:src" before Webpack's defaults.
 
 #### `watchOptions`
 

--- a/projects/js-packages/webpack-config/changelog/remove-npmrc-jetpack-webpack-config-resolve-conditions
+++ b/projects/js-packages/webpack-config/changelog/remove-npmrc-jetpack-webpack-config-resolve-conditions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove use of `.npmrc` environment variable for setting condition names. The "jetpack:src" condition is now always added.

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -85,12 +85,7 @@ const optimization = {
 };
 const resolve = {
 	extensions: [ '.js', '.jsx', '.ts', '.tsx', '...' ],
-	conditionNames: [
-		...( process.env.npm_config_jetpack_webpack_config_resolve_conditions
-			? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
-			: [] ),
-		'...',
-	],
+	conditionNames: [ 'jetpack:src', '...' ],
 };
 const watchOptions = {
 	ignored: [ '**/node_modules', '**/dist', '**/vendor' ],

--- a/tools/js-tools/eslintrc/base.mjs
+++ b/tools/js-tools/eslintrc/base.mjs
@@ -127,8 +127,7 @@ export function makeBaseConfig( configurl, opts = {} ) {
 		}
 	}
 
-	const envConditionNames =
-		process.env.npm_config_jetpack_webpack_config_resolve_conditions?.split( ',' ) ?? [];
+	const envConditionNames = [ 'jetpack:src' ];
 
 	const jsPackageJsons = glob
 		.sync( path.join( rootdir, 'projects/js-packages/*/package.json' ) )

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -6,12 +6,7 @@ module.exports = {
 	testEnvironment: path.join( __dirname, 'fix-environment-jsdom.mjs' ),
 	testEnvironmentOptions: {
 		// Note we need to repeat the environment's default conditions here too, sigh.
-		customExportConditions: [
-			'browser',
-			...( process.env.npm_config_jetpack_webpack_config_resolve_conditions
-				? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
-				: [] ),
-		],
+		customExportConditions: [ 'browser', 'jetpack:src' ],
 	},
 	transform: {
 		'\\.(gif|jpg|jpeg|png|webp|svg|scss|sass|css|ttf|woff|woff2)$': path.join(


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This was added back in #30313, with the thinking that we'd be able to somehow use the configs without change outside of the monorepo. Turns out we've never had a need to do that, and now npm has started complaining about the custom setting there. So let's drop the setting and just hard-code "jetpack:src" in the relevant places.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1780095093328069-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* No changes to build artifacts?