### PR TITLE
Protect: use ui Text component for settings

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-settings-text
+++ b/projects/plugins/protect/changelog/fix-protect-settings-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Switch to wp/ui Text for wrapping account protection settings

--- a/projects/plugins/protect/src/js/routes/settings/index.jsx
+++ b/projects/plugins/protect/src/js/routes/settings/index.jsx
@@ -1,7 +1,6 @@
 import {
 	Col,
 	Container,
-	Text,
 	ToggleControl,
 	AdminSectionHero,
 	getRedirectUrl,
@@ -9,7 +8,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
-import { Notice, Link } from '@wordpress/ui';
+import { Notice, Link, Text } from '@wordpress/ui';
 import { useCallback } from 'react';
 import useAccountProtectionQuery from '../../data/account-protection/use-account-protection-query';
 import useToggleAccountProtectionMutation from '../../data/account-protection/use-toggle-account-protection-module-mutation';
@@ -57,7 +56,7 @@ const SettingsPage = () => {
 				/>
 			</div>
 			<div className={ styles[ 'toggle-section__content' ] }>
-				<Text variant="title-medium">{ __( 'Account protection', 'jetpack-protect' ) }</Text>
+				<Text variant="heading-xl">{ __( 'Account protection', 'jetpack-protect' ) }</Text>
 				{ ! accountProtection.isSupported && (
 					<Notice.Root intent="warning" className={ styles[ 'toggle-section__alert' ] }>
 						<Notice.Title>


### PR DESCRIPTION

## Proposed changes
Switch to wp/ui Text component for the settings toggle. The old component would allow for the link white space to wrap awkwardly

Before:
<img width="774" height="133" alt="image" src="https://github.com/user-attachments/assets/a4294eb0-944d-4dce-bddf-de624af282d6" />


After:
<img width="818" height="303" alt="image" src="https://github.com/user-attachments/assets/81e9f3f5-5fe2-4a33-92b4-93e7ac91b7b2" />


## Related product discussion/links


## Does this pull request change what data or activity we track or use?
No

## Testing instructions
Visit Protect page and go to settings. Verify the toggle looks good.