### PR TITLE
VideoPress: fix legacy admin crash on video upload/delete (base-ui ref-merge)

### DIFF
--- a/projects/packages/videopress/changelog/fix-vidp-245-upgradetrigger-base-ui-crash
+++ b/projects/packages/videopress/changelog/fix-vidp-245-upgradetrigger-base-ui-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix admin page crash on video upload/delete when the free-plan upgrade nudge is shown

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -236,9 +236,17 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 		run
 	);
 
+	// VIDP-245: keep the `Notice.Root` children shape invariant across the
+	// `hasUsedVideo` flip. base-ui@1.4.1's `useRenderElement` swaps between two
+	// different ref-merge hooks depending on subtree shape, so conditionally
+	// mounting `<Notice.Description>` (as this did before) misaligns its stored
+	// fork-ref and crashes on the next upload/delete. Always render the
+	// Description — mirroring the modern dashboard's `free-tier-notice.tsx` —
+	// varying only its text, with a non-empty fallback nudge before the first
+	// upload so we never render an empty styled row.
 	const description = hasUsedVideo
 		? __( 'You have used your free video upload', 'jetpack-videopress-pkg' )
-		: '';
+		: __( 'The free plan includes one video upload.', 'jetpack-videopress-pkg' );
 
 	const cta = __(
 		'Upgrade now to unlock unlimited videos, 1TB of storage, and more!',
@@ -247,7 +255,7 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 
 	return (
 		<Notice.Root intent="info" className={ styles[ 'upgrade-trigger' ] }>
-			{ description && <Notice.Description>{ description }</Notice.Description> }
+			<Notice.Description>{ description }</Notice.Description>
 			<Notice.Actions>
 				<Notice.ActionButton onClick={ onButtonClickHandler }>{ cta }</Notice.ActionButton>
 			</Notice.Actions>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -211,6 +211,19 @@ const Admin = () => {
 
 export default Admin;
 
+// VIDP-245: keep these `__()` calls at module scope as separate statements.
+// If they live as the two arms of an inline ternary, terser folds them into a
+// single `__( cond ? 'a' : 'b', domain )`, which breaks string-literal POT
+// extraction (the i18n-check-webpack-plugin fails the production build).
+const UPGRADE_TRIGGER_USED_VIDEO_TEXT = __(
+	'You have used your free video upload',
+	'jetpack-videopress-pkg'
+);
+const UPGRADE_TRIGGER_FREE_PLAN_TEXT = __(
+	'The free plan includes one video upload.',
+	'jetpack-videopress-pkg'
+);
+
 const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) => {
 	const { adminUri, siteSuffix } = window.jetpackVideoPressInitialState;
 
@@ -243,10 +256,11 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 	// fork-ref and crashes on the next upload/delete. Always render the
 	// Description — mirroring the modern dashboard's `free-tier-notice.tsx` —
 	// varying only its text, with a non-empty fallback nudge before the first
-	// upload so we never render an empty styled row.
+	// upload so we never render an empty styled row. The two strings are hoisted
+	// to module scope (above) to avoid the terser i18n ternary-fold.
 	const description = hasUsedVideo
-		? __( 'You have used your free video upload', 'jetpack-videopress-pkg' )
-		: __( 'The free plan includes one video upload.', 'jetpack-videopress-pkg' );
+		? UPGRADE_TRIGGER_USED_VIDEO_TEXT
+		: UPGRADE_TRIGGER_FREE_PLAN_TEXT;
 
 	const cta = __(
 		'Upgrade now to unlock unlimited videos, 1TB of storage, and more!',

--- a/projects/plugins/jetpack/changelog/fix-vidp-245-upgradetrigger-base-ui-crash
+++ b/projects/plugins/jetpack/changelog/fix-vidp-245-upgradetrigger-base-ui-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: fix admin page crash on video upload/delete when the free-plan upgrade nudge is shown

--- a/projects/plugins/videopress/changelog/fix-vidp-245-upgradetrigger-base-ui-crash
+++ b/projects/plugins/videopress/changelog/fix-vidp-245-upgradetrigger-base-ui-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix admin page crash on video upload/delete when the free-plan upgrade nudge is shown


### PR DESCRIPTION
Fixes #49230

## Proposed changes

The legacy VideoPress admin dashboard threw an uncaught `TypeError` from `@base-ui/react@1.4.1`'s `useMergedRefs` / `useRenderElement` path on every video **upload** or **delete**, crashing the React tree and leaving the admin unresponsive. This was a regression from #48909 (`27bf601935`), which migrated `UpgradeTrigger` from `ContextualUpgradeTrigger` to a `@wordpress/ui` `Notice` compound tree.

**Root cause.** In `UpgradeTrigger`, the `Notice.Description` child was mounted conditionally:

```jsx
{ description && <Notice.Description>{ description }</Notice.Description> }
```

`description` derives from `hasUsedVideo` (= `hasVideos`), which flips on upload/delete. Mounting/unmounting that child changes the `Notice.Root` subtree shape across renders. base-ui@1.4.1's `useRenderElement` conditionally swaps between two different ref-merge hook functions (`useMergedRefs` vs `useMergedRefsN`, separate `useRef` slots) depending on subtree shape, so the changing shape misaligns the stored fork-ref and `didChange` reads `.refs` off `null`. Crash.

The modern wp-build dashboard's equivalent (`src/dashboard/components/overview/free-tier-notice.tsx`) uses the **same** `@wordpress/ui` Notice but never crashes because it **always** renders `<Notice.Description>` (static, never conditional).

**The fix.** Make the `Notice.Root` children shape invariant across the `hasVideos` flip: always render `<Notice.Description>`, varying only its text — mirroring `free-tier-notice.tsx`. No more `&&`-gated direct child of `Notice.Root`.

* `projects/packages/videopress/src/client/admin/components/admin-page/index.tsx` — `UpgradeTrigger` now renders `<Notice.Description>` unconditionally.

**Empty-description edge case.** Before the first upload on a free site, `description` was previously `''` — that's *why* it was conditional (an empty `<Notice.Description>` would render an empty styled row). Rather than gating the child (which reintroduces the crash) or rendering blank, I gave the no-videos branch a sensible non-empty fallback nudge:

```js
const description = hasUsedVideo
    ? __( 'You have used your free video upload', 'jetpack-videopress-pkg' )
    : __( 'The free plan includes one video upload.', 'jetpack-videopress-pkg' );
```

This keeps the children shape constant in **both** states while never rendering an empty row. (`.upgrade-trigger` SCSS only sets a `margin-top` on `Notice.Root`; `Notice.Description` carries its own internal spacing, so a blank one would have looked broken — hence the copy, not an empty string.)

This **keeps** the JETPACK-1543 `@wordpress/ui` Notice migration — it does **not** revert #48909.

## Related product discussion/links

* VIDP-245
* Regressed by #48909 (`27bf601935`)

## Does this pull request change what data or activity we track or use?

No. Analytics (`jetpack_videopress_upgrade_trigger_link_click`) are unchanged.

## Testing instructions

The **legacy dashboard renders by default** — the modern dashboard is gated behind `apply_filters( 'rsm_jetpack_ui_modernization_videopress', false )` in `src/class-admin-ui.php` (default `false`, nothing in shipped code enables it). So the default VideoPress admin **is** the legacy/crashing one; no filter is needed to reproduce.

> Note: the upgrade nudge only shows for sites **without** a VideoPress purchase (`! hasVideoPressPurchase`). A site with a VideoPress plan won't render `UpgradeTrigger` and can't reproduce this.

1. Fresh-connect Jetpack on a **free-tier** site (no VideoPress purchase) so `UpgradeTrigger` renders.
2. Open `wp-admin/admin.php?page=jetpack-videopress`.
3. Upload a video, then delete a video.

### Before
* The React tree crashes with `TypeError: Cannot read properties of null (reading 'refs')` (on delete) / `...undefined (reading 'length')` (on upload). The admin becomes unresponsive.

### After
* Upload and delete complete without any crash.
* The upgrade nudge renders correctly in **both** states:
  * **No videos yet:** "The free plan includes one video upload." + Upgrade CTA.
  * **After a video exists:** "You have used your free video upload" + Upgrade CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
