### PR TITLE
Agents Manager: Include build folder when pushing changes to mirror repo

### DIFF
--- a/projects/packages/agents-manager/.gitattributes
+++ b/projects/packages/agents-manager/.gitattributes
@@ -1,6 +1,7 @@
 # Files to include in the mirror repo, but excluded via gitignore
 # Remember to end all directories with `/**` to properly tag every file.
 # /src/js/example.min.js  production-include
+build/**          production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # (see also entries in the monorepo root .gitattributes)

--- a/projects/packages/agents-manager/changelog/agents-manager-add-build-to-production-include
+++ b/projects/packages/agents-manager/changelog/agents-manager-add-build-to-production-include
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Agents Manager: Include build folder when pushing changes to mirror repo.


### PR DESCRIPTION
Part of WOOAI-501.

## Proposed changes

The new version of the `agents-manager` package includes JS files that should be bundled and distributed within the mirror repo. Right now, the v0.2.0 release does not include it. This PR fixes that by following the existing patterns from other packages, which is to explicitly include the ignored directory within `.gitattributes` so it's actually picked up.

## Related product discussion/links

None.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

None.