### PR TITLE
AI Sidebar: preserve Agents Manager provider composition

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-sidebar-provider-composition
+++ b/projects/plugins/jetpack/changelog/update-ai-sidebar-provider-composition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+AI Sidebar: Preserve peer Agents Manager providers when loading Jetpack AI.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -19,16 +19,15 @@ use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 require_once __DIR__ . '/../../../shared/cdn-locale.php';
 
-const AM_ASSET_BASE_PATH          = 'widgets.wp.com/agents-manager/';
-const AM_ASSET_TRANSIENT          = 'jetpack_am_gutenberg_asset';
-const AM_ASSET_DC_TRANSIENT       = 'jetpack_am_gutenberg_dc_asset';
-const AI_SIDEBAR_ASSET_TRANSIENT  = 'jetpack_ai_sidebar_asset';
-const AI_SIDEBAR_JS_URL           = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
-const AI_SIDEBAR_CSS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
-const AI_SIDEBAR_RTL_CSS_URL      = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
-const AI_SIDEBAR_PROVIDER_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
-const AI_SIDEBAR_AGENT_ID         = 'wp-orchestrator';
-const BIG_SKY_AGENT_PROVIDER_PATH = '/big-sky-plugin/build/calypso-agent-provider/';
+const AM_ASSET_BASE_PATH         = 'widgets.wp.com/agents-manager/';
+const AM_ASSET_TRANSIENT         = 'jetpack_am_gutenberg_asset';
+const AM_ASSET_DC_TRANSIENT      = 'jetpack_am_gutenberg_dc_asset';
+const AI_SIDEBAR_ASSET_TRANSIENT = 'jetpack_ai_sidebar_asset';
+const AI_SIDEBAR_JS_URL          = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.min.js';
+const AI_SIDEBAR_CSS_URL         = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.css';
+const AI_SIDEBAR_RTL_CSS_URL     = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.rtl.css';
+const AI_SIDEBAR_PROVIDER_URL    = 'https://' . AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.provider.mjs';
+const AI_SIDEBAR_AGENT_ID        = 'wp-orchestrator';
 
 /**
  * Handles loading the Agents Manager from CDN and registering the
@@ -61,8 +60,8 @@ class Jetpack_AI_Sidebar {
 
 		add_filter( 'jetpack_ai_sidebar_agents_manager_data', array( __CLASS__, 'add_agents_manager_data' ), 10, 1 );
 
-		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in the
-		// post editor on WordPress.com and Atomic sites.
+		// Allow jetpack-mu-wpcom's bundled Agents Manager to mount in supported
+		// block editor surfaces on WordPress.com and Atomic sites.
 		add_filter( 'agents_manager_enabled_in_block_editor', array( __CLASS__, 'enable_agents_manager_in_post_editor' ) );
 
 		// Load AM from CDN if not already present.
@@ -70,7 +69,7 @@ class Jetpack_AI_Sidebar {
 		// so wp_script_is('agents-manager') correctly detects if AM is already loaded.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_am' ), 200 );
 
-		// Enqueue the IIFE bundle in the preview post editor — it registers
+		// Enqueue the IIFE bundle in supported preview editors — it registers
 		// Jetpack AI abilities via @wordpress/abilities, which Big Sky or AM
 		// can discover regardless of which provider system is active.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'maybe_enqueue_abilities_script' ), 201 );
@@ -87,12 +86,12 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Load AM from CDN if not already present and we're in the preview post editor.
+	 * Load AM from CDN if not already present and we're in a supported preview editor.
 	 *
 	 * @return void
 	 */
 	public static function maybe_enqueue_am(): void {
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_supported_block_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -128,7 +127,7 @@ class Jetpack_AI_Sidebar {
 	 * @return void
 	 */
 	public static function maybe_enqueue_abilities_script(): void {
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_supported_block_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 
@@ -272,9 +271,9 @@ class Jetpack_AI_Sidebar {
 		$filtered = apply_filters( 'jetpack_ai_sidebar_agents_manager_data', $am_data );
 		$am_data  = is_array( $filtered ) ? $filtered : $am_data;
 
-		// Direct CDN-loader fallback. Jetpack owns these defaults; hosts can
-		// override via the AI Editorial Review and preview filters.
-		$am_data['agentId']                  = AI_SIDEBAR_AGENT_ID;
+		// Direct CDN-loader fallback. Preserve a host-provided agentId so AM
+		// can compose Jetpack AI with host-owned agents such as Dolly.
+		$am_data                             = self::add_default_agent_id( $am_data );
 		$am_data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$am_data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $am_data;
@@ -407,10 +406,10 @@ class Jetpack_AI_Sidebar {
 			return $providers;
 		}
 
-		// The provider IIFE is only enqueued in the post editor. Avoid registering
-		// the ESM wrapper on other block-editor surfaces, where AM may import it
+		// The provider IIFE is only enqueued in supported block editors. Avoid registering
+		// the ESM wrapper on other editor surfaces, where AM may import it
 		// before window.__JetpackAIProvider exists.
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_supported_block_editor() || ! self::has_ai_features() ) {
 			return $providers;
 		}
 
@@ -422,11 +421,27 @@ class Jetpack_AI_Sidebar {
 			return $providers;
 		}
 
+		return self::append_ai_sidebar_provider_url( $providers );
+	}
+
+	/**
+	 * Append the Jetpack AI Sidebar provider URL if it is not already registered.
+	 *
+	 * @param array $providers Existing provider URLs.
+	 * @return array Updated providers.
+	 */
+	private static function append_ai_sidebar_provider_url( array $providers ): array {
+		if ( ! self::get_ai_sidebar_asset_data() ) {
+			return $providers;
+		}
+
 		// Register as AM provider via CDN-hosted ESM wrapper.
 		// AM dynamically imports this module to merge tools, suggestions, and components.
 		// No ?ver= needed — the wrapper re-exports from window.__JetpackAIProvider
 		// at import time, so its behavior always matches the loaded IIFE bundle.
-		$providers[] = AI_SIDEBAR_PROVIDER_URL;
+		if ( ! in_array( AI_SIDEBAR_PROVIDER_URL, $providers, true ) ) {
+			$providers[] = AI_SIDEBAR_PROVIDER_URL;
+		}
 
 		return $providers;
 	}
@@ -552,40 +567,39 @@ class Jetpack_AI_Sidebar {
 			return $data;
 		}
 
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_supported_block_editor() || ! self::has_ai_features() ) {
 			return $data;
 		}
 
-		// Set Jetpack's defaults for externally emitted payloads. Hosts that need
-		// intentional overrides should use the AI Editorial Review and preview filters.
-		if ( isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] ) ) {
-			$data['agentProviders'] = self::filter_agent_providers_for_jetpack_ai_sidebar( $data['agentProviders'] );
-		}
-		$data['agentId']                  = AI_SIDEBAR_AGENT_ID;
+		// Set Jetpack's defaults for externally emitted payloads without
+		// replacing a host-provided agentId.
+		$data['agentProviders']           = self::append_ai_sidebar_provider_url(
+			isset( $data['agentProviders'] ) && is_array( $data['agentProviders'] )
+				? $data['agentProviders']
+				: array()
+		);
+		$data                             = self::add_default_agent_id( $data );
 		$data['aiEditorialReviewEnabled'] = self::is_ai_editorial_review_enabled();
 		$data['jetpackAiSidebarPreview']  = self::get_jetpack_ai_sidebar_preview_config();
 		return $data;
 	}
 
 	/**
-	 * Remove providers that should not participate in the Jetpack AI Sidebar surface.
+	 * Add Jetpack AI's default agent only when a host has not already selected one.
 	 *
-	 * @param array $providers Provider URLs.
-	 * @return array Filtered provider URLs.
+	 * @param array $data Data encoded into `agentsManagerData`.
+	 * @return array Data with a default agent ID.
 	 */
