### PR TITLE
Newsletter: fix missing body padding in Add subscribers and Comp modals

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -371,26 +371,28 @@ export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.E
 					<Dialog.Title>{ __( 'Add subscribers', 'jetpack-newsletter' ) }</Dialog.Title>
 					<Dialog.CloseIcon />
 				</Dialog.Header>
-				<Tabs.Root
-					value={ tab }
-					onValueChange={ handleTabChange }
-					render={ <Stack direction="column" gap="lg" /> }
-				>
-					<Tabs.List variant="minimal">
-						<Tabs.Tab value="manual">{ __( 'Manual', 'jetpack-newsletter' ) }</Tabs.Tab>
-						<Tabs.Tab value="upload">{ __( 'Upload CSV', 'jetpack-newsletter' ) }</Tabs.Tab>
-						<Tabs.Tab value="substack">{ __( 'Substack', 'jetpack-newsletter' ) }</Tabs.Tab>
-					</Tabs.List>
-					<Tabs.Panel value="manual">
-						<ManualTab mutation={ mutation } onClose={ onClose } />
-					</Tabs.Panel>
-					<Tabs.Panel value="upload">
-						<UploadTab mutation={ mutation } onClose={ onClose } />
-					</Tabs.Panel>
-					<Tabs.Panel value="substack">
-						<SubstackTab />
-					</Tabs.Panel>
-				</Tabs.Root>
+				<Dialog.Content>
+					<Tabs.Root
+						value={ tab }
+						onValueChange={ handleTabChange }
+						render={ <Stack direction="column" gap="lg" /> }
+					>
+						<Tabs.List variant="minimal">
+							<Tabs.Tab value="manual">{ __( 'Manual', 'jetpack-newsletter' ) }</Tabs.Tab>
+							<Tabs.Tab value="upload">{ __( 'Upload CSV', 'jetpack-newsletter' ) }</Tabs.Tab>
+							<Tabs.Tab value="substack">{ __( 'Substack', 'jetpack-newsletter' ) }</Tabs.Tab>
+						</Tabs.List>
+						<Tabs.Panel value="manual">
+							<ManualTab mutation={ mutation } onClose={ onClose } />
+						</Tabs.Panel>
+						<Tabs.Panel value="upload">
+							<UploadTab mutation={ mutation } onClose={ onClose } />
+						</Tabs.Panel>
+						<Tabs.Panel value="substack">
+							<SubstackTab />
+						</Tabs.Panel>
+					</Tabs.Root>
+				</Dialog.Content>
 			</Dialog.Popup>
 		</Dialog.Root>
 	);

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/comp-modal.tsx
@@ -153,57 +153,59 @@ export default function CompModal( { subscriber, onClose }: Props ): JSX.Element
 					</Dialog.Title>
 					<Dialog.CloseIcon />
 				</Dialog.Header>
