### PR TITLE
wpcomsh: add php83-plugin-patch command to fix mega_main_menu PHP 8.3+ fatal

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-mega-main-menu-php83-patch
+++ b/projects/plugins/wpcomsh/changelog/add-mega-main-menu-php83-patch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a `wpcomsh php83-plugin-patch mega_main_menu` CLI command that removes the duplicate `static $theme_option_file` declaration triggering a "Duplicate declaration of static variable" fatal error under PHP 8.3+.

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -951,6 +951,17 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				WP_CLI::error( 'mega_main_menu plugin is not installed.' );
 			}
 
+			// Don't patch if an update is pending: the new version may already fix this,
+			// and an update would overwrite the patched file anyway. Refresh the
+			// transient first so the decision is based on current data.
+			wp_update_plugins();
+			$update_plugins = get_site_transient( 'update_plugins' );
+
+			if ( isset( $update_plugins->response[ $folder ] ) ) {
+				$new_version = $update_plugins->response[ $folder ]->new_version ?? 'unknown';
+				WP_CLI::error( "An update to mega_main_menu $new_version is available; update the plugin instead of patching." );
+			}
+
 			$file = WP_PLUGIN_DIR . '/mega_main_menu/framework/options_generator.php';
 
 			if ( ! file_exists( $file ) ) {

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -922,6 +922,86 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		}
 
 		/**
+		 * Patch mega_main_menu plugin to work with PHP 8.3+.
+		 *
+		 * The `mm_options_generator()` function declares `static $theme_option_file`
+		 * in both the `file` and `background_image` cases of the same switch. PHP 8.3
+		 * turned a repeated `static` declaration of the same variable in one function
+		 * scope into a "Duplicate declaration of static variable" fatal error. This
+		 * renames the copy in the `background_image` case so only a single declaration
+		 * of `$theme_option_file` remains. Both cases merely enqueue the media uploader
+		 * scripts, and `wp_enqueue_*` is idempotent, so behavior is unchanged.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <plugin>
+		 * : The plugin to patch.
+		 *
+		 * @subcommand php83-plugin-patch
+		 */
+		public function php_83_plugin_patch( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			if ( 'mega_main_menu' !== $args[0] ) {
+				WP_CLI::error( 'Wrong plugin to patch.' );
+			}
+
+			$plugins = get_plugins();
+			$folder  = 'mega_main_menu/mega_main_menu.php';
+
+			if ( ! isset( $plugins[ $folder ] ) ) {
+				WP_CLI::error( 'mega_main_menu plugin is not installed.' );
+			}
+
+			$file = WP_PLUGIN_DIR . '/mega_main_menu/framework/options_generator.php';
+
+			if ( ! file_exists( $file ) ) {
+				WP_CLI::error( 'File not found: ' . $file );
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$file_content = file_get_contents( $file );
+
+			if ( false === $file_content ) {
+				WP_CLI::error( 'File not found: ' . $file );
+			}
+
+			// Already patched: re-running is a safe no-op.
+			if ( false !== strpos( $file_content, '$theme_option_file_background' ) ) {
+				WP_CLI::success( 'Already patched.' );
+				return;
+			}
+
+			// The duplicate `static $theme_option_file` lives in the `background_image`
+			// case. Split the file there so we only rename that copy and leave the
+			// original declaration in the `file` case untouched.
+			$marker     = "case 'background_image':";
+			$marker_pos = strpos( $file_content, $marker );
+
+			if ( false === $marker_pos ) {
+				WP_CLI::error( 'Patch target not found in ' . $file );
+			}
+
+			$before = substr( $file_content, 0, $marker_pos );
+			$after  = substr( $file_content, $marker_pos );
+
+			// Within $after only the `background_image` case references
+			// `$theme_option_file` (the `file` case sits in $before, `gradient` uses a
+			// different variable), so renaming every occurrence here is surgical.
+			$count = 0;
+			$after = str_replace( '$theme_option_file', '$theme_option_file_background', $after, $count );
+
+			if ( ! $count ) {
+				WP_CLI::error( 'String not found on ' . $file );
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			if ( ! file_put_contents( $file, $before . $after ) ) {
+				WP_CLI::error( 'Failed to write to ' . $file );
+			}
+
+			WP_CLI::success( 'Success' );
+		}
+
+		/**
 		 * Enable or disable fatal error emails.
 		 *
 		 * ## OPTIONS


### PR DESCRIPTION
Fixes:
- https://linear.app/a8c/issue/DOTCOM-17389/mega-main-menu-php-83-patch-script

## Proposed changes

* Adds a new `wpcomsh php83-plugin-patch mega_main_menu` WP-CLI subcommand that patches Mega Main Menu to work under PHP 8.3+.
* The plugin's `mm_options_generator()` (in `framework/options_generator.php`) declares `static $theme_option_file = 1;` in **both** the `file` and `background_image` cases of the same `switch`. PHP ≤8.2 tolerated this; PHP 8.3 turned a repeated `static` declaration of the same variable in one function scope into a hard fatal: `Duplicate declaration of static variable $theme_option_file`. This surfaces when a site is upgraded from PHP 8.2 to 8.4.
* The command renames the duplicate in the `background_image` case to `$theme_option_file_background`, leaving the original declaration in the `file` case intact. Both branches only enqueue the media-uploader scripts, and `wp_enqueue_*` is idempotent, so behavior is unchanged.
* Modeled on the existing `php81-plugin-patch` command, with the same fail-safe semantics: it validates the plugin/file exist, is a no-op if already patched, and cleanly errors (`String not found`) rather than corrupting the file if the target isn't present.

## Related product discussion/links

* DOTCOM-17389

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a test site that has the Mega Main Menu plugin installed and is running PHP 8.3 or 8.4:

* Confirm the site fatals with `PHP Fatal error: Duplicate declaration of static variable $theme_option_file in .../mega_main_menu/framework/options_generator.php`.
* Run `wp wpcomsh php83-plugin-patch mega_main_menu`.
* Confirm it reports `Success`, and that line ~503 of `framework/options_generator.php` now reads `static $theme_option_file_background = 1;` (the `file` case's declaration is unchanged).
* Reload the site / Mega Main Menu options screen and confirm the fatal is gone and the media uploader still works.
* Run the command a second time and confirm it reports `Already patched.` and makes no further changes.
* Run it against a different plugin (e.g. `wp wpcomsh php83-plugin-patch foo`) and confirm it errors with `Wrong plugin to patch.`
