### PR TITLE
Carousel: Skip core Gallery lightbox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-skip-core-gallery-lightbox
+++ b/projects/plugins/jetpack/changelog/fix-carousel-skip-core-gallery-lightbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: Prevent Jetpack from overriding Gallery blocks that use the core lightbox.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -357,9 +357,14 @@ class Jetpack_Carousel {
 			! empty( $parsed_block['blockName'] ) &&
 			'core/image' === $parsed_block['blockName'] &&
 			! empty( $parent_block->name ) &&
-			'core/gallery' === $parent_block->name &&
-			! $this->is_core_gallery_lightbox_enabled( $parent_block )
+			'core/gallery' === $parent_block->name
 		) {
+			if ( $this->is_core_gallery_lightbox_enabled( $parent_block ) ) {
+				$parsed_block['attrs']['lightbox']        = array( 'enabled' => true );
+				$parsed_block['attrs']['linkDestination'] = 'none';
+				return $parsed_block;
+			}
+
 			unset( $parsed_block['attrs']['lightbox'] );
 		}
 		return $parsed_block;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -357,14 +357,9 @@ class Jetpack_Carousel {
 			! empty( $parsed_block['blockName'] ) &&
 			'core/image' === $parsed_block['blockName'] &&
 			! empty( $parent_block->name ) &&
-			'core/gallery' === $parent_block->name
+			'core/gallery' === $parent_block->name &&
+			! $this->is_core_gallery_lightbox_enabled( $parent_block )
 		) {
-			if ( $this->is_core_gallery_lightbox_enabled( $parent_block ) ) {
-				$parsed_block['attrs']['lightbox']        = array( 'enabled' => true );
-				$parsed_block['attrs']['linkDestination'] = 'none';
-				return $parsed_block;
-			}
-
 			unset( $parsed_block['attrs']['lightbox'] );
 		}
 		return $parsed_block;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -394,7 +394,10 @@ class Jetpack_Carousel {
 			}
 		}
 
-		return 'core/gallery' === $block_name && ! empty( $attrs['lightbox']['enabled'] );
+		return 'core/gallery' === $block_name && (
+			! empty( $attrs['lightbox']['enabled'] )
+			|| ( isset( $attrs['linkTo'] ) && 'lightbox' === $attrs['linkTo'] )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -357,11 +357,44 @@ class Jetpack_Carousel {
 			! empty( $parsed_block['blockName'] ) &&
 			'core/image' === $parsed_block['blockName'] &&
 			! empty( $parent_block->name ) &&
-			'core/gallery' === $parent_block->name
+			'core/gallery' === $parent_block->name &&
+			! $this->is_core_gallery_lightbox_enabled( $parent_block )
 		) {
 			unset( $parsed_block['attrs']['lightbox'] );
 		}
 		return $parsed_block;
+	}
+
+	/**
+	 * Determine whether a core Gallery block has the core lightbox enabled.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array|object $block The parsed block data, or a WP_Block-like object.
+	 * @return bool Whether the core lightbox is enabled on the gallery block.
+	 */
+	private function is_core_gallery_lightbox_enabled( $block ) {
+		$block_name = '';
+		$attrs      = array();
+
+		if ( is_array( $block ) ) {
+			$block_name = $block['blockName'] ?? '';
+			$attrs      = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+		} elseif ( is_object( $block ) ) {
+			if ( ! empty( $block->name ) ) {
+				$block_name = $block->name;
+			} elseif ( isset( $block->parsed_block ) && is_array( $block->parsed_block ) ) {
+				$block_name = $block->parsed_block['blockName'] ?? '';
+			}
+
+			if ( isset( $block->attributes ) && is_array( $block->attributes ) ) {
+				$attrs = $block->attributes;
+			} elseif ( isset( $block->parsed_block['attrs'] ) && is_array( $block->parsed_block['attrs'] ) ) {
+				$attrs = $block->parsed_block['attrs'];
+			}
+		}
+
+		return 'core/gallery' === $block_name && ! empty( $attrs['lightbox']['enabled'] );
 	}
 
 	/**
@@ -381,6 +414,10 @@ class Jetpack_Carousel {
 		global $post;
 
 		if ( empty( $block['blockName'] ) || ! in_array( $block['blockName'], array( 'core/gallery', 'jetpack/tiled-gallery' ), true ) ) {
+			return $block_content;
+		}
+
+		if ( $this->is_core_gallery_lightbox_enabled( $block ) ) {
 			return $block_content;
 		}
 

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -178,9 +178,9 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that core image lightbox settings are added when the parent Gallery block uses the core lightbox.
+	 * Test that core image attributes are kept when the parent Gallery block uses the core lightbox.
 	 */
