### PR TITLE
Social: fix Mastodon share preview showing the post URL twice [SOCIAL-497]

### DIFF
--- a/projects/js-packages/social-previews/changelog/social-497-mastodon-social-sharing-preview-shows-url-twice
+++ b/projects/js-packages/social-previews/changelog/social-497-mastodon-social-sharing-preview-shows-url-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Mastodon share preview showing the post URL twice when the custom message already includes it

--- a/projects/js-packages/social-previews/changelog/social-497-mastodon-social-sharing-preview-shows-url-twice
+++ b/projects/js-packages/social-previews/changelog/social-497-mastodon-social-sharing-preview-shows-url-twice
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix Mastodon share preview showing the post URL twice when the custom message already includes it
+Fix Mastodon share preview showing the post URL twice when the custom message already includes it.

--- a/projects/js-packages/social-previews/src/mastodon-preview/helpers.ts
+++ b/projects/js-packages/social-previews/src/mastodon-preview/helpers.ts
@@ -28,12 +28,20 @@ export const mastodonTitle: Formatter = text =>
 		hardTruncation( TITLE_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
 
-export const mastodonBody = ( text: string, options: { offset: number; instance: string } ) => {
-	const { instance, offset } = options;
+export const mastodonBody = (
+	text: string,
+	options: { offset: number; instance: string; reserveUrlSpace?: boolean }
+) => {
+	const { instance, offset, reserveUrlSpace = true } = options;
+
+	// Reserve room for the URL only when it is rendered as a separate link below
+	// the body. When the URL is already part of the body text, it counts towards
+	// the body itself and no extra space should be set aside for it.
+	const urlReservation = reserveUrlSpace ? URL_LENGTH : 0;
 
 	return preparePreviewText( text, {
 		platform: 'mastodon',
-		maxChars: BODY_LENGTH - URL_LENGTH - offset,
+		maxChars: BODY_LENGTH - urlReservation - offset,
 		hashtagDomain: instance,
 	} );
 };

--- a/projects/js-packages/social-previews/src/mastodon-preview/helpers.ts
+++ b/projects/js-packages/social-previews/src/mastodon-preview/helpers.ts
@@ -11,14 +11,6 @@ import { MastodonAddressDetails } from './types';
 
 const TITLE_LENGTH = 200;
 const BODY_LENGTH = 500;
-const URL_LENGTH = 30;
-
-/**
- * Visible body-text cap used by the preview component, leaving room for the
- * URL that gets rendered separately below the body. Mirrors the `maxChars`
- * passed to `preparePreviewText` in {@link mastodonBody}.
- */
-export const BODY_CHAR_LIMIT = BODY_LENGTH - URL_LENGTH;
 
 const ADDRESS_PATTERN = /^@([^@]*)@([^@]*)$/i;
 
@@ -28,27 +20,15 @@ export const mastodonTitle: Formatter = text =>
 		hardTruncation( TITLE_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
 
-export const mastodonBody = (
-	text: string,
-	options: { offset: number; instance: string; reserveUrlSpace?: boolean }
-) => {
-	const { instance, offset, reserveUrlSpace = true } = options;
-
-	// Reserve room for the URL only when it is rendered as a separate link below
-	// the body. When the URL is already part of the body text, it counts towards
-	// the body itself and no extra space should be set aside for it.
-	const urlReservation = reserveUrlSpace ? URL_LENGTH : 0;
+export const mastodonBody = ( text: string, options: { offset: number; instance: string } ) => {
+	const { instance, offset } = options;
 
 	return preparePreviewText( text, {
 		platform: 'mastodon',
-		maxChars: BODY_LENGTH - urlReservation - offset,
+		maxChars: BODY_LENGTH - offset,
 		hashtagDomain: instance,
 	} );
 };
-
-export const mastodonUrl: Formatter = text =>
-	firstValid( shortEnough( URL_LENGTH ), hardTruncation( URL_LENGTH ) )( stripHtmlTags( text ) ) ||
-	'';
 
 export const getMastodonAddressDetails = ( address: string ): MastodonAddressDetails => {
 	const matches = address.match( ADDRESS_PATTERN );

--- a/projects/js-packages/social-previews/src/mastodon-preview/post/body/index.tsx
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post/body/index.tsx
@@ -1,6 +1,6 @@
 import { stripHtmlTags } from '../../../helpers';
 import { ExpandableText } from '../../../shared/expandable-text';
-import { getMastodonAddressDetails, mastodonBody, mastodonUrl } from '../../helpers';
+import { getMastodonAddressDetails, mastodonBody } from '../../helpers';
 import type { MastodonPreviewProps } from '../../types';
 
 import './styles.scss';
@@ -8,19 +8,12 @@ import './styles.scss';
 type Props = MastodonPreviewProps & { children?: React.ReactNode };
 
 const MastonPostBody: React.FC< Props > = props => {
-	const { title, description, customText, url, user, children } = props;
+	const { title, description, customText, user, children } = props;
 	const instance = user?.address ? getMastodonAddressDetails( user.address ).instance : '';
-
-	// When the custom message already contains the URL (e.g. via the {url}
-	// placeholder), it gets auto-linked within the body, so appending it again
-	// below would show the URL twice — and the body should not reserve extra
-	// room for a separate URL link that isn't rendered.
-	const urlInBody = Boolean( customText && url && customText.includes( url ) );
 
 	const options = {
 		instance,
 		offset: 0,
-		reserveUrlSpace: ! urlInBody,
 	};
 
 	let bodyTxt;
@@ -62,14 +55,12 @@ const MastonPostBody: React.FC< Props > = props => {
 		bodyTxt = <p>{ mastodonBody( title, options ) }</p>;
 	}
 
+	// The post URL is not appended separately: the message body (and any
+	// {url} placeholder it contains) is the source of truth, so the URL is
+	// only shown when it is part of the body itself.
 	return (
 		<div className="mastodon-preview__body">
 			{ bodyTxt }
-			{ ! urlInBody && (
-				<a href={ url } target="_blank" rel="noreferrer noopener">
-					{ mastodonUrl( url.replace( /^https?:\/\//, '' ) ) }
-				</a>
-			) }
 			{ children }
 		</div>
 	);

--- a/projects/js-packages/social-previews/src/mastodon-preview/post/body/index.tsx
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post/body/index.tsx
@@ -10,9 +10,17 @@ type Props = MastodonPreviewProps & { children?: React.ReactNode };
 const MastonPostBody: React.FC< Props > = props => {
 	const { title, description, customText, url, user, children } = props;
 	const instance = user?.address ? getMastodonAddressDetails( user.address ).instance : '';
+
+	// When the custom message already contains the URL (e.g. via the {url}
+	// placeholder), it gets auto-linked within the body, so appending it again
+	// below would show the URL twice — and the body should not reserve extra
+	// room for a separate URL link that isn't rendered.
+	const urlInBody = Boolean( customText && url && customText.includes( url ) );
+
 	const options = {
 		instance,
 		offset: 0,
+		reserveUrlSpace: ! urlInBody,
 	};
 
 	let bodyTxt;
@@ -53,11 +61,6 @@ const MastonPostBody: React.FC< Props > = props => {
 	} else {
 		bodyTxt = <p>{ mastodonBody( title, options ) }</p>;
 	}
-
-	// When the custom message already contains the URL (e.g. via the {url}
-	// placeholder), it gets auto-linked within the body, so appending it again
-	// here would show the URL twice.
-	const urlInBody = Boolean( customText && url && customText.includes( url ) );
 
 	return (
 		<div className="mastodon-preview__body">

--- a/projects/js-packages/social-previews/src/mastodon-preview/post/body/index.tsx
+++ b/projects/js-packages/social-previews/src/mastodon-preview/post/body/index.tsx
@@ -54,12 +54,19 @@ const MastonPostBody: React.FC< Props > = props => {
 		bodyTxt = <p>{ mastodonBody( title, options ) }</p>;
 	}
 
+	// When the custom message already contains the URL (e.g. via the {url}
+	// placeholder), it gets auto-linked within the body, so appending it again
+	// here would show the URL twice.
+	const urlInBody = Boolean( customText && url && customText.includes( url ) );
+
 	return (
 		<div className="mastodon-preview__body">
 			{ bodyTxt }
-			<a href={ url } target="_blank" rel="noreferrer noopener">
-				{ mastodonUrl( url.replace( /^https?:\/\//, '' ) ) }
-			</a>
+			{ ! urlInBody && (
+				<a href={ url } target="_blank" rel="noreferrer noopener">
+					{ mastodonUrl( url.replace( /^https?:\/\//, '' ) ) }
+				</a>
+			) }
 			{ children }
 		</div>
 	);

--- a/projects/js-packages/social-previews/tests/index.test.tsx
+++ b/projects/js-packages/social-previews/tests/index.test.tsx
@@ -734,7 +734,9 @@ describe( 'Mastodon previews', () => {
 		expect( body.querySelectorAll( `a[href="${ DEFAULT_POST_URL }"]` ) ).toHaveLength( 1 );
 	} );
 
-	it( 'should append the URL link when the custom message does not contain it', () => {
+	it( 'should not render a URL link when the message does not contain it', () => {
+		// The body is the source of truth: the post URL is no longer appended
+		// separately, so a message without the URL shows no URL link.
 		const { container } = render(
 			<Mastodon
 				url={ DEFAULT_POST_URL }
@@ -746,30 +748,16 @@ describe( 'Mastodon previews', () => {
 
 		const body = container.querySelector( '.mastodon-preview__body' );
 		expect( body ).toBeVisible();
-		expect( body.querySelectorAll( `a[href="${ DEFAULT_POST_URL }"]` ) ).toHaveLength( 1 );
+		expect( body.querySelectorAll( `a[href="${ DEFAULT_POST_URL }"]` ) ).toHaveLength( 0 );
 	} );
 
-	it( 'should not reserve space for a separate URL link when the URL is part of the message', () => {
-		// A message just over the URL-reserved body limit, with the URL near the
-		// end. When the URL lives in the body, no separate URL link is rendered,
-		// so the body should not reserve ~30 characters for one — otherwise the
-		// trailing URL gets truncated.
+	it( 'should not reserve body space for a separately-appended URL', () => {
+		// The full Mastodon character budget is available to the body, since the
+		// URL is no longer rendered as a separate link below it. A trailing URL
+		// within the limit therefore survives instead of being truncated early.
 		const text = `${ 'a'.repeat( 460 ) } ${ DEFAULT_POST_URL }`;
 
-		// Default behaviour reserves URL space, truncating the trailing URL.
-		const { container: reservedContainer } = render(
-			<>{ mastodonBody( text, { offset: 0, instance: '' } ) }</>
-		);
-		expect(
-			reservedContainer.querySelector( `a[href="${ DEFAULT_POST_URL }"]` )
-		).not.toBeInTheDocument();
-
-		// With reservation disabled, the full URL survives.
-		const { container: unreservedContainer } = render(
-			<>{ mastodonBody( text, { offset: 0, instance: '', reserveUrlSpace: false } ) }</>
-		);
-		expect(
-			unreservedContainer.querySelector( `a[href="${ DEFAULT_POST_URL }"]` )
-		).toBeInTheDocument();
+		const { container } = render( <>{ mastodonBody( text, { offset: 0, instance: '' } ) }</> );
+		expect( container.querySelector( `a[href="${ DEFAULT_POST_URL }"]` ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/js-packages/social-previews/tests/index.test.tsx
+++ b/projects/js-packages/social-previews/tests/index.test.tsx
@@ -12,6 +12,7 @@ import {
 	MastodonPostPreview as Mastodon,
 } from '../src';
 import { formatTweetDate } from '../src/helpers';
+import { mastodonBody } from '../src/mastodon-preview/helpers';
 
 // Mock @wordpress/components SandBox to avoid iframe initialization issues in tests
 // The mock prefix is required for jest to allow variable access in the factory
@@ -746,5 +747,29 @@ describe( 'Mastodon previews', () => {
 		const body = container.querySelector( '.mastodon-preview__body' );
 		expect( body ).toBeVisible();
 		expect( body.querySelectorAll( `a[href="${ DEFAULT_POST_URL }"]` ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should not reserve space for a separate URL link when the URL is part of the message', () => {
+		// A message just over the URL-reserved body limit, with the URL near the
+		// end. When the URL lives in the body, no separate URL link is rendered,
+		// so the body should not reserve ~30 characters for one — otherwise the
+		// trailing URL gets truncated.
+		const text = `${ 'a'.repeat( 460 ) } ${ DEFAULT_POST_URL }`;
+
+		// Default behaviour reserves URL space, truncating the trailing URL.
+		const { container: reservedContainer } = render(
+			<>{ mastodonBody( text, { offset: 0, instance: '' } ) }</>
+		);
+		expect(
+			reservedContainer.querySelector( `a[href="${ DEFAULT_POST_URL }"]` )
+		).not.toBeInTheDocument();
+
+		// With reservation disabled, the full URL survives.
+		const { container: unreservedContainer } = render(
+			<>{ mastodonBody( text, { offset: 0, instance: '', reserveUrlSpace: false } ) }</>
+		);
+		expect(
+			unreservedContainer.querySelector( `a[href="${ DEFAULT_POST_URL }"]` )
+		).toBeInTheDocument();
 	} );
 } );

--- a/projects/js-packages/social-previews/tests/index.test.tsx
+++ b/projects/js-packages/social-previews/tests/index.test.tsx
@@ -9,6 +9,7 @@ import {
 	TwitterPostPreview as Twitter,
 	TwitterPreviews,
 	GoogleSearchPreview as Search,
+	MastodonPostPreview as Mastodon,
 } from '../src';
 import { formatTweetDate } from '../src/helpers';
 
@@ -706,5 +707,44 @@ describe( 'Google Search previews', () => {
 			expect( fallback ).toBeVisible();
 			expect( fallback.querySelector( 'svg' ) ).toBeVisible();
 		} );
+	} );
+} );
+
+describe( 'Mastodon previews', () => {
+	const mastodonUser = {
+		displayName: 'Test User',
+		avatarUrl: 'https://example.com/avatar.png',
+		address: '@test@mastodon.social',
+	};
+
+	it( 'should not duplicate the URL when the custom message already contains it', () => {
+		const { container } = render(
+			<Mastodon
+				url={ DEFAULT_POST_URL }
+				title={ DEFAULT_POST_TITLE }
+				customText={ `Hello World\n\nAn excerpt\n\n${ DEFAULT_POST_URL }` }
+				user={ mastodonUser }
+			/>
+		);
+
+		const body = container.querySelector( '.mastodon-preview__body' );
+		expect( body ).toBeVisible();
+		// The URL is auto-linked once within the body; it must not be appended a second time.
+		expect( body.querySelectorAll( `a[href="${ DEFAULT_POST_URL }"]` ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should append the URL link when the custom message does not contain it', () => {
+		const { container } = render(
+			<Mastodon
+				url={ DEFAULT_POST_URL }
+				title={ DEFAULT_POST_TITLE }
+				customText="Hello World, an excerpt"
+				user={ mastodonUser }
+			/>
+		);
+
+		const body = container.querySelector( '.mastodon-preview__body' );
+		expect( body ).toBeVisible();
+		expect( body.querySelectorAll( `a[href="${ DEFAULT_POST_URL }"]` ) ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
Internal ref: SOCIAL-497

## Proposed changes
* Fix the Mastodon share preview rendering the post URL twice when the custom message already contains it.
* The `MastonPostBody` component always appended the post URL as a link below the body. When the custom message already includes the URL (for example via the `{url}` placeholder, which the message templates feature renders into the real URL), that URL is auto-linked within the body — so the appended link showed it a second time.
* The appended URL link is now skipped when the body text already contains the URL, mirroring the existing Threads preview behavior (`! caption.includes( url )`).
* This is a preview-only fix: the actual published Mastodon status renders server-side on WordPress.com and was not affected.

## Related product discussion/links
* SOCIAL-497

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Edit a post and open the Jetpack Social / Publicize sidebar with a Mastodon connection enabled.
* Set a custom share message that includes the `{url}` placeholder (the default template is `{title}\n\n{excerpt}\n\n{url}`).
* Open the social preview and select the Mastodon tab.
* **Before:** the post URL appears twice — once inside the message body and once as a separate link below it.
* **After:** the URL appears only once (auto-linked within the body).
* Also confirm that a custom message **without** the URL still shows the URL appended once below the body.
* Automated coverage: `pnpm test` in `projects/js-packages/social-previews` (see the new "Mastodon previews" tests in `tests/index.test.tsx`).
