### PR TITLE
Boost: fix double scrollbar on the dashboard

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
@@ -83,10 +83,6 @@ p {
 }
 
 // Reset WP-Admin styles for boost dashboard
-.jetpack_page_jetpack-boost #wpcontent {
-	min-height: 100vh;
-}
-
 .jetpack_page_jetpack-boost #jb-admin-settings {
 	background: #fff;
 }

--- a/projects/plugins/boost/changelog/2026-06-01-16-49-37-026611
+++ b/projects/plugins/boost/changelog/2026-06-01-16-49-37-026611
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a duplicate scrollbar on the Boost dashboard by removing an obsolete full-height override.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Remove the obsolete `.jetpack_page_jetpack-boost #wpcontent { min-height: 100vh }` reset from the Boost dashboard styles.
* This rule predates Boost's adoption of the shared `jetpack-admin-page-layout` mixin. The mixin already pins `#wpbody-content` (`position: fixed; top: admin-bar-height; bottom: 0; overflow: hidden`) and owns the full content height internally.
* With the old reset in place, the in-flow `#wpcontent` → `#wpwrap` were forced to a full `100vh`, which ignores the 32px WP admin bar they sit below. They therefore extended exactly 32px past the viewport, producing a phantom **outer** window scrollbar on top of the intended **inner** content scrollbar — the "double scrollbar". Removing the reset lets `#wpwrap` size to `min-height: 100%` and fit the viewport, matching My Jetpack and the other modernized dashboards.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the Boost plugin: `jetpack build plugins/boost`.
* On a Jetpack-connected site, go to **Jetpack → Boost** (`wp-admin/admin.php?page=jetpack-boost`).
* Make the browser window short enough that the dashboard content overflows (so it scrolls).
* **Before:** there are two vertical scrollbars on the right edge — the inner content scrollbar plus a near-empty outer window scrollbar (the window scrolls ~32px, the admin-bar height).
* **After:** only the inner content scrollbar is present; the window itself does not scroll. The fixed Jetpack header stays put and the content scrolls within its region.
* Sanity check another modernized dashboard (e.g. **My Jetpack**) still behaves the same — single inner scrollbar, no window scroll.