-	public function test_remove_core_lightbox_in_gallery_adds_image_lightbox_when_parent_gallery_lightbox_is_enabled() {
+	public function test_remove_core_lightbox_in_gallery_keeps_image_attributes_when_parent_gallery_lightbox_is_enabled() {
 		$parsed_block = array(
 			'blockName' => 'core/image',
 			'attrs'     => array(
@@ -196,9 +196,7 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 
 		$result = $this->instance->remove_core_lightbox_in_gallery( $parsed_block, $parsed_block, $parent_block );
 
-		$this->assertSame( array( 'enabled' => true ), $result['attrs']['lightbox'] );
-		$this->assertSame( 'none', $result['attrs']['linkDestination'] );
-		$this->assertSame( 123, $result['attrs']['id'] );
+		$this->assertSame( $parsed_block, $result );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -146,9 +146,7 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 		$block         = array(
 			'blockName' => 'core/gallery',
 			'attrs'     => array(
-				'lightbox' => array(
-					'enabled' => true,
-				),
+				'linkTo' => 'lightbox',
 			),
 		);
 
@@ -194,9 +192,7 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 		$parent_block = (object) array(
 			'name'       => 'core/gallery',
 			'attributes' => array(
-				'lightbox' => array(
-					'enabled' => true,
-				),
+				'linkTo' => 'lightbox',
 			),
 		);
 

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -37,6 +37,18 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Cleans up after each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function tear_down() {
+		remove_filter( 'jetpack_is_amp_request', '__return_true' );
+		wp_dequeue_script( 'jetpack-carousel' );
+		wp_deregister_script( 'jetpack-carousel' );
+		parent::tear_down();
+	}
+
+	/**
 	 * Gets the test data for test_add_data_img_tags_and_enqueue_assets().
 	 *
 	 * @return array The test data.
@@ -121,5 +133,102 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 		if ( $is_amp ) {
 			$this->assertFalse( wp_script_is( 'jetpack-carousel' ) );
 		}
+	}
+
+	/**
+	 * Test that Jetpack Carousel is not enabled for Gallery blocks using the core lightbox.
+	 */
+	public function test_filter_gallery_block_render_skips_core_gallery_with_lightbox_enabled() {
+		global $post;
+
+		$post          = self::factory()->post->create_and_get();
+		$block_content = '<figure class="wp-block-gallery has-nested-images"></figure>';
+		$block         = array(
+			'blockName' => 'core/gallery',
+			'attrs'     => array(
+				'lightbox' => array(
+					'enabled' => true,
+				),
+			),
+		);
+
+		$this->assertSame( $block_content, $this->instance->filter_gallery_block_render( $block_content, $block ) );
+		$this->assertFalse( wp_script_is( 'jetpack-carousel' ) );
+	}
+
+	/**
+	 * Test that Jetpack Carousel is still enabled for Gallery blocks without the core lightbox.
+	 */
+	public function test_filter_gallery_block_render_adds_data_when_core_gallery_lightbox_is_disabled() {
+		global $post;
+
+		$post          = self::factory()->post->create_and_get();
+		$block_content = '<figure class="wp-block-gallery has-nested-images"></figure>';
+		$block         = array(
+			'blockName' => 'core/gallery',
+			'attrs'     => array(
+				'lightbox' => array(
+					'enabled' => false,
+				),
+			),
+		);
+
+		$result = $this->instance->filter_gallery_block_render( $block_content, $block );
+
+		$this->assertStringContainsString( 'data-carousel-extra=', $result );
+		$this->assertTrue( wp_script_is( 'jetpack-carousel' ) );
+	}
+
+	/**
+	 * Test that core image lightbox settings are kept when the parent Gallery block uses the core lightbox.
+	 */
+	public function test_remove_core_lightbox_in_gallery_keeps_image_lightbox_when_parent_gallery_lightbox_is_enabled() {
+		$parsed_block = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'lightbox' => array(
+					'enabled' => true,
+				),
+			),
+		);
+		$parent_block = (object) array(
+			'name'       => 'core/gallery',
+			'attributes' => array(
+				'lightbox' => array(
+					'enabled' => true,
+				),
+			),
+		);
+
+		$this->assertSame(
+			$parsed_block,
+			$this->instance->remove_core_lightbox_in_gallery( $parsed_block, $parsed_block, $parent_block )
+		);
+	}
+
+	/**
+	 * Test that core image lightbox settings are removed when Jetpack Carousel handles the parent Gallery block.
+	 */
+	public function test_remove_core_lightbox_in_gallery_removes_image_lightbox_when_parent_gallery_lightbox_is_disabled() {
+		$parsed_block = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'lightbox' => array(
+					'enabled' => true,
+				),
+			),
+		);
+		$parent_block = (object) array(
+			'name'       => 'core/gallery',
+			'attributes' => array(
+				'lightbox' => array(
+					'enabled' => false,
+				),
+			),
+		);
+
+		$result = $this->instance->remove_core_lightbox_in_gallery( $parsed_block, $parsed_block, $parent_block );
+
+		$this->assertArrayNotHasKey( 'lightbox', $result['attrs'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -178,15 +178,13 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that core image lightbox settings are kept when the parent Gallery block uses the core lightbox.
+	 * Test that core image lightbox settings are added when the parent Gallery block uses the core lightbox.
 	 */
-	public function test_remove_core_lightbox_in_gallery_keeps_image_lightbox_when_parent_gallery_lightbox_is_enabled() {
+	public function test_remove_core_lightbox_in_gallery_adds_image_lightbox_when_parent_gallery_lightbox_is_enabled() {
 		$parsed_block = array(
 			'blockName' => 'core/image',
 			'attrs'     => array(
-				'lightbox' => array(
-					'enabled' => true,
-				),
+				'id' => 123,
 			),
 		);
 		$parent_block = (object) array(
@@ -196,10 +194,11 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertSame(
-			$parsed_block,
-			$this->instance->remove_core_lightbox_in_gallery( $parsed_block, $parsed_block, $parent_block )
-		);
+		$result = $this->instance->remove_core_lightbox_in_gallery( $parsed_block, $parsed_block, $parent_block );
+
+		$this->assertSame( array( 'enabled' => true ), $result['attrs']['lightbox'] );
+		$this->assertSame( 'none', $result['attrs']['linkDestination'] );
+		$this->assertSame( 123, $result['attrs']['id'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Skip Jetpack Carousel processing for core Gallery blocks when the Gallery block uses the core lightbox setting, including `linkTo: "lightbox"`.
* Preserve existing nested core Image block lightbox attributes in that case, while still removing them when Jetpack Carousel handles the gallery.
* Add regression coverage and a Jetpack changelog entry.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Enable Jetpack Carousel.
* Add a core Gallery block with `linkTo: "lightbox"`, for example `<!-- wp:gallery {"linkTo":"lightbox"} -->`.
* Confirm Jetpack Carousel does not process that gallery.
* Confirm core lightbox behavior is handled by WordPress core.
* Add a core Gallery block without the core lightbox enabled and confirm Jetpack Carousel still handles it.
* Run `pnpm jetpack docker phpunit jetpack -- --filter=Jetpack_Carousel_Test`.
