### PR TITLE
Agents Manager: Add Sidebar Preservation On Load Mechanism

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1987,6 +1987,9 @@ importers:
       '@babel/runtime':
         specifier: 7.29.2
         version: 7.29.2
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -1999,6 +2002,9 @@ importers:
       browserslist:
         specifier: ^4.24.0
         version: 4.28.2
+      concurrently:
+        specifier: 9.2.1
+        version: 9.2.1
       jest:
         specifier: 30.4.2
         version: 30.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1973,7 +1973,41 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.105.2)
 
-  projects/packages/agents-manager: {}
+  projects/packages/agents-manager:
+    devDependencies:
+      '@automattic/jetpack-webpack-config':
+        specifier: workspace:*
+        version: link:../../js-packages/webpack-config
+      '@babel/core':
+        specifier: 7.29.0
+        version: 7.29.0
+      '@babel/preset-env':
+        specifier: 7.29.2
+        version: 7.29.2(@babel/core@7.29.0)
+      '@babel/runtime':
+        specifier: 7.29.2
+        version: 7.29.2
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
+      '@wordpress/browserslist-config':
+        specifier: 6.46.0
+        version: 6.46.0
+      browserslist:
+        specifier: ^4.24.0
+        version: 4.28.2
+      jest:
+        specifier: 30.4.2
+        version: 30.4.2
+      webpack:
+        specifier: 5.105.2
+        version: 5.105.2(webpack-cli@6.0.1)
+      webpack-cli:
+        specifier: 6.0.1
+        version: 6.0.1(webpack@5.105.2)
 
   projects/packages/assets:
     dependencies:

--- a/projects/packages/agents-manager/.gitignore
+++ b/projects/packages/agents-manager/.gitignore
@@ -1,2 +1,3 @@
-vendor/
 node_modules/
+.cache
+build

--- a/projects/packages/agents-manager/changelog/agents-manager-persisted-sidebar-open-mechanism
+++ b/projects/packages/agents-manager/changelog/agents-manager-persisted-sidebar-open-mechanism
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: Add Sidebar Preservation On Load Mechanism

--- a/projects/packages/agents-manager/composer.json
+++ b/projects/packages/agents-manager/composer.json
@@ -33,12 +33,11 @@
 		"test-coverage": [
 			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 		],
