### PR TITLE
wpcomsh: Remove environment-dependent protected owner error handler test

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-protected-owner-error-handler-flaky-test
+++ b/projects/plugins/wpcomsh/changelog/remove-protected-owner-error-handler-flaky-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove environment-dependent test for the protected owner error handler.
+
+

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -69,40 +69,6 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_error method returns protected owner error when active error exists.
-	 *
-	 * Note: This test requires the Atomic_Persistent_Data class to exist (simulating Atomic environment)
-	 * and to return empty/null for JETPACK_CONNECTION_OWNER_EMAIL. In the real test environment,
-	 * this depends on the actual APD implementation.
-	 */
-	public function test_handle_error_returns_protected_owner_error() {
-		// Skip if Atomic_Persistent_Data class doesn't exist (not on Atomic, error would be cleared)
-		if ( ! class_exists( \Atomic_Persistent_Data::class ) ) {
-			$this->markTestSkipped( 'Test requires Atomic_Persistent_Data class (Atomic environment).' );
-		}
-
-		$test_email = 'test@example.com';
-
-		// Set an error
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-			)
-		);
-
-		$result = $this->handler->handle_error( array() );
-
-		// If APD returns an owner email, the error will be cleared (test will fail)
-		// This is expected behavior - we can only verify the error is returned when APD has no owner email
-		$this->assertArrayHasKey( 'protected_owner_missing', $result );
-		$error_details = $result['protected_owner_missing']['0'];
-		$this->assertEquals( 'protected_owner_missing', $error_details['error_code'] );
-		$this->assertEquals( $test_email, $error_details['error_data']['email'] );
-	}
-
-	/**
 	 * Test handle_error method returns empty array when no active error exists.
 	 */
 	public function test_handle_error_returns_empty_when_no_active_error() {


### PR DESCRIPTION
## Proposed changes

* Remove the `test_handle_error_returns_protected_owner_error` test from `ProtectedOwnerErrorHandlerTest`.

This test was environment-dependent and unreliable. It exercises `Protected_Owner_Error_Handler::handle_error()`, which only returns an active protected-owner error when `Atomic_Persistent_Data` (APD) exists **and** reports an empty owner email. The test only guards against APD being entirely absent (in which case it skips). When APD is present but exposes a populated `JETPACK_CONNECTION_OWNER_EMAIL` (any value), `get_active_error()` clears the stored error and `handle_error()` returns an empty array, so the test fails rather than skipping. The remaining tests in the file already cover the meaningful behavior (empty result when no active error, error clearing when the user exists, error clearing when not on Atomic, etc.).

## Related product discussion/links

* p1780420746604889/1780410311.727899-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm the test file no longer contains `test_handle_error_returns_protected_owner_error`.
* Run the wpcomsh PHP test suite and confirm it still passes: `jp docker phpunit wpcomsh -- --filter=ProtectedOwnerErrorHandlerTest`.