### PR TITLE
Newsletter: don't show the connection prompt in Subscribers on Simple sites

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-connection-wpcom
+++ b/projects/packages/newsletter/changelog/fix-newsletter-connection-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: don't show the WordPress.com connection prompt on Simple sites, which are already connected

--- a/projects/packages/newsletter/routes/dashboard/stage.tsx
+++ b/projects/packages/newsletter/routes/dashboard/stage.tsx
@@ -1,6 +1,6 @@
 import analytics from '@automattic/jetpack-analytics';
 import useConnection from '@automattic/jetpack-connection/use-connection';
-import { getSiteData, getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteData, getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useSearch } from '@wordpress/route';
@@ -71,7 +71,11 @@ const Stage = () => {
 
 	// Subscriber management proxies to WP.com signed as the current user, so a
 	// fully connected site AND user are required. Mirrors the VideoPress gate.
-	const canManageSubscribers = isRegistered && hasConnectedOwner && isUserConnected;
+	// Simple sites are already hosted on WP.com — they never have a Jetpack
+	// connection, and the `/wpcom/v2/subscribers/*` endpoints resolve directly
+	// to WP.com authenticated by the logged-in user — so the gate never applies.
+	const canManageSubscribers =
+		isSimpleSite() || ( isRegistered && hasConnectedOwner && isUserConnected );
 
 	// `handleRegisterSite` registers the site if needed and then connects the
 	// user; on an already-registered site it connects the user directly.

--- a/projects/packages/newsletter/tests/stage.test.tsx
+++ b/projects/packages/newsletter/tests/stage.test.tsx
@@ -13,6 +13,8 @@
 const mockRecordEvent = jest.fn();
 const mockInitialize = jest.fn();
 const mockSearch = jest.fn< { tab?: string }, [] >();
+const mockIsSimpleSite = jest.fn< boolean, [] >();
+const mockConnection = jest.fn< Record< string, unknown >, [] >();
 
 jest.mock( '@automattic/jetpack-analytics', () => ( {
 	__esModule: true,
@@ -25,18 +27,12 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	getSiteData: () => ( { admin_url: 'https://example.com/wp-admin/' } ),
 	getSiteType: () => 'jetpack',
+	isSimpleSite: () => mockIsSimpleSite(),
 } ) );
 
 jest.mock( '@automattic/jetpack-connection/use-connection', () => ( {
 	__esModule: true,
-	default: () => ( {
-		isRegistered: false,
-		hasConnectedOwner: false,
-		isUserConnected: false,
-		siteIsRegistering: false,
-		userIsConnecting: false,
-		handleRegisterSite: jest.fn(),
-	} ),
+	default: () => mockConnection(),
 } ) );
 
 jest.mock( '@wordpress/route', () => ( {
@@ -64,12 +60,12 @@ jest.mock( '../_inc/subscribers/components/subscribers-body', () => ( {
 		children,
 	}: {
 		children: ( ctx: { body: React.ReactNode; actions: React.ReactNode } ) => React.ReactNode;
-	} ) => <>{ children( { body: null, actions: null } ) }</>,
+	} ) => <>{ children( { body: <div data-testid="subscribers-body" />, actions: null } ) }</>,
 } ) );
 
 jest.mock( '../_inc/subscribers/components/connection-gate', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: () => <div data-testid="connection-gate" />,
 } ) );
 
 jest.mock( '../_inc/subscribers/lib/query-client', () => ( {
@@ -100,7 +96,7 @@ jest.mock( '../src/settings/style.scss', () => ( {} ), { virtual: true } );
 jest.mock( '../routes/dashboard/route.scss', () => ( {} ), { virtual: true } );
 
 // Imports must come after the jest.mock factories above.
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { StrictMode } from 'react';
 import { stage as Stage } from '../routes/dashboard/stage';
 
@@ -109,6 +105,17 @@ beforeEach( () => {
 	mockInitialize.mockReset();
 	mockSearch.mockReset();
 	mockSearch.mockReturnValue( {} );
+	mockIsSimpleSite.mockReset();
+	mockIsSimpleSite.mockReturnValue( false );
+	mockConnection.mockReset();
+	mockConnection.mockReturnValue( {
+		isRegistered: false,
+		hasConnectedOwner: false,
+		isUserConnected: false,
+		siteIsRegistering: false,
+		userIsConnecting: false,
+		handleRegisterSite: jest.fn(),
+	} );
 } );
 
 describe( 'Newsletter dashboard Stage analytics', () => {
@@ -177,5 +184,41 @@ describe( 'Newsletter dashboard Stage analytics', () => {
 
 		expect( mockInitialize ).toHaveBeenCalledTimes( 1 );
 		expect( mockInitialize ).toHaveBeenCalledWith( 1, 'tester' );
+	} );
+} );
+
+describe( 'Newsletter dashboard Stage connection gate', () => {
+	it( 'shows the connection gate on a disconnected non-Simple site', () => {
+		render( <Stage /> );
+
+		expect( screen.getByTestId( 'connection-gate' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'subscribers-body' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'bypasses the gate on a Simple site even without a Jetpack connection', () => {
+		// Simple sites are hosted on WP.com and never carry a Jetpack
+		// connection; the subscriber endpoints resolve directly to WP.com.
+		mockIsSimpleSite.mockReturnValue( true );
+
+		render( <Stage /> );
+
+		expect( screen.getByTestId( 'subscribers-body' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'connection-gate' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the subscribers body on a fully connected non-Simple site', () => {
+		mockConnection.mockReturnValue( {
+			isRegistered: true,
+			hasConnectedOwner: true,
+			isUserConnected: true,
+			siteIsRegistering: false,
+			userIsConnecting: false,
+			handleRegisterSite: jest.fn(),
+		} );
+
+		render( <Stage /> );
+
+		expect( screen.getByTestId( 'subscribers-body' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'connection-gate' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes #

## Proposed changes
* The modernized Newsletter dashboard's **Subscribers** tab no longer shows the "Connect to manage your subscribers" prompt on WordPress.com Simple sites.
* Simple sites are hosted on WP.com and never carry a Jetpack connection, so the existing gate (`isRegistered && hasConnectedOwner && isUserConnected`) was always false there — a false positive. The `/wpcom/v2/subscribers/*` endpoints resolve directly to WP.com on Simple sites, authenticated by the logged-in user, so subscriber management already works without any connection step.
* `canManageSubscribers` is now short-circuited with `isSimpleSite()` in `routes/dashboard/stage.tsx`.
* Added stage tests covering the three gate states: gate shown when disconnected on a non-Simple site, gate bypassed on Simple sites, and body shown when fully connected.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a **WordPress.com Simple site**, open the Newsletter dashboard (`wp-admin/admin.php?page=jetpack-newsletter`) and go to the **Subscribers** tab.
* Confirm you see the subscribers data view directly — **not** the "Connect to manage your subscribers" prompt.
* On a **self-hosted Jetpack site that is not connected** (no registered site / connected user), confirm the connection prompt still appears in the Subscribers tab.
* On a **fully connected Jetpack site**, confirm the subscribers data view shows as before.
* Run the package tests: `pnpm test -- tests/stage.test.tsx` from `projects/packages/newsletter`.
