### PR TITLE
Hack for `eslint-plugin-package-json` node dep

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -281,6 +281,12 @@ async function fixDeps( pkg ) {
 		pkg.dependencies[ '@date-fns/tz' ] ??= '^1.2.0';
 	}
 
+	// Temporary override. Seems to work fine with 24.14, and bumping the min version is more disruptive.
+	// We'll plan to remove this hack and bump the version along with pnpm 11 and/or composer 2.10 soon.
+	if ( pkg.name === 'eslint-plugin-package-json' ) {
+		delete pkg.engines;
+	}
+
 	return pkg;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-KrBHPLv8FlPoa5OUGbvotku6TLmuhZiq22jdIe7yBHc=
+pnpmfileChecksum: sha256-HvcDj4j87Sh7PgclZifi5F8ayW+vvKBzmoCc14WMPmw=
 
 patchedDependencies:
   react-autosize-textarea:
@@ -12903,7 +12903,6 @@ packages:
 
   eslint-plugin-package-json@1.2.0:
     resolution: {integrity: sha512-3BszsD7XVddaUNbMfK+1lF1Qg8ck0nO3bNT/7IjXP8wrGzPThHZpkhm5UnbY1Nb/s3o6DUNgHI4aEqQV/t83fw==}
-    engines: {node: ^22.22.2 || >=24.15.0}
     peerDependencies:
       '@eslint/json': '>=1.0.0'
       eslint: '>=9.0.0'


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #49322 updated `eslint-plugin-package-json`, which depends on node >=24.15.0 while our minimum is 24.14.0.

Since bumping our node version is somewhat disruptive and we have some other similar bumps soon (pnpm 11, composer 2.10), and the package seems to work fine with 24.14.0, let's hack this for now and do all the bumps at once soon.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None linkable

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* With nodejs 24.14.0 installed, try a `pnpm install`.