### PR TITLE
Jetpack Network Admin: pin footers and remove core notices on modernized pages

### DIFF
--- a/projects/plugins/jetpack/_inc/client/network-admin.scss
+++ b/projects/plugins/jetpack/_inc/client/network-admin.scss
@@ -1,13 +1,16 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 
-// Sites: default view of the toplevel menu — WP emits
-//   `toplevel_page_jetpack-network-sites`.
-// Settings: secondary submenu — the body class prefix is derived from the
-//   menu *title* ("JP Network") sanitized to `jp-network`, producing
-//   `jp-network_page_jetpack-network-settings`. See the
-//   `admin_print_scripts-jp-network_page_jetpack-network-settings` hook in
-//   `tools/docker/mu-plugins/0-sandbox.php` for the canonical reference.
-// Both share `#jp-network-admin-root`; React branches on `data-page`.
+// These pages mount `AdminPage` and need the shared viewport-pinned layout
+// (fixed `#wpbody-content`, scrollable middle, pinned `JetpackFooter`). The
+// body classes differ between real Network Admin and the single-site preview,
+// so target both. The `.network-admin` qualifier keeps the real-multisite
+// selectors from matching the single-site Jetpack dashboard/settings pages,
+// which share the same page slugs.
+
+// Real multisite : `Jetpack_Network::add_network_admin_menu()`
+// Single-site    : `tools/docker/mu-plugins/0-sandbox.php`
+body.network-admin.toplevel_page_jetpack,
+body.network-admin.jetpack_page_jetpack-settings,
 body.toplevel_page_jetpack-network-sites,
 body.jp-network_page_jetpack-network-settings {
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-network-admin-footer-notices
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-network-admin-footer-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Network Admin: pin the Sites and Settings footers to the bottom on real multisite, and remove core admin notices on those modernized pages.

--- a/projects/plugins/jetpack/class.jetpack-network.php
+++ b/projects/plugins/jetpack/class.jetpack-network.php
@@ -512,6 +512,15 @@ class Jetpack_Network {
 	 */
 	public function admin_init_network_page() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_network_admin_scripts' ) );
+
+		// Match the modernized single-site dashboards (e.g. Jetpack Forms): the
+		// network Sites/Settings pages render as full-viewport AdminPage shells,
+		// so strip core admin notices that would otherwise break the pinned
+		// layout. Network Admin fires `network_admin_notices`/`all_admin_notices`
+		// (not `admin_notices`). Jetpack's own notices use the `jetpack_notices`
+		// hook and are unaffected.
+		remove_all_actions( 'network_admin_notices' );
+		remove_all_actions( 'all_admin_notices' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

The modernized Jetpack **Network Admin** Sites/Settings pages mount `AdminPage` and rely on the shared viewport-pinned layout (fixed `#wpbody-content`, scrollable middle, pinned `JetpackFooter`). But `network-admin.scss` scoped that layout only to the **single-site preview** body classes from `0-sandbox.php` (`toplevel_page_jetpack-network-sites` / `jp-network_page_jetpack-network-settings`).

On **real multisite** the body classes are `network-admin toplevel_page_jetpack` (Sites) and `network-admin jetpack_page_jetpack-settings` (Settings), so the layout mixin never applied — the footer floated mid-page with a gray dead zone below it instead of pinning to the bottom.

* **`_inc/client/network-admin.scss`**: scope `@include jetpack-admin-page-layout` to the real-multisite body classes as well. The `.network-admin` qualifier keeps them from matching the single-site Jetpack dashboard/settings pages, which share the same page slugs.
* **`class.jetpack-network.php`**: in `admin_init_network_page()`, strip `network_admin_notices` + `all_admin_notices` on both network pages so core admin notices don't break the pinned layout — matching the modernized Jetpack Forms dashboard. Jetpack's own `jetpack_notices` hook is unaffected. (Hello Dolly rides `admin_notices`, which doesn't fire under Network Admin, so it was already absent there.)

### How it was verified

Built `network-admin.css` and rsynced to a real multisite Jurassic Ninja site, then measured the live DOM (no class injection):

| Page | `#wpbody-content` | Footer | Dolly |
| --- | --- | --- | --- |
| Sites (`toplevel_page_jetpack`) | `position: fixed; overflow: hidden` | pinned, 0px gap to viewport bottom | absent |
| Settings (`jetpack_page_jetpack-settings`) | `position: fixed` | pinned, 0px gap | absent |

Note: the single-site preview in `tools/docker/mu-plugins/0-sandbox.php` (gitignored) was also updated to strip `admin_notices`, so the local preview faithfully mirrors real Network Admin (and Dolly, which rides `admin_notices` on single-site, is removed there too). That file is not part of this PR.

## Related product discussion/links

* Part of the broader Hello Dolly / admin-notices normalization across Jetpack admin pages (#49285).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a **multisite** install (`jetpack docker multisite-convert` locally, or a JN site spawned as multisite).

1. Network Admin → **Jetpack → Sites** (`wp-admin/network/admin.php?page=jetpack`).
   * **Before:** the "Jetpack / Support … An Automattic Airline" footer sits directly under the content mid-page, with a gray gap filling the rest of the viewport.
   * **After:** the footer is pinned flush to the bottom of the viewport.
2. Network Admin → **Jetpack → Settings** (`?page=jetpack-settings`): same — footer pinned to the bottom.
3. Confirm no core admin-notice boxes render at the top of either page.
4. Resize the window: the footer stays pinned and content scrolls in the middle region.

## Screenshots

<!-- Drag-and-drop the before/after PNGs here. -->

| Before (footer floating) | After (footer pinned) |
| --- | --- |
| <img width="1488" height="800" alt="jn-network-sites-before" src="https://github.com/user-attachments/assets/9c645997-687d-4d9c-be8e-f683c861b707" /> | <img width="1488" height="800" alt="jn-network-sites-FIXED" src="https://github.com/user-attachments/assets/22080a3c-e050-44cb-bf2b-757c59c9a6e7" /> |
| | <img width="1488" height="800" alt="jn-network-settings-FIXED" src="https://github.com/user-attachments/assets/616a533d-758c-45aa-9378-4feccb7f3197" /> |



