### PR TITLE
VideoPress: Add drag-and-drop video upload to the new Library dashboard

### DIFF
--- a/projects/packages/videopress/changelog/readd-file-upload-videopress
+++ b/projects/packages/videopress/changelog/readd-file-upload-videopress
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: Add drag-and-drop video upload to the new Library, with upload progress and a notice when the single-video plan limit is reached.

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -37,6 +37,9 @@ export declare global {
 				assets: {
 					buildUrl: string;
 				};
+				// Authoritative accepted-upload map (extension => mimetype) from the
+				// server's `Admin_UI::get_allowed_video_extensions()`.
+				allowedVideoExtensions: Record< string, string >;
 				pricing: null | {
 					title: string;
 					features: string[];

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -121,7 +121,6 @@ const StageInner = () => {
 	const handleFilesDrop = useCallback(
 		( files: File[] ) => {
 			const decision = planVideoDrop( files, {
-				isAtLimit,
 				isFree,
 				isUnlimited,
 				limit,
@@ -163,16 +162,7 @@ const StageInner = () => {
 				);
 			}
 		},
-		[
-			isAtLimit,
-			isFree,
-			isUnlimited,
-			limit,
-			videoCount,
-			startUpload,
-			createErrorNotice,
-			runUpgrade,
-		]
+		[ isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice, runUpgrade ]
 	);
 
 	const promoteLocal = useCallback(

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,5 +1,5 @@
 import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
-import { Tooltip } from '@wordpress/components';
+import { DropZone, Tooltip } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -16,6 +16,7 @@ import { useLibrary } from '../../src/dashboard/hooks/use-library';
 import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
 import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-library';
+import { planVideoDrop } from './upload-drop';
 import './style.scss';
 import type { LibraryItem, LibraryItemPrivacy } from '../../src/dashboard/types/library';
 import type { SupportedLayouts, View } from '@wordpress/dataviews';
@@ -69,7 +70,7 @@ const StageInner = () => {
 	const { mutate: deleteVideo } = useDeleteVideo();
 	const { mutate: updateMeta } = useUpdateVideoMeta();
 	const { mutate: uploadFromLibrary } = useUploadFromLibrary();
-	const { isAtLimit } = useFreeTier();
+	const { isAtLimit, isFree, isUnlimited, videoCount, limit } = useFreeTier();
 
 	const onChangeView = useCallback( ( next: View ) => {
 		setView( current => {
@@ -111,6 +112,54 @@ const StageInner = () => {
 	);
 
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
+
+	// Drag-and-drop entry point. Mirrors the file-picker's `startUpload`
+	// path but accepts multiple files and enforces the free-tier cap up
+	// front so a drop can't sneak past the limit the picker button guards.
+	const handleFilesDrop = useCallback(
+		( files: File[] ) => {
+			const decision = planVideoDrop( files, {
+				isAtLimit,
+				isFree,
+				isUnlimited,
+				limit,
+				videoCount,
+			} );
+
+			if ( decision.kind === 'no-videos' ) {
+				createErrorNotice( __( 'Only video files can be uploaded.', 'jetpack-videopress-pkg' ) );
+				return;
+			}
+
+			if ( decision.kind === 'at-limit' ) {
+				createErrorNotice(
+					__(
+						'You’ve reached the free plan’s 1-video limit. Upgrade to upload more.',
+						'jetpack-videopress-pkg'
+					)
+				);
+				return;
+			}
+
+			decision.toUpload.forEach( file => startUpload( file ) );
+
+			if ( decision.skipped > 0 ) {
+				createErrorNotice(
+					sprintf(
+						/* translators: %d: number of videos that could not be uploaded because the plan limit was reached. */
+						_n(
+							'%d video wasn’t uploaded because it exceeds your plan’s limit.',
+							'%d videos weren’t uploaded because they exceed your plan’s limit.',
+							decision.skipped,
+							'jetpack-videopress-pkg'
+						),
+						decision.skipped
+					)
+				);
+			}
+		},
+		[ isAtLimit, isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice ]
+	);
 
 	const promoteLocal = useCallback(
 		( id: string ) => {
@@ -296,6 +345,10 @@ const StageInner = () => {
 		>
 			<UploadActionsProvider value={ { promoteLocal, retryUpload } }>
 				<div className={ `vp-library__viewport vp-library__viewport--${ view.type }` }>
+					<DropZone
+						label={ __( 'Drop a video to upload', 'jetpack-videopress-pkg' ) }
+						onFilesDrop={ handleFilesDrop }
+					/>
 					<DataViews< LibraryItem >
 						data={ renderedItems }
 						fields={ libraryFields }

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -16,6 +16,7 @@ import { useLibrary } from '../../src/dashboard/hooks/use-library';
 import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
 import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-library';
+import { useVideoPressUpgrade } from '../../src/dashboard/hooks/use-videopress-upgrade';
 import { planVideoDrop } from './upload-drop';
 import './style.scss';
 import type { LibraryItem, LibraryItemPrivacy } from '../../src/dashboard/types/library';
@@ -71,6 +72,7 @@ const StageInner = () => {
 	const { mutate: updateMeta } = useUpdateVideoMeta();
 	const { mutate: uploadFromLibrary } = useUploadFromLibrary();
 	const { isAtLimit, isFree, isUnlimited, videoCount, limit } = useFreeTier();
+	const runUpgrade = useVideoPressUpgrade();
 
 	const onChangeView = useCallback( ( next: View ) => {
 		setView( current => {
@@ -136,7 +138,10 @@ const StageInner = () => {
 					__(
 						'You’ve reached the free plan’s 1-video limit. Upgrade to upload more.',
 						'jetpack-videopress-pkg'
-					)
+					),
+					{
+						actions: [ { label: __( 'Upgrade', 'jetpack-videopress-pkg' ), onClick: runUpgrade } ],
+					}
 				);
 				return;
 			}
@@ -158,7 +163,16 @@ const StageInner = () => {
 				);
 			}
 		},
-		[ isAtLimit, isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice ]
+		[
+			isAtLimit,
+			isFree,
+			isUnlimited,
+			limit,
+			videoCount,
+			startUpload,
+			createErrorNotice,
+			runUpgrade,
+		]
 	);
 
 	const promoteLocal = useCallback(

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -18,6 +18,11 @@
 		flex: 1;
 		min-height: 0;
 
+		// Positioning context for the `@wordpress/components` DropZone, which
+		// overlays its nearest positioned ancestor while a file is dragged
+		// over the library so a video can be dropped anywhere on the listing.
+		position: relative;
+
 		// Flex-grow the single DataViews child inside this viewport so its
 		// pagination footer lands at the bottom. Targets `> *` rather than
 		// `.dataviews-wrapper` to avoid coupling to DataViews' internal class

--- a/projects/packages/videopress/routes/library/test/upload-drop.test.ts
+++ b/projects/packages/videopress/routes/library/test/upload-drop.test.ts
@@ -11,7 +11,6 @@ import type { DropPlanFreeTier } from '../upload-drop';
 const file = ( name: string, type = '' ): File => new File( [ 'x' ], name, { type } );
 
 const PAID: DropPlanFreeTier = {
-	isAtLimit: false,
 	isFree: false,
 	isUnlimited: false,
 	limit: 1,
@@ -19,7 +18,6 @@ const PAID: DropPlanFreeTier = {
 };
 
 const FREE_EMPTY: DropPlanFreeTier = {
-	isAtLimit: false,
 	isFree: true,
 	isUnlimited: false,
 	limit: 1,
@@ -57,6 +55,12 @@ describe( 'filterVideoFiles', () => {
 		expect( filterVideoFiles( [ file( 'photo.jpg', 'image/jpeg' ) ] ) ).toEqual( [] );
 	} );
 
+	it( 'does not accept a non-video MIME type just because the name ends in a video extension', () => {
+		// A reported MIME type is authoritative: a PDF renamed to `.mp4` must
+		// not slip through the extension fallback.
+		expect( filterVideoFiles( [ file( 'evil.mp4', 'application/pdf' ) ] ) ).toEqual( [] );
+	} );
+
 	it( 'does not match an extension that is merely a substring', () => {
 		// "notmp4" ends with "mp4" but not ".mp4" — the dot guards against it.
 		expect( filterVideoFiles( [ file( 'video.notmp4' ) ] ) ).toEqual( [] );
@@ -71,8 +75,20 @@ describe( 'planVideoDrop', () => {
 	} );
 
 	it( 'returns at-limit when the free plan is already at its cap', () => {
-		const atLimit = { ...FREE_EMPTY, isAtLimit: true, videoCount: 1 };
+		const atLimit = { ...FREE_EMPTY, videoCount: 1 };
 		expect( planVideoDrop( [ file( 'a.mp4' ) ], atLimit ) ).toEqual( { kind: 'at-limit' } );
+	} );
+
+	it( 'never caps an unlimited plan, even when it is over the nominal limit', () => {
+		// The library hook can report `isUnlimited: true` alongside a videoCount
+		// at/over the limit; an unlimited plan must still upload everything.
+		const unlimitedOverLimit = { ...FREE_EMPTY, isUnlimited: true, videoCount: 5 };
+		const decision = planVideoDrop( [ file( 'a.mp4' ), file( 'b.mov' ) ], unlimitedOverLimit );
+		expect( decision ).toMatchObject( { kind: 'ok', skipped: 0 } );
+		expect( decision.kind === 'ok' && decision.toUpload.map( f => f.name ) ).toEqual( [
+			'a.mp4',
+			'b.mov',
+		] );
 	} );
 
 	it( 'uploads everything on a paid plan', () => {

--- a/projects/packages/videopress/routes/library/test/upload-drop.test.ts
+++ b/projects/packages/videopress/routes/library/test/upload-drop.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the drag-and-drop upload decision logic powering the
+ * VideoPress Library DropZone (see routes/library/stage.tsx).
+ */
+
+import { filterVideoFiles, planVideoDrop } from '../upload-drop';
+import type { DropPlanFreeTier } from '../upload-drop';
+
+// Default to a typeless file so tests exercise the extension fallback; pass a
+// MIME type explicitly to exercise the primary `video/*` check.
+const file = ( name: string, type = '' ): File => new File( [ 'x' ], name, { type } );
+
+const PAID: DropPlanFreeTier = {
+	isAtLimit: false,
+	isFree: false,
+	isUnlimited: false,
+	limit: 1,
+	videoCount: 0,
+};
+
+const FREE_EMPTY: DropPlanFreeTier = {
+	isAtLimit: false,
+	isFree: true,
+	isUnlimited: false,
+	limit: 1,
+	videoCount: 0,
+};
+
+describe( 'filterVideoFiles', () => {
+	it( 'keeps only files with an allowed video extension', () => {
+		const result = filterVideoFiles( [
+			file( 'clip.mp4' ),
+			file( 'photo.jpg' ),
+			file( 'movie.MOV' ), // case-insensitive
+			file( 'doc.pdf' ),
+		] );
+		expect( result.map( f => f.name ) ).toEqual( [ 'clip.mp4', 'movie.MOV' ] );
+	} );
+
+	it( 'accepts .mov files (regression: video/quicktime must pass)', () => {
+		expect(
+			filterVideoFiles( [ file( 'clip.mov', 'video/quicktime' ) ] ).map( f => f.name )
+		).toEqual( [ 'clip.mov' ] );
+		// And via the extension fallback when the browser leaves the type empty.
+		expect( filterVideoFiles( [ file( 'clip.mov' ) ] ).map( f => f.name ) ).toEqual( [
+			'clip.mov',
+		] );
+	} );
+
+	it( 'accepts any video/* MIME type even with an unusual name', () => {
+		expect(
+			filterVideoFiles( [ file( 'recording-no-extension', 'video/webm' ) ] ).map( f => f.name )
+		).toEqual( [ 'recording-no-extension' ] );
+	} );
+
+	it( 'rejects non-video MIME types', () => {
+		expect( filterVideoFiles( [ file( 'photo.jpg', 'image/jpeg' ) ] ) ).toEqual( [] );
+	} );
+
+	it( 'does not match an extension that is merely a substring', () => {
+		// "notmp4" ends with "mp4" but not ".mp4" — the dot guards against it.
+		expect( filterVideoFiles( [ file( 'video.notmp4' ) ] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'planVideoDrop', () => {
+	it( 'returns no-videos when nothing dropped is a video', () => {
+		expect( planVideoDrop( [ file( 'a.jpg' ), file( 'b.pdf' ) ], PAID ) ).toEqual( {
+			kind: 'no-videos',
+		} );
+	} );
+
+	it( 'returns at-limit when the free plan is already at its cap', () => {
+		const atLimit = { ...FREE_EMPTY, isAtLimit: true, videoCount: 1 };
+		expect( planVideoDrop( [ file( 'a.mp4' ) ], atLimit ) ).toEqual( { kind: 'at-limit' } );
+	} );
+
+	it( 'uploads everything on a paid plan', () => {
+		const decision = planVideoDrop( [ file( 'a.mp4' ), file( 'b.mov' ), file( 'c.webm' ) ], PAID );
+		expect( decision ).toMatchObject( { kind: 'ok', skipped: 0 } );
+		expect( decision.kind === 'ok' && decision.toUpload.map( f => f.name ) ).toEqual( [
+			'a.mp4',
+			'b.mov',
+			'c.webm',
+		] );
+	} );
+
+	it( 'uploads everything on an unlimited (free-flagged) plan', () => {
+		const unlimited = { ...FREE_EMPTY, isUnlimited: true };
+		const decision = planVideoDrop( [ file( 'a.mp4' ), file( 'b.mov' ) ], unlimited );
+		expect( decision ).toMatchObject( { kind: 'ok', skipped: 0 } );
+	} );
+
+	it( 'caps a free-plan multi-drop to the remaining slots and reports the rest skipped', () => {
+		const decision = planVideoDrop(
+			[ file( 'a.mp4' ), file( 'b.mov' ), file( 'photo.jpg' ), file( 'c.webm' ) ],
+			FREE_EMPTY
+		);
+		// 3 videos pass the filter, 1 free slot → 1 uploaded, 2 skipped.
+		expect( decision ).toMatchObject( { kind: 'ok', skipped: 2 } );
+		expect( decision.kind === 'ok' && decision.toUpload.map( f => f.name ) ).toEqual( [ 'a.mp4' ] );
+	} );
+
+	it( 'accounts for already-stored videos when computing remaining slots', () => {
+		// A higher free limit with some slots used: limit 3, 2 used → 1 free.
+		const partlyUsed = { ...FREE_EMPTY, limit: 3, videoCount: 2 };
+		const decision = planVideoDrop( [ file( 'a.mp4' ), file( 'b.mov' ) ], partlyUsed );
+		expect( decision ).toMatchObject( { kind: 'ok', skipped: 1 } );
+		expect( decision.kind === 'ok' && decision.toUpload.map( f => f.name ) ).toEqual( [ 'a.mp4' ] );
+	} );
+} );

--- a/projects/packages/videopress/routes/library/test/upload-drop.test.ts
+++ b/projects/packages/videopress/routes/library/test/upload-drop.test.ts
@@ -6,9 +6,21 @@
 import { filterVideoFiles, planVideoDrop } from '../upload-drop';
 import type { DropPlanFreeTier } from '../upload-drop';
 
-// Default to a typeless file so tests exercise the extension fallback; pass a
-// MIME type explicitly to exercise the primary `video/*` check.
+// Default to a typeless file so tests exercise the extension allow-list; pass a
+// MIME type explicitly to exercise the `video/*` guard against renamed files.
 const file = ( name: string, type = '' ): File => new File( [ 'x' ], name, { type } );
+
+const setAllowedVideoExtensions = ( map: Record< string, string > | undefined ) => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE = map
+		? { allowedVideoExtensions: map }
+		: undefined;
+};
+
+// Clear the initial state between tests so cases that don't set it fall back to
+// the static (server-mirroring) extension list deterministically.
+afterEach( () => {
+	setAllowedVideoExtensions( undefined );
+} );
 
 const PAID: DropPlanFreeTier = {
 	isFree: false,
@@ -45,10 +57,22 @@ describe( 'filterVideoFiles', () => {
 		] );
 	} );
 
-	it( 'accepts any video/* MIME type even with an unusual name', () => {
-		expect(
-			filterVideoFiles( [ file( 'recording-no-extension', 'video/webm' ) ] ).map( f => f.name )
-		).toEqual( [ 'recording-no-extension' ] );
+	it( 'rejects extensions the backend does not accept (e.g. .webm/.mkv)', () => {
+		// `.webm`/`.mkv` are valid video MIME types but absent from the server
+		// allow-list, so the drop filter rejects them rather than starting an
+		// upload the backend would fail.
+		expect( filterVideoFiles( [ file( 'clip.webm', 'video/webm' ) ] ) ).toEqual( [] );
+		expect( filterVideoFiles( [ file( 'clip.mkv', 'video/x-matroska' ) ] ) ).toEqual( [] );
+	} );
+
+	it( 'sources the accepted extensions from the server allow-list', () => {
+		// A site whose backend advertises `.flv` accepts it; one that omits
+		// `.mp4` rejects it — proving the list comes from the initial state.
+		setAllowedVideoExtensions( { flv: 'video/x-flv' } );
+		expect( filterVideoFiles( [ file( 'a.flv', 'video/x-flv' ) ] ).map( f => f.name ) ).toEqual( [
+			'a.flv',
+		] );
+		expect( filterVideoFiles( [ file( 'a.mp4', 'video/mp4' ) ] ) ).toEqual( [] );
 	} );
 
 	it( 'rejects non-video MIME types', () => {
@@ -92,12 +116,12 @@ describe( 'planVideoDrop', () => {
 	} );
 
 	it( 'uploads everything on a paid plan', () => {
-		const decision = planVideoDrop( [ file( 'a.mp4' ), file( 'b.mov' ), file( 'c.webm' ) ], PAID );
+		const decision = planVideoDrop( [ file( 'a.mp4' ), file( 'b.mov' ), file( 'c.m4v' ) ], PAID );
 		expect( decision ).toMatchObject( { kind: 'ok', skipped: 0 } );
 		expect( decision.kind === 'ok' && decision.toUpload.map( f => f.name ) ).toEqual( [
 			'a.mp4',
 			'b.mov',
-			'c.webm',
+			'c.m4v',
 		] );
 	} );
 
@@ -109,7 +133,7 @@ describe( 'planVideoDrop', () => {
 
 	it( 'caps a free-plan multi-drop to the remaining slots and reports the rest skipped', () => {
 		const decision = planVideoDrop(
-			[ file( 'a.mp4' ), file( 'b.mov' ), file( 'photo.jpg' ), file( 'c.webm' ) ],
+			[ file( 'a.mp4' ), file( 'b.mov' ), file( 'photo.jpg' ), file( 'c.m4v' ) ],
 			FREE_EMPTY
 		);
 		// 3 videos pass the filter, 1 free slot → 1 uploaded, 2 skipped.

--- a/projects/packages/videopress/routes/library/upload-drop.ts
+++ b/projects/packages/videopress/routes/library/upload-drop.ts
@@ -1,3 +1,5 @@
+import type { FreeTierState } from '../../src/dashboard/hooks/use-free-tier';
+
 // Fallback video extensions, used only when a dropped file carries no MIME
 // type (some OS/browser combinations leave `File.type` empty). The primary
 // check is the `video/*` MIME prefix — the same contract the header file
@@ -21,16 +23,14 @@ const FALLBACK_VIDEO_EXTENSIONS = [
 	'wmv',
 ];
 
-// Free-tier facts the drop decision needs. Mirrors the subset of
-// `FreeTierState` (use-free-tier.ts) consumed when deciding what a drop is
-// allowed to upload.
-export type DropPlanFreeTier = {
-	isAtLimit: boolean;
-	isFree: boolean;
-	isUnlimited: boolean;
-	limit: number;
-	videoCount: number;
-};
+// Free-tier facts the drop decision needs — the subset of `FreeTierState`
+// consumed when deciding what a drop is allowed to upload. Derived via `Pick`
+// (a type-only import, so this stays a pure, hook-free module) so it tracks
+// `FreeTierState` automatically instead of drifting from it.
+export type DropPlanFreeTier = Pick<
+	FreeTierState,
+	'isAtLimit' | 'isFree' | 'isUnlimited' | 'limit' | 'videoCount'
+>;
 
 // Outcome of inspecting a drop. The component maps each `kind` to a
 // (translated) notice and/or kicks off uploads; keeping i18n out of here

--- a/projects/packages/videopress/routes/library/upload-drop.ts
+++ b/projects/packages/videopress/routes/library/upload-drop.ts
@@ -1,27 +1,44 @@
 import type { FreeTierState } from '../../src/dashboard/hooks/use-free-tier';
 
-// Fallback video extensions, used only when a dropped file carries no MIME
-// type (some OS/browser combinations leave `File.type` empty). The primary
-// check is the `video/*` MIME prefix — the same contract the header file
-// picker enforces via `accept="video/*"` — so e.g. `.mov` (video/quicktime)
-// is accepted. We deliberately don't read the server's
-// `allowedVideoExtensions` here: it's exposed on the legacy
-// `window.jetpackVideoPressInitialState` global, which the modernized
-// dashboard doesn't define, so relying on it rejected every drop.
+// Fallback accepted-upload extensions, used only when the server-provided
+// allow-list is absent (unit tests, or a render before the initial state is
+// inlined). Mirrors the server's `Admin_UI::get_allowed_video_extensions()`
+// keys so behaviour matches the backend even on the fallback path. The live
+// list is read from `JPVIDEOPRESS_INITIAL_STATE.allowedVideoExtensions`.
 const FALLBACK_VIDEO_EXTENSIONS = [
 	'3g2',
 	'3gp',
+	'3gp2',
+	'3gpp',
 	'avi',
 	'm4v',
-	'mkv',
 	'mov',
 	'mp4',
+	'mpe',
 	'mpeg',
 	'mpg',
 	'ogv',
-	'webm',
 	'wmv',
 ];
+
+/**
+ * The set of accepted upload extensions, sourced from the server's
+ * authoritative allow-list (`Admin_UI::get_allowed_video_extensions()`, inlined
+ * as `JPVIDEOPRESS_INITIAL_STATE.allowedVideoExtensions`). Falls back to the
+ * static list when the initial state isn't present (tests / pre-hydration).
+ * Read lazily so it always reflects the current initial state.
+ *
+ * @return Lower-cased accepted extensions (without the leading dot).
+ */
+function getAllowedExtensions(): Set< string > {
+	const map =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+			? JPVIDEOPRESS_INITIAL_STATE?.allowedVideoExtensions
+			: undefined;
+	const extensions =
+		map && Object.keys( map ).length ? Object.keys( map ) : FALLBACK_VIDEO_EXTENSIONS;
+	return new Set( extensions.map( extension => extension.toLowerCase() ) );
+}
 
 // Free-tier facts the drop decision needs — the subset of `FreeTierState`
 // consumed when deciding what a drop is allowed to upload. Derived via `Pick`
@@ -43,25 +60,29 @@ export type DropDecision =
 	| { kind: 'ok'; toUpload: File[]; skipped: number };
 
 /**
- * Filter a dropped file set down to videos. When the browser reports a MIME
- * type, it is authoritative: the file qualifies only if it is `video/*` (the
- * same contract the header file picker enforces via `accept="video/*"`, so
- * `.mov` → video/quicktime is accepted, while a renamed PDF is not). Only when
- * the browser reports *no* MIME type does it fall back to the file extension.
- * Keeps the drop handler from trying to upload images, PDFs, etc.
+ * Filter a dropped file set down to the video types the VideoPress backend
+ * accepts. A file qualifies when its extension is in the server's allow-list
+ * (so we accept exactly what the backend supports — e.g. `.mov`, but not
+ * `.webm`, rather than guessing client-side). A reported MIME type is also
+ * required to be `video/*`, so a non-video file renamed to a video extension
+ * (e.g. a `.mp4`-renamed PDF) is rejected. Keeps the drop handler from trying
+ * to upload images, PDFs, or unsupported video containers.
  *
  * @param files - The files dropped onto the DropZone.
- * @return Only the files that look like videos.
+ * @return Only the files the backend accepts.
  */
 export function filterVideoFiles( files: File[] ): File[] {
+	const allowed = getAllowedExtensions();
 	return files.filter( file => {
-		// A reported MIME type is authoritative — don't let a video extension
-		// override a non-video type (e.g. a `.mp4`-renamed `application/pdf`).
-		if ( file.type ) {
-			return file.type.startsWith( 'video/' );
+		// A reported MIME type must be a video type — blocks a non-video file
+		// (e.g. application/pdf) renamed to a video extension.
+		if ( file.type && ! file.type.startsWith( 'video/' ) ) {
+			return false;
 		}
-		const name = file.name.toLocaleLowerCase();
-		return FALLBACK_VIDEO_EXTENSIONS.some( extension => name.endsWith( `.${ extension }` ) );
+		const name = file.name.toLowerCase();
+		const dot = name.lastIndexOf( '.' );
+		const extension = dot === -1 ? '' : name.slice( dot + 1 );
+		return allowed.has( extension );
 	} );
 }
 

--- a/projects/packages/videopress/routes/library/upload-drop.ts
+++ b/projects/packages/videopress/routes/library/upload-drop.ts
@@ -1,0 +1,90 @@
+// Fallback video extensions, used only when a dropped file carries no MIME
+// type (some OS/browser combinations leave `File.type` empty). The primary
+// check is the `video/*` MIME prefix — the same contract the header file
+// picker enforces via `accept="video/*"` — so e.g. `.mov` (video/quicktime)
+// is accepted. We deliberately don't read the server's
+// `allowedVideoExtensions` here: it's exposed on the legacy
+// `window.jetpackVideoPressInitialState` global, which the modernized
+// dashboard doesn't define, so relying on it rejected every drop.
+const FALLBACK_VIDEO_EXTENSIONS = [
+	'3g2',
+	'3gp',
+	'avi',
+	'm4v',
+	'mkv',
+	'mov',
+	'mp4',
+	'mpeg',
+	'mpg',
+	'ogv',
+	'webm',
+	'wmv',
+];
+
+// Free-tier facts the drop decision needs. Mirrors the subset of
+// `FreeTierState` (use-free-tier.ts) consumed when deciding what a drop is
+// allowed to upload.
+export type DropPlanFreeTier = {
+	isAtLimit: boolean;
+	isFree: boolean;
+	isUnlimited: boolean;
+	limit: number;
+	videoCount: number;
+};
+
+// Outcome of inspecting a drop. The component maps each `kind` to a
+// (translated) notice and/or kicks off uploads; keeping i18n out of here
+// makes the branching logic unit-testable without asserting on copy.
+export type DropDecision =
+	| { kind: 'no-videos' }
+	| { kind: 'at-limit' }
+	| { kind: 'ok'; toUpload: File[]; skipped: number };
+
+/**
+ * Filter a dropped file set down to videos. A file qualifies when its MIME
+ * type is `video/*` (covers `.mov` → video/quicktime, `.mp4`, `.webm`, …) or,
+ * when the browser reports no MIME type, when its name ends in a known video
+ * extension. Keeps the drop handler from trying to upload images, PDFs, etc.
+ *
+ * @param files - The files dropped onto the DropZone.
+ * @return Only the files that look like videos.
+ */
+export function filterVideoFiles( files: File[] ): File[] {
+	return files.filter( file => {
+		if ( file.type.startsWith( 'video/' ) ) {
+			return true;
+		}
+		const name = file.name.toLocaleLowerCase();
+		return FALLBACK_VIDEO_EXTENSIONS.some( extension => name.endsWith( `.${ extension }` ) );
+	} );
+}
+
+/**
+ * Decide what a dropped file set should do, given the current free-tier
+ * state. Pure so the filtering + plan-limit math can be tested in isolation
+ * from the route component and the upload/notice side effects.
+ *
+ * @param files    - The raw files dropped onto the DropZone.
+ * @param freeTier - The relevant free-tier facts from useFreeTier().
+ * @return The drop decision: no videos, at the limit, or an upload plan.
+ */
+export function planVideoDrop( files: File[], freeTier: DropPlanFreeTier ): DropDecision {
+	const videoFiles = filterVideoFiles( files );
+	if ( videoFiles.length === 0 ) {
+		return { kind: 'no-videos' };
+	}
+
+	if ( freeTier.isAtLimit ) {
+		return { kind: 'at-limit' };
+	}
+
+	// Free (non-unlimited) plans cap how many videos can be hosted, so only
+	// accept as many as there's room for. Paid/unlimited plans take everything.
+	const remaining =
+		freeTier.isFree && ! freeTier.isUnlimited
+			? Math.max( 0, freeTier.limit - freeTier.videoCount )
+			: Infinity;
+	const toUpload = videoFiles.slice( 0, remaining );
+
+	return { kind: 'ok', toUpload, skipped: videoFiles.length - toUpload.length };
+}

--- a/projects/packages/videopress/routes/library/upload-drop.ts
+++ b/projects/packages/videopress/routes/library/upload-drop.ts
@@ -26,10 +26,12 @@ const FALLBACK_VIDEO_EXTENSIONS = [
 // Free-tier facts the drop decision needs — the subset of `FreeTierState`
 // consumed when deciding what a drop is allowed to upload. Derived via `Pick`
 // (a type-only import, so this stays a pure, hook-free module) so it tracks
-// `FreeTierState` automatically instead of drifting from it.
+// `FreeTierState` automatically instead of drifting from it. Note the absence
+// of `isAtLimit`: the decision derives the cap from these primitives rather
+// than trusting that flag, so an unlimited plan can never be treated as capped.
 export type DropPlanFreeTier = Pick<
 	FreeTierState,
-	'isAtLimit' | 'isFree' | 'isUnlimited' | 'limit' | 'videoCount'
+	'isFree' | 'isUnlimited' | 'limit' | 'videoCount'
 >;
 
 // Outcome of inspecting a drop. The component maps each `kind` to a
@@ -41,18 +43,22 @@ export type DropDecision =
 	| { kind: 'ok'; toUpload: File[]; skipped: number };
 
 /**
- * Filter a dropped file set down to videos. A file qualifies when its MIME
- * type is `video/*` (covers `.mov` → video/quicktime, `.mp4`, `.webm`, …) or,
- * when the browser reports no MIME type, when its name ends in a known video
- * extension. Keeps the drop handler from trying to upload images, PDFs, etc.
+ * Filter a dropped file set down to videos. When the browser reports a MIME
+ * type, it is authoritative: the file qualifies only if it is `video/*` (the
+ * same contract the header file picker enforces via `accept="video/*"`, so
+ * `.mov` → video/quicktime is accepted, while a renamed PDF is not). Only when
+ * the browser reports *no* MIME type does it fall back to the file extension.
+ * Keeps the drop handler from trying to upload images, PDFs, etc.
  *
  * @param files - The files dropped onto the DropZone.
  * @return Only the files that look like videos.
  */
 export function filterVideoFiles( files: File[] ): File[] {
 	return files.filter( file => {
-		if ( file.type.startsWith( 'video/' ) ) {
-			return true;
+		// A reported MIME type is authoritative — don't let a video extension
+		// override a non-video type (e.g. a `.mp4`-renamed `application/pdf`).
+		if ( file.type ) {
+			return file.type.startsWith( 'video/' );
 		}
 		const name = file.name.toLocaleLowerCase();
 		return FALLBACK_VIDEO_EXTENSIONS.some( extension => name.endsWith( `.${ extension }` ) );
@@ -74,17 +80,20 @@ export function planVideoDrop( files: File[], freeTier: DropPlanFreeTier ): Drop
 		return { kind: 'no-videos' };
 	}
 
-	if ( freeTier.isAtLimit ) {
+	// Only the free, non-unlimited tier caps how many videos can be hosted;
+	// paid and grandfathered-unlimited plans take everything. Deriving the cap
+	// from these primitives (rather than trusting a precomputed `isAtLimit`)
+	// guarantees an unlimited plan is never treated as capped.
+	const isCapped = freeTier.isFree && ! freeTier.isUnlimited;
+	if ( ! isCapped ) {
+		return { kind: 'ok', toUpload: videoFiles, skipped: 0 };
+	}
+
+	const remaining = Math.max( 0, freeTier.limit - freeTier.videoCount );
+	if ( remaining === 0 ) {
 		return { kind: 'at-limit' };
 	}
 
-	// Free (non-unlimited) plans cap how many videos can be hosted, so only
-	// accept as many as there's room for. Paid/unlimited plans take everything.
-	const remaining =
-		freeTier.isFree && ! freeTier.isUnlimited
-			? Math.max( 0, freeTier.limit - freeTier.videoCount )
-			: Infinity;
 	const toUpload = videoFiles.slice( 0, remaining );
-
 	return { kind: 'ok', toUpload, skipped: videoFiles.length - toUpload.length };
 }

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -100,19 +100,19 @@ class Initial_State {
 		$home_host       = wp_parse_url( get_site_url(), PHP_URL_HOST );
 
 		return array(
-			'API'           => array(
+			'API'                    => array(
 				'WP_API_root'  => esc_url_raw( rest_url() ),
 				'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
 				'contentNonce' => wp_create_nonce( 'videopress-content-nonce' ),
 			),
-			'jetpackStatus' => array(
+			'jetpackStatus'          => array(
 				'calypsoSlug' => ( new Status() )->get_site_suffix(),
 			),
-			'product'       => array(
+			'product'                => array(
 				// Fed to `useProductCheckoutWorkflow` as the product to purchase.
 				'slug' => self::VIDEOPRESS_PRODUCT_SLUG,
 			),
-			'siteData'      => array(
+			'siteData'               => array(
 				'id'                    => Jetpack_Options::get_option( 'id' ),
 				'title'                 => get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url(),
 				'adminUrl'              => esc_url_raw( admin_url() ),
@@ -130,15 +130,19 @@ class Initial_State {
 				'isVideoPress1TB'       => self::has_videopress_feature( 'videopress-1tb-storage' ),
 				'isVideoPressUnlimited' => self::has_videopress_feature( 'videopress-unlimited-storage' ),
 			),
-			'assets'        => array(
+			'assets'                 => array(
 				'buildUrl' => plugins_url( '../build/', __FILE__ ),
 			),
+			// Authoritative map of accepted upload types (extension => mimetype),
+			// so the dashboard's drag-and-drop filter accepts exactly what the
+			// VideoPress backend supports rather than guessing client-side.
+			'allowedVideoExtensions' => Admin_UI::get_allowed_video_extensions(),
 			// Product/pricing payload for the pre-connection upsell. Only
 			// populated when the site isn't connected — the only time the
 			// connection gate renders the upsell — so connected dashboards never
 			// incur the synchronous WPCOM pricing request `get_pricing_data()`
 			// makes.
-			'pricing'       => ( new Connection_Manager() )->is_connected() ? null : $this->get_pricing_data(),
+			'pricing'                => ( new Connection_Manager() )->is_connected() ? null : $this->get_pricing_data(),
 		);
 	}
 

--- a/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
+++ b/projects/packages/videopress/src/dashboard/components/overview/free-tier-notice.tsx
@@ -1,29 +1,8 @@
-import analytics from '@automattic/jetpack-analytics';
-// Imported via its deep export rather than the package barrel: the barrel
-// (`@automattic/jetpack-connection`) re-exports the disconnect dialog, which
-// imports `.jpg` assets the wp-build esbuild pipeline has no loader for, so a
-// barrel import fails the build even though the hook itself needs none of it.
-import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
-import { VIDEOPRESS_ADMIN_PAGE } from '../../utils/constants';
+import { useVideoPressUpgrade } from '../../hooks/use-videopress-upgrade';
 import type { ReactElement } from 'react';
-
-// Tracks event recorded when the upgrade CTA is clicked. Carried over verbatim
-// from the legacy dashboard's `UpgradeTrigger` so both dashboards report
-// against the same funnel.
-const UPGRADE_CLICK_EVENT = 'jetpack_videopress_upgrade_trigger_link_click';
-
-/**
- * Read the inlined initial state, guarding for environments (tests, the
- * legacy page) where the `var JPVIDEOPRESS_INITIAL_STATE` is absent.
- *
- * @return The initial-state payload, or undefined when it isn't present.
- */
-function getInitialState() {
-	return typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined' ? JPVIDEOPRESS_INITIAL_STATE : undefined;
-}
 
 /**
  * Permanent (non-dismissible) free-plan Notice rendered at the top of the
@@ -31,45 +10,26 @@ function getInitialState() {
  * non-dismissibility by omitting `<Notice.CloseIcon>` rather than via a boolean
  * prop.
  *
- * The upgrade CTA reuses the shared `useProductCheckoutWorkflow` hook — the
- * same one the legacy dashboard used — so VideoPress stays in lockstep with
- * every other product's checkout behavior instead of hand-rolling a URL. The
- * connection details the hook needs are hydrated server-side by
- * `class-initial-state.php` (`Connection_Initial_State::render_script()`); the
- * product to purchase and the post-checkout redirect come from
- * `JPVIDEOPRESS_INITIAL_STATE`. The hook exposes an action (`run`, which
- * registers the site if needed then redirects) rather than a URL, so the CTA is
- * an `ActionLink` with a placeholder `href` whose default `run` cancels before
- * redirecting — keeping anchor semantics (focus, hover) while delegating
- * navigation to the workflow.
- *
- * Tracks identity is initialized centrally by `useDashboardAnalytics`, so the
- * click handler only records the event; its `blog_id` is supplied
- * automatically by `window.jpTracksContext`.
+ * The upgrade CTA delegates to the shared `useVideoPressUpgrade` hook so this
+ * notice and the Library at-limit notice drive the exact same checkout. The
+ * hook starts a workflow (register-then-redirect) rather than exposing a URL,
+ * so the CTA is an `ActionLink` with a placeholder `href` whose default is
+ * cancelled before the workflow runs — keeping anchor semantics (focus, hover)
+ * while delegating navigation to the workflow.
  *
  * @return The Notice element.
  */
 export default function FreeTierNotice(): ReactElement {
-	const state = getInitialState();
-
-	const { run } = useProductCheckoutWorkflow( {
-		productSlug: state?.product?.slug ?? '',
-		redirectUrl: VIDEOPRESS_ADMIN_PAGE,
-		useBlogIdSuffix: true,
-		from: 'jetpack-videopress',
-	} );
+	const runUpgrade = useVideoPressUpgrade();
 
 	const handleUpgradeClick = useCallback(
 		( event: { preventDefault: () => void } ) => {
-			// Cancel the placeholder-href default, record the click, then defer the
-			// checkout redirect by a microtask so the Tracks pixel is dispatched
-			// before navigation can cancel it. Mirrors the legacy dashboard's
-			// `recordEvent( … ).then( run )`.
+			// Cancel the placeholder-href default so the workflow, not the
+			// anchor, performs navigation.
 			event.preventDefault();
-			analytics.tracks.recordEvent( UPGRADE_CLICK_EVENT );
-			void Promise.resolve().then( () => run() );
+			runUpgrade();
 		},
-		[ run ]
+		[ runUpgrade ]
 	);
 
 	return (

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier.test.ts
@@ -47,6 +47,46 @@ describe( 'useFreeTier', () => {
 		expect( result.current.isAtLimit ).toBe( true );
 	} );
 
+	// Regression: an unlimited (grandfathered) plan must never be reported as
+	// at the limit, even when the counted videos reach the free-tier cap.
+	// `isFree` and `isUnlimited` come from independent signals, so `isAtLimit`
+	// must explicitly exclude unlimited.
+	it( 'is not at the limit on an unlimited plan even at the nominal cap', async () => {
+		const win = window as unknown as {
+			JPVIDEOPRESS_INITIAL_STATE: { siteData: unknown };
+		};
+		const previousSiteData = win.JPVIDEOPRESS_INITIAL_STATE.siteData;
+		win.JPVIDEOPRESS_INITIAL_STATE.siteData = {
+			hasVideoPressAccess: false,
+			isVideoPressUnlimited: true,
+		};
+
+		mockApiFetch( async ( { parse } ) => {
+			if ( parse === false ) {
+				return {
+					headers: { get: ( key: string ) => ( key === 'X-WP-Total' ? '0' : '0' ) },
+					json: async () => [],
+				};
+			}
+			return {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: false,
+				isVideoPressUnlimitedSupported: false,
+			};
+		} );
+
+		try {
+			const { result } = renderHook( () => useFreeTier(), { wrapper: createTestWrapper() } );
+			// 0 completed + 1 in-flight = 1, which equals the free-tier cap…
+			await waitFor( () => expect( result.current.videoCount ).toBe( 1 ) );
+			expect( result.current.isUnlimited ).toBe( true );
+			// …but an unlimited plan is never gated.
+			expect( result.current.isAtLimit ).toBe( false );
+		} finally {
+			win.JPVIDEOPRESS_INITIAL_STATE.siteData = previousSiteData;
+		}
+	} );
+
 	// Regression: the listing call that drives the free-tier count must
 	// restrict to VideoPress-hosted videos (`mime_type=video/videopress`).
 	// Without the filter, local video attachments were counted toward the

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-videopress-upgrade.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-videopress-upgrade.test.ts
@@ -1,0 +1,67 @@
+import analytics from '@automattic/jetpack-analytics';
+import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
+import { act, renderHook } from '@testing-library/react';
+import { useVideoPressUpgrade } from '../use-videopress-upgrade';
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: jest.fn() } },
+} ) );
+
+jest.mock( '@automattic/jetpack-connection/hooks/use-product-checkout-workflow', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockedCheckout = useProductCheckoutWorkflow as jest.Mock;
+const mockedAnalytics = analytics as unknown as { tracks: { recordEvent: jest.Mock } };
+
+const setInitialState = ( state: unknown ) => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE =
+		state;
+};
+
+describe( 'useVideoPressUpgrade', () => {
+	let mockRun: jest.Mock;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setInitialState( { product: { slug: 'jetpack_videopress' } } );
+		mockRun = jest.fn();
+		mockedCheckout.mockReturnValue( { run: mockRun } );
+	} );
+
+	it( 'configures the checkout workflow with the VideoPress product and redirect', () => {
+		renderHook( () => useVideoPressUpgrade() );
+
+		expect( mockedCheckout ).toHaveBeenCalledWith( {
+			productSlug: 'jetpack_videopress',
+			redirectUrl: 'admin.php?page=jetpack-videopress',
+			useBlogIdSuffix: true,
+			from: 'jetpack-videopress',
+		} );
+	} );
+
+	it( 'records the upgrade-click event and runs the workflow when invoked', async () => {
+		const { result } = renderHook( () => useVideoPressUpgrade() );
+
+		await act( async () => {
+			result.current();
+			// `run` is deferred to a microtask so the Tracks pixel fires first.
+			await Promise.resolve();
+		} );
+
+		expect( mockedAnalytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_videopress_upgrade_trigger_link_click'
+		);
+		expect( mockRun ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'falls back to an empty product slug when initial state is absent', () => {
+		setInitialState( undefined );
+
+		renderHook( () => useVideoPressUpgrade() );
+
+		expect( mockedCheckout ).toHaveBeenCalledWith( expect.objectContaining( { productSlug: '' } ) );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -57,7 +57,11 @@ export function useFreeTier(): FreeTierState {
 	const isAtomic = isWoASite();
 	const isUnlimited = useIsVideoPressUnlimited();
 
-	const isAtLimit = isFree && videoCount >= FREE_TIER_UPLOAD_LIMIT;
+	// Only the free, non-unlimited tier is capped. `isUnlimited` (grandfathered
+	// 2TB plans) and paid access come from signals independent of `isFree`, so
+	// guard against an "unlimited yet free-flagged" combination wrongly gating
+	// uploads.
+	const isAtLimit = isFree && ! isUnlimited && videoCount >= FREE_TIER_UPLOAD_LIMIT;
 
 	return {
 		isFree,

--- a/projects/packages/videopress/src/dashboard/hooks/use-videopress-upgrade.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-videopress-upgrade.ts
@@ -1,0 +1,59 @@
+import analytics from '@automattic/jetpack-analytics';
+// Imported via its deep export rather than the package barrel: the barrel
+// (`@automattic/jetpack-connection`) re-exports the disconnect dialog, which
+// imports `.jpg` assets the wp-build esbuild pipeline has no loader for, so a
+// barrel import fails the build even though the hook itself needs none of it.
+import useProductCheckoutWorkflow from '@automattic/jetpack-connection/hooks/use-product-checkout-workflow';
+import { useCallback } from '@wordpress/element';
+import { VIDEOPRESS_ADMIN_PAGE } from '../utils/constants';
+
+// Tracks event recorded when the upgrade CTA is clicked. Carried over verbatim
+// from the legacy dashboard's `UpgradeTrigger` so both dashboards report
+// against the same funnel.
+const UPGRADE_CLICK_EVENT = 'jetpack_videopress_upgrade_trigger_link_click';
+
+/**
+ * Read the inlined initial state, guarding for environments (tests, the legacy
+ * page) where the `var JPVIDEOPRESS_INITIAL_STATE` is absent.
+ *
+ * @return The initial-state payload, or undefined when it isn't present.
+ */
+function getInitialState() {
+	return typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined' ? JPVIDEOPRESS_INITIAL_STATE : undefined;
+}
+
+/**
+ * Shared "upgrade to paid VideoPress" action for the modernized dashboard.
+ *
+ * Wraps the cross-product `useProductCheckoutWorkflow` hook so every upgrade
+ * CTA — the Overview free-tier notice and the Library at-limit drop notice —
+ * drives the exact same checkout (same product slug, redirect, and Tracks
+ * event) instead of each re-deriving the wiring. The connection details the
+ * workflow needs are hydrated server-side by `class-initial-state.php`; the
+ * product to purchase and the post-checkout redirect come from
+ * `JPVIDEOPRESS_INITIAL_STATE`.
+ *
+ * Tracks identity is initialized centrally by `useDashboardAnalytics`, so the
+ * returned callback only records the event; its `blog_id` is supplied
+ * automatically by `window.jpTracksContext`.
+ *
+ * @return A callback that records the upgrade-click event and starts checkout.
+ */
+export function useVideoPressUpgrade(): () => void {
+	const state = getInitialState();
+
+	const { run } = useProductCheckoutWorkflow( {
+		productSlug: state?.product?.slug ?? '',
+		redirectUrl: VIDEOPRESS_ADMIN_PAGE,
+		useBlogIdSuffix: true,
+		from: 'jetpack-videopress',
+	} );
+
+	return useCallback( () => {
+		// Record the click, then defer the checkout redirect by a microtask so
+		// the Tracks pixel is dispatched before navigation can cancel it.
+		// Mirrors the legacy dashboard's `recordEvent( … ).then( run )`.
+		analytics.tracks.recordEvent( UPGRADE_CLICK_EVENT );
+		void Promise.resolve().then( () => run() );
+	}, [ run ] );
+}


### PR DESCRIPTION
See https://wp.me/p8oabR-1P8#comment-9039 for more context.

## Proposed changes
* Add drag-and-drop video upload to the modernized VideoPress Library dashboard using the core `@wordpress/components` `DropZone`. Dropping a video anywhere over the listing starts the upload and shows progress inline (reusing the existing `useUpload`/tus pipeline and the per-card `ProgressBar` overlay — no new endpoint).
* Accept videos only: dropped files are filtered by `video/*` MIME type (matching the header picker's `accept="video/*"`, so `.mov`/`video/quicktime` is accepted), with a static extension fallback for files browsers leave typeless. Non-video drops show an error notice.
* Respect the free / single-video plan: when at the limit, a drop shows a transient notice ("You've reached the free plan's 1-video limit. Upgrade to upload more.") instead of uploading. Multi-file drops upload only as many as the plan allows and report how many were skipped.
* Extract the filtering + plan-limit decision into a pure, unit-tested helper (`routes/library/upload-drop.ts`); add `position: relative` to the library viewport so the DropZone overlay anchors correctly.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Requires the modernized dashboard, which is gated behind a filter that is off by default. Enable it via an mu-plugin: `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );`

* Go to **Jetpack → VideoPress → Library** (`admin.php?page=jetpack-videopress&p=/library`).
* On a paid/unlimited site: drag a video file (try a `.mov` and a `.mp4`) onto the Library. The DropZone overlay appears; on drop a new tile shows the upload progress climbing to 100%, then resolves to the video.
* Drag a non-video file (e.g. an image or PDF) → you should see an error notice "Only video files can be uploaded." and no upload.
* On a free site already at the 1-video limit: drop a video → transient notice about the plan limit, no upload.
* Drop several videos at once on a free site with one slot free → only one uploads; a notice reports the rest were skipped.
* Run unit tests: `cd projects/packages/videopress && pnpm test` (see `routes/library/test/upload-drop.test.ts`, including the `.mov` regression coverage).
