### PR TITLE
Update woocommerce-analytics to 0.16.5

### DIFF
--- a/projects/plugins/jetpack/changelog/update-woocommerce-analytics-0.16.5
+++ b/projects/plugins/jetpack/changelog/update-woocommerce-analytics-0.16.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated WooCommerce Analytics package to version 0.16.5.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3743,16 +3743,16 @@
         },
         {
             "name": "automattic/woocommerce-analytics",
-            "version": "0.16.4",
+            "version": "0.16.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-analytics.git",
-                "reference": "3108d3cabe127d4a30d213d610968067fbeb5c3f"
+                "reference": "9dd2e37ae64bbccb03d52447b3ee050dd5265a4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/3108d3cabe127d4a30d213d610968067fbeb5c3f",
-                "reference": "3108d3cabe127d4a30d213d610968067fbeb5c3f",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/9dd2e37ae64bbccb03d52447b3ee050dd5265a4f",
+                "reference": "9dd2e37ae64bbccb03d52447b3ee050dd5265a4f",
                 "shasum": ""
             },
             "require": {
@@ -3789,9 +3789,9 @@
             ],
             "description": "Enhanced analytics for WooCommerce users.",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.4"
+                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.5"
             },
-            "time": "2026-05-11T04:52:05+00:00"
+            "time": "2026-06-02T02:43:49+00:00"
         },
         {
             "name": "wikimedia/aho-corasick",


### PR DESCRIPTION
Fixes #

## Proposed changes
* Update the `automattic/woocommerce-analytics` Composer dependency from 0.16.4 to 0.16.5 in the Jetpack plugin.
* The `^0.16` version constraint already permitted this, so only `composer.lock` is updated (reference `3108d3c` → `9dd2e37`).

## Related product discussion/links
* https://github.com/Automattic/woocommerce-analytics/releases/tag/v0.16.5

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Check out this branch and run `composer install` in `projects/plugins/jetpack`.
* Confirm `composer show automattic/woocommerce-analytics` reports version `0.16.5`.
* Smoke-test a site with WooCommerce active to confirm WooCommerce Analytics tracking still loads without errors.
