### PR TITLE
Newsletter: avoid fatal on modernization filter lookup

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-modernization-filter-fatal
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-modernization-filter-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Prevent a fatal error when loading wp-admin with the modernization filter unavailable.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1032,8 +1032,12 @@ class Jetpack_Subscriptions {
 		 * Once the Newsletter modernization filter is on, the unified Newsletter
 		 * page owns the Subscribers tab and this standalone Calypso shortcut is
 		 * retired. While the filter is off (the default) we keep showing it.
+		 *
+		 * Referenced as a string literal (mirrors Newsletter\Settings::MODERNIZATION_FILTER)
+		 * to keep this bootstrap path safe if the packaged Newsletter Settings class does
+		 * not expose the constant yet.
 		 */
-		if ( apply_filters( Newsletter_Settings::MODERNIZATION_FILTER, false ) ) {
+		if ( apply_filters( 'rsm_jetpack_ui_modernization_newsletter', false ) ) {
 			return;
 		}
 


### PR DESCRIPTION

## Proposed changes
* Prevent a fatal error in `Jetpack_Subscriptions::add_subscribers_menu()` by using the Newsletter modernization filter name directly during wp-admin menu bootstrap.
* Keep the existing behavior: the Subscribers shortcut is still hidden when `rsm_jetpack_ui_modernization_newsletter` is enabled.

## Related product discussion/links
* Triggered by recurring Gutenberg Atomic Edge E2E failures where wp-admin showed a critical error before the editor could load.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `php -l projects/plugins/jetpack/modules/subscriptions.php`
* `composer phpcs:lint -- projects/plugins/jetpack/modules/subscriptions.php`
* `CI=true JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack test php packages/newsletter`
* `CI=true JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack phan plugins/jetpack --allow-polyfill-parser --include-analysis-file-list=projects/plugins/jetpack/modules/subscriptions.php`
* `CI=true JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack docker phpunit jetpack -- --filter Jetpack_Subscriptions_Test`
* `CI=true JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack docker phpunit jp-wpcomsh -- --filter Jetpack_Subscriptions_Test`