### PR TITLE
Agents Manager: Release 0.2.1

### DIFF
--- a/projects/packages/agents-manager/CHANGELOG.md
+++ b/projects/packages/agents-manager/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-06-03
+### Fixed
+- Agents Manager: Include build folder when pushing changes to mirror repo. [#49383]
+
 ## [0.2.0] - 2026-06-03
 ### Added
 - Agents Manager: Ensure sidebar preserves open state on load. [#49325]
@@ -14,4 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agents Manager: Allow overriding variant and sectionName through filters [#49283]
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption. [#49202]
 
+[0.2.1]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.1.0...v0.2.0

--- a/projects/packages/agents-manager/changelog/agents-manager-add-build-to-production-include
+++ b/projects/packages/agents-manager/changelog/agents-manager-add-build-to-production-include
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Agents Manager: Include build folder when pushing changes to mirror repo.

--- a/projects/packages/agents-manager/package.json
+++ b/projects/packages/agents-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-agents-manager",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"private": true,
 	"description": "Shared AI infrastructure helpers for Automattic plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/agents-manager/#readme",

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -19,7 +19,7 @@ class Agents_Manager {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1';
 
 	/**
 	 * Help Center URL for disconnected variants.


### PR DESCRIPTION
Part of WOOAI-501.

## Proposed changes

Patch release to fix a bug where the `build` artifacts were not being pushed to the `agents-manager` mirror repo. 

Related PR: https://github.com/Automattic/jetpack/pull/49383.

## Related product discussion/links

See Linear issue.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

None.