### PR TITLE
[codex] Fix stats abilities empty input defaults

### DIFF
--- a/projects/packages/stats/changelog/2026-06-03-13-58-02-949605
+++ b/projects/packages/stats/changelog/2026-06-03-13-58-02-949605
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Abilities: Allow readonly stats abilities with optional input to run when no input is sent.

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -166,6 +166,7 @@ class Stats_Abilities extends Registrar {
 			),
 			'input_schema'        => array(
 				'type'                 => 'object',
+				'default'              => array(),
 				'properties'           => new \stdClass(),
 				'additionalProperties' => false,
 			),
@@ -355,6 +356,7 @@ class Stats_Abilities extends Registrar {
 			),
 			'input_schema'        => array(
 				'type'                 => 'object',
+				'default'              => array(),
 				'properties'           => array(
 					'unit'     => array(
 						'type'        => 'string',
@@ -425,6 +427,7 @@ class Stats_Abilities extends Registrar {
 			),
 			'input_schema'        => array(
 				'type'                 => 'object',
+				'default'              => array(),
 				'properties'           => new \stdClass(),
 				'additionalProperties' => false,
 			),
@@ -469,6 +472,7 @@ class Stats_Abilities extends Registrar {
 			),
 			'input_schema'        => array(
 				'type'                 => 'object',
+				'default'              => array(),
 				'properties'           => new \stdClass(),
 				'additionalProperties' => false,
 			),

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -213,6 +213,26 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		}
 	}
 
+	public function test_read_abilities_without_required_input_have_empty_object_default(): void {
+		$abilities = Stats_Abilities::get_abilities();
+
+		foreach (
+			array(
+				'jetpack-stats/get-site-overview',
+				'jetpack-stats/get-visits',
+				'jetpack-stats/get-followers',
+				'jetpack-stats/get-settings',
+			) as $slug
+		) {
+			$schema = $abilities[ $slug ]['input_schema'];
+
+			$this->assertSame( 'object', $schema['type'], "{$slug} input must remain an object schema." );
+			$this->assertArrayNotHasKey( 'required', $schema, "{$slug} should continue to allow empty input." );
+			$this->assertArrayHasKey( 'default', $schema, "{$slug} must default missing tunnel input to an empty object." );
+			$this->assertSame( array(), $schema['default'], "{$slug} must default missing tunnel input to an empty object." );
+		}
+	}
+
 	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
 		foreach ( Stats_Abilities::get_abilities() as $slug => $spec ) {
 			$this->assertSame( true, $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add explicit empty object defaults to Jetpack Stats readonly ability input schemas that have no required input.
* Cover `jetpack-stats/get-site-overview`, `jetpack-stats/get-visits`, `jetpack-stats/get-followers`, and `jetpack-stats/get-settings`, so remote readonly calls with no query input normalize to `{}` instead of failing object validation.
* Add a regression test for optional-input readonly stats abilities and include a manual changelog entry.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Follow-up to Automattic/jetpack#48286.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `jetpack test php packages/stats --verbose`.
* Run `cd projects/packages/stats && composer phpunit -- --filter Stats_Abilities_Test`.
* On a connected site with `jetpack_wp_abilities_enabled` enabled, invoke `jetpack-stats/get-site-overview` through the remote abilities path with no params. Confirm it no longer returns `ability_invalid_input` for `input is not of type object`; it should return the stats overview, or the existing Stats data unavailable error if WordPress.com stats cannot be fetched.
