### PR TITLE
Pricing table: stop feature tooltips from being hidden behind the admin sidebar

### DIFF
--- a/projects/js-packages/components/changelog/fix-popover-hidden-by-sidebar
+++ b/projects/js-packages/components/changelog/fix-popover-hidden-by-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pricing table: render feature tooltips as a portal so they are no longer hidden behind the admin sidebar

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -103,6 +103,8 @@ export const PricingTableItem: FC< PricingTableItemProps > = ( {
 					iconSize={ 14 }
 					offset={ 4 }
 					wide={ Boolean( tooltipTitle && tooltipInfo ) }
+					inline={ false }
+					shift
 				>
 					<Text variant="body-small" component="div">
 						{ tooltipInfo || defaultTooltipInfo }
@@ -204,6 +206,8 @@ const PricingTable: FC< PricingTableProps > = ( {
 											iconSize={ 14 }
 											offset={ 4 }
 											wide={ Boolean( item.tooltipTitle && item.tooltipInfo ) }
+											inline={ false }
+											shift
 										>
 											<Text variant="body-small">{ item.tooltipInfo }</Text>
 										</IconTooltip>


### PR DESCRIPTION
Before:
<img width="467" height="564" alt="Screenshot 2026-06-01 at 9 38 44 AM" src="https://github.com/user-attachments/assets/2d4b4d0f-f231-470b-99b7-37915ca783e6" />

After:
<img width="617" height="369" alt="Screenshot 2026-06-01 at 10 08 58 AM" src="https://github.com/user-attachments/assets/50d071a7-6e00-4c54-b84c-8537abd5f1e4" />



## Proposed changes
* The `IconTooltip` instances inside the shared `PricingTable` component rendered their popover inline in the page DOM (`inline=true`), placing it in the page's normal stacking context — below the WP-admin sidebar's `z-index`. With `bottom-end` placement the popover opened leftward, so on narrow content (e.g. My Jetpack `#/add-social`) it was painted over / hidden by the dark admin sidebar.
* Pass `inline={ false }` so the popover renders in the high-`z-index` portal/popover-slot and floats above the sidebar, plus `shift` so it stays within the viewport — matching the pattern already used by `IconTooltip` in the Publicize package.
* Because the fix is in the shared `PricingTable`, it also resolves the same clipping for pricing/feature tooltips on the Search, Boost, Protect, VideoPress, and Publicize pricing pages.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the affected packages: `jetpack build js-packages/components` then `jetpack build packages/my-jetpack`.
* In wp-admin, open `admin.php?page=my-jetpack#/add-social`.
* Click a feature info (ⓘ) icon near the left edge — e.g. "Scheduled posts" or "Recycle content".
* **Before:** the popover is clipped/hidden behind the dark left admin sidebar.
* **After:** the popover renders above the sidebar and shifts to stay fully in view.
* Optionally confirm other pricing tables still render their tooltips correctly (e.g. Search/Boost/Protect/Publicize upsell pages).