+		"test-js": [
+			"pnpm run test"
+		],
 		"test-php": [
 			"@composer phpunit"
-		],
-		"watch": [
-			"Composer\\Config::disableProcessTimeout",
-			"pnpm run watch"
 		]
 	},
 	"repositories": [

--- a/projects/packages/agents-manager/composer.json
+++ b/projects/packages/agents-manager/composer.json
@@ -4,6 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"php": ">=7.4"
@@ -20,8 +21,12 @@
 		]
 	},
 	"scripts": {
-		"build-development": "echo 'Add your build step to composer.json, please!'",
-		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"build-development": [
+			"pnpm run build"
+		],
+		"build-production": [
+			"pnpm run build-production"
+		],
 		"phpunit": [
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
@@ -30,6 +35,10 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
 		]
 	},
 	"repositories": [

--- a/projects/packages/agents-manager/composer.json
+++ b/projects/packages/agents-manager/composer.json
@@ -30,9 +30,7 @@
 		"phpunit": [
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
-		"test-coverage": [
-			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-		],
+		"test-coverage": "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'",
 		"test-js": [
 			"pnpm run test"
 		],

--- a/projects/packages/agents-manager/eslint.config.mjs
+++ b/projects/packages/agents-manager/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { makeBaseConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
+
+export default makeBaseConfig( import.meta.url );

--- a/projects/packages/agents-manager/package.json
+++ b/projects/packages/agents-manager/package.json
@@ -15,10 +15,29 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "echo 'Not implemented.'",
-		"build-js": "echo 'Not implemented.'",
-		"build-production": "echo 'Not implemented.'",
-		"build-production-js": "echo 'Not implemented.'",
-		"clean": "true"
+		"build": "pnpm run clean && pnpm run build-client",
+		"build-client": "webpack",
+		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
+		"clean": "rm -rf build/",
+		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.js",
+		"typecheck": "tsgo --noEmit",
+		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
+		"watch": "webpack --watch"
+	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
+	"devDependencies": {
+		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@babel/core": "7.29.0",
+		"@babel/preset-env": "7.29.2",
+		"@babel/runtime": "7.29.2",
+		"@types/jest": "30.0.0",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
+		"@wordpress/browserslist-config": "6.46.0",
+		"browserslist": "^4.24.0",
+		"jest": "30.4.2",
+		"webpack": "5.105.2",
+		"webpack-cli": "6.0.1"
 	}
 }

--- a/projects/packages/agents-manager/package.json
+++ b/projects/packages/agents-manager/package.json
@@ -20,6 +20,7 @@
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
 		"clean": "rm -rf build/",
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest --config=tests/jest.config.js",
+		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "webpack --watch"
@@ -32,10 +33,12 @@
 		"@babel/core": "7.29.0",
 		"@babel/preset-env": "7.29.2",
 		"@babel/runtime": "7.29.2",
+		"@jest/globals": "30.4.1",
 		"@types/jest": "30.0.0",
 		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/browserslist-config": "6.46.0",
 		"browserslist": "^4.24.0",
+		"concurrently": "9.2.1",
 		"jest": "30.4.2",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -46,6 +46,8 @@ class Agents_Manager {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'next_admin_init', array( $this, 'enqueue_scripts' ), 1001 );
 		add_filter( 'agents_manager_use_unified_experience', array( $this, 'should_use_unified_experience' ) );
+
+		Sidebar_Open_Preservation::init();
 	}
 
 	/**

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -433,7 +433,13 @@ class Agents_Manager {
 			'https://widgets.wp.com/agents-manager/agents-manager-' . $variant . '.min.js',
 			$script_dependencies,
 			$version,
-			true
+			/**
+			 * Filter the strategy to use when enqueuing the script.
+			 *
+			 * @param array|bool $args The arguments to pass to wp_enqueue_script. Default is true.
+			 * @param string $handle The handle of the script.
+			 */
+			apply_filters( 'agents_manager_enqueue_script_strategy', true, 'agents-manager' )
 		);
 
 		if ( 'gutenberg-disconnected' !== $variant && 'ciab-disconnected' !== $variant ) {

--- a/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
+++ b/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Sidebar Open Watcher file.
+ *
+ * @package automattic/jetpack-agents-manager
+ */
+
+namespace Automattic\Jetpack\Agents_Manager;
+
+use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Constants;
+
+/**
+ * Preserves Agents Manager sidebar-open body classes across full wp-admin navigations.
+ */
+class Sidebar_Open_Preservation {
+	/**
+	 * Class instance.
+	 *
+	 * @var Sidebar_Open_Preservation
+	 */
+	private static $instance;
+
+	/**
+	 * The cookie key for the agents manager chat sidebar open state.
+	 *
+	 * @var string
+	 */
+	private const COOKIE_KEY = 'agents_manager_chat_sidebar_open';
+
+	/**
+	 * The class name for the agents manager sidebar open state.
+	 *
+	 * @var string
+	 */
+	private const SIDEBAR_OPEN_CLASS = 'agents-manager-sidebar-container--sidebar-open';
+
+	/**
+	 * Creates instance.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+	}
+
+	/**
+	 * Sidebar_Open_Preservation constructor.
+	 */
+	public function __construct() {
+		add_filter( 'admin_body_class', array( $this, 'add_preopen_body_classes' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_sidebar_open_watcher_script' ), 1 );
+	}
+
+	/**
+	 * Inject pre-open assistant classes in initial admin body markup.
+	 *
+	 * Cookie reflects sidebar open (not chat docked).
+	 *
+	 * @param string $classes Existing admin body classes.
+	 * @return string
+	 */
+	public function add_preopen_body_classes( string $classes ): string {
+		if ( ! $this->should_preserve_sidebar_open_state() ) {
+			return $classes;
+		}
+
+		$cookie_value = isset( $_COOKIE[ self::COOKIE_KEY ] )
+			? sanitize_text_field( wp_unslash( (string) $_COOKIE[ self::COOKIE_KEY ] ) )
+			: '';
+		$is_open      = '1' === $cookie_value;
+
+		if ( ! $is_open ) {
+			return $classes;
+		}
+
+		return implode(
+			' ',
+			array_filter(
+				array(
+					$classes,
+					'agents-manager-sidebar-container',
+					self::SIDEBAR_OPEN_CLASS,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Enqueue the locally bundled Sidebar Open Watcher script.
+	 *
+	 * Keeps the sidebar open-state cookie in sync with the admin body
+	 * class. Built by webpack into `build/sidebar-open-watcher.js`;
+	 * the sibling `.asset.php` supplies dependencies and version.
+	 */
+	public function enqueue_sidebar_open_watcher_script() {
+		if ( ! $this->should_preserve_sidebar_open_state() ) {
+			return;
+		}
+
+		$script_handle = 'jetpack-agents-manager-sidebar-open-watcher';
+
+		Assets::register_script(
+			$script_handle,
+			'../build/sidebar-open-watcher.js',
+			__FILE__,
+			array(
+				'in_footer'  => true,
+				'textdomain' => 'jetpack-agents-manager',
+			)
+		);
+
+		$script_data = array(
+			'cookieKey'        => self::COOKIE_KEY,
+			'cookiePath'       => Constants::get_constant( 'ADMIN_COOKIE_PATH' ),
+			'sidebarOpenClass' => self::SIDEBAR_OPEN_CLASS,
+		);
+
+		$script_data = wp_json_encode(
+			$script_data,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE
+		);
+
+		wp_add_inline_script(
+			$script_handle,
+			sprintf( 'window.AgentsManagerSidebarOpenWatcherData = %s;', $script_data ),
+			'before'
+		);
+
+		Assets::enqueue_script( $script_handle );
+	}
+
+	/**
+	 * Whether sidebar open preservation should run for this request.
+	 *
+	 * @return bool
+	 */
+	private function should_preserve_sidebar_open_state(): bool {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		/**
+		 * Filter whether to use the unified Agents Manager experience.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param bool $use_unified Whether to use the unified experience.
+		 */
+		return (bool) apply_filters( 'agents_manager_use_unified_experience', false );
+	}
+}

--- a/projects/packages/agents-manager/src/js/sidebar-open-watcher.ts
+++ b/projects/packages/agents-manager/src/js/sidebar-open-watcher.ts
@@ -1,0 +1,59 @@
+declare global {
+	interface Window {
+		AgentsManagerSidebarOpenWatcherData?: {
+			cookieKey: string;
+			cookiePath: string;
+			sidebarOpenClass: string;
+		};
+	}
+}
+
+/**
+ * Register the sidebar open watcher client script.
+ *
+ * Keeps the sidebar open cookie in sync with body classes so the next
+ * full admin page load can pre-apply them server-side.
+ */
+function registerSidebarOpenWatcher() {
+	if ( ! window.AgentsManagerSidebarOpenWatcherData ) {
+		throw new Error( 'AgentsManagerSidebarOpenWatcherData is not defined' );
+	}
+
+	const { cookieKey, cookiePath, sidebarOpenClass } = window.AgentsManagerSidebarOpenWatcherData;
+
+	/**
+	 * Update the sidebar open cookie from the current body class.
+	 */
+	function syncSidebarOpenCookie() {
+		const isOpen = document.body.classList.contains( sidebarOpenClass );
+
+		if ( isOpen ) {
+			document.cookie = `${ cookieKey }=1; path=${ cookiePath }; samesite=lax`;
+		} else {
+			document.cookie = `${ cookieKey }=; path=${ cookiePath }; samesite=lax`;
+		}
+	}
+
+	const observer = new window.MutationObserver( function () {
+		syncSidebarOpenCookie();
+	} );
+
+	observer.observe( document.body, {
+		attributes: true,
+		attributeFilter: [ 'class' ],
+	} );
+
+	syncSidebarOpenCookie();
+
+	window.addEventListener( 'pagehide', function () {
+		observer.disconnect();
+	} );
+}
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', registerSidebarOpenWatcher );
+} else {
+	registerSidebarOpenWatcher();
+}
+
+export { registerSidebarOpenWatcher };

--- a/projects/packages/agents-manager/tests/jest.config.js
+++ b/projects/packages/agents-manager/tests/jest.config.js
@@ -1,0 +1,7 @@
+import path from 'path';
+import baseConfig from 'jetpack-js-tools/jest/config.base.js';
+
+export default {
+	...baseConfig,
+	rootDir: path.join( import.meta.dirname, '..' ),
+};

--- a/projects/packages/agents-manager/tests/js/sidebar-open-watcher.test.ts
+++ b/projects/packages/agents-manager/tests/js/sidebar-open-watcher.test.ts
@@ -1,0 +1,125 @@
+const WATCHER_DATA = {
+	cookieKey: 'agents_manager_chat_sidebar_open',
+	// jsdom only returns cookies whose path matches the document URL ("/"),
+	// so use a root path here rather than the real "/wp-admin".
+	cookiePath: '/',
+	sidebarOpenClass: 'agents-manager-sidebar-container--sidebar-open',
+};
+
+/**
+ * Freshly (re)import the watcher module so its top-level "register on load"
+ * side effect runs against the current document/window state.
+ *
+ * @return The imported module namespace.
+ */
+async function importWatcher() {
+	jest.resetModules();
+	return import( '../../src/js/sidebar-open-watcher' );
+}
+
+/**
+ * Read a cookie value by key from document.cookie.
+ *
+ * @param key - Cookie name to read.
+ * @return The cookie value, or undefined when absent/empty.
+ */
+function readCookie( key: string ): string | undefined {
+	const match = document.cookie
+		.split( '; ' )
+		.map( pair => pair.split( '=' ) )
+		.find( ( [ name ] ) => name === key );
+
+	const value = match?.[ 1 ];
+	return value ? value : undefined;
+}
+
+/**
+ * Wait for the MutationObserver callback (a microtask) to flush.
+ *
+ * @return A promise that resolves once pending mutations have been observed.
+ */
+function flushMutations(): Promise< void > {
+	return new Promise( resolve => setTimeout( resolve, 0 ) );
+}
+
+describe( 'registerSidebarOpenWatcher', () => {
+	afterEach( () => {
+		// Disconnect observers/pagehide listeners created during the test so
+		// they cannot keep mutating the cookie across tests (the jsdom
+		// document is shared for the whole file).
+		window.dispatchEvent( new window.Event( 'pagehide' ) );
+
+		delete window.AgentsManagerSidebarOpenWatcherData;
+		document.body.className = '';
+		document.cookie = `${ WATCHER_DATA.cookieKey }=; path=${ WATCHER_DATA.cookiePath }; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+	} );
+
+	it( 'throws when the watcher data global is missing', async () => {
+		window.AgentsManagerSidebarOpenWatcherData = WATCHER_DATA;
+		const mod = await importWatcher();
+
+		delete window.AgentsManagerSidebarOpenWatcherData;
+
+		expect( () => mod.registerSidebarOpenWatcher() ).toThrow(
+			'AgentsManagerSidebarOpenWatcherData is not defined'
+		);
+	} );
+
+	it( 'sets the cookie to 1 on init when the sidebar-open class is present', async () => {
+		window.AgentsManagerSidebarOpenWatcherData = WATCHER_DATA;
+		document.body.classList.add( WATCHER_DATA.sidebarOpenClass );
+
+		await importWatcher();
+
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBe( '1' );
+	} );
+
+	it( 'clears the cookie on init when the sidebar-open class is absent', async () => {
+		window.AgentsManagerSidebarOpenWatcherData = WATCHER_DATA;
+		// Seed an existing open cookie to prove it gets cleared.
+		document.cookie = `${ WATCHER_DATA.cookieKey }=1; path=${ WATCHER_DATA.cookiePath }`;
+
+		await importWatcher();
+
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBeUndefined();
+	} );
+
+	it( 'updates the cookie when the body class is added after init', async () => {
+		window.AgentsManagerSidebarOpenWatcherData = WATCHER_DATA;
+
+		await importWatcher();
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBeUndefined();
+
+		document.body.classList.add( WATCHER_DATA.sidebarOpenClass );
+		await flushMutations();
+
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBe( '1' );
+	} );
+
+	it( 'clears the cookie when the body class is removed after init', async () => {
+		window.AgentsManagerSidebarOpenWatcherData = WATCHER_DATA;
+		document.body.classList.add( WATCHER_DATA.sidebarOpenClass );
+
+		await importWatcher();
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBe( '1' );
+
+		document.body.classList.remove( WATCHER_DATA.sidebarOpenClass );
+		await flushMutations();
+
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBeUndefined();
+	} );
+
+	it( 'stops syncing after the pagehide event disconnects the observer', async () => {
+		window.AgentsManagerSidebarOpenWatcherData = WATCHER_DATA;
+
+		await importWatcher();
+
+		window.dispatchEvent( new window.Event( 'pagehide' ) );
+
+		document.body.classList.add( WATCHER_DATA.sidebarOpenClass );
+		await flushMutations();
+
+		// Observer disconnected: the post-pagehide class change is ignored.
+		expect( readCookie( WATCHER_DATA.cookieKey ) ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/agents-manager/tests/js/sidebar-open-watcher.test.ts
+++ b/projects/packages/agents-manager/tests/js/sidebar-open-watcher.test.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 const WATCHER_DATA = {
 	cookieKey: 'agents_manager_chat_sidebar_open',
 	// jsdom only returns cookies whose path matches the document URL ("/"),

--- a/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
+++ b/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Sidebar_Open_Preservation Tests File
+ *
+ * @package automattic/jetpack-agents-manager
+ */
+
+namespace Automattic\Jetpack\Agents_Manager;
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once __DIR__ . '/../../src/class-sidebar-open-preservation.php';
+
+/**
+ * Class Sidebar_Open_Preservation_Test
+ *
+ * @covers \Automattic\Jetpack\Agents_Manager\Sidebar_Open_Preservation
+ */
+#[CoversClass( Sidebar_Open_Preservation::class )]
+class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
+
+	const COOKIE_KEY         = 'agents_manager_chat_sidebar_open';
+	const SIDEBAR_OPEN_CLASS = 'agents-manager-sidebar-container--sidebar-open';
+
+	/**
+	 * The Sidebar_Open_Preservation instance.
+	 *
+	 * @var Sidebar_Open_Preservation
+	 */
+	private $preservation;
+
+	/**
+	 * Original $_COOKIE value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_cookie;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->preservation = new Sidebar_Open_Preservation();
+
+		// Save original cookie value so tests can mutate it freely.
+		$this->original_cookie = $_COOKIE[ self::COOKIE_KEY ] ?? null;
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		// Remove hooks added by the constructor.
+		remove_filter( 'admin_body_class', array( $this->preservation, 'add_preopen_body_classes' ) );
+		remove_action( 'admin_enqueue_scripts', array( $this->preservation, 'enqueue_sidebar_open_watcher_script' ), 1 );
+
+		// Clean up the unified experience filter that tests may add.
+		remove_all_filters( 'agents_manager_use_unified_experience' );
+
+		// Restore the cookie superglobal.
+		if ( $this->original_cookie === null ) {
+			unset( $_COOKIE[ self::COOKIE_KEY ] );
+		} else {
+			$_COOKIE[ self::COOKIE_KEY ] = $this->original_cookie;
+		}
+
+		// Restore admin/screen context.
+		if ( function_exists( 'set_current_screen' ) ) {
+			set_current_screen( 'front' );
+		}
+		unset( $GLOBALS['current_screen'] );
+
+		// Reset the script registry.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		Constants::clear_constants();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Put the request into the "should preserve" state: admin context with the
+	 * unified experience enabled.
+	 */
+	private function enable_preservation() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+		add_filter( 'agents_manager_use_unified_experience', '__return_true' );
+	}
+
+	/**
+	 * Tests that init() creates a single shared instance.
+	 */
+	public function test_init_creates_singleton_instance() {
+		$reflection = new \ReflectionClass( Sidebar_Open_Preservation::class );
+		$property   = $reflection->getProperty( 'instance' );
+		if ( PHP_VERSION_ID < 80500 ) {
+			$property->setAccessible( true );
+		}
+
+		// Reset any instance leaked from another test.
+		$property->setValue( null, null );
+
+		Sidebar_Open_Preservation::init();
+		$first = $property->getValue();
+		$this->assertInstanceOf( Sidebar_Open_Preservation::class, $first );
+
+		Sidebar_Open_Preservation::init();
+		$second = $property->getValue();
+
+		$this->assertSame( $first, $second, 'init() should not replace an existing instance.' );
+
+		// Clean up hooks added by the instance created here.
+		remove_filter( 'admin_body_class', array( $first, 'add_preopen_body_classes' ) );
+		remove_action( 'admin_enqueue_scripts', array( $first, 'enqueue_sidebar_open_watcher_script' ), 1 );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Tests that the constructor registers the expected hooks.
+	 */
+	public function test_constructor_registers_hooks() {
+		$this->assertNotFalse(
+			has_filter( 'admin_body_class', array( $this->preservation, 'add_preopen_body_classes' ) )
+		);
+		$this->assertSame(
+			1,
+			has_action( 'admin_enqueue_scripts', array( $this->preservation, 'enqueue_sidebar_open_watcher_script' ) )
+		);
+	}
+
+	/**
+	 * Tests that body classes are unchanged on the site frontend.
+	 */
+	public function test_add_preopen_body_classes_unchanged_on_frontend() {
+		// Not admin, even though the cookie says the sidebar is open.
+		$_COOKIE[ self::COOKIE_KEY ] = '1';
+
+		$this->assertFalse( is_admin() );
+		$this->assertSame( 'foo bar', $this->preservation->add_preopen_body_classes( 'foo bar' ) );
+	}
+
+	/**
+	 * Tests that body classes are unchanged when the unified experience is disabled.
+	 */
+	public function test_add_preopen_body_classes_unchanged_when_unified_experience_disabled() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+		$_COOKIE[ self::COOKIE_KEY ] = '1';
+
+		// No unified experience filter added -> defaults to false.
+		$this->assertSame( 'foo bar', $this->preservation->add_preopen_body_classes( 'foo bar' ) );
+	}
+
+	/**
+	 * Tests that body classes are unchanged when the cookie is absent.
+	 */
+	public function test_add_preopen_body_classes_unchanged_when_cookie_missing() {
+		$this->enable_preservation();
+		unset( $_COOKIE[ self::COOKIE_KEY ] );
+
+		$this->assertSame( 'foo bar', $this->preservation->add_preopen_body_classes( 'foo bar' ) );
+	}
+
+	/**
+	 * Tests that body classes are unchanged when the cookie is not "1".
+	 */
+	public function test_add_preopen_body_classes_unchanged_when_cookie_not_open() {
+		$this->enable_preservation();
+		$_COOKIE[ self::COOKIE_KEY ] = '0';
+
+		$this->assertSame( 'foo bar', $this->preservation->add_preopen_body_classes( 'foo bar' ) );
+	}
+
+	/**
+	 * Tests that the sidebar-open classes are appended when the cookie is "1".
+	 */
+	public function test_add_preopen_body_classes_appends_classes_when_open() {
+		$this->enable_preservation();
+		$_COOKIE[ self::COOKIE_KEY ] = '1';
+
+		$result = $this->preservation->add_preopen_body_classes( 'foo bar' );
+
+		$this->assertStringContainsString( 'foo bar', $result );
+		$this->assertStringContainsString( 'agents-manager-sidebar-container', $result );
+		$this->assertStringContainsString( self::SIDEBAR_OPEN_CLASS, $result );
+	}
+
+	/**
+	 * Tests that no leading whitespace is produced when the incoming class string is empty.
+	 */
+	public function test_add_preopen_body_classes_trims_when_input_empty() {
+		$this->enable_preservation();
+		$_COOKIE[ self::COOKIE_KEY ] = '1';
+
+		$result = $this->preservation->add_preopen_body_classes( '' );
+
+		$this->assertSame(
+			'agents-manager-sidebar-container ' . self::SIDEBAR_OPEN_CLASS,
+			$result
+		);
+	}
+
+	/**
+	 * Tests that the open cookie value is sanitized before being compared.
+	 */
+	public function test_add_preopen_body_classes_handles_slashed_cookie_value() {
+		$this->enable_preservation();
+		// A slashed/padded value that is not exactly "1" should not open the sidebar.
+		$_COOKIE[ self::COOKIE_KEY ] = '1; rm -rf';
+
+		$result = $this->preservation->add_preopen_body_classes( 'foo' );
+
+		$this->assertSame( 'foo', $result );
+	}
+
+	/**
+	 * Tests that the watcher script is not enqueued when preservation is disabled.
+	 */
+	public function test_enqueue_does_nothing_when_disabled() {
+		// Frontend context: should_preserve_sidebar_open_state() returns false.
+		$this->preservation->enqueue_sidebar_open_watcher_script();
+
+		$this->assertFalse( wp_script_is( 'jetpack-agents-manager-sidebar-open-watcher', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'jetpack-agents-manager-sidebar-open-watcher', 'enqueued' ) );
+	}
+
+	/**
+	 * Tests that the watcher script is registered, enqueued, and carries inline data when enabled.
+	 */
+	public function test_enqueue_registers_and_enqueues_script_when_enabled() {
+		$this->enable_preservation();
+		Constants::set_constant( 'ADMIN_COOKIE_PATH', '/wp-admin' );
+
+		$this->preservation->enqueue_sidebar_open_watcher_script();
+
+		$handle = 'jetpack-agents-manager-sidebar-open-watcher';
+		$this->assertTrue( wp_script_is( $handle, 'registered' ) );
+		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
+
+		global $wp_scripts;
+		$inline_scripts = $wp_scripts->registered[ $handle ]->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( (array) $inline_scripts ) );
+
+		$this->assertStringContainsString( 'window.AgentsManagerSidebarOpenWatcherData =', $inline_script );
+		$this->assertStringContainsString( '"cookieKey":"' . self::COOKIE_KEY . '"', $inline_script );
+		$this->assertStringContainsString( '"sidebarOpenClass":"' . self::SIDEBAR_OPEN_CLASS . '"', $inline_script );
+		$this->assertStringContainsString( '"cookiePath":"/wp-admin"', $inline_script );
+	}
+}

--- a/projects/packages/agents-manager/tsconfig.json
+++ b/projects/packages/agents-manager/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "jetpack-js-tools/tsconfig.base.json",
+	"include": [ "./src/js" ]
+}

--- a/projects/packages/agents-manager/webpack.config.js
+++ b/projects/packages/agents-manager/webpack.config.js
@@ -1,0 +1,43 @@
+const path = require( 'path' );
+const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+
+module.exports = [
+	{
+		entry: {
+			// Add more standalone scripts here; each becomes build/<name>.js
+			// plus build/<name>.asset.php for Assets::register_script().
+			'sidebar-open-watcher': './src/js/sidebar-open-watcher.ts',
+		},
+		mode: jetpackWebpackConfig.mode,
+		devtool: jetpackWebpackConfig.devtool,
+		output: {
+			...jetpackWebpackConfig.output,
+			path: path.resolve( './build' ),
+		},
+		optimization: {
+			...jetpackWebpackConfig.optimization,
+		},
+		resolve: {
+			...jetpackWebpackConfig.resolve,
+		},
+		node: false,
+		plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+		module: {
+			strictExportPresence: true,
+			rules: [
+				// Transpile JavaScript/TypeScript.
+				jetpackWebpackConfig.TranspileRule( {
+					exclude: /node_modules\//,
+				} ),
+
+				// Transpile @automattic/jetpack-* in node_modules too.
+				jetpackWebpackConfig.TranspileRule( {
+					includeNodeModules: [ '@automattic/jetpack-' ],
+				} ),
+			],
+		},
+		externals: {
+			...jetpackWebpackConfig.externals,
+		},
+	},
+];

--- a/projects/plugins/mu-wpcom-plugin/changelog/agents-manager-persisted-sidebar-open-mechanism
+++ b/projects/plugins/mu-wpcom-plugin/changelog/agents-manager-persisted-sidebar-open-mechanism
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: Add Sidebar Preservation On Load Mechanism

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -214,9 +214,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "894fafed62835429fc5097cb711da25e745176b4"
+                "reference": "78bfafb16efae36e02b44648fb07f7b893eb8734"
             },
             "require": {
+                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
@@ -253,16 +254,19 @@
             },
             "scripts": {
                 "build-development": [
-                    "echo 'Add your build step to composer.json, please!'"
+                    "pnpm run build"
                 ],
                 "build-production": [
-                    "echo 'Add your build step to composer.json, please!'"
+                    "pnpm run build-production"
                 ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],
                 "test-coverage": [
                     "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run test"
                 ],
                 "test-php": [
                     "@composer phpunit"

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -214,7 +214,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "78bfafb16efae36e02b44648fb07f7b893eb8734"
+                "reference": "323c7575603d89130951be79a982c71c6d7b9aa8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -263,7 +263,7 @@
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],
                 "test-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
                 ],
                 "test-js": [
                     "pnpm run test"

--- a/projects/plugins/wpcomsh/changelog/agents-manager-persisted-sidebar-open-mechanism
+++ b/projects/plugins/wpcomsh/changelog/agents-manager-persisted-sidebar-open-mechanism
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: Add Sidebar Preservation On Load Mechanism

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -282,9 +282,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "894fafed62835429fc5097cb711da25e745176b4"
+                "reference": "78bfafb16efae36e02b44648fb07f7b893eb8734"
             },
             "require": {
+                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
@@ -321,16 +322,19 @@
             },
             "scripts": {
                 "build-development": [
-                    "echo 'Add your build step to composer.json, please!'"
+                    "pnpm run build"
                 ],
                 "build-production": [
-                    "echo 'Add your build step to composer.json, please!'"
+                    "pnpm run build-production"
                 ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],
                 "test-coverage": [
                     "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run test"
                 ],
                 "test-php": [
                     "@composer phpunit"

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -282,7 +282,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/agents-manager",
-                "reference": "78bfafb16efae36e02b44648fb07f7b893eb8734"
+                "reference": "323c7575603d89130951be79a982c71c6d7b9aa8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -331,7 +331,7 @@
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],
                 "test-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
                 ],
                 "test-js": [
                     "pnpm run test"


### PR DESCRIPTION
Part of WOOAI-501.

## Proposed changes

Moves the sidebar open persistency logic from WooAI to Jetpack so other consumers can benefit from it. It also addresses the feedback from the original PR.

## Related product discussion/links

See Linear issue.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Follow the instructions from woocommerce-ai/pull/93.