### PR TITLE
Fix/json api unknown user warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-json-api-unknown-user-warnings
+++ b/projects/plugins/jetpack/changelog/fix-json-api-unknown-user-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+JSON API: stop emitting "Unknown user" PHP warnings from get_author() for the expected case of an unresolvable author.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1475,8 +1475,6 @@ abstract class WPCOM_JSON_API_Endpoint {
 					$first_name = $user->first_name ?? '';
 					$last_name  = $user->last_name ?? '';
 					$nice       = $user->user_nicename ?? '';
-				} else {
-					trigger_error( 'Unknown user', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				}
 			}
 
@@ -1523,8 +1521,6 @@ abstract class WPCOM_JSON_API_Endpoint {
 		if ( ! isset( $id ) ) {
 			$user = get_user_by( 'id', $author );
 			if ( ! $user || is_wp_error( $user ) ) {
-				trigger_error( 'Unknown user', E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-
 				return null;
 			}
 			$id         = $user->ID;


### PR DESCRIPTION
## Proposed changes

  `WPCOM_JSON_API_Endpoint::get_author()` called `trigger_error( 'Unknown user', E_USER_WARNING )` in two spots when an author/commenter user could not be resolved on the current blog. This is an expected-but-rare condition (e.g. a deleted user, or a cross-blog/Jetpack-synced author id that doesn't resolve here), and
  the code already handles it gracefully — so the warnings were polluting the logs without providing any actionable signal (there's no information to act on beyond "it happened").
  
  Per discussion, we're handling this case silently rather than keeping unused diagnostics.
  
  * **Comment-author path:** removed the `else { trigger_error( 'Unknown user', … ) }` branch. When `get_user_by( 'id', $id )` returns no `WP_User`, the method simply continues with the empty `$login`/`$first_name`/etc. it was already defaulting to. No behaviour change beyond no longer emitting the warning.
  * **Fallback author lookup:** removed the `trigger_error( 'Unknown user', … )` call; the subsequent `return null;` bail-out is untouched, so a failed lookup still returns `null` exactly as before — just silently.
  
  ## Related product discussion/links
  
p1780326934448719-slack-C05PV073SG3
  
  ## Does this pull request change what data or activity we track or use?
 
  No.
 
  ## Testing instructions
Code Review