-	private static function filter_agent_providers_for_jetpack_ai_sidebar( array $providers ): array {
-		return array_values(
-			array_filter(
-				$providers,
-				static function ( $provider ): bool {
-					return ! is_string( $provider ) || ! str_contains( $provider, BIG_SKY_AGENT_PROVIDER_PATH );
-				}
-			)
-		);
+	private static function add_default_agent_id( array $data ): array {
+		if ( empty( $data['agentId'] ) || ! is_string( $data['agentId'] ) ) {
+			$data['agentId'] = AI_SIDEBAR_AGENT_ID;
+		}
+
+		return $data;
 	}
 
 	/**
-	 * Enable Agents Manager in the post editor when Jetpack AI Sidebar Preview is available.
+	 * Enable Agents Manager in supported block editors when Jetpack AI Sidebar Preview is available.
 	 *
 	 * @param mixed $enabled Existing Agents Manager block-editor gate value.
 	 * @return bool
@@ -595,7 +609,7 @@ class Jetpack_AI_Sidebar {
 			return true;
 		}
 
-		return self::is_jetpack_ai_sidebar_preview_enabled() && self::is_post_editor() && self::has_ai_features();
+		return self::is_jetpack_ai_sidebar_preview_enabled() && self::is_supported_block_editor() && self::has_ai_features();
 	}
 
 	/**
@@ -619,7 +633,7 @@ class Jetpack_AI_Sidebar {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return;
 		}
-		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_post_editor() || ! self::has_ai_features() ) {
+		if ( ! self::is_jetpack_ai_sidebar_preview_enabled() || ! self::is_supported_block_editor() || ! self::has_ai_features() ) {
 			return;
 		}
 		// 'registered' rather than 'enqueued': wp_add_inline_script attaches to any
@@ -641,16 +655,20 @@ class Jetpack_AI_Sidebar {
 			AI_SIDEBAR_AGENT_ID,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
-		$big_sky_provider_payload    = wp_json_encode(
-			BIG_SKY_AGENT_PROVIDER_PATH,
+		$provider_url_payload        = wp_json_encode(
+			AI_SIDEBAR_PROVIDER_URL,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
+		$provider_patch_script       = self::get_ai_sidebar_asset_data()
+			? ' if ( ! Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = []; }'
+				. ' if ( agentsManagerData.agentProviders.indexOf( ' . $provider_url_payload . ' ) === -1 ) { agentsManagerData.agentProviders.push( ' . $provider_url_payload . ' ); }'
+			: '';
 
 		wp_add_inline_script(
 			'agents-manager',
 			'if ( typeof agentsManagerData === "object" && agentsManagerData !== null ) {'
-				. ' if ( Array.isArray( agentsManagerData.agentProviders ) ) { agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter( function( provider ) { return typeof provider !== "string" || provider.indexOf( ' . $big_sky_provider_payload . ' ) === -1; } ); }'
-				. ' agentsManagerData.agentId = ' . $agent_id_payload . ';'
+				. $provider_patch_script
+				. ' if ( typeof agentsManagerData.agentId !== "string" || agentsManagerData.agentId === "" ) { agentsManagerData.agentId = ' . $agent_id_payload . '; }'
 				. ' agentsManagerData.aiEditorialReviewEnabled = ' . $ai_editorial_review_payload . ';'
 				. ' agentsManagerData.jetpackAiSidebarPreview = ' . $preview_payload . ';'
 				. ' }',
@@ -673,11 +691,11 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Check if the current screen is the post block editor.
+	 * Check if the current screen is a supported content block editor.
 	 *
 	 * @return bool
 	 */
-	private static function is_post_editor(): bool {
+	private static function is_supported_block_editor(): bool {
 		if ( ! self::is_block_editor() ) {
 			return false;
 		}
@@ -685,7 +703,7 @@ class Jetpack_AI_Sidebar {
 		$screen = get_current_screen();
 		return $screen instanceof \WP_Screen
 			&& 'post' === $screen->base
-			&& 'post' === $screen->post_type;
+			&& in_array( $screen->post_type, array( 'post', 'page' ), true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -350,12 +350,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Agents Manager block-editor gate does not open in the page editor.
+	 * Test that the Agents Manager block-editor gate opens in the page editor.
 	 */
-	public function test_enable_agents_manager_in_post_editor_skips_page_editor() {
+	public function test_enable_agents_manager_in_post_editor_enables_page_editor() {
 		$this->set_page_block_editor_screen();
 
-		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
+		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_in_post_editor( false ) );
 	}
 
 	/**
@@ -416,15 +416,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that maybe_enqueue_am does nothing outside the post editor.
+	 * Test that maybe_enqueue_am loads in the page editor.
 	 */
-	public function test_maybe_enqueue_am_skips_page_editor() {
+	public function test_maybe_enqueue_am_enqueues_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_am_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_am();
 
-		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'agents-manager', 'enqueued' ) );
 	}
 
 	/**
@@ -503,6 +503,26 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A host-selected agent ID should not be replaced by Jetpack AI.
+	 */
+	public function test_maybe_enqueue_am_preserves_host_agent_id() {
+		$this->set_block_editor_screen();
+		$this->cache_am_asset_data();
+		add_filter(
+			'jetpack_ai_sidebar_agents_manager_data',
+			function ( $data ) {
+				$data['agentId'] = 'dolly';
+				return $data;
+			}
+		);
+
+		Jetpack_AI_Sidebar::maybe_enqueue_am();
+
+		$this->assertStringContainsString( '"agentId":"dolly"', $this->get_agents_manager_inline_script() );
+		$this->assertStringNotContainsString( '"agentId":"wp-orchestrator"', $this->get_agents_manager_inline_script() );
+	}
+
+	/**
 	 * Dev-mode signals keep AI Editorial Review enabled by default.
 	 */
 	public function test_maybe_enqueue_am_exposes_ai_editorial_review_enabled_in_dev_mode() {
@@ -537,11 +557,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][0] );
 		$this->assertSame( true, $data['aiEditorialReviewEnabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['aiEditorialReview'] );
@@ -552,10 +574,30 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Big Sky's provider should not participate in the Jetpack AI Sidebar surface.
+	 * Platform-emitted Agents Manager data keeps an existing host agent.
 	 */
-	public function test_add_agents_manager_data_filters_big_sky_provider() {
+	public function test_add_agents_manager_data_preserves_existing_agent_id() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName' => 'gutenberg',
+				'agentId'     => 'dolly',
+			)
+		);
+
+		$this->assertSame( 'dolly', $data['agentId'] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][0] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
+	}
+
+	/**
+	 * Provider composition remains owned by Agents Manager.
+	 */
+	public function test_add_agents_manager_data_preserves_registered_providers_for_am_composition() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
 			array(
@@ -570,6 +612,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array(
+				'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
 				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
 				array( 'provider' => 'metadata' ),
 			),
@@ -578,10 +621,35 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Platform-emitted provider lists get the Jetpack provider appended when missing.
+	 */
+	public function test_add_agents_manager_data_appends_jetpack_provider_when_missing() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
+			array(
+				'sectionName'    => 'gutenberg',
+				'agentProviders' => array(
+					'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+				),
+			)
+		);
+
+		$this->assertCount( 2, $data['agentProviders'] );
+		$this->assertSame(
+			'https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123',
+			$data['agentProviders'][0]
+		);
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][1] );
+	}
+
+	/**
 	 * Preview and AI Editorial Review have separate gates.
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
 
@@ -595,16 +663,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted preview data is scoped to the post editor.
+	 * Platform-emitted preview data is available in the page editor.
 	 */
