### PR TITLE
CI: Alert when WP Cloud workflow fails on trunk

### DIFF
--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -16,6 +16,7 @@ on:
       - Tests
       - Update Jetpack Staging Test Sites
       - Update Phan stubs
+      - WP Cloud Unit Testing for WPCOMSH
     branches: [ 'trunk', 'prerelease', '*/branch-*' ]
 
 permissions:

--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -13,6 +13,7 @@ on:
       - Monorepo Auto-tagger
       - Post-Build
       - PR is up-to-date
+      - PR is up-to-date (trunk push)
       - Tests
       - Update Jetpack Staging Test Sites
       - Update Phan stubs


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Enable alerts when WP Cloud workflow fails on `trunk`.

Also added "PR is up-to-date (trunk push)", which was split out in #49057.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1780422862993359/1780410311.727899-slack-C08PN0LHCCT
* p1779183326800519-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

🦐