### PR TITLE
Write editor: support Cmd-S / Ctrl-S to save

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-rsm-3949-write-save-shortcut
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-rsm-3949-write-save-shortcut
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: support Cmd+S / Ctrl+S to save

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5466,6 +5466,25 @@ window.addEventListener( 'pagehide', () => {
 	}
 } );
 
+// Cmd+S (Mac) / Ctrl+S (Windows/Linux) — trigger the primary save action,
+// matching whichever button is visible (Save draft on a draft, Update on a
+// published post). Attached at the document level so the shortcut works
+// regardless of which field has focus.
+document.addEventListener( 'keydown', event => {
+	if ( event.key?.toLowerCase() !== 's' ) return;
+	if ( ! ( event.ctrlKey || event.metaKey ) ) return;
+	if ( event.shiftKey || event.altKey ) return;
+	if ( state.isSaving || state.unsupportedWarning || state.showPostPicker ) return;
+
+	event.preventDefault();
+	const { actions } = store( 'wpcom-write' );
+	if ( state.isPublishedPost ) {
+		actions.publish();
+	} else {
+		actions.saveDraft();
+	}
+} );
+
 // File-drop safety net: .bw-content has min-height:60vh but doesn't
 // fill the rest of the viewport, and a long post can extend below the
 // viewport entirely. A file dropped outside .bw-content would otherwise

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -5474,7 +5474,15 @@ document.addEventListener( 'keydown', event => {
 	if ( event.key?.toLowerCase() !== 's' ) return;
 	if ( ! ( event.ctrlKey || event.metaKey ) ) return;
 	if ( event.shiftKey || event.altKey ) return;
-	if ( state.isSaving || state.unsupportedWarning || state.showPostPicker ) return;
+	if (
+		state.isSaving ||
+		state.unsupportedWarning ||
+		state.showImageModal ||
+		state.showVideoModal ||
+		state.showPostPicker
+	) {
+		return;
+	}
 
 	event.preventDefault();
 	const { actions } = store( 'wpcom-write' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -916,6 +916,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<div class="bw-help-row"><kbd>Ctrl+B</kbd><span><?php echo esc_html__( 'Bold', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Ctrl+I</kbd><span><?php echo esc_html__( 'Italic', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Ctrl+K</kbd><span><?php echo esc_html__( 'Insert link', 'jetpack-mu-wpcom' ); ?></span></div>
+			<div class="bw-help-row"><kbd>Ctrl+S</kbd><span><?php echo esc_html__( 'Save', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Tab</kbd><span><?php echo esc_html__( 'Navigate slash menu options', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>Shift+Tab</kbd><span><?php echo esc_html__( 'Focus formatting toolbar', 'jetpack-mu-wpcom' ); ?></span></div>
 			<div class="bw-help-row"><kbd>#tag</kbd><span><?php echo esc_html__( 'A line containing only #tags assigns them to the post on save', 'jetpack-mu-wpcom' ); ?></span></div>


### PR DESCRIPTION
Fixes [RSM-3949](https://linear.app/a8c/issue/RSM-3949/add-cmd-s-ctrl-s-keyboard-shortcut-to-save-in-write).

## Proposed changes
* Wires up the standard save keyboard shortcut (Cmd-S on Mac, Ctrl-S on Windows/Linux) in the Write editor.
* The shortcut triggers the same primary save action as the visible button: `saveDraft` for new/draft posts, `publish` (which renders as "Update") for already-published posts.
* The listener is attached at the document level so it works regardless of which field has focus (title, content, sidebar). It bails out while a save is in flight or while a modal (post picker, unsupported-content warning) owns the keyboard.
* `event.preventDefault()` suppresses the browser's "Save page as..." dialog.

## Related product discussion/links
* Linear: [RSM-3949](https://linear.app/a8c/issue/RSM-3949/add-cmd-s-ctrl-s-keyboard-shortcut-to-save-in-write)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Open the Write editor (Dashboard → Write submenu, or `/wp-admin/admin.php?page=write`).
2. Type a title and some content.
3. Press **Cmd+S** (Mac) or **Ctrl+S** (Windows/Linux).
   * Expected: the post is saved as a draft (no browser "Save page" dialog appears).
4. Edit something and press the shortcut again.
   * Expected: the same draft updates — no duplicate post is created.
5. Open an already-published post in the Write editor (`?page=write&post=<id>`) and press the shortcut.
   * Expected: the post is updated (same effect as clicking the **Update** button); the page then redirects to the published post URL, as it does for the Update button.
6. Try the shortcut while the post picker modal is open.
   * Expected: nothing happens — the modal owns the keyboard.

Verified end-to-end via Playwright against a local docker WP: draft creation, draft update (no duplicate), and published-post update all work; Ctrl+S and Cmd+S both fire the handler.