### PR TITLE
Shortcodes: Escape SoundCloud iframe src with esc_url()

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-soundcloud-esc_url-iframe-src
+++ b/projects/plugins/jetpack/changelog/fix-soundcloud-esc_url-iframe-src
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Escape the SoundCloud player iframe src URL with esc_url().

--- a/projects/plugins/jetpack/changelog/fix-soundcloud-esc_url-iframe-src
+++ b/projects/plugins/jetpack/changelog/fix-soundcloud-esc_url-iframe-src
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
-Escape the SoundCloud player iframe src URL with esc_url().
+Shortcode embeds: ensure the SoundCloud player iFrame is always correctly escaped.

--- a/projects/plugins/jetpack/modules/shortcodes/soundcloud.php
+++ b/projects/plugins/jetpack/modules/shortcodes/soundcloud.php
@@ -170,7 +170,7 @@ function soundcloud_shortcode( $atts, $content = null ) {
 		'<iframe width="%1$s" height="%2$d" scrolling="no" frameborder="no" src="%3$s"></iframe>',
 		esc_attr( $width ),
 		esc_attr( $height ),
-		$url
+		esc_url( $url )
 	);
 }
 add_shortcode( 'soundcloud', 'soundcloud_shortcode' );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Soundcloud_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Soundcloud_Test.php
@@ -44,7 +44,7 @@ class Jetpack_Shortcodes_Soundcloud_Test extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertStringContainsString( '<iframe width="100%" height="450"', $shortcode_content );
-		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&auto_play=false&hide_related=false&visual=true', $shortcode_content );
+		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&#038;auto_play=false&#038;hide_related=false&#038;visual=true', $shortcode_content );
 	}
 
 	public function test_shortcodes_implicit_non_visual() {
@@ -53,7 +53,7 @@ class Jetpack_Shortcodes_Soundcloud_Test extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertStringContainsString( '<iframe width="100%" height="450"', $shortcode_content );
-		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&auto_play=false&hide_related=false', $shortcode_content );
+		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&#038;auto_play=false&#038;hide_related=false', $shortcode_content );
 	}
 
 	public function test_shortcodes_explicit_non_visual() {
@@ -62,7 +62,7 @@ class Jetpack_Shortcodes_Soundcloud_Test extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertStringContainsString( '<iframe width="100%" height="450"', $shortcode_content );
-		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&auto_play=false&hide_related=false', $shortcode_content );
+		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&#038;auto_play=false&#038;hide_related=false', $shortcode_content );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class Jetpack_Shortcodes_Soundcloud_Test extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertStringContainsString( '<iframe width="100%" height="166"', $shortcode_content );
-		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fpaul-is-dead&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false', $shortcode_content );
+		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fpaul-is-dead&#038;width=false&#038;height=false&#038;auto_play=false&#038;hide_related=false&#038;visual=false&#038;show_comments=false&#038;color=false&#038;show_user=false&#038;show_reposts=false', $shortcode_content );
 	}
 
 	/**
@@ -90,7 +90,7 @@ class Jetpack_Shortcodes_Soundcloud_Test extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertStringContainsString( '<iframe width="100%" height="450"', $shortcode_content );
-		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fsets%2Fsmells-like-lynx-africa-private&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false', $shortcode_content );
+		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fsets%2Fsmells-like-lynx-africa-private&#038;width=false&#038;height=false&#038;auto_play=false&#038;hide_related=false&#038;visual=false&#038;show_comments=false&#038;color=false&#038;show_user=false&#038;show_reposts=false', $shortcode_content );
 	}
 
 	/**
@@ -104,7 +104,7 @@ class Jetpack_Shortcodes_Soundcloud_Test extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertStringContainsString( '<iframe width="100%" height="450"', $shortcode_content );
-		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fsets%2Fsmells-like-lynx-africa-private&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&show_user=false&show_reposts=false&color=00cc11', $shortcode_content );
+		$this->assertStringContainsString( 'w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclosetorgan%2Fsets%2Fsmells-like-lynx-africa-private&#038;width=false&#038;height=false&#038;auto_play=false&#038;hide_related=false&#038;visual=false&#038;show_comments=false&#038;show_user=false&#038;show_reposts=false&#038;color=00cc11', $shortcode_content );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
* The `soundcloud_shortcode()` function builds the player URL via `add_query_arg()` and passes it straight into the iframe `src` without escaping. This PR wraps the `$url` argument in `esc_url()` on the final `sprintf()` return.
* Every other shortcode in this directory that constructs an iframe already does this: `vimeo.php` uses `esc_url( $url )`, `spotify.php` uses `esc_url( $embed_url )`. The SoundCloud shortcode was the one exception, so this aligns it with the rest.
* Added a changelog entry under `projects/plugins/jetpack/changelog/`.

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a test site, go to My Jetpack > Products and enable shortcode embeds
* create a post or page and add a SoundCloud shortcode, e.g. `[soundcloud url="https://api.soundcloud.com/tracks/156010013"]`.
* View the post on the front end and confirm the SoundCloud player still renders and plays correctly.
* Inspect the rendered `<iframe>` and confirm the `src` attribute is a properly escaped URL.
* Optionally, test with a shortcode that includes extra query parameters to confirm the URL built by `add_query_arg()` is escaped as expected.