-				<Stack direction="column" gap="md">
-					<Text variant="body-md">
-						{ __(
-							'Pick a paid plan and we’ll add a complimentary subscription for this reader.',
-							'jetpack-newsletter'
-						) }
-					</Text>
-					{ productsQuery.isError ? (
-						<Notice.Root intent="error">
-							<Notice.Description>
-								{ productsQuery.error?.message ||
-									__( 'Could not load your paid plans.', 'jetpack-newsletter' ) }
-							</Notice.Description>
-						</Notice.Root>
-					) : null }
-					{ ! productsQuery.isLoading && products.length === 0 && ! productsQuery.isError ? (
-						<Notice.Root intent="info">
-							<Notice.Description>
-								{ __(
-									'You don’t have any paid newsletter plans configured on this site yet.',
-									'jetpack-newsletter'
-								) }
-							</Notice.Description>
-						</Notice.Root>
-					) : null }
-					{ allComped ? (
-						<Notice.Root intent="info">
-							<Notice.Description>
-								{ __(
-									'This subscriber already has a comp on every available plan.',
-									'jetpack-newsletter'
-								) }
-							</Notice.Description>
-						</Notice.Root>
-					) : null }
-					<SelectControl
-						__nextHasNoMarginBottom
-						label={ __( 'Plan', 'jetpack-newsletter' ) }
-						value={ planId }
-						onChange={ setPlanId }
-						options={ options }
-						disabled={ productsQuery.isLoading || mutation.isPending || allComped }
-					/>
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ __( 'Doesn’t expire', 'jetpack-newsletter' ) }
-						checked={ noExpiration }
-						onChange={ setNoExpiration }
-						disabled={ mutation.isPending }
-					/>
-				</Stack>
+				<Dialog.Content>
+					<Stack direction="column" gap="md">
+						<Text variant="body-md">
+							{ __(
+								'Pick a paid plan and we’ll add a complimentary subscription for this reader.',
+								'jetpack-newsletter'
+							) }
+						</Text>
+						{ productsQuery.isError ? (
+							<Notice.Root intent="error">
+								<Notice.Description>
+									{ productsQuery.error?.message ||
+										__( 'Could not load your paid plans.', 'jetpack-newsletter' ) }
+								</Notice.Description>
+							</Notice.Root>
+						) : null }
+						{ ! productsQuery.isLoading && products.length === 0 && ! productsQuery.isError ? (
+							<Notice.Root intent="info">
+								<Notice.Description>
+									{ __(
+										'You don’t have any paid newsletter plans configured on this site yet.',
+										'jetpack-newsletter'
+									) }
+								</Notice.Description>
+							</Notice.Root>
+						) : null }
+						{ allComped ? (
+							<Notice.Root intent="info">
+								<Notice.Description>
+									{ __(
+										'This subscriber already has a comp on every available plan.',
+										'jetpack-newsletter'
+									) }
+								</Notice.Description>
+							</Notice.Root>
+						) : null }
+						<SelectControl
+							__nextHasNoMarginBottom
+							label={ __( 'Plan', 'jetpack-newsletter' ) }
+							value={ planId }
+							onChange={ setPlanId }
+							options={ options }
+							disabled={ productsQuery.isLoading || mutation.isPending || allComped }
+						/>
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							label={ __( 'Doesn’t expire', 'jetpack-newsletter' ) }
+							checked={ noExpiration }
+							onChange={ setNoExpiration }
+							disabled={ mutation.isPending }
+						/>
+					</Stack>
+				</Dialog.Content>
 				<Dialog.Footer>
 					<Dialog.Action
 						render={ <Button variant="outline" tone="neutral" /> }

--- a/projects/packages/newsletter/changelog/fix-newsletter-add-subscribers
+++ b/projects/packages/newsletter/changelog/fix-newsletter-add-subscribers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add subscribers and Comp modals: restore body padding by wrapping content in Dialog.Content


### PR DESCRIPTION
Fixes #

## Proposed changes
* Fix missing body padding in the modernized Newsletter dashboard's "Add subscribers" and "Comp a subscription" modals.
* Root cause: both modals rendered their body content (`Tabs.Root` / a `Stack`) as a bare sibling of `Dialog.Header` inside `Dialog.Popup`, skipping the `Dialog.Content` wrapper. `@wordpress/ui` puts all popup inset on the chrome regions (header/content/footer), not on the popup itself, so the body had zero padding and sat flush against the popup edges.
* Wrapped each modal body in `Dialog.Content`, which restores the standard 24px inset and also gives the body the proper scroll container (fixing latent overflow-clipping for tall content).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open the modernized Newsletter dashboard: **Jetpack → Newsletter** (`admin.php?page=jetpack-newsletter`).
* Click the **Add subscribers** button in the page header.
  * Confirm the modal body — the Manual/Upload CSV/Substack tabs, the "Email addresses" field, helper text, and the submit button — is inset with comfortable padding and no longer touches the popup edges.
* From a subscriber row's "⋮" actions menu, choose **Comp a subscription**.
  * Confirm the modal body — description text, any notices, the Plan select, and the "Doesn't expire" checkbox — is likewise inset with padding rather than flush against the edges.
* In both modals, the header, body, and footer/buttons should share a consistent 24px gutter.
