### PR TITLE
Fix xmlrpc json api php warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-xmlrpc-json-api-php-warnings
+++ b/projects/plugins/jetpack/changelog/fix-xmlrpc-json-api-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+XML-RPC: guard JSON API request parsing to avoid PHP warnings on non-scalar post bodies and failed signature verification.

--- a/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
+++ b/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
@@ -116,7 +116,7 @@ class Jetpack_XMLRPC_Methods {
 
 		$method       = (string) $json_api_args[0];
 		$url          = (string) $json_api_args[1];
-		$post_body    = $json_api_args[2] === null ? null : (string) $json_api_args[2];
+		$post_body    = is_scalar( $json_api_args[2] ) ? (string) $json_api_args[2] : null;
 		$user_details = (array) $json_api_args[4];
 		$locale       = (string) $json_api_args[5];
 

--- a/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
+++ b/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
@@ -144,7 +144,7 @@ class Jetpack_XMLRPC_Methods {
 			$token_key = false;
 		} else {
 			$verified  = ( new Connection_Manager() )->verify_xml_rpc_signature();
-			$token_key = $verified['token_key'];
+			$token_key = $verified['token_key'] ?? false;
 		}
 
 		$token = ( new Tokens() )->get_access_token( $user_id, $token_key );


### PR DESCRIPTION
 
  ## Proposed changes
  
  This PR fixes two PHP warnings emitted by `Jetpack_XMLRPC_Methods::json_api()` in `class-jetpack-xmlrpc-methods.php` while parsing an incoming JSON API request over XML-RPC. Both are defensive guards only — behaviour is unchanged for all valid requests.
  
  * **`Array to string conversion`:** the post body was cast with `(string) $json_api_args[2]`, which warns when the value arrives as an array (or object). Changed `$json_api_args[2] === null ? null : (string) …` to `is_scalar( $json_api_args[2] ) ? (string) … : null`. Every previously-valid case is preserved (`null`
  → `null`, and string/int/float/bool cast exactly as before); only non-scalar values — which can't be a meaningful raw post body — now resolve to `null` instead of the literal string `"Array"`.
  * **`Trying to access array offset on false`:** `( new Connection_Manager() )->verify_xml_rpc_signature()` returns `false` when signature verification fails, so `$verified['token_key']` warned. It's now $verified['token_key'] ?? false, matching the $token_key = false default already used in the other branch of the same if. The subsequent `get_access_token()` call already returns `false`/`WP_Error` for a missing key, so genuine verification failures behave exactly as before — just without the warning.
  
  ## Related product discussion/links
  p1780326934448719-slack-C05PV073SG3
   
  ## Does this pull request change what data or activity we track or use?
  
  No. These are guards around existing reads; request handling and the resulting API behaviour are unchanged for valid requests.

## Testing instructions

Code review