-	public function test_add_agents_manager_data_skips_page_editor() {
+	public function test_add_agents_manager_data_exposes_preview_data_in_page_editor() {
 		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		$this->assertArrayNotHasKey( 'agentId', $data );
-		$this->assertArrayNotHasKey( 'aiEditorialReviewEnabled', $data );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebarPreview', $data );
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $data['agentProviders'][0] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['enabled'] );
+		$this->assertSame( true, $data['jetpackAiSidebarPreview']['features']['blockTransformations'] );
+		$this->assertSame( false, $data['jetpackAiSidebarPreview']['features']['optimizeTitleSuggestion'] );
 	}
 
 	/**
@@ -736,28 +807,37 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Simulate an external host having enqueued AM and declared upstream
-		// data with both Jetpack AI Sidebar and Big Sky providers.
+		// data with Big Sky's provider but without Jetpack's provider.
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script(
 			'agents-manager',
-			'const agentsManagerData = { sectionName: "gutenberg", agentProviders: [ "https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123", "https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs" ] };',
+			'const agentsManagerData = { sectionName: "gutenberg", agentProviders: [ "https://example.com/wp-content/plugins/big-sky-plugin/build/calypso-agent-provider/index.js?ver=123" ] };',
 			'before'
 		);
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringNotContainsString(
 			'agentsManagerData.agentProviders = agentsManagerData.agentProviders.filter',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
-			'/big-sky-plugin/build/calypso-agent-provider/',
+			'agentsManagerData.agentProviders.push',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
-			'agentsManagerData.agentId = "wp-orchestrator"',
+			'jetpack-ai-sidebar.provider.mjs',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
+			'if ( typeof agentsManagerData.agentId !== "string" || agentsManagerData.agentId === "" ) { agentsManagerData.agentId = "wp-orchestrator"; }',
 			$this->get_agents_manager_inline_script()
 		);
 		$this->assertStringContainsString(
@@ -783,25 +863,30 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The external AM payload patch is limited to the post editor.
+	 * The external AM payload patch runs in the page editor.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_skips_page_editor() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_in_page_editor() {
 		$this->set_page_block_editor_screen();
+		$this->cache_sidebar_asset_data();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
-		$this->assertStringNotContainsString(
+		$this->assertStringContainsString(
+			'agentsManagerData.agentProviders.push',
+			$this->get_agents_manager_inline_script()
+		);
+		$this->assertStringContainsString(
 			'agentsManagerData.agentId',
 			$this->get_agents_manager_inline_script()
 		);
-		$this->assertStringNotContainsString(
+		$this->assertStringContainsString(
 			'agentsManagerData.aiEditorialReviewEnabled',
 			$this->get_agents_manager_inline_script()
 		);
-		$this->assertStringNotContainsString(
+		$this->assertStringContainsString(
 			'agentsManagerData.jetpackAiSidebarPreview',
 			$this->get_agents_manager_inline_script()
 		);
@@ -849,15 +934,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is not enqueued outside the post editor.
+	 * Test that abilities script is enqueued in the page editor.
 	 */
