### PR TITLE
RTC: Require Gutenberg before enabling collaboration

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-17366-require-gutenberg-for-rtc
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-17366-require-gutenberg-for-rtc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RTC: Require Gutenberg before enabling real-time collaboration.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -84,12 +84,7 @@ function wpcom_enable_rtc() {
 
 	$has_needed_gutenberg_version = defined( 'GUTENBERG_VERSION' ) && is_string( GUTENBERG_VERSION ) && version_compare( (string) GUTENBERG_VERSION, '22.7.0', '>=' );
 
-	// WordPress 7.0+ includes RTC support in core.
-	// strtok strips beta/RC suffixes (e.g. "7.0-beta1" → "7.0") so pre-release versions match.
-	global $wp_version;
-	$has_needed_wp_version = version_compare( strtok( $wp_version, '-' ), '7.0', '>=' );
-
-	if ( ! $has_needed_gutenberg_version && ! $has_needed_wp_version ) {
+	if ( ! $has_needed_gutenberg_version ) {
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -8,7 +8,10 @@
 declare( strict_types = 1 );
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/gutenberg-rtc/gutenberg-rtc.php';
@@ -43,6 +46,7 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
+		\Brain\Monkey\setUp();
 		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
 	}
 
@@ -59,6 +63,8 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 		remove_all_filters( 'jetpack_rtc_enabled' );
 		remove_all_filters( 'jetpack_rtc_providers' );
+
+		\Brain\Monkey\tearDown();
 
 		parent::tear_down();
 	}
@@ -124,6 +130,46 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_enable_rtc_returns_false_without_rtc_feature() {
 		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 Chrome/120.0.0.0';
 		$this->assertFalse( wpcom_enable_rtc() );
+	}
+
+	/**
+	 * Tests that RTC is disabled on WordPress 7.0+ when Gutenberg is not available.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_enable_rtc_returns_false_on_wp_7_without_gutenberg() {
+		define( 'IS_WPCOM', true );
+
+		global $wp_version;
+		$wp_version = '7.0';
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 Chrome/120.0.0.0';
+
+		Functions\expect( 'wpcom_site_has_feature' )->andReturn( true );
+
+		$this->assertFalse( wpcom_enable_rtc() );
+	}
+
+	/**
+	 * Tests that RTC can be enabled when the site has the RTC feature and Gutenberg is available.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_enable_rtc_returns_true_with_rtc_feature_and_gutenberg() {
+		define( 'IS_WPCOM', true );
+		define( 'GUTENBERG_VERSION', '22.7.0' );
+
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 Chrome/120.0.0.0';
+
+		Functions\expect( 'wpcom_site_has_feature' )->andReturn( true );
+
+		$this->assertTrue( wpcom_enable_rtc() );
 	}
 
 	// ─── wpcom_is_rtc_http_polling_rollout ───────────────────────────


### PR DESCRIPTION
Fixes DOTCOM-17366

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove the WordPress 7.0+ fallback from `wpcom_enable_rtc()` so RTC requires the needed Gutenberg version before it can be enabled.
* Add tests for the WordPress 7.0-without-Gutenberg path and the Gutenberg-enabled path.
* Add a `jetpack-mu-wpcom` changelog entry.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* DOTCOM-17366
* https://make.wordpress.org/core/2026/05/08/rtc-removed-from-7-0/

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Apply these changes to a WoW dev site
* Remove Gutenberg
* Go to Settings > Writing
* Make sure the RTC option is not there
