### PR TITLE
E2E tests: improve Sync cleanup isolation

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-fix-sync-cleanup-isolation
+++ b/projects/plugins/jetpack/changelog/e2e-fix-sync-cleanup-isolation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: Improve Sync cleanup and isolation.

--- a/projects/plugins/jetpack/tests/e2e/helpers/sync-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/sync-helper.ts
@@ -29,6 +29,18 @@ export async function resetSync(): Promise< string > {
 }
 
 /**
+ * Reset sync locks
+ * @return {string} wp-cli command output
+ */
+export async function resetSyncLocks(): Promise< string > {
+	logger.debug( 'Resetting sync locks' );
+	return executeWpCommand( [
+		'eval',
+		'\\Automattic\\Jetpack\\Sync\\Actions::reset_sync_locks();',
+	] );
+}
+
+/**
  * Get sync status
  * @return {string} wp-cli command output
  */
@@ -63,7 +75,7 @@ export async function isSyncQueueEmpty(): Promise< boolean > {
 	try {
 		const status = await getSyncStatus();
 		logger.debug( status );
-		return status.includes( 'queue_size' ) && status.includes( 'queue_size	0' );
+		return /(^|\n)queue_size\s+0(\n|$)/.test( status );
 	} catch ( e ) {
 		logger.error( `isSyncQueueEmpty: ${ e }` );
 		return false;

--- a/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.ts
@@ -4,15 +4,15 @@ import {
 	enableSync,
 	disableSync,
 	resetSync,
+	resetSyncLocks,
+	getSyncStatus,
 	enableDedicatedSync,
 	disableDedicatedSync,
-	isSyncQueueEmpty,
 } from '../../helpers/sync-helper';
 
 test.describe( 'Sync', () => {
 	const wpcomRestAPIBase = 'https://public-api.wordpress.com/rest/';
-	let wpcomBlogId;
-	let wpcomForcedPostsUrl: string;
+	let wpcomBlogId: number;
 	let wpcomPostsResponse;
 	let wpcomPosts;
 
@@ -21,22 +21,20 @@ test.describe( 'Sync', () => {
 			'option get jetpack_options --format=json'
 		);
 		wpcomBlogId = JSON.parse( jetpackOptions ).id;
-		wpcomForcedPostsUrl =
-			wpcomRestAPIBase + `v1/sites/${ wpcomBlogId }/posts?force=wpcom&search=Sync`;
 		logger.debug( `START: ${ jetpackOptions }` );
 	} );
 
 	test.beforeEach( async () => {
-		await test.step( 'Check sync queue status before test', async () => {
+		await test.step( 'Reset Sync defaults before test', async () => {
+			await resetSyncDefaults();
 			await assertSyncQueueIsEmpty( 'Sync queue should be empty [before]' );
 		} );
 	} );
 
 	test.afterEach( async () => {
 		await test.step( 'Reset Sync defaults', async () => {
-			await resetSync();
-			await enableSync();
-			await disableDedicatedSync();
+			await resetSyncDefaults();
+			await assertSyncQueueIsEmpty( 'Sync queue should be empty [after cleanup]' );
 		} );
 	} );
 
@@ -54,7 +52,7 @@ test.describe( 'Sync', () => {
 		await test.step( 'Assert post is synced', async () => {
 			await assertSyncQueueIsEmpty( 'Sync queue should be empty [after post publish]' );
 
-			wpcomPostsResponse = await page.request.get( wpcomForcedPostsUrl );
+			wpcomPostsResponse = await page.request.get( getWpcomForcedPostsUrl( title ) );
 			expect( wpcomPostsResponse.ok(), 'WPCOM get posts response is OK' ).toBeTruthy();
 
 			wpcomPosts = await wpcomPostsResponse.json();
@@ -86,15 +84,15 @@ test.describe( 'Sync', () => {
 		} );
 
 		await test.step( 'Assert post is not synced', async () => {
-			wpcomPostsResponse = await page.request.get( wpcomForcedPostsUrl );
+			wpcomPostsResponse = await page.request.get( getWpcomForcedPostsUrl( title ) );
 			expect( wpcomPostsResponse.ok(), 'WPCOM get posts response is OK' ).toBeTruthy();
 
 			wpcomPosts = await wpcomPostsResponse.json();
 			expect(
 				wpcomPosts.posts,
 				'Previously created post should NOT be present in the synced posts'
-			).toContainEqual(
-				expect.not.objectContaining( {
+			).not.toContainEqual(
+				expect.objectContaining( {
 					title,
 				} )
 			);
@@ -120,7 +118,7 @@ test.describe( 'Sync', () => {
 		await test.step( 'Assert post is synced', async () => {
 			await assertSyncQueueIsEmpty( 'Sync queue should be empty [after post publish]' );
 
-			wpcomPostsResponse = await page.request.get( wpcomForcedPostsUrl );
+			wpcomPostsResponse = await page.request.get( getWpcomForcedPostsUrl( title ) );
 			expect( wpcomPostsResponse.ok(), 'WPCOM get posts response is OK' ).toBeTruthy();
 
 			wpcomPosts = await wpcomPostsResponse.json();
@@ -136,21 +134,50 @@ test.describe( 'Sync', () => {
 	} );
 
 	/**
-	 * Assert sync queue is empty
-	 * @param {string} message - Message to report.
-	 * @param {number} timeout - Timeout.
+	 * Reset Sync state before or after a test.
+	 */
+	async function resetSyncDefaults() {
+		await resetSync();
+		await resetSyncLocks();
+		await disableDedicatedSync();
+		await enableSync();
+	}
+
+	/**
+	 * Build the WPCOM forced posts URL for a unique post title.
+	 *
+	 * @param {string} title - Post title to search for.
+	 * @return {string} WPCOM forced posts URL.
+	 */
+	function getWpcomForcedPostsUrl( title: string ) {
+		return (
+			wpcomRestAPIBase +
+			`v1/sites/${ wpcomBlogId }/posts?force=wpcom&search=${ encodeURIComponent( title ) }`
+		);
+	}
+
+	/**
+	 * Assert sync queue is empty.
+	 *
+	 * @param {string} message - Failure message.
+	 * @param {number} timeout - Timeout in milliseconds.
 	 */
 	async function assertSyncQueueIsEmpty( message = 'Sync queue should be empty', timeout = 30000 ) {
 		await expect
 			.poll(
 				async () => {
-					return await isSyncQueueEmpty();
+					try {
+						return await getSyncStatus();
+					} catch ( e ) {
+						logger.error( `assertSyncQueueIsEmpty: ${ e }` );
+						return '';
+					}
 				},
 				{
 					message,
 					timeout,
 				}
 			)
-			.toBeTruthy();
+			.toMatch( /(^|\n)queue_size\s+0(\n|$)/ );
 	}
 } );


### PR DESCRIPTION
## Proposed changes
* Reset Sync queues, locks, and dedicated-sync state before and after each Sync E2E test.
* Narrow the WPCOM REST post lookup to each generated post title instead of a shared `search=Sync` query.
* Fix the disabled-sync assertion so it checks that the generated title is absent.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `pnpm --dir projects/plugins/jetpack/tests/e2e typecheck`
* `pnpm --dir . exec eslint --flag v10_config_lookup_from_file --max-warnings=0 --fix projects/plugins/jetpack/tests/e2e/helpers/sync-helper.ts projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.ts`
* Focused E2E verification, with a configured Jetpack E2E site URL:

```bash
PLAYWRIGHT_WORKERS=1 pnpm --dir projects/plugins/jetpack/tests/e2e test:run specs/sync/sync.test.ts --project="jetpack e2e" --reporter=list
```