-	public function test_abilities_script_skips_page_editor() {
+	public function test_abilities_script_enqueues_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
-		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
 	}
 
 	/**
@@ -958,16 +1043,32 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers unchanged outside the post editor.
+	 * Test that register_provider does not duplicate the Jetpack provider.
 	 */
-	public function test_register_provider_skips_page_editor() {
+	public function test_register_provider_does_not_duplicate_provider_url() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+
+		$existing  = array( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertCount( 1, $providers );
+		$this->assertSame( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL, $providers[0] );
+	}
+
+	/**
+	 * Test that register_provider adds the provider in the page editor.
+	 */
+	public function test_register_provider_adds_url_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
 
-		$this->assertSame( $existing, $providers );
+		$this->assertCount( 2, $providers );
+		$this->assertSame( 'https://example.com/provider-a.mjs', $providers[0] );
+		$this->assertStringContainsString( 'jetpack-ai-sidebar.provider.mjs', $providers[1] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Preserve a host-provided Agents Manager `agentId` instead of forcing Jetpack AI Sidebar to `wp-orchestrator` on every surface.
* Append the Jetpack AI Sidebar provider to existing `agentsManagerData.agentProviders` instead of filtering peer providers out.
* Register the Jetpack AI Sidebar provider without duplicating the provider URL.
* Keep Optimize Title disabled in this smaller provider-composition PR.
* Add tests for preserving peer providers, preserving host `agentId`, page editor support, and missing payload defaults.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Pairs with Automattic/wp-calypso#111335.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->

Automated checks run locally:

* `php -l projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php`
* `php -l projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php`
* `JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test`
* `JETPACK_CLI_NONFATAL_VERSION_CHECKS=1 pnpm jetpack changelog validate plugins/jetpack`
* `git diff --check`

Manual testing notes:

* Use the paired Calypso Agents Manager provider-composition PR.
* In the post editor with Jetpack AI only, confirm Jetpack AI Sidebar suggestions and interactive UI still render.
* In the page/site editor with Big Sky + Jetpack AI, confirm Big Sky suggestions still render and Big Sky picker UI renders after running a suggestion.
* Confirm Optimize Title is not newly enabled by this PR